### PR TITLE
fix(chat): gate stored chat content on session workspace access

### DIFF
--- a/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
+++ b/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
@@ -20,23 +20,61 @@ UPDATE chat_threads
   WHERE workspace_id IS NOT NULL
     AND cardinality(data_workspace_ids) = 0;
 
--- Global threads: derive the data scope from any embedded
--- search-summary citation parts. True conversational global chats
--- have no such parts and keep the empty default ('{}'), which the
--- new RLS predicate treats as "no embedded workspace data" and
--- therefore unrestricted by workspace.
+-- Global threads: derive the data scope from every workspace-
+-- bearing carrier we know about — `data-stella-source-document`
+-- parts (search summaries, document references) and entity-
+-- mention or workspace-mention HTML inside text parts. UUID-
+-- shaped strings extracted from text are then intersected with
+-- the workspaces table so noise (any UUID-looking substring) is
+-- dropped. True conversational global chats have no such carriers
+-- and keep the empty default ('{}'), which the new RLS predicate
+-- treats as "no embedded workspace data" and therefore unrestricted
+-- by workspace.
+WITH thread_workspace_refs AS (
+  -- Source-document parts carry the workspace ID directly.
+  SELECT
+    cm.thread_id,
+    (part->'data'->>'workspaceId')::uuid AS workspace_id
+  FROM chat_messages cm,
+       LATERAL jsonb_array_elements(cm.content->'data') AS part
+  WHERE part->>'type' = 'data-stella-source-document'
+    AND part->'data'->>'workspaceId' ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+
+  UNION
+
+  -- Entity-mention HTML inside text parts carries the workspace
+  -- in `data-source-workspace-id="<uuid>"`; workspace mentions
+  -- carry the workspace ID directly in `data-id="<uuid>"`. Both
+  -- are matched by extracting any UUID-shaped substring from the
+  -- text and validating against the workspaces table below. This
+  -- avoids regex lookbehind (not portable) and tolerates either
+  -- attribute order.
+  SELECT
+    cm.thread_id,
+    uuid_match.uuid_text::uuid AS workspace_id
+  FROM chat_messages cm,
+       LATERAL jsonb_array_elements(cm.content->'data') AS part,
+       LATERAL regexp_matches(
+         coalesce(part->>'text', ''),
+         '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+         'g'
+       ) AS rm(captures),
+       LATERAL (SELECT rm.captures[1]) AS uuid_match(uuid_text)
+  WHERE part->>'type' = 'text'
+    AND part->>'text' IS NOT NULL
+)
 UPDATE chat_threads ct
   SET data_workspace_ids = derived.workspace_ids
   FROM (
     SELECT
-      cm.thread_id,
-      ARRAY_AGG(DISTINCT (part->'data'->>'workspaceId')::uuid)
-        AS workspace_ids
-    FROM chat_messages cm,
-         LATERAL jsonb_array_elements(cm.content->'data') AS part
-    WHERE part->>'type' = 'data-stella-source-document'
-      AND part->'data'->>'workspaceId' IS NOT NULL
-    GROUP BY cm.thread_id
+      twr.thread_id,
+      ARRAY_AGG(DISTINCT twr.workspace_id) AS workspace_ids
+    FROM thread_workspace_refs twr
+    -- Drop UUIDs that aren't actually workspaces in this DB.
+    WHERE EXISTS (
+      SELECT 1 FROM workspaces w WHERE w.id = twr.workspace_id
+    )
+    GROUP BY twr.thread_id
   ) AS derived
   WHERE ct.id = derived.thread_id
     AND ct.workspace_id IS NULL

--- a/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
+++ b/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
@@ -78,22 +78,35 @@ content_workspace_ids AS (
   FROM thread_workspace_refs twr
   WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.id = twr.workspace_id)
   GROUP BY twr.thread_id
-)
-UPDATE chat_threads ct
-  SET data_workspace_ids = (
-    SELECT ARRAY(
-      SELECT DISTINCT unnest(
-        CASE
-          WHEN ct.workspace_id IS NOT NULL THEN ARRAY[ct.workspace_id]::uuid[]
-          ELSE '{}'::uuid[]
-        END || COALESCE(cwi.workspace_ids, '{}'::uuid[])
+),
+thread_final_scope AS (
+  -- Compute the final union per thread up-front. Doing this
+  -- here keeps the UPDATE's FROM clause flat — Postgres rejects
+  -- references to the UPDATE target's alias from inside a JOIN
+  -- ON clause, so we cannot `LEFT JOIN content_workspace_ids
+  -- cwi ON cwi.thread_id = ct.id` directly off the target.
+  SELECT
+    ct.id AS thread_id,
+    (
+      SELECT ARRAY(
+        SELECT DISTINCT unnest(
+          CASE
+            WHEN ct.workspace_id IS NOT NULL
+              THEN ARRAY[ct.workspace_id]::uuid[]
+            ELSE '{}'::uuid[]
+          END || COALESCE(cwi.workspace_ids, '{}'::uuid[])
+        )
       )
-    )
-  )
-  FROM (SELECT 1) AS dummy
+    ) AS workspace_ids
+  FROM chat_threads ct
   LEFT JOIN content_workspace_ids cwi ON cwi.thread_id = ct.id
   WHERE cardinality(ct.data_workspace_ids) = 0
-    AND (ct.workspace_id IS NOT NULL OR cwi.thread_id IS NOT NULL);
+    AND (ct.workspace_id IS NOT NULL OR cwi.thread_id IS NOT NULL)
+)
+UPDATE chat_threads
+  SET data_workspace_ids = tfs.workspace_ids
+  FROM thread_final_scope tfs
+  WHERE chat_threads.id = tfs.thread_id;
 
 -- The new RLS predicate is added by drizzle from the updated
 -- `chatThreadPolicies` / `chatMessagePolicies` definitions; see

--- a/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
+++ b/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
@@ -12,24 +12,32 @@
 ALTER TABLE chat_threads
   ADD COLUMN IF NOT EXISTS data_workspace_ids uuid[] NOT NULL DEFAULT '{}';
 
--- Workspace-scoped threads: their data scope is exactly that
--- workspace. This keeps existing matter chats accessible after the
--- new RLS predicate kicks in.
-UPDATE chat_threads
-  SET data_workspace_ids = ARRAY[workspace_id]::uuid[]
-  WHERE workspace_id IS NOT NULL
-    AND cardinality(data_workspace_ids) = 0;
-
--- Global threads: derive the data scope from every workspace-
--- bearing carrier we know about — `data-stella-source-document`
--- parts (search summaries, document references) and entity-
--- mention or workspace-mention HTML inside text parts. UUID-
--- shaped strings extracted from text are then intersected with
--- the workspaces table so noise (any UUID-looking substring) is
--- dropped. True conversational global chats have no such carriers
--- and keep the empty default ('{}'), which the new RLS predicate
--- treats as "no embedded workspace data" and therefore unrestricted
--- by workspace.
+-- Backfill `data_workspace_ids` for every existing chat thread as
+-- the union of:
+--   (a) the thread's own `workspace_id` (if non-null) — keeps
+--       workspace-scoped chats accessible after the new RLS
+--       predicate kicks in.
+--   (b) every workspace whose content is embedded in any of the
+--       thread's messages — `data-stella-source-document` parts
+--       (search summaries, document references) and any UUID
+--       extracted from text-part HTML (covers
+--       `data-source-workspace-id` on entity mentions and
+--       `data-id` on workspace mentions). Extracted UUIDs are
+--       intersected with the `workspaces` table so noise is
+--       dropped.
+--
+-- This is a single union so a workspace-scoped thread that
+-- embedded another workspace's content (e.g., the user attached
+-- an entity from matter B inside a chat in matter A) is recorded
+-- as `[A, B]` rather than just `[A]`. Without this, the new RLS
+-- predicate would still treat the thread as accessible after
+-- access to B is revoked, leaving the historical leakage path
+-- open for pre-migration data.
+--
+-- True conversational global chats with no embedded workspace
+-- carriers keep the empty default ('{}'), which the new RLS
+-- predicate treats as "no embedded workspace data" and therefore
+-- unrestricted by workspace.
 WITH thread_workspace_refs AS (
   -- Source-document parts carry the workspace ID directly.
   SELECT
@@ -62,23 +70,30 @@ WITH thread_workspace_refs AS (
        LATERAL (SELECT rm.captures[1]) AS uuid_match(uuid_text)
   WHERE part->>'type' = 'text'
     AND part->>'text' IS NOT NULL
+),
+content_workspace_ids AS (
+  SELECT
+    twr.thread_id,
+    ARRAY_AGG(DISTINCT twr.workspace_id) AS workspace_ids
+  FROM thread_workspace_refs twr
+  WHERE EXISTS (SELECT 1 FROM workspaces w WHERE w.id = twr.workspace_id)
+  GROUP BY twr.thread_id
 )
 UPDATE chat_threads ct
-  SET data_workspace_ids = derived.workspace_ids
-  FROM (
-    SELECT
-      twr.thread_id,
-      ARRAY_AGG(DISTINCT twr.workspace_id) AS workspace_ids
-    FROM thread_workspace_refs twr
-    -- Drop UUIDs that aren't actually workspaces in this DB.
-    WHERE EXISTS (
-      SELECT 1 FROM workspaces w WHERE w.id = twr.workspace_id
+  SET data_workspace_ids = (
+    SELECT ARRAY(
+      SELECT DISTINCT unnest(
+        CASE
+          WHEN ct.workspace_id IS NOT NULL THEN ARRAY[ct.workspace_id]::uuid[]
+          ELSE '{}'::uuid[]
+        END || COALESCE(cwi.workspace_ids, '{}'::uuid[])
+      )
     )
-    GROUP BY twr.thread_id
-  ) AS derived
-  WHERE ct.id = derived.thread_id
-    AND ct.workspace_id IS NULL
-    AND cardinality(ct.data_workspace_ids) = 0;
+  )
+  FROM (SELECT 1) AS dummy
+  LEFT JOIN content_workspace_ids cwi ON cwi.thread_id = ct.id
+  WHERE cardinality(ct.data_workspace_ids) = 0
+    AND (ct.workspace_id IS NOT NULL OR cwi.thread_id IS NOT NULL);
 
 -- The new RLS predicate is added by drizzle from the updated
 -- `chatThreadPolicies` / `chatMessagePolicies` definitions; see

--- a/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
+++ b/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
@@ -51,25 +51,45 @@ WITH thread_workspace_refs AS (
   UNION
 
   -- Entity-mention HTML inside text parts carries the workspace
-  -- in `data-source-workspace-id="<uuid>"`; workspace mentions
-  -- carry the workspace ID directly in `data-id="<uuid>"`. Both
-  -- are matched by extracting any UUID-shaped substring from the
-  -- text and validating against the workspaces table below. This
-  -- avoids regex lookbehind (not portable) and tolerates either
-  -- attribute order.
+  -- in the `data-source-workspace-id` attribute. Match the
+  -- attribute name explicitly so unrelated UUID-looking strings
+  -- pasted into chat text (other workspace IDs, ticket IDs, etc.)
+  -- do not get treated as embedded workspace data — that would
+  -- incorrectly widen the thread's data scope and lock the
+  -- thread's owner out under the new RLS subset check.
   SELECT
     cm.thread_id,
-    uuid_match.uuid_text::uuid AS workspace_id
+    (rm.captures[1])::uuid AS workspace_id
   FROM chat_messages cm,
        LATERAL jsonb_array_elements(cm.content->'data') AS part,
        LATERAL regexp_matches(
          coalesce(part->>'text', ''),
-         '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+         'data-source-workspace-id="([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"',
          'g'
-       ) AS rm(captures),
-       LATERAL (SELECT rm.captures[1]) AS uuid_match(uuid_text)
+       ) AS rm(captures)
   WHERE part->>'type' = 'text'
     AND part->>'text' IS NOT NULL
+
+  UNION
+
+  -- Workspace mentions carry the workspace ID directly in the
+  -- `data-id` attribute, paired with `data-category="workspace"`.
+  -- Postgres regex lacks lookbehind, so both attribute orders
+  -- are matched as separate alternatives — only one capture
+  -- group will be non-null per match, so coalesce to pick it up.
+  SELECT
+    cm.thread_id,
+    (COALESCE(rm.captures[1], rm.captures[2]))::uuid AS workspace_id
+  FROM chat_messages cm,
+       LATERAL jsonb_array_elements(cm.content->'data') AS part,
+       LATERAL regexp_matches(
+         coalesce(part->>'text', ''),
+         'data-category="workspace"[^>]*data-id="([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"|data-id="([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"[^>]*data-category="workspace"',
+         'g'
+       ) AS rm(captures)
+  WHERE part->>'type' = 'text'
+    AND part->>'text' IS NOT NULL
+    AND COALESCE(rm.captures[1], rm.captures[2]) IS NOT NULL
 ),
 content_workspace_ids AS (
   SELECT

--- a/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
+++ b/apps/api/drizzle/20260503100000_chat-threads-data-workspace-ids/migration.sql
@@ -1,0 +1,152 @@
+-- stella-migration-safety: reviewed destructive-change - rotate chat RLS policies to gate reads on data_workspace_ids; existing chat_* policies are recreated as chat_thread_* and chat_message_* with the new subset check.
+-- Track which workspaces' content is embedded in a chat thread, so
+-- read access can be gated against the user's currently accessible
+-- workspaces — not just against the thread's own workspace_id.
+--
+-- Search-summary threads are stored as global threads (workspace_id
+-- IS NULL) but embed citations and excerpts from one or more
+-- workspaces. Without this column, a user who later loses access to
+-- a contributing workspace can still read the stored content via
+-- the global chat list. The new column plus the updated RLS policy
+-- gate every read on `data_workspace_ids <@ session_workspace_ids`.
+ALTER TABLE chat_threads
+  ADD COLUMN IF NOT EXISTS data_workspace_ids uuid[] NOT NULL DEFAULT '{}';
+
+-- Workspace-scoped threads: their data scope is exactly that
+-- workspace. This keeps existing matter chats accessible after the
+-- new RLS predicate kicks in.
+UPDATE chat_threads
+  SET data_workspace_ids = ARRAY[workspace_id]::uuid[]
+  WHERE workspace_id IS NOT NULL
+    AND cardinality(data_workspace_ids) = 0;
+
+-- Global threads: derive the data scope from any embedded
+-- search-summary citation parts. True conversational global chats
+-- have no such parts and keep the empty default ('{}'), which the
+-- new RLS predicate treats as "no embedded workspace data" and
+-- therefore unrestricted by workspace.
+UPDATE chat_threads ct
+  SET data_workspace_ids = derived.workspace_ids
+  FROM (
+    SELECT
+      cm.thread_id,
+      ARRAY_AGG(DISTINCT (part->'data'->>'workspaceId')::uuid)
+        AS workspace_ids
+    FROM chat_messages cm,
+         LATERAL jsonb_array_elements(cm.content->'data') AS part
+    WHERE part->>'type' = 'data-stella-source-document'
+      AND part->'data'->>'workspaceId' IS NOT NULL
+    GROUP BY cm.thread_id
+  ) AS derived
+  WHERE ct.id = derived.thread_id
+    AND ct.workspace_id IS NULL
+    AND cardinality(ct.data_workspace_ids) = 0;
+
+-- The new RLS predicate is added by drizzle from the updated
+-- `chatThreadPolicies` / `chatMessagePolicies` definitions; see
+-- src/db/rls.ts. Existing 'chat_*' policies are dropped and
+-- recreated with the data-workspace-ids check included.
+DROP POLICY IF EXISTS chat_select ON chat_threads;
+DROP POLICY IF EXISTS chat_insert ON chat_threads;
+DROP POLICY IF EXISTS chat_update ON chat_threads;
+DROP POLICY IF EXISTS chat_delete ON chat_threads;
+DROP POLICY IF EXISTS chat_select ON chat_messages;
+DROP POLICY IF EXISTS chat_insert ON chat_messages;
+DROP POLICY IF EXISTS chat_update ON chat_messages;
+DROP POLICY IF EXISTS chat_delete ON chat_messages;
+
+CREATE POLICY chat_thread_select ON chat_threads
+  FOR SELECT TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_insert ON chat_threads
+  FOR INSERT TO stella
+  WITH CHECK (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_update ON chat_threads
+  FOR UPDATE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_delete ON chat_threads
+  FOR DELETE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_message_select ON chat_messages
+  FOR SELECT TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_insert ON chat_messages
+  FOR INSERT TO stella
+  WITH CHECK (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_update ON chat_messages
+  FOR UPDATE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_delete ON chat_messages
+  FOR DELETE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -32,9 +32,38 @@ const userCheck = sql`user_id =
     '${sql.raw(SETTING_USER_ID)}', true
   ))`;
 
-const chatScopeCheck = sql`(
+// `data_workspace_ids` records every workspace whose content is
+// embedded in the thread (citations, document excerpts, etc.). The
+// empty default means "no workspace data embedded" — true global
+// chats. Any non-empty value must be a subset of the session's
+// accessible workspaces, which prevents a stored search-summary
+// thread from outliving the user's access to a contributing matter.
+const chatThreadDataScopeCheck = sql`(
+  cardinality(data_workspace_ids) = 0
+  OR data_workspace_ids <@ ${wsIdsArray}
+)`;
+
+const chatThreadScopeCheck = sql`(
   ${userCheck} AND
-  (workspace_id IS NULL OR ${workspaceCheck})
+  (workspace_id IS NULL OR ${workspaceCheck}) AND
+  ${chatThreadDataScopeCheck}
+)`;
+
+// Messages inherit the data scope from their owning thread. RLS on
+// `chat_messages` joins `chat_threads` so a leaked global thread
+// row cannot expose its messages even if the thread row itself
+// somehow becomes readable.
+const chatMessageScopeCheck = sql`(
+  ${userCheck} AND
+  (workspace_id IS NULL OR ${workspaceCheck}) AND
+  EXISTS (
+    SELECT 1 FROM chat_threads ct
+    WHERE ct.id = chat_messages.thread_id
+      AND (
+        cardinality(ct.data_workspace_ids) = 0
+        OR ct.data_workspace_ids <@ ${wsIdsArray}
+      )
+  )
 )`;
 
 export const wsPolicies = () => [
@@ -106,25 +135,48 @@ export const userPolicies = () => [
   }),
 ];
 
-export const chatPolicies = () => [
-  p.pgPolicy("chat_select", {
+export const chatThreadPolicies = () => [
+  p.pgPolicy("chat_thread_select", {
     for: "select",
     to: stella,
-    using: chatScopeCheck,
+    using: chatThreadScopeCheck,
   }),
-  p.pgPolicy("chat_insert", {
+  p.pgPolicy("chat_thread_insert", {
     for: "insert",
     to: stella,
-    withCheck: chatScopeCheck,
+    withCheck: chatThreadScopeCheck,
   }),
-  p.pgPolicy("chat_update", {
+  p.pgPolicy("chat_thread_update", {
     for: "update",
     to: stella,
-    using: chatScopeCheck,
+    using: chatThreadScopeCheck,
   }),
-  p.pgPolicy("chat_delete", {
+  p.pgPolicy("chat_thread_delete", {
     for: "delete",
     to: stella,
-    using: chatScopeCheck,
+    using: chatThreadScopeCheck,
+  }),
+];
+
+export const chatMessagePolicies = () => [
+  p.pgPolicy("chat_message_select", {
+    for: "select",
+    to: stella,
+    using: chatMessageScopeCheck,
+  }),
+  p.pgPolicy("chat_message_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: chatMessageScopeCheck,
+  }),
+  p.pgPolicy("chat_message_update", {
+    for: "update",
+    to: stella,
+    using: chatMessageScopeCheck,
+  }),
+  p.pgPolicy("chat_message_delete", {
+    for: "delete",
+    to: stella,
+    using: chatMessageScopeCheck,
   }),
 ];

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -9,7 +9,8 @@ import { customType } from "drizzle-orm/pg-core";
 import { organization, user } from "@/api/db/auth-schema";
 import { jsonb } from "@/api/db/columns";
 import {
-  chatPolicies,
+  chatMessagePolicies,
+  chatThreadPolicies,
   organizationCheck,
   orgPolicies,
   stella,
@@ -2171,6 +2172,18 @@ export const chatThreads = p.pgTable(
       .array()
       .notNull()
       .default([]),
+    /**
+     * Workspaces whose content (citations, document excerpts) is
+     * embedded in this thread. Empty means "no workspace data
+     * embedded" (true global chat). Any non-empty value gates RLS
+     * reads: the user's session workspace IDs must be a superset.
+     * Used by search-summary chats so the stored summary cannot
+     * outlive the user's access to a contributing matter.
+     */
+    dataWorkspaceIds: safeWorkspaceId("data_workspace_ids")
+      .array()
+      .notNull()
+      .default([]),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
       .timestamp("updated_at")
@@ -2183,7 +2196,7 @@ export const chatThreads = p.pgTable(
       .index("chat_threads_workspace_user_idx")
       .on(table.workspaceId, table.userId),
     p.index("chat_threads_user_updated_idx").on(table.userId, table.updatedAt),
-    ...chatPolicies(),
+    ...chatThreadPolicies(),
   ],
 );
 
@@ -2217,7 +2230,7 @@ export const chatMessages = p.pgTable(
     p
       .index("chat_messages_user_workspace_created_idx")
       .on(table.userId, table.workspaceId, table.createdAt),
-    ...chatPolicies(),
+    ...chatMessagePolicies(),
   ],
 );
 

--- a/apps/api/src/handlers/chat/data-scope.test.ts
+++ b/apps/api/src/handlers/chat/data-scope.test.ts
@@ -1,0 +1,207 @@
+import { Result } from "better-result";
+import { describe, expect, mock, test } from "bun:test";
+
+import type { ChatMention } from "@/api/handlers/chat/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { toSafeId } from "@/api/lib/branded-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+import {
+  expandThreadDataScope,
+  extractAssistantWorkspaceIds,
+  extractMentionWorkspaceIds,
+} from "./data-scope";
+
+const wsA = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000a");
+const wsB = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000b");
+const wsC = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000c");
+const threadId = toSafeId<"chatThread">("00000000-0000-0000-0000-0000000000aa");
+
+describe("extractMentionWorkspaceIds", () => {
+  test("workspace mention contributes its own ID", () => {
+    const mentions: ChatMention[] = [
+      { id: wsA, label: "Matter A", category: "workspace" },
+    ];
+    expect(extractMentionWorkspaceIds(mentions)).toEqual([wsA]);
+  });
+
+  test("entity mention contributes its workspace ID", () => {
+    const mentions: ChatMention[] = [
+      {
+        id: "entity_1",
+        label: "Doc 1",
+        category: "entity",
+        workspaceId: wsA,
+      },
+    ];
+    expect(extractMentionWorkspaceIds(mentions)).toEqual([wsA]);
+  });
+
+  test("entity mention without workspace contributes nothing", () => {
+    const mentions: ChatMention[] = [
+      {
+        id: "entity_1",
+        label: "Doc 1",
+        category: "entity",
+        workspaceId: null,
+      },
+    ];
+    expect(extractMentionWorkspaceIds(mentions)).toEqual([]);
+  });
+
+  test("multiple mentions across workspaces deduplicate", () => {
+    const mentions: ChatMention[] = [
+      { id: wsA, label: "Matter A", category: "workspace" },
+      {
+        id: "entity_1",
+        label: "Doc 1",
+        category: "entity",
+        workspaceId: wsA,
+      },
+      {
+        id: "entity_2",
+        label: "Doc 2",
+        category: "entity",
+        workspaceId: wsB,
+      },
+    ];
+    expect(new Set(extractMentionWorkspaceIds(mentions))).toEqual(
+      new Set([wsA, wsB]),
+    );
+  });
+});
+
+describe("extractAssistantWorkspaceIds", () => {
+  test("source-document parts contribute their workspaceId", () => {
+    const parts = [
+      {
+        type: "data-stella-source-document" as const,
+        data: {
+          entityId: "entity_1",
+          kind: "document",
+          mimeType: "application/pdf",
+          title: "Motion.pdf",
+          workspaceId: wsA,
+        },
+      },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([wsA]);
+  });
+
+  test("source-document parts dedupe across workspaces", () => {
+    const parts = [
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: wsA },
+      },
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: wsB },
+      },
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: wsA },
+      },
+    ];
+    expect(new Set(extractAssistantWorkspaceIds(parts))).toEqual(
+      new Set([wsA, wsB]),
+    );
+  });
+
+  test("non-source parts are ignored", () => {
+    const parts = [
+      { type: "text" as const, text: "hello" },
+      { type: "data-stella-mentions" as const, data: { mentions: [] } },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
+  });
+
+  test("source-document with empty workspaceId contributes nothing", () => {
+    const parts = [
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: "" },
+      },
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: null },
+      },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
+  });
+});
+
+describe("expandThreadDataScope", () => {
+  const buildTx = () => {
+    const setMock = mock(() => ({
+      where: mock(async () => undefined),
+    }));
+    const updateMock = mock(() => ({ set: setMock }));
+    const tx = { update: updateMock };
+    const { safeDb } = createScopedDbMock(tx);
+    return { safeDb, updateMock, setMock };
+  };
+
+  test("no new IDs → no UPDATE issued", async () => {
+    const { safeDb, updateMock } = buildTx();
+    const result = await expandThreadDataScope({
+      currentDataWorkspaceIds: [wsA],
+      newWorkspaceIds: [],
+      safeDb,
+      threadId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test("all new IDs already present → no UPDATE issued", async () => {
+    const { safeDb, updateMock } = buildTx();
+    const result = await expandThreadDataScope({
+      currentDataWorkspaceIds: [wsA, wsB],
+      newWorkspaceIds: [wsA, wsB],
+      safeDb,
+      threadId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test("regression: genuinely new workspace IDs trigger UPDATE", async () => {
+    const { safeDb, updateMock, setMock } = buildTx();
+    const result = await expandThreadDataScope({
+      currentDataWorkspaceIds: [wsA],
+      newWorkspaceIds: [wsB, wsC],
+      safeDb,
+      threadId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(setMock).toHaveBeenCalledTimes(1);
+    if (Result.isOk(result)) {
+      expect(new Set<SafeId<"workspace">>(result.value)).toEqual(
+        new Set([wsA, wsB, wsC]),
+      );
+    }
+  });
+
+  test("partial overlap: only the genuinely-new IDs are appended", async () => {
+    const { safeDb, updateMock } = buildTx();
+    const result = await expandThreadDataScope({
+      currentDataWorkspaceIds: [wsA, wsB],
+      newWorkspaceIds: [wsB, wsC],
+      safeDb,
+      threadId,
+    });
+
+    expect(Result.isOk(result)).toBe(true);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    if (Result.isOk(result)) {
+      expect(new Set<SafeId<"workspace">>(result.value)).toEqual(
+        new Set([wsA, wsB, wsC]),
+      );
+    }
+  });
+});

--- a/apps/api/src/handlers/chat/data-scope.test.ts
+++ b/apps/api/src/handlers/chat/data-scope.test.ts
@@ -108,10 +108,52 @@ describe("extractAssistantWorkspaceIds", () => {
     );
   });
 
-  test("non-source parts are ignored", () => {
+  test("text parts without stella refs are ignored", () => {
     const parts = [
-      { type: "text" as const, text: "hello" },
+      { type: "text" as const, text: "Just a normal reply, no refs." },
       { type: "data-stella-mentions" as const, data: { mentions: [] } },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
+  });
+
+  test("regression: assistant text refs widen the data scope", () => {
+    // Resolved by `resolveAssistantTextRefs` after the stream
+    // finishes; the workspace ID then needs to be added to
+    // `data_workspace_ids` so the persisted reply doesn't
+    // outlive the user's access to that workspace.
+    const parts = [
+      {
+        type: "text" as const,
+        text: `See [matter](#stella-workspace=${wsA}) and the related document at #stella-entity=${wsB}:abc.`,
+      },
+    ];
+    expect(new Set(extractAssistantWorkspaceIds(parts))).toEqual(
+      new Set([wsA, wsB]),
+    );
+  });
+
+  test("text and source-document parts are unioned", () => {
+    const parts = [
+      {
+        type: "data-stella-source-document" as const,
+        data: { workspaceId: wsA },
+      },
+      {
+        type: "text" as const,
+        text: `more context #stella-workspace=${wsB}`,
+      },
+    ];
+    expect(new Set(extractAssistantWorkspaceIds(parts))).toEqual(
+      new Set([wsA, wsB]),
+    );
+  });
+
+  test("malformed UUIDs in text refs are ignored", () => {
+    const parts = [
+      {
+        type: "text" as const,
+        text: "garbage #stella-workspace=not-a-uuid and #stella-entity=zz:yy",
+      },
     ];
     expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
   });

--- a/apps/api/src/handlers/chat/data-scope.test.ts
+++ b/apps/api/src/handlers/chat/data-scope.test.ts
@@ -158,6 +158,61 @@ describe("extractAssistantWorkspaceIds", () => {
     expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
   });
 
+  test("regression: tool output parts with matterRef widen the data scope", () => {
+    // Tool outputs persist UUIDs in `matterRef` / `workspaceId`
+    // fields after `resolveAssistantValueRefs` rehydrates them
+    // from the in-memory `mat_N` ref shorthand. Without scanning
+    // these, a thread that only contains tool output (no
+    // source-document parts and no text refs) would keep an
+    // empty data scope and leak after revocation.
+    const parts = [
+      {
+        type: "tool-listMatters-output" as const,
+        toolCallId: "call_1",
+        state: "output-available" as const,
+        output: {
+          items: [
+            { matterRef: wsA, name: "Matter A" },
+            { matterRef: wsB, name: "Matter B" },
+          ],
+          nextOffset: null,
+          hasMore: false,
+        },
+      },
+    ];
+    expect(new Set(extractAssistantWorkspaceIds(parts))).toEqual(
+      new Set([wsA, wsB]),
+    );
+  });
+
+  test("regression: deeply nested workspaceId fields are picked up", () => {
+    const parts = [
+      {
+        type: "tool-getProperty-output" as const,
+        output: {
+          property: {
+            id: "prop_1",
+            owner: { workspaceId: wsA },
+          },
+        },
+      },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([wsA]);
+  });
+
+  test("non-UUID matterRef values are ignored (e.g. unresolved ref shorthand)", () => {
+    // If a tool output ever lands with the in-memory shorthand
+    // (mat_1) instead of a UUID, the structural walker must not
+    // brand it as a workspace ID and must not crash.
+    const parts = [
+      {
+        type: "tool-listMatters-output" as const,
+        output: { items: [{ matterRef: "mat_1" }] },
+      },
+    ];
+    expect(extractAssistantWorkspaceIds(parts)).toEqual([]);
+  });
+
   test("source-document with empty workspaceId contributes nothing", () => {
     const parts = [
       {

--- a/apps/api/src/handlers/chat/data-scope.ts
+++ b/apps/api/src/handlers/chat/data-scope.ts
@@ -1,0 +1,138 @@
+import { Result } from "better-result";
+import { eq, sql } from "drizzle-orm";
+
+import type { SafeDb, SafeDbError } from "@/api/db";
+import { chatThreads } from "@/api/db/schema";
+import type { ChatMention } from "@/api/handlers/chat/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { brandPersistedWorkspaceId } from "@/api/lib/safe-id-boundaries";
+
+// Walks a parsed user-message mention list for any workspace IDs the
+// message embeds — entity mentions carry a workspaceId; workspace
+// mentions are a workspace ID themselves. Used to expand a chat
+// thread's data scope when the user pastes/attaches workspace
+// content into a global thread.
+export const extractMentionWorkspaceIds = (
+  mentions: readonly ChatMention[],
+): SafeId<"workspace">[] => {
+  const ids = new Set<SafeId<"workspace">>();
+  for (const mention of mentions) {
+    if (mention.category === "workspace") {
+      ids.add(brandPersistedWorkspaceId(mention.id));
+      continue;
+    }
+    if (mention.workspaceId !== null) {
+      ids.add(brandPersistedWorkspaceId(mention.workspaceId));
+    }
+  }
+  return Array.from(ids);
+};
+
+// Walks an assistant message's parts for workspace-scoped data
+// embedded by tools (search hits, document references, etc.). Today
+// the only persisted carrier is `data-stella-source-document`; new
+// workspace-scoped part types must be added here so a thread that
+// embeds them widens its data scope correctly.
+//
+// Accepts `readonly unknown[]` and narrows per-part so this also
+// handles legacy/migrated message shapes without forcing callers to
+// pre-validate against the live `ChatMessage` union.
+export const extractAssistantWorkspaceIds = (
+  parts: readonly unknown[],
+): SafeId<"workspace">[] => {
+  const ids = new Set<SafeId<"workspace">>();
+  for (const part of parts) {
+    const workspaceId = sourceDocumentWorkspaceId(part);
+    if (workspaceId !== null) {
+      ids.add(workspaceId);
+    }
+  }
+  return Array.from(ids);
+};
+
+const sourceDocumentWorkspaceId = (
+  part: unknown,
+): SafeId<"workspace"> | null => {
+  if (typeof part !== "object" || part === null) {
+    return null;
+  }
+  if (!("type" in part) || part.type !== "data-stella-source-document") {
+    return null;
+  }
+  if (
+    !("data" in part) ||
+    typeof part.data !== "object" ||
+    part.data === null
+  ) {
+    return null;
+  }
+  if (!("workspaceId" in part.data)) {
+    return null;
+  }
+  const workspaceId = part.data.workspaceId;
+  if (typeof workspaceId !== "string" || workspaceId.length === 0) {
+    return null;
+  }
+  return brandPersistedWorkspaceId(workspaceId);
+};
+
+type ExpandThreadDataScopeInput = {
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  // Workspaces already recorded on the thread row — this is the
+  // local view we compare against to skip the UPDATE when nothing
+  // would change. The DB source of truth still wins under
+  // concurrent writes (the SQL appends + dedupes atomically).
+  currentDataWorkspaceIds: readonly SafeId<"workspace">[];
+  // Workspaces newly observed in the message about to be persisted.
+  // May overlap with the current set; only genuinely new IDs cause
+  // an UPDATE.
+  newWorkspaceIds: readonly SafeId<"workspace">[];
+};
+
+type ExpandThreadDataScopeResult = Result<SafeId<"workspace">[], SafeDbError>;
+
+// Atomically widens a chat thread's `data_workspace_ids` to include
+// any workspaces a new message references. The append-and-dedupe
+// happens in SQL so two concurrent message persists cannot lose
+// entries. Returns the union (best effort, since we don't re-read
+// the row) so callers can keep their local view in sync.
+export const expandThreadDataScope = async ({
+  safeDb,
+  threadId,
+  currentDataWorkspaceIds,
+  newWorkspaceIds,
+}: ExpandThreadDataScopeInput): Promise<ExpandThreadDataScopeResult> => {
+  if (newWorkspaceIds.length === 0) {
+    return Result.ok([...currentDataWorkspaceIds]);
+  }
+  const currentSet = new Set<SafeId<"workspace">>(currentDataWorkspaceIds);
+  const additions = newWorkspaceIds.filter((id) => !currentSet.has(id));
+  if (additions.length === 0) {
+    return Result.ok([...currentDataWorkspaceIds]);
+  }
+
+  const updateResult = await safeDb((tx) =>
+    tx
+      .update(chatThreads)
+      .set({
+        // Append-and-dedupe in SQL so concurrent persists on the
+        // same thread cannot lose entries. Postgres handles the
+        // uniqueness; the local return value below is best-effort
+        // for callers that want to keep their view in sync.
+        dataWorkspaceIds: sql`(
+          SELECT ARRAY(
+            SELECT DISTINCT unnest(
+              ${chatThreads.dataWorkspaceIds} || ${additions}::uuid[]
+            )
+          )
+        )`,
+      })
+      .where(eq(chatThreads.id, threadId)),
+  );
+
+  if (Result.isError(updateResult)) {
+    return Result.err(updateResult.error);
+  }
+  return Result.ok([...currentSet, ...additions]);
+};

--- a/apps/api/src/handlers/chat/data-scope.ts
+++ b/apps/api/src/handlers/chat/data-scope.ts
@@ -29,10 +29,20 @@ export const extractMentionWorkspaceIds = (
 };
 
 // Walks an assistant message's parts for workspace-scoped data
-// embedded by tools (search hits, document references, etc.). Today
-// the only persisted carrier is `data-stella-source-document`; new
-// workspace-scoped part types must be added here so a thread that
-// embeds them widens its data scope correctly.
+// embedded by the model. Today there are two carriers:
+//
+//   1. `data-stella-source-document` parts emitted by search /
+//      workspace tools — workspace ID lives in `data.workspaceId`.
+//   2. Resolved `#stella-workspace=<id>` and
+//      `#stella-entity=<workspace>:<entity>` href fragments inside
+//      assistant text parts (produced by `resolveAssistantTextRefs`
+//      after the stream finishes). Without scanning these, an
+//      assistant reply that links a workspace in plain text would
+//      not widen `chat_threads.data_workspace_ids`, leaving the
+//      stored content readable after access is revoked.
+//
+// New workspace-scoped part types must be added to this dispatcher
+// so a thread that embeds them widens its data scope correctly.
 //
 // Accepts `readonly unknown[]` and narrows per-part so this also
 // handles legacy/migrated message shapes without forcing callers to
@@ -42,9 +52,12 @@ export const extractAssistantWorkspaceIds = (
 ): SafeId<"workspace">[] => {
   const ids = new Set<SafeId<"workspace">>();
   for (const part of parts) {
-    const workspaceId = sourceDocumentWorkspaceId(part);
-    if (workspaceId !== null) {
-      ids.add(workspaceId);
+    const sourceDocId = sourceDocumentWorkspaceId(part);
+    if (sourceDocId !== null) {
+      ids.add(sourceDocId);
+    }
+    for (const textRefId of textRefWorkspaceIds(part)) {
+      ids.add(textRefId);
     }
   }
   return Array.from(ids);
@@ -74,6 +87,33 @@ const sourceDocumentWorkspaceId = (
     return null;
   }
   return brandPersistedWorkspaceId(workspaceId);
+};
+
+// Captures the workspace UUID from `#stella-workspace=<uuid>` and
+// the leading workspace UUID from `#stella-entity=<workspace>:<entity>`.
+// The entity form's second segment (the entity UUID) is intentionally
+// not captured — only the workspace it belongs to gates RLS.
+const STELLA_TEXT_REF_WORKSPACE_REGEX =
+  /#stella-(?:workspace|entity)=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/g;
+
+const textRefWorkspaceIds = (part: unknown): SafeId<"workspace">[] => {
+  if (typeof part !== "object" || part === null) {
+    return [];
+  }
+  if (!("type" in part) || part.type !== "text") {
+    return [];
+  }
+  if (!("text" in part) || typeof part.text !== "string") {
+    return [];
+  }
+  const ids: SafeId<"workspace">[] = [];
+  for (const match of part.text.matchAll(STELLA_TEXT_REF_WORKSPACE_REGEX)) {
+    const captured = match[1];
+    if (captured) {
+      ids.push(brandPersistedWorkspaceId(captured));
+    }
+  }
+  return ids;
 };
 
 type ExpandThreadDataScopeInput = {

--- a/apps/api/src/handlers/chat/data-scope.ts
+++ b/apps/api/src/handlers/chat/data-scope.ts
@@ -29,20 +29,20 @@ export const extractMentionWorkspaceIds = (
 };
 
 // Walks an assistant message's parts for workspace-scoped data
-// embedded by the model. Today there are two carriers:
+// embedded by the model. Two complementary carriers are scanned:
 //
-//   1. `data-stella-source-document` parts emitted by search /
-//      workspace tools — workspace ID lives in `data.workspaceId`.
-//   2. Resolved `#stella-workspace=<id>` and
-//      `#stella-entity=<workspace>:<entity>` href fragments inside
-//      assistant text parts (produced by `resolveAssistantTextRefs`
-//      after the stream finishes). Without scanning these, an
-//      assistant reply that links a workspace in plain text would
-//      not widen `chat_threads.data_workspace_ids`, leaving the
-//      stored content readable after access is revoked.
-//
-// New workspace-scoped part types must be added to this dispatcher
-// so a thread that embeds them widens its data scope correctly.
+//   1. **Structural fields** — any property at any depth named
+//      `workspaceId` or `matterRef` whose value is a UUID string.
+//      Covers `data-stella-source-document` parts
+//      (`data.workspaceId`), tool output parts that include
+//      `matterRef` / `workspaceId` (search hits, file lookups,
+//      property/entity records), and any future part shape that
+//      reuses these conventional field names.
+//   2. **Resolved text refs** — `#stella-workspace=<uuid>` and
+//      `#stella-entity=<workspace>:<entity>` produced by
+//      `resolveAssistantTextRefs` after the stream finishes.
+//      Without these, an assistant reply that links a workspace in
+//      plain text would not widen `chat_threads.data_workspace_ids`.
 //
 // Accepts `readonly unknown[]` and narrows per-part so this also
 // handles legacy/migrated message shapes without forcing callers to
@@ -52,41 +52,44 @@ export const extractAssistantWorkspaceIds = (
 ): SafeId<"workspace">[] => {
   const ids = new Set<SafeId<"workspace">>();
   for (const part of parts) {
-    const sourceDocId = sourceDocumentWorkspaceId(part);
-    if (sourceDocId !== null) {
-      ids.add(sourceDocId);
-    }
-    for (const textRefId of textRefWorkspaceIds(part)) {
-      ids.add(textRefId);
-    }
+    collectStructuralWorkspaceIds(part, ids);
+    collectTextRefWorkspaceIds(part, ids);
   }
   return Array.from(ids);
 };
 
-const sourceDocumentWorkspaceId = (
-  part: unknown,
-): SafeId<"workspace"> | null => {
-  if (typeof part !== "object" || part === null) {
-    return null;
+// Conventional field names across tool inputs/outputs that carry
+// a workspace ID. Adding a new field name here is the one place to
+// extend coverage when a new tool output shape ships.
+const WORKSPACE_KEY_FIELDS = new Set(["workspaceId", "matterRef"]);
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const collectStructuralWorkspaceIds = (
+  value: unknown,
+  ids: Set<SafeId<"workspace">>,
+): void => {
+  if (typeof value !== "object" || value === null) {
+    return;
   }
-  if (!("type" in part) || part.type !== "data-stella-source-document") {
-    return null;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStructuralWorkspaceIds(item, ids);
+    }
+    return;
   }
-  if (
-    !("data" in part) ||
-    typeof part.data !== "object" ||
-    part.data === null
-  ) {
-    return null;
+  for (const [key, child] of Object.entries(value)) {
+    if (
+      WORKSPACE_KEY_FIELDS.has(key) &&
+      typeof child === "string" &&
+      UUID_REGEX.test(child)
+    ) {
+      ids.add(brandPersistedWorkspaceId(child));
+      continue;
+    }
+    collectStructuralWorkspaceIds(child, ids);
   }
-  if (!("workspaceId" in part.data)) {
-    return null;
-  }
-  const workspaceId = part.data.workspaceId;
-  if (typeof workspaceId !== "string" || workspaceId.length === 0) {
-    return null;
-  }
-  return brandPersistedWorkspaceId(workspaceId);
 };
 
 // Captures the workspace UUID from `#stella-workspace=<uuid>` and
@@ -96,24 +99,25 @@ const sourceDocumentWorkspaceId = (
 const STELLA_TEXT_REF_WORKSPACE_REGEX =
   /#stella-(?:workspace|entity)=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/g;
 
-const textRefWorkspaceIds = (part: unknown): SafeId<"workspace">[] => {
+const collectTextRefWorkspaceIds = (
+  part: unknown,
+  ids: Set<SafeId<"workspace">>,
+): void => {
   if (typeof part !== "object" || part === null) {
-    return [];
+    return;
   }
   if (!("type" in part) || part.type !== "text") {
-    return [];
+    return;
   }
   if (!("text" in part) || typeof part.text !== "string") {
-    return [];
+    return;
   }
-  const ids: SafeId<"workspace">[] = [];
   for (const match of part.text.matchAll(STELLA_TEXT_REF_WORKSPACE_REGEX)) {
     const captured = match[1];
     if (captured) {
-      ids.push(brandPersistedWorkspaceId(captured));
+      ids.add(brandPersistedWorkspaceId(captured));
     }
   }
-  return ids;
 };
 
 type ExpandThreadDataScopeInput = {

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -392,8 +392,16 @@ const loadThread = async ({
     // workspaceId=X but requested as global would look "missing"
     // and the insert below would then collide on the PK. We want a
     // clear 400 instead of a constraint violation 500.
-    const thread = yield* Result.await(
-      safeDb((tx) =>
+    type ExistingThreadRow = {
+      id: SafeId<"chatThread">;
+      workspaceId: SafeId<"workspace"> | null;
+      contextMatterIds: SafeId<"workspace">[];
+      dataWorkspaceIds: SafeId<"workspace">[];
+      messages: ThreadRecord["messages"];
+    };
+
+    const lookup = async () =>
+      await safeDb((tx) =>
         tx.query.chatThreads.findFirst({
           where: {
             id: { eq: threadId },
@@ -416,11 +424,12 @@ const loadThread = async ({
             },
           },
         }),
-      ),
-    );
+      );
 
-    if (thread) {
-      const persistedWorkspaceId = thread.workspaceId ?? null;
+    const buildExisting = (
+      existing: ExistingThreadRow,
+    ): Result<LoadThreadResult, HandlerError<400>> => {
+      const persistedWorkspaceId = existing.workspaceId ?? null;
       if (persistedWorkspaceId !== workspaceId) {
         return Result.err(
           new HandlerError({
@@ -432,25 +441,23 @@ const loadThread = async ({
       return Result.ok<LoadThreadResult>({
         type: "existing",
         data: {
-          id: thread.id,
-          contextMatterIds: thread.contextMatterIds,
-          dataWorkspaceIds: thread.dataWorkspaceIds,
-          messages: thread.messages,
+          id: existing.id,
+          contextMatterIds: existing.contextMatterIds,
+          dataWorkspaceIds: existing.dataWorkspaceIds,
+          messages: existing.messages,
         },
       });
+    };
+
+    const thread = yield* Result.await(lookup());
+    if (thread) {
+      return buildExisting(thread);
     }
 
     const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
       ? [workspaceId]
       : [];
 
-    // The findFirst above runs under RLS, so a thread that exists
-    // but is no longer visible (data_workspace_ids ⊄ session) looks
-    // missing. Falling straight through to insert would collide on
-    // the primary key and surface as a 500. Translate that specific
-    // case to a 404 so the client gets a stable answer; matching the
-    // "not found" status that get-messages returns for the same
-    // shape avoids leaking thread existence to a revoked user.
     const insertResult = await safeDb((tx) =>
       tx.insert(chatThreads).values({
         id: threadId,
@@ -468,17 +475,35 @@ const loadThread = async ({
     );
     if (Result.isError(insertResult)) {
       if (
-        DatabaseError.is(insertResult.error) &&
-        insertResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+        !DatabaseError.is(insertResult.error) ||
+        insertResult.error.code !== PG_ERROR.UNIQUE_VIOLATION
       ) {
-        return Result.err(
-          new HandlerError({
-            status: 404,
-            message: "Chat thread not found",
-          }),
-        );
+        return Result.err(insertResult.error);
       }
-      return Result.err(insertResult.error);
+      // Two interleaved cases collide on the primary key here:
+      //
+      //   (a) Race: two concurrent send-message calls with the
+      //       same new threadId — one insert wins, the other
+      //       sees the winner's row and should treat it as
+      //       existing.
+      //   (b) Hidden thread: the row exists but is invisible
+      //       under the new RLS predicate (data_workspace_ids ⊄
+      //       session), so the initial findFirst returned null.
+      //       Returning 404 matches what get-messages already
+      //       returns for the same shape and avoids leaking
+      //       thread existence to a revoked user.
+      //
+      // Re-run the lookup under current RLS to disambiguate.
+      const recovered = yield* Result.await(lookup());
+      if (recovered) {
+        return buildExisting(recovered);
+      }
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Chat thread not found",
+        }),
+      );
     }
 
     return Result.ok<LoadThreadResult>({

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -19,6 +19,11 @@ import {
   validateMessage,
 } from "@/api/handlers/chat/chat-schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  expandThreadDataScope,
+  extractAssistantWorkspaceIds,
+  extractMentionWorkspaceIds,
+} from "@/api/handlers/chat/data-scope";
 import { ChatError } from "@/api/handlers/chat/errors";
 import type { MessagePersistencePlan } from "@/api/handlers/chat/persist-message";
 import {
@@ -26,6 +31,10 @@ import {
   planMessagePersistence,
 } from "@/api/handlers/chat/persist-message";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
+import {
+  intersectAccessibleWorkspaceIds,
+  resolveToolWorkspaceIds,
+} from "@/api/handlers/chat/tools/authorized-workspace-ids";
 import { getChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type {
@@ -105,7 +114,12 @@ const sendMessage = createSafeRootHandler(
       safeDb,
       scopedDb,
       userId: user.id,
-      accessibleWorkspaceIds,
+      // Schema validation runs against the user's full accessible
+      // set; per-tool scope checks happen at execute time below.
+      toolWorkspaceIds: resolveToolWorkspaceIds({
+        pinnedIds: [],
+        accessibleWorkspaceIds,
+      }),
       workspaceId,
       hasActiveFileChat: true,
     });
@@ -134,38 +148,33 @@ const sendMessage = createSafeRootHandler(
     // For an existing thread, accept a non-empty body update as
     // "user changed scope, persist it"; an omitted/empty body keeps
     // the stored value so re-sends from cached transports don't
-    // silently widen access. The effective set used for the rest
-    // of the request is whatever ends up persisted.
-    let effectiveContextMatterIds = thread.data.contextMatterIds;
+    // silently widen access. Persisted pins are always intersected
+    // with the currently accessible set so a revoked workspace
+    // cannot be re-authorized through a stale stored pin.
+    const storedPinsThisRequest =
+      thread.type === "existing" && body.contextMatterIds !== undefined
+        ? requestedContextMatterIds
+        : thread.data.contextMatterIds;
+    const effectiveContextMatterIds = intersectAccessibleWorkspaceIds({
+      pinnedIds: storedPinsThisRequest,
+      accessibleWorkspaceIds,
+    });
     if (
       thread.type === "existing" &&
-      body.contextMatterIds !== undefined &&
       !contextMatterIdsEqual(
         thread.data.contextMatterIds,
-        requestedContextMatterIds,
+        effectiveContextMatterIds,
       )
     ) {
       yield* Result.await(
         safeDb((tx) =>
           tx
             .update(chatThreads)
-            .set({ contextMatterIds: requestedContextMatterIds })
+            .set({ contextMatterIds: effectiveContextMatterIds })
             .where(eq(chatThreads.id, body.threadId)),
         ),
       );
-      effectiveContextMatterIds = requestedContextMatterIds;
     }
-
-    // Narrow tool authorization to the pinned matters when the
-    // user has set a non-empty scope; otherwise tools see every
-    // accessible matter so the AI can discover relevant ones via
-    // the readonly stella API. The narrowed list is always a
-    // subset of `accessibleWorkspaceIds` (validated above), so
-    // this never widens authorization.
-    const toolWorkspaceIds =
-      effectiveContextMatterIds.length > 0
-        ? effectiveContextMatterIds
-        : accessibleWorkspaceIds;
 
     // Streaming tools mirror the surface the user is on: only the
     // file-overlay client knows how to satisfy
@@ -180,7 +189,10 @@ const sendMessage = createSafeRootHandler(
       safeDb,
       scopedDb,
       userId: user.id,
-      accessibleWorkspaceIds: toolWorkspaceIds,
+      toolWorkspaceIds: resolveToolWorkspaceIds({
+        pinnedIds: effectiveContextMatterIds,
+        accessibleWorkspaceIds,
+      }),
       workspaceId,
       hasActiveFileChat: body.activeFile !== undefined,
     });
@@ -204,6 +216,24 @@ const sendMessage = createSafeRootHandler(
       message: parsedMessage.message,
       storedMessages: thread.data.messages,
     });
+
+    // Widen the thread's data scope BEFORE persisting the message so
+    // any workspace IDs the user just embedded (entity mentions,
+    // workspace mentions) are recorded on the thread row. Without
+    // this, a global thread with workspace mentions would remain
+    // visible to the user even after they lose access to those
+    // workspaces.
+    const userMessageWorkspaceIds = extractMentionWorkspaceIds(
+      parsedMessage.mentions,
+    );
+    const dataScopeAfterUserMessage = yield* Result.await(
+      expandThreadDataScope({
+        currentDataWorkspaceIds: thread.data.dataWorkspaceIds,
+        newWorkspaceIds: userMessageWorkspaceIds,
+        safeDb,
+        threadId: body.threadId,
+      }),
+    );
 
     yield* Result.await(
       persistMessage({
@@ -252,6 +282,25 @@ const sendMessage = createSafeRootHandler(
                 message: resolvedResponseMessage,
               });
 
+              // Widen the thread's data scope to cover any
+              // workspace-scoped content the assistant just
+              // emitted (source-document parts from search and
+              // workspace tools). Run before persistMessage so the
+              // recorded scope already includes the workspaces
+              // when the message lands in chat_messages.
+              const assistantWorkspaceIds = extractAssistantWorkspaceIds(
+                resolvedResponseMessage.parts,
+              );
+              const expandResult = await expandThreadDataScope({
+                currentDataWorkspaceIds: dataScopeAfterUserMessage,
+                newWorkspaceIds: assistantWorkspaceIds,
+                safeDb,
+                threadId: body.threadId,
+              });
+              if (Result.isError(expandResult)) {
+                captureError(expandResult.error, { threadId: body.threadId });
+              }
+
               const persistResult = await persistMessage({
                 persistencePlan,
                 safeDb,
@@ -290,6 +339,7 @@ export default sendMessage;
 type ThreadRecord = {
   id: SafeId<"chatThread">;
   contextMatterIds: SafeId<"workspace">[];
+  dataWorkspaceIds: SafeId<"workspace">[];
   messages: {
     id: SafeId<"chatMessage">;
     role: ChatMessage["role"];
@@ -343,6 +393,7 @@ const loadThread = async ({
             id: true,
             workspaceId: true,
             contextMatterIds: true,
+            dataWorkspaceIds: true,
           },
           with: {
             messages: {
@@ -373,10 +424,15 @@ const loadThread = async ({
         data: {
           id: thread.id,
           contextMatterIds: thread.contextMatterIds,
+          dataWorkspaceIds: thread.dataWorkspaceIds,
           messages: thread.messages,
         },
       });
     }
+
+    const initialDataWorkspaceIds: SafeId<"workspace">[] = workspaceId
+      ? [workspaceId]
+      : [];
 
     yield* Result.await(
       safeDb((tx) =>
@@ -386,6 +442,12 @@ const loadThread = async ({
           userId,
           workspaceId,
           contextMatterIds: initialContextMatterIds,
+          // Workspace-scoped chats embed at minimum their own
+          // workspace's content. Global chats start with no
+          // embedded workspace data; subsequent messages widen
+          // this set via expandThreadDataScope when they reference
+          // workspace assets (mentions, source-document parts).
+          dataWorkspaceIds: initialDataWorkspaceIds,
         }),
       ),
     );
@@ -395,6 +457,7 @@ const loadThread = async ({
       data: {
         id: threadId,
         contextMatterIds: initialContextMatterIds,
+        dataWorkspaceIds: initialDataWorkspaceIds,
         messages: [],
       },
     });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -224,9 +224,15 @@ const sendMessage = createSafeRootHandler(
     // this, a global thread with workspace mentions would remain
     // visible to the user even after they lose access to those
     // workspaces.
+    //
+    // Intersect with `accessibleWorkspaceIds` first: an unknown ID
+    // (model hallucination, copy-pasted UUID from elsewhere) added
+    // to `data_workspace_ids` would fail the RLS subset check on
+    // every subsequent message persist, silently breaking the
+    // thread.
     const userMessageWorkspaceIds = extractMentionWorkspaceIds(
       parsedMessage.mentions,
-    );
+    ).filter((id) => accessibleSet.has(id));
     const dataScopeAfterUserMessage = yield* Result.await(
       expandThreadDataScope({
         currentDataWorkspaceIds: thread.data.dataWorkspaceIds,
@@ -297,9 +303,14 @@ const sendMessage = createSafeRootHandler(
               // leave the new content readable after the user
               // loses access to those workspaces — the same
               // class of leak this whole change exists to close.
+              // Intersect with `accessibleWorkspaceIds` so a
+              // hallucinated or stale UUID from the model never
+              // lands in `data_workspace_ids`. An out-of-set ID
+              // would fail the RLS subset check on every later
+              // persist, silently breaking the thread.
               const assistantWorkspaceIds = extractAssistantWorkspaceIds(
                 resolvedResponseMessage.parts,
-              );
+              ).filter((id) => accessibleSet.has(id));
               const expandResult = await expandThreadDataScope({
                 currentDataWorkspaceIds: dataScopeAfterUserMessage,
                 newWorkspaceIds: assistantWorkspaceIds,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -46,7 +46,8 @@ import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
 import { brandPersistedChatMessageId } from "@/api/lib/safe-id-boundaries";
 
 const config = {
@@ -383,7 +384,7 @@ const loadThread = async ({
   userId,
   workspaceId,
 }: LoadThreadProps): Promise<
-  Result<LoadThreadResult, HandlerError<400> | SafeDbError>
+  Result<LoadThreadResult, HandlerError<400 | 404> | SafeDbError>
 > =>
   await Result.gen(async function* () {
     // Look the thread up by id+user only. Filtering by workspaceId
@@ -443,23 +444,42 @@ const loadThread = async ({
       ? [workspaceId]
       : [];
 
-    yield* Result.await(
-      safeDb((tx) =>
-        tx.insert(chatThreads).values({
-          id: threadId,
-          title,
-          userId,
-          workspaceId,
-          contextMatterIds: initialContextMatterIds,
-          // Workspace-scoped chats embed at minimum their own
-          // workspace's content. Global chats start with no
-          // embedded workspace data; subsequent messages widen
-          // this set via expandThreadDataScope when they reference
-          // workspace assets (mentions, source-document parts).
-          dataWorkspaceIds: initialDataWorkspaceIds,
-        }),
-      ),
+    // The findFirst above runs under RLS, so a thread that exists
+    // but is no longer visible (data_workspace_ids ⊄ session) looks
+    // missing. Falling straight through to insert would collide on
+    // the primary key and surface as a 500. Translate that specific
+    // case to a 404 so the client gets a stable answer; matching the
+    // "not found" status that get-messages returns for the same
+    // shape avoids leaking thread existence to a revoked user.
+    const insertResult = await safeDb((tx) =>
+      tx.insert(chatThreads).values({
+        id: threadId,
+        title,
+        userId,
+        workspaceId,
+        contextMatterIds: initialContextMatterIds,
+        // Workspace-scoped chats embed at minimum their own
+        // workspace's content. Global chats start with no
+        // embedded workspace data; subsequent messages widen
+        // this set via expandThreadDataScope when they reference
+        // workspace assets (mentions, source-document parts).
+        dataWorkspaceIds: initialDataWorkspaceIds,
+      }),
     );
+    if (Result.isError(insertResult)) {
+      if (
+        DatabaseError.is(insertResult.error) &&
+        insertResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 404,
+            message: "Chat thread not found",
+          }),
+        );
+      }
+      return Result.err(insertResult.error);
+    }
 
     return Result.ok<LoadThreadResult>({
       type: "created",

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -289,20 +289,33 @@ const sendMessage = createSafeRootHandler(
                 message: resolvedResponseMessage,
               });
 
+              // Skip scope expansion when the assistant message
+              // will not be persisted (aborted stream, planner
+              // returned `none`). Widening `data_workspace_ids`
+              // for transient parts that never land in
+              // `chat_messages` could make the thread unreadable
+              // after future access changes even though no
+              // corresponding content was saved.
+              if (persistencePlan.type === "none") {
+                return;
+              }
+
               // Widen the thread's data scope to cover any
               // workspace-scoped content the assistant just
               // emitted (source-document parts from search and
-              // workspace tools). Run before persistMessage so the
-              // recorded scope already includes the workspaces
-              // when the message lands in chat_messages.
+              // workspace tools). Run before persistMessage so
+              // the recorded scope already includes the
+              // workspaces when the message lands in
+              // `chat_messages`.
               //
               // If expansion fails (transient DB error, etc.),
               // SKIP the message persist. Storing workspace-
-              // scoped content in chat_messages while the owning
-              // thread's data_workspace_ids stays stale would
-              // leave the new content readable after the user
-              // loses access to those workspaces — the same
+              // scoped content in `chat_messages` while the
+              // owning thread's `data_workspace_ids` stays stale
+              // would leave the new content readable after the
+              // user loses access to those workspaces — the same
               // class of leak this whole change exists to close.
+              //
               // Intersect with `accessibleWorkspaceIds` so a
               // hallucinated or stale UUID from the model never
               // lands in `data_workspace_ids`. An out-of-set ID

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -288,6 +288,14 @@ const sendMessage = createSafeRootHandler(
               // workspace tools). Run before persistMessage so the
               // recorded scope already includes the workspaces
               // when the message lands in chat_messages.
+              //
+              // If expansion fails (transient DB error, etc.),
+              // SKIP the message persist. Storing workspace-
+              // scoped content in chat_messages while the owning
+              // thread's data_workspace_ids stays stale would
+              // leave the new content readable after the user
+              // loses access to those workspaces — the same
+              // class of leak this whole change exists to close.
               const assistantWorkspaceIds = extractAssistantWorkspaceIds(
                 resolvedResponseMessage.parts,
               );
@@ -299,6 +307,7 @@ const sendMessage = createSafeRootHandler(
               });
               if (Result.isError(expandResult)) {
                 captureError(expandResult.error, { threadId: body.threadId });
+                return;
               }
 
               const persistResult = await persistMessage({

--- a/apps/api/src/handlers/chat/tools/authorized-workspace-ids.test.ts
+++ b/apps/api/src/handlers/chat/tools/authorized-workspace-ids.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SafeId } from "@/api/lib/branded-types";
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  intersectAccessibleWorkspaceIds,
+  resolveToolWorkspaceIds,
+} from "./authorized-workspace-ids";
+
+const wsA = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000a");
+const wsB = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000b");
+const wsC = toSafeId<"workspace">("00000000-0000-0000-0000-00000000000c");
+const wsStale = toSafeId<"workspace">("00000000-0000-0000-0000-0000000000ff");
+
+const asArray = (ids: readonly SafeId<"workspace">[]): SafeId<"workspace">[] =>
+  Array.from(ids);
+
+describe("resolveToolWorkspaceIds", () => {
+  test("no pins → returns the full accessible set", () => {
+    expect(
+      asArray(
+        resolveToolWorkspaceIds({
+          pinnedIds: [],
+          accessibleWorkspaceIds: [wsA, wsB],
+        }),
+      ),
+    ).toEqual([wsA, wsB]);
+  });
+
+  test("all pins still accessible → returns the pins", () => {
+    expect(
+      asArray(
+        resolveToolWorkspaceIds({
+          pinnedIds: [wsA, wsB],
+          accessibleWorkspaceIds: [wsA, wsB, wsC],
+        }),
+      ),
+    ).toEqual([wsA, wsB]);
+  });
+
+  test("partially stale pins → returns only the still-accessible ones", () => {
+    expect(
+      asArray(
+        resolveToolWorkspaceIds({
+          pinnedIds: [wsA, wsStale, wsB],
+          accessibleWorkspaceIds: [wsA, wsB, wsC],
+        }),
+      ),
+    ).toEqual([wsA, wsB]);
+  });
+
+  test("regression: pins entirely stale → falls back to accessible, never to the stale set", () => {
+    const result = asArray(
+      resolveToolWorkspaceIds({
+        pinnedIds: [wsStale],
+        accessibleWorkspaceIds: [wsA, wsB],
+      }),
+    );
+    expect(result).toEqual([wsA, wsB]);
+    expect(result).not.toContain(wsStale);
+  });
+
+  test("regression: stale pin must never reach tool surface even when other pins are valid", () => {
+    const result = asArray(
+      resolveToolWorkspaceIds({
+        pinnedIds: [wsA, wsStale],
+        accessibleWorkspaceIds: [wsA],
+      }),
+    );
+    expect(result).not.toContain(wsStale);
+  });
+
+  test("empty accessible + empty pins → empty result", () => {
+    expect(
+      asArray(
+        resolveToolWorkspaceIds({
+          pinnedIds: [],
+          accessibleWorkspaceIds: [],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  test("empty accessible + non-empty pins → empty result (no fallback to pins)", () => {
+    expect(
+      asArray(
+        resolveToolWorkspaceIds({
+          pinnedIds: [wsA, wsB],
+          accessibleWorkspaceIds: [],
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("intersectAccessibleWorkspaceIds", () => {
+  test("strips stale IDs without falling back to accessible", () => {
+    expect(
+      intersectAccessibleWorkspaceIds({
+        pinnedIds: [wsA, wsStale, wsB],
+        accessibleWorkspaceIds: [wsA, wsB, wsC],
+      }),
+    ).toEqual([wsA, wsB]);
+  });
+
+  test("regression: all pins stale → returns empty (does NOT widen back to accessible)", () => {
+    expect(
+      intersectAccessibleWorkspaceIds({
+        pinnedIds: [wsStale],
+        accessibleWorkspaceIds: [wsA, wsB],
+      }),
+    ).toEqual([]);
+  });
+
+  test("empty pins → empty result", () => {
+    expect(
+      intersectAccessibleWorkspaceIds({
+        pinnedIds: [],
+        accessibleWorkspaceIds: [wsA, wsB],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/api/src/handlers/chat/tools/authorized-workspace-ids.ts
+++ b/apps/api/src/handlers/chat/tools/authorized-workspace-ids.ts
@@ -1,0 +1,68 @@
+import type { SafeId } from "@/api/lib/branded-types";
+
+declare const __authorizedToolWorkspaceIdsBrand: unique symbol;
+
+// A list of workspace IDs that has been verified, in this request, to be
+// a subset of the user's currently accessible workspaces. The chat tool
+// surface accepts only this branded type so a stale persisted pin or a
+// raw body field cannot reach the AI's tools without going through
+// `resolveToolWorkspaceIds`.
+export type AuthorizedToolWorkspaceIds = SafeId<"workspace">[] & {
+  readonly [__authorizedToolWorkspaceIdsBrand]: true;
+};
+
+type ResolveToolWorkspaceIdsInput = {
+  // Workspace IDs the user pinned for this thread, either fresh from
+  // the request body or loaded from the persisted thread row. May be
+  // empty and may contain stale IDs the user no longer has access to.
+  pinnedIds: readonly SafeId<"workspace">[];
+  // The user's currently accessible workspaces, as resolved from the
+  // active session. This is the only authoritative source.
+  accessibleWorkspaceIds: readonly SafeId<"workspace">[];
+};
+
+// Returns the workspace IDs the AI's tools may operate on. Pins are
+// always intersected with the currently accessible set so a revoked
+// matter cannot be queried through a stale stored pin. If no pins
+// remain after intersection, falls back to the full accessible set so
+// the AI can still discover relevant matters via its read-only API.
+// SAFETY: Branding an array as `AuthorizedToolWorkspaceIds`
+// asserts that every element has been verified against the
+// session's accessible workspaces. Both branches of this function
+// either copy the accessible set verbatim or filter by it, so the
+// brand is sound. Keep this assertion local to this module — no
+// other code path may construct a value of this brand without
+// going through this function or `intersectAccessibleWorkspaceIds`.
+const brand = (ids: SafeId<"workspace">[]): AuthorizedToolWorkspaceIds =>
+  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  ids as AuthorizedToolWorkspaceIds;
+
+export const resolveToolWorkspaceIds = ({
+  pinnedIds,
+  accessibleWorkspaceIds,
+}: ResolveToolWorkspaceIdsInput): AuthorizedToolWorkspaceIds => {
+  if (pinnedIds.length === 0) {
+    return brand([...accessibleWorkspaceIds]);
+  }
+  const accessible = new Set<string>(accessibleWorkspaceIds);
+  const intersected = pinnedIds.filter((id) => accessible.has(id));
+  if (intersected.length === 0) {
+    return brand([...accessibleWorkspaceIds]);
+  }
+  return brand(intersected);
+};
+
+// Narrows persisted pins to the currently accessible set without the
+// "fall back to all accessible" behaviour. Use this when persisting
+// the effective context back to the thread row, so stale IDs are
+// stripped from storage rather than silently re-authorized later.
+export const intersectAccessibleWorkspaceIds = ({
+  pinnedIds,
+  accessibleWorkspaceIds,
+}: ResolveToolWorkspaceIdsInput): SafeId<"workspace">[] => {
+  if (pinnedIds.length === 0) {
+    return [];
+  }
+  const accessible = new Set<string>(accessibleWorkspaceIds);
+  return pinnedIds.filter((id) => accessible.has(id));
+};

--- a/apps/api/src/handlers/chat/tools/chat-tools.ts
+++ b/apps/api/src/handlers/chat/tools/chat-tools.ts
@@ -4,6 +4,7 @@ import {
   APPLY_ACTIVE_DOCX_EDITS_TOOL_NAME,
   createActiveDocxEditTool,
 } from "@/api/handlers/chat/tools/active-docx-edit-tool";
+import type { AuthorizedToolWorkspaceIds } from "@/api/handlers/chat/tools/authorized-workspace-ids";
 import { createChatExecutionTools } from "@/api/handlers/chat/tools/execute/chat-execution-tools";
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import { createOrgTools } from "@/api/handlers/chat/tools/org-tools";
@@ -28,7 +29,11 @@ type GetChatToolsProps = {
   scopedDb: ScopedDb;
   organizationId: SafeId<"organization">;
   userId: SafeId<"user">;
-  accessibleWorkspaceIds: SafeId<"workspace">[];
+  // Use `resolveToolWorkspaceIds` to construct this — that helper is
+  // the only path that intersects pinned IDs with the currently
+  // accessible set, preventing stale stored pins from widening tool
+  // authorization.
+  toolWorkspaceIds: AuthorizedToolWorkspaceIds;
   refRegistry: ChatRefRegistry;
   workspaceId: SafeId<"workspace"> | null;
   /**
@@ -50,18 +55,18 @@ export const getChatTools = ({
   scopedDb,
   organizationId,
   userId,
-  accessibleWorkspaceIds,
+  toolWorkspaceIds,
   refRegistry,
   workspaceId,
   hasActiveFileChat,
 }: GetChatToolsProps): Partial<ChatTools> => {
   const orgTools = createOrgTools({
-    accessibleWorkspaceIds,
+    accessibleWorkspaceIds: toolWorkspaceIds,
     organizationId,
     scopedDb,
   });
   const executionTools = createChatExecutionTools({
-    accessibleWorkspaceIds,
+    accessibleWorkspaceIds: toolWorkspaceIds,
     organizationId,
     refRegistry,
     safeDb,
@@ -84,7 +89,7 @@ export const getChatTools = ({
   }
 
   const workspaceTools = createWorkspaceTools({
-    allowedWorkspaceIds: accessibleWorkspaceIds,
+    allowedWorkspaceIds: toolWorkspaceIds,
     organizationId,
     refRegistry,
     userId,

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -1,6 +1,7 @@
 import { toJsonSchema } from "@valibot/to-json-schema";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { SafeId } from "@/api/lib/branded-types";
 import { toSafeId } from "@/api/lib/branded-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -118,7 +119,14 @@ describe("search summary chat", () => {
     });
 
     expect(result).toHaveProperty("threadId");
-    expect(insertedValues.at(0)).toMatchObject({ workspaceId: null });
+    expect(insertedValues.at(0)).toMatchObject({
+      workspaceId: null,
+      // Regression: the data scope must include the contributing
+      // workspace so the thread becomes invisible (RLS) the moment
+      // the user loses access to it. An empty array would leak the
+      // stored summary back via the global chat list.
+      dataWorkspaceIds: [workspaceId],
+    });
     expect(insertedValues.at(1)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ role: "user", workspaceId: null }),
@@ -182,7 +190,14 @@ describe("search summary chat", () => {
     });
 
     expect(result).toHaveProperty("threadId");
-    expect(insertedValues.at(0)).toMatchObject({ workspaceId: null });
+    expect(insertedValues.at(0)).toMatchObject({
+      workspaceId: null,
+      // Even without an explicit workspace filter, the data scope
+      // must reflect the workspace of every embedded hit. Otherwise
+      // a user who loses access to a hit's workspace would still
+      // see the stored summary.
+      dataWorkspaceIds: [workspaceId],
+    });
     expect(insertedValues.at(1)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ role: "user", workspaceId: null }),
@@ -262,7 +277,14 @@ describe("search summary chat", () => {
 
     expect(result).toHaveProperty("threadId");
     expect(insertMock).toHaveBeenCalled();
-    expect(insertedValues.at(0)).toMatchObject({ workspaceId: null });
+    const inserted = insertedValues.at(0);
+    expect(inserted).toMatchObject({ workspaceId: null });
+    // Multi-workspace summaries must record EVERY contributing
+    // workspace; RLS rejects the read if the user loses access to
+    // ANY of them. Order is not guaranteed, so compare as a set.
+    expect(new Set(extractDataWorkspaceIds(inserted))).toEqual(
+      new Set([firstWorkspaceId, secondWorkspaceId]),
+    );
     expect(insertedValues.at(1)).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ role: "user", workspaceId: null }),
@@ -270,4 +292,84 @@ describe("search summary chat", () => {
       ]),
     );
   });
+
+  test("regression: never stores a global summary thread without a data scope", async () => {
+    // A summary chat with no workspace data scope would be visible
+    // through the global chat list to any user who keeps the same
+    // user_id, regardless of their current workspace access. The
+    // RLS policy permits empty `data_workspace_ids` only for true
+    // global chats — any thread that embeds workspace content must
+    // record those workspaces here.
+    const organizationId = toSafeId<"organization">("org_1");
+    const workspaceId = toSafeId<"workspace">("ws_1");
+    const insertedValues: unknown[] = [];
+    const tx = {
+      query: { workspaces: {} },
+      insert: mock((_table: unknown) => ({
+        values: mock(async (values: unknown) => {
+          insertedValues.push(values);
+        }),
+      })),
+      select: dbSelectMock,
+    };
+    const { safeDb, scopedDb } = createScopedDbMock(tx);
+
+    searchGlobalMock.mockResolvedValueOnce({
+      facets: { editor: [], mimeType: [], type: [], workspace: [] },
+      hits: [
+        {
+          entityId: "entity_1",
+          headline: null,
+          id: "entity:entity_1",
+          lastEditedByImage: null,
+          lastEditedByName: null,
+          mimeType: "application/pdf",
+          title: "Motion.pdf",
+          type: "document",
+          updatedAt: "2026-04-30T08:00:00.000Z",
+          workspaceId,
+          workspaceName: "Motion matter",
+        },
+      ],
+      nextCursor: null,
+      totalCount: 1,
+    });
+
+    const { createSearchSummaryChatThread } =
+      await import("@/api/handlers/search/ai");
+    await createSearchSummaryChatThread({
+      accessibleWorkspaceIds: [workspaceId],
+      body: {
+        ...emptySearchSummaryFilters(),
+        citations: [{ number: 1 }],
+        limit: 1,
+        query: "motion",
+        summary: "Relevant document [1].",
+        title: "Search summary",
+      },
+      organizationId,
+      safeDb,
+      scopedDb,
+      userId: toSafeId<"user">("user_1"),
+    });
+
+    const inserted = insertedValues.at(0);
+    const dataIds = extractDataWorkspaceIds(inserted);
+    expect(dataIds.length).toBeGreaterThan(0);
+    expect(dataIds).toContain(workspaceId);
+  });
 });
+
+const extractDataWorkspaceIds = (
+  value: unknown,
+): readonly SafeId<"workspace">[] => {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "dataWorkspaceIds" in value &&
+    Array.isArray(value.dataWorkspaceIds)
+  ) {
+    return value.dataWorkspaceIds;
+  }
+  return [];
+};

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -545,12 +545,28 @@ export const createSearchSummaryChatThread = async ({
     contexts: citedContexts,
   });
 
+  // Derive the embedded data scope from the actual cited and
+  // ranked context. The AI summary draws from every context, not
+  // only those it explicitly cited, so include all of them. Org-
+  // scoped hit types (case-law, contact) have no workspaceId and
+  // are correctly excluded — RLS for those is enforced elsewhere.
+  const dataWorkspaceIds = uniqueWorkspaceIds(
+    contextsResult
+      .map((context) => extractHitWorkspaceId(context.hit))
+      .filter((id): id is SafeId<"workspace"> => id !== null),
+  );
+
   const insertResult = await safeDb(async (tx) => {
     await tx.insert(chatThreads).values({
       id: threadId,
       title: body.title,
       userId,
+      // Search summaries can span multiple workspaces, so the
+      // thread's own workspaceId stays null. Tenant gating happens
+      // via dataWorkspaceIds — the row is invisible (RLS) the
+      // moment the user loses access to any contributing matter.
       workspaceId: null,
+      dataWorkspaceIds,
       createdAt: now,
       updatedAt: now,
     });
@@ -687,6 +703,19 @@ const buildChatSummaryText = ({
 
   return [`## ${title}`, summary, "### Sources", ...sourceLines].join("\n\n");
 };
+
+const extractHitWorkspaceId = (
+  hit: GlobalSearchHit,
+): SafeId<"workspace"> | null => {
+  if (hit.type === "case-law" || hit.type === "contact") {
+    return null;
+  }
+  return brandPersistedWorkspaceId(hit.workspaceId);
+};
+
+const uniqueWorkspaceIds = (
+  ids: readonly SafeId<"workspace">[],
+): SafeId<"workspace">[] => Array.from(new Set(ids));
 
 const toChatSourceParts = (context: SearchResultContext) => {
   const hit = context.hit;


### PR DESCRIPTION
## Summary

Three related tenant-isolation gaps let stored chat content outlive a user's access to the workspaces it was drawn from. All three are fixed by tracking the data scope of every chat thread at the row level (new `chat_threads.data_workspace_ids` column) and gating reads on it via RLS.

### What was wrong

1. **Stored matter pins authorize tools after access is revoked.** `chatThreads.contextMatterIds` was used as the AI's "draw-from" set without re-validating against the user's current workspace access. A user who pinned matter W, later lost access to W, and posted a new message in the same thread (without supplying `contextMatterIds` in the body) had W silently restored as the tool scope — `search-across-matters` and friends would then run against W via the root DB.
2. **Search-summary chats embed cross-workspace content as global threads.** `createSearchSummaryChatThread` persisted threads with `workspaceId: null`. Because the existing chat RLS policy treats `workspace_id IS NULL` as "global, gated on `user_id` only", the persisted summary text + cited document excerpts remained readable in the user's global chat list after they lost access to the contributing matter.
3. **General workspace asset references in any chat thread.** Mentions (`@entity`, `@workspace`) in user text and assistant-produced `data-stella-source-document` parts also embed workspace data. Same leak surface as #2 but reached through normal chat usage rather than the search-summary path.

### How it's fixed

**Schema** — new `chat_threads.data_workspace_ids uuid[] NOT NULL DEFAULT '{}'`. Empty means "no workspace data embedded" (true global chats keep working unchanged); non-empty must be a subset of the session's accessible workspaces. Migration backfills existing rows from `workspace_id` for workspace-scoped threads and from embedded source-document parts for global threads.

**RLS** — combined `chat_*` policy set rotated into `chat_thread_*` and `chat_message_*`. Thread reads add the subset check directly; message reads add an `EXISTS` join on the owning thread, so a leaked thread row cannot expose its messages even if the row itself somehow becomes readable.

**Brand for tool authorization** (#1) — new `AuthorizedToolWorkspaceIds` whose only constructor (`resolveToolWorkspaceIds`) intersects pinned IDs with the active session set and falls back to the full accessible set when the intersection is empty. `getChatTools` accepts only the brand, so stale pins cannot reach the tool surface without going through the helper. Persisted pins are also stripped at save time via `intersectAccessibleWorkspaceIds`, so the stored value never contains inaccessible IDs.

**Data scope tracking** (#2 + #3) — `createSearchSummaryChatThread` records the workspace IDs of every cited hit. `expandThreadDataScope` widens the thread's `data_workspace_ids` whenever a new message references a workspace asset (mentions for the user message, source-document parts for the assistant message). The SQL appends + dedupes atomically so concurrent persists don't lose entries.

### Tests

- `authorized-workspace-ids.test.ts` — 10 cases covering the pin/intersect helpers, including explicit regression cases for entirely-stale pins and partially-stale pins.
- `data-scope.test.ts` — 12 cases covering mention extraction, source-document extraction, and `expandThreadDataScope` no-op + new-addition paths.
- `search/ai.test.ts` — 1 new regression test plus 3 existing assertions tightened: every `createSearchSummaryChatThread` path now asserts `dataWorkspaceIds` includes the contributing workspace; the regression test refuses any path that would persist an empty data scope when workspace content is embedded.

## Test plan

- [ ] `bun --filter @stll/api typecheck` clean.
- [ ] `bun --filter @stll/api lint` clean.
- [ ] `bun test apps/api/src/handlers/chat/ apps/api/src/handlers/search/ai.test.ts` — 27 new tests pass.
- [ ] Run `bun run db:push` against a test DB; verify the migration applies cleanly and the new policies are present (`\d+ chat_threads`, `\d+ chat_messages`).
- [ ] Manual: create a workspace-scoped chat in matter A; confirm reads/writes work normally.
- [ ] Manual: create a global chat, mention an entity from matter B; rotate the session to drop matter B from accessible workspaces; reload the global chat list and confirm the thread no longer appears (RLS rejects the read because `data_workspace_ids = {B}` is not a subset of the new session set).
- [ ] Manual: run a multi-matter search summary across A + B, save as chat; drop access to B; confirm the saved summary chat is no longer readable.
- [ ] Manual: pin matter A in a chat (set `contextMatterIds=[A]`), drop access to A, send a follow-up message without `contextMatterIds`; confirm the AI tools see the empty/full accessible set, never A.

---
_Mirror of original PR #1111 by @jan-kubica_