### PR TITLE
fix: handle embedded docx text newlines

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -98,6 +98,55 @@ describe("toProseDoc", () => {
     expect(commentMark?.attrs.commentId).toBe(42);
   });
 
+  test("converts embedded DOCX text newlines to hard breaks", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "text", text: "Seller\nBuyer\r\nPrice\rDate" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const paragraph = doc.firstChild;
+    const childTypes: string[] = [];
+    const textNodes: string[] = [];
+
+    for (let index = 0; index < (paragraph?.childCount ?? 0); index++) {
+      const child = paragraph?.child(index);
+      if (!child) {
+        continue;
+      }
+      childTypes.push(child.type.name);
+      if (child.isText) {
+        textNodes.push(child.text ?? "");
+      }
+    }
+
+    expect(childTypes).toEqual([
+      "text",
+      "hardBreak",
+      "text",
+      "hardBreak",
+      "text",
+      "hardBreak",
+      "text",
+    ]);
+    expect(textNodes).toEqual(["Seller", "Buyer", "Price", "Date"]);
+  });
+
   test("applies active comment ranges to every text-emitting inline branch", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1426,7 +1426,7 @@ function convertRunContent(
   switch (content.type) {
     case "text":
       if (content.text) {
-        return [schema.text(content.text, marks)];
+        return textToInlineNodes(content.text, marks);
       }
       return [];
 
@@ -1479,6 +1479,27 @@ function convertRunContent(
     default:
       return [];
   }
+}
+
+function textToInlineNodes(
+  text: string,
+  marks: ReturnType<typeof schema.mark>[],
+): PMNode[] {
+  const nodes: PMNode[] = [];
+  const parts = text.split(/(\r\n|\r|\n)/);
+
+  for (const part of parts) {
+    if (part === "") {
+      continue;
+    }
+    if (part === "\r\n" || part === "\r" || part === "\n") {
+      nodes.push(schema.node("hardBreak"));
+      continue;
+    }
+    nodes.push(schema.text(part, marks));
+  }
+
+  return nodes;
 }
 
 /**
@@ -1713,7 +1734,7 @@ function convertHyperlink(
 
       for (const content of child.content) {
         if (content.type === "text" && content.text) {
-          nodes.push(schema.text(content.text, allMarks));
+          nodes.push(...textToInlineNodes(content.text, allMarks));
         }
       }
     }


### PR DESCRIPTION
JK:
I am on the verge here... comes from real .docx, probably converted from another format to .docx in a slightly broken state and the MS Word seems to be do similar logic. At the other hand we ar epatching noncompliant .docx format, which opens up a tricky category of issues. 


## Summary
- convert embedded CR/LF characters in DOCX text runs into explicit hard-break nodes during Folio import
- apply the same splitting to hyperlink text so layout measurement and browser rendering stay aligned
- add a regression for DOCX text nodes containing mixed newline forms

## Test Plan
- bun --filter @stll/folio typecheck
- bun --filter @stll/folio lint
- bun test packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
- pre-push hook: format, i18n, lint, typecheck

---
_Mirror of original PR #1052 by @jan-kubica_