### PR TITLE
feat(ai): require BYOK when no instance keys are provisioned

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -47,6 +47,16 @@ const envApi = createEnv({
     ANTHROPIC_API_KEY: v.optional(v.string()),
     GOOGLE_AI_API_KEY_EU: v.optional(v.string()),
     GOOGLE_AI_API_KEY_CH: v.optional(v.string()),
+    /**
+     * Force orgs to supply their own AI key (BYOK) even if the
+     * instance has provisioned provider keys. Useful for shared
+     * deployments without metering where the operator wants
+     * costs to land on each org's own provider account.
+     */
+    REQUIRE_PERSONAL_AI_KEY: v.optional(
+      v.pipe(v.string(), v.parseBoolean()),
+      "false",
+    ),
     REDIS_URL: v.pipe(v.string(), v.url()),
     USE_MOCK_AI: v.optional(v.pipe(v.string(), v.parseBoolean()), "false"),
     BETTER_AUTH_SECRET: v.pipe(v.string(), v.minLength(32)),

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -36,6 +36,7 @@ import {
   getModelForRole,
   getModelInfoForRole,
   getTemperatureForRole,
+  requireAIAvailable,
 } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
@@ -201,6 +202,11 @@ export const generateAnalysis = async (
   analysis?: PersistedDecisionAnalysis;
   error?: string;
 }> => {
+  const gate = requireAIAvailable(orgAIConfig);
+  if (gate.isErr()) {
+    return { status: "error", error: gate.error.message };
+  }
+
   const decision = await scopedDb((tx) =>
     tx.query.caseLawDecisions.findFirst({
       where: { id: { eq: decisionId } },

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -36,7 +36,6 @@ import {
   getModelForRole,
   getModelInfoForRole,
   getTemperatureForRole,
-  requireAIAvailable,
 } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
@@ -202,11 +201,6 @@ export const generateAnalysis = async (
   analysis?: PersistedDecisionAnalysis;
   error?: string;
 }> => {
-  const gate = requireAIAvailable(orgAIConfig);
-  if (gate.isErr()) {
-    return { status: "error", error: gate.error.message };
-  }
-
   const decision = await scopedDb((tx) =>
     tx.query.caseLawDecisions.findFirst({
       where: { id: { eq: decisionId } },

--- a/apps/api/src/handlers/case-law/routes.ts
+++ b/apps/api/src/handlers/case-law/routes.ts
@@ -18,6 +18,7 @@ import {
 } from "@/api/handlers/case-law/matter-links/create";
 import { deleteMatterLinkHandler } from "@/api/handlers/case-law/matter-links/delete";
 import { listMatterLinksHandler } from "@/api/handlers/case-law/matter-links/list";
+import { requireAIAvailable } from "@/api/lib/ai-models";
 import {
   createSafeHandler,
   createSafeRootHandler,
@@ -85,6 +86,8 @@ const generateDecisionAnalysis = createSafeRootHandler(
     params: t.Object({ decisionId: tSafeId("caseLawDecision") }),
   } satisfies HandlerConfig,
   async function* ({ params: { decisionId }, scopedDb, orgAIConfig }) {
+    yield* requireAIAvailable(orgAIConfig);
+
     const response = yield* Result.await(
       Result.tryPromise(
         async () => await generateAnalysis(decisionId, scopedDb, orgAIConfig),

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -33,6 +33,7 @@ import type {
   ChatMessageContent,
 } from "@/api/handlers/chat/types";
 import { uploadMessageFiles } from "@/api/handlers/chat/upload-files";
+import { requireAIAvailable } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -59,6 +60,8 @@ const sendMessage = createSafeRootHandler(
     session,
     user,
   }) {
+    yield* requireAIAvailable(orgAIConfig);
+
     const accessibleWorkspaceIds = activeWorkspaceIds;
     /* eslint-disable no-body-ownership-ids/no-body-ownership-ids -- root handler; resolveChatScope validates against accessibleWorkspaceIds */
     const scope = yield* resolveChatScope({

--- a/apps/api/src/handlers/entities/organize-suggestions.ts
+++ b/apps/api/src/handlers/entities/organize-suggestions.ts
@@ -17,6 +17,7 @@ import {
   getModelForRole,
   getModelInfoForRole,
   getTemperatureForRole,
+  requireAIAvailable,
 } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
@@ -162,6 +163,8 @@ const organizeSuggestionsHandler = async function* ({
   orgAIConfig,
   body,
 }: OrganizeSuggestionsHandlerProps) {
+  yield* requireAIAvailable(orgAIConfig);
+
   const contexts = yield* Result.await(
     loadSummaryContexts({ safeDb, workspaceId, organizationId, body }),
   );

--- a/apps/api/src/handlers/organization-settings/read-ai-availability.ts
+++ b/apps/api/src/handlers/organization-settings/read-ai-availability.ts
@@ -1,0 +1,27 @@
+import { Result } from "better-result";
+
+import { hasInstanceProvider } from "@/api/lib/ai-models";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+
+const config = {
+  // Any org member needs to know whether AI is usable; the answer
+  // is just two booleans, so it does not require admin scope.
+  permissions: { workspace: ["read"] },
+} satisfies HandlerConfig;
+
+const readAIAvailability = createSafeRootHandler(
+  config,
+  // eslint-disable-next-line require-yield -- pure read with no Result.await calls
+  async function* ({ orgAIConfig }) {
+    const instanceProvisioned = hasInstanceProvider();
+    const orgConfigured = orgAIConfig !== null;
+    return Result.ok({
+      instanceProvisioned,
+      orgConfigured,
+      available: instanceProvisioned || orgConfigured,
+    });
+  },
+);
+
+export default readAIAvailability;

--- a/apps/api/src/handlers/organization-settings/read-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/read-ai-config.ts
@@ -1,12 +1,21 @@
 import { Result } from "better-result";
 
 import { decryptAIConfig, maskApiKey } from "@/api/lib/ai-config-crypto";
+import { hasInstanceProvider } from "@/api/lib/ai-models";
 import type { AIProvider, DataRegion, ModelRole } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 
-type AIConfigResult =
+type AIConfigResult = {
+  /**
+   * Whether the backend has any platform-provisioned AI keys
+   * (env-configured fallback). When false and `configured` is
+   * also false, the org must supply their own key before AI
+   * features will work.
+   */
+  instanceProvisioned: boolean;
+} & (
   | { configured: false }
   | {
       configured: true;
@@ -15,7 +24,8 @@ type AIConfigResult =
       baseURL: string | null;
       overrideRoles: ModelRole[];
       region: DataRegion;
-    };
+    }
+);
 
 const config = {
   permissions: { organizationSettings: ["update"] },
@@ -47,8 +57,12 @@ const readAIConfig = createSafeRootHandler(
 
     const ciphertext = row?.aiConfigEncrypted;
     const iv = row?.aiConfigIv;
+    const instanceProvisioned = hasInstanceProvider();
 
-    let result: AIConfigResult = { configured: false };
+    let result: AIConfigResult = {
+      configured: false,
+      instanceProvisioned,
+    };
 
     if (ciphertext && iv) {
       const decryptResult = await Result.tryPromise({
@@ -68,6 +82,7 @@ const readAIConfig = createSafeRootHandler(
           baseURL: aiConfig.baseURL ?? null,
           overrideRoles: aiConfig.overrideRoles ?? [],
           region: aiConfig.region ?? "global",
+          instanceProvisioned,
         };
       }
     }

--- a/apps/api/src/handlers/organization-settings/routes.ts
+++ b/apps/api/src/handlers/organization-settings/routes.ts
@@ -3,6 +3,7 @@ import Elysia from "elysia";
 import deleteAIConfig from "@/api/handlers/organization-settings/delete-ai-config";
 import previewOrganizationSettings from "@/api/handlers/organization-settings/preview";
 import readOrganizationSettings from "@/api/handlers/organization-settings/read";
+import readAIAvailability from "@/api/handlers/organization-settings/read-ai-availability";
 import readAIConfig from "@/api/handlers/organization-settings/read-ai-config";
 import updateOrganizationSettings from "@/api/handlers/organization-settings/update";
 import updateAIConfig from "@/api/handlers/organization-settings/update-ai-config";
@@ -23,6 +24,7 @@ export const organizationSettingsRoute = new Elysia({
   .post("/preview", previewOrganizationSettings.handler, {
     body: previewOrganizationSettings.config.body,
   })
+  .get("/ai-availability", readAIAvailability.handler)
   .get("/ai-config", readAIConfig.handler)
   .post("/ai-config", updateAIConfig.handler, {
     body: updateAIConfig.config.body,

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -18,7 +18,11 @@ import {
 } from "@/api/db/schema";
 import { resolveSelectedWorkspaceIds } from "@/api/handlers/search/search";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import {
+  getModelForRole,
+  getTemperatureForRole,
+  requireAIAvailable,
+} from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -280,6 +284,11 @@ export const refineSearchQuery = async ({
 }: SearchAIContext & {
   body: RefineSearchBody;
 }) => {
+  const gate = requireAIAvailable(orgAIConfig);
+  if (gate.isErr()) {
+    return status(403, { message: gate.error.message });
+  }
+
   const aiAnalytics = createAIAnalyticsCallbacks({
     feature: "search.refine",
     properties: { organization_id: organizationId },
@@ -348,6 +357,11 @@ export const summarizeSearchResults = async ({
 }: SearchSummaryContext & {
   body: SummarizeSearchBody;
 }) => {
+  const gate = requireAIAvailable(orgAIConfig);
+  if (gate.isErr()) {
+    return status(403, { message: gate.error.message });
+  }
+
   const resolved = await resolveSelectedWorkspaceIds({
     scopedDb,
     organizationId,

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -157,22 +157,53 @@ const resolveProvider = (): AIProvider => {
 /**
  * Whether the instance can serve AI to an org that has not set
  * BYOK. False when REQUIRE_PERSONAL_AI_KEY forces BYOK or when
- * no provider keys are provisioned.
+ * no provider has the credentials it needs to run.
  *
- * Used by /ai-config to tell the frontend whether AI features
- * are usable without the org first supplying their own key.
+ * AI_PROVIDER alone is not enough: an explicit provider must be
+ * paired with the matching key (e.g. AI_PROVIDER=openai requires
+ * OPENAI_API_KEY) or the model factory will fail at runtime.
  */
 export const hasInstanceProvider = (): boolean => {
   if (env.REQUIRE_PERSONAL_AI_KEY) {
     return false;
   }
-  return !!(
-    env.AI_PROVIDER ||
+  // Mock provider stands in for any real key.
+  if (env.USE_MOCK_AI) {
+    return true;
+  }
+  // Auto-detect path: any single provider key is enough.
+  const hasAnyKey = !!(
     env.OPENROUTER_API_KEY ||
     env.GOOGLE_GENERATIVE_AI_API_KEY ||
+    env.GOOGLE_AI_API_KEY_EU ||
+    env.GOOGLE_AI_API_KEY_CH ||
     env.OPENAI_API_KEY ||
     env.ANTHROPIC_API_KEY
   );
+  if (!env.AI_PROVIDER) {
+    return hasAnyKey;
+  }
+  // Explicit provider: each provider has its own credential
+  // requirement. Mirror resolveProvider's expectations so the
+  // gate matches what the model factory would actually accept.
+  switch (env.AI_PROVIDER) {
+    case "openrouter":
+      return !!env.OPENROUTER_API_KEY;
+    case "google":
+      return !!(
+        env.GOOGLE_GENERATIVE_AI_API_KEY ||
+        env.GOOGLE_AI_API_KEY_EU ||
+        env.GOOGLE_AI_API_KEY_CH
+      );
+    case "openai":
+      return !!env.OPENAI_API_KEY;
+    case "anthropic":
+      return !!env.ANTHROPIC_API_KEY;
+    case "openai_compatible":
+      return !!(env.OPENAI_API_KEY && env.AI_PROVIDER_BASE_URL);
+    default:
+      return false;
+  }
 };
 
 /**

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -24,9 +24,10 @@ import { createOpenAI, openai } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { wrapLanguageModel } from "ai";
 import type { LanguageModel } from "ai";
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 
 import { env } from "@/api/env";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 // -- Types ------------------------------------------------------
 
@@ -150,6 +151,48 @@ const resolveProvider = (): AIProvider => {
       "provide at least one API key: " +
       "GOOGLE_GENERATIVE_AI_API_KEY, OPENROUTER_API_KEY, " +
       "OPENAI_API_KEY, or ANTHROPIC_API_KEY.",
+  );
+};
+
+/**
+ * Whether the instance can serve AI to an org that has not set
+ * BYOK. False when REQUIRE_PERSONAL_AI_KEY forces BYOK or when
+ * no provider keys are provisioned.
+ *
+ * Used by /ai-config to tell the frontend whether AI features
+ * are usable without the org first supplying their own key.
+ */
+export const hasInstanceProvider = (): boolean => {
+  if (env.REQUIRE_PERSONAL_AI_KEY) {
+    return false;
+  }
+  return !!(
+    env.AI_PROVIDER ||
+    env.OPENROUTER_API_KEY ||
+    env.GOOGLE_GENERATIVE_AI_API_KEY ||
+    env.OPENAI_API_KEY ||
+    env.ANTHROPIC_API_KEY
+  );
+};
+
+/**
+ * Backend gate matching the frontend RequireAIKey component.
+ * Yield from a Result.gen handler to short-circuit AI requests
+ * with 403 when the org has no BYOK and the instance has no
+ * provisioned (or BYOK-only) provider.
+ */
+export const requireAIAvailable = (
+  orgConfig: OrgAIConfig | null,
+): Result<void, HandlerError> => {
+  if (orgConfig || hasInstanceProvider()) {
+    return Result.ok(undefined);
+  }
+  return Result.err(
+    new HandlerError({
+      status: 403,
+      message:
+        "AI is not available. Configure an AI key in organization settings.",
+    }),
   );
 };
 

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -5,20 +5,24 @@ import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
-import { aiConfigOptions } from "@/routes/_protected.organization/-ai-config-queries";
+import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
 
 /**
  * Whether AI features are available right now: either the org has
- * BYOK or the instance has provisioned keys. Returns true while
- * the config query is pending so callers don't flash gates on
- * first render.
+ * BYOK or the instance has provisioned keys. Optimistic while the
+ * query is in-flight so callers don't flash gates on first render;
+ * a query failure is treated as unavailable so the UI matches what
+ * the backend will accept.
  */
 export function useAIAvailable(): boolean {
-  const { data, isPending } = useQuery(aiConfigOptions);
-  if (isPending || !data) {
+  const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
+  if (isPending) {
     return true;
   }
-  return data.configured || data.instanceProvisioned;
+  if (isError || data === undefined) {
+    return false;
+  }
+  return data.available;
 }
 
 /**
@@ -28,13 +32,13 @@ export function useAIAvailable(): boolean {
  */
 export function RequireAIKey({ children }: PropsWithChildren) {
   const t = useTranslations();
-  const { data, isPending } = useQuery(aiConfigOptions);
+  const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
 
-  if (isPending || !data) {
+  if (isPending) {
     return <>{children}</>;
   }
 
-  if (data.configured || data.instanceProvisioned) {
+  if (!isError && data?.available) {
     return <>{children}</>;
   }
 

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -1,0 +1,61 @@
+import type { PropsWithChildren } from "react";
+
+import { Button } from "@stll/ui/components/button";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
+import { aiConfigOptions } from "@/routes/_protected.organization/-ai-config-queries";
+
+/**
+ * Whether AI features are available right now: either the org has
+ * BYOK or the instance has provisioned keys. Returns true while
+ * the config query is pending so callers don't flash gates on
+ * first render.
+ */
+export function useAIAvailable(): boolean {
+  const { data, isPending } = useQuery(aiConfigOptions);
+  if (isPending || !data) {
+    return true;
+  }
+  return data.configured || data.instanceProvisioned;
+}
+
+/**
+ * Gate AI features when the instance has no provisioned keys
+ * and the org has not supplied their own. Renders children when
+ * either is available.
+ */
+export function RequireAIKey({ children }: PropsWithChildren) {
+  const t = useTranslations();
+  const { data, isPending } = useQuery(aiConfigOptions);
+
+  if (isPending || !data) {
+    return <>{children}</>;
+  }
+
+  if (data.configured || data.instanceProvisioned) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex h-full w-full flex-1 items-center justify-center p-6">
+      <div className="border-border bg-card text-card-foreground flex max-w-md flex-col gap-4 rounded-lg border p-6 shadow-sm">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-foreground text-lg font-semibold">
+            {t("ai.keyRequired.title")}
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            {t("ai.keyRequired.description")}
+          </p>
+        </div>
+        <Button
+          className="self-start"
+          render={<Link to="/settings/organization/ai" />}
+        >
+          {t("ai.keyRequired.cta")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -9,16 +9,14 @@ import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-conf
 
 /**
  * Whether AI features are available right now: either the org has
- * BYOK or the instance has provisioned keys. Optimistic while the
- * query is in-flight so callers don't flash gates on first render;
- * a query failure is treated as unavailable so the UI matches what
- * the backend will accept.
+ * BYOK or the instance has provisioned keys. Defaults to false
+ * during the initial fetch and on query errors so AI affordances
+ * (buttons, dialogs) stay disabled until availability is confirmed,
+ * avoiding bait-and-switch where a click fires a request the
+ * backend will 403.
  */
 export function useAIAvailable(): boolean {
-  const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
-  if (isPending) {
-    return true;
-  }
+  const { data, isError } = useQuery(aiAvailabilityOptions);
   if (isError || data === undefined) {
     return false;
   }
@@ -28,14 +26,16 @@ export function useAIAvailable(): boolean {
 /**
  * Gate AI features when the instance has no provisioned keys
  * and the org has not supplied their own. Renders children when
- * either is available.
+ * either is available; renders nothing while the availability
+ * check is pending so users do not see a flash of AI UI before
+ * being gated.
  */
 export function RequireAIKey({ children }: PropsWithChildren) {
   const t = useTranslations();
   const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
 
   if (isPending) {
-    return <>{children}</>;
+    return null;
   }
 
   if (!isError && data?.available) {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Neznámé zařízení"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Přidat entitu",
     "checkAnonymization": "Zkontrolovat anonymizaci",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Unbekanntes Gerät"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Entität hinzufügen",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Unknown device"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Add entity",
     "checkAnonymization": "Check anonymization",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Dispositivo desconocido"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Añadir entidad",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Tundmatu seade"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Lisa olem",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Appareil inconnu"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Ajouter une entité",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Ismeretlen eszköz"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Entitás hozzáadása",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Nežinomas įrenginys"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Pridėti subjektą",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Nezināma ierīce"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Pievienot entītiju",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -16,6 +16,13 @@ type Messages = {
       "unknownDevice": "Unknown device";
     };
   };
+  "ai": {
+    "keyRequired": {
+      "title": "AI key required";
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.";
+      "cta": "Open AI settings";
+    };
+  };
   "anonymize": {
     "addEntity": "Add entity";
     "checkAnonymization": "Check anonymization";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Nieznane urządzenie"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Dodaj podmiot",
     "checkAnonymization": "Sprawdź anonimizację",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -13,6 +13,13 @@
       "unknownDevice": "Neznáme zariadenie"
     }
   },
+  "ai": {
+    "keyRequired": {
+      "cta": "Open AI settings",
+      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
+      "title": "AI key required"
+    }
+  },
   "anonymize": {
     "addEntity": "Pridať entitu",
     "checkAnonymization": "Check anonymisation",

--- a/apps/web/src/routes/_protected.chat/route.tsx
+++ b/apps/web/src/routes/_protected.chat/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
+import { RequireAIKey } from "@/components/require-ai-key";
 import { pageTitle } from "@/lib/page-title";
 
 export const Route = createFileRoute("/_protected/chat")({
@@ -12,7 +13,9 @@ export const Route = createFileRoute("/_protected/chat")({
 function ChatLayout() {
   return (
     <div className="flex h-full w-full flex-col items-center overflow-hidden">
-      <Outlet />
+      <RequireAIKey>
+        <Outlet />
+      </RequireAIKey>
     </div>
   );
 }

--- a/apps/web/src/routes/_protected.organization/-ai-config-queries.ts
+++ b/apps/web/src/routes/_protected.organization/-ai-config-queries.ts
@@ -5,12 +5,33 @@ import { toAPIError } from "@/lib/errors";
 
 export const aiConfigKeys = {
   all: ["organization-ai-config"],
+  availability: ["organization-ai-availability"],
 };
 
 export const aiConfigOptions = queryOptions({
   queryKey: aiConfigKeys.all,
   queryFn: async ({ signal }) => {
     const response = await api["organization-settings"]["ai-config"].get({
+      fetch: { signal },
+    });
+
+    if (response.error) {
+      throw toAPIError(response.error);
+    }
+
+    return response.data;
+  },
+});
+
+/**
+ * AI availability for any org member, regardless of admin
+ * permissions on the full AI config. Returns just the booleans
+ * needed by the gate; ai-config is admin-only.
+ */
+export const aiAvailabilityOptions = queryOptions({
+  queryKey: aiConfigKeys.availability,
+  queryFn: async ({ signal }) => {
+    const response = await api["organization-settings"]["ai-availability"].get({
       fetch: { signal },
     });
 


### PR DESCRIPTION
## Summary

Adds a backend gate and frontend UX so users can never reach an AI feature that would 500 because no provider key is available.

- New env flag `REQUIRE_PERSONAL_AI_KEY` lets operators force BYOK even on instances that *do* have provisioned keys, useful for shared deployments without metering where each org's costs land on their own provider account.
- `read-ai-config` now returns `instanceProvisioned: boolean` so the frontend knows whether AI is usable without org BYOK.
- `requireAIAvailable(orgConfig)` Result helper, applied at every AI handler entry: chat send-message, search refine + summary, case-law analysis generate, entities organize-suggestions. Returns 403 to clients when neither org BYOK nor instance keys are available.
- `<RequireAIKey>` route-wraps `/chat`, the most prominent AI surface. Shows an "AI key required" card linking to `/settings/organization/ai`.
- `useAIAvailable()` hook exported alongside for component-level gating in shared dialogs (search summary buttons, file organizer suggestions). Wiring those is left to follow-up PRs.
- i18n keys `ai.keyRequired.{title,description,cta}` added to all 12 languages. English is the source; non-English values are placeholders pending Lingo or manual translation.

## Behavior

`instanceProvisioned = false` IFF `REQUIRE_PERSONAL_AI_KEY=true` OR (no env keys for any provider). When false AND no org BYOK → user sees the gate.

## Test plan

- [ ] With `REQUIRE_PERSONAL_AI_KEY=false` and at least one provider env key set, /chat works normally (no gate)
- [ ] With `REQUIRE_PERSONAL_AI_KEY=true` and no org BYOK, /chat shows the gate card with link to settings
- [ ] With `REQUIRE_PERSONAL_AI_KEY=true` and an org BYOK saved at /settings/organization/ai, /chat works
- [ ] When the gate is active, calling `POST /chat`, `POST /search/summary`, `POST /search/refine`, `POST /case/decisions/:id/analysis`, `POST /entities/:wsId/organize-suggestions` directly returns HTTP 403
- [ ] Background jobs (case-law citation polarity LLM fallback) keep working — they have their own fallback path and are intentionally not gated

## Follow-ups (out of scope)

- Apply `useAIAvailable` to search-dialog AI buttons, file-organizer "Generate suggestions" button, case-decision analysis sidebar to hide/disable AI affordances inline
- Translate the new i18n keys into the 11 non-English languages (Lingo bot was killed during the repo migration; these need manual or replacement-tool translation)