### PR TITLE
fix: eliminate chat input placeholder flicker on new chat

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1236,7 +1236,7 @@ export function PromptBar(props: PromptBarProps) {
           !busy &&
           !isSendBlocked &&
           emptyPlaceholder !== undefined && (
-            <div className="pointer-events-none absolute inset-0 z-10 flex items-center px-1.5">
+            <div className="pointer-events-none absolute inset-0 z-10 flex min-w-0 items-center px-1.5">
               {emptyPlaceholder}
             </div>
           )}

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -15,7 +15,7 @@
 
 import "@/components/chat-editor.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 import {
   applySuggestions,
@@ -1066,6 +1066,60 @@ type PromptBarProps = {
   sendDisabledReason?: "editor-loading" | undefined;
 };
 
+/**
+ * Styled placeholder label rendered in the prompt bar when the editor
+ * is empty. Shared between the live `PromptBar` (via `emptyPlaceholder`)
+ * and the loading `PromptBarPlaceholder` shell so both surfaces are
+ * pixel-identical and can never drift.
+ */
+export function PromptBarPlaceholderContent({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <span className="text-muted-foreground/60 truncate text-[13px] leading-5">
+      {children}
+    </span>
+  );
+}
+
+type PromptBarShellProps = {
+  layout: FileAIChatLayout;
+  children: ReactNode;
+} & Omit<ComponentProps<"div">, "children">;
+
+/**
+ * Shared outer shell for the glass prompt bar. Both the live
+ * `PromptBar` and the loading `PromptBarPlaceholder` (in the
+ * inspector) render through this so they can never drift apart.
+ */
+export function PromptBarShell({
+  layout,
+  children,
+  className,
+  ...rest
+}: PromptBarShellProps) {
+  return (
+    <div
+      {...rest}
+      className={cn(
+        "group/bar bg-background/75 relative flex items-end gap-1 rounded-2xl border backdrop-blur-xl backdrop-saturate-150 transition-[box-shadow,border-color]",
+        "shadow-[0_0_0_1px_rgb(0_0_0/0.02),0_1px_2px_rgb(0_0_0/0.03),0_8px_20px_rgb(0_0_0/0.05)]",
+        "after:pointer-events-none after:absolute after:-inset-4 after:-z-10 after:rounded-2xl after:bg-[radial-gradient(ellipse_at_center,var(--background)_0%,transparent_70%)] after:opacity-50",
+        "focus-within:border-foreground/30",
+        "w-[min(560px,calc(100%-2rem))] py-1 ps-1.5 pe-1",
+        layout === "floating"
+          ? "absolute start-1/2 bottom-8 z-50 -translate-x-1/2"
+          : "relative mb-8 shrink-0 self-center",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
 export function PromptBar(props: PromptBarProps) {
   const {
     layout,
@@ -1141,14 +1195,10 @@ export function PromptBar(props: PromptBarProps) {
   }, [setSubmitHandler, submitDraft]);
 
   return (
-    <div
+    <PromptBarShell
+      aria-busy={busy}
+      aria-label="AI prompt"
       className={cn(
-        // ── Shared bar look — IDENTICAL in floating and standalone.
-        "group/bar bg-background/75 relative flex items-end gap-1 rounded-2xl border backdrop-blur-xl backdrop-saturate-150 transition-[box-shadow,border-color]",
-        "shadow-[0_0_0_1px_rgb(0_0_0/0.02),0_1px_2px_rgb(0_0_0/0.03),0_8px_20px_rgb(0_0_0/0.05)]",
-        "after:pointer-events-none after:absolute after:-inset-4 after:-z-10 after:rounded-2xl after:bg-[radial-gradient(ellipse_at_center,var(--background)_0%,transparent_70%)] after:opacity-50",
-        "focus-within:border-foreground/30",
-        "w-[min(560px,calc(100%-2rem))] py-1 ps-1.5 pe-1",
         // While the model is generating or applying, signal the
         // wait clearly: a soft primary ring + the inline spinner
         // overlay below. Without this the bar looks identical to
@@ -1159,14 +1209,9 @@ export function PromptBar(props: PromptBarProps) {
         // than the busy state because it's transient and meant to
         // catch the eye, not communicate ongoing work.
         attention && "border-primary ring-primary/40 ring-4",
-        // ── Layout-specific positioning ONLY.
-        layout === "floating"
-          ? "absolute start-1/2 bottom-8 z-50 -translate-x-1/2"
-          : "relative mb-8 shrink-0 self-center",
       )}
+      layout={layout}
       role="toolbar"
-      aria-label="AI prompt"
-      aria-busy={busy}
     >
       <div className="relative flex min-h-8 min-w-0 flex-1 items-center gap-1.5 px-1.5">
         {isEmpty && busy && (
@@ -1298,7 +1343,7 @@ export function PromptBar(props: PromptBarProps) {
           </TooltipPopup>
         </Tooltip>
       )}
-    </div>
+    </PromptBarShell>
   );
 }
 

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1236,7 +1236,7 @@ export function PromptBar(props: PromptBarProps) {
           !busy &&
           !isSendBlocked &&
           emptyPlaceholder !== undefined && (
-            <div className="pointer-events-none absolute inset-x-1.5 top-1/2 z-10 min-w-0 -translate-y-1/2">
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center px-1.5">
               {emptyPlaceholder}
             </div>
           )}

--- a/apps/web/src/components/chat-editor.css
+++ b/apps/web/src/components/chat-editor.css
@@ -6,13 +6,9 @@
   margin: 0;
 }
 
-.chat-editor .tiptap p.is-editor-empty:first-child::before {
-  color: color-mix(in srgb, var(--color-muted-foreground) 64%, transparent);
-  content: attr(data-placeholder);
-  float: left;
-  height: 0;
-  pointer-events: none;
-}
+/* Placeholder is rendered as a React element in ChatInputSurface,
+ * keyed off the stable isEmpty state rather than TipTap's own
+ * is-editor-empty class (which can flicker during initialisation). */
 
 .folio-ai-bar-editor--custom-placeholder
   .tiptap

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -5,6 +5,7 @@ import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 import { EditorContent } from "@tiptap/react";
 import { ArrowUpIcon, PaperclipIcon, SquareIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
 
 import type {
   ChatEditorController,
@@ -37,6 +38,7 @@ export const ChatInputSurface = ({
   isGenerating = false,
   onStop,
 }: ChatInputSurfaceProps) => {
+  const t = useTranslations();
   const {
     attachments,
     canSubmit,
@@ -48,6 +50,7 @@ export const ChatInputSurface = ({
     handleDrop,
     handleFileInputChange,
     handlePaste,
+    isEmpty,
     openFilePicker,
     removeFile,
     setSubmitHandler,
@@ -97,11 +100,19 @@ export const ChatInputSurface = ({
     >
       <ChatDraftAttachmentChips files={attachments} onRemove={removeFile} />
       <div
-        className="chat-editor px-3 pt-2 pb-1"
+        className="chat-editor relative px-3 pt-2 pb-1"
         onKeyDown={(event) => event.stopPropagation()}
         role="presentation"
       >
         <EditorContent editor={editor} />
+        {isEmpty && attachments.length === 0 && (
+          <span
+            aria-hidden="true"
+            className="text-muted-foreground/64 pointer-events-none absolute start-3 top-2 text-sm"
+          >
+            {t("chat.placeholder")}
+          </span>
+        )}
       </div>
       <div className="flex items-center gap-0.5 px-1.5 pb-1.5">
         <Button
@@ -132,18 +143,13 @@ export const ChatInputSurface = ({
           </Button>
         ) : (
           <Button
-            className={cn(
-              "ms-auto shrink-0 transition-colors",
-              canSubmit &&
-                !disabled &&
-                "bg-foreground text-background hover:bg-foreground/90",
-            )}
+            className="bg-foreground text-background hover:bg-foreground/90 ms-auto shrink-0"
             disabled={disabled || !canSubmit}
             onClick={() => {
               void submitDraft();
             }}
             size="icon-sm"
-            variant={canSubmit && !disabled ? "default" : "ghost"}
+            variant="default"
           >
             <ArrowUpIcon className="size-3.5" />
           </Button>

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -143,7 +143,10 @@ export const ChatInputSurface = ({
           </Button>
         ) : (
           <Button
-            className="bg-foreground text-background hover:bg-foreground/90 ms-auto shrink-0"
+            className={cn(
+              "bg-foreground text-background hover:bg-foreground/90 ms-auto shrink-0",
+              (disabled || !canSubmit) && "opacity-50",
+            )}
             disabled={disabled || !canSubmit}
             onClick={() => {
               void submitDraft();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -34,7 +34,11 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from "@/components/ai-elements/conversation";
-import { PromptBar } from "@/components/ai-suggestions/host";
+import {
+  PromptBar,
+  PromptBarPlaceholderContent,
+  PromptBarShell,
+} from "@/components/ai-suggestions/host";
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
@@ -266,6 +270,11 @@ export const ChatTabPanel = ({
 
       <PromptBar
         editorController={editorController}
+        emptyPlaceholder={
+          <PromptBarPlaceholderContent>
+            {t("chat.contextPlaceholder", { context: chatContextLabel })}
+          </PromptBarPlaceholderContent>
+        }
         layout="standalone"
         onStop={() => {
           void stop();
@@ -449,24 +458,16 @@ const PromptBarPlaceholder = ({ tab }: { tab: ChatTab }) => {
   const t = useTranslations();
   const chatContextLabel = useChatContextLabel(tab);
   return (
-    <div
-      aria-hidden="true"
-      className="group/bar bg-background/75 relative mb-8 flex w-[min(560px,calc(100%-2rem))] shrink-0 items-end gap-1 self-center rounded-2xl border py-1 ps-1.5 pe-1 backdrop-blur-xl backdrop-saturate-150"
-    >
-      <div className="flex min-h-8 min-w-0 flex-1 items-center gap-1.5 px-1.5">
-        <span className="text-muted-foreground/60 truncate text-[13px] leading-5">
+    <PromptBarShell aria-hidden="true" layout="standalone">
+      <div className="flex min-h-8 min-w-0 flex-1 items-center px-1.5">
+        <PromptBarPlaceholderContent>
           {t("chat.contextPlaceholder", { context: chatContextLabel })}
-        </span>
+        </PromptBarPlaceholderContent>
       </div>
-      <Button
-        className="rounded-full opacity-50"
-        disabled
-        size="icon"
-        type="button"
-      >
+      <Button className="rounded-full" disabled size="icon" type="button">
         <ArrowUpIcon aria-hidden="true" />
       </Button>
-    </div>
+    </PromptBarShell>
   );
 };
 


### PR DESCRIPTION
## Summary

- Replaces TipTap's CSS `::before` placeholder (which transiently disappears during editor initialisation, causing a visible flash) with a React element controlled by the stable `isEmpty` state
- Extracts `PromptBarShell` so the live `PromptBar` and the Suspense loading shell (`PromptBarPlaceholder`) share identical outer chrome and can never drift apart
- Extracts `PromptBarPlaceholderContent` for the placeholder span, ensuring pixel-identical rendering in both the live bar and the loading shell
- Fixes placeholder vertical alignment: wrapper changed from `top-1/2 -translate-y-1/2` to `inset-0 flex items-center`, matching the flex centering used in the shell and eliminating a subpixel shift during TipTap init
- Passes `emptyPlaceholder` to `PromptBar` from the inspector chat tab, activating the React-element approach for that surface (previously left on TipTap's CSS placeholder)

## Files changed

- `apps/web/src/components/ai-suggestions/host.tsx` — `PromptBarPlaceholderContent`, `PromptBarShell`, positioning fix, `emptyPlaceholder` wiring
- `apps/web/src/components/chat-editor.css` — remove CSS placeholder rule for `ChatInputSurface` (replaced by React element)
- `apps/web/src/components/chat-input-surface.tsx` — React placeholder span keyed off `isEmpty` state; button always dark variant
- `apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx` — use `PromptBarShell` + `PromptBarPlaceholderContent` in loading shell; pass `emptyPlaceholder` to live `PromptBar`

## Test plan

- [ ] Open a new chat via the sidebar icon — placeholder text and button should appear immediately with no flash or style change
- [ ] Placeholder text in the loading shell and live bar should be visually identical (same position, same style)
- [ ] Typing in the bar clears the placeholder cleanly
- [ ] Stop/send button variant stays consistent throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)