### PR TITLE
docs: refresh beta preview landing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ Full-text search, versioning and granular access control included.
 built for due diligence, discovery and research.
 
 **Research.** Find relevant laws, cases or doctrinal materials, with a database of
-legal sources, premium reading experience and connection to AI.
+legal sources, premium reading experience. Coming soon.
 
 **Anonymization.** Remove personally identifiable information from documents and data
-before they are sent to AI or shared with external parties.
+before they are sent to AI. Coming soon.
 
 ## Quickstart
 
 ### stella Cloud
 
-Hosted stella available at [stll.app](https://stll.app).
+Hosted stella preview is available at [my.stll.app](https://my.stll.app).
 
 ### Self-hosting
 

--- a/apps/landing/public/llms.txt
+++ b/apps/landing/public/llms.txt
@@ -15,7 +15,7 @@ stella is built for firms that need control. Matters, documents, and search are 
 ## Start here
 
 - [Website](https://stll.app): Product overview and pricing.
-- [Application](https://app.stll.app): Start using stella in the cloud.
+- [Application](https://my.stll.app): Start using stella in the cloud.
 - [Contact](mailto:contact@stll.app): Deployment, pilots, and general questions.
 
 ## Open source

--- a/apps/landing/src/data/capabilities.ts
+++ b/apps/landing/src/data/capabilities.ts
@@ -5,9 +5,9 @@ export const primaryCapabilities = [
       "Extract key fields from large document sets into a table you can sort, filter, and review.",
   },
   {
-    title: "Template drafting",
+    title: "First-class .docx support",
     description:
-      "Turn structured inputs into a clean first draft without rebuilding the document each time.",
+      "Open and edit Word documents in the browser or via the stella desktop app, with AI support along the way.",
   },
   {
     title: "Grounded research",
@@ -23,11 +23,11 @@ export const controlCapabilities = [
   },
   {
     title: "Anonymize sensitive text",
-    body: "Prepare material for AI workflows without exposing names, entities, or identifying details.",
+    body: "Prepare material for AI workflows without exposing names, entities, or identifying details. Coming soon.",
   },
   {
-    title: "Keep keys under your control",
-    body: "Use BYOK or external key management when your security model requires tighter control over encryption.",
+    title: "Use your AI provider key",
+    body: "Connect your own AI provider key when using AI features.",
   },
   {
     title: "Self-host or managed cloud",

--- a/apps/landing/src/pages/404.astro
+++ b/apps/landing/src/pages/404.astro
@@ -5,7 +5,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
 <Base title="Not found — stella" description="Page not found.">
   <div class="flex min-h-dvh flex-col">
-    <nav class="mx-auto flex w-full max-w-[1200px] items-center justify-between px-6 py-5">
+    <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">
         <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
       </a>

--- a/apps/landing/src/pages/imprint.astro
+++ b/apps/landing/src/pages/imprint.astro
@@ -1,18 +1,20 @@
 ---
 import Base from "../layouts/Base.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
+
+const appUrl = "https://my.stll.app";
 ---
 
 <Base title="Imprint — stella" description="Legal information.">
   <div class="flex min-h-dvh flex-col">
-    <nav class="mx-auto flex w-full max-w-[1200px] items-center justify-between px-6 py-5">
+    <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">
         <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
       </a>
       <div class="flex items-center gap-4">
         <ThemeToggle />
         <a
-          href="https://app.stll.app"
+          href={appUrl}
           class="text-sm font-medium transition-colors whitespace-nowrap"
           style="color: var(--muted-foreground)"
         >
@@ -22,7 +24,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
     </nav>
 
     <div class="flex flex-1 items-center justify-center px-6">
-      <div class="w-full max-w-[1200px] grid grid-cols-1 gap-16 py-16 md:grid-cols-2 md:gap-24">
+      <div class="w-full max-w-300 grid grid-cols-1 gap-16 py-16 md:grid-cols-2 md:gap-24">
         <div>
           <h1 class="font-display text-4xl font-medium tracking-tight sm:text-5xl">
             Imprint
@@ -56,7 +58,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
     </div>
 
     <footer class="relative px-6 py-12">
-      <div class="mx-auto max-w-[1200px] text-center">
+      <div class="mx-auto max-w-300 text-center">
         <p class="text-sm" style="color: var(--muted-foreground); opacity: 0.6">
           <a href="/" class="transition-opacity hover:opacity-70">stella labs, s.r.o.</a>
           <span aria-hidden="true"> · </span>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -3,11 +3,15 @@ import Base from "../layouts/Base.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
 import ProductShowcase from "../components/react/ProductShowcase";
 import { controlCapabilities } from "../data/capabilities";
+
+const appUrl = "https://my.stll.app";
+const selfHostingDocsUrl =
+  "https://github.com/stella/stella/blob/main/apps/docs/src/content/docs/guides/self-hosting.md";
 ---
 
 <Base>
   <!-- Brand accent line -->
-  <div class="h-[2px]" style="background: linear-gradient(to right, var(--auth-gradient-end), transparent 70%)" data-no-transition></div>
+  <div class="h-0.5" style="background: linear-gradient(to right, var(--auth-gradient-end), transparent 70%)" data-no-transition></div>
 
   <main>
     <!-- ——— Hero ——— -->
@@ -16,7 +20,7 @@ import { controlCapabilities } from "../data/capabilities";
         <div id="gradient-light" class="absolute inset-0 dark:opacity-0 transition-opacity duration-500"></div>
         <div id="gradient-dark" class="absolute inset-0 opacity-0 dark:opacity-100 transition-opacity duration-500"></div>
       </div>
-      <nav class="relative z-10 mx-auto flex w-full max-w-[1200px] items-center justify-between px-6 py-5">
+      <nav class="relative z-10 mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
         <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
         <div class="flex items-center gap-4">
           <ThemeToggle />
@@ -45,12 +49,13 @@ import { controlCapabilities } from "../data/capabilities";
           <br />
           Free to use, open to inspect, yours to keep.
         </p>
-        <span
-          class="mt-8 inline-flex h-9 cursor-default items-center rounded-[0.625rem] px-4 text-sm font-medium opacity-60 whitespace-nowrap"
+        <a
+          href={appUrl}
+          class="mt-8 inline-flex h-9 items-center rounded-[0.625rem] px-4 text-sm font-medium transition-opacity hover:opacity-90 whitespace-nowrap"
           style="background: var(--primary); color: var(--primary-foreground)"
         >
-          Coming soon
-        </span>
+          Start free
+        </a>
       </div>
 
       <div
@@ -61,12 +66,12 @@ import { controlCapabilities } from "../data/capabilities";
 
     <!-- ——— Product ——— -->
     <section class="-mt-24 relative z-10 px-6 pb-16">
-      <div class="mx-auto max-w-[1200px]">
+      <div class="mx-auto max-w-300">
         <ProductShowcase />
       </div>
     </section>
     <section class="px-6 py-16 lg:py-20">
-      <div class="mx-auto max-w-[1200px]">
+      <div class="mx-auto max-w-300">
         <div class="mx-auto max-w-4xl text-center">
           <p class="text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Built to last</p>
           <h2 class="mt-3 font-display text-4xl font-medium leading-[1.1] sm:text-5xl lg:text-6xl">
@@ -77,15 +82,8 @@ import { controlCapabilities } from "../data/capabilities";
             And whatever comes next.
           </h2>
           <p class="mx-auto mt-5 max-w-3xl text-base leading-[1.9] sm:text-lg" style="color: var(--muted-foreground)">
-            Documents, matters, and search are free. AI-powered review, drafting, and research stay grounded in your workspace and trusted sources.
+            Documents, matters, and search are free in the beta preview. AI features are available with your own provider key.
           </p>
-          <a
-            href="/docs"
-            class="mt-4 inline-flex text-sm font-medium transition-opacity hover:opacity-70"
-            style="color: var(--muted-foreground)"
-          >
-            Docs &rarr;
-          </a>
         </div>
 
         <div class="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -102,12 +100,12 @@ import { controlCapabilities } from "../data/capabilities";
       </div>
     </section>
 
-    <!-- ——— Pricing ——— -->
+    <!-- ——— Usage options ——— -->
     <section class="px-6 py-16 lg:py-20">
-      <div class="mx-auto max-w-[1200px]">
-        <p class="mb-3 text-center text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Pricing</p>
+      <div class="mx-auto max-w-300">
+        <p class="mb-3 text-center text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Usage options</p>
         <h2 class="mb-10 text-center font-display text-4xl font-medium leading-[1.1] sm:text-5xl lg:text-6xl">
-          Simple, transparent.
+          Choose how to run stella.
         </h2>
         <p class="mx-auto mb-10 max-w-2xl text-center text-base leading-[1.8] sm:text-lg" style="color: var(--muted-foreground)">
           No lock-in, no per-seat licensing, no hidden pricing.
@@ -115,43 +113,56 @@ import { controlCapabilities } from "../data/capabilities";
         <div class="mx-auto grid max-w-3xl grid-cols-1 gap-6 md:grid-cols-2">
           {[
             {
-              name: "Standard",
+              name: "Self-host",
+              cta: "Read docs",
+              external: true,
+              href: selfHostingDocsUrl,
               price: "Free",
-              cta: "Coming soon",
-              features: ["Unlimited users", "Document management", "Matters\u00A0&\u00A0search", "Self\u2011hosting", "Community support"],
+              note: "",
+              features: ["Run on your infrastructure", "Full source access", "AGPL\u20113.0 license", "Currently in beta demo"],
             },
             {
-              name: "Pro",
-              price: "Usage\u2011based",
-              cta: "Coming soon",
-              features: ["Everything in Standard", "AI review\u00A0&\u00A0research", "Automated drafting", "Priority support"],
+              name: "Cloud preview",
+              cta: "Try it out now",
+              href: appUrl,
+              note: "",
+              price: "Free",
+              features: ["Use hosted architecture", "Currently in beta preview", "BYOK only"],
             },
           ].map((tier) => (
             <div
               class="pricing-card group flex flex-col rounded-2xl p-8 transition-[background-color,border-color,box-shadow] duration-200"
               style="background: var(--card); border: 1px solid var(--border); color: inherit"
             >
+              <p class="min-h-5 text-sm italic" style="color: var(--muted-foreground)">
+                {tier.note ?? ""}
+              </p>
               <p class="text-xs font-medium uppercase tracking-[0.15em]" style="color: var(--muted-foreground)">{tier.name}</p>
               <p class="tabular-nums mt-2 font-display text-3xl font-medium">{tier.price}</p>
               <div class="my-6 h-px" style="background: var(--border)"></div>
               <div class="flex-1 space-y-1.5 text-sm leading-[1.7]" style="color: var(--muted-foreground)">
                 {tier.features.map((f) => <p set:html={f} />)}
               </div>
-              <span
-                class="mt-8 inline-flex h-9 cursor-default items-center self-start rounded-[0.625rem] px-4 text-sm font-medium opacity-60 whitespace-nowrap"
+              <a
+                href={tier.href}
+                class="mt-8 inline-flex h-9 items-center self-start rounded-[0.625rem] px-4 text-sm font-medium transition-opacity hover:opacity-90 whitespace-nowrap"
+                rel={tier.external ? "noopener noreferrer" : undefined}
                 style="background: var(--primary); color: var(--primary-foreground)"
+                target={tier.external ? "_blank" : undefined}
               >
                 {tier.cta}
-              </span>
+              </a>
             </div>
           ))}
         </div>
       </div>
     </section>
 
-    <!-- ——— Trust ——— -->
+    <!--
+      Removing the design scaffold until everything for the beta preview.
+
     <section class="px-6 py-16 lg:py-20">
-      <div class="mx-auto max-w-[1200px]">
+      <div class="mx-auto max-w-300">
         <div class="grid grid-cols-1 gap-10 text-center md:grid-cols-3 md:gap-8">
           {[
             { label: "Deployment", title: "Self-host or managed cloud", body: "Choose the operating model that fits your firm. Move data on your timetable, not ours.", href: "mailto:contact@stll.app?subject=stella%20deployment", linkText: "Talk deployment \u2192" },
@@ -174,11 +185,12 @@ import { controlCapabilities } from "../data/capabilities";
         </div>
       </div>
     </section>
+    -->
 
     <!-- ——— Final CTA ——— -->
     <section class="px-6 pb-20 lg:pb-24">
       <div
-        class="relative mx-auto max-w-[1200px] overflow-hidden rounded-[2rem] p-8 sm:p-10 lg:p-12"
+        class="relative mx-auto max-w-300 overflow-hidden rounded-[2rem] p-8 sm:p-10 lg:p-12"
         style="background: var(--card); border: 1px solid var(--border)"
       >
         <div
@@ -210,12 +222,13 @@ import { controlCapabilities } from "../data/capabilities";
         </div>
 
         <div class="mt-8 flex flex-col gap-3 sm:flex-row">
-          <span
-            class="inline-flex h-11 cursor-default items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium opacity-60 whitespace-nowrap"
+          <a
+            href={appUrl}
+            class="inline-flex h-11 items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium transition-opacity hover:opacity-90 whitespace-nowrap"
             style="background: var(--primary); color: var(--primary-foreground)"
             >
-            Coming soon
-          </span>
+            Start free
+          </a>
           <a
             href="mailto:contact@stll.app?subject=stella%20walkthrough"
             class="inline-flex h-11 items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium transition-colors whitespace-nowrap"
@@ -231,10 +244,9 @@ import { controlCapabilities } from "../data/capabilities";
 
   <!-- ——— Footer ——— -->
   <footer class="relative px-6 py-12" style="border-top: 1px solid var(--border)">
-    <div class="mx-auto max-w-[1200px]">
+    <div class="mx-auto max-w-300">
       <div class="flex flex-col items-center justify-between gap-6 sm:flex-row">
         <nav class="flex items-center gap-4 text-sm" style="color: var(--muted-foreground)" aria-label="Footer">
-          <a href="/docs" class="transition-opacity hover:opacity-70">Docs</a>
           <a href="https://github.com/stella/stella" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener noreferrer">GitHub</a>
           <a href="/security" class="transition-opacity hover:opacity-70">Security</a>
           <a href="/terms" class="transition-opacity hover:opacity-70">Terms</a>

--- a/apps/landing/src/pages/security.astro
+++ b/apps/landing/src/pages/security.astro
@@ -5,7 +5,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
 <Base title="Security — stella" description="How stella protects your data. Security controls, data handling, and compliance.">
   <div class="flex min-h-dvh flex-col">
-    <nav class="mx-auto flex w-full max-w-[1200px] items-center justify-between px-6 py-5">
+    <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">
         <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
       </a>
@@ -24,7 +24,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
     <main class="flex-1">
       <!-- ——— Hero ——— -->
       <section class="px-6 pt-16 pb-8 lg:pt-24 lg:pb-10">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <div class="max-w-4xl">
             <h1 class="font-display text-4xl font-medium tracking-tight sm:text-5xl">
               Security at stella
@@ -34,13 +34,28 @@ import ThemeToggle from "../components/ThemeToggle.astro";
               everything else is built on. Our architecture enforces least
               privilege, workspace isolation, and encryption at every layer.
             </p>
+            <div
+              class="mt-8 rounded-2xl p-6"
+              style="background: var(--card); border: 1px solid var(--border)"
+            >
+              <p class="font-display text-xl font-medium tracking-tight">
+                We are currently in beta.
+              </p>
+              <p class="mt-2 text-sm leading-[1.7]" style="color: var(--muted-foreground)">
+                Please treat the beta preview accordingly while we harden the
+                product, documentation, and operational controls. Stable v1 will
+                be announced in the future. Do not upload sensitive, privileged,
+                personal, irreplaceable, or production-critical data. The
+                service is offered as a demo.
+              </p>
+            </div>
           </div>
         </div>
       </section>
 
       <!-- ——— Principles ——— -->
       <section class="px-6 py-10 lg:py-12">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <h2 class="mb-6 text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Principles</h2>
           <div class="grid grid-cols-1 gap-5 md:grid-cols-3">
             {[
@@ -59,7 +74,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
       <!-- ——— Controls ——— -->
       <section class="px-6 py-10 lg:py-12">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <h2 class="mb-6 text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Controls</h2>
           <div class="grid grid-cols-1 gap-x-8 gap-y-10 md:grid-cols-2 lg:grid-cols-3">
             {[
@@ -124,7 +139,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
       <!-- ——— Subprocessors ——— -->
       <section class="px-6 py-10 lg:py-12">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <h2 class="mb-6 text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Subprocessors</h2>
           <div class="overflow-x-auto">
             <table class="w-full text-sm">
@@ -137,9 +152,8 @@ import ThemeToggle from "../components/ThemeToggle.astro";
               </thead>
               <tbody style="color: var(--muted-foreground)">
                 {[
-                  { provider: "Amazon Web Services", purpose: "Cloud infrastructure, S3 storage", region: "Customer-selected" },
+                  { provider: "Amazon Web Services", purpose: "Cloud infrastructure, RDS PostgreSQL, S3 storage", region: "Customer-selected" },
                   { provider: "Google Cloud", purpose: "AI model inference (Gemini)", region: "Customer-selected" },
-                  { provider: "PostgreSQL (self-managed)", purpose: "Primary database", region: "Customer-selected" },
                   { provider: "PostHog", purpose: "Product analytics", region: "EU" },
                 ].map((row) => (
                   <tr style="border-bottom: 1px solid var(--border)">
@@ -156,13 +170,11 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 
       <!-- ——— Resources ——— -->
       <section class="px-6 py-10 lg:py-12">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <h2 class="mb-6 text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">Resources</h2>
-          <div class="grid grid-cols-1 gap-5 md:grid-cols-3">
+          <div class="grid max-w-sm grid-cols-1 gap-5">
             {[
-              { title: "Data Processing Agreement", body: "GDPR&#8209;compliant DPA for your records." },
-              { title: "Architecture overview", body: "Data flow diagram and infrastructure summary." },
-              { title: "Compliance scan report", body: "Latest Prowler scan against SOC&#8209;2 and ISO&#8209;27001 benchmarks." },
+              { title: "Prowler scan report", body: "Latest Prowler scan against SOC&#8209;2 and ISO&#8209;27001 benchmarks." },
             ].map((item) => (
               <a
                 href={`mailto:security@stll.app?subject=${encodeURIComponent(`Request: ${item.title}`)}`}
@@ -182,9 +194,11 @@ import ThemeToggle from "../components/ThemeToggle.astro";
         </div>
       </section>
 
-      <!-- ——— FAQ ——— -->
+      <!--
+        Once infra stabilises be more detailed.
+
       <section class="px-6 py-10 lg:py-12">
-        <div class="mx-auto max-w-[1200px]">
+        <div class="mx-auto max-w-300">
           <h2 class="mb-6 text-xs font-medium uppercase tracking-[0.2em]" style="color: var(--muted-foreground)">FAQ</h2>
           <div class="max-w-4xl space-y-8">
             {[
@@ -202,11 +216,12 @@ import ThemeToggle from "../components/ThemeToggle.astro";
           </div>
         </div>
       </section>
+      -->
     </main>
 
     <!-- ——— Footer ——— -->
     <footer class="relative px-6 py-12" style="border-top: 1px solid var(--border)">
-      <div class="mx-auto max-w-[1200px] text-center">
+      <div class="mx-auto max-w-300 text-center">
         <p class="text-sm" style="color: var(--muted-foreground)">
           <a href="/imprint" class="transition-opacity hover:opacity-70">stella labs, s.r.o.</a>
           <span aria-hidden="true"> · </span>
@@ -219,18 +234,6 @@ import ThemeToggle from "../components/ThemeToggle.astro";
       ></div>
     </footer>
   </div>
-
-  <script is:inline type="application/ld+json" set:html={JSON.stringify({
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      { "@type": "Question", "name": "Is customer data used to train AI models?", "acceptedAnswer": { "@type": "Answer", "text": "No. Customer data is never used for model training. AI queries are scoped to the workspace and processed in real time without retention by the model provider." }},
-      { "@type": "Question", "name": "Where is data stored?", "acceptedAnswer": { "@type": "Answer", "text": "You choose the region. Our managed cloud supports EU, US, and Swiss deployments. Self-hosted runs wherever you choose." }},
-      { "@type": "Question", "name": "Do you support SSO?", "acceptedAnswer": { "@type": "Answer", "text": "SSO via Google Workspace and Microsoft Entra is available as an enterprise add-on. SAML support is on the roadmap." }},
-      { "@type": "Question", "name": "Can I export all my data?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. Full data export is available at any time in standard formats. There are no contractual or technical barriers to leaving." }},
-      { "@type": "Question", "name": "How do I report a vulnerability?", "acceptedAnswer": { "@type": "Answer", "text": "Email security@stll.app with details. We follow responsible disclosure practices and will acknowledge within 48 hours." }},
-    ],
-  })} />
 
   <style>
     .resource-card { cursor: pointer; }

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -46,6 +46,8 @@
     "warm": "Teplé"
   },
   "auth": {
+    "betaNoticeBody": "Jako preventivní opatření během bety nenahrávejte citlivá, privilegovaná, osobní, nenahraditelná ani produkčně kritická data. Cloud je demonstrační služba.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Vyberte organizaci, ve které chcete pracovat",
     "codeSentAgain": "Poslali jsme nový kód.",
     "continueWithEmail": "Pokračovat",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -46,6 +46,8 @@
     "warm": "Warm"
   },
   "auth": {
+    "betaNoticeBody": "Laden Sie während der Beta vorsichtshalber keine sensiblen, privilegierten, personenbezogenen, unersetzlichen oder produktionskritischen Daten hoch. Cloud ist ein Demodienst.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Wählen Sie die Organisation, in der Sie arbeiten möchten",
     "codeSentAgain": "Wir haben einen neuen Code gesendet.",
     "continueWithEmail": "Weiter",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -46,6 +46,8 @@
     "warm": "Warm"
   },
   "auth": {
+    "betaNoticeBody": "As a precaution during beta, do not upload sensitive, privileged, personal, irreplaceable, or production-critical data. Cloud is a demo service.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Choose which organization to work in",
     "codeSentAgain": "We sent a new code.",
     "continueWithEmail": "Continue",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -46,6 +46,8 @@
     "warm": "Cálido"
   },
   "auth": {
+    "betaNoticeBody": "Como precaución durante la beta, no subas datos sensibles, privilegiados, personales, irremplazables o críticos para producción. Cloud es un servicio de demostración.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Seleccione en qué organización desea trabajar",
     "codeSentAgain": "Hemos enviado un código nuevo.",
     "continueWithEmail": "Continuar",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -46,6 +46,8 @@
     "warm": "Soe"
   },
   "auth": {
+    "betaNoticeBody": "Ettevaatusabinõuna ärge laadige beetaperioodil üles tundlikke, privilegeeritud, isikuandmeid sisaldavaid, asendamatuid ega tootmiskriitilisi andmeid. Cloud on demoteenus.",
+    "betaNoticeTitle": "Beeta",
     "chooseOrganization": "Valige organisatsioon, milles soovite töötada",
     "codeSentAgain": "Saatsime uue koodi.",
     "continueWithEmail": "Jätka",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -46,6 +46,8 @@
     "warm": "Chaud"
   },
   "auth": {
+    "betaNoticeBody": "Par précaution pendant la bêta, n'importez pas de données sensibles, privilégiées, personnelles, irremplaçables ou critiques pour la production. Le cloud est un service de démonstration.",
+    "betaNoticeTitle": "Bêta",
     "chooseOrganization": "Choisissez l'organisation dans laquelle vous souhaitez travailler",
     "codeSentAgain": "Nous avons envoyé un nouveau code.",
     "continueWithEmail": "Continuer",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -46,6 +46,8 @@
     "warm": "Meleg"
   },
   "auth": {
+    "betaNoticeBody": "Elővigyázatosságból a béta időszakban ne töltsön fel érzékeny, privilegizált, személyes, pótolhatatlan vagy éles működéshez kritikus adatokat. A Cloud bemutató szolgáltatás.",
+    "betaNoticeTitle": "Béta",
     "chooseOrganization": "Válassza ki a szervezetet, amelyben dolgozni szeretne",
     "codeSentAgain": "Új kódot küldtünk.",
     "continueWithEmail": "Tovább",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -46,6 +46,8 @@
     "warm": "Šilti"
   },
   "auth": {
+    "betaNoticeBody": "Atsargumo sumetimais beta laikotarpiu neįkelkite jautrių, privilegijuotų, asmens duomenų, nepakeičiamų ar gamybai kritinių duomenų. Cloud yra demonstracinė paslauga.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Pasirinkite organizaciją, kurioje norite dirbti",
     "codeSentAgain": "Išsiuntėme naują kodą.",
     "continueWithEmail": "Tęsti",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -46,6 +46,8 @@
     "warm": "Silts"
   },
   "auth": {
+    "betaNoticeBody": "Piesardzības nolūkos beta periodā neaugšupielādējiet sensitīvus, priviliģētus, personas datus, neaizstājamus vai ražošanai kritiskus datus. Cloud ir demonstrācijas pakalpojums.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Izvēlieties organizāciju, kurā strādāt",
     "codeSentAgain": "Nosūtījām jaunu kodu.",
     "continueWithEmail": "Turpināt",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -49,6 +49,8 @@ type Messages = {
     "warm": "Warm";
   };
   "auth": {
+    "betaNoticeBody": "As a precaution during beta, do not upload sensitive, privileged, personal, irreplaceable, or production-critical data. Cloud is a demo service.";
+    "betaNoticeTitle": "Beta";
     "chooseOrganization": "Choose which organization to work in";
     "codeSentAgain": "We sent a new code.";
     "continueWithEmail": "Continue";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -46,6 +46,8 @@
     "warm": "Ciepłe"
   },
   "auth": {
+    "betaNoticeBody": "Na czas bety, dla ostrożności, nie przesyłaj danych wrażliwych, uprzywilejowanych, osobowych, niemożliwych do odtworzenia ani krytycznych produkcyjnie. Cloud jest usługą demonstracyjną.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Wybierz organizację, w której chcesz pracować",
     "codeSentAgain": "Wysłaliśmy nowy kod.",
     "continueWithEmail": "Kontynuuj",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -46,6 +46,8 @@
     "warm": "Teplé"
   },
   "auth": {
+    "betaNoticeBody": "Ako preventívne opatrenie počas bety nenahrávajte citlivé, privilegované, osobné, nenahraditeľné ani produkčne kritické údaje. Cloud je demo služba.",
+    "betaNoticeTitle": "Beta",
     "chooseOrganization": "Vyberte organizáciu, v ktorej chcete pracovať",
     "codeSentAgain": "Poslali sme nový kód.",
     "continueWithEmail": "Pokračovať",

--- a/apps/web/src/routes/auth/route.tsx
+++ b/apps/web/src/routes/auth/route.tsx
@@ -4,6 +4,8 @@ import { useTranslations } from "use-intl";
 import { LanguagePicker } from "@/components/language-picker";
 import { StellaWordmark } from "@/components/stella-wordmark";
 
+const landingUrl = "https://stll.app";
+
 export const Route = createFileRoute("/auth")({
   component: AuthLayout,
 });
@@ -27,7 +29,21 @@ function AuthLayout() {
       `}</style>
       <div className="flex flex-1 flex-col px-8 lg:px-16 xl:px-24">
         <header className="pt-12">
-          <StellaWordmark className="text-foreground h-6 w-auto" />
+          <a
+            aria-label="stella"
+            className="inline-flex transition-opacity hover:opacity-80"
+            href={landingUrl}
+          >
+            <StellaWordmark className="text-foreground h-6 w-auto" />
+          </a>
+          <div className="border-border bg-card/80 mt-8 max-w-2xl rounded-lg border p-4">
+            <p className="text-foreground text-sm font-medium">
+              {t("auth.betaNoticeTitle")}
+            </p>
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              {t("auth.betaNoticeBody")}
+            </p>
+          </div>
         </header>
         <div className="flex flex-1 flex-col items-center min-[70rem]:flex-row min-[70rem]:items-baseline">
           <div className="hidden flex-1 pt-[18vh] min-[70rem]:block">


### PR DESCRIPTION
JK: We are launching a public beta to gather feedback and build more openly. The product is still changing quickly as we refine the feature set and design, so please treat the current cloud preview and repository as a beta demo rather than production software. We will continue to harden the project toward production readiness, including review from third-party experts. We welcome community security review. If you find a security issue, **please** contact us privately rather than opening a public issue, so we can coordinate a fix.


## Summary
- updates landing usage options, public beta/demo wording, and app links
- adds beta demo warning to auth and security pages
- trims security resources/FAQ scaffolding and updates README beta feature copy

## Test plan
- bun run lint
- bun run format
- bun run typecheck
- bun --filter @stll/web i18n:check
- bun --filter @stll/web test
- git diff --check --cached

Full `bun run test` currently fails in `@stll/api` on current main with existing API test/module initialization failures unrelated to this copy/UI diff.
