### PR TITLE
feat: add anonymized AI boundary

### DIFF
--- a/apps/api/drizzle/20260503120000_anonymization_blacklist_entries/migration.sql
+++ b/apps/api/drizzle/20260503120000_anonymization_blacklist_entries/migration.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "anonymization_blacklist_entries" (
+	"id" uuid PRIMARY KEY,
+	"organization_id" varchar(128) NOT NULL,
+	"label" varchar(64) NOT NULL,
+	"canonical" varchar(512) NOT NULL,
+	"variants" jsonb DEFAULT '[]' NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"created_by" text,
+	"updated_by" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "anonymization_blacklist_entries" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX "anonymization_blacklist_entries_org_enabled_idx" ON "anonymization_blacklist_entries" ("organization_id","enabled");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "anonymization_blacklist_entries_org_canonical_uidx" ON "anonymization_blacklist_entries" ("organization_id","canonical");
+--> statement-breakpoint
+ALTER TABLE "anonymization_blacklist_entries" ADD CONSTRAINT "anonymization_blacklist_entries_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "anonymization_blacklist_entries" ADD CONSTRAINT "anonymization_blacklist_entries_created_by_user_id_fkey" FOREIGN KEY ("created_by") REFERENCES "user"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "anonymization_blacklist_entries" ADD CONSTRAINT "anonymization_blacklist_entries_updated_by_user_id_fkey" FOREIGN KEY ("updated_by") REFERENCES "user"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+CREATE POLICY "organization_select" ON "anonymization_blacklist_entries" AS PERMISSIVE FOR SELECT TO "stella" USING (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )));
+--> statement-breakpoint
+CREATE POLICY "organization_insert" ON "anonymization_blacklist_entries" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )));
+--> statement-breakpoint
+CREATE POLICY "organization_update" ON "anonymization_blacklist_entries" AS PERMISSIVE FOR UPDATE TO "stella" USING (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )));
+--> statement-breakpoint
+CREATE POLICY "organization_delete" ON "anonymization_blacklist_entries" AS PERMISSIVE FOR DELETE TO "stella" USING (organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )));

--- a/apps/api/drizzle/20260503120000_anonymization_blacklist_entries/migration.sql
+++ b/apps/api/drizzle/20260503120000_anonymization_blacklist_entries/migration.sql
@@ -15,7 +15,7 @@ ALTER TABLE "anonymization_blacklist_entries" ENABLE ROW LEVEL SECURITY;
 --> statement-breakpoint
 CREATE INDEX "anonymization_blacklist_entries_org_enabled_idx" ON "anonymization_blacklist_entries" ("organization_id","enabled");
 --> statement-breakpoint
-CREATE UNIQUE INDEX "anonymization_blacklist_entries_org_canonical_uidx" ON "anonymization_blacklist_entries" ("organization_id","canonical");
+CREATE UNIQUE INDEX "anonymization_blacklist_entries_org_canonical_uidx" ON "anonymization_blacklist_entries" ("organization_id",lower("canonical"));
 --> statement-breakpoint
 ALTER TABLE "anonymization_blacklist_entries" ADD CONSTRAINT "anonymization_blacklist_entries_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE;
 --> statement-breakpoint

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1644,7 +1644,7 @@ export const anonymizationBlacklistEntries = p.pgTable(
       .on(table.organizationId, table.enabled),
     p
       .uniqueIndex("anonymization_blacklist_entries_org_canonical_uidx")
-      .on(table.organizationId, table.canonical),
+      .on(table.organizationId, sql`lower(${table.canonical})`),
     ...orgPolicies(),
   ],
 );

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1614,6 +1614,41 @@ export const organizationSettings = p.pgTable(
   () => [...orgPolicies()],
 );
 
+export const anonymizationBlacklistEntries = p.pgTable(
+  "anonymization_blacklist_entries",
+  {
+    id: pUuid<"anonymizationBlacklistEntry">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    label: p.varchar({ length: 64 }).notNull(),
+    canonical: p.varchar({ length: 512 }).notNull(),
+    variants: jsonb().$type<string[]>().notNull().default([]),
+    enabled: p.boolean().notNull().default(true),
+    createdBy: p
+      .text("created_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    updatedBy: p
+      .text("updated_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    p
+      .index("anonymization_blacklist_entries_org_enabled_idx")
+      .on(table.organizationId, table.enabled),
+    p
+      .uniqueIndex("anonymization_blacklist_entries_org_canonical_uidx")
+      .on(table.organizationId, table.canonical),
+    ...orgPolicies(),
+  ],
+);
+
 export const clauseCategories = p.pgTable(
   "clause_categories",
   {
@@ -2330,6 +2365,7 @@ export const relations = defineRelations(
     matterCounters,
     documentCounters,
     organizationSettings,
+    anonymizationBlacklistEntries,
     clauseCategories,
     clauses,
     clauseVariants,
@@ -2762,6 +2798,7 @@ export const relations = defineRelations(
     matterCounters: {},
     documentCounters: {},
     organizationSettings: {},
+    anonymizationBlacklistEntries: {},
     clauseCategories: {
       parent: r.one.clauseCategories({
         from: r.clauseCategories.parentId,

--- a/apps/api/src/handlers/chat/chat-schema.ts
+++ b/apps/api/src/handlers/chat/chat-schema.ts
@@ -67,6 +67,7 @@ export const activeDecisionSchema = t.Object({
 export const sendMessageBodySchema = t.Object({
   threadId: tSafeId("chatThread"),
   workspaceId: t.Optional(tSafeId("workspace")),
+  anonymized: t.Optional(t.Boolean()),
   /**
    * Matters the chat draws context from. Empty (or omitted) means
    * "no matters pinned" — the AI discovers matters lazily via the

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -31,11 +31,11 @@ import {
   planMessagePersistence,
 } from "@/api/handlers/chat/persist-message";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
+import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import {
   intersectAccessibleWorkspaceIds,
   resolveToolWorkspaceIds,
 } from "@/api/handlers/chat/tools/authorized-workspace-ids";
-import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { getChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type {
@@ -200,6 +200,7 @@ const sendMessage = createSafeRootHandler(
     });
     const thirdPartyBoundary = createChatThirdPartyBoundary({
       anonymized: body.anonymized ?? false,
+      anonymizationScopeId: workspaceId ?? body.threadId,
       organizationId: session.activeOrganizationId,
       scopedDb,
     });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -225,6 +225,22 @@ const sendMessage = createSafeRootHandler(
       storedMessages: thread.data.messages,
     });
 
+    const messageWindow = latestMessagePlan.messages.slice(-MESSAGE_WINDOW);
+    const chatContext = yield* Result.await(
+      prepareChatContext({
+        activeDecision: body.activeDecision,
+        activeFile: body.activeFile,
+        contextMatterIds: effectiveContextMatterIds,
+        messageWindow,
+        refuseNonPlainTextFiles: thirdPartyBoundary.type === "anonymized",
+        safeDb,
+        userContext: body.userContext,
+        userId: user.id,
+        workspaceId,
+        refRegistry,
+      }),
+    );
+
     // Widen the thread's data scope BEFORE persisting the message so
     // any workspace IDs the user just embedded (entity mentions,
     // workspace mentions) are recorded on the thread row. Without
@@ -256,22 +272,6 @@ const sendMessage = createSafeRootHandler(
         userId: user.id,
         workspaceId,
         persistencePlan: latestMessagePlan.persistencePlan,
-      }),
-    );
-
-    const messageWindow = latestMessagePlan.messages.slice(-MESSAGE_WINDOW);
-    const chatContext = yield* Result.await(
-      prepareChatContext({
-        activeDecision: body.activeDecision,
-        activeFile: body.activeFile,
-        contextMatterIds: effectiveContextMatterIds,
-        messageWindow,
-        refuseNonPlainTextFiles: thirdPartyBoundary.type === "anonymized",
-        safeDb,
-        userContext: body.userContext,
-        userId: user.id,
-        workspaceId,
-        refRegistry,
       }),
     );
 

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -35,6 +35,7 @@ import {
   intersectAccessibleWorkspaceIds,
   resolveToolWorkspaceIds,
 } from "@/api/handlers/chat/tools/authorized-workspace-ids";
+import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import { getChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type {
@@ -197,6 +198,11 @@ const sendMessage = createSafeRootHandler(
       workspaceId,
       hasActiveFileChat: body.activeFile !== undefined,
     });
+    const thirdPartyBoundary = createChatThirdPartyBoundary({
+      anonymized: body.anonymized ?? false,
+      organizationId: session.activeOrganizationId,
+      scopedDb,
+    });
 
     const uploadedMessage = yield* Result.await(
       uploadMessageFilesWithRollback({
@@ -259,6 +265,7 @@ const sendMessage = createSafeRootHandler(
         activeFile: body.activeFile,
         contextMatterIds: effectiveContextMatterIds,
         messageWindow,
+        refuseNonPlainTextFiles: thirdPartyBoundary.type === "anonymized",
         safeDb,
         userContext: body.userContext,
         userId: user.id,
@@ -351,6 +358,7 @@ const sendMessage = createSafeRootHandler(
             promptCacheKey: chatContext.promptCacheKey,
             resolveAssistantTextRefs: refRegistry.resolveAssistantTextRefs,
             resolveAssistantValueRefs: refRegistry.resolveAssistantValueRefs,
+            thirdPartyBoundary,
             threadId: body.threadId,
             tools: chatTools,
             system: chatContext.system,
@@ -590,6 +598,7 @@ type PrepareChatContextProps = {
   contextMatterIds: SafeId<"workspace">[];
   messageWindow: ChatMessage[];
   refRegistry: ReturnType<typeof createChatRefRegistry>;
+  refuseNonPlainTextFiles: boolean;
   safeDb: SafeDb;
   userContext: IncomingUserContext | undefined;
   userId: SafeId<"user">;
@@ -611,6 +620,7 @@ const prepareChatContext = async ({
   contextMatterIds,
   messageWindow,
   refRegistry,
+  refuseNonPlainTextFiles,
   safeDb,
   userContext,
   userId,
@@ -629,6 +639,7 @@ const prepareChatContext = async ({
       }),
       hydrateMessages({
         messages: messageWindow,
+        refuseNonPlainTextFiles,
         safeDb,
         userId,
       }),

--- a/apps/api/src/handlers/chat/stream-chat.test.ts
+++ b/apps/api/src/handlers/chat/stream-chat.test.ts
@@ -1,11 +1,15 @@
 import type { InferUIMessageChunk } from "ai";
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import { createChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type { ChatMessage } from "@/api/handlers/chat/types";
+import { toUserFileUrl } from "@/api/handlers/user-files/types";
 import { toSafeId } from "@/api/lib/branded-types";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
-import { resolveRefsInTextStream } from "./stream-chat";
+import { hydrateMessages, resolveRefsInTextStream } from "./stream-chat";
 
 const collectChunks = async (
   stream: ReadableStream<InferUIMessageChunk<ChatMessage>>,
@@ -170,5 +174,64 @@ describe("chat stream refs", () => {
         success: true,
       },
     });
+  });
+});
+
+describe("chat message hydration", () => {
+  test("refuses stored DOCX attachments for anonymized third-party sends", async () => {
+    const userFileId = toSafeId<"userFile">(
+      "11111111-1111-4111-8111-111111111111",
+    );
+    const threadId = toSafeId<"chatThread">(
+      "22222222-2222-4222-8222-222222222222",
+    );
+    const userId = toSafeId<"user">("33333333-3333-4333-8333-333333333333");
+    const { safeDb } = createScopedDbMock({
+      query: {
+        userFiles: {
+          findMany: async () => [
+            {
+              id: userFileId,
+              userId,
+              threadId,
+              fileName: "draft.docx",
+              mimeType: DOCX_MIME_TYPE,
+              s3Key: "user/file",
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await hydrateMessages({
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          parts: [
+            {
+              type: "file",
+              filename: "draft.docx",
+              mediaType: DOCX_MIME_TYPE,
+              url: toUserFileUrl(userFileId),
+            },
+          ],
+        },
+      ],
+      refuseNonPlainTextFiles: true,
+      safeDb,
+      userId,
+    });
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected DOCX hydration refusal");
+    }
+
+    if (!("status" in result.error)) {
+      throw result.error;
+    }
+
+    expect(result.error.status).toBe(422);
   });
 });

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -10,8 +10,17 @@ import type { InferUIMessageChunk, UIMessageStreamOnFinishCallback } from "ai";
 import { panic, Result } from "better-result";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
-import { getUserFileIdFromPart } from "@/api/handlers/chat/attachment-validation";
+import {
+  getUserFileIdFromPart,
+  TEXT_PLAIN_MIME_TYPE,
+} from "@/api/handlers/chat/attachment-validation";
 import { repairActiveDocxEditToolCall } from "@/api/handlers/chat/tools/active-docx-edit-tool-repair";
+import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
+import {
+  prepareMessagesForThirdParty,
+  prepareTextForThirdParty,
+  prepareToolsForThirdParty,
+} from "@/api/handlers/chat/third-party-boundary";
 import type { ChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type { ChatMessage } from "@/api/handlers/chat/types";
@@ -20,6 +29,7 @@ import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 const MAX_TOOL_STEPS = 8;
 
@@ -43,6 +53,7 @@ type StreamChatProps = {
   resolveAssistantTextRefs?: ((text: string) => string) | undefined;
   resolveAssistantValueRefs?: AssistantValueRefResolver | undefined;
   system: string;
+  thirdPartyBoundary: ChatThirdPartyBoundary;
   threadId: SafeId<"chatThread">;
   tools: Partial<ChatTools>;
 };
@@ -56,13 +67,54 @@ export const streamChat = async ({
   resolveAssistantTextRefs,
   resolveAssistantValueRefs,
   system,
+  thirdPartyBoundary,
   threadId,
   tools,
 }: StreamChatProps) => {
-  const modelMessages = await convertToModelMessages(messages);
+  const preparedMessages = await prepareMessagesForThirdParty({
+    boundary: thirdPartyBoundary,
+    messages,
+  });
+
+  if (Result.isError(preparedMessages)) {
+    return new Response(
+      JSON.stringify({
+        message: preparedMessages.error.message,
+        type: "third_party_boundary_refusal",
+      }),
+      {
+        headers: { "Content-Type": "application/json" },
+        status: preparedMessages.error.status,
+      },
+    );
+  }
+
+  const preparedSystem = await prepareTextForThirdParty({
+    boundary: thirdPartyBoundary,
+    text: system,
+  });
+
+  if (Result.isError(preparedSystem)) {
+    return new Response(
+      JSON.stringify({
+        message: preparedSystem.error.message,
+        type: "third_party_boundary_refusal",
+      }),
+      {
+        headers: { "Content-Type": "application/json" },
+        status: preparedSystem.error.status,
+      },
+    );
+  }
+
+  const modelMessages = await convertToModelMessages(preparedMessages.value);
+  const modelTools = prepareToolsForThirdParty({
+    boundary: thirdPartyBoundary,
+    tools,
+  });
   const stream = createUIMessageStream<ChatMessage>({
     generateId: () => Bun.randomUUIDv7(),
-    originalMessages: messages,
+    originalMessages: preparedMessages.value,
     onFinish,
     onError: (error) => {
       captureError(error, { threadId });
@@ -73,8 +125,8 @@ export const streamChat = async ({
         abortSignal,
         model: getModelForRole("chat", orgAIConfig),
         temperature: getTemperatureForRole("chat"),
-        system,
-        tools,
+        system: preparedSystem.value,
+        tools: modelTools,
         experimental_repairToolCall: async ({ toolCall }) =>
           await Promise.resolve(repairActiveDocxEditToolCall(toolCall)),
         providerOptions: {
@@ -191,12 +243,14 @@ export const resolveRefsInTextStream = (
 
 type HydrateMessagesProps = {
   messages: ChatMessage[];
+  refuseNonPlainTextFiles?: boolean | undefined;
   safeDb: SafeDb;
   userId: SafeId<"user">;
 };
 
 export const hydrateMessages = async ({
   messages,
+  refuseNonPlainTextFiles = false,
   safeDb,
   userId,
 }: HydrateMessagesProps) =>
@@ -227,6 +281,16 @@ export const hydrateMessages = async ({
         const file = userFilesById.get(fileIdResult.value);
         if (!file) {
           panic("Persisted chat file reference missing user_files row");
+        }
+
+        if (refuseNonPlainTextFiles && file.mimeType !== TEXT_PLAIN_MIME_TYPE) {
+          return Result.err(
+            new HandlerError({
+              status: 422,
+              message:
+                "Cannot send this attachment to the AI in anonymized mode because Stella cannot extract and anonymize it safely.",
+            }),
+          );
         }
 
         const hydratedPart = yield* Result.await(

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -71,10 +71,16 @@ export const streamChat = async ({
   threadId,
   tools,
 }: StreamChatProps) => {
-  const preparedMessages = await prepareMessagesForThirdParty({
-    boundary: thirdPartyBoundary,
-    messages,
-  });
+  const [preparedMessages, preparedSystem] = await Promise.all([
+    prepareMessagesForThirdParty({
+      boundary: thirdPartyBoundary,
+      messages,
+    }),
+    prepareTextForThirdParty({
+      boundary: thirdPartyBoundary,
+      text: system,
+    }),
+  ]);
 
   if (Result.isError(preparedMessages)) {
     return new Response(
@@ -88,11 +94,6 @@ export const streamChat = async ({
       },
     );
   }
-
-  const preparedSystem = await prepareTextForThirdParty({
-    boundary: thirdPartyBoundary,
-    text: system,
-  });
 
   if (Result.isError(preparedSystem)) {
     return new Response(

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -14,13 +14,13 @@ import {
   getUserFileIdFromPart,
   TEXT_PLAIN_MIME_TYPE,
 } from "@/api/handlers/chat/attachment-validation";
-import { repairActiveDocxEditToolCall } from "@/api/handlers/chat/tools/active-docx-edit-tool-repair";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import {
   prepareMessagesForThirdParty,
   prepareTextForThirdParty,
   prepareToolsForThirdParty,
 } from "@/api/handlers/chat/third-party-boundary";
+import { repairActiveDocxEditToolCall } from "@/api/handlers/chat/tools/active-docx-edit-tool-repair";
 import type { ChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type { ChatMessage } from "@/api/handlers/chat/types";

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -168,8 +168,12 @@ describe("chat third-party anonymization boundary", () => {
   test("returns anonymized live tool output values", async () => {
     const boundary = createBoundary();
     const tools = {
-      "read-secret": {
-        execute: async () => ({ text: "Secret notes for Jan Novák" }),
+      read_secret: {
+        execute: async () => ({
+          documentId: "doc_Secret_Jan_Novák",
+          ids: ["person_Secret"],
+          text: "Secret notes for Jan Novák",
+        }),
       },
     };
     const prepared = prepareToolsForThirdParty({
@@ -180,11 +184,13 @@ describe("chat third-party anonymization boundary", () => {
     });
     // SAFETY: the test fixture above defines this execute signature.
     // eslint-disable-next-line typescript/no-unsafe-type-assertion
-    const executable = prepared["read-secret"] as
+    const executable = prepared["read_secret"] as
       | { execute?: (() => Promise<unknown>) | undefined }
       | undefined;
 
     expect(await executable?.execute?.()).toEqual({
+      documentId: "doc_Secret_Jan_Novák",
+      ids: ["person_Secret"],
       text: "[CUSTOM_1] notes for [PERSON_1]",
     });
   });

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -1,0 +1,191 @@
+import type { ToolSet } from "ai";
+import { Result } from "better-result";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { TEXT_PLAIN_MIME_TYPE } from "@/api/handlers/chat/attachment-validation";
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import { toSafeId } from "@/api/lib/branded-types";
+import { toDataUrl } from "@/api/lib/data-url";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
+
+const anonymizeTextFieldsMock = mock(
+  async ({ fields }: { fields: string[] }) => ({
+    entityCount: fields.length,
+    fields: fields.map((field) =>
+      field
+        .replaceAll("Jan Novák", "[PERSON_1]")
+        .replaceAll("Secret", "[CUSTOM_1]"),
+    ),
+  }),
+);
+
+const {
+  createChatThirdPartyBoundary,
+  prepareMessagesForThirdParty,
+  prepareTextForThirdParty,
+  prepareToolsForThirdParty,
+} = await import("@/api/handlers/chat/third-party-boundary");
+
+const createBoundary = () => {
+  const { scopedDb } = createScopedDbMock({});
+
+  return createChatThirdPartyBoundary({
+    anonymized: true,
+    anonymizeFields: anonymizeTextFieldsMock,
+    organizationId: toSafeId<"organization">(
+      "11111111-1111-4111-8111-111111111111",
+    ),
+    scopedDb,
+  });
+};
+
+describe("chat third-party anonymization boundary", () => {
+  beforeEach(() => {
+    anonymizeTextFieldsMock.mockClear();
+  });
+
+  test("anonymizes system text and message text before provider use", async () => {
+    const boundary = createBoundary();
+    const system = await prepareTextForThirdParty({
+      boundary,
+      text: "System context mentions Jan Novák and Secret.",
+    });
+
+    expect(Result.isOk(system)).toBe(true);
+    if (Result.isError(system)) {
+      throw system.error;
+    }
+
+    expect(system.value).toBe(
+      "System context mentions [PERSON_1] and [CUSTOM_1].",
+    );
+
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "user",
+        parts: [
+          {
+            type: "text",
+            text: "Does Jan Novák appear in Secret contract?",
+          },
+        ],
+      },
+    ];
+
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages,
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+
+    expect(prepared.value?.at(0)?.parts.at(0)).toEqual({
+      type: "text",
+      text: "Does [PERSON_1] appear in [CUSTOM_1] contract?",
+    });
+  });
+
+  test("refuses attachments that cannot be safely anonymized as text", async () => {
+    const boundary = createBoundary();
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            filename: "Jan Novák draft.docx",
+            mediaType: DOCX_MIME_TYPE,
+            url: toDataUrl(new Uint8Array([1, 2, 3]), DOCX_MIME_TYPE),
+          },
+        ],
+      },
+    ];
+
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages,
+    });
+
+    expect(Result.isError(prepared)).toBe(true);
+    if (Result.isOk(prepared)) {
+      throw new Error("Expected attachment refusal");
+    }
+
+    expect(prepared.error.status).toBe(422);
+    expect(anonymizeTextFieldsMock).not.toHaveBeenCalled();
+  });
+
+  test("rewrites plain-text attachment data URLs with anonymized content", async () => {
+    const boundary = createBoundary();
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            filename: "Jan Novák notes.txt",
+            mediaType: TEXT_PLAIN_MIME_TYPE,
+            url: toDataUrl(
+              Buffer.from("Secret notes for Jan Novák", "utf-8"),
+              TEXT_PLAIN_MIME_TYPE,
+            ),
+          },
+        ],
+      },
+    ];
+
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages,
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+
+    const part = prepared.value?.at(0)?.parts.at(0);
+
+    expect(part).toMatchObject({
+      type: "file",
+      filename: "[PERSON_1] notes.txt",
+      mediaType: TEXT_PLAIN_MIME_TYPE,
+    });
+    expect(part?.type === "file" ? part.url : "").toContain(
+      Buffer.from("[CUSTOM_1] notes for [PERSON_1]", "utf-8").toString(
+        "base64",
+      ),
+    );
+  });
+
+  test("returns anonymized live tool output values", async () => {
+    const boundary = createBoundary();
+    const tools = {
+      "read-secret": {
+        execute: async () => ({ text: "Secret notes for Jan Novák" }),
+      },
+    };
+    const prepared = prepareToolsForThirdParty({
+      boundary,
+      // SAFETY: the helper only reads and wraps execute() in this unit test.
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
+      tools: tools as unknown as ToolSet,
+    });
+    // SAFETY: the test fixture above defines this execute signature.
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
+    const executable = prepared["read-secret"] as
+      | { execute?: (() => Promise<unknown>) | undefined }
+      | undefined;
+
+    expect(await executable?.execute?.()).toEqual({
+      text: "[CUSTOM_1] notes for [PERSON_1]",
+    });
+  });
+});

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -171,8 +171,9 @@ describe("chat third-party anonymization boundary", () => {
     const tools = {
       read_secret: {
         execute: async () => ({
-          documentId: "doc_Secret_Jan_Novák",
-          ids: ["person_Secret"],
+          documentId: "doc_123",
+          ids: ["person_456"],
+          nationalId: "Secret-123",
           text: "Secret notes for Jan Novák",
         }),
       },
@@ -190,8 +191,9 @@ describe("chat third-party anonymization boundary", () => {
       | undefined;
 
     expect(await executable?.execute?.()).toEqual({
-      documentId: "doc_Secret_Jan_Novák",
-      ids: ["person_Secret"],
+      documentId: "doc_123",
+      ids: ["person_456"],
+      nationalId: "[CUSTOM_1]-123",
       text: "[CUSTOM_1] notes for [PERSON_1]",
     });
   });

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -33,6 +33,7 @@ const createBoundary = () => {
   return createChatThirdPartyBoundary({
     anonymized: true,
     anonymizeFields: anonymizeTextFieldsMock,
+    anonymizationScopeId: "workspace-A",
     organizationId: toSafeId<"organization">(
       "11111111-1111-4111-8111-111111111111",
     ),

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -18,6 +18,7 @@ export type ChatThirdPartyBoundary =
   | { type: "raw" }
   | {
       anonymizeFields?: typeof anonymizeTextFields | undefined;
+      anonymizationScopeId: string;
       gazetteerEntries: ReturnType<typeof loadAnonymizationGazetteerEntries>;
       organizationId: SafeId<"organization">;
       scopedDb: ScopedDb;
@@ -27,11 +28,13 @@ export type ChatThirdPartyBoundary =
 export const createChatThirdPartyBoundary = ({
   anonymized,
   anonymizeFields,
+  anonymizationScopeId,
   organizationId,
   scopedDb,
 }: {
   anonymized: boolean;
   anonymizeFields?: typeof anonymizeTextFields | undefined;
+  anonymizationScopeId: string;
   organizationId: SafeId<"organization">;
   scopedDb: ScopedDb;
 }): ChatThirdPartyBoundary =>
@@ -39,6 +42,7 @@ export const createChatThirdPartyBoundary = ({
     ? {
         type: "anonymized",
         anonymizeFields,
+        anonymizationScopeId,
         gazetteerEntries: anonymizeFields
           ? Promise.resolve([])
           : loadAnonymizationGazetteerEntries({ organizationId, scopedDb }),
@@ -68,7 +72,7 @@ export const prepareTextForThirdParty = async ({
         gazetteerEntries: await boundary.gazetteerEntries,
         organizationId: boundary.organizationId,
         scopedDb: boundary.scopedDb,
-        workspaceId: boundary.organizationId,
+        workspaceId: boundary.anonymizationScopeId,
       }),
     catch: (cause) =>
       new HandlerError({

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -3,18 +3,22 @@ import { isFileUIPart, isToolUIPart } from "ai";
 import { Result } from "better-result";
 
 import type { ScopedDb } from "@/api/db";
-import { TEXT_PLAIN_MIME_TYPE } from "@/api/handlers/chat/attachment-validation";
+import {
+  CHAT_MAX_FILE_BYTES,
+  TEXT_PLAIN_MIME_TYPE,
+} from "@/api/handlers/chat/attachment-validation";
 import type { ChatMessage } from "@/api/handlers/chat/types";
+import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
 import type { SafeId } from "@/api/lib/branded-types";
 import { parseDataUrl, toDataUrl } from "@/api/lib/data-url";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { LIMITS } from "@/api/lib/limits";
 import { anonymizeTextFields } from "@/api/mcp/anonymization";
 
 export type ChatThirdPartyBoundary =
   | { type: "raw" }
   | {
       anonymizeFields?: typeof anonymizeTextFields | undefined;
+      gazetteerEntries: ReturnType<typeof loadAnonymizationGazetteerEntries>;
       organizationId: SafeId<"organization">;
       scopedDb: ScopedDb;
       type: "anonymized";
@@ -32,7 +36,15 @@ export const createChatThirdPartyBoundary = ({
   scopedDb: ScopedDb;
 }): ChatThirdPartyBoundary =>
   anonymized
-    ? { type: "anonymized", anonymizeFields, organizationId, scopedDb }
+    ? {
+        type: "anonymized",
+        anonymizeFields,
+        gazetteerEntries: anonymizeFields
+          ? Promise.resolve([])
+          : loadAnonymizationGazetteerEntries({ organizationId, scopedDb }),
+        organizationId,
+        scopedDb,
+      }
     : { type: "raw" };
 
 type BoundaryRefusal = HandlerError<422 | 500>;
@@ -53,6 +65,7 @@ export const prepareTextForThirdParty = async ({
     try: async () =>
       await anonymizeFields({
         fields: [text],
+        gazetteerEntries: await boundary.gazetteerEntries,
         organizationId: boundary.organizationId,
         scopedDb: boundary.scopedDb,
         workspaceId: boundary.organizationId,
@@ -91,7 +104,7 @@ const anonymizePlainTextFile = async ({
 
   const parsed = parseDataUrl({
     expectedMimeType: TEXT_PLAIN_MIME_TYPE,
-    maxBytes: LIMITS.chatContextFileMaxChars * 4,
+    maxBytes: CHAT_MAX_FILE_BYTES,
     url: part.url,
   });
 
@@ -265,11 +278,36 @@ export const prepareMessagesForThirdParty = async ({
   });
 };
 
+const shouldPreserveStructuredString = (key: string): boolean => {
+  const normalized = key.toLocaleLowerCase();
+
+  return (
+    normalized === "id" ||
+    normalized === "ids" ||
+    normalized === "uuid" ||
+    normalized === "uuids" ||
+    normalized.endsWith("_id") ||
+    normalized.endsWith("_ids") ||
+    normalized.endsWith("_uuid") ||
+    normalized.endsWith("_uuids") ||
+    key.endsWith("Id") ||
+    key.endsWith("Ids") ||
+    key.endsWith("ID") ||
+    key.endsWith("IDs") ||
+    key.endsWith("Uuid") ||
+    key.endsWith("Uuids") ||
+    key.endsWith("UUID") ||
+    key.endsWith("UUIDs")
+  );
+};
+
 const anonymizeUnknownStrings = async ({
   boundary,
+  key,
   value,
 }: {
   boundary: ChatThirdPartyBoundary;
+  key?: string | undefined;
   value: unknown;
 }): Promise<Result<unknown, BoundaryRefusal>> => {
   if (boundary.type === "raw") {
@@ -277,6 +315,10 @@ const anonymizeUnknownStrings = async ({
   }
 
   if (typeof value === "string") {
+    if (key && shouldPreserveStructuredString(key)) {
+      return Result.ok(value);
+    }
+
     return await prepareTextForThirdParty({ boundary, text: value });
   }
 
@@ -287,7 +329,7 @@ const anonymizeUnknownStrings = async ({
       for (const item of value) {
         output.push(
           yield* Result.await(
-            anonymizeUnknownStrings({ boundary, value: item }),
+            anonymizeUnknownStrings({ boundary, key, value: item }),
           ),
         );
       }
@@ -303,12 +345,13 @@ const anonymizeUnknownStrings = async ({
   return await Result.gen(async function* () {
     const entries: [string, unknown][] = [];
 
-    for (const [key, nestedValue] of Object.entries(value)) {
+    for (const [nestedKey, nestedValue] of Object.entries(value)) {
       entries.push([
-        key,
+        nestedKey,
         yield* Result.await(
           anonymizeUnknownStrings({
             boundary,
+            key: nestedKey,
             value: nestedValue,
           }),
         ),

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -1,0 +1,432 @@
+import type { FileUIPart, ToolSet } from "ai";
+import { isFileUIPart, isToolUIPart } from "ai";
+import { Result } from "better-result";
+
+import type { ScopedDb } from "@/api/db";
+import { TEXT_PLAIN_MIME_TYPE } from "@/api/handlers/chat/attachment-validation";
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { parseDataUrl, toDataUrl } from "@/api/lib/data-url";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+import { anonymizeTextFields } from "@/api/mcp/anonymization";
+
+export type ChatThirdPartyBoundary =
+  | { type: "raw" }
+  | {
+      anonymizeFields?: typeof anonymizeTextFields | undefined;
+      organizationId: SafeId<"organization">;
+      scopedDb: ScopedDb;
+      type: "anonymized";
+    };
+
+export const createChatThirdPartyBoundary = ({
+  anonymized,
+  anonymizeFields,
+  organizationId,
+  scopedDb,
+}: {
+  anonymized: boolean;
+  anonymizeFields?: typeof anonymizeTextFields | undefined;
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+}): ChatThirdPartyBoundary =>
+  anonymized
+    ? { type: "anonymized", anonymizeFields, organizationId, scopedDb }
+    : { type: "raw" };
+
+type BoundaryRefusal = HandlerError<422 | 500>;
+
+export const prepareTextForThirdParty = async ({
+  boundary,
+  text,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  text: string;
+}): Promise<Result<string, BoundaryRefusal>> => {
+  if (boundary.type === "raw" || text.length === 0) {
+    return Result.ok(text);
+  }
+
+  const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  const anonymized = await Result.tryPromise({
+    try: async () =>
+      await anonymizeFields({
+        fields: [text],
+        organizationId: boundary.organizationId,
+        scopedDb: boundary.scopedDb,
+        workspaceId: boundary.organizationId,
+      }),
+    catch: (cause) =>
+      new HandlerError({
+        status: 500,
+        message: "Failed to anonymize content before sending it to the AI.",
+        cause,
+      }),
+  });
+
+  if (Result.isError(anonymized)) {
+    return Result.err(anonymized.error);
+  }
+
+  return Result.ok(anonymized.value.fields.at(0) ?? "");
+};
+
+const anonymizePlainTextFile = async ({
+  boundary,
+  part,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  part: FileUIPart;
+}): Promise<Result<FileUIPart, BoundaryRefusal>> => {
+  if (part.mediaType !== TEXT_PLAIN_MIME_TYPE) {
+    return Result.err(
+      new HandlerError({
+        status: 422,
+        message:
+          "Cannot send this attachment to the AI in anonymized mode because Stella cannot extract and anonymize it safely.",
+      }),
+    );
+  }
+
+  const parsed = parseDataUrl({
+    expectedMimeType: TEXT_PLAIN_MIME_TYPE,
+    maxBytes: LIMITS.chatContextFileMaxChars * 4,
+    url: part.url,
+  });
+
+  if (Result.isError(parsed)) {
+    return Result.err(
+      new HandlerError({
+        status: 422,
+        message:
+          "Cannot send this attachment to the AI in anonymized mode because Stella cannot read it as text.",
+        cause: parsed.error,
+      }),
+    );
+  }
+
+  const text = Buffer.from(parsed.value.bytes).toString("utf-8");
+  const anonymizedTextResult = await prepareTextForThirdParty({
+    boundary,
+    text,
+  });
+
+  if (Result.isError(anonymizedTextResult)) {
+    return Result.err(anonymizedTextResult.error);
+  }
+
+  const filenameResult = part.filename
+    ? await prepareTextForThirdParty({ boundary, text: part.filename })
+    : Result.ok<string | undefined>(undefined);
+
+  if (Result.isError(filenameResult)) {
+    return Result.err(filenameResult.error);
+  }
+
+  return Result.ok({
+    ...part,
+    ...(filenameResult.value ? { filename: filenameResult.value } : {}),
+    mediaType: TEXT_PLAIN_MIME_TYPE,
+    url: toDataUrl(
+      Buffer.from(anonymizedTextResult.value, "utf-8"),
+      TEXT_PLAIN_MIME_TYPE,
+    ),
+  });
+};
+
+const preparePartForThirdParty = async ({
+  boundary,
+  part,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  part: ChatMessage["parts"][number];
+}): Promise<Result<ChatMessage["parts"][number], BoundaryRefusal>> => {
+  if (boundary.type === "raw") {
+    return Result.ok(part);
+  }
+
+  if (part.type === "text" || part.type === "reasoning") {
+    const text = await prepareTextForThirdParty({ boundary, text: part.text });
+
+    if (Result.isError(text)) {
+      return Result.err(text.error);
+    }
+
+    return Result.ok({
+      ...part,
+      text: text.value,
+    });
+  }
+
+  if (isFileUIPart(part)) {
+    return await anonymizePlainTextFile({ boundary, part });
+  }
+
+  if (isToolUIPart(part)) {
+    return await anonymizeToolPart({ boundary, part });
+  }
+
+  if (part.type === "source-document") {
+    const title = await prepareTextForThirdParty({
+      boundary,
+      text: part.title,
+    });
+
+    if (Result.isError(title)) {
+      return Result.err(title.error);
+    }
+
+    const filename = part.filename
+      ? await prepareTextForThirdParty({
+          boundary,
+          text: part.filename,
+        })
+      : Result.ok<string | undefined>(undefined);
+
+    if (Result.isError(filename)) {
+      return Result.err(filename.error);
+    }
+
+    return Result.ok({
+      ...part,
+      title: title.value,
+      ...(filename.value ? { filename: filename.value } : {}),
+    });
+  }
+
+  if (part.type === "source-url" && part.title) {
+    const title = await prepareTextForThirdParty({
+      boundary,
+      text: part.title,
+    });
+
+    if (Result.isError(title)) {
+      return Result.err(title.error);
+    }
+
+    return Result.ok({
+      ...part,
+      title: title.value,
+    });
+  }
+
+  if ("data" in part) {
+    const data = await anonymizeUnknownStrings({
+      boundary,
+      value: part.data,
+    });
+
+    if (Result.isError(data)) {
+      return Result.err(data.error);
+    }
+
+    const preparedPart = {
+      ...part,
+      data: data.value,
+    };
+
+    // SAFETY: data part discriminators and IDs are preserved. The recursive
+    // anonymizer only replaces nested string values in the existing data shape.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return Result.ok(preparedPart as ChatMessage["parts"][number]);
+  }
+
+  return Result.ok(part);
+};
+
+export const prepareMessagesForThirdParty = async ({
+  boundary,
+  messages,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  messages: ChatMessage[];
+}): Promise<Result<ChatMessage[], BoundaryRefusal>> => {
+  if (boundary.type === "raw") {
+    return Result.ok(messages);
+  }
+
+  return await Result.gen(async function* () {
+    const prepared: ChatMessage[] = [];
+
+    for (const message of messages) {
+      const parts: ChatMessage["parts"] = [];
+
+      for (const part of message.parts) {
+        parts.push(
+          yield* Result.await(preparePartForThirdParty({ boundary, part })),
+        );
+      }
+
+      prepared.push({ ...message, parts });
+    }
+
+    return Result.ok(prepared);
+  });
+};
+
+const anonymizeUnknownStrings = async ({
+  boundary,
+  value,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  value: unknown;
+}): Promise<Result<unknown, BoundaryRefusal>> => {
+  if (boundary.type === "raw") {
+    return Result.ok(value);
+  }
+
+  if (typeof value === "string") {
+    return await prepareTextForThirdParty({ boundary, text: value });
+  }
+
+  if (Array.isArray(value)) {
+    return await Result.gen(async function* () {
+      const output: unknown[] = [];
+
+      for (const item of value) {
+        output.push(
+          yield* Result.await(
+            anonymizeUnknownStrings({ boundary, value: item }),
+          ),
+        );
+      }
+
+      return Result.ok(output);
+    });
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return Result.ok(value);
+  }
+
+  return await Result.gen(async function* () {
+    const entries: [string, unknown][] = [];
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+      entries.push([
+        key,
+        yield* Result.await(
+          anonymizeUnknownStrings({
+            boundary,
+            value: nestedValue,
+          }),
+        ),
+      ]);
+    }
+
+    return Result.ok(Object.fromEntries(entries));
+  });
+};
+
+type ToolLikePart = Extract<ChatMessage["parts"][number], { state: string }>;
+
+const anonymizeToolPart = async ({
+  boundary,
+  part,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  part: ToolLikePart;
+}): Promise<Result<ToolLikePart, BoundaryRefusal>> =>
+  await Result.gen(async function* () {
+    const input =
+      "input" in part
+        ? yield* Result.await(
+            anonymizeUnknownStrings({ boundary, value: part.input }),
+          )
+        : undefined;
+
+    const output =
+      "output" in part
+        ? yield* Result.await(
+            anonymizeUnknownStrings({ boundary, value: part.output }),
+          )
+        : undefined;
+
+    const errorText =
+      "errorText" in part && part.errorText
+        ? yield* Result.await(
+            prepareTextForThirdParty({ boundary, text: part.errorText }),
+          )
+        : undefined;
+
+    const title =
+      "title" in part && part.title
+        ? yield* Result.await(
+            prepareTextForThirdParty({ boundary, text: part.title }),
+          )
+        : undefined;
+
+    const approvalReason =
+      "approval" in part &&
+      part.approval !== undefined &&
+      "reason" in part.approval &&
+      part.approval.reason
+        ? yield* Result.await(
+            prepareTextForThirdParty({
+              boundary,
+              text: part.approval.reason,
+            }),
+          )
+        : undefined;
+
+    const prepared = {
+      ...part,
+      ...("input" in part ? { input } : {}),
+      ...("output" in part ? { output } : {}),
+      ...(errorText ? { errorText } : {}),
+      ...(title ? { title } : {}),
+      ...(approvalReason && "approval" in part
+        ? { approval: { ...part.approval, reason: approvalReason } }
+        : {}),
+    };
+
+    // SAFETY: the tool UI part discriminator fields are preserved. We only
+    // anonymize provider-visible text nested in input/output/error/title fields.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    return Result.ok(prepared as ToolLikePart);
+  });
+
+export const prepareToolsForThirdParty = <TTools extends ToolSet>({
+  boundary,
+  tools,
+}: {
+  boundary: ChatThirdPartyBoundary;
+  tools: TTools;
+}): TTools => {
+  if (boundary.type === "raw") {
+    return tools;
+  }
+
+  const wrapped: Partial<TTools> = {};
+
+  for (const key of Object.keys(tools) as (keyof TTools & string)[]) {
+    const current = tools[key];
+    if (!current?.execute) {
+      wrapped[key] = current;
+      continue;
+    }
+
+    const execute = current.execute;
+    wrapped[key] = {
+      ...current,
+      execute: async (...args: Parameters<typeof execute>) => {
+        const anonymizedOutput = await anonymizeUnknownStrings({
+          boundary,
+          value: await execute(...args),
+        });
+
+        if (Result.isError(anonymizedOutput)) {
+          throw anonymizedOutput.error;
+        }
+
+        return anonymizedOutput.value;
+      },
+    };
+  }
+
+  // SAFETY: each tool is copied unchanged except for execute(), whose output
+  // is recursively string-anonymized while preserving the original shape.
+  // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+  return wrapped as TTools;
+};

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -53,6 +53,11 @@ export const createChatThirdPartyBoundary = ({
 
 type BoundaryRefusal = HandlerError<422 | 500>;
 
+type TextReplacement = {
+  text: string;
+  apply: (value: string) => void;
+};
+
 export const prepareTextForThirdParty = async ({
   boundary,
   text,
@@ -89,13 +94,71 @@ export const prepareTextForThirdParty = async ({
   return Result.ok(anonymized.value.fields.at(0) ?? "");
 };
 
-const anonymizePlainTextFile = async ({
+const prepareTextBatchForThirdParty = async ({
   boundary,
-  part,
+  replacements,
 }: {
-  boundary: ChatThirdPartyBoundary;
+  boundary: Extract<ChatThirdPartyBoundary, { type: "anonymized" }>;
+  replacements: TextReplacement[];
+}): Promise<Result<void, BoundaryRefusal>> => {
+  const fields = replacements.map((replacement) => replacement.text);
+  if (fields.every((field) => field.length === 0)) {
+    return Result.ok(undefined);
+  }
+
+  const anonymizeFields = boundary.anonymizeFields ?? anonymizeTextFields;
+  const anonymized = await Result.tryPromise({
+    try: async () =>
+      await anonymizeFields({
+        fields,
+        gazetteerEntries: await boundary.gazetteerEntries,
+        organizationId: boundary.organizationId,
+        scopedDb: boundary.scopedDb,
+        workspaceId: boundary.anonymizationScopeId,
+      }),
+    catch: (cause) =>
+      new HandlerError({
+        status: 500,
+        message: "Failed to anonymize content before sending it to the AI.",
+        cause,
+      }),
+  });
+
+  if (Result.isError(anonymized)) {
+    return Result.err(anonymized.error);
+  }
+
+  for (let index = 0; index < replacements.length; index += 1) {
+    const replacement = replacements[index];
+    if (replacement === undefined) {
+      continue;
+    }
+
+    replacement.apply(anonymized.value.fields.at(index) ?? "");
+  }
+
+  return Result.ok(undefined);
+};
+
+const queueTextReplacement = (
+  replacements: TextReplacement[],
+  text: string,
+  apply: (value: string) => void,
+) => {
+  if (text.length === 0) {
+    return;
+  }
+
+  replacements.push({ text, apply });
+};
+
+const anonymizePlainTextFile = ({
+  part,
+  replacements,
+}: {
   part: FileUIPart;
-}): Promise<Result<FileUIPart, BoundaryRefusal>> => {
+  replacements: TextReplacement[];
+}): Result<FileUIPart, BoundaryRefusal> => {
   if (part.mediaType !== TEXT_PLAIN_MIME_TYPE) {
     return Result.err(
       new HandlerError({
@@ -124,113 +187,94 @@ const anonymizePlainTextFile = async ({
   }
 
   const text = Buffer.from(parsed.value.bytes).toString("utf-8");
-  const anonymizedTextResult = await prepareTextForThirdParty({
-    boundary,
-    text,
-  });
+  let anonymizedText = text;
+  let filename = part.filename;
 
-  if (Result.isError(anonymizedTextResult)) {
-    return Result.err(anonymizedTextResult.error);
-  }
-
-  const filenameResult = part.filename
-    ? await prepareTextForThirdParty({ boundary, text: part.filename })
-    : Result.ok<string | undefined>(undefined);
-
-  if (Result.isError(filenameResult)) {
-    return Result.err(filenameResult.error);
-  }
-
-  return Result.ok({
+  const prepared: FileUIPart = {
     ...part,
-    ...(filenameResult.value ? { filename: filenameResult.value } : {}),
+    ...(filename ? { filename } : {}),
     mediaType: TEXT_PLAIN_MIME_TYPE,
-    url: toDataUrl(
-      Buffer.from(anonymizedTextResult.value, "utf-8"),
+    url: toDataUrl(Buffer.from(anonymizedText, "utf-8"), TEXT_PLAIN_MIME_TYPE),
+  };
+
+  queueTextReplacement(replacements, text, (value) => {
+    anonymizedText = value;
+    prepared.url = toDataUrl(
+      Buffer.from(anonymizedText, "utf-8"),
       TEXT_PLAIN_MIME_TYPE,
-    ),
+    );
   });
+
+  if (filename) {
+    queueTextReplacement(replacements, filename, (value) => {
+      filename = value;
+      prepared.filename = filename;
+    });
+  }
+
+  return Result.ok(prepared);
 };
 
-const preparePartForThirdParty = async ({
+const preparePartForThirdParty = ({
   boundary,
   part,
+  replacements,
 }: {
   boundary: ChatThirdPartyBoundary;
   part: ChatMessage["parts"][number];
-}): Promise<Result<ChatMessage["parts"][number], BoundaryRefusal>> => {
+  replacements: TextReplacement[];
+}): Result<ChatMessage["parts"][number], BoundaryRefusal> => {
   if (boundary.type === "raw") {
     return Result.ok(part);
   }
 
   if (part.type === "text" || part.type === "reasoning") {
-    const text = await prepareTextForThirdParty({ boundary, text: part.text });
-
-    if (Result.isError(text)) {
-      return Result.err(text.error);
-    }
-
-    return Result.ok({
-      ...part,
-      text: text.value,
+    const prepared = { ...part };
+    queueTextReplacement(replacements, part.text, (value) => {
+      prepared.text = value;
     });
+    return Result.ok(prepared);
   }
 
   if (isFileUIPart(part)) {
-    return await anonymizePlainTextFile({ boundary, part });
+    return anonymizePlainTextFile({ part, replacements });
   }
 
   if (isToolUIPart(part)) {
-    return await anonymizeToolPart({ boundary, part });
+    return anonymizeToolPart({ part, replacements });
   }
 
   if (part.type === "source-document") {
-    const title = await prepareTextForThirdParty({
-      boundary,
-      text: part.title,
+    const prepared = { ...part };
+    queueTextReplacement(replacements, part.title, (value) => {
+      prepared.title = value;
     });
-
-    if (Result.isError(title)) {
-      return Result.err(title.error);
+    if (part.filename) {
+      queueTextReplacement(replacements, part.filename, (value) => {
+        prepared.filename = value;
+      });
     }
-
-    const filename = part.filename
-      ? await prepareTextForThirdParty({
-          boundary,
-          text: part.filename,
-        })
-      : Result.ok<string | undefined>(undefined);
-
-    if (Result.isError(filename)) {
-      return Result.err(filename.error);
-    }
-
-    return Result.ok({
-      ...part,
-      title: title.value,
-      ...(filename.value ? { filename: filename.value } : {}),
-    });
+    return Result.ok(prepared);
   }
 
   if (part.type === "source-url" && part.title) {
-    const title = await prepareTextForThirdParty({
-      boundary,
-      text: part.title,
+    const prepared = { ...part };
+    queueTextReplacement(replacements, part.title, (value) => {
+      prepared.title = value;
     });
-
-    if (Result.isError(title)) {
-      return Result.err(title.error);
-    }
-
-    return Result.ok({
-      ...part,
-      title: title.value,
-    });
+    return Result.ok(prepared);
   }
 
   if ("data" in part) {
-    const data = await anonymizeUnknownStrings({
-      boundary,
+    const preparedPart: Omit<typeof part, "data"> & { data: unknown } = {
+      ...part,
+      data: part.data,
+    };
+    const data = anonymizeUnknownStrings({
+      apply: (value) => {
+        preparedPart.data = value;
+      },
+      replacements,
       value: part.data,
     });
 
@@ -238,13 +282,10 @@ const preparePartForThirdParty = async ({
       return Result.err(data.error);
     }
 
-    const preparedPart = {
-      ...part,
-      data: data.value,
-    };
+    preparedPart.data = data.value;
 
-    // SAFETY: data part discriminators and IDs are preserved. The recursive
-    // anonymizer only replaces nested string values in the existing data shape.
+    // SAFETY: data part discriminators are preserved. Nested provider-visible
+    // text values are written back after the request-level batch anonymization.
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     return Result.ok(preparedPart as ChatMessage["parts"][number]);
   }
@@ -265,31 +306,61 @@ export const prepareMessagesForThirdParty = async ({
 
   return await Result.gen(async function* () {
     const prepared: ChatMessage[] = [];
+    const replacements: TextReplacement[] = [];
 
     for (const message of messages) {
       const parts: ChatMessage["parts"] = [];
 
       for (const part of message.parts) {
         parts.push(
-          yield* Result.await(preparePartForThirdParty({ boundary, part })),
+          yield* preparePartForThirdParty({ boundary, part, replacements }),
         );
       }
 
       prepared.push({ ...message, parts });
     }
 
+    yield* Result.await(
+      prepareTextBatchForThirdParty({ boundary, replacements }),
+    );
+
     return Result.ok(prepared);
   });
 };
 
-const shouldPreserveStructuredString = (key: string): boolean => {
+const TECHNICAL_IDENTIFIER_KEYS = new Set([
+  "callId",
+  "documentId",
+  "entityId",
+  "fileId",
+  "id",
+  "ids",
+  "messageId",
+  "organizationId",
+  "threadId",
+  "toolCallId",
+  "userId",
+  "uuid",
+  "uuids",
+  "workspaceId",
+]);
+
+const TECHNICAL_IDENTIFIER_PATTERN =
+  /^(?:[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}|[a-z][a-z0-9]*_[A-Za-z0-9-]+)$/i;
+
+const shouldPreserveStructuredString = (
+  key: string,
+  value: string,
+): boolean => {
+  if (!TECHNICAL_IDENTIFIER_PATTERN.test(value)) {
+    return false;
+  }
+
   const normalized = key.toLocaleLowerCase();
 
   return (
-    normalized === "id" ||
-    normalized === "ids" ||
-    normalized === "uuid" ||
-    normalized === "uuids" ||
+    TECHNICAL_IDENTIFIER_KEYS.has(key) ||
+    TECHNICAL_IDENTIFIER_KEYS.has(normalized) ||
     normalized.endsWith("_id") ||
     normalized.endsWith("_ids") ||
     normalized.endsWith("_uuid") ||
@@ -305,37 +376,42 @@ const shouldPreserveStructuredString = (key: string): boolean => {
   );
 };
 
-const anonymizeUnknownStrings = async ({
-  boundary,
+const anonymizeUnknownStrings = ({
+  apply,
   key,
+  replacements,
   value,
 }: {
-  boundary: ChatThirdPartyBoundary;
+  apply?: ((value: unknown) => void) | undefined;
   key?: string | undefined;
+  replacements: TextReplacement[];
   value: unknown;
-}): Promise<Result<unknown, BoundaryRefusal>> => {
-  if (boundary.type === "raw") {
-    return Result.ok(value);
-  }
-
+}): Result<unknown, BoundaryRefusal> => {
   if (typeof value === "string") {
-    if (key && shouldPreserveStructuredString(key)) {
+    if (key && shouldPreserveStructuredString(key, value)) {
       return Result.ok(value);
     }
 
-    return await prepareTextForThirdParty({ boundary, text: value });
+    let prepared = value;
+    queueTextReplacement(replacements, value, (next) => {
+      prepared = next;
+      apply?.(prepared);
+    });
+
+    return Result.ok(prepared);
   }
 
   if (Array.isArray(value)) {
-    return await Result.gen(async function* () {
+    return Result.gen(function* () {
       const output: unknown[] = [];
 
-      for (const item of value) {
-        output.push(
-          yield* Result.await(
-            anonymizeUnknownStrings({ boundary, key, value: item }),
-          ),
-        );
+      for (let index = 0; index < value.length; index += 1) {
+        const item: unknown = value.at(index);
+        output[index] = yield* anonymizeUnknownStrings({
+          key,
+          replacements,
+          value: item,
+        });
       }
 
       return Result.ok(output);
@@ -346,87 +422,92 @@ const anonymizeUnknownStrings = async ({
     return Result.ok(value);
   }
 
-  return await Result.gen(async function* () {
-    const entries: [string, unknown][] = [];
+  return Result.gen(function* () {
+    const output = {};
 
     for (const [nestedKey, nestedValue] of Object.entries(value)) {
-      entries.push([
-        nestedKey,
-        yield* Result.await(
-          anonymizeUnknownStrings({
-            boundary,
-            key: nestedKey,
-            value: nestedValue,
-          }),
-        ),
-      ]);
+      const nestedPrepared = yield* anonymizeUnknownStrings({
+        apply: (next) => {
+          Object.assign(output, { [nestedKey]: next });
+        },
+        key: nestedKey,
+        replacements,
+        value: nestedValue,
+      });
+      Object.assign(output, { [nestedKey]: nestedPrepared });
     }
 
-    return Result.ok(Object.fromEntries(entries));
+    return Result.ok(output);
   });
 };
 
 type ToolLikePart = Extract<ChatMessage["parts"][number], { state: string }>;
+type MutableToolLikePart = ToolLikePart & {
+  approval?: unknown;
+  errorText?: string | undefined;
+  input?: unknown;
+  output?: unknown;
+  title?: string | undefined;
+};
 
-const anonymizeToolPart = async ({
-  boundary,
+const anonymizeToolPart = ({
   part,
+  replacements,
 }: {
-  boundary: ChatThirdPartyBoundary;
   part: ToolLikePart;
-}): Promise<Result<ToolLikePart, BoundaryRefusal>> =>
-  await Result.gen(async function* () {
-    const input =
-      "input" in part
-        ? yield* Result.await(
-            anonymizeUnknownStrings({ boundary, value: part.input }),
-          )
-        : undefined;
+  replacements: TextReplacement[];
+}): Result<ToolLikePart, BoundaryRefusal> =>
+  Result.gen(function* () {
+    const prepared: MutableToolLikePart = { ...part };
 
-    const output =
-      "output" in part
-        ? yield* Result.await(
-            anonymizeUnknownStrings({ boundary, value: part.output }),
-          )
-        : undefined;
+    if ("input" in part) {
+      const input = yield* anonymizeUnknownStrings({
+        apply: (value) => {
+          prepared.input = value;
+        },
+        replacements,
+        value: part.input,
+      });
+      prepared.input = input;
+    }
 
-    const errorText =
-      "errorText" in part && part.errorText
-        ? yield* Result.await(
-            prepareTextForThirdParty({ boundary, text: part.errorText }),
-          )
-        : undefined;
+    if ("output" in part) {
+      const output = yield* anonymizeUnknownStrings({
+        apply: (value) => {
+          prepared.output = value;
+        },
+        replacements,
+        value: part.output,
+      });
+      prepared.output = output;
+    }
 
-    const title =
-      "title" in part && part.title
-        ? yield* Result.await(
-            prepareTextForThirdParty({ boundary, text: part.title }),
-          )
-        : undefined;
+    const errorText = "errorText" in part ? part.errorText : undefined;
+    if (errorText) {
+      queueTextReplacement(replacements, errorText, (value) => {
+        prepared.errorText = value;
+      });
+    }
 
-    const approvalReason =
+    const title = "title" in part ? part.title : undefined;
+    if (title) {
+      queueTextReplacement(replacements, title, (value) => {
+        prepared.title = value;
+      });
+    }
+
+    const approval =
       "approval" in part &&
       part.approval !== undefined &&
       "reason" in part.approval &&
       part.approval.reason
-        ? yield* Result.await(
-            prepareTextForThirdParty({
-              boundary,
-              text: part.approval.reason,
-            }),
-          )
+        ? part.approval
         : undefined;
-
-    const prepared = {
-      ...part,
-      ...("input" in part ? { input } : {}),
-      ...("output" in part ? { output } : {}),
-      ...(errorText ? { errorText } : {}),
-      ...(title ? { title } : {}),
-      ...(approvalReason && "approval" in part
-        ? { approval: { ...part.approval, reason: approvalReason } }
-        : {}),
-    };
+    if (approval?.reason) {
+      queueTextReplacement(replacements, approval.reason, (value) => {
+        prepared.approval = { ...approval, reason: value };
+      });
+    }
 
     // SAFETY: the tool UI part discriminator fields are preserved. We only
     // anonymize provider-visible text nested in input/output/error/title fields.
@@ -458,16 +539,30 @@ export const prepareToolsForThirdParty = <TTools extends ToolSet>({
     wrapped[key] = {
       ...current,
       execute: async (...args: Parameters<typeof execute>) => {
-        const anonymizedOutput = await anonymizeUnknownStrings({
-          boundary,
-          value: await execute(...args),
+        const replacements: TextReplacement[] = [];
+        let outputValue: unknown = await execute(...args);
+        const anonymizedOutput = anonymizeUnknownStrings({
+          apply: (value) => {
+            outputValue = value;
+          },
+          replacements,
+          value: outputValue,
         });
 
         if (Result.isError(anonymizedOutput)) {
           throw anonymizedOutput.error;
         }
 
-        return anonymizedOutput.value;
+        outputValue = anonymizedOutput.value;
+        const anonymizedBatch = await prepareTextBatchForThirdParty({
+          boundary,
+          replacements,
+        });
+        if (Result.isError(anonymizedBatch)) {
+          throw anonymizedBatch.error;
+        }
+
+        return outputValue;
       },
     };
   }

--- a/apps/api/src/handlers/organization-settings/read-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/read-anonymization-blacklist.ts
@@ -1,0 +1,40 @@
+import { Result } from "better-result";
+import { asc, eq } from "drizzle-orm";
+
+import { anonymizationBlacklistEntries } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+
+const config = {
+  permissions: { organizationSettings: ["update"] },
+} satisfies HandlerConfig;
+
+const readAnonymizationBlacklist = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session }) {
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            canonical: anonymizationBlacklistEntries.canonical,
+            enabled: anonymizationBlacklistEntries.enabled,
+            id: anonymizationBlacklistEntries.id,
+            label: anonymizationBlacklistEntries.label,
+            variants: anonymizationBlacklistEntries.variants,
+          })
+          .from(anonymizationBlacklistEntries)
+          .where(
+            eq(
+              anonymizationBlacklistEntries.organizationId,
+              session.activeOrganizationId,
+            ),
+          )
+          .orderBy(asc(anonymizationBlacklistEntries.canonical)),
+      ),
+    );
+
+    return Result.ok({ entries: rows });
+  },
+);
+
+export default readAnonymizationBlacklist;

--- a/apps/api/src/handlers/organization-settings/routes.ts
+++ b/apps/api/src/handlers/organization-settings/routes.ts
@@ -4,8 +4,10 @@ import deleteAIConfig from "@/api/handlers/organization-settings/delete-ai-confi
 import previewOrganizationSettings from "@/api/handlers/organization-settings/preview";
 import readOrganizationSettings from "@/api/handlers/organization-settings/read";
 import readAIConfig from "@/api/handlers/organization-settings/read-ai-config";
+import readAnonymizationBlacklist from "@/api/handlers/organization-settings/read-anonymization-blacklist";
 import updateOrganizationSettings from "@/api/handlers/organization-settings/update";
 import updateAIConfig from "@/api/handlers/organization-settings/update-ai-config";
+import updateAnonymizationBlacklist from "@/api/handlers/organization-settings/update-anonymization-blacklist";
 import { authMacro, permissionMacro } from "@/api/lib/auth";
 
 export const organizationSettingsRoute = new Elysia({
@@ -27,4 +29,8 @@ export const organizationSettingsRoute = new Elysia({
   .post("/ai-config", updateAIConfig.handler, {
     body: updateAIConfig.config.body,
   })
-  .delete("/ai-config", deleteAIConfig.handler);
+  .delete("/ai-config", deleteAIConfig.handler)
+  .get("/anonymization-blacklist", readAnonymizationBlacklist.handler)
+  .put("/anonymization-blacklist", updateAnonymizationBlacklist.handler, {
+    body: updateAnonymizationBlacklist.config.body,
+  });

--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -1,14 +1,12 @@
 import { Result } from "better-result";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { anonymizationBlacklistEntries } from "@/api/db/schema";
-import type { AnonymizationBlacklistEntryInput } from "@/api/lib/anonymization-blacklist";
-import { normalizeAnonymizationBlacklistEntry } from "@/api/lib/anonymization-blacklist";
+import { normalizeAnonymizationBlacklistEntries } from "@/api/lib/anonymization-blacklist";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 
 const blacklistEntrySchema = t.Object({
@@ -33,42 +31,22 @@ const config = {
   body: updateAnonymizationBlacklistBodySchema,
 } satisfies HandlerConfig;
 
-const normalizeEntries = (entries: AnonymizationBlacklistEntryInput[]) => {
-  const seenCanonical = new Set<string>();
-  const normalized = [];
-
-  for (const entry of entries) {
-    const next = normalizeAnonymizationBlacklistEntry(entry);
-    const canonicalKey = next.canonical.toLocaleLowerCase();
-
-    if (seenCanonical.has(canonicalKey)) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Duplicate anonymization blacklist term",
-        }),
-      );
-    }
-
-    seenCanonical.add(canonicalKey);
-    normalized.push(next);
-  }
-
-  return Result.ok(normalized);
-};
-
 const updateAnonymizationBlacklist = createSafeRootHandler(
   config,
   async function* ({ body, safeDb, session, user }) {
-    const entries = normalizeEntries(body.entries);
+    const entries = normalizeAnonymizationBlacklistEntries(body.entries);
     if (Result.isError(entries)) {
       return Result.err(entries.error);
     }
 
     yield* Result.await(
       safeDb(async (tx) => {
-        await tx
-          .delete(anonymizationBlacklistEntries)
+        const existingRows = await tx
+          .select({
+            canonical: anonymizationBlacklistEntries.canonical,
+            id: anonymizationBlacklistEntries.id,
+          })
+          .from(anonymizationBlacklistEntries)
           .where(
             eq(
               anonymizationBlacklistEntries.organizationId,
@@ -76,12 +54,68 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
             ),
           );
 
+        const existingByCanonical = new Map(
+          existingRows.map((row) => [row.canonical.toLocaleLowerCase(), row]),
+        );
+        const incomingCanonicalKeys = new Set(
+          entries.value.map((entry) => entry.canonical.toLocaleLowerCase()),
+        );
+
+        for (const existing of existingRows) {
+          if (
+            incomingCanonicalKeys.has(existing.canonical.toLocaleLowerCase())
+          ) {
+            continue;
+          }
+
+          await tx
+            .delete(anonymizationBlacklistEntries)
+            .where(
+              and(
+                eq(anonymizationBlacklistEntries.id, existing.id),
+                eq(
+                  anonymizationBlacklistEntries.organizationId,
+                  session.activeOrganizationId,
+                ),
+              ),
+            );
+        }
+
         if (entries.value.length === 0) {
           return;
         }
 
-        await tx.insert(anonymizationBlacklistEntries).values(
-          entries.value.map((entry) => ({
+        const now = new Date();
+
+        for (const entry of entries.value) {
+          const existing = existingByCanonical.get(
+            entry.canonical.toLocaleLowerCase(),
+          );
+
+          if (existing) {
+            await tx
+              .update(anonymizationBlacklistEntries)
+              .set({
+                label: entry.label,
+                canonical: entry.canonical,
+                variants: entry.variants,
+                enabled: entry.enabled,
+                updatedBy: user.id,
+                updatedAt: now,
+              })
+              .where(
+                and(
+                  eq(anonymizationBlacklistEntries.id, existing.id),
+                  eq(
+                    anonymizationBlacklistEntries.organizationId,
+                    session.activeOrganizationId,
+                  ),
+                ),
+              );
+            continue;
+          }
+
+          await tx.insert(anonymizationBlacklistEntries).values({
             id: createSafeId<"anonymizationBlacklistEntry">(),
             organizationId: session.activeOrganizationId,
             label: entry.label,
@@ -90,8 +124,8 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
             enabled: entry.enabled,
             createdBy: user.id,
             updatedBy: user.id,
-          })),
-        );
+          });
+        }
       }),
     );
 

--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
 
 import { anonymizationBlacklistEntries } from "@/api/db/schema";
@@ -61,22 +61,23 @@ const updateAnonymizationBlacklist = createSafeRootHandler(
           entries.value.map((entry) => entry.canonical.toLocaleLowerCase()),
         );
 
-        for (const existing of existingRows) {
-          if (
-            incomingCanonicalKeys.has(existing.canonical.toLocaleLowerCase())
-          ) {
-            continue;
-          }
+        const idsToDelete = existingRows
+          .filter(
+            (row) =>
+              !incomingCanonicalKeys.has(row.canonical.toLocaleLowerCase()),
+          )
+          .map((row) => row.id);
 
+        if (idsToDelete.length > 0) {
           await tx
             .delete(anonymizationBlacklistEntries)
             .where(
               and(
-                eq(anonymizationBlacklistEntries.id, existing.id),
                 eq(
                   anonymizationBlacklistEntries.organizationId,
                   session.activeOrganizationId,
                 ),
+                inArray(anonymizationBlacklistEntries.id, idsToDelete),
               ),
             );
         }

--- a/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
+++ b/apps/api/src/handlers/organization-settings/update-anonymization-blacklist.ts
@@ -1,0 +1,102 @@
+import { Result } from "better-result";
+import { eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { anonymizationBlacklistEntries } from "@/api/db/schema";
+import type { AnonymizationBlacklistEntryInput } from "@/api/lib/anonymization-blacklist";
+import { normalizeAnonymizationBlacklistEntry } from "@/api/lib/anonymization-blacklist";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+
+const blacklistEntrySchema = t.Object({
+  canonical: t.String({ minLength: 1, maxLength: 512 }),
+  enabled: t.Optional(t.Boolean()),
+  label: t.String({ minLength: 1, maxLength: 64 }),
+  variants: t.Optional(
+    t.Array(t.String({ minLength: 1, maxLength: 512 }), {
+      maxItems: LIMITS.anonymizationBlacklistVariantsPerEntry,
+    }),
+  ),
+});
+
+const updateAnonymizationBlacklistBodySchema = t.Object({
+  entries: t.Array(blacklistEntrySchema, {
+    maxItems: LIMITS.anonymizationBlacklistEntriesPerOrganization,
+  }),
+});
+
+const config = {
+  permissions: { organizationSettings: ["update"] },
+  body: updateAnonymizationBlacklistBodySchema,
+} satisfies HandlerConfig;
+
+const normalizeEntries = (entries: AnonymizationBlacklistEntryInput[]) => {
+  const seenCanonical = new Set<string>();
+  const normalized = [];
+
+  for (const entry of entries) {
+    const next = normalizeAnonymizationBlacklistEntry(entry);
+    const canonicalKey = next.canonical.toLocaleLowerCase();
+
+    if (seenCanonical.has(canonicalKey)) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Duplicate anonymization blacklist term",
+        }),
+      );
+    }
+
+    seenCanonical.add(canonicalKey);
+    normalized.push(next);
+  }
+
+  return Result.ok(normalized);
+};
+
+const updateAnonymizationBlacklist = createSafeRootHandler(
+  config,
+  async function* ({ body, safeDb, session, user }) {
+    const entries = normalizeEntries(body.entries);
+    if (Result.isError(entries)) {
+      return Result.err(entries.error);
+    }
+
+    yield* Result.await(
+      safeDb(async (tx) => {
+        await tx
+          .delete(anonymizationBlacklistEntries)
+          .where(
+            eq(
+              anonymizationBlacklistEntries.organizationId,
+              session.activeOrganizationId,
+            ),
+          );
+
+        if (entries.value.length === 0) {
+          return;
+        }
+
+        await tx.insert(anonymizationBlacklistEntries).values(
+          entries.value.map((entry) => ({
+            id: createSafeId<"anonymizationBlacklistEntry">(),
+            organizationId: session.activeOrganizationId,
+            label: entry.label,
+            canonical: entry.canonical,
+            variants: entry.variants,
+            enabled: entry.enabled,
+            createdBy: user.id,
+            updatedBy: user.id,
+          })),
+        );
+      }),
+    );
+
+    return Result.ok({ entries: entries.value });
+  },
+);
+
+export default updateAnonymizationBlacklist;

--- a/apps/api/src/lib/anonymization-blacklist.test.ts
+++ b/apps/api/src/lib/anonymization-blacklist.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeAnonymizationBlacklistEntry } from "@/api/lib/anonymization-blacklist";
+
+describe("anonymization blacklist normalization", () => {
+  test("trims terms and removes duplicate empty variants", () => {
+    expect(
+      normalizeAnonymizationBlacklistEntry({
+        canonical: "  Acme GmbH  ",
+        label: " organization ",
+        variants: [" Acme ", "", "Acme", "ACME GmbH "],
+      }),
+    ).toEqual({
+      canonical: "Acme GmbH",
+      enabled: true,
+      label: "organization",
+      variants: ["Acme", "ACME GmbH"],
+    });
+  });
+});

--- a/apps/api/src/lib/anonymization-blacklist.test.ts
+++ b/apps/api/src/lib/anonymization-blacklist.test.ts
@@ -1,6 +1,10 @@
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
-import { normalizeAnonymizationBlacklistEntry } from "@/api/lib/anonymization-blacklist";
+import {
+  normalizeAnonymizationBlacklistEntries,
+  normalizeAnonymizationBlacklistEntry,
+} from "@/api/lib/anonymization-blacklist";
 
 describe("anonymization blacklist normalization", () => {
   test("trims terms and removes duplicate empty variants", () => {
@@ -16,5 +20,21 @@ describe("anonymization blacklist normalization", () => {
       label: "organization",
       variants: ["Acme", "ACME GmbH"],
     });
+  });
+
+  test("rejects entries that become blank after normalization", () => {
+    const result = normalizeAnonymizationBlacklistEntries([
+      {
+        canonical: "   ",
+        label: "person",
+      },
+    ]);
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected blank term rejection");
+    }
+
+    expect(result.error.status).toBe(400);
   });
 });

--- a/apps/api/src/lib/anonymization-blacklist.ts
+++ b/apps/api/src/lib/anonymization-blacklist.ts
@@ -1,0 +1,82 @@
+import type { GazetteerEntry } from "@stll/anonymize-wasm";
+import { and, asc, eq } from "drizzle-orm";
+
+import type { ScopedDb } from "@/api/db";
+import { anonymizationBlacklistEntries } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+
+export type AnonymizationBlacklistEntryInput = {
+  canonical: string;
+  enabled?: boolean | undefined;
+  label: string;
+  variants?: string[] | undefined;
+};
+
+const normalizeTerm = (value: string): string => value.trim();
+
+const normalizeVariants = (variants: readonly string[]): string[] => {
+  const normalized = new Set<string>();
+
+  for (const variant of variants) {
+    const value = normalizeTerm(variant);
+    if (value.length > 0) {
+      normalized.add(value);
+    }
+  }
+
+  return [...normalized];
+};
+
+export const normalizeAnonymizationBlacklistEntry = ({
+  canonical,
+  enabled,
+  label,
+  variants,
+}: AnonymizationBlacklistEntryInput) => ({
+  canonical: normalizeTerm(canonical),
+  enabled: enabled ?? true,
+  label: normalizeTerm(label),
+  variants: normalizeVariants(variants ?? []),
+});
+
+export const loadAnonymizationGazetteerEntries = async ({
+  organizationId,
+  scopedDb,
+}: {
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+}) => {
+  const rows = await scopedDb((tx) =>
+    tx
+      .select({
+        canonical: anonymizationBlacklistEntries.canonical,
+        id: anonymizationBlacklistEntries.id,
+        label: anonymizationBlacklistEntries.label,
+        variants: anonymizationBlacklistEntries.variants,
+        createdAt: anonymizationBlacklistEntries.createdAt,
+      })
+      .from(anonymizationBlacklistEntries)
+      .where(
+        and(
+          eq(anonymizationBlacklistEntries.organizationId, organizationId),
+          eq(anonymizationBlacklistEntries.enabled, true),
+        ),
+      )
+      .orderBy(asc(anonymizationBlacklistEntries.canonical)),
+  );
+
+  return rows.map(
+    (row): GazetteerEntry => ({
+      id: row.id,
+      canonical: row.canonical,
+      label: row.label,
+      variants: row.variants,
+      workspaceId: organizationId,
+      createdAt: row.createdAt.getTime(),
+      source: "manual",
+    }),
+  );
+};
+
+// TODO: Add org-wide custom regex rules here once @stll/anonymize-wasm
+// exposes a safe first-class custom regex detector API.

--- a/apps/api/src/lib/anonymization-blacklist.ts
+++ b/apps/api/src/lib/anonymization-blacklist.ts
@@ -1,9 +1,11 @@
 import type { GazetteerEntry } from "@stll/anonymize-wasm";
+import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db";
 import { anonymizationBlacklistEntries } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 export type AnonymizationBlacklistEntryInput = {
   canonical: string;
@@ -38,6 +40,41 @@ export const normalizeAnonymizationBlacklistEntry = ({
   label: normalizeTerm(label),
   variants: normalizeVariants(variants ?? []),
 });
+
+export const normalizeAnonymizationBlacklistEntries = (
+  entries: AnonymizationBlacklistEntryInput[],
+) => {
+  const seenCanonical = new Set<string>();
+  const normalized = [];
+
+  for (const entry of entries) {
+    const next = normalizeAnonymizationBlacklistEntry(entry);
+    if (next.canonical.length === 0 || next.label.length === 0) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Anonymization blacklist terms cannot be blank",
+        }),
+      );
+    }
+
+    const canonicalKey = next.canonical.toLocaleLowerCase();
+
+    if (seenCanonical.has(canonicalKey)) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Duplicate anonymization blacklist term",
+        }),
+      );
+    }
+
+    seenCanonical.add(canonicalKey);
+    normalized.push(next);
+  }
+
+  return Result.ok(normalized);
+};
 
 export const loadAnonymizationGazetteerEntries = async ({
   organizationId,

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -2,6 +2,7 @@ declare const __brand: unique symbol;
 
 export type SafeIdType =
   | "auditLog"
+  | "anonymizationBlacklistEntry"
   | "billingCode"
   | "caseLawCitation"
   | "caseLawCourtWeight"

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -78,6 +78,10 @@ export const LIMITS = {
   chatExecuteContentIdsMax: 20,
   /** Max DOCX size for stamp injection (bytes). */
   docxStampMaxBytes: 50 * 1024 * 1024,
+  /** Max org-wide custom blacklist terms for anonymization. */
+  anonymizationBlacklistEntriesPerOrganization: 1000,
+  /** Max variants per org-wide custom blacklist term. */
+  anonymizationBlacklistVariantsPerEntry: 20,
 } as const;
 
 const CHAT_CONTEXT_FILE_MAX_MEGABYTES = 10;

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -75,11 +75,13 @@ const splitRedactedFields = ({
 
 export const anonymizeTextFields = async ({
   fields,
+  gazetteerEntries,
   organizationId,
   scopedDb,
   workspaceId,
 }: {
   fields: string[];
+  gazetteerEntries?: GazetteerEntry[] | undefined;
   organizationId: SafeId<"organization">;
   scopedDb: ScopedDb;
   workspaceId: string;
@@ -100,15 +102,17 @@ export const anonymizeTextFields = async ({
     .map((field, index) => `${markers[index]}${field}`)
     .join("");
 
-  const gazetteerEntries = await loadAnonymizationGazetteerEntries({
-    organizationId,
-    scopedDb,
-  });
+  const entries =
+    gazetteerEntries ??
+    (await loadAnonymizationGazetteerEntries({
+      organizationId,
+      scopedDb,
+    }));
 
   const entities = await runPipeline({
     fullText: combinedText,
-    config: buildPipelineConfig({ gazetteerEntries, workspaceId }),
-    gazetteerEntries,
+    config: buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
+    gazetteerEntries: entries,
     context,
   });
   const result = redactText(

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -8,17 +8,24 @@ import {
 import type { GazetteerEntry, PipelineConfig } from "@stll/anonymize-wasm";
 import { panic } from "better-result";
 
+import type { ScopedDb } from "@/api/db";
+import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
+import type { SafeId } from "@/api/lib/branded-types";
 import { buildFieldMarkers } from "@/api/mcp/field-markers";
 
-const EMPTY_GAZETTEER_ENTRIES: GazetteerEntry[] = [];
-
-const buildPipelineConfig = (workspaceId: string): PipelineConfig => ({
+const buildPipelineConfig = ({
+  gazetteerEntries,
+  workspaceId,
+}: {
+  gazetteerEntries: GazetteerEntry[];
+  workspaceId: string;
+}): PipelineConfig => ({
   threshold: 0.4,
   enableTriggerPhrases: true,
   enableRegex: true,
   enableNameCorpus: true,
   enableDenyList: false,
-  enableGazetteer: false,
+  enableGazetteer: gazetteerEntries.length > 0,
   enableNer: false,
   enableConfidenceBoost: false,
   enableCoreference: true,
@@ -68,9 +75,13 @@ const splitRedactedFields = ({
 
 export const anonymizeTextFields = async ({
   fields,
+  organizationId,
+  scopedDb,
   workspaceId,
 }: {
   fields: string[];
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
   workspaceId: string;
 }) => {
   if (fields.every((field) => field.length === 0)) {
@@ -89,10 +100,15 @@ export const anonymizeTextFields = async ({
     .map((field, index) => `${markers[index]}${field}`)
     .join("");
 
+  const gazetteerEntries = await loadAnonymizationGazetteerEntries({
+    organizationId,
+    scopedDb,
+  });
+
   const entities = await runPipeline({
     fullText: combinedText,
-    config: buildPipelineConfig(workspaceId),
-    gazetteerEntries: EMPTY_GAZETTEER_ENTRIES,
+    config: buildPipelineConfig({ gazetteerEntries, workspaceId }),
+    gazetteerEntries,
     context,
   });
   const result = redactText(

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -108,14 +108,18 @@ const getFetchableEntityMap = async ({
 };
 
 const anonymizeCompatSearchResults = async ({
+  context,
   results,
 }: {
+  context: McpRequestContext;
   results: CompatSearchResult[];
 }) =>
   await Promise.all(
     results.map(async ({ workspaceId, ...result }) => {
       const anonymized = await anonymizeTextFields({
         fields: [result.title],
+        organizationId: context.organizationId,
+        scopedDb: context.scopedDb,
         workspaceId,
       });
 
@@ -132,16 +136,20 @@ const anonymizeCompatSearchResults = async ({
   );
 
 const anonymizeCompatFetchPayload = async ({
+  context,
   text,
   title,
   workspaceId,
 }: {
+  context: McpRequestContext;
   text: string;
   title: string;
   workspaceId: string;
 }) => {
   const anonymized = await anonymizeTextFields({
     fields: [title, text],
+    organizationId: context.organizationId,
+    scopedDb: context.scopedDb,
     workspaceId,
   });
 
@@ -404,8 +412,13 @@ const handleCompatSearchTool: McpToolHandler = async ({
   }).slice(0, limit);
 
   if (mode === "anonymized") {
+    // MCP access is for authorized Stella users only. In anonymized
+    // mode we still search raw, non-anonymized indexed text so
+    // retrieval quality stays useful, then anonymize all returned
+    // corpus text before it leaves Stella for the AI client.
     return textResult({
       results: await anonymizeCompatSearchResults({
+        context,
         results: limitedResults,
       }),
     });
@@ -487,7 +500,11 @@ const handleCompatFetchTool: McpToolHandler = async ({
   }
 
   if (mode === "anonymized") {
+    // Same boundary as anonymized search: the user may fetch a raw
+    // document internally, but the AI client receives only the
+    // anonymized title/body generated below.
     const anonymized = await anonymizeCompatFetchPayload({
+      context,
       text: fetchPayload.text,
       title: fetchPayload.title,
       workspaceId: fetchPayload.workspaceId,

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -3,6 +3,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 
 import { entities, extractedContent, fields } from "@/api/db/schema";
 import { readEntityByIdHandler } from "@/api/handlers/entities/read-by-id";
+import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
 import { anonymizeTextFields } from "@/api/mcp/anonymization";
@@ -113,11 +114,21 @@ const anonymizeCompatSearchResults = async ({
 }: {
   context: McpRequestContext;
   results: CompatSearchResult[];
-}) =>
-  await Promise.all(
+}) => {
+  if (results.length === 0) {
+    return [];
+  }
+
+  const gazetteerEntries = await loadAnonymizationGazetteerEntries({
+    organizationId: context.organizationId,
+    scopedDb: context.scopedDb,
+  });
+
+  return await Promise.all(
     results.map(async ({ workspaceId, ...result }) => {
       const anonymized = await anonymizeTextFields({
         fields: [result.title],
+        gazetteerEntries,
         organizationId: context.organizationId,
         scopedDb: context.scopedDb,
         workspaceId,
@@ -134,6 +145,7 @@ const anonymizeCompatSearchResults = async ({
       };
     }),
   );
+};
 
 const anonymizeCompatFetchPayload = async ({
   context,

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -8,6 +8,7 @@ import type { McpRequestContext } from "@/api/mcp/context";
 import { toSafeDbMock } from "@/api/tests/scoped-db-mock";
 
 const anonymizeTextFieldsMock = mock();
+const loadAnonymizationGazetteerEntriesMock = mock();
 const captureErrorMock = mock();
 const identifyMock = mock();
 const analyticsCaptureMock = mock();
@@ -52,6 +53,10 @@ void mock.module("@/api/lib/analytics", () => ({
 
 void mock.module("@/api/mcp/anonymization", () => ({
   anonymizeTextFields: anonymizeTextFieldsMock,
+}));
+
+void mock.module("@/api/lib/anonymization-blacklist", () => ({
+  loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
 }));
 
 void mock.module("@/api/handlers/chat/tools/org-tools", () => ({
@@ -208,6 +213,8 @@ const createContext = ({
 describe("OpenAI-compatible MCP tools", () => {
   beforeEach(() => {
     anonymizeTextFieldsMock.mockReset();
+    loadAnonymizationGazetteerEntriesMock.mockReset();
+    loadAnonymizationGazetteerEntriesMock.mockResolvedValue([]);
     captureErrorMock.mockReset();
     identifyMock.mockReset();
     searchAcrossMattersExecute.mockReset();
@@ -792,10 +799,12 @@ describe("OpenAI-compatible MCP tools", () => {
     const anonymizeInput = anonymizeTextFieldsMock.mock.calls.at(-1)?.[0];
     expect(anonymizeInput).toMatchObject({
       fields: ["John Smith SPA"],
+      gazetteerEntries: [],
       organizationId: toSafeId<"organization">("org_1"),
       workspaceId: "ws_1",
     });
     expect(anonymizeInput?.scopedDb).toBeTypeOf("function");
+    expect(loadAnonymizationGazetteerEntriesMock).toHaveBeenCalledTimes(1);
   });
 
   test("search preserves empty anonymized output instead of leaking the original title", async () => {

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -45,6 +45,57 @@ const searchDecisionsHandlerMock = mock();
 const readDecisionHandlerMock = mock();
 const APP_BASE_URL = env.FRONTEND_URL.replace(/\/$/, "");
 
+type AnonymizationBlacklistEntryInput = {
+  canonical: string;
+  enabled?: boolean | undefined;
+  label: string;
+  variants?: string[] | undefined;
+};
+
+const normalizeAnonymizationBlacklistEntryMock = ({
+  canonical,
+  enabled,
+  label,
+  variants,
+}: AnonymizationBlacklistEntryInput) => ({
+  canonical: canonical.trim(),
+  enabled: enabled ?? true,
+  label: label.trim(),
+  variants: [...new Set((variants ?? []).map((value) => value.trim()))].filter(
+    (value) => value.length > 0,
+  ),
+});
+
+const normalizeAnonymizationBlacklistEntriesMock = (
+  entries: AnonymizationBlacklistEntryInput[],
+) => {
+  const seenCanonical = new Set<string>();
+  const normalized = [];
+
+  for (const entry of entries) {
+    const next = normalizeAnonymizationBlacklistEntryMock(entry);
+    if (next.canonical.length === 0 || next.label.length === 0) {
+      return Result.err({
+        status: 400,
+        message: "Anonymization blacklist terms cannot be blank",
+      });
+    }
+
+    const canonicalKey = next.canonical.toLocaleLowerCase();
+    if (seenCanonical.has(canonicalKey)) {
+      return Result.err({
+        status: 400,
+        message: "Duplicate anonymization blacklist term",
+      });
+    }
+
+    seenCanonical.add(canonicalKey);
+    normalized.push(next);
+  }
+
+  return Result.ok(normalized);
+};
+
 void mock.module("@/api/lib/analytics", () => ({
   captureError: captureErrorMock,
   getAnalytics: getAnalyticsMock,
@@ -57,6 +108,10 @@ void mock.module("@/api/mcp/anonymization", () => ({
 
 void mock.module("@/api/lib/anonymization-blacklist", () => ({
   loadAnonymizationGazetteerEntries: loadAnonymizationGazetteerEntriesMock,
+  normalizeAnonymizationBlacklistEntries:
+    normalizeAnonymizationBlacklistEntriesMock,
+  normalizeAnonymizationBlacklistEntry:
+    normalizeAnonymizationBlacklistEntryMock,
 }));
 
 void mock.module("@/api/handlers/chat/tools/org-tools", () => ({

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -789,10 +789,13 @@ describe("OpenAI-compatible MCP tools", () => {
         },
       ],
     });
-    expect(anonymizeTextFieldsMock).toHaveBeenCalledWith({
+    const anonymizeInput = anonymizeTextFieldsMock.mock.calls.at(-1)?.[0];
+    expect(anonymizeInput).toMatchObject({
       fields: ["John Smith SPA"],
+      organizationId: toSafeId<"organization">("org_1"),
       workspaceId: "ws_1",
     });
+    expect(anonymizeInput?.scopedDb).toBeTypeOf("function");
   });
 
   test("search preserves empty anonymized output instead of leaking the original title", async () => {

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -4,6 +4,7 @@ import type { AnyPgTable } from "drizzle-orm/pg-core";
 import { member, organization, user } from "@/api/db/auth-schema";
 import { stella } from "@/api/db/rls";
 import {
+  anonymizationBlacklistEntries,
   billingCodes,
   caseLawDecisions,
   caseLawMatterLinks,
@@ -151,6 +152,8 @@ export const createTestIds = () => ({
   clauseVersionB: id<"clauseVersion">(),
   orgSettingsA: id<"organizationSettings">(),
   orgSettingsB: id<"organizationSettings">(),
+  anonymizationBlacklistEntryA: id<"anonymizationBlacklistEntry">(),
+  anonymizationBlacklistEntryB: id<"anonymizationBlacklistEntry">(),
   matterCounterA: id<"matterCounter">(),
   matterCounterB: id<"matterCounter">(),
 });
@@ -198,6 +201,7 @@ export const orgScopedTables = [
   clauseCategories,
   clauses,
   organizationSettings,
+  anonymizationBlacklistEntries,
   matterCounters,
   contactRelationships,
   templateVersions,
@@ -531,6 +535,27 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
   await db.insert(organizationSettings).values([
     { id: ids.orgSettingsA, organizationId: ids.orgA },
     { id: ids.orgSettingsB, organizationId: ids.orgB },
+  ]);
+
+  await db.insert(anonymizationBlacklistEntries).values([
+    {
+      id: ids.anonymizationBlacklistEntryA,
+      organizationId: ids.orgA,
+      label: "organization",
+      canonical: "Acme A",
+      variants: [],
+      createdBy: ids.userA1,
+      updatedBy: ids.userA1,
+    },
+    {
+      id: ids.anonymizationBlacklistEntryB,
+      organizationId: ids.orgB,
+      label: "organization",
+      canonical: "Acme B",
+      variants: [],
+      createdBy: ids.userB1,
+      updatedBy: ids.userB1,
+    },
   ]);
 
   await db.insert(matterCounters).values([

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -282,15 +282,15 @@
       "toastDescription": "Celostránkový chat bude k dispozici s perzistentními vlákny.",
       "toastTitle": "Celý pohled zatím není dostupný"
     },
+    "anonymizedMode": "Anonymizovaný režim AI",
+    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
+    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "applyMode": {
       "description": "Word ukládá, kdo provedl každou změnu. Vaši volbu si zapamatujeme.",
       "direct": "Ne, použít přímo",
       "title": "Použít úpravy se sledováním změn?",
       "tracked": "Ano, se sledováním"
     },
-    "anonymizedMode": "Anonymizovaný režim AI",
-    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
-    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "approval": {
       "allow": "Povolit",
       "alwaysAllow": "Vždy povolit v tomto vlákně",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -288,6 +288,9 @@
       "title": "Použít úpravy se sledováním změn?",
       "tracked": "Ano, se sledováním"
     },
+    "anonymizedMode": "Anonymizovaný režim AI",
+    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
+    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "approval": {
       "allow": "Povolit",
       "alwaysAllow": "Vždy povolit v tomto vlákně",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonymisierter KI-Modus",
+    "anonymizedModeDisabled": "Anonymisierter KI-Modus ist aus",
+    "anonymizedModeEnabled": "Anonymisierter KI-Modus ist an",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonymisierter KI-Modus",
-    "anonymizedModeDisabled": "Anonymisierter KI-Modus ist aus",
-    "anonymizedModeEnabled": "Anonymisierter KI-Modus ist an",
     "approval": {
       "allow": "Erlauben",
       "alwaysAllow": "Immer in diesem Thread erlauben",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonymisierter KI-Modus",
+    "anonymizedModeDisabled": "Anonymisierter KI-Modus ist aus",
+    "anonymizedModeEnabled": "Anonymisierter KI-Modus ist an",
     "approval": {
       "allow": "Erlauben",
       "alwaysAllow": "Immer in diesem Thread erlauben",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonymized AI mode",
+    "anonymizedModeDisabled": "Anonymized AI mode is off",
+    "anonymizedModeEnabled": "Anonymized AI mode is on",
     "approval": {
       "allow": "Allow",
       "alwaysAllow": "Always allow in this thread",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonymized AI mode",
+    "anonymizedModeDisabled": "Anonymized AI mode is off",
+    "anonymizedModeEnabled": "Anonymized AI mode is on",
     "applyMode": {
       "description": "Word stores who made each change. We'll remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonymized AI mode",
-    "anonymizedModeDisabled": "Anonymized AI mode is off",
-    "anonymizedModeEnabled": "Anonymized AI mode is on",
     "approval": {
       "allow": "Allow",
       "alwaysAllow": "Always allow in this thread",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Modo de IA anonimizado",
+    "anonymizedModeDisabled": "El modo de IA anonimizado está desactivado",
+    "anonymizedModeEnabled": "El modo de IA anonimizado está activado",
     "approval": {
       "allow": "Permitir",
       "alwaysAllow": "Permitir siempre",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Modo de IA anonimizado",
+    "anonymizedModeDisabled": "El modo de IA anonimizado está desactivado",
+    "anonymizedModeEnabled": "El modo de IA anonimizado está activado",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Modo de IA anonimizado",
-    "anonymizedModeDisabled": "El modo de IA anonimizado está desactivado",
-    "anonymizedModeEnabled": "El modo de IA anonimizado está activado",
     "approval": {
       "allow": "Permitir",
       "alwaysAllow": "Permitir siempre",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonüümitud AI režiim",
+    "anonymizedModeDisabled": "Anonüümitud AI režiim on väljas",
+    "anonymizedModeEnabled": "Anonüümitud AI režiim on sees",
     "approval": {
       "allow": "Luba",
       "alwaysAllow": "Luba alati",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonüümitud AI režiim",
+    "anonymizedModeDisabled": "Anonüümitud AI režiim on väljas",
+    "anonymizedModeEnabled": "Anonüümitud AI režiim on sees",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonüümitud AI režiim",
-    "anonymizedModeDisabled": "Anonüümitud AI režiim on väljas",
-    "anonymizedModeEnabled": "Anonüümitud AI režiim on sees",
     "approval": {
       "allow": "Luba",
       "alwaysAllow": "Luba alati",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Mode IA anonymisé",
+    "anonymizedModeDisabled": "Le mode IA anonymisé est désactivé",
+    "anonymizedModeEnabled": "Le mode IA anonymisé est activé",
     "approval": {
       "allow": "Autoriser",
       "alwaysAllow": "Toujours autoriser",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Mode IA anonymisé",
+    "anonymizedModeDisabled": "Le mode IA anonymisé est désactivé",
+    "anonymizedModeEnabled": "Le mode IA anonymisé est activé",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Mode IA anonymisé",
-    "anonymizedModeDisabled": "Le mode IA anonymisé est désactivé",
-    "anonymizedModeEnabled": "Le mode IA anonymisé est activé",
     "approval": {
       "allow": "Autoriser",
       "alwaysAllow": "Toujours autoriser",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonimizált AI mód",
+    "anonymizedModeDisabled": "Az anonimizált AI mód ki van kapcsolva",
+    "anonymizedModeEnabled": "Az anonimizált AI mód be van kapcsolva",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonimizált AI mód",
-    "anonymizedModeDisabled": "Az anonimizált AI mód ki van kapcsolva",
-    "anonymizedModeEnabled": "Az anonimizált AI mód be van kapcsolva",
     "approval": {
       "allow": "Engedélyezés",
       "alwaysAllow": "Mindig engedélyezze ebben a szálban",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonimizált AI mód",
+    "anonymizedModeDisabled": "Az anonimizált AI mód ki van kapcsolva",
+    "anonymizedModeEnabled": "Az anonimizált AI mód be van kapcsolva",
     "approval": {
       "allow": "Engedélyezés",
       "alwaysAllow": "Mindig engedélyezze ebben a szálban",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonimizuotas DI režimas",
+    "anonymizedModeDisabled": "Anonimizuotas DI režimas išjungtas",
+    "anonymizedModeEnabled": "Anonimizuotas DI režimas įjungtas",
     "approval": {
       "allow": "Leisti",
       "alwaysAllow": "Visada leisti",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonimizuotas DI režimas",
+    "anonymizedModeDisabled": "Anonimizuotas DI režimas išjungtas",
+    "anonymizedModeEnabled": "Anonimizuotas DI režimas įjungtas",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonimizuotas DI režimas",
-    "anonymizedModeDisabled": "Anonimizuotas DI režimas išjungtas",
-    "anonymizedModeEnabled": "Anonimizuotas DI režimas įjungtas",
     "approval": {
       "allow": "Leisti",
       "alwaysAllow": "Visada leisti",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonimizēts AI režīms",
+    "anonymizedModeDisabled": "Anonimizēts AI režīms ir izslēgts",
+    "anonymizedModeEnabled": "Anonimizēts AI režīms ir ieslēgts",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonimizēts AI režīms",
-    "anonymizedModeDisabled": "Anonimizēts AI režīms ir izslēgts",
-    "anonymizedModeEnabled": "Anonimizēts AI režīms ir ieslēgts",
     "approval": {
       "allow": "Atļaut",
       "alwaysAllow": "Vienmēr atļaut",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonimizēts AI režīms",
+    "anonymizedModeDisabled": "Anonimizēts AI režīms ir izslēgts",
+    "anonymizedModeEnabled": "Anonimizēts AI režīms ir ieslēgts",
     "approval": {
       "allow": "Atļaut",
       "alwaysAllow": "Vienmēr atļaut",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -307,6 +307,9 @@ type Messages = {
     };
     "attachFile": "Attach file";
     "attachedImage": "Attached image";
+    "anonymizedMode": "Anonymized AI mode";
+    "anonymizedModeDisabled": "Anonymized AI mode is off";
+    "anonymizedModeEnabled": "Anonymized AI mode is on";
     "attachment": "Attachment";
     "caseLawGreeting": "Ask about this decision — its full text is available here.";
     "chatAbout": "Chat about this";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -282,15 +282,15 @@
       "toastDescription": "Pełnoekranowy czat zostanie udostępniony wraz z zapisanymi wątkami.",
       "toastTitle": "Pełny widok niedostępny"
     },
+    "anonymizedMode": "Zanonimizowany tryb AI",
+    "anonymizedModeDisabled": "Zanonimizowany tryb AI jest wyłączony",
+    "anonymizedModeEnabled": "Zanonimizowany tryb AI jest włączony",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Zanonimizowany tryb AI",
-    "anonymizedModeDisabled": "Zanonimizowany tryb AI jest wyłączony",
-    "anonymizedModeEnabled": "Zanonimizowany tryb AI jest włączony",
     "approval": {
       "allow": "Zezwól",
       "alwaysAllow": "Zawsze zezwalaj w tym wątku",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Zanonimizowany tryb AI",
+    "anonymizedModeDisabled": "Zanonimizowany tryb AI jest wyłączony",
+    "anonymizedModeEnabled": "Zanonimizowany tryb AI jest włączony",
     "approval": {
       "allow": "Zezwól",
       "alwaysAllow": "Zawsze zezwalaj w tym wątku",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -288,6 +288,9 @@
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
+    "anonymizedMode": "Anonymizovaný režim AI",
+    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
+    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "approval": {
       "allow": "Povoliť",
       "alwaysAllow": "Vždy povoliť v tomto vlákne",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -282,15 +282,15 @@
       "toastDescription": "Full-page chat lands with persisted threads.",
       "toastTitle": "Full view not yet available"
     },
+    "anonymizedMode": "Anonymizovaný režim AI",
+    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
+    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "applyMode": {
       "description": "Word stores who made each change. We will remember your choice.",
       "direct": "No, apply directly",
       "title": "Apply edits with tracked changes?",
       "tracked": "Yes, tracked"
     },
-    "anonymizedMode": "Anonymizovaný režim AI",
-    "anonymizedModeDisabled": "Anonymizovaný režim AI je vypnutý",
-    "anonymizedModeEnabled": "Anonymizovaný režim AI je zapnutý",
     "approval": {
       "allow": "Povoliť",
       "alwaysAllow": "Vždy povoliť v tomto vlákne",

--- a/apps/web/src/routes/_protected.chat/-components/chat-anonymized-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-anonymized-toggle.tsx
@@ -1,0 +1,40 @@
+import { Button } from "@stll/ui/components/button";
+import { ShieldCheckIcon, ShieldIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import Tooltip from "@/components/tooltip";
+
+type ChatAnonymizedToggleProps = {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+  size?: "icon-sm" | "icon-xs" | undefined;
+};
+
+export const ChatAnonymizedToggle = ({
+  enabled,
+  onChange,
+  size = "icon-sm",
+}: ChatAnonymizedToggleProps) => {
+  const t = useTranslations();
+  const Icon = enabled ? ShieldCheckIcon : ShieldIcon;
+
+  return (
+    <Tooltip
+      content={t(
+        enabled ? "chat.anonymizedModeEnabled" : "chat.anonymizedModeDisabled",
+      )}
+      render={
+        <Button
+          aria-label={t("chat.anonymizedMode")}
+          aria-pressed={enabled}
+          data-pressed={enabled ? "" : undefined}
+          onClick={() => onChange(!enabled)}
+          size={size}
+          variant={enabled ? "secondary" : "ghost"}
+        >
+          <Icon className={size === "icon-xs" ? "size-3.5" : "size-4"} />
+        </Button>
+      }
+    />
+  );
+};

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -18,6 +18,7 @@ import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import Tooltip from "@/components/tooltip";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
+import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
@@ -58,7 +59,9 @@ export const ChatThreadPage = ({
   const [seededForThreadId, setSeededForThreadId] = useState<string | null>(
     null,
   );
+  const [anonymized, setAnonymized] = useState(false);
   const getContextMatterIds = useEffectEvent(() => contextMatterIds ?? []);
+  const getAnonymized = useEffectEvent(() => anonymized);
 
   const { data } = useSuspenseQuery(
     chatThreadOptions({
@@ -71,6 +74,7 @@ export const ChatThreadPage = ({
         allowMissingThread: true,
         getUserContext,
         getContextMatterIds,
+        getAnonymized,
       },
     }),
   );
@@ -166,6 +170,7 @@ export const ChatThreadPage = ({
           )}
         </div>
         <div className="flex items-center gap-1">
+          <ChatAnonymizedToggle enabled={anonymized} onChange={setAnonymized} />
           <Tooltip
             content={t("chat.moveToSide")}
             render={

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, test } from "bun:test";
 
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import {
+  buildSendRequestBody,
   chatKeys,
   matchesChatThreadAcrossScopes,
 } from "@/routes/_protected.chat/-queries";
+
+const createMessage = (): PersistedChatMessage => ({
+  id: "message-A",
+  role: "user",
+  parts: [{ type: "text", text: "Hello" }],
+});
 
 describe("chatKeys", () => {
   test("separates plain chat transports from active DOCX edit transports", () => {
@@ -27,32 +35,33 @@ describe("matchesChatThreadAcrossScopes", () => {
   const threadId = "thread-A";
 
   test("matches the global scope's key for the same thread", () => {
-    const key = ["chat", "thread", "global", threadId, false] as const;
+    const key = chatKeys.thread({ scope: "global", threadId });
     expect(matchesChatThreadAcrossScopes(key, threadId)).toBe(true);
   });
 
   test("matches the workspace scope's key for the same thread", () => {
-    const key = [
-      "chat",
-      "thread",
-      "workspace",
-      "ws-1",
+    const key = chatKeys.thread({
+      scope: "workspace",
+      workspaceId: "ws-1",
       threadId,
-      false,
-    ] as const;
+    });
     expect(matchesChatThreadAcrossScopes(key, threadId)).toBe(true);
   });
 
   test("rejects keys for other threads", () => {
     expect(
       matchesChatThreadAcrossScopes(
-        ["chat", "thread", "global", "thread-B", false],
+        chatKeys.thread({ scope: "global", threadId: "thread-B" }),
         threadId,
       ),
     ).toBe(false);
     expect(
       matchesChatThreadAcrossScopes(
-        ["chat", "thread", "workspace", "ws-1", "thread-B", false],
+        chatKeys.thread({
+          scope: "workspace",
+          workspaceId: "ws-1",
+          threadId: "thread-B",
+        }),
         threadId,
       ),
     ).toBe(false);
@@ -77,5 +86,20 @@ describe("matchesChatThreadAcrossScopes", () => {
         threadId,
       ),
     ).toBe(false);
+  });
+});
+
+describe("buildSendRequestBody", () => {
+  test("includes anonymized mode when the chat surface enables it", () => {
+    expect(
+      buildSendRequestBody({
+        context: { getAnonymized: () => true },
+        key: { scope: "global", threadId: "thread-A" },
+        messages: [createMessage()],
+      }),
+    ).toMatchObject({
+      anonymized: true,
+      threadId: "thread-A",
+    });
   });
 });

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -68,6 +68,7 @@ type ChatThreadOptionsContext = {
    * next send carries the latest set.
    */
   getContextMatterIds?: (() => string[]) | undefined;
+  getAnonymized?: (() => boolean) | undefined;
   getUserContext?: (() => ChatUserContext) | undefined;
   handleActiveDocxEditToolCall?:
     | ((
@@ -177,7 +178,7 @@ const fetchGroupedChatThreads = async () => {
 
 const getChatApiPath = () => `${env.VITE_API_URL}/v1/chat`;
 
-const buildSendRequestBody = ({
+export const buildSendRequestBody = ({
   context,
   key,
   messages,
@@ -194,6 +195,7 @@ const buildSendRequestBody = ({
   const body: {
     activeDecision?: ActiveDecisionContext | undefined;
     activeFile?: ActiveFileContext | undefined;
+    anonymized?: boolean | undefined;
     contextMatterIds?: string[] | undefined;
     message: PersistedChatMessage;
     threadId: string;
@@ -226,6 +228,11 @@ const buildSendRequestBody = ({
   const contextMatterIds = context?.getContextMatterIds?.();
   if (contextMatterIds !== undefined) {
     body.contextMatterIds = contextMatterIds;
+  }
+
+  const anonymized = context?.getAnonymized?.();
+  if (anonymized !== undefined) {
+    body.anonymized = anonymized;
   }
 
   return body;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -45,6 +45,7 @@ import { useDevStore } from "@/lib/dev-store";
 import { useStockPrompts } from "@/lib/prompts/stock";
 import type { ChatPrompt } from "@/lib/prompts/types";
 import { toSafeId } from "@/lib/safe-id";
+import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { chatThreadOptions } from "@/routes/_protected.chat/-queries";
@@ -99,6 +100,8 @@ export const ChatTabPanel = ({
   // picker updates would land in the store but never reach the
   // server. `useEffectEvent` always reads the latest closure values.
   const getContextMatterIds = useEffectEvent(() => tab.contextMatterIds);
+  const [anonymized, setAnonymized] = useState(false);
+  const getAnonymized = useEffectEvent(() => anonymized);
   const showToolCalls = useDevStore((s) => s.showToolCalls);
   const chatContextLabel = useChatContextLabel(tab);
 
@@ -144,6 +147,7 @@ export const ChatTabPanel = ({
         getUserContext,
         getActiveDecision,
         getContextMatterIds,
+        getAnonymized,
       },
     }),
   );
@@ -217,6 +221,7 @@ export const ChatTabPanel = ({
       onClose={onClose}
       onLabelContextMenu={onLabelContextMenu}
       onMoveToMain={moveToMain}
+      anonymized={anonymized}
       onNewThread={() =>
         openChat({
           workspaceId: tabWorkspaceId,
@@ -226,6 +231,7 @@ export const ChatTabPanel = ({
             : {}),
         })
       }
+      onSetAnonymized={setAnonymized}
       onSetContext={(next) => setChatContext(tab.id, next)}
       onStartRename={startRename}
       rename={{
@@ -337,6 +343,7 @@ const noop = () => {
 };
 
 type ChatTabPanelChromeProps = {
+  anonymized: boolean;
   tab: ChatTab;
   onClose: () => void;
   onLabelContextMenu: (event: MouseEvent<HTMLElement>) => void;
@@ -350,6 +357,7 @@ type ChatTabPanelChromeProps = {
   };
   onMoveToMain?: (() => void) | undefined;
   onNewThread?: (() => void) | undefined;
+  onSetAnonymized: (enabled: boolean) => void;
   onSetContext: (matterIds: string[]) => void;
   matterColor?: string | null | undefined;
   children: React.ReactNode;
@@ -366,6 +374,7 @@ type ChatTabPanelChromeProps = {
  * placeholder bar shape).
  */
 const ChatTabPanelChrome = ({
+  anonymized,
   tab,
   onClose,
   onLabelContextMenu,
@@ -373,6 +382,7 @@ const ChatTabPanelChrome = ({
   rename,
   onMoveToMain,
   onNewThread,
+  onSetAnonymized,
   onSetContext,
   matterColor,
   children,
@@ -390,6 +400,11 @@ const ChatTabPanelChrome = ({
           }
         />
       )}
+      <ChatAnonymizedToggle
+        enabled={anonymized}
+        onChange={onSetAnonymized}
+        size="icon-xs"
+      />
       {onMoveToMain && (
         <Tooltip
           content={t("chat.moveToMain")}
@@ -488,11 +503,13 @@ export const ChatTabPanelShell = ({
   const stockPrompts = useStockPrompts();
   return (
     <ChatTabPanelChrome
+      anonymized={false}
       matterColor={matterColor}
       onClose={noop}
       onLabelContextMenu={noop}
       onMoveToMain={noop}
       onNewThread={noop}
+      onSetAnonymized={noop}
       onSetContext={noop}
       onStartRename={noop}
       rename={{


### PR DESCRIPTION
## Summary
- add organization-scoped anonymization blacklist entries and feed them into anonymization gazetteer loading
- anonymize MCP returned corpus text in anonymized mode while preserving raw internal search
- add chat `anonymized` request mode, fail closed for non-plain-text attachments, and add a chat toolbar toggle
- scope anonymized chat pseudonyms to the active workspace or global thread and enforce case-insensitive blacklist canonical uniqueness

## Test plan
- bun --filter @stll/api format
- bun --filter @stll/api typecheck
- bun --filter @stll/api lint
- bun --filter @stll/web format
- bun --filter @stll/web typecheck
- bun --filter @stll/web lint (passes with an existing warning in docx-browser-editor.tsx)
- bun --filter @stll/web i18n:check
- VITE_API_URL=http://localhost:3001 bun test ./apps/web/src/routes/_protected.chat/-queries.test.ts
- DATABASE_URL=... bun test ./apps/api/src/handlers/chat/third-party-boundary.test.ts ./apps/api/src/lib/anonymization-blacklist.test.ts ./apps/api/src/handlers/chat/stream-chat.test.ts ./apps/api/src/mcp/tools.test.ts ./apps/api/src/mcp/server.test.ts
- git push pre-push gate: i18n, format, typecheck, lint