### PR TITLE
docs: add Discord links to README, CONTRIBUTING, and landing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for considering a contribution to Stella. Whether you are
 reporting a bug, suggesting a feature, improving documentation, or
 writing code, your help is welcome.
 
+Please join our [Discord](https://discord.gg/8dZjmVFjTK) to discuss
+and coordinate development.
+
 ## Getting Started
 
 1. Fork the repository and clone your fork.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
   <a href="https://stll.app">Website</a> &middot;
   <a href="MANIFESTO.md">Manifesto</a> &middot;
   <a href="https://github.com/stella/stella/issues">Issues</a> &middot;
-  <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="CONTRIBUTING.md">Contributing</a> &middot;
+  <a href="https://discord.gg/8dZjmVFjTK">Discord</a>
 </p>
 
 <p align="center">
@@ -18,6 +19,7 @@
   <a href="https://github.com/stella/stella/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License" /></a>
   <a href="https://stll.app"><img src="https://img.shields.io/badge/cloud-stll.app-black" alt="Stella Cloud" /></a>
   <a href="https://github.com/stella/stella/issues"><img src="https://img.shields.io/github/issues/stella/stella" alt="Issues" /></a>
+  <a href="https://discord.gg/8dZjmVFjTK"><img src="https://img.shields.io/badge/discord-join%20chat-5865F2?logo=discord&logoColor=white" alt="Discord" /></a>
 </p>
 
 ---

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -248,6 +248,7 @@ const selfHostingDocsUrl =
       <div class="flex flex-col items-center justify-between gap-6 sm:flex-row">
         <nav class="flex items-center gap-4 text-sm" style="color: var(--muted-foreground)" aria-label="Footer">
           <a href="https://github.com/stella/stella" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://discord.gg/8dZjmVFjTK" class="transition-opacity hover:opacity-70" target="_blank" rel="noopener noreferrer">Discord</a>
           <a href="/security" class="transition-opacity hover:opacity-70">Security</a>
           <a href="/terms" class="transition-opacity hover:opacity-70">Terms</a>
           <a href="/imprint" class="transition-opacity hover:opacity-70">Imprint</a>
@@ -263,6 +264,16 @@ const selfHostingDocsUrl =
             aria-label="GitHub"
           >
             <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .5C5.648.5.5 5.648.5 12a11.5 11.5 0 008.073 10.95c.59.11.805-.257.805-.57 0-.281-.01-1.024-.016-2.01-3.282.713-3.975-1.582-3.975-1.582-.536-1.362-1.31-1.725-1.31-1.725-1.072-.733.081-.718.081-.718 1.186.083 1.81 1.218 1.81 1.218 1.054 1.806 2.766 1.284 3.44.982.107-.764.413-1.285.752-1.58-2.62-.298-5.377-1.31-5.377-5.829 0-1.287.46-2.34 1.216-3.166-.122-.298-.527-1.5.116-3.126 0 0 .992-.317 3.25 1.209A11.33 11.33 0 0112 6.227c1.02.005 2.047.138 3.007.404 2.257-1.526 3.247-1.209 3.247-1.209.645 1.626.24 2.828.118 3.126.759.826 1.214 1.879 1.214 3.166 0 4.53-2.76 5.527-5.387 5.819.424.365.801 1.084.801 2.185 0 1.577-.014 2.85-.014 3.238 0 .316.212.686.81.569A11.502 11.502 0 0023.5 12C23.5 5.648 18.352.5 12 .5z"/></svg>
+          </a>
+          <a
+            href="https://discord.gg/8dZjmVFjTK"
+            class="transition-opacity hover:opacity-70"
+            style="color: var(--muted-foreground)"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Discord"
+          >
+            <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24"><path d="M20.317 4.369A19.79 19.79 0 0016.558 3a14.27 14.27 0 00-.642 1.318 18.27 18.27 0 00-5.487 0A12.84 12.84 0 009.781 3 19.74 19.74 0 006.02 4.371C2.09 10.215 1.022 15.913 1.556 21.53a19.94 19.94 0 006.073 3.066 14.7 14.7 0 001.3-2.114 12.85 12.85 0 01-2.045-.98c.171-.126.34-.258.5-.392a14.18 14.18 0 0012.231 0c.163.135.331.267.502.392-.654.388-1.34.717-2.05.982a14.55 14.55 0 001.3 2.113 19.92 19.92 0 006.077-3.066c.625-6.51-1.072-12.157-4.487-17.162zM8.677 18.06c-1.21 0-2.207-1.108-2.207-2.471 0-1.364.97-2.477 2.207-2.477 1.236 0 2.227 1.113 2.207 2.477 0 1.363-.98 2.471-2.207 2.471zm6.646 0c-1.21 0-2.207-1.108-2.207-2.471 0-1.364.97-2.477 2.207-2.477 1.236 0 2.227 1.113 2.207 2.477 0 1.363-.97 2.471-2.207 2.471z"/></svg>
           </a>
           <a
             href="https://x.com/stll_app"


### PR DESCRIPTION
## Summary
- Add Discord badge and header nav link to `README.md`
- Add a Discord invite line to `CONTRIBUTING.md` so contributors can coordinate development
- Add a Discord text link and social icon to the landing page footer

Invite: https://discord.gg/8dZjmVFjTK

## Test plan
- [x] `bun run lint` (1 pre-existing warning, unrelated)
- [x] `bun run format` (no changes)
- [x] `bun run typecheck`
- [ ] Visual check of landing footer in dev (`bun --filter @stll/landing dev`)