### PR TITLE
chore: minor changes

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -48,3 +48,4 @@ package-lock.json
 
 # Local AI devtools capture dir (generations.json). Dev-only.
 /.devtools/
+.devtools

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -21,7 +21,15 @@ const selfHostingDocsUrl =
         <div id="gradient-dark" class="absolute inset-0 opacity-0 dark:opacity-100 transition-opacity duration-500"></div>
       </div>
       <nav class="relative z-10 mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
-        <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
+        <div class="flex items-center gap-3">
+          <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
+          <span
+            class="rounded-sm px-1.5 py-0.5 text-[0.625rem] font-medium uppercase tracking-[0.1em]"
+            style="border: 1px solid var(--border); color: var(--muted-foreground)"
+          >
+            Beta
+          </span>
+        </div>
         <div class="flex items-center gap-4">
           <ThemeToggle />
         </div>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -23,10 +23,7 @@ const selfHostingDocsUrl =
       <nav class="relative z-10 mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
         <div class="flex items-center gap-3">
           <img src="/images/stella-logo.svg" alt="stella" class="h-6 dark:invert" />
-          <span
-            class="rounded-sm px-1.5 py-0.5 text-[0.625rem] font-medium uppercase tracking-[0.1em]"
-            style="border: 1px solid var(--border); color: var(--muted-foreground)"
-          >
+          <span class="border-border text-muted-foreground rounded-sm border px-1.5 py-0.5 text-[0.625rem] font-medium tracking-[0.1em] uppercase">
             Beta
           </span>
         </div>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -12,13 +12,6 @@ import {
   AvatarImage,
 } from "@stll/ui/components/avatar";
 import { Button } from "@stll/ui/components/button";
-import {
-  Combobox,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxList,
-  ComboboxPopup,
-} from "@stll/ui/components/combobox";
 import { Input } from "@stll/ui/components/input";
 import {
   Menu,
@@ -34,11 +27,6 @@ import {
   MenuSubTrigger,
   MenuTrigger,
 } from "@stll/ui/components/menu";
-import {
-  Popover,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
 import { toastManager } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 import {
@@ -51,11 +39,9 @@ import { getRouteApi, Link, useMatch } from "@tanstack/react-router";
 import {
   BookOpenIcon,
   ChevronsUpDownIcon,
-  ClockIcon,
   EllipsisVerticalIcon,
   GlobeIcon,
   LayersIcon,
-  Loader2Icon,
   LogOutIcon,
   MessageSquareIcon,
   MonitorIcon,
@@ -63,11 +49,9 @@ import {
   PanelLeftIcon,
   PinIcon,
   PinOffIcon,
-  PlayIcon,
   PlusIcon,
   SearchIcon,
   Settings2Icon,
-  SquareIcon,
   SunIcon,
   UsersIcon,
 } from "lucide-react";
@@ -110,15 +94,6 @@ import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
 import { knowledgeSections } from "@/routes/_protected.knowledge/index";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";
 import {
-  useStartTimer,
-  useStopTimer,
-} from "@/routes/_protected.workspaces/$workspaceId/-mutations/time-entries";
-import { entitySummariesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
-import {
-  activeTimerOptions,
-  timeEntriesKeys,
-} from "@/routes/_protected.workspaces/$workspaceId/-queries/time-entries";
-import {
   AddMemberDialog,
   MatterMenuItems,
 } from "@/routes/_protected.workspaces/-components/matter-context-menu";
@@ -139,16 +114,6 @@ const HOLD_DELAY_MS = 500;
 // TODO: Persist pinned workspaces on the backend (user
 // preference or a `pinned` flag on the workspace member).
 
-const formatTimer = (seconds: number) => {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
-  if (h > 0) {
-    return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
-  }
-  return `${m}:${String(s).padStart(2, "0")}`;
-};
-
 /**
  * Minimum shape required to identify and render a matter.
  * Any component or function that represents a matter must
@@ -168,212 +133,6 @@ const MatterIcon = ({ id, color }: Pick<MatterIdentity, "id" | "color">) => (
     }}
   />
 );
-
-type SidebarTimerPopoverProps = {
-  workspaceId: string;
-};
-
-type SidebarTimerBadgeProps = {
-  workspaceId: string;
-};
-
-const SidebarTimerBadge = ({ workspaceId }: SidebarTimerBadgeProps) => {
-  const t = useTranslations();
-  const queryClient = useQueryClient();
-  const stopTimer = useStopTimer();
-  const { data: activeTimer } = useQuery({
-    ...activeTimerOptions(workspaceId),
-  });
-  const [timerSeconds, setTimerSeconds] = useState(0);
-
-  useEffect(() => {
-    if (!activeTimer?.timerStartedAt) {
-      setTimerSeconds(0);
-      return undefined;
-    }
-
-    const startMs = new Date(activeTimer.timerStartedAt).getTime();
-    const tick = () => {
-      const elapsed = Math.floor((Date.now() - startMs) / 1000);
-      setTimerSeconds(elapsed);
-    };
-
-    tick();
-    const interval = setInterval(tick, 1000);
-
-    return () => clearInterval(interval);
-  }, [activeTimer?.timerStartedAt]);
-
-  if (activeTimer) {
-    return (
-      <SidebarMenuBadge>
-        <span className="flex items-center gap-1.5 text-xs tabular-nums">
-          <span className="size-1.5 animate-pulse rounded-full bg-green-500" />
-          {formatTimer(timerSeconds)}
-          <Button
-            aria-label={t("billing.stopTimer")}
-            className="text-muted-foreground size-5"
-            disabled={stopTimer.isPending}
-            onClick={() => {
-              stopTimer.mutate(
-                {
-                  workspaceId,
-                },
-                {
-                  onSuccess: () => {
-                    // eslint-disable-next-line typescript/no-floating-promises
-                    queryClient.invalidateQueries({
-                      queryKey: timeEntriesKeys.all(workspaceId),
-                    });
-                    // eslint-disable-next-line typescript/no-floating-promises
-                    queryClient.invalidateQueries({
-                      queryKey: timeEntriesKeys.activeTimer(workspaceId),
-                    });
-                  },
-                  onError: () => {
-                    toastManager.add({
-                      title: t("billing.failedToStopTimer"),
-                      type: "error",
-                    });
-                  },
-                },
-              );
-            }}
-            size="icon"
-            variant="ghost"
-          >
-            <SquareIcon className="size-3 fill-current" />
-          </Button>
-        </span>
-      </SidebarMenuBadge>
-    );
-  }
-
-  return (
-    <SidebarMenuBadge>
-      <SidebarTimerPopover workspaceId={workspaceId} />
-    </SidebarMenuBadge>
-  );
-};
-
-const SidebarTimerPopover = ({ workspaceId }: SidebarTimerPopoverProps) => {
-  const t = useTranslations();
-  const queryClient = useQueryClient();
-  const [open, setOpen] = useState(false);
-  const [selectedMatterId, setSelectedMatterId] = useState("");
-  const startTimer = useStartTimer();
-
-  const { data: matters, isPending: entitiesLoading } = useQuery({
-    ...entitySummariesOptions(workspaceId),
-    enabled: open,
-  });
-
-  const handleStart = () => {
-    if (!selectedMatterId) {
-      toastManager.add({
-        title: t("billing.matterRequired"),
-        type: "error",
-      });
-      return;
-    }
-
-    startTimer.mutate(
-      {
-        workspaceId,
-        matterId: selectedMatterId,
-        timezoneId: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        // TODO(phase-2): resolve rate from user/matter settings
-        rateAtEntry: 0,
-        currency: "USD",
-      },
-      {
-        onSuccess: () => {
-          setOpen(false);
-          setSelectedMatterId("");
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: timeEntriesKeys.all(workspaceId),
-          });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: timeEntriesKeys.activeTimer(workspaceId),
-          });
-        },
-        onError: () => {
-          toastManager.add({
-            title: t("billing.failedToStartTimer"),
-            type: "error",
-          });
-        },
-      },
-    );
-  };
-
-  return (
-    <Popover
-      onOpenChange={(nextOpen) => {
-        setOpen(nextOpen);
-        if (!nextOpen) {
-          setSelectedMatterId("");
-        }
-      }}
-      open={open}
-    >
-      <PopoverTrigger
-        render={
-          <Button
-            aria-label={t("billing.startTimer")}
-            className="size-5"
-            size="icon"
-            title={t("billing.startTimer")}
-            variant="ghost"
-          />
-        }
-      >
-        <PlayIcon className="size-3" />
-      </PopoverTrigger>
-      <PopoverPopup align="start" className="w-64" side="right" sideOffset={8}>
-        <div className="flex flex-col gap-3">
-          <p className="text-muted-foreground text-xs">
-            {t("billing.selectMatterToStart")}
-          </p>
-          {entitiesLoading && (
-            <div className="text-muted-foreground flex items-center gap-2 py-2 text-xs">
-              <Loader2Icon className="size-3 animate-spin" />
-              {t("billing.loading")}
-            </div>
-          )}
-          <Combobox
-            onValueChange={(val) => {
-              if (val) {
-                setSelectedMatterId(val);
-              }
-            }}
-            value={selectedMatterId || null}
-          >
-            <ComboboxInput placeholder={t("billing.selectMatter")} size="sm" />
-            <ComboboxPopup>
-              <ComboboxList>
-                {matters?.map((matter) => (
-                  <ComboboxItem key={matter.id} value={matter.id}>
-                    {matter.name ?? t("workspaces.defaultName")}
-                  </ComboboxItem>
-                ))}
-              </ComboboxList>
-            </ComboboxPopup>
-          </Combobox>
-          <Button
-            disabled={!selectedMatterId || startTimer.isPending}
-            onClick={handleStart}
-            size="sm"
-          >
-            {t("billing.startTimer")}
-          </Button>
-        </div>
-      </PopoverPopup>
-    </Popover>
-  );
-};
 
 type ContextAction = {
   label: string;
@@ -872,13 +631,10 @@ export function AppSidebar(props: AppSidebarProps) {
   const displayName = user.name ?? user.email;
   const orgName = organization?.name;
 
-  // Active timer: try to detect current workspace
   const workspaceMatch = useMatch({
     from: "/_protected/workspaces/$workspaceId",
     shouldThrow: false,
   });
-  const currentWorkspaceId =
-    workspaceMatch?.params.workspaceId ?? workspaces?.at(0)?.id;
 
   const handleCreateWorkspace = () => {
     if (!canCreateMatter) {
@@ -933,14 +689,6 @@ export function AppSidebar(props: AppSidebarProps) {
     handleCreateWorkspace();
   });
 
-  useHotkey(HOTKEYS.TOGGLE_TIME_TRACKING, () => {
-    if (currentWorkspaceId) {
-      void navigate({
-        to: `/workspaces/${currentWorkspaceId}/timesheets`,
-      });
-    }
-  });
-
   const pinned = useMemo(() => {
     if (!workspaces) {
       return [];
@@ -966,13 +714,6 @@ export function AppSidebar(props: AppSidebarProps) {
       )
       .slice(0, RECENTS_LIMIT);
   }, [workspaces, pinnedIds]);
-
-  const comingSoon = () => {
-    toastManager.add({
-      title: t("common.comingSoon"),
-      type: "foreground",
-    });
-  };
 
   // Hold-to-reveal nav badges (Control on Mac, Alt on Win/Linux)
   const isNavKeyHeld = useKeyHold(NAV_KEY);
@@ -1020,8 +761,7 @@ export function AppSidebar(props: AppSidebarProps) {
     /* 2: chat */ FixedNavTarget,
     /* 3: workspaces */ FixedNavTarget,
     /* 4: knowledge */ FixedNavTarget,
-    /* 5: time tracking */ FixedNavTarget,
-    /* 6: contacts */ FixedNavTarget,
+    /* 5: contacts */ FixedNavTarget,
   ] = [
     {
       action: () => setSearchOpen(true),
@@ -1077,30 +817,6 @@ export function AppSidebar(props: AppSidebarProps) {
             };
           }),
       },
-    },
-    {
-      action: () => {
-        if (currentWorkspaceId) {
-          void navigate({
-            to: "/workspaces/$workspaceId/timesheets",
-            params: { workspaceId: currentWorkspaceId },
-          });
-        }
-      },
-      contextMenu: currentWorkspaceId
-        ? {
-            primaryAction: {
-              label: t("navigation.timeTracking"),
-              icon: <ClockIcon />,
-              onClick: () => {
-                void navigate({
-                  to: "/workspaces/$workspaceId/timesheets",
-                  params: { workspaceId: currentWorkspaceId },
-                });
-              },
-            },
-          }
-        : {},
     },
     {
       action: () => {
@@ -1259,46 +975,13 @@ export function AppSidebar(props: AppSidebarProps) {
             </NavContextMenu>
             <NavContextMenu config={fixedNavTargets[4].contextMenu}>
               <SidebarMenuItem>
-                {currentWorkspaceId ? (
-                  <SidebarMenuButton
-                    asChild
-                    tooltip={t("navigation.timeTracking")}
-                  >
-                    <Link
-                      params={{
-                        workspaceId: currentWorkspaceId,
-                      }}
-                      to="/workspaces/$workspaceId/timesheets"
-                    >
-                      <ClockIcon />
-                      <span>{t("navigation.timeTracking")}</span>
-                    </Link>
-                  </SidebarMenuButton>
-                ) : (
-                  <SidebarMenuButton
-                    onClick={comingSoon}
-                    tooltip={t("navigation.timeTracking")}
-                  >
-                    <ClockIcon />
-                    <span>{t("navigation.timeTracking")}</span>
-                  </SidebarMenuButton>
-                )}
-                {showNavBadges ? (
-                  <NavBadge digit={5} />
-                ) : currentWorkspaceId ? (
-                  <SidebarTimerBadge workspaceId={currentWorkspaceId} />
-                ) : null}
-              </SidebarMenuItem>
-            </NavContextMenu>
-            <NavContextMenu config={fixedNavTargets[5].contextMenu}>
-              <SidebarMenuItem>
                 <SidebarMenuButton asChild tooltip={t("navigation.contacts")}>
                   <Link activeProps={{ "data-active": true }} to="/contacts">
                     <UsersIcon />
                     <span>{t("navigation.contacts")}</span>
                   </Link>
                 </SidebarMenuButton>
-                {showNavBadges && <NavBadge digit={6} />}
+                {showNavBadges && <NavBadge digit={5} />}
               </SidebarMenuItem>
             </NavContextMenu>
           </SidebarMenu>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1004,7 +1004,7 @@ export function AppSidebar(props: AppSidebarProps) {
                     <MatterItem
                       isPinned
                       key={ws.id}
-                      navBadge={showNavBadges && i < 3 ? 7 + i : undefined}
+                      navBadge={showNavBadges && i < 3 ? 6 + i : undefined}
                       onDelete={handleDeleteWorkspace}
                       onReorder={reorderPinned}
                       onTogglePin={togglePin}

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -16,15 +16,28 @@ import { toastManager } from "@stll/ui/components/toast";
 import { useQueryClient } from "@tanstack/react-query";
 import {
   DatabaseIcon,
+  ExternalLinkIcon,
   PlayIcon,
   RotateCcwIcon,
+  SparklesIcon,
   Trash2Icon,
   WrenchIcon,
 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 
+import { env } from "@/env";
 import { api } from "@/lib/api";
 import { useDevStore } from "@/lib/dev-store";
+
+// Build the AI SDK DevTools URL from VITE_API_URL's host so it
+// follows the same per-worktree port offset, then swap in the
+// devtools port (default 4983, override with VITE_AI_SDK_DEVTOOLS_PORT).
+const aiSdkDevtoolsUrl = (() => {
+  const apiUrl = new URL(env.VITE_API_URL);
+  apiUrl.port = String(env.VITE_AI_SDK_DEVTOOLS_PORT);
+  apiUrl.pathname = "/";
+  return apiUrl.toString();
+})();
 
 /**
  * Models available in the dev model selector.
@@ -290,6 +303,25 @@ export const DevSidebarGroup = () => {
         >
           <WrenchIcon />
           UI playground
+        </MenuItem>
+        <MenuItem
+          disabled={!env.VITE_AI_DEVTOOLS_ENABLED}
+          onClick={() => {
+            // Dev-runner only spawns the devtools CLI when
+            // AI_DEVTOOLS_ENABLED=true in apps/api/.env, so the
+            // disabled state mirrors that gate.
+            window.open(aiSdkDevtoolsUrl, "_blank", "noopener,noreferrer");
+          }}
+        >
+          <SparklesIcon />
+          AI SDK Devtools
+          {env.VITE_AI_DEVTOOLS_ENABLED ? (
+            <ExternalLinkIcon className="ms-auto size-3 opacity-60" />
+          ) : (
+            <span className="ms-auto text-[0.625rem] opacity-60">
+              Set AI_DEVTOOLS_ENABLED
+            </span>
+          )}
         </MenuItem>
       </MenuSubPopup>
     </MenuSub>

--- a/apps/web/src/components/table.tsx
+++ b/apps/web/src/components/table.tsx
@@ -75,7 +75,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   return (
     <td
       className={cn(
-        "group/cell-content bg-background relative z-0 h-auto min-h-8 overflow-hidden border-e p-2 align-middle whitespace-nowrap group-hover/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[active]/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[state=selected]/row:bg-[color-mix(in_srgb,var(--color-info)_10%,var(--color-background))] group-data-[state=selected]/row:group-hover/row:bg-[color-mix(in_srgb,var(--color-info)_15%,var(--color-background))] last:border-e-0",
+        "group/cell-content bg-background relative z-0 h-auto min-h-10 overflow-hidden border-e p-2 align-middle whitespace-nowrap group-hover/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[active]/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[state=selected]/row:bg-[color-mix(in_srgb,var(--color-info)_10%,var(--color-background))] group-data-[state=selected]/row:group-hover/row:bg-[color-mix(in_srgb,var(--color-info)_15%,var(--color-background))] last:border-e-0",
         className,
       )}
       data-slot="table-cell"

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -32,6 +32,21 @@ export const env = createEnv({
       ),
       "45901",
     ),
+    VITE_AI_SDK_DEVTOOLS_PORT: v.optional(
+      v.pipe(
+        v.string(),
+        v.digits(),
+        v.transform(Number),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(65_535),
+      ),
+      "4983",
+    ),
+    VITE_AI_DEVTOOLS_ENABLED: v.optional(
+      v.pipe(v.string(), v.parseBoolean()),
+      "false",
+    ),
     VITE_AUTH_GOOGLE: v.optional(v.pipe(v.string(), v.parseBoolean()), "false"),
     VITE_AUTH_MICROSOFT: v.optional(
       v.pipe(v.string(), v.parseBoolean()),

--- a/apps/web/src/lib/hotkeys.ts
+++ b/apps/web/src/lib/hotkeys.ts
@@ -9,7 +9,6 @@ export const HOTKEYS = {
   TOGGLE_CHAT: "Mod+J",
   NEW_CHAT: "Mod+Shift+J",
   NEW_MATTER: "Mod+Shift+E",
-  TOGGLE_TIME_TRACKING: "Mod+Shift+H",
   SELECT_ALL: "Mod+A",
 } as const satisfies Record<string, Hotkey>;
 
@@ -49,11 +48,6 @@ export const SHORTCUT_HINT_GROUPS = [
         hotkey: HOTKEYS.NEW_MATTER,
         labelKey: "navigation.newMatter",
         contexts: ["global", "workspace"],
-      },
-      {
-        hotkey: HOTKEYS.TOGGLE_TIME_TRACKING,
-        labelKey: "navigation.timeTracking",
-        contexts: ["global"],
       },
     ],
   },

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -311,7 +311,7 @@ function ProtectedContent({
         </>
       )}
       {canShowInspectorButton && (
-        <>
+        <div className="contents md:hidden">
           <Separator className="mx-1 h-4" orientation="vertical" />
           <Button
             aria-pressed={
@@ -325,7 +325,7 @@ function ProtectedContent({
           >
             <PanelRightIcon className="size-4" />
           </Button>
-        </>
+        </div>
       )}
     </div>
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
@@ -145,6 +145,22 @@ export const AddEntityMenu = ({
     fileInputRef.current?.click();
   };
 
+  const fileInput = hasFileProperties ? (
+    <input
+      className="sr-only"
+      multiple
+      onChange={(e) => {
+        const files = [...(e.currentTarget.files ?? [])];
+        if (files.length > 0) {
+          createFileEntities(files);
+        }
+        e.target.value = "";
+      }}
+      ref={fileInputRef}
+      type="file"
+    />
+  ) : null;
+
   if (uploadOnly && hasFileProperties) {
     const trigger = render ?? (
       <Button size="xs" variant="ghost">
@@ -155,19 +171,7 @@ export const AddEntityMenu = ({
     return (
       <>
         {React.cloneElement(trigger, { onClick: handleUploadClick })}
-        <input
-          className="sr-only"
-          multiple
-          onChange={(e) => {
-            const files = [...(e.currentTarget.files ?? [])];
-            if (files.length > 0) {
-              createFileEntities(files);
-            }
-            e.target.value = "";
-          }}
-          ref={fileInputRef}
-          type="file"
-        />
+        {fileInput}
       </>
     );
   }
@@ -190,12 +194,7 @@ export const AddEntityMenu = ({
         <MenuPopup anchor={anchor ?? undefined}>
           {hasFileProperties && (
             <>
-              <MenuItem
-                disabled={isUploadDisabled}
-                onClick={() => {
-                  fileInputRef.current?.click();
-                }}
-              >
+              <MenuItem disabled={isUploadDisabled} onClick={handleUploadClick}>
                 <UploadIcon />
                 {t("common.uploadFiles")}
               </MenuItem>
@@ -221,21 +220,7 @@ export const AddEntityMenu = ({
           </MenuItem>
         </MenuPopup>
       </Menu>
-      {hasFileProperties && (
-        <input
-          className="sr-only"
-          multiple
-          onChange={(e) => {
-            const files = [...(e.currentTarget.files ?? [])];
-            if (files.length > 0) {
-              createFileEntities(files);
-            }
-            e.target.value = "";
-          }}
-          ref={fileInputRef}
-          type="file"
-        />
-      )}
+      {fileInput}
     </>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import React, { useRef } from "react";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -48,6 +48,13 @@ type AddEntityMenuProps = {
    * action whose result the user can't see in place.
    */
   showTaskOption?: boolean | undefined;
+  /**
+   * Skip the menu entirely: clicking the trigger opens the file
+   * picker. Used by the table's bottom-row "+" so a single click
+   * goes straight to upload without intermediate New-task / New-
+   * folder choices the user doesn't want here.
+   */
+  uploadOnly?: boolean | undefined;
 };
 
 export const AddEntityMenu = ({
@@ -59,6 +66,7 @@ export const AddEntityMenu = ({
   onOpenChange,
   anchor,
   showTaskOption = true,
+  uploadOnly = false,
 }: AddEntityMenuProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const isWorkflowRunning = useIsWorkflowRunning(workspaceId);
@@ -129,6 +137,40 @@ export const AddEntityMenu = ({
     });
     useInspectorStore.getState().openTask(entityId, "", true);
   };
+
+  const handleUploadClick = () => {
+    if (isUploadDisabled) {
+      return;
+    }
+    fileInputRef.current?.click();
+  };
+
+  if (uploadOnly && hasFileProperties) {
+    const trigger = render ?? (
+      <Button size="xs" variant="ghost">
+        <PlusIcon />
+        {t("common.uploadFiles")}
+      </Button>
+    );
+    return (
+      <>
+        {React.cloneElement(trigger, { onClick: handleUploadClick })}
+        <input
+          className="sr-only"
+          multiple
+          onChange={(e) => {
+            const files = [...(e.currentTarget.files ?? [])];
+            if (files.length > 0) {
+              createFileEntities(files);
+            }
+            e.target.value = "";
+          }}
+          ref={fileInputRef}
+          type="file"
+        />
+      </>
+    );
+  }
 
   return (
     <>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -32,6 +32,7 @@ export const BottomRow = ({
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
+          uploadOnly
           render={
             <Button
               className="absolute inset-0 z-10 flex size-auto! min-w-12 shrink-0 rounded-none bg-transparent"
@@ -53,6 +54,7 @@ export const BottomRow = ({
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
+          uploadOnly
           render={
             <button
               className="absolute inset-0 cursor-pointer text-start"
@@ -69,6 +71,7 @@ export const BottomRow = ({
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
+          uploadOnly
           render={
             <button className="absolute inset-0 cursor-pointer" type="button" />
           }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -48,6 +48,7 @@ import {
   visibleEntityFieldIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
+import { taskKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/tasks";
 import { getInternalPropertyId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 type KanbanViewProps = {
@@ -190,12 +191,17 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
           type: "error",
         });
       }
-      return response.data;
+      return { taskId };
     },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: entitiesKeys.all(workspaceId),
-      });
+    onSuccess: async ({ taskId }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: entitiesKeys.all(workspaceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: taskKeys.detail(workspaceId, taskId),
+        }),
+      ]);
     },
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -656,18 +656,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
               <ClockIcon className="me-1.5 inline size-3.5" />
               {t("workspaces.overview.timeAndTeam")}
             </h2>
-            <Button
-              className="h-7 text-xs"
-              onClick={() => {
-                // eslint-disable-next-line typescript/no-floating-promises
-                navigate({
-                  to: "/workspaces/$workspaceId/timesheets",
-                  params: { workspaceId },
-                });
-              }}
-              size="sm"
-              variant="ghost"
-            >
+            <Button className="h-7 text-xs" disabled size="sm" variant="ghost">
               <PlusIcon className="size-3" />
               {t("common.logTime")}
             </Button>

--- a/apps/web/src/routes/auth/route.tsx
+++ b/apps/web/src/routes/auth/route.tsx
@@ -29,20 +29,17 @@ function AuthLayout() {
       `}</style>
       <div className="flex flex-1 flex-col px-8 lg:px-16 xl:px-24">
         <header className="pt-12">
-          <a
-            aria-label="stella"
-            className="inline-flex transition-opacity hover:opacity-80"
-            href={landingUrl}
-          >
-            <StellaWordmark className="text-foreground h-6 w-auto" />
-          </a>
-          <div className="border-border bg-card/80 mt-8 max-w-2xl rounded-lg border p-4">
-            <p className="text-foreground text-sm font-medium">
-              {t("auth.betaNoticeTitle")}
-            </p>
-            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              {t("auth.betaNoticeBody")}
-            </p>
+          <div className="flex items-center gap-3">
+            <a
+              aria-label="stella"
+              className="inline-flex transition-opacity hover:opacity-80"
+              href={landingUrl}
+            >
+              <StellaWordmark className="text-foreground h-6 w-auto" />
+            </a>
+            <span className="border-border text-muted-foreground rounded-sm border px-1.5 py-0.5 text-[0.625rem] font-medium tracking-[0.1em] uppercase">
+              Beta
+            </span>
           </div>
         </header>
         <div className="flex flex-1 flex-col items-center min-[70rem]:flex-row min-[70rem]:items-baseline">

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -313,11 +313,28 @@ describe("requiredPortsForMode", () => {
     const ports = portsForOffset(5);
 
     expect(requiredPortsForMode("dev:web", ports)).toEqual([3005]);
-    expect(requiredPortsForMode("dev:api", ports)).toEqual([3006, 4988]);
-    expect(requiredPortsForMode("dev", ports)).toEqual([3006, 4988, 3005]);
+    expect(requiredPortsForMode("dev:api", ports)).toEqual([3006]);
+    expect(requiredPortsForMode("dev", ports)).toEqual([3006, 3005]);
     expect(requiredPortsForMode("dev:desktop", ports)).toEqual([
-      3006, 4988, 3005, 5182, 45_906,
+      3006, 3005, 5182, 45_906,
     ]);
+  });
+
+  test("reserves the AI SDK devtools port only when the flag is on", () => {
+    const ports = portsForOffset(5);
+
+    expect(
+      requiredPortsForMode("dev:api", ports, { aiDevtoolsEnabled: false }),
+    ).toEqual([3006]);
+    expect(
+      requiredPortsForMode("dev:api", ports, { aiDevtoolsEnabled: true }),
+    ).toEqual([3006, 4988]);
+    expect(
+      requiredPortsForMode("dev", ports, { aiDevtoolsEnabled: true }),
+    ).toEqual([3006, 4988, 3005]);
+    expect(
+      requiredPortsForMode("dev:web", ports, { aiDevtoolsEnabled: true }),
+    ).toEqual([3005]);
   });
 });
 

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -152,12 +152,14 @@ describe("resolveOffset", () => {
 describe("portsForOffset", () => {
   test("keeps the API, web, and desktop ports in sync", () => {
     expect(portsForOffset(0)).toEqual({
+      aiSdkDevtools: 4983,
       api: 3001,
       desktopBridge: 45_901,
       desktopView: 5177,
       web: 3000,
     });
     expect(portsForOffset(24)).toEqual({
+      aiSdkDevtools: 5007,
       api: 3025,
       desktopBridge: 45_925,
       desktopView: 5201,
@@ -510,6 +512,7 @@ describe("dev env factories", () => {
       infraOffset: 0,
       infraPorts: infraPortsForOffset(0),
       ports: {
+        aiSdkDevtools: 5083,
         api: 3101,
         desktopBridge: 45_999,
         desktopView: 5199,
@@ -536,6 +539,7 @@ describe("dev env factories", () => {
         infraOffset: 10,
         infraPorts: infraPortsForOffset(10),
         ports: {
+          aiSdkDevtools: 5083,
           api: 3101,
           desktopBridge: 45_999,
           desktopView: 5199,
@@ -553,8 +557,10 @@ describe("dev env factories", () => {
   test("threads computed ports into the web env", () => {
     expect(
       createWebEnv({
+        aiDevtoolsEnabled: false,
         baseEnv: { KEEP_ME: "1" },
         ports: {
+          aiSdkDevtools: 5083,
           api: 3101,
           desktopBridge: 45_999,
           desktopView: 5199,
@@ -565,9 +571,24 @@ describe("dev env factories", () => {
       KEEP_ME: "1",
       STELLA_API_PORT: "3101",
       STELLA_WEB_PORT: "3100",
+      VITE_AI_DEVTOOLS_ENABLED: "false",
+      VITE_AI_SDK_DEVTOOLS_PORT: "5083",
       VITE_API_URL: "http://localhost:3101",
       VITE_DESKTOP_BRIDGE_PORT: "45999",
     });
+    expect(
+      createWebEnv({
+        aiDevtoolsEnabled: true,
+        baseEnv: {},
+        ports: {
+          aiSdkDevtools: 5083,
+          api: 3101,
+          desktopBridge: 45_999,
+          desktopView: 5199,
+          web: 3100,
+        },
+      }),
+    ).toMatchObject({ VITE_AI_DEVTOOLS_ENABLED: "true" });
   });
 
   test("threads computed ports into the desktop env", () => {
@@ -575,6 +596,7 @@ describe("dev env factories", () => {
       createDesktopEnv({
         baseEnv: { KEEP_ME: "1" },
         ports: {
+          aiSdkDevtools: 5083,
           api: 3101,
           desktopBridge: 45_999,
           desktopView: 5199,

--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -313,10 +313,10 @@ describe("requiredPortsForMode", () => {
     const ports = portsForOffset(5);
 
     expect(requiredPortsForMode("dev:web", ports)).toEqual([3005]);
-    expect(requiredPortsForMode("dev:api", ports)).toEqual([3006]);
-    expect(requiredPortsForMode("dev", ports)).toEqual([3006, 3005]);
+    expect(requiredPortsForMode("dev:api", ports)).toEqual([3006, 4988]);
+    expect(requiredPortsForMode("dev", ports)).toEqual([3006, 4988, 3005]);
     expect(requiredPortsForMode("dev:desktop", ports)).toEqual([
-      3006, 3005, 5182, 45_906,
+      3006, 4988, 3005, 5182, 45_906,
     ]);
   });
 });

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -28,6 +28,7 @@ const ENV_FILE_SPECS = [
 ] as const;
 const PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0"] as const;
 const DEFAULT_PORTS = {
+  aiSdkDevtools: 4983,
   api: 3001,
   desktopBridge: 45_901,
   desktopView: 5177,
@@ -98,6 +99,7 @@ export type ResolvedOffset = {
 };
 
 export type DevPorts = {
+  aiSdkDevtools: number;
   api: number;
   desktopBridge: number;
   desktopView: number;
@@ -347,6 +349,7 @@ const dockerProjectName = (infraOffset: number) =>
     : `${SHARED_DOCKER_PROJECT_BASE}-${String(infraOffset)}`;
 
 export const portsForOffset = (offset: number): DevPorts => ({
+  aiSdkDevtools: DEFAULT_PORTS.aiSdkDevtools + offset,
   api: DEFAULT_PORTS.api + offset,
   desktopBridge: DEFAULT_PORTS.desktopBridge + offset,
   desktopView: DEFAULT_PORTS.desktopView + offset,
@@ -360,7 +363,7 @@ export const requiredPortsForMode = (
   const requiredPorts: number[] = [];
 
   if (modeIncludesApi(mode)) {
-    requiredPorts.push(ports.api);
+    requiredPorts.push(ports.api, ports.aiSdkDevtools);
   }
 
   if (modeIncludesWeb(mode)) {
@@ -858,6 +861,7 @@ export const createApiEnv = ({
   ports: DevPorts;
 }) => ({
   ...baseEnv,
+  AI_SDK_DEVTOOLS_PORT: String(ports.aiSdkDevtools),
   BETTER_AUTH_COOKIE_PREFIX: `stella-dev-${String(ports.api)}`,
   BETTER_AUTH_URL: apiUrlForPort(ports.api),
   FRONTEND_URL: webUrlForPort(ports.web),
@@ -873,15 +877,19 @@ export const createApiEnv = ({
 });
 
 export const createWebEnv = ({
+  aiDevtoolsEnabled,
   baseEnv,
   ports,
 }: {
+  aiDevtoolsEnabled: boolean;
   baseEnv: NodeJS.ProcessEnv;
   ports: DevPorts;
 }) => ({
   ...baseEnv,
   STELLA_API_PORT: String(ports.api),
   STELLA_WEB_PORT: String(ports.web),
+  VITE_AI_DEVTOOLS_ENABLED: aiDevtoolsEnabled ? "true" : "false",
+  VITE_AI_SDK_DEVTOOLS_PORT: String(ports.aiSdkDevtools),
   VITE_API_URL: apiUrlForPort(ports.api),
   VITE_DESKTOP_BRIDGE_PORT: String(ports.desktopBridge),
 });
@@ -914,6 +922,56 @@ const decodeOutput = (value: Uint8Array) =>
   new TextDecoder().decode(value).trim();
 
 const resolveEnv = (env: NodeJS.ProcessEnv | undefined) => env ?? process.env;
+
+const TRUTHY_ENV_VALUES: ReadonlySet<string> = new Set([
+  "1",
+  "true",
+  "yes",
+  "on",
+]);
+
+const readEnvFlag = ({
+  envFilePath,
+  key,
+  processEnv,
+}: {
+  envFilePath: string;
+  key: string;
+  processEnv: NodeJS.ProcessEnv;
+}): boolean => {
+  const raw = processEnv[key];
+  if (raw !== undefined) {
+    return TRUTHY_ENV_VALUES.has(
+      raw.trim().toLowerCase().replace(/^"|"$/gu, ""),
+    );
+  }
+  if (!existsSync(envFilePath)) {
+    return false;
+  }
+  for (const line of readFileSync(envFilePath, "utf-8").split(/\r?\n/u)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0 || trimmed.startsWith("#")) {
+      continue;
+    }
+    const withoutExport = trimmed.startsWith("export ")
+      ? trimmed.slice("export ".length)
+      : trimmed;
+    const eqIndex = withoutExport.indexOf("=");
+    if (eqIndex === -1) {
+      continue;
+    }
+    if (withoutExport.slice(0, eqIndex).trim() !== key) {
+      continue;
+    }
+    const value = withoutExport
+      .slice(eqIndex + 1)
+      .trim()
+      .replace(/^"|"$/gu, "")
+      .toLowerCase();
+    return TRUTHY_ENV_VALUES.has(value);
+  }
+  return false;
+};
 
 const stripAppEnvKeys = ({
   baseEnv,
@@ -1207,7 +1265,13 @@ const buildPersistentSteps = ({
     infraPorts,
     ports,
   });
+  const aiDevtoolsEnabled = readEnvFlag({
+    envFilePath: pathResolve(rootDir, "apps/api/.env"),
+    key: "AI_DEVTOOLS_ENABLED",
+    processEnv: process.env,
+  });
   const webEnv = createWebEnv({
+    aiDevtoolsEnabled,
     baseEnv: webBaseEnv,
     ports,
   });
@@ -1225,6 +1289,19 @@ const buildPersistentSteps = ({
       env: apiEnv,
       label: "API server",
     });
+    // AI SDK DevTools UI: only useful alongside the API and only
+    // when the API is set to publish traces (AI_DEVTOOLS_ENABLED=true
+    // in apps/api/.env). Honors the worktree's port offset so
+    // multiple worktrees can run side-by-side without colliding on
+    // 4983.
+    if (aiDevtoolsEnabled) {
+      secondary.push({
+        cmd: [resolveCommandPath("bun"), "run", "dev:ai-tools"],
+        cwd: pathResolve(rootDir, "apps/api"),
+        env: apiEnv,
+        label: "AI SDK Devtools",
+      });
+    }
   }
 
   if (modeIncludesWeb(mode)) {
@@ -1391,6 +1468,9 @@ const printSummary = ({
   }
   if (modeIncludesApi(mode)) {
     console.log(`  api: ${apiUrlForPort(ports.api)}`);
+    console.log(
+      `  ai sdk devtools: http://localhost:${String(ports.aiSdkDevtools)}`,
+    );
     console.log(`  postgres: localhost:${String(infraPorts.postgres)}`);
     console.log(`  valkey: localhost:${String(infraPorts.valkey)}`);
     console.log(`  minio: localhost:${String(infraPorts.minio)}`);

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -963,8 +963,25 @@ const readEnvFlag = ({
     if (withoutExport.slice(0, eqIndex).trim() !== key) {
       continue;
     }
-    const value = withoutExport
-      .slice(eqIndex + 1)
+    const rawValue = withoutExport.slice(eqIndex + 1).trimStart();
+    // Strip trailing comments. A `#` inside double quotes is part of
+    // the value, so only honor `#` once the opening quote has closed
+    // (or when no quotes were used at all).
+    const isQuoted = rawValue.startsWith('"');
+    let endIndex = rawValue.length;
+    if (isQuoted) {
+      const closingQuote = rawValue.indexOf('"', 1);
+      if (closingQuote !== -1) {
+        endIndex = closingQuote + 1;
+      }
+    } else {
+      const hashIndex = rawValue.indexOf("#");
+      if (hashIndex !== -1) {
+        endIndex = hashIndex;
+      }
+    }
+    const value = rawValue
+      .slice(0, endIndex)
       .trim()
       .replace(/^"|"$/gu, "")
       .toLowerCase();

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -359,11 +359,18 @@ export const portsForOffset = (offset: number): DevPorts => ({
 export const requiredPortsForMode = (
   mode: DevMode,
   ports: DevPorts,
+  options: { aiDevtoolsEnabled?: boolean } = {},
 ): number[] => {
   const requiredPorts: number[] = [];
 
   if (modeIncludesApi(mode)) {
-    requiredPorts.push(ports.api, ports.aiSdkDevtools);
+    requiredPorts.push(ports.api);
+    // Reserve the AI SDK Devtools port only when the runner will
+    // actually spawn the CLI; otherwise an unrelated process holding
+    // 4983 (or its offset twin) would force a needless offset shift.
+    if (options.aiDevtoolsEnabled) {
+      requiredPorts.push(ports.aiSdkDevtools);
+    }
   }
 
   if (modeIncludesWeb(mode)) {
@@ -758,11 +765,13 @@ const ensureDockerServices = async ({
 };
 
 export const findFirstAvailableOffset = async ({
+  aiDevtoolsEnabled = false,
   checkReusableApiPort = isHealthyApiPort,
   checkPortAvailability = checkPortAvailabilityOnHosts,
   mode,
   startOffset,
 }: {
+  aiDevtoolsEnabled?: boolean;
   checkReusableApiPort?: CheckReusableApiPort;
   checkPortAvailability?: (port: number) => Promise<boolean>;
   mode: DevMode;
@@ -775,7 +784,7 @@ export const findFirstAvailableOffset = async ({
   ) {
     const ports = portsForOffset(offset);
     const availability = await Promise.all(
-      requiredPortsForMode(mode, ports).map(
+      requiredPortsForMode(mode, ports, { aiDevtoolsEnabled }).map(
         async (port) => await checkPortAvailability(port),
       ),
     );
@@ -1252,12 +1261,14 @@ const buildPreparationSteps = ({
 };
 
 const buildPersistentSteps = ({
+  aiDevtoolsEnabled,
   infraOffset,
   infraPorts,
   mode,
   ports,
   rootDir,
 }: {
+  aiDevtoolsEnabled: boolean;
   infraOffset: number;
   infraPorts: InfraPorts;
   mode: DevMode;
@@ -1281,11 +1292,6 @@ const buildPersistentSteps = ({
     infraOffset,
     infraPorts,
     ports,
-  });
-  const aiDevtoolsEnabled = readEnvFlag({
-    envFilePath: pathResolve(rootDir, "apps/api/.env"),
-    key: "AI_DEVTOOLS_ENABLED",
-    processEnv: process.env,
   });
   const webEnv = createWebEnv({
     aiDevtoolsEnabled,
@@ -1601,7 +1607,13 @@ const main = async () => {
         : undefined),
     worktreeName: basename(gitContext.currentRoot),
   });
+  const aiDevtoolsEnabled = readEnvFlag({
+    envFilePath: pathResolve(gitContext.currentRoot, "apps/api/.env"),
+    key: "AI_DEVTOOLS_ENABLED",
+    processEnv: process.env,
+  });
   const resolvedOffset = await findFirstAvailableOffset({
+    aiDevtoolsEnabled,
     mode: parsedArgs.mode,
     startOffset: initialOffset.offset,
   });
@@ -1620,6 +1632,7 @@ const main = async () => {
     skipInstall: parsedArgs.skipInstall,
   });
   const persistentSteps = buildPersistentSteps({
+    aiDevtoolsEnabled,
     infraOffset,
     infraPorts,
     mode: parsedArgs.mode,


### PR DESCRIPTION
## Summary

- Auth + landing: small uppercase BETA marker next to the wordmark, dropped the beta warning card.
- Sidebar: removed the Time Tracking nav entry and its hotkey (also unused timer popover/badge).
- Inspector chrome button is `md:hidden` so the always-mounted rail is the single right-side toggle on desktop.
- Workspace overview: "Log time" button deactivated (kept visible).
- Table bottom row: `uploadOnly` mode on AddEntityMenu so "+" / "Nový dokument" go straight to the file picker.
- Default `TableCell` height bumped from `min-h-8` to `min-h-10`.
- Kanban drag-drop: also invalidates `taskKeys.detail` so the inspector panel reflects the new status.
- Dev menu: new "AI SDK Devtools" item that opens the worktree's devtools URL; disabled with a hint when `AI_DEVTOOLS_ENABLED` is off.
- Dev runner: allocates `aiSdkDevtools` per-worktree, injects `AI_SDK_DEVTOOLS_PORT` into the API and `VITE_AI_SDK_DEVTOOLS_PORT` / `VITE_AI_DEVTOOLS_ENABLED` into web, spawns `dev:ai-tools` as a secondary persistent step only when the flag is on, prints the devtools URL in the banner.

## Test plan

- [ ] Auth page renders BETA pill next to wordmark; landing page same.
- [ ] Sidebar has no Time Tracking entry; nav digit 5 lands on Contacts.
- [ ] Workspace right-side has a single panel toggle on desktop, two only on mobile breakpoint.
- [ ] Table bottom row "+" opens the file picker directly; no menu appears.
- [ ] Table rows are visibly taller than before.
- [ ] Drag a task in kanban to a different status column; the inspector detail panel for that task updates.
- [ ] Dev runner banner shows `ai sdk devtools: http://localhost:<port>`; menu item opens it.
- [ ] Set `AI_DEVTOOLS_ENABLED=false` in `apps/api/.env`, restart dev: secondary step is skipped, menu item shows the disabled state with hint.