### PR TITLE
feat(ci): wire up landing deploy via reusable workflow

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,30 @@
+name: Deploy Landing
+
+# Triggers the landing site deploy on every main merge that
+# touches the landing app or shared deps. Implementation lives in
+# a private reusable workflow so this file stays free of bucket
+# names, distribution IDs, role ARNs, and region strings.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/landing/**"
+      - "packages/**"
+      - "bun.lock"
+      - ".github/workflows/deploy-landing.yml"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    # Belt-and-suspenders: the trigger above already restricts to
+    # main, but a manual dispatch via API can pass a feature ref;
+    # the reusable workflow refuses non-main refs as well.
+    if: github.ref == 'refs/heads/main'
+    uses: stella/private-workflows/.github/workflows/deploy-landing.yml@main
+    secrets:
+      AWS_ROLE_ARN_DEPLOY: ${{ secrets.AWS_ROLE_ARN_DEPLOY }}


### PR DESCRIPTION
## Summary

Adds the trigger half of the landing site auto-deploy. Implementation (build + sync + cache invalidation) lives in a private reusable workflow; this file only declares when to run.

## Triggers

- \`push\` to \`main\` with paths: \`apps/landing/**\`, \`packages/**\`, \`bun.lock\`, the workflow file itself
- \`workflow_dispatch\` for manual deploys

## Security

Three layers of \`main\`-only enforcement so a feature branch can't deploy itself:
- Trigger \`branches: [main]\` for the push event
- Job-level \`if: github.ref == 'refs/heads/main'\` — guards \`workflow_dispatch\` from any non-default ref
- The downstream reusable workflow refuses non-main refs as well

## Pre-conditions

- The matching role permission must already be applied in the infra repo, or the deploy will 403 on first run.

## Test plan

- [ ] Trigger \`workflow_dispatch\` from main — completes successfully
- [ ] Trigger \`workflow_dispatch\` from a non-main branch — job skipped (or reusable workflow refuses)
- [ ] Push a change touching \`apps/landing/**\` to a PR; merge; verify the deploy fires and the live site updates