### PR TITLE
refactor(release): move promote job to private reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,31 +275,12 @@ jobs:
     # ("no hyphen") rather than a deny-list against `-rc.`, so future
     # prerelease conventions (-rc1, -beta.N, -alpha) cannot reach
     # production by accident if the upstream validation regex changes.
-    name: Promote to production
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
     needs: publish
     if: ${{ !contains(needs.publish.outputs.release_ref, '-') }}
-
-    steps:
-      - name: Mint App token for the infra repo
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        with:
-          app-id: ${{ secrets.STELLA_RELEASE_APP_ID }}
-          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: stella-infra
-
-      - name: Dispatch promote-release.yml
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          RELEASE_REF: ${{ needs.publish.outputs.release_ref }}
-          IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
-        run: |
-          gh workflow run promote-release.yml \
-            --repo "${{ github.repository_owner }}/stella-infra" \
-            --field release_ref="$RELEASE_REF" \
-            --field image_digest="$IMAGE_DIGEST" \
-            --field run_migrations=true \
-            --field frontend=true
+    uses: stella/private-workflows/.github/workflows/promote-release.yml@main
+    with:
+      release_ref: ${{ needs.publish.outputs.release_ref }}
+      image_digest: ${{ needs.publish.outputs.image_digest }}
+    secrets:
+      STELLA_RELEASE_APP_ID: ${{ secrets.STELLA_RELEASE_APP_ID }}
+      STELLA_RELEASE_APP_PRIVATE_KEY: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The release pipeline's \`promote\` job currently mints a cross-repo App token inline and dispatches a workflow on a separate infra repo. The job named that repo, named the dispatched workflow, and listed the full dispatch payload schema — all on the public surface.

This PR replaces the inline implementation with a 9-line call to a reusable workflow on a private repo. The reusable workflow owns the App-token mint, the dispatch target, and the payload schema. None of those leak into the public pipeline anymore.

## Public surface diff

Before: 36 lines, mentions a separate infra repo twice, declares all dispatch fields.
After: 9 lines, no infra-repo references, no payload schema.

## Pre-conditions

- The reusable workflow must be merged to the private repo's main first (private-workflows#2).

## Behavior

Identical to the current job:
- Runs only after \`publish\` succeeds
- Skips for prerelease tags (\`-rc.X\`, \`-beta.X\`, etc.)
- Same App token, same dispatch fields (defaults match the current values)

The reusable workflow adds defense-in-depth: refuses non-main / non-tag refs and refuses non-stable release tags, so a workflow_dispatch from a feature branch can't sneak through.