### PR TITLE
feat: prompt shortcuts — CRUD, chat integration, Knowledge > Skills UI

### DIFF
--- a/.agents/plans/038-prompt-shortcuts.md
+++ b/.agents/plans/038-prompt-shortcuts.md
@@ -1,0 +1,101 @@
+# Plan: Prompt Shortcuts ("Skills")
+
+Date: 2026-05-03
+
+## Goal
+
+Let users create personal or org-shared `/` prompt shortcuts with a name, description, command handle, and prompt body. The Knowledge > Skills tile becomes the management surface; the chat home screen surfaces a random selection from the user's saved shortcuts.
+
+## Design Decisions
+
+- **Reuse `ChatPrompt` shape**: `apps/web/src/lib/prompts/types.ts` already defines `scope: "stock" | "team" | "private"` and the `ChatPrompt` type. The DB-backed shortcuts feed the same `PromptSuggestions` component and the future slash-command picker without any shape changes. The `"stock"` scope value is removed — all prompts are DB-backed.
+- **`command` field**: Shortcuts carry a `/command` handle (e.g. `/summarize-nda`). Validation: `^[a-z0-9][a-z0-9_-]{0,48}$` — no whitespace, no uppercase. Reserved: `model`, `new` (blocked at the API boundary and validated on the frontend).
+- **Scope = ownership**: `scope: "team"` means org-wide; creating team shortcuts requires Admin or Owner role. `scope: "private"` means only the creating user. `organizationId` is always stored for RLS; `userId` is stored for private shortcuts (non-null) and for team shortcuts (creator audit trail).
+- **Command uniqueness is split by scope**: team commands are unique per-org; private commands are unique per-user. This allows a user's private `/foo` to coexist with an org-wide `/foo`. When both exist for the same command string, team takes precedence in the slash menu and the Skills page shows a "shadowed by team shortcut" badge on the private one.
+- **Pre-seeded defaults via `isDefault` flag**: On first visit to the Skills page (or during onboarding if one is added later), four default private shortcuts are seeded into the DB for the user (the same content as today's hardcoded stock prompts). They carry `isDefault: true` so the UI can label them "Default" but they are otherwise fully editable and deletable. The hardcoded `useStockPrompts` hook is deleted once seeding is in place.
+- **Seeding trigger**: The list endpoint returns a `seeded: boolean` field. On first load (empty result + `seeded: false`), the frontend calls a dedicated `POST /shortcuts/seed` endpoint that inserts the defaults for the current user. Idempotent: re-calling it is a no-op if any shortcuts already exist.
+- **Chat home screen**: Queries the user's shortcuts (private + team) via the list endpoint; samples up to 4 at random. Falls back to the seeded defaults if the list is empty (edge case during first page load before seeding completes).
+
+## Scope
+
+**In scope:**
+
+- `promptShortcuts` DB table with `id`, `organizationId`, `userId`, `scope`, `name`, `description`, `command`, `prompt`, `isDefault`, `createdAt`, `updatedAt`
+- API: CRUD + seed endpoints under `/api/shortcuts`
+- Command validation + reserved-word rejection at the API boundary
+- Team shortcut creation restricted to Admin/Owner; any member can create private shortcuts
+- Knowledge > Skills route (`/knowledge/skills`) with full CRUD table UI (shows both team and private, grouped or tabbed)
+- Knowledge landing tile linked (remove "coming soon" state)
+- Skills page triggers seeding on first load
+- Chat home screen samples up to 4 from the user's shortcuts
+- `PromptSuggestions` extended to show `/command` handle alongside name
+- "Shadowed" badge on private shortcuts whose command collides with a team shortcut
+- Remove `useStockPrompts` and the hardcoded stock list once seeding covers the same content
+- i18n keys for all new strings
+
+**Out of scope:**
+
+- Slash-command autocomplete in the chat composer (separate feature)
+- Workspace-scoped shortcuts
+- Import/export of shortcut libraries
+- Per-shortcut usage analytics
+
+## Implementation
+
+- `apps/api/src/db/schema.ts` — add `promptShortcuts` table
+- `apps/api/src/db/schema-validators.ts` — add `PromptShortcutScope` union, command regex constant, reserved command list
+- `apps/api/src/handlers/shortcuts/` — `create.ts`, `update.ts`, `delete.ts`, `list.ts`, `seed.ts`, `routes.ts`
+- `apps/api/src/routes.ts` — mount shortcuts router
+- `apps/web/src/routes/_protected.knowledge/skills.tsx` — Skills page (grouped table + form dialog + seed-on-mount effect)
+- `apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx` — create/edit dialog with command validation
+- `apps/web/src/routes/_protected.knowledge/-queries.ts` — add `shortcutsOptions` query factory
+- `apps/web/src/routes/_protected.knowledge/index.tsx` — wire up skills tile link
+- `apps/web/src/lib/prompts/use-prompts.ts` — new hook that queries DB shortcuts and samples 4 for the home screen
+- `apps/web/src/lib/prompts/stock.ts` — deleted (replaced by DB-backed defaults)
+- `apps/web/src/routes/_protected.chat/index.tsx` — switch to `use-prompts` hook
+- `apps/web/src/i18n/langs/en.json` (and other langs) — new keys under `knowledge.skills.*`
+
+## DB Schema (sketch)
+
+```ts
+export const promptShortcuts = stella.table("prompt_shortcuts", {
+  id: safeId("id", "shortcut"),
+  organizationId: safeOrganizationId("organization_id").notNull(),
+  userId: p.text("user_id").notNull(),   // always set; creator for team, owner for private
+  scope: p.text("scope").notNull(),      // "team" | "private"
+  name: p.text("name").notNull(),
+  description: p.text("description"),
+  command: p.text("command").notNull(),
+  prompt: p.text("prompt").notNull(),
+  isDefault: p.boolean("is_default").notNull().default(false),
+  createdAt: p.timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: p.timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+}, (table) => [
+  // Team commands: unique per org
+  p.uniqueIndex("prompt_shortcuts_org_team_command_idx")
+    .on(table.organizationId, table.command)
+    .where(sql`scope = 'team'`),
+  // Private commands: unique per user
+  p.uniqueIndex("prompt_shortcuts_user_private_command_idx")
+    .on(table.userId, table.command)
+    .where(sql`scope = 'private'`),
+  p.index("prompt_shortcuts_org_scope_idx").on(table.organizationId, table.scope),
+  p.index("prompt_shortcuts_user_idx").on(table.userId),
+]);
+```
+
+## Test Cases
+
+- Command validation rejects: whitespace, uppercase, leading hyphen/underscore, reserved words (`model`, `new`), empty string
+- Command validation accepts: `summarize-nda`, `draft_response`, `q`, `find-risks`
+- Creating two team shortcuts with the same command in the same org returns 409
+- Creating two private shortcuts with the same command for the same user returns 409
+- Private `/foo` + team `/foo` in the same org can coexist; list returns both with `shadowed: true` on the private one
+- Team shortcut creation by a Member role returns 403; Admin succeeds
+- Seed endpoint inserts 4 defaults for a new user; re-calling it is a no-op
+- Delete removes the record; subsequent list does not include it
+- Chat home screen renders at most 4 prompts
+
+## Open Questions
+
+None — all resolved above.

--- a/apps/api/drizzle/20260504000000_prompt-shortcuts/migration.sql
+++ b/apps/api/drizzle/20260504000000_prompt-shortcuts/migration.sql
@@ -1,0 +1,49 @@
+CREATE TABLE "prompt_shortcuts" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" varchar(128) NOT NULL,
+	"user_id" text NOT NULL,
+	"scope" text NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"description" text,
+	"command" varchar(50) NOT NULL,
+	"prompt" text NOT NULL,
+	"is_default" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "prompt_shortcuts" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "prompt_shortcuts" ADD CONSTRAINT "prompt_shortcuts_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE NO ACTION;--> statement-breakpoint
+ALTER TABLE "prompt_shortcuts" ADD CONSTRAINT "prompt_shortcuts_user_id_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION;--> statement-breakpoint
+CREATE UNIQUE INDEX "prompt_shortcuts_org_team_command_uidx" ON "prompt_shortcuts" USING btree ("organization_id","command") WHERE scope = 'team';--> statement-breakpoint
+CREATE UNIQUE INDEX "prompt_shortcuts_user_private_command_uidx" ON "prompt_shortcuts" USING btree ("user_id","command") WHERE scope = 'private';--> statement-breakpoint
+CREATE INDEX "prompt_shortcuts_org_scope_idx" ON "prompt_shortcuts" USING btree ("organization_id","scope");--> statement-breakpoint
+CREATE INDEX "prompt_shortcuts_user_idx" ON "prompt_shortcuts" USING btree ("user_id");--> statement-breakpoint
+CREATE POLICY "prompt_shortcut_select" ON "prompt_shortcuts" AS PERMISSIVE FOR SELECT TO "stella" USING ((
+  organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)) AND (scope = 'team' OR user_id = (SELECT current_setting(
+  'app.user_id', true
+)))
+));--> statement-breakpoint
+CREATE POLICY "prompt_shortcut_insert" ON "prompt_shortcuts" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK ((
+  organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)) AND user_id = (SELECT current_setting(
+  'app.user_id', true
+))
+));--> statement-breakpoint
+CREATE POLICY "prompt_shortcut_update" ON "prompt_shortcuts" AS PERMISSIVE FOR UPDATE TO "stella" USING ((
+  organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)) AND (scope = 'team' OR user_id = (SELECT current_setting(
+  'app.user_id', true
+)))
+));--> statement-breakpoint
+CREATE POLICY "prompt_shortcut_delete" ON "prompt_shortcuts" AS PERMISSIVE FOR DELETE TO "stella" USING ((
+  organization_id = (SELECT current_setting(
+  'app.organization_id', true
+)) AND (scope = 'team' OR user_id = (SELECT current_setting(
+  'app.user_id', true
+)))
+));

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -139,6 +139,55 @@ export const userPolicies = () => [
   }),
 ];
 
+/**
+ * Prompt shortcuts are org-scoped for team shortcuts (all org
+ * members can read them) and user-scoped for private ones.
+ *
+ * SELECT:  org matches AND (team scope OR owned by current user)
+ * INSERT:  org matches AND user_id is the current user
+ * UPDATE/DELETE: org matches AND (team scope OR owned by current user)
+ *   — admin/owner enforcement for team mutations is done at
+ *     handler level, not DB level.
+ */
+const promptShortcutOrgCheck = sql`organization_id = (SELECT current_setting(
+  '${sql.raw(SETTING_ORGANIZATION_ID)}', true
+))`;
+
+const promptShortcutUserCheck = sql`user_id = (SELECT current_setting(
+  '${sql.raw(SETTING_USER_ID)}', true
+))`;
+
+const promptShortcutReadWriteCheck = sql`(
+  ${promptShortcutOrgCheck} AND (scope = 'team' OR ${promptShortcutUserCheck})
+)`;
+
+const promptShortcutInsertCheck = sql`(
+  ${promptShortcutOrgCheck} AND ${promptShortcutUserCheck}
+)`;
+
+export const promptShortcutPolicies = () => [
+  p.pgPolicy("prompt_shortcut_select", {
+    for: "select",
+    to: stella,
+    using: promptShortcutReadWriteCheck,
+  }),
+  p.pgPolicy("prompt_shortcut_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: promptShortcutInsertCheck,
+  }),
+  p.pgPolicy("prompt_shortcut_update", {
+    for: "update",
+    to: stella,
+    using: promptShortcutReadWriteCheck,
+  }),
+  p.pgPolicy("prompt_shortcut_delete", {
+    for: "delete",
+    to: stella,
+    using: promptShortcutReadWriteCheck,
+  }),
+];
+
 export const chatThreadPolicies = () => [
   p.pgPolicy("chat_thread_select", {
     for: "select",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,6 +13,7 @@ import {
   chatThreadPolicies,
   organizationCheck,
   orgPolicies,
+  promptShortcutPolicies,
   stella,
   userPolicies,
   workspaceIdCheck,
@@ -2362,6 +2363,57 @@ export const workspaceViews = p.pgTable(
       .index("workspace_views_workspace_position_idx")
       .on(table.workspaceId, table.position),
     ...wsPolicies(),
+  ],
+);
+
+// -- Prompt Shortcuts --
+
+export const PROMPT_SHORTCUT_SCOPES = ["team", "private"] as const;
+export type PromptShortcutScope = (typeof PROMPT_SHORTCUT_SCOPES)[number];
+
+export const RESERVED_SHORTCUT_COMMANDS = ["model", "new"] as const;
+export const SHORTCUT_COMMAND_PATTERN = /^[a-z0-9][a-z0-9_-]{0,48}$/;
+
+export const promptShortcuts = p.pgTable(
+  "prompt_shortcuts",
+  {
+    id: pUuid<"promptShortcut">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: p
+      .text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    scope: p.text("scope", { enum: PROMPT_SHORTCUT_SCOPES }).notNull(),
+    name: p.varchar({ length: 256 }).notNull(),
+    description: p.text(),
+    command: p.varchar({ length: 50 }).notNull(),
+    prompt: p.text().notNull(),
+    isDefault: p.boolean("is_default").notNull().default(false),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    // Team commands: unique per org
+    p
+      .uniqueIndex("prompt_shortcuts_org_team_command_uidx")
+      .on(table.organizationId, table.command)
+      .where(sql`scope = 'team'`),
+    // Private commands: unique per user
+    p
+      .uniqueIndex("prompt_shortcuts_user_private_command_uidx")
+      .on(table.userId, table.command)
+      .where(sql`scope = 'private'`),
+    p
+      .index("prompt_shortcuts_org_scope_idx")
+      .on(table.organizationId, table.scope),
+    p.index("prompt_shortcuts_user_idx").on(table.userId),
+    ...promptShortcutPolicies(),
   ],
 );
 

--- a/apps/api/src/handlers/shortcuts/create.ts
+++ b/apps/api/src/handlers/shortcuts/create.ts
@@ -1,0 +1,126 @@
+import { panic, Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import {
+  promptShortcuts,
+  RESERVED_SHORTCUT_COMMANDS,
+  SHORTCUT_COMMAND_PATTERN,
+} from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+import { PG_ERROR } from "@/api/lib/pg-error";
+
+const createShortcutBodySchema = t.Object({
+  scope: t.UnionEnum(["team", "private"]),
+  name: t.String({ minLength: 1, maxLength: 256 }),
+  description: t.Optional(t.String({ maxLength: 1024 })),
+  command: t.String({ minLength: 1, maxLength: 50 }),
+  prompt: t.String({ minLength: 1 }),
+});
+
+const config = {
+  permissions: { promptShortcut: ["create"] },
+  body: createShortcutBodySchema,
+} satisfies HandlerConfig;
+
+const createShortcut = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session, user, body, memberRole }) {
+    const userCount = yield* Result.await(
+      safeDb((tx) =>
+        tx.$count(
+          promptShortcuts,
+          and(
+            eq(promptShortcuts.organizationId, session.activeOrganizationId),
+            eq(promptShortcuts.userId, user.id),
+          ),
+        ),
+      ),
+    );
+
+    if (userCount >= LIMITS.shortcutsPerUser) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Shortcut limit reached for this user",
+        }),
+      );
+    }
+
+    if (!SHORTCUT_COMMAND_PATTERN.test(body.command)) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message:
+            "Command must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores",
+        }),
+      );
+    }
+
+    if (
+      (RESERVED_SHORTCUT_COMMANDS as readonly string[]).includes(body.command)
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: `"/${body.command}" is a reserved command`,
+        }),
+      );
+    }
+
+    if (
+      body.scope === "team" &&
+      !["admin", "owner"].includes(memberRole.role)
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Only admins and owners can create team shortcuts",
+        }),
+      );
+    }
+
+    const insertResult = await safeDb((tx) =>
+      tx
+        .insert(promptShortcuts)
+        .values({
+          organizationId: session.activeOrganizationId,
+          userId: user.id,
+          scope: body.scope,
+          name: body.name,
+          description: body.description ?? null,
+          command: body.command,
+          prompt: body.prompt,
+          isDefault: false,
+        })
+        .returning({ id: promptShortcuts.id }),
+    );
+
+    if (Result.isError(insertResult)) {
+      if (
+        DatabaseError.is(insertResult.error) &&
+        insertResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: `A shortcut with command "/${body.command}" already exists`,
+          }),
+        );
+      }
+      return Result.err(insertResult.error);
+    }
+
+    const row = insertResult.value.at(0);
+    if (!row) {
+      panic("Failed to create shortcut");
+    }
+
+    return Result.ok({ id: row.id });
+  },
+);
+
+export default createShortcut;

--- a/apps/api/src/handlers/shortcuts/delete.ts
+++ b/apps/api/src/handlers/shortcuts/delete.ts
@@ -1,0 +1,79 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { promptShortcuts } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const deleteShortcutParamsSchema = t.Object({
+  shortcutId: tSafeId("promptShortcut"),
+});
+
+const config = {
+  permissions: { promptShortcut: ["delete"] },
+  params: deleteShortcutParamsSchema,
+} satisfies HandlerConfig;
+
+const deleteShortcut = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session, user, params, memberRole }) {
+    const existing = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: promptShortcuts.id,
+            scope: promptShortcuts.scope,
+            userId: promptShortcuts.userId,
+          })
+          .from(promptShortcuts)
+          .where(
+            and(
+              eq(promptShortcuts.id, params.shortcutId),
+              eq(promptShortcuts.organizationId, session.activeOrganizationId),
+            ),
+          )
+          .limit(1),
+      ),
+    );
+
+    const shortcut = existing.at(0);
+    if (!shortcut) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Shortcut not found" }),
+      );
+    }
+
+    if (
+      shortcut.scope === "team" &&
+      !["admin", "owner"].includes(memberRole.role)
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Only admins and owners can delete team shortcuts",
+        }),
+      );
+    }
+
+    if (shortcut.scope === "private" && shortcut.userId !== user.id) {
+      return Result.err(
+        new HandlerError({ status: 403, message: "Forbidden" }),
+      );
+    }
+
+    yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .delete(promptShortcuts)
+          .where(eq(promptShortcuts.id, params.shortcutId)),
+      ),
+    );
+
+    return Result.ok({ id: params.shortcutId });
+  },
+);
+
+export default deleteShortcut;

--- a/apps/api/src/handlers/shortcuts/list.ts
+++ b/apps/api/src/handlers/shortcuts/list.ts
@@ -1,0 +1,46 @@
+import { Result } from "better-result";
+import { and, eq, or } from "drizzle-orm";
+
+import { promptShortcuts, PROMPT_SHORTCUT_SCOPES } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+
+const config = {
+  permissions: { promptShortcut: ["create"] },
+} satisfies HandlerConfig;
+
+const listShortcuts = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session, user }) {
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: promptShortcuts.id,
+            scope: promptShortcuts.scope,
+            name: promptShortcuts.name,
+            description: promptShortcuts.description,
+            command: promptShortcuts.command,
+            prompt: promptShortcuts.prompt,
+            isDefault: promptShortcuts.isDefault,
+            userId: promptShortcuts.userId,
+          })
+          .from(promptShortcuts)
+          .where(
+            and(
+              eq(promptShortcuts.organizationId, session.activeOrganizationId),
+              or(
+                eq(promptShortcuts.scope, PROMPT_SHORTCUT_SCOPES[0]), // "team"
+                eq(promptShortcuts.userId, user.id),
+              ),
+            ),
+          )
+          .orderBy(promptShortcuts.createdAt),
+      ),
+    );
+
+    return Result.ok(rows);
+  },
+);
+
+export default listShortcuts;

--- a/apps/api/src/handlers/shortcuts/list.ts
+++ b/apps/api/src/handlers/shortcuts/list.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, or } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 
 import { promptShortcuts, PROMPT_SHORTCUT_SCOPES } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -35,7 +35,7 @@ const listShortcuts = createSafeRootHandler(
               ),
             ),
           )
-          .orderBy(promptShortcuts.createdAt),
+          .orderBy(desc(promptShortcuts.createdAt)),
       ),
     );
 

--- a/apps/api/src/handlers/shortcuts/routes.ts
+++ b/apps/api/src/handlers/shortcuts/routes.ts
@@ -1,0 +1,32 @@
+import Elysia from "elysia";
+
+import createShortcut from "@/api/handlers/shortcuts/create";
+import deleteShortcut from "@/api/handlers/shortcuts/delete";
+import listShortcuts from "@/api/handlers/shortcuts/list";
+import seedShortcuts from "@/api/handlers/shortcuts/seed";
+import updateShortcut from "@/api/handlers/shortcuts/update";
+import { authMacro, permissionMacro } from "@/api/lib/auth";
+import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
+
+export const shortcutsRoute = new Elysia({ prefix: "/shortcuts" })
+  .use(authMacro)
+  .use(permissionMacro)
+  .use(invalidateQuery)
+  .guard({ validateAuth: true })
+  .get("/", listShortcuts.handler)
+  .put("/", createShortcut.handler, {
+    body: createShortcut.config.body,
+    invalidateQuery: true,
+  })
+  .post("/seed", seedShortcuts.handler, {
+    invalidateQuery: true,
+  })
+  .post("/:shortcutId", updateShortcut.handler, {
+    params: updateShortcut.config.params,
+    body: updateShortcut.config.body,
+    invalidateQuery: true,
+  })
+  .delete("/:shortcutId", deleteShortcut.handler, {
+    params: deleteShortcut.config.params,
+    invalidateQuery: true,
+  });

--- a/apps/api/src/handlers/shortcuts/seed.ts
+++ b/apps/api/src/handlers/shortcuts/seed.ts
@@ -1,0 +1,85 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import { promptShortcuts } from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+
+const DEFAULT_SHORTCUTS = [
+  {
+    name: "Summarise a document",
+    description: "Get a structured summary of the key terms",
+    command: "summarize",
+    prompt:
+      "Summarise this document. Cover parties, key obligations, dates, financial terms, and any termination or liability provisions.",
+  },
+  {
+    name: "Find risks",
+    description: "Spot legal risks and ambiguous clauses",
+    command: "risks",
+    prompt:
+      "Review this document for legal risks, missing protections, and ambiguous clauses. Cite the specific clause for each finding.",
+  },
+  {
+    name: "Compare versions",
+    description: "List every material change between two versions",
+    command: "compare",
+    prompt:
+      "Compare two versions of this document and list every material change with its location.",
+  },
+  {
+    name: "Draft a response",
+    description: "Draft a professional reply to a letter",
+    command: "draft",
+    prompt:
+      "Draft a measured response to this letter. Keep the tone professional, address each point raised, and flag any open questions for me to confirm.",
+  },
+] as const;
+
+const config = {
+  permissions: { promptShortcut: ["create"] },
+} satisfies HandlerConfig;
+
+const seedShortcuts = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session, user }) {
+    const existing = yield* Result.await(
+      safeDb((tx) =>
+        tx.$count(
+          promptShortcuts,
+          and(
+            eq(promptShortcuts.organizationId, session.activeOrganizationId),
+            eq(promptShortcuts.userId, user.id),
+          ),
+        ),
+      ),
+    );
+
+    if (existing > 0) {
+      return Result.ok({ seeded: false });
+    }
+
+    yield* Result.await(
+      safeDb((tx) =>
+        tx.insert(promptShortcuts).values(
+          DEFAULT_SHORTCUTS.map((s) => ({
+            id: createSafeId<"promptShortcut">(),
+            organizationId: session.activeOrganizationId,
+            userId: user.id,
+            scope: "private" as const,
+            name: s.name,
+            description: s.description,
+            command: s.command,
+            prompt: s.prompt,
+            isDefault: true,
+          })),
+        ),
+      ),
+    );
+
+    return Result.ok({ seeded: true });
+  },
+);
+
+export default seedShortcuts;

--- a/apps/api/src/handlers/shortcuts/update.ts
+++ b/apps/api/src/handlers/shortcuts/update.ts
@@ -1,0 +1,137 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import {
+  promptShortcuts,
+  RESERVED_SHORTCUT_COMMANDS,
+  SHORTCUT_COMMAND_PATTERN,
+} from "@/api/db/schema";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+
+const updateShortcutParamsSchema = t.Object({
+  shortcutId: tSafeId("promptShortcut"),
+});
+
+const updateShortcutBodySchema = t.Object({
+  name: t.Optional(t.String({ minLength: 1, maxLength: 256 })),
+  description: t.Optional(t.Nullable(t.String({ maxLength: 1024 }))),
+  command: t.Optional(t.String({ minLength: 1, maxLength: 50 })),
+  prompt: t.Optional(t.String({ minLength: 1 })),
+});
+
+const config = {
+  permissions: { promptShortcut: ["update"] },
+  params: updateShortcutParamsSchema,
+  body: updateShortcutBodySchema,
+} satisfies HandlerConfig;
+
+const updateShortcut = createSafeRootHandler(
+  config,
+  async function* ({ safeDb, session, user, params, body, memberRole }) {
+    const existing = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: promptShortcuts.id,
+            scope: promptShortcuts.scope,
+            userId: promptShortcuts.userId,
+          })
+          .from(promptShortcuts)
+          .where(
+            and(
+              eq(promptShortcuts.id, params.shortcutId),
+              eq(promptShortcuts.organizationId, session.activeOrganizationId),
+            ),
+          )
+          .limit(1),
+      ),
+    );
+
+    const shortcut = existing.at(0);
+    if (!shortcut) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Shortcut not found" }),
+      );
+    }
+
+    if (
+      shortcut.scope === "team" &&
+      !["admin", "owner"].includes(memberRole.role)
+    ) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Only admins and owners can edit team shortcuts",
+        }),
+      );
+    }
+
+    if (shortcut.scope === "private" && shortcut.userId !== user.id) {
+      return Result.err(
+        new HandlerError({ status: 403, message: "Forbidden" }),
+      );
+    }
+
+    if (body.command !== undefined) {
+      if (!SHORTCUT_COMMAND_PATTERN.test(body.command)) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message:
+              "Command must start with a letter or digit and contain only lowercase letters, digits, hyphens, and underscores",
+          }),
+        );
+      }
+      if (
+        (RESERVED_SHORTCUT_COMMANDS as readonly string[]).includes(body.command)
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: `"/${body.command}" is a reserved command`,
+          }),
+        );
+      }
+    }
+
+    const updateResult = await safeDb((tx) =>
+      tx
+        .update(promptShortcuts)
+        .set({
+          ...(body.name !== undefined && { name: body.name }),
+          ...(body.description !== undefined && {
+            description: body.description,
+          }),
+          ...(body.command !== undefined && { command: body.command }),
+          ...(body.prompt !== undefined && { prompt: body.prompt }),
+          isDefault: false,
+        })
+        .where(eq(promptShortcuts.id, params.shortcutId))
+        .returning({ id: promptShortcuts.id }),
+    );
+
+    if (Result.isError(updateResult)) {
+      if (
+        DatabaseError.is(updateResult.error) &&
+        updateResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: `A shortcut with command "/${body.command}" already exists`,
+          }),
+        );
+      }
+      return Result.err(updateResult.error);
+    }
+
+    return Result.ok({ id: params.shortcutId });
+  },
+);
+
+export default updateShortcut;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -27,6 +27,7 @@ import { organizationSettingsRoute } from "@/api/handlers/organization-settings/
 import { propertiesRoute } from "@/api/handlers/properties/routes";
 import { ratesRoute } from "@/api/handlers/rates/routes";
 import { searchRoute } from "@/api/handlers/search/routes";
+import { shortcutsRoute } from "@/api/handlers/shortcuts/routes";
 import { myTasksRoute } from "@/api/handlers/tasks/my-tasks-route";
 import { tasksRoute } from "@/api/handlers/tasks/routes";
 import {
@@ -318,6 +319,7 @@ const api = new Elysia()
       .use(caseLawRoute)
       .use(chatRoute)
       .use(userFilesRoute)
+      .use(shortcutsRoute)
       .use(viewsRoute)
       .use(tasksRoute)
       .use(myTasksRoute)

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -37,6 +37,7 @@ export type SafeIdType =
   | "organization"
   | "organizationSettings"
   | "property"
+  | "promptShortcut"
   | "propertyDependency"
   | "rateEntry"
   | "rateTable"

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -16,6 +16,7 @@ export const LIMITS = {
   clauseCategoriesCount: 100,
   templateCategoriesCount: 100,
   clausesPerOrganization: 500,
+  shortcutsPerUser: 100,
   clauseVariantsPerClause: 10,
   clauseVersionsPerClause: 50,
   templateClausesPerTemplate: 50,

--- a/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
@@ -84,6 +84,9 @@ export const AppBreadcrumbs = () => {
       [serializeKey(["/contacts/$contactId"])]: (params) => (
         <ContactBreadcrumb {...params} />
       ),
+      [serializeKey(["/knowledge/skills"])]: () => (
+        <BreadcrumbItem>{t("knowledge.sections.skills.title")}</BreadcrumbItem>
+      ),
       [serializeKey(["/knowledge/case/"])]: () => (
         <BreadcrumbLink to="/knowledge/case">
           {t("common.caseLaw")}

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type React from "react";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryKey } from "@tanstack/react-query";
 import Document from "@tiptap/extension-document";
 import HardBreak from "@tiptap/extension-hard-break";
@@ -48,8 +48,8 @@ import {
 } from "@/lib/chat-draft-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { getChatThreadKey } from "@/lib/chat-thread-ref";
-import { useStockPrompts } from "@/lib/prompts/stock";
 import type { WorkspaceEntity } from "@/lib/types";
+import { shortcutsOptions } from "@/routes/_protected.knowledge/-queries";
 import { entitiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 
@@ -579,9 +579,19 @@ export const useChatEditor = ({
     }
   });
 
-  const stockPrompts = useStockPrompts();
-  const promptsRef = useRef(stockPrompts);
-  promptsRef.current = stockPrompts;
+  const { data: shortcuts = [] } = useQuery(shortcutsOptions());
+  const allPrompts = useMemo(
+    () =>
+      shortcuts.map((s) => ({
+        id: s.id,
+        scope: s.scope,
+        name: s.name,
+        body: s.prompt,
+      })),
+    [shortcuts],
+  );
+  const promptsRef = useRef(allPrompts);
+  promptsRef.current = allPrompts;
 
   const editor = useEditor({
     autofocus: false,

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -586,6 +586,7 @@ export const useChatEditor = ({
         id: s.id,
         scope: s.scope,
         name: s.name,
+        command: s.command,
         body: s.prompt,
       })),
     [shortcuts],

--- a/apps/web/src/components/chat/prompt-slash-extension.ts
+++ b/apps/web/src/components/chat/prompt-slash-extension.ts
@@ -14,10 +14,11 @@ type PromptSlashOptions = {
 
 /**
  * `/`-triggered TipTap extension that lets the user pick a saved
- * prompt and drop its body into the composer. Triggers only at
- * the start of an empty paragraph (so a `/` mid-sentence is just
- * a slash). Selection inserts the prompt's `body` as plain text
- * and removes the trigger range.
+ * prompt and drop its body into the composer. Triggers when `/`
+ * is typed at the start of a paragraph or after whitespace, so a
+ * `/` inside a URL (e.g. `https://...`) is just a slash. Selection
+ * inserts the prompt's `body` as plain text and removes the trigger
+ * range.
  */
 export const PromptSlash = Extension.create<PromptSlashOptions>({
   name: PLUGIN_NAME,
@@ -26,7 +27,6 @@ export const PromptSlash = Extension.create<PromptSlashOptions>({
     return {
       suggestion: {
         char: "/",
-        startOfLine: true,
         allowSpaces: false,
         items: () => [],
         command: ({ editor, range, props }) => {
@@ -73,7 +73,6 @@ export const createPromptSlashSuggestion = (
   getPrompts: () => ChatPrompt[],
 ): Omit<SuggestionOptions<ChatPrompt, ChatPrompt>, "editor"> => ({
   char: "/",
-  startOfLine: true,
   allowSpaces: false,
   items: ({ query }) => filterPrompts(getPrompts(), query),
 

--- a/apps/web/src/components/chat/prompt-slash-extension.ts
+++ b/apps/web/src/components/chat/prompt-slash-extension.ts
@@ -59,6 +59,7 @@ const filterPrompts = (prompts: ChatPrompt[], query: string): ChatPrompt[] => {
   return prompts.filter(
     (prompt) =>
       prompt.name.toLowerCase().includes(trimmed) ||
+      prompt.command?.toLowerCase().includes(trimmed) === true ||
       prompt.body.toLowerCase().includes(trimmed),
   );
 };

--- a/apps/web/src/components/chat/prompt-slash-list.tsx
+++ b/apps/web/src/components/chat/prompt-slash-list.tsx
@@ -13,7 +13,7 @@ import { useTranslations } from "use-intl";
 
 import type { ChatPrompt, PromptScope } from "@/lib/prompts/types";
 
-const SCOPE_ORDER: PromptScope[] = ["private", "team", "stock"];
+const SCOPE_ORDER: PromptScope[] = ["private", "team"];
 
 const useScopeLabel = () => {
   const t = useTranslations();

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -354,6 +354,7 @@
     "placeholder": "Co byste chtěli vědět?",
     "prompts": {
       "noResults": "Žádné odpovídající promty",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Vaše promty",
         "stock": "Vestavěné",
@@ -1053,6 +1054,38 @@
         "description": "Šablony dokumentů se zástupnými znaky",
         "title": "Šablony"
       }
+    },
+    "skills": {
+      "addShortcut": "Přidat zkratku",
+      "defaultBadge": "Výchozí",
+      "deleteConfirmDescription": "Tato zkratka bude trvale odstraněna.",
+      "deleteConfirmTitle": "Smazat zkratku?",
+      "deleteShortcut": "Smazat zkratku",
+      "editShortcut": "Upravit zkratku",
+      "emptyState": "Žádné zkratky. Přidejte první.",
+      "errors": {
+        "commandConflict": "Zkratka s tímto příkazem již existuje",
+        "commandInvalid": "Používejte pouze malá písmena, číslice, pomlčky a podtržítka",
+        "commandReserved": "\"/{command}\" je rezervovaný příkaz"
+      },
+      "form": {
+        "command": "Příkaz",
+        "commandHint": "Pouze malá písmena, číslice, pomlčky a podtržítka",
+        "commandPlaceholder": "např. shrnout",
+        "commandPrefix": "/",
+        "description": "Popis",
+        "descriptionPlaceholder": "Stručný popis zobrazený ve výběru",
+        "name": "Název",
+        "namePlaceholder": "např. Shrnout dokument",
+        "prompt": "Prompt",
+        "promptPlaceholder": "Text vložený do kompozéru chatu při použití této zkratky",
+        "scope": "Viditelnost",
+        "scopePrivate": "Pouze já",
+        "scopeTeam": "Všichni v organizaci"
+      },
+      "privateSection": "Moje zkratky",
+      "shadowed": "Překryto týmovou zkratkou",
+      "teamSection": "Týmové zkratky"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -354,7 +354,7 @@
     "placeholder": "Co byste chtěli vědět?",
     "prompts": {
       "noResults": "Žádné odpovídající promty",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Zatím žádné zkratky. Přidejte je v části Znalosti → Dovednosti.",
       "scope": {
         "private": "Vaše promty",
         "stock": "Vestavěné",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -354,7 +354,7 @@
     "placeholder": "Was möchten Sie wissen?",
     "prompts": {
       "noResults": "Keine passenden Prompts",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Noch keine Kürzel. Fügen Sie welche unter Wissen → Kürzel hinzu.",
       "scope": {
         "private": "Eigene Prompts",
         "stock": "Vorgegeben",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -354,6 +354,7 @@
     "placeholder": "Was möchten Sie wissen?",
     "prompts": {
       "noResults": "Keine passenden Prompts",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Eigene Prompts",
         "stock": "Vorgegeben",
@@ -1053,6 +1054,38 @@
         "description": "Dokumentvorlagen mit Platzhaltern",
         "title": "Vorlagen"
       }
+    },
+    "skills": {
+      "addShortcut": "Kürzel hinzufügen",
+      "defaultBadge": "Standard",
+      "deleteConfirmDescription": "Dieses Kürzel wird dauerhaft entfernt.",
+      "deleteConfirmTitle": "Kürzel löschen?",
+      "deleteShortcut": "Kürzel löschen",
+      "editShortcut": "Kürzel bearbeiten",
+      "emptyState": "Noch keine Kürzel. Fügen Sie eines hinzu.",
+      "errors": {
+        "commandConflict": "Ein Kürzel mit diesem Befehl existiert bereits",
+        "commandInvalid": "Nur Kleinbuchstaben, Ziffern, Bindestriche und Unterstriche verwenden",
+        "commandReserved": "\"/{command}\" ist ein reservierter Befehl"
+      },
+      "form": {
+        "command": "Befehl",
+        "commandHint": "Nur Kleinbuchstaben, Ziffern, Bindestriche und Unterstriche",
+        "commandPlaceholder": "z.B. zusammenfassen",
+        "commandPrefix": "/",
+        "description": "Beschreibung",
+        "descriptionPlaceholder": "Kurze Beschreibung im Auswahlmenü",
+        "name": "Name",
+        "namePlaceholder": "z.B. Dokument zusammenfassen",
+        "prompt": "Prompt",
+        "promptPlaceholder": "Der Text, der in das Chat-Eingabefeld eingefügt wird",
+        "scope": "Sichtbarkeit",
+        "scopePrivate": "Nur ich",
+        "scopeTeam": "Alle in der Organisation"
+      },
+      "privateSection": "Meine Kürzel",
+      "shadowed": "Vom Team-Kürzel überschattet",
+      "teamSection": "Team-Kürzel"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -354,6 +354,7 @@
     "placeholder": "What would you like to know?",
     "prompts": {
       "noResults": "No matching prompts",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Your prompts",
         "stock": "Built-in",
@@ -1053,6 +1054,38 @@
         "description": "Document templates with placeholders",
         "title": "Templates"
       }
+    },
+    "skills": {
+      "addShortcut": "Add shortcut",
+      "defaultBadge": "Default",
+      "deleteConfirmDescription": "This shortcut will be permanently removed.",
+      "deleteConfirmTitle": "Delete shortcut?",
+      "deleteShortcut": "Delete shortcut",
+      "editShortcut": "Edit shortcut",
+      "emptyState": "No shortcuts yet. Add one to get started.",
+      "errors": {
+        "commandConflict": "A shortcut with this command already exists",
+        "commandInvalid": "Use only lowercase letters, digits, hyphens and underscores",
+        "commandReserved": "\"/{command}\" is a reserved command"
+      },
+      "form": {
+        "command": "Command",
+        "commandHint": "Lowercase letters, digits, hyphens and underscores only",
+        "commandPlaceholder": "e.g. summarize",
+        "commandPrefix": "/",
+        "description": "Description",
+        "descriptionPlaceholder": "Short description shown in the picker",
+        "name": "Name",
+        "namePlaceholder": "e.g. Summarise document",
+        "prompt": "Prompt",
+        "promptPlaceholder": "The text inserted into the chat composer when this shortcut is used",
+        "scope": "Visibility",
+        "scopePrivate": "Only me",
+        "scopeTeam": "Everyone in the organisation"
+      },
+      "privateSection": "Your shortcuts",
+      "shadowed": "Shadowed by team shortcut",
+      "teamSection": "Team shortcuts"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -354,7 +354,7 @@
     "placeholder": "¿Qué le gustaría saber?",
     "prompts": {
       "noResults": "Sin prompts coincidentes",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Aún no hay atajos. Añade algunos en Conocimiento → Habilidades.",
       "scope": {
         "private": "Tus prompts",
         "stock": "Predefinidos",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -354,6 +354,7 @@
     "placeholder": "¿Qué le gustaría saber?",
     "prompts": {
       "noResults": "Sin prompts coincidentes",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Tus prompts",
         "stock": "Predefinidos",
@@ -1053,6 +1054,38 @@
         "description": "Plantillas de documentos con marcadores de posición",
         "title": "Plantillas"
       }
+    },
+    "skills": {
+      "addShortcut": "Añadir atajo",
+      "defaultBadge": "Predeterminado",
+      "deleteConfirmDescription": "Este atajo se eliminará permanentemente.",
+      "deleteConfirmTitle": "¿Eliminar atajo?",
+      "deleteShortcut": "Eliminar atajo",
+      "editShortcut": "Editar atajo",
+      "emptyState": "Aún no hay atajos. Añade uno para comenzar.",
+      "errors": {
+        "commandConflict": "Ya existe un atajo con este comando",
+        "commandInvalid": "Usa solo letras minúsculas, dígitos, guiones y guiones bajos",
+        "commandReserved": "\"/{command}\" es un comando reservado"
+      },
+      "form": {
+        "command": "Comando",
+        "commandHint": "Solo letras minúsculas, dígitos, guiones y guiones bajos",
+        "commandPlaceholder": "p. ej. resumir",
+        "commandPrefix": "/",
+        "description": "Descripción",
+        "descriptionPlaceholder": "Descripción breve en el selector",
+        "name": "Nombre",
+        "namePlaceholder": "p. ej. Resumir documento",
+        "prompt": "Prompt",
+        "promptPlaceholder": "El texto que se inserta en el compositor de chat al usar este atajo",
+        "scope": "Visibilidad",
+        "scopePrivate": "Solo yo",
+        "scopeTeam": "Todos en la organización"
+      },
+      "privateSection": "Mis atajos",
+      "shadowed": "Eclipsado por atajo de equipo",
+      "teamSection": "Atajos de equipo"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -354,6 +354,7 @@
     "placeholder": "Mida soovite teada?",
     "prompts": {
       "noResults": "Sobivaid küsimusi pole",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Sinu küsimused",
         "stock": "Sisseehitatud",
@@ -1053,6 +1054,38 @@
         "description": "Dokumendimallid kohatäitjatega",
         "title": "Mallid"
       }
+    },
+    "skills": {
+      "addShortcut": "Lisa otsetee",
+      "defaultBadge": "Vaikimisi",
+      "deleteConfirmDescription": "See otsetee eemaldatakse jäädavalt.",
+      "deleteConfirmTitle": "Kustuta otsetee?",
+      "deleteShortcut": "Kustuta otsetee",
+      "editShortcut": "Muuda otseteed",
+      "emptyState": "Otseteid pole veel. Lisa esimene.",
+      "errors": {
+        "commandConflict": "Selle käsuga otsetee on juba olemas",
+        "commandInvalid": "Kasuta ainult väiketähti, numbreid, sidekriipse ja allkriipse",
+        "commandReserved": "\"/{command}\" on reserveeritud käsk"
+      },
+      "form": {
+        "command": "Käsk",
+        "commandHint": "Ainult väiketähed, numbrid, sidekriipsud ja allkriipsud",
+        "commandPlaceholder": "nt. kokkuvõte",
+        "commandPrefix": "/",
+        "description": "Kirjeldus",
+        "descriptionPlaceholder": "Lühike kirjeldus valijas",
+        "name": "Nimi",
+        "namePlaceholder": "nt. Dokumendi kokkuvõte",
+        "prompt": "Prompt",
+        "promptPlaceholder": "Tekst, mis lisatakse vestluse koostajasse selle otsetee kasutamisel",
+        "scope": "Nähtavus",
+        "scopePrivate": "Ainult mina",
+        "scopeTeam": "Kõik organisatsioonis"
+      },
+      "privateSection": "Minu otseteed",
+      "shadowed": "Varjatud meeskonna otsteega",
+      "teamSection": "Meeskonna otseteed"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -354,7 +354,7 @@
     "placeholder": "Mida soovite teada?",
     "prompts": {
       "noResults": "Sobivaid küsimusi pole",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Otseteid pole veel. Lisage neid jaotises Teadmised → Oskused.",
       "scope": {
         "private": "Sinu küsimused",
         "stock": "Sisseehitatud",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -354,6 +354,7 @@
     "placeholder": "Que souhaitez-vous savoir ?",
     "prompts": {
       "noResults": "Aucun prompt correspondant",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Vos prompts",
         "stock": "Intégrés",
@@ -1053,6 +1054,38 @@
         "description": "Modèles de documents avec espaces réservés",
         "title": "Modèles"
       }
+    },
+    "skills": {
+      "addShortcut": "Ajouter un raccourci",
+      "defaultBadge": "Par défaut",
+      "deleteConfirmDescription": "Ce raccourci sera supprimé définitivement.",
+      "deleteConfirmTitle": "Supprimer le raccourci ?",
+      "deleteShortcut": "Supprimer le raccourci",
+      "editShortcut": "Modifier le raccourci",
+      "emptyState": "Aucun raccourci pour l'instant. Ajoutez-en un pour commencer.",
+      "errors": {
+        "commandConflict": "Un raccourci avec cette commande existe déjà",
+        "commandInvalid": "Utilisez uniquement des minuscules, chiffres, tirets et tirets bas",
+        "commandReserved": "\"/{command}\" est une commande réservée"
+      },
+      "form": {
+        "command": "Commande",
+        "commandHint": "Minuscules, chiffres, tirets et tirets bas uniquement",
+        "commandPlaceholder": "ex. résumer",
+        "commandPrefix": "/",
+        "description": "Description",
+        "descriptionPlaceholder": "Courte description affichée dans le sélecteur",
+        "name": "Nom",
+        "namePlaceholder": "ex. Résumer le document",
+        "prompt": "Invite",
+        "promptPlaceholder": "Le texte inséré dans le compositeur de chat lors de l'utilisation de ce raccourci",
+        "scope": "Visibilité",
+        "scopePrivate": "Moi uniquement",
+        "scopeTeam": "Tous dans l'organisation"
+      },
+      "privateSection": "Mes raccourcis",
+      "shadowed": "Masqué par un raccourci d'équipe",
+      "teamSection": "Raccourcis d'équipe"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -354,7 +354,7 @@
     "placeholder": "Que souhaitez-vous savoir ?",
     "prompts": {
       "noResults": "Aucun prompt correspondant",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Aucun raccourci pour l'instant. Ajoutez-en dans Connaissance → Compétences.",
       "scope": {
         "private": "Vos prompts",
         "stock": "Intégrés",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -354,7 +354,7 @@
     "placeholder": "Mit szeretne tudni?",
     "prompts": {
       "noResults": "Nincs egyező prompt",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Még nincsenek parancsikonok. Adjon hozzá néhányat a Tudás → Készségek menüpontban.",
       "scope": {
         "private": "Saját promptok",
         "stock": "Beépített",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -354,6 +354,7 @@
     "placeholder": "Mit szeretne tudni?",
     "prompts": {
       "noResults": "Nincs egyező prompt",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Saját promptok",
         "stock": "Beépített",
@@ -1053,6 +1054,38 @@
         "description": "Dokumentumsablonok helyőrzőkkel",
         "title": "Sablonok"
       }
+    },
+    "skills": {
+      "addShortcut": "Parancsikon hozzáadása",
+      "defaultBadge": "Alapértelmezett",
+      "deleteConfirmDescription": "Ez a parancsikon véglegesen törlésre kerül.",
+      "deleteConfirmTitle": "Parancsikon törlése?",
+      "deleteShortcut": "Parancsikon törlése",
+      "editShortcut": "Parancsikon szerkesztése",
+      "emptyState": "Még nincsenek parancsikonok. Adjon hozzá egyet.",
+      "errors": {
+        "commandConflict": "Ezzel a paranccsal már létezik egy parancsikon",
+        "commandInvalid": "Csak kisbetűket, számokat, kötőjeleket és aláhúzásokat használjon",
+        "commandReserved": "\"/{command}\" egy fenntartott parancs"
+      },
+      "form": {
+        "command": "Parancs",
+        "commandHint": "Csak kisbetűk, számok, kötőjelek és aláhúzások",
+        "commandPlaceholder": "pl. összefoglalás",
+        "commandPrefix": "/",
+        "description": "Leírás",
+        "descriptionPlaceholder": "Rövid leírás a kiválasztóban",
+        "name": "Név",
+        "namePlaceholder": "pl. Dokumentum összefoglalása",
+        "prompt": "Prompt",
+        "promptPlaceholder": "A szöveg, amely be lesz illesztve a csevegő szerkesztőbe",
+        "scope": "Láthatóság",
+        "scopePrivate": "Csak én",
+        "scopeTeam": "Mindenki a szervezetben"
+      },
+      "privateSection": "Saját parancsikonok",
+      "shadowed": "Csapat parancsikon takarja",
+      "teamSection": "Csapat parancsikonok"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -354,7 +354,7 @@
     "placeholder": "Ko norėtumėte paklausti?",
     "prompts": {
       "noResults": "Nėra atitinkančių raginimų",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Dar nėra sparčiųjų klavišų. Pridėkite juos dalyje Žinios → Įgūdžiai.",
       "scope": {
         "private": "Jūsų raginimai",
         "stock": "Įmontuoti",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -354,6 +354,7 @@
     "placeholder": "Ko norėtumėte paklausti?",
     "prompts": {
       "noResults": "Nėra atitinkančių raginimų",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Jūsų raginimai",
         "stock": "Įmontuoti",
@@ -1053,6 +1054,38 @@
         "description": "Dokumentų šablonai su vietos žymėmis",
         "title": "Šablonai"
       }
+    },
+    "skills": {
+      "addShortcut": "Pridėti spartąjį klavišą",
+      "defaultBadge": "Numatytasis",
+      "deleteConfirmDescription": "Šis spartysis klavišas bus visam laikui pašalintas.",
+      "deleteConfirmTitle": "Ištrinti spartųjį klavišą?",
+      "deleteShortcut": "Ištrinti spartųjį klavišą",
+      "editShortcut": "Redaguoti spartąjį klavišą",
+      "emptyState": "Dar nėra sparčiųjų klavišų. Pridėkite pirmąjį.",
+      "errors": {
+        "commandConflict": "Spartysis klavišas su šia komanda jau egzistuoja",
+        "commandInvalid": "Naudokite tik mažąsias raides, skaičius, brūkšnelius ir pabraukimus",
+        "commandReserved": "\"/{command}\" yra rezervuota komanda"
+      },
+      "form": {
+        "command": "Komanda",
+        "commandHint": "Tik mažosios raidės, skaičiai, brūkšneliai ir pabraukimai",
+        "commandPlaceholder": "pvz. sutraukti",
+        "commandPrefix": "/",
+        "description": "Aprašymas",
+        "descriptionPlaceholder": "Trumpas aprašymas rinkiklyje",
+        "name": "Pavadinimas",
+        "namePlaceholder": "pvz. Dokumento santrauka",
+        "prompt": "Užklausa",
+        "promptPlaceholder": "Tekstas, įterpiamas į pokalbio rengyklę naudojant šį spartąjį klavišą",
+        "scope": "Matomumas",
+        "scopePrivate": "Tik aš",
+        "scopeTeam": "Visi organizacijoje"
+      },
+      "privateSection": "Mano spartieji klavišai",
+      "shadowed": "Dengia komandos spartysis klavišas",
+      "teamSection": "Komandos spartieji klavišai"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -354,7 +354,7 @@
     "placeholder": "Ko vēlaties uzzināt?",
     "prompts": {
       "noResults": "Nav atbilstošu uzvedņu",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Vēl nav saīšņu. Pievienojiet tās sadaļā Zināšanas → Prasmes.",
       "scope": {
         "private": "Jūsu uzvednes",
         "stock": "Iebūvētas",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -354,6 +354,7 @@
     "placeholder": "Ko vēlaties uzzināt?",
     "prompts": {
       "noResults": "Nav atbilstošu uzvedņu",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Jūsu uzvednes",
         "stock": "Iebūvētas",
@@ -1053,6 +1054,38 @@
         "description": "Dokumentu veidnes ar vietturiem",
         "title": "Veidnes"
       }
+    },
+    "skills": {
+      "addShortcut": "Pievienot saīsni",
+      "defaultBadge": "Noklusējuma",
+      "deleteConfirmDescription": "Šī saīsne tiks neatgriezeniski dzēsta.",
+      "deleteConfirmTitle": "Dzēst saīsni?",
+      "deleteShortcut": "Dzēst saīsni",
+      "editShortcut": "Rediģēt saīsni",
+      "emptyState": "Vēl nav saīšņu. Pievienojiet pirmo.",
+      "errors": {
+        "commandConflict": "Saīsne ar šo komandu jau pastāv",
+        "commandInvalid": "Izmantojiet tikai mazos burtus, ciparus, defises un pasvītrojumus",
+        "commandReserved": "\"/{command}\" ir rezervēta komanda"
+      },
+      "form": {
+        "command": "Komanda",
+        "commandHint": "Tikai mazie burti, cipari, defises un pasvītrojumi",
+        "commandPlaceholder": "piem. kopsavilkums",
+        "commandPrefix": "/",
+        "description": "Apraksts",
+        "descriptionPlaceholder": "Īss apraksts atlasītājā",
+        "name": "Nosaukums",
+        "namePlaceholder": "piem. Dokumenta kopsavilkums",
+        "prompt": "Uzvedne",
+        "promptPlaceholder": "Teksts, kas tiek ievietots tērzēšanas redaktorā, izmantojot šo saīsni",
+        "scope": "Redzamība",
+        "scopePrivate": "Tikai es",
+        "scopeTeam": "Visi organizācijā"
+      },
+      "privateSection": "Manas saīsnes",
+      "shadowed": "Pārklāts ar komandas saīsni",
+      "teamSection": "Komandas saīsnes"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -357,6 +357,7 @@ type Messages = {
     "placeholder": "What would you like to know?";
     "prompts": {
       "noResults": "No matching prompts";
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.";
       "scope": {
         "private": "Your prompts";
         "stock": "Built-in";
@@ -1056,6 +1057,38 @@ type Messages = {
         "description": "Document templates with placeholders";
         "title": "Templates";
       };
+    };
+    "skills": {
+      "addShortcut": "Add shortcut";
+      "defaultBadge": "Default";
+      "deleteConfirmDescription": "This shortcut will be permanently removed.";
+      "deleteConfirmTitle": "Delete shortcut?";
+      "deleteShortcut": "Delete shortcut";
+      "editShortcut": "Edit shortcut";
+      "emptyState": "No shortcuts yet. Add one to get started.";
+      "errors": {
+        "commandConflict": "A shortcut with this command already exists";
+        "commandInvalid": "Use only lowercase letters, digits, hyphens and underscores";
+        "commandReserved": "\"/{command}\" is a reserved command";
+      };
+      "form": {
+        "command": "Command";
+        "commandHint": "Lowercase letters, digits, hyphens and underscores only";
+        "commandPlaceholder": "e.g. summarize";
+        "commandPrefix": "/";
+        "description": "Description";
+        "descriptionPlaceholder": "Short description shown in the picker";
+        "name": "Name";
+        "namePlaceholder": "e.g. Summarise document";
+        "prompt": "Prompt";
+        "promptPlaceholder": "The text inserted into the chat composer when this shortcut is used";
+        "scope": "Visibility";
+        "scopePrivate": "Only me";
+        "scopeTeam": "Everyone in the organisation";
+      };
+      "privateSection": "Your shortcuts";
+      "shadowed": "Shadowed by team shortcut";
+      "teamSection": "Team shortcuts";
     };
   };
   "navigation": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -354,7 +354,7 @@
     "placeholder": "Co chciałbyś wiedzieć?",
     "prompts": {
       "noResults": "Brak pasujących promptów",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Brak skrótów. Dodaj je w sekcji Wiedza → Umiejętności.",
       "scope": {
         "private": "Twoje prompty",
         "stock": "Wbudowane",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -354,6 +354,7 @@
     "placeholder": "Co chciałbyś wiedzieć?",
     "prompts": {
       "noResults": "Brak pasujących promptów",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Twoje prompty",
         "stock": "Wbudowane",
@@ -1053,6 +1054,38 @@
         "description": "Szablony dokumentów z symbolami zastępczymi",
         "title": "Szablony"
       }
+    },
+    "skills": {
+      "addShortcut": "Dodaj skrót",
+      "defaultBadge": "Domyślny",
+      "deleteConfirmDescription": "Ten skrót zostanie trwale usunięty.",
+      "deleteConfirmTitle": "Usunąć skrót?",
+      "deleteShortcut": "Usuń skrót",
+      "editShortcut": "Edytuj skrót",
+      "emptyState": "Brak skrótów. Dodaj pierwszy.",
+      "errors": {
+        "commandConflict": "Skrót z tą komendą już istnieje",
+        "commandInvalid": "Używaj tylko małych liter, cyfr, myślników i podkreśleń",
+        "commandReserved": "\"/{command}\" jest zarezerwowaną komendą"
+      },
+      "form": {
+        "command": "Komenda",
+        "commandHint": "Tylko małe litery, cyfry, myślniki i podkreślenia",
+        "commandPlaceholder": "np. podsumuj",
+        "commandPrefix": "/",
+        "description": "Opis",
+        "descriptionPlaceholder": "Krótki opis widoczny w selektorze",
+        "name": "Nazwa",
+        "namePlaceholder": "np. Podsumuj dokument",
+        "prompt": "Prompt",
+        "promptPlaceholder": "Tekst wstawiany do kompozytora czatu przy użyciu tego skrótu",
+        "scope": "Widoczność",
+        "scopePrivate": "Tylko ja",
+        "scopeTeam": "Wszyscy w organizacji"
+      },
+      "privateSection": "Moje skróty",
+      "shadowed": "Przysłonięty przez skrót zespołu",
+      "teamSection": "Skróty zespołu"
     }
   },
   "navigation": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -354,7 +354,7 @@
     "placeholder": "Čo by ste chceli vedieť?",
     "prompts": {
       "noResults": "Žiadne zhodné prompty",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "Zatiaľ žiadne skratky. Pridajte ich v časti Vedomosti → Zručnosti.",
       "scope": {
         "private": "Vaše prompty",
         "stock": "Vstavané",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -354,6 +354,7 @@
     "placeholder": "Čo by ste chceli vedieť?",
     "prompts": {
       "noResults": "Žiadne zhodné prompty",
+      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Vaše prompty",
         "stock": "Vstavané",
@@ -1053,6 +1054,38 @@
         "description": "Šablóny dokumentov so zástupnými znakmi",
         "title": "Šablóny"
       }
+    },
+    "skills": {
+      "addShortcut": "Pridať skratku",
+      "defaultBadge": "Predvolená",
+      "deleteConfirmDescription": "Táto skratka bude trvalo odstránená.",
+      "deleteConfirmTitle": "Odstrániť skratku?",
+      "deleteShortcut": "Odstrániť skratku",
+      "editShortcut": "Upraviť skratku",
+      "emptyState": "Zatiaľ žiadne skratky. Pridajte prvú.",
+      "errors": {
+        "commandConflict": "Skratka s týmto príkazom už existuje",
+        "commandInvalid": "Používajte iba malé písmená, číslice, pomlčky a podčiarkovníky",
+        "commandReserved": "\"/{command}\" je rezervovaný príkaz"
+      },
+      "form": {
+        "command": "Príkaz",
+        "commandHint": "Iba malé písmená, číslice, pomlčky a podčiarkovníky",
+        "commandPlaceholder": "napr. zhrnúť",
+        "commandPrefix": "/",
+        "description": "Popis",
+        "descriptionPlaceholder": "Stručný popis zobrazený vo výbere",
+        "name": "Názov",
+        "namePlaceholder": "napr. Zhrnúť dokument",
+        "prompt": "Výzva",
+        "promptPlaceholder": "Text vložený do skladača chatu pri použití tejto skratky",
+        "scope": "Viditeľnosť",
+        "scopePrivate": "Len ja",
+        "scopeTeam": "Všetci v organizácii"
+      },
+      "privateSection": "Moje skratky",
+      "shadowed": "Prekryté tímovou skratkou",
+      "teamSection": "Tímové skratky"
     }
   },
   "navigation": {

--- a/apps/web/src/lib/chat-anonymized-store.ts
+++ b/apps/web/src/lib/chat-anonymized-store.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+
+import type { ChatThreadRef } from "@/lib/chat-thread-ref";
+import { getChatThreadKey } from "@/lib/chat-thread-ref";
+
+type ChatAnonymizedStore = {
+  byThreadKey: Record<string, boolean>;
+  setAnonymized: (threadKey: string, anonymized: boolean) => void;
+};
+
+export const useChatAnonymizedStore = create<ChatAnonymizedStore>((set) => ({
+  byThreadKey: {},
+  setAnonymized: (threadKey, anonymized) =>
+    set((state) => ({
+      byThreadKey: { ...state.byThreadKey, [threadKey]: anonymized },
+    })),
+}));
+
+export const useChatAnonymized = (threadRef: ChatThreadRef): boolean => {
+  const key = getChatThreadKey(threadRef);
+  return useChatAnonymizedStore((s) => s.byThreadKey[key] ?? false);
+};
+
+export const useSetChatAnonymized = (threadRef: ChatThreadRef) => {
+  const key = getChatThreadKey(threadRef);
+  const setAnonymized = useChatAnonymizedStore((s) => s.setAnonymized);
+  return (anonymized: boolean) => setAnonymized(key, anonymized);
+};
+
+export const getChatAnonymized = (threadRef: ChatThreadRef): boolean =>
+  useChatAnonymizedStore.getState().byThreadKey[getChatThreadKey(threadRef)] ??
+  false;

--- a/apps/web/src/lib/prompts/types.ts
+++ b/apps/web/src/lib/prompts/types.ts
@@ -27,6 +27,12 @@ export type ChatPrompt = {
   /** Short label shown on the chip and in the slash menu. */
   name: string;
   /**
+   * The slash command handle (without the leading `/`). Used for
+   * filtering when the user types `/foo` in the composer.
+   * Stock prompts don't have a command handle; DB-backed shortcuts do.
+   */
+  command?: string | undefined;
+  /**
    * The body inserted into the composer when the prompt is picked.
    * Plain text — entity mentions get added by the user after.
    */

--- a/apps/web/src/lib/prompts/use-saved-prompts.ts
+++ b/apps/web/src/lib/prompts/use-saved-prompts.ts
@@ -22,6 +22,7 @@ export const useSavedPrompts = (): ChatPrompt[] => {
         id: s.id,
         scope: s.scope,
         name: s.name,
+        command: s.command,
         body: s.prompt,
       })),
     [shortcuts],

--- a/apps/web/src/lib/prompts/use-saved-prompts.ts
+++ b/apps/web/src/lib/prompts/use-saved-prompts.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { shortcutsOptions } from "@/routes/_protected.knowledge/-queries";
+
+import type { ChatPrompt } from "./types";
+
+const MAX_SUGGESTIONS = 4;
+
+/**
+ * Returns up to 4 of the most recently created shortcuts from the
+ * user's saved shortcuts (private + team). Deterministic order avoids
+ * the flicker that random sampling causes across stale→fresh refetches.
+ */
+export const useSavedPrompts = (): ChatPrompt[] => {
+  const { data: shortcuts = [] } = useQuery(shortcutsOptions());
+
+  return useMemo(
+    () =>
+      shortcuts.slice(0, MAX_SUGGESTIONS).map((s) => ({
+        id: s.id,
+        scope: s.scope,
+        name: s.name,
+        body: s.prompt,
+      })),
+    [shortcuts],
+  );
+};

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as ProtectedContactsIndexRouteImport } from './routes/_protected.
 import { Route as ProtectedChatIndexRouteImport } from './routes/_protected.chat/index'
 import { Route as AuthAcceptInvitationInvitationIdRouteImport } from './routes/auth/accept-invitation.$invitationId'
 import { Route as ProtectedKnowledgeTemplatesRouteImport } from './routes/_protected.knowledge/templates'
+import { Route as ProtectedKnowledgeSkillsRouteImport } from './routes/_protected.knowledge/skills'
 import { Route as ProtectedKnowledgeClausesRouteImport } from './routes/_protected.knowledge/clauses'
 import { Route as ProtectedContactsContactIdRouteImport } from './routes/_protected.contacts/$contactId'
 import { Route as ProtectedChatNewRouteImport } from './routes/_protected.chat/new'
@@ -156,6 +157,12 @@ const ProtectedKnowledgeTemplatesRoute =
   ProtectedKnowledgeTemplatesRouteImport.update({
     id: '/templates',
     path: '/templates',
+    getParentRoute: () => ProtectedKnowledgeRouteRoute,
+  } as any)
+const ProtectedKnowledgeSkillsRoute =
+  ProtectedKnowledgeSkillsRouteImport.update({
+    id: '/skills',
+    path: '/skills',
     getParentRoute: () => ProtectedKnowledgeRouteRoute,
   } as any)
 const ProtectedKnowledgeClausesRoute =
@@ -332,6 +339,7 @@ export interface FileRoutesByFullPath {
   '/chat/new': typeof ProtectedChatNewRoute
   '/contacts/$contactId': typeof ProtectedContactsContactIdRoute
   '/knowledge/clauses': typeof ProtectedKnowledgeClausesRoute
+  '/knowledge/skills': typeof ProtectedKnowledgeSkillsRoute
   '/knowledge/templates': typeof ProtectedKnowledgeTemplatesRoute
   '/auth/accept-invitation/$invitationId': typeof AuthAcceptInvitationInvitationIdRoute
   '/chat/': typeof ProtectedChatIndexRoute
@@ -372,6 +380,7 @@ export interface FileRoutesByTo {
   '/chat/new': typeof ProtectedChatNewRoute
   '/contacts/$contactId': typeof ProtectedContactsContactIdRoute
   '/knowledge/clauses': typeof ProtectedKnowledgeClausesRoute
+  '/knowledge/skills': typeof ProtectedKnowledgeSkillsRoute
   '/knowledge/templates': typeof ProtectedKnowledgeTemplatesRoute
   '/auth/accept-invitation/$invitationId': typeof AuthAcceptInvitationInvitationIdRoute
   '/chat': typeof ProtectedChatIndexRoute
@@ -420,6 +429,7 @@ export interface FileRoutesById {
   '/_protected/chat/new': typeof ProtectedChatNewRoute
   '/_protected/contacts/$contactId': typeof ProtectedContactsContactIdRoute
   '/_protected/knowledge/clauses': typeof ProtectedKnowledgeClausesRoute
+  '/_protected/knowledge/skills': typeof ProtectedKnowledgeSkillsRoute
   '/_protected/knowledge/templates': typeof ProtectedKnowledgeTemplatesRoute
   '/auth/accept-invitation/$invitationId': typeof AuthAcceptInvitationInvitationIdRoute
   '/_protected/chat/': typeof ProtectedChatIndexRoute
@@ -469,6 +479,7 @@ export interface FileRouteTypes {
     | '/chat/new'
     | '/contacts/$contactId'
     | '/knowledge/clauses'
+    | '/knowledge/skills'
     | '/knowledge/templates'
     | '/auth/accept-invitation/$invitationId'
     | '/chat/'
@@ -509,6 +520,7 @@ export interface FileRouteTypes {
     | '/chat/new'
     | '/contacts/$contactId'
     | '/knowledge/clauses'
+    | '/knowledge/skills'
     | '/knowledge/templates'
     | '/auth/accept-invitation/$invitationId'
     | '/chat'
@@ -556,6 +568,7 @@ export interface FileRouteTypes {
     | '/_protected/chat/new'
     | '/_protected/contacts/$contactId'
     | '/_protected/knowledge/clauses'
+    | '/_protected/knowledge/skills'
     | '/_protected/knowledge/templates'
     | '/auth/accept-invitation/$invitationId'
     | '/_protected/chat/'
@@ -734,6 +747,13 @@ declare module '@tanstack/react-router' {
       path: '/templates'
       fullPath: '/knowledge/templates'
       preLoaderRoute: typeof ProtectedKnowledgeTemplatesRouteImport
+      parentRoute: typeof ProtectedKnowledgeRouteRoute
+    }
+    '/_protected/knowledge/skills': {
+      id: '/_protected/knowledge/skills'
+      path: '/skills'
+      fullPath: '/knowledge/skills'
+      preLoaderRoute: typeof ProtectedKnowledgeSkillsRouteImport
       parentRoute: typeof ProtectedKnowledgeRouteRoute
     }
     '/_protected/knowledge/clauses': {
@@ -980,6 +1000,7 @@ const ProtectedKnowledgeCaseRouteRouteWithChildren =
 interface ProtectedKnowledgeRouteRouteChildren {
   ProtectedKnowledgeCaseRouteRoute: typeof ProtectedKnowledgeCaseRouteRouteWithChildren
   ProtectedKnowledgeClausesRoute: typeof ProtectedKnowledgeClausesRoute
+  ProtectedKnowledgeSkillsRoute: typeof ProtectedKnowledgeSkillsRoute
   ProtectedKnowledgeTemplatesRoute: typeof ProtectedKnowledgeTemplatesRoute
   ProtectedKnowledgeIndexRoute: typeof ProtectedKnowledgeIndexRoute
 }
@@ -989,6 +1010,7 @@ const ProtectedKnowledgeRouteRouteChildren: ProtectedKnowledgeRouteRouteChildren
     ProtectedKnowledgeCaseRouteRoute:
       ProtectedKnowledgeCaseRouteRouteWithChildren,
     ProtectedKnowledgeClausesRoute: ProtectedKnowledgeClausesRoute,
+    ProtectedKnowledgeSkillsRoute: ProtectedKnowledgeSkillsRoute,
     ProtectedKnowledgeTemplatesRoute: ProtectedKnowledgeTemplatesRoute,
     ProtectedKnowledgeIndexRoute: ProtectedKnowledgeIndexRoute,
   }

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -3,7 +3,7 @@ import { useEffectEvent, useState } from "react";
 import { Button, buttonVariants } from "@stll/ui/components/button";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { PanelRightIcon, PlusIcon } from "lucide-react";
+import { Maximize2Icon, PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import {
@@ -16,6 +16,10 @@ import { ChatInputSurface } from "@/components/chat-input-surface";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import Tooltip from "@/components/tooltip";
+import {
+  useChatAnonymized,
+  useSetChatAnonymized,
+} from "@/lib/chat-anonymized-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
 import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
@@ -59,7 +63,8 @@ export const ChatThreadPage = ({
   const [seededForThreadId, setSeededForThreadId] = useState<string | null>(
     null,
   );
-  const [anonymized, setAnonymized] = useState(false);
+  const anonymized = useChatAnonymized(threadRef);
+  const setAnonymized = useSetChatAnonymized(threadRef);
   const getContextMatterIds = useEffectEvent(() => contextMatterIds ?? []);
   const getAnonymized = useEffectEvent(() => anonymized);
 
@@ -175,7 +180,7 @@ export const ChatThreadPage = ({
             content={t("chat.moveToSide")}
             render={
               <Button onClick={moveToSide} size="icon-sm" variant="ghost">
-                <PanelRightIcon className="size-4" />
+                <Maximize2Icon className="size-4" />
               </Button>
             }
           />

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -1,14 +1,24 @@
 import { useEffectEvent, useRef } from "react";
 
+import { Button } from "@stll/ui/components/button";
 import { useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Maximize2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { v7 as uuidv7 } from "uuid";
 
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
+import Tooltip from "@/components/tooltip";
+import {
+  getChatAnonymized,
+  useChatAnonymized,
+  useSetChatAnonymized,
+} from "@/lib/chat-anonymized-store";
+import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
+import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
@@ -16,6 +26,7 @@ import {
   chatThreadOptions,
   invalidateGroupedChatThreads,
 } from "@/routes/_protected.chat/-queries";
+import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 
 export const Route = createFileRoute("/_protected/chat/")({
   component: ChatIndex,
@@ -28,14 +39,34 @@ function ChatIndex() {
   const userContext = useChatUserContext();
   const getUserContext = useEffectEvent(() => userContext);
   const threadIdRef = useRef(uuidv7());
-  const controller = useChatEditor({
-    threadRef: { scope: "global", threadId: threadIdRef.current },
-  });
+  const threadRef: ChatThreadRef = {
+    scope: "global",
+    threadId: threadIdRef.current,
+  };
+  const controller = useChatEditor({ threadRef });
   const stockPrompts = useSavedPrompts();
+  const anonymized = useChatAnonymized(threadRef);
+  const setAnonymized = useSetChatAnonymized(threadRef);
+  const getAnonymized = useEffectEvent(() => getChatAnonymized(threadRef));
+  const openInspectorChat = useInspectorStore((s) => s.openChat);
+
+  const moveToSide = () => {
+    openInspectorChat({ id: threadIdRef.current });
+    void navigate({ to: "/chat" });
+  };
 
   return (
     <div className="flex w-full max-w-2xl flex-1 flex-col overflow-hidden">
-      <div className="flex items-center justify-end px-4 py-2">
+      <div className="flex items-center justify-end gap-1 px-4 py-2">
+        <ChatAnonymizedToggle enabled={anonymized} onChange={setAnonymized} />
+        <Tooltip
+          content={t("chat.moveToSide")}
+          render={
+            <Button onClick={moveToSide} size="icon-sm" variant="ghost">
+              <Maximize2Icon className="size-4" />
+            </Button>
+          }
+        />
         <ThreadsSheet />
       </div>
       <div className="flex flex-1 flex-col items-center justify-center gap-6 px-4">
@@ -55,10 +86,11 @@ function ChatIndex() {
               const message = await buildChatRequestMessage(draft);
               const { chat } = await queryClient.ensureQueryData(
                 chatThreadOptions({
-                  key: { scope: "global", threadId: threadIdRef.current },
+                  key: threadRef,
                   context: {
                     allowMissingThread: true,
                     getUserContext,
+                    getAnonymized,
                   },
                 }),
               );

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -8,7 +8,7 @@ import { v7 as uuidv7 } from "uuid";
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
-import { useStockPrompts } from "@/lib/prompts/stock";
+import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
@@ -31,7 +31,7 @@ function ChatIndex() {
   const controller = useChatEditor({
     threadRef: { scope: "global", threadId: threadIdRef.current },
   });
-  const stockPrompts = useStockPrompts();
+  const stockPrompts = useSavedPrompts();
 
   return (
     <div className="flex w-full max-w-2xl flex-1 flex-col overflow-hidden">

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { Input } from "@stll/ui/components/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { Textarea } from "@stll/ui/components/textarea";
+import { toastManager } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
+import { useTranslations } from "use-intl";
+
+import { api } from "@/lib/api";
+import { userErrorMessage } from "@/lib/errors";
+
+// ── Types ────────────────────────────────────────────
+
+type ShortcutScope = "team" | "private";
+
+type ShortcutFormData = {
+  name: string;
+  description: string;
+  command: string;
+  prompt: string;
+  scope: ShortcutScope;
+};
+
+export type ShortcutInitial = {
+  id: string;
+  name: string;
+  description: string | null;
+  command: string;
+  prompt: string;
+  scope: ShortcutScope;
+};
+
+type ShortcutFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  canManageTeam: boolean;
+  initial?: ShortcutInitial;
+};
+
+const COMMAND_PATTERN = /^[a-z0-9][a-z0-9_-]{0,48}$/;
+const RESERVED_COMMANDS = ["model", "new"] as const;
+
+// ── Component ────────────────────────────────────────
+
+export const ShortcutFormDialog = ({
+  open,
+  onOpenChange,
+  onSaved,
+  canManageTeam,
+  initial,
+}: ShortcutFormDialogProps) => {
+  const t = useTranslations();
+  const isEdit = !!initial?.id;
+
+  const [form, setForm] = useState<ShortcutFormData>(() => ({
+    name: initial?.name ?? "",
+    description: initial?.description ?? "",
+    command: initial?.command ?? "",
+    prompt: initial?.prompt ?? "",
+    scope: initial?.scope ?? "private",
+  }));
+  const [commandError, setCommandError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        name: initial?.name ?? "",
+        description: initial?.description ?? "",
+        command: initial?.command ?? "",
+        prompt: initial?.prompt ?? "",
+        scope: initial?.scope ?? "private",
+      });
+      setCommandError(null);
+    }
+  }, [open, initial]);
+
+  const validateCommand = (cmd: string): string | null => {
+    if (!cmd) {
+      return null;
+    }
+    if (!COMMAND_PATTERN.test(cmd)) {
+      return t("knowledge.skills.errors.commandInvalid");
+    }
+    if ((RESERVED_COMMANDS as readonly string[]).includes(cmd)) {
+      return t("knowledge.skills.errors.commandReserved", { command: cmd });
+    }
+    return null;
+  };
+
+  const handleCommandChange = (value: string) => {
+    const lower = value.toLowerCase().replace(/\s/g, "");
+    setForm((f) => ({ ...f, command: lower }));
+    setCommandError(validateCommand(lower));
+  };
+
+  const handleSubmit = async () => {
+    const err = validateCommand(form.command);
+    if (err) {
+      setCommandError(err);
+      return;
+    }
+    if (!form.name.trim() || !form.command || !form.prompt.trim()) {
+      return;
+    }
+
+    setSaving(true);
+
+    if (isEdit && initial?.id) {
+      const response = await api.shortcuts({ shortcutId: initial.id }).post({
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        command: form.command,
+        prompt: form.prompt.trim(),
+        queryKey: ["shortcuts"],
+      });
+
+      setSaving(false);
+
+      if (response.error) {
+        if (response.error.status === 409) {
+          setCommandError(t("knowledge.skills.errors.commandConflict"));
+          return;
+        }
+        toastManager.add({
+          type: "error",
+          description: userErrorMessage(
+            response.error,
+            t("common.unexpectedError"),
+          ),
+        });
+        return;
+      }
+    } else {
+      const trimmedDescription = form.description.trim();
+      const response = await api.shortcuts.put({
+        name: form.name.trim(),
+        ...(trimmedDescription ? { description: trimmedDescription } : {}),
+        command: form.command,
+        prompt: form.prompt.trim(),
+        scope: form.scope,
+        queryKey: ["shortcuts"],
+      });
+
+      setSaving(false);
+
+      if (response.error) {
+        if (response.error.status === 409) {
+          setCommandError(t("knowledge.skills.errors.commandConflict"));
+          return;
+        }
+        toastManager.add({
+          type: "error",
+          description: userErrorMessage(
+            response.error,
+            t("common.unexpectedError"),
+          ),
+        });
+        return;
+      }
+    }
+
+    onSaved();
+    onOpenChange(false);
+  };
+
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    form.command.length > 0 &&
+    form.prompt.trim().length > 0 &&
+    !commandError;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogPopup className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit
+              ? t("knowledge.skills.editShortcut")
+              : t("knowledge.skills.addShortcut")}
+          </DialogTitle>
+        </DialogHeader>
+
+        <DialogPanel className="flex flex-col gap-4">
+          {/* Name */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="shortcut-name">
+              {t("knowledge.skills.form.name")}
+            </label>
+            <Input
+              id="shortcut-name"
+              placeholder={t("knowledge.skills.form.namePlaceholder")}
+              value={form.name}
+              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            />
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-1.5">
+            <label
+              className="text-sm font-medium"
+              htmlFor="shortcut-description"
+            >
+              {t("knowledge.skills.form.description")}
+            </label>
+            <Input
+              id="shortcut-description"
+              placeholder={t("knowledge.skills.form.descriptionPlaceholder")}
+              value={form.description}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, description: e.target.value }))
+              }
+            />
+          </div>
+
+          {/* Command */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="shortcut-command">
+              {t("knowledge.skills.form.command")}
+            </label>
+            <div className="flex items-stretch">
+              <span className="bg-muted border-border flex items-center rounded-s-md border border-e-0 px-3 text-sm">
+                {t("knowledge.skills.form.commandPrefix")}
+              </span>
+              <Input
+                id="shortcut-command"
+                className={cn(
+                  "rounded-s-none",
+                  commandError && "border-destructive",
+                )}
+                placeholder={t("knowledge.skills.form.commandPlaceholder")}
+                value={form.command}
+                onChange={(e) => handleCommandChange(e.target.value)}
+              />
+            </div>
+            {commandError ? (
+              <p className="text-destructive text-xs">{commandError}</p>
+            ) : (
+              <p className="text-muted-foreground text-xs">
+                {t("knowledge.skills.form.commandHint")}
+              </p>
+            )}
+          </div>
+
+          {/* Prompt */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="shortcut-prompt">
+              {t("knowledge.skills.form.prompt")}
+            </label>
+            <Textarea
+              id="shortcut-prompt"
+              className="min-h-30 resize-y"
+              placeholder={t("knowledge.skills.form.promptPlaceholder")}
+              value={form.prompt}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, prompt: e.target.value }))
+              }
+            />
+          </div>
+
+          {/* Scope — only shown on create and only for admins/owners */}
+          {!isEdit && canManageTeam && (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium" htmlFor="shortcut-scope">
+                {t("knowledge.skills.form.scope")}
+              </label>
+              <Select
+                value={form.scope}
+                onValueChange={(v) =>
+                  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                  setForm((f) => ({ ...f, scope: v as ShortcutScope }))
+                }
+              >
+                <SelectTrigger id="shortcut-scope">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectPopup>
+                  <SelectItem value="private">
+                    {t("knowledge.skills.form.scopePrivate")}
+                  </SelectItem>
+                  <SelectItem value="team">
+                    {t("knowledge.skills.form.scopeTeam")}
+                  </SelectItem>
+                </SelectPopup>
+              </Select>
+            </div>
+          )}
+        </DialogPanel>
+
+        <DialogFooter>
+          <DialogClose render={<Button variant="ghost" />}>
+            {t("common.cancel")}
+          </DialogClose>
+          <Button
+            disabled={!canSubmit || saving}
+            onClick={() => {
+              void handleSubmit();
+            }}
+          >
+            {isEdit ? t("common.save") : t("common.add")}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+};

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -9,6 +9,10 @@ import { toSafeId } from "@/lib/safe-id";
 // ── Key factory ─────────────────────────────────────
 
 export const knowledgeKeys = {
+  shortcuts: {
+    all: ["shortcuts"] as const,
+    list: () => [...knowledgeKeys.shortcuts.all, "list"] as const,
+  },
   templates: {
     all: ["templates"] as const,
     list: (categoryId?: string | null) =>
@@ -206,6 +210,21 @@ export const clausesOptions = (params: {
         throw toAPIError(response.error);
       }
 
+      return response.data;
+    },
+    staleTime: STALE_TIME.FIVE.MINUTES,
+  });
+
+// ── Shortcuts queries ────────────────────────────────
+
+export const shortcutsOptions = () =>
+  queryOptions({
+    queryKey: knowledgeKeys.shortcuts.list(),
+    queryFn: async ({ signal }) => {
+      const response = await api.shortcuts.get({ fetch: { signal } });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
       return response.data;
     },
     staleTime: STALE_TIME.FIVE.MINUTES,

--- a/apps/web/src/routes/_protected.knowledge/index.tsx
+++ b/apps/web/src/routes/_protected.knowledge/index.tsx
@@ -11,12 +11,12 @@ export const Route = createFileRoute("/_protected/knowledge/")({
 type KnowledgeSection = {
   key: "caseLaw" | "skills" | "connectors";
   icon: LucideIcon;
-  to?: "/knowledge/case";
+  to?: "/knowledge/case" | "/knowledge/skills";
 };
 
 export const knowledgeSections: readonly KnowledgeSection[] = [
   { key: "caseLaw", icon: LandmarkIcon, to: "/knowledge/case" },
-  { key: "skills", icon: LightbulbIcon },
+  { key: "skills", icon: LightbulbIcon, to: "/knowledge/skills" },
   { key: "connectors", icon: PlugIcon },
 ];
 

--- a/apps/web/src/routes/_protected.knowledge/skills.tsx
+++ b/apps/web/src/routes/_protected.knowledge/skills.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { toastManager } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { api } from "@/lib/api";
+import { userErrorMessage } from "@/lib/errors";
+import { roleOptions } from "@/routes/-queries";
+import {
+  knowledgeKeys,
+  shortcutsOptions,
+} from "@/routes/_protected.knowledge/-queries";
+
+import { ShortcutFormDialog } from "./-components/shortcut-form-dialog";
+import type { ShortcutInitial } from "./-components/shortcut-form-dialog";
+
+export const Route = createFileRoute("/_protected/knowledge/skills")({
+  component: SkillsPage,
+});
+
+// ── Types ────────────────────────────────────────────
+
+type ShortcutRow = {
+  id: string;
+  scope: "team" | "private";
+  name: string;
+  description: string | null;
+  command: string;
+  prompt: string;
+  isDefault: boolean;
+  userId: string;
+};
+
+// ── Component ────────────────────────────────────────
+
+function SkillsPage() {
+  const t = useTranslations();
+  const queryClient = useQueryClient();
+
+  const { data: shortcuts = [], isLoading } = useQuery(shortcutsOptions());
+  const { data: role } = useQuery(roleOptions);
+
+  const canManageTeam = role === "owner" || role === "admin";
+
+  // Seed defaults on first mount if no shortcuts exist yet
+  useEffect(() => {
+    if (!isLoading && shortcuts.length === 0) {
+      void api.shortcuts.seed.post({ queryKey: ["shortcuts"] }).then(() => {
+        void queryClient.invalidateQueries({
+          queryKey: knowledgeKeys.shortcuts.all,
+        });
+      });
+    }
+  }, [isLoading, shortcuts.length, queryClient]);
+
+  const [formOpen, setFormOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<ShortcutInitial | undefined>();
+  const [deleteTarget, setDeleteTarget] = useState<ShortcutRow | undefined>();
+  const [deleting, setDeleting] = useState(false);
+
+  const teamShortcuts = shortcuts.filter((s) => s.scope === "team");
+  const privateShortcuts = shortcuts.filter((s) => s.scope === "private");
+  const teamCommands = new Set(teamShortcuts.map((s) => s.command));
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({
+      queryKey: knowledgeKeys.shortcuts.all,
+    });
+  };
+
+  const openEdit = (s: ShortcutRow) => {
+    setEditTarget({
+      id: s.id,
+      name: s.name,
+      description: s.description,
+      command: s.command,
+      prompt: s.prompt,
+      scope: s.scope,
+    });
+    setFormOpen(true);
+  };
+
+  const openCreate = () => {
+    setEditTarget(undefined);
+    setFormOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) {
+      return;
+    }
+    setDeleting(true);
+
+    const response = await api
+      .shortcuts({ shortcutId: deleteTarget.id })
+      .delete({ queryKey: ["shortcuts"] });
+    setDeleting(false);
+
+    if (response.error) {
+      toastManager.add({
+        type: "error",
+        description: userErrorMessage(
+          response.error,
+          t("common.unexpectedError"),
+        ),
+      });
+      return;
+    }
+
+    invalidate();
+    setDeleteTarget(undefined);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col overflow-y-auto p-6">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-foreground text-xl font-semibold">
+          {t("knowledge.sections.skills.title")}
+        </h1>
+        <Button onClick={openCreate} size="sm">
+          <PlusIcon className="me-1.5 size-4" />
+          {t("knowledge.skills.addShortcut")}
+        </Button>
+      </div>
+
+      {shortcuts.length === 0 && !isLoading && (
+        <p className="text-muted-foreground text-sm">
+          {t("knowledge.skills.emptyState")}
+        </p>
+      )}
+
+      {teamShortcuts.length > 0 && (
+        <Section title={t("knowledge.skills.teamSection")}>
+          {teamShortcuts.map((s) => (
+            <ShortcutCard
+              key={s.id}
+              shortcut={s}
+              canEdit={canManageTeam}
+              shadowed={false}
+              onEdit={openEdit}
+              onDelete={setDeleteTarget}
+            />
+          ))}
+        </Section>
+      )}
+
+      {privateShortcuts.length > 0 && (
+        <Section title={t("knowledge.skills.privateSection")}>
+          {privateShortcuts.map((s) => (
+            <ShortcutCard
+              key={s.id}
+              shortcut={s}
+              canEdit
+              shadowed={teamCommands.has(s.command)}
+              onEdit={openEdit}
+              onDelete={setDeleteTarget}
+            />
+          ))}
+        </Section>
+      )}
+
+      <ShortcutFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        onSaved={invalidate}
+        canManageTeam={canManageTeam}
+        {...(editTarget ? { initial: editTarget } : {})}
+      />
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(undefined);
+          }
+        }}
+      >
+        <DialogPopup className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle>
+              {t("knowledge.skills.deleteConfirmTitle")}
+            </DialogTitle>
+          </DialogHeader>
+          <DialogPanel>
+            <p className="text-muted-foreground text-sm">
+              {t("knowledge.skills.deleteConfirmDescription")}
+            </p>
+          </DialogPanel>
+          <DialogFooter>
+            <DialogClose render={<Button variant="ghost" />}>
+              {t("common.cancel")}
+            </DialogClose>
+            <Button
+              variant="destructive"
+              disabled={deleting}
+              onClick={() => {
+                void confirmDelete();
+              }}
+            >
+              {t("knowledge.skills.deleteShortcut")}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────
+
+type SectionProps = {
+  title: string;
+  children: React.ReactNode;
+};
+
+function Section({ title, children }: SectionProps) {
+  return (
+    <div className="mb-8">
+      <h2 className="text-muted-foreground mb-3 text-xs font-semibold tracking-wider uppercase">
+        {title}
+      </h2>
+      <div className="flex flex-col gap-2">{children}</div>
+    </div>
+  );
+}
+
+type ShortcutCardProps = {
+  shortcut: ShortcutRow;
+  canEdit: boolean;
+  shadowed: boolean;
+  onEdit: (s: ShortcutRow) => void;
+  onDelete: (s: ShortcutRow) => void;
+};
+
+function ShortcutCard({
+  shortcut,
+  canEdit,
+  shadowed,
+  onEdit,
+  onDelete,
+}: ShortcutCardProps) {
+  const t = useTranslations();
+
+  return (
+    <div
+      className={cn(
+        "bg-card group flex items-start justify-between gap-4 rounded-xl border p-4",
+        "hover:border-foreground/15 transition-colors hover:shadow-sm",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-foreground text-sm font-medium">
+            {shortcut.name}
+          </span>
+          <span className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 font-mono text-xs">
+            /{shortcut.command}
+          </span>
+          {shortcut.isDefault && (
+            <span className="text-muted-foreground rounded border px-1.5 py-0.5 text-xs">
+              {t("knowledge.skills.defaultBadge")}
+            </span>
+          )}
+          {shadowed && (
+            <span className="rounded border border-amber-200 px-1.5 py-0.5 text-xs text-amber-600 dark:border-amber-800 dark:text-amber-400">
+              {t("knowledge.skills.shadowed")}
+            </span>
+          )}
+        </div>
+        {shortcut.description && (
+          <p className="text-muted-foreground mt-0.5 text-sm">
+            {shortcut.description}
+          </p>
+        )}
+        <p className="text-muted-foreground mt-1 line-clamp-2 text-xs">
+          {shortcut.prompt}
+        </p>
+      </div>
+
+      {canEdit && (
+        <div className="flex shrink-0 gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onEdit(shortcut)}
+            aria-label={t("knowledge.skills.editShortcut")}
+          >
+            <PencilIcon className="size-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={() => onDelete(shortcut)}
+            aria-label={t("knowledge.skills.deleteShortcut")}
+          >
+            <TrashIcon className="size-4" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -46,8 +46,8 @@ import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import Tooltip from "@/components/tooltip";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
-import { useStockPrompts } from "@/lib/prompts/stock";
 import type { ChatPrompt } from "@/lib/prompts/types";
+import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
 import { toSafeId } from "@/lib/safe-id";
 import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
@@ -180,7 +180,7 @@ export const ChatTabPanel = ({
     threadRef,
   });
 
-  const stockPrompts = useStockPrompts();
+  const stockPrompts = useSavedPrompts();
   const handleSelectPrompt = (prompt: ChatPrompt) => {
     const editor = editorController.editor;
     if (!editor) {
@@ -501,7 +501,7 @@ export const ChatTabPanelShell = ({
   tab: ChatTab;
   matterColor?: string | null | undefined;
 }) => {
-  const stockPrompts = useStockPrompts();
+  const stockPrompts = useSavedPrompts();
   return (
     <ChatTabPanelChrome
       anonymized={false}

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -29,6 +29,7 @@ export const statements = {
   chat: ["create", "delete"],
   organizationSettings: ["update"],
   auditLog: ["read"],
+  promptShortcut: ["create", "update", "delete"],
 } as const;
 
 type PermissionMap = {
@@ -64,6 +65,7 @@ const memberAc = ac.newRole({
   chat: ["create", "delete"],
   organizationSettings: [],
   auditLog: [],
+  promptShortcut: ["create", "update", "delete"],
 });
 
 export const roles = {
@@ -88,6 +90,7 @@ export const roles = {
     chat: ["create", "delete"],
     organizationSettings: ["update"],
     auditLog: ["read"],
+    promptShortcut: ["create", "update", "delete"],
   }),
   admin: ac.newRole({
     organization: ["update"],
@@ -110,6 +113,7 @@ export const roles = {
     chat: ["create", "delete"],
     organizationSettings: ["update"],
     auditLog: ["read"],
+    promptShortcut: ["create", "update", "delete"],
   }),
   member: memberAc,
   intern: ac.newRole({
@@ -133,6 +137,7 @@ export const roles = {
     chat: ["create", "delete"],
     organizationSettings: [],
     auditLog: [],
+    promptShortcut: [],
   }),
   external: ac.newRole({
     organization: [],
@@ -155,5 +160,6 @@ export const roles = {
     chat: [],
     organizationSettings: [],
     auditLog: [],
+    promptShortcut: [],
   }),
 };

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -163,7 +163,7 @@ function Toasts({ position }: { position: ToastPosition }) {
     <Toast.Portal data-slot="toast-portal">
       <Toast.Viewport
         className={cn(
-          "fixed z-50 mx-auto flex w-[calc(100%-var(--toast-inset)*2)] max-w-90 [--toast-inset:--spacing(4)] sm:[--toast-inset:--spacing(8)]",
+          "fixed z-[60] mx-auto flex w-[calc(100%-var(--toast-inset)*2)] max-w-90 [--toast-inset:--spacing(4)] sm:[--toast-inset:--spacing(8)]",
           // Vertical positioning
           "data-[position*=top]:top-(--toast-inset)",
           "data-[position*=bottom]:bottom-(--toast-inset)",


### PR DESCRIPTION
## Summary

- Adds user-defined `/` prompt shortcuts with **team** (admin/owner only) and **private** scopes, stored in the DB with per-org partial unique indexes for command namespacing
- Full CRUD API (`GET /shortcuts`, `PUT`, `POST /:id`, `DELETE /:id`, `POST /seed`) with RLS policies, permission declarations, and a 100-shortcut-per-user limit
- Auto-seeds 4 default shortcuts on first visit to Knowledge > Skills; they are editable and deletable like any user shortcut
- **Knowledge > Skills** management page with grouped sections (Team / Yours), shadowed-command badge, inline edit/delete, and a Knowledge > Skills breadcrumb
- Chat composer `/` slash menu now pulls from DB shortcuts instead of hardcoded stock prompts; home-screen suggestion chips show the 4 most recently created shortcuts (both main chat and inspector sidebar)
- Dialog structure fixed (`DialogHeader` / `DialogPanel` / `DialogFooter` as siblings), command prefix RTL-safe (`rounded-s-*`, `border-e-0`), Skills page scrollable
- Translated strings for all 10 supported locales (cs, de, es, et, fr, hu, lt, lv, pl, sk)

## Test plan

- [ ] `bun run db:push` to apply the new `prompt_shortcuts` table and RLS policies
- [ ] Visit Knowledge > Skills — 4 default shortcuts seeded on first load
- [ ] Create a private shortcut; verify command validation (format, reserved words) fires live; uniqueness error on save
- [ ] Create a team shortcut as admin/owner; verify members cannot create team shortcuts
- [ ] Edit and delete shortcuts; confirm scoped ownership rules (can't delete another user's private shortcut)
- [ ] Type `/` in the main chat composer — DB shortcuts appear, stock prompts do not
- [ ] Type `/` in the inspector sidebar chat — same behaviour
- [ ] Chat home screen shows up to 4 of your most recent shortcuts
- [ ] Breadcrumb shows Knowledge > Skills when on the Skills page
- [ ] Verify all 10 non-English locales render translated strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)