### PR TITLE
fix(api): raise bun-test default timeout for sandbox suite

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
 import * as v from "valibot";
 
 import { createToolFunction } from "@/api/handlers/chat/tools/execute/execute-tool-function";
@@ -8,6 +8,9 @@ import type {
   SandboxFunctionRegistry,
 } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
 import { runSandbox as runSandboxInternal } from "@/api/handlers/chat/tools/execute/sandbox/run-sandbox";
+
+// Sandbox runs spin up isolated V8 contexts; raise the bun-test ceiling so CI runner load doesn't flake. Product code enforces its own smaller deadlines.
+setDefaultTimeout(15_000);
 
 type RunTestSandboxProps = Omit<RunSandboxInput, "concurrencyKey"> & {
   concurrencyKey?: string;


### PR DESCRIPTION
## Summary
- Add `setDefaultTimeout(15_000)` to `apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts` so the bun-test 5000ms ceiling stops flaking under CI runner load.
- Five tests in this file timed out at exactly 5000ms on PR #62's CI run despite that PR only touching the landing page; same suite passed on every other recent PR. The harness ceiling is just a runtime-hang guard — the product itself enforces much smaller internal deadlines (e.g. `maxDurationMs: 30`), so raising the harness limit doesn't weaken any assertion.
- File-level rather than per-test: all 40 tests in the file have the same shape (spin up isolated V8 context, run code, tear down). Per-test bumps would just play whack-a-mole.

## Test plan
- [x] `bun test apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts` — 40 pass, 2.78s total
- [ ] CI green