### PR TITLE
feat(desktop): point updater at downloads.stll.app

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -40,9 +40,7 @@
       }
     },
     "updater": {
-      "endpoints": [
-        "https://github.com/stella/stella/releases/latest/download/latest.json"
-      ],
+      "endpoints": ["https://downloads.stll.app/desktop/prod/latest.json"],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IENFMTlDRDhGMTRDQjg0RkMKUldUOGhNc1VqODBaem4zNmNFVVJlT3VSOVh2RlRKanBKVGIrRS8xNWt4aGt4VkduWmdDL1MwdHkK"
     }
   }


### PR DESCRIPTION
## Summary
The Tauri updater plugin is fully wired (Cargo dep + \`updater.rs\` module + tray + startup check). The endpoint just pointed at GitHub releases, which forces public artifact assets on the source repo.