### PR TITLE
fix(email): send text/plain alongside HTML, support optional config set

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -85,6 +85,7 @@ const envApi = createEnv({
     SES_REGION: v.optional(v.string()),
     SES_ACCESS_KEY_ID: v.optional(v.string()),
     SES_SECRET_ACCESS_KEY: v.optional(v.string()),
+    SES_CONFIGURATION_SET: v.optional(v.string()),
     SMTP_HOST: v.optional(v.string()),
     SMTP_PORT: v.optional(
       v.pipe(

--- a/apps/api/src/lib/email/index.tsx
+++ b/apps/api/src/lib/email/index.tsx
@@ -24,6 +24,9 @@ const resolveTransport = (): EmailTransport => {
         ...(env.SES_SECRET_ACCESS_KEY && {
           secretAccessKey: env.SES_SECRET_ACCESS_KEY,
         }),
+        ...(env.SES_CONFIGURATION_SET && {
+          configurationSetName: env.SES_CONFIGURATION_SET,
+        }),
       });
     case "smtp":
       return createSMTPTransport({
@@ -66,15 +69,18 @@ export const sendOTPEmail = async ({
   type,
   lang,
 }: SendOTPEmailProps) => {
-  const html = await render(
-    <BetterAuthOTP.Email lang={lang} otp={otp} type={type} />,
-  );
+  const node = <BetterAuthOTP.Email lang={lang} otp={otp} type={type} />;
+  const [html, text] = await Promise.all([
+    render(node),
+    render(node, { plainText: true }),
+  ]);
 
   await getTransport().send({
     from: env.TRANSACTIONAL_EMAIL_FROM,
     to: email,
     subject: BetterAuthOTP.subject(lang),
     html,
+    text,
   });
 };
 
@@ -95,21 +101,26 @@ export const sendNewDeviceLoginEmail = async ({
   sessionsUrl,
   lang,
 }: SendNewDeviceLoginEmailProps) => {
-  const html = await render(
+  const node = (
     <NewDeviceLogin.Email
       device={device}
       ipAddress={ipAddress}
       lang={lang}
       sessionsUrl={sessionsUrl}
       time={time}
-    />,
+    />
   );
+  const [html, text] = await Promise.all([
+    render(node),
+    render(node, { plainText: true }),
+  ]);
 
   await getTransport().send({
     from: env.TRANSACTIONAL_EMAIL_FROM,
     to: email,
     subject: NewDeviceLogin.subject(lang),
     html,
+    text,
   });
 };
 
@@ -128,14 +139,18 @@ export const sendOrganizationInvitation = async ({
   organizationName,
   lang,
 }: SendOrganizationInvitationProps) => {
-  const html = await render(
+  const node = (
     <OrganizationInvitation.Email
       invitedByUsername={invitedByUsername}
       inviteLink={inviteLink}
       lang={lang}
       organizationName={organizationName}
-    />,
+    />
   );
+  const [html, text] = await Promise.all([
+    render(node),
+    render(node, { plainText: true }),
+  ]);
 
   await getTransport().send({
     from: env.TRANSACTIONAL_EMAIL_FROM,
@@ -144,5 +159,6 @@ export const sendOrganizationInvitation = async ({
       organizationName,
     }),
     html,
+    text,
   });
 };

--- a/apps/api/src/lib/email/ses.ts
+++ b/apps/api/src/lib/email/ses.ts
@@ -8,6 +8,8 @@ type SESTransportConfig = {
   /** Omit both to use the SDK default credential chain (IAM roles, env vars, etc.). */
   accessKeyId?: string;
   secretAccessKey?: string;
+  /** Optional SES configuration set name to attach to every send. */
+  configurationSetName?: string;
 };
 
 // eslint-disable-next-line unicorn/text-encoding-identifier-case -- IANA-standard name required by AWS SES API
@@ -42,16 +44,20 @@ export const createSESTransport = (
   });
 
   return {
-    async send({ from, to, subject, html }) {
+    async send({ from, to, subject, html, text }) {
       await client.send(
         new SendEmailCommand({
           FromEmailAddress: from,
           Destination: { ToAddresses: [to] },
+          ...(config.configurationSetName && {
+            ConfigurationSetName: config.configurationSetName,
+          }),
           Content: {
             Simple: {
               Subject: { Data: subject, Charset: SES_CHARSET },
               Body: {
                 Html: { Data: html, Charset: SES_CHARSET },
+                Text: { Data: text, Charset: SES_CHARSET },
               },
             },
           },

--- a/apps/api/src/lib/email/smtp.ts
+++ b/apps/api/src/lib/email/smtp.ts
@@ -50,8 +50,8 @@ export const createSMTPTransport = (
   });
 
   return {
-    async send({ from, to, subject, html }) {
-      await transporter.sendMail({ from, to, subject, html });
+    async send({ from, to, subject, html, text }) {
+      await transporter.sendMail({ from, to, subject, html, text });
     },
   };
 };

--- a/apps/api/src/lib/email/transport.ts
+++ b/apps/api/src/lib/email/transport.ts
@@ -10,6 +10,12 @@ export type EmailMessage = {
   to: string;
   subject: string;
   html: string;
+  /**
+   * Plain-text alternative. Required: HTML-only mail is a known
+   * spam signal at Gmail and Outlook, and accessibility tooling
+   * (screen readers, text-only clients) needs the text part.
+   */
+  text: string;
 };
 
 export type EmailTransport = {


### PR DESCRIPTION
## Summary
- HTML-only mail is a known spam signal at Gmail and Outlook, and screen readers / text-only clients need the text part. Render every email twice (HTML + plain text via `@react-email/render`) and send both parts.
- Accept an optional `SES_CONFIGURATION_SET` env so `SendEmail` can attach a configuration set when one is provided. The env is optional so the app keeps working when it isn't set (dev, SMTP transport, etc.).
- Adds the new optional field to the `EmailMessage` transport contract; both SES and SMTP transports forward it.

## Test plan
- [ ] `bun run typecheck` shows no new errors (pre-existing module-resolution errors in `ai-models.ts` / `workflow/*` are unaffected)
- [ ] `bun run lint` clean
- [ ] Trigger an OTP email locally with the SMTP dev relay and confirm both parts (HTML + text) arrive
- [ ] In a deploy with `SES_CONFIGURATION_SET` set, send a test mail and confirm the configuration set is recorded in SES sending stats