### PR TITLE
fix: enforce rust formatting in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,10 @@ jobs:
         # to oxfmt instead of filtering packages.
         run: bun --bun turbo run format ${{ steps.affected.outputs.flag }} -- --check
 
+      - name: Rust format
+        if: steps.changed-files.outputs.package_checks_required == 'true'
+        run: cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
+
       - name: Typecheck
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun run typecheck -- ${{ steps.affected.outputs.flag }}

--- a/apps/desktop/src-tauri/src/i18n.rs
+++ b/apps/desktop/src-tauri/src/i18n.rs
@@ -93,7 +93,9 @@ fn init_with_locale(locale: &str) {
 
 /// Look up a translation key. Falls back to English, then returns the key itself.
 pub fn t(key: &str) -> &str {
-  let tr = TRANSLATIONS.get().expect("i18n not initialized; call i18n::init() first");
+  let tr = TRANSLATIONS
+    .get()
+    .expect("i18n not initialized; call i18n::init() first");
   tr.messages
     .get(key)
     .or_else(|| tr.fallback.get(key))
@@ -141,10 +143,7 @@ fn select_plural_form(count: usize) -> &'static str {
   let tr = TRANSLATIONS.get().expect("i18n not initialized");
 
   // Check if this locale has a "few" branch by testing a known key
-  let has_few = tr
-    .messages
-    .values()
-    .any(|v| v.contains("few {"));
+  let has_few = tr.messages.values().any(|v| v.contains("few {"));
 
   if count == 1 {
     "one"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -109,21 +109,23 @@ pub fn run() {
               tray::MenuAction::OpenPreferences(tab) => {
                 ensure_main_window(&handle, tab);
               }
-              tray::MenuAction::CheckForUpdates => match updater::run_check(&handle).await {
-                updater::CheckOutcome::UpToDate => {
-                  if let Err(err) = handle
-                    .notification()
-                    .builder()
-                    .title("Stella is up to date")
-                    .show()
-                  {
-                    tracing::warn!(error = %err, "up-to-date notification failed");
+              tray::MenuAction::CheckForUpdates => {
+                match updater::run_check(&handle).await {
+                  updater::CheckOutcome::UpToDate => {
+                    if let Err(err) = handle
+                      .notification()
+                      .builder()
+                      .title("Stella is up to date")
+                      .show()
+                    {
+                      tracing::warn!(error = %err, "up-to-date notification failed");
+                    }
+                  }
+                  updater::CheckOutcome::Failed(msg) => {
+                    tracing::warn!(error = %msg, "tray-triggered updater check failed");
                   }
                 }
-                updater::CheckOutcome::Failed(msg) => {
-                  tracing::warn!(error = %msg, "tray-triggered updater check failed");
-                }
-              },
+              }
               tray::MenuAction::OpenEditRoot => {
                 let mgr = manager.lock().await;
                 mgr.open_edit_root().await;

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -1123,10 +1123,7 @@ impl SessionManager {
           self.show_notification(
             NotifType::SyncIssues,
             crate::i18n::t("notification.finalizeDelayedTitle"),
-            Some(&format!(
-              "{file_name} — {}",
-              crate::i18n::t(body_key)
-            )),
+            Some(&format!("{file_name} — {}", crate::i18n::t(body_key))),
           );
         }
         false
@@ -1437,7 +1434,10 @@ impl SessionManager {
     };
 
     // Don't spawn if already active or session is in error state
-    if session.sse_listener.as_ref().is_some_and(|h| !h.is_finished())
+    if session
+      .sse_listener
+      .as_ref()
+      .is_some_and(|h| !h.is_finished())
       || session.takeover_detected
     {
       return;

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -24,31 +24,23 @@ fn format_session_status(session: &SessionSnapshot) -> String {
     return t("tray.sessionMovedToAnotherDevice").to_string();
   }
   match session.status {
-    crate::types::SessionStatus::Error => {
-      t("tray.sessionNeedsAttention").to_string()
-    }
+    crate::types::SessionStatus::Error => t("tray.sessionNeedsAttention").to_string(),
     crate::types::SessionStatus::Finalizing => {
       t("tray.sessionCreatingRevision").to_string()
     }
-    crate::types::SessionStatus::Opening => {
-      t("tray.sessionOpeningInWord").to_string()
+    crate::types::SessionStatus::Opening => t("tray.sessionOpeningInWord").to_string(),
+    crate::types::SessionStatus::Ready => if session.pending_finalize {
+      t("tray.sessionFinishingEdit")
+    } else {
+      t("tray.sessionEditingLive")
     }
-    crate::types::SessionStatus::Ready => {
-      if session.pending_finalize {
-        t("tray.sessionFinishingEdit")
-      } else {
-        t("tray.sessionEditingLive")
-      }
-      .to_string()
+    .to_string(),
+    crate::types::SessionStatus::Syncing => if session.pending_finalize {
+      t("tray.sessionFinishingEdit")
+    } else {
+      t("tray.sessionSavingDraft")
     }
-    crate::types::SessionStatus::Syncing => {
-      if session.pending_finalize {
-        t("tray.sessionFinishingEdit")
-      } else {
-        t("tray.sessionSavingDraft")
-      }
-      .to_string()
-    }
+    .to_string(),
   }
 }
 
@@ -147,8 +139,7 @@ pub fn build_tray_menu(
   builder = builder.item(&support_menu);
 
   // Active edits submenu
-  let mut edits_builder =
-    SubmenuBuilder::new(app, t("tray.activeEditsSubmenu"));
+  let mut edits_builder = SubmenuBuilder::new(app, t("tray.activeEditsSubmenu"));
   if snapshot.sessions.is_empty() {
     edits_builder = edits_builder.item(
       &MenuItemBuilder::with_id("no-edits", t("tray.noActiveEdits"))
@@ -210,8 +201,7 @@ pub fn build_tray_menu(
   );
   builder = builder.separator();
   builder = builder.item(
-    &MenuItemBuilder::with_id(QUIT_ACTION, t("tray.quitStellaDesktop"))
-      .build(app)?,
+    &MenuItemBuilder::with_id(QUIT_ACTION, t("tray.quitStellaDesktop")).build(app)?,
   );
 
   builder.build()

--- a/apps/desktop/src-tauri/src/updater.rs
+++ b/apps/desktop/src-tauri/src/updater.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use tauri::{AppHandle, async_runtime};
+use tauri::{async_runtime, AppHandle};
 use tauri_plugin_notification::NotificationExt;
 use tauri_plugin_updater::UpdaterExt;
 
@@ -57,7 +57,11 @@ pub async fn run_check(handle: &AppHandle) -> CheckOutcome {
   };
 
   let version = update.version.clone();
-  notify(handle, "Stella update available", &format!("Installing v{version}…"));
+  notify(
+    handle,
+    "Stella update available",
+    &format!("Installing v{version}…"),
+  );
 
   if let Err(err) = update
     .download_and_install(|_chunk, _total| {}, || {})


### PR DESCRIPTION
## Summary
- apply rustfmt to desktop Rust sources
- add a CI check for desktop Rust formatting

## Tests
- cargo fmt --manifest-path apps/desktop/src-tauri/Cargo.toml -- --check
- pre-push hook: i18n, format, lint, typecheck