### PR TITLE
fix: general hardening cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
       - name: Turbo remote cache
         if: steps.changed-files.outputs.package_checks_required == 'true'
         uses: rharkor/caching-for-turbo@56219402aacc0d06b650d898c222996dbc1191ec # v2.3.14
-        with:
-          max-age: 7d
 
       - name: Install dependencies
         if: steps.changed-files.outputs.package_checks_required == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,11 @@ jobs:
             exit 1
           fi
 
-          echo "ref=$release_ref" >> "$GITHUB_OUTPUT"
-          echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
-          echo "version=${release_ref#v}" >> "$GITHUB_OUTPUT"
+          {
+            echo "ref=$release_ref"
+            echo "sha=$release_sha"
+            echo "version=${release_ref#v}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout resolved commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -323,7 +325,7 @@ jobs:
     # prerelease conventions (-rc1, -beta.N, -alpha) cannot reach
     # production by accident if the upstream validation regex changes.
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 30
     needs: publish
     if: ${{ !contains(needs.publish.outputs.release_ref, '-') }}
     permissions:
@@ -338,15 +340,57 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: stella-infra
 
-      - name: Dispatch promote-release.yml
+      - name: Dispatch and watch promote-release.yml
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_REF: ${{ needs.publish.outputs.release_ref }}
           IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+          INFRA_REPO: ${{ github.repository_owner }}/stella-infra
         run: |
-          gh workflow run promote-release.yml \
-            --repo "${{ github.repository_owner }}/stella-infra" \
-            --field release_ref="$RELEASE_REF" \
-            --field image_digest="$IMAGE_DIGEST" \
-            --field run_migrations=true \
-            --field frontend=true
+          dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          dispatch_output="$(
+            gh workflow run promote-release.yml \
+              --repo "$INFRA_REPO" \
+              --field release_ref="$RELEASE_REF" \
+              --field image_digest="$IMAGE_DIGEST" \
+              --field run_migrations=true \
+              --field frontend=true 2>&1
+          )"
+          printf '%s\n' "$dispatch_output"
+
+          run_id="$(
+            printf '%s\n' "$dispatch_output" \
+              | sed -nE 's#.*https://github.com/[^/]+/[^/]+/actions/runs/([0-9]+).*#\1#p' \
+              | head -n 1
+          )"
+
+          for _ in {1..30}; do
+            if [[ -n "$run_id" ]]; then
+              break
+            fi
+
+            run_id="$(
+              gh run list \
+                --repo "$INFRA_REPO" \
+                --workflow promote-release.yml \
+                --event workflow_dispatch \
+                --json databaseId,createdAt \
+                --jq ".[] | select(.createdAt >= \"$dispatched_at\") | .databaseId" \
+                --limit 10 \
+                | head -n 1
+            )"
+
+            if [[ -z "$run_id" ]]; then
+              sleep 2
+            fi
+          done
+
+          if [[ -z "$run_id" ]]; then
+            echo "Could not find the dispatched promotion workflow run." >&2
+            exit 1
+          fi
+
+          gh run watch "$run_id" \
+            --repo "$INFRA_REPO" \
+            --compact \
+            --exit-status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,79 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/stella-api
 
 jobs:
+  resolve:
+    name: Resolve trusted release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      release_ref: ${{ steps.release.outputs.ref }}
+      release_sha: ${{ steps.release.outputs.sha }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - name: Resolve release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}
+        run: |
+          release_ref="$RELEASE_INPUT"
+          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "::error::Release ref must look like v1.2.3 or v1.2.3-rc.1"
+            exit 1
+          fi
+
+          tag_ref_json=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${release_ref}" 2>/dev/null) || {
+            echo "::error::Tag ${release_ref} does not exist"
+            exit 1
+          }
+          tag_object_type=$(echo "$tag_ref_json" | jq -r '.object.type')
+          tag_object_sha=$(echo "$tag_ref_json" | jq -r '.object.sha')
+          if [[ "$tag_object_type" == "tag" ]]; then
+            release_sha=$(gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object_sha}" --jq '.object.sha')
+          else
+            release_sha="$tag_object_sha"
+          fi
+          if [[ ! "$release_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Could not resolve $release_ref to a commit SHA"
+            exit 1
+          fi
+
+          echo "ref=$release_ref" >> "$GITHUB_OUTPUT"
+          echo "sha=$release_sha" >> "$GITHUB_OUTPUT"
+          echo "version=${release_ref#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout resolved commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.release.outputs.sha }}
+          fetch-depth: 0
+
+      - name: Verify release source
+        env:
+          RELEASE_REF: ${{ steps.release.outputs.ref }}
+          RELEASE_SHA: ${{ steps.release.outputs.sha }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "::error::Release tag $RELEASE_REF is not reachable from protected main"
+            exit 1
+          fi
+
+          file_version="$(tr -d '[:space:]' < VERSION)"
+          if [[ "$file_version" != "$VERSION" ]]; then
+            echo "::error::VERSION ($file_version) does not match $RELEASE_REF"
+            exit 1
+          fi
+
   smoke:
     name: Build and smoke test API image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    needs: resolve
     permissions:
       contents: read
 
@@ -57,17 +126,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_ref) || github.ref }}
-
-      - name: Validate release ref
-        env:
-          RELEASE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}
-        run: |
-          release_ref="$RELEASE_INPUT"
-          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Release ref must look like v1.2.3 or v1.2.3-rc.1"
-            exit 1
-          fi
+          ref: ${{ needs.resolve.outputs.release_sha }}
 
       - name: Build smoke image
         run: docker build -f apps/api/Dockerfile -t stella-api:smoke .
@@ -141,30 +200,18 @@ jobs:
     name: Publish API image and manifest
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: smoke
+    needs: [resolve, smoke]
 
     outputs:
       image_digest: ${{ steps.build.outputs.digest }}
-      release_ref: ${{ steps.release.outputs.ref }}
+      release_ref: ${{ needs.resolve.outputs.release_ref }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.release_ref) || github.ref }}
+          ref: ${{ needs.resolve.outputs.release_sha }}
           fetch-depth: 0
-
-      - name: Resolve release
-        id: release
-        env:
-          RELEASE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}
-        run: |
-          release_ref="$RELEASE_INPUT"
-          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Release ref must look like v1.2.3 or v1.2.3-rc.1"
-            exit 1
-          fi
-          echo "ref=$release_ref" >> "$GITHUB_OUTPUT"
 
       - name: Resolve app version (strip leading `v`)
         # The frontend reads `VERSION` literally (`0.0.1-rc.1`) at
@@ -173,7 +220,7 @@ jobs:
         # the two sides won't group together.
         id: app-version
         env:
-          REF: ${{ steps.release.outputs.ref }}
+          REF: ${{ needs.resolve.outputs.release_ref }}
         run: echo "value=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
@@ -192,7 +239,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.release.outputs.ref }}
+            type=raw,value=${{ needs.resolve.outputs.release_ref }}
             type=sha,prefix=sha-
 
       - name: Build and push API image
@@ -226,7 +273,7 @@ jobs:
         env:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
           IMAGE_NAME: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          RELEASE_REF: ${{ steps.release.outputs.ref }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
           bash scripts/create-release-manifest.sh \
             "$RELEASE_REF" \
@@ -237,7 +284,7 @@ jobs:
       - name: Upload manifest artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: release-manifest-${{ steps.release.outputs.ref }}
+          name: release-manifest-${{ needs.resolve.outputs.release_ref }}
           path: release-manifest.json
           retention-days: 90
 
@@ -252,7 +299,7 @@ jobs:
       - name: Publish GitHub release manifest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_REF: ${{ steps.release.outputs.ref }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
           if ! gh release view "$RELEASE_REF" >/dev/null 2>&1; then
             prerelease_args=()
@@ -275,12 +322,31 @@ jobs:
     # ("no hyphen") rather than a deny-list against `-rc.`, so future
     # prerelease conventions (-rc1, -beta.N, -alpha) cannot reach
     # production by accident if the upstream validation regex changes.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     needs: publish
     if: ${{ !contains(needs.publish.outputs.release_ref, '-') }}
-    uses: stella/private-workflows/.github/workflows/promote-release.yml@main
-    with:
-      release_ref: ${{ needs.publish.outputs.release_ref }}
-      image_digest: ${{ needs.publish.outputs.image_digest }}
-    secrets:
-      STELLA_RELEASE_APP_ID: ${{ secrets.STELLA_RELEASE_APP_ID }}
-      STELLA_RELEASE_APP_PRIVATE_KEY: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
+    permissions:
+      contents: read
+    steps:
+      - name: Mint App token for the infra repo
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.STELLA_RELEASE_APP_ID }}
+          private-key: ${{ secrets.STELLA_RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: stella-infra
+
+      - name: Dispatch promote-release.yml
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_REF: ${{ needs.publish.outputs.release_ref }}
+          IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+        run: |
+          gh workflow run promote-release.yml \
+            --repo "${{ github.repository_owner }}/stella-infra" \
+            --field release_ref="$RELEASE_REF" \
+            --field image_digest="$IMAGE_DIGEST" \
+            --field run_migrations=true \
+            --field frontend=true

--- a/apps/api/drizzle/20260504100000_chat-threads-organization-scope/migration.sql
+++ b/apps/api/drizzle/20260504100000_chat-threads-organization-scope/migration.sql
@@ -21,6 +21,18 @@ SET organization_id = COALESCE(
 )
 WHERE organization_id IS NULL;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM chat_threads
+    WHERE organization_id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'chat_threads.organization_id backfill failed for rows without workspace or organization membership; assign or remove those rows before applying this migration';
+  END IF;
+END $$;
+
 ALTER TABLE chat_threads
   ALTER COLUMN organization_id SET NOT NULL,
   ADD CONSTRAINT chat_threads_organization_id_organization_id_fk

--- a/apps/api/drizzle/20260504100000_chat-threads-organization-scope/migration.sql
+++ b/apps/api/drizzle/20260504100000_chat-threads-organization-scope/migration.sql
@@ -1,0 +1,143 @@
+-- stella-migration-safety: reviewed destructive-change - rotate chat RLS policies to add organization_id checks; policies are recreated in the same migration and no table data is dropped.
+-- Scope global chat threads to the active organization. This prevents
+-- user-owned global rows from following a user across organizations.
+ALTER TABLE chat_threads
+  ADD COLUMN organization_id varchar(128);
+
+UPDATE chat_threads
+SET organization_id = COALESCE(
+  (
+    SELECT w.organization_id
+    FROM workspaces w
+    WHERE w.id = chat_threads.workspace_id
+  ),
+  (
+    SELECT m.organization_id
+    FROM member m
+    WHERE m.user_id = chat_threads.user_id
+    ORDER BY m.created_at DESC
+    LIMIT 1
+  )
+)
+WHERE organization_id IS NULL;
+
+ALTER TABLE chat_threads
+  ALTER COLUMN organization_id SET NOT NULL,
+  ADD CONSTRAINT chat_threads_organization_id_organization_id_fk
+    FOREIGN KEY (organization_id) REFERENCES organization(id) ON DELETE cascade;
+
+CREATE INDEX chat_threads_organization_user_idx
+  ON chat_threads (organization_id, user_id);
+
+DROP POLICY IF EXISTS chat_thread_select ON chat_threads;
+DROP POLICY IF EXISTS chat_thread_insert ON chat_threads;
+DROP POLICY IF EXISTS chat_thread_update ON chat_threads;
+DROP POLICY IF EXISTS chat_thread_delete ON chat_threads;
+DROP POLICY IF EXISTS chat_message_select ON chat_messages;
+DROP POLICY IF EXISTS chat_message_insert ON chat_messages;
+DROP POLICY IF EXISTS chat_message_update ON chat_messages;
+DROP POLICY IF EXISTS chat_message_delete ON chat_messages;
+
+CREATE POLICY chat_thread_select ON chat_threads
+  FOR SELECT TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_insert ON chat_threads
+  FOR INSERT TO stella
+  WITH CHECK (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_update ON chat_threads
+  FOR UPDATE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_thread_delete ON chat_threads
+  FOR DELETE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND (cardinality(data_workspace_ids) = 0
+         OR data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY chat_message_select ON chat_messages
+  FOR SELECT TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND ct.organization_id = (SELECT current_setting('app.organization_id', true))
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_insert ON chat_messages
+  FOR INSERT TO stella
+  WITH CHECK (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND ct.organization_id = (SELECT current_setting('app.organization_id', true))
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_update ON chat_messages
+  FOR UPDATE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND ct.organization_id = (SELECT current_setting('app.organization_id', true))
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );
+
+CREATE POLICY chat_message_delete ON chat_messages
+  FOR DELETE TO stella
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND (workspace_id IS NULL
+         OR workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[]))
+    AND EXISTS (
+      SELECT 1 FROM chat_threads ct
+      WHERE ct.id = chat_messages.thread_id
+        AND ct.organization_id = (SELECT current_setting('app.organization_id', true))
+        AND (cardinality(ct.data_workspace_ids) = 0
+             OR ct.data_workspace_ids <@ (SELECT current_setting('app.workspace_ids', true))::uuid[])
+    )
+  );

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,6 +46,7 @@
     "@opentelemetry/sdk-logs": "^0.215.0",
     "@react-email/render": "^2.0.7",
     "@sinclair/typebox": "^0.34.49",
+    "@stll/anonymize-data": "catalog:",
     "@stll/anonymize-wasm": "catalog:",
     "@stll/ares": "workspace:*",
     "@stll/case-law": "workspace:*",

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -45,6 +45,7 @@ const chatThreadDataScopeCheck = sql`(
 
 const chatThreadScopeCheck = sql`(
   ${userCheck} AND
+  ${organizationCheck} AND
   (workspace_id IS NULL OR ${workspaceCheck}) AND
   ${chatThreadDataScopeCheck}
 )`;
@@ -59,6 +60,9 @@ const chatMessageScopeCheck = sql`(
   EXISTS (
     SELECT 1 FROM chat_threads ct
     WHERE ct.id = chat_messages.thread_id
+      AND ct.organization_id = (SELECT current_setting(
+        '${sql.raw(SETTING_ORGANIZATION_ID)}', true
+      ))
       AND (
         cardinality(ct.data_workspace_ids) = 0
         OR ct.data_workspace_ids <@ ${wsIdsArray}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -2217,6 +2217,9 @@ export const chatThreads = p.pgTable(
       .text("user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
     title: p.varchar({ length: 255 }).notNull(),
     /**
      * Matters the chat draws context from. Empty array (the
@@ -2254,6 +2257,9 @@ export const chatThreads = p.pgTable(
     p
       .index("chat_threads_workspace_user_idx")
       .on(table.workspaceId, table.userId),
+    p
+      .index("chat_threads_organization_user_idx")
+      .on(table.organizationId, table.userId),
     p.index("chat_threads_user_updated_idx").on(table.userId, table.updatedAt),
     ...chatThreadPolicies(),
   ],

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -134,6 +134,15 @@ const envApi = createEnv({
   runtimeEnv: process.env,
 });
 
+if (
+  (envApi.MICROSOFT_AUTH_CLIENT_ID || envApi.MICROSOFT_AUTH_CLIENT_SECRET) &&
+  !envApi.MICROSOFT_AUTH_TENANT_ID
+) {
+  throw new Error(
+    "MICROSOFT_AUTH_TENANT_ID is required when Microsoft OAuth is configured.",
+  );
+}
+
 export const env = { ...envBase, ...envApi };
 
 // Prevent accidental mutation of env vars at runtime.

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -142,6 +142,7 @@ const sendMessage = createSafeRootHandler(
     const thread = yield* Result.await(
       loadThread({
         initialContextMatterIds: requestedContextMatterIds,
+        organizationId: session.activeOrganizationId,
         safeDb,
         threadId: body.threadId,
         title: extractTitle(validatedMessage.message.parts),
@@ -395,6 +396,7 @@ type ThreadRecord = {
 
 type LoadThreadProps = {
   initialContextMatterIds: SafeId<"workspace">[];
+  organizationId: SafeId<"organization">;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
   title: string;
@@ -414,6 +416,7 @@ type LoadThreadResult =
 
 const loadThread = async ({
   initialContextMatterIds,
+  organizationId,
   safeDb,
   threadId,
   title,
@@ -497,6 +500,7 @@ const loadThread = async ({
     const insertResult = await safeDb((tx) =>
       tx.insert(chatThreads).values({
         id: threadId,
+        organizationId,
         title,
         userId,
         workspaceId,

--- a/apps/api/src/handlers/entities/checkpoint-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/checkpoint-desktop-edit-session.ts
@@ -73,6 +73,14 @@ export const checkpointDesktopEditSessionHandler = async ({
     });
   }
 
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, {
+      code: "desktop_edit_session_permission_revoked",
+      message:
+        "Desktop edit permission was revoked. Reopen the document from stella.",
+    });
+  }
+
   const fileName = authorizedSession.value.fileName;
   const buffer = await file.arrayBuffer();
   const sha256Hex = new Bun.CryptoHasher("sha256").update(buffer).digest("hex");

--- a/apps/api/src/handlers/entities/desktop-edit-session-events.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.ts
@@ -79,9 +79,6 @@ type DesktopEditSessionEventsHandlerProps = {
 export const desktopEditSessionEventsHandler = async ({
   sessionId,
 }: DesktopEditSessionEventsHandlerProps) => {
-  // SSE connections are authenticated by session ID + open status only.
-  // The token was validated on the initial open_docx call; we don't
-  // re-validate here because token rotation would break reconnects.
   const eventState = await readDesktopEditSessionEventState(sessionId);
 
   if (!eventState) {

--- a/apps/api/src/handlers/entities/desktop-edit-sessions-route.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-sessions-route.ts
@@ -8,6 +8,7 @@ import {
 import {
   desktopEditSessionEventsHandler,
   desktopEditSessionEventsParamsSchema,
+  desktopEditSessionEventsQuerySchema,
 } from "@/api/handlers/entities/desktop-edit-session-events";
 import {
   finalizeDesktopEditSessionBodySchema,
@@ -48,6 +49,7 @@ export const desktopEditSessionsRoute = new Elysia({
       }),
     {
       params: desktopEditSessionEventsParamsSchema,
+      query: desktopEditSessionEventsQuerySchema,
     },
   )
   .post(

--- a/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
@@ -79,6 +79,14 @@ export const finalizeDesktopEditSessionHandler = async ({
     });
   }
 
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, {
+      code: "desktop_edit_session_permission_revoked",
+      message:
+        "Desktop edit permission was revoked. Reopen the document from stella.",
+    });
+  }
+
   const uploadedKeys: string[] = [];
   let checkpointKeyToDelete: string | null = null;
   let shouldRollbackUploadedKeys = true;

--- a/apps/api/src/handlers/entities/respond-desktop-edit-takeover.ts
+++ b/apps/api/src/handlers/entities/respond-desktop-edit-takeover.ts
@@ -62,6 +62,13 @@ export const respondDesktopEditTakeoverHandler = async ({
     });
   }
 
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, {
+      code: "desktop_edit_session_permission_revoked",
+      message: "Desktop edit permission was revoked.",
+    });
+  }
+
   const txResult = await authorizedSession.value.scopedDb(async (tx) => {
     const sessions = await tx
       .select({

--- a/apps/api/src/handlers/entities/status-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/status-desktop-edit-session.ts
@@ -51,5 +51,13 @@ export const statusDesktopEditSessionHandler = async ({
     });
   }
 
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, {
+      code: "desktop_edit_session_permission_revoked",
+      message:
+        "Desktop edit permission was revoked. Reopen the document from stella.",
+    });
+  }
+
   return { status: "open" };
 };

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -573,6 +573,7 @@ export const createSearchSummaryChatThread = async ({
   const insertResult = await safeDb(async (tx) => {
     await tx.insert(chatThreads).values({
       id: threadId,
+      organizationId,
       title: body.title,
       userId,
       // Search summaries can span multiple workspaces, so the

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -304,12 +304,14 @@ const createAuth = () => {
             },
           }
         : {}),
-      ...(env.MICROSOFT_AUTH_CLIENT_ID && env.MICROSOFT_AUTH_CLIENT_SECRET
+      ...(env.MICROSOFT_AUTH_CLIENT_ID &&
+      env.MICROSOFT_AUTH_CLIENT_SECRET &&
+      env.MICROSOFT_AUTH_TENANT_ID
         ? {
             microsoft: {
               clientId: env.MICROSOFT_AUTH_CLIENT_ID,
               clientSecret: env.MICROSOFT_AUTH_CLIENT_SECRET,
-              tenantId: env.MICROSOFT_AUTH_TENANT_ID ?? "common",
+              tenantId: env.MICROSOFT_AUTH_TENANT_ID,
             },
           }
         : {}),
@@ -539,23 +541,50 @@ export const getAuth = () => {
 
 export type MemberRole = keyof typeof roles;
 
+const isMemberRole = (role: string): role is MemberRole => role in roles;
+
 export const getSessionAndMemberRole = async (
   headers: Headers | Record<string, string>,
 ) => {
-  const [sessionResult, memberRoleResult] = await Promise.all([
-    Result.tryPromise(
-      async () =>
-        await getAuth().api.getSession({
-          headers,
-        }),
-    ),
-    Result.tryPromise(
-      async () =>
-        await getAuth().api.getActiveMemberRole({
-          headers,
-        }),
-    ),
-  ]);
+  const sessionResult = await Result.tryPromise(
+    async () =>
+      await getAuth().api.getSession({
+        headers,
+      }),
+  );
+
+  const session = Result.isOk(sessionResult)
+    ? sessionResult.value?.session
+    : null;
+  const user = Result.isOk(sessionResult) ? sessionResult.value?.user : null;
+  const activeOrganizationId = getSessionActiveOrganizationId(session);
+
+  const memberRoleResult =
+    session && user && activeOrganizationId
+      ? await Result.tryPromise(async () => {
+          const row = await db.query.member.findFirst({
+            where: {
+              userId: { eq: user.id },
+              organizationId: { eq: activeOrganizationId },
+            },
+            columns: {
+              role: true,
+            },
+          });
+
+          if (!row) {
+            return null;
+          }
+
+          if (!isMemberRole(row.role)) {
+            return null;
+          }
+
+          return {
+            role: row.role,
+          };
+        })
+      : Result.ok(null);
 
   return {
     sessionResult,
@@ -645,6 +674,9 @@ export const authMacro = new Elysia({ name: "authMacro" }).macro({
       }
 
       const memberRole = memberRoleResult.value;
+      if (!memberRole) {
+        return status(401);
+      }
       const activeOrganizationId = toSafeId<"organization">(rawOrgId);
       const userId = toSafeId<"user">(user.id);
 

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -36,6 +36,8 @@ import {
 } from "@/api/lib/email";
 import { AUTH_RATE_LIMIT_MAX_WINDOW, AUTH_RATE_LIMITS } from "@/api/lib/limits";
 import { extractLangFromRequest } from "@/api/lib/locale";
+import { isMemberRole } from "@/api/lib/member-roles";
+import type { MemberRole } from "@/api/lib/member-roles";
 import { enrichRequestContext } from "@/api/lib/observability/request-context";
 import { parseUserAgent } from "@/api/lib/parse-user-agent";
 import {
@@ -539,9 +541,7 @@ export const getAuth = () => {
   return _auth;
 };
 
-export type MemberRole = keyof typeof roles;
-
-const isMemberRole = (role: string): role is MemberRole => role in roles;
+export type { MemberRole } from "@/api/lib/member-roles";
 
 export const getSessionAndMemberRole = async (
   headers: Headers | Record<string, string>,

--- a/apps/api/src/lib/desktop-edit-sessions.test.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import { canUseDesktopEditSession } from "@/api/lib/desktop-edit-sessions";
+
+describe("canUseDesktopEditSession", () => {
+  test("requires current workspace access for non-admin edit roles", () => {
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "member",
+        workspaceMemberId: null,
+      }),
+    ).toBe(false);
+
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "member",
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(true);
+  });
+
+  test("allows owner and admin roles without a workspace membership row", () => {
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "owner",
+        workspaceMemberId: null,
+      }),
+    ).toBe(true);
+
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "admin",
+        workspaceMemberId: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects roles without entity update permission", () => {
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "intern",
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(false);
+
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "external",
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects missing or unknown organization roles", () => {
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: null,
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(false);
+
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "custom",
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/lib/desktop-edit-sessions.test.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.test.ts
@@ -65,5 +65,12 @@ describe("canUseDesktopEditSession", () => {
         workspaceMemberId: "workspace_member_test",
       }),
     ).toBe(false);
+
+    expect(
+      canUseDesktopEditSession({
+        organizationRole: "toString",
+        workspaceMemberId: "workspace_member_test",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/lib/desktop-edit-sessions.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.ts
@@ -10,6 +10,8 @@ import {
   workspaces,
 } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { isMemberRole } from "@/api/lib/member-roles";
+import type { MemberRole } from "@/api/lib/member-roles";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 
@@ -59,12 +61,7 @@ export const createDesktopEditSessionToken = () =>
 export const hashDesktopEditSessionToken = (sessionToken: string) =>
   new Bun.CryptoHasher("sha256").update(sessionToken).digest("hex");
 
-type DesktopEditRole = keyof typeof roles;
-
-const ADMIN_BYPASS_ROLES = new Set<DesktopEditRole>(["owner", "admin"]);
-
-const isDesktopEditRole = (role: string): role is DesktopEditRole =>
-  role in roles;
+const ADMIN_BYPASS_ROLES = new Set<MemberRole>(["owner", "admin"]);
 
 export const canUseDesktopEditSession = ({
   organizationRole,
@@ -73,7 +70,7 @@ export const canUseDesktopEditSession = ({
   organizationRole: string | null;
   workspaceMemberId: string | null;
 }) => {
-  if (!organizationRole || !isDesktopEditRole(organizationRole)) {
+  if (!organizationRole || !isMemberRole(organizationRole)) {
     return false;
   }
 

--- a/apps/api/src/lib/desktop-edit-sessions.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.ts
@@ -1,9 +1,14 @@
+import { roles } from "@stll/permissions";
 import { and, eq } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";
 import { db } from "@/api/db/root";
-import { desktopEditSessions, workspaces } from "@/api/db/schema";
+import {
+  desktopEditSessions,
+  workspaceMembers,
+  workspaces,
+} from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
@@ -29,6 +34,9 @@ type DesktopEditSessionAuthorizationResult =
     }
   | {
       status: "token-mismatch";
+    }
+  | {
+      status: "permission-revoked";
     };
 
 /** Session tokens expire after 24 hours. Each checkpoint extends by this amount. */
@@ -51,6 +59,33 @@ export const createDesktopEditSessionToken = () =>
 export const hashDesktopEditSessionToken = (sessionToken: string) =>
   new Bun.CryptoHasher("sha256").update(sessionToken).digest("hex");
 
+type DesktopEditRole = keyof typeof roles;
+
+const ADMIN_BYPASS_ROLES = new Set<DesktopEditRole>(["owner", "admin"]);
+
+const isDesktopEditRole = (role: string): role is DesktopEditRole =>
+  role in roles;
+
+export const canUseDesktopEditSession = ({
+  organizationRole,
+  workspaceMemberId,
+}: {
+  organizationRole: string | null;
+  workspaceMemberId: string | null;
+}) => {
+  if (!organizationRole || !isDesktopEditRole(organizationRole)) {
+    return false;
+  }
+
+  const hasEntityUpdate = roles[organizationRole].authorize({
+    entity: ["update"],
+  }).success;
+  const hasWorkspaceAccess =
+    ADMIN_BYPASS_ROLES.has(organizationRole) || workspaceMemberId !== null;
+
+  return hasEntityUpdate && hasWorkspaceAccess;
+};
+
 export const authorizeDesktopEditSession = async ({
   sessionId,
   sessionToken,
@@ -65,13 +100,29 @@ export const authorizeDesktopEditSession = async ({
       createdBy: desktopEditSessions.createdBy,
       fileName: desktopEditSessions.fileName,
       organizationId: workspaces.organizationId,
+      organizationRole: member.role,
       sessionStatus: desktopEditSessions.status,
       sessionTokenHash: desktopEditSessions.sessionTokenHash,
       tokenExpiresAt: desktopEditSessions.tokenExpiresAt,
+      workspaceMemberId: workspaceMembers.id,
       workspaceId: desktopEditSessions.workspaceId,
     })
     .from(desktopEditSessions)
     .innerJoin(workspaces, eq(desktopEditSessions.workspaceId, workspaces.id))
+    .leftJoin(
+      member,
+      and(
+        eq(member.userId, desktopEditSessions.createdBy),
+        eq(member.organizationId, workspaces.organizationId),
+      ),
+    )
+    .leftJoin(
+      workspaceMembers,
+      and(
+        eq(workspaceMembers.userId, desktopEditSessions.createdBy),
+        eq(workspaceMembers.workspaceId, desktopEditSessions.workspaceId),
+      ),
+    )
     .where(eq(desktopEditSessions.id, sessionId))
     .limit(1);
 
@@ -91,6 +142,17 @@ export const authorizeDesktopEditSession = async ({
   if (session.tokenExpiresAt < new Date()) {
     return {
       status: "token-expired",
+    };
+  }
+
+  if (
+    !canUseDesktopEditSession({
+      organizationRole: session.organizationRole,
+      workspaceMemberId: session.workspaceMemberId,
+    })
+  ) {
+    return {
+      status: "permission-revoked",
     };
   }
 
@@ -114,8 +176,26 @@ export const readDesktopEditSessionEventState = async (
   sessionId: SafeId<"desktopEditSession">,
 ) => {
   const sessions = await db
-    .select({ id: desktopEditSessions.id })
+    .select({
+      organizationRole: member.role,
+      workspaceMemberId: workspaceMembers.id,
+    })
     .from(desktopEditSessions)
+    .innerJoin(workspaces, eq(desktopEditSessions.workspaceId, workspaces.id))
+    .leftJoin(
+      member,
+      and(
+        eq(member.userId, desktopEditSessions.createdBy),
+        eq(member.organizationId, workspaces.organizationId),
+      ),
+    )
+    .leftJoin(
+      workspaceMembers,
+      and(
+        eq(workspaceMembers.userId, desktopEditSessions.createdBy),
+        eq(workspaceMembers.workspaceId, desktopEditSessions.workspaceId),
+      ),
+    )
     .where(
       and(
         eq(desktopEditSessions.id, sessionId),
@@ -124,7 +204,14 @@ export const readDesktopEditSessionEventState = async (
     )
     .limit(1);
 
-  if (!sessions.at(0)) {
+  const session = sessions.at(0);
+  if (
+    !session ||
+    !canUseDesktopEditSession({
+      organizationRole: session.organizationRole,
+      workspaceMemberId: session.workspaceMemberId,
+    })
+  ) {
     return null;
   }
 
@@ -146,7 +233,9 @@ export const readDesktopEditSessionEventState = async (
     .where(eq(desktopEditSessions.id, sessionId))
     .limit(1);
 
+  const pendingRequest = pendingRequests.at(0);
+
   return {
-    pendingRequest: pendingRequests.at(0) ?? null,
+    pendingRequest: pendingRequest ?? null,
   };
 };

--- a/apps/api/src/lib/member-roles.test.ts
+++ b/apps/api/src/lib/member-roles.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { isMemberRole } from "@/api/lib/member-roles";
+
+describe("isMemberRole", () => {
+  test("only accepts role keys owned by the permissions map", () => {
+    expect(isMemberRole("owner")).toBe(true);
+    expect(isMemberRole("admin")).toBe(true);
+    expect(isMemberRole("member")).toBe(true);
+    expect(isMemberRole("intern")).toBe(true);
+    expect(isMemberRole("external")).toBe(true);
+
+    expect(isMemberRole("toString")).toBe(false);
+    expect(isMemberRole("constructor")).toBe(false);
+    expect(isMemberRole("custom")).toBe(false);
+  });
+});

--- a/apps/api/src/lib/member-roles.ts
+++ b/apps/api/src/lib/member-roles.ts
@@ -1,0 +1,6 @@
+import { roles } from "@stll/permissions";
+
+export type MemberRole = keyof typeof roles;
+
+export const isMemberRole = (role: string): role is MemberRole =>
+  Object.hasOwn(roles, role);

--- a/apps/api/src/mcp/anonymization-core.ts
+++ b/apps/api/src/mcp/anonymization-core.ts
@@ -1,0 +1,166 @@
+import {
+  DEFAULT_ENTITY_LABELS,
+  DEFAULT_OPERATOR_CONFIG,
+} from "@stll/anonymize-wasm";
+import type {
+  Entity,
+  GazetteerEntry,
+  PipelineConfig,
+  PipelineContext,
+  RedactionResult,
+} from "@stll/anonymize-wasm";
+import { panic } from "better-result";
+
+import type { ScopedDb } from "@/api/db";
+import type { SafeId } from "@/api/lib/branded-types";
+import { buildFieldMarkers } from "@/api/mcp/field-markers";
+
+export type AnonymizeTextFieldsInput = {
+  fields: string[];
+  gazetteerEntries?: GazetteerEntry[] | undefined;
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+  workspaceId: string;
+};
+
+export type AnonymizeTextFieldsDependencies = {
+  createPipelineContext: () => PipelineContext;
+  loadAnonymizationGazetteerEntries: (input: {
+    organizationId: SafeId<"organization">;
+    scopedDb: ScopedDb;
+  }) => Promise<GazetteerEntry[]>;
+  loadNameDictionaries: () => Promise<
+    NonNullable<PipelineConfig["dictionaries"]>
+  >;
+  redactText: (
+    fullText: string,
+    entities: Entity[],
+    operatorConfig: typeof DEFAULT_OPERATOR_CONFIG,
+    context: PipelineContext,
+  ) => RedactionResult;
+  runPipeline: (input: {
+    fullText: string;
+    config: PipelineConfig;
+    gazetteerEntries: GazetteerEntry[];
+    context: PipelineContext;
+  }) => Promise<Entity[]>;
+};
+
+const buildPipelineConfig = ({
+  gazetteerEntries,
+  workspaceId,
+}: {
+  gazetteerEntries: GazetteerEntry[];
+  workspaceId: string;
+}): PipelineConfig => ({
+  threshold: 0.4,
+  enableTriggerPhrases: true,
+  enableRegex: true,
+  enableNameCorpus: true,
+  enableDenyList: false,
+  enableGazetteer: gazetteerEntries.length > 0,
+  enableNer: false,
+  enableConfidenceBoost: false,
+  enableCoreference: true,
+  enableLegalForms: true,
+  labels: [...DEFAULT_ENTITY_LABELS],
+  workspaceId,
+});
+
+const splitRedactedFields = ({
+  markers,
+  redactedText,
+}: {
+  markers: string[];
+  redactedText: string;
+}): string[] => {
+  const fields: string[] = [];
+  let searchStart = 0;
+
+  for (let index = 0; index < markers.length; index += 1) {
+    const marker = markers[index];
+    if (marker === undefined) {
+      panic(`Missing anonymized field marker at index ${index}`);
+    }
+
+    const markerStart = redactedText.indexOf(marker, searchStart);
+    if (markerStart === -1) {
+      panic(`Missing anonymized field marker at index ${index}`);
+    }
+
+    const nextMarker = markers[index + 1];
+    const contentStart = markerStart + marker.length;
+    const contentEnd =
+      nextMarker === undefined
+        ? redactedText.length
+        : redactedText.indexOf(nextMarker, contentStart);
+
+    if (contentEnd === -1) {
+      panic(`Missing anonymized field boundary at index ${index}`);
+    }
+
+    fields.push(redactedText.slice(contentStart, contentEnd));
+    searchStart = contentEnd;
+  }
+
+  return fields;
+};
+
+export const anonymizeTextFieldsWithDependencies = async ({
+  dependencies,
+  fields,
+  gazetteerEntries,
+  organizationId,
+  scopedDb,
+  workspaceId,
+}: AnonymizeTextFieldsInput & {
+  dependencies: AnonymizeTextFieldsDependencies;
+}) => {
+  if (fields.every((field) => field.length === 0)) {
+    return {
+      entityCount: 0,
+      fields,
+    };
+  }
+
+  const context = dependencies.createPipelineContext();
+  const markers = buildFieldMarkers({
+    fieldCount: fields.length,
+    fields,
+  });
+  const combinedText = fields
+    .map((field, index) => `${markers[index]}${field}`)
+    .join("");
+
+  const entries =
+    gazetteerEntries ??
+    (await dependencies.loadAnonymizationGazetteerEntries({
+      organizationId,
+      scopedDb,
+    }));
+  const dictionaries = await dependencies.loadNameDictionaries();
+
+  const entities = await dependencies.runPipeline({
+    fullText: combinedText,
+    config: {
+      ...buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
+      dictionaries,
+    },
+    gazetteerEntries: entries,
+    context,
+  });
+  const result = dependencies.redactText(
+    combinedText,
+    entities,
+    DEFAULT_OPERATOR_CONFIG,
+    context,
+  );
+
+  return {
+    entityCount: result.entityCount,
+    fields: splitRedactedFields({
+      markers,
+      redactedText: result.redactedText,
+    }),
+  };
+};

--- a/apps/api/src/mcp/anonymization.test.ts
+++ b/apps/api/src/mcp/anonymization.test.ts
@@ -1,6 +1,41 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 
+import type { ScopedDb } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
 import { buildFieldMarkers } from "@/api/mcp/field-markers";
+
+const dictionaries = {
+  femaleNames: new Set(["Alice"]),
+  maleNames: new Set(["Bob"]),
+  surnames: new Set(["Novak"]),
+};
+const loadNameDictionariesMock = mock(async () => dictionaries);
+let capturedDictionaries: unknown;
+const runPipelineMock = mock(
+  async ({ config }: { config: { dictionaries?: unknown } }) => {
+    capturedDictionaries = config.dictionaries;
+    return [];
+  },
+);
+
+void mock.module("@stll/anonymize-data", () => ({
+  loadNameDictionaries: loadNameDictionariesMock,
+}));
+
+void mock.module("@stll/anonymize-wasm", () => ({
+  createPipelineContext: () => ({}),
+  DEFAULT_ENTITY_LABELS: ["PERSON"],
+  DEFAULT_OPERATOR_CONFIG: {},
+  redactText: (fullText: string) => ({
+    entityCount: 0,
+    redactedText: fullText,
+  }),
+  runPipeline: runPipelineMock,
+}));
+
+void mock.module("@/api/lib/anonymization-blacklist", () => ({
+  loadAnonymizationGazetteerEntries: async () => [],
+}));
 
 describe("anonymizeTextFields", () => {
   test("regenerates markers when crafted content contains a candidate delimiter", async () => {
@@ -31,5 +66,24 @@ describe("anonymizeTextFields", () => {
       "[[[__stella_mcp_anonymized_field_00000000-0000-4000-8000-000000000002_0__]]]",
       "[[[__stella_mcp_anonymized_field_00000000-0000-4000-8000-000000000002_1__]]]",
     ]);
+  });
+
+  test("injects name dictionaries into the API anonymization pipeline", async () => {
+    const { anonymizeTextFields } = await import("@/api/mcp/anonymization");
+    const scopedDb: ScopedDb = async () => {
+      throw new Error("Expected gazetteer loader mock to avoid DB access");
+    };
+    capturedDictionaries = undefined;
+
+    await anonymizeTextFields({
+      fields: ["Alice Novak"],
+      organizationId: toSafeId<"organization">("org_test"),
+      scopedDb,
+      workspaceId: "00000000-0000-4000-8000-000000000001",
+    });
+
+    expect(loadNameDictionariesMock).toHaveBeenCalledTimes(1);
+    expect(runPipelineMock).toHaveBeenCalledTimes(1);
+    expect(capturedDictionaries).toBe(dictionaries);
   });
 });

--- a/apps/api/src/mcp/anonymization.test.ts
+++ b/apps/api/src/mcp/anonymization.test.ts
@@ -3,8 +3,8 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db";
 import { toSafeId } from "@/api/lib/branded-types";
-import type { AnonymizeTextFieldsDependencies } from "@/api/mcp/anonymization";
-import { anonymizeTextFieldsWithDependencies } from "@/api/mcp/anonymization";
+import type { AnonymizeTextFieldsDependencies } from "@/api/mcp/anonymization-core";
+import { anonymizeTextFieldsWithDependencies } from "@/api/mcp/anonymization-core";
 import { buildFieldMarkers } from "@/api/mcp/field-markers";
 
 const dictionaries = {

--- a/apps/api/src/mcp/anonymization.test.ts
+++ b/apps/api/src/mcp/anonymization.test.ts
@@ -1,41 +1,20 @@
+import { createPipelineContext } from "@stll/anonymize-wasm";
 import { describe, expect, mock, test } from "bun:test";
 
 import type { ScopedDb } from "@/api/db";
 import { toSafeId } from "@/api/lib/branded-types";
+import type { AnonymizeTextFieldsDependencies } from "@/api/mcp/anonymization";
+import { anonymizeTextFieldsWithDependencies } from "@/api/mcp/anonymization";
 import { buildFieldMarkers } from "@/api/mcp/field-markers";
 
 const dictionaries = {
-  femaleNames: new Set(["Alice"]),
-  maleNames: new Set(["Bob"]),
-  surnames: new Set(["Novak"]),
-};
-const loadNameDictionariesMock = mock(async () => dictionaries);
-let capturedDictionaries: unknown;
-const runPipelineMock = mock(
-  async ({ config }: { config: { dictionaries?: unknown } }) => {
-    capturedDictionaries = config.dictionaries;
-    return [];
+  firstNames: {
+    en: ["Alice"],
   },
-);
-
-void mock.module("@stll/anonymize-data", () => ({
-  loadNameDictionaries: loadNameDictionariesMock,
-}));
-
-void mock.module("@stll/anonymize-wasm", () => ({
-  createPipelineContext: () => ({}),
-  DEFAULT_ENTITY_LABELS: ["PERSON"],
-  DEFAULT_OPERATOR_CONFIG: {},
-  redactText: (fullText: string) => ({
-    entityCount: 0,
-    redactedText: fullText,
-  }),
-  runPipeline: runPipelineMock,
-}));
-
-void mock.module("@/api/lib/anonymization-blacklist", () => ({
-  loadAnonymizationGazetteerEntries: async () => [],
-}));
+  surnames: {
+    en: ["Novak"],
+  },
+};
 
 describe("anonymizeTextFields", () => {
   test("regenerates markers when crafted content contains a candidate delimiter", async () => {
@@ -69,13 +48,32 @@ describe("anonymizeTextFields", () => {
   });
 
   test("injects name dictionaries into the API anonymization pipeline", async () => {
-    const { anonymizeTextFields } = await import("@/api/mcp/anonymization");
+    let capturedDictionaries: unknown;
+    const loadNameDictionariesMock: AnonymizeTextFieldsDependencies["loadNameDictionaries"] =
+      mock(async () => dictionaries);
+    const runPipelineMock: AnonymizeTextFieldsDependencies["runPipeline"] =
+      mock(async ({ config }) => {
+        capturedDictionaries = config.dictionaries;
+        return [];
+      });
+    const dependencies = {
+      createPipelineContext,
+      loadAnonymizationGazetteerEntries: async () => [],
+      loadNameDictionaries: loadNameDictionariesMock,
+      redactText: (fullText: string) => ({
+        entityCount: 0,
+        operatorMap: new Map(),
+        redactionMap: new Map(),
+        redactedText: fullText,
+      }),
+      runPipeline: runPipelineMock,
+    } satisfies AnonymizeTextFieldsDependencies;
     const scopedDb: ScopedDb = async () => {
       throw new Error("Expected gazetteer loader mock to avoid DB access");
     };
-    capturedDictionaries = undefined;
 
-    await anonymizeTextFields({
+    await anonymizeTextFieldsWithDependencies({
+      dependencies,
       fields: ["Alice Novak"],
       organizationId: toSafeId<"organization">("org_test"),
       scopedDb,

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -1,36 +1,15 @@
 import { loadNameDictionaries } from "@stll/anonymize-data";
 import {
   createPipelineContext,
-  DEFAULT_ENTITY_LABELS,
-  DEFAULT_OPERATOR_CONFIG,
   redactText,
   runPipeline,
 } from "@stll/anonymize-wasm";
-import type { GazetteerEntry, PipelineConfig } from "@stll/anonymize-wasm";
-import { panic } from "better-result";
 
-import type { ScopedDb } from "@/api/db";
 import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
-import type { SafeId } from "@/api/lib/branded-types";
-import { buildFieldMarkers } from "@/api/mcp/field-markers";
+import type { AnonymizeTextFieldsInput } from "@/api/mcp/anonymization-core";
+import { anonymizeTextFieldsWithDependencies } from "@/api/mcp/anonymization-core";
 
-type AnonymizeTextFieldsInput = {
-  fields: string[];
-  gazetteerEntries?: GazetteerEntry[] | undefined;
-  organizationId: SafeId<"organization">;
-  scopedDb: ScopedDb;
-  workspaceId: string;
-};
-
-export type AnonymizeTextFieldsDependencies = {
-  createPipelineContext: typeof createPipelineContext;
-  loadAnonymizationGazetteerEntries: typeof loadAnonymizationGazetteerEntries;
-  loadNameDictionaries: typeof loadNameDictionaries;
-  redactText: typeof redactText;
-  runPipeline: typeof runPipeline;
-};
-
-const anonymizeTextFieldsDependencies: AnonymizeTextFieldsDependencies = {
+const anonymizeTextFieldsDependencies = {
   createPipelineContext,
   loadAnonymizationGazetteerEntries,
   loadNameDictionaries,
@@ -38,137 +17,8 @@ const anonymizeTextFieldsDependencies: AnonymizeTextFieldsDependencies = {
   runPipeline,
 };
 
-const buildPipelineConfig = ({
-  gazetteerEntries,
-  workspaceId,
-}: {
-  gazetteerEntries: GazetteerEntry[];
-  workspaceId: string;
-}): PipelineConfig => ({
-  threshold: 0.4,
-  enableTriggerPhrases: true,
-  enableRegex: true,
-  enableNameCorpus: true,
-  enableDenyList: false,
-  enableGazetteer: gazetteerEntries.length > 0,
-  enableNer: false,
-  enableConfidenceBoost: false,
-  enableCoreference: true,
-  enableLegalForms: true,
-  labels: [...DEFAULT_ENTITY_LABELS],
-  workspaceId,
-});
-
-const splitRedactedFields = ({
-  markers,
-  redactedText,
-}: {
-  markers: string[];
-  redactedText: string;
-}): string[] => {
-  const fields: string[] = [];
-  let searchStart = 0;
-
-  for (let index = 0; index < markers.length; index += 1) {
-    const marker = markers[index];
-    if (marker === undefined) {
-      panic(`Missing anonymized field marker at index ${index}`);
-    }
-
-    const markerStart = redactedText.indexOf(marker, searchStart);
-    if (markerStart === -1) {
-      panic(`Missing anonymized field marker at index ${index}`);
-    }
-
-    const nextMarker = markers[index + 1];
-    const contentStart = markerStart + marker.length;
-    const contentEnd =
-      nextMarker === undefined
-        ? redactedText.length
-        : redactedText.indexOf(nextMarker, contentStart);
-
-    if (contentEnd === -1) {
-      panic(`Missing anonymized field boundary at index ${index}`);
-    }
-
-    fields.push(redactedText.slice(contentStart, contentEnd));
-    searchStart = contentEnd;
-  }
-
-  return fields;
-};
-
-export const anonymizeTextFields = async ({
-  fields,
-  gazetteerEntries,
-  organizationId,
-  scopedDb,
-  workspaceId,
-}: AnonymizeTextFieldsInput) =>
+export const anonymizeTextFields = async (input: AnonymizeTextFieldsInput) =>
   await anonymizeTextFieldsWithDependencies({
+    ...input,
     dependencies: anonymizeTextFieldsDependencies,
-    fields,
-    gazetteerEntries,
-    organizationId,
-    scopedDb,
-    workspaceId,
   });
-
-export const anonymizeTextFieldsWithDependencies = async ({
-  dependencies,
-  fields,
-  gazetteerEntries,
-  organizationId,
-  scopedDb,
-  workspaceId,
-}: AnonymizeTextFieldsInput & {
-  dependencies: AnonymizeTextFieldsDependencies;
-}) => {
-  if (fields.every((field) => field.length === 0)) {
-    return {
-      entityCount: 0,
-      fields,
-    };
-  }
-
-  const context = dependencies.createPipelineContext();
-  const markers = buildFieldMarkers({
-    fieldCount: fields.length,
-    fields,
-  });
-  const combinedText = fields
-    .map((field, index) => `${markers[index]}${field}`)
-    .join("");
-
-  const entries =
-    gazetteerEntries ??
-    (await dependencies.loadAnonymizationGazetteerEntries({
-      organizationId,
-      scopedDb,
-    }));
-  const dictionaries = await dependencies.loadNameDictionaries();
-
-  const entities = await dependencies.runPipeline({
-    fullText: combinedText,
-    config: {
-      ...buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
-      dictionaries,
-    },
-    gazetteerEntries: entries,
-    context,
-  });
-  const result = dependencies.redactText(
-    combinedText,
-    entities,
-    DEFAULT_OPERATOR_CONFIG,
-    context,
-  );
-
-  return {
-    entityCount: result.entityCount,
-    fields: splitRedactedFields({
-      markers,
-      redactedText: result.redactedText,
-    }),
-  };
-};

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -14,6 +14,30 @@ import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-black
 import type { SafeId } from "@/api/lib/branded-types";
 import { buildFieldMarkers } from "@/api/mcp/field-markers";
 
+type AnonymizeTextFieldsInput = {
+  fields: string[];
+  gazetteerEntries?: GazetteerEntry[] | undefined;
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+  workspaceId: string;
+};
+
+export type AnonymizeTextFieldsDependencies = {
+  createPipelineContext: typeof createPipelineContext;
+  loadAnonymizationGazetteerEntries: typeof loadAnonymizationGazetteerEntries;
+  loadNameDictionaries: typeof loadNameDictionaries;
+  redactText: typeof redactText;
+  runPipeline: typeof runPipeline;
+};
+
+const anonymizeTextFieldsDependencies: AnonymizeTextFieldsDependencies = {
+  createPipelineContext,
+  loadAnonymizationGazetteerEntries,
+  loadNameDictionaries,
+  redactText,
+  runPipeline,
+};
+
 const buildPipelineConfig = ({
   gazetteerEntries,
   workspaceId,
@@ -80,12 +104,25 @@ export const anonymizeTextFields = async ({
   organizationId,
   scopedDb,
   workspaceId,
-}: {
-  fields: string[];
-  gazetteerEntries?: GazetteerEntry[] | undefined;
-  organizationId: SafeId<"organization">;
-  scopedDb: ScopedDb;
-  workspaceId: string;
+}: AnonymizeTextFieldsInput) =>
+  await anonymizeTextFieldsWithDependencies({
+    dependencies: anonymizeTextFieldsDependencies,
+    fields,
+    gazetteerEntries,
+    organizationId,
+    scopedDb,
+    workspaceId,
+  });
+
+export const anonymizeTextFieldsWithDependencies = async ({
+  dependencies,
+  fields,
+  gazetteerEntries,
+  organizationId,
+  scopedDb,
+  workspaceId,
+}: AnonymizeTextFieldsInput & {
+  dependencies: AnonymizeTextFieldsDependencies;
 }) => {
   if (fields.every((field) => field.length === 0)) {
     return {
@@ -94,7 +131,7 @@ export const anonymizeTextFields = async ({
     };
   }
 
-  const context = createPipelineContext();
+  const context = dependencies.createPipelineContext();
   const markers = buildFieldMarkers({
     fieldCount: fields.length,
     fields,
@@ -105,13 +142,13 @@ export const anonymizeTextFields = async ({
 
   const entries =
     gazetteerEntries ??
-    (await loadAnonymizationGazetteerEntries({
+    (await dependencies.loadAnonymizationGazetteerEntries({
       organizationId,
       scopedDb,
     }));
-  const dictionaries = await loadNameDictionaries();
+  const dictionaries = await dependencies.loadNameDictionaries();
 
-  const entities = await runPipeline({
+  const entities = await dependencies.runPipeline({
     fullText: combinedText,
     config: {
       ...buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
@@ -120,7 +157,7 @@ export const anonymizeTextFields = async ({
     gazetteerEntries: entries,
     context,
   });
-  const result = redactText(
+  const result = dependencies.redactText(
     combinedText,
     entities,
     DEFAULT_OPERATOR_CONFIG,

--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -1,3 +1,4 @@
+import { loadNameDictionaries } from "@stll/anonymize-data";
 import {
   createPipelineContext,
   DEFAULT_ENTITY_LABELS,
@@ -108,10 +109,14 @@ export const anonymizeTextFields = async ({
       organizationId,
       scopedDb,
     }));
+  const dictionaries = await loadNameDictionaries();
 
   const entities = await runPipeline({
     fullText: combinedText,
-    config: buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
+    config: {
+      ...buildPipelineConfig({ gazetteerEntries: entries, workspaceId }),
+      dictionaries,
+    },
     gazetteerEntries: entries,
     context,
   });

--- a/apps/api/src/mcp/context.ts
+++ b/apps/api/src/mcp/context.ts
@@ -6,8 +6,9 @@ import type { SafeDb, ScopedDb } from "@/api/db";
 import { member } from "@/api/db/auth-schema";
 import { db } from "@/api/db/root";
 import { resolveAccessibleWorkspaces } from "@/api/lib/auth";
-import type { MemberRole } from "@/api/lib/auth";
 import type { SafeId } from "@/api/lib/branded-types";
+import { isMemberRole } from "@/api/lib/member-roles";
+import type { MemberRole } from "@/api/lib/member-roles";
 import {
   brandActorSessionIdentity,
   brandPersistedWorkspaceId,
@@ -23,19 +24,6 @@ export type McpRequestContext = {
   safeDb: SafeDb;
   scopedDb: ScopedDb;
   userId: SafeId<"user">;
-};
-
-const isMemberRole = (role: string): role is MemberRole => {
-  switch (role) {
-    case "owner":
-    case "admin":
-    case "member":
-    case "intern":
-    case "external":
-      return true;
-    default:
-      return false;
-  }
 };
 
 export const resolveMcpSessionContext = async (

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -848,24 +848,28 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
   await db.insert(chatThreads).values([
     {
       id: ids.chatThreadGlobalA1,
+      organizationId: ids.orgA,
       userId: ids.userA1,
       title: "Global thread A1",
       workspaceId: null,
     },
     {
       id: ids.chatThreadWorkspaceA1,
+      organizationId: ids.orgA,
       userId: ids.userA1,
       title: "Workspace thread A1",
       workspaceId: ids.wsA1,
     },
     {
       id: ids.chatThreadWorkspaceA2,
+      organizationId: ids.orgA,
       userId: ids.userA1,
       title: "Workspace thread A2",
       workspaceId: ids.wsA2,
     },
     {
       id: ids.chatThreadWorkspaceB1,
+      organizationId: ids.orgB,
       userId: ids.userB1,
       title: "Workspace thread B1",
       workspaceId: ids.wsA1,

--- a/apps/api/src/tests/security/rls-negative.test.ts
+++ b/apps/api/src/tests/security/rls-negative.test.ts
@@ -158,6 +158,28 @@ describe("organization SELECT — wrong scope", () => {
 });
 
 describe("chat SELECT — wrong user or workspace", () => {
+  test("same user in another organization cannot read global chat rows", async () => {
+    const c = await scopedQuery(
+      [ids.wsB1],
+      ids.orgB,
+      (tx) =>
+        tx.$count(chatThreads, eq(chatThreads.id, ids.chatThreadGlobalA1)),
+      ids.userA1,
+    );
+    expect(c).toBe(0);
+  });
+
+  test("same user in another organization cannot read global chat messages", async () => {
+    const c = await scopedQuery(
+      [ids.wsB1],
+      ids.orgB,
+      (tx) =>
+        tx.$count(chatMessages, eq(chatMessages.id, ids.chatMessageGlobalA1)),
+      ids.userA1,
+    );
+    expect(c).toBe(0);
+  });
+
   test("different user in the same workspace sees zero rows", async () => {
     const c = await scopedQuery(
       [ids.wsA1],
@@ -1376,6 +1398,7 @@ describe("chat mutations — wrong user", () => {
         async (tx) => {
           await tx.insert(chatThreads).values({
             id: testId(),
+            organizationId: ids.orgA,
             userId: ids.userB1,
             title: "forbidden",
             workspaceId: ids.wsA1,

--- a/apps/desktop/src-tauri/src/sse.rs
+++ b/apps/desktop/src-tauri/src/sse.rs
@@ -29,8 +29,6 @@ pub fn spawn_sse_listener(
 ) -> tokio::task::JoinHandle<()> {
   tokio::spawn(async move {
     loop {
-      // SSE endpoint authenticates by session ID + open status only
-      // (no token needed; it was validated on open_docx).
       // Replace localhost with 127.0.0.1 to avoid IPv6 resolution
       // issues with reqwest on macOS.
       let base = api_base_url.replace("localhost", "127.0.0.1");
@@ -61,7 +59,7 @@ pub fn spawn_sse_listener(
           if !r.status().is_success() {
             let status = r.status().as_u16();
             tracing::warn!(session_id = %session_id, status, "SSE rejected");
-            if status == 404 || status == 409 || status == 401 {
+            if status == 404 || status == 409 || status == 401 || status == 403 {
               let mut mgr = manager.lock().await;
               if status == 409 {
                 mgr

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "@opentelemetry/sdk-logs": "^0.215.0",
         "@react-email/render": "^2.0.7",
         "@sinclair/typebox": "^0.34.49",
+        "@stll/anonymize-data": "catalog:",
         "@stll/anonymize-wasm": "catalog:",
         "@stll/ares": "workspace:*",
         "@stll/case-law": "workspace:*",


### PR DESCRIPTION
## Summary
- tighten release workflow validation and deployment handoff
- align chat persistence and access checks with organization scope
- centralize current-access checks for desktop edit session operations
- require complete provider configuration before enabling optional auth flows
- ensure anonymization uses packaged reference data

## Tests
- bun --filter @stll/api typecheck
- bun --filter @stll/api lint
- bun --filter @stll/api format -- --check
- bun --filter @stll/api test src/lib/desktop-edit-sessions.test.ts src/mcp/anonymization.test.ts src/tests/security/rls-negative.test.ts
- bun scripts/check-migration-safety.ts
- cargo check --manifest-path apps/desktop/src-tauri/Cargo.toml
- pre-push hook: i18n, format, typecheck, lint