### PR TITLE
fix(release-desktop): repin trusted-signing-action SHA to current v0.5.9

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Sign Windows installers via Azure Trusted Signing
         if: matrix.os == 'windows'
-        uses: azure/trusted-signing-action@5dc2f74e4ca38d1e3abee5b53cab17d35aafa0d2 # v0.5.9
+        uses: azure/trusted-signing-action@bb15ca63eb5548cc306f4f335c5617bb414abcad # v0.5.9
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}


### PR DESCRIPTION
The pinned SHA \`5dc2f74e...\` no longer resolves on GitHub — the upstream \`v0.5.9\` tag was force-repointed at some point. Build fails at \"Set up job\":
\`\`\`
Unable to resolve action \`azure/trusted-signing-action@5dc2f74e4ca38d1e3abee5b53cab17d35aafa0d2\`, unable to find version \`5dc2f74e4ca38d1e3abee5b53cab17d35aafa0d2\`
\`\`\`

Updated to the current \`v0.5.9\` SHA (\`bb15ca6...\`). Same semver. Caught while running v0.0.2-rc.1.