### PR TITLE
fix(release-desktop): pass explicit toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.target }}
 
       - name: Cache cargo registry


### PR DESCRIPTION
The action was pinned by SHA but the \`toolchain\` input was left implicit, relying on the branch name (\`stable\`) to fill it in. SHA pinning bypasses that path, so the action errors at "Setup Rust" with:
\`\`\`
'toolchain' is a required input
\`\`\`

Pass \`toolchain: stable\` explicitly. Caught while running v0.0.2-rc.1.