### PR TITLE
feat(auth): add inbox quick-jump buttons on the OTP screen

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -74,6 +74,7 @@
       "title": "Pozvánka do organizace"
     },
     "lastUsed": "Naposledy použito",
+    "openInProvider": "Otevřít {provider}",
     "orSignInWithEmail": "nebo se přihlaste e-mailem",
     "organizationNamePlaceholder": "Moje organizace",
     "rateLimitExceeded": "Příliš mnoho pokusů. Zkuste to prosím později.",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -74,6 +74,7 @@
       "title": "Einladung zur Organisation"
     },
     "lastUsed": "Zuletzt verwendet",
+    "openInProvider": "{provider} öffnen",
     "orSignInWithEmail": "oder mit E-Mail anmelden",
     "organizationNamePlaceholder": "Meine Organisation",
     "rateLimitExceeded": "Zu viele Versuche. Bitte versuchen Sie es später erneut.",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -74,6 +74,7 @@
       "title": "Organization invitation"
     },
     "lastUsed": "Last used",
+    "openInProvider": "Open {provider}",
     "orSignInWithEmail": "or sign in with email",
     "organizationNamePlaceholder": "My organization",
     "rateLimitExceeded": "Too many attempts. Please try again later.",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -74,6 +74,7 @@
       "title": "Invitación a la organización"
     },
     "lastUsed": "Último utilizado",
+    "openInProvider": "Abrir {provider}",
     "orSignInWithEmail": "o inicia sesión con el correo electrónico",
     "organizationNamePlaceholder": "Mi Organización",
     "rateLimitExceeded": "Demasiados intentos. Inténtelo de nuevo más tarde.",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -74,6 +74,7 @@
       "title": "Kutse organisatsiooni"
     },
     "lastUsed": "Viimati kasutatud",
+    "openInProvider": "Ava {provider}",
     "orSignInWithEmail": "või logi sisse e-postiga",
     "organizationNamePlaceholder": "Minu organisatsioon",
     "rateLimitExceeded": "Liiga palju katseid. Palun proovige hiljem uuesti.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -74,6 +74,7 @@
       "title": "Invitation à l'organisation"
     },
     "lastUsed": "Dernière utilisation",
+    "openInProvider": "Ouvrir {provider}",
     "orSignInWithEmail": "ou connectez-vous avec l'e-mail",
     "organizationNamePlaceholder": "Mon organisation",
     "rateLimitExceeded": "Trop de tentatives. Veuillez réessayer plus tard.",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -74,6 +74,7 @@
       "title": "Szervezeti meghívó"
     },
     "lastUsed": "Legutóbb használt",
+    "openInProvider": "{provider} megnyitása",
     "orSignInWithEmail": "vagy jelentkezz be e-maillel",
     "organizationNamePlaceholder": "Szervezetem",
     "rateLimitExceeded": "Túl sok próbálkozás. Kérjük, próbálja újra később.",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -74,6 +74,7 @@
       "title": "Kvietimas į organizaciją"
     },
     "lastUsed": "Paskutinį kartą naudotas",
+    "openInProvider": "Atverti {provider}",
     "orSignInWithEmail": "arba prisijunkite el. paštu",
     "organizationNamePlaceholder": "Mano organizacija",
     "rateLimitExceeded": "Per daug bandymų. Bandykite dar kartą vėliau.",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -74,6 +74,7 @@
       "title": "Uzaicinājums organizācijā"
     },
     "lastUsed": "Pēdējoreiz izmantots",
+    "openInProvider": "Atvērt {provider}",
     "orSignInWithEmail": "vai pierakstieties ar e-pastu",
     "organizationNamePlaceholder": "Mana organizācija",
     "rateLimitExceeded": "Pārāk daudz mēģinājumu. Lūdzu, mēģiniet vēlāk.",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -77,6 +77,7 @@ type Messages = {
       "title": "Organization invitation";
     };
     "lastUsed": "Last used";
+    "openInProvider": "Open {provider}";
     "orSignInWithEmail": "or sign in with email";
     "organizationNamePlaceholder": "My organization";
     "rateLimitExceeded": "Too many attempts. Please try again later.";
@@ -294,7 +295,6 @@ type Messages = {
       "toastDescription": "Full-page chat lands with persisted threads.";
       "toastTitle": "Full view not yet available";
     };
-    "folioCitationFallback": "p. {n}";
     "anonymizedMode": "Anonymized AI mode";
     "anonymizedModeDisabled": "Anonymized AI mode is off";
     "anonymizedModeEnabled": "Anonymized AI mode is on";
@@ -337,6 +337,7 @@ type Messages = {
     "filePlaceholder": "Chat about {fileName}";
     "filePlaceholderAction": "Chat about";
     "fileTooLarge": "File exceeds {maxSize} limit";
+    "folioCitationFallback": "p. {n}";
     "greeting": "What would you like to work on?";
     "maxAttachmentsReached": "Maximum {count} files per message";
     "mention": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -74,6 +74,7 @@
       "title": "Zaproszenie do organizacji"
     },
     "lastUsed": "Ostatnio użyte",
+    "openInProvider": "Otwórz {provider}",
     "orSignInWithEmail": "lub zaloguj się e-mailem",
     "organizationNamePlaceholder": "Moja organizacja",
     "rateLimitExceeded": "Zbyt wiele prób. Spróbuj ponownie później.",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -74,6 +74,7 @@
       "title": "Pozvánka do organizácie"
     },
     "lastUsed": "Naposledy použité",
+    "openInProvider": "Otvoriť {provider}",
     "orSignInWithEmail": "alebo sa prihláste e-mailom",
     "organizationNamePlaceholder": "Moja organizácia",
     "rateLimitExceeded": "Príliš veľa pokusov. Skúste to znova neskôr.",

--- a/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
+++ b/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@stll/ui/components/button";
+import { useTranslations } from "use-intl";
+
+import { sanitizeHref } from "@/lib/sanitize-href";
+
+type Provider = {
+  readonly name: string;
+  readonly url: string;
+  readonly domains: readonly string[];
+};
+
+const PROVIDERS: readonly Provider[] = [
+  {
+    name: "Gmail",
+    url: "https://mail.google.com/mail/u/0/#inbox",
+    domains: ["gmail.com", "googlemail.com"],
+  },
+  {
+    name: "Outlook",
+    url: "https://outlook.live.com/mail/0/inbox",
+    domains: ["outlook.com", "hotmail.com", "live.com", "msn.com"],
+  },
+  {
+    name: "iCloud",
+    url: "https://www.icloud.com/mail",
+    domains: ["icloud.com", "me.com", "mac.com"],
+  },
+  {
+    name: "Yahoo",
+    url: "https://mail.yahoo.com",
+    domains: ["yahoo.com", "ymail.com"],
+  },
+  {
+    name: "Proton Mail",
+    url: "https://mail.proton.me/u/0/inbox",
+    domains: ["proton.me", "protonmail.com", "pm.me"],
+  },
+  {
+    name: "Fastmail",
+    url: "https://app.fastmail.com/mail/Inbox",
+    domains: ["fastmail.com", "fastmail.fm"],
+  },
+];
+
+// Most corporate domains run on Workspace or M365, so a generic email
+// from a custom domain gets the two best-guess buttons.
+const isFallbackProvider = (name: string) =>
+  name === "Gmail" || name === "Outlook";
+
+const getProvidersForEmail = (email: string): readonly Provider[] => {
+  const domain = email.split("@").at(1)?.toLowerCase() ?? "";
+  const exact = PROVIDERS.find((p) => p.domains.includes(domain));
+  if (exact) {
+    return [exact];
+  }
+  return PROVIDERS.filter((p) => isFallbackProvider(p.name));
+};
+
+export const InboxQuickJump = ({ email }: { email: string }) => {
+  const t = useTranslations();
+  const providers = getProvidersForEmail(email);
+  return (
+    <div className="flex flex-wrap justify-center gap-2">
+      {providers.map((p) => (
+        <Button
+          key={p.name}
+          render={
+            <a
+              href={sanitizeHref(p.url)}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {t("auth.openInProvider", { provider: p.name })}
+            </a>
+          }
+          size="sm"
+          variant="outline"
+        />
+      ))}
+    </div>
+  );
+};

--- a/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
+++ b/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
@@ -3,8 +3,16 @@ import { useTranslations } from "use-intl";
 
 import { sanitizeHref } from "@/lib/sanitize-href";
 
+type ProviderName =
+  | "Gmail"
+  | "Outlook"
+  | "iCloud"
+  | "Yahoo"
+  | "Proton Mail"
+  | "Fastmail";
+
 type Provider = {
-  readonly name: string;
+  readonly name: ProviderName;
   readonly url: string;
   readonly domains: readonly string[];
 };
@@ -44,7 +52,7 @@ const PROVIDERS: readonly Provider[] = [
 
 // Most corporate domains run on Workspace or M365, so a generic email
 // from a custom domain gets the two best-guess buttons.
-const isFallbackProvider = (name: string) =>
+const isFallbackProvider = (name: ProviderName) =>
   name === "Gmail" || name === "Outlook";
 
 const getProvidersForEmail = (email: string): readonly Provider[] => {

--- a/apps/web/src/routes/auth/otp.tsx
+++ b/apps/web/src/routes/auth/otp.tsx
@@ -27,6 +27,8 @@ import { redirectToSchema } from "@/lib/redirect";
 import { emailSchema } from "@/lib/schema";
 import { COMMON_TIMEZONES } from "@/lib/timezones";
 
+import { InboxQuickJump } from "./-components/inbox-quick-jump";
+
 const OTP_LENGTH = 6;
 
 const searchSchema = v.strictObject({
@@ -177,6 +179,9 @@ function OTP() {
         >
           {t("common.verify")}
         </Button>
+        <div className="mt-3">
+          <InboxQuickJump email={email} />
+        </div>
         <div className="mt-3 flex flex-col gap-1">
           <Button
             className="h-auto min-h-9 w-full py-2 text-center leading-snug break-words whitespace-normal"


### PR DESCRIPTION
## Summary
After we send an OTP, the user has to switch tabs to grab the code from their email. Mirror the BetterStack pattern of showing one or two webmail buttons that jump straight to the right inbox.

## Behaviour
- Detects provider from the email domain (Gmail, Outlook, iCloud, Yahoo, Proton, Fastmail).
- Custom domains (most law-firm setups) get a Gmail + Outlook fallback pair, since corporate mail is overwhelmingly hosted on Workspace or M365.
- New translation key \`auth.openInProvider\` with the localised "Open" verb for every supported language.

## Test plan
- [ ] Trigger the OTP flow with a \`@gmail.com\` address — only a Gmail button shows
- [ ] Trigger with an \`@outlook.com\` address — only an Outlook button shows
- [ ] Trigger with a \`@some-firm.cz\` (custom) address — Gmail + Outlook buttons show
- [ ] Click a button — opens the corresponding webmail in a new tab, \`noopener\` set
- [ ] Switch UI to Czech / German / etc. — button label localises ("Otevřít Gmail", etc.)