### PR TITLE
feat(landing): add Status link in footer

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -390,6 +390,12 @@ const selfHostingDocsUrl =
           <a href="/security" class="transition-opacity hover:opacity-70"
             >Security</a
           >
+          <a
+            href="https://status.stll.app"
+            class="transition-opacity hover:opacity-70"
+            target="_blank"
+            rel="noopener noreferrer">Status</a
+          >
           <a href="/terms" class="transition-opacity hover:opacity-70">Terms</a>
           <a href="/imprint" class="transition-opacity hover:opacity-70"
             >Imprint</a


### PR DESCRIPTION
Adds a `Status` entry in the landing footer pointing to https://status.stll.app, between Security and Terms. Plain link, no live status indicator to simplify things for now