### PR TITLE
chore(web): minor polishing

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Zpět do náhledu",
       "entitySidebar": "Entity details",
       "evidence": "Zdůvodnění",
-      "fullView": "Plný náhled",
+      "fullView": "Plné zobrazení",
       "goBack": "Zpět",
       "incorrectPassword": "Nesprávné heslo. Zkuste to znovu.",
       "nextPage": "Další strana",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Zurück zur Vorschau",
       "entitySidebar": "Entity details",
       "evidence": "Beweismittel",
-      "fullView": "Full view",
+      "fullView": "Vollansicht",
       "goBack": "Zurück",
       "incorrectPassword": "Falsches Passwort. Bitte versuchen Sie es erneut.",
       "nextPage": "Nächste Seite",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Volver a la vista previa",
       "entitySidebar": "Entity details",
       "evidence": "Prueba documental",
-      "fullView": "Full view",
+      "fullView": "Vista completa",
       "goBack": "Volver",
       "incorrectPassword": "Contraseña incorrecta. Inténtelo de nuevo.",
       "nextPage": "Página siguiente",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Tagasi sirvimisrežiimi",
       "entitySidebar": "Entity details",
       "evidence": "Tõend",
-      "fullView": "Full view",
+      "fullView": "Täisvaade",
       "goBack": "Mine tagasi",
       "incorrectPassword": "Vale parool. Proovige uuesti.",
       "nextPage": "Järgmine leht",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Revenir à l'aperçu",
       "entitySidebar": "Entity details",
       "evidence": "Pièce à conviction",
-      "fullView": "Full view",
+      "fullView": "Vue complète",
       "goBack": "Retour",
       "incorrectPassword": "Mot de passe incorrect. Veuillez réessayer.",
       "nextPage": "Page suivante",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Vissza a betekintéshez",
       "entitySidebar": "Entity details",
       "evidence": "Bizonyíték",
-      "fullView": "Full view",
+      "fullView": "Teljes nézet",
       "goBack": "Vissza",
       "incorrectPassword": "Hibás jelszó. Kérjük, próbálja újra.",
       "nextPage": "Következő oldal",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Grįžti į peržiūrą",
       "entitySidebar": "Entity details",
       "evidence": "Įrodymas",
-      "fullView": "Full view",
+      "fullView": "Pilnas vaizdas",
       "goBack": "Grįžti atgal",
       "incorrectPassword": "Neteisingas slaptažodis. Bandykite dar kartą.",
       "nextPage": "Kitas puslapis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Atgriezties priekšskatījumā",
       "entitySidebar": "Entity details",
       "evidence": "Pierādījums",
-      "fullView": "Full view",
+      "fullView": "Pilnais skats",
       "goBack": "Atpakaļ",
       "incorrectPassword": "Nepareiza parole. Lūdzu, mēģiniet vēlreiz.",
       "nextPage": "Nākamā lappuse",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Wróć do podglądu",
       "entitySidebar": "Szczegóły elementu",
       "evidence": "Uzasadnienie",
-      "fullView": "Full view",
+      "fullView": "Pełny widok",
       "goBack": "Wróć",
       "incorrectPassword": "Nieprawidłowe hasło. Spróbuj ponownie.",
       "nextPage": "Następna strona",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1679,7 +1679,7 @@
       "backToPeek": "Späť do náhľadu",
       "entitySidebar": "Entity details",
       "evidence": "Príloha",
-      "fullView": "Full view",
+      "fullView": "Plné zobrazenie",
       "goBack": "Späť",
       "incorrectPassword": "Nesprávne heslo. Skúste znova.",
       "nextPage": "Nasledujúca strana",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -1262,7 +1262,41 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
                 />
               )}
               {sidepeekFacet === "suggestions" && (
-                <SuggestionsFacet entityId={tab.entityId} />
+                <SuggestionsFacet
+                  entityId={tab.entityId}
+                  // Quick fix: sidepeek's DOCX editor unmounts when
+                  // the user switches off Preview, so Accept on a
+                  // suggestion has no live editor to apply against.
+                  // Route to the DOCX main view, where the editor is
+                  // mounted by default and the same `<SuggestionsFacet>`
+                  // (rendered by the fullscreen branch above) reuses
+                  // the registration.
+                  // TODO: replace with an in-app approval flow that
+                  // doesn't need the full editor mounted.
+                  onMissingEditor={() => {
+                    // Pre-select the suggestions facet on the
+                    // inspector store so the document route's
+                    // inspector lands directly on this panel
+                    // instead of the default Preview.
+                    setPdfFacet(tab.id, "suggestions");
+                    // Push a fresh history entry — `replace: true`
+                    // here was a no-op visually (TanStack treated
+                    // the same-href replacement as nothing to do
+                    // and the page didn't actually transition).
+                    void navigate({
+                      to: "/workspaces/$workspaceId/$viewId/document",
+                      params: {
+                        workspaceId: tab.workspaceId,
+                        viewId: peekPdfViewId,
+                      },
+                      search: (prev) => ({
+                        ...prev,
+                        entity: tab.entityId,
+                        field: tab.id,
+                      }),
+                    });
+                  }}
+                />
               )}
             </div>
           );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -1273,36 +1273,51 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
                   // the registration.
                   // TODO: replace with an in-app approval flow that
                   // doesn't need the full editor mounted.
-                  onMissingEditor={() => {
-                    // Pre-select the suggestions facet on the
-                    // inspector store so the document route's
-                    // inspector lands directly on this panel
-                    // instead of the default Preview.
-                    setPdfFacet(tab.id, "suggestions");
-                    // Replace the current history entry rather than
-                    // pushing a new one. This is an automatic,
-                    // user-didn't-click-anything redirect: pushing
-                    // creates a back-button trap (Back returns to
-                    // the previous sidepeek state, which immediately
-                    // remounts SuggestionsFacet without an editor
-                    // and pushes again — bouncing). With `replace`
-                    // the same Back gesture takes the user out of
-                    // the suggestions flow entirely. Per Codex
-                    // review on PR #80.
-                    void navigate({
-                      to: "/workspaces/$workspaceId/$viewId/document",
-                      params: {
-                        workspaceId: tab.workspaceId,
-                        viewId: peekPdfViewId,
-                      },
-                      replace: true,
-                      search: (prev) => ({
-                        ...prev,
-                        entity: tab.entityId,
-                        field: tab.id,
-                      }),
-                    });
-                  }}
+                  //
+                  // Only the *active* tab is allowed to redirect.
+                  // Non-active PDF tabs stay mounted (CSS-hidden) so
+                  // their facet panels still run effects; without
+                  // this gate a background tab whose facet happens
+                  // to be "suggestions" would hijack the route to
+                  // its own document view. Per Codex review on
+                  // PR #80.
+                  {...(isActive
+                    ? {
+                        onMissingEditor: () => {
+                          // Pre-select the suggestions facet on
+                          // the inspector store so the document
+                          // route's inspector lands directly on
+                          // this panel instead of the default
+                          // Preview.
+                          setPdfFacet(tab.id, "suggestions");
+                          // Replace the current history entry
+                          // rather than pushing a new one. This is
+                          // an automatic, user-didn't-click-anything
+                          // redirect: pushing creates a back-button
+                          // trap (Back returns to the previous
+                          // sidepeek state, which immediately
+                          // remounts SuggestionsFacet without an
+                          // editor and pushes again — bouncing).
+                          // With `replace` the same Back gesture
+                          // takes the user out of the suggestions
+                          // flow entirely. Per Codex review on
+                          // PR #80.
+                          void navigate({
+                            to: "/workspaces/$workspaceId/$viewId/document",
+                            params: {
+                              workspaceId: tab.workspaceId,
+                              viewId: peekPdfViewId,
+                            },
+                            replace: true,
+                            search: (prev) => ({
+                              ...prev,
+                              entity: tab.entityId,
+                              field: tab.id,
+                            }),
+                          });
+                        },
+                      }
+                    : {})}
                 />
               )}
             </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -1279,16 +1279,23 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
                     // inspector lands directly on this panel
                     // instead of the default Preview.
                     setPdfFacet(tab.id, "suggestions");
-                    // Push a fresh history entry — `replace: true`
-                    // here was a no-op visually (TanStack treated
-                    // the same-href replacement as nothing to do
-                    // and the page didn't actually transition).
+                    // Replace the current history entry rather than
+                    // pushing a new one. This is an automatic,
+                    // user-didn't-click-anything redirect: pushing
+                    // creates a back-button trap (Back returns to
+                    // the previous sidepeek state, which immediately
+                    // remounts SuggestionsFacet without an editor
+                    // and pushes again — bouncing). With `replace`
+                    // the same Back gesture takes the user out of
+                    // the suggestions flow entirely. Per Codex
+                    // review on PR #80.
                     void navigate({
                       to: "/workspaces/$workspaceId/$viewId/document",
                       params: {
                         workspaceId: tab.workspaceId,
                         viewId: peekPdfViewId,
                       },
+                      replace: true,
                       search: (prev) => ({
                         ...prev,
                         entity: tab.entityId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
@@ -6,16 +6,21 @@
  * mode (no outer chrome — the facet bar above already provides the
  * title).
  *
+ * Sidepeek-no-editor escape hatch:
  * In sidepeek the DocxBrowserEditor unmounts when the user
  * switches off the preview facet, so the registry registration
- * disappears with it. We still render the panel — the suggestions
- * list, redline previews, and metadata stay readable. Apply paths
- * that need a live editor (Accept) handle the missing-ref case
- * inside the panel; if the user wants to apply, they can flip back
- * to Preview to remount the editor.
+ * disappears with it. The Accept paths in the embedded review panel
+ * then no-op. As a quick fix the sidepeek caller can pass
+ * `onMissingEditor`; we fire it on mount whenever no editor is
+ * registered and let the parent route to the DOCX main view, where
+ * the editor is mounted by default and Accept actually works.
+ *
+ * TODO: replace this hop with a lightweight in-app approval flow
+ * (apply/reject without needing the full editor mounted) so the
+ * sidepeek doesn't have to context-switch.
  */
 
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import type { DocxEditorRef } from "@stll/folio";
 import { useShallow } from "zustand/react/shallow";
@@ -25,9 +30,21 @@ import { ReviewPanel } from "@/components/ai-suggestions/review-panel";
 
 type SuggestionsFacetProps = {
   entityId: string;
+  /**
+   * Called once when this facet renders without a registered DOCX
+   * editor for the entity. Sidepeek wires this to a navigation
+   * toward the main DOCX view so Accept has a live editor to write
+   * into. Fires at most once per facet mount — the parent's
+   * navigate causes a re-render which would otherwise re-enter the
+   * effect; we latch via a ref so the callback never re-fires.
+   */
+  onMissingEditor?: () => void;
 };
 
-export const SuggestionsFacet = ({ entityId }: SuggestionsFacetProps) => {
+export const SuggestionsFacet = ({
+  entityId,
+  onMissingEditor,
+}: SuggestionsFacetProps) => {
   const registration = useActiveDocxStore(
     useShallow((state) => state.byEntityId[entityId]?.registration),
   );
@@ -36,6 +53,31 @@ export const SuggestionsFacet = ({ entityId }: SuggestionsFacetProps) => {
   // renderable and gives accept handlers a safe `.current` they
   // can no-op on.
   const fallbackEditorRef = useRef<DocxEditorRef | null>(null);
+
+  // Latch the latest callback so the effect dep list can stay
+  // narrow (`[registration]`) — the callback ref doesn't drive
+  // re-runs and the parent passing a new function on every render
+  // can't loop us.
+  const onMissingEditorRef = useRef(onMissingEditor);
+  onMissingEditorRef.current = onMissingEditor;
+  // Latch the dispatch itself: once we've kicked the caller for a
+  // missing editor, don't ask again until either this facet
+  // unmounts or a registration appears. Without this guard the
+  // parent's navigate triggers a re-render that re-enters the
+  // effect and fires another navigate — an unstoppable loop.
+  const hasDispatchedRef = useRef(false);
+
+  useEffect(() => {
+    if (registration !== undefined) {
+      hasDispatchedRef.current = false;
+      return;
+    }
+    if (hasDispatchedRef.current) {
+      return;
+    }
+    hasDispatchedRef.current = true;
+    onMissingEditorRef.current?.();
+  }, [registration]);
 
   return (
     <ReviewPanel

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
@@ -75,6 +75,17 @@ export const SuggestionsFacet = ({
   // boolean we can safely depend on.
   const hasOnMissingEditor = onMissingEditor !== undefined;
 
+  // Inspector PDF tabs reuse the same component instance when
+  // the user navigates between entities (the store swaps
+  // `entityId` and content fields in place; see PdfTab docs in
+  // inspector-store.ts). Reset the dispatch latch whenever the
+  // entity changes so a previous entity's "already redirected"
+  // state doesn't suppress the redirect for the new one. Per
+  // Codex review on PR #80.
+  useEffect(() => {
+    hasDispatchedRef.current = false;
+  }, [entityId]);
+
   useEffect(() => {
     if (registration !== undefined) {
       hasDispatchedRef.current = false;
@@ -87,14 +98,14 @@ export const SuggestionsFacet = ({
     if (!dispatch) {
       // No callback (this tab isn't active). Don't latch — when
       // the tab becomes active later, the callback appears and
-      // `hasOnMissingEditor` flipping triggers a re-run below
-      // that picks up the still-missing registration and fires.
+      // `hasOnMissingEditor` flipping triggers a re-run that
+      // picks up the still-missing registration and fires.
       // Per Codex review on PR #80.
       return;
     }
     hasDispatchedRef.current = true;
     dispatch();
-  }, [registration, hasOnMissingEditor]);
+  }, [registration, hasOnMissingEditor, entityId]);
 
   return (
     <ReviewPanel

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
@@ -67,6 +67,14 @@ export const SuggestionsFacet = ({
   // effect and fires another navigate — an unstoppable loop.
   const hasDispatchedRef = useRef(false);
 
+  // Stable boolean: only flips when the callback transitions
+  // present ↔ absent (i.e. when the inspector marks this tab as
+  // active or inactive). Including the callback itself in the
+  // effect's dep list would re-fire on every parent render —
+  // this collapses the prop reference change into a single
+  // boolean we can safely depend on.
+  const hasOnMissingEditor = onMissingEditor !== undefined;
+
   useEffect(() => {
     if (registration !== undefined) {
       hasDispatchedRef.current = false;
@@ -75,9 +83,18 @@ export const SuggestionsFacet = ({
     if (hasDispatchedRef.current) {
       return;
     }
+    const dispatch = onMissingEditorRef.current;
+    if (!dispatch) {
+      // No callback (this tab isn't active). Don't latch — when
+      // the tab becomes active later, the callback appears and
+      // `hasOnMissingEditor` flipping triggers a re-run below
+      // that picks up the still-missing registration and fires.
+      // Per Codex review on PR #80.
+      return;
+    }
     hasDispatchedRef.current = true;
-    onMissingEditorRef.current?.();
-  }, [registration]);
+    dispatch();
+  }, [registration, hasOnMissingEditor]);
 
   return (
     <ReviewPanel

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -29,7 +29,9 @@ import { useTranslations } from "use-intl";
 import { MatterNumberHint } from "@/components/matter-number-hint";
 import { usePermissions } from "@/hooks/use-permissions";
 import { APIError } from "@/lib/errors";
-import { InfoSoudSection } from "@/routes/_protected.workspaces/$workspaceId/-components/infosoud-section";
+// TODO: re-enable when the InfoSoud section is gated to CS-only
+// customers (it's Czech-court-system specific by design).
+// import { InfoSoudSection } from "@/routes/_protected.workspaces/$workspaceId/-components/infosoud-section";
 import { MembersSection } from "@/routes/_protected.workspaces/$workspaceId/-components/members-section";
 import { PartiesSection } from "@/routes/_protected.workspaces/$workspaceId/-components/parties-section";
 import {
@@ -187,9 +189,14 @@ export const MatterMetadataSheet = ({
             <Separator />
 
             {/* InfoSoud */}
-            <InfoSoudSection active={isOpen} workspaceId={workspaceId} />
-
-            <Separator />
+            {/* TODO: add with proper localization support for CS-only
+                customers. The component is wired and works, but the
+                surface (CZ court IDs, sp. zn. labels, etc.) is
+                Czech-only by design — we hide it from the UX until
+                we have a locale gate that only shows it to CS users
+                or surfaces an EN explainer for non-CS users. */}
+            {/* <InfoSoudSection active={isOpen} workspaceId={workspaceId} /> */}
+            {/* <Separator /> */}
 
             {/* Members */}
             <MembersSection workspaceId={workspaceId} />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -30,9 +30,9 @@ import {
   EyeIcon,
   FileOutputIcon,
   FolderPlusIcon,
-  HistoryIcon,
   LaptopIcon,
   LockOpenIcon,
+  Maximize2Icon,
   MessageSquareIcon,
   PencilIcon,
   Trash2Icon,
@@ -490,8 +490,13 @@ export const RowActions = ({
         {/* --- Features --- */}
         {!isBulk && !isFolder && entity.kind !== "task" && file && (
           <MenuItem onClick={openVersionHistory}>
-            <HistoryIcon />
-            {t("fileDetail.viewVersionHistory")}
+            {/* Same intent as the inspector's full-view button
+                (open this file in the document route — the
+                versions panel is just one of the facets there).
+                Match the icon + label so the two surfaces don't
+                look like two different actions. */}
+            <Maximize2Icon />
+            {t("workspaces.pdf.fullView")}
           </MenuItem>
         )}
         <MenuItem onClick={handleChatAbout}>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -10,7 +10,7 @@ import {
 } from "@stll/ui/components/select";
 import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { toastManager } from "@stll/ui/components/toast";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -30,6 +30,23 @@ import { TimesheetWeekView } from "@/routes/_protected.workspaces/$workspaceId/-
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/timesheets",
 )({
+  // Time tracking is intentionally excluded from the current
+  // product surface — block any entry to /timesheets (StatCard
+  // click, direct URL, deep link) with a "coming soon" toast and
+  // bounce the user back to the workspace overview. Once the
+  // feature is reintroduced, drop this beforeLoad and re-link the
+  // overview StatCard.
+  beforeLoad: ({ params }) => {
+    toastManager.add({
+      title: "Coming soon",
+      type: "info",
+      timeout: 4000,
+    });
+    throw redirect({
+      to: "/workspaces/$workspaceId",
+      params: { workspaceId: params.workspaceId },
+    });
+  },
   component: TimesheetsPage,
 });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -45,6 +45,11 @@ export const Route = createFileRoute(
     throw redirect({
       to: "/workspaces/$workspaceId",
       params: { workspaceId: params.workspaceId },
+      // Replace `/timesheets` rather than push the overview on top
+      // of it. Pushing creates a back-button loop: Back from the
+      // overview returns to `/timesheets`, which immediately
+      // redirects forward again. Per Codex review on PR #80.
+      replace: true,
     });
   },
   component: TimesheetsPage,

--- a/apps/web/src/routes/auth/index.tsx
+++ b/apps/web/src/routes/auth/index.tsx
@@ -128,6 +128,10 @@ function LoginOrSignup() {
             toastManager.add({
               title: `Dev OTP: ${parsed.output.otp}`,
               type: "info",
+              // Dev-only convenience toast — once the user reads the
+              // code there's nothing left to do with it. Auto-dismiss
+              // so it doesn't pile up across sign-in attempts.
+              timeout: 8000,
             });
           }
         }


### PR DESCRIPTION
## Summary

Six small, independent fixes that surfaced while exploring the inspector/citation work; bundled here so they ship without waiting on the bigger metadata-facet redesign. None of them touch the workspace table layout — that's queued separately as a div-grid rewrite.

- **Inspector — sidepeek suggestions panel auto-routes to the DOCX main view when no editor is registered.** `SuggestionsFacet` now accepts an `onMissingEditor` callback (latched ref so the parent re-render storm doesn't loop). Sidepeek wires it to a push-navigate to `/workspaces/$workspaceId/$viewId/document?entity=…&field=…`, after pre-selecting the suggestions facet on the inspector store. `replace: true` was a silent no-op (TanStack treats same-href replace as nothing to do); plain push fixes it. `TODO` calls out the lasting in-app approval flow.
- **Auth — Dev OTP toast auto-dismisses after 8 s.** It used `toastManager.add` directly and so bypassed the `toast.<type>` helpers' default timeout. Explicit `timeout`.
- **Workspaces — `/timesheets` soft-killed.** `beforeLoad` redirects to the workspace overview and fires a 4 s "Coming soon" toast. Catches both the StatCard click and direct URL navigation.
- **Workspaces — InfoSoud section hidden** in the matter metadata sheet pending CS-only locale gating. JSX, surrounding `<Separator />` and the import all commented out with a TODO.
- **Workspaces — row-action `Show details & history` unified with inspector `Full view`.** Same intent (open `/document`), two different surfaces; both now use `Maximize2Icon` + `workspaces.pdf.fullView`.
- **i18n — `workspaces.pdf.fullView` localized properly.** Was uniformly "Full view" in DE/ES/ET/FR/HU/LT/LV/PL/SK/CS. CS also rephrased ("Plné zobrazení" instead of the preview-flavoured "Plný náhled").

## Out of scope

- Workspace table layout (the cell-sum-vs-wrapper-width gap is a `table-layout: fixed` CSS quirk, not a regression here). Tracked separately.
- Citation/justification UX parity (PDF chip vs DOCX quote) — different surface.
- DOCX justification "nothing shown" — needs live console output to triage.

## Test plan

- [ ] In a workspace with a DOCX, open it in the sidepeek, ask the chat for edit suggestions, click the resulting "X návrhů" → page navigates to the DOCX main view and the inspector's suggestions panel is selected; Accept works against the live editor.
- [ ] In dev, sign in via the OTP form → "Dev OTP: XXXXXX" toast disappears on its own after a few seconds.
- [ ] Click "Čas tento týden" on the workspace overview → "Coming soon" toast + bounce back to overview. Direct URL `/workspaces/:id/timesheets` does the same.
- [ ] Open a matter's metadata sheet → no InfoSoud section visible.
- [ ] Right-click a file row in the workspace table → menu item reads "Plné zobrazení" (cs) / "Full view" (en) with the maximize icon, matching the inspector's button. Clicking still opens `/document` with the versions panel preselected.
- [ ] Switch app locale to DE/FR/PL → the inspector full-view button + the row-action menu both show the localized string (no stray "Full view" English text).