### PR TITLE
feat: rewrite workspace table as grid

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,7 +7,7 @@
     "./types": "./src/types.ts"
   },
   "scripts": {
-    "test": "bun test",
+    "test": "bun test --preload ./src/tests/setup-env.ts",
     "dev": "bun run docker:dev && NODE_ENV=development bun --port 3001 --watch src/index.ts",
     "dev:ai-tools": "devtools",
     "docker:dev": "docker compose --profile dev up -d",

--- a/apps/api/src/handlers/entities/read.test.ts
+++ b/apps/api/src/handlers/entities/read.test.ts
@@ -1,15 +1,12 @@
 import { Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { createReadEntitiesHandler } from "@/api/handlers/entities/read";
 import { toSafeId } from "@/api/lib/branded-types";
 
 const queryEntitiesMock = mock();
 
-void mock.module("@/api/handlers/entities/query-entities", () => ({
-  queryEntities: queryEntitiesMock,
-}));
-
-const readEntities = (await import("@/api/handlers/entities/read")).default;
+const readEntities = createReadEntitiesHandler(queryEntitiesMock);
 
 const workspaceId = toSafeId<"workspace">("ws_entity_read");
 const organizationId = toSafeId<"organization">("org_entity_read");

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -36,37 +36,50 @@ const config = {
   body: readEntitiesBodySchema,
 } satisfies HandlerConfig;
 
-const readEntities = createSafeHandler(
-  config,
-  async function* ({ safeDb, workspaceId, session, body, user: currentUser }) {
-    const page = body.page ?? 1;
-    const pageSize = body.pageSize ?? LIMITS.entitiesPageSizeDefault;
-    const result = yield* Result.await(
-      queryEntities({
-        safeDb,
-        workspaceId,
-        currentUserId: currentUser.id,
-        currentOrganizationId: session.activeOrganizationId,
-        filters: body.filters ?? [],
-        sorts: body.sorts ?? [],
-        ...(body.search !== undefined && { search: body.search }),
-        offset: (page - 1) * pageSize,
-        limit: pageSize,
-        fieldMode: body.fieldMode ?? "full",
-        fieldIds: body.fieldIds ?? [],
-        excludedKinds: [],
-        previewableForAi: body.previewableForAi ?? false,
-        includeTotalCount: true,
-      }),
-    );
+type QueryEntities = typeof queryEntities;
 
-    return Result.ok({
-      entities: result.entities,
-      totalCount: result.totalCount ?? 0,
-      page,
-      pageSize,
-    });
-  },
-);
+export const createReadEntitiesHandler = (
+  queryEntitiesImpl: QueryEntities = queryEntities,
+) =>
+  createSafeHandler(
+    config,
+    async function* ({
+      safeDb,
+      workspaceId,
+      session,
+      body,
+      user: currentUser,
+    }) {
+      const page = body.page ?? 1;
+      const pageSize = body.pageSize ?? LIMITS.entitiesPageSizeDefault;
+      const result = yield* Result.await(
+        queryEntitiesImpl({
+          safeDb,
+          workspaceId,
+          currentUserId: currentUser.id,
+          currentOrganizationId: session.activeOrganizationId,
+          filters: body.filters ?? [],
+          sorts: body.sorts ?? [],
+          ...(body.search !== undefined && { search: body.search }),
+          offset: (page - 1) * pageSize,
+          limit: pageSize,
+          fieldMode: body.fieldMode ?? "full",
+          fieldIds: body.fieldIds ?? [],
+          excludedKinds: [],
+          previewableForAi: body.previewableForAi ?? false,
+          includeTotalCount: true,
+        }),
+      );
+
+      return Result.ok({
+        entities: result.entities,
+        totalCount: result.totalCount ?? 0,
+        page,
+        pageSize,
+      });
+    },
+  );
+
+const readEntities = createReadEntitiesHandler();
 
 export default readEntities;

--- a/apps/api/src/handlers/views/read.ts
+++ b/apps/api/src/handlers/views/read.ts
@@ -47,7 +47,21 @@ const readViews = createSafeHandler(
     // Seed default views on first access (replaces actor onWake).
     if (views.length === 0) {
       const lang = extractLangFromRequest(request);
-      const defaults = getDefaultViews(lang).map((v) => ({
+      const workspaceProperties = yield* Result.await(
+        safeDb((tx) =>
+          tx.query.properties.findMany({
+            where: { workspaceId: { eq: workspaceId } },
+            columns: { id: true, content: true },
+            orderBy: { createdAt: "asc" },
+          }),
+        ),
+      );
+      const filePropertyId = workspaceProperties.find(
+        (property) => property.content.type === "file",
+      )?.id;
+      const defaults = getDefaultViews(lang, {
+        tableColumnPinning: filePropertyId ? [filePropertyId] : [],
+      }).map((v) => ({
         workspaceId,
         name: v.name,
         layout: v.layout,

--- a/apps/api/src/lib/views.test.ts
+++ b/apps/api/src/lib/views.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { getDefaultViews } from "@/api/lib/views";
+
+describe("getDefaultViews", () => {
+  test("pins requested file columns in the default table view", () => {
+    const views = getDefaultViews("en", {
+      tableColumnPinning: ["property-file"],
+    });
+
+    const tableView = views.find((view) => view.layout.type === "table");
+
+    expect(tableView?.layout).toMatchObject({
+      type: "table",
+      columnPinning: ["property-file"],
+    });
+  });
+
+  test("returns cloned table pinning arrays", () => {
+    const pinned = ["property-file"];
+    const views = getDefaultViews("en", { tableColumnPinning: pinned });
+    pinned.push("property-status");
+
+    const tableView = views.find((view) => view.layout.type === "table");
+
+    expect(tableView?.layout).toMatchObject({
+      type: "table",
+      columnPinning: ["property-file"],
+    });
+  });
+});

--- a/apps/api/src/lib/views.ts
+++ b/apps/api/src/lib/views.ts
@@ -131,12 +131,44 @@ type DefaultView = {
   position: number;
 };
 
+type GetDefaultViewsOptions = {
+  tableColumnPinning?: string[];
+};
+
+const cloneDefaultLayout = (
+  layout: ViewLayout,
+  options: GetDefaultViewsOptions,
+): ViewLayout => {
+  if (layout.type === "table") {
+    return {
+      ...layout,
+      hiddenProperties: [...layout.hiddenProperties],
+      filters: [...layout.filters],
+      sorts: [...layout.sorts],
+      columnOrder: [...layout.columnOrder],
+      columnPinning: options.tableColumnPinning
+        ? [...options.tableColumnPinning]
+        : [...layout.columnPinning],
+    };
+  }
+
+  return {
+    ...layout,
+    hiddenProperties: [...layout.hiddenProperties],
+    filters: [...layout.filters],
+    sorts: [...layout.sorts],
+  };
+};
+
 /** Get default views with localized names. */
-export const getDefaultViews = (lang: SupportedLang): DefaultView[] => {
+export const getDefaultViews = (
+  lang: SupportedLang,
+  options: GetDefaultViewsOptions = {},
+): DefaultView[] => {
   const names = VIEW_NAMES[lang] ?? VIEW_NAMES.en;
   return DEFAULT_VIEW_TEMPLATES.map((tmpl) => ({
     name: names[tmpl.nameKey],
-    layout: tmpl.layout,
+    layout: cloneDefaultLayout(tmpl.layout, options),
     position: tmpl.position,
   }));
 };

--- a/apps/api/src/tests/setup-env.ts
+++ b/apps/api/src/tests/setup-env.ts
@@ -1,0 +1,18 @@
+process.env["DATABASE_URL"] ??=
+  "postgres://stella:stella@localhost:5432/stella";
+process.env["S3_ENDPOINT"] ??= "http://localhost:9000";
+process.env["S3_BUCKET"] ??= "stella-test";
+process.env["S3_REGION"] ??= "us-east-1";
+process.env["AI_DEVTOOLS_ENABLED"] = "false";
+
+process.env["REDIS_URL"] ??= "redis://localhost:6379";
+process.env["BETTER_AUTH_SECRET"] ??= "x".repeat(32);
+process.env["BETTER_AUTH_URL"] ??= "http://localhost:3001";
+process.env["EMAIL_PROVIDER"] ??= "smtp";
+process.env["SMTP_HOST"] ??= "localhost";
+process.env["SMTP_PORT"] ??= "1025";
+process.env["TRANSACTIONAL_EMAIL_FROM"] ??= "test@example.com";
+process.env["FRONTEND_URL"] ??= "http://localhost:3000";
+process.env["GOTENBERG_URL"] ??= "http://localhost:3002";
+process.env["GOTENBERG_USERNAME"] ??= "test";
+process.env["GOTENBERG_PASSWORD"] ??= "test";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -11,6 +11,7 @@ import {
 import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 const selectColId = getInternalColId("select");
+const addPropertyColId = getInternalColId("add-property");
 
 type BottomRowProps = {
   workspaceId: string;
@@ -24,6 +25,7 @@ export const BottomRow = ({
   onFolderCreated,
 }: BottomRowProps) => {
   const t = useTranslations();
+  const addPropertyColumn = table.getColumn(addPropertyColId);
 
   return (
     <WorkspaceGridRow className="bg-muted/40 hover:bg-muted sticky bottom-0 z-10 transition-colors">
@@ -72,7 +74,7 @@ export const BottomRow = ({
       </WorkspaceGridCell>
       <WorkspaceGridCell
         className="relative border-e-0 border-t-2 p-0"
-        style={{ gridColumn: "3 / -1" }}
+        style={{ gridColumn: addPropertyColumn ? "3 / -2" : "3 / -1" }}
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
@@ -83,6 +85,14 @@ export const BottomRow = ({
           workspaceId={workspaceId}
         />
       </WorkspaceGridCell>
+      {addPropertyColumn && (
+        <WorkspaceGridCell
+          aria-hidden="true"
+          className="bg-muted/40 sticky end-0 z-10 border-s border-t-2 p-0"
+          role="presentation"
+          style={{ gridColumn: "-2 / -1" }}
+        />
+      )}
     </WorkspaceGridRow>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -2,9 +2,12 @@ import { Button } from "@stll/ui/components/button";
 import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { TableCell, TableRow } from "@/components/table";
 import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu";
 import type { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
+import {
+  WorkspaceGridCell,
+  WorkspaceGridRow,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid";
 import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 const selectColId = getInternalColId("select");
@@ -23,11 +26,12 @@ export const BottomRow = ({
   const t = useTranslations();
 
   return (
-    <TableRow className="bg-muted/40 hover:bg-muted sticky bottom-0 z-10 transition-colors [&_td]:sticky [&_td]:border-e-0 [&_td]:border-t-2">
-      <TableCell
-        className="relative z-10 min-w-12 shrink-0 p-0"
+    <WorkspaceGridRow className="bg-muted/40 hover:bg-muted sticky bottom-0 z-10 transition-colors">
+      <WorkspaceGridCell
+        className="relative z-10 min-w-12 shrink-0 border-e-0 border-t-2 p-0"
         style={{
           left: table.getColumn(selectColId)?.getStart("left"),
+          position: "sticky",
         }}
       >
         <AddEntityMenu
@@ -45,11 +49,12 @@ export const BottomRow = ({
           }
           workspaceId={workspaceId}
         />
-      </TableCell>
-      <TableCell
-        className="text-muted-foreground relative z-10"
+      </WorkspaceGridCell>
+      <WorkspaceGridCell
+        className="text-muted-foreground relative z-10 border-e-0 border-t-2"
         style={{
           left: table.getColumn(selectColId)?.getSize(),
+          position: "sticky",
         }}
       >
         <AddEntityMenu
@@ -64,10 +69,10 @@ export const BottomRow = ({
           workspaceId={workspaceId}
         />
         {t("workspaces.newDocument")}
-      </TableCell>
-      <TableCell
-        className="relative p-0"
-        colSpan={table.getAllColumns().length - 2}
+      </WorkspaceGridCell>
+      <WorkspaceGridCell
+        className="relative border-e-0 border-t-2 p-0"
+        style={{ gridColumn: "3 / -1" }}
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
@@ -77,7 +82,7 @@ export const BottomRow = ({
           }
           workspaceId={workspaceId}
         />
-      </TableCell>
-    </TableRow>
+      </WorkspaceGridCell>
+    </WorkspaceGridRow>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -67,11 +67,13 @@ type CreatePropertyProps = {
    *    toolbar so the action is discoverable next to the other
    *    chip-shaped controls.
    *  - `panel`: full-width action used in side panels.
+   *  - `blank-cell`: invisible full-cell action used in the
+   *    table's trailing add-column track.
    *  - `none`: no built-in trigger. The caller controls `open` /
    *    `onOpenChange` and renders its own trigger (used by the
    *    column popover's "Edit column…" item).
    */
-  triggerVariant?: "icon" | "labelled" | "panel" | "none";
+  triggerVariant?: "icon" | "labelled" | "panel" | "blank-cell" | "none";
   extractionContext?: {
     entityId: string;
     filePropertyId: string | null;
@@ -263,6 +265,20 @@ export const CreateProperty = ({
         >
           <PlusIcon />
         </DialogTrigger>
+      ) : triggerVariant === "blank-cell" ? (
+        <DialogTrigger
+          render={
+            <button
+              aria-label={t("workspaces.properties.newColumn")}
+              className="ring-ring focus-visible:ring-offset-background absolute inset-0 z-10 cursor-pointer border-0 bg-transparent p-0 outline-none focus-visible:ring-2 focus-visible:ring-offset-1"
+              onClick={(event) => {
+                event.currentTarget.blur();
+              }}
+              title={t("workspaces.properties.newColumn")}
+              type="button"
+            />
+          }
+        />
       ) : null}
 
       <DialogPopup className="sm:max-w-[600px]">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getNextSelectAllRowSelection,
+  getSelectAllState,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic";
+
+describe("workspace table select-all state", () => {
+  test("is unchecked when no selectable rows are selected", () => {
+    expect(
+      getSelectAllState({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: {},
+      }),
+    ).toEqual({
+      checked: false,
+      indeterminate: false,
+      key: "none",
+    });
+  });
+
+  test("is indeterminate when only some selectable rows are selected", () => {
+    expect(
+      getSelectAllState({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: { "row-1": true },
+      }),
+    ).toEqual({
+      checked: false,
+      indeterminate: true,
+      key: "some",
+    });
+  });
+
+  test("is checked only when every selectable row is selected", () => {
+    expect(
+      getSelectAllState({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: { "row-1": true, "row-2": true },
+      }),
+    ).toEqual({
+      checked: true,
+      indeterminate: false,
+      key: "all",
+    });
+  });
+
+  test("ignores stale selected ids that are no longer selectable rows", () => {
+    expect(
+      getSelectAllState({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: { "deleted-row": true },
+      }),
+    ).toEqual({
+      checked: false,
+      indeterminate: false,
+      key: "none",
+    });
+  });
+
+  test("select-all selects each selectable row", () => {
+    expect(
+      getNextSelectAllRowSelection({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: {},
+      }),
+    ).toEqual({ "row-1": true, "row-2": true });
+  });
+
+  test("unselect-all clears stale selected ids too", () => {
+    expect(
+      getNextSelectAllRowSelection({
+        selectableRowIds: ["row-1", "row-2"],
+        rowSelection: {
+          "deleted-row": true,
+          "row-1": true,
+          "row-2": true,
+        },
+      }),
+    ).toEqual({});
+  });
+
+  test("does not require hidden descendant rows to mark visible rows selected", () => {
+    const visibleRowIds = ["folder-row"];
+    const hiddenDescendantIds = ["child-row"];
+
+    expect(
+      getSelectAllState({
+        selectableRowIds: visibleRowIds,
+        rowSelection: getNextSelectAllRowSelection({
+          selectableRowIds: visibleRowIds,
+          rowSelection: {},
+        }),
+      }),
+    ).toEqual({
+      checked: true,
+      indeterminate: false,
+      key: "all",
+    });
+
+    expect(
+      getSelectAllState({
+        selectableRowIds: [...visibleRowIds, ...hiddenDescendantIds],
+        rowSelection: { "folder-row": true },
+      }),
+    ).toEqual({
+      checked: false,
+      indeterminate: true,
+      key: "some",
+    });
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic.ts
@@ -1,0 +1,54 @@
+import type { RowSelectionState } from "@tanstack/react-table";
+
+type SelectAllStateInput = {
+  selectableRowIds: readonly string[];
+  rowSelection: RowSelectionState;
+};
+
+export type SelectAllState = {
+  checked: boolean;
+  indeterminate: boolean;
+  key: "none" | "some" | "all";
+};
+
+export const getSelectAllState = ({
+  selectableRowIds,
+  rowSelection,
+}: SelectAllStateInput): SelectAllState => {
+  let selectedCount = 0;
+
+  for (const rowId of selectableRowIds) {
+    if (rowSelection[rowId]) {
+      selectedCount += 1;
+    }
+  }
+
+  const checked =
+    selectableRowIds.length > 0 && selectedCount === selectableRowIds.length;
+  const indeterminate =
+    selectedCount > 0 && selectedCount < selectableRowIds.length;
+
+  return {
+    checked,
+    indeterminate,
+    key: checked ? "all" : indeterminate ? "some" : "none",
+  };
+};
+
+export const getNextSelectAllRowSelection = ({
+  selectableRowIds,
+  rowSelection,
+}: SelectAllStateInput): RowSelectionState => {
+  const state = getSelectAllState({ selectableRowIds, rowSelection });
+
+  if (state.checked) {
+    return {};
+  }
+
+  const next: RowSelectionState = {};
+  for (const rowId of selectableRowIds) {
+    next[rowId] = true;
+  }
+
+  return next;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 
-import { Checkbox } from "@stll/ui/components/checkbox";
 import {
   useSuspenseInfiniteQuery,
   useSuspenseQuery,
@@ -96,17 +95,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       {
         id: selectColId,
         accessorKey: selectColId,
-        header: (props) => (
-          <div className="flex items-center justify-center">
-            <Checkbox
-              checked={props.table.getIsAllRowsSelected()}
-              indeterminate={props.table.getIsSomeRowsSelected()}
-              onCheckedChange={(checked) =>
-                props.table.toggleAllRowsSelected(checked)
-              }
-            />
-          </div>
-        ),
+        header: () => null,
         enableResizing: false,
         enableSorting: false,
         enableHiding: false,
@@ -172,6 +161,9 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       id: addPropertyColId,
       accessorKey: addPropertyColId,
       header: () => <CreateProperty workspaceId={workspaceId} />,
+      cell: () => (
+        <CreateProperty triggerVariant="blank-cell" workspaceId={workspaceId} />
+      ),
       enableResizing: false,
       enablePinning: false,
       enableSorting: false,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getGridTemplateColumns,
+  getOrderedCells,
+  getOrderedColumns,
+  reorderColumnIds,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order";
+
+const column = (id: string, size = 100) => ({
+  id,
+  getSize: () => size,
+});
+
+const cell = (id: string) => ({
+  id: `${id}-cell`,
+  column: { id },
+});
+
+describe("workspace grid column ordering", () => {
+  test("places pinned columns before center columns", () => {
+    const ordered = getOrderedColumns({
+      leftColumns: [column("select", 48), column("documents", 240)],
+      centerColumns: [column("status", 200), column("due-date", 160)],
+      rightColumns: [],
+    });
+
+    expect(ordered.map((c) => c.id)).toEqual([
+      "select",
+      "documents",
+      "status",
+      "due-date",
+    ]);
+  });
+
+  test("orders cells by the rendered column order instead of source order", () => {
+    const orderedColumns = [
+      column("select"),
+      column("documents"),
+      column("status"),
+      column("due-date"),
+    ];
+    const sourceCells = [
+      cell("select"),
+      cell("status"),
+      cell("documents"),
+      cell("due-date"),
+    ];
+
+    expect(
+      getOrderedCells(sourceCells, orderedColumns).map((c) => c.id),
+    ).toEqual([
+      "select-cell",
+      "documents-cell",
+      "status-cell",
+      "due-date-cell",
+    ]);
+  });
+
+  test("grid template has no hidden slot for a pinned column's original position", () => {
+    const orderedColumns = getOrderedColumns({
+      leftColumns: [column("select", 48), column("documents", 240)],
+      centerColumns: [column("status", 200), column("due-date", 160)],
+      rightColumns: [],
+    });
+
+    expect(getGridTemplateColumns(orderedColumns, 0)).toBe(
+      "48px 240px 200px 160px 0px",
+    );
+  });
+
+  test("moves a dragged column before the targeted column", () => {
+    expect(
+      reorderColumnIds({
+        ids: ["select", "documents", "status", "due-date"],
+        sourceId: "due-date",
+        targetId: "status",
+        edge: "left",
+      }),
+    ).toEqual(["select", "documents", "due-date", "status"]);
+  });
+
+  test("moves a dragged column after the targeted column", () => {
+    expect(
+      reorderColumnIds({
+        ids: ["select", "documents", "status", "due-date"],
+        sourceId: "documents",
+        targetId: "due-date",
+        edge: "right",
+      }),
+    ).toEqual(["select", "status", "due-date", "documents"]);
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
@@ -69,6 +69,16 @@ describe("workspace grid column ordering", () => {
     );
   });
 
+  test("places the filler before end-pinned utility columns", () => {
+    expect(
+      getGridTemplateColumns(
+        [column("select", 48), column("documents", 240)],
+        120,
+        [column("add-property", 48)],
+      ),
+    ).toBe("48px 240px 120px 48px");
+  });
+
   test("moves a dragged column before the targeted column", () => {
     expect(
       reorderColumnIds({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
@@ -1,0 +1,84 @@
+type ColumnLike = {
+  id: string;
+  getSize: () => number;
+};
+
+type CellLike = {
+  column: {
+    id: string;
+  };
+};
+
+export type ColumnDropEdge = "left" | "right";
+
+type OrderedColumnsInput<TColumn extends ColumnLike> = {
+  leftColumns: readonly TColumn[];
+  centerColumns: readonly TColumn[];
+  rightColumns: readonly TColumn[];
+};
+
+export const getOrderedColumns = <TColumn extends ColumnLike>({
+  leftColumns,
+  centerColumns,
+  rightColumns,
+}: OrderedColumnsInput<TColumn>): TColumn[] => [
+  ...leftColumns,
+  ...centerColumns,
+  ...rightColumns,
+];
+
+export const getOrderedCells = <TCell extends CellLike>(
+  cells: readonly TCell[],
+  columns: readonly ColumnLike[],
+): TCell[] => {
+  const cellsByColumnId = new Map(cells.map((cell) => [cell.column.id, cell]));
+  const orderedCells: TCell[] = [];
+
+  for (const column of columns) {
+    const cell = cellsByColumnId.get(column.id);
+    if (cell) {
+      orderedCells.push(cell);
+    }
+  }
+
+  return orderedCells;
+};
+
+export const getGridTemplateColumns = (
+  columns: readonly ColumnLike[],
+  trailingFillerWidth: number,
+) =>
+  `${columns.map((column) => `${column.getSize()}px`).join(" ")} ${trailingFillerWidth}px`;
+
+type ReorderColumnIdsOptions = {
+  ids: readonly string[];
+  sourceId: string;
+  targetId: string;
+  edge: ColumnDropEdge;
+};
+
+export const reorderColumnIds = ({
+  ids,
+  sourceId,
+  targetId,
+  edge,
+}: ReorderColumnIdsOptions): string[] => {
+  if (sourceId === targetId) {
+    return [...ids];
+  }
+
+  const sourceIndex = ids.indexOf(sourceId);
+  const targetIndex = ids.indexOf(targetId);
+  if (sourceIndex === -1 || targetIndex === -1) {
+    return [...ids];
+  }
+
+  const withoutSource = ids.toSpliced(sourceIndex, 1);
+  const targetIndexAfterRemoval = withoutSource.indexOf(targetId);
+  const insertIndex =
+    edge === "left" ? targetIndexAfterRemoval : targetIndexAfterRemoval + 1;
+
+  withoutSource.splice(insertIndex, 0, sourceId);
+
+  return withoutSource;
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
@@ -47,8 +47,13 @@ export const getOrderedCells = <TCell extends CellLike>(
 export const getGridTemplateColumns = (
   columns: readonly ColumnLike[],
   trailingFillerWidth: number,
+  endColumns: readonly ColumnLike[] = [],
 ) =>
-  `${columns.map((column) => `${column.getSize()}px`).join(" ")} ${trailingFillerWidth}px`;
+  [
+    ...columns.map((column) => `${column.getSize()}px`),
+    `${trailingFillerWidth}px`,
+    ...endColumns.map((column) => `${column.getSize()}px`),
+  ].join(" ");
 
 type ReorderColumnIdsOptions = {
   ids: readonly string[];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@stll/ui/lib/utils";
+
+export const WORKSPACE_TABLE_COLUMNS_VAR = "var(--workspace-table-columns)";
+
+export const WorkspaceGridRow = ({
+  className,
+  style,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "group/row isolate grid border-none transition-colors",
+      className,
+    )}
+    data-slot="workspace-grid-row"
+    role="row"
+    style={{
+      gridTemplateColumns: WORKSPACE_TABLE_COLUMNS_VAR,
+      ...style,
+    }}
+    {...props}
+  />
+);
+
+export const WorkspaceGridHead = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "group/table-head bg-background text-foreground hover:bg-background relative z-0 grid h-10 items-center overflow-hidden border-e border-t border-b px-0 text-start font-semibold whitespace-nowrap transition-colors",
+      className,
+    )}
+    data-slot="workspace-grid-head"
+    role="columnheader"
+    {...props}
+  />
+);
+
+export const WorkspaceGridCell = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <div
+    className={cn(
+      "group/cell-content bg-background relative z-0 h-auto min-h-10 overflow-hidden border-e border-b p-2 whitespace-nowrap group-hover/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[active]/row:bg-[color-mix(in_srgb,var(--color-foreground)_4%,var(--color-background))] group-data-[state=selected]/row:bg-[color-mix(in_srgb,var(--color-info)_10%,var(--color-background))] group-data-[state=selected]/row:group-hover/row:bg-[color-mix(in_srgb,var(--color-info)_15%,var(--color-background))]",
+      className,
+    )}
+    data-slot="workspace-grid-cell"
+    role="gridcell"
+    {...props}
+  />
+);
+
+export const WorkspaceGridFillerCell = ({
+  className,
+  ...props
+}: React.ComponentProps<"div">) => (
+  <WorkspaceGridCell
+    aria-hidden="true"
+    className={cn("border-e-0 p-0", className)}
+    role="presentation"
+    {...props}
+  />
+);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -1026,6 +1026,7 @@ const DraggableRow = ({
         aria-rowindex={virtualIndex + 2}
         aria-selected={row.getIsSelected()}
         data-active={entity.entityId === activeEntityId || undefined}
+        data-index={virtualIndex}
         data-state={row.getIsSelected() ? "selected" : undefined}
         key={row.id}
         onContextMenu={handleContextMenu}
@@ -1096,6 +1097,7 @@ const DraggableRow = ({
         entity.entityId === activeTaskId ||
         undefined
       }
+      data-index={virtualIndex}
       data-state={row.getIsSelected() ? "selected" : undefined}
       key={row.id}
       onClick={handleRowClick}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -1,51 +1,99 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
+import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import {
   draggable,
   dropTargetForElements,
+  monitorForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { toastManager } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 import { flexRender } from "@tanstack/react-table";
-import type { Table as ReactTable, Row } from "@tanstack/react-table";
+import type {
+  Cell,
+  Column,
+  Table as ReactTable,
+  Row,
+} from "@tanstack/react-table";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ChevronRightIcon, FolderIcon, FolderOpenIcon } from "lucide-react";
+import type { Header } from "@tanstack/table-core";
+import {
+  CheckIcon,
+  ChevronRightIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  GripVerticalIcon,
+  MinusIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { renderDragPreview } from "@/components/drag-preview";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/table";
 import { BottomRow } from "@/routes/_protected.workspaces/$workspaceId/-components/bottom-row";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { RowActions } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
 import type { VirtualAnchor } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions";
+import {
+  getNextSelectAllRowSelection,
+  getSelectAllState,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic";
+import type { SelectAllState } from "@/routes/_protected.workspaces/$workspaceId/-components/table/select-all.logic";
 import type {
   TableTreeNode,
   WorkspaceTable as WorkspaceTableType,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
+import {
+  WorkspaceGridCell,
+  WorkspaceGridFillerCell,
+  WorkspaceGridHead,
+  WorkspaceGridRow,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid";
+import {
+  getGridTemplateColumns,
+  getOrderedCells,
+  getOrderedColumns,
+  reorderColumnIds,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order";
+import type { ColumnDropEdge } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";
 import { useRenameEntity } from "@/routes/_protected.workspaces/$workspaceId/-mutations/entities";
+import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 import {
   countDescendants,
   getEntityName,
   getFirstFile,
   getInternalColId,
-  getPinningStyles,
 } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 const selectColId = getInternalColId("select");
+const addPropertyColId = getInternalColId("add-property");
 const TABLE_ROW_ESTIMATE_PX = 41;
 const TABLE_ROW_OVERSCAN = 16;
+const EXPANDED_ROW_MAX_HEIGHT_PX = 192;
+const TABLE_COLUMN_DRAG_TYPE = "workspace-table-column";
+const ADD_COLUMN_HOVER_COLOR =
+  "color-mix(in srgb, var(--color-foreground) 4%, var(--color-background))";
+
+type WorkspaceGridStyle = CSSProperties & {
+  "--workspace-table-columns": string;
+};
 
 type WorkspaceTableProps = {
   workspaceId: string;
@@ -53,6 +101,20 @@ type WorkspaceTableProps = {
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
+};
+
+type ColumnDragData = {
+  type: typeof TABLE_COLUMN_DRAG_TYPE;
+  columnId: string;
+  pinning: ColumnDragPinning;
+};
+
+type ColumnDragPinning = "left" | "right" | "center";
+
+type ColumnDropPosition = {
+  sourceId: string;
+  targetId: string;
+  edge: ColumnDropEdge;
 };
 
 export const WorkspaceTable = ({
@@ -65,7 +127,20 @@ export const WorkspaceTable = ({
   const t = useTranslations();
   const tableWrapperRef = useRef<HTMLDivElement>(null);
   const lastSelectedIndex = useRef<number | null>(null);
+  const previousHorizontalMaxScroll = useRef<number | null>(null);
+  const lastColumnDropPosition = useRef<ColumnDropPosition | null>(null);
   const [editingEntityId, setEditingEntityId] = useState<string | null>(null);
+  const [wrapperWidth, setWrapperWidth] = useState(0);
+  const [addColumnHoverRowId, setAddColumnHoverRowId] = useState<string | null>(
+    null,
+  );
+  const [isAddColumnHovered, setIsAddColumnHovered] = useState(false);
+  const expandedTableRowEntityId = useWorkspaceStore(
+    (s) => s.expandedTableRowEntityId,
+  );
+  const setExpandedTableRowEntityId = useWorkspaceStore(
+    (s) => s.setExpandedTableRowEntityId,
+  );
 
   const renameEntity = useRenameEntity();
 
@@ -86,6 +161,23 @@ export const WorkspaceTable = ({
   });
 
   const rowModel = table.getRowModel();
+  const selectableRowIds = useMemo(
+    () =>
+      rowModel.rows.filter((row) => row.getCanSelect()).map((row) => row.id),
+    [rowModel.rows],
+  );
+  const selectAllState = getSelectAllState({
+    selectableRowIds,
+    rowSelection: table.getState().rowSelection,
+  });
+  const handleToggleSelectAll = useCallback(() => {
+    table.setRowSelection(
+      getNextSelectAllRowSelection({
+        selectableRowIds,
+        rowSelection: table.getState().rowSelection,
+      }),
+    );
+  }, [selectableRowIds, table]);
 
   const rowLabels = useMemo(() => {
     // Compute logical row labels that account for collapsed
@@ -123,6 +215,7 @@ export const WorkspaceTable = ({
     getScrollElement: () => tableWrapperRef.current,
     estimateSize: () => TABLE_ROW_ESTIMATE_PX,
     getItemKey: getVirtualRowKey,
+    measureElement: (element) => element.getBoundingClientRect().height,
     overscan: TABLE_ROW_OVERSCAN,
   });
   const virtualRows = rowVirtualizer.getVirtualItems();
@@ -147,9 +240,48 @@ export const WorkspaceTable = ({
   const paddingTop = virtualRows.at(0)?.start ?? 0;
   const paddingBottom =
     rowVirtualizer.getTotalSize() - (virtualRows.at(-1)?.end ?? 0);
-  const visibleColumns = table.getVisibleLeafColumns();
-  const visibleColumnCount = visibleColumns.length;
-  const tableWidth = table.getTotalSize();
+  const renderColumns = getOrderedColumns({
+    leftColumns: table.getLeftLeafColumns(),
+    centerColumns: table.getCenterLeafColumns(),
+    rightColumns: table.getRightLeafColumns(),
+  });
+  const visibleColumnCount = renderColumns.length;
+  const tableWidth = renderColumns.reduce(
+    (sum, column) => sum + column.getSize(),
+    0,
+  );
+  const leftoverWidth = Math.max(0, wrapperWidth - tableWidth);
+  const trailingFillerWidth = leftoverWidth;
+  const gridStyle: WorkspaceGridStyle = {
+    "--workspace-table-columns": getGridTemplateColumns(
+      renderColumns,
+      trailingFillerWidth,
+    ),
+    minWidth: tableWidth + trailingFillerWidth,
+  };
+  const horizontalMaxScroll = Math.max(
+    0,
+    tableWidth + trailingFillerWidth - wrapperWidth,
+  );
+  const handleColumnReorder = useCallback(
+    (sourceId: string, targetId: string, edge: ColumnDropEdge) => {
+      const currentVisibleIds = renderColumns.map((column) => column.id);
+      const reorderedVisibleIds = reorderColumnIds({
+        ids: currentVisibleIds,
+        sourceId,
+        targetId,
+        edge,
+      });
+      const visibleIdSet = new Set(currentVisibleIds);
+      const hiddenIds = table
+        .getAllLeafColumns()
+        .map((column) => column.id)
+        .filter((id) => !visibleIdSet.has(id));
+
+      table.setColumnOrder([...reorderedVisibleIds, ...hiddenIds]);
+    },
+    [renderColumns, table],
+  );
 
   useEffect(() => {
     const element = tableWrapperRef.current;
@@ -157,81 +289,152 @@ export const WorkspaceTable = ({
       return undefined;
     }
 
-    return dropTargetForElements({
-      element,
-      canDrop: ({ source }) => source.data["type"] === ENTITY_DRAG_TYPE,
-      onDrop: ({ source }) => {
-        if (source.data["type"] !== ENTITY_DRAG_TYPE) {
-          return;
-        }
-        toastManager.add({
-          title: t("workspaces.table.reorderReadOnly"),
-          type: "info",
-        });
-      },
+    return combine(
+      autoScrollForElements({
+        element,
+        getAllowedAxis: () => "horizontal",
+      }),
+      dropTargetForElements({
+        element,
+        canDrop: ({ source }) => source.data["type"] === ENTITY_DRAG_TYPE,
+        onDrop: ({ source }) => {
+          if (source.data["type"] !== ENTITY_DRAG_TYPE) {
+            return;
+          }
+          toastManager.add({
+            title: t("workspaces.table.reorderReadOnly"),
+            type: "info",
+          });
+        },
+      }),
+      monitorForElements({
+        canMonitor: ({ source }) =>
+          source.data["type"] === TABLE_COLUMN_DRAG_TYPE,
+        onDragStart: () => {
+          lastColumnDropPosition.current = null;
+        },
+        onDrag: ({ source, location }) => {
+          const target = location.current.dropTargets.at(0);
+          if (!target) {
+            return;
+          }
+
+          const edge = toColumnDropEdge(extractClosestEdge(target.data));
+          const sourceColumnId = source.data["columnId"];
+          const targetColumnId = target.data["columnId"];
+          if (
+            edge &&
+            typeof sourceColumnId === "string" &&
+            typeof targetColumnId === "string" &&
+            sourceColumnId !== targetColumnId
+          ) {
+            lastColumnDropPosition.current = {
+              sourceId: sourceColumnId,
+              targetId: targetColumnId,
+              edge,
+            };
+          }
+        },
+        onDrop: () => {
+          const position = lastColumnDropPosition.current;
+          lastColumnDropPosition.current = null;
+          if (position) {
+            handleColumnReorder(
+              position.sourceId,
+              position.targetId,
+              position.edge,
+            );
+          }
+        },
+      }),
+    );
+  }, [handleColumnReorder, t]);
+
+  useEffect(() => {
+    const element = tableWrapperRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    setWrapperWidth(element.clientWidth);
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (entry) {
+        setWrapperWidth(entry.contentRect.width);
+      }
     });
-  }, [t]);
+    resizeObserver.observe(element);
+
+    return () => resizeObserver.disconnect();
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = tableWrapperRef.current;
+    if (!element) {
+      return;
+    }
+
+    const previousMax = previousHorizontalMaxScroll.current;
+    previousHorizontalMaxScroll.current = horizontalMaxScroll;
+    if (previousMax === null) {
+      return;
+    }
+
+    const wasAtRightEdge = element.scrollLeft >= previousMax - 2;
+    if (wasAtRightEdge) {
+      element.scrollLeft = horizontalMaxScroll;
+      return;
+    }
+
+    if (element.scrollLeft > horizontalMaxScroll) {
+      element.scrollLeft = horizontalMaxScroll;
+    }
+  }, [horizontalMaxScroll]);
 
   return (
     <div className="relative h-full flex-1 overflow-auto" ref={tableWrapperRef}>
-      <Table
-        className="[&_td]:border-border [&_th]:border-border table-fixed border-separate border-spacing-0 [&_td:has([data-slot=select-trigger])]:min-w-40 [&_tfoot_td]:border-t [&_th]:border-b [&_tr]:border-none [&_tr:not(:nth-last-child(2))_td]:border-b"
-        style={{
-          minWidth: tableWidth,
-          width: "100%",
-        }}
+      <div
+        aria-colcount={visibleColumnCount}
+        aria-rowcount={rowModel.rows.length}
+        className="relative min-h-full w-full text-sm"
+        role="grid"
+        style={gridStyle}
       >
-        <colgroup>
-          {visibleColumns.map((column) => (
-            <col key={column.id} style={{ width: column.getSize() }} />
-          ))}
-        </colgroup>
-        <TableHeader className="bg-background sticky top-0 z-30 border-b">
+        <div className="bg-background sticky top-0 z-30">
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
-              {headerGroup.headers.map((header) => (
-                <TableHead
-                  className={cn(
-                    "group/table-head bg-background hover:bg-background relative h-10 border-t px-0",
-                    header.column.getIsResizing() &&
-                      "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
-                  )}
-                  colSpan={header.colSpan}
-                  key={header.id}
-                  style={{
-                    ...getPinningStyles(header.column),
-                  }}
-                >
-                  {header.isPlaceholder
-                    ? null
-                    : flexRender(
-                        header.column.columnDef.header,
-                        header.getContext(),
-                      )}
-                  {header.column.getCanResize() && (
-                    <button
-                      className="user-select-none absolute top-0 -right-2 z-30 hidden h-full w-4 cursor-col-resize touch-none py-1 group-hover/table-head:flex"
-                      onDoubleClick={() => header.column.resetSize()}
-                      onMouseDown={header.getResizeHandler()}
-                      onTouchStart={header.getResizeHandler()}
-                      type="button"
-                    >
-                      <span className="bg-primary/25 mr-auto h-full w-1 rounded" />
-                    </button>
-                  )}
-                </TableHead>
-              ))}
-            </TableRow>
-          ))}
-        </TableHeader>
-        <TableBody>
-          {paddingTop > 0 && (
-            <TableRow aria-hidden="true">
-              <TableCell
-                colSpan={visibleColumnCount}
-                style={{ height: paddingTop, padding: 0 }}
+            <WorkspaceGridRow key={headerGroup.id}>
+              {getOrderedHeaders(headerGroup.headers, renderColumns).map(
+                (header, index) => (
+                  <DraggableHeaderCell
+                    addColumnHovered={isAddColumnHovered}
+                    header={header}
+                    index={index}
+                    key={header.id}
+                    onAddColumnHoverChange={setIsAddColumnHovered}
+                    onToggleSelectAll={handleToggleSelectAll}
+                    selectAllState={selectAllState}
+                  />
+                ),
+              )}
+              <WorkspaceGridHead
+                aria-hidden="true"
+                className="border-e-0"
+                role="presentation"
               />
-            </TableRow>
+            </WorkspaceGridRow>
+          ))}
+        </div>
+        <div>
+          {paddingTop > 0 && (
+            <WorkspaceGridRow aria-hidden="true">
+              <WorkspaceGridFillerCell
+                className="border-b-0"
+                style={{
+                  gridColumn: "1 / -1",
+                  height: paddingTop,
+                }}
+              />
+            </WorkspaceGridRow>
           )}
           {virtualRows.map((virtualRow) => {
             const row = rowModel.rows.at(virtualRow.index);
@@ -243,10 +446,14 @@ export const WorkspaceTable = ({
               <DraggableRow
                 activeEntityId={activeEntityId}
                 activeTaskId={activeTaskId}
+                addColumnHoverRowId={addColumnHoverRowId}
+                addColumnHovered={isAddColumnHovered}
                 editingEntityId={editingEntityId}
+                expanded={expandedTableRowEntityId === row.original.entityId}
                 index={virtualRow.index}
                 key={row.id}
                 lastSelectedIndex={lastSelectedIndex}
+                measureElement={rowVirtualizer.measureElement}
                 onRename={(entityId, newName) => {
                   renameEntity.mutate({
                     workspaceId,
@@ -256,29 +463,364 @@ export const WorkspaceTable = ({
                 }}
                 onStartEditing={setEditingEntityId}
                 onStopEditing={() => setEditingEntityId(null)}
+                onAddColumnHoverChange={(hovered) => {
+                  setIsAddColumnHovered(hovered);
+                  setAddColumnHoverRowId(hovered ? row.id : null);
+                }}
+                onToggleExpanded={(entityId) => {
+                  setExpandedTableRowEntityId(
+                    expandedTableRowEntityId === entityId ? null : entityId,
+                  );
+                }}
                 row={row}
                 rowLabel={rowLabels[virtualRow.index] ?? ""}
+                renderColumns={renderColumns}
                 table={table}
+                virtualIndex={virtualRow.index}
                 workspaceId={workspaceId}
               />
             );
           })}
           {paddingBottom > 0 && (
-            <TableRow aria-hidden="true">
-              <TableCell
-                colSpan={visibleColumnCount}
-                style={{ height: paddingBottom, padding: 0 }}
+            <WorkspaceGridRow aria-hidden="true">
+              <WorkspaceGridFillerCell
+                className="border-b-0"
+                style={{
+                  gridColumn: "1 / -1",
+                  height: paddingBottom,
+                }}
               />
-            </TableRow>
+            </WorkspaceGridRow>
           )}
           <BottomRow
             onFolderCreated={setEditingEntityId}
             table={table}
             workspaceId={workspaceId}
           />
-        </TableBody>
-      </Table>
+        </div>
+      </div>
     </div>
+  );
+};
+
+type DraggableHeaderCellProps = {
+  header: Header<TableTreeNode, unknown>;
+  index: number;
+  addColumnHovered: boolean;
+  onAddColumnHoverChange: (hovered: boolean) => void;
+  onToggleSelectAll: () => void;
+  selectAllState: SelectAllState;
+};
+
+const DraggableHeaderCell = ({
+  header,
+  index,
+  addColumnHovered,
+  onAddColumnHoverChange,
+  onToggleSelectAll,
+  selectAllState,
+}: DraggableHeaderCellProps) => {
+  const headerRef = useRef<HTMLDivElement>(null);
+  const dragHandleRef = useRef<HTMLDivElement>(null);
+  const [closestEdge, setClosestEdge] = useState<ColumnDropEdge | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const canReorderColumn =
+    !header.isPlaceholder &&
+    header.column.id !== selectColId &&
+    header.column.id !== addPropertyColId;
+  const isAddPropertyColumn = header.column.id === addPropertyColId;
+  const pinning = getColumnPinningGroup(header.column);
+
+  useEffect(() => {
+    const element = headerRef.current;
+    const dragHandle = dragHandleRef.current;
+    if (!element) {
+      return undefined;
+    }
+
+    const cleanups = [
+      dropTargetForElements({
+        element,
+        canDrop: ({ source }) => {
+          const dragData = getColumnDragData(source.data);
+          return Boolean(
+            canReorderColumn &&
+            dragData &&
+            dragData.columnId !== header.column.id &&
+            dragData.pinning === pinning,
+          );
+        },
+        getData: ({ input, element: targetElement }) =>
+          attachClosestEdge(
+            {
+              columnId: header.column.id,
+              pinning,
+            },
+            {
+              input,
+              element: targetElement,
+              allowedEdges: ["left", "right"],
+            },
+          ),
+        onDragEnter: ({ self, source }) => {
+          const dragData = getColumnDragData(source.data);
+          if (!dragData || dragData.columnId === header.column.id) {
+            return;
+          }
+          setClosestEdge(toColumnDropEdge(extractClosestEdge(self.data)));
+        },
+        onDrag: ({ self, source }) => {
+          const dragData = getColumnDragData(source.data);
+          if (!dragData || dragData.columnId === header.column.id) {
+            return;
+          }
+          const nextEdge = toColumnDropEdge(extractClosestEdge(self.data));
+          setClosestEdge((prev) => (prev === nextEdge ? prev : nextEdge));
+        },
+        onDragLeave: () => setClosestEdge(null),
+        onDrop: () => setClosestEdge(null),
+      }),
+    ];
+
+    if (canReorderColumn && dragHandle) {
+      cleanups.push(
+        draggable({
+          element,
+          dragHandle,
+          getInitialData: (): ColumnDragData => ({
+            type: TABLE_COLUMN_DRAG_TYPE,
+            columnId: header.column.id,
+            pinning,
+          }),
+          onDragStart: () => setIsDragging(true),
+          onDrop: () => setIsDragging(false),
+        }),
+      );
+    }
+
+    return combine(...cleanups);
+  }, [canReorderColumn, header.column, pinning]);
+
+  return (
+    <WorkspaceGridHead
+      aria-colindex={index + 1}
+      className={cn(
+        "relative",
+        isAddPropertyColumn && "border-s",
+        isDragging && "opacity-50",
+        closestEdge && "overflow-visible",
+        header.column.getIsResizing() &&
+          "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
+      )}
+      ref={headerRef}
+      onPointerEnter={
+        isAddPropertyColumn ? () => onAddColumnHoverChange(true) : undefined
+      }
+      onPointerDown={
+        isAddPropertyColumn ? () => onAddColumnHoverChange(false) : undefined
+      }
+      onPointerLeave={
+        isAddPropertyColumn ? () => onAddColumnHoverChange(false) : undefined
+      }
+      style={{
+        ...getGridPinningStyles(header.column),
+        ...getAddColumnHoverStyles(isAddPropertyColumn && addColumnHovered),
+      }}
+    >
+      <PinnedBoundary column={header.column} />
+      {closestEdge && !isDragging && (
+        <span
+          className={cn(
+            "bg-primary pointer-events-none absolute inset-y-1 z-50 w-0.5 rounded-full",
+            closestEdge === "left" ? "left-0" : "right-0",
+          )}
+        />
+      )}
+      {canReorderColumn && (
+        <div
+          aria-hidden="true"
+          className="text-muted-foreground hover:text-foreground border-border/70 bg-background/95 absolute top-1/2 left-2 z-40 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded border opacity-0 shadow-sm transition-opacity group-hover/table-head:opacity-100 active:cursor-grabbing"
+          data-row-expansion-ignore
+          ref={dragHandleRef}
+        >
+          <GripVerticalIcon className="size-3.5" />
+        </div>
+      )}
+      {header.column.id === selectColId ? (
+        <SelectAllHeader onToggle={onToggleSelectAll} state={selectAllState} />
+      ) : header.isPlaceholder ? null : (
+        flexRender(header.column.columnDef.header, header.getContext())
+      )}
+      {header.column.getCanResize() && (
+        <button
+          className="user-select-none absolute top-0 -right-2 z-30 hidden h-full w-4 cursor-col-resize touch-none py-1 group-hover/table-head:flex"
+          data-row-expansion-ignore
+          onDoubleClick={() => header.column.resetSize()}
+          onMouseDown={header.getResizeHandler()}
+          onTouchStart={header.getResizeHandler()}
+          type="button"
+        >
+          <span className="bg-primary/25 mr-auto h-full w-1 rounded" />
+        </button>
+      )}
+    </WorkspaceGridHead>
+  );
+};
+
+const getOrderedHeaders = (
+  headers: Header<TableTreeNode, unknown>[],
+  columns: Column<TableTreeNode>[],
+) => {
+  const headersByColumnId = new Map(
+    headers.map((header) => [header.column.id, header]),
+  );
+  const orderedHeaders: Header<TableTreeNode, unknown>[] = [];
+
+  for (const column of columns) {
+    const header = headersByColumnId.get(column.id);
+    if (header) {
+      orderedHeaders.push(header);
+    }
+  }
+
+  return orderedHeaders;
+};
+
+type SelectAllHeaderProps = {
+  state: SelectAllState;
+  onToggle: () => void;
+};
+
+const SelectAllHeader = ({ state, onToggle }: SelectAllHeaderProps) => {
+  const ariaChecked = state.indeterminate ? "mixed" : state.checked;
+
+  return (
+    <div className="flex items-center justify-center">
+      <button
+        aria-checked={ariaChecked}
+        className={cn(
+          "ring-ring focus-visible:ring-offset-background inline-flex size-4 shrink-0 items-center justify-center rounded-[4px] border shadow-xs/5 transition-shadow outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
+          (state.checked || state.indeterminate) &&
+            "bg-primary border-primary text-primary-foreground shadow-none",
+          !(state.checked || state.indeterminate) &&
+            "border-input bg-background",
+        )}
+        data-select-all-state={state.key}
+        onClick={onToggle}
+        // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
+        role="checkbox"
+        type="button"
+      >
+        {state.indeterminate ? (
+          <MinusIcon className="size-3" strokeWidth={3} />
+        ) : state.checked ? (
+          <CheckIcon className="size-3" strokeWidth={3} />
+        ) : null}
+      </button>
+    </div>
+  );
+};
+
+const getGridPinningStyles = (column: Column<TableTreeNode>): CSSProperties => {
+  if (column.id === addPropertyColId) {
+    return {
+      position: "sticky",
+      right: 0,
+      zIndex: 2,
+    };
+  }
+
+  const isLeftPinned = column.getIsPinned() === "left";
+  if (!isLeftPinned) {
+    return {};
+  }
+
+  return {
+    left: `${column.getStart("left")}px`,
+    position: "sticky",
+    zIndex: column.id === selectColId ? 3 : 2,
+  };
+};
+
+const getAddColumnHoverStyles = (hovered: boolean): CSSProperties => {
+  if (!hovered) {
+    return {};
+  }
+
+  return {
+    backgroundColor: ADD_COLUMN_HOVER_COLOR,
+    borderBottomColor: ADD_COLUMN_HOVER_COLOR,
+  };
+};
+
+type PinnedBoundaryProps = {
+  column: Column<TableTreeNode>;
+};
+
+const PinnedBoundary = ({ column }: PinnedBoundaryProps) => {
+  const isLeftPinned = column.getIsPinned() === "left";
+  const isLastLeftPinned = isLeftPinned && column.getIsLastColumn("left");
+  if (!isLastLeftPinned || column.id === selectColId) {
+    return null;
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-y-0 right-0 z-40 w-1"
+    >
+      <span className="bg-border absolute inset-y-0 left-0 w-px" />
+      <span className="bg-border absolute inset-y-0 right-0 w-px" />
+    </span>
+  );
+};
+
+const getColumnPinningGroup = (
+  column: Column<TableTreeNode>,
+): ColumnDragPinning => {
+  const pinning = column.getIsPinned();
+  if (pinning === "left" || pinning === "right") {
+    return pinning;
+  }
+
+  return "center";
+};
+
+const getColumnDragData = (
+  data: Record<string | symbol, unknown>,
+): ColumnDragData | null => {
+  const type = data["type"];
+  const columnId = data["columnId"];
+  const pinning = data["pinning"];
+
+  if (
+    type === TABLE_COLUMN_DRAG_TYPE &&
+    typeof columnId === "string" &&
+    (pinning === "left" || pinning === "right" || pinning === "center")
+  ) {
+    return { type, columnId, pinning };
+  }
+
+  return null;
+};
+
+const toColumnDropEdge = (edge: Edge | null): ColumnDropEdge | null => {
+  if (edge === "left" || edge === "right") {
+    return edge;
+  }
+
+  return null;
+};
+
+const shouldIgnoreRowExpansionClick = (target: EventTarget) => {
+  if (!(target instanceof HTMLElement)) {
+    return true;
+  }
+
+  return Boolean(
+    target.closest(
+      "button, a, input, textarea, select, [role='button'], [role='checkbox'], [data-row-expansion-ignore], [data-slot='select-trigger']",
+    ),
   );
 };
 
@@ -286,34 +828,57 @@ export const WorkspaceTable = ({
 
 type DraggableRowProps = {
   row: Row<TableTreeNode>;
+  virtualIndex: number;
   index: number;
   rowLabel: string;
+  renderColumns: Column<TableTreeNode>[];
   table: WorkspaceTableType;
   workspaceId: string;
   activeEntityId: string | null;
   activeTaskId: string | null;
+  addColumnHoverRowId: string | null;
+  addColumnHovered: boolean;
   editingEntityId: string | null;
+  expanded: boolean;
   lastSelectedIndex: React.RefObject<number | null>;
+  measureElement: (element: Element | null) => void;
+  onAddColumnHoverChange: (hovered: boolean) => void;
   onRename: (entityId: string, newName: string) => void;
   onStartEditing: (entityId: string) => void;
   onStopEditing: () => void;
+  onToggleExpanded: (entityId: string) => void;
 };
 
 const DraggableRow = ({
   row,
+  virtualIndex,
   index,
   rowLabel,
+  renderColumns,
   table,
   workspaceId,
   activeEntityId,
   activeTaskId,
+  addColumnHoverRowId,
+  addColumnHovered,
   editingEntityId,
+  expanded,
   lastSelectedIndex,
+  measureElement,
+  onAddColumnHoverChange,
   onRename,
   onStartEditing,
   onStopEditing,
+  onToggleExpanded,
 }: DraggableRowProps) => {
-  const rowRef = useRef<HTMLTableRowElement>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const setRowRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      rowRef.current = element;
+      measureElement(element);
+    },
+    [measureElement],
+  );
   const bulkEntitiesRef = useRef<TableTreeNode[] | undefined>(undefined);
   const [contextOpen, setContextOpen] = useState(false);
   const [contextAnchor, setContextAnchor] = useState<VirtualAnchor | null>(
@@ -324,7 +889,8 @@ const DraggableRow = ({
   useInspectorFlash(entity.entityId, rowRef);
   const isFolder = entity.kind === "folder";
   const isTask = entity.kind === "task";
-  const visibleCells = row.getVisibleCells();
+  const isAddColumnHoverRow = addColumnHoverRowId === row.id;
+  const visibleCells = getOrderedCells(row.getVisibleCells(), renderColumns);
   const name = getEntityName(entity);
   const file = getFirstFile(entity);
 
@@ -344,6 +910,21 @@ const DraggableRow = ({
       getBoundingClientRect: () => new DOMRect(e.clientX, e.clientY, 0, 0),
     });
     setContextOpen(true);
+  };
+
+  const handleRowClick = (e: React.MouseEvent) => {
+    if (shouldIgnoreRowExpansionClick(e.target)) {
+      return;
+    }
+
+    if (isTask) {
+      useInspectorStore.getState().openTask(entity.entityId, name);
+      return;
+    }
+
+    if (!isFolder) {
+      onToggleExpanded(entity.entityId);
+    }
   };
 
   const selectCellContent = (
@@ -390,6 +971,12 @@ const DraggableRow = ({
   );
 
   useEffect(() => {
+    if (rowRef.current) {
+      measureElement(rowRef.current);
+    }
+  }, [expanded, measureElement]);
+
+  useEffect(() => {
     const el = rowRef.current;
     if (!el) {
       return undefined;
@@ -428,37 +1015,44 @@ const DraggableRow = ({
   if (isFolder && visibleCells.length > 2) {
     const selectCell = visibleCells[0];
     const nameCell = visibleCells[1];
+    const addPropertyCell = visibleCells.find(
+      (cell) => cell.column.id === addPropertyColId,
+    );
     if (!selectCell || !nameCell) {
       return null;
     }
-    const remainingCount = visibleCells.length - 2;
-
     return (
-      <TableRow
+      <WorkspaceGridRow
+        aria-rowindex={virtualIndex + 2}
+        aria-selected={row.getIsSelected()}
         data-active={entity.entityId === activeEntityId || undefined}
         data-state={row.getIsSelected() ? "selected" : undefined}
         key={row.id}
         onContextMenu={handleContextMenu}
-        ref={rowRef}
+        ref={setRowRef}
       >
-        <TableCell
+        <WorkspaceGridCell
+          aria-colindex={1}
           data-state={row.getIsSelected() ? "selected" : undefined}
           key={selectCell.id}
           style={{
-            ...getPinningStyles(selectCell.column),
+            ...getGridPinningStyles(selectCell.column),
           }}
         >
+          <PinnedBoundary column={selectCell.column} />
           {selectCellWithActions}
-        </TableCell>
-        <TableCell
+        </WorkspaceGridCell>
+        <WorkspaceGridCell
+          aria-colindex={2}
           className="cursor-pointer"
           data-state={row.getIsSelected() ? "selected" : undefined}
           key={nameCell.id}
           onClick={() => row.toggleExpanded()}
           style={{
-            ...getPinningStyles(nameCell.column),
+            ...getGridPinningStyles(nameCell.column),
           }}
         >
+          <PinnedBoundary column={nameCell.column} />
           <FolderCell
             depth={row.depth}
             editingEntityId={editingEntityId}
@@ -468,22 +1062,35 @@ const DraggableRow = ({
             onStopEditing={onStopEditing}
             startEditing={() => onStartEditing(entity.entityId)}
           />
-        </TableCell>
-        {remainingCount > 0 && (
-          <TableCell
-            className="cursor-pointer"
-            colSpan={remainingCount}
-            data-state={row.getIsSelected() ? "selected" : undefined}
-            onClick={() => row.toggleExpanded()}
-          />
-        )}
-      </TableRow>
+        </WorkspaceGridCell>
+        <WorkspaceGridCell
+          aria-colindex={3}
+          className="cursor-pointer border-e-0"
+          data-state={row.getIsSelected() ? "selected" : undefined}
+          onClick={() => row.toggleExpanded()}
+          style={{ gridColumn: addPropertyCell ? "3 / -3" : "3 / -1" }}
+        />
+        <FolderAddPropertyCell
+          addColumnHovered={addColumnHovered}
+          cell={addPropertyCell}
+          columnIndex={
+            visibleCells.findIndex(
+              (cell) => cell.column.id === addPropertyColId,
+            ) + 1
+          }
+          onAddColumnHoverChange={onAddColumnHoverChange}
+          selected={row.getIsSelected()}
+        />
+      </WorkspaceGridRow>
     );
   }
 
   return (
-    <TableRow
-      className={cn(isTask && "cursor-pointer")}
+    <WorkspaceGridRow
+      aria-expanded={expanded}
+      aria-rowindex={virtualIndex + 2}
+      aria-selected={row.getIsSelected()}
+      className={cn((isTask || !isFolder) && "cursor-pointer")}
       data-active={
         entity.entityId === activeEntityId ||
         entity.entityId === activeTaskId ||
@@ -491,29 +1098,51 @@ const DraggableRow = ({
       }
       data-state={row.getIsSelected() ? "selected" : undefined}
       key={row.id}
-      onClick={
-        isTask
-          ? () => useInspectorStore.getState().openTask(entity.entityId, name)
-          : undefined
-      }
+      onClick={handleRowClick}
       onContextMenu={handleContextMenu}
-      ref={rowRef}
+      ref={setRowRef}
     >
-      {visibleCells.map((cell) => (
-        <TableCell
+      {visibleCells.map((cell, cellIndex) => (
+        <WorkspaceGridCell
+          aria-colindex={cellIndex + 1}
           className={cn(
             "relative",
+            isAddColumnHoverRow && "group-hover/row:bg-background",
             cell.column.id === selectColId && "min-w-12 shrink-0",
+            cell.column.id === addPropertyColId &&
+              "group-hover/row:bg-background border-s border-e-0 p-0",
             cell.column.columnDef.meta?.muted && "text-muted-foreground",
+            expanded &&
+              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:overflow-visible [&_.truncate]:whitespace-normal",
             cell.column.getIsResizing() &&
               "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
           )}
           data-state={cell.row.getIsSelected() ? "selected" : undefined}
           key={cell.id}
+          onPointerEnter={
+            cell.column.id === addPropertyColId
+              ? () => onAddColumnHoverChange(true)
+              : undefined
+          }
+          onPointerDown={
+            cell.column.id === addPropertyColId
+              ? () => onAddColumnHoverChange(false)
+              : undefined
+          }
+          onPointerLeave={
+            cell.column.id === addPropertyColId
+              ? () => onAddColumnHoverChange(false)
+              : undefined
+          }
           style={{
-            ...getPinningStyles(cell.column),
+            ...getGridPinningStyles(cell.column),
+            ...getAddColumnHoverStyles(
+              cell.column.id === addPropertyColId && addColumnHovered,
+            ),
+            maxHeight: expanded ? EXPANDED_ROW_MAX_HEIGHT_PX : undefined,
           }}
         >
+          <PinnedBoundary column={cell.column} />
           {cell.column.id === selectColId ? (
             selectCellWithActions
           ) : (
@@ -521,9 +1150,50 @@ const DraggableRow = ({
               {flexRender(cell.column.columnDef.cell, cell.getContext())}
             </span>
           )}
-        </TableCell>
+        </WorkspaceGridCell>
       ))}
-    </TableRow>
+      <WorkspaceGridFillerCell />
+    </WorkspaceGridRow>
+  );
+};
+
+type FolderAddPropertyCellProps = {
+  cell: Cell<TableTreeNode, unknown> | undefined;
+  columnIndex: number;
+  selected: boolean;
+  addColumnHovered: boolean;
+  onAddColumnHoverChange: (hovered: boolean) => void;
+};
+
+const FolderAddPropertyCell = ({
+  cell,
+  columnIndex,
+  selected,
+  addColumnHovered,
+  onAddColumnHoverChange,
+}: FolderAddPropertyCellProps) => {
+  if (!cell) {
+    return null;
+  }
+
+  return (
+    <>
+      <WorkspaceGridCell
+        aria-colindex={columnIndex}
+        className={cn("group-hover/row:bg-background border-s border-e-0 p-0")}
+        data-state={selected ? "selected" : undefined}
+        onPointerEnter={() => onAddColumnHoverChange(true)}
+        onPointerDown={() => onAddColumnHoverChange(false)}
+        onPointerLeave={() => onAddColumnHoverChange(false)}
+        style={{
+          ...getGridPinningStyles(cell.column),
+          ...getAddColumnHoverStyles(addColumnHovered),
+        }}
+      >
+        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+      </WorkspaceGridCell>
+      <WorkspaceGridFillerCell />
+    </>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -345,6 +345,7 @@ export const WorkspaceTable = ({
         onDrag: ({ source, location }) => {
           const target = location.current.dropTargets.at(0);
           if (!target) {
+            lastColumnDropPosition.current = null;
             return;
           }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -271,6 +271,29 @@ export const WorkspaceTable = ({
   );
   const handleColumnReorder = useCallback(
     (sourceId: string, targetId: string, edge: ColumnDropEdge) => {
+      const sourceColumn = table.getColumn(sourceId);
+      const targetColumn = table.getColumn(targetId);
+      if (!sourceColumn || !targetColumn) {
+        return;
+      }
+
+      const pinning = getColumnPinningGroup(sourceColumn);
+      if (
+        pinning !== "center" &&
+        pinning === getColumnPinningGroup(targetColumn)
+      ) {
+        table.setColumnPinning((prev) => ({
+          ...prev,
+          [pinning]: reorderColumnIds({
+            ids: prev[pinning] ?? [],
+            sourceId,
+            targetId,
+            edge,
+          }),
+        }));
+        return;
+      }
+
       const currentVisibleIds = orderedColumns.map((column) => column.id);
       const reorderedVisibleIds = reorderColumnIds({
         ids: currentVisibleIds,
@@ -671,7 +694,7 @@ const DraggableHeaderCell = ({
       {canReorderColumn && (
         <div
           aria-hidden="true"
-          className="text-muted-foreground hover:text-foreground border-border/70 bg-background/95 absolute top-1/2 left-2 z-40 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded border opacity-0 shadow-sm transition-opacity group-hover/table-head:opacity-100 active:cursor-grabbing"
+          className="text-muted-foreground hover:text-foreground border-border/70 bg-background absolute top-1/2 left-2 z-40 flex size-5 -translate-y-1/2 cursor-grab items-center justify-center rounded border opacity-0 shadow-sm transition-opacity group-hover/table-head:opacity-100 active:cursor-grabbing"
           data-row-expansion-ignore
           ref={dragHandleRef}
         >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -240,13 +240,18 @@ export const WorkspaceTable = ({
   const paddingTop = virtualRows.at(0)?.start ?? 0;
   const paddingBottom =
     rowVirtualizer.getTotalSize() - (virtualRows.at(-1)?.end ?? 0);
-  const renderColumns = getOrderedColumns({
+  const orderedColumns = getOrderedColumns({
     leftColumns: table.getLeftLeafColumns(),
     centerColumns: table.getCenterLeafColumns(),
     rightColumns: table.getRightLeafColumns(),
   });
-  const visibleColumnCount = renderColumns.length;
-  const tableWidth = renderColumns.reduce(
+  const addPropertyColumn =
+    orderedColumns.find((column) => column.id === addPropertyColId) ?? null;
+  const renderColumns = orderedColumns.filter(
+    (column) => column.id !== addPropertyColId,
+  );
+  const visibleColumnCount = renderColumns.length + (addPropertyColumn ? 1 : 0);
+  const tableWidth = orderedColumns.reduce(
     (sum, column) => sum + column.getSize(),
     0,
   );
@@ -256,6 +261,7 @@ export const WorkspaceTable = ({
     "--workspace-table-columns": getGridTemplateColumns(
       renderColumns,
       trailingFillerWidth,
+      addPropertyColumn ? [addPropertyColumn] : [],
     ),
     minWidth: tableWidth + trailingFillerWidth,
   };
@@ -265,7 +271,7 @@ export const WorkspaceTable = ({
   );
   const handleColumnReorder = useCallback(
     (sourceId: string, targetId: string, edge: ColumnDropEdge) => {
-      const currentVisibleIds = renderColumns.map((column) => column.id);
+      const currentVisibleIds = orderedColumns.map((column) => column.id);
       const reorderedVisibleIds = reorderColumnIds({
         ids: currentVisibleIds,
         sourceId,
@@ -280,7 +286,7 @@ export const WorkspaceTable = ({
 
       table.setColumnOrder([...reorderedVisibleIds, ...hiddenIds]);
     },
-    [renderColumns, table],
+    [orderedColumns, table],
   );
 
   useEffect(() => {
@@ -421,6 +427,19 @@ export const WorkspaceTable = ({
                 className="border-e-0"
                 role="presentation"
               />
+              {addPropertyColumn && (
+                <DraggableHeaderCell
+                  addColumnHovered={isAddColumnHovered}
+                  header={getRequiredHeader(
+                    headerGroup.headers,
+                    addPropertyColumn.id,
+                  )}
+                  index={renderColumns.length}
+                  onAddColumnHoverChange={setIsAddColumnHovered}
+                  onToggleSelectAll={handleToggleSelectAll}
+                  selectAllState={selectAllState}
+                />
+              )}
             </WorkspaceGridRow>
           ))}
         </div>
@@ -430,10 +449,16 @@ export const WorkspaceTable = ({
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
-                  gridColumn: "1 / -1",
+                  gridColumn: addPropertyColumn ? "1 / -2" : "1 / -1",
                   height: paddingTop,
                 }}
               />
+              {addPropertyColumn && (
+                <AddPropertyRailSpacer
+                  addColumnHovered={isAddColumnHovered}
+                  height={paddingTop}
+                />
+              )}
             </WorkspaceGridRow>
           )}
           {virtualRows.map((virtualRow) => {
@@ -472,6 +497,7 @@ export const WorkspaceTable = ({
                     expandedTableRowEntityId === entityId ? null : entityId,
                   );
                 }}
+                addPropertyColumn={addPropertyColumn}
                 row={row}
                 rowLabel={rowLabels[virtualRow.index] ?? ""}
                 renderColumns={renderColumns}
@@ -486,10 +512,16 @@ export const WorkspaceTable = ({
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
-                  gridColumn: "1 / -1",
+                  gridColumn: addPropertyColumn ? "1 / -2" : "1 / -1",
                   height: paddingBottom,
                 }}
               />
+              {addPropertyColumn && (
+                <AddPropertyRailSpacer
+                  addColumnHovered={isAddColumnHovered}
+                  height={paddingBottom}
+                />
+              )}
             </WorkspaceGridRow>
           )}
           <BottomRow
@@ -686,6 +718,18 @@ const getOrderedHeaders = (
   return orderedHeaders;
 };
 
+const getRequiredHeader = (
+  headers: Header<TableTreeNode, unknown>[],
+  columnId: string,
+) => {
+  const header = headers.find((candidate) => candidate.column.id === columnId);
+  if (!header) {
+    throw new Error(`Missing header for workspace table column "${columnId}"`);
+  }
+
+  return header;
+};
+
 type SelectAllHeaderProps = {
   state: SelectAllState;
   onToggle: () => void;
@@ -832,6 +876,7 @@ type DraggableRowProps = {
   index: number;
   rowLabel: string;
   renderColumns: Column<TableTreeNode>[];
+  addPropertyColumn: Column<TableTreeNode> | null;
   table: WorkspaceTableType;
   workspaceId: string;
   activeEntityId: string | null;
@@ -855,6 +900,7 @@ const DraggableRow = ({
   index,
   rowLabel,
   renderColumns,
+  addPropertyColumn,
   table,
   workspaceId,
   activeEntityId,
@@ -891,6 +937,11 @@ const DraggableRow = ({
   const isTask = entity.kind === "task";
   const isAddColumnHoverRow = addColumnHoverRowId === row.id;
   const visibleCells = getOrderedCells(row.getVisibleCells(), renderColumns);
+  const addPropertyCell = addPropertyColumn
+    ? row
+        .getVisibleCells()
+        .find((cell) => cell.column.id === addPropertyColumn.id)
+    : undefined;
   const name = getEntityName(entity);
   const file = getFirstFile(entity);
 
@@ -1015,9 +1066,6 @@ const DraggableRow = ({
   if (isFolder && visibleCells.length > 2) {
     const selectCell = visibleCells[0];
     const nameCell = visibleCells[1];
-    const addPropertyCell = visibleCells.find(
-      (cell) => cell.column.id === addPropertyColId,
-    );
     if (!selectCell || !nameCell) {
       return null;
     }
@@ -1069,16 +1117,12 @@ const DraggableRow = ({
           className="cursor-pointer border-e-0"
           data-state={row.getIsSelected() ? "selected" : undefined}
           onClick={() => row.toggleExpanded()}
-          style={{ gridColumn: addPropertyCell ? "3 / -3" : "3 / -1" }}
+          style={{ gridColumn: addPropertyCell ? "3 / -2" : "3 / -1" }}
         />
         <FolderAddPropertyCell
           addColumnHovered={addColumnHovered}
           cell={addPropertyCell}
-          columnIndex={
-            visibleCells.findIndex(
-              (cell) => cell.column.id === addPropertyColId,
-            ) + 1
-          }
+          columnIndex={renderColumns.length + 1}
           onAddColumnHoverChange={onAddColumnHoverChange}
           selected={row.getIsSelected()}
         />
@@ -1111,8 +1155,6 @@ const DraggableRow = ({
             "relative",
             isAddColumnHoverRow && "group-hover/row:bg-background",
             cell.column.id === selectColId && "min-w-12 shrink-0",
-            cell.column.id === addPropertyColId &&
-              "group-hover/row:bg-background border-s border-e-0 p-0",
             cell.column.columnDef.meta?.muted && "text-muted-foreground",
             expanded &&
               "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:overflow-visible [&_.truncate]:whitespace-normal",
@@ -1154,7 +1196,16 @@ const DraggableRow = ({
           )}
         </WorkspaceGridCell>
       ))}
-      <WorkspaceGridFillerCell />
+      <WorkspaceGridFillerCell
+        className={cn(isAddColumnHoverRow && "group-hover/row:bg-background")}
+      />
+      <AddPropertyCell
+        addColumnHovered={addColumnHovered}
+        cell={addPropertyCell}
+        columnIndex={renderColumns.length + 1}
+        onAddColumnHoverChange={onAddColumnHoverChange}
+        selected={row.getIsSelected()}
+      />
     </WorkspaceGridRow>
   );
 };
@@ -1173,31 +1224,68 @@ const FolderAddPropertyCell = ({
   selected,
   addColumnHovered,
   onAddColumnHoverChange,
+}: FolderAddPropertyCellProps) => (
+  <AddPropertyCell
+    addColumnHovered={addColumnHovered}
+    cell={cell}
+    columnIndex={columnIndex}
+    onAddColumnHoverChange={onAddColumnHoverChange}
+    selected={selected}
+  />
+);
+
+const AddPropertyCell = ({
+  cell,
+  columnIndex,
+  selected,
+  addColumnHovered,
+  onAddColumnHoverChange,
 }: FolderAddPropertyCellProps) => {
   if (!cell) {
     return null;
   }
 
   return (
-    <>
-      <WorkspaceGridCell
-        aria-colindex={columnIndex}
-        className={cn("group-hover/row:bg-background border-s border-e-0 p-0")}
-        data-state={selected ? "selected" : undefined}
-        onPointerEnter={() => onAddColumnHoverChange(true)}
-        onPointerDown={() => onAddColumnHoverChange(false)}
-        onPointerLeave={() => onAddColumnHoverChange(false)}
-        style={{
-          ...getGridPinningStyles(cell.column),
-          ...getAddColumnHoverStyles(addColumnHovered),
-        }}
-      >
-        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-      </WorkspaceGridCell>
-      <WorkspaceGridFillerCell />
-    </>
+    <WorkspaceGridCell
+      aria-colindex={columnIndex}
+      className="group-hover/row:bg-background group-data-[state=selected]/row:bg-background group-data-[state=selected]/row:group-hover/row:bg-background border-s p-0"
+      data-state={selected ? "selected" : undefined}
+      onPointerEnter={() => onAddColumnHoverChange(true)}
+      onPointerDown={() => onAddColumnHoverChange(false)}
+      onPointerLeave={() => onAddColumnHoverChange(false)}
+      style={{
+        ...getGridPinningStyles(cell.column),
+        ...getAddColumnHoverStyles(addColumnHovered),
+      }}
+    >
+      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+    </WorkspaceGridCell>
   );
 };
+
+type AddPropertyRailSpacerProps = {
+  addColumnHovered: boolean;
+  height: number;
+};
+
+const AddPropertyRailSpacer = ({
+  addColumnHovered,
+  height,
+}: AddPropertyRailSpacerProps) => (
+  <WorkspaceGridCell
+    aria-hidden="true"
+    className="group-hover/row:bg-background border-s border-b-0 p-0"
+    role="presentation"
+    style={{
+      gridColumn: "-2 / -1",
+      height,
+      position: "sticky",
+      right: 0,
+      zIndex: 2,
+      ...getAddColumnHoverStyles(addColumnHovered),
+    }}
+  />
+);
 
 // -- Select row content --
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 
 import type {
+  ColumnOrderState,
   ColumnPinningState,
   ColumnSizingState,
   OnChangeFn,
@@ -18,6 +19,7 @@ import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-u
 
 const EMPTY_ROW_SELECTION: RowSelectionState = {};
 const selectColId = getInternalColId("select");
+const addPropertyColId = getInternalColId("add-property");
 const COLUMN_SIZING_DEBOUNCE_MS = 100;
 
 type UseTableStateProps = {
@@ -73,16 +75,37 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
   };
 
   const columnPinning: ColumnPinningState = {
-    left: [selectColId, ...view.layout.columnPinning],
+    left: [
+      selectColId,
+      ...view.layout.columnPinning.filter((id) => id !== addPropertyColId),
+    ],
   };
 
   const onColumnPinningChange: OnChangeFn<ColumnPinningState> = (updater) => {
     const data =
       typeof updater === "function" ? updater(columnPinning) : updater;
-    const pinned = (data.left ?? []).filter((id) => id !== selectColId);
+    const pinned = (data.left ?? []).filter(
+      (id) => id !== selectColId && id !== addPropertyColId,
+    );
     updateView.mutate({
       viewId,
       layout: { ...view.layout, columnPinning: pinned },
+    });
+  };
+
+  const columnOrder = useMemo<ColumnOrderState>(
+    () => [selectColId, ...view.layout.columnOrder],
+    [view.layout.columnOrder],
+  );
+
+  const onColumnOrderChange: OnChangeFn<ColumnOrderState> = (updater) => {
+    const data = typeof updater === "function" ? updater(columnOrder) : updater;
+    const order = data.filter(
+      (id) => id !== selectColId && id !== addPropertyColId,
+    );
+    updateView.mutate({
+      viewId,
+      layout: { ...view.layout, columnOrder: order },
     });
   };
 
@@ -123,6 +146,7 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
     view,
     state: {
       columnSizing,
+      columnOrder,
       columnPinning,
       columnVisibility,
       sorting,
@@ -130,6 +154,7 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
     },
     listeners: {
       onColumnSizingChange,
+      onColumnOrderChange,
       onColumnPinningChange,
       onColumnVisibilityChange,
       onSortingChange,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
@@ -30,6 +30,7 @@ type State = {
   pdfViewer: PdfViewerState;
   folderState: FolderState;
   filesystemSelectedIds: Set<string>;
+  expandedTableRowEntityId: string | null;
 };
 
 type Actions = {
@@ -56,6 +57,7 @@ type Actions = {
   toggleAllFolders: () => void;
   setFilesystemSelectedIds: (selectedIds: Set<string>) => void;
   clearFilesystemSelectedIds: () => void;
+  setExpandedTableRowEntityId: (entityId: string | null) => void;
 };
 
 const initialPdfViewerState = (): PdfViewerState => ({
@@ -78,6 +80,7 @@ export const useWorkspaceStore = create<State & Actions>()(
       toggleVersion: 0,
     },
     filesystemSelectedIds: new Set(),
+    expandedTableRowEntityId: null,
 
     syncJustifications: (justifications) =>
       set((state) => {
@@ -177,6 +180,10 @@ export const useWorkspaceStore = create<State & Actions>()(
     clearFilesystemSelectedIds: () =>
       set((state) => {
         state.filesystemSelectedIds = new Set();
+      }),
+    setExpandedTableRowEntityId: (entityId) =>
+      set((state) => {
+        state.expandedTableRowEntityId = entityId;
       }),
   })),
 );


### PR DESCRIPTION
## Summary
- Replace the workspace table renderer with CSS-grid rows/cells for deterministic column sizing, sticky pinned columns, and a trailing filler track.
- Add column drag-and-drop, default file-column pinning for newly seeded table views, click-to-expand rows, sticky add-column behavior, and focused unit tests for select-all and grid ordering logic.
- Stabilize API tests with a preload test env and remove a process-wide entity-query module mock from `read.test.ts`.

## Test plan
- `bun run lint && bun run format && bun run typecheck && bun run test`
- Pre-push hook: lint, typecheck, i18n, and format checks passed.

## Security review
- Reviewed changed handlers and table UI paths for ownership/auth bypasses, secret leakage, and unsafe client-side data handling. No critical or high findings found.
- `bun pm scan` is unavailable because no security scanner is configured in `bunfig.toml`; Dependabot alerts API reports alerts disabled or inaccessible for this repository.
