### PR TITLE
chore(release-desktop): staple notarization ticket to DMG

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -351,6 +351,25 @@ jobs:
           printf '%s' "$APPLE_API_KEY_BASE64" | base64 -d > "$APPLE_API_KEY_PATH"
           bun run build -- --target ${{ matrix.target }} --bundles dmg,updater
 
+      # Tauri's bundler staples notarization to the .app inside the
+      # DMG, but not to the DMG itself. Without this step, users on
+      # a cold network on first launch hit a Gatekeeper online
+      # check and may see a "verifying" delay or unsigned warning
+      # if the check fails. Stapling the DMG embeds the notarization
+      # ticket so launch is offline-instant.
+      - name: Staple notarization ticket to DMG
+        if: matrix.os == 'macos'
+        working-directory: apps/desktop
+        shell: bash
+        run: |
+          bundle_dir="src-tauri/target/${{ matrix.target }}/release/bundle"
+          for dmg in "$bundle_dir"/dmg/*.dmg; do
+            [[ -f "$dmg" ]] || continue
+            echo "Stapling $dmg"
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+          done
+
       - name: Rename artifacts to stable, version-less filenames
         # Tauri produces version-stamped names like
         # `Stella_0.0.1_x64-setup.exe`. We collapse them into stable


### PR DESCRIPTION
Tauri 2's bundler staples the notarization ticket to the inner \`.app\` after notarization, but not to the wrapper \`.dmg\`. Without an explicit staple on the DMG, users on a cold network on first launch hit a Gatekeeper online check — they see a "verifying" delay, or an unsigned-app warning if the check times out.

Add an \`xcrun stapler staple\` + \`stapler validate\` step on every DMG produced by the macOS leg.

## Test plan
- [ ] After merge, the next desktop build's macOS job logs include \`Stapling stella desktop_<v>_universal.dmg\` followed by \`The validate action worked!\`
- [ ] Manually verify on the produced DMG: \`stapler validate /path/to.dmg\` returns \`The validate action worked!\`