### PR TITLE
chore(desktop): proper build via tauri cli

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -228,14 +228,6 @@ jobs:
         with:
           workspaces: apps/desktop/src-tauri -> target
 
-      # The `bun run build` script in apps/desktop is `cargo tauri
-      # build`, which needs the cargo-tauri subcommand on PATH. Not
-      # in the workspace as an npm dep, install via cargo so the
-      # build invocation works on every runner.
-      - name: Install Tauri CLI
-        shell: bash
-        run: cargo install tauri-cli --version "^2.0.0" --locked
-
       - name: Stamp release version into tauri.conf.json + Cargo.toml
         shell: bash
         env:
@@ -265,10 +257,34 @@ jobs:
       # .msi.zip the updater downloads wrap signed binaries. The
       # post-build Azure step below stays as a safety net for any
       # loose artifact the bundler doesn't run signCommand against.
+      # baptiste0928/cargo-install caches ~/.cargo/bin/<binary>
+      # keyed on tool + version + runner image, so subsequent runs
+      # short-circuit the ~5 min source compile.
       - name: Install trusted-signing-cli (Windows only)
         if: matrix.os == 'windows'
+        uses: baptiste0928/cargo-install@916aa2c680eb54f322199a9756e0699f98f10638 # v3.4.0
+        with:
+          crate: trusted-signing-cli
+          version: "0.10.0"
+          locked: true
+
+      # Tauri spawns bundle.windows.signCommand directly (no shell),
+      # so %VAR%-style env interpolation isn't applied — placeholders
+      # arrive at trusted-signing-cli as literal strings and the auth
+      # call fails. Substitute the values at build time so the spawned
+      # process gets the real endpoint/account/profile.
+      - name: Inline Azure values into bundle.windows.signCommand
+        if: matrix.os == 'windows'
         shell: bash
-        run: cargo install trusted-signing-cli --version 0.10.0 --locked
+        env:
+          AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
+          AZURE_CODE_SIGNING_ACCOUNT: ${{ secrets.AZURE_CODE_SIGNING_ACCOUNT }}
+          AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
+        run: |
+          conf=apps/desktop/src-tauri/tauri.conf.json
+          cmd="trusted-signing-cli -e $AZURE_ENDPOINT -a $AZURE_CODE_SIGNING_ACCOUNT -c $AZURE_CERT_PROFILE -d \"Stella desktop\" %1"
+          jq --arg c "$cmd" '.bundle.windows.signCommand = $c' "$conf" > "$conf.tmp"
+          mv "$conf.tmp" "$conf"
 
       - name: Build (Windows)
         if: matrix.os == 'windows'
@@ -351,21 +367,31 @@ jobs:
           printf '%s' "$APPLE_API_KEY_BASE64" | base64 -d > "$APPLE_API_KEY_PATH"
           bun run build -- --target ${{ matrix.target }} --bundles dmg,updater
 
-      # Tauri's bundler staples notarization to the .app inside the
-      # DMG, but not to the DMG itself. Without this step, users on
-      # a cold network on first launch hit a Gatekeeper online
-      # check and may see a "verifying" delay or unsigned warning
-      # if the check fails. Stapling the DMG embeds the notarization
-      # ticket so launch is offline-instant.
-      - name: Staple notarization ticket to DMG
+      # Tauri 2's bundler notarizes + staples the inner .app but
+      # leaves the DMG wrapper unnotarized (tauri-apps/tauri#7533,
+      # PR #15118 still open). Submit the DMG ourselves and staple
+      # the resulting ticket so users on a cold network at first
+      # mount don't hit Apple's online Gatekeeper check.
+      - name: Notarize and staple DMG
         if: matrix.os == 'macos'
         working-directory: apps/desktop
+        env:
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_KEY_BASE64: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: ${{ runner.temp }}/apple-api.p8
         shell: bash
         run: |
+          printf '%s' "$APPLE_API_KEY_BASE64" | base64 -d > "$APPLE_API_KEY_PATH"
           bundle_dir="src-tauri/target/${{ matrix.target }}/release/bundle"
           for dmg in "$bundle_dir"/dmg/*.dmg; do
             [[ -f "$dmg" ]] || continue
-            echo "Stapling $dmg"
+            echo "Notarizing $dmg"
+            xcrun notarytool submit "$dmg" \
+              --key      "$APPLE_API_KEY_PATH" \
+              --key-id   "$APPLE_API_KEY_ID" \
+              --issuer   "$APPLE_API_ISSUER" \
+              --wait --timeout 30m
             xcrun stapler staple "$dmg"
             xcrun stapler validate "$dmg"
           done

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,10 +5,10 @@
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
-    "build": "cargo tauri build",
+    "build": "tauri build",
     "build:view": "vite build",
     "clean": "git clean -xdf .cache .turbo dist node_modules src-tauri/target",
-    "dev": "cargo tauri dev",
+    "dev": "tauri dev",
     "dev:view": "vite --host 127.0.0.1 --strictPort",
     "format": "oxfmt -c ../../.oxfmtrc.json .",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware apps/desktop",
@@ -26,6 +26,7 @@
   "devDependencies": {
     "@stll/typescript-config": "workspace:*",
     "@tailwindcss/vite": "catalog:",
+    "@tauri-apps/cli": "^2.0.0",
     "@types/react": "catalog:react19",
     "@types/react-dom": "catalog:react19",
     "@vitejs/plugin-react": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,7 @@
       "devDependencies": {
         "@stll/typescript-config": "workspace:*",
         "@tailwindcss/vite": "catalog:",
+        "@tauri-apps/cli": "^2.0.0",
         "@types/react": "catalog:react19",
         "@types/react-dom": "catalog:react19",
         "@vitejs/plugin-react": "catalog:",
@@ -1699,6 +1700,30 @@
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
     "@tauri-apps/api": ["@tauri-apps/api@2.10.1", "", {}, "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw=="],
+
+    "@tauri-apps/cli": ["@tauri-apps/cli@2.10.1", "", { "optionalDependencies": { "@tauri-apps/cli-darwin-arm64": "2.10.1", "@tauri-apps/cli-darwin-x64": "2.10.1", "@tauri-apps/cli-linux-arm-gnueabihf": "2.10.1", "@tauri-apps/cli-linux-arm64-gnu": "2.10.1", "@tauri-apps/cli-linux-arm64-musl": "2.10.1", "@tauri-apps/cli-linux-riscv64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-gnu": "2.10.1", "@tauri-apps/cli-linux-x64-musl": "2.10.1", "@tauri-apps/cli-win32-arm64-msvc": "2.10.1", "@tauri-apps/cli-win32-ia32-msvc": "2.10.1", "@tauri-apps/cli-win32-x64-msvc": "2.10.1" }, "bin": { "tauri": "tauri.js" } }, "sha512-jQNGF/5quwORdZSSLtTluyKQ+o6SMa/AUICfhf4egCGFdMHqWssApVgYSbg+jmrZoc8e1DscNvjTnXtlHLS11g=="],
+
+    "@tauri-apps/cli-darwin-arm64": ["@tauri-apps/cli-darwin-arm64@2.10.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2OjCXiZ+fbYZy7PmP3WRnOpM9+Fy+oonKDEmUE6MwN4IGaYqgceTjwHucc/kEEYZos5GICve35f7ZiizgqEnQ=="],
+
+    "@tauri-apps/cli-darwin-x64": ["@tauri-apps/cli-darwin-x64@2.10.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-V/irQVvjPMGOTQqNj55PnQPVuH4VJP8vZCN7ajnj+ZS8Kom1tEM2hR3qbbIRoS3dBKs5mbG8yg1WC+97dq17Pw=="],
+
+    "@tauri-apps/cli-linux-arm-gnueabihf": ["@tauri-apps/cli-linux-arm-gnueabihf@2.10.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Hyzwsb4VnCWKGfTw+wSt15Z2pLw2f0JdFBfq2vHBOBhvg7oi6uhKiF87hmbXOBXUZaGkyRDkCHsdzJcIfoJC2w=="],
+
+    "@tauri-apps/cli-linux-arm64-gnu": ["@tauri-apps/cli-linux-arm64-gnu@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-OyOYs2t5GkBIvyWjA1+h4CZxTcdz1OZPCWAPz5DYEfB0cnWHERTnQ/SLayQzncrT0kwRoSfSz9KxenkyJoTelA=="],
+
+    "@tauri-apps/cli-linux-arm64-musl": ["@tauri-apps/cli-linux-arm64-musl@2.10.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-MIj78PDDGjkg3NqGptDOGgfXks7SYJwhiMh8SBoZS+vfdz7yP5jN18bNaLnDhsVIPARcAhE1TlsZe/8Yxo2zqg=="],
+
+    "@tauri-apps/cli-linux-riscv64-gnu": ["@tauri-apps/cli-linux-riscv64-gnu@2.10.1", "", { "os": "linux", "cpu": "none" }, "sha512-X0lvOVUg8PCVaoEtEAnpxmnkwlE1gcMDTqfhbefICKDnOTJ5Est3qL0SrWxizDackIOKBcvtpejrSiVpuJI1kw=="],
+
+    "@tauri-apps/cli-linux-x64-gnu": ["@tauri-apps/cli-linux-x64-gnu@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-2/12bEzsJS9fAKybxgicCDFxYD1WEI9kO+tlDwX5znWG2GwMBaiWcmhGlZ8fi+DMe9CXlcVarMTYc0L3REIRxw=="],
+
+    "@tauri-apps/cli-linux-x64-musl": ["@tauri-apps/cli-linux-x64-musl@2.10.1", "", { "os": "linux", "cpu": "x64" }, "sha512-Y8J0ZzswPz50UcGOFuXGEMrxbjwKSPgXftx5qnkuMs2rmwQB5ssvLb6tn54wDSYxe7S6vlLob9vt0VKuNOaCIQ=="],
+
+    "@tauri-apps/cli-win32-arm64-msvc": ["@tauri-apps/cli-win32-arm64-msvc@2.10.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-iSt5B86jHYAPJa/IlYw++SXtFPGnWtFJriHn7X0NFBVunF6zu9+/zOn8OgqIWSl8RgzhLGXQEEtGBdR4wzpVgg=="],
+
+    "@tauri-apps/cli-win32-ia32-msvc": ["@tauri-apps/cli-win32-ia32-msvc@2.10.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-gXyxgEzsFegmnWywYU5pEBURkcFN/Oo45EAwvZrHMh+zUSEAvO5E8TXsgPADYm31d1u7OQU3O3HsYfVBf2moHw=="],
+
+    "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.10.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6Cn7YpPFwzChy0ERz6djKEmUehWrYlM+xTaNzGPgZocw3BD7OfwfWHKVWxXzdjEW2KfKkHddfdxK1XXTYqBRLg=="],
 
     "@tiptap/core": ["@tiptap/core@3.22.3", "", { "peerDependencies": { "@tiptap/pm": "^3.22.3" } }, "sha512-Dv9MKK5BDWCF0N2l6/Pxv3JNCce2kwuWf2cKMBc2bEetx0Pn6o7zlFmSxMvYK4UtG1Tw9Yg/ZHi6QOFWK0Zm9Q=="],
 


### PR DESCRIPTION
Cleanup pass on the desktop release pipeline.

- Tauri CLI from npm via `@tauri-apps/cli`; drop the in-CI `cargo install`.
- Cache `trusted-signing-cli` builds.
- Notarize + staple the DMG ourselves (Tauri 2 doesn't, see [tauri#7533](https://github.com/tauri-apps/tauri/issues/7533)).
- Inline Azure endpoint/account/profile into the Windows `signCommand` at build time.