### PR TITLE
chore: update landing community CTA

### DIFF
--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -5,6 +5,8 @@ import ProductShowcase from "../components/react/ProductShowcase";
 import { controlCapabilities } from "../data/capabilities";
 
 const appUrl = "https://my.stll.app";
+const discordUrl = "https://discord.gg/8dZjmVFjTK";
+const githubUrl = "https://github.com/stella/stella";
 const selfHostingDocsUrl =
   "https://github.com/stella/stella/blob/main/apps/docs/src/content/docs/guides/self-hosting.md";
 ---
@@ -52,6 +54,27 @@ const selfHostingDocsUrl =
           <ThemeToggle />
         </div>
       </nav>
+
+      <a
+        id="github-stars-banner"
+        href={githubUrl}
+        class="relative z-10 mx-auto mt-2 inline-flex max-w-[calc(100%-3rem)] items-center gap-3 rounded-full px-4 py-2 text-sm font-medium shadow-sm transition-[border-color,opacity,transform] hover:-translate-y-0.5 hover:opacity-90"
+        style="background: color-mix(in srgb, var(--card) 88%, transparent); border: 1px solid var(--border); color: var(--foreground); backdrop-filter: blur(14px)"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="stella on GitHub"
+      >
+        <svg
+          class="h-4 w-4 shrink-0"
+          fill="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          ><path
+            d="M12 .5C5.648.5.5 5.648.5 12a11.5 11.5 0 008.073 10.95c.59.11.805-.257.805-.57 0-.281-.01-1.024-.016-2.01-3.282.713-3.975-1.582-3.975-1.582-.536-1.362-1.31-1.725-1.31-1.725-1.072-.733.081-.718.081-.718 1.186.083 1.81 1.218 1.81 1.218 1.054 1.806 2.766 1.284 3.44.982.107-.764.413-1.285.752-1.58-2.62-.298-5.377-1.31-5.377-5.829 0-1.287.46-2.34 1.216-3.166-.122-.298-.527-1.5.116-3.126 0 0 .992-.317 3.25 1.209A11.33 11.33 0 0112 6.227c1.02.005 2.047.138 3.007.404 2.257-1.526 3.247-1.209 3.247-1.209.645 1.626.24 2.828.118 3.126.759.826 1.214 1.879 1.214 3.166 0 4.53-2.76 5.527-5.387 5.819.424.365.801 1.084.801 2.185 0 1.577-.014 2.85-.014 3.238 0 .316.212.686.81.569A11.502 11.502 0 0023.5 12C23.5 5.648 18.352.5 12 .5z"
+          ></path></svg
+        >
+        <span class="min-w-0 truncate">stella is open source</span>
+      </a>
 
       <div
         class="relative z-10 flex flex-1 flex-col items-center justify-center px-6 pb-16"
@@ -190,7 +213,6 @@ const selfHostingDocsUrl =
                   "Run on your infrastructure",
                   "Full source access",
                   "AGPL\u20113.0 license",
-                  "Currently in beta demo",
                 ],
               },
               {
@@ -314,7 +336,7 @@ const selfHostingDocsUrl =
             >
               Start with a single click.
               <br />
-              Bring us in when you need rollout help.
+              Need help? Join the community.
             </h2>
           </div>
 
@@ -327,11 +349,13 @@ const selfHostingDocsUrl =
               Start free
             </a>
             <a
-              href="mailto:contact@stll.app?subject=stella%20walkthrough"
+              href={discordUrl}
               class="inline-flex h-11 items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium transition-colors whitespace-nowrap"
               style="background: var(--background); border: 1px solid var(--border); color: var(--foreground)"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              Talk to us
+              Join our community
             </a>
           </div>
         </div>
@@ -352,13 +376,13 @@ const selfHostingDocsUrl =
           aria-label="Footer"
         >
           <a
-            href="https://github.com/stella/stella"
+            href={githubUrl}
             class="transition-opacity hover:opacity-70"
             target="_blank"
             rel="noopener noreferrer">GitHub</a
           >
           <a
-            href="https://discord.gg/8dZjmVFjTK"
+            href={discordUrl}
             class="transition-opacity hover:opacity-70"
             target="_blank"
             rel="noopener noreferrer">Discord</a
@@ -377,7 +401,7 @@ const selfHostingDocsUrl =
         </nav>
         <div class="flex items-center gap-4" aria-label="Social">
           <a
-            href="https://github.com/stella/stella"
+            href={githubUrl}
             class="transition-opacity hover:opacity-70"
             style="color: var(--muted-foreground)"
             target="_blank"
@@ -391,7 +415,7 @@ const selfHostingDocsUrl =
             >
           </a>
           <a
-            href="https://discord.gg/8dZjmVFjTK"
+            href={discordUrl}
             class="transition-opacity hover:opacity-70"
             style="color: var(--muted-foreground)"
             target="_blank"

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -350,7 +350,7 @@ const selfHostingDocsUrl =
             </a>
             <a
               href={discordUrl}
-              class="inline-flex h-11 items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium transition-colors whitespace-nowrap"
+              class="inline-flex h-11 items-center justify-center rounded-[0.85rem] px-5 text-sm font-medium transition-opacity hover:opacity-90 whitespace-nowrap"
               style="background: var(--background); border: 1px solid var(--border); color: var(--foreground)"
               target="_blank"
               rel="noopener noreferrer"


### PR DESCRIPTION
## Summary
- add a compact GitHub banner to the landing hero
- route the community CTA to Discord
- remove repeated beta-demo copy from the self-host option

## Checks
- bun --filter @stll/landing typecheck
- bun --filter @stll/landing build
- bun run lint && bun run format && bun run typecheck: passed before tests
- bun run test: failed in @stll/api on existing main-branch API test failures unrelated to this landing-only change

## Security
- Changed external links use rel="noopener noreferrer".
- No API calls, secrets, auth, storage, or data-access paths changed.
- Dependency scanner is not configured in bunfig.toml; Dependabot alerts are disabled for this repository.