### PR TITLE
fix: surface BYOK setup for AI actions

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -658,7 +658,11 @@ const FileChatOverlayInner = ({
     streamdownComponents,
     approvalPendingMessageId,
   } = useChatSession({ chat, threadRef, workspaceId });
-  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { ensureAIAvailable, openIfAIUnavailable } = useAIKeyGate();
+
+  useEffect(() => {
+    openIfAIUnavailable();
+  }, [openIfAIUnavailable]);
 
   const filePlaceholder =
     activeFile === undefined
@@ -808,8 +812,8 @@ const FileChatOverlayInner = ({
         onStop={() => {
           void stop();
         }}
-        onSubmit={({ prompt }) => {
-          if (!ensureAIAvailable()) {
+        onSubmit={async ({ prompt }) => {
+          if (!(await ensureAIAvailable())) {
             return;
           }
           // Always pop the thread open on send, even if the user
@@ -829,7 +833,6 @@ const FileChatOverlayInner = ({
         showThreadToggle={hasMessages}
         status={isGenerating ? "generating" : "idle"}
       />
-      {byokDialog}
     </>
   );
 };

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -52,6 +52,7 @@ import type {
   ApprovalToolName,
   PersistedChatMessage,
 } from "@/components/chat/chat-ui-tools";
+import { useAIKeyGate } from "@/components/require-ai-key";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
@@ -657,6 +658,7 @@ const FileChatOverlayInner = ({
     streamdownComponents,
     approvalPendingMessageId,
   } = useChatSession({ chat, threadRef, workspaceId });
+  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
 
   const filePlaceholder =
     activeFile === undefined
@@ -807,6 +809,9 @@ const FileChatOverlayInner = ({
           void stop();
         }}
         onSubmit={({ prompt }) => {
+          if (!ensureAIAvailable()) {
+            return;
+          }
           // Always pop the thread open on send, even if the user
           // minimised it earlier — they're sending a new prompt
           // and want to see the response stream in.
@@ -824,6 +829,7 @@ const FileChatOverlayInner = ({
         showThreadToggle={hasMessages}
         status={isGenerating ? "generating" : "idle"}
       />
+      {byokDialog}
     </>
   );
 };

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -812,15 +812,17 @@ const FileChatOverlayInner = ({
         onStop={() => {
           void stop();
         }}
-        onSubmit={async ({ prompt }) => {
-          if (!(await ensureAIAvailable())) {
-            return;
-          }
-          // Always pop the thread open on send, even if the user
-          // minimised it earlier — they're sending a new prompt
-          // and want to see the response stream in.
-          setPanelOpen(true);
-          void sendMessage({ text: prompt });
+        onSubmit={({ prompt }) => {
+          void ensureAIAvailable().then((available) => {
+            if (!available) {
+              return;
+            }
+            // Always pop the thread open on send, even if the user
+            // minimised it earlier — they're sending a new prompt
+            // and want to see the response stream in.
+            setPanelOpen(true);
+            void sendMessage({ text: prompt });
+          });
         }}
         onTogglePanel={() => setPanelOpen((v) => !v)}
         panelOpen={panelOpen}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -799,21 +799,23 @@ export function AppSidebar(props: AppSidebarProps) {
         void navigate({ to: "/knowledge" });
       },
       contextMenu: {
-        recents: knowledgeSections
-          .filter(
-            (s): s is typeof s & { to: NonNullable<typeof s.to> } =>
-              s.to !== undefined,
-          )
-          .map((s) => {
-            const Icon = s.icon;
-            return {
-              label: t(`knowledge.sections.${s.key}.title`),
-              icon: <Icon />,
-              onClick: () => {
+        recents: knowledgeSections.map((s) => {
+          const Icon = s.icon;
+          return {
+            label: t(`knowledge.sections.${s.key}.title`),
+            icon: <Icon />,
+            onClick: () => {
+              if (s.to) {
                 void navigate({ to: s.to });
-              },
-            };
-          }),
+                return;
+              }
+              toastManager.add({
+                title: t("common.comingSoon"),
+                type: "foreground",
+              });
+            },
+          };
+        }),
       },
     },
     {

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -1,5 +1,12 @@
 import type { PropsWithChildren } from "react";
-import { useCallback, useEffect, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -57,24 +64,70 @@ const API_KEY_PLACEHOLDER = {
   openai_compatible: "sk-...",
 } as const satisfies Record<ProviderValue, string>;
 
-let openGlobalAIKeyDialog: (() => void) | null = null;
-
-export const openAIKeyRequiredDialog = () => {
-  openGlobalAIKeyDialog?.();
+type AIAvailabilityContextValue = {
+  ensureAIAvailable: () => Promise<boolean>;
+  openAIKeyDialog: () => void;
+  openIfAIUnavailable: () => void;
 };
 
-export function AIKeyRequiredDialogHost() {
-  const [open, setOpen] = useState(false);
+const AIAvailabilityContext = createContext<AIAvailabilityContextValue | null>(
+  null,
+);
 
-  useEffect(() => {
-    openGlobalAIKeyDialog = () => setOpen(true);
-    return () => {
-      openGlobalAIKeyDialog = null;
-    };
+export function AIAvailabilityProvider({ children }: PropsWithChildren) {
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+  const { data } = useQuery(aiAvailabilityOptions);
+
+  const openAIKeyDialog = useCallback(() => {
+    setOpen(true);
   }, []);
 
-  return <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />;
+  const ensureAIAvailable = useCallback(async () => {
+    const availability = await queryClient
+      .ensureQueryData(aiAvailabilityOptions)
+      .catch(() => undefined);
+
+    if (availability?.available) {
+      return true;
+    }
+
+    setOpen(true);
+    return false;
+  }, [queryClient]);
+
+  const openIfAIUnavailable = useCallback(() => {
+    if (data && !data.available) {
+      setOpen(true);
+    }
+  }, [data]);
+
+  const value = useMemo(
+    () => ({
+      ensureAIAvailable,
+      openAIKeyDialog,
+      openIfAIUnavailable,
+    }),
+    [ensureAIAvailable, openAIKeyDialog, openIfAIUnavailable],
+  );
+
+  return (
+    <AIAvailabilityContext.Provider value={value}>
+      {children}
+      <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />
+    </AIAvailabilityContext.Provider>
+  );
 }
+
+export const useAIKeyGate = () => {
+  const context = useContext(AIAvailabilityContext);
+
+  if (!context) {
+    throw new Error("useAIKeyGate must be used within AIAvailabilityProvider");
+  }
+
+  return context;
+};
 
 /**
  * Whether AI features are available right now: either the org has
@@ -88,26 +141,6 @@ export function useAIAvailable(): boolean {
   return data.available;
 }
 
-export const useAIKeyGate = () => {
-  const [open, setOpen] = useState(false);
-  const { data } = useQuery(aiAvailabilityOptions);
-
-  const ensureAIAvailable = useCallback(() => {
-    if (data?.available) {
-      return true;
-    }
-
-    setOpen(true);
-    return false;
-  }, [data?.available]);
-
-  return {
-    ensureAIAvailable,
-    byokDialog: <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />,
-    openAIKeyDialog: () => setOpen(true),
-  };
-};
-
 /**
  * Gate AI routes when the instance has no provisioned keys and
  * the org has not supplied their own. Send-time surfaces should
@@ -116,7 +149,11 @@ export const useAIKeyGate = () => {
 export function RequireAIKey({ children }: PropsWithChildren) {
   const t = useTranslations();
   const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
-  const { byokDialog, openAIKeyDialog } = useAIKeyGate();
+  const { openAIKeyDialog, openIfAIUnavailable } = useAIKeyGate();
+
+  useEffect(() => {
+    openIfAIUnavailable();
+  }, [openIfAIUnavailable]);
 
   if (isPending) {
     return null;
@@ -147,7 +184,6 @@ export function RequireAIKey({ children }: PropsWithChildren) {
           </Button>
         </div>
       </div>
-      {byokDialog}
     </div>
   );
 }

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -1,19 +1,84 @@
 import type { PropsWithChildren } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@stll/ui/components/button";
-import { useQuery } from "@tanstack/react-query";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { Field, FieldLabel } from "@stll/ui/components/field";
+import { Input } from "@stll/ui/components/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { toastManager } from "@stll/ui/components/toast";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
-import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
+import { useAnalytics } from "@/lib/analytics/provider";
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import {
+  aiAvailabilityOptions,
+  aiConfigKeys,
+} from "@/routes/_protected.organization/-ai-config-queries";
+
+const PROVIDER_KEYS = [
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+  "openai_compatible",
+] as const;
+
+const REGION_KEYS = ["global", "eu", "ch"] as const;
+
+type ProviderValue = (typeof PROVIDER_KEYS)[number];
+type RegionValue = (typeof REGION_KEYS)[number];
+
+const REGIONAL_PROVIDERS = new Set<ProviderValue>(["google"]);
+
+const API_KEY_PLACEHOLDER = {
+  google: "AIza...",
+  openrouter: "sk-or-v1-...",
+  openai: "sk-proj-...",
+  anthropic: "sk-ant-...",
+  openai_compatible: "sk-...",
+} as const satisfies Record<ProviderValue, string>;
+
+let openGlobalAIKeyDialog: (() => void) | null = null;
+
+export const openAIKeyRequiredDialog = () => {
+  openGlobalAIKeyDialog?.();
+};
+
+export function AIKeyRequiredDialogHost() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    openGlobalAIKeyDialog = () => setOpen(true);
+    return () => {
+      openGlobalAIKeyDialog = null;
+    };
+  }, []);
+
+  return <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />;
+}
 
 /**
  * Whether AI features are available right now: either the org has
- * BYOK or the instance has provisioned keys. Defaults to false
- * during the initial fetch and on query errors so AI affordances
- * (buttons, dialogs) stay disabled until availability is confirmed,
- * avoiding bait-and-switch where a click fires a request the
- * backend will 403.
+ * BYOK or the instance has provisioned keys.
  */
 export function useAIAvailable(): boolean {
   const { data, isError } = useQuery(aiAvailabilityOptions);
@@ -23,16 +88,35 @@ export function useAIAvailable(): boolean {
   return data.available;
 }
 
+export const useAIKeyGate = () => {
+  const [open, setOpen] = useState(false);
+  const { data } = useQuery(aiAvailabilityOptions);
+
+  const ensureAIAvailable = useCallback(() => {
+    if (data?.available) {
+      return true;
+    }
+
+    setOpen(true);
+    return false;
+  }, [data?.available]);
+
+  return {
+    ensureAIAvailable,
+    byokDialog: <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />,
+    openAIKeyDialog: () => setOpen(true),
+  };
+};
+
 /**
- * Gate AI features when the instance has no provisioned keys
- * and the org has not supplied their own. Renders children when
- * either is available; renders nothing while the availability
- * check is pending so users do not see a flash of AI UI before
- * being gated.
+ * Gate AI routes when the instance has no provisioned keys and
+ * the org has not supplied their own. Send-time surfaces should
+ * use `useAIKeyGate()` so every AI action opens the same dialog.
  */
 export function RequireAIKey({ children }: PropsWithChildren) {
   const t = useTranslations();
   const { data, isPending, isError } = useQuery(aiAvailabilityOptions);
+  const { byokDialog, openAIKeyDialog } = useAIKeyGate();
 
   if (isPending) {
     return null;
@@ -53,13 +137,192 @@ export function RequireAIKey({ children }: PropsWithChildren) {
             {t("ai.keyRequired.description")}
           </p>
         </div>
-        <Button
-          className="self-start"
-          render={<Link to="/settings/organization/ai" />}
-        >
-          {t("ai.keyRequired.cta")}
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button onClick={openAIKeyDialog}>{t("ai.keyRequired.cta")}</Button>
+          <Button
+            render={<Link to="/settings/organization/ai" />}
+            variant="ghost"
+          >
+            {t("organization.aiConfig.title")}
+          </Button>
+        </div>
       </div>
+      {byokDialog}
     </div>
   );
 }
+
+type AIKeyRequiredDialogProps = {
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+};
+
+export function AIKeyRequiredDialog({
+  onOpenChange,
+  open,
+}: AIKeyRequiredDialogProps) {
+  const t = useTranslations();
+  const tCommon = useTranslations("common");
+  const tOrganization = useTranslations("organization");
+  const tErrors = useTranslations("errors");
+  const tSuccess = useTranslations("success");
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+  const [provider, setProvider] = useState<ProviderValue>("google");
+  const [apiKey, setApiKey] = useState("");
+  const [baseURL, setBaseURL] = useState("");
+  const [region, setRegion] = useState<RegionValue>("global");
+
+  useEffect(() => {
+    if (!REGIONAL_PROVIDERS.has(provider)) {
+      setRegion("global");
+    }
+  }, [provider]);
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api["organization-settings"]["ai-config"].post({
+        provider,
+        apiKey,
+        ...(provider === "openai_compatible" ? { baseURL } : {}),
+        overrideRoles: [],
+        region,
+      });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+    onSuccess: async () => {
+      setApiKey("");
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: aiConfigKeys.all }),
+        queryClient.invalidateQueries({ queryKey: aiConfigKeys.availability }),
+      ]);
+      toastManager.add({
+        title: tSuccess("aiConfigUpdated"),
+        type: "success",
+      });
+      onOpenChange(false);
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+      toastManager.add({
+        title: error instanceof Error ? error.message : tErrors("actionFailed"),
+        type: "error",
+      });
+    },
+  });
+
+  const needsBaseURL = provider === "openai_compatible";
+  const canSave: boolean =
+    apiKey.trim().length > 0 && (!needsBaseURL || baseURL.trim().length > 0);
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogPopup className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("ai.keyRequired.title")}</DialogTitle>
+          <DialogDescription>
+            {t("ai.keyRequired.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel className="grid gap-4">
+          <Field>
+            <FieldLabel>{tOrganization("aiConfig.provider")}</FieldLabel>
+            <Select
+              onValueChange={(value) => {
+                if (isProviderValue(value)) {
+                  setProvider(value);
+                }
+              }}
+              value={provider}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup alignItemWithTrigger={false}>
+                {PROVIDER_KEYS.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {tOrganization(`aiConfig.providers.${key}`)}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          </Field>
+
+          <Field>
+            <FieldLabel>{tOrganization("aiConfig.apiKey")}</FieldLabel>
+            <Input
+              autoComplete="off"
+              onChange={(event) => setApiKey(event.target.value)}
+              placeholder={API_KEY_PLACEHOLDER[provider]}
+              type="password"
+              value={apiKey}
+            />
+          </Field>
+
+          {needsBaseURL && (
+            <Field>
+              <FieldLabel>{tOrganization("aiConfig.baseUrl")}</FieldLabel>
+              <Input
+                onChange={(event) => setBaseURL(event.target.value)}
+                placeholder="https://api.example.com/v1"
+                value={baseURL}
+              />
+            </Field>
+          )}
+
+          <Field>
+            <FieldLabel>{tOrganization("aiConfig.dataRegion")}</FieldLabel>
+            <Select
+              disabled={!REGIONAL_PROVIDERS.has(provider)}
+              onValueChange={(value) => {
+                if (isRegionValue(value)) {
+                  setRegion(value);
+                }
+              }}
+              value={region}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup alignItemWithTrigger={false}>
+                {REGION_KEYS.map((key) => (
+                  <SelectItem key={key} value={key}>
+                    {tOrganization(`aiConfig.regions.${key}`)}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+            <p className="text-muted-foreground text-xs">
+              {REGIONAL_PROVIDERS.has(provider)
+                ? tOrganization("aiConfig.dataRegionDescription")
+                : tOrganization("aiConfig.dataRegionUnsupported")}
+            </p>
+          </Field>
+        </DialogPanel>
+        <DialogFooter>
+          <DialogClose render={<Button variant="ghost" />}>
+            {tCommon("cancel")}
+          </DialogClose>
+          <Button
+            disabled={!canSave}
+            loading={saveMutation.isPending}
+            onClick={() => saveMutation.mutate()}
+          >
+            {tOrganization("aiConfig.configure")}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+}
+
+const isProviderValue = (value: string | null): value is ProviderValue =>
+  value !== null && PROVIDER_KEYS.some((key) => key === value);
+
+const isRegionValue = (value: string | null): value is RegionValue =>
+  value !== null && REGION_KEYS.some((key) => key === value);

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -15,6 +15,7 @@ import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
+import { useAIKeyGate } from "@/components/require-ai-key";
 import Tooltip from "@/components/tooltip";
 import {
   useChatAnonymized,
@@ -43,6 +44,7 @@ export const ChatThreadPage = ({
   workspaceId,
 }: ChatThreadPageProps) => {
   const t = useTranslations();
+  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
   const userContext = useChatUserContext();
   const getUserContext = useEffectEvent(() => userContext);
   const showToolCalls = useDevStore((state) => state.showToolCalls);
@@ -217,9 +219,13 @@ export const ChatThreadPage = ({
             void stop();
           }}
           onSubmit={async (draft) => {
+            if (!ensureAIAvailable()) {
+              return;
+            }
             await sendMessage(await buildChatRequestMessage(draft));
           }}
         />
+        {byokDialog}
       </div>
     </div>
   );

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -44,7 +44,7 @@ export const ChatThreadPage = ({
   workspaceId,
 }: ChatThreadPageProps) => {
   const t = useTranslations();
-  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { ensureAIAvailable } = useAIKeyGate();
   const userContext = useChatUserContext();
   const getUserContext = useEffectEvent(() => userContext);
   const showToolCalls = useDevStore((state) => state.showToolCalls);
@@ -219,13 +219,12 @@ export const ChatThreadPage = ({
             void stop();
           }}
           onSubmit={async (draft) => {
-            if (!ensureAIAvailable()) {
+            if (!(await ensureAIAvailable())) {
               return;
             }
             await sendMessage(await buildChatRequestMessage(draft));
           }}
         />
-        {byokDialog}
       </div>
     </div>
   );

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -10,6 +10,7 @@ import { v7 as uuidv7 } from "uuid";
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
+import { useAIKeyGate } from "@/components/require-ai-key";
 import Tooltip from "@/components/tooltip";
 import {
   getChatAnonymized,
@@ -34,6 +35,7 @@ export const Route = createFileRoute("/_protected/chat/")({
 
 function ChatIndex() {
   const t = useTranslations();
+  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const userContext = useChatUserContext();
@@ -78,6 +80,9 @@ function ChatIndex() {
             autoFocus
             controller={controller}
             onSubmit={async (draft) => {
+              if (!ensureAIAvailable()) {
+                return;
+              }
               // Build the request payload first, then resolve the
               // Chat<> instance from the cache; the thread route
               // reads the *same* cached instance, so kicking off
@@ -108,6 +113,7 @@ function ChatIndex() {
               void invalidateGroupedChatThreads(queryClient);
             }}
           />
+          {byokDialog}
         </div>
         <PromptSuggestions
           onSelect={(prompt) => {

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -35,7 +35,7 @@ export const Route = createFileRoute("/_protected/chat/")({
 
 function ChatIndex() {
   const t = useTranslations();
-  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { ensureAIAvailable } = useAIKeyGate();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const userContext = useChatUserContext();
@@ -80,7 +80,7 @@ function ChatIndex() {
             autoFocus
             controller={controller}
             onSubmit={async (draft) => {
-              if (!ensureAIAvailable()) {
+              if (!(await ensureAIAvailable())) {
                 return;
               }
               // Build the request payload first, then resolve the
@@ -113,7 +113,6 @@ function ChatIndex() {
               void invalidateGroupedChatThreads(queryClient);
             }}
           />
-          {byokDialog}
         </div>
         <PromptSuggestions
           onSelect={(prompt) => {

--- a/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { parseDocumentAst } from "@stll/case-law/document-ast";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -7,6 +7,7 @@ import { Loader2Icon, SparklesIcon } from "lucide-react";
 import * as v from "valibot";
 import { useShallow } from "zustand/react/shallow";
 
+import { useAIKeyGate } from "@/components/require-ai-key";
 import { useCaseSearchStore } from "@/lib/case-search-store";
 import { ensureCriticalQueryData } from "@/lib/react-query";
 import type { SafeId } from "@/lib/safe-id";
@@ -91,10 +92,15 @@ function DecisionViewer() {
     })),
   );
 
-  const { state: analysisState, generate } = useDecisionAnalysis(
-    decisionId,
-    decision.analysis,
-  );
+  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { state: analysisState, generate: generateDecisionAnalysis } =
+    useDecisionAnalysis(decisionId, decision.analysis);
+  const generate = useCallback(async () => {
+    if (!ensureAIAvailable()) {
+      return;
+    }
+    await generateDecisionAnalysis();
+  }, [ensureAIAvailable, generateDecisionAnalysis]);
 
   const hasAnalysis =
     analysisState.status === "done" ||
@@ -279,6 +285,7 @@ function DecisionViewer() {
           </div>
         </div>
       </div>
+      {byokDialog}
     </div>
   );
 }

--- a/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
@@ -92,11 +92,16 @@ function DecisionViewer() {
     })),
   );
 
-  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { ensureAIAvailable, openIfAIUnavailable } = useAIKeyGate();
+
+  useEffect(() => {
+    openIfAIUnavailable();
+  }, [openIfAIUnavailable]);
+
   const { state: analysisState, generate: generateDecisionAnalysis } =
     useDecisionAnalysis(decisionId, decision.analysis);
   const generate = useCallback(async () => {
-    if (!ensureAIAvailable()) {
+    if (!(await ensureAIAvailable())) {
       return;
     }
     await generateDecisionAnalysis();
@@ -285,7 +290,6 @@ function DecisionViewer() {
           </div>
         </div>
       </div>
-      {byokDialog}
     </div>
   );
 }

--- a/apps/web/src/routes/_protected.knowledge/index.tsx
+++ b/apps/web/src/routes/_protected.knowledge/index.tsx
@@ -1,3 +1,4 @@
+import { toastManager } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { LandmarkIcon, LightbulbIcon, PlugIcon } from "lucide-react";
@@ -68,18 +69,25 @@ function KnowledgeLanding() {
           }
 
           return (
-            <div
+            <button
+              type="button"
               className={cn(
-                "bg-card rounded-xl border p-5",
-                "cursor-default opacity-50",
+                "bg-card rounded-xl border p-5 text-start",
+                "hover:border-foreground/15 opacity-50 transition-colors",
               )}
               key={section.key}
+              onClick={() => {
+                toastManager.add({
+                  title: t("common.comingSoon"),
+                  type: "foreground",
+                });
+              }}
             >
               {cardBody}
               <p className="text-muted-foreground mt-3 text-xs">
                 {t("common.comingSoon")}
               </p>
-            </div>
+            </button>
           );
         })}
       </div>

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -120,9 +120,14 @@ export const AIConfigCard = () => {
     },
     onSuccess: async () => {
       setApiKey("");
-      await queryClient.invalidateQueries({
-        queryKey: aiConfigKeys.all,
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.availability,
+        }),
+      ]);
       toastManager.add({
         title: tSuccess("aiConfigUpdated"),
         type: "success",
@@ -148,9 +153,14 @@ export const AIConfigCard = () => {
     },
     onSuccess: async () => {
       setApiKey("");
-      await queryClient.invalidateQueries({
-        queryKey: aiConfigKeys.all,
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.all,
+        }),
+        queryClient.invalidateQueries({
+          queryKey: aiConfigKeys.availability,
+        }),
+      ]);
       toastManager.add({
         title: tSuccess("aiConfigDeleted"),
         type: "success",

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -36,7 +36,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { AppBreadcrumbs } from "@/components/breadcrumbs/app-breadcrumbs";
 import { ChatEditorProvider } from "@/components/chat-editor-provider";
 import { ChatMentionProviders } from "@/components/chat-mention-providers";
-import { AIKeyRequiredDialogHost } from "@/components/require-ai-key";
+import { AIAvailabilityProvider } from "@/components/require-ai-key";
 import { DefaultPendingComponent } from "@/components/route-components";
 import { SelfhostUpdateBanner } from "@/components/selfhost-update-banner";
 import { ShortcutHintsOverlay } from "@/components/shortcut-hints-overlay";
@@ -176,15 +176,16 @@ function ProtectedComponent() {
   return (
     <SidebarProvider>
       <ChatMentionProviders>
-        <ChatEditorProvider>
-          <GlobalChatMentionRegistration />
-          <AppSidebar />
-          <CreateMatterDialog />
-          <ProtectedContent decisionId={activeDecisionId} />
-          <WorkspaceInspectorSidePanel />
-          <ShortcutHintsOverlay />
-          <AIKeyRequiredDialogHost />
-        </ChatEditorProvider>
+        <AIAvailabilityProvider>
+          <ChatEditorProvider>
+            <GlobalChatMentionRegistration />
+            <AppSidebar />
+            <CreateMatterDialog />
+            <ProtectedContent decisionId={activeDecisionId} />
+            <WorkspaceInspectorSidePanel />
+            <ShortcutHintsOverlay />
+          </ChatEditorProvider>
+        </AIAvailabilityProvider>
       </ChatMentionProviders>
     </SidebarProvider>
   );

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -36,6 +36,7 @@ import { AppSidebar } from "@/components/app-sidebar";
 import { AppBreadcrumbs } from "@/components/breadcrumbs/app-breadcrumbs";
 import { ChatEditorProvider } from "@/components/chat-editor-provider";
 import { ChatMentionProviders } from "@/components/chat-mention-providers";
+import { AIKeyRequiredDialogHost } from "@/components/require-ai-key";
 import { DefaultPendingComponent } from "@/components/route-components";
 import { SelfhostUpdateBanner } from "@/components/selfhost-update-banner";
 import { ShortcutHintsOverlay } from "@/components/shortcut-hints-overlay";
@@ -182,6 +183,7 @@ function ProtectedComponent() {
           <ProtectedContent decisionId={activeDecisionId} />
           <WorkspaceInspectorSidePanel />
           <ShortcutHintsOverlay />
+          <AIKeyRequiredDialogHost />
         </ChatEditorProvider>
       </ChatMentionProviders>
     </SidebarProvider>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -292,14 +292,16 @@ export const ChatTabPanel = ({
         onStop={() => {
           void stop();
         }}
-        onSubmit={async ({ prompt }) => {
-          if (!(await ensureAIAvailable())) {
-            return;
-          }
-          // PromptBar emits the raw editor HTML; the legacy
-          // backend already parses `<entity-mention>` tags out
-          // of the `text` field, so we forward unchanged.
-          void sendMessage({ text: prompt });
+        onSubmit={({ prompt }) => {
+          void ensureAIAvailable().then((available) => {
+            if (!available) {
+              return;
+            }
+            // PromptBar emits the raw editor HTML; the legacy
+            // backend already parses `<entity-mention>` tags out
+            // of the `text` field, so we forward unchanged.
+            void sendMessage({ text: prompt });
+          });
         }}
         onTogglePanel={() => {
           // Standalone has no thread toggle; never called.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -43,6 +43,7 @@ import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
+import { useAIKeyGate } from "@/components/require-ai-key";
 import Tooltip from "@/components/tooltip";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
@@ -98,6 +99,7 @@ export const ChatTabPanel = ({
       : undefined,
   );
   const t = useTranslations();
+  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
   // Read live tab state on every send. The Chat instance is created
   // once and cached per `threadRef`, so a plain closure over `tab`
   // would freeze the IDs from the render that built the instance —
@@ -286,6 +288,9 @@ export const ChatTabPanel = ({
           void stop();
         }}
         onSubmit={({ prompt }) => {
+          if (!ensureAIAvailable()) {
+            return;
+          }
           // PromptBar emits the raw editor HTML; the legacy
           // backend already parses `<entity-mention>` tags out
           // of the `text` field, so we forward unchanged.
@@ -299,6 +304,7 @@ export const ChatTabPanel = ({
         showThreadToggle={false}
         status={isGenerating ? "generating" : "idle"}
       />
+      {byokDialog}
     </ChatTabPanelChrome>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -99,7 +99,12 @@ export const ChatTabPanel = ({
       : undefined,
   );
   const t = useTranslations();
-  const { byokDialog, ensureAIAvailable } = useAIKeyGate();
+  const { ensureAIAvailable, openIfAIUnavailable } = useAIKeyGate();
+
+  useEffect(() => {
+    openIfAIUnavailable();
+  }, [openIfAIUnavailable]);
+
   // Read live tab state on every send. The Chat instance is created
   // once and cached per `threadRef`, so a plain closure over `tab`
   // would freeze the IDs from the render that built the instance —
@@ -287,8 +292,8 @@ export const ChatTabPanel = ({
         onStop={() => {
           void stop();
         }}
-        onSubmit={({ prompt }) => {
-          if (!ensureAIAvailable()) {
+        onSubmit={async ({ prompt }) => {
+          if (!(await ensureAIAvailable())) {
             return;
           }
           // PromptBar emits the raw editor HTML; the legacy
@@ -304,7 +309,6 @@ export const ChatTabPanel = ({
         showThreadToggle={false}
         status={isGenerating ? "generating" : "idle"}
       />
-      {byokDialog}
     </ChatTabPanelChrome>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
   useSuspenseInfiniteQuery,
@@ -8,6 +8,7 @@ import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
 import { ClockIcon, HashIcon, TableIcon, UserIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { useAIKeyGate } from "@/components/require-ai-key";
 import type { WorkspaceView } from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";
 import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
@@ -45,6 +46,7 @@ type TableLayoutProps = {
 
 export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
   const t = useTranslations();
+  const { openIfAIUnavailable } = useAIKeyGate();
   const tableState = useTableState({ workspaceId, view });
 
   const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
@@ -56,6 +58,10 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       }),
     [properties, view.layout.hiddenProperties],
   );
+
+  useEffect(() => {
+    openIfAIUnavailable();
+  }, [openIfAIUnavailable]);
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useSuspenseInfiniteQuery(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -7,7 +7,6 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
-import { openAIKeyRequiredDialog } from "@/components/require-ai-key";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
@@ -86,7 +85,6 @@ export const useCreateBBoxes = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return useCallback(() => {
     if (!aiAvailability?.available) {
-      openAIKeyRequiredDialog();
       return;
     }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -3,13 +3,16 @@ import { useCallback, useRef } from "react";
 import {
   useIsMutating,
   useMutation,
+  useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
 
+import { openAIKeyRequiredDialog } from "@/components/require-ai-key";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceJustification } from "@/lib/types";
+import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
 import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 type UseCreateBBoxesProps = {
@@ -25,6 +28,7 @@ export const useCreateBBoxes = ({
 }: UseCreateBBoxesProps) => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
+  const { data: aiAvailability } = useQuery(aiAvailabilityOptions);
   const pendingMutationsCount = useIsMutating({
     mutationKey: [CREATE_BBOXES_MUTATION_KEY],
   });
@@ -81,12 +85,17 @@ export const useCreateBBoxes = ({
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   return useCallback(() => {
+    if (!aiAvailability?.available) {
+      openAIKeyRequiredDialog();
+      return;
+    }
+
     if (pendingRef.current > 0) {
       return;
     }
 
     mutateRef.current();
-  }, []);
+  }, [aiAvailability?.available]);
 };
 
 export const useIsCreatingBBoxes = () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
@@ -1,6 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { openAIKeyRequiredDialog } from "@/components/require-ai-key";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
@@ -18,7 +17,6 @@ export const useStartWorkflow = (workspaceId: string) => {
 
   return async (args?: { entityIds?: string[]; entityIdsOrder?: string[] }) => {
     if (!aiAvailability?.available) {
-      openAIKeyRequiredDialog();
       return undefined;
     }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow.ts
@@ -1,8 +1,10 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { openAIKeyRequiredDialog } from "@/components/require-ai-key";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";
+import { aiAvailabilityOptions } from "@/routes/_protected.organization/-ai-config-queries";
 import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 /**
@@ -12,8 +14,14 @@ import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-quer
 export const useStartWorkflow = (workspaceId: string) => {
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
+  const { data: aiAvailability } = useQuery(aiAvailabilityOptions);
 
   return async (args?: { entityIds?: string[]; entityIdsOrder?: string[] }) => {
+    if (!aiAvailability?.available) {
+      openAIKeyRequiredDialog();
+      return undefined;
+    }
+
     try {
       const response = await api
         .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })


### PR DESCRIPTION
## Summary
- add a reusable BYOK setup dialog and gate chat/workflow AI actions before making requests
- invalidate AI availability after organization AI config changes
- keep Judikatura behind a coming-soon toast instead of navigating into the unfinished case-law surface

## Test plan
- bun --filter @stll/web lint
- bun --filter @stll/web typecheck
- bun --filter @stll/web format
- pre-push: i18n check, turbo typecheck, turbo format --check, turbo lint

Full test suite was not run manually.