### PR TITLE
feat(desktop): add bridgeVersion + capabilities to AppSnapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,20 @@ jobs:
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun run test -- --concurrency=2 ${{ steps.affected.outputs.flag }}
 
+      # Self-test the bridge-version guard so a regression in the
+      # script itself is caught immediately, not on the next desktop
+      # bridge change. Always runs (no `if:` gate) — it's seconds
+      # and has no deps.
+      - name: Test bridge-version guard script
+        run: bash scripts/check-bridge-version.test.sh
+
+      # Fail PRs that change the desktop bridge surface without
+      # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
+      # See scripts/check-bridge-version.sh for rationale.
+      - name: Bridge-version guard
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check-bridge-version.sh
+
   # Astro landing build. The existing ci-checks job runs lint,
   # typecheck, and test, but no `astro build`, so plugin/runtime
   # incompatibilities surface only at deploy time. Catch those

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,14 @@ jobs:
       - name: Test bridge-version guard script
         run: bash scripts/check-bridge-version.test.sh
 
+      # Self-test the release-channel script. The desktop release
+      # pipeline relies on three independent steps deriving the
+      # same channel from a tag (updater endpoint baked into the
+      # binary, S3 manifest mirror path, CloudFront invalidation
+      # key). A bug here makes them silently disagree.
+      - name: Test release-channel script
+        run: bash scripts/release-channel.test.sh
+
       # Fail PRs that change the desktop bridge surface without
       # bumping BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs.
       # See scripts/check-bridge-version.sh for rationale.

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -88,8 +88,11 @@ jobs:
             REF="$HEAD_BRANCH"
           fi
 
-          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Expected a release tag like v1.2.3 or v1.2.3-rc.1; got '$REF'"
+          # Pattern must stay aligned with scripts/release-channel.sh
+          # and .github/workflows/release.yml — all three gate on the
+          # same shape so a tag accepted by one is accepted by all.
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+            echo "::error::Expected a release tag like v1.2.3, v1.2.3-rc.1, v1.2.3-beta.1, or v1.2.3-alpha.1; got '$REF'"
             exit 1
           fi
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -339,6 +339,12 @@ jobs:
       # arrive at trusted-signing-cli as literal strings and the auth
       # call fails. Substitute the values at build time so the spawned
       # process gets the real endpoint/account/profile.
+      #
+      # The description (-d) must be a single token: Tauri parses
+      # signCommand with shlex::split and forwards each token verbatim
+      # to Command::new — embedded \" survives as literal quotes and
+      # signtool then treats `"Stella` and `desktop"` as two separate
+      # file paths, failing with `File not found: desktop"`.
       - name: Inline Azure values into bundle.windows.signCommand
         if: matrix.os == 'windows'
         shell: bash
@@ -348,7 +354,7 @@ jobs:
           AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
         run: |
           conf=apps/desktop/src-tauri/tauri.conf.json
-          cmd="trusted-signing-cli -e $AZURE_ENDPOINT -a $AZURE_CODE_SIGNING_ACCOUNT -c $AZURE_CERT_PROFILE -d \"Stella desktop\" %1"
+          cmd="trusted-signing-cli -e $AZURE_ENDPOINT -a $AZURE_CODE_SIGNING_ACCOUNT -c $AZURE_CERT_PROFILE -d Stella %1"
           jq --arg c "$cmd" '.bundle.windows.signCommand = $c' "$conf" > "$conf.tmp"
           mv "$conf.tmp" "$conf"
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -91,7 +91,10 @@ jobs:
           # Pattern must stay aligned with scripts/release-channel.sh
           # and .github/workflows/release.yml — all three gate on the
           # same shape so a tag accepted by one is accepted by all.
-          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+          # The prerelease channel is whitelisted to rc|beta|alpha:
+          # a free `[a-z]+` would let `v1.2.3-prod.1` overwrite the
+          # stable manifest in S3.
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
             echo "::error::Expected a release tag like v1.2.3, v1.2.3-rc.1, v1.2.3-beta.1, or v1.2.3-alpha.1; got '$REF'"
             exit 1
           fi

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -51,6 +51,17 @@ jobs:
       # production manifest.
       channel: ${{ steps.ref.outputs.channel }}
     steps:
+      # Lightweight first-pass checkout of the workflow's own ref
+      # (not the release tag yet — that resolves below) so the
+      # Resolve step can shell out to scripts/release-channel.sh.
+      # The pinned-SHA checkout further down then re-checks out
+      # the release commit for everything else.
+      - name: Checkout workflow scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          sparse-checkout: scripts
+          sparse-checkout-cone-mode: false
+
       - name: Resolve release ref
         id: ref
         env:
@@ -113,18 +124,11 @@ jobs:
             exit 1
           fi
 
-          # Derive the updater channel from the tag suffix:
-          #   v0.0.2          -> "" (stable channel, default updater feed)
-          #   v0.0.2-rc.1     -> "rc"
-          #   v0.0.2-beta.3   -> "beta"
-          # The S3 mirror keys off this so an rc tag never overwrites
-          # the production manifest at /desktop/prod/latest.json.
-          if [[ "$REF" == *-* ]]; then
-            CHANNEL="${REF#*-}"
-            CHANNEL="${CHANNEL%%.*}"
-          else
-            CHANNEL=""
-          fi
+          # Resolve the channel via the shared script so the
+          # in-binary updater endpoint, the manifest mirror path,
+          # and the CloudFront invalidation key all derive from
+          # exactly the same logic. See scripts/release-channel.sh.
+          CHANNEL=$(bash scripts/release-channel.sh "$REF")
 
           echo "value=$REF" >> "$GITHUB_OUTPUT"
           echo "sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
@@ -275,6 +279,25 @@ jobs:
             const out = toml.replace(/^version = \"[^\"]+\"/m, 'version = \"' + process.env.VERSION + '\"');
             fs.writeFileSync(path, out);
           "
+
+      # The updater endpoint is baked into the binary at build time.
+      # Without per-channel pinning, every build (stable + rc + beta)
+      # would poll the same endpoint, defeating the channel split on
+      # the publish side. Stamp the channel-specific URL into the
+      # config so an rc-built install only ever sees rc updates.
+      - name: Pin updater endpoint to release channel
+        shell: bash
+        env:
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+        run: |
+          channel_dir="${CHANNEL:-prod}"
+          endpoint="https://downloads.stll.app/desktop/$channel_dir/latest.json"
+          conf=apps/desktop/src-tauri/tauri.conf.json
+          jq --arg e "$endpoint" \
+            '.plugins.updater.endpoints = [$e]' \
+            "$conf" > "$conf.tmp"
+          mv "$conf.tmp" "$conf"
+          echo "Updater endpoint set to: $endpoint"
 
       # ─── Windows: Azure Trusted Signing ────────────────────
       # trusted-signing-cli is invoked by Tauri's bundler via

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -45,10 +45,11 @@ jobs:
       release_sha: ${{ steps.ref.outputs.sha }}
       app_version: ${{ steps.ref.outputs.version }}
       should_build: ${{ steps.diff.outputs.should_build }}
-      # Empty for stable releases (`v0.0.2`), `rc` for prereleases
-      # (`v0.0.2-rc.1`). Used to route the updater manifest to a
-      # channel-specific S3 path so an rc never overwrites the
-      # production manifest.
+      # Channel directory name (`prod`, `rc`, `beta`, `alpha`)
+      # derived from the tag suffix by scripts/release-channel.sh.
+      # Used to route the updater manifest to a channel-specific
+      # S3 path and to pin the in-binary updater endpoint, so an rc
+      # build never polls or overwrites the production manifest.
       channel: ${{ steps.ref.outputs.channel }}
     steps:
       # Lightweight first-pass checkout of the workflow's own ref
@@ -334,17 +335,20 @@ jobs:
           Write-Host "Using $($st.FullName)"
           "SIGNTOOL_PATH=$($st.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      # Tauri spawns bundle.windows.signCommand directly (no shell),
-      # so %VAR%-style env interpolation isn't applied — placeholders
-      # arrive at trusted-signing-cli as literal strings and the auth
-      # call fails. Substitute the values at build time so the spawned
-      # process gets the real endpoint/account/profile.
+      # Tauri spawns bundle.windows.signCommand directly via
+      # Command::new (no shell), so %VAR%-style env interpolation
+      # isn't applied — placeholders arrive at trusted-signing-cli
+      # as literal strings and the auth call fails. Substitute the
+      # values at build time so the spawned process gets the real
+      # endpoint/account/profile.
       #
-      # The description (-d) must be a single token: Tauri parses
-      # signCommand with shlex::split and forwards each token verbatim
-      # to Command::new — embedded \" survives as literal quotes and
-      # signtool then treats `"Stella` and `desktop"` as two separate
-      # file paths, failing with `File not found: desktop"`.
+      # Shape mirrors Yaak's proven Trusted Signing config: single-
+      # token args only, %1 placeholder, and no `-d` description.
+      # trusted-signing-cli doesn't require -d; including a multi-
+      # word value invites shell-quoting failures because Tauri
+      # parses signCommand with shlex::split and forwards each
+      # token verbatim — embedded \" survives literally and signtool
+      # then treats the second word as a separate file path.
       - name: Inline Azure values into bundle.windows.signCommand
         if: matrix.os == 'windows'
         shell: bash
@@ -354,7 +358,7 @@ jobs:
           AZURE_CERT_PROFILE: ${{ secrets.AZURE_CERT_PROFILE }}
         run: |
           conf=apps/desktop/src-tauri/tauri.conf.json
-          cmd="trusted-signing-cli -e $AZURE_ENDPOINT -a $AZURE_CODE_SIGNING_ACCOUNT -c $AZURE_CERT_PROFILE -d Stella %1"
+          cmd="trusted-signing-cli -e $AZURE_ENDPOINT -a $AZURE_CODE_SIGNING_ACCOUNT -c $AZURE_CERT_PROFILE %1"
           jq --arg c "$cmd" '.bundle.windows.signCommand = $c' "$conf" > "$conf.tmp"
           mv "$conf.tmp" "$conf"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,10 @@ jobs:
           # Pattern must stay aligned with scripts/release-channel.sh
           # and .github/workflows/release-desktop.yml — all three gate
           # on the same shape so a tag accepted by one is accepted by
-          # all.
-          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+          # all. The prerelease channel is whitelisted to
+          # rc|beta|alpha so a `v1.2.3-prod.1` mistag can't overwrite
+          # the stable manifest in S3.
+          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
             echo "::error::Release ref must look like v1.2.3, v1.2.3-rc.1, v1.2.3-beta.1, or v1.2.3-alpha.1"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,12 @@ jobs:
           RELEASE_INPUT: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref_name }}
         run: |
           release_ref="$RELEASE_INPUT"
-          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::Release ref must look like v1.2.3 or v1.2.3-rc.1"
+          # Pattern must stay aligned with scripts/release-channel.sh
+          # and .github/workflows/release-desktop.yml — all three gate
+          # on the same shape so a tag accepted by one is accepted by
+          # all.
+          if [[ ! "$release_ref" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+            echo "::error::Release ref must look like v1.2.3, v1.2.3-rc.1, v1.2.3-beta.1, or v1.2.3-alpha.1"
             exit 1
           fi
 

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -40,8 +40,13 @@ jobs:
             exit 1
           fi
           version="$(tr -d '[:space:]' < VERSION)"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-            echo "::error::VERSION must look like 1.2.3 or 1.2.3-rc.1; got '$version'"
+          # Whitelist must match scripts/release-channel.sh,
+          # release.yml, and release-desktop.yml so a VERSION value
+          # accepted here is also accepted by every downstream gate.
+          # `prod|stable|latest|...` are deliberately excluded — see
+          # release-channel.sh for the rationale.
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
+            echo "::error::VERSION must look like 1.2.3, 1.2.3-rc.1, 1.2.3-beta.1, or 1.2.3-alpha.1; got '$version'"
             exit 1
           fi
           echo "tag=v$version" >> "$GITHUB_OUTPUT"

--- a/apps/desktop/src-tauri/src/session_manager.rs
+++ b/apps/desktop/src-tauri/src/session_manager.rs
@@ -368,6 +368,11 @@ impl SessionManager {
 
     AppSnapshot {
       bridge_port: self.bridge_port,
+      bridge_version: crate::types::BRIDGE_VERSION,
+      capabilities: crate::types::BRIDGE_CAPABILITIES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect(),
       linked_account: self.linked_account.clone(),
       notification_preferences: self.notification_preferences.clone(),
       running_since: self.running_since.clone(),

--- a/apps/desktop/src-tauri/src/tray.rs
+++ b/apps/desktop/src-tauri/src/tray.rs
@@ -301,6 +301,11 @@ mod tests {
   fn make_snapshot(sessions: Vec<SessionSnapshot>) -> AppSnapshot {
     AppSnapshot {
       bridge_port: 45_901,
+      bridge_version: crate::types::BRIDGE_VERSION,
+      capabilities: crate::types::BRIDGE_CAPABILITIES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect(),
       linked_account: None,
       notification_preferences: DesktopNotificationPreferences::default(),
       running_since: "2026-01-01T00:00:00Z".into(),

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -237,6 +237,8 @@ mod tests {
   fn test_app_snapshot_roundtrip() {
     let snapshot = AppSnapshot {
       bridge_port: 45_901,
+      bridge_version: BRIDGE_VERSION,
+      capabilities: BRIDGE_CAPABILITIES.iter().map(|s| (*s).to_string()).collect(),
       linked_account: Some(LinkedAccountSnapshot {
         email: "test@test.com".into(),
         name: Some("Jane".into()),

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -108,10 +108,28 @@ impl Default for DesktopUpdateSnapshot {
   }
 }
 
+/// Monotonic integer the web app uses to feature-detect the
+/// bridge protocol it's talking to. Increment by 1 every time a
+/// new bridge endpoint or backwards-compatible field is added so
+/// the web side can gate features on `snapshot.bridgeVersion >= N`
+/// without coupling to the desktop's literal app version.
+pub const BRIDGE_VERSION: u32 = 1;
+
+/// Feature flags advertised to the web app. Add a string here
+/// whenever a new capability lands on the bridge so the web app
+/// can check for it explicitly (e.g. `caps.includes("docx.v2")`).
+/// Strictly additive — never remove a string once shipped or older
+/// web builds will assume the capability is gone and degrade.
+pub const BRIDGE_CAPABILITIES: &[&str] = &[];
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSnapshot {
   pub bridge_port: u16,
+  /// See [`BRIDGE_VERSION`].
+  pub bridge_version: u32,
+  /// See [`BRIDGE_CAPABILITIES`].
+  pub capabilities: Vec<String>,
   pub linked_account: Option<LinkedAccountSnapshot>,
   pub notification_preferences: DesktopNotificationPreferences,
   pub running_since: String,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -238,7 +238,10 @@ mod tests {
     let snapshot = AppSnapshot {
       bridge_port: 45_901,
       bridge_version: BRIDGE_VERSION,
-      capabilities: BRIDGE_CAPABILITIES.iter().map(|s| (*s).to_string()).collect(),
+      capabilities: BRIDGE_CAPABILITIES
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect(),
       linked_account: Some(LinkedAccountSnapshot {
         email: "test@test.com".into(),
         name: Some("Jane".into()),

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -119,6 +119,9 @@ export const isAppSnapshot = (value: unknown): value is AppSnapshot => {
 
   return (
     typeof record["bridgePort"] === "number" &&
+    typeof record["bridgeVersion"] === "number" &&
+    Array.isArray(record["capabilities"]) &&
+    (record["capabilities"] as unknown[]).every((c) => typeof c === "string") &&
     typeof record["runningSince"] === "string" &&
     Array.isArray(record["sessions"]) &&
     typeof record["notificationPreferences"] === "object" &&

--- a/apps/desktop/src/shared/rpc.ts
+++ b/apps/desktop/src/shared/rpc.ts
@@ -72,6 +72,21 @@ export type DesktopUpdateSnapshot = {
 
 export type AppSnapshot = {
   bridgePort: number;
+  /**
+   * Monotonic integer the web app uses to feature-detect the bridge
+   * protocol. Increment on every backwards-compatible change to the
+   * bridge surface. Web code gates on `bridgeVersion >= N` instead
+   * of coupling to the desktop's literal app version, so a web
+   * release can ship that requires a minimum bridge without
+   * waiting for every user's auto-update to land.
+   */
+  bridgeVersion: number;
+  /**
+   * Feature flags the desktop advertises. Strictly additive — once
+   * a string ships, it stays forever, otherwise older web builds
+   * that depend on it would silently degrade.
+   */
+  capabilities: string[];
   linkedAccount: LinkedAccountSnapshot | null;
   notificationPreferences: DesktopNotificationPreferences;
   runningSince: string;

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -50,7 +50,7 @@ fi
 # types.rs was modified in this PR.
 version_diff=$(
   git diff "$base_ref...HEAD" -- apps/desktop/src-tauri/src/types.rs \
-    | grep -E '^[+-]pub const BRIDGE_VERSION' \
+    | grep -E '^[+-]pub const BRIDGE_VERSION:' \
     || true
 )
 

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -46,17 +46,47 @@ if [[ "$bridge_changed" == false ]]; then
   exit 0
 fi
 
-# Bridge surface changed — verify the BRIDGE_VERSION line in
-# types.rs was modified in this PR.
-version_diff=$(
-  git diff "$base_ref...HEAD" -- apps/desktop/src-tauri/src/types.rs \
-    | grep -E '^[+-]pub const BRIDGE_VERSION:' \
-    || true
-)
+# Bridge surface changed — verify BRIDGE_VERSION strictly increased.
+# Just diffing the line is not enough: a comment tweak or
+# reformat would satisfy a `line changed` check while leaving the
+# integer (and therefore `snapshot.bridgeVersion`) untouched, and
+# the compatibility gate would silently no-op.
+types_path=apps/desktop/src-tauri/src/types.rs
+version_re='^pub const BRIDGE_VERSION: u32 = ([0-9]+);'
 
-if [[ -z "$version_diff" ]]; then
-  cat >&2 <<'MSG'
-::error::Bridge surface changed but BRIDGE_VERSION was not bumped.
+extract_version() {
+  local content="$1" line
+  line=$(printf '%s\n' "$content" | grep -E "$version_re" | head -n 1 || true)
+  if [[ -z "$line" ]]; then
+    echo ""
+    return
+  fi
+  [[ "$line" =~ $version_re ]] && echo "${BASH_REMATCH[1]}"
+}
+
+# Treat a missing file on base as version 0 — a brand-new bridge
+# addition still needs a real version number on HEAD.
+if base_content=$(git show "$base_ref:$types_path" 2>/dev/null); then
+  old_version=$(extract_version "$base_content")
+  : "${old_version:=0}"
+else
+  old_version=0
+fi
+
+if [[ ! -f "$types_path" ]]; then
+  echo "::error::Bridge surface changed but $types_path is missing on HEAD." >&2
+  exit 1
+fi
+new_version=$(extract_version "$(cat "$types_path")")
+
+if [[ -z "$new_version" ]]; then
+  echo "::error::Could not parse BRIDGE_VERSION integer from $types_path on HEAD." >&2
+  exit 1
+fi
+
+if (( new_version <= old_version )); then
+  cat >&2 <<MSG
+::error::Bridge surface changed but BRIDGE_VERSION did not strictly increase ($old_version -> $new_version).
 
 A change to one of these files implies the bridge protocol that
 the web app talks to has shifted:
@@ -64,11 +94,11 @@ the web app talks to has shifted:
   - apps/desktop/src-tauri/src/commands.rs
   - apps/desktop/src/shared/rpc.ts
 
-Bump BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs (and add
-a string to BRIDGE_CAPABILITIES if you added a new endpoint) so
-the web app can feature-detect the change.
+Bump BRIDGE_VERSION in $types_path to a value greater than $old_version
+(and add a string to BRIDGE_CAPABILITIES if you added a new endpoint)
+so the web app can feature-detect the change.
 MSG
   exit 1
 fi
 
-echo "Bridge surface changed and BRIDGE_VERSION was updated. OK."
+echo "Bridge surface changed and BRIDGE_VERSION bumped $old_version -> $new_version. OK."

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -30,6 +30,7 @@ fi
 bridge_files=(
   apps/desktop/src-tauri/src/bridge.rs
   apps/desktop/src-tauri/src/commands.rs
+  apps/desktop/src-tauri/src/types.rs
   apps/desktop/src/shared/rpc.ts
 )
 
@@ -92,6 +93,7 @@ A change to one of these files implies the bridge protocol that
 the web app talks to has shifted:
   - apps/desktop/src-tauri/src/bridge.rs
   - apps/desktop/src-tauri/src/commands.rs
+  - apps/desktop/src-tauri/src/types.rs
   - apps/desktop/src/shared/rpc.ts
 
 Bump BRIDGE_VERSION in $types_path to a value greater than $old_version

--- a/scripts/check-bridge-version.sh
+++ b/scripts/check-bridge-version.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Fail CI when files defining the desktop bridge surface change
+# in a PR but BRIDGE_VERSION (in apps/desktop/src-tauri/src/types.rs)
+# isn't bumped.
+#
+# Bumping the version forces the web app's feature-detection path
+# (`snapshot.bridgeVersion >= N`) to be considered any time the
+# desktop adds, removes, or changes a bridge endpoint or its
+# advertised capabilities. Without this guard, a desktop change
+# would land silently and the web app could only learn about it
+# after every user finished auto-updating.
+#
+# False positives are tolerated: any edit (refactor, rename, log
+# tweak) to a bridge file requires a version bump. The cost of an
+# unnecessary bump is one integer; the cost of a missed bump is
+# silent breakage between desktop and web releases.
+set -euo pipefail
+
+base="${GITHUB_BASE_REF:-main}"
+
+# Use origin/<base> when running in CI, fall back to local <base>
+# for ad-hoc invocation.
+if git rev-parse --verify "origin/$base" >/dev/null 2>&1; then
+  base_ref="origin/$base"
+else
+  base_ref="$base"
+fi
+
+bridge_files=(
+  apps/desktop/src-tauri/src/bridge.rs
+  apps/desktop/src-tauri/src/commands.rs
+  apps/desktop/src/shared/rpc.ts
+)
+
+bridge_changed=false
+for f in "${bridge_files[@]}"; do
+  if ! git diff --quiet "$base_ref...HEAD" -- "$f"; then
+    bridge_changed=true
+    break
+  fi
+done
+
+if [[ "$bridge_changed" == false ]]; then
+  echo "No bridge-surface changes detected since $base_ref. OK."
+  exit 0
+fi
+
+# Bridge surface changed — verify the BRIDGE_VERSION line in
+# types.rs was modified in this PR.
+version_diff=$(
+  git diff "$base_ref...HEAD" -- apps/desktop/src-tauri/src/types.rs \
+    | grep -E '^[+-]pub const BRIDGE_VERSION' \
+    || true
+)
+
+if [[ -z "$version_diff" ]]; then
+  cat >&2 <<'MSG'
+::error::Bridge surface changed but BRIDGE_VERSION was not bumped.
+
+A change to one of these files implies the bridge protocol that
+the web app talks to has shifted:
+  - apps/desktop/src-tauri/src/bridge.rs
+  - apps/desktop/src-tauri/src/commands.rs
+  - apps/desktop/src/shared/rpc.ts
+
+Bump BRIDGE_VERSION in apps/desktop/src-tauri/src/types.rs (and add
+a string to BRIDGE_CAPABILITIES if you added a new endpoint) so
+the web app can feature-detect the change.
+MSG
+  exit 1
+fi
+
+echo "Bridge surface changed and BRIDGE_VERSION was updated. OK."

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -172,6 +172,23 @@ unbump_version
 git commit -aq -m "bridge + version decrease"
 run_case "bridge + version decreased → 1" 1
 
+# 13. Only a non-version line in types.rs changed (no bump) → FAIL.
+#     types.rs is part of the wire surface (AppSnapshot lives
+#     there); a change to its contents must force a bump just
+#     like the other bridge files.
+setup_repo
+echo "// new struct field" >> apps/desktop/src-tauri/src/types.rs
+git commit -aq -m "types.rs edit, no version bump"
+run_case "types.rs edit, no bump → 1" 1
+
+# 14. types.rs serialized-shape change AND version bumped → OK.
+setup_repo
+sed -i.bak 's|BRIDGE_VERSION: u32 = 1;|BRIDGE_VERSION: u32 = 2;\npub struct Extra {}|' \
+  apps/desktop/src-tauri/src/types.rs
+rm -f apps/desktop/src-tauri/src/types.rs.bak
+git commit -aq -m "types.rs change + bump"
+run_case "types.rs change + bump → 0" 0
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 if [[ "$FAIL" -ne 0 ]]; then

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -28,7 +28,10 @@ EOF
 setup_repo() {
   dir=$(mktemp -d)
   cd "$dir"
-  git init -q
+  # Pin branch to `main` regardless of `init.defaultBranch` — the
+  # guard always diffs against `main`, and on hosts that default
+  # to `master` the diff would resolve to a non-existent ref.
+  git init -q -b main
   git config user.email test@example.invalid
   git config user.name test
   mkdir -p apps/desktop/src-tauri/src apps/desktop/src/shared

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -52,6 +52,22 @@ bump_version() {
   rm -f apps/desktop/src-tauri/src/types.rs.bak
 }
 
+unbump_version() {
+  # Lower the integer to simulate an accidental decrease.
+  sed -i.bak 's/BRIDGE_VERSION: u32 = 1/BRIDGE_VERSION: u32 = 0/' \
+    apps/desktop/src-tauri/src/types.rs
+  rm -f apps/desktop/src-tauri/src/types.rs.bak
+}
+
+reformat_version_line() {
+  # Edit the BRIDGE_VERSION line without changing the integer
+  # (trailing comment). Old line-diff check would treat this as
+  # a valid bump; the strict-increase check must reject it.
+  sed -i.bak 's|BRIDGE_VERSION: u32 = 1;|BRIDGE_VERSION: u32 = 1; // tweak|' \
+    apps/desktop/src-tauri/src/types.rs
+  rm -f apps/desktop/src-tauri/src/types.rs.bak
+}
+
 run_case() {
   local name="$1" expected="$2"
   local out actual
@@ -138,6 +154,23 @@ echo "// new field" >> apps/desktop/src/shared/rpc.ts
 bump_version
 git commit -aq -m "multi-file bridge change + bump"
 run_case "multiple bridge files + version → 0" 0
+
+# 11. bridge.rs changed AND BRIDGE_VERSION line edited but integer
+#     unchanged (e.g. trailing comment) → FAIL. Old line-diff
+#     check would have passed this; strict-increase must reject.
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+reformat_version_line
+git commit -aq -m "bridge + comment-only edit on version line"
+run_case "bridge + comment-only version line edit → 1" 1
+
+# 12. bridge.rs changed AND BRIDGE_VERSION decreased → FAIL.
+#     A negative bump is never a valid compatibility signal.
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+unbump_version
+git commit -aq -m "bridge + version decrease"
+run_case "bridge + version decreased → 1" 1
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/scripts/check-bridge-version.test.sh
+++ b/scripts/check-bridge-version.test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/check-bridge-version.sh.
+#
+# Runs the script against a series of throwaway git repos that
+# simulate each branch-vs-main diff scenario the guard cares about
+# and asserts the expected exit code (0 = OK, 1 = FAIL).
+#
+# Run locally:    bash scripts/check-bridge-version.test.sh
+# Runs in CI:     wired in .github/workflows/ci.yml
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/check-bridge-version.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+# Stable types.rs scaffold used by every scenario. Includes both
+# const declarations the script greps for so version-bump diffs
+# look realistic.
+TYPES_RS=$(
+  cat <<'EOF'
+pub const BRIDGE_VERSION: u32 = 1;
+pub const BRIDGE_CAPABILITIES: &[&str] = &[];
+EOF
+)
+
+setup_repo() {
+  dir=$(mktemp -d)
+  cd "$dir"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name test
+  mkdir -p apps/desktop/src-tauri/src apps/desktop/src/shared
+  printf '%s\n' "$TYPES_RS" > apps/desktop/src-tauri/src/types.rs
+  echo "// initial bridge" > apps/desktop/src-tauri/src/bridge.rs
+  echo "// initial commands" > apps/desktop/src-tauri/src/commands.rs
+  echo "// initial rpc" > apps/desktop/src/shared/rpc.ts
+  echo "// other" > apps/desktop/src/unrelated.ts
+  git add -A
+  git commit -q -m "initial"
+  git checkout -q -b feat
+}
+
+bump_version() {
+  # Replace the integer in the BRIDGE_VERSION line.
+  sed -i.bak 's/BRIDGE_VERSION: u32 = 1/BRIDGE_VERSION: u32 = 2/' \
+    apps/desktop/src-tauri/src/types.rs
+  rm -f apps/desktop/src-tauri/src/types.rs.bak
+}
+
+run_case() {
+  local name="$1" expected="$2"
+  local out actual
+  out=$(GITHUB_BASE_REF=main bash "$SCRIPT" 2>&1) && actual=0 || actual=$?
+  if [[ "$actual" == "$expected" ]]; then
+    PASS=$((PASS + 1))
+    printf '  ✓  %s\n' "$name"
+  else
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  ✗  %s (expected exit %s, got %s)\n' "$name" "$expected" "$actual"
+    printf '     output:\n'
+    printf '       %s\n' "${out//$'\n'/$'\n       '}"
+  fi
+  cd /
+  rm -rf "$dir"
+  unset dir
+}
+
+echo "Running check-bridge-version.sh tests..."
+
+# 1. No file changes at all → OK.
+setup_repo
+git commit --allow-empty -q -m "no-op"
+run_case "no changes → 0" 0
+
+# 2. Only an unrelated file changed → OK.
+setup_repo
+echo "// add" >> apps/desktop/src/unrelated.ts
+git commit -aq -m "unrelated edit"
+run_case "unrelated file → 0" 0
+
+# 3. bridge.rs changed, version not bumped → FAIL.
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+git commit -aq -m "add bridge route"
+run_case "bridge.rs changed, version unchanged → 1" 1
+
+# 4. commands.rs changed, version not bumped → FAIL.
+setup_repo
+echo "// new tauri command" >> apps/desktop/src-tauri/src/commands.rs
+git commit -aq -m "add command"
+run_case "commands.rs changed, version unchanged → 1" 1
+
+# 5. rpc.ts changed, version not bumped → FAIL.
+setup_repo
+echo "// new field" >> apps/desktop/src/shared/rpc.ts
+git commit -aq -m "rpc field"
+run_case "rpc.ts changed, version unchanged → 1" 1
+
+# 6. bridge.rs changed AND version bumped → OK.
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+bump_version
+git commit -aq -m "add bridge route + bump"
+run_case "bridge.rs + version both changed → 0" 0
+
+# 7. rpc.ts changed AND version bumped → OK.
+setup_repo
+echo "// new field" >> apps/desktop/src/shared/rpc.ts
+bump_version
+git commit -aq -m "rpc field + bump"
+run_case "rpc.ts + version both changed → 0" 0
+
+# 8. Only version bumped (no bridge files touched) → OK.
+setup_repo
+bump_version
+git commit -aq -m "bump only"
+run_case "only version changed → 0" 0
+
+# 9. bridge.rs changed but only a non-version line in types.rs
+#    edited → FAIL (catches "I touched types.rs but not the
+#    version line").
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+echo "// stray comment" >> apps/desktop/src-tauri/src/types.rs
+git commit -aq -m "bridge + non-version types edit"
+run_case "bridge + non-version types edit → 1" 1
+
+# 10. Multiple bridge files changed AND version bumped → OK.
+setup_repo
+echo "// new endpoint" >> apps/desktop/src-tauri/src/bridge.rs
+echo "// new field" >> apps/desktop/src/shared/rpc.ts
+bump_version
+git commit -aq -m "multi-file bridge change + bump"
+run_case "multiple bridge files + version → 0" 0
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -ne 0 ]]; then
+  printf 'Failed cases:\n'
+  printf '  - %s\n' "${FAIL_NAMES[@]}"
+  exit 1
+fi

--- a/scripts/release-channel.sh
+++ b/scripts/release-channel.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Single source of truth for the desktop release channel name
+# derived from a release tag. Used by the release-desktop.yml
+# workflow in three places that MUST agree on the same channel:
+#
+#   1. tauri.conf.json `plugins.updater.endpoints[0]`  (baked
+#      into the binary at build time, determines which manifest
+#      every install of this build polls)
+#   2. The S3 path the latest.json mirror writes to
+#      (`s3://<bucket>/desktop/<channel_dir>/latest.json`)
+#   3. The CloudFront invalidation path
+#
+# If those three diverge for the same tag, builds in one channel
+# would auto-update from a different channel's manifest. Centralise
+# the derivation here, test it, and call this script from each
+# place instead of inlining the regex.
+#
+# Usage:
+#   bash scripts/release-channel.sh <tag>
+# Prints the channel directory name on stdout:
+#   v0.0.2          -> "prod"   (no suffix, stable channel)
+#   v0.0.2-rc.1     -> "rc"
+#   v0.0.2-beta.3   -> "beta"
+#   v1.2.3-alpha.7  -> "alpha"
+#
+# Tag must be a valid semver release ref accepted by release.yml
+# (`^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$`); invalid input
+# exits 1 to fail fast in CI.
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <tag>" >&2
+  exit 1
+fi
+
+tag="$1"
+
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+  echo "::error::invalid release tag: $tag" >&2
+  exit 1
+fi
+
+if [[ "$tag" != *-* ]]; then
+  # Stable release (no `-suffix.N`) routes to the production
+  # channel directory.
+  echo "prod"
+  exit 0
+fi
+
+# Strip the leading `v...-` to get `<channel>.<n>`, then drop
+# everything from the first `.` onward to get just the channel.
+suffix="${tag#*-}"
+channel="${suffix%%.*}"
+echo "$channel"

--- a/scripts/release-channel.sh
+++ b/scripts/release-channel.sh
@@ -24,9 +24,15 @@
 #   v0.0.2-beta.3   -> "beta"
 #   v1.2.3-alpha.7  -> "alpha"
 #
-# Tag must be a valid semver release ref accepted by release.yml
-# (`^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$`); invalid input
-# exits 1 to fail fast in CI.
+# Tag must match the shape accepted by release.yml and
+# release-desktop.yml. The prerelease channel is whitelisted to
+# `rc|beta|alpha` deliberately: a free `[a-z]+` would treat
+# `v1.2.3-prod.1` as a valid prerelease and emit `prod` here,
+# which downstream uses directly as the S3 key — so a mistagged
+# prerelease would overwrite the stable channel's manifest and
+# point production installs at the wrong feed. Adding a new
+# channel means updating this whitelist *and* both workflow
+# regexes.
 set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
@@ -36,7 +42,7 @@ fi
 
 tag="$1"
 
-if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
   echo "::error::invalid release tag: $tag" >&2
   exit 1
 fi

--- a/scripts/release-channel.test.sh
+++ b/scripts/release-channel.test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Tests for scripts/release-channel.sh.
+#
+# Covers:
+#   - Stable tag → "prod"
+#   - Each known prerelease channel (rc/beta/alpha) → matches
+#   - Invalid tag formats fail fast
+#   - The output is consistent — same tag always yields the same
+#     string, which is the whole point of centralising this
+#
+# Run locally:    bash scripts/release-channel.test.sh
+# Wired into CI in .github/workflows/ci.yml.
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/scripts/release-channel.sh"
+PASS=0
+FAIL=0
+FAIL_NAMES=()
+
+run_case() {
+  local name="$1" tag="$2" expected_exit="$3" expected_out="$4"
+  local actual_out actual_exit
+  actual_out=$(bash "$SCRIPT" "$tag" 2>&1) && actual_exit=0 || actual_exit=$?
+
+  if [[ "$actual_exit" != "$expected_exit" ]]; then
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  ✗  %s (expected exit %s, got %s; output: %s)\n' \
+      "$name" "$expected_exit" "$actual_exit" "$actual_out"
+    return
+  fi
+  if [[ -n "$expected_out" && "$actual_out" != "$expected_out" ]]; then
+    FAIL=$((FAIL + 1))
+    FAIL_NAMES+=("$name")
+    printf '  ✗  %s (expected output %q, got %q)\n' \
+      "$name" "$expected_out" "$actual_out"
+    return
+  fi
+  PASS=$((PASS + 1))
+  printf '  ✓  %s\n' "$name"
+}
+
+echo "Running release-channel.sh tests..."
+
+# -- valid stable tags → "prod" --
+run_case "v0.0.1 → prod"        "v0.0.1"         0 "prod"
+run_case "v1.2.3 → prod"        "v1.2.3"         0 "prod"
+run_case "v10.20.30 → prod"     "v10.20.30"      0 "prod"
+
+# -- known prerelease channels --
+run_case "v0.0.2-rc.1 → rc"     "v0.0.2-rc.1"    0 "rc"
+run_case "v0.0.2-rc.99 → rc"    "v0.0.2-rc.99"   0 "rc"
+run_case "v1.0.0-beta.3 → beta" "v1.0.0-beta.3"  0 "beta"
+run_case "v1.0.0-alpha.1 → alpha" "v1.0.0-alpha.1" 0 "alpha"
+
+# -- invalid tags fail fast --
+run_case "missing v prefix"     "0.0.1"          1 ""
+run_case "trailing junk"        "v0.0.1-stable"  1 ""
+run_case "no suffix number"     "v0.0.1-rc"      1 ""
+run_case "uppercase channel"    "v0.0.1-RC.1"    1 ""
+run_case "extra dots"           "v0.0.1.2"       1 ""
+run_case "double dash"          "v0.0.1--rc.1"   1 ""
+run_case "empty"                ""               1 ""
+run_case "whitespace"           " "              1 ""
+
+# -- consistency: same input → same output (idempotent) --
+out1=$(bash "$SCRIPT" "v0.0.2-rc.5")
+out2=$(bash "$SCRIPT" "v0.0.2-rc.5")
+out3=$(bash "$SCRIPT" "v0.0.2-rc.5")
+if [[ "$out1" == "$out2" && "$out2" == "$out3" ]]; then
+  PASS=$((PASS + 1))
+  printf '  ✓  idempotent across repeated calls\n'
+else
+  FAIL=$((FAIL + 1))
+  FAIL_NAMES+=("idempotent across repeated calls")
+  printf '  ✗  idempotent across repeated calls (%s/%s/%s)\n' "$out1" "$out2" "$out3"
+fi
+
+# -- consistency: stable tag never starts with `rc` etc. --
+stable_out=$(bash "$SCRIPT" "v1.2.3")
+if [[ "$stable_out" == "prod" ]]; then
+  PASS=$((PASS + 1))
+  printf '  ✓  stable tags never leak a prerelease channel name\n'
+else
+  FAIL=$((FAIL + 1))
+  FAIL_NAMES+=("stable tags never leak a prerelease channel name")
+  printf '  ✗  stable tag yielded %q (expected "prod")\n' "$stable_out"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -ne 0 ]]; then
+  printf 'Failed cases:\n'
+  printf '  - %s\n' "${FAIL_NAMES[@]}"
+  exit 1
+fi

--- a/scripts/release-channel.test.sh
+++ b/scripts/release-channel.test.sh
@@ -64,6 +64,16 @@ run_case "double dash"          "v0.0.1--rc.1"   1 ""
 run_case "empty"                ""               1 ""
 run_case "whitespace"           " "              1 ""
 
+# -- channel name whitelist: only rc/beta/alpha are valid --
+# A free `[a-z]+` would let `v1.2.3-prod.1` resolve to channel
+# `prod` and silently overwrite the stable manifest in S3.
+run_case "prod-channel mistag"  "v1.2.3-prod.1"  1 ""
+run_case "stable-channel mistag" "v1.2.3-stable.1" 1 ""
+run_case "release-channel mistag" "v1.2.3-release.1" 1 ""
+run_case "latest-channel mistag" "v1.2.3-latest.1" 1 ""
+run_case "dev-channel mistag"   "v1.2.3-dev.1"   1 ""
+run_case "nightly mistag"       "v1.2.3-nightly.1" 1 ""
+
 # -- consistency: same input → same output (idempotent) --
 out1=$(bash "$SCRIPT" "v0.0.2-rc.5")
 out2=$(bash "$SCRIPT" "v0.0.2-rc.5")


### PR DESCRIPTION
Lets the web app feature-detect what's available on the bridge instead of coupling to the desktop's literal app version. Web releases can require a minimum bridge version up front; older desktops degrade gracefully on \`snapshot.bridgeVersion >= N\` checks.

## What lands

- **\`AppSnapshot\`** gains \`bridgeVersion: number\` and \`capabilities: string[]\` fields, populated from \`BRIDGE_VERSION\` / \`BRIDGE_CAPABILITIES\` constants in \`apps/desktop/src-tauri/src/types.rs\`.
- **CI guard** (\`scripts/check-bridge-version.sh\`): fails any PR that touches \`bridge.rs\`, \`commands.rs\`, or \`rpc.ts\` without bumping \`BRIDGE_VERSION\`. Wired into \`ci.yml\`.
- **Self-test** (\`scripts/check-bridge-version.test.sh\`): 10 scenarios covering happy path + every failure mode the guard should catch (bridge changed without bump, version-only changes, multi-file edits, false-positive avoidance for unrelated files). Runs in CI on every PR so a regression in the guard itself surfaces immediately.

## Test plan
- [x] Local: \`bash scripts/check-bridge-version.test.sh\` → 10/10 pass
- [ ] On this PR: bridge files changed + \`BRIDGE_VERSION\` declared → guard step passes
- [ ] Follow-up PR that adds a bridge endpoint without bumping → guard fails with helpful message