### PR TITLE
fix(shortcuts/seed): user-private existence check matches the unique index

### DIFF
--- a/apps/api/src/handlers/shortcuts/seed.ts
+++ b/apps/api/src/handlers/shortcuts/seed.ts
@@ -44,13 +44,19 @@ const config = {
 const seedShortcuts = createSafeRootHandler(
   config,
   async function* ({ safeDb, session, user }) {
+    // Private shortcuts are user-global (the unique index is
+    // `(userId, command) WHERE scope = 'private'`), so the existence
+    // check must scope by user + private — not by active org. Filtering
+    // by org made this handler 500 with a duplicate-key error when a
+    // user who already had private shortcuts in one org switched to
+    // another and the seed call ran afresh.
     const existing = yield* Result.await(
       safeDb((tx) =>
         tx.$count(
           promptShortcuts,
           and(
-            eq(promptShortcuts.organizationId, session.activeOrganizationId),
             eq(promptShortcuts.userId, user.id),
+            eq(promptShortcuts.scope, "private"),
           ),
         ),
       ),
@@ -62,19 +68,24 @@ const seedShortcuts = createSafeRootHandler(
 
     yield* Result.await(
       safeDb((tx) =>
-        tx.insert(promptShortcuts).values(
-          DEFAULT_SHORTCUTS.map((s) => ({
-            id: createSafeId<"promptShortcut">(),
-            organizationId: session.activeOrganizationId,
-            userId: user.id,
-            scope: "private" as const,
-            name: s.name,
-            description: s.description,
-            command: s.command,
-            prompt: s.prompt,
-            isDefault: true,
-          })),
-        ),
+        tx
+          .insert(promptShortcuts)
+          .values(
+            DEFAULT_SHORTCUTS.map((s) => ({
+              id: createSafeId<"promptShortcut">(),
+              organizationId: session.activeOrganizationId,
+              userId: user.id,
+              scope: "private" as const,
+              name: s.name,
+              description: s.description,
+              command: s.command,
+              prompt: s.prompt,
+              isDefault: true,
+            })),
+          )
+          // Defensive in case two clients race the seed; the existence
+          // check above is the primary gate.
+          .onConflictDoNothing(),
       ),
     );
 


### PR DESCRIPTION
## Summary

The handler counted existing shortcuts by `(userId, organizationId)`, but the unique index `prompt_shortcuts_user_private_command_uidx` is on `(userId, command) WHERE scope = 'private'` — no organization in the key. Switching the active org made the count return 0 even when a user already had private shortcuts; the subsequent insert hit the unique violation and the route returned 500.

The fix aligns the existence check with the unique index: `(userId, scope = 'private')`.

`onConflictDoNothing()` is kept as a defensive guard for concurrent seed calls, but the existence check is now the primary gate so the route returns `{ seeded: false }` predictably.

## Test plan

- [x] Repro: `POST /v1/shortcuts/seed` no longer 500s after switching active organization for a user that already has private shortcuts.
- [ ] First-time call still inserts the four defaults.
- [ ] Subsequent call returns `{ seeded: false }`.