### PR TITLE
feat: stream extraction previews

### DIFF
--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -34,6 +34,7 @@ import {
   getExecutionPlanData,
   getPropertyExecutionPlan,
 } from "@/api/lib/workflow/get-execution-plan";
+import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { prepareBatch } from "@/api/lib/workflow/utils";
 
 // ── Redis keys ─────────────────────────────────────────
@@ -41,6 +42,17 @@ const WORKFLOW_KEY_PREFIX = "workflow";
 
 const workflowKey = (workspaceId: SafeId<"workspace">, field: string) =>
   `${WORKFLOW_KEY_PREFIX}:${workspaceId}:${field}`;
+
+const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
+const EXTRACTION_PREVIEW_THROTTLE_MS = 500;
+
+type ExtractionPreviewPayload = {
+  entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyId: SafeId<"property">;
+  answer: string | null;
+  status: "streaming" | "clear";
+};
 
 // ── Queue name ─────────────────────────────────────────
 const QUEUE_NAME = "workflow";
@@ -472,6 +484,79 @@ type ProcessOneBatchArgs = {
   signal: AbortSignal;
 };
 
+type BatchPreviewPublisherArgs = {
+  workspaceId: SafeId<"workspace">;
+  entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyIds: SafeId<"property">[];
+};
+
+const createBatchPreviewPublisher = ({
+  workspaceId,
+  entityId,
+  entityVersionId,
+  propertyIds,
+}: BatchPreviewPublisherArgs) => {
+  const propertyIdSet = new Set(propertyIds);
+  const lastAnswers = new Map<SafeId<"property">, string>();
+  const lastSentAt = new Map<SafeId<"property">, number>();
+
+  const broadcastPreview = (payload: ExtractionPreviewPayload) => {
+    broadcast(workspaceId, {
+      type: EXTRACTION_PREVIEW_EVENT_TYPE,
+      data: payload,
+    });
+  };
+
+  const publish = (update: PartialAnswerUpdate): void => {
+    const propertyId = brandPersistedPropertyId(update.propertyId);
+    if (!propertyIdSet.has(propertyId)) {
+      return;
+    }
+
+    const answer = update.answer.trim();
+    if (answer.length === 0 || lastAnswers.get(propertyId) === answer) {
+      return;
+    }
+
+    const now = Date.now();
+    const previousSentAt = lastSentAt.get(propertyId);
+    if (
+      previousSentAt !== undefined &&
+      now - previousSentAt < EXTRACTION_PREVIEW_THROTTLE_MS
+    ) {
+      return;
+    }
+
+    lastAnswers.set(propertyId, answer);
+    lastSentAt.set(propertyId, now);
+
+    const payload: ExtractionPreviewPayload = {
+      entityId,
+      entityVersionId,
+      propertyId,
+      answer,
+      status: "streaming",
+    };
+
+    broadcastPreview(payload);
+  };
+
+  const clear = (): void => {
+    for (const propertyId of propertyIds) {
+      broadcastPreview({
+        entityId,
+        entityVersionId,
+        propertyId,
+        answer: null,
+        status: "clear",
+      });
+    }
+  };
+
+  return { clear, publish };
+};
+
 const processOneBatch = async ({
   workspaceId,
   organizationId,
@@ -523,114 +608,128 @@ const processOneBatch = async ({
     return;
   }
 
-  // Set fields to "pending"
-  await setFieldsStatus({
+  const previewPublisher = createBatchPreviewPublisher({
     workspaceId,
+    entityId,
     entityVersionId,
-    batch,
-    contentType: "pending",
-    scopedDb,
+    propertyIds: batch.properties.map((property) => property.id),
   });
 
-  // Broadcast so frontend shows pending state
-  broadcastInvalidation(workspaceId, ["entities", workspaceId]);
-
-  const orgAIConfig = await loadOrgAIConfig(organizationId);
-  const generateFn = isMockAI() ? generateBatchMock : generateBatch;
-
-  // generateBatch returns a Result<T, E> directly. The combined
-  // signal aborts when EITHER the per-batch AI timeout fires OR the
-  // worker-level per-job timeout does, so the AI SDK actually cancels
-  // the in-flight request.
-  const batchResult = await generateFn({
-    abortSignal: AbortSignal.any([
-      AbortSignal.timeout(BATCH_AI_TIMEOUT_MS),
-      signal,
-    ]),
-    batch,
-    entityVersionId,
-    organizationId,
-    workspaceId,
-    scopedDb,
-    orgAIConfig,
-  });
-
-  if (Result.isError(batchResult)) {
-    captureError(batchResult.error, {
-      workspaceId,
-      entityId,
-      batchId: batch.id,
-      level: String(level),
-      requestId,
-    });
-
+  try {
+    // Set fields to "pending"
     await setFieldsStatus({
       workspaceId,
       entityVersionId,
       batch,
-      contentType: "error",
+      contentType: "pending",
       scopedDb,
     });
-    return;
-  }
 
-  const processedFields = batchResult.value;
+    // Broadcast so frontend shows pending state
+    broadcastInvalidation(workspaceId, ["entities", workspaceId]);
 
-  // Write AI results to DB
-  const allPropertyIds = [
-    ...processedFields.aiResults.map((r) => r.propertyId),
-    ...processedFields.unsupportedPropertyIds,
-    ...processedFields.skippedPropertyIds,
-  ];
+    const orgAIConfig = await loadOrgAIConfig(organizationId);
+    const generateFn = isMockAI() ? generateBatchMock : generateBatch;
 
-  await scopedDb(async (tx) => {
-    if (allPropertyIds.length > 0) {
-      await tx
-        .delete(fields)
-        .where(
-          and(
-            eq(fields.entityVersionId, entityVersionId),
-            inArray(fields.propertyId, allPropertyIds),
-          ),
-        );
+    // generateBatch returns a Result<T, E> directly. The combined
+    // signal aborts when EITHER the per-batch AI timeout fires OR the
+    // worker-level per-job timeout does, so the AI SDK actually cancels
+    // the in-flight request.
+    const batchResult = await generateFn({
+      abortSignal: AbortSignal.any([
+        AbortSignal.timeout(BATCH_AI_TIMEOUT_MS),
+        signal,
+      ]),
+      batch,
+      entityVersionId,
+      organizationId,
+      workspaceId,
+      scopedDb,
+      orgAIConfig,
+      onPartialAnswer: previewPublisher.publish,
+    });
+
+    if (Result.isError(batchResult)) {
+      captureError(batchResult.error, {
+        workspaceId,
+        entityId,
+        batchId: batch.id,
+        level: String(level),
+        requestId,
+      });
+
+      await setFieldsStatus({
+        workspaceId,
+        entityVersionId,
+        batch,
+        contentType: "error",
+        scopedDb,
+      });
+      return;
     }
 
-    const fieldValues = [
-      ...processedFields.aiResults.map(({ fieldId, propertyId, content }) => ({
-        id: fieldId,
-        workspaceId,
-        propertyId,
-        entityVersionId,
-        content,
-      })),
-      ...processedFields.unsupportedPropertyIds.map((propertyId) => ({
-        id: createSafeId<"field">(),
-        workspaceId,
-        propertyId,
-        entityVersionId,
-        content: { type: "unsupported" as const, version: 1 as const },
-      })),
+    const processedFields = batchResult.value;
+
+    // Write AI results to DB
+    const allPropertyIds = [
+      ...processedFields.aiResults.map((r) => r.propertyId),
+      ...processedFields.unsupportedPropertyIds,
+      ...processedFields.skippedPropertyIds,
     ];
 
-    if (fieldValues.length > 0) {
-      await tx.insert(fields).values(fieldValues);
-    }
+    await scopedDb(async (tx) => {
+      if (allPropertyIds.length > 0) {
+        await tx
+          .delete(fields)
+          .where(
+            and(
+              eq(fields.entityVersionId, entityVersionId),
+              inArray(fields.propertyId, allPropertyIds),
+            ),
+          );
+      }
 
-    if (processedFields.aiJustifications.length > 0) {
-      await tx.insert(justifications).values(
-        processedFields.aiJustifications.map((j) => ({
-          id: j.justificationId,
+      const fieldValues = [
+        ...processedFields.aiResults.map(
+          ({ fieldId, propertyId, content }) => ({
+            id: fieldId,
+            workspaceId,
+            propertyId,
+            entityVersionId,
+            content,
+          }),
+        ),
+        ...processedFields.unsupportedPropertyIds.map((propertyId) => ({
+          id: createSafeId<"field">(),
           workspaceId,
-          fieldId: j.fieldId,
-          content: j.content,
-          fileFieldIds: j.fileFieldIds,
+          propertyId,
+          entityVersionId,
+          content: { type: "unsupported" as const, version: 1 as const },
         })),
-      );
-    }
-  });
+      ];
 
-  // Broadcast so frontend shows updated fields
-  broadcastInvalidation(workspaceId, ["entities", workspaceId]);
+      if (fieldValues.length > 0) {
+        await tx.insert(fields).values(fieldValues);
+      }
+
+      if (processedFields.aiJustifications.length > 0) {
+        await tx.insert(justifications).values(
+          processedFields.aiJustifications.map((j) => ({
+            id: j.justificationId,
+            workspaceId,
+            fieldId: j.fieldId,
+            content: j.content,
+            fileFieldIds: j.fileFieldIds,
+          })),
+        );
+      }
+    });
+
+    // Broadcast so frontend shows updated fields
+    broadcastInvalidation(workspaceId, ["entities", workspaceId]);
+  } finally {
+    previewPublisher.clear();
+  }
 };
 
 // ── Completion tracking ────────────────────────────────

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -132,10 +132,11 @@ export const generateWorkflowData = async ({
           })
         : Promise.resolve();
 
-      const output = await result.output;
-      await partialAnswerTask;
-
-      return output;
+      try {
+        return await result.output;
+      } finally {
+        await partialAnswerTask;
+      }
     },
     catch: (error) => {
       aiAnalytics.captureError(error);

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -1,5 +1,5 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-import { generateText, Output } from "ai";
+import { Output, streamText } from "ai";
 import type { FilePart, TextPart } from "ai";
 import { Result } from "better-result";
 
@@ -23,6 +23,8 @@ import type {
   AIJustificationOutput,
   JustificationFilenames,
 } from "@/api/lib/workflow/parse-justifications";
+import { consumePartialAnswers } from "@/api/lib/workflow/streaming-answer";
+import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 
 type GenerateWorkflowDataProps = {
   files: PreparedInputFile[];
@@ -34,6 +36,9 @@ type GenerateWorkflowDataProps = {
   workspaceId: SafeId<"workspace">;
   entityVersionId: string;
   orgAIConfig?: OrgAIConfig | null;
+  onPartialAnswer?:
+    | ((update: PartialAnswerUpdate) => Promise<void> | void)
+    | undefined;
 };
 
 type WorkflowDataOutput = Record<
@@ -51,6 +56,7 @@ export const generateWorkflowData = async ({
   organizationId,
   workspaceId,
   orgAIConfig,
+  onPartialAnswer,
 }: GenerateWorkflowDataProps): Promise<
   Result<WorkflowDataOutput, WorkflowIntegrationError>
 > => {
@@ -106,7 +112,7 @@ export const generateWorkflowData = async ({
 
   return await Result.tryPromise({
     try: async () => {
-      const result = await generateText({
+      const result = streamText({
         model: getModelForRole("pdf", orgAIConfig),
         temperature: getTemperatureForRole("pdf"),
         messages: [{ role: "user", content: messageContent }],
@@ -116,7 +122,20 @@ export const generateWorkflowData = async ({
         ...aiAnalytics.stepCallbacks,
       });
 
-      return result.output;
+      const partialAnswerTask = onPartialAnswer
+        ? consumePartialAnswers({
+            partialOutputs: result.partialOutputStream,
+            propertyIds: properties.map((property) => property.id),
+            onPartialAnswer,
+          }).catch((error: unknown) => {
+            aiAnalytics.captureError(error);
+          })
+        : Promise.resolve();
+
+      const output = await result.output;
+      await partialAnswerTask;
+
+      return output;
     },
     catch: (error) => {
       aiAnalytics.captureError(error);

--- a/apps/api/src/lib/workflow/generate-batch-mock.ts
+++ b/apps/api/src/lib/workflow/generate-batch-mock.ts
@@ -53,6 +53,7 @@ const getValueFromInputFields = (
 export const generateBatchMock = async ({
   batch,
   entityVersionId,
+  onPartialAnswer,
   scopedDb,
 }: GenerateBatchProps): Promise<GenerateBatchResult> =>
   await Result.gen(async function* () {
@@ -113,13 +114,15 @@ export const generateBatchMock = async ({
 
       switch (content.type) {
         case "text": {
+          const value = `${inputFieldValue} + ${faker.lorem.word()}`;
+          await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
             propertyId: property.id,
             content: {
               type: "text",
               version: 1,
-              value: `${inputFieldValue} + ${faker.lorem.word()}`,
+              value,
             },
           });
           break;
@@ -128,6 +131,7 @@ export const generateBatchMock = async ({
         case "single-select": {
           const possibleValues = content.options.map((option) => option.value);
           const value = faker.helpers.arrayElement(possibleValues);
+          await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
             propertyId: property.id,
@@ -146,6 +150,10 @@ export const generateBatchMock = async ({
             min: 1,
             max: possibleValues.length,
           });
+          await onPartialAnswer?.({
+            propertyId: property.id,
+            answer: value.join(", "),
+          });
 
           aiResults.push({
             fieldId,
@@ -160,14 +168,16 @@ export const generateBatchMock = async ({
         }
 
         case "date": {
+          const value =
+            faker.date.past().toISOString().split("T")[0] ?? "1970-01-01";
+          await onPartialAnswer?.({ propertyId: property.id, answer: value });
           aiResults.push({
             fieldId,
             propertyId: property.id,
             content: {
               type: "date",
               version: 1,
-              value:
-                faker.date.past().toISOString().split("T")[0] ?? "1970-01-01",
+              value,
             },
           });
           break;
@@ -175,14 +185,20 @@ export const generateBatchMock = async ({
 
         case "int": {
           const currencies = ["USD", "EUR", "CZK", null];
+          const value = faker.number.int({ min: 0, max: 1_000_000 });
+          const currency = faker.helpers.arrayElement(currencies);
+          await onPartialAnswer?.({
+            propertyId: property.id,
+            answer: currency ? `${value} ${currency}` : String(value),
+          });
           aiResults.push({
             fieldId,
             propertyId: property.id,
             content: {
               type: "int",
               version: 1,
-              value: faker.number.int({ min: 0, max: 1_000_000 }),
-              currency: faker.helpers.arrayElement(currencies),
+              value,
+              currency,
             },
           });
           break;

--- a/apps/api/src/lib/workflow/generate-batch-shared.ts
+++ b/apps/api/src/lib/workflow/generate-batch-shared.ts
@@ -16,6 +16,7 @@ import type {
   BatchProperty,
   PropertyBatch,
 } from "@/api/lib/workflow/get-execution-plan";
+import type { PartialAnswerUpdate } from "@/api/lib/workflow/streaming-answer";
 import { evaluateCondition } from "@/api/lib/workflow/utils";
 
 // Types shared between mock and real AI implementations
@@ -48,6 +49,9 @@ export type GenerateBatchProps = {
   batch: PropertyBatch;
   entityVersionId: SafeId<"entityVersion">;
   orgAIConfig?: OrgAIConfig | null;
+  onPartialAnswer?:
+    | ((update: PartialAnswerUpdate) => Promise<void> | void)
+    | undefined;
 };
 
 export type GenerateBatchResult = Result<

--- a/apps/api/src/lib/workflow/generate-batch.ts
+++ b/apps/api/src/lib/workflow/generate-batch.ts
@@ -184,6 +184,7 @@ export const generateBatch = async ({
   workspaceId,
   scopedDb,
   orgAIConfig,
+  onPartialAnswer,
 }: GenerateBatchProps): Promise<GenerateBatchResult> =>
   await Result.gen(async function* () {
     const inputFields = await fetchInputFieldsForBatch({
@@ -234,6 +235,7 @@ export const generateBatch = async ({
         abortSignal,
         organizationId,
         orgAIConfig: orgAIConfig ?? null,
+        onPartialAnswer,
         workspaceId,
       }),
     );

--- a/apps/api/src/lib/workflow/streaming-answer.test.ts
+++ b/apps/api/src/lib/workflow/streaming-answer.test.ts
@@ -34,6 +34,11 @@ describe("formatPartialAnswer", () => {
   test("caps long streamed text before publishing it", () => {
     expect(formatPartialAnswer("x".repeat(600))).toHaveLength(500);
   });
+
+  test("does not over-truncate multibyte text below the character cap", () => {
+    const answer = "🙂".repeat(300);
+    expect(formatPartialAnswer(answer)).toBe(answer);
+  });
 });
 
 describe("consumePartialAnswers", () => {

--- a/apps/api/src/lib/workflow/streaming-answer.test.ts
+++ b/apps/api/src/lib/workflow/streaming-answer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  consumePartialAnswers,
+  formatPartialAnswer,
+} from "@/api/lib/workflow/streaming-answer";
+
+describe("formatPartialAnswer", () => {
+  test("formats plain text answers", () => {
+    expect(formatPartialAnswer("  Governing law is New York. ")).toBe(
+      "Governing law is New York.",
+    );
+  });
+
+  test("formats multi-select answers as comma-separated text", () => {
+    expect(formatPartialAnswer(["Signed", "", "  Counterparty "])).toBe(
+      "Signed, Counterparty",
+    );
+  });
+
+  test("formats numeric currency answers", () => {
+    expect(formatPartialAnswer({ amount: 1500, currency: "EUR" })).toBe(
+      "1500 EUR",
+    );
+    expect(formatPartialAnswer({ amount: 1500, currency: null })).toBe("1500");
+  });
+
+  test("drops empty and incomplete answers", () => {
+    expect(formatPartialAnswer(" ")).toBeNull();
+    expect(formatPartialAnswer([])).toBeNull();
+    expect(formatPartialAnswer({ currency: "EUR" })).toBeNull();
+  });
+
+  test("caps long streamed text before publishing it", () => {
+    expect(formatPartialAnswer("x".repeat(600))).toHaveLength(500);
+  });
+});
+
+describe("consumePartialAnswers", () => {
+  test("emits only answer text for known properties", async () => {
+    const updates: { propertyId: string; answer: string }[] = [];
+
+    await consumePartialAnswers({
+      propertyIds: ["p1", "p2"],
+      partialOutputs: [
+        { p1: { answer: "Alpha", justification: "ignored" } },
+        { p2: { answer: ["Beta", "Gamma"] }, p3: { answer: "ignored" } },
+      ],
+      onPartialAnswer: (update) => {
+        updates.push(update);
+      },
+    });
+
+    expect(updates).toEqual([
+      { propertyId: "p1", answer: "Alpha" },
+      { propertyId: "p2", answer: "Beta, Gamma" },
+    ]);
+  });
+});

--- a/apps/api/src/lib/workflow/streaming-answer.ts
+++ b/apps/api/src/lib/workflow/streaming-answer.ts
@@ -1,0 +1,90 @@
+const MAX_STREAMED_ANSWER_CHARS = 500;
+
+const truncateStreamedAnswer = (value: string): string => {
+  const normalized = value.trim();
+  const chars = Array.from(normalized);
+  if (chars.length <= MAX_STREAMED_ANSWER_CHARS) {
+    return normalized;
+  }
+  return chars.slice(0, MAX_STREAMED_ANSWER_CHARS).join("").trim();
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const formatPartialAnswer = (answer: unknown): string | null => {
+  if (typeof answer === "string") {
+    const text = truncateStreamedAnswer(answer);
+    return text.length > 0 ? text : null;
+  }
+
+  if (typeof answer === "number" && Number.isFinite(answer)) {
+    return String(answer);
+  }
+
+  if (Array.isArray(answer)) {
+    const values = answer
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+
+    if (values.length === 0) {
+      return null;
+    }
+
+    return truncateStreamedAnswer(values.join(", "));
+  }
+
+  if (!isPlainObject(answer)) {
+    return null;
+  }
+
+  const amount = answer["amount"];
+  if (typeof amount !== "number" || !Number.isFinite(amount)) {
+    return null;
+  }
+
+  const currency = answer["currency"];
+  if (typeof currency === "string" && currency.trim().length > 0) {
+    return truncateStreamedAnswer(`${amount} ${currency}`);
+  }
+
+  return String(amount);
+};
+
+export type PartialAnswerUpdate = {
+  propertyId: string;
+  answer: string;
+};
+
+type ConsumePartialAnswersArgs = {
+  partialOutputs: AsyncIterable<unknown> | Iterable<unknown>;
+  propertyIds: readonly string[];
+  onPartialAnswer: (update: PartialAnswerUpdate) => Promise<void> | void;
+};
+
+export const consumePartialAnswers = async ({
+  partialOutputs,
+  propertyIds,
+  onPartialAnswer,
+}: ConsumePartialAnswersArgs): Promise<void> => {
+  for await (const partialOutput of partialOutputs) {
+    if (!isPlainObject(partialOutput)) {
+      continue;
+    }
+
+    for (const propertyId of propertyIds) {
+      const propertyOutput = partialOutput[propertyId];
+      if (!isPlainObject(propertyOutput) || !("answer" in propertyOutput)) {
+        continue;
+      }
+
+      const answer = formatPartialAnswer(propertyOutput["answer"]);
+      if (!answer) {
+        continue;
+      }
+
+      await onPartialAnswer({ propertyId, answer });
+    }
+  }
+};

--- a/apps/api/src/lib/workflow/streaming-answer.ts
+++ b/apps/api/src/lib/workflow/streaming-answer.ts
@@ -2,6 +2,9 @@ const MAX_STREAMED_ANSWER_CHARS = 500;
 
 const truncateStreamedAnswer = (value: string): string => {
   const normalized = value.trim();
+  if (normalized.length <= MAX_STREAMED_ANSWER_CHARS) {
+    return normalized;
+  }
   const chars = Array.from(normalized);
   if (chars.length <= MAX_STREAMED_ANSWER_CHARS) {
     return normalized;

--- a/apps/web/src/lib/sse.ts
+++ b/apps/web/src/lib/sse.ts
@@ -10,8 +10,34 @@ const WORKSPACE_SSE_EVENT_SOURCE_INIT = {
   withCredentials: true,
 } satisfies EventSourceInit;
 
+type WorkspaceSSEEvent = {
+  type: string;
+  data: unknown;
+};
+
+type UseWorkspaceSSEOptions = {
+  onEvent?: (event: WorkspaceSSEEvent) => void;
+};
+
 const getWorkspaceSSEUrl = (workspaceId: string) =>
   `${env.VITE_API_URL}/v1/workspaces/${workspaceId}/events`;
+
+const parseWorkspaceSSEEvent = (data: string): WorkspaceSSEEvent | null => {
+  const parsed: unknown = JSON.parse(data);
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("type" in parsed) ||
+    typeof parsed.type !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    type: parsed.type,
+    data: "data" in parsed ? parsed.data : undefined,
+  };
+};
 
 /**
  * Subscribe to workspace-scoped SSE events. On receiving an
@@ -21,7 +47,10 @@ const getWorkspaceSSEUrl = (workspaceId: string) =>
  * Auto-reconnects via the native EventSource reconnection
  * behaviour. Cleans up on unmount or when workspaceId changes.
  */
-export const useWorkspaceSSE = (workspaceId: string) => {
+export const useWorkspaceSSE = (
+  workspaceId: string,
+  options: UseWorkspaceSSEOptions = {},
+) => {
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
 
@@ -33,6 +62,9 @@ export const useWorkspaceSSE = (workspaceId: string) => {
   const analyticsRef = useRef(analytics);
   analyticsRef.current = analytics;
 
+  const onEventRef = useRef(options.onEvent);
+  onEventRef.current = options.onEvent;
+
   useEffect(() => {
     const source = new EventSource(
       getWorkspaceSSEUrl(workspaceId),
@@ -41,14 +73,15 @@ export const useWorkspaceSSE = (workspaceId: string) => {
 
     source.addEventListener("message", (event: MessageEvent) => {
       try {
-        const parsed: unknown = JSON.parse(String(event.data));
+        const parsed = parseWorkspaceSSEEvent(String(event.data));
+        if (!parsed) {
+          return;
+        }
+
+        onEventRef.current?.(parsed);
 
         if (
-          typeof parsed === "object" &&
-          parsed !== null &&
-          "type" in parsed &&
           parsed.type === INVALIDATE_QUERY_EVENT_TYPE &&
-          "data" in parsed &&
           Array.isArray(parsed.data)
         ) {
           // eslint-disable-next-line typescript/no-floating-promises

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -13,11 +13,16 @@ import {
 } from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 
 type CellResultProps = {
+  extractionPreview?: string | null;
   field: WorkspaceField | undefined;
   property: WorkspaceProperty;
 };
 
-export const CellResult = ({ field, property }: CellResultProps) => {
+export const CellResult = ({
+  extractionPreview,
+  field,
+  property,
+}: CellResultProps) => {
   const t = useTranslations();
   const locale = useLocale();
 
@@ -28,9 +33,14 @@ export const CellResult = ({ field, property }: CellResultProps) => {
   const type = field.content.type;
 
   if (type === "pending") {
+    const preview = extractionPreview?.trim();
+    const hasPreview = preview !== undefined && preview.length > 0;
+
     return (
       <div className="grid min-w-0 grid-cols-[1fr_auto] items-center justify-between gap-1.5">
-        <span className="truncate">{t("workspaces.fields.calculating")}</span>
+        <span className={hasPreview ? "line-clamp-2" : "truncate"}>
+          {hasPreview ? preview : t("workspaces.fields.calculating")}
+        </span>
         <span className="bg-muted-foreground size-2 shrink-0 animate-pulse rounded-full" />
       </div>
     );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -36,9 +36,20 @@ const PropertyCell = ({
   const justification = useWorkspaceStore((s) =>
     s.justifications.find((j) => j.fieldId === field?.id),
   );
+  const extractionPreview = useWorkspaceStore((s) =>
+    fieldContent?.type === "pending"
+      ? s.getExtractionPreview(entity.entityId, property.id)
+      : null,
+  );
 
   if (fieldContent?.type === "pending") {
-    return <CellResult field={field} property={property} />;
+    return (
+      <CellResult
+        extractionPreview={extractionPreview}
+        field={field}
+        property={property}
+      />
+    );
   }
 
   if (property.content.type === "file" || fieldContent?.type === "file") {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
@@ -25,6 +25,7 @@ type PdfViewerState = {
 type State = {
   pendingBoundingBoxIds: Set<string>;
   justifications: WorkspaceJustification[];
+  extractionPreviews: Map<string, string>;
   activeJustification: ActiveJustification | null;
   pdfPageCount: number;
   pdfViewer: PdfViewerState;
@@ -37,6 +38,14 @@ type Actions = {
   syncJustifications: (justifications: WorkspaceJustification[]) => void;
   clearJustifications: () => void;
   getJustifications: (justificationIds: string[]) => WorkspaceJustification[];
+  getExtractionPreview: (entityId: string, propertyId: string) => string | null;
+  setExtractionPreview: (preview: {
+    entityId: string;
+    propertyId: string;
+    answer: string;
+  }) => void;
+  clearExtractionPreview: (entityId: string, propertyId: string) => void;
+  clearExtractionPreviews: () => void;
   setJustificationBoundingBoxes: (
     justificationId: string,
     boundingesBox: { version: number; boxes: BoundingBox[] },
@@ -67,10 +76,14 @@ const initialPdfViewerState = (): PdfViewerState => ({
   sidebar: "entity",
 });
 
+const extractionPreviewKey = (entityId: string, propertyId: string) =>
+  `${entityId}:${propertyId}`;
+
 export const useWorkspaceStore = create<State & Actions>()(
   immer((set, get) => ({
     pendingBoundingBoxIds: new Set(),
     justifications: [],
+    extractionPreviews: new Map(),
     activeJustification: null,
     pdfPageCount: 0,
     pdfViewer: initialPdfViewerState(),
@@ -119,6 +132,27 @@ export const useWorkspaceStore = create<State & Actions>()(
 
       return justifications;
     },
+    getExtractionPreview: (entityId, propertyId) =>
+      get().extractionPreviews.get(
+        extractionPreviewKey(entityId, propertyId),
+      ) ?? null,
+    setExtractionPreview: ({ entityId, propertyId, answer }) =>
+      set((state) => {
+        state.extractionPreviews.set(
+          extractionPreviewKey(entityId, propertyId),
+          answer,
+        );
+      }),
+    clearExtractionPreview: (entityId, propertyId) =>
+      set((state) => {
+        state.extractionPreviews.delete(
+          extractionPreviewKey(entityId, propertyId),
+        );
+      }),
+    clearExtractionPreviews: () =>
+      set((state) => {
+        state.extractionPreviews = new Map();
+      }),
     setJustificationBoundingBoxes: (justificationId, boundingBoxes) =>
       set((state) => {
         const justification = state.justifications.find(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { toastManager } from "@stll/ui/components/toast";
 import { useHotkey } from "@tanstack/react-hotkeys";
@@ -33,6 +33,41 @@ import {
   overviewOptions,
   workspaceOptions,
 } from "@/routes/_protected.workspaces/-queries";
+
+const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
+const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
+const ENTITIES_QUERY_KEY_PREFIX = "entities";
+const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
+
+type ExtractionPreviewEventData = {
+  entityId: string;
+  propertyId: string;
+  answer: string | null;
+  status: "streaming" | "clear";
+};
+
+const isExtractionPreviewEventData = (
+  data: unknown,
+): data is ExtractionPreviewEventData => {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  if (
+    !("entityId" in data) ||
+    typeof data.entityId !== "string" ||
+    !("propertyId" in data) ||
+    typeof data.propertyId !== "string" ||
+    !("status" in data) ||
+    (data.status !== "streaming" && data.status !== "clear") ||
+    !("answer" in data)
+  ) {
+    return false;
+  }
+  return typeof data.answer === "string" || data.answer === null;
+};
+
+const extractionPreviewKey = (entityId: string, propertyId: string) =>
+  `${entityId}:${propertyId}`;
 
 export const Route = createFileRoute("/_protected/workspaces/$workspaceId")({
   component: RouteComponent,
@@ -121,10 +156,71 @@ function RouteComponent() {
   const workspaceId = Route.useParams({
     select: (p) => p.workspaceId,
   });
+  const previewClearTimersRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
+  );
+
+  const handleWorkspaceSSEEvent = useCallback(
+    ({ type, data }: { type: string; data: unknown }) => {
+      const workspaceStore = useWorkspaceStore.getState();
+      if (
+        type === INVALIDATE_QUERY_EVENT_TYPE &&
+        Array.isArray(data) &&
+        data.at(0) === ENTITIES_QUERY_KEY_PREFIX &&
+        data.at(1) === workspaceId
+      ) {
+        for (const timer of previewClearTimersRef.current.values()) {
+          clearTimeout(timer);
+        }
+        previewClearTimersRef.current.clear();
+        workspaceStore.clearExtractionPreviews();
+        return;
+      }
+
+      if (
+        type !== EXTRACTION_PREVIEW_EVENT_TYPE ||
+        !isExtractionPreviewEventData(data)
+      ) {
+        return;
+      }
+
+      if (data.status === "clear" || data.answer === null) {
+        const key = extractionPreviewKey(data.entityId, data.propertyId);
+        const timer = previewClearTimersRef.current.get(key);
+        if (timer !== undefined) {
+          clearTimeout(timer);
+          previewClearTimersRef.current.delete(key);
+        }
+        workspaceStore.clearExtractionPreview(data.entityId, data.propertyId);
+        return;
+      }
+
+      const key = extractionPreviewKey(data.entityId, data.propertyId);
+      const previousTimer = previewClearTimersRef.current.get(key);
+      if (previousTimer !== undefined) {
+        clearTimeout(previousTimer);
+      }
+
+      workspaceStore.setExtractionPreview({
+        entityId: data.entityId,
+        propertyId: data.propertyId,
+        answer: data.answer,
+      });
+
+      const nextTimer = setTimeout(() => {
+        useWorkspaceStore
+          .getState()
+          .clearExtractionPreview(data.entityId, data.propertyId);
+        previewClearTimersRef.current.delete(key);
+      }, EXTRACTION_PREVIEW_CLIENT_TTL_MS);
+      previewClearTimersRef.current.set(key, nextTimer);
+    },
+    [workspaceId],
+  );
 
   // Subscribe to workspace SSE events for real-time query
   // invalidation (replaces the Rivet sync actor for this workspace).
-  useWorkspaceSSE(workspaceId);
+  useWorkspaceSSE(workspaceId, { onEvent: handleWorkspaceSSEEvent });
 
   // Register the matter's entities as `@`-mention sources for any
   // chat editor mounted inside this workspace (right-panel chat,
@@ -143,8 +239,14 @@ function RouteComponent() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(
     () => () => {
+      for (const timer of previewClearTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      previewClearTimersRef.current.clear();
+
       const workspaceStore = useWorkspaceStore.getState();
       workspaceStore.clearJustifications();
+      workspaceStore.clearExtractionPreviews();
       workspaceStore.setActiveJustification(null);
       workspaceStore.resetPdfViewerState();
     },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -35,8 +35,6 @@ import {
 } from "@/routes/_protected.workspaces/-queries";
 
 const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
-const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
-const ENTITIES_QUERY_KEY_PREFIX = "entities";
 const EXTRACTION_PREVIEW_CLIENT_TTL_MS = 5 * 60 * 1000;
 
 type ExtractionPreviewEventData = {
@@ -164,20 +162,6 @@ function RouteComponent() {
     ({ type, data }: { type: string; data: unknown }) => {
       const workspaceStore = useWorkspaceStore.getState();
       if (
-        type === INVALIDATE_QUERY_EVENT_TYPE &&
-        Array.isArray(data) &&
-        data.at(0) === ENTITIES_QUERY_KEY_PREFIX &&
-        data.at(1) === workspaceId
-      ) {
-        for (const timer of previewClearTimersRef.current.values()) {
-          clearTimeout(timer);
-        }
-        previewClearTimersRef.current.clear();
-        workspaceStore.clearExtractionPreviews();
-        return;
-      }
-
-      if (
         type !== EXTRACTION_PREVIEW_EVENT_TYPE ||
         !isExtractionPreviewEventData(data)
       ) {
@@ -215,7 +199,7 @@ function RouteComponent() {
       }, EXTRACTION_PREVIEW_CLIENT_TTL_MS);
       previewClearTimersRef.current.set(key, nextTimer);
     },
-    [workspaceId],
+    [],
   );
 
   // Subscribe to workspace SSE events for real-time query


### PR DESCRIPTION
## Summary
- stream AI extraction answer previews from AI SDK partial object output into pending table cells
- route previews over the existing workspace SSE channel without storing preview text in Redis keys
- clear previews on final entity invalidation, explicit clear events, unmount, and a 5-minute client fallback TTL

## Test plan
- bun test apps/api/src/lib/workflow/streaming-answer.test.ts
- bun run format
- bun run lint
- bun run typecheck
- bun run test
- pre-push i18n/typecheck/lint/format hooks passed

## Security notes
- preview payloads are workspace-scoped SSE events behind existing workspace auth
- preview text is capped to 500 characters and excludes justifications/citations
- no durable Redis preview keys are written; Redis is used only through existing SSE pub/sub