### PR TITLE
fix: update transactional email footer

### DIFF
--- a/packages/transactional/emails/_shared.ts
+++ b/packages/transactional/emails/_shared.ts
@@ -1,6 +1,7 @@
 import type React from "react";
 
 export const ICON_URL = "https://assets.stll.app/email/stella-icon.png";
+export const BRAND_FOOTER_TEXT = "stella | open source legal workspace";
 
 export const brand = {
   blue: "#205ea6",

--- a/packages/transactional/emails/better-auth-otp.tsx
+++ b/packages/transactional/emails/better-auth-otp.tsx
@@ -13,7 +13,7 @@ import {
 
 import { getTranslator } from "../i18n/translate";
 import type { SupportedLang } from "../i18n/translate";
-import { ICON_URL, brand, sharedStyles } from "./_shared";
+import { BRAND_FOOTER_TEXT, ICON_URL, brand, sharedStyles } from "./_shared";
 
 const otpTypeKey = {
   "sign-in": "otp.signIn",
@@ -57,7 +57,7 @@ export const Email = ({ otp, type, lang }: Props) => {
           <Text style={sharedStyles.muted}>{tr("otp.expires")}</Text>
           <Hr style={sharedStyles.hr} />
           <Text style={sharedStyles.footer}>{tr("otp.ignore")}</Text>
-          <Text style={sharedStyles.brandFooter}>stella — Legal workspace</Text>
+          <Text style={sharedStyles.brandFooter}>{BRAND_FOOTER_TEXT}</Text>
         </Container>
       </Body>
     </Html>

--- a/packages/transactional/emails/organization-invitation.tsx
+++ b/packages/transactional/emails/organization-invitation.tsx
@@ -14,7 +14,7 @@ import {
 
 import { getTranslator } from "../i18n/translate";
 import type { SupportedLang } from "../i18n/translate";
-import { ICON_URL, brand, sharedStyles } from "./_shared";
+import { BRAND_FOOTER_TEXT, ICON_URL, brand, sharedStyles } from "./_shared";
 
 type Props = {
   inviteLink: string;
@@ -70,7 +70,7 @@ export const Email = ({
           <Text style={sharedStyles.muted}>{t("invitation.expires")}</Text>
           <Hr style={sharedStyles.hr} />
           <Text style={sharedStyles.footer}>{t("invitation.ignore")}</Text>
-          <Text style={sharedStyles.brandFooter}>stella — Legal workspace</Text>
+          <Text style={sharedStyles.brandFooter}>{BRAND_FOOTER_TEXT}</Text>
         </Container>
       </Body>
     </Html>


### PR DESCRIPTION
## Summary
- centralize the transactional email footer text in the shared email helper
- update OTP and organization invitation templates to use `stella | open source legal workspace`

## Test plan
- `bun run lint && bun run format && bun run typecheck && bun run test`
- pre-push hook: typecheck, i18n, lint, format

## Security
- no auth, data access, or external input handling changes
- `diff --check` passed
- hardcoded secret scan found no new source secrets; `bun pm scan` is unavailable because no scanner is configured and Dependabot alerts are disabled/inaccessible for this repository
