### PR TITLE
fix: harden object storage credentials

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -54,6 +54,10 @@ SMTP_PASSWORD=""
 S3_ENDPOINT="http://localhost:9000"
 S3_BUCKET="stella"
 S3_REGION="us-east-1"
+# Credential source: "auto" prefers IAM roles for AWS S3 endpoints and env
+# credentials for S3-compatible endpoints. Use "env", "aws-runtime", or "none"
+# to force a specific mode.
+S3_CREDENTIALS_PROVIDER="auto"
 # Optional credentials. Omit both to use the SDK default credential chain
 # (IAM role on Fargate, AWS_PROFILE locally, etc.).
 S3_ACCESS_KEY_ID="minioadmin"

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -15,6 +15,10 @@ export const envBase = createEnv({
     DATABASE_URL: v.pipe(v.string(), v.url()),
     S3_ENDPOINT: v.string(),
     S3_BUCKET: v.string(),
+    S3_CREDENTIALS_PROVIDER: v.optional(
+      v.picklist(["auto", "env", "aws-runtime", "none"]),
+      "auto",
+    ),
     S3_ACCESS_KEY_ID: v.optional(v.string()),
     S3_SECRET_ACCESS_KEY: v.optional(v.string()),
     S3_REGION: v.string(),

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -56,20 +56,16 @@ import {
   InMemoryRateLimitContext,
   scopedGenerator,
 } from "@/api/lib/rate-limit";
+import { isS3Stale, refreshS3 } from "@/api/lib/s3";
 import { setSecurityHeaders } from "@/api/lib/security-headers";
 import { initWorkflowWorker } from "@/api/lib/workflow-queue";
-
-// BullMQ worker for asynchronous file derivatives.
-initFileDerivativeWorker();
-
-// BullMQ workflow worker for AI extraction.
-initWorkflowWorker();
 
 const HEALTH_PATH = "/health";
 const DEFAULT_API_PORT = 3001;
 const SESSION_ID_HEADER = "x-posthog-session-id";
 const SESSION_ID_MAX_LENGTH = 64;
 const SESSION_ID_PATTERN = /^[\w-]+$/;
+const S3_REFRESH_CHECK_INTERVAL_MS = 60_000;
 
 const getApiPort = () => {
   const rawPort = process.env["STELLA_API_PORT"];
@@ -331,5 +327,30 @@ const api = new Elysia()
   );
 
 export default api;
+
+const startS3RefreshLoop = () => {
+  const timer = setInterval(() => {
+    if (!isS3Stale()) {
+      return;
+    }
+
+    refreshS3().catch((error: unknown) => {
+      logger.error("s3.refresh_failed", {
+        "error.type": errorTag(error),
+      });
+    });
+  }, S3_REFRESH_CHECK_INTERVAL_MS);
+
+  timer.unref();
+};
+
+await refreshS3();
+startS3RefreshLoop();
+
+// BullMQ worker for asynchronous file derivatives.
+initFileDerivativeWorker();
+
+// BullMQ workflow worker for AI extraction.
+initWorkflowWorker();
 
 api.listen(getApiPort());

--- a/apps/api/src/lib/s3.test.ts
+++ b/apps/api/src/lib/s3.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveS3Credentials } from "@/api/lib/s3";
+
+const jsonResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), { status: 200 });
+
+const notFoundResponse = (): Response => new Response(null, { status: 404 });
+
+const requestUrl = (input: string | URL | Request): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input.url;
+};
+
+describe("resolveS3Credentials", () => {
+  test("prefers ECS task credentials over static credentials for AWS S3 endpoints", async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl = async (
+      url: string | URL | Request,
+    ): Promise<Response> => {
+      requestedUrls.push(requestUrl(url));
+
+      return jsonResponse({
+        AccessKeyId: "ecs-access-key",
+        SecretAccessKey: "ecs-secret-key",
+        Token: "ecs-session-token",
+      });
+    };
+
+    const credentials = await resolveS3Credentials({
+      endpoint: "https://s3.eu-central-1.amazonaws.com",
+      fetchImpl,
+      runtimeEnv: {
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/task",
+      },
+      staticCredentials: {
+        accessKeyId: "static-access-key",
+        secretAccessKey: "static-secret-key",
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessKeyId: "ecs-access-key",
+      secretAccessKey: "ecs-secret-key",
+      sessionToken: "ecs-session-token",
+    });
+    expect(requestedUrls).toEqual(["http://169.254.170.2/v2/credentials/task"]);
+  });
+
+  test("prefers static credentials for S3-compatible endpoints in auto mode", async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl = async (
+      url: string | URL | Request,
+    ): Promise<Response> => {
+      requestedUrls.push(requestUrl(url));
+
+      return jsonResponse({
+        AccessKeyId: "ecs-access-key",
+        SecretAccessKey: "ecs-secret-key",
+        Token: "ecs-session-token",
+      });
+    };
+
+    const credentials = await resolveS3Credentials({
+      endpoint: "https://s3.example.com",
+      fetchImpl,
+      runtimeEnv: {
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/task",
+      },
+      staticCredentials: {
+        accessKeyId: "static-access-key",
+        secretAccessKey: "static-secret-key",
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessKeyId: "static-access-key",
+      secretAccessKey: "static-secret-key",
+    });
+    expect(requestedUrls).toEqual([]);
+  });
+
+  test("supports explicit AWS runtime credentials for S3-compatible endpoints", async () => {
+    const fetchImpl = async (): Promise<Response> =>
+      jsonResponse({
+        AccessKeyId: "ecs-access-key",
+        SecretAccessKey: "ecs-secret-key",
+        Token: "ecs-session-token",
+      });
+
+    const credentials = await resolveS3Credentials({
+      endpoint: "https://s3.example.com",
+      fetchImpl,
+      provider: "aws-runtime",
+      runtimeEnv: {
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "/v2/credentials/task",
+      },
+      staticCredentials: {
+        accessKeyId: "static-access-key",
+        secretAccessKey: "static-secret-key",
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessKeyId: "ecs-access-key",
+      secretAccessKey: "ecs-secret-key",
+      sessionToken: "ecs-session-token",
+    });
+  });
+
+  test("falls back to static credentials when AWS metadata credentials are unavailable", async () => {
+    const fetchImpl = async (): Promise<Response> => notFoundResponse();
+
+    const credentials = await resolveS3Credentials({
+      endpoint: "https://s3.eu-central-1.amazonaws.com",
+      fetchImpl,
+      runtimeEnv: {},
+      staticCredentials: {
+        accessKeyId: "static-access-key",
+        secretAccessKey: "static-secret-key",
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessKeyId: "static-access-key",
+      secretAccessKey: "static-secret-key",
+    });
+  });
+
+  test("ignores invalid ECS relative credential URIs", async () => {
+    const requestedUrls: string[] = [];
+    const fetchImpl = async (
+      url: string | URL | Request,
+    ): Promise<Response> => {
+      requestedUrls.push(requestUrl(url));
+
+      return notFoundResponse();
+    };
+
+    const credentials = await resolveS3Credentials({
+      endpoint: "https://s3.eu-central-1.amazonaws.com",
+      fetchImpl,
+      runtimeEnv: {
+        AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: "v2/credentials/task",
+      },
+      staticCredentials: {
+        accessKeyId: "static-access-key",
+        secretAccessKey: "static-secret-key",
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessKeyId: "static-access-key",
+      secretAccessKey: "static-secret-key",
+    });
+    expect(requestedUrls).toEqual(["http://169.254.169.254/latest/api/token"]);
+  });
+});

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -3,68 +3,58 @@ import { S3Client } from "bun";
 import { envBase } from "@/api/env-base";
 import { contentDisposition } from "@/api/lib/content-disposition";
 
-/**
- * Fetch temporary credentials from EC2 Instance Metadata
- * Service (IMDSv2). Bun's S3Client resolves credentials
- * from constructor options or AWS_* env vars but does NOT
- * query IMDS directly. On EC2, Docker injects stale
- * AWS_ACCESS_KEY_ID / AWS_SESSION_TOKEN env vars at
- * container start that expire after ~6 hours.
- *
- * Returns null when not running on EC2 (local dev).
- */
-const fetchImdsCredentials = async (): Promise<{
+type S3Credentials = {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken: string;
-} | null> => {
+};
+
+type CredentialRuntimeEnv = Record<string, string | undefined>;
+type Fetcher = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => ReturnType<typeof fetch>;
+type S3CredentialsProvider = "auto" | "env" | "aws-runtime" | "none";
+
+const ECS_CREDENTIALS_BASE_URL = "http://169.254.170.2";
+
+const isCredentialsShape = (
+  value: unknown,
+): value is {
+  AccessKeyId: string;
+  SecretAccessKey: string;
+  Token: string;
+} =>
+  typeof value === "object" &&
+  value !== null &&
+  "AccessKeyId" in value &&
+  "SecretAccessKey" in value &&
+  "Token" in value &&
+  typeof value.AccessKeyId === "string" &&
+  typeof value.SecretAccessKey === "string" &&
+  typeof value.Token === "string";
+
+const fetchCredentialJson = async (
+  url: string,
+  {
+    fetchImpl,
+    headers,
+  }: {
+    fetchImpl: Fetcher;
+    headers?: Record<string, string>;
+  },
+): Promise<S3Credentials | null> => {
   try {
-    const tokenResponse = await fetch(
-      "http://169.254.169.254/latest/api/token",
-      {
-        method: "PUT",
-        headers: { "X-aws-ec2-metadata-token-ttl-seconds": "300" },
-        signal: AbortSignal.timeout(2000),
-      },
-    );
-    if (!tokenResponse.ok) {
+    const response = await fetchImpl(url, {
+      ...(headers ? { headers } : {}),
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!response.ok) {
       return null;
     }
-    const imdsToken = await tokenResponse.text();
 
-    const roleResponse = await fetch(
-      "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
-      {
-        headers: { "X-aws-ec2-metadata-token": imdsToken },
-        signal: AbortSignal.timeout(2000),
-      },
-    );
-    if (!roleResponse.ok) {
-      return null;
-    }
-    const roleName = (await roleResponse.text()).trim();
-
-    const credsResponse = await fetch(
-      `http://169.254.169.254/latest/meta-data/iam/security-credentials/${roleName}`,
-      {
-        headers: { "X-aws-ec2-metadata-token": imdsToken },
-        signal: AbortSignal.timeout(2000),
-      },
-    );
-    if (!credsResponse.ok) {
-      return null;
-    }
-    const creds: unknown = await credsResponse.json();
-    if (
-      typeof creds !== "object" ||
-      creds === null ||
-      !("AccessKeyId" in creds) ||
-      !("SecretAccessKey" in creds) ||
-      !("Token" in creds) ||
-      typeof creds.AccessKeyId !== "string" ||
-      typeof creds.SecretAccessKey !== "string" ||
-      typeof creds.Token !== "string"
-    ) {
+    const creds: unknown = await response.json();
+    if (!isCredentialsShape(creds)) {
       return null;
     }
 
@@ -78,13 +68,137 @@ const fetchImdsCredentials = async (): Promise<{
   }
 };
 
-const buildS3Client = (
-  creds?: {
-    accessKeyId: string;
-    secretAccessKey: string;
-    sessionToken?: string;
-  } | null,
-): S3Client =>
+const fetchEcsCredentials = async ({
+  fetchImpl = fetch,
+  runtimeEnv = process.env,
+}: {
+  fetchImpl?: Fetcher;
+  runtimeEnv?: CredentialRuntimeEnv;
+} = {}): Promise<S3Credentials | null> => {
+  const relativeUri = runtimeEnv["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"];
+  const fullUri = runtimeEnv["AWS_CONTAINER_CREDENTIALS_FULL_URI"];
+
+  if (!relativeUri && !fullUri) {
+    return null;
+  }
+
+  const url = (() => {
+    if (relativeUri) {
+      if (!relativeUri.startsWith("/")) {
+        return null;
+      }
+      return `${ECS_CREDENTIALS_BASE_URL}${relativeUri}`;
+    }
+
+    if (!fullUri) {
+      return null;
+    }
+
+    try {
+      const parsedUrl = new URL(fullUri);
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        return null;
+      }
+      return parsedUrl.toString();
+    } catch {
+      return null;
+    }
+  })();
+
+  if (!url) {
+    return null;
+  }
+
+  const headers: Record<string, string> = {};
+  const authorizationToken = runtimeEnv["AWS_CONTAINER_AUTHORIZATION_TOKEN"];
+  const authorizationTokenFile =
+    runtimeEnv["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"];
+
+  if (authorizationToken) {
+    headers["Authorization"] = authorizationToken;
+  } else if (authorizationTokenFile) {
+    const token = await Bun.file(authorizationTokenFile)
+      .text()
+      .catch(() => null);
+    if (token) {
+      headers["Authorization"] = token.trim();
+    }
+  }
+
+  return await fetchCredentialJson(url, { fetchImpl, headers });
+};
+
+/**
+ * Fetch temporary credentials from EC2 Instance Metadata
+ * Service (IMDSv2). Bun's S3Client resolves credentials
+ * from constructor options or AWS_* env vars but does NOT
+ * query IMDS directly.
+ *
+ * Returns null when not running on EC2 (local dev).
+ */
+const fetchImdsCredentials = async ({
+  fetchImpl = fetch,
+}: {
+  fetchImpl?: Fetcher;
+} = {}): Promise<S3Credentials | null> => {
+  try {
+    const tokenResponse = await fetchImpl(
+      "http://169.254.169.254/latest/api/token",
+      {
+        method: "PUT",
+        headers: { "X-aws-ec2-metadata-token-ttl-seconds": "300" },
+        signal: AbortSignal.timeout(2000),
+      },
+    );
+    if (!tokenResponse.ok) {
+      return null;
+    }
+    const imdsToken = await tokenResponse.text();
+
+    const roleResponse = await fetchImpl(
+      "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      {
+        headers: { "X-aws-ec2-metadata-token": imdsToken },
+        signal: AbortSignal.timeout(2000),
+      },
+    );
+    if (!roleResponse.ok) {
+      return null;
+    }
+    const roleName = (await roleResponse.text()).trim();
+
+    const credsResponse = await fetchImpl(
+      `http://169.254.169.254/latest/meta-data/iam/security-credentials/${roleName}`,
+      {
+        headers: { "X-aws-ec2-metadata-token": imdsToken },
+        signal: AbortSignal.timeout(2000),
+      },
+    );
+    if (!credsResponse.ok) {
+      return null;
+    }
+    const creds: unknown = await credsResponse.json();
+    if (!isCredentialsShape(creds)) {
+      return null;
+    }
+
+    return {
+      accessKeyId: creds.AccessKeyId,
+      secretAccessKey: creds.SecretAccessKey,
+      sessionToken: creds.Token,
+    };
+  } catch {
+    return null;
+  }
+};
+
+type OptionalS3Credentials = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+};
+
+const buildS3Client = (creds?: OptionalS3Credentials | null): S3Client =>
   new S3Client({
     acl: "private",
     bucket: envBase.S3_BUCKET,
@@ -99,24 +213,98 @@ const buildS3Client = (
       : {}),
   });
 
+type ResolveS3CredentialsOptions = {
+  endpoint?: string;
+  fetchImpl?: Fetcher;
+  provider?: S3CredentialsProvider;
+  runtimeEnv?: CredentialRuntimeEnv;
+  staticCredentials?: OptionalS3Credentials | null;
+};
+
+const staticCredentialsFromEnv = (): OptionalS3Credentials | null => {
+  if (!envBase.S3_ACCESS_KEY_ID || !envBase.S3_SECRET_ACCESS_KEY) {
+    return null;
+  }
+
+  return {
+    accessKeyId: envBase.S3_ACCESS_KEY_ID,
+    secretAccessKey: envBase.S3_SECRET_ACCESS_KEY,
+  };
+};
+
+const isAwsS3Endpoint = (endpoint: string): boolean => {
+  try {
+    const host = new URL(endpoint).hostname.toLowerCase();
+    return host.includes("s3") && host.endsWith(".amazonaws.com");
+  } catch {
+    return false;
+  }
+};
+
+const resolveAwsRuntimeCredentials = async (
+  fetchImpl: Fetcher,
+  runtimeEnv: CredentialRuntimeEnv,
+): Promise<S3Credentials | null> => {
+  const ecsCredentials = await fetchEcsCredentials({ fetchImpl, runtimeEnv });
+  if (ecsCredentials) {
+    return ecsCredentials;
+  }
+
+  const imdsCredentials = await fetchImdsCredentials({ fetchImpl });
+  if (imdsCredentials) {
+    return imdsCredentials;
+  }
+
+  return null;
+};
+
+export const resolveS3Credentials = async ({
+  endpoint = envBase.S3_ENDPOINT,
+  fetchImpl = fetch,
+  provider = envBase.S3_CREDENTIALS_PROVIDER,
+  runtimeEnv = process.env,
+  staticCredentials = staticCredentialsFromEnv(),
+}: ResolveS3CredentialsOptions = {}): Promise<OptionalS3Credentials | null> => {
+  if (provider === "none") {
+    return null;
+  }
+
+  if (provider === "env") {
+    return staticCredentials;
+  }
+
+  if (provider === "aws-runtime") {
+    return await resolveAwsRuntimeCredentials(fetchImpl, runtimeEnv);
+  }
+
+  if (!isAwsS3Endpoint(endpoint)) {
+    return (
+      staticCredentials ??
+      (await resolveAwsRuntimeCredentials(fetchImpl, runtimeEnv))
+    );
+  }
+
+  const awsRuntimeCredentials = await resolveAwsRuntimeCredentials(
+    fetchImpl,
+    runtimeEnv,
+  );
+  if (awsRuntimeCredentials) {
+    return awsRuntimeCredentials;
+  }
+
+  return staticCredentials;
+};
+
 /**
- * Recreate the S3 client with fresh credentials. On EC2,
- * fetches from IMDS; locally, falls back to env vars / no
- * credentials (MinIO via S3_ENDPOINT).
+ * Recreate the S3 client with fresh credentials. The default
+ * auto mode prefers AWS runtime roles for AWS S3 endpoints and
+ * static env credentials for S3-compatible endpoints.
  *
  * Call at process startup and periodically in long-running
  * processes to prevent STS credential expiry.
  */
 export const refreshS3 = async (): Promise<void> => {
-  if (envBase.S3_ACCESS_KEY_ID && envBase.S3_SECRET_ACCESS_KEY) {
-    _client = buildS3Client({
-      accessKeyId: envBase.S3_ACCESS_KEY_ID,
-      secretAccessKey: envBase.S3_SECRET_ACCESS_KEY,
-    });
-  } else {
-    const imdsCreds = await fetchImdsCredentials();
-    _client = buildS3Client(imdsCreds);
-  }
+  _client = buildS3Client(await resolveS3Credentials());
   _clientCreatedAt = Date.now();
 };
 

--- a/apps/docs/src/content/docs/guides/self-hosting.md
+++ b/apps/docs/src/content/docs/guides/self-hosting.md
@@ -80,6 +80,7 @@ REDIS_URL="redis://valkey.example.internal:6379"
 S3_ENDPOINT="https://s3.example.com"
 S3_BUCKET="stella"
 S3_REGION="us-east-1"
+S3_CREDENTIALS_PROVIDER="env"
 S3_ACCESS_KEY_ID="..."
 S3_SECRET_ACCESS_KEY="..."
 ```

--- a/apps/docs/src/content/docs/reference/configuration.md
+++ b/apps/docs/src/content/docs/reference/configuration.md
@@ -8,7 +8,11 @@ stella is configured via environment variables. All variables are documented bel
 | Variable | Description | Required |
 |---|---|---|
 | `DATABASE_URL` | PostgreSQL connection string | Yes |
+| `S3_ENDPOINT` | S3 or S3-compatible object storage endpoint | Yes |
 | `S3_BUCKET` | S3 bucket name for file storage | Yes |
 | `S3_REGION` | S3 region | Yes |
+| `S3_CREDENTIALS_PROVIDER` | Credential source: `auto`, `env`, `aws-runtime`, or `none` | No |
+| `S3_ACCESS_KEY_ID` | Static object storage access key, required when `S3_CREDENTIALS_PROVIDER=env` | No |
+| `S3_SECRET_ACCESS_KEY` | Static object storage secret key, required when `S3_CREDENTIALS_PROVIDER=env` | No |
 
 Full reference coming soon.


### PR DESCRIPTION
## Summary
- add explicit object storage credential provider modes
- refresh object storage credentials during startup and on a timer
- document credential provider configuration for self-hosted deployments

## Test plan
- bun run format
- bun run lint
- bun run typecheck
- bun run test