### PR TITLE
fix(api): typed errors surface as their own status; BYOK role guard

### DIFF
--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -506,6 +506,9 @@ export const getModelForRole = (
     // role falls back to instance provider. Route through
     // the regional endpoint.
     if (orgConfig.region && orgConfig.region !== "global") {
+      if (!hasInstanceProvider()) {
+        throw byokRoleNotConfiguredError(role);
+      }
       const factory = getRegionalInstanceFactory(orgConfig.region);
       const modelId =
         MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[getActiveProvider()][role];
@@ -513,11 +516,31 @@ export const getModelForRole = (
     }
   }
 
-  // Default instance path.
+  // Default instance path. requireAIAvailable() gates the entry
+  // point but only checks "any provider available" — it returns
+  // ok if orgConfig is non-null without verifying the org's BYOK
+  // covers the requested role. So when an org has partial BYOK
+  // overrides and the role falls through here on a deployment
+  // with REQUIRE_PERSONAL_AI_KEY=true, getActiveProvider() panics
+  // with a generic error and the user sees a 500. Throw a typed
+  // HandlerError instead so the request boundary returns 403 with
+  // an actionable message.
+  if (!hasInstanceProvider()) {
+    throw byokRoleNotConfiguredError(role);
+  }
   const modelId =
     MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[getActiveProvider()][role];
   return withLocalAIDevTools(getInstanceFactory()(modelId));
 };
+
+const byokRoleNotConfiguredError = (role: ModelRole): HandlerError =>
+  new HandlerError({
+    status: 403,
+    message:
+      `AI is not available for the "${role}" role on this deployment. ` +
+      "Configure an organization-wide AI key (or include this role in " +
+      "the BYOK override list) in organization settings.",
+  });
 
 export const getModelInfoForRole = (
   role: ModelRole,

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -190,6 +190,25 @@ const createSafeScopedHandler = <
 
       return toSafeStatusResponse(500, { message: "Internal server error" });
     } catch (error) {
+      // A typed HandlerError thrown synchronously (or escaping the
+      // Result.gen pipeline) must still surface as its own status,
+      // not a generic 500. Without this branch a deeper handler
+      // that throws HandlerError for a recoverable condition (e.g.
+      // an AI request hitting a role the org has not configured a
+      // BYOK key for) gets reported to the user as "Internal
+      // server error" with no actionable detail.
+      if (HandlerError.is(error)) {
+        if (error.status >= 500) {
+          logAndCaptureSafeError({
+            request: ctx.request,
+            route: ctx.route,
+            error,
+            statusCode: error.status,
+          });
+        }
+        return toSafeStatusResponse(error.status, { message: error.message });
+      }
+
       logAndCaptureSafeError({
         request: ctx.request,
         route: ctx.route,


### PR DESCRIPTION
Two bugs that combined to turn a recoverable BYOK condition into an opaque 500.

## Outer-catch handler
`createSafeScopedHandler` outer catch always returned 500 even when the thrown value was a typed `HandlerError`. Add a `HandlerError.is` check at the top so the original status (e.g. 403) propagates with a useful message.

## getModelForRole BYOK role coverage
`requireAIAvailable()` only asks 'any provider available'. When an org has partial `overrideRoles` and the requested role isn't covered, the gate passes but `getModelForRole` falls through to the instance path and `getActiveProvider()` panics — generic "Internal server error" with no actionable detail.