### PR TITLE
fix(web): extract dark-mode init to /public so CSP can stay strict

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,27 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="alternate icon" href="/favicon.ico" />
-    <!-- Inline blocking script to apply dark mode before first
-         paint. Must NOT be type="module" (deferred) to prevent
-         a white flash. Storage keys duplicated from consts.ts. -->
-    <script>
-      (function () {
-        var t = "stella-ui-theme";
-        var p = "stella-ui-palette";
-        var d =
-          localStorage[t] === "dark" ||
-          (localStorage[t] !== "light" &&
-            matchMedia("(prefers-color-scheme: dark)").matches);
-        var el = document.documentElement;
-        if (d) {
-          el.classList.add("dark");
-          el.style.colorScheme = "dark";
-          el.style.backgroundColor = "#0c0c0d";
-        }
-        var pal = localStorage.getItem(p) || "neutral";
-        if (pal !== "neutral") el.classList.add("palette-" + pal);
-      })();
-    </script>
+    <!-- Synchronous (non-module) script so it runs before the SPA
+         bundle and prevents a white flash for dark-mode users.
+         Lives in /public so the strict frontend CSP doesn't need
+         'unsafe-inline' or a hash. -->
+    <script src="/dark-mode-init.js"></script>
     <script type="module">
       import { getStorageKey } from "/src/consts.ts";
 

--- a/apps/web/public/dark-mode-init.js
+++ b/apps/web/public/dark-mode-init.js
@@ -1,0 +1,28 @@
+/**
+ * Apply dark mode + palette before first paint to avoid a white
+ * flash on dark-mode users. Loaded synchronously (non-module)
+ * from index.html so it runs before the SPA bundle. Storage keys
+ * are duplicated from src/consts.ts — keep them in sync.
+ *
+ * Lives here (not inline in index.html) so the frontend CSP can
+ * stay strict (script-src 'self') without needing 'unsafe-inline'
+ * or per-script hashes.
+ */
+(function () {
+  const t = "stella-ui-theme";
+  const p = "stella-ui-palette";
+  const d =
+    localStorage[t] === "dark" ||
+    (localStorage[t] !== "light" &&
+      matchMedia("(prefers-color-scheme: dark)").matches);
+  const el = document.documentElement;
+  if (d) {
+    el.classList.add("dark");
+    el.style.colorScheme = "dark";
+    el.style.backgroundColor = "#0c0c0d";
+  }
+  const pal = localStorage.getItem(p) || "neutral";
+  if (pal !== "neutral") {
+    el.classList.add(`palette-${pal}`);
+  }
+})();


### PR DESCRIPTION
Removes the only inline-script CSP violation on every page load. Moves the dark-mode init script body to `apps/web/public/dark-mode-init.js` and references via `<script src>`. No behavior change.