### PR TITLE
fix: clean up ai settings copy

### DIFF
--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -333,11 +333,11 @@ export function AIKeyRequiredDialog({
                 ))}
               </SelectPopup>
             </Select>
-            <p className="text-muted-foreground text-xs">
-              {REGIONAL_PROVIDERS.has(provider)
-                ? tOrganization("aiConfig.dataRegionDescription")
-                : tOrganization("aiConfig.dataRegionUnsupported")}
-            </p>
+            {!REGIONAL_PROVIDERS.has(provider) && (
+              <p className="text-muted-foreground text-xs">
+                {tOrganization("aiConfig.dataRegionUnsupported")}
+              </p>
+            )}
           </Field>
         </DialogPanel>
         <DialogFooter>

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Upravit pomocí AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Přidat API klíč",
+      "description": "Nejsou nastavené žádné výchozí AI klíče. Přidejte vlastní API klíč, abyste mohli používat funkce AI.",
+      "title": "Chybí AI klíč"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Zadejte svůj API klíč",
       "apiKeyUpdatePlaceholder": "Zadejte nový klíč pro aktualizaci",
       "baseUrl": "Základní URL",
-      "configure": "Konfigurovat",
+      "configure": "Nastavit",
       "dataRegion": "Region dat",
-      "dataRegionDescription": "Volání AI poteče přes vybraný region kvůli suverenitě dat.",
       "dataRegionUnsupported": "Regionální směrování je dostupné jen pro Google AI (Vertex AI).",
-      "description": "Připojte vlastní API klíč nebo zvolte region pro suverenitu dat.",
+      "description": "Přidejte vlastní API klíč nebo zvolte region.",
       "overrideRoles": "Přepsat role",
-      "overrideRolesDescription": "Vyberte, které AI role použijí váš klíč. Nevybrané role poběží na výchozím klíči platformy.",
+      "overrideRolesDescription": "Vyberte, pro které AI role se má použít váš klíč.",
       "provider": "Poskytovatel",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (dokumenty)",
         "reasoning": "Uvažování (analýza)"
       },
-      "title": "Konfigurace AI"
+      "title": "Nastavení AI"
     },
     "invitations": {
       "cancelInvitation": "Zrušit pozvánku",
@@ -1322,7 +1321,7 @@
     "organization": {
       "activeMembers": "Aktivní členové",
       "ai": "Nastavení AI",
-      "aiDescription": "Připojte vlastní API klíč nebo zvolte region pro suverenitu dat",
+      "aiDescription": "Přidejte vlastní API klíč nebo zvolte region",
       "matterNumbering": "Číslování spisů",
       "matterNumberingDescription": "Nastavte, jak se generují referenční čísla nových spisů",
       "membersDescription": "Spravujte, kdo má přístup k této organizaci, a čekající pozvánky",
@@ -1338,8 +1337,8 @@
     "title": "Nastavení"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "Nastavení AI odstraněno",
+    "aiConfigUpdated": "Nastavení AI aktualizováno",
     "clientUpdated": "Klient aktualizován",
     "contactCreated": "Klient vytvořen",
     "contactDeleted": "Klient smazán",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Mit KI bearbeiten",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "API-Schlüssel hinzufügen",
+      "description": "Für diese Instanz sind keine plattformweiten KI-Schlüssel eingerichtet. Fügen Sie Ihren eigenen API-Schlüssel hinzu, um KI-Funktionen zu nutzen.",
+      "title": "KI-Schlüssel erforderlich"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Einrichten",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Wählen Sie aus, für welche KI-Rollen Ihr Schlüssel verwendet werden soll.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "KI-Einstellungen"
     },
     "invitations": {
       "cancelInvitation": "Einladung stornieren",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "KI-Einstellungen",
+      "aiDescription": "Eigenen API-Schlüssel hinterlegen oder Region für Datensouveränität wählen",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "KI-Einstellungen entfernt",
+    "aiConfigUpdated": "KI-Einstellungen aktualisiert",
     "clientUpdated": "Klient aktualisiert",
     "contactCreated": "Klient erstellt",
     "contactDeleted": "Klient gelöscht",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -16,7 +16,7 @@
   "ai": {
     "editWithAI": "Edit with AI",
     "keyRequired": {
-      "cta": "Open AI settings",
+      "cta": "Add API key",
       "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
       "title": "AI key required"
     }
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Set up",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Choose which AI roles should use your key.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "AI settings"
     },
     "invitations": {
       "cancelInvitation": "Cancel invitation",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "AI settings",
+      "aiDescription": "Add your own API key or choose a data sovereignty region",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization and any pending invitations",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "AI settings removed",
+    "aiConfigUpdated": "AI settings updated",
     "clientUpdated": "Client updated",
     "contactCreated": "Client created",
     "contactDeleted": "Client deleted",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Editar con IA",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Añadir clave de API",
+      "description": "Esta instancia no tiene claves de IA de la plataforma configuradas. Añade tu propia clave de API para empezar a usar las funciones de IA.",
+      "title": "Se requiere una clave de IA"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Configurar",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Elige qué roles de IA deben usar tu clave.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "Ajustes de IA"
     },
     "invitations": {
       "cancelInvitation": "Cancelar invitación",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "Ajustes de IA",
+      "aiDescription": "Añade tu propia clave de API o elige una región para la soberanía de datos",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "Ajustes de IA eliminados",
+    "aiConfigUpdated": "Ajustes de IA actualizados",
     "clientUpdated": "Cliente actualizado",
     "contactCreated": "Cliente creado",
     "contactDeleted": "Cliente eliminado",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Muuda AI-ga",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Lisa API võti",
+      "description": "Sellel eksemplaril pole platvormi AI-võtmeid seadistatud. AI-funktsioonide kasutamiseks lisa oma API võti.",
+      "title": "AI võti on vajalik"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Seadista",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Vali, millised AI rollid peaksid kasutama sinu võtit.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "AI seaded"
     },
     "invitations": {
       "cancelInvitation": "Tühista kutse",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "AI seaded",
+      "aiDescription": "Lisa oma API võti või vali andmesuveräänsuse piirkond",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "AI seaded eemaldatud",
+    "aiConfigUpdated": "AI seaded värskendatud",
     "clientUpdated": "Klient uuendatud",
     "contactCreated": "Klient loodud",
     "contactDeleted": "Klient kustutatud",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Modifier avec l’IA",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Ajouter une clé API",
+      "description": "Aucune clé d’IA de plateforme n’est configurée pour cette instance. Ajoutez votre propre clé API pour utiliser les fonctionnalités d’IA.",
+      "title": "Clé d’IA requise"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Configurer",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Choisissez les rôles d’IA qui doivent utiliser votre clé.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "Paramètres d’IA"
     },
     "invitations": {
       "cancelInvitation": "Annuler l'invitation",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "Paramètres d’IA",
+      "aiDescription": "Ajoutez votre propre clé API ou choisissez une région pour la souveraineté des données",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "Paramètres d’IA supprimés",
+    "aiConfigUpdated": "Paramètres d’IA mis à jour",
     "clientUpdated": "Client mis à jour",
     "contactCreated": "Client créé",
     "contactDeleted": "Client supprimé",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Szerkesztés AI-val",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "API-kulcs hozzáadása",
+      "description": "Ehhez a példányhoz nincs platformszintű AI-kulcs beállítva. Az AI-funkciók használatához adja meg a saját API-kulcsát.",
+      "title": "AI-kulcs szükséges"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Beállítás",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Válassza ki, mely AI-szerepkörök használják az Ön kulcsát.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "AI-beállítások"
     },
     "invitations": {
       "cancelInvitation": "Meghívó visszavonása",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "AI-beállítások",
+      "aiDescription": "Adja meg saját API-kulcsát, vagy válasszon adatszuverenitási régiót",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "AI-beállítások törölve",
+    "aiConfigUpdated": "AI-beállítások frissítve",
     "clientUpdated": "Ügyfél frissítve",
     "contactCreated": "Ügyfél létrehozva",
     "contactDeleted": "Ügyfél törölve",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Redaguoti su DI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Pridėti API raktą",
+      "description": "Šiame egzemplioriuje nesukonfigūruoti platformos DI raktai. Pridėkite savo API raktą, kad galėtumėte naudoti DI funkcijas.",
+      "title": "Reikalingas DI raktas"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Nustatyti",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Pasirinkite, kurie DI vaidmenys turėtų naudoti jūsų raktą.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "DI nustatymai"
     },
     "invitations": {
       "cancelInvitation": "Atšaukti kvietimą",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "DI nustatymai",
+      "aiDescription": "Pridėkite savo API raktą arba pasirinkite duomenų suvereniteto regioną",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "DI nustatymai pašalinti",
+    "aiConfigUpdated": "DI nustatymai atnaujinti",
     "clientUpdated": "Klientas atnaujintas",
     "contactCreated": "Klientas sukurtas",
     "contactDeleted": "Klientas ištrintas",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Rediģēt ar AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Pievienot API atslēgu",
+      "description": "Šai instancei nav konfigurētu platformas AI atslēgu. Pievienojiet savu API atslēgu, lai sāktu izmantot AI funkcijas.",
+      "title": "Vajadzīga AI atslēga"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Iestatīt",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Izvēlieties, kurām AI lomām jāizmanto jūsu atslēga.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "AI iestatījumi"
     },
     "invitations": {
       "cancelInvitation": "Atcelt uzaicinājumu",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "AI iestatījumi",
+      "aiDescription": "Pievienojiet savu API atslēgu vai izvēlieties datu suverenitātes reģionu",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "AI iestatījumi noņemti",
+    "aiConfigUpdated": "AI iestatījumi atjaunināti",
     "clientUpdated": "Klients atjaunināts",
     "contactCreated": "Klients izveidots",
     "contactDeleted": "Klients dzēsts",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -19,7 +19,7 @@ type Messages = {
   "ai": {
     "editWithAI": "Edit with AI";
     "keyRequired": {
-      "cta": "Open AI settings";
+      "cta": "Add API key";
       "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.";
       "title": "AI key required";
     };
@@ -1161,13 +1161,12 @@ type Messages = {
       "apiKeyPlaceholder": "Enter your API key";
       "apiKeyUpdatePlaceholder": "Enter new key to update";
       "baseUrl": "Base URL";
-      "configure": "Configure";
+      "configure": "Set up";
       "dataRegion": "Data region";
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.";
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).";
       "description": "Bring your own API key or configure data sovereignty region.";
       "overrideRoles": "Override roles";
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.";
+      "overrideRolesDescription": "Choose which AI roles should use your key.";
       "provider": "Provider";
       "providers": {
         "anthropic": "Anthropic";
@@ -1187,7 +1186,7 @@ type Messages = {
         "pdf": "PDF (documents)";
         "reasoning": "Reasoning (analysis)";
       };
-      "title": "AI configuration";
+      "title": "AI settings";
     };
     "invitations": {
       "cancelInvitation": "Cancel invitation";
@@ -1324,8 +1323,8 @@ type Messages = {
     };
     "organization": {
       "activeMembers": "Active members";
-      "ai": "AI configuration";
-      "aiDescription": "Bring your own API key or configure data sovereignty region";
+      "ai": "AI settings";
+      "aiDescription": "Add your own API key or choose a data sovereignty region";
       "matterNumbering": "Matter numbering";
       "matterNumberingDescription": "Configure how new matter reference numbers are generated";
       "membersDescription": "Manage who has access to this organization and any pending invitations";
@@ -1341,8 +1340,8 @@ type Messages = {
     "title": "Settings";
   };
   "success": {
-    "aiConfigDeleted": "AI configuration removed";
-    "aiConfigUpdated": "AI configuration updated";
+    "aiConfigDeleted": "AI settings removed";
+    "aiConfigUpdated": "AI settings updated";
     "clientUpdated": "Client updated";
     "contactCreated": "Client created";
     "contactDeleted": "Client deleted";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Edytuj z AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Dodaj klucz API",
+      "description": "Ta instancja nie ma skonfigurowanych platformowych kluczy AI. Dodaj własny klucz API, aby zacząć korzystać z funkcji AI.",
+      "title": "Wymagany klucz AI"
     }
   },
   "anonymize": {
@@ -1160,11 +1160,10 @@
       "baseUrl": "Bazowy URL",
       "configure": "Skonfiguruj",
       "dataRegion": "Region danych",
-      "dataRegionDescription": "Kieruje żądania AI przez wybrany region dla zachowania suwerenności danych.",
       "dataRegionUnsupported": "Routing regionalny jest dostępny tylko dla Google AI (Vertex AI).",
       "description": "Użyj własnego klucza API lub skonfiguruj region suwerenności danych.",
       "overrideRoles": "Nadpisz role",
-      "overrideRolesDescription": "Wybierz, które role AI używają Twojego klucza. Niezaznaczone role używają domyślnego klucza platformy.",
+      "overrideRolesDescription": "Wybierz, które role AI mają używać Twojego klucza.",
       "provider": "Dostawca",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "Konfiguracja AI"
+      "title": "Ustawienia AI"
     },
     "invitations": {
       "cancelInvitation": "Anuluj zaproszenie",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "Ustawienia AI",
+      "aiDescription": "Dodaj własny klucz API albo wybierz region suwerenności danych",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "Konfiguracja AI usunięta",
-    "aiConfigUpdated": "Konfiguracja AI zaktualizowana",
+    "aiConfigDeleted": "Usunięto ustawienia AI",
+    "aiConfigUpdated": "Zaktualizowano ustawienia AI",
     "clientUpdated": "Klient zaktualizowany",
     "contactCreated": "Klient utworzony",
     "contactDeleted": "Klient usunięty",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Upraviť pomocou AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Pridať API kľúč",
+      "description": "Táto inštancia nemá nastavené platformové kľúče AI. Ak chcete používať funkcie AI, pridajte vlastný API kľúč.",
+      "title": "Vyžaduje sa kľúč AI"
     }
   },
   "anonymize": {
@@ -1158,13 +1158,12 @@
       "apiKeyPlaceholder": "Enter your API key",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
-      "configure": "Configure",
+      "configure": "Nastaviť",
       "dataRegion": "Data region",
-      "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
       "description": "Bring your own API key or configure data sovereignty region.",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Vyberte, pre ktoré AI roly sa má použiť váš kľúč.",
       "provider": "Provider",
       "providers": {
         "anthropic": "Anthropic",
@@ -1184,7 +1183,7 @@
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
-      "title": "AI configuration"
+      "title": "Nastavenia AI"
     },
     "invitations": {
       "cancelInvitation": "Zrušiť pozvánku",
@@ -1321,8 +1320,8 @@
     },
     "organization": {
       "activeMembers": "Active members",
-      "ai": "AI configuration",
-      "aiDescription": "Bring your own API key or configure data sovereignty region",
+      "ai": "Nastavenia AI",
+      "aiDescription": "Pridajte vlastný API kľúč alebo vyberte región pre suverenitu dát",
       "matterNumbering": "Matter numbering",
       "matterNumberingDescription": "Configure how new matter reference numbers are generated",
       "membersDescription": "Manage who has access to this organization",
@@ -1338,8 +1337,8 @@
     "title": "Settings"
   },
   "success": {
-    "aiConfigDeleted": "AI configuration removed",
-    "aiConfigUpdated": "AI configuration updated",
+    "aiConfigDeleted": "Nastavenia AI boli odstránené",
+    "aiConfigUpdated": "Nastavenia AI boli aktualizované",
     "clientUpdated": "Klient aktualizovaný",
     "contactCreated": "Klient vytvorený",
     "contactDeleted": "Klient vymazaný",

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -276,11 +276,11 @@ export const AIConfigCard = () => {
                   ))}
                 </SelectPopup>
               </Select>
-              <p className="text-muted-foreground text-xs">
-                {REGIONAL_PROVIDERS.has(provider)
-                  ? t("aiConfig.dataRegionDescription")
-                  : t("aiConfig.dataRegionUnsupported")}
-              </p>
+              {!REGIONAL_PROVIDERS.has(provider) && (
+                <p className="text-muted-foreground text-xs">
+                  {t("aiConfig.dataRegionUnsupported")}
+                </p>
+              )}
             </Field>
 
             <Field>


### PR DESCRIPTION
## Summary
- remove the AI data-region explanatory string and hide that help text for supported providers
- improve AI key and AI settings copy across locales
- regenerate i18n message types

## Test plan
- bun run lint
- bun run format
- bun run typecheck
- bun run test
- bun run i18n:check