### PR TITLE
feat: add BYOK provider model routing

### DIFF
--- a/apps/api/src/handlers/organization-settings/read-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/read-ai-config.ts
@@ -22,7 +22,6 @@ type AIConfigResult = {
       providers: {
         provider: OrgAIConfig["providers"][number]["provider"];
         apiKeyMasked: string;
-        baseURL: string | null;
         region: DataRegion;
       }[];
       overrideModels: OrgAIConfig["overrideModels"];
@@ -82,7 +81,6 @@ const readAIConfig = createSafeRootHandler(
           providers: aiConfig.providers.map((providerConfig) => ({
             provider: providerConfig.provider,
             apiKeyMasked: maskApiKey(providerConfig.apiKey),
-            baseURL: providerConfig.baseURL ?? null,
             region: providerConfig.region ?? "global",
           })),
           overrideModels: aiConfig.overrideModels,

--- a/apps/api/src/handlers/organization-settings/read-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/read-ai-config.ts
@@ -2,7 +2,7 @@ import { Result } from "better-result";
 
 import { decryptAIConfig, maskApiKey } from "@/api/lib/ai-config-crypto";
 import { hasInstanceProvider } from "@/api/lib/ai-models";
-import type { AIProvider, DataRegion, ModelRole } from "@/api/lib/ai-models";
+import type { DataRegion, OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -19,11 +19,13 @@ type AIConfigResult = {
   | { configured: false }
   | {
       configured: true;
-      provider: AIProvider;
-      apiKeyMasked: string;
-      baseURL: string | null;
-      overrideRoles: ModelRole[];
-      region: DataRegion;
+      providers: {
+        provider: OrgAIConfig["providers"][number]["provider"];
+        apiKeyMasked: string;
+        baseURL: string | null;
+        region: DataRegion;
+      }[];
+      overrideModels: OrgAIConfig["overrideModels"];
     }
 );
 
@@ -77,11 +79,13 @@ const readAIConfig = createSafeRootHandler(
         const aiConfig = decryptResult.value;
         result = {
           configured: true,
-          provider: aiConfig.provider,
-          apiKeyMasked: maskApiKey(aiConfig.apiKey),
-          baseURL: aiConfig.baseURL ?? null,
-          overrideRoles: aiConfig.overrideRoles ?? [],
-          region: aiConfig.region ?? "global",
+          providers: aiConfig.providers.map((providerConfig) => ({
+            provider: providerConfig.provider,
+            apiKeyMasked: maskApiKey(providerConfig.apiKey),
+            baseURL: providerConfig.baseURL ?? null,
+            region: providerConfig.region ?? "global",
+          })),
+          overrideModels: aiConfig.overrideModels,
           instanceProvisioned,
         };
       }

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -10,32 +10,55 @@ import {
   maskApiKey,
 } from "@/api/lib/ai-config-crypto";
 import {
+  DEFAULT_MODELS,
   getModelForRole,
   getTemperatureForRole,
+  MODEL_ROLES,
   supportsRegion,
 } from "@/api/lib/ai-models";
-import type { OrgAIConfig } from "@/api/lib/ai-models";
+import type {
+  AIProvider,
+  DataRegion,
+  ModelRole,
+  OrgAIConfig,
+  OrgAIModelSelection,
+  OrgAIProviderConfig,
+} from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { validateSafeBaseURL } from "@/api/lib/safe-base-url";
+
+const BYOK_PROVIDER_VALUES = [
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+] as const satisfies readonly AIProvider[];
+type BYOKProvider = (typeof BYOK_PROVIDER_VALUES)[number];
+
+const providerBody = t.Object({
+  provider: t.UnionEnum(BYOK_PROVIDER_VALUES),
+  apiKey: t.Optional(t.String({ minLength: 1 })),
+  region: t.Optional(t.UnionEnum(["eu", "global", "ch"])),
+});
+
+const modelSelectionBody = t.Object({
+  provider: t.UnionEnum(BYOK_PROVIDER_VALUES),
+  modelId: t.String({ minLength: 1, maxLength: 256 }),
+});
 
 const updateAIConfigBody = t.Object({
-  provider: t.UnionEnum([
-    "google",
-    "openrouter",
-    "openai",
-    "anthropic",
-    "openai_compatible",
-  ]),
-  apiKey: t.Optional(t.String({ minLength: 1 })),
-  baseURL: t.Optional(t.String({ format: "uri" })),
-  overrideRoles: t.Optional(
-    t.Array(t.UnionEnum(["fast", "chat", "reasoning", "pdf"])),
+  providers: t.Array(providerBody, { minItems: 1 }),
+  overrideModels: t.Optional(
+    t.Object({
+      fast: t.Optional(modelSelectionBody),
+      chat: t.Optional(modelSelectionBody),
+      reasoning: t.Optional(modelSelectionBody),
+      pdf: t.Optional(modelSelectionBody),
+    }),
   ),
-  region: t.Optional(t.UnionEnum(["eu", "global", "ch"])),
 });
 
 const config = {
@@ -52,128 +75,74 @@ const config = {
 const updateAIConfig = createSafeRootHandler(
   config,
   async function* ({ safeDb, session, body }) {
-    // Resolve the API key and existing config: use the new
-    // key if provided, otherwise read from storage.
-    let resolvedKey: string | undefined = body.apiKey;
     let existingConfig: OrgAIConfig | undefined;
-
-    if (!resolvedKey) {
-      const row = yield* Result.await(
-        safeDb((tx) =>
-          tx.query.organizationSettings.findFirst({
-            where: {
-              organizationId: {
-                eq: session.activeOrganizationId,
-              },
+    const row = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.organizationSettings.findFirst({
+          where: {
+            organizationId: {
+              eq: session.activeOrganizationId,
             },
-            columns: {
-              aiConfigEncrypted: true,
-              aiConfigIv: true,
-            },
-          }),
-        ),
-      );
+          },
+          columns: {
+            aiConfigEncrypted: true,
+            aiConfigIv: true,
+          },
+        }),
+      ),
+    );
 
-      const ciphertext = row?.aiConfigEncrypted;
-      const iv = row?.aiConfigIv;
+    const ciphertext = row?.aiConfigEncrypted;
+    const iv = row?.aiConfigIv;
+    if (ciphertext && iv) {
+      const decryptResult = await Result.tryPromise({
+        try: async () =>
+          await decryptAIConfig(session.activeOrganizationId, ciphertext, iv),
+        catch: (error: unknown) => error,
+      });
 
-      if (ciphertext && iv) {
-        const decryptResult = await Result.tryPromise({
-          try: async () =>
-            await decryptAIConfig(session.activeOrganizationId, ciphertext, iv),
-          catch: (error: unknown) => error,
-        });
-
-        if (decryptResult.isErr()) {
-          captureError(decryptResult.error);
-          return Result.err(
-            new HandlerError({
-              status: 400,
-              message:
-                "Stored AI config could not be decrypted. " +
-                "Please re-enter your API key.",
-            }),
-          );
-        }
-
+      if (decryptResult.isErr()) {
+        captureError(decryptResult.error);
+        existingConfig = undefined;
+      } else {
         existingConfig = decryptResult.value;
-        resolvedKey = existingConfig.apiKey;
       }
     }
 
-    if (!resolvedKey) {
+    const providerResult = resolveProviderConfigs(
+      body.providers,
+      existingConfig,
+    );
+    if (!providerResult.valid) {
       return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "API key is required for initial setup",
-        }),
+        new HandlerError({ status: 400, message: providerResult.error }),
       );
     }
 
-    // Require a new key when switching providers; the old
-    // provider's key won't authenticate with the new one.
-    if (
-      !body.apiKey &&
-      existingConfig &&
-      existingConfig.provider !== body.provider
-    ) {
+    const modelResult = normalizeOverrideModels(
+      body.overrideModels,
+      providerResult.providers,
+    );
+    if (!modelResult.valid) {
       return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "API key is required when changing provider",
-        }),
+        new HandlerError({ status: 400, message: modelResult.error }),
       );
     }
 
-    // Resolve baseURL: body > existing > reject for
-    // openai_compatible.
-    let resolvedBaseURL = body.baseURL ?? existingConfig?.baseURL;
-    if (body.provider === "openai_compatible" && !resolvedBaseURL) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "Base URL is required for OpenAI-compatible provider",
-        }),
-      );
-    }
+    const newKeyProviders = new Set(
+      body.providers
+        .filter((provider) => provider.apiKey)
+        .map((provider) => provider.provider),
+    );
 
-    // SSRF guard: when a baseURL is in play (caller-supplied
-    // or carried over from storage), require HTTPS and reject
-    // private/loopback/link-local hosts before we make any
-    // outbound call with it.
-    if (resolvedBaseURL) {
-      const urlCheck = validateSafeBaseURL(resolvedBaseURL);
-      if (!urlCheck.ok) {
-        return Result.err(
-          new HandlerError({ status: 400, message: urlCheck.error }),
-        );
+    for (const providerConfig of providerResult.providers) {
+      if (!newKeyProviders.has(providerConfig.provider)) {
+        continue;
       }
-      resolvedBaseURL = urlCheck.url;
-    }
 
-    // Reject region + non-regional provider at the boundary.
-    if (
-      body.region &&
-      body.region !== "global" &&
-      !supportsRegion(body.provider)
-    ) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message:
-            `Regional routing is not supported for ${body.provider}. ` +
-            "Only Google AI supports EU/CH regional endpoints via Vertex AI.",
-        }),
-      );
-    }
-
-    // Only validate when a new key is provided.
-    if (body.apiKey) {
       const validationResult = await validateProviderKey(
-        body.provider,
-        resolvedKey,
-        resolvedBaseURL,
-        body.region ?? existingConfig?.region,
+        providerConfig,
+        modelResult.overrideModels,
       );
 
       if (!validationResult.valid) {
@@ -187,11 +156,8 @@ const updateAIConfig = createSafeRootHandler(
     }
 
     const orgConfig: OrgAIConfig = {
-      provider: body.provider,
-      apiKey: resolvedKey,
-      baseURL: resolvedBaseURL,
-      overrideRoles: body.overrideRoles ?? existingConfig?.overrideRoles,
-      region: body.region ?? existingConfig?.region,
+      providers: providerResult.providers,
+      overrideModels: modelResult.overrideModels,
     };
 
     const { ciphertext: newCiphertext, iv: newIv } = await encryptAIConfig(
@@ -223,38 +189,168 @@ const updateAIConfig = createSafeRootHandler(
     invalidateOrgAIConfig(session.activeOrganizationId);
 
     return Result.ok({
-      provider: body.provider,
-      apiKeyMasked: maskApiKey(resolvedKey),
-      region: orgConfig.region ?? "global",
+      providers: orgConfig.providers.map((providerConfig) => ({
+        provider: providerConfig.provider,
+        apiKeyMasked: maskApiKey(providerConfig.apiKey),
+        baseURL: providerConfig.baseURL ?? null,
+        region: providerConfig.region ?? "global",
+      })),
+      overrideModels: orgConfig.overrideModels,
     });
   },
 );
 
 type ValidationResult = { valid: true } | { valid: false; error: string };
 
+type ProviderConfigInput = {
+  provider: BYOKProvider;
+  apiKey?: string | undefined;
+  region?: DataRegion | undefined;
+};
+
+type ProviderConfigResult =
+  | {
+      valid: true;
+      providers: (OrgAIProviderConfig & { provider: BYOKProvider })[];
+    }
+  | { valid: false; error: string };
+
+const resolveProviderConfigs = (
+  providers: readonly ProviderConfigInput[],
+  existingConfig: OrgAIConfig | undefined,
+): ProviderConfigResult => {
+  const resolvedProviders: (OrgAIProviderConfig & {
+    provider: BYOKProvider;
+  })[] = [];
+  const seenProviders = new Set<AIProvider>();
+
+  for (const providerInput of providers) {
+    if (seenProviders.has(providerInput.provider)) {
+      return {
+        valid: false,
+        error: `Provider ${providerInput.provider} is configured more than once`,
+      };
+    }
+    seenProviders.add(providerInput.provider);
+
+    const existingProvider = existingConfig?.providers.find(
+      (candidate) => candidate.provider === providerInput.provider,
+    );
+    const apiKey = providerInput.apiKey?.trim() || existingProvider?.apiKey;
+
+    if (!apiKey) {
+      return {
+        valid: false,
+        error: `API key is required for ${providerInput.provider}`,
+      };
+    }
+
+    if (
+      providerInput.region &&
+      providerInput.region !== "global" &&
+      !supportsRegion(providerInput.provider)
+    ) {
+      return {
+        valid: false,
+        error:
+          `Regional routing is not supported for ${providerInput.provider}. ` +
+          "Only Google AI supports EU/CH regional endpoints via Vertex AI.",
+      };
+    }
+
+    resolvedProviders.push({
+      provider: providerInput.provider,
+      apiKey,
+      region: supportsRegion(providerInput.provider)
+        ? (providerInput.region ?? existingProvider?.region ?? "global")
+        : "global",
+    });
+  }
+
+  return { valid: true, providers: resolvedProviders };
+};
+
+type OverrideModelsInput =
+  | Partial<Record<ModelRole, OrgAIModelSelection | undefined>>
+  | undefined;
+
+type OverrideModelsResult =
+  | { valid: true; overrideModels: NonNullable<OrgAIConfig["overrideModels"]> }
+  | { valid: false; error: string };
+
+const normalizeOverrideModels = (
+  overrideModels: OverrideModelsInput,
+  providers: readonly OrgAIProviderConfig[],
+): OverrideModelsResult => {
+  const normalized: Partial<Record<ModelRole, OrgAIModelSelection>> = {};
+  const configuredProviders = new Set(
+    providers.map((providerConfig) => providerConfig.provider),
+  );
+
+  for (const role of MODEL_ROLES) {
+    const selection = overrideModels?.[role];
+    const modelId = selection?.modelId.trim();
+
+    if (!(selection && modelId)) {
+      return {
+        valid: false,
+        error: `Model selection is required for ${role}`,
+      };
+    }
+
+    if (!configuredProviders.has(selection.provider)) {
+      return {
+        valid: false,
+        error: `Model selection for ${role} uses an unconfigured provider`,
+      };
+    }
+
+    normalized[role] = {
+      provider: selection.provider,
+      modelId,
+    };
+  }
+
+  return { valid: true, overrideModels: normalized };
+};
+
+const getValidationRole = (
+  provider: AIProvider,
+  overrideModels: NonNullable<OrgAIConfig["overrideModels"]>,
+): ModelRole =>
+  MODEL_ROLES.find((role) => overrideModels[role]?.provider === provider) ??
+  "fast";
+
 /**
  * Validate a provider API key by making a minimal API call.
  * Uses a tiny prompt to minimize cost.
  */
 const validateProviderKey = async (
-  provider: OrgAIConfig["provider"],
-  apiKey: string,
-  baseURL?: string,
-  region?: OrgAIConfig["region"],
+  providerConfig: OrgAIProviderConfig,
+  overrideModels: NonNullable<OrgAIConfig["overrideModels"]>,
 ): Promise<ValidationResult> => {
+  const role = getValidationRole(providerConfig.provider, overrideModels);
+  const configuredSelection = overrideModels[role];
+  const selection =
+    configuredSelection?.provider === providerConfig.provider
+      ? configuredSelection
+      : {
+          provider: providerConfig.provider,
+          modelId: DEFAULT_MODELS[providerConfig.provider][role],
+        };
   const tempConfig: OrgAIConfig = {
-    provider,
-    apiKey,
-    baseURL,
-    region,
+    providers: [providerConfig],
+    overrideModels: {
+      [role]: selection,
+    },
   };
 
   const result = await Result.tryPromise({
     try: async () => {
-      const model = getModelForRole("fast", tempConfig);
+      const model = getModelForRole(role, tempConfig);
       return await generateText({
         model,
-        temperature: getTemperatureForRole("fast"),
+        temperature: getTemperatureForRole(role),
         prompt: "Say OK",
         maxOutputTokens: 3,
         abortSignal: AbortSignal.timeout(10_000),

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { t } from "elysia";
 
 import { organizationSettings } from "@/api/db/schema";
@@ -10,9 +10,9 @@ import {
   maskApiKey,
 } from "@/api/lib/ai-config-crypto";
 import {
-  DEFAULT_MODELS,
   getModelForRole,
   getTemperatureForRole,
+  isAllowedBYOKModel,
   MODEL_ROLES,
   supportsRegion,
 } from "@/api/lib/ai-models";
@@ -51,14 +51,12 @@ const modelSelectionBody = t.Object({
 
 const updateAIConfigBody = t.Object({
   providers: t.Array(providerBody, { minItems: 1 }),
-  overrideModels: t.Optional(
-    t.Object({
-      fast: t.Optional(modelSelectionBody),
-      chat: t.Optional(modelSelectionBody),
-      reasoning: t.Optional(modelSelectionBody),
-      pdf: t.Optional(modelSelectionBody),
-    }),
-  ),
+  overrideModels: t.Object({
+    fast: modelSelectionBody,
+    chat: modelSelectionBody,
+    reasoning: modelSelectionBody,
+    pdf: modelSelectionBody,
+  }),
 });
 
 const config = {
@@ -135,24 +133,34 @@ const updateAIConfig = createSafeRootHandler(
         .map((provider) => provider.provider),
     );
 
-    for (const providerConfig of providerResult.providers) {
-      if (!newKeyProviders.has(providerConfig.provider)) {
-        continue;
-      }
+    const providersToValidate = providerResult.providers.filter(
+      (providerConfig) => newKeyProviders.has(providerConfig.provider),
+    );
 
-      const validationResult = await validateProviderKey(
-        providerConfig,
-        modelResult.overrideModels,
+    const validationResults = await Promise.all(
+      providersToValidate.map(
+        async (providerConfig) =>
+          await validateProviderKey(providerConfig, modelResult.overrideModels),
+      ),
+    );
+
+    const failures = validationResults.flatMap((result, index) => {
+      if (result.valid) {
+        return [];
+      }
+      const providerConfig =
+        providersToValidate[index] ??
+        panic("validation result index out of range");
+      return [`${providerConfig.provider}: ${result.error}`];
+    });
+
+    if (failures.length > 0) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: failures.join("; "),
+        }),
       );
-
-      if (!validationResult.valid) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: validationResult.error,
-          }),
-        );
-      }
     }
 
     const orgConfig: OrgAIConfig = {
@@ -192,7 +200,6 @@ const updateAIConfig = createSafeRootHandler(
       providers: orgConfig.providers.map((providerConfig) => ({
         provider: providerConfig.provider,
         apiKeyMasked: maskApiKey(providerConfig.apiKey),
-        baseURL: providerConfig.baseURL ?? null,
         region: providerConfig.region ?? "global",
       })),
       overrideModels: orgConfig.overrideModels,
@@ -270,79 +277,137 @@ const resolveProviderConfigs = (
   return { valid: true, providers: resolvedProviders };
 };
 
-type OverrideModelsInput =
-  | Partial<Record<ModelRole, OrgAIModelSelection | undefined>>
-  | undefined;
+type OverrideModelsInput = Record<ModelRole, OrgAIModelSelection>;
 
 type OverrideModelsResult =
-  | { valid: true; overrideModels: NonNullable<OrgAIConfig["overrideModels"]> }
+  | { valid: true; overrideModels: Record<ModelRole, OrgAIModelSelection> }
   | { valid: false; error: string };
+
+const normalizeRoleSelection = (
+  role: ModelRole,
+  overrideModels: OverrideModelsInput,
+  configuredProviders: ReadonlySet<AIProvider>,
+):
+  | { valid: true; selection: OrgAIModelSelection }
+  | { valid: false; error: string } => {
+  const selection = overrideModels[role];
+  const modelId = selection.modelId.trim();
+
+  if (!modelId) {
+    return { valid: false, error: `Model selection is required for ${role}` };
+  }
+
+  if (!configuredProviders.has(selection.provider)) {
+    return {
+      valid: false,
+      error: `Model selection for ${role} uses an unconfigured provider`,
+    };
+  }
+
+  if (!isAllowedBYOKModel(selection.provider, modelId)) {
+    return {
+      valid: false,
+      error: `Model "${modelId}" is not offered for ${selection.provider}`,
+    };
+  }
+
+  return {
+    valid: true,
+    selection: { provider: selection.provider, modelId },
+  };
+};
 
 const normalizeOverrideModels = (
   overrideModels: OverrideModelsInput,
   providers: readonly OrgAIProviderConfig[],
 ): OverrideModelsResult => {
-  const normalized: Partial<Record<ModelRole, OrgAIModelSelection>> = {};
   const configuredProviders = new Set(
     providers.map((providerConfig) => providerConfig.provider),
   );
 
-  for (const role of MODEL_ROLES) {
-    const selection = overrideModels?.[role];
-    const modelId = selection?.modelId.trim();
-
-    if (!(selection && modelId)) {
-      return {
-        valid: false,
-        error: `Model selection is required for ${role}`,
-      };
-    }
-
-    if (!configuredProviders.has(selection.provider)) {
-      return {
-        valid: false,
-        error: `Model selection for ${role} uses an unconfigured provider`,
-      };
-    }
-
-    normalized[role] = {
-      provider: selection.provider,
-      modelId,
-    };
+  const chat = normalizeRoleSelection(
+    "chat",
+    overrideModels,
+    configuredProviders,
+  );
+  if (!chat.valid) {
+    return chat;
+  }
+  const fast = normalizeRoleSelection(
+    "fast",
+    overrideModels,
+    configuredProviders,
+  );
+  if (!fast.valid) {
+    return fast;
+  }
+  const reasoning = normalizeRoleSelection(
+    "reasoning",
+    overrideModels,
+    configuredProviders,
+  );
+  if (!reasoning.valid) {
+    return reasoning;
+  }
+  const pdf = normalizeRoleSelection(
+    "pdf",
+    overrideModels,
+    configuredProviders,
+  );
+  if (!pdf.valid) {
+    return pdf;
   }
 
-  return { valid: true, overrideModels: normalized };
+  const referencedProviders = new Set<AIProvider>([
+    chat.selection.provider,
+    fast.selection.provider,
+    reasoning.selection.provider,
+    pdf.selection.provider,
+  ]);
+
+  for (const provider of configuredProviders) {
+    if (!referencedProviders.has(provider)) {
+      return {
+        valid: false,
+        error: `Provider ${provider} is configured but not used by any role`,
+      };
+    }
+  }
+
+  return {
+    valid: true,
+    overrideModels: {
+      chat: chat.selection,
+      fast: fast.selection,
+      reasoning: reasoning.selection,
+      pdf: pdf.selection,
+    },
+  };
 };
 
 const getValidationRole = (
   provider: AIProvider,
-  overrideModels: NonNullable<OrgAIConfig["overrideModels"]>,
+  overrideModels: Record<ModelRole, OrgAIModelSelection>,
 ): ModelRole =>
-  MODEL_ROLES.find((role) => overrideModels[role]?.provider === provider) ??
-  "fast";
+  MODEL_ROLES.find((role) => overrideModels[role].provider === provider) ??
+  panic(
+    `validateProviderKey called for ${provider} but no role is bound to it`,
+  );
 
 /**
  * Validate a provider API key by making a minimal API call.
- * Uses a tiny prompt to minimize cost.
+ * Uses a tiny prompt to minimize cost. Always exercises a
+ * model the user explicitly chose for this provider —
+ * orphan providers are rejected upstream.
  */
 const validateProviderKey = async (
   providerConfig: OrgAIProviderConfig,
-  overrideModels: NonNullable<OrgAIConfig["overrideModels"]>,
+  overrideModels: Record<ModelRole, OrgAIModelSelection>,
 ): Promise<ValidationResult> => {
   const role = getValidationRole(providerConfig.provider, overrideModels);
-  const configuredSelection = overrideModels[role];
-  const selection =
-    configuredSelection?.provider === providerConfig.provider
-      ? configuredSelection
-      : {
-          provider: providerConfig.provider,
-          modelId: DEFAULT_MODELS[providerConfig.provider][role],
-        };
   const tempConfig: OrgAIConfig = {
     providers: [providerConfig],
-    overrideModels: {
-      [role]: selection,
-    },
+    overrideModels,
   };
 
   const result = await Result.tryPromise({

--- a/apps/api/src/lib/ai-config-crypto.test.ts
+++ b/apps/api/src/lib/ai-config-crypto.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 
-import { isOrgAIConfig, maskApiKey } from "@/api/lib/ai-config-crypto";
+process.env["EMAIL_PROVIDER"] ??= "smtp";
+process.env["GOTENBERG_PASSWORD"] ??= "gotenberg";
+process.env["GOTENBERG_URL"] ??= "http://localhost:3003";
+process.env["GOTENBERG_USERNAME"] ??= "gotenberg";
+process.env["REDIS_URL"] ??= "redis://localhost:6379";
+process.env["SMTP_HOST"] ??= "localhost";
+process.env["SMTP_PORT"] ??= "1025";
+
+const { isOrgAIConfig, maskApiKey } =
+  await import("@/api/lib/ai-config-crypto");
 
 describe("maskApiKey", () => {
   test("shows first 8 chars for keys longer than 16 chars", () => {
@@ -36,18 +45,57 @@ describe("isOrgAIConfig", () => {
   test("accepts a valid org AI config", () => {
     expect(
       isOrgAIConfig({
-        provider: "openai",
-        apiKey: "sk-test",
-        overrideRoles: ["chat"],
-        region: "eu",
+        providers: [{ provider: "openai", apiKey: "sk-test" }],
+        overrideModels: {
+          chat: { provider: "openai", modelId: "gpt-5.4" },
+        },
       }),
     ).toBe(true);
   });
 
-  test("rejects configs missing the api key", () => {
+  test("rejects unknown model override roles", () => {
     expect(
       isOrgAIConfig({
-        provider: "openai",
+        providers: [{ provider: "openai", apiKey: "sk-test" }],
+        overrideModels: {
+          unknown: { provider: "openai", modelId: "gpt-5.4" },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects configs missing providers", () => {
+    expect(
+      isOrgAIConfig({
+        overrideModels: {
+          chat: { provider: "openai", modelId: "gpt-5.4" },
+        },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects configs with model selections missing provider context", () => {
+    expect(
+      isOrgAIConfig({
+        providers: [{ provider: "openai", apiKey: "sk-test" }],
+        overrideModels: { chat: "gpt-5.4" },
+      }),
+    ).toBe(false);
+  });
+
+  test("rejects OpenAI-compatible org BYOK configs", () => {
+    expect(
+      isOrgAIConfig({
+        providers: [
+          {
+            provider: "openai_compatible",
+            apiKey: "sk-test",
+            baseURL: "https://api.example.com/v1",
+          },
+        ],
+        overrideModels: {
+          chat: { provider: "openai_compatible", modelId: "default" },
+        },
       }),
     ).toBe(false);
   });

--- a/apps/api/src/lib/ai-config-crypto.test.ts
+++ b/apps/api/src/lib/ai-config-crypto.test.ts
@@ -42,7 +42,23 @@ describe("maskApiKey", () => {
 });
 
 describe("isOrgAIConfig", () => {
+  const fullOverrideModels = {
+    chat: { provider: "openai", modelId: "gpt-5.4" },
+    fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    reasoning: { provider: "openai", modelId: "gpt-5.4" },
+    pdf: { provider: "openai", modelId: "gpt-5.4" },
+  };
+
   test("accepts a valid org AI config", () => {
+    expect(
+      isOrgAIConfig({
+        providers: [{ provider: "openai", apiKey: "sk-test" }],
+        overrideModels: fullOverrideModels,
+      }),
+    ).toBe(true);
+  });
+
+  test("rejects configs missing any role in overrideModels", () => {
     expect(
       isOrgAIConfig({
         providers: [{ provider: "openai", apiKey: "sk-test" }],
@@ -50,7 +66,7 @@ describe("isOrgAIConfig", () => {
           chat: { provider: "openai", modelId: "gpt-5.4" },
         },
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   test("rejects unknown model override roles", () => {
@@ -58,6 +74,7 @@ describe("isOrgAIConfig", () => {
       isOrgAIConfig({
         providers: [{ provider: "openai", apiKey: "sk-test" }],
         overrideModels: {
+          ...fullOverrideModels,
           unknown: { provider: "openai", modelId: "gpt-5.4" },
         },
       }),
@@ -67,9 +84,7 @@ describe("isOrgAIConfig", () => {
   test("rejects configs missing providers", () => {
     expect(
       isOrgAIConfig({
-        overrideModels: {
-          chat: { provider: "openai", modelId: "gpt-5.4" },
-        },
+        overrideModels: fullOverrideModels,
       }),
     ).toBe(false);
   });
@@ -78,7 +93,7 @@ describe("isOrgAIConfig", () => {
     expect(
       isOrgAIConfig({
         providers: [{ provider: "openai", apiKey: "sk-test" }],
-        overrideModels: { chat: "gpt-5.4" },
+        overrideModels: { ...fullOverrideModels, chat: "gpt-5.4" },
       }),
     ).toBe(false);
   });
@@ -90,11 +105,13 @@ describe("isOrgAIConfig", () => {
           {
             provider: "openai_compatible",
             apiKey: "sk-test",
-            baseURL: "https://api.example.com/v1",
           },
         ],
         overrideModels: {
           chat: { provider: "openai_compatible", modelId: "default" },
+          fast: { provider: "openai_compatible", modelId: "default" },
+          reasoning: { provider: "openai_compatible", modelId: "default" },
+          pdf: { provider: "openai_compatible", modelId: "default" },
         },
       }),
     ).toBe(false);

--- a/apps/api/src/lib/ai-config-crypto.ts
+++ b/apps/api/src/lib/ai-config-crypto.ts
@@ -14,21 +14,38 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { decryptContent, encryptContent } from "@/api/lib/content-encryption";
 import type { EncryptedContent } from "@/api/lib/content-encryption";
 
+const providerSchema = v.picklist([
+  "google",
+  "openrouter",
+  "openai",
+  "anthropic",
+]);
+
+const modelSelectionSchema = v.strictObject({
+  provider: providerSchema,
+  modelId: v.pipe(v.string(), v.minLength(1)),
+});
+
 /** Validate the decrypted JSON matches OrgAIConfig shape. */
 const orgAIConfigSchema = v.strictObject({
-  provider: v.picklist([
-    "google",
-    "openrouter",
-    "openai",
-    "anthropic",
-    "openai_compatible",
-  ]),
-  apiKey: v.pipe(v.string(), v.minLength(1)),
-  baseURL: v.optional(v.pipe(v.string(), v.url())),
-  overrideRoles: v.optional(
-    v.array(v.picklist(["fast", "chat", "reasoning", "pdf"])),
+  providers: v.pipe(
+    v.array(
+      v.strictObject({
+        provider: providerSchema,
+        apiKey: v.pipe(v.string(), v.minLength(1)),
+        region: v.optional(v.picklist(["eu", "global", "ch"])),
+      }),
+    ),
+    v.minLength(1),
   ),
-  region: v.optional(v.picklist(["eu", "global", "ch"])),
+  overrideModels: v.optional(
+    v.strictObject({
+      fast: v.optional(modelSelectionSchema),
+      chat: v.optional(modelSelectionSchema),
+      reasoning: v.optional(modelSelectionSchema),
+      pdf: v.optional(modelSelectionSchema),
+    }),
+  ),
 });
 const parseOrgAIConfig = v.safeParser(orgAIConfigSchema);
 

--- a/apps/api/src/lib/ai-config-crypto.ts
+++ b/apps/api/src/lib/ai-config-crypto.ts
@@ -38,14 +38,12 @@ const orgAIConfigSchema = v.strictObject({
     ),
     v.minLength(1),
   ),
-  overrideModels: v.optional(
-    v.strictObject({
-      fast: v.optional(modelSelectionSchema),
-      chat: v.optional(modelSelectionSchema),
-      reasoning: v.optional(modelSelectionSchema),
-      pdf: v.optional(modelSelectionSchema),
-    }),
-  ),
+  overrideModels: v.strictObject({
+    fast: modelSelectionSchema,
+    chat: modelSelectionSchema,
+    reasoning: modelSelectionSchema,
+    pdf: modelSelectionSchema,
+  }),
 });
 const parseOrgAIConfig = v.safeParser(orgAIConfigSchema);
 

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -58,9 +58,9 @@ describe("isAllowedBYOKModel", () => {
     expect(isAllowedBYOKModel("anthropic", "claude-opus-4-7")).toBe(true);
     expect(isAllowedBYOKModel("google", "gemini-3-pro-preview")).toBe(true);
     expect(isAllowedBYOKModel("openai", "gpt-5.4")).toBe(true);
-    expect(
-      isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.5"),
-    ).toBe(true);
+    expect(isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.5")).toBe(
+      true,
+    );
   });
 
   test("rejects models outside the curated catalog", () => {

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -15,6 +15,7 @@ process.env["SMTP_PORT"] ??= "1025";
 const {
   getModelForRole,
   getModelInfoForRole,
+  isAllowedBYOKModel,
   REGIONAL_PROVIDERS,
   supportsRegion,
 } = await import("@/api/lib/ai-models");
@@ -49,6 +50,29 @@ describe("REGIONAL_PROVIDERS", () => {
   test("contains exactly one provider (google)", () => {
     expect(REGIONAL_PROVIDERS.size).toBe(1);
     expect(REGIONAL_PROVIDERS.has("google")).toBe(true);
+  });
+});
+
+describe("isAllowedBYOKModel", () => {
+  test("accepts curated catalog models", () => {
+    expect(isAllowedBYOKModel("anthropic", "claude-opus-4-7")).toBe(true);
+    expect(isAllowedBYOKModel("google", "gemini-3-pro-preview")).toBe(true);
+    expect(isAllowedBYOKModel("openai", "gpt-5.4")).toBe(true);
+    expect(
+      isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.5"),
+    ).toBe(true);
+  });
+
+  test("rejects models outside the curated catalog", () => {
+    expect(isAllowedBYOKModel("openrouter", "x-ai/grok-4")).toBe(false);
+    expect(isAllowedBYOKModel("anthropic", "claude-2")).toBe(false);
+    expect(isAllowedBYOKModel("google", "gemini-1.5-pro")).toBe(false);
+    expect(isAllowedBYOKModel("openai", "gpt-4o")).toBe(false);
+  });
+
+  test("rejects every model id for openai_compatible", () => {
+    expect(isAllowedBYOKModel("openai_compatible", "default")).toBe(false);
+    expect(isAllowedBYOKModel("openai_compatible", "gpt-5.4")).toBe(false);
   });
 });
 

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, test } from "bun:test";
 
+import type { OrgAIConfig } from "@/api/lib/ai-models";
+
 process.env["EMAIL_PROVIDER"] ??= "smtp";
 process.env["GOTENBERG_PASSWORD"] ??= "gotenberg";
 process.env["GOTENBERG_URL"] ??= "http://localhost:3003";
 process.env["GOTENBERG_USERNAME"] ??= "gotenberg";
+process.env["AI_PROVIDER"] = "openai";
+process.env["OPENAI_API_KEY"] ??= "sk-instance";
 process.env["REDIS_URL"] ??= "redis://localhost:6379";
 process.env["SMTP_HOST"] ??= "localhost";
 process.env["SMTP_PORT"] ??= "1025";
 
-const { REGIONAL_PROVIDERS, supportsRegion } =
-  await import("@/api/lib/ai-models");
+const {
+  DEFAULT_MODELS,
+  getModelForRole,
+  getModelInfoForRole,
+  REGIONAL_PROVIDERS,
+  supportsRegion,
+} = await import("@/api/lib/ai-models");
 
 type AIProvider =
   | "google"
@@ -41,5 +50,135 @@ describe("REGIONAL_PROVIDERS", () => {
   test("contains exactly one provider (google)", () => {
     expect(REGIONAL_PROVIDERS.size).toBe(1);
     expect(REGIONAL_PROVIDERS.has("google")).toBe(true);
+  });
+});
+
+describe("BYOK model overrides", () => {
+  test("uses a per-role provider-qualified model selection", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org-anthropic",
+          provider: "anthropic",
+        },
+        {
+          apiKey: "sk-org-openai",
+          provider: "openai",
+        },
+      ],
+      overrideModels: {
+        chat: { provider: "anthropic", modelId: "claude-opus-4-5" },
+        fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      },
+    };
+
+    expect(getModelInfoForRole("chat", orgConfig)).toMatchObject({
+      keySource: "byok",
+      modelId: "claude-opus-4-5",
+      provider: "anthropic",
+    });
+    expect(getModelInfoForRole("fast", orgConfig)).toMatchObject({
+      keySource: "byok",
+      modelId: "gpt-5.4-nano",
+      provider: "openai",
+    });
+  });
+
+  test("falls back to the primary provider default when a role has no selection", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org",
+          provider: "anthropic",
+        },
+      ],
+    };
+
+    expect(getModelInfoForRole("fast", orgConfig)).toMatchObject({
+      keySource: "byok",
+      modelId: DEFAULT_MODELS.anthropic.fast,
+      provider: "anthropic",
+    });
+  });
+
+  test("reports the selected provider region for BYOK calls", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-google",
+          provider: "google",
+          region: "eu",
+        },
+      ],
+      overrideModels: {
+        pdf: {
+          provider: "google",
+          modelId: "gemini-3.1-flash-lite-preview",
+        },
+      },
+    };
+
+    expect(getModelInfoForRole("pdf", orgConfig)).toMatchObject({
+      keySource: "byok",
+      provider: "google",
+      region: "eu",
+    });
+  });
+
+  test("routes every Stella role through configured OpenRouter models", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-or-v1-org",
+          provider: "openrouter",
+        },
+      ],
+      overrideModels: {
+        fast: {
+          provider: "openrouter",
+          modelId: "google/gemini-3.1-flash-lite-preview",
+        },
+        chat: {
+          provider: "openrouter",
+          modelId: "anthropic/claude-sonnet-4.5",
+        },
+        reasoning: {
+          provider: "openrouter",
+          modelId: "google/gemini-3.1-pro-preview",
+        },
+        pdf: {
+          provider: "openrouter",
+          modelId: "google/gemini-3.1-flash-lite-preview",
+        },
+      },
+    };
+
+    for (const role of ["fast", "chat", "reasoning", "pdf"] as const) {
+      expect(getModelInfoForRole(role, orgConfig)).toMatchObject({
+        keySource: "byok",
+        provider: "openrouter",
+        modelId: orgConfig.overrideModels?.[role]?.modelId,
+      });
+      expect(() => getModelForRole(role, orgConfig)).not.toThrow();
+    }
+  });
+
+  test("getModelForRole accepts the configured override model id", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org",
+          provider: "openai",
+        },
+      ],
+      overrideModels: {
+        reasoning: { provider: "openai", modelId: "gpt-5.4-pro" },
+      },
+    };
+
+    expect(() => getModelForRole("reasoning", orgConfig)).not.toThrow();
+    expect(getModelInfoForRole("reasoning", orgConfig).modelId).toBe(
+      "gpt-5.4-pro",
+    );
   });
 });

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -13,7 +13,6 @@ process.env["SMTP_HOST"] ??= "localhost";
 process.env["SMTP_PORT"] ??= "1025";
 
 const {
-  DEFAULT_MODELS,
   getModelForRole,
   getModelInfoForRole,
   REGIONAL_PROVIDERS,
@@ -69,6 +68,8 @@ describe("BYOK model overrides", () => {
       overrideModels: {
         chat: { provider: "anthropic", modelId: "claude-opus-4-5" },
         fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+        reasoning: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+        pdf: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
       },
     };
 
@@ -81,23 +82,6 @@ describe("BYOK model overrides", () => {
       keySource: "byok",
       modelId: "gpt-5.4-nano",
       provider: "openai",
-    });
-  });
-
-  test("falls back to the primary provider default when a role has no selection", () => {
-    const orgConfig: OrgAIConfig = {
-      providers: [
-        {
-          apiKey: "sk-org",
-          provider: "anthropic",
-        },
-      ],
-    };
-
-    expect(getModelInfoForRole("fast", orgConfig)).toMatchObject({
-      keySource: "byok",
-      modelId: DEFAULT_MODELS.anthropic.fast,
-      provider: "anthropic",
     });
   });
 
@@ -114,6 +98,18 @@ describe("BYOK model overrides", () => {
         pdf: {
           provider: "google",
           modelId: "gemini-3.1-flash-lite-preview",
+        },
+        chat: {
+          provider: "google",
+          modelId: "gemini-3.1-flash-lite-preview",
+        },
+        fast: {
+          provider: "google",
+          modelId: "gemini-3.1-flash-lite-preview",
+        },
+        reasoning: {
+          provider: "google",
+          modelId: "gemini-3.1-pro-preview",
         },
       },
     };
@@ -157,7 +153,7 @@ describe("BYOK model overrides", () => {
       expect(getModelInfoForRole(role, orgConfig)).toMatchObject({
         keySource: "byok",
         provider: "openrouter",
-        modelId: orgConfig.overrideModels?.[role]?.modelId,
+        modelId: orgConfig.overrideModels[role].modelId,
       });
       expect(() => getModelForRole(role, orgConfig)).not.toThrow();
     }
@@ -172,7 +168,10 @@ describe("BYOK model overrides", () => {
         },
       ],
       overrideModels: {
+        chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+        fast: { provider: "openai", modelId: "gpt-5.4-nano" },
         reasoning: { provider: "openai", modelId: "gpt-5.4-pro" },
+        pdf: { provider: "openai", modelId: "gpt-5.4" },
       },
     };
 

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -91,6 +91,61 @@ export const DEFAULT_MODELS = {
   },
 } as const satisfies Record<AIProvider, Record<ModelRole, string>>;
 
+/**
+ * BYOK-offered model IDs per provider. Server-side allowlist
+ * mirroring the picker catalog in
+ * apps/web/src/components/ai-config-role-models.logic.ts —
+ * keep the two in sync. The frontend list is not a security
+ * boundary; this is what the API will accept.
+ *
+ * Limited to providers BYOK supports (no openai_compatible).
+ */
+export const BYOK_MODEL_OPTIONS = {
+  google: [
+    "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+  ],
+  anthropic: [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-haiku-4-5-20251001",
+  ],
+  openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
+  openrouter: [
+    "google/gemini-3-flash-preview",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-2.5-flash-lite",
+    "anthropic/claude-opus-4.5",
+    "anthropic/claude-sonnet-4.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
+  ],
+} as const satisfies Record<
+  Exclude<AIProvider, "openai_compatible">,
+  readonly string[]
+>;
+
+export type BYOKProvider = keyof typeof BYOK_MODEL_OPTIONS;
+
+export const isBYOKProvider = (
+  provider: AIProvider,
+): provider is BYOKProvider => provider in BYOK_MODEL_OPTIONS;
+
+export const isAllowedBYOKModel = (
+  provider: AIProvider,
+  modelId: string,
+): boolean => {
+  if (!isBYOKProvider(provider)) {
+    return false;
+  }
+  const allowed: readonly string[] = BYOK_MODEL_OPTIONS[provider];
+  return allowed.includes(modelId);
+};
+
 export type DataRegion = "eu" | "global" | "ch";
 
 /**
@@ -360,20 +415,17 @@ const createModelFactory = (
 export type OrgAIConfig = {
   providers: OrgAIProviderConfig[];
   /**
-   * Per-role model selections. Each role selects a model
-   * through one of the configured org providers.
+   * Per-role model selection. Every role must resolve to a
+   * configured provider; the update endpoint enforces this
+   * and rejects orphan providers (configured but unused).
    */
-  overrideModels?:
-    | Partial<Record<ModelRole, OrgAIModelSelection | undefined>>
-    | undefined;
+  overrideModels: Record<ModelRole, OrgAIModelSelection>;
 };
 
 export type OrgAIProviderConfig = {
   provider: AIProvider;
   /** Decrypted API key. */
   apiKey: string;
-  /** For openai_compatible only. */
-  baseURL?: string | undefined;
   /**
    * Data sovereignty region. When set, AI calls are
    * routed to region-specific endpoints (e.g. Vertex AI
@@ -398,10 +450,10 @@ export type ResolvedModelInfo = {
 
 /**
  * LRU cache for BYOK model factories. Keyed by a stable
- * hash of (provider + apiKey + baseURL + region) so we
- * don't recreate HTTP clients on every call within the
- * same connection. Uses a truncated SHA-256 digest to
- * avoid holding full secrets as map keys.
+ * hash of (provider + apiKey + region) so we don't
+ * recreate HTTP clients on every call within the same
+ * connection. Uses a truncated SHA-256 digest to avoid
+ * holding full secrets as map keys.
  */
 const BYOK_CACHE_MAX = 64;
 const byokCache = new Map<string, ModelFactory>();
@@ -410,7 +462,7 @@ const byokCacheKey = (config: OrgAIProviderConfig): string => {
   const hasher = new Bun.CryptoHasher("sha256");
   hasher.update(config.apiKey);
   const hash = hasher.digest("hex").slice(0, 16);
-  return `${config.provider}:${hash}:${config.baseURL ?? ""}:${config.region ?? "global"}`;
+  return `${config.provider}:${hash}:${config.region ?? "global"}`;
 };
 
 const getCachedFactory = (config: OrgAIProviderConfig): ModelFactory => {
@@ -429,7 +481,7 @@ const getCachedFactory = (config: OrgAIProviderConfig): ModelFactory => {
   const factory = createModelFactory(
     config.provider,
     config.apiKey,
-    config.baseURL,
+    undefined,
     config.region,
   );
   byokCache.set(key, factory);
@@ -484,22 +536,6 @@ const getOrgProviderConfig = (
   config.providers.find((candidate) => candidate.provider === provider) ??
   panic(`Org AI config has no ${provider} provider`);
 
-const getOrgModelSelection = (
-  config: OrgAIConfig,
-  role: ModelRole,
-): OrgAIModelSelection => {
-  const selection = config.overrideModels?.[role];
-  if (selection) {
-    return selection;
-  }
-
-  const primaryProvider = getPrimaryOrgProvider(config).provider;
-  return {
-    provider: primaryProvider,
-    modelId: DEFAULT_MODELS[primaryProvider][role],
-  };
-};
-
 /**
  * Get a model instance for a logical role.
  *
@@ -519,7 +555,7 @@ export const getModelForRole = (
   // BYOK path: org selects a model for each role through
   // one of its configured provider credentials.
   if (orgConfig) {
-    const selection = getOrgModelSelection(orgConfig, role);
+    const selection = orgConfig.overrideModels[role];
     const providerConfig = getOrgProviderConfig(orgConfig, selection.provider);
     const factory = getCachedFactory(providerConfig);
     return withLocalAIDevTools(factory(selection.modelId));
@@ -556,7 +592,7 @@ export const getModelInfoForRole = (
   orgConfig?: OrgAIConfig | null,
 ): ResolvedModelInfo => {
   if (orgConfig) {
-    const selection = getOrgModelSelection(orgConfig, role);
+    const selection = orgConfig.overrideModels[role];
     const providerConfig = getOrgProviderConfig(orgConfig, selection.provider);
     return {
       keySource: "byok",

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -42,6 +42,13 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
  */
 export type ModelRole = "fast" | "chat" | "reasoning" | "pdf";
 
+export const MODEL_ROLES = [
+  "fast",
+  "chat",
+  "reasoning",
+  "pdf",
+] as const satisfies readonly ModelRole[];
+
 export type AIProvider =
   | "google"
   | "openrouter"
@@ -51,7 +58,7 @@ export type AIProvider =
 
 // -- Default model IDs per provider -----------------------------
 
-const DEFAULT_MODELS = {
+export const DEFAULT_MODELS = {
   google: {
     fast: "gemini-3.1-flash-lite-preview",
     chat: "gemini-3.1-flash-lite-preview",
@@ -351,23 +358,33 @@ const createModelFactory = (
  * per AI call.
  */
 export type OrgAIConfig = {
+  providers: OrgAIProviderConfig[];
+  /**
+   * Per-role model selections. Each role selects a model
+   * through one of the configured org providers.
+   */
+  overrideModels?:
+    | Partial<Record<ModelRole, OrgAIModelSelection | undefined>>
+    | undefined;
+};
+
+export type OrgAIProviderConfig = {
   provider: AIProvider;
   /** Decrypted API key. */
   apiKey: string;
   /** For openai_compatible only. */
   baseURL?: string | undefined;
   /**
-   * Which roles use the org key. Roles not listed fall
-   * back to the instance-level provider. Empty array or
-   * omitted = override all roles.
-   */
-  overrideRoles?: ModelRole[] | undefined;
-  /**
    * Data sovereignty region. When set, AI calls are
    * routed to region-specific endpoints (e.g. Vertex AI
    * europe-west4 for EU).
    */
   region?: DataRegion | undefined;
+};
+
+export type OrgAIModelSelection = {
+  provider: AIProvider;
+  modelId: string;
 };
 
 export type ResolvedModelInfo = {
@@ -389,14 +406,14 @@ export type ResolvedModelInfo = {
 const BYOK_CACHE_MAX = 64;
 const byokCache = new Map<string, ModelFactory>();
 
-const byokCacheKey = (config: OrgAIConfig): string => {
+const byokCacheKey = (config: OrgAIProviderConfig): string => {
   const hasher = new Bun.CryptoHasher("sha256");
   hasher.update(config.apiKey);
   const hash = hasher.digest("hex").slice(0, 16);
   return `${config.provider}:${hash}:${config.baseURL ?? ""}:${config.region ?? "global"}`;
 };
 
-const getCachedFactory = (config: OrgAIConfig): ModelFactory => {
+const getCachedFactory = (config: OrgAIProviderConfig): ModelFactory => {
   const key = byokCacheKey(config);
   const cached = byokCache.get(key);
   if (cached) {
@@ -457,22 +474,30 @@ const withLocalAIDevTools = (model: WrappableLanguageModel): LanguageModel => {
 
 // -- Public API -------------------------------------------------
 
-/** Regional instance factory cache (non-BYOK). */
-const regionalFactoryCache = new Map<DataRegion, ModelFactory>();
+const getPrimaryOrgProvider = (config: OrgAIConfig): OrgAIProviderConfig =>
+  config.providers.at(0) ?? panic("Org AI config has no configured providers");
 
-const getRegionalInstanceFactory = (region: DataRegion): ModelFactory => {
-  const cached = regionalFactoryCache.get(region);
-  if (cached) {
-    return cached;
+const getOrgProviderConfig = (
+  config: OrgAIConfig,
+  provider: AIProvider,
+): OrgAIProviderConfig =>
+  config.providers.find((candidate) => candidate.provider === provider) ??
+  panic(`Org AI config has no ${provider} provider`);
+
+const getOrgModelSelection = (
+  config: OrgAIConfig,
+  role: ModelRole,
+): OrgAIModelSelection => {
+  const selection = config.overrideModels?.[role];
+  if (selection) {
+    return selection;
   }
-  const factory = createModelFactory(
-    getActiveProvider(),
-    undefined,
-    undefined,
-    region,
-  );
-  regionalFactoryCache.set(region, factory);
-  return factory;
+
+  const primaryProvider = getPrimaryOrgProvider(config).provider;
+  return {
+    provider: primaryProvider,
+    modelId: DEFAULT_MODELS[primaryProvider][role],
+  };
 };
 
 /**
@@ -491,29 +516,13 @@ export const getModelForRole = (
   role: ModelRole,
   orgConfig?: OrgAIConfig | null,
 ): LanguageModel => {
-  // BYOK path: org overrides this role with their own key.
+  // BYOK path: org selects a model for each role through
+  // one of its configured provider credentials.
   if (orgConfig) {
-    const roles = orgConfig.overrideRoles;
-    const shouldOverride = !roles || roles.length === 0 || roles.includes(role);
-
-    if (shouldOverride) {
-      const factory = getCachedFactory(orgConfig);
-      const modelId = DEFAULT_MODELS[orgConfig.provider][role];
-      return withLocalAIDevTools(factory(modelId));
-    }
-
-    // Region-only path: org has a region booster but this
-    // role falls back to instance provider. Route through
-    // the regional endpoint.
-    if (orgConfig.region && orgConfig.region !== "global") {
-      if (!hasInstanceProvider()) {
-        throw byokRoleNotConfiguredError(role);
-      }
-      const factory = getRegionalInstanceFactory(orgConfig.region);
-      const modelId =
-        MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[getActiveProvider()][role];
-      return withLocalAIDevTools(factory(modelId));
-    }
+    const selection = getOrgModelSelection(orgConfig, role);
+    const providerConfig = getOrgProviderConfig(orgConfig, selection.provider);
+    const factory = getCachedFactory(providerConfig);
+    return withLocalAIDevTools(factory(selection.modelId));
   }
 
   // Default instance path. requireAIAvailable() gates the entry
@@ -547,17 +556,14 @@ export const getModelInfoForRole = (
   orgConfig?: OrgAIConfig | null,
 ): ResolvedModelInfo => {
   if (orgConfig) {
-    const roles = orgConfig.overrideRoles;
-    const shouldOverride = !roles || roles.length === 0 || roles.includes(role);
-
-    if (shouldOverride) {
-      return {
-        keySource: "byok",
-        provider: orgConfig.provider,
-        modelId: DEFAULT_MODELS[orgConfig.provider][role],
-        region: orgConfig.region,
-      };
-    }
+    const selection = getOrgModelSelection(orgConfig, role);
+    const providerConfig = getOrgProviderConfig(orgConfig, selection.provider);
+    return {
+      keySource: "byok",
+      provider: providerConfig.provider,
+      modelId: selection.modelId,
+      region: providerConfig.region,
+    };
   }
 
   const provider = getActiveProvider();
@@ -565,7 +571,6 @@ export const getModelInfoForRole = (
     keySource: "instance",
     provider,
     modelId: MODEL_OVERRIDES[role] ?? DEFAULT_MODELS[provider][role],
-    region: orgConfig?.region,
   };
 };
 
@@ -581,7 +586,9 @@ export const getModelById = (
   orgConfig?: OrgAIConfig | null,
 ): LanguageModel => {
   if (orgConfig) {
-    return withLocalAIDevTools(getCachedFactory(orgConfig)(modelId));
+    return withLocalAIDevTools(
+      getCachedFactory(getPrimaryOrgProvider(orgConfig))(modelId),
+    );
   }
   return withLocalAIDevTools(getInstanceFactory()(modelId));
 };

--- a/apps/api/src/lib/analytics/ai.test.ts
+++ b/apps/api/src/lib/analytics/ai.test.ts
@@ -271,8 +271,12 @@ describe("createAIAnalyticsCallbacks", () => {
       feature: "chat.basic",
       modelRole: "fast",
       orgAIConfig: {
-        apiKey: "org-secret",
-        provider: "openai",
+        providers: [
+          {
+            apiKey: "org-secret",
+            provider: "openai",
+          },
+        ],
       },
       properties: {
         entity_version_id: "ev_secret",
@@ -381,8 +385,12 @@ describe("createAIAnalyticsCallbacks", () => {
       feature: "analysis.basic",
       modelRole: "fast",
       orgAIConfig: {
-        apiKey: "org-secret",
-        provider: "openai",
+        providers: [
+          {
+            apiKey: "org-secret",
+            provider: "openai",
+          },
+        ],
       },
       properties: {
         organization_id: "org_123",

--- a/apps/api/src/lib/analytics/ai.test.ts
+++ b/apps/api/src/lib/analytics/ai.test.ts
@@ -277,6 +277,12 @@ describe("createAIAnalyticsCallbacks", () => {
             provider: "openai",
           },
         ],
+        overrideModels: {
+          chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+          fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+          reasoning: { provider: "openai", modelId: "gpt-5.4" },
+          pdf: { provider: "openai", modelId: "gpt-5.4" },
+        },
       },
       properties: {
         entity_version_id: "ev_secret",
@@ -391,6 +397,12 @@ describe("createAIAnalyticsCallbacks", () => {
             provider: "openai",
           },
         ],
+        overrideModels: {
+          chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+          fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+          reasoning: { provider: "openai", modelId: "gpt-5.4" },
+          pdf: { provider: "openai", modelId: "gpt-5.4" },
+        },
       },
       properties: {
         organization_id: "org_123",

--- a/apps/web/src/components/ai-config-providers-editor.tsx
+++ b/apps/web/src/components/ai-config-providers-editor.tsx
@@ -1,0 +1,422 @@
+import { Button } from "@stll/ui/components/button";
+import { Field, FieldDescription, FieldLabel } from "@stll/ui/components/field";
+import { Input } from "@stll/ui/components/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import {
+  createProviderCredentialDraft,
+  getAvailableProviderKeys,
+  getNextAvailableProvider,
+  isProviderValue,
+  isRegionValue,
+  PROVIDER_KEYS,
+  REGION_KEYS,
+  REGIONAL_PROVIDERS,
+} from "@/components/ai-config-role-models.logic";
+import type {
+  ProviderCredentialDraft,
+  ProviderValue,
+} from "@/components/ai-config-role-models.logic";
+
+const API_KEY_PLACEHOLDER = {
+  google: "AIza...",
+  anthropic: "sk-ant-...",
+  openai: "sk-proj-...",
+  openrouter: "sk-or-v1-...",
+} as const satisfies Record<ProviderValue, string>;
+
+type AIConfigProvidersEditorProps = {
+  compact?: boolean;
+  disabled?: boolean;
+  onProvidersChange: (providers: ProviderCredentialDraft[]) => void;
+  providers: ProviderCredentialDraft[];
+};
+
+export const AIConfigProvidersEditor = ({
+  compact = false,
+  disabled = false,
+  onProvidersChange,
+  providers,
+}: AIConfigProvidersEditorProps) => {
+  const t = useTranslations("organization");
+  const canAddProvider = providers.length < PROVIDER_KEYS.length;
+
+  const updateProvider = (
+    index: number,
+    nextProvider: ProviderCredentialDraft,
+  ) => {
+    onProvidersChange(
+      providers.map((provider, providerIndex) =>
+        providerIndex === index ? nextProvider : provider,
+      ),
+    );
+  };
+
+  const addProvider = () => {
+    const provider = getNextAvailableProvider(providers);
+    if (!provider) {
+      return;
+    }
+    onProvidersChange([...providers, createProviderCredentialDraft(provider)]);
+  };
+
+  const removeProvider = (index: number) => {
+    onProvidersChange(
+      providers.filter((_, providerIndex) => providerIndex !== index),
+    );
+  };
+
+  return (
+    <Field>
+      <div className="flex w-full items-start gap-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <FieldLabel>{t("aiConfig.providersPanel")}</FieldLabel>
+          {!compact && (
+            <FieldDescription>
+              {t("aiConfig.providersDescription")}
+            </FieldDescription>
+          )}
+        </div>
+        <Button
+          disabled={disabled || !canAddProvider}
+          className="ms-auto shrink-0"
+          onClick={addProvider}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <PlusIcon className="size-4" />
+          {t("aiConfig.addProvider")}
+        </Button>
+      </div>
+
+      <div className="w-full overflow-hidden rounded-md border">
+        {providers.map((providerDraft, index) => {
+          const supportsRegionalRouting = REGIONAL_PROVIDERS.has(
+            providerDraft.provider,
+          );
+          const providerOptions = getAvailableProviderKeys({
+            currentProvider: providerDraft.provider,
+            providers,
+          });
+          const savedKey = providerDraft.apiKeyMasked;
+          const hasSavedKey = savedKey !== undefined;
+          const showKeyInput = providerDraft.replacingKey || !hasSavedKey;
+
+          if (compact) {
+            return (
+              <div
+                className="grid gap-2 border-t p-2 first:border-t-0 sm:grid-cols-[minmax(8rem,0.9fr)_minmax(10rem,1fr)_minmax(9rem,1fr)_2.25rem] sm:items-center"
+                key={`${providerDraft.provider}-${index}`}
+              >
+                <Select
+                  disabled={disabled}
+                  onValueChange={(value) => {
+                    if (!isProviderValue(value)) {
+                      return;
+                    }
+
+                    updateProvider(index, {
+                      ...createProviderCredentialDraft(value),
+                      apiKey: "",
+                      apiKeyMasked: undefined,
+                      replacingKey: true,
+                    });
+                  }}
+                  value={providerDraft.provider}
+                >
+                  <SelectTrigger
+                    aria-label={t("aiConfig.provider")}
+                    className="min-w-0"
+                  >
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectPopup alignItemWithTrigger={false}>
+                    {providerOptions.map((provider) => (
+                      <SelectItem key={provider} value={provider}>
+                        {t(`aiConfig.providers.${provider}`)}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+
+                <div className="min-w-0">
+                  {showKeyInput ? (
+                    <Input
+                      aria-label={
+                        hasSavedKey
+                          ? t("aiConfig.newApiKey")
+                          : t("aiConfig.apiKey")
+                      }
+                      autoComplete="off"
+                      disabled={disabled}
+                      onChange={(event) =>
+                        updateProvider(index, {
+                          ...providerDraft,
+                          apiKey: event.target.value,
+                          replacingKey: true,
+                        })
+                      }
+                      placeholder={
+                        hasSavedKey
+                          ? t("aiConfig.newApiKey")
+                          : API_KEY_PLACEHOLDER[providerDraft.provider]
+                      }
+                      type="password"
+                      value={providerDraft.apiKey}
+                    />
+                  ) : (
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="bg-muted text-muted-foreground min-w-0 flex-1 truncate rounded border px-2 py-1 font-mono text-xs">
+                        {t("aiConfig.apiKeySaved", { key: savedKey })}
+                      </span>
+                      <Button
+                        disabled={disabled}
+                        onClick={() =>
+                          updateProvider(index, {
+                            ...providerDraft,
+                            apiKey: "",
+                            replacingKey: true,
+                          })
+                        }
+                        size="sm"
+                        type="button"
+                        variant="ghost"
+                      >
+                        {t("aiConfig.replaceKey")}
+                      </Button>
+                    </div>
+                  )}
+                </div>
+
+                <div className="min-w-0">
+                  {supportsRegionalRouting && (
+                    <Select
+                      disabled={disabled}
+                      onValueChange={(value) => {
+                        if (isRegionValue(value)) {
+                          updateProvider(index, {
+                            ...providerDraft,
+                            region: value,
+                          });
+                        }
+                      }}
+                      value={providerDraft.region}
+                    >
+                      <SelectTrigger
+                        aria-label={t("aiConfig.dataRegion")}
+                        className="min-w-0"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectPopup alignItemWithTrigger={false}>
+                        {REGION_KEYS.map((region) => (
+                          <SelectItem key={region} value={region}>
+                            {t(`aiConfig.regions.${region}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                  )}
+                </div>
+
+                <Button
+                  aria-label={t("aiConfig.removeProvider")}
+                  disabled={disabled || providers.length === 1}
+                  onClick={() => removeProvider(index)}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  <Trash2Icon className="size-4" />
+                </Button>
+              </div>
+            );
+          }
+
+          return (
+            <div
+              className={
+                compact
+                  ? "grid gap-2 border-t p-2 first:border-t-0"
+                  : "grid gap-3 border-t p-3 first:border-t-0"
+              }
+              key={`${providerDraft.provider}-${index}`}
+            >
+              <div className="grid gap-2 sm:grid-cols-[minmax(8rem,0.85fr)_minmax(0,1fr)] sm:items-start">
+                <Field className="min-w-0">
+                  <FieldLabel>{t("aiConfig.provider")}</FieldLabel>
+                  <Select
+                    disabled={disabled}
+                    onValueChange={(value) => {
+                      if (!isProviderValue(value)) {
+                        return;
+                      }
+
+                      updateProvider(index, {
+                        ...createProviderCredentialDraft(value),
+                        apiKey: "",
+                        apiKeyMasked: undefined,
+                        replacingKey: true,
+                      });
+                    }}
+                    value={providerDraft.provider}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectPopup alignItemWithTrigger={false}>
+                      {providerOptions.map((provider) => (
+                        <SelectItem key={provider} value={provider}>
+                          {t(`aiConfig.providers.${provider}`)}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                </Field>
+
+                <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 sm:pt-6">
+                  {hasSavedKey && !providerDraft.replacingKey && (
+                    <>
+                      <span className="bg-muted text-muted-foreground min-w-0 truncate rounded border px-2 py-1 font-mono text-xs">
+                        {t("aiConfig.apiKeySaved", {
+                          key: savedKey,
+                        })}
+                      </span>
+                      <Button
+                        disabled={disabled}
+                        onClick={() =>
+                          updateProvider(index, {
+                            ...providerDraft,
+                            apiKey: "",
+                            replacingKey: true,
+                          })
+                        }
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                        className={compact ? "px-2" : undefined}
+                      >
+                        {t("aiConfig.replaceKey")}
+                      </Button>
+                    </>
+                  )}
+
+                  {hasSavedKey && providerDraft.replacingKey && (
+                    <Button
+                      disabled={disabled}
+                      onClick={() =>
+                        updateProvider(index, {
+                          ...providerDraft,
+                          apiKey: "",
+                          replacingKey: false,
+                        })
+                      }
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                      className={compact ? "px-2" : undefined}
+                    >
+                      {t("aiConfig.keepSavedKey")}
+                    </Button>
+                  )}
+
+                  <Button
+                    disabled={disabled || providers.length === 1}
+                    onClick={() => removeProvider(index)}
+                    size="sm"
+                    type="button"
+                    variant="ghost"
+                    className={compact ? "px-2" : undefined}
+                  >
+                    <Trash2Icon className="size-4" />
+                    {compact ? null : t("aiConfig.removeProvider")}
+                  </Button>
+                </div>
+              </div>
+
+              <div
+                className={
+                  compact
+                    ? "grid gap-2 sm:grid-cols-2"
+                    : "grid gap-3 sm:grid-cols-2"
+                }
+              >
+                {showKeyInput && (
+                  <Field>
+                    <FieldLabel>
+                      {hasSavedKey
+                        ? t("aiConfig.newApiKey")
+                        : t("aiConfig.apiKey")}
+                    </FieldLabel>
+                    <Input
+                      autoComplete="off"
+                      disabled={disabled}
+                      onChange={(event) =>
+                        updateProvider(index, {
+                          ...providerDraft,
+                          apiKey: event.target.value,
+                          replacingKey: true,
+                        })
+                      }
+                      placeholder={API_KEY_PLACEHOLDER[providerDraft.provider]}
+                      type="password"
+                      value={providerDraft.apiKey}
+                    />
+                    {hasSavedKey && !compact && (
+                      <p className="text-muted-foreground text-xs">
+                        {t("aiConfig.newApiKeyDescription")}
+                      </p>
+                    )}
+                  </Field>
+                )}
+
+                {supportsRegionalRouting && (
+                  <Field>
+                    <FieldLabel>{t("aiConfig.dataRegion")}</FieldLabel>
+                    <Select
+                      disabled={disabled}
+                      onValueChange={(value) => {
+                        if (isRegionValue(value)) {
+                          updateProvider(index, {
+                            ...providerDraft,
+                            region: value,
+                          });
+                        }
+                      }}
+                      value={providerDraft.region}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectPopup alignItemWithTrigger={false}>
+                        {REGION_KEYS.map((region) => (
+                          <SelectItem key={region} value={region}>
+                            {t(`aiConfig.regions.${region}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectPopup>
+                    </Select>
+                    {!compact && (
+                      <p className="text-muted-foreground text-xs">
+                        {t("aiConfig.dataRegionDescription")}
+                      </p>
+                    )}
+                  </Field>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Field>
+  );
+};

--- a/apps/web/src/components/ai-config-role-model-picker.tsx
+++ b/apps/web/src/components/ai-config-role-model-picker.tsx
@@ -1,0 +1,180 @@
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+} from "@stll/ui/components/combobox";
+import { Field, FieldDescription, FieldLabel } from "@stll/ui/components/field";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { cn } from "@stll/ui/lib/utils";
+import { useTranslations } from "use-intl";
+
+import {
+  getDefaultModelSelection,
+  getRolePickerRows,
+  isProviderValue,
+  MODEL_OPTIONS_BY_PROVIDER,
+} from "@/components/ai-config-role-models.logic";
+import type {
+  ModelSelection,
+  ProviderValue,
+  RoleModelSelections,
+  RoleValue,
+} from "@/components/ai-config-role-models.logic";
+
+type AIConfigRoleModelPickerProps = {
+  className?: string;
+  compact?: boolean;
+  disabled?: boolean;
+  onModelChange: (role: RoleValue, selection: ModelSelection | null) => void;
+  providers: readonly ProviderValue[];
+  roleModels: RoleModelSelections;
+};
+
+export const AIConfigRoleModelPicker = ({
+  className,
+  compact = false,
+  disabled = false,
+  onModelChange,
+  providers,
+  roleModels,
+}: AIConfigRoleModelPickerProps) => {
+  const t = useTranslations("organization");
+  const rows = getRolePickerRows({ providers, roleModels });
+  const hasProviders = providers.length > 0;
+
+  return (
+    <Field className={className}>
+      <div className="flex flex-col gap-1">
+        <FieldLabel>{t("aiConfig.modelsPanel")}</FieldLabel>
+        {!compact && (
+          <FieldDescription>{t("aiConfig.modelsDescription")}</FieldDescription>
+        )}
+      </div>
+
+      <div className="w-full overflow-hidden rounded-md border">
+        {rows.map((row) => {
+          const roleLabel = t(`aiConfig.roles.${row.role}`);
+          const selectedProvider = row.selection?.provider ?? providers.at(0);
+          const modelOptions = selectedProvider
+            ? MODEL_OPTIONS_BY_PROVIDER[selectedProvider].map((modelId) => ({
+                modelId,
+                provider: selectedProvider,
+              }))
+            : [];
+          const selectedModelOption =
+            modelOptions.find(
+              (option) =>
+                option.provider === row.selection?.provider &&
+                option.modelId === row.selection.modelId,
+            ) ?? null;
+
+          return (
+            <div
+              className={cn(
+                "grid border-t first:border-t-0 sm:items-center",
+                compact
+                  ? "gap-2 p-2 sm:grid-cols-[7.5rem_8.5rem_minmax(0,1fr)]"
+                  : "gap-3 p-3 sm:grid-cols-[minmax(10rem,0.65fr)_minmax(11rem,0.75fr)_minmax(14rem,1.35fr)]",
+              )}
+              key={row.role}
+            >
+              <span className="min-w-0 truncate text-sm font-medium">
+                {roleLabel}
+              </span>
+
+              <Select
+                disabled={disabled || !hasProviders}
+                onValueChange={(value) => {
+                  if (!isProvider(value, providers)) {
+                    return;
+                  }
+                  onModelChange(
+                    row.role,
+                    getDefaultModelSelection(value, row.role),
+                  );
+                }}
+                value={selectedProvider}
+              >
+                <SelectTrigger
+                  aria-label={t("aiConfig.providerForRole", {
+                    role: roleLabel,
+                  })}
+                  className="min-w-0"
+                >
+                  <SelectValue placeholder={t("aiConfig.addProviderFirst")} />
+                </SelectTrigger>
+                <SelectPopup alignItemWithTrigger={false}>
+                  {providers.map((provider) => (
+                    <SelectItem key={provider} value={provider}>
+                      {t(`aiConfig.providers.${provider}`)}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+
+              <Combobox<ModelSelection>
+                autoHighlight
+                disabled={disabled || !selectedProvider}
+                items={modelOptions}
+                itemToStringLabel={(option) => option.modelId}
+                onInputValueChange={(value) => {
+                  if (!value.trim()) {
+                    onModelChange(row.role, null);
+                  }
+                }}
+                onValueChange={(option) => {
+                  if (!option) {
+                    return;
+                  }
+
+                  onModelChange(row.role, option);
+                }}
+                value={selectedModelOption}
+              >
+                <ComboboxInput
+                  aria-invalid={!row.selection}
+                  aria-label={t("aiConfig.modelForRole", {
+                    role: roleLabel,
+                  })}
+                  className="min-w-0"
+                  placeholder={t("aiConfig.modelIdPlaceholder")}
+                  showClear={Boolean(row.selection)}
+                />
+                <ComboboxPopup>
+                  <ComboboxList>
+                    {(option: ModelSelection) => (
+                      <ComboboxItem
+                        key={`${option.provider}:${option.modelId}`}
+                        value={option}
+                      >
+                        <span className="block min-w-0 truncate">
+                          {option.modelId}
+                        </span>
+                      </ComboboxItem>
+                    )}
+                  </ComboboxList>
+                  <ComboboxEmpty>{t("aiConfig.noModelResults")}</ComboboxEmpty>
+                </ComboboxPopup>
+              </Combobox>
+            </div>
+          );
+        })}
+      </div>
+    </Field>
+  );
+};
+
+const isProvider = (
+  value: string | null,
+  providers: readonly ProviderValue[],
+): value is ProviderValue =>
+  value !== null && isProviderValue(value) && providers.includes(value);

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createDefaultRoleModels,
+  createProviderCredentialDraft,
+  decodeModelSelection,
+  encodeModelSelection,
+  ensureRoleModelsForProviders,
+  getAvailableModelOptions,
+  getNextAvailableProvider,
+  getProviderValues,
+  getRolePickerRows,
+  hasUsableProviderDrafts,
+  isKnownModelSelection,
+  providerDraftsFromStoredProviders,
+  roleModelsFromOverrideModels,
+  serializeOverrideModels,
+} from "@/components/ai-config-role-models.logic";
+import type { RoleModelSelections } from "@/components/ai-config-role-models.logic";
+
+describe("BYOK provider and model configuration", () => {
+  test("creates role defaults from the first configured provider", () => {
+    expect(createDefaultRoleModels(["anthropic", "openai"])).toEqual({
+      chat: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      fast: {
+        provider: "anthropic",
+        modelId: "claude-haiku-4-5-20251001",
+      },
+      reasoning: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      pdf: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+    });
+  });
+
+  test("normalizes stored providers for editing without exposing keys", () => {
+    expect(
+      providerDraftsFromStoredProviders([
+        {
+          provider: "google",
+          apiKeyMasked: "AIza****",
+          region: "eu",
+        },
+        {
+          provider: "openai",
+          apiKeyMasked: "sk-proj****",
+          region: "eu",
+        },
+      ]),
+    ).toEqual([
+      {
+        provider: "google",
+        apiKey: "",
+        apiKeyMasked: "AIza****",
+        baseURL: "",
+        region: "eu",
+        replacingKey: false,
+      },
+      {
+        provider: "openai",
+        apiKey: "",
+        apiKeyMasked: "sk-proj****",
+        baseURL: "",
+        region: "global",
+        replacingKey: false,
+      },
+    ]);
+  });
+
+  test("builds model options from the union of configured providers", () => {
+    expect(
+      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+    ).toContainEqual({
+      provider: "anthropic",
+      modelId: "claude-opus-4-7",
+      value: "anthropic::claude-opus-4-7",
+    });
+    expect(
+      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+    ).toContainEqual({
+      provider: "openai",
+      modelId: "gpt-5.4",
+      value: "openai::gpt-5.4",
+    });
+    expect(
+      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+    ).toContainEqual({
+      provider: "openrouter",
+      modelId: "google/gemini-3-flash-preview",
+      value: "openrouter::google/gemini-3-flash-preview",
+    });
+  });
+
+  test("limits suggestions to current model families", () => {
+    const modelOptions = getAvailableModelOptions([
+      "anthropic",
+      "google",
+      "openai",
+    ]);
+
+    expect(modelOptions).toContainEqual({
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      value: "anthropic::claude-opus-4-6",
+    });
+    expect(modelOptions).toContainEqual({
+      provider: "google",
+      modelId: "gemini-3-pro-preview",
+      value: "google::gemini-3-pro-preview",
+    });
+    expect(modelOptions).toContainEqual({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      value: "openai::gpt-5.2",
+    });
+    expect(modelOptions).not.toContainEqual({
+      provider: "anthropic",
+      modelId: "claude-2",
+      value: "anthropic::claude-2",
+    });
+    expect(modelOptions).not.toContainEqual({
+      provider: "google",
+      modelId: "gemini-1.5-pro",
+      value: "google::gemini-1.5-pro",
+    });
+    expect(modelOptions).not.toContainEqual({
+      provider: "openai",
+      modelId: "gpt-4o",
+      value: "openai::gpt-4o",
+    });
+  });
+
+  test("serializes every role as a provider-qualified model selection", () => {
+    const roleModels: RoleModelSelections = {
+      ...createDefaultRoleModels(["anthropic"]),
+      fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+    };
+
+    expect(
+      serializeOverrideModels({
+        providers: ["anthropic", "openai"],
+        roleModels,
+      }),
+    ).toEqual({
+      chat: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      reasoning: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      pdf: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+    });
+  });
+
+  test("blocks serialization when a role is missing a model", () => {
+    expect(
+      serializeOverrideModels({
+        providers: ["openai"],
+        roleModels: {
+          ...createDefaultRoleModels(["openai"]),
+          pdf: null,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps selected models only while their provider remains configured", () => {
+    expect(
+      ensureRoleModelsForProviders({
+        providers: ["openai"],
+        roleModels: {
+          ...createDefaultRoleModels(["anthropic"]),
+          fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+        },
+      }),
+    ).toEqual({
+      chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+      fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      reasoning: { provider: "openai", modelId: "gpt-5.4" },
+      pdf: { provider: "openai", modelId: "gpt-5.4" },
+    });
+  });
+
+  test("normalizes stored role selections into picker state", () => {
+    expect(
+      roleModelsFromOverrideModels({
+        providers: ["anthropic", "openai"],
+        overrideModels: {
+          chat: { provider: "anthropic", modelId: "claude-opus-4-5" },
+          fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+        },
+      }),
+    ).toEqual({
+      chat: { provider: "anthropic", modelId: "claude-opus-4-5" },
+      fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      reasoning: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+      pdf: { provider: "anthropic", modelId: "claude-sonnet-4-6" },
+    });
+  });
+
+  test("encodes OpenRouter model values without breaking model IDs that contain slashes", () => {
+    const selection = {
+      provider: "openrouter" as const,
+      modelId: "anthropic/claude-opus-4.5",
+    };
+
+    expect(decodeModelSelection(encodeModelSelection(selection))).toEqual(
+      selection,
+    );
+  });
+
+  test("validates provider drafts before enabling save", () => {
+    expect(
+      hasUsableProviderDrafts([
+        {
+          ...createProviderCredentialDraft("openrouter"),
+        },
+      ]),
+    ).toBe(false);
+    expect(
+      hasUsableProviderDrafts([
+        {
+          ...createProviderCredentialDraft("openrouter"),
+          apiKey: "sk-or-v1-test",
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  test("accepts saved provider drafts without requiring key replacement", () => {
+    expect(
+      hasUsableProviderDrafts([
+        {
+          ...createProviderCredentialDraft("openai"),
+          apiKeyMasked: "sk-proj****",
+          replacingKey: false,
+        },
+      ]),
+    ).toBe(true);
+    expect(
+      hasUsableProviderDrafts([
+        {
+          ...createProviderCredentialDraft("openai"),
+          apiKeyMasked: "sk-proj****",
+          replacingKey: true,
+        },
+      ]),
+    ).toBe(false);
+  });
+
+  test("blocks model IDs outside Stella's offered list", () => {
+    expect(
+      isKnownModelSelection({
+        provider: "openrouter",
+        modelId: "anthropic/claude-opus-4.5",
+      }),
+    ).toBe(true);
+    expect(
+      isKnownModelSelection({
+        provider: "openrouter",
+        modelId: "x-ai/grok-4",
+      }),
+    ).toBe(false);
+    expect(
+      serializeOverrideModels({
+        providers: ["openrouter"],
+        roleModels: {
+          ...createDefaultRoleModels(["openrouter"]),
+          chat: { provider: "openrouter", modelId: "x-ai/grok-4" },
+        },
+      }),
+    ).toBeNull();
+  });
+
+  test("finds provider values and the next addable provider", () => {
+    const providers = [createProviderCredentialDraft("google")];
+
+    expect(getProviderValues(providers)).toEqual(["google"]);
+    expect(getNextAvailableProvider(providers)).toBe("anthropic");
+  });
+
+  test("builds stable rows for the role/model picker", () => {
+    const rows = getRolePickerRows({
+      providers: ["anthropic", "openai"],
+      roleModels: {
+        ...createDefaultRoleModels(["anthropic"]),
+        fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      },
+    });
+
+    expect(rows.map((row) => row.role)).toEqual([
+      "chat",
+      "fast",
+      "reasoning",
+      "pdf",
+    ]);
+    expect(rows.at(0)?.selection).toEqual({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    });
+    expect(rows.at(1)?.value).toBe("openai::gpt-5.4-nano");
+    expect(rows.at(0)?.modelOptions).toContainEqual({
+      provider: "openai",
+      modelId: "gpt-5.2",
+      value: "openai::gpt-5.2",
+    });
+    expect(rows.at(0)?.modelOptions).toContainEqual({
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      value: "anthropic::claude-opus-4-6",
+    });
+  });
+});

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -50,7 +50,6 @@ describe("BYOK provider and model configuration", () => {
         provider: "google",
         apiKey: "",
         apiKeyMasked: "AIza****",
-        baseURL: "",
         region: "eu",
         replacingKey: false,
       },
@@ -58,7 +57,6 @@ describe("BYOK provider and model configuration", () => {
         provider: "openai",
         apiKey: "",
         apiKeyMasked: "sk-proj****",
-        baseURL: "",
         region: "global",
         replacingKey: false,
       },
@@ -155,6 +153,15 @@ describe("BYOK provider and model configuration", () => {
           ...createDefaultRoleModels(["openai"]),
           pdf: null,
         },
+      }),
+    ).toBeNull();
+  });
+
+  test("blocks serialization when a configured provider is unused", () => {
+    expect(
+      serializeOverrideModels({
+        providers: ["openai", "anthropic"],
+        roleModels: createDefaultRoleModels(["openai"]),
       }),
     ).toBeNull();
   });

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -1,0 +1,405 @@
+export const PROVIDER_KEYS = [
+  "google",
+  "anthropic",
+  "openai",
+  "openrouter",
+] as const;
+
+export const REGION_KEYS = ["global", "eu", "ch"] as const;
+
+export const ROLE_KEYS = ["chat", "fast", "reasoning", "pdf"] as const;
+
+export type ProviderValue = (typeof PROVIDER_KEYS)[number];
+export type RegionValue = (typeof REGION_KEYS)[number];
+export type RoleValue = (typeof ROLE_KEYS)[number];
+
+export type ProviderCredentialDraft = {
+  provider: ProviderValue;
+  apiKey: string;
+  apiKeyMasked?: string | undefined;
+  baseURL: string;
+  region: RegionValue;
+  replacingKey: boolean;
+};
+
+export type ModelSelection = {
+  provider: ProviderValue;
+  modelId: string;
+};
+
+export type RoleModelSelections = Record<RoleValue, ModelSelection | null>;
+
+export type ModelOption = ModelSelection & {
+  value: string;
+};
+
+export type StoredProviderConfig = {
+  provider: string;
+  apiKeyMasked?: string | undefined;
+  baseURL?: string | null | undefined;
+  region?: string | undefined;
+};
+
+export type StoredOverrideModels =
+  | Partial<
+      Record<
+        RoleValue,
+        | { provider?: string | undefined; modelId?: string | undefined }
+        | undefined
+      >
+    >
+  | null
+  | undefined;
+
+const PROVIDER_VALUES = new Set<string>(PROVIDER_KEYS);
+const REGION_VALUES = new Set<string>(REGION_KEYS);
+const ROLE_VALUES = new Set<string>(ROLE_KEYS);
+
+export const REGIONAL_PROVIDERS = new Set<ProviderValue>(["google"]);
+
+export const DEFAULT_MODELS_BY_PROVIDER = {
+  google: {
+    chat: "gemini-3-flash-preview",
+    fast: "gemini-2.5-flash-lite",
+    reasoning: "gemini-3-pro-preview",
+    pdf: "gemini-3-flash-preview",
+  },
+  anthropic: {
+    chat: "claude-sonnet-4-6",
+    fast: "claude-haiku-4-5-20251001",
+    reasoning: "claude-sonnet-4-6",
+    pdf: "claude-sonnet-4-6",
+  },
+  openai: {
+    chat: "gpt-5.4-mini",
+    fast: "gpt-5.4-nano",
+    reasoning: "gpt-5.4",
+    pdf: "gpt-5.4",
+  },
+  openrouter: {
+    chat: "google/gemini-3-flash-preview",
+    fast: "google/gemini-2.5-flash-lite",
+    reasoning: "google/gemini-3.1-pro-preview",
+    pdf: "google/gemini-3-flash-preview",
+  },
+} as const satisfies Record<ProviderValue, Record<RoleValue, string>>;
+
+export const MODEL_OPTIONS_BY_PROVIDER = {
+  google: [
+    "gemini-3-pro-preview",
+    "gemini-3-flash-preview",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+  ],
+  anthropic: [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+    "claude-haiku-4-5-20251001",
+  ],
+  openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
+  openrouter: [
+    "google/gemini-3-flash-preview",
+    "google/gemini-3.1-pro-preview",
+    "google/gemini-2.5-flash-lite",
+    "anthropic/claude-opus-4.5",
+    "anthropic/claude-sonnet-4.5",
+    "openai/gpt-5.4",
+    "openai/gpt-5.4-mini",
+  ],
+} as const satisfies Record<ProviderValue, readonly string[]>;
+
+export const isProviderValue = (value: string | null): value is ProviderValue =>
+  value !== null && PROVIDER_VALUES.has(value);
+
+export const isRegionValue = (value: string | null): value is RegionValue =>
+  value !== null && REGION_VALUES.has(value);
+
+export const isRoleValue = (value: string): value is RoleValue =>
+  ROLE_VALUES.has(value);
+
+export const createProviderCredentialDraft = (
+  provider: ProviderValue = "google",
+): ProviderCredentialDraft => ({
+  provider,
+  apiKey: "",
+  baseURL: "",
+  region: "global",
+  replacingKey: true,
+});
+
+export const providerDraftsFromStoredProviders = (
+  providers: readonly StoredProviderConfig[] | undefined,
+): ProviderCredentialDraft[] => {
+  if (!providers || providers.length === 0) {
+    return [createProviderCredentialDraft()];
+  }
+
+  const drafts: ProviderCredentialDraft[] = [];
+
+  for (const providerConfig of providers) {
+    if (!isProviderValue(providerConfig.provider)) {
+      continue;
+    }
+
+    const provider = providerConfig.provider;
+    const storedRegion = providerConfig.region;
+    let region: RegionValue = "global";
+    if (
+      storedRegion &&
+      isRegionValue(storedRegion) &&
+      REGIONAL_PROVIDERS.has(provider)
+    ) {
+      region = storedRegion;
+    }
+
+    drafts.push({
+      provider,
+      apiKey: "",
+      apiKeyMasked: providerConfig.apiKeyMasked,
+      baseURL: providerConfig.baseURL ?? "",
+      region,
+      replacingKey: false,
+    });
+  }
+
+  return drafts.length > 0 ? drafts : [createProviderCredentialDraft()];
+};
+
+export const createDefaultRoleModels = (
+  providers: readonly ProviderValue[] = ["google"],
+): RoleModelSelections => {
+  const provider = providers.at(0);
+  return {
+    chat: getDefaultModelSelection(provider, "chat"),
+    fast: getDefaultModelSelection(provider, "fast"),
+    reasoning: getDefaultModelSelection(provider, "reasoning"),
+    pdf: getDefaultModelSelection(provider, "pdf"),
+  };
+};
+
+export const roleModelsFromOverrideModels = ({
+  overrideModels,
+  providers,
+}: {
+  overrideModels: StoredOverrideModels;
+  providers: readonly ProviderValue[];
+}): RoleModelSelections => {
+  const models = createDefaultRoleModels(providers);
+
+  if (!overrideModels) {
+    return models;
+  }
+
+  for (const role of ROLE_KEYS) {
+    const selection = overrideModels[role];
+    if (
+      selection?.provider &&
+      selection.modelId &&
+      isProviderValue(selection.provider) &&
+      providers.includes(selection.provider)
+    ) {
+      models[role] = {
+        provider: selection.provider,
+        modelId: selection.modelId,
+      };
+    }
+  }
+
+  return models;
+};
+
+export const ensureRoleModelsForProviders = ({
+  providers,
+  roleModels,
+}: {
+  providers: readonly ProviderValue[];
+  roleModels: RoleModelSelections;
+}): RoleModelSelections => {
+  const configuredProviders = new Set(providers);
+  const nextModels = createDefaultRoleModels(providers);
+
+  for (const role of ROLE_KEYS) {
+    const selection = roleModels[role];
+    if (selection && configuredProviders.has(selection.provider)) {
+      nextModels[role] = selection;
+    }
+  }
+
+  return nextModels;
+};
+
+export const encodeModelSelection = ({
+  provider,
+  modelId,
+}: ModelSelection): string => `${provider}::${modelId}`;
+
+export const decodeModelSelection = (value: string): ModelSelection | null => {
+  const [providerRaw, ...modelParts] = value.split("::");
+  const modelId = modelParts.join("::");
+
+  if (!providerRaw || !isProviderValue(providerRaw) || !modelId) {
+    return null;
+  }
+
+  return { provider: providerRaw, modelId };
+};
+
+export const getAvailableModelOptions = (
+  providers: readonly ProviderValue[],
+): ModelOption[] => {
+  const options: ModelOption[] = [];
+  const seen = new Set<string>();
+
+  for (const provider of providers) {
+    for (const modelId of MODEL_OPTIONS_BY_PROVIDER[provider]) {
+      const option = {
+        provider,
+        modelId,
+      };
+      const value = encodeModelSelection(option);
+      if (seen.has(value)) {
+        continue;
+      }
+      seen.add(value);
+      options.push({ ...option, value });
+    }
+  }
+
+  return options;
+};
+
+export const getRolePickerRows = ({
+  providers,
+  roleModels,
+}: {
+  providers: readonly ProviderValue[];
+  roleModels: RoleModelSelections;
+}) => {
+  const options = getAvailableModelOptions(providers);
+
+  return ROLE_KEYS.map((role) => ({
+    modelOptions: options,
+    role,
+    selection: roleModels[role],
+    value: roleModels[role] ? encodeModelSelection(roleModels[role]) : "",
+  }));
+};
+
+export const isKnownModelSelection = (
+  selection: ModelSelection | null,
+): boolean => {
+  if (!selection) {
+    return false;
+  }
+  const knownModels: readonly string[] =
+    MODEL_OPTIONS_BY_PROVIDER[selection.provider];
+  return knownModels.includes(selection.modelId);
+};
+
+export const serializeOverrideModels = ({
+  providers,
+  roleModels,
+}: {
+  providers: readonly ProviderValue[];
+  roleModels: RoleModelSelections;
+}): Record<RoleValue, ModelSelection> | null => {
+  if (providers.length === 0) {
+    return null;
+  }
+
+  const chat = roleModels.chat;
+  const fast = roleModels.fast;
+  const reasoning = roleModels.reasoning;
+  const pdf = roleModels.pdf;
+
+  if (!(chat && fast && reasoning && pdf)) {
+    return null;
+  }
+
+  const selections = [chat, fast, reasoning, pdf];
+  if (
+    selections.some(
+      (selection) =>
+        !providers.includes(selection.provider) ||
+        !isKnownModelSelection(selection),
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    chat,
+    fast,
+    reasoning,
+    pdf,
+  };
+};
+
+export const getAvailableProviderKeys = ({
+  currentProvider,
+  providers,
+}: {
+  currentProvider?: ProviderValue | undefined;
+  providers: readonly ProviderCredentialDraft[];
+}): ProviderValue[] => {
+  const usedProviders = new Set(
+    providers
+      .map((providerDraft) => providerDraft.provider)
+      .filter((provider) => provider !== currentProvider),
+  );
+
+  return PROVIDER_KEYS.filter((provider) => !usedProviders.has(provider));
+};
+
+export const getProviderValues = (
+  providers: readonly ProviderCredentialDraft[],
+): ProviderValue[] => providers.map((providerDraft) => providerDraft.provider);
+
+export const getNextAvailableProvider = (
+  providers: readonly ProviderCredentialDraft[],
+): ProviderValue | null =>
+  PROVIDER_KEYS.find(
+    (provider) =>
+      !providers.some((providerDraft) => providerDraft.provider === provider),
+  ) ?? null;
+
+export const hasUsableProviderDrafts = (
+  providers: readonly ProviderCredentialDraft[],
+): boolean => {
+  if (providers.length === 0) {
+    return false;
+  }
+
+  const seenProviders = new Set<ProviderValue>();
+
+  for (const providerDraft of providers) {
+    if (seenProviders.has(providerDraft.provider)) {
+      return false;
+    }
+    seenProviders.add(providerDraft.provider);
+
+    if (
+      (providerDraft.replacingKey || !providerDraft.apiKeyMasked) &&
+      !providerDraft.apiKey.trim()
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const getDefaultModelSelection = (
+  provider: ProviderValue | undefined,
+  role: RoleValue,
+): ModelSelection | null => {
+  if (!provider) {
+    return null;
+  }
+  return {
+    provider,
+    modelId: DEFAULT_MODELS_BY_PROVIDER[provider][role],
+  };
+};

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -17,7 +17,6 @@ export type ProviderCredentialDraft = {
   provider: ProviderValue;
   apiKey: string;
   apiKeyMasked?: string | undefined;
-  baseURL: string;
   region: RegionValue;
   replacingKey: boolean;
 };
@@ -36,7 +35,6 @@ export type ModelOption = ModelSelection & {
 export type StoredProviderConfig = {
   provider: string;
   apiKeyMasked?: string | undefined;
-  baseURL?: string | null | undefined;
   region?: string | undefined;
 };
 
@@ -124,7 +122,6 @@ export const createProviderCredentialDraft = (
 ): ProviderCredentialDraft => ({
   provider,
   apiKey: "",
-  baseURL: "",
   region: "global",
   replacingKey: true,
 });
@@ -158,7 +155,6 @@ export const providerDraftsFromStoredProviders = (
       provider,
       apiKey: "",
       apiKeyMasked: providerConfig.apiKeyMasked,
-      baseURL: providerConfig.baseURL ?? "",
       region,
       replacingKey: false,
     });
@@ -326,6 +322,16 @@ export const serializeOverrideModels = ({
         !isKnownModelSelection(selection),
     )
   ) {
+    return null;
+  }
+
+  // Reject orphan providers — every configured provider
+  // must drive at least one role. Mirrors the API check;
+  // gating it here keeps the save button honest.
+  const referencedProviders = new Set(
+    selections.map((selection) => selection.provider),
+  );
+  if (providers.some((provider) => !referencedProviders.has(provider))) {
     return null;
   }
 

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -15,54 +15,40 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogPanel,
   DialogPopup,
   DialogTitle,
 } from "@stll/ui/components/dialog";
-import { Field, FieldLabel } from "@stll/ui/components/field";
-import { Input } from "@stll/ui/components/input";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
 import { toastManager } from "@stll/ui/components/toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
+import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
+import { AIConfigRoleModelPicker } from "@/components/ai-config-role-model-picker";
+import {
+  createProviderCredentialDraft,
+  createDefaultRoleModels,
+  ensureRoleModelsForProviders,
+  getProviderValues,
+  hasUsableProviderDrafts,
+  providerDraftsFromStoredProviders,
+  roleModelsFromOverrideModels,
+  serializeOverrideModels,
+} from "@/components/ai-config-role-models.logic";
+import type {
+  ModelSelection,
+  ProviderCredentialDraft,
+  RoleModelSelections,
+  RoleValue,
+} from "@/components/ai-config-role-models.logic";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
 import {
   aiAvailabilityOptions,
+  aiConfigOptions,
   aiConfigKeys,
 } from "@/routes/_protected.organization/-ai-config-queries";
-
-const PROVIDER_KEYS = [
-  "google",
-  "openrouter",
-  "openai",
-  "anthropic",
-  "openai_compatible",
-] as const;
-
-const REGION_KEYS = ["global", "eu", "ch"] as const;
-
-type ProviderValue = (typeof PROVIDER_KEYS)[number];
-type RegionValue = (typeof REGION_KEYS)[number];
-
-const REGIONAL_PROVIDERS = new Set<ProviderValue>(["google"]);
-
-const API_KEY_PLACEHOLDER = {
-  google: "AIza...",
-  openrouter: "sk-or-v1-...",
-  openai: "sk-proj-...",
-  anthropic: "sk-ant-...",
-  openai_compatible: "sk-...",
-} as const satisfies Record<ProviderValue, string>;
 
 type AIAvailabilityContextValue = {
   ensureAIAvailable: () => Promise<boolean>;
@@ -204,25 +190,78 @@ export function AIKeyRequiredDialog({
   const tSuccess = useTranslations("success");
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
-  const [provider, setProvider] = useState<ProviderValue>("google");
-  const [apiKey, setApiKey] = useState("");
-  const [baseURL, setBaseURL] = useState("");
-  const [region, setRegion] = useState<RegionValue>("global");
+  const { data: config } = useQuery(aiConfigOptions);
+  const [providers, setProviders] = useState<ProviderCredentialDraft[]>(() => [
+    createProviderCredentialDraft(),
+  ]);
+  const [roleModels, setRoleModels] = useState<RoleModelSelections>(
+    createDefaultRoleModels,
+  );
 
   useEffect(() => {
-    if (!REGIONAL_PROVIDERS.has(provider)) {
-      setRegion("global");
+    if (!open) {
+      return;
     }
-  }, [provider]);
+
+    if (!config?.configured) {
+      const nextProviders = [createProviderCredentialDraft()];
+      setProviders(nextProviders);
+      setRoleModels(createDefaultRoleModels(getProviderValues(nextProviders)));
+      return;
+    }
+
+    const nextProviders = providerDraftsFromStoredProviders(
+      config.providers,
+    ).slice(0, 1);
+    const providerValues = getProviderValues(nextProviders);
+    setProviders(nextProviders);
+    setRoleModels(
+      roleModelsFromOverrideModels({
+        overrideModels: config.overrideModels,
+        providers: providerValues,
+      }),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, config?.configured]);
+
+  const updateProviders = (nextProviders: ProviderCredentialDraft[]) => {
+    const providerValues = getProviderValues(nextProviders);
+    setProviders(nextProviders);
+    setRoleModels((prev) =>
+      ensureRoleModelsForProviders({
+        providers: providerValues,
+        roleModels: prev,
+      }),
+    );
+  };
+
+  const setRoleModel = (role: RoleValue, model: ModelSelection | null) => {
+    setRoleModels((prev) => ({
+      ...prev,
+      [role]: model,
+    }));
+  };
 
   const saveMutation = useMutation({
     mutationFn: async () => {
+      const providerValues = getProviderValues(providers);
+      const overrideModels = serializeOverrideModels({
+        providers: providerValues,
+        roleModels,
+      });
+      if (!overrideModels) {
+        throw new Error(tOrganization("aiConfig.selectModelForEachRole"));
+      }
+
       const response = await api["organization-settings"]["ai-config"].post({
-        provider,
-        apiKey,
-        ...(provider === "openai_compatible" ? { baseURL } : {}),
-        overrideRoles: [],
-        region,
+        providers: providers.map((providerDraft) => ({
+          provider: providerDraft.provider,
+          ...(providerDraft.apiKey.trim()
+            ? { apiKey: providerDraft.apiKey.trim() }
+            : {}),
+          region: providerDraft.region,
+        })),
+        overrideModels,
       });
 
       if (response.error) {
@@ -231,8 +270,8 @@ export function AIKeyRequiredDialog({
 
       return response.data;
     },
-    onSuccess: async () => {
-      setApiKey("");
+    onSuccess: async (data) => {
+      setProviders(providerDraftsFromStoredProviders(data.providers));
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: aiConfigKeys.all }),
         queryClient.invalidateQueries({ queryKey: aiConfigKeys.availability }),
@@ -252,95 +291,45 @@ export function AIKeyRequiredDialog({
     },
   });
 
-  const needsBaseURL = provider === "openai_compatible";
-  const canSave: boolean =
-    apiKey.trim().length > 0 && (!needsBaseURL || baseURL.trim().length > 0);
+  const providerValues = getProviderValues(providers);
+  const canSave =
+    hasUsableProviderDrafts(providers) &&
+    serializeOverrideModels({ providers: providerValues, roleModels }) !== null;
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogPopup className="sm:max-w-md">
-        <DialogHeader>
+      <DialogPopup className="max-h-[calc(100dvh-2rem)] overflow-hidden sm:max-w-3xl">
+        <DialogHeader className="p-4 pb-2">
           <DialogTitle>{t("ai.keyRequired.title")}</DialogTitle>
           <DialogDescription>
             {t("ai.keyRequired.description")}
           </DialogDescription>
         </DialogHeader>
-        <DialogPanel className="grid gap-4">
-          <Field>
-            <FieldLabel>{tOrganization("aiConfig.provider")}</FieldLabel>
-            <Select
-              onValueChange={(value) => {
-                if (isProviderValue(value)) {
-                  setProvider(value);
-                }
-              }}
-              value={provider}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectPopup alignItemWithTrigger={false}>
-                {PROVIDER_KEYS.map((key) => (
-                  <SelectItem key={key} value={key}>
-                    {tOrganization(`aiConfig.providers.${key}`)}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-          </Field>
-
-          <Field>
-            <FieldLabel>{tOrganization("aiConfig.apiKey")}</FieldLabel>
-            <Input
-              autoComplete="off"
-              onChange={(event) => setApiKey(event.target.value)}
-              placeholder={API_KEY_PLACEHOLDER[provider]}
-              type="password"
-              value={apiKey}
+        <div className="min-h-0 overflow-x-hidden overflow-y-auto px-4 pb-3">
+          <div className="grid gap-3">
+            <AIConfigProvidersEditor
+              compact
+              disabled={saveMutation.isPending}
+              onProvidersChange={updateProviders}
+              providers={providers}
             />
-          </Field>
 
-          {needsBaseURL && (
-            <Field>
-              <FieldLabel>{tOrganization("aiConfig.baseUrl")}</FieldLabel>
-              <Input
-                onChange={(event) => setBaseURL(event.target.value)}
-                placeholder="https://api.example.com/v1"
-                value={baseURL}
-              />
-            </Field>
-          )}
+            <AIConfigRoleModelPicker
+              compact
+              disabled={saveMutation.isPending}
+              onModelChange={setRoleModel}
+              providers={providerValues}
+              roleModels={roleModels}
+            />
 
-          <Field>
-            <FieldLabel>{tOrganization("aiConfig.dataRegion")}</FieldLabel>
-            <Select
-              disabled={!REGIONAL_PROVIDERS.has(provider)}
-              onValueChange={(value) => {
-                if (isRegionValue(value)) {
-                  setRegion(value);
-                }
-              }}
-              value={region}
-            >
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectPopup alignItemWithTrigger={false}>
-                {REGION_KEYS.map((key) => (
-                  <SelectItem key={key} value={key}>
-                    {tOrganization(`aiConfig.regions.${key}`)}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-            <p className="text-muted-foreground text-xs">
-              {REGIONAL_PROVIDERS.has(provider)
-                ? tOrganization("aiConfig.dataRegionDescription")
-                : tOrganization("aiConfig.dataRegionUnsupported")}
-            </p>
-          </Field>
-        </DialogPanel>
-        <DialogFooter>
+            {!canSave && (
+              <p className="text-destructive-foreground text-xs">
+                {tOrganization("aiConfig.selectModelForEachRole")}
+              </p>
+            )}
+          </div>
+        </div>
+        <DialogFooter className="px-4 py-3">
           <DialogClose render={<Button variant="ghost" />}>
             {tCommon("cancel")}
           </DialogClose>
@@ -356,9 +345,3 @@ export function AIKeyRequiredDialog({
     </Dialog>
   );
 }
-
-const isProviderValue = (value: string | null): value is ProviderValue =>
-  value !== null && PROVIDER_KEYS.some((key) => key === value);
-
-const isRegionValue = (value: string | null): value is RegionValue =>
-  value !== null && REGION_KEYS.some((key) => key === value);

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Upravit pomocí AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Otevřít nastavení AI",
+      "description": "Přidejte přihlašovací údaje poskytovatele a začněte používat funkce AI.",
+      "title": "Připojit poskytovatele AI"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Aktivní",
+      "addProvider": "Přidat poskytovatele",
+      "addProviderFirst": "Nejprve přidejte poskytovatele",
       "apiKey": "API klíč",
+      "apiKeyConfiguredPlaceholder": "Nastaveno: {key}. Zadáním nového klíče jej nahradíte.",
       "apiKeyPlaceholder": "Zadejte svůj API klíč",
+      "apiKeySaved": "Uložený klíč {key}",
       "apiKeyUpdatePlaceholder": "Zadejte nový klíč pro aktualizaci",
       "baseUrl": "Základní URL",
       "configure": "Konfigurovat",
+      "credentialsPanel": "Klíč",
+      "customModelBadge": "Vlastní · {provider}",
+      "customModelDescription": "Toto ID modelu není v katalogu Stella. Vybranému poskytovateli se předá přesně tak, jak je zadané.",
+      "customModelHint": "Žádná shoda v katalogu. Zadejte libovolné ID modelu; vlastní ID se uloží přesně tak, jak je napsané.",
       "dataRegion": "Region dat",
       "dataRegionDescription": "Volání AI poteče přes vybraný region kvůli suverenitě dat.",
       "dataRegionUnsupported": "Regionální směrování je dostupné jen pro Google AI (Vertex AI).",
+      "defaultModel": "Výchozí: {model}",
+      "defaultModelOption": "Výchozí",
       "description": "Připojte vlastní API klíč nebo zvolte region pro suverenitu dat.",
+      "keepSavedKey": "Ponechat uložený klíč",
+      "modelForRole": "Model pro roli {role}",
+      "modelIdPlaceholder": "Hledat modely",
+      "modelRequired": "Povinné",
+      "modelsDescription": "Pro každou kategorii AI vyberte poskytovatele a jeden nabízený multimodální model.",
+      "modelsPanel": "Modely",
+      "newApiKey": "Nový API klíč",
+      "newApiKeyDescription": "Po uložení změn nahradí uložený klíč.",
+      "noModelResults": "Žádné odpovídající nabízené modely",
       "overrideRoles": "Přepsat role",
-      "overrideRolesDescription": "Vyberte, které AI role použijí váš klíč. Nevybrané role poběží na výchozím klíči platformy.",
+      "overrideRolesDescription": "Vyberte, které role použijí tento klíč, a pro každou zvolte model. Nevybrané role použijí výchozí nastavení platformy.",
       "provider": "Poskytovatel",
+      "providerForRole": "Poskytovatel pro {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-kompatibilní",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Přidejte přihlašovací údaje poskytovatelů, které má Stella používat.",
+      "providersPanel": "Poskytovatelé",
       "regions": {
         "ch": "Švýcarsko (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Globální"
       },
+      "removeProvider": "Odebrat poskytovatele",
+      "replaceKey": "Nahradit klíč",
       "roles": {
         "chat": "Chat (konverzace)",
         "fast": "Rychlé (klasifikace)",
         "pdf": "PDF (dokumenty)",
         "reasoning": "Uvažování (analýza)"
       },
+      "selectAtLeastOneRole": "Vyberte pro tento klíč alespoň jednu roli.",
+      "selectModelForEachRole": "Přidejte poskytovatele a pro každou kategorii vyberte model.",
+      "selectedProvider": "{provider}",
       "title": "Konfigurace AI"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Mit KI bearbeiten",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "AI-Einstellungen öffnen",
+      "description": "Füge Provider-Zugangsdaten hinzu, um AI-Funktionen zu nutzen.",
+      "title": "AI-Provider verbinden"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Provider hinzufügen",
+      "addProviderFirst": "Zuerst Provider hinzufügen",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Konfiguriert: {key}. Gib einen neuen Schlüssel ein, um ihn zu ersetzen.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Gespeicherter Schlüssel {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Schlüssel",
+      "customModelBadge": "Benutzerdefiniert · {provider}",
+      "customModelDescription": "Diese Modell-ID ist nicht im Stella-Katalog. Sie wird unverändert an den gewählten Provider gesendet.",
+      "customModelHint": "Kein Katalogtreffer. Gib eine beliebige Modell-ID ein; benutzerdefinierte IDs werden unverändert gespeichert.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Standard: {model}",
+      "defaultModelOption": "Standard",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Gespeicherten Schlüssel behalten",
+      "modelForRole": "Modell für {role}",
+      "modelIdPlaceholder": "Modelle suchen",
+      "modelRequired": "Erforderlich",
+      "modelsDescription": "Wähle für jede AI-Kategorie einen Provider und ein angebotenes multimodales Modell.",
+      "modelsPanel": "Modelle",
+      "newApiKey": "Neuer API-Schlüssel",
+      "newApiKeyDescription": "Er ersetzt den gespeicherten Schlüssel beim Speichern.",
+      "noModelResults": "Keine passenden angebotenen Modelle",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Wähle aus, welche Rollen diesen Schlüssel verwenden, und lege für jede Rolle ein Modell fest. Nicht ausgewählte Rollen verwenden den Plattformstandard.",
       "provider": "Provider",
+      "providerForRole": "Provider für {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Füge die Provider-Zugangsdaten hinzu, die Stella verwenden soll.",
+      "providersPanel": "Provider",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Provider entfernen",
+      "replaceKey": "Schlüssel ersetzen",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Wähle mindestens eine Rolle für diesen Schlüssel aus.",
+      "selectModelForEachRole": "Füge einen Provider hinzu und wähle für jede Kategorie ein Modell aus.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -17,8 +17,8 @@
     "editWithAI": "Edit with AI",
     "keyRequired": {
       "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "description": "Add provider credentials to start using AI features.",
+      "title": "Connect AI provider"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Add provider",
+      "addProviderFirst": "Add a provider first",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Configured: {key}. Enter a new key to replace it.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Saved key {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Key",
+      "customModelBadge": "Custom · {provider}",
+      "customModelDescription": "This model ID is not in Stella’s catalog. It will be passed to the selected provider as typed.",
+      "customModelHint": "No catalog match. Type any model ID; custom IDs are saved as typed.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Default: {model}",
+      "defaultModelOption": "Default",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Keep saved key",
+      "modelForRole": "{role} model",
+      "modelIdPlaceholder": "Search models",
+      "modelRequired": "Required",
+      "modelsDescription": "Choose a provider and one offered multimodal model for each AI category.",
+      "modelsPanel": "Models",
+      "newApiKey": "New API key",
+      "newApiKeyDescription": "This will replace the saved key when you save changes.",
+      "noModelResults": "No matching offered models",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Choose which roles use this key, then choose a model for each role. Unselected roles use the platform default.",
       "provider": "Provider",
+      "providerForRole": "{role} provider",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Add the provider credentials you want Stella to use.",
+      "providersPanel": "Providers",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Remove provider",
+      "replaceKey": "Replace key",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Select at least one role for this key.",
+      "selectModelForEachRole": "Add a provider and select a model for each category.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Editar con IA",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Abrir ajustes de IA",
+      "description": "Añade credenciales de proveedor para empezar a usar funciones de IA.",
+      "title": "Conectar proveedor de IA"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Añadir proveedor",
+      "addProviderFirst": "Añade primero un proveedor",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Configurada: {key}. Introduce una clave nueva para sustituirla.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Clave guardada {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Clave",
+      "customModelBadge": "Personalizado · {provider}",
+      "customModelDescription": "Este ID de modelo no está en el catálogo de Stella. Se enviará al proveedor seleccionado tal como lo escribiste.",
+      "customModelHint": "No hay coincidencias en el catálogo. Escribe cualquier ID de modelo; los IDs personalizados se guardan tal cual.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Predeterminado: {model}",
+      "defaultModelOption": "Predeterminado",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Conservar clave guardada",
+      "modelForRole": "Modelo para {role}",
+      "modelIdPlaceholder": "Buscar modelos",
+      "modelRequired": "Obligatorio",
+      "modelsDescription": "Elige un proveedor y un modelo multimodal ofrecido para cada categoría de IA.",
+      "modelsPanel": "Modelos",
+      "newApiKey": "Nueva clave API",
+      "newApiKeyDescription": "Sustituirá la clave guardada al guardar los cambios.",
+      "noModelResults": "No hay modelos ofrecidos que coincidan",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Elige qué roles usan esta clave y luego el modelo de cada rol. Los roles no seleccionados usan el valor predeterminado de la plataforma.",
       "provider": "Provider",
+      "providerForRole": "Proveedor para {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Añade las credenciales de los proveedores que quieres que use Stella.",
+      "providersPanel": "Proveedores",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Quitar proveedor",
+      "replaceKey": "Sustituir clave",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Selecciona al menos un rol para esta clave.",
+      "selectModelForEachRole": "Añade un proveedor y elige un modelo para cada categoría.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Muuda AI-ga",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Ava AI seaded",
+      "description": "Lisa teenusepakkuja pääsuandmed, et hakata AI-funktsioone kasutama.",
+      "title": "Ühenda AI teenusepakkuja"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Lisa teenusepakkuja",
+      "addProviderFirst": "Lisa esmalt teenusepakkuja",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Seadistatud: {key}. Sisesta uus võti, et see asendada.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Salvestatud võti {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Võti",
+      "customModelBadge": "Kohandatud · {provider}",
+      "customModelDescription": "Seda mudeli ID-d Stella kataloogis ei ole. See saadetakse valitud teenusepakkujale sisestatud kujul.",
+      "customModelHint": "Kataloogis vastet pole. Sisesta ükskõik milline mudeli ID; kohandatud ID salvestatakse sisestatud kujul.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Vaikimisi: {model}",
+      "defaultModelOption": "Vaikimisi",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Hoia salvestatud võti alles",
+      "modelForRole": "Rolli {role} mudel",
+      "modelIdPlaceholder": "Otsi mudeleid",
+      "modelRequired": "Nõutav",
+      "modelsDescription": "Vali iga AI-kategooria jaoks teenusepakkuja ja üks pakutud multimodaalne mudel.",
+      "modelsPanel": "Mudelid",
+      "newApiKey": "Uus API võti",
+      "newApiKeyDescription": "See asendab salvestatud võtme muudatuste salvestamisel.",
+      "noModelResults": "Sobivaid pakutud mudeleid ei leitud",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Vali, millised rollid kasutavad seda võtit, ja seejärel iga rolli mudel. Valimata rollid kasutavad platvormi vaikevalikut.",
       "provider": "Provider",
+      "providerForRole": "{role} teenusepakkuja",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Lisa nende teenusepakkujate mandaadid, mida Stella peaks kasutama.",
+      "providersPanel": "Teenusepakkujad",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Eemalda teenusepakkuja",
+      "replaceKey": "Asenda võti",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Vali selle võtme jaoks vähemalt üks roll.",
+      "selectModelForEachRole": "Lisa teenusepakkuja ja vali iga kategooria jaoks mudel.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Modifier avec l’IA",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Ouvrir les paramètres IA",
+      "description": "Ajoutez les identifiants d’un fournisseur pour commencer à utiliser les fonctions IA.",
+      "title": "Connecter un fournisseur IA"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Ajouter un fournisseur",
+      "addProviderFirst": "Ajoutez d’abord un fournisseur",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Configurée : {key}. Saisissez une nouvelle clé pour la remplacer.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Clé enregistrée {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Clé",
+      "customModelBadge": "Personnalisé · {provider}",
+      "customModelDescription": "Cet ID de modèle n’est pas dans le catalogue Stella. Il sera transmis tel quel au fournisseur sélectionné.",
+      "customModelHint": "Aucune correspondance dans le catalogue. Saisissez n’importe quel ID de modèle; les IDs personnalisés sont enregistrés tels quels.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Par défaut : {model}",
+      "defaultModelOption": "Par défaut",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Conserver la clé enregistrée",
+      "modelForRole": "Modèle pour {role}",
+      "modelIdPlaceholder": "Rechercher des modèles",
+      "modelRequired": "Obligatoire",
+      "modelsDescription": "Choisissez un fournisseur et un modèle multimodal proposé pour chaque catégorie IA.",
+      "modelsPanel": "Modèles",
+      "newApiKey": "Nouvelle clé API",
+      "newApiKeyDescription": "Elle remplacera la clé enregistrée lors de l’enregistrement.",
+      "noModelResults": "Aucun modèle proposé correspondant",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Choisissez les rôles qui utilisent cette clé, puis choisissez un modèle pour chaque rôle. Les rôles non sélectionnés utilisent le réglage par défaut de la plateforme.",
       "provider": "Provider",
+      "providerForRole": "Fournisseur pour {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Ajoutez les identifiants des fournisseurs que Stella doit utiliser.",
+      "providersPanel": "Fournisseurs",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Supprimer le fournisseur",
+      "replaceKey": "Remplacer la clé",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Sélectionnez au moins un rôle pour cette clé.",
+      "selectModelForEachRole": "Ajoutez un fournisseur et choisissez un modèle pour chaque catégorie.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Szerkesztés AI-val",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "AI-beállítások megnyitása",
+      "description": "Adj hozzá szolgáltatói hitelesítési adatokat az AI-funkciók használatához.",
+      "title": "AI-szolgáltató csatlakoztatása"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Szolgáltató hozzáadása",
+      "addProviderFirst": "Először adj hozzá szolgáltatót",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Beállítva: {key}. Új kulccsal lecserélheted.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Mentett kulcs {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Kulcs",
+      "customModelBadge": "Egyedi · {provider}",
+      "customModelDescription": "Ez a modellazonosító nincs a Stella katalógusában. A kiválasztott szolgáltatónak pontosan így lesz továbbítva.",
+      "customModelHint": "Nincs katalógustalálat. Írj be bármilyen modellazonosítót; az egyedi azonosítók változatlanul mentésre kerülnek.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Alapértelmezett: {model}",
+      "defaultModelOption": "Alapértelmezett",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Mentett kulcs megtartása",
+      "modelForRole": "{role} modellje",
+      "modelIdPlaceholder": "Modellek keresése",
+      "modelRequired": "Kötelező",
+      "modelsDescription": "Válassz szolgáltatót és egy felkínált multimodális modellt minden AI-kategóriához.",
+      "modelsPanel": "Modellek",
+      "newApiKey": "Új API-kulcs",
+      "newApiKeyDescription": "Mentéskor lecseréli a mentett kulcsot.",
+      "noModelResults": "Nincs egyező felkínált modell",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Válaszd ki, mely szerepkörök használják ezt a kulcsot, majd válassz modellt minden szerepkörhöz. A ki nem választott szerepkörök a platform alapértelmezését használják.",
       "provider": "Provider",
+      "providerForRole": "{role} szolgáltatója",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Add meg azoknak a szolgáltatóknak a hitelesítő adatait, amelyeket Stella használjon.",
+      "providersPanel": "Szolgáltatók",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Szolgáltató eltávolítása",
+      "replaceKey": "Kulcs cseréje",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Válassz legalább egy szerepkört ehhez a kulcshoz.",
+      "selectModelForEachRole": "Adj hozzá szolgáltatót, és válassz modellt minden kategóriához.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Redaguoti su DI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Atidaryti AI nustatymus",
+      "description": "Pridėkite teikėjo prisijungimo duomenis, kad galėtumėte naudoti AI funkcijas.",
+      "title": "Prijungti AI teikėją"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Pridėti teikėją",
+      "addProviderFirst": "Pirmiausia pridėkite teikėją",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Sukonfigūruota: {key}. Įveskite naują raktą, kad pakeistumėte.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Išsaugotas raktas {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Raktas",
+      "customModelBadge": "Pasirinktinis · {provider}",
+      "customModelDescription": "Šio modelio ID nėra Stella kataloge. Jis bus perduotas pasirinktam teikėjui taip, kaip įvestas.",
+      "customModelHint": "Kataloge atitikmens nėra. Įveskite bet kokį modelio ID; pasirinktiniai ID išsaugomi taip, kaip įvesti.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Numatytasis: {model}",
+      "defaultModelOption": "Numatytasis",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Palikti išsaugotą raktą",
+      "modelForRole": "{role} modelis",
+      "modelIdPlaceholder": "Ieškoti modelių",
+      "modelRequired": "Privaloma",
+      "modelsDescription": "Kiekvienai AI kategorijai pasirinkite teikėją ir vieną siūlomą multimodalinį modelį.",
+      "modelsPanel": "Modeliai",
+      "newApiKey": "Naujas API raktas",
+      "newApiKeyDescription": "Išsaugojus pakeitimus jis pakeis išsaugotą raktą.",
+      "noModelResults": "Nėra atitinkančių siūlomų modelių",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Pasirinkite, kurie vaidmenys naudoja šį raktą, tada kiekvienam vaidmeniui pasirinkite modelį. Nepasirinkti vaidmenys naudoja platformos numatytuosius nustatymus.",
       "provider": "Provider",
+      "providerForRole": "{role} teikėjas",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Pridėkite teikėjų prisijungimo duomenis, kuriuos Stella turėtų naudoti.",
+      "providersPanel": "Teikėjai",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Pašalinti teikėją",
+      "replaceKey": "Pakeisti raktą",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Pasirinkite bent vieną vaidmenį šiam raktui.",
+      "selectModelForEachRole": "Pridėkite teikėją ir kiekvienai kategorijai pasirinkite modelį.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Rediģēt ar AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Atvērt AI iestatījumus",
+      "description": "Pievienojiet pakalpojumu sniedzēja piekļuves datus, lai sāktu izmantot AI funkcijas.",
+      "title": "Pievienot AI pakalpojumu sniedzēju"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Pievienot pakalpojumu sniedzēju",
+      "addProviderFirst": "Vispirms pievienojiet pakalpojumu sniedzēju",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Konfigurēts: {key}. Ievadiet jaunu atslēgu, lai to aizstātu.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Saglabātā atslēga {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Atslēga",
+      "customModelBadge": "Pielāgots · {provider}",
+      "customModelDescription": "Šis modeļa ID nav Stella katalogā. Tas tiks nosūtīts izvēlētajam pakalpojumu sniedzējam tieši tā, kā ievadīts.",
+      "customModelHint": "Katalogā nav atbilstības. Ievadiet jebkuru modeļa ID; pielāgotie ID tiek saglabāti tieši tā, kā ievadīti.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Noklusējums: {model}",
+      "defaultModelOption": "Noklusējums",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Paturēt saglabāto atslēgu",
+      "modelForRole": "{role} modelis",
+      "modelIdPlaceholder": "Meklēt modeļus",
+      "modelRequired": "Obligāts",
+      "modelsDescription": "Katrai AI kategorijai izvēlieties pakalpojumu sniedzēju un vienu piedāvāto multimodālo modeli.",
+      "modelsPanel": "Modeļi",
+      "newApiKey": "Jauna API atslēga",
+      "newApiKeyDescription": "Saglabājot izmaiņas, tā aizstās saglabāto atslēgu.",
+      "noModelResults": "Nav atbilstošu piedāvāto modeļu",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Izvēlieties, kuras lomas izmanto šo atslēgu, un pēc tam izvēlieties modeli katrai lomai. Neatlasītās lomas izmanto platformas noklusējumu.",
       "provider": "Provider",
+      "providerForRole": "{role} pakalpojumu sniedzējs",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Pievienojiet to pakalpojumu sniedzēju akreditācijas datus, kurus Stella izmantos.",
+      "providersPanel": "Pakalpojumu sniedzēji",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Noņemt pakalpojumu sniedzēju",
+      "replaceKey": "Aizstāt atslēgu",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Atlasiet vismaz vienu lomu šai atslēgai.",
+      "selectModelForEachRole": "Pievienojiet pakalpojumu sniedzēju un izvēlieties modeli katrai kategorijai.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -20,8 +20,8 @@ type Messages = {
     "editWithAI": "Edit with AI";
     "keyRequired": {
       "cta": "Open AI settings";
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.";
-      "title": "AI key required";
+      "description": "Add provider credentials to start using AI features.";
+      "title": "Connect AI provider";
     };
   };
   "anonymize": {
@@ -1157,36 +1157,62 @@ type Messages = {
   "organization": {
     "aiConfig": {
       "active": "Active";
+      "addProvider": "Add provider";
+      "addProviderFirst": "Add a provider first";
       "apiKey": "API key";
+      "apiKeyConfiguredPlaceholder": "Configured: {key}. Enter a new key to replace it.";
       "apiKeyPlaceholder": "Enter your API key";
+      "apiKeySaved": "Saved key {key}";
       "apiKeyUpdatePlaceholder": "Enter new key to update";
       "baseUrl": "Base URL";
       "configure": "Configure";
+      "credentialsPanel": "Key";
+      "customModelBadge": "Custom · {provider}";
+      "customModelDescription": "This model ID is not in Stella’s catalog. It will be passed to the selected provider as typed.";
+      "customModelHint": "No catalog match. Type any model ID; custom IDs are saved as typed.";
       "dataRegion": "Data region";
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.";
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).";
+      "defaultModel": "Default: {model}";
+      "defaultModelOption": "Default";
       "description": "Bring your own API key or configure data sovereignty region.";
+      "keepSavedKey": "Keep saved key";
+      "modelForRole": "{role} model";
+      "modelIdPlaceholder": "Search models";
+      "modelRequired": "Required";
+      "modelsDescription": "Choose a provider and one offered multimodal model for each AI category.";
+      "modelsPanel": "Models";
+      "newApiKey": "New API key";
+      "newApiKeyDescription": "This will replace the saved key when you save changes.";
+      "noModelResults": "No matching offered models";
       "overrideRoles": "Override roles";
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.";
+      "overrideRolesDescription": "Choose which roles use this key, then choose a model for each role. Unselected roles use the platform default.";
       "provider": "Provider";
+      "providerForRole": "{role} provider";
       "providers": {
         "anthropic": "Anthropic";
-        "google": "Google AI";
-        "openai": "OpenAI";
-        "openai_compatible": "OpenAI-compatible";
+        "google": "Google";
+        "openai": "ChatGPT";
         "openrouter": "OpenRouter";
       };
+      "providersDescription": "Add the provider credentials you want Stella to use.";
+      "providersPanel": "Providers";
       "regions": {
         "ch": "Switzerland (europe-west6)";
         "eu": "EU (europe-west4)";
         "global": "Global";
       };
+      "removeProvider": "Remove provider";
+      "replaceKey": "Replace key";
       "roles": {
         "chat": "Chat (conversation)";
         "fast": "Fast (classification)";
         "pdf": "PDF (documents)";
         "reasoning": "Reasoning (analysis)";
       };
+      "selectAtLeastOneRole": "Select at least one role for this key.";
+      "selectModelForEachRole": "Add a provider and select a model for each category.";
+      "selectedProvider": "{provider}";
       "title": "AI configuration";
     };
     "invitations": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Edytuj z AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Otwórz ustawienia AI",
+      "description": "Dodaj dane dostępu dostawcy, aby zacząć używać funkcji AI.",
+      "title": "Połącz dostawcę AI"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Aktywna",
+      "addProvider": "Dodaj dostawcę",
+      "addProviderFirst": "Najpierw dodaj dostawcę",
       "apiKey": "Klucz API",
+      "apiKeyConfiguredPlaceholder": "Skonfigurowano: {key}. Wpisz nowy klucz, aby go zastąpić.",
       "apiKeyPlaceholder": "Wprowadź klucz API",
+      "apiKeySaved": "Zapisany klucz {key}",
       "apiKeyUpdatePlaceholder": "Wprowadź nowy klucz, aby go zaktualizować",
       "baseUrl": "Bazowy URL",
       "configure": "Skonfiguruj",
+      "credentialsPanel": "Klucz",
+      "customModelBadge": "Niestandardowy · {provider}",
+      "customModelDescription": "Tego identyfikatora modelu nie ma w katalogu Stella. Zostanie przekazany do wybranego dostawcy dokładnie tak, jak wpisano.",
+      "customModelHint": "Brak dopasowania w katalogu. Wpisz dowolny identyfikator modelu; niestandardowe ID są zapisywane bez zmian.",
       "dataRegion": "Region danych",
       "dataRegionDescription": "Kieruje żądania AI przez wybrany region dla zachowania suwerenności danych.",
       "dataRegionUnsupported": "Routing regionalny jest dostępny tylko dla Google AI (Vertex AI).",
+      "defaultModel": "Domyślny: {model}",
+      "defaultModelOption": "Domyślny",
       "description": "Użyj własnego klucza API lub skonfiguruj region suwerenności danych.",
+      "keepSavedKey": "Zachowaj zapisany klucz",
+      "modelForRole": "Model dla roli {role}",
+      "modelIdPlaceholder": "Szukaj modeli",
+      "modelRequired": "Wymagane",
+      "modelsDescription": "Dla każdej kategorii AI wybierz dostawcę i jeden oferowany model multimodalny.",
+      "modelsPanel": "Modele",
+      "newApiKey": "Nowy klucz API",
+      "newApiKeyDescription": "Po zapisaniu zmian zastąpi zapisany klucz.",
+      "noModelResults": "Brak pasujących oferowanych modeli",
       "overrideRoles": "Nadpisz role",
-      "overrideRolesDescription": "Wybierz, które role AI używają Twojego klucza. Niezaznaczone role używają domyślnego klucza platformy.",
+      "overrideRolesDescription": "Wybierz, które role używają tego klucza, a potem wybierz model dla każdej roli. Niezaznaczone role używają domyślnych ustawień platformy.",
       "provider": "Dostawca",
+      "providerForRole": "Dostawca dla {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Dodaj dane uwierzytelniające dostawców, których Stella ma używać.",
+      "providersPanel": "Dostawcy",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Usuń dostawcę",
+      "replaceKey": "Zastąp klucz",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Wybierz co najmniej jedną rolę dla tego klucza.",
+      "selectModelForEachRole": "Dodaj dostawcę i wybierz model dla każdej kategorii.",
+      "selectedProvider": "{provider}",
       "title": "Konfiguracja AI"
     },
     "invitations": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -16,9 +16,9 @@
   "ai": {
     "editWithAI": "Upraviť pomocou AI",
     "keyRequired": {
-      "cta": "Open AI settings",
-      "description": "This instance has no platform AI keys provisioned. Add your own API key to start using AI features.",
-      "title": "AI key required"
+      "cta": "Otvoriť nastavenia AI",
+      "description": "Pridajte prihlasovacie údaje poskytovateľa a začnite používať funkcie AI.",
+      "title": "Pripojiť poskytovateľa AI"
     }
   },
   "anonymize": {
@@ -1154,36 +1154,62 @@
   "organization": {
     "aiConfig": {
       "active": "Active",
+      "addProvider": "Pridať poskytovateľa",
+      "addProviderFirst": "Najprv pridajte poskytovateľa",
       "apiKey": "API key",
+      "apiKeyConfiguredPlaceholder": "Nastavené: {key}. Zadaním nového kľúča ho nahradíte.",
       "apiKeyPlaceholder": "Enter your API key",
+      "apiKeySaved": "Uložený kľúč {key}",
       "apiKeyUpdatePlaceholder": "Enter new key to update",
       "baseUrl": "Base URL",
       "configure": "Configure",
+      "credentialsPanel": "Kľúč",
+      "customModelBadge": "Vlastný · {provider}",
+      "customModelDescription": "Toto ID modelu nie je v katalógu Stella. Vybranému poskytovateľovi sa odošle presne tak, ako je zadané.",
+      "customModelHint": "Žiadna zhoda v katalógu. Zadajte ľubovoľné ID modelu; vlastné ID sa uloží presne tak, ako je napísané.",
       "dataRegion": "Data region",
       "dataRegionDescription": "Routes AI calls through the selected region for data sovereignty.",
       "dataRegionUnsupported": "Regional routing is only available for Google AI (Vertex AI).",
+      "defaultModel": "Predvolené: {model}",
+      "defaultModelOption": "Predvolené",
       "description": "Bring your own API key or configure data sovereignty region.",
+      "keepSavedKey": "Ponechať uložený kľúč",
+      "modelForRole": "Model pre rolu {role}",
+      "modelIdPlaceholder": "Hľadať modely",
+      "modelRequired": "Povinné",
+      "modelsDescription": "Pre každú kategóriu AI vyberte poskytovateľa a jeden ponúkaný multimodálny model.",
+      "modelsPanel": "Modely",
+      "newApiKey": "Nový API kľúč",
+      "newApiKeyDescription": "Po uložení zmien nahradí uložený kľúč.",
+      "noModelResults": "Žiadne zodpovedajúce ponúkané modely",
       "overrideRoles": "Override roles",
-      "overrideRolesDescription": "Select which AI roles use your key. Unselected roles use the platform default.",
+      "overrideRolesDescription": "Vyberte, ktoré roly používajú tento kľúč, a potom vyberte model pre každú rolu. Nevybrané roly použijú predvolené nastavenie platformy.",
       "provider": "Provider",
+      "providerForRole": "Poskytovateľ pre {role}",
       "providers": {
         "anthropic": "Anthropic",
-        "google": "Google AI",
-        "openai": "OpenAI",
-        "openai_compatible": "OpenAI-compatible",
+        "google": "Google",
+        "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },
+      "providersDescription": "Pridajte prihlasovacie údaje poskytovateľov, ktoré má Stella používať.",
+      "providersPanel": "Poskytovatelia",
       "regions": {
         "ch": "Switzerland (europe-west6)",
         "eu": "EU (europe-west4)",
         "global": "Global"
       },
+      "removeProvider": "Odstrániť poskytovateľa",
+      "replaceKey": "Nahradiť kľúč",
       "roles": {
         "chat": "Chat (conversation)",
         "fast": "Fast (classification)",
         "pdf": "PDF (documents)",
         "reasoning": "Reasoning (analysis)"
       },
+      "selectAtLeastOneRole": "Vyberte pre tento kľúč aspoň jednu rolu.",
+      "selectModelForEachRole": "Pridajte poskytovateľa a pre každú kategóriu vyberte model.",
+      "selectedProvider": "{provider}",
       "title": "AI configuration"
     },
     "invitations": {

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -1,22 +1,31 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@stll/ui/components/button";
-import { Checkbox } from "@stll/ui/components/checkbox";
-import { Field, FieldLabel } from "@stll/ui/components/field";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
-import { Input } from "@stll/ui/components/input";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
 import { toastManager } from "@stll/ui/components/toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
+import { AIConfigRoleModelPicker } from "@/components/ai-config-role-model-picker";
+import {
+  createProviderCredentialDraft,
+  createDefaultRoleModels,
+  ensureRoleModelsForProviders,
+  getProviderValues,
+  hasUsableProviderDrafts,
+  providerDraftsFromStoredProviders,
+  roleModelsFromOverrideModels,
+  serializeOverrideModels,
+  isProviderValue,
+} from "@/components/ai-config-role-models.logic";
+import type {
+  ModelSelection,
+  ProviderCredentialDraft,
+  RoleModelSelections,
+  RoleValue,
+} from "@/components/ai-config-role-models.logic";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -24,33 +33,6 @@ import {
   aiConfigKeys,
   aiConfigOptions,
 } from "@/routes/_protected.organization/-ai-config-queries";
-
-const PROVIDER_KEYS = [
-  "google",
-  "openrouter",
-  "openai",
-  "anthropic",
-  "openai_compatible",
-] as const;
-
-const REGION_KEYS = ["global", "eu", "ch"] as const;
-
-const ROLE_KEYS = ["fast", "chat", "reasoning", "pdf"] as const;
-
-type ProviderValue = (typeof PROVIDER_KEYS)[number];
-type RegionValue = (typeof REGION_KEYS)[number];
-type RoleValue = (typeof ROLE_KEYS)[number];
-
-const PROVIDER_VALUES = new Set<string>(PROVIDER_KEYS);
-const REGION_VALUES = new Set<string>(REGION_KEYS);
-const ROLE_VALUES = new Set<string>(ROLE_KEYS);
-
-/** Providers that support EU/CH regional routing. */
-const REGIONAL_PROVIDERS = new Set<ProviderValue>(["google"]);
-
-const isProvider = (v: string): v is ProviderValue => PROVIDER_VALUES.has(v);
-const isRegion = (v: string): v is RegionValue => REGION_VALUES.has(v);
-const isRole = (v: string): v is RoleValue => ROLE_VALUES.has(v);
 
 export const AIConfigCard = () => {
   const t = useTranslations("organization");
@@ -61,23 +43,22 @@ export const AIConfigCard = () => {
   const queryClient = useQueryClient();
   const { data: config } = useQuery(aiConfigOptions);
 
-  const initialProvider =
-    config?.configured && isProvider(config.provider)
-      ? config.provider
-      : "google";
-  const initialRegion =
-    config?.configured && isRegion(config.region) ? config.region : "global";
-  const initialRoles = config?.configured
-    ? config.overrideRoles.filter(isRole)
-    : [];
+  const initialProviders =
+    config?.configured && config.providers.length > 0
+      ? providerDraftsFromStoredProviders(config.providers)
+      : [createProviderCredentialDraft()];
+  const initialProviderValues = getProviderValues(initialProviders);
+  const initialRoleModels = config?.configured
+    ? roleModelsFromOverrideModels({
+        overrideModels: config.overrideModels,
+        providers: initialProviderValues,
+      })
+    : createDefaultRoleModels(initialProviderValues);
 
-  const [provider, setProvider] = useState<ProviderValue>(initialProvider);
-  const [apiKey, setApiKey] = useState("");
-  const [baseURL, setBaseURL] = useState(
-    config?.configured ? (config.baseURL ?? "") : "",
-  );
-  const [region, setRegion] = useState<RegionValue>(initialRegion);
-  const [overrideRoles, setOverrideRoles] = useState(initialRoles);
+  const [providers, setProviders] =
+    useState<ProviderCredentialDraft[]>(initialProviders);
+  const [roleModels, setRoleModels] =
+    useState<RoleModelSelections>(initialRoleModels);
 
   // Sync form state when the config query resolves after
   // initial render (useState initializers only run once).
@@ -87,39 +68,64 @@ export const AIConfigCard = () => {
     if (!config?.configured) {
       return;
     }
-    if (isProvider(config.provider)) {
-      setProvider(config.provider);
-    }
-    if (isRegion(config.region)) {
-      setRegion(config.region);
-    }
-    setOverrideRoles(config.overrideRoles.filter(isRole));
-    setBaseURL(config.baseURL ?? "");
+    const nextProviders = providerDraftsFromStoredProviders(config.providers);
+    const providerValues = getProviderValues(nextProviders);
+    setProviders(nextProviders);
+    setRoleModels(
+      roleModelsFromOverrideModels({
+        overrideModels: config.overrideModels,
+        providers: providerValues,
+      }),
+    );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.configured]);
 
-  const toggleRole = (role: RoleValue) => {
-    setOverrideRoles((prev) =>
-      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role],
+  const updateProviders = (nextProviders: ProviderCredentialDraft[]) => {
+    const providerValues = getProviderValues(nextProviders);
+    setProviders(nextProviders);
+    setRoleModels((prev) =>
+      ensureRoleModelsForProviders({
+        providers: providerValues,
+        roleModels: prev,
+      }),
     );
+  };
+
+  const setRoleModel = (role: RoleValue, model: ModelSelection | null) => {
+    setRoleModels((prev) => ({
+      ...prev,
+      [role]: model,
+    }));
   };
 
   const saveMutation = useMutation({
     mutationFn: async () => {
+      const providerValues = getProviderValues(providers);
+      const overrideModels = serializeOverrideModels({
+        providers: providerValues,
+        roleModels,
+      });
+      if (!overrideModels) {
+        throw new Error(t("aiConfig.selectModelForEachRole"));
+      }
+
       const response = await api["organization-settings"]["ai-config"].post({
-        provider,
-        ...(apiKey ? { apiKey } : {}),
-        ...(baseURL ? { baseURL } : {}),
-        overrideRoles,
-        region,
+        providers: providers.map((providerDraft) => ({
+          provider: providerDraft.provider,
+          ...(providerDraft.apiKey.trim()
+            ? { apiKey: providerDraft.apiKey.trim() }
+            : {}),
+          region: providerDraft.region,
+        })),
+        overrideModels,
       });
       if (response.error) {
         throw toAPIError(response.error);
       }
       return response.data;
     },
-    onSuccess: async () => {
-      setApiKey("");
+    onSuccess: async (data) => {
+      setProviders(providerDraftsFromStoredProviders(data.providers));
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: aiConfigKeys.all,
@@ -152,7 +158,9 @@ export const AIConfigCard = () => {
       }
     },
     onSuccess: async () => {
-      setApiKey("");
+      const nextProviders = [createProviderCredentialDraft()];
+      setProviders(nextProviders);
+      setRoleModels(createDefaultRoleModels(getProviderValues(nextProviders)));
       await Promise.all([
         queryClient.invalidateQueries({
           queryKey: aiConfigKeys.all,
@@ -175,20 +183,34 @@ export const AIConfigCard = () => {
     },
   });
 
+  const providerValues = getProviderValues(providers);
+  const canSave =
+    hasUsableProviderDrafts(providers) &&
+    serializeOverrideModels({ providers: providerValues, roleModels }) !== null;
+
   return (
     <div className="flex flex-col gap-4">
       {config?.configured && (
         <div className="flex items-center justify-between gap-2">
-          <div className="bg-muted flex items-center gap-2 rounded border px-3 py-2">
+          <div className="bg-muted flex flex-wrap items-center gap-2 rounded border px-3 py-2">
             <span className="text-muted-foreground text-xs">
               {t("aiConfig.active")}:
             </span>
-            <span className="text-xs font-medium">
-              {t(`aiConfig.providers.${config.provider}`)}
-            </span>
-            <span className="text-muted-foreground font-mono text-xs">
-              {config.apiKeyMasked}
-            </span>
+            {config.providers.map((providerConfig) => (
+              <span
+                className="text-xs"
+                key={`${providerConfig.provider}-${providerConfig.apiKeyMasked}`}
+              >
+                <span className="font-medium">
+                  {isProviderValue(providerConfig.provider)
+                    ? t(`aiConfig.providers.${providerConfig.provider}`)
+                    : providerConfig.provider}
+                </span>{" "}
+                <span className="text-muted-foreground font-mono">
+                  {providerConfig.apiKeyMasked}
+                </span>
+              </span>
+            ))}
           </div>
           <Button
             loading={deleteMutation.isPending}
@@ -202,122 +224,40 @@ export const AIConfigCard = () => {
       )}
       <Frame>
         <FramePanel>
-          <div className="flex flex-col gap-3 p-1">
-            <Field>
-              <FieldLabel>{t("aiConfig.provider")}</FieldLabel>
-              <Select
-                onValueChange={(val) => {
-                  if (val && isProvider(val)) {
-                    setProvider(val);
-                    if (!REGIONAL_PROVIDERS.has(val)) {
-                      setRegion("global");
-                    }
-                  }
-                }}
-                value={provider}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup alignItemWithTrigger={false}>
-                  {PROVIDER_KEYS.map((key) => (
-                    <SelectItem key={key} value={key}>
-                      {t(`aiConfig.providers.${key}`)}
-                    </SelectItem>
-                  ))}
-                </SelectPopup>
-              </Select>
-            </Field>
+          <div className="flex flex-col gap-5 p-1">
+            <AIConfigProvidersEditor
+              disabled={saveMutation.isPending}
+              onProvidersChange={updateProviders}
+              providers={providers}
+            />
 
-            <Field>
-              <FieldLabel>{t("aiConfig.apiKey")}</FieldLabel>
-              <Input
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder={
-                  config?.configured
-                    ? t("aiConfig.apiKeyUpdatePlaceholder")
-                    : t("aiConfig.apiKeyPlaceholder")
-                }
-                type="password"
-                value={apiKey}
-              />
-            </Field>
+            <div className="border-t" />
 
-            {provider === "openai_compatible" && (
-              <Field>
-                <FieldLabel>{t("aiConfig.baseUrl")}</FieldLabel>
-                <Input
-                  onChange={(e) => setBaseURL(e.target.value)}
-                  placeholder="https://api.example.com/v1"
-                  value={baseURL}
-                />
-              </Field>
-            )}
-
-            <Field>
-              <FieldLabel>{t("aiConfig.dataRegion")}</FieldLabel>
-              <Select
-                disabled={!REGIONAL_PROVIDERS.has(provider)}
-                onValueChange={(val) => {
-                  if (val && isRegion(val)) {
-                    setRegion(val);
-                  }
-                }}
-                value={region}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup alignItemWithTrigger={false}>
-                  {REGION_KEYS.map((key) => (
-                    <SelectItem key={key} value={key}>
-                      {t(`aiConfig.regions.${key}`)}
-                    </SelectItem>
-                  ))}
-                </SelectPopup>
-              </Select>
-              <p className="text-muted-foreground text-xs">
-                {REGIONAL_PROVIDERS.has(provider)
-                  ? t("aiConfig.dataRegionDescription")
-                  : t("aiConfig.dataRegionUnsupported")}
-              </p>
-            </Field>
-
-            <Field>
-              <FieldLabel>{t("aiConfig.overrideRoles")}</FieldLabel>
-              <p className="text-muted-foreground text-xs">
-                {t("aiConfig.overrideRolesDescription")}
-              </p>
-              <div className="mt-1 flex flex-wrap gap-3">
-                {ROLE_KEYS.map((key) => (
-                  <label
-                    className="flex items-center gap-1.5 text-sm"
-                    key={key}
-                  >
-                    <Checkbox
-                      checked={overrideRoles.includes(key)}
-                      onCheckedChange={() => toggleRole(key)}
-                    />
-                    {t(`aiConfig.roles.${key}`)}
-                  </label>
-                ))}
-              </div>
-            </Field>
-
-            <Button
-              className="self-start"
-              disabled={!config?.configured && !apiKey}
-              loading={saveMutation.isPending}
-              onClick={() => saveMutation.mutate()}
-              size="sm"
-            >
-              {config?.configured
-                ? tCommon("saveChanges")
-                : t("aiConfig.configure")}
-            </Button>
+            <AIConfigRoleModelPicker
+              disabled={saveMutation.isPending}
+              onModelChange={setRoleModel}
+              providers={providerValues}
+              roleModels={roleModels}
+            />
           </div>
         </FramePanel>
       </Frame>
+
+      {!canSave && (
+        <p className="text-destructive-foreground text-xs">
+          {t("aiConfig.selectModelForEachRole")}
+        </p>
+      )}
+
+      <Button
+        className="self-start"
+        disabled={!canSave}
+        loading={saveMutation.isPending}
+        onClick={() => saveMutation.mutate()}
+        size="sm"
+      >
+        {config?.configured ? tCommon("saveChanges") : t("aiConfig.configure")}
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -191,6 +191,7 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { AIKeyRequiredDialog } from "@/components/require-ai-key";
 
 type ComboboxOption = {
   id: string;
@@ -256,6 +257,7 @@ export function UiPlayground() {
   const [dateValue, setDateValue] = useState<string | null>("2026-04-27");
   const [colorValue, setColorValue] = useState("blue");
   const [hexColor, setHexColor] = useState("#59A1D4");
+  const [byokDialogOpen, setByokDialogOpen] = useState(false);
   const destructiveConfirmation = useDestructiveActionConfirmation(
     "delete this workspace",
   );
@@ -751,6 +753,23 @@ export function UiPlayground() {
                     </AlertDialogPopup>
                   </AlertDialog>
                 </div>
+              </PlaygroundSection>
+
+              <PlaygroundSection
+                description="Production BYOK setup dialog as shown when AI requires an organization key."
+                title="BYOK dialog"
+              >
+                <Button
+                  className="w-fit"
+                  onClick={() => setByokDialogOpen(true)}
+                  variant="outline"
+                >
+                  Open BYOK dialog
+                </Button>
+                <AIKeyRequiredDialog
+                  onOpenChange={setByokDialogOpen}
+                  open={byokDialogOpen}
+                />
               </PlaygroundSection>
 
               <PlaygroundSection


### PR DESCRIPTION
## Summary
- replace single-provider BYOK editing with provider credentials plus per-role provider/model selection
- persist provider-qualified overrideModels for chat, fast, reasoning, and pdf roles
- limit BYOK choices to Google, OpenRouter, ChatGPT, and Anthropic with curated multimodal model options only
- expose the BYOK dialog in the UI playground and localize the AI-provider-required copy

## OpenRouter validation
Checked OpenRouter live model metadata during development for the curated OpenRouter IDs. The offered Anthropic and ChatGPT IDs exist and advertise both file input and tools support:
- anthropic/claude-opus-4.5
- anthropic/claude-sonnet-4.5
- openai/gpt-5.4
- openai/gpt-5.4-mini

Also checked the Google OpenRouter options:
- google/gemini-3-flash-preview
- google/gemini-3.1-pro-preview
- google/gemini-2.5-flash-lite

## Tests
- bun run format
- bun run lint
- bun run typecheck
- bun run test
- bun --filter @stll/api typecheck
- bun --filter @stll/web typecheck
- bun test apps/api/src/lib/ai-models.test.ts apps/api/src/lib/ai-config-crypto.test.ts apps/api/src/lib/analytics/ai.test.ts
- bun test src/components/ai-config-role-models.logic.test.ts