### PR TITLE
feat: improve sidepeek citation flow

### DIFF
--- a/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
+++ b/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
@@ -11,6 +11,7 @@ import { generateBBoxes } from "@/api/lib/bbox/generate-b-boxes";
 import { generateBBoxesMock } from "@/api/lib/bbox/generate-b-boxes-mock";
 import { prepareJustificationData } from "@/api/lib/bbox/generate-b-boxes-shared";
 import { tSafeId } from "@/api/lib/custom-schema";
+import type { BoundingBox } from "@/api/types";
 
 const config = {
   permissions: { workspace: ["update"] },
@@ -51,41 +52,40 @@ const generateBoundingBoxes = createSafeHandler(
     const preparedData = preparedDataResult.value;
 
     const generateFn = isMockAI() ? generateBBoxesMock : generateBBoxes;
-    const bBoxes = await Promise.all(
-      preparedData.pageNumbers.map(
-        async (pageNumber) =>
-          await generateFn({
-            abortSignal: AbortSignal.timeout(60_000),
-            justificationId,
-            organizationId,
-            orgAIConfig: orgAIConfig ?? null,
-            workspaceId,
-            data: {
-              pdf: preparedData.pdf,
-              pageNumber,
-              prompt: preparedData.prompt,
-              fieldContent: preparedData.fieldContent,
-              justificationText: preparedData.justificationText,
-            },
-          }),
-      ),
-    );
+    const boxes: BoundingBox[] = [];
 
-    const boxes = bBoxes.flat();
+    for (const pageNumber of preparedData.pageNumbers) {
+      const pageBoxes = await generateFn({
+        abortSignal: AbortSignal.timeout(60_000),
+        justificationId,
+        organizationId,
+        orgAIConfig: orgAIConfig ?? null,
+        workspaceId,
+        data: {
+          pdf: preparedData.pdf,
+          pageNumber,
+          prompt: preparedData.prompt,
+          fieldContent: preparedData.fieldContent,
+          justificationText: preparedData.justificationText,
+        },
+      });
 
-    yield* Result.await(
-      safeDb((tx) =>
-        tx
-          .update(justifications)
-          .set({
-            boundingBoxes: {
-              version: 1,
-              boxes,
-            },
-          })
-          .where(eq(justifications.id, justificationId)),
-      ),
-    );
+      boxes.push(...pageBoxes);
+
+      yield* Result.await(
+        safeDb((tx) =>
+          tx
+            .update(justifications)
+            .set({
+              boundingBoxes: {
+                version: 1,
+                boxes,
+              },
+            })
+            .where(eq(justifications.id, justificationId)),
+        ),
+      );
+    }
 
     return Result.ok({ boxes });
   },

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -20,6 +20,7 @@ import { openEntityInInspector } from "@/components/chat/entity-open";
 import { navigateToWorkspaceFolder } from "@/components/chat/folder-navigation";
 import { PDF_MIME_TYPE } from "@/consts";
 import { DOCX_MIME } from "@/lib/consts";
+import { FOLIO_SCROLL_EVENT } from "@/lib/folio-scroll-event";
 import { getMatterColor } from "@/lib/matter-colors";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
@@ -36,26 +37,6 @@ const WORKSPACE_REF_HASH_PREFIX = "#stella-workspace-ref=";
 // pass through untouched, matching how `#stella-entity-ref=`
 // and friends already work.
 const FOLIO_BLOCK_PREFIX = "#folio:";
-
-/**
- * Public window event broadcast when a `#folio:` citation chip
- * is clicked. Both the peek DOCX viewer (inspector) and the file
- * chat overlay editor listen for this; whichever has the live
- * editor mounted scrolls. Augmenting `WindowEventMap` lets
- * listeners receive a strongly-typed event without an `as` cast.
- */
-export const FOLIO_SCROLL_EVENT = "folio:scroll-to-block";
-
-export type FolioScrollEventDetail = { blockId: string };
-
-declare global {
-  // Global augmentation requires an interface — `type` doesn't merge
-  // with the lib.dom WindowEventMap declaration.
-  // eslint-disable-next-line typescript-eslint/consistent-type-definitions
-  interface WindowEventMap {
-    "folio:scroll-to-block": CustomEvent<FolioScrollEventDetail>;
-  }
-}
 
 const CATEGORY_ICON: Record<
   Exclude<MentionCategory, "entity">,

--- a/apps/web/src/lib/folio-scroll-event.ts
+++ b/apps/web/src/lib/folio-scroll-event.ts
@@ -1,0 +1,12 @@
+export const FOLIO_SCROLL_EVENT = "folio:scroll-to-block";
+
+export type FolioScrollEventDetail = { blockId: string };
+
+declare global {
+  // Global augmentation requires an interface; `type` does not merge
+  // with the lib.dom WindowEventMap declaration.
+  // eslint-disable-next-line typescript-eslint/consistent-type-definitions
+  interface WindowEventMap {
+    "folio:scroll-to-block": CustomEvent<FolioScrollEventDetail>;
+  }
+}

--- a/apps/web/src/lib/pdf/pdf-page.tsx
+++ b/apps/web/src/lib/pdf/pdf-page.tsx
@@ -44,15 +44,15 @@ export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
     <div
       ref={(el) => {
         const shouldScrollToPage =
-          scrollTo !== null &&
-          scrollTo.target === undefined &&
-          scrollTo.pageId === pageId;
+          scrollTo !== null && scrollTo.pageId === pageId;
 
         if (!el || !shouldScrollToPage) {
           return;
         }
         el.scrollIntoView({ block: "start" });
-        setScrollTo(null);
+        if (scrollTo.target === undefined) {
+          setScrollTo(null);
+        }
       }}
       {...{ [PAGE_ID_ATTRIBUTE]: pageId }}
       className="relative mx-auto border-transparent"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -48,6 +48,7 @@ import {
   useDocxFitZoom,
   useDocxWheelZoom,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom";
+import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
 import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
 import "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-docx.css";
 import {
@@ -358,20 +359,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     editorRef.current?.setZoom(targetZoom);
   }, [targetZoom]);
   useDocxWheelZoom(containerRef, editorRef);
-
-  // Listen for citation-chip clicks broadcast by the chat overlay.
-  // The peek viewer has its own listener; this one covers the
-  // editing-mode editor where the inspector path doesn't apply.
-  useEffect(() => {
-    const handler = (event: CustomEvent<{ blockId: string }>) => {
-      if (!event.detail.blockId) {
-        return;
-      }
-      editorRef.current?.scrollToBlock(event.detail.blockId);
-    };
-    window.addEventListener("folio:scroll-to-block", handler);
-    return () => window.removeEventListener("folio:scroll-to-block", handler);
-  }, []);
+  useDocxBlockScroll({ editorRef, fieldId });
 
   useEffect(() => {
     if (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll.ts
@@ -1,0 +1,168 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+
+import type { DocxEditorRef } from "@stll/folio";
+
+import { FOLIO_SCROLL_EVENT } from "@/lib/folio-scroll-event";
+import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+
+const BLOCK_SCROLL_RETRY_DELAY_MS = 50;
+const BLOCK_SCROLL_RETRY_LIMIT = 20;
+const BLOCK_SCROLL_SETTLE_DELAY_MS = 180;
+const BLOCK_SCROLL_SETTLE_ATTEMPTS = 2;
+const FOLIO_SCROLL_DEBUG_KEY = "folio:debug-scroll";
+
+type UseDocxBlockScrollProps = {
+  editorRef: RefObject<DocxEditorRef | null>;
+  fieldId: string;
+};
+
+type ScheduleDocxBlockScrollProps = {
+  blockId: string;
+  onSuccess?: (() => void) | undefined;
+  scrollToBlock: (blockId: string) => boolean | undefined;
+};
+
+const debugDocxBlockScroll = (
+  event: string,
+  details: Record<string, unknown>,
+) => {
+  if (
+    typeof window === "undefined" ||
+    window.localStorage.getItem(FOLIO_SCROLL_DEBUG_KEY) !== "1"
+  ) {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.info("[folio:scroll]", event, details);
+};
+
+export const useDocxBlockScroll = ({
+  editorRef,
+  fieldId,
+}: UseDocxBlockScrollProps) => {
+  const pendingBlockScroll = useInspectorStore((s) => s.pendingBlockScroll);
+  const clearPendingBlockScroll = useInspectorStore(
+    (s) => s.clearPendingBlockScroll,
+  );
+
+  useEffect(() => {
+    if (pendingBlockScroll === null || pendingBlockScroll.tabId !== fieldId) {
+      return undefined;
+    }
+
+    debugDocxBlockScroll("hook:pending", {
+      blockId: pendingBlockScroll.blockId,
+      fieldId,
+    });
+
+    return scheduleDocxBlockScroll({
+      blockId: pendingBlockScroll.blockId,
+      onSuccess: clearPendingBlockScroll,
+      scrollToBlock: (blockId) => editorRef.current?.scrollToBlock(blockId),
+    });
+  }, [clearPendingBlockScroll, editorRef, fieldId, pendingBlockScroll]);
+
+  useEffect(() => {
+    let cancelScroll: (() => void) | null = null;
+
+    const handler = (event: CustomEvent<{ blockId: string }>) => {
+      if (!event.detail.blockId) {
+        return;
+      }
+
+      debugDocxBlockScroll("hook:event", {
+        blockId: event.detail.blockId,
+        fieldId,
+      });
+
+      cancelScroll?.();
+      cancelScroll = scheduleDocxBlockScroll({
+        blockId: event.detail.blockId,
+        scrollToBlock: (blockId) => editorRef.current?.scrollToBlock(blockId),
+      });
+    };
+
+    window.addEventListener(FOLIO_SCROLL_EVENT, handler);
+    return () => {
+      cancelScroll?.();
+      window.removeEventListener(FOLIO_SCROLL_EVENT, handler);
+    };
+  }, [editorRef, fieldId]);
+};
+
+const scheduleDocxBlockScroll = ({
+  blockId,
+  onSuccess,
+  scrollToBlock,
+}: ScheduleDocxBlockScrollProps) => {
+  let cancelled = false;
+  let attempts = 0;
+  let settledAttempts = 0;
+  let didNotifySuccess = false;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const notifySuccess = () => {
+    if (didNotifySuccess) {
+      return;
+    }
+    didNotifySuccess = true;
+    onSuccess?.();
+  };
+
+  const settleScroll = () => {
+    notifySuccess();
+    if (settledAttempts >= BLOCK_SCROLL_SETTLE_ATTEMPTS) {
+      return;
+    }
+
+    settledAttempts += 1;
+    retryTimer = setTimeout(() => {
+      if (cancelled) {
+        return;
+      }
+
+      const ok = scrollToBlock(blockId);
+      if (ok === true) {
+        settleScroll();
+        return;
+      }
+
+      attempts = 0;
+      tryScroll();
+    }, BLOCK_SCROLL_SETTLE_DELAY_MS);
+  };
+
+  const tryScroll = () => {
+    if (cancelled) {
+      return;
+    }
+
+    const ok = scrollToBlock(blockId);
+    debugDocxBlockScroll("hook:try", {
+      attempts,
+      blockId,
+      ok,
+      settledAttempts,
+    });
+    if (ok === true) {
+      settleScroll();
+      return;
+    }
+
+    attempts += 1;
+    if (attempts < BLOCK_SCROLL_RETRY_LIMIT) {
+      retryTimer = setTimeout(tryScroll, BLOCK_SCROLL_RETRY_DELAY_MS);
+    }
+  };
+
+  tryScroll();
+
+  return () => {
+    cancelled = true;
+    if (retryTimer !== null) {
+      clearTimeout(retryTimer);
+    }
+  };
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -47,6 +47,8 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { getAnalytics, useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { getFreshLinkedAccount } from "@/lib/auth-session";
+import type { Citation } from "@/lib/citations";
+import { iterateJustificationCitations } from "@/lib/citations";
 import { DOCX_MIME, TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { openDocxInDesktop } from "@/lib/desktop-bridge";
 import { isUnauthorizedError } from "@/lib/errors";
@@ -55,9 +57,10 @@ import { getCachedAnonymization } from "@/lib/pdf/anonymization-cache";
 import {
   PDFProvider,
   getPDFPageIdByNumber,
-  usePDFStore,
+  useOptionalPDFStore,
 } from "@/lib/pdf/pdf-context";
 import type { PDFPageFallback } from "@/lib/pdf/pdf-page";
+import { renderJustificationContent } from "@/lib/render-justification-content";
 import { toSafeId } from "@/lib/safe-id";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 import { DocxBrowserEditor } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor";
@@ -84,13 +87,13 @@ import { SuggestionsFacet } from "@/routes/_protected.workspaces/$workspaceId/-c
 import { useRailContextMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-rail-context-menu";
 import { useTabContextMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu";
 import { VersionsFacet } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/versions-facet";
-import { PeekJustification } from "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-justification";
 import {
   PeekPdfControls,
   PeekPdfViewer,
   PeekSuspenseFallback,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer";
 import { TaskDetailPanel } from "@/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel";
+import { useSyncJustifications } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useRenameEntity } from "@/routes/_protected.workspaces/$workspaceId/-mutations/entities";
 import { entityOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { entityVersionsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entity-versions";
@@ -767,7 +770,7 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
         </Suspense>
       )}
 
-      {/* PDF content — render all open PDF tabs, show only the active one.
+      {/* Document content — render all open document tabs, show only the active one.
          Keeping inactive viewers mounted avoids the blink on tab switch
          (no unmount → Suspense fallback → remount cycle). */}
       {pdfTabs.map((tab) => {
@@ -1109,9 +1112,83 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
           });
         };
 
+        const fileViewer =
+          isNativeDocxDisplay && tab.propertyId !== undefined ? (
+            <DocxBrowserEditor
+              actionsKey={tab.id}
+              actionsMapRef={docxActionsRef}
+              entityId={tab.entityId}
+              errorFallback={viewerErrorFallback}
+              fieldId={tab.id}
+              initialScrollTop={docxScrollTopByTab.get(tab.id)}
+              isEditing={isEditingNativeDocx}
+              onClose={() => {
+                docxActionsRef.current.delete(tab.id);
+                setEditingDocxTabId(null);
+              }}
+              onCompatibilityChange={(compatibility) => {
+                setDocxCompatibilityByTab((prev) => {
+                  if (prev.get(tab.id) === compatibility) {
+                    return prev;
+                  }
+                  const next = new Map(prev);
+                  next.set(tab.id, compatibility);
+                  return next;
+                });
+              }}
+              onError={handleViewerError}
+              onReadonlyEditAttempt={promptDocxUnlock}
+              onSaved={(fieldId) => {
+                if (fieldId !== tab.id) {
+                  setDocxScrollTopByTab((prev) => {
+                    const scrollTop = prev.get(tab.id);
+                    if (scrollTop === undefined) {
+                      return prev;
+                    }
+                    const next = new Map(prev);
+                    next.set(fieldId, scrollTop);
+                    return next;
+                  });
+                  setScaleOffsets((prev) => {
+                    const scaleOffset = prev.get(tab.id);
+                    if (scaleOffset === undefined) {
+                      return prev;
+                    }
+                    const next = new Map(prev);
+                    next.set(fieldId, scaleOffset);
+                    return next;
+                  });
+                  useInspectorStore
+                    .getState()
+                    .replacePdfFieldId(tab.id, fieldId);
+                }
+              }}
+              onScrollTopChange={handleDocxScrollTopChange}
+              propertyId={tab.propertyId}
+              scaleOffset={scaleOffsets.get(tab.id) ?? 0}
+              showActionBar={false}
+              workspaceId={tab.workspaceId}
+            />
+          ) : (
+            <PeekPdfViewer
+              activePropertyId={tab.propertyId ?? ""}
+              entityId={tab.entityId}
+              errorFallback={viewerErrorFallback}
+              fieldId={tab.id}
+              filePurpose={isNativeDocxDisplay ? "native-display" : "display"}
+              mimeType={tab.mimeType ?? undefined}
+              onDocxScrollTopChange={handleDocxScrollTopChange}
+              onError={handleViewerError}
+              onPeekNavigate={closeAll}
+              scaleOffset={scaleOffsets.get(tab.id) ?? 0}
+              viewId={peekPdfViewId}
+              workspaceId={tab.workspaceId}
+            />
+          );
+
         const viewerPane = (
           <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-            {!isNativeDocxDisplay && tab.justificationFieldId && (
+            {tab.justificationFieldId && (
               <Suspense
                 fallback={
                   <div
@@ -1124,7 +1201,7 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
                   </div>
                 }
               >
-                <JustificationBar
+                <DocumentAiSourceBar
                   activeTab={tab}
                   fieldId={tab.justificationFieldId}
                   isActiveTab={isActive}
@@ -1132,85 +1209,16 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
                 />
               </Suspense>
             )}
-            {isNativeDocxDisplay && tab.propertyId !== undefined ? (
-              <DocxBrowserEditor
-                actionsKey={tab.id}
-                actionsMapRef={docxActionsRef}
-                entityId={tab.entityId}
-                errorFallback={viewerErrorFallback}
-                fieldId={tab.id}
-                initialScrollTop={docxScrollTopByTab.get(tab.id)}
-                isEditing={isEditingNativeDocx}
-                onClose={() => {
-                  docxActionsRef.current.delete(tab.id);
-                  setEditingDocxTabId(null);
-                }}
-                onCompatibilityChange={(compatibility) => {
-                  setDocxCompatibilityByTab((prev) => {
-                    if (prev.get(tab.id) === compatibility) {
-                      return prev;
-                    }
-                    const next = new Map(prev);
-                    next.set(tab.id, compatibility);
-                    return next;
-                  });
-                }}
-                onError={handleViewerError}
-                onReadonlyEditAttempt={promptDocxUnlock}
-                onSaved={(fieldId) => {
-                  if (fieldId !== tab.id) {
-                    setDocxScrollTopByTab((prev) => {
-                      const scrollTop = prev.get(tab.id);
-                      if (scrollTop === undefined) {
-                        return prev;
-                      }
-                      const next = new Map(prev);
-                      next.set(fieldId, scrollTop);
-                      return next;
-                    });
-                    setScaleOffsets((prev) => {
-                      const scaleOffset = prev.get(tab.id);
-                      if (scaleOffset === undefined) {
-                        return prev;
-                      }
-                      const next = new Map(prev);
-                      next.set(fieldId, scaleOffset);
-                      return next;
-                    });
-                    useInspectorStore
-                      .getState()
-                      .replacePdfFieldId(tab.id, fieldId);
-                  }
-                }}
-                onScrollTopChange={handleDocxScrollTopChange}
-                propertyId={tab.propertyId}
-                scaleOffset={scaleOffsets.get(tab.id) ?? 0}
-                showActionBar={false}
-                workspaceId={tab.workspaceId}
-              />
-            ) : (
-              <PeekPdfViewer
-                activePropertyId={tab.propertyId ?? ""}
-                entityId={tab.entityId}
-                errorFallback={viewerErrorFallback}
-                fieldId={tab.id}
-                filePurpose={isNativeDocxDisplay ? "native-display" : "display"}
-                mimeType={tab.mimeType ?? undefined}
-                onDocxScrollTopChange={handleDocxScrollTopChange}
-                onError={handleViewerError}
-                onPeekNavigate={closeAll}
-                scaleOffset={scaleOffsets.get(tab.id) ?? 0}
-                viewId={peekPdfViewId}
-                workspaceId={tab.workspaceId}
-              />
-            )}
+            <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+              {fileViewer}
+              {previewOverlay}
+            </div>
           </div>
         );
 
         const viewerContent = (
           <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
             {viewerPane}
-            {previewOverlay}
           </div>
         );
 
@@ -1813,9 +1821,9 @@ const InspectorPdfErrorFallback = ({
   );
 };
 
-// ── Justification bar ──────────────────────────────
+// ── Document AI source bar ─────────────────────────
 
-const JustificationBar = ({
+const DocumentAiSourceBar = ({
   activeTab,
   fieldId,
   isActiveTab,
@@ -1833,6 +1841,10 @@ const JustificationBar = ({
   const { data: entity } = useSuspenseQuery(
     entityOptions(workspaceId, activeTab.entityId),
   );
+  useSyncJustifications({
+    workspaceId,
+    entityIds: [activeTab.entityId],
+  });
 
   const justification = useWorkspaceStore((s) =>
     s.justifications.find((j) => j.fieldId === fieldId),
@@ -1860,23 +1872,51 @@ const JustificationBar = ({
       ? slots[currentIdx + 1]
       : null;
 
-  const [isExpanded, setIsExpanded] = useState(false);
   const setActiveJustification = useWorkspaceStore(
     (s) => s.setActiveJustification,
   );
+  const requestBlockScroll = useInspectorStore((s) => s.requestBlockScroll);
+  const [isAnswerExpanded, setIsAnswerExpanded] = useState(false);
 
   // Eagerly generate bboxes when the justification bar mounts.
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
   const [isGeneratingBoxes, setIsGeneratingBoxes] = useState(false);
-  const setScrollTo = usePDFStore((s) => s.setScrollTo);
-  const pages = usePDFStore((s) => s.pages);
+  const setScrollTo = useOptionalPDFStore((s) => s.setScrollTo);
+  const pages = useOptionalPDFStore((s) => s.pages);
 
   const justificationId = justification?.id;
   const boundingBoxes = justification?.boundingBoxes;
+  const activeDocumentJustificationContent = useMemo(
+    () =>
+      justification
+        ? {
+            ...justification.content,
+            blocks: justification.content.blocks.filter(
+              (block) => block.fileFieldId === activeTab.id,
+            ),
+          }
+        : null,
+    [activeTab.id, justification],
+  );
+  const citations = useMemo(
+    () =>
+      activeDocumentJustificationContent
+        ? [...iterateJustificationCitations(activeDocumentJustificationContent)]
+        : [],
+    [activeDocumentJustificationContent],
+  );
+  const hasBoundingBoxCitations = citations.some(
+    (citation) => citation.kind === "pdf-bates",
+  );
 
   useEffect(() => {
-    if (!justificationId || !isActiveTab || boundingBoxes) {
+    if (
+      !justificationId ||
+      !isActiveTab ||
+      !hasBoundingBoxCitations ||
+      boundingBoxes
+    ) {
       return undefined;
     }
 
@@ -1917,6 +1957,7 @@ const JustificationBar = ({
     };
   }, [
     justificationId,
+    hasBoundingBoxCitations,
     boundingBoxes,
     isActiveTab,
     workspaceId,
@@ -1924,14 +1965,26 @@ const JustificationBar = ({
     analytics,
   ]);
 
-  // Scroll to the first bbox page when boxes become available.
-  // Use a ref for `pages` so viewport/zoom changes don't re-trigger
-  // the scroll (the effect should run once when boxes appear).
-  const pagesRef = useRef(pages);
-  pagesRef.current = pages;
+  useEffect(() => {
+    setIsAnswerExpanded(false);
+  }, [fieldId]);
 
   useEffect(() => {
-    if (!boundingBoxes || !isActiveTab) {
+    if (!isGeneratingBoxes) {
+      return undefined;
+    }
+
+    const interval = window.setInterval(() => {
+      void queryClient.invalidateQueries({
+        queryKey: workspaceKeys.justifications(workspaceId),
+      });
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [isGeneratingBoxes, queryClient, workspaceId]);
+
+  useEffect(() => {
+    if (!boundingBoxes || !isActiveTab || !pages || !setScrollTo) {
       return;
     }
 
@@ -1945,7 +1998,7 @@ const JustificationBar = ({
 
     const pageId = getPDFPageIdByNumber({
       fieldId: activeTab.id,
-      pages: pagesRef.current,
+      pages,
       pageNumber: firstBox.pageNumber,
     });
     if (pageId && justificationId) {
@@ -1954,7 +2007,14 @@ const JustificationBar = ({
         target: { kind: "justification", id: justificationId },
       });
     }
-  }, [activeTab.id, boundingBoxes, justificationId, isActiveTab, setScrollTo]);
+  }, [
+    activeTab.id,
+    boundingBoxes,
+    justificationId,
+    isActiveTab,
+    pages,
+    setScrollTo,
+  ]);
 
   // Sync activeJustification before paint so PageCitation can
   // render bboxes without waiting for PeekJustification's effect.
@@ -1962,7 +2022,7 @@ const JustificationBar = ({
   // hidden, and their effects must not overwrite the active tab's
   // justification.
   useLayoutEffect(() => {
-    if (justificationId && isActiveTab) {
+    if (justificationId && isActiveTab && hasBoundingBoxCitations) {
       setActiveJustification({ id: justificationId, pageNumber: 1 });
     }
     return () => {
@@ -1970,7 +2030,12 @@ const JustificationBar = ({
         setActiveJustification(null);
       }
     };
-  }, [justificationId, isActiveTab, setActiveJustification]);
+  }, [
+    justificationId,
+    hasBoundingBoxCitations,
+    isActiveTab,
+    setActiveJustification,
+  ]);
 
   if (!justification) {
     return null;
@@ -2000,92 +2065,163 @@ const JustificationBar = ({
     }
     return null;
   })();
+  const handleCitationClick = (citation: Citation) => {
+    if (citation.kind === "docx-folio") {
+      requestBlockScroll(activeTab.id, citation.blockId);
+      return;
+    }
+
+    setActiveJustification({
+      id: justification.id,
+      pageNumber: citation.pageNumber,
+    });
+    if (!pages || !setScrollTo) {
+      return;
+    }
+    const pageId = getPDFPageIdByNumber({
+      fieldId: activeTab.id,
+      pages,
+      pageNumber: citation.pageNumber,
+    });
+    if (!pageId) {
+      return;
+    }
+    setScrollTo({
+      pageId,
+      target: { kind: "justification", id: justification.id },
+    });
+  };
+  const justificationNodes = activeDocumentJustificationContent
+    ? renderJustificationContent({
+        content: activeDocumentJustificationContent,
+        renderCitation: ({ citation, key }) => (
+          <SourceCitationChip
+            citation={citation}
+            key={key}
+            onClick={() => handleCitationClick(citation)}
+          />
+        ),
+      }).nodes
+    : [];
 
   return (
     <div className="bg-muted/30 flex shrink-0 flex-col border-b px-3">
       <div
-        className={cn("flex items-center justify-between", TOOLBAR_ROW_HEIGHT)}
+        className={cn(
+          "flex w-full min-w-0 items-center gap-2 text-xs",
+          TOOLBAR_ROW_HEIGHT,
+        )}
       >
+        {isGeneratingBoxes && (
+          <LoaderCircleIcon className="text-muted-foreground size-3 shrink-0 animate-spin" />
+        )}
         <button
-          className="flex flex-1 cursor-pointer items-center gap-2 overflow-hidden text-start text-xs"
-          onClick={() => setIsExpanded((prev) => !prev)}
+          aria-expanded={isAnswerExpanded}
+          className="min-w-0 flex-1 truncate text-start"
+          onClick={() => setIsAnswerExpanded((expanded) => !expanded)}
+          title={shortAnswer ?? undefined}
           type="button"
         >
-          <div className="flex items-center gap-1.5 truncate">
-            {isGeneratingBoxes && (
-              <LoaderCircleIcon className="text-muted-foreground size-3 shrink-0 animate-spin" />
-            )}
-            {propertyName && (
-              <span className="text-muted-foreground">{propertyName}: </span>
-            )}
-            <span className="font-medium">
-              {shortAnswer ?? t("workspaces.pdf.evidence")}
-            </span>
-          </div>
-        </button>
-
-        <div className="flex shrink-0 items-center gap-1 ps-4">
-          <Button
-            disabled={!prevSlot}
-            onClick={() => {
-              if (!prevSlot) {
-                return;
-              }
-              openPdf({
-                id: activeTab.id,
-                entityId: activeTab.entityId,
-                label: activeTab.label,
-                workspaceId: activeTab.workspaceId,
-                mimeType: activeTab.mimeType,
-                pdfFileId: activeTab.pdfFileId,
-                justificationFieldId: prevSlot.fieldId,
-                propertyId: prevSlot.property.id,
-              });
-            }}
-            size="icon-xs"
-            variant="ghost"
-          >
-            <ChevronLeftIcon className="size-3.5" />
-          </Button>
-          <span className="text-muted-foreground min-w-8 text-center text-[10px] tabular-nums">
-            {currentIdx + 1} / {slots.length}
+          {propertyName && (
+            <span className="text-muted-foreground">{propertyName}: </span>
+          )}
+          <span className="font-medium">
+            {shortAnswer ?? t("workspaces.pdf.evidence")}
           </span>
-          <Button
-            disabled={!nextSlot}
-            onClick={() => {
-              if (!nextSlot) {
-                return;
-              }
-              openPdf({
-                id: activeTab.id,
-                entityId: activeTab.entityId,
-                label: activeTab.label,
-                workspaceId: activeTab.workspaceId,
-                mimeType: activeTab.mimeType,
-                pdfFileId: activeTab.pdfFileId,
-                justificationFieldId: nextSlot.fieldId,
-                propertyId: nextSlot.property.id,
-              });
-            }}
-            size="icon-xs"
-            variant="ghost"
-          >
-            <ChevronRightIcon className="size-3.5" />
-          </Button>
-        </div>
+        </button>
+        <Button
+          disabled={!prevSlot}
+          onClick={() => {
+            if (!prevSlot) {
+              return;
+            }
+            openPdf({
+              id: activeTab.id,
+              entityId: activeTab.entityId,
+              label: activeTab.label,
+              workspaceId: activeTab.workspaceId,
+              mimeType: activeTab.mimeType,
+              pdfFileId: activeTab.pdfFileId,
+              justificationFieldId: prevSlot.fieldId,
+              propertyId: prevSlot.property.id,
+            });
+          }}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <ChevronLeftIcon className="size-3.5" />
+        </Button>
+        <span className="text-muted-foreground min-w-8 text-center text-[10px] tabular-nums">
+          {currentIdx + 1} / {slots.length}
+        </span>
+        <Button
+          disabled={!nextSlot}
+          onClick={() => {
+            if (!nextSlot) {
+              return;
+            }
+            openPdf({
+              id: activeTab.id,
+              entityId: activeTab.entityId,
+              label: activeTab.label,
+              workspaceId: activeTab.workspaceId,
+              mimeType: activeTab.mimeType,
+              pdfFileId: activeTab.pdfFileId,
+              justificationFieldId: nextSlot.fieldId,
+              propertyId: nextSlot.property.id,
+            });
+          }}
+          size="icon-xs"
+          variant="ghost"
+        >
+          <ChevronRightIcon className="size-3.5" />
+        </Button>
       </div>
-      {isExpanded && (
-        <div className="max-h-40 overflow-y-auto pb-2 text-xs">
-          <p className="text-muted-foreground mb-1 font-semibold">
-            {t("workspaces.pdf.evidence")}:
-          </p>
-          <PeekJustification
-            activeFileFieldId={activeTab.id}
-            justification={justification}
-          />
+      {isAnswerExpanded && shortAnswer !== null && (
+        <div className="text-foreground/85 max-h-32 min-w-0 overflow-y-auto pb-2 text-xs leading-relaxed break-words">
+          {justificationNodes}
         </div>
       )}
     </div>
+  );
+};
+
+const DOCX_SOURCE_PREVIEW_CHARS = 28;
+
+const SourceCitationChip = ({
+  citation,
+  onClick,
+}: {
+  citation: Citation;
+  onClick: () => void;
+}) => {
+  if (citation.kind === "pdf-bates") {
+    return (
+      <button
+        className="bg-primary/10 text-primary hover:bg-primary/20 inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-[11px] font-medium transition-colors"
+        onClick={onClick}
+        type="button"
+      >
+        p.&nbsp;{citation.pageNumber}
+      </button>
+    );
+  }
+
+  const trimmed = citation.text.trim();
+  const preview =
+    trimmed.length > DOCX_SOURCE_PREVIEW_CHARS
+      ? `${trimmed.slice(0, DOCX_SOURCE_PREVIEW_CHARS).trimEnd()}...`
+      : trimmed || "Text";
+
+  return (
+    <button
+      className="bg-primary/10 text-primary hover:bg-primary/20 inline-flex max-w-36 shrink-0 items-center truncate rounded-md px-1.5 py-0.5 text-[11px] font-medium transition-colors"
+      onClick={onClick}
+      title={trimmed || undefined}
+      type="button"
+    >
+      "{preview}"
+    </button>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
@@ -80,7 +80,7 @@ const FullscreenPdfViewer = () => {
         buffer={file.buffer}
         className="document-preview-surface h-full"
         contentClassName="relative mt-2 space-y-2 px-2"
-        fileId={file.fileId}
+        fileId={fieldId}
         invertColors={isImageOrigin ? false : undefined}
         onPageChanged={handlePageChanged}
         onPageCountChanged={setPdfPageCount}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -39,8 +39,8 @@ import {
   useDocxFitZoom,
   useDocxWheelZoom,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom";
+import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
 import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
-import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { PageAnonymization } from "@/routes/_protected.workspaces/$workspaceId/-components/pdf/page-anonymization";
 import { PageCitation } from "@/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation";
 
@@ -149,7 +149,7 @@ const PeekPdfViewerContent = ({
         buffer={file.buffer}
         className="document-preview-surface h-full"
         contentClassName="relative space-y-2 px-2 pt-2"
-        fileId={file.fileId}
+        fileId={fieldId}
         invertColors={isImageOrigin ? false : undefined}
         scaleOffset={scaleOffset}
         renderPage={(props) => (
@@ -437,41 +437,7 @@ const PeekDocxViewer = ({
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const targetZoom = useDocxFitZoom(containerRef, scaleOffset);
-  const pendingBlockScroll = useInspectorStore((s) => s.pendingBlockScroll);
-  const clearPendingBlockScroll = useInspectorStore(
-    (s) => s.clearPendingBlockScroll,
-  );
-
-  // Consume the workspace store's one-shot block scroll request when
-  // it targets this DOCX field. Fires on every change while the
-  // editor is mounted, so opening a file via a citation chip and
-  // clicking another chip both work — the editor is the canonical
-  // owner of the scroll, the store just signals "go to this block".
-  useEffect(() => {
-    if (pendingBlockScroll === null || pendingBlockScroll.tabId !== fieldId) {
-      return;
-    }
-    const ok = editorRef.current?.scrollToBlock(pendingBlockScroll.blockId);
-    if (ok !== undefined) {
-      clearPendingBlockScroll();
-    }
-  }, [clearPendingBlockScroll, fieldId, pendingBlockScroll]);
-
-  // Window-level fallback: citation chips also dispatch a window
-  // event for surfaces (e.g. the file-chat-overlay editor) that
-  // aren't tracked in the inspector store. The peek viewer reacts
-  // too, so a chip click reaches whichever DOCX editor is mounted
-  // — overlay or inspector.
-  useEffect(() => {
-    const handler = (event: CustomEvent<{ blockId: string }>) => {
-      if (!event.detail.blockId) {
-        return;
-      }
-      editorRef.current?.scrollToBlock(event.detail.blockId);
-    };
-    window.addEventListener("folio:scroll-to-block", handler);
-    return () => window.removeEventListener("folio:scroll-to-block", handler);
-  }, []);
+  useDocxBlockScroll({ editorRef, fieldId });
 
   // Sync scaleOffset from inspector +/- buttons to Folio zoom
   useLayoutEffect(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -151,6 +151,13 @@ export const WorkspaceTable = ({
     const tab = s.tabs.find((candidate) => candidate.id === s.activeId);
     return tab?.type === "pdf" ? tab.entityId : null;
   });
+  const activePropertyId = useInspectorStore((s) => {
+    if (!s.activeId) {
+      return null;
+    }
+    const tab = s.tabs.find((candidate) => candidate.id === s.activeId);
+    return tab?.type === "pdf" ? (tab.propertyId ?? null) : null;
+  });
 
   const activeTaskId = useInspectorStore((s) => {
     if (!s.activeId) {
@@ -494,6 +501,7 @@ export const WorkspaceTable = ({
             return (
               <DraggableRow
                 activeEntityId={activeEntityId}
+                activePropertyId={activePropertyId}
                 activeTaskId={activeTaskId}
                 addColumnHoverRowId={addColumnHoverRowId}
                 addColumnHovered={isAddColumnHovered}
@@ -892,6 +900,71 @@ const shouldIgnoreRowExpansionClick = (target: EventTarget) => {
   );
 };
 
+type ActiveCellFlashInput = {
+  activeCellPropertyId: string | null;
+  activationSeq: number;
+  rowRef: React.RefObject<HTMLDivElement | null>;
+  visibleCells: Cell<TableTreeNode, unknown>[];
+};
+
+const useActiveCellFlash = ({
+  activeCellPropertyId,
+  activationSeq,
+  rowRef,
+  visibleCells,
+}: ActiveCellFlashInput) => {
+  const previousCellActivationSeq = useRef(activationSeq);
+
+  useEffect(() => {
+    const rowElement = rowRef.current;
+    if (
+      !rowElement ||
+      !activeCellPropertyId ||
+      activationSeq === previousCellActivationSeq.current
+    ) {
+      previousCellActivationSeq.current = activationSeq;
+      return;
+    }
+
+    const cellIndex = visibleCells.findIndex(
+      (cell) => cell.column.id === activeCellPropertyId,
+    );
+    const cellElement = rowElement.children.item(cellIndex);
+    if (!(cellElement instanceof HTMLElement)) {
+      previousCellActivationSeq.current = activationSeq;
+      return;
+    }
+
+    cellElement.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    const c = "var(--color-primary)";
+    const t = "transparent";
+    cellElement.animate(
+      [
+        { boxShadow: `inset 0 0 0 2px ${c}` },
+        { boxShadow: `inset 0 0 0 2px ${t}` },
+      ],
+      { duration: 500, easing: "ease-out" },
+    );
+    previousCellActivationSeq.current = activationSeq;
+  }, [activationSeq, activeCellPropertyId, rowRef, visibleCells]);
+};
+
+type ActiveRowInput = {
+  activeCellPropertyId: string | null;
+  activeEntityId: string | null;
+  activeTaskId: string | null;
+  entityId: string;
+};
+
+const isActiveRow = ({
+  activeCellPropertyId,
+  activeEntityId,
+  activeTaskId,
+  entityId,
+}: ActiveRowInput) =>
+  entityId === activeTaskId ||
+  (entityId === activeEntityId && activeCellPropertyId === null);
+
 // -- Draggable table row --
 
 type DraggableRowProps = {
@@ -904,6 +977,7 @@ type DraggableRowProps = {
   table: WorkspaceTableType;
   workspaceId: string;
   activeEntityId: string | null;
+  activePropertyId: string | null;
   activeTaskId: string | null;
   addColumnHoverRowId: string | null;
   addColumnHovered: boolean;
@@ -928,6 +1002,7 @@ const DraggableRow = ({
   table,
   workspaceId,
   activeEntityId,
+  activePropertyId,
   activeTaskId,
   addColumnHoverRowId,
   addColumnHovered,
@@ -955,8 +1030,6 @@ const DraggableRow = ({
     null,
   );
   const entity = row.original;
-
-  useInspectorFlash(entity.entityId, rowRef);
   const isFolder = entity.kind === "folder";
   const isTask = entity.kind === "task";
   const isAddColumnHoverRow = addColumnHoverRowId === row.id;
@@ -968,6 +1041,25 @@ const DraggableRow = ({
     : undefined;
   const name = getEntityName(entity);
   const file = getFirstFile(entity);
+  const activeCellPropertyId =
+    entity.entityId === activeEntityId ? activePropertyId : null;
+  const activeRow = isActiveRow({
+    activeCellPropertyId,
+    activeEntityId,
+    activeTaskId,
+    entityId: entity.entityId,
+  });
+  const activationSeq = useInspectorStore((s) => s.activationSeq);
+
+  useInspectorFlash(entity.entityId, rowRef, {
+    enabled: activeCellPropertyId === null,
+  });
+  useActiveCellFlash({
+    activeCellPropertyId,
+    activationSeq,
+    rowRef,
+    visibleCells,
+  });
 
   const getBulkSelectedEntities = () => {
     const selectedRows = table.getSelectedRowModel().rows;
@@ -1160,11 +1252,7 @@ const DraggableRow = ({
       aria-rowindex={virtualIndex + 2}
       aria-selected={row.getIsSelected()}
       className={cn((isTask || !isFolder) && "cursor-pointer")}
-      data-active={
-        entity.entityId === activeEntityId ||
-        entity.entityId === activeTaskId ||
-        undefined
-      }
+      data-active={activeRow || undefined}
       data-index={virtualIndex}
       data-state={row.getIsSelected() ? "selected" : undefined}
       key={row.id}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash.ts
@@ -11,6 +11,7 @@ import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-
 export const useInspectorFlash = (
   entityId: string,
   ref: React.RefObject<HTMLElement | null>,
+  { enabled = true }: { enabled?: boolean } = {},
 ) => {
   const isActive = useInspectorStore((s) => {
     if (!s.activeId) {
@@ -27,7 +28,7 @@ export const useInspectorFlash = (
 
   useEffect(() => {
     const el = ref.current;
-    if (el && isActive && seq !== prevSeq.current) {
+    if (enabled && el && isActive && seq !== prevSeq.current) {
       el.scrollIntoView({ block: "nearest", behavior: "smooth" });
 
       const c = "var(--color-primary)";
@@ -70,5 +71,5 @@ export const useInspectorFlash = (
       }
     }
     prevSeq.current = seq;
-  }, [isActive, seq, ref]);
+  }, [enabled, isActive, seq, ref]);
 };


### PR DESCRIPTION
## Summary
- show AI answer/source context in sidepeek for PDF and DOCX documents
- render citation chips in the expanded sidepeek answer and route clicks to PDF pages or DOCX folio blocks
- flash only the clicked table cell and poll partial PDF bounding-box generation results

## Test plan
- bun --filter @stll/api typecheck
- bun --filter @stll/api lint
- bun --filter @stll/web typecheck
- bun --filter @stll/web lint
- bun --filter @stll/folio typecheck
- bun --filter @stll/folio lint
- bun --filter @stll/web test -- use-sync-justifications
- bun --filter @stll/web test -- table-store