### PR TITLE
feat(api): fail-fast on schema drift at startup

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -42,6 +42,7 @@ import { workspaceEventsRoute } from "@/api/handlers/workspaces/events";
 import { workspacesRoute } from "@/api/handlers/workspaces/routes";
 import { captureRequestError, getAnalytics } from "@/api/lib/analytics";
 import { getAuth } from "@/api/lib/auth";
+import { assertMigrationsApplied } from "@/api/lib/db/assert-migrations-applied";
 import { DEV_INSPECTOR_ORIGINS } from "@/api/lib/dev-origins";
 import { httpError } from "@/api/lib/errors/http-error";
 import { errorTag } from "@/api/lib/errors/utils";
@@ -343,6 +344,11 @@ const startS3RefreshLoop = () => {
 
   timer.unref();
 };
+
+// Schema-drift fail-fast. If the runtime expects migrations
+// the database has not received, exit before serving any
+// request against a stale schema.
+await assertMigrationsApplied();
 
 await refreshS3();
 startS3RefreshLoop();

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -1,0 +1,67 @@
+import { sql } from "drizzle-orm";
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { db } from "@/api/db/root";
+
+const MIGRATIONS_DIR = resolve(process.cwd(), "drizzle");
+const ESCAPE_HATCH_ENV = "SKIP_MIGRATION_CHECK";
+
+type LocalMigration = { name: string; hash: string };
+type AppliedMigrationRow = { hash: string };
+
+const hashMigrationFile = (path: string): string =>
+  createHash("sha256").update(readFileSync(path)).digest("hex");
+
+const listLocalMigrations = (): LocalMigration[] =>
+  readdirSync(MIGRATIONS_DIR)
+    .filter((name) => existsSync(join(MIGRATIONS_DIR, name, "migration.sql")))
+    .sort()
+    .map((name) => ({
+      name,
+      hash: hashMigrationFile(join(MIGRATIONS_DIR, name, "migration.sql")),
+    }));
+
+const queryAppliedHashes = async (): Promise<Set<string>> => {
+  // Compare on `hash` (always populated) rather than `name` (NULL
+  // on rows applied by older drizzle versions). Hash is the SHA-256
+  // of the migration.sql contents at apply time, so a mismatch
+  // also catches a file edited after it was applied.
+  const result = await db.execute<AppliedMigrationRow>(
+    sql`SELECT hash FROM drizzle.__drizzle_migrations`,
+  );
+  return new Set(result.map((row) => row.hash));
+};
+
+export const assertMigrationsApplied = async (): Promise<void> => {
+  if (process.env[ESCAPE_HATCH_ENV] === "true") {
+    console.warn(
+      `[startup] ${ESCAPE_HATCH_ENV}=true; migration drift check disabled. ` +
+        "Use only for incident recovery; remove the env var after.",
+    );
+    return;
+  }
+
+  const local = listLocalMigrations();
+  if (local.length === 0) {
+    throw new Error(
+      `[startup] No migration files at ${MIGRATIONS_DIR}; refusing to start. ` +
+        "The runtime image must include apps/api/drizzle/.",
+    );
+  }
+
+  const appliedHashes = await queryAppliedHashes();
+  const missing = local.filter((m) => !appliedHashes.has(m.hash));
+
+  if (missing.length > 0) {
+    const missingNames = missing.map((m) => m.name).join(", ");
+    throw new Error(
+      `[startup] Schema drift: ${missing.length} migration(s) in code are not applied to the database. ` +
+        `Code has ${local.length}; DB has ${appliedHashes.size}. ` +
+        `Missing or modified after apply: ${missingNames}. ` +
+        `Run \`bunx drizzle-kit migrate\` against this database, or set ${ESCAPE_HATCH_ENV}=true ` +
+        "to bypass the check (emergency only).",
+    );
+  }
+};


### PR DESCRIPTION
## Summary
If the runtime expects migrations the database has not yet received, exit with a clear error before serving any request against a stale schema. Catches the silent-rollback class of incident: new code shipped, migration was skipped/missed, endpoints that depend on the new objects 500 at runtime.

## How
On startup, list local migration files and SHA-256 each one. Compare hashes against \`drizzle.__drizzle_migrations\`. Throw on any mismatch — the process exits, the orchestrator marks the new task unhealthy, deploy aborts.

## Why hash, not name
- The \`name\` column on \`__drizzle_migrations\` can be NULL on rows applied by older drizzle versions. Hash is always populated.
- A hash mismatch additionally catches the related failure mode where a migration file is edited after it was applied, leaving DB state and code in disagreement.

## Escape hatch
\`SKIP_MIGRATION_CHECK=true\` env var bypasses the check.