### PR TITLE
feat(observability): add stdout backstop for ERROR-level logs

### DIFF
--- a/apps/api/src/lib/observability/logger.ts
+++ b/apps/api/src/lib/observability/logger.ts
@@ -26,10 +26,25 @@ const emit = ({
       ...record,
       attributes,
     });
-    return;
+  } else {
+    otelLogger.emit(record);
   }
 
-  otelLogger.emit(record);
+  // Stdout backstop for ERROR records. The OTel pipeline above
+  // can be wired to a remote exporter later; until it is, this
+  // mirrors ERROR records to stdout so incidents are debuggable
+  // from the runtime's standard log stream. ERROR-only by
+  // default keeps volume small and avoids surfacing request
+  // payloads that might appear at lower severities.
+  if (severityNumber === SeverityNumber.ERROR) {
+    process.stderr.write(
+      `${JSON.stringify({
+        severity: severityText,
+        message,
+        ...attributes,
+      })}\n`,
+    );
+  }
 };
 
 export const logger = {


### PR DESCRIPTION
## Summary
The OTel logger pipeline can be wired to a remote exporter later; until it is, mirror ERROR records to stdout so incidents are debuggable from the runtime's standard log stream. Today (silent search 500 + a missed migration) would have been resolved in seconds with this in place instead of hours.

## Shape
- ERROR severity only — keeps volume small; avoids surfacing request payloads that might appear at lower severities.
- One-line JSON to \`process.stderr\` so log-search tools parse it cleanly.
- The OTel pipeline still receives every level, so adding a remote exporter later (PostHog, Sentry, Grafana Cloud, whatever) is a one-line change in \`otel.ts\` — no callsite churn.

## Test plan
- [ ] Locally: \`logger.error(\"x\", { foo: 1 })\` prints \`{\"severity\":\"ERROR\",\"message\":\"x\",\"foo\":1}\` to stderr
- [ ] Locally: \`logger.info\` / \`warn\` / \`debug\` print nothing to stderr
- [ ] After deploy: trigger a 5xx; confirm a single JSON line in the runtime log stream with the expected fields