### PR TITLE
feat: polish chat landing experience

### DIFF
--- a/apps/api/src/handlers/ai-config/routes.ts
+++ b/apps/api/src/handlers/ai-config/routes.ts
@@ -6,6 +6,7 @@ import {
   probeProvider,
 } from "@/api/lib/ai-provider-probe";
 import { getSessionAndMemberRole } from "@/api/lib/auth";
+import { logger } from "@/api/lib/observability/logger";
 
 /**
  * Authenticated, org-agnostic AI provider key health-check.
@@ -29,18 +30,16 @@ export const aiConfigPublicRoute = new Elysia({ prefix: "/ai-config" }).post(
     try {
       const result = await probeProvider(body.provider, body.apiKey);
       if (!result.valid) {
-        console.warn(
-          `[validate-ai-provider] ${body.provider} rejected:`,
-          result.error,
-        );
+        logger.warn("ai_config.provider_validation_rejected", {
+          provider: body.provider,
+        });
       }
       return result;
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
-      console.warn(
-        `[validate-ai-provider] ${body.provider} unreachable:`,
-        message,
-      );
+      logger.warn("ai_config.provider_validation_unreachable", {
+        provider: body.provider,
+      });
       return status(502, { message });
     }
   },

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1148,7 +1148,8 @@ export function PromptBar(props: PromptBarProps) {
   // control (and the bar stays the single point of intent).
   const showStop = isGenerating && onStop !== undefined;
   const isSendBlocked = sendDisabledReason !== undefined;
-  const inputDisabled = busy || isSendBlocked;
+  const inputDisabled = isSendBlocked;
+  const submitDisabled = busy || isSendBlocked;
 
   // Glow on attention pulse — kicked from the inspector when the
   // user clicks the AI-suggestions chip so they see the bar light
@@ -1176,13 +1177,13 @@ export function PromptBar(props: PromptBarProps) {
   // Wrap controller.submit so the host's `onSubmit` is the only
   // outbound channel; the editor's draft (HTML) becomes the prompt.
   const submitDraft = useCallback(async () => {
-    if (inputDisabled) {
+    if (submitDisabled) {
       return;
     }
     await submit((draft) => {
       onSubmit({ prompt: draft.html });
     });
-  }, [inputDisabled, onSubmit, submit]);
+  }, [onSubmit, submit, submitDisabled]);
 
   // Register Enter handler — TipTap's keymap delegates Enter to
   // the `setSubmitHandler` registered here. Without this, Enter
@@ -1289,7 +1290,7 @@ export function PromptBar(props: PromptBarProps) {
             <Button
               aria-label={showStop ? "Stop response" : "Send prompt"}
               className="rounded-full"
-              disabled={showStop ? false : busy || !canSubmit || isSendBlocked}
+              disabled={showStop ? false : submitDisabled || !canSubmit}
               onClick={() => {
                 if (showStop) {
                   onStop?.();

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -1,5 +1,5 @@
 import "./chat-editor.css";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
@@ -19,6 +19,7 @@ type ChatInputSurfaceProps = {
   controller: ChatEditorController;
   disabled?: boolean;
   onSubmit: (draft: ChatInputDraft) => Promise<void> | void;
+  onFocusChange?: ((focused: boolean) => void) | undefined;
   /**
    * When set, the surface renders an in-line stop button while
    * generating instead of the send affordance, replacing the need
@@ -28,17 +29,18 @@ type ChatInputSurfaceProps = {
   onStop?: () => void;
 };
 
-// todo: check the code quality
 export const ChatInputSurface = ({
   autoFocus,
   className,
   controller,
   disabled = false,
   onSubmit,
+  onFocusChange,
   isGenerating = false,
   onStop,
 }: ChatInputSurfaceProps) => {
   const t = useTranslations();
+  const rootRef = useRef<HTMLDivElement>(null);
   const {
     attachments,
     canSubmit,
@@ -56,21 +58,22 @@ export const ChatInputSurface = ({
     setSubmitHandler,
     submit,
   } = controller;
-  const inputDisabled = disabled || isGenerating;
+  const inputDisabled = disabled;
+  const submitDisabled = disabled || isGenerating;
 
   const submitDraft = useCallback(async () => {
     // While the assistant is streaming we render Stop in place of
     // Send, but Enter still calls submit unless we gate it here.
     // Without this guard, a user pressing Enter during a turn fires
     // an overlapping `sendMessage` and the two responses interleave.
-    if (inputDisabled) {
+    if (submitDisabled) {
       return;
     }
 
     await submit(async (draft) => {
       await onSubmit(draft);
     });
-  }, [inputDisabled, onSubmit, submit]);
+  }, [onSubmit, submit, submitDisabled]);
 
   useEffect(() => {
     setSubmitHandler(submitDraft);
@@ -94,6 +97,22 @@ export const ChatInputSurface = ({
     }
   }, [editor, inputDisabled]);
 
+  const handleFocus = useCallback(() => {
+    onFocusChange?.(true);
+  }, [onFocusChange]);
+
+  const handleBlur = useCallback(
+    (event: React.FocusEvent<HTMLDivElement>) => {
+      const nextTarget = event.relatedTarget;
+      if (nextTarget instanceof Node && rootRef.current?.contains(nextTarget)) {
+        return;
+      }
+
+      onFocusChange?.(false);
+    },
+    [onFocusChange],
+  );
+
   return (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions
     <div
@@ -103,9 +122,12 @@ export const ChatInputSurface = ({
         !inputDisabled && "focus-within:border-ring",
         className,
       )}
+      onBlurCapture={handleBlur}
       onDragOver={inputDisabled ? undefined : handleDragOver}
       onDrop={inputDisabled ? undefined : handleDrop}
+      onFocusCapture={handleFocus}
       onPaste={inputDisabled ? undefined : handlePaste}
+      ref={rootRef}
     >
       <ChatDraftAttachmentChips files={attachments} onRemove={removeFile} />
       <div
@@ -157,9 +179,9 @@ export const ChatInputSurface = ({
           <Button
             className={cn(
               "bg-foreground text-background hover:bg-foreground/90 ms-auto shrink-0",
-              (inputDisabled || !canSubmit) && "opacity-50",
+              (submitDisabled || !canSubmit) && "opacity-50",
             )}
-            disabled={inputDisabled || !canSubmit}
+            disabled={submitDisabled || !canSubmit}
             onClick={() => {
               void submitDraft();
             }}

--- a/apps/web/src/components/chat/prompt-suggestions.tsx
+++ b/apps/web/src/components/chat/prompt-suggestions.tsx
@@ -28,23 +28,28 @@ export const PromptSuggestions = ({
   }
 
   return (
-    <div className={cn("flex flex-col items-center gap-3", className)}>
-      <p className="text-muted-foreground text-xs">
+    <div className={cn("flex w-full flex-col items-center gap-3", className)}>
+      <p className="text-muted-foreground text-sm">
         {t("chat.prompts.tryOne")}
       </p>
-      <div className="flex flex-col items-stretch gap-1.5 self-stretch">
+      <div className="flex w-full flex-col items-stretch gap-2">
         {prompts.map((prompt) => (
           <button
-            className="border-border hover:border-foreground/20 hover:bg-accent/50 group flex items-center gap-2 rounded-md border px-3 py-2 text-start transition-colors"
+            className="border-border hover:border-foreground/20 hover:bg-accent/50 group flex gap-3 rounded-md border px-4 py-3 text-start transition-colors"
             key={prompt.id}
             onClick={() => onSelect(prompt)}
             type="button"
           >
-            <span className="text-foreground text-xs font-medium">
-              {prompt.name}
+            <span className="text-muted-foreground/55 group-hover:text-muted-foreground mt-0.5 flex size-4 shrink-0 items-center justify-center font-mono text-[13px] leading-none transition-colors">
+              /
             </span>
-            <span className="text-muted-foreground line-clamp-1 flex-1 text-xs">
-              {prompt.body}
+            <span className="min-w-0 flex-1">
+              <span className="text-foreground block text-sm leading-5 font-medium">
+                {prompt.name}
+              </span>
+              <span className="text-muted-foreground line-clamp-2 text-xs leading-4">
+                {prompt.body}
+              </span>
             </span>
           </button>
         ))}

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -321,7 +321,7 @@
     "attachment": "Příloha",
     "caseLawGreeting": "Zeptejte se na toto rozhodnutí — plný text je k dispozici.",
     "chatAbout": "Vložit do AI chatu",
-    "contextPlaceholder": "Chat o {context}",
+    "contextPlaceholder": "Chat o {context}, / pro dovednosti, @ pro přidání kontextu",
     "deleteThread": "Smazat konverzaci",
     "documentView": {
       "original": "Originál",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Soubor překračuje limit {maxSize}",
     "folioCitationFallback": "str. {n}",
     "greeting": "Na čem chcete pracovat?",
+    "greetingSubtitle": "Začněte spisem, dokumentem nebo obyčejnou otázkou.",
+    "landing": {
+      "lastAccessedMatters": "Naposledy otevřené spisy",
+      "noMatters": "Zatím žádné spisy",
+      "noPrompts": "Zatím žádné prompty",
+      "noRecentChats": "Zatím žádné nedávné chaty",
+      "pinnedMatters": "Připnuté spisy",
+      "prompts": "Prompty",
+      "recentChats": "Nedávné chaty"
+    },
     "maxAttachmentsReached": "Maximálně {count} souborů na zprávu",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Přesunout do bočního panelu",
     "newChat": "Nový chat",
     "noThreads": "Zatím žádné konverzace",
-    "placeholder": "Co byste chtěli vědět?",
+    "placeholder": "Zde napište svůj dotaz, / pro dovednosti, @ pro přidání kontextu",
     "prompts": {
       "noResults": "Žádné odpovídající promty",
-      "noShortcuts": "Zatím žádné zkratky. Přidejte je v části Znalosti → Dovednosti.",
+      "noShortcuts": "Zatím žádné dovednosti. Přidejte je v části Znalosti → Dovednosti.",
       "scope": {
         "private": "Vaše promty",
         "stock": "Vestavěné",
@@ -384,7 +394,7 @@
     },
     "send": "Odeslat zprávu",
     "thinking": "Pracuji s kontextem",
-    "threads": "Konverzace",
+    "threads": "Historie",
     "tool": {
       "apply-active-docx-edits": "Používám úpravy DOCX",
       "ask-user": "Žádost o upřesnění",
@@ -537,6 +547,7 @@
     "error": "Chyba",
     "expenses": "Výdaje",
     "filter": "Filtr",
+    "history": "Historie",
     "invite": "Pozvat",
     "invoices": "Faktury",
     "kind": "Druh",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Přidat zkratku",
+      "addShortcut": "Přidat dovednost",
       "defaultBadge": "Výchozí",
-      "deleteConfirmDescription": "Tato zkratka bude trvale odstraněna.",
-      "deleteConfirmTitle": "Smazat zkratku?",
-      "deleteShortcut": "Smazat zkratku",
-      "editShortcut": "Upravit zkratku",
-      "emptyState": "Žádné zkratky. Přidejte první.",
+      "deleteConfirmDescription": "Tato dovednost bude trvale odstraněna.",
+      "deleteConfirmTitle": "Smazat dovednost?",
+      "deleteShortcut": "Smazat dovednost",
+      "editShortcut": "Upravit dovednost",
+      "emptyState": "Žádné dovednosti. Přidejte první.",
       "errors": {
-        "commandConflict": "Zkratka s tímto příkazem již existuje",
+        "commandConflict": "Dovednost s tímto / názvem již existuje",
         "commandInvalid": "Používejte pouze malá písmena, číslice, pomlčky a podtržítka",
-        "commandReserved": "\"/{command}\" je rezervovaný příkaz"
+        "commandReserved": "\"/{command}\" je rezervovaná dovednost"
       },
       "form": {
-        "command": "Příkaz",
-        "commandHint": "Pouze malá písmena, číslice, pomlčky a podtržítka",
+        "command": "Dovednost",
+        "commandHint": "Název / dovednosti: pouze malá písmena, číslice, pomlčky a podtržítka",
         "commandPlaceholder": "např. shrnout",
         "commandPrefix": "/",
         "description": "Popis",
@@ -1078,7 +1089,7 @@
         "name": "Název",
         "namePlaceholder": "např. Shrnout dokument",
         "prompt": "Prompt",
-        "promptPlaceholder": "Text vložený do kompozéru chatu při použití této zkratky",
+        "promptPlaceholder": "Text vložený do kompozéru chatu při použití této dovednosti",
         "scope": "Viditelnost",
         "scopePrivate": "Pouze já",
         "scopeTeam": "Všichni v organizaci"

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -321,7 +321,7 @@
     "attachment": "Anhang",
     "caseLawGreeting": "Stelle Fragen zu dieser Entscheidung — der vollständige Text ist hier verfügbar.",
     "chatAbout": "In AI-Chat einfügen",
-    "contextPlaceholder": "Chat über {context}",
+    "contextPlaceholder": "Chat über {context}, / für Skills, @ für Kontext",
     "deleteThread": "Konversation löschen",
     "documentView": {
       "original": "Original",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Datei überschreitet das Limit von {maxSize}",
     "folioCitationFallback": "S. {n}",
     "greeting": "Woran möchten Sie arbeiten?",
+    "greetingSubtitle": "Beginnen Sie mit einer Sache, einem Dokument oder einer einfachen Frage.",
+    "landing": {
+      "lastAccessedMatters": "Zuletzt geöffnete Sachen",
+      "noMatters": "Noch keine Sachen",
+      "noPrompts": "Noch keine Prompts",
+      "noRecentChats": "Keine letzten Chats",
+      "pinnedMatters": "Angeheftete Sachen",
+      "prompts": "Prompts",
+      "recentChats": "Letzte Chats"
+    },
     "maxAttachmentsReached": "Maximal {count} Dateien pro Nachricht",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "In Seitenleiste verschieben",
     "newChat": "Neuer Chat",
     "noThreads": "Noch keine Konversationen",
-    "placeholder": "Was möchten Sie wissen?",
+    "placeholder": "Geben Sie hier Ihre Frage ein, / für Skills, @ für Kontext",
     "prompts": {
       "noResults": "Keine passenden Prompts",
-      "noShortcuts": "Noch keine Kürzel. Fügen Sie welche unter Wissen → Kürzel hinzu.",
+      "noShortcuts": "Noch keine Skills. Fügen Sie welche unter Wissen → Skills hinzu.",
       "scope": {
         "private": "Eigene Prompts",
         "stock": "Vorgegeben",
@@ -384,7 +394,7 @@
     },
     "send": "Nachricht senden",
     "thinking": "Arbeite mit Kontext",
-    "threads": "Konversationen",
+    "threads": "Verlauf",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Um Klärung bitten",
@@ -537,6 +547,7 @@
     "error": "Fehler",
     "expenses": "Ausgaben",
     "filter": "Filtern",
+    "history": "Verlauf",
     "invite": "Einladen",
     "invoices": "Rechnungen",
     "kind": "Art",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Kürzel hinzufügen",
+      "addShortcut": "Skill hinzufügen",
       "defaultBadge": "Standard",
-      "deleteConfirmDescription": "Dieses Kürzel wird dauerhaft entfernt.",
-      "deleteConfirmTitle": "Kürzel löschen?",
-      "deleteShortcut": "Kürzel löschen",
-      "editShortcut": "Kürzel bearbeiten",
-      "emptyState": "Noch keine Kürzel. Fügen Sie eines hinzu.",
+      "deleteConfirmDescription": "Dieser Skill wird dauerhaft entfernt.",
+      "deleteConfirmTitle": "Skill löschen?",
+      "deleteShortcut": "Skill löschen",
+      "editShortcut": "Skill bearbeiten",
+      "emptyState": "Noch keine Skills. Fügen Sie einen hinzu.",
       "errors": {
-        "commandConflict": "Ein Kürzel mit diesem Befehl existiert bereits",
+        "commandConflict": "Ein Skill mit diesem / Namen existiert bereits",
         "commandInvalid": "Nur Kleinbuchstaben, Ziffern, Bindestriche und Unterstriche verwenden",
-        "commandReserved": "\"/{command}\" ist ein reservierter Befehl"
+        "commandReserved": "\"/{command}\" ist ein reservierter Skill"
       },
       "form": {
-        "command": "Befehl",
-        "commandHint": "Nur Kleinbuchstaben, Ziffern, Bindestriche und Unterstriche",
+        "command": "Skill",
+        "commandHint": "Der / Skill-Name: nur Kleinbuchstaben, Ziffern, Bindestriche und Unterstriche",
         "commandPlaceholder": "z.B. zusammenfassen",
         "commandPrefix": "/",
         "description": "Beschreibung",
@@ -1078,7 +1089,7 @@
         "name": "Name",
         "namePlaceholder": "z.B. Dokument zusammenfassen",
         "prompt": "Prompt",
-        "promptPlaceholder": "Der Text, der in das Chat-Eingabefeld eingefügt wird",
+        "promptPlaceholder": "Der Text, der beim Verwenden dieses Skills in den Chat-Composer eingefügt wird",
         "scope": "Sichtbarkeit",
         "scopePrivate": "Nur ich",
         "scopeTeam": "Alle in der Organisation"

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -321,7 +321,7 @@
     "attachment": "Attachment",
     "caseLawGreeting": "Ask about this decision — its full text is available here.",
     "chatAbout": "Chat about this",
-    "contextPlaceholder": "Chat about {context}",
+    "contextPlaceholder": "Chat about {context}, / for skills, @ to add context",
     "deleteThread": "Delete conversation",
     "documentView": {
       "original": "Original",
@@ -337,6 +337,16 @@
     "fileTooLarge": "File exceeds {maxSize} limit",
     "folioCitationFallback": "p. {n}",
     "greeting": "What would you like to work on?",
+    "greetingSubtitle": "Start with a matter, document, or plain question.",
+    "landing": {
+      "lastAccessedMatters": "Last accessed matters",
+      "noMatters": "No matters yet",
+      "noPrompts": "No prompts yet",
+      "noRecentChats": "No recent chats",
+      "pinnedMatters": "Pinned matters",
+      "prompts": "Prompts",
+      "recentChats": "Recent chats"
+    },
     "maxAttachmentsReached": "Maximum {count} files per message",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Move to side panel",
     "newChat": "New chat",
     "noThreads": "No conversations yet",
-    "placeholder": "What would you like to know?",
+    "placeholder": "Type your question here, / for skills, @ to add context",
     "prompts": {
       "noResults": "No matching prompts",
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.",
+      "noShortcuts": "No skills yet. Add some in Knowledge → Skills.",
       "scope": {
         "private": "Your prompts",
         "stock": "Built-in",
@@ -384,7 +394,7 @@
     },
     "send": "Send message",
     "thinking": "Working with context",
-    "threads": "Conversations",
+    "threads": "History",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Asking for clarification",
@@ -537,6 +547,7 @@
     "error": "Error",
     "expenses": "Expenses",
     "filter": "Filter",
+    "history": "History",
     "invite": "Invite",
     "invoices": "Invoices",
     "kind": "Kind",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Add shortcut",
+      "addShortcut": "Add skill",
       "defaultBadge": "Default",
-      "deleteConfirmDescription": "This shortcut will be permanently removed.",
-      "deleteConfirmTitle": "Delete shortcut?",
-      "deleteShortcut": "Delete shortcut",
-      "editShortcut": "Edit shortcut",
-      "emptyState": "No shortcuts yet. Add one to get started.",
+      "deleteConfirmDescription": "This skill will be permanently removed.",
+      "deleteConfirmTitle": "Delete skill?",
+      "deleteShortcut": "Delete skill",
+      "editShortcut": "Edit skill",
+      "emptyState": "No skills yet. Add your first one.",
       "errors": {
-        "commandConflict": "A shortcut with this command already exists",
+        "commandConflict": "A skill with this / name already exists",
         "commandInvalid": "Use only lowercase letters, digits, hyphens and underscores",
-        "commandReserved": "\"/{command}\" is a reserved command"
+        "commandReserved": "\"/{command}\" is a reserved skill"
       },
       "form": {
-        "command": "Command",
-        "commandHint": "Lowercase letters, digits, hyphens and underscores only",
+        "command": "Skill",
+        "commandHint": "The / skill name: lowercase letters, numbers, hyphens, and underscores only",
         "commandPlaceholder": "e.g. summarize",
         "commandPrefix": "/",
         "description": "Description",
@@ -1078,7 +1089,7 @@
         "name": "Name",
         "namePlaceholder": "e.g. Summarise document",
         "prompt": "Prompt",
-        "promptPlaceholder": "The text inserted into the chat composer when this shortcut is used",
+        "promptPlaceholder": "The text inserted into the chat composer when this skill is used",
         "scope": "Visibility",
         "scopePrivate": "Only me",
         "scopeTeam": "Everyone in the organisation"

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -321,7 +321,7 @@
     "attachment": "Adjunto",
     "caseLawGreeting": "Pregunta sobre esta decisión — el texto completo está disponible aquí.",
     "chatAbout": "Insertar en chat de IA",
-    "contextPlaceholder": "Chat sobre {context}",
+    "contextPlaceholder": "Chat sobre {context}, / para skills, @ para añadir contexto",
     "deleteThread": "Eliminar conversación",
     "documentView": {
       "original": "Original",
@@ -337,6 +337,16 @@
     "fileTooLarge": "El archivo supera el límite de {maxSize}",
     "folioCitationFallback": "p. {n}",
     "greeting": "¿En qué le gustaría trabajar?",
+    "greetingSubtitle": "Empiece con un asunto, un documento o una pregunta sencilla.",
+    "landing": {
+      "lastAccessedMatters": "Asuntos abiertos recientemente",
+      "noMatters": "Aún no hay asuntos",
+      "noPrompts": "Aún no hay prompts",
+      "noRecentChats": "No hay chats recientes",
+      "pinnedMatters": "Asuntos fijados",
+      "prompts": "Prompts",
+      "recentChats": "Chats recientes"
+    },
     "maxAttachmentsReached": "Máximo {count} archivos por mensaje",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Mover al panel lateral",
     "newChat": "Nueva conversación",
     "noThreads": "Aún no hay conversaciones",
-    "placeholder": "¿Qué le gustaría saber?",
+    "placeholder": "Escriba su pregunta aquí, / para skills, @ para añadir contexto",
     "prompts": {
       "noResults": "Sin prompts coincidentes",
-      "noShortcuts": "Aún no hay atajos. Añade algunos en Conocimiento → Habilidades.",
+      "noShortcuts": "Aún no hay skills. Añádalas en Conocimiento → Skills.",
       "scope": {
         "private": "Tus prompts",
         "stock": "Predefinidos",
@@ -384,7 +394,7 @@
     },
     "send": "Enviar mensaje",
     "thinking": "Trabajando con contexto",
-    "threads": "Conversaciones",
+    "threads": "Historial",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Pidiendo una aclaración",
@@ -537,6 +547,7 @@
     "error": "Error",
     "expenses": "Gastos",
     "filter": "Filtro",
+    "history": "Historial",
     "invite": "Invitar",
     "invoices": "Facturas",
     "kind": "Tipo",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Añadir atajo",
+      "addShortcut": "Añadir skill",
       "defaultBadge": "Predeterminado",
-      "deleteConfirmDescription": "Este atajo se eliminará permanentemente.",
-      "deleteConfirmTitle": "¿Eliminar atajo?",
-      "deleteShortcut": "Eliminar atajo",
-      "editShortcut": "Editar atajo",
-      "emptyState": "Aún no hay atajos. Añade uno para comenzar.",
+      "deleteConfirmDescription": "Esta skill se eliminará de forma permanente.",
+      "deleteConfirmTitle": "¿Eliminar skill?",
+      "deleteShortcut": "Eliminar skill",
+      "editShortcut": "Editar skill",
+      "emptyState": "Aún no hay skills. Añada la primera.",
       "errors": {
-        "commandConflict": "Ya existe un atajo con este comando",
+        "commandConflict": "Ya existe una skill con este nombre /",
         "commandInvalid": "Usa solo letras minúsculas, dígitos, guiones y guiones bajos",
-        "commandReserved": "\"/{command}\" es un comando reservado"
+        "commandReserved": "\"/{command}\" es una skill reservada"
       },
       "form": {
-        "command": "Comando",
-        "commandHint": "Solo letras minúsculas, dígitos, guiones y guiones bajos",
+        "command": "Skill",
+        "commandHint": "Nombre de la skill /: solo minúsculas, números, guiones y guiones bajos",
         "commandPlaceholder": "p. ej. resumir",
         "commandPrefix": "/",
         "description": "Descripción",
@@ -1078,7 +1089,7 @@
         "name": "Nombre",
         "namePlaceholder": "p. ej. Resumir documento",
         "prompt": "Prompt",
-        "promptPlaceholder": "El texto que se inserta en el compositor de chat al usar este atajo",
+        "promptPlaceholder": "El texto que se inserta en el compositor de chat al usar esta skill",
         "scope": "Visibilidad",
         "scopePrivate": "Solo yo",
         "scopeTeam": "Todos en la organización"

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -321,7 +321,7 @@
     "attachment": "Manus",
     "caseLawGreeting": "Esita küsimusi selle otsuse kohta — täistekst on siin saadaval.",
     "chatAbout": "Lisa AI vestlusesse",
-    "contextPlaceholder": "Vestle teemal {context}",
+    "contextPlaceholder": "Vestle teemal {context}, / oskuste jaoks, @ konteksti lisamiseks",
     "deleteThread": "Kustuta vestlus",
     "documentView": {
       "original": "Originaal",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Fail ületab {maxSize} piirangu",
     "folioCitationFallback": "lk {n}",
     "greeting": "Millega soovite tegeleda?",
+    "greetingSubtitle": "Alustage asjast, dokumendist või lihtsast küsimusest.",
+    "landing": {
+      "lastAccessedMatters": "Viimati avatud asjad",
+      "noMatters": "Asju veel pole",
+      "noPrompts": "Prompte veel pole",
+      "noRecentChats": "Hiljutisi vestlusi pole",
+      "pinnedMatters": "Kinnitatud asjad",
+      "prompts": "Promptid",
+      "recentChats": "Hiljutised vestlused"
+    },
     "maxAttachmentsReached": "Maksimaalselt {count} faili sõnumi kohta",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Vii külgpaneeli",
     "newChat": "Uus vestlus",
     "noThreads": "Vestlusi pole veel",
-    "placeholder": "Mida soovite teada?",
+    "placeholder": "Kirjutage oma küsimus siia, / oskuste jaoks, @ konteksti lisamiseks",
     "prompts": {
       "noResults": "Sobivaid küsimusi pole",
-      "noShortcuts": "Otseteid pole veel. Lisage neid jaotises Teadmised → Oskused.",
+      "noShortcuts": "Oskusi veel pole. Lisage need jaotises Teadmised → Oskused.",
       "scope": {
         "private": "Sinu küsimused",
         "stock": "Sisseehitatud",
@@ -384,7 +394,7 @@
     },
     "send": "Saada sõnum",
     "thinking": "Töötan kontekstiga",
-    "threads": "Vestlused",
+    "threads": "Ajalugu",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Täpsustuse küsimine",
@@ -537,6 +547,7 @@
     "error": "Viga",
     "expenses": "Kulud",
     "filter": "Filter",
+    "history": "Ajalugu",
     "invite": "Kutsu",
     "invoices": "Arved",
     "kind": "Liik",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Lisa otsetee",
+      "addShortcut": "Lisa oskus",
       "defaultBadge": "Vaikimisi",
-      "deleteConfirmDescription": "See otsetee eemaldatakse jäädavalt.",
-      "deleteConfirmTitle": "Kustuta otsetee?",
-      "deleteShortcut": "Kustuta otsetee",
-      "editShortcut": "Muuda otseteed",
-      "emptyState": "Otseteid pole veel. Lisa esimene.",
+      "deleteConfirmDescription": "See oskus eemaldatakse jäädavalt.",
+      "deleteConfirmTitle": "Kas kustutada oskus?",
+      "deleteShortcut": "Kustuta oskus",
+      "editShortcut": "Muuda oskust",
+      "emptyState": "Oskusi veel pole. Lisage esimene.",
       "errors": {
-        "commandConflict": "Selle käsuga otsetee on juba olemas",
+        "commandConflict": "Selle / nimega oskus on juba olemas",
         "commandInvalid": "Kasuta ainult väiketähti, numbreid, sidekriipse ja allkriipse",
-        "commandReserved": "\"/{command}\" on reserveeritud käsk"
+        "commandReserved": "\"/{command}\" on reserveeritud oskus"
       },
       "form": {
-        "command": "Käsk",
-        "commandHint": "Ainult väiketähed, numbrid, sidekriipsud ja allkriipsud",
+        "command": "Oskus",
+        "commandHint": "/ oskuse nimi: ainult väiketähed, numbrid, sidekriipsud ja alakriipsud",
         "commandPlaceholder": "nt. kokkuvõte",
         "commandPrefix": "/",
         "description": "Kirjeldus",
@@ -1078,7 +1089,7 @@
         "name": "Nimi",
         "namePlaceholder": "nt. Dokumendi kokkuvõte",
         "prompt": "Prompt",
-        "promptPlaceholder": "Tekst, mis lisatakse vestluse koostajasse selle otsetee kasutamisel",
+        "promptPlaceholder": "Tekst, mis lisatakse vestluse koostajasse selle oskuse kasutamisel",
         "scope": "Nähtavus",
         "scopePrivate": "Ainult mina",
         "scopeTeam": "Kõik organisatsioonis"

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -321,7 +321,7 @@
     "attachment": "Pièce jointe",
     "caseLawGreeting": "Pose des questions sur cette décision — le texte complet est disponible ici.",
     "chatAbout": "Insérer dans le chat IA",
-    "contextPlaceholder": "Discuter de {context}",
+    "contextPlaceholder": "Chat sur {context}, / pour les skills, @ pour ajouter du contexte",
     "deleteThread": "Supprimer la conversation",
     "documentView": {
       "original": "Original",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Le fichier dépasse la limite de {maxSize}",
     "folioCitationFallback": "p. {n}",
     "greeting": "Sur quoi souhaitez-vous travailler ?",
+    "greetingSubtitle": "Commencez par un dossier, un document ou une question simple.",
+    "landing": {
+      "lastAccessedMatters": "Dossiers consultés récemment",
+      "noMatters": "Aucun dossier pour le moment",
+      "noPrompts": "Aucun prompt pour le moment",
+      "noRecentChats": "Aucun chat récent",
+      "pinnedMatters": "Dossiers épinglés",
+      "prompts": "Prompts",
+      "recentChats": "Chats récents"
+    },
     "maxAttachmentsReached": "Maximum {count} fichiers par message",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Déplacer vers le panneau latéral",
     "newChat": "Nouvelle conversation",
     "noThreads": "Aucune conversation",
-    "placeholder": "Que souhaitez-vous savoir ?",
+    "placeholder": "Saisissez votre question ici, / pour les skills, @ pour ajouter du contexte",
     "prompts": {
       "noResults": "Aucun prompt correspondant",
-      "noShortcuts": "Aucun raccourci pour l'instant. Ajoutez-en dans Connaissance → Compétences.",
+      "noShortcuts": "Aucun skill pour le moment. Ajoutez-en dans Connaissances → Skills.",
       "scope": {
         "private": "Vos prompts",
         "stock": "Intégrés",
@@ -384,7 +394,7 @@
     },
     "send": "Envoyer le message",
     "thinking": "Traitement du contexte",
-    "threads": "Conversations",
+    "threads": "Historique",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Demande de précision",
@@ -537,6 +547,7 @@
     "error": "Erreur",
     "expenses": "Dépenses",
     "filter": "Filtrer",
+    "history": "Historique",
     "invite": "Inviter",
     "invoices": "Factures",
     "kind": "Type",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Ajouter un raccourci",
+      "addShortcut": "Ajouter un skill",
       "defaultBadge": "Par défaut",
-      "deleteConfirmDescription": "Ce raccourci sera supprimé définitivement.",
-      "deleteConfirmTitle": "Supprimer le raccourci ?",
-      "deleteShortcut": "Supprimer le raccourci",
-      "editShortcut": "Modifier le raccourci",
-      "emptyState": "Aucun raccourci pour l'instant. Ajoutez-en un pour commencer.",
+      "deleteConfirmDescription": "Ce skill sera supprimé définitivement.",
+      "deleteConfirmTitle": "Supprimer le skill ?",
+      "deleteShortcut": "Supprimer le skill",
+      "editShortcut": "Modifier le skill",
+      "emptyState": "Aucun skill pour le moment. Ajoutez le premier.",
       "errors": {
-        "commandConflict": "Un raccourci avec cette commande existe déjà",
+        "commandConflict": "Un skill avec ce nom / existe déjà",
         "commandInvalid": "Utilisez uniquement des minuscules, chiffres, tirets et tirets bas",
-        "commandReserved": "\"/{command}\" est une commande réservée"
+        "commandReserved": "\"/{command}\" est un skill réservé"
       },
       "form": {
-        "command": "Commande",
-        "commandHint": "Minuscules, chiffres, tirets et tirets bas uniquement",
+        "command": "Skill",
+        "commandHint": "Nom du skill / : minuscules, chiffres, tirets et underscores uniquement",
         "commandPlaceholder": "ex. résumer",
         "commandPrefix": "/",
         "description": "Description",
@@ -1078,7 +1089,7 @@
         "name": "Nom",
         "namePlaceholder": "ex. Résumer le document",
         "prompt": "Invite",
-        "promptPlaceholder": "Le texte inséré dans le compositeur de chat lors de l'utilisation de ce raccourci",
+        "promptPlaceholder": "Le texte inséré dans le compositeur de chat lorsque ce skill est utilisé",
         "scope": "Visibilité",
         "scopePrivate": "Moi uniquement",
         "scopeTeam": "Tous dans l'organisation"

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -321,7 +321,7 @@
     "attachment": "Melléklet",
     "caseLawGreeting": "Kérdezz erről a határozatról — a teljes szöveg itt elérhető.",
     "chatAbout": "Beszúrás az AI chatbe",
-    "contextPlaceholder": "Csevegés erről: {context}",
+    "contextPlaceholder": "Chat erről: {context}, / a skillekhez, @ kontextus hozzáadásához",
     "deleteThread": "Beszélgetés törlése",
     "documentView": {
       "original": "Eredeti",
@@ -337,6 +337,16 @@
     "fileTooLarge": "A fájl meghaladja a {maxSize} korlátot",
     "folioCitationFallback": "o. {n}",
     "greeting": "Min szeretne dolgozni?",
+    "greetingSubtitle": "Kezdje egy üggyel, dokumentummal vagy egyszerű kérdéssel.",
+    "landing": {
+      "lastAccessedMatters": "Legutóbb megnyitott ügyek",
+      "noMatters": "Még nincsenek ügyek",
+      "noPrompts": "Még nincsenek promptok",
+      "noRecentChats": "Nincsenek legutóbbi chatek",
+      "pinnedMatters": "Kitűzött ügyek",
+      "prompts": "Promptok",
+      "recentChats": "Legutóbbi chatek"
+    },
     "maxAttachmentsReached": "Üzenetenként legfeljebb {count} fájl",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Áthelyezés az oldalsó panelbe",
     "newChat": "Új csevegés",
     "noThreads": "Még nincsenek beszélgetések",
-    "placeholder": "Mit szeretne tudni?",
+    "placeholder": "Írja ide a kérdését, / a skillekhez, @ kontextus hozzáadásához",
     "prompts": {
       "noResults": "Nincs egyező prompt",
-      "noShortcuts": "Még nincsenek parancsikonok. Adjon hozzá néhányat a Tudás → Készségek menüpontban.",
+      "noShortcuts": "Még nincsenek skillek. Adjon hozzá a Tudás → Skillek részen.",
       "scope": {
         "private": "Saját promptok",
         "stock": "Beépített",
@@ -384,7 +394,7 @@
     },
     "send": "Üzenet küldése",
     "thinking": "Kontextussal dolgozom",
-    "threads": "Beszélgetések",
+    "threads": "Előzmények",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Pontosítás kérése",
@@ -537,6 +547,7 @@
     "error": "Hiba",
     "expenses": "Kiadások",
     "filter": "Szűrő",
+    "history": "Előzmények",
     "invite": "Meghívás",
     "invoices": "Számlák",
     "kind": "Fajta",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Parancsikon hozzáadása",
+      "addShortcut": "Skill hozzáadása",
       "defaultBadge": "Alapértelmezett",
-      "deleteConfirmDescription": "Ez a parancsikon véglegesen törlésre kerül.",
-      "deleteConfirmTitle": "Parancsikon törlése?",
-      "deleteShortcut": "Parancsikon törlése",
-      "editShortcut": "Parancsikon szerkesztése",
-      "emptyState": "Még nincsenek parancsikonok. Adjon hozzá egyet.",
+      "deleteConfirmDescription": "Ez a skill véglegesen törlődik.",
+      "deleteConfirmTitle": "Skill törlése?",
+      "deleteShortcut": "Skill törlése",
+      "editShortcut": "Skill szerkesztése",
+      "emptyState": "Még nincsenek skillek. Adja hozzá az elsőt.",
       "errors": {
-        "commandConflict": "Ezzel a paranccsal már létezik egy parancsikon",
+        "commandConflict": "Már létezik skill ezzel a / névvel",
         "commandInvalid": "Csak kisbetűket, számokat, kötőjeleket és aláhúzásokat használjon",
-        "commandReserved": "\"/{command}\" egy fenntartott parancs"
+        "commandReserved": "\"/{command}\" fenntartott skill"
       },
       "form": {
-        "command": "Parancs",
-        "commandHint": "Csak kisbetűk, számok, kötőjelek és aláhúzások",
+        "command": "Skill",
+        "commandHint": "A / skill neve: csak kisbetűk, számok, kötőjelek és aláhúzások",
         "commandPlaceholder": "pl. összefoglalás",
         "commandPrefix": "/",
         "description": "Leírás",
@@ -1078,7 +1089,7 @@
         "name": "Név",
         "namePlaceholder": "pl. Dokumentum összefoglalása",
         "prompt": "Prompt",
-        "promptPlaceholder": "A szöveg, amely be lesz illesztve a csevegő szerkesztőbe",
+        "promptPlaceholder": "A chat szerkesztőbe beszúrt szöveg, amikor ezt a skillt használják",
         "scope": "Láthatóság",
         "scopePrivate": "Csak én",
         "scopeTeam": "Mindenki a szervezetben"

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -321,7 +321,7 @@
     "attachment": "Priedas",
     "caseLawGreeting": "Klausk apie šį sprendimą — visas tekstas pasiekiamas čia.",
     "chatAbout": "Įterpti į AI pokalbį",
-    "contextPlaceholder": "Pokalbis apie {context}",
+    "contextPlaceholder": "Pokalbis apie {context}, / įgūdžiams, @ kontekstui pridėti",
     "deleteThread": "Ištrinti pokalbį",
     "documentView": {
       "original": "Originalas",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Failas viršija {maxSize} limitą",
     "folioCitationFallback": "p. {n}",
     "greeting": "Prie ko norėtumėte dirbti?",
+    "greetingSubtitle": "Pradėkite nuo bylos, dokumento arba paprasto klausimo.",
+    "landing": {
+      "lastAccessedMatters": "Paskutinės atidarytos bylos",
+      "noMatters": "Bylų dar nėra",
+      "noPrompts": "Raginimų dar nėra",
+      "noRecentChats": "Nėra naujausių pokalbių",
+      "pinnedMatters": "Prisegtos bylos",
+      "prompts": "Raginimai",
+      "recentChats": "Neseniai naudoti pokalbiai"
+    },
     "maxAttachmentsReached": "Daugiausiai {count} failų vienoje žinutėje",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Perkelti į šoninį skydelį",
     "newChat": "Naujas pokalbis",
     "noThreads": "Pokalbių dar nėra",
-    "placeholder": "Ko norėtumėte paklausti?",
+    "placeholder": "Čia įveskite klausimą, / įgūdžiams, @ kontekstui pridėti",
     "prompts": {
       "noResults": "Nėra atitinkančių raginimų",
-      "noShortcuts": "Dar nėra sparčiųjų klavišų. Pridėkite juos dalyje Žinios → Įgūdžiai.",
+      "noShortcuts": "Įgūdžių dar nėra. Pridėkite juos skiltyje Žinios → Įgūdžiai.",
       "scope": {
         "private": "Jūsų raginimai",
         "stock": "Įmontuoti",
@@ -384,7 +394,7 @@
     },
     "send": "Siųsti žinutę",
     "thinking": "Dirbama su kontekstu",
-    "threads": "Pokalbiai",
+    "threads": "Istorija",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Prašoma patikslinimo",
@@ -537,6 +547,7 @@
     "error": "Klaida",
     "expenses": "Išlaidos",
     "filter": "Filtras",
+    "history": "Istorija",
     "invite": "Pakviesti",
     "invoices": "Sąskaitos",
     "kind": "Rūšis",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Pridėti spartąjį klavišą",
+      "addShortcut": "Pridėti įgūdį",
       "defaultBadge": "Numatytasis",
-      "deleteConfirmDescription": "Šis spartysis klavišas bus visam laikui pašalintas.",
-      "deleteConfirmTitle": "Ištrinti spartųjį klavišą?",
-      "deleteShortcut": "Ištrinti spartųjį klavišą",
-      "editShortcut": "Redaguoti spartąjį klavišą",
-      "emptyState": "Dar nėra sparčiųjų klavišų. Pridėkite pirmąjį.",
+      "deleteConfirmDescription": "Šis įgūdis bus pašalintas visam laikui.",
+      "deleteConfirmTitle": "Ištrinti įgūdį?",
+      "deleteShortcut": "Ištrinti įgūdį",
+      "editShortcut": "Redaguoti įgūdį",
+      "emptyState": "Įgūdžių dar nėra. Pridėkite pirmąjį.",
       "errors": {
-        "commandConflict": "Spartysis klavišas su šia komanda jau egzistuoja",
+        "commandConflict": "Įgūdis su šiuo / pavadinimu jau yra",
         "commandInvalid": "Naudokite tik mažąsias raides, skaičius, brūkšnelius ir pabraukimus",
-        "commandReserved": "\"/{command}\" yra rezervuota komanda"
+        "commandReserved": "\"/{command}\" yra rezervuotas įgūdis"
       },
       "form": {
-        "command": "Komanda",
-        "commandHint": "Tik mažosios raidės, skaičiai, brūkšneliai ir pabraukimai",
+        "command": "Įgūdis",
+        "commandHint": "/ įgūdžio pavadinimas: tik mažosios raidės, skaičiai, brūkšneliai ir pabraukimai",
         "commandPlaceholder": "pvz. sutraukti",
         "commandPrefix": "/",
         "description": "Aprašymas",
@@ -1078,7 +1089,7 @@
         "name": "Pavadinimas",
         "namePlaceholder": "pvz. Dokumento santrauka",
         "prompt": "Užklausa",
-        "promptPlaceholder": "Tekstas, įterpiamas į pokalbio rengyklę naudojant šį spartąjį klavišą",
+        "promptPlaceholder": "Tekstas, įterpiamas į pokalbio lauką naudojant šį įgūdį",
         "scope": "Matomumas",
         "scopePrivate": "Tik aš",
         "scopeTeam": "Visi organizacijoje"

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -321,7 +321,7 @@
     "attachment": "Pielikums",
     "caseLawGreeting": "Uzdod jautājumus par šo lēmumu — pilns teksts ir pieejams šeit.",
     "chatAbout": "Ievietot AI čatā",
-    "contextPlaceholder": "Tērzēt par {context}",
+    "contextPlaceholder": "Tērzēt par {context}, / prasmēm, @ konteksta pievienošanai",
     "deleteThread": "Dzēst sarunu",
     "documentView": {
       "original": "Oriģināls",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Fails pārsniedz {maxSize} ierobežojumu",
     "folioCitationFallback": "lpp. {n}",
     "greeting": "Pie kā vēlaties strādāt?",
+    "greetingSubtitle": "Sāciet ar lietu, dokumentu vai vienkāršu jautājumu.",
+    "landing": {
+      "lastAccessedMatters": "Pēdējās atvērtās lietas",
+      "noMatters": "Lietu vēl nav",
+      "noPrompts": "Promptu vēl nav",
+      "noRecentChats": "Nav nesenu čatu",
+      "pinnedMatters": "Piespraustās lietas",
+      "prompts": "Prompti",
+      "recentChats": "Nesenie čati"
+    },
     "maxAttachmentsReached": "Maksimāli {count} faili vienā ziņojumā",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Pārvietot uz sānu paneli",
     "newChat": "Jauna saruna",
     "noThreads": "Sarunu vēl nav",
-    "placeholder": "Ko vēlaties uzzināt?",
+    "placeholder": "Ierakstiet jautājumu šeit, / prasmēm, @ konteksta pievienošanai",
     "prompts": {
       "noResults": "Nav atbilstošu uzvedņu",
-      "noShortcuts": "Vēl nav saīšņu. Pievienojiet tās sadaļā Zināšanas → Prasmes.",
+      "noShortcuts": "Prasmju vēl nav. Pievienojiet tās sadaļā Zināšanas → Prasmes.",
       "scope": {
         "private": "Jūsu uzvednes",
         "stock": "Iebūvētas",
@@ -384,7 +394,7 @@
     },
     "send": "Nosūtīt ziņu",
     "thinking": "Strādāju ar kontekstu",
-    "threads": "Sarunas",
+    "threads": "Vēsture",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Precizējuma pieprasīšana",
@@ -537,6 +547,7 @@
     "error": "Kļūda",
     "expenses": "Izdevumi",
     "filter": "Filtrs",
+    "history": "Vēsture",
     "invite": "Uzaicināt",
     "invoices": "Rēķini",
     "kind": "Veids",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Pievienot saīsni",
+      "addShortcut": "Pievienot prasmi",
       "defaultBadge": "Noklusējuma",
-      "deleteConfirmDescription": "Šī saīsne tiks neatgriezeniski dzēsta.",
-      "deleteConfirmTitle": "Dzēst saīsni?",
-      "deleteShortcut": "Dzēst saīsni",
-      "editShortcut": "Rediģēt saīsni",
-      "emptyState": "Vēl nav saīšņu. Pievienojiet pirmo.",
+      "deleteConfirmDescription": "Šī prasme tiks neatgriezeniski noņemta.",
+      "deleteConfirmTitle": "Dzēst prasmi?",
+      "deleteShortcut": "Dzēst prasmi",
+      "editShortcut": "Rediģēt prasmi",
+      "emptyState": "Prasmju vēl nav. Pievienojiet pirmo.",
       "errors": {
-        "commandConflict": "Saīsne ar šo komandu jau pastāv",
+        "commandConflict": "Prasme ar šo / nosaukumu jau pastāv",
         "commandInvalid": "Izmantojiet tikai mazos burtus, ciparus, defises un pasvītrojumus",
-        "commandReserved": "\"/{command}\" ir rezervēta komanda"
+        "commandReserved": "\"/{command}\" ir rezervēta prasme"
       },
       "form": {
-        "command": "Komanda",
-        "commandHint": "Tikai mazie burti, cipari, defises un pasvītrojumi",
+        "command": "Prasme",
+        "commandHint": "/ prasmes nosaukums: tikai mazie burti, cipari, defises un pasvītras",
         "commandPlaceholder": "piem. kopsavilkums",
         "commandPrefix": "/",
         "description": "Apraksts",
@@ -1078,7 +1089,7 @@
         "name": "Nosaukums",
         "namePlaceholder": "piem. Dokumenta kopsavilkums",
         "prompt": "Uzvedne",
-        "promptPlaceholder": "Teksts, kas tiek ievietots tērzēšanas redaktorā, izmantojot šo saīsni",
+        "promptPlaceholder": "Teksts, kas tiek ievietots čata kompozitorā, kad tiek izmantota šī prasme",
         "scope": "Redzamība",
         "scopePrivate": "Tikai es",
         "scopeTeam": "Visi organizācijā"

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -324,7 +324,7 @@ type Messages = {
     "attachment": "Attachment";
     "caseLawGreeting": "Ask about this decision — its full text is available here.";
     "chatAbout": "Chat about this";
-    "contextPlaceholder": "Chat about {context}";
+    "contextPlaceholder": "Chat about {context}, / for skills, @ to add context";
     "deleteThread": "Delete conversation";
     "documentView": {
       "original": "Original";
@@ -340,6 +340,16 @@ type Messages = {
     "fileTooLarge": "File exceeds {maxSize} limit";
     "folioCitationFallback": "p. {n}";
     "greeting": "What would you like to work on?";
+    "greetingSubtitle": "Start with a matter, document, or plain question.";
+    "landing": {
+      "lastAccessedMatters": "Last accessed matters";
+      "noMatters": "No matters yet";
+      "noPrompts": "No prompts yet";
+      "noRecentChats": "No recent chats";
+      "pinnedMatters": "Pinned matters";
+      "prompts": "Prompts";
+      "recentChats": "Recent chats";
+    };
     "maxAttachmentsReached": "Maximum {count} files per message";
     "mention": {
       "category": {
@@ -356,10 +366,10 @@ type Messages = {
     "moveToSide": "Move to side panel";
     "newChat": "New chat";
     "noThreads": "No conversations yet";
-    "placeholder": "What would you like to know?";
+    "placeholder": "Type your question here, / for skills, @ to add context";
     "prompts": {
       "noResults": "No matching prompts";
-      "noShortcuts": "No shortcuts yet. Add some in Knowledge → Skills.";
+      "noShortcuts": "No skills yet. Add some in Knowledge → Skills.";
       "scope": {
         "private": "Your prompts";
         "stock": "Built-in";
@@ -387,7 +397,7 @@ type Messages = {
     };
     "send": "Send message";
     "thinking": "Working with context";
-    "threads": "Conversations";
+    "threads": "History";
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits";
       "ask-user": "Asking for clarification";
@@ -540,6 +550,7 @@ type Messages = {
     "error": "Error";
     "expenses": "Expenses";
     "filter": "Filter";
+    "history": "History";
     "invite": "Invite";
     "invoices": "Invoices";
     "kind": "Kind";
@@ -1059,21 +1070,21 @@ type Messages = {
       };
     };
     "skills": {
-      "addShortcut": "Add shortcut";
+      "addShortcut": "Add skill";
       "defaultBadge": "Default";
-      "deleteConfirmDescription": "This shortcut will be permanently removed.";
-      "deleteConfirmTitle": "Delete shortcut?";
-      "deleteShortcut": "Delete shortcut";
-      "editShortcut": "Edit shortcut";
-      "emptyState": "No shortcuts yet. Add one to get started.";
+      "deleteConfirmDescription": "This skill will be permanently removed.";
+      "deleteConfirmTitle": "Delete skill?";
+      "deleteShortcut": "Delete skill";
+      "editShortcut": "Edit skill";
+      "emptyState": "No skills yet. Add your first one.";
       "errors": {
-        "commandConflict": "A shortcut with this command already exists";
+        "commandConflict": "A skill with this / name already exists";
         "commandInvalid": "Use only lowercase letters, digits, hyphens and underscores";
-        "commandReserved": "\"/{command}\" is a reserved command";
+        "commandReserved": "\"/{command}\" is a reserved skill";
       };
       "form": {
-        "command": "Command";
-        "commandHint": "Lowercase letters, digits, hyphens and underscores only";
+        "command": "Skill";
+        "commandHint": "The / skill name: lowercase letters, numbers, hyphens, and underscores only";
         "commandPlaceholder": "e.g. summarize";
         "commandPrefix": "/";
         "description": "Description";
@@ -1081,7 +1092,7 @@ type Messages = {
         "name": "Name";
         "namePlaceholder": "e.g. Summarise document";
         "prompt": "Prompt";
-        "promptPlaceholder": "The text inserted into the chat composer when this shortcut is used";
+        "promptPlaceholder": "The text inserted into the chat composer when this skill is used";
         "scope": "Visibility";
         "scopePrivate": "Only me";
         "scopeTeam": "Everyone in the organisation";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -321,7 +321,7 @@
     "attachment": "Załącznik",
     "caseLawGreeting": "Zapytaj mnie o to orzeczenie — mam dostęp do pełnej treści.",
     "chatAbout": "Omów na czacie",
-    "contextPlaceholder": "Czat o {context}",
+    "contextPlaceholder": "Czat o {context}, / dla umiejętności, @ aby dodać kontekst",
     "deleteThread": "Usuń rozmowę",
     "documentView": {
       "original": "Oryginał",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Plik przekracza limit {maxSize}",
     "folioCitationFallback": "s. {n}",
     "greeting": "Nad czym chcesz pracować?",
+    "greetingSubtitle": "Zacznij od sprawy, dokumentu albo prostego pytania.",
+    "landing": {
+      "lastAccessedMatters": "Ostatnio otwarte sprawy",
+      "noMatters": "Nie ma jeszcze spraw",
+      "noPrompts": "Nie ma jeszcze promptów",
+      "noRecentChats": "Brak ostatnich chatów",
+      "pinnedMatters": "Przypięte sprawy",
+      "prompts": "Prompty",
+      "recentChats": "Ostatnie chaty"
+    },
     "maxAttachmentsReached": "Maksymalnie {count} plików na wiadomość",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Przenieś do panelu bocznego",
     "newChat": "Nowy czat",
     "noThreads": "Brak rozmów",
-    "placeholder": "Co chciałbyś wiedzieć?",
+    "placeholder": "Wpisz pytanie tutaj, / dla umiejętności, @ aby dodać kontekst",
     "prompts": {
       "noResults": "Brak pasujących promptów",
-      "noShortcuts": "Brak skrótów. Dodaj je w sekcji Wiedza → Umiejętności.",
+      "noShortcuts": "Nie ma jeszcze umiejętności. Dodaj je w Wiedza → Umiejętności.",
       "scope": {
         "private": "Twoje prompty",
         "stock": "Wbudowane",
@@ -384,7 +394,7 @@
     },
     "send": "Wyślij wiadomość",
     "thinking": "Pracuję z kontekstem",
-    "threads": "Rozmowy",
+    "threads": "Historia",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Prośba o wyjaśnienie",
@@ -537,6 +547,7 @@
     "error": "Błąd",
     "expenses": "Wydatki",
     "filter": "Filtr",
+    "history": "Historia",
     "invite": "Zaproś",
     "invoices": "Faktury",
     "kind": "Rodzaj",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Dodaj skrót",
+      "addShortcut": "Dodaj umiejętność",
       "defaultBadge": "Domyślny",
-      "deleteConfirmDescription": "Ten skrót zostanie trwale usunięty.",
-      "deleteConfirmTitle": "Usunąć skrót?",
-      "deleteShortcut": "Usuń skrót",
-      "editShortcut": "Edytuj skrót",
-      "emptyState": "Brak skrótów. Dodaj pierwszy.",
+      "deleteConfirmDescription": "Ta umiejętność zostanie trwale usunięta.",
+      "deleteConfirmTitle": "Usunąć umiejętność?",
+      "deleteShortcut": "Usuń umiejętność",
+      "editShortcut": "Edytuj umiejętność",
+      "emptyState": "Nie ma jeszcze umiejętności. Dodaj pierwszą.",
       "errors": {
-        "commandConflict": "Skrót z tą komendą już istnieje",
+        "commandConflict": "Umiejętność o tej nazwie / już istnieje",
         "commandInvalid": "Używaj tylko małych liter, cyfr, myślników i podkreśleń",
-        "commandReserved": "\"/{command}\" jest zarezerwowaną komendą"
+        "commandReserved": "\"/{command}\" jest zarezerwowaną umiejętnością"
       },
       "form": {
-        "command": "Komenda",
-        "commandHint": "Tylko małe litery, cyfry, myślniki i podkreślenia",
+        "command": "Umiejętność",
+        "commandHint": "Nazwa umiejętności /: tylko małe litery, cyfry, myślniki i podkreślenia",
         "commandPlaceholder": "np. podsumuj",
         "commandPrefix": "/",
         "description": "Opis",
@@ -1078,7 +1089,7 @@
         "name": "Nazwa",
         "namePlaceholder": "np. Podsumuj dokument",
         "prompt": "Prompt",
-        "promptPlaceholder": "Tekst wstawiany do kompozytora czatu przy użyciu tego skrótu",
+        "promptPlaceholder": "Tekst wstawiany do kompozytora chatu po użyciu tej umiejętności",
         "scope": "Widoczność",
         "scopePrivate": "Tylko ja",
         "scopeTeam": "Wszyscy w organizacji"

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -321,7 +321,7 @@
     "attachment": "Príloha",
     "caseLawGreeting": "Spýtajte sa na toto rozhodnutie — plný text je k dispozícii.",
     "chatAbout": "Vložiť do AI chatu",
-    "contextPlaceholder": "Chat o {context}",
+    "contextPlaceholder": "Chat o {context}, / pre zručnosti, @ na pridanie kontextu",
     "deleteThread": "Zmazať konverzáciu",
     "documentView": {
       "original": "Originál",
@@ -337,6 +337,16 @@
     "fileTooLarge": "Súbor prekračuje limit {maxSize}",
     "folioCitationFallback": "str. {n}",
     "greeting": "Na čom chcete pracovať?",
+    "greetingSubtitle": "Začnite spisom, dokumentom alebo obyčajnou otázkou.",
+    "landing": {
+      "lastAccessedMatters": "Naposledy otvorené spisy",
+      "noMatters": "Zatiaľ žiadne spisy",
+      "noPrompts": "Zatiaľ žiadne prompty",
+      "noRecentChats": "Zatiaľ žiadne nedávne chaty",
+      "pinnedMatters": "Pripnuté spisy",
+      "prompts": "Prompty",
+      "recentChats": "Nedávne chaty"
+    },
     "maxAttachmentsReached": "Maximálne {count} súborov na správu",
     "mention": {
       "category": {
@@ -353,10 +363,10 @@
     "moveToSide": "Presunúť do bočného panela",
     "newChat": "Nový chat",
     "noThreads": "Zatiaľ žiadne konverzácie",
-    "placeholder": "Čo by ste chceli vedieť?",
+    "placeholder": "Sem napíšte svoju otázku, / pre zručnosti, @ na pridanie kontextu",
     "prompts": {
       "noResults": "Žiadne zhodné prompty",
-      "noShortcuts": "Zatiaľ žiadne skratky. Pridajte ich v časti Vedomosti → Zručnosti.",
+      "noShortcuts": "Zatiaľ žiadne zručnosti. Pridajte ich v časti Znalosti → Zručnosti.",
       "scope": {
         "private": "Vaše prompty",
         "stock": "Vstavané",
@@ -384,7 +394,7 @@
     },
     "send": "Odoslať správu",
     "thinking": "Pracujem s kontextom",
-    "threads": "Konverzácie",
+    "threads": "História",
     "tool": {
       "apply-active-docx-edits": "Applying DOCX edits",
       "ask-user": "Žiadosť o upresnenie",
@@ -537,6 +547,7 @@
     "error": "Chyba",
     "expenses": "Výdavky",
     "filter": "Filtrovať",
+    "history": "História",
     "invite": "Pozvať",
     "invoices": "Faktúry",
     "kind": "Druh",
@@ -1056,21 +1067,21 @@
       }
     },
     "skills": {
-      "addShortcut": "Pridať skratku",
+      "addShortcut": "Pridať zručnosť",
       "defaultBadge": "Predvolená",
-      "deleteConfirmDescription": "Táto skratka bude trvalo odstránená.",
-      "deleteConfirmTitle": "Odstrániť skratku?",
-      "deleteShortcut": "Odstrániť skratku",
-      "editShortcut": "Upraviť skratku",
-      "emptyState": "Zatiaľ žiadne skratky. Pridajte prvú.",
+      "deleteConfirmDescription": "Táto zručnosť bude natrvalo odstránená.",
+      "deleteConfirmTitle": "Zmazať zručnosť?",
+      "deleteShortcut": "Zmazať zručnosť",
+      "editShortcut": "Upraviť zručnosť",
+      "emptyState": "Žiadne zručnosti. Pridajte prvú.",
       "errors": {
-        "commandConflict": "Skratka s týmto príkazom už existuje",
+        "commandConflict": "Zručnosť s týmto / názvom už existuje",
         "commandInvalid": "Používajte iba malé písmená, číslice, pomlčky a podčiarkovníky",
-        "commandReserved": "\"/{command}\" je rezervovaný príkaz"
+        "commandReserved": "\"/{command}\" je rezervovaná zručnosť"
       },
       "form": {
-        "command": "Príkaz",
-        "commandHint": "Iba malé písmená, číslice, pomlčky a podčiarkovníky",
+        "command": "Zručnosť",
+        "commandHint": "Názov / zručnosti: iba malé písmená, číslice, pomlčky a podčiarkovníky",
         "commandPlaceholder": "napr. zhrnúť",
         "commandPrefix": "/",
         "description": "Popis",
@@ -1078,7 +1089,7 @@
         "name": "Názov",
         "namePlaceholder": "napr. Zhrnúť dokument",
         "prompt": "Výzva",
-        "promptPlaceholder": "Text vložený do skladača chatu pri použití tejto skratky",
+        "promptPlaceholder": "Text vložený do kompozéra chatu pri použití tejto zručnosti",
         "scope": "Viditeľnosť",
         "scopePrivate": "Len ja",
         "scopeTeam": "Všetci v organizácii"

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -15,6 +15,7 @@ import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
+import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import Tooltip from "@/components/tooltip";
 import {
@@ -23,6 +24,8 @@ import {
 } from "@/lib/chat-anonymized-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
+import type { ChatPrompt } from "@/lib/prompts/types";
+import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
 import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
@@ -49,6 +52,7 @@ export const ChatThreadPage = ({
   const getUserContext = useEffectEvent(() => userContext);
   const showToolCalls = useDevStore((state) => state.showToolCalls);
   const controller = useChatEditor({ threadRef });
+  const prompts = useSavedPrompts();
 
   // Local copy of the persisted contextMatterIds, seeded from the
   // server and re-seeded whenever the page navigates to a different
@@ -141,6 +145,15 @@ export const ChatThreadPage = ({
     void navigate({ to: "/chat" });
   };
 
+  const selectPrompt = (prompt: ChatPrompt) => {
+    const editor = controller.editor;
+    if (!editor) {
+      return;
+    }
+    editor.commands.setContent(prompt.body);
+    editor.commands.focus("end");
+  };
+
   return (
     <div className="flex w-full max-w-2xl flex-1 flex-col overflow-hidden">
       <div className="flex items-center justify-between gap-2 px-4 py-2">
@@ -192,20 +205,26 @@ export const ChatThreadPage = ({
 
       <Conversation>
         <ConversationContent className="gap-3">
-          <ChatThreadMessages
-            approvalPendingMessageId={approvalPendingMessageId}
-            autoApprovedTools={autoApprovedTools}
-            handleAlwaysAllow={handleAlwaysAllow}
-            handleApprove={handleApprove}
-            handleDeny={handleDeny}
-            isGenerating={isGenerating}
-            messages={messages}
-            onAskUserSubmit={handleAskUserSubmit}
-            showThinkingIndicator
-            showToolCalls={showToolCalls}
-            streamdownComponents={streamdownComponents}
-            workspaceId={workspaceId}
-          />
+          {messages.length === 0 && !isGenerating ? (
+            <div className="m-auto w-full max-w-md px-4">
+              <PromptSuggestions onSelect={selectPrompt} prompts={prompts} />
+            </div>
+          ) : (
+            <ChatThreadMessages
+              approvalPendingMessageId={approvalPendingMessageId}
+              autoApprovedTools={autoApprovedTools}
+              handleAlwaysAllow={handleAlwaysAllow}
+              handleApprove={handleApprove}
+              handleDeny={handleDeny}
+              isGenerating={isGenerating}
+              messages={messages}
+              onAskUserSubmit={handleAskUserSubmit}
+              showThinkingIndicator
+              showToolCalls={showToolCalls}
+              streamdownComponents={streamdownComponents}
+              workspaceId={workspaceId}
+            />
+          )}
         </ConversationContent>
         <ConversationScrollButton />
       </Conversation>

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { ReactNode } from "react";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -23,9 +24,21 @@ import type { SafeId } from "@/lib/safe-id";
 import { toSafeId } from "@/lib/safe-id";
 import { groupedChatThreadsOptions } from "@/routes/_protected.chat/-queries";
 
-export const ThreadsSheet = () => {
+type ThreadsSheetProps = {
+  icon?: ReactNode;
+  label?: string | undefined;
+  triggerVariant?: "section" | "toolbar";
+};
+
+export const ThreadsSheet = ({
+  icon,
+  label,
+  triggerVariant = "toolbar",
+}: ThreadsSheetProps) => {
   const t = useTranslations();
+  const commonT = useTranslations("common");
   const [isOpen, setIsOpen] = useState(false);
+  const triggerLabel = label ?? commonT("history");
 
   const globalThreadMatch = useMatch({
     from: "/_protected/chat/$threadId",
@@ -53,17 +66,31 @@ export const ThreadsSheet = () => {
 
   return (
     <Sheet onOpenChange={setIsOpen} open={isOpen}>
-      <SheetTrigger
-        render={
-          <Button aria-label={t("chat.threads")} size="sm" variant="ghost" />
-        }
-      >
-        <MessageSquareIcon className="size-4" />
-        {t("chat.threads")}
-      </SheetTrigger>
+      {triggerVariant === "section" ? (
+        <SheetTrigger
+          render={
+            <button
+              className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex items-center gap-2 rounded-md px-1 text-xs font-semibold tracking-widest uppercase transition-colors outline-none focus-visible:ring-2"
+              type="button"
+            />
+          }
+        >
+          {icon ?? <MessageSquareIcon className="size-4" />}
+          {triggerLabel}
+        </SheetTrigger>
+      ) : (
+        <SheetTrigger
+          render={
+            <Button aria-label={triggerLabel} size="sm" variant="ghost" />
+          }
+        >
+          <MessageSquareIcon className="size-4" />
+          {triggerLabel}
+        </SheetTrigger>
+      )}
       <SheetPopup side="right">
         <SheetHeader>
-          <SheetTitle>{t("chat.threads")}</SheetTitle>
+          <SheetTitle>{triggerLabel}</SheetTitle>
         </SheetHeader>
         <SheetPanel>
           <div className="flex flex-col gap-4">

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -1,33 +1,48 @@
-import { useEffectEvent, useRef } from "react";
+import { useEffectEvent, useMemo, useRef, useState } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import { Button } from "@stll/ui/components/button";
-import { useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { Maximize2Icon } from "lucide-react";
+import { cn } from "@stll/ui/lib/utils";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  HistoryIcon,
+  LayersIcon,
+  MessageSquareIcon,
+  Minimize2Icon,
+  PinIcon,
+} from "lucide-react";
 import { useTranslations } from "use-intl";
 import { v7 as uuidv7 } from "uuid";
 
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
-import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
+import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { useAIKeyGate } from "@/components/require-ai-key";
+import { StellaMark } from "@/components/stella-mark";
 import Tooltip from "@/components/tooltip";
+import { useI18nStore } from "@/i18n/i18n-store";
 import {
   getChatAnonymized,
   useChatAnonymized,
   useSetChatAnonymized,
 } from "@/lib/chat-anonymized-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
+import { usePinnedStore } from "@/lib/pinned-store";
+import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
+import { formatRelativeTime } from "@/lib/relative-time";
 import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
 import { buildChatRequestMessage } from "@/routes/_protected.chat/-lib/build-chat-request-message";
 import {
   chatThreadOptions,
+  groupedChatThreadsOptions,
   invalidateGroupedChatThreads,
 } from "@/routes/_protected.chat/-queries";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
 
 export const Route = createFileRoute("/_protected/chat/")({
   component: ChatIndex,
@@ -35,6 +50,7 @@ export const Route = createFileRoute("/_protected/chat/")({
 
 function ChatIndex() {
   const t = useTranslations();
+  const lang = useI18nStore((s) => s.lang);
   const { ensureAIAvailable } = useAIKeyGate();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -46,86 +62,404 @@ function ChatIndex() {
     threadId: threadIdRef.current,
   };
   const controller = useChatEditor({ threadRef });
-  const stockPrompts = useSavedPrompts();
+  const prompts = useSavedPrompts();
+  const pinnedOrder = usePinnedStore((s) => s.pinnedOrder);
+  const { data: workspacesData } = useQuery(workspacesNavigationOptions);
+  const workspaces = workspacesData?.workspaces;
+  const { data: groupedThreads } = useQuery(groupedChatThreadsOptions());
   const anonymized = useChatAnonymized(threadRef);
   const setAnonymized = useSetChatAnonymized(threadRef);
   const getAnonymized = useEffectEvent(() => getChatAnonymized(threadRef));
   const openInspectorChat = useInspectorStore((s) => s.openChat);
+  const [contextMatterIds, setContextMatterIds] = useState<string[]>([]);
+  const getContextMatterIds = useEffectEvent(() => contextMatterIds);
+  const [isComposerFocused, setIsComposerFocused] = useState(false);
+
+  const pinnedMatters = useMemo(() => {
+    const workspaceById = new Map<string, PinnedMatter>();
+    for (const workspace of workspaces ?? []) {
+      workspaceById.set(workspace.id, {
+        id: workspace.id,
+        lastActivityAt: workspace.lastActivityAt,
+        name: workspace.name,
+      });
+    }
+    const matters: PinnedMatter[] = [];
+    for (const workspaceId of pinnedOrder) {
+      const workspace = workspaceById.get(workspaceId);
+      if (workspace) {
+        matters.push(workspace);
+      }
+    }
+    return matters.slice(0, 5);
+  }, [pinnedOrder, workspaces]);
+
+  const lastAccessedMatters = useMemo(
+    () =>
+      (workspaces ?? [])
+        .toSorted(
+          (left, right) =>
+            new Date(right.lastActivityAt).getTime() -
+            new Date(left.lastActivityAt).getTime(),
+        )
+        .slice(0, 5)
+        .map((workspace) => ({
+          id: workspace.id,
+          lastActivityAt: workspace.lastActivityAt,
+          name: workspace.name,
+        })),
+    [workspaces],
+  );
+
+  const visibleMatters =
+    pinnedMatters.length > 0 ? pinnedMatters : lastAccessedMatters;
+  const mattersHeading =
+    pinnedMatters.length > 0
+      ? t("chat.landing.pinnedMatters")
+      : t("chat.landing.lastAccessedMatters");
+
+  const recentChats = useMemo(() => {
+    const threads: RecentChat[] = [];
+    for (const thread of groupedThreads?.global ?? []) {
+      threads.push({
+        scope: "global",
+        id: thread.id,
+        title: thread.title,
+        updatedAt: thread.updatedAt,
+      });
+    }
+    for (const workspace of groupedThreads?.workspaces ?? []) {
+      for (const thread of workspace.threads) {
+        threads.push({
+          scope: "workspace",
+          id: thread.id,
+          title: thread.title,
+          updatedAt: thread.updatedAt,
+          workspaceId: workspace.workspaceId,
+          workspaceName: workspace.workspaceName,
+        });
+      }
+    }
+    return threads
+      .toSorted(
+        (left, right) =>
+          new Date(right.updatedAt).getTime() -
+          new Date(left.updatedAt).getTime(),
+      )
+      .slice(0, 5);
+  }, [groupedThreads]);
+
+  const selectPrompt = (prompt: ChatPrompt) => {
+    const editor = controller.editor;
+    if (!editor) {
+      return;
+    }
+    editor.commands.setContent(prompt.body);
+    editor.commands.focus("end");
+  };
 
   const moveToSide = () => {
-    openInspectorChat({ id: threadIdRef.current });
+    openInspectorChat({
+      id: threadIdRef.current,
+      contextMatterIds,
+    });
     void navigate({ to: "/chat" });
   };
 
   return (
-    <div className="flex w-full max-w-2xl flex-1 flex-col overflow-hidden">
-      <div className="flex items-center justify-end gap-1 px-4 py-2">
-        <ChatAnonymizedToggle enabled={anonymized} onChange={setAnonymized} />
-        <Tooltip
-          content={t("chat.moveToSide")}
-          render={
-            <Button onClick={moveToSide} size="icon-sm" variant="ghost">
-              <Maximize2Icon className="size-4" />
-            </Button>
-          }
+    <div className="flex w-full max-w-5xl flex-1 flex-col overflow-hidden">
+      <div className="flex items-center justify-between gap-2 px-4 py-2">
+        <ChatMatterPicker
+          matterIds={contextMatterIds}
+          onChange={setContextMatterIds}
         />
-        <ThreadsSheet />
-      </div>
-      <div className="flex flex-1 flex-col items-center justify-center gap-6 px-4">
-        <h1 className="text-foreground text-2xl font-semibold">
-          {t("chat.greeting")}
-        </h1>
-        <div className="w-full">
-          <ChatInputSurface
-            autoFocus
-            controller={controller}
-            onSubmit={async (draft) => {
-              if (!(await ensureAIAvailable())) {
-                return;
-              }
-              // Build the request payload first, then resolve the
-              // Chat<> instance from the cache; the thread route
-              // reads the *same* cached instance, so kicking off
-              // `sendMessage` here lets the thread page observe
-              // the in-flight stream as soon as it mounts.
-              const message = await buildChatRequestMessage(draft);
-              const { chat } = await queryClient.ensureQueryData(
-                chatThreadOptions({
-                  key: threadRef,
-                  context: {
-                    allowMissingThread: true,
-                    getUserContext,
-                    getAnonymized,
-                  },
-                }),
-              );
-
-              // Fire-and-forget: don't block navigation on the
-              // streaming response. The thread page picks up the
-              // same Chat instance from cache and renders the
-              // user message + streaming reply as it arrives.
-              void chat.sendMessage(message);
-
-              await navigate({
-                to: "/chat/$threadId",
-                params: { threadId: threadIdRef.current },
-              });
-              void invalidateGroupedChatThreads(queryClient);
-            }}
+        <div className="flex items-center gap-1">
+          <ChatAnonymizedToggle enabled={anonymized} onChange={setAnonymized} />
+          <Tooltip
+            content={t("chat.moveToSide")}
+            render={
+              <Button onClick={moveToSide} size="icon-sm" variant="ghost">
+                <Minimize2Icon className="size-4" />
+              </Button>
+            }
           />
         </div>
-        <PromptSuggestions
-          onSelect={(prompt) => {
-            const editor = controller.editor;
-            if (!editor) {
-              return;
+      </div>
+      <div className="flex flex-1 flex-col items-center overflow-y-auto px-4 pb-16">
+        <div className="flex min-h-[22rem] w-full max-w-2xl shrink-0 flex-col items-center justify-center gap-8">
+          <div
+            className={cn(
+              "flex flex-col items-center gap-4 text-center transition-opacity duration-150",
+              isComposerFocused && "opacity-60",
+            )}
+          >
+            <div className="border-border bg-background text-foreground flex size-12 items-center justify-center rounded-lg border shadow-sm">
+              <StellaMark className="size-7" />
+            </div>
+            <p className="text-foreground max-w-md text-center text-lg font-medium">
+              {t("chat.greetingSubtitle")}
+            </p>
+          </div>
+          <div className="w-full">
+            <ChatInputSurface
+              autoFocus
+              controller={controller}
+              onFocusChange={setIsComposerFocused}
+              onSubmit={async (draft) => {
+                if (!(await ensureAIAvailable())) {
+                  return;
+                }
+                // Build the request payload first, then resolve the
+                // Chat<> instance from the cache; the thread route
+                // reads the *same* cached instance, so kicking off
+                // `sendMessage` here lets the thread page observe
+                // the in-flight stream as soon as it mounts.
+                const message = await buildChatRequestMessage(draft);
+                const { chat } = await queryClient.ensureQueryData(
+                  chatThreadOptions({
+                    key: threadRef,
+                    context: {
+                      allowMissingThread: true,
+                      getUserContext,
+                      getContextMatterIds,
+                      getAnonymized,
+                    },
+                  }),
+                );
+
+                // Fire-and-forget: don't block navigation on the
+                // streaming response. The thread page picks up the
+                // same Chat instance from cache and renders the
+                // user message + streaming reply as it arrives.
+                void chat.sendMessage(message);
+
+                await navigate({
+                  to: "/chat/$threadId",
+                  params: { threadId: threadIdRef.current },
+                });
+                void invalidateGroupedChatThreads(queryClient);
+              }}
+            />
+          </div>
+        </div>
+        <div
+          className={cn(
+            "grid min-h-52 w-full gap-8 transition-opacity duration-150 md:grid-cols-3",
+            isComposerFocused && "opacity-55",
+          )}
+        >
+          <LandingSection
+            heading={
+              <Link
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex items-center gap-2 rounded-md px-1 text-xs font-semibold tracking-widest uppercase transition-colors outline-none focus-visible:ring-2"
+                to="/workspaces"
+              >
+                <PinIcon className="size-4" />
+                {mattersHeading}
+              </Link>
             }
-            editor.commands.setContent(prompt.body);
-            editor.commands.focus("end");
-          }}
-          prompts={stockPrompts}
-        />
+          >
+            {visibleMatters.length > 0 ? (
+              visibleMatters.map((matter) => (
+                <Link
+                  className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
+                  key={matter.id}
+                  params={{ workspaceId: matter.id }}
+                  to="/workspaces/$workspaceId"
+                >
+                  <LandingItemText
+                    icon={<LayersIcon className="size-4" />}
+                    meta={formatRelativeTime(matter.lastActivityAt, lang)}
+                    title={matter.name}
+                  />
+                </Link>
+              ))
+            ) : (
+              <LandingEmpty>{t("chat.landing.noMatters")}</LandingEmpty>
+            )}
+          </LandingSection>
+          <LandingSection
+            heading={
+              <Link
+                className="text-muted-foreground hover:text-foreground focus-visible:ring-ring flex items-center gap-2 rounded-md px-1 text-xs font-semibold tracking-widest uppercase transition-colors outline-none focus-visible:ring-2"
+                to="/knowledge/skills"
+              >
+                <SlashPromptIcon />
+                {t("chat.landing.prompts")}
+              </Link>
+            }
+          >
+            {prompts.length > 0 ? (
+              prompts.map((prompt) => (
+                <LandingButton
+                  icon={<SlashPromptIcon />}
+                  key={prompt.id}
+                  meta={prompt.body}
+                  onClick={() => selectPrompt(prompt)}
+                  title={prompt.name}
+                />
+              ))
+            ) : (
+              <LandingEmpty>{t("chat.landing.noPrompts")}</LandingEmpty>
+            )}
+          </LandingSection>
+          <LandingSection
+            heading={
+              <ThreadsSheet
+                icon={<HistoryIcon className="size-4" />}
+                label={t("chat.landing.recentChats")}
+                triggerVariant="section"
+              />
+            }
+          >
+            {recentChats.length > 0 ? (
+              recentChats.map((chat) =>
+                chat.scope === "workspace" ? (
+                  <Link
+                    className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
+                    key={chat.id}
+                    params={{
+                      workspaceId: chat.workspaceId,
+                      threadId: chat.id,
+                    }}
+                    to="/chat/workspaces/$workspaceId/$threadId"
+                  >
+                    <LandingItemText
+                      icon={<MessageSquareIcon className="size-4" />}
+                      meta={`${chat.workspaceName} - ${formatRelativeTime(chat.updatedAt, lang)}`}
+                      title={chat.title}
+                    />
+                  </Link>
+                ) : (
+                  <Link
+                    className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
+                    key={chat.id}
+                    params={{ threadId: chat.id }}
+                    to="/chat/$threadId"
+                  >
+                    <LandingItemText
+                      icon={<MessageSquareIcon className="size-4" />}
+                      meta={formatRelativeTime(chat.updatedAt, lang)}
+                      title={chat.title}
+                    />
+                  </Link>
+                ),
+              )
+            ) : (
+              <LandingEmpty>{t("chat.landing.noRecentChats")}</LandingEmpty>
+            )}
+          </LandingSection>
+        </div>
       </div>
     </div>
   );
 }
+
+type PinnedMatter = {
+  id: string;
+  lastActivityAt: string | Date;
+  name: string;
+};
+
+type RecentChat =
+  | {
+      scope: "global";
+      id: string;
+      title: string;
+      updatedAt: string | Date;
+    }
+  | {
+      scope: "workspace";
+      id: string;
+      title: string;
+      updatedAt: string | Date;
+      workspaceId: string;
+      workspaceName: string;
+    };
+
+type LandingSectionProps = {
+  children: ReactNode;
+  heading: ReactNode;
+};
+
+const LandingSection = ({ children, heading }: LandingSectionProps) => (
+  <section className="min-w-0">
+    <div className="mb-3">{heading}</div>
+    <div className="flex flex-col gap-1">{children}</div>
+  </section>
+);
+
+type LandingButtonProps = {
+  icon?: ReactElement;
+  meta?: string | undefined;
+  onClick: () => void;
+  title: string;
+};
+
+const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
+  <button
+    className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
+    onClick={onClick}
+    type="button"
+  >
+    <span className="flex min-w-0 items-start gap-2">
+      {icon !== undefined && <LandingRowIcon>{icon}</LandingRowIcon>}
+      <span className="min-w-0 flex-1">
+        <span className="text-foreground block truncate text-sm font-medium">
+          {title}
+        </span>
+        {meta && (
+          <span className="text-muted-foreground block truncate text-xs">
+            {meta}
+          </span>
+        )}
+      </span>
+    </span>
+  </button>
+);
+
+type LandingItemTextProps = {
+  icon?: ReactElement;
+  meta?: string | undefined;
+  title: string;
+};
+
+const LandingItemText = ({ icon, meta, title }: LandingItemTextProps) => (
+  <span className="flex min-w-0 items-start gap-2">
+    {icon !== undefined && <LandingRowIcon>{icon}</LandingRowIcon>}
+    <span className="min-w-0 flex-1">
+      <span className="text-foreground block truncate text-sm font-medium">
+        {title}
+      </span>
+      {meta && (
+        <span className="text-muted-foreground block truncate text-xs">
+          {meta}
+        </span>
+      )}
+    </span>
+  </span>
+);
+
+type LandingRowIconProps = {
+  children: ReactElement;
+};
+
+const LandingRowIcon = ({ children }: LandingRowIconProps) => (
+  <span className="text-muted-foreground/55 group-hover:text-muted-foreground mt-0.5 flex size-4 shrink-0 items-center justify-center transition-colors">
+    {children}
+  </span>
+);
+
+const SlashPromptIcon = () => (
+  <span className="font-mono text-[13px] leading-none">/</span>
+);
+
+type LandingEmptyProps = {
+  children: ReactNode;
+};
+
+const LandingEmpty = ({ children }: LandingEmptyProps) => (
+  <div className="border-border text-muted-foreground rounded-md border border-dashed px-3 py-3 text-sm">
+    {children}
+  </div>
+);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -44,6 +44,7 @@ import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useAIKeyGate } from "@/components/require-ai-key";
+import { StellaMark } from "@/components/stella-mark";
 import Tooltip from "@/components/tooltip";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
@@ -186,6 +187,21 @@ export const ChatTabPanel = ({
     placeholder: t("chat.contextPlaceholder", { context: chatContextLabel }),
     threadRef,
   });
+  const focusComposer = editorController.focus;
+
+  useEffect(() => {
+    if (messages.length > 0 || isGenerating) {
+      return undefined;
+    }
+
+    const timer = window.setTimeout(() => {
+      focusComposer();
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [focusComposer, isGenerating, messages.length, tab.id]);
 
   const stockPrompts = useSavedPrompts();
   const handleSelectPrompt = (prompt: ChatPrompt) => {
@@ -347,17 +363,12 @@ type ChatEmptyStateProps = {
   onSelectPrompt: (prompt: ChatPrompt) => void;
 };
 
-const ChatEmptyState = ({ prompts, onSelectPrompt }: ChatEmptyStateProps) => {
-  const t = useTranslations();
-  return (
-    <div className="m-auto flex flex-col items-center gap-6 py-12">
-      <p className="text-foreground text-base font-medium">
-        {t("chat.greeting")}
-      </p>
-      <PromptSuggestions onSelect={onSelectPrompt} prompts={prompts} />
-    </div>
-  );
-};
+const ChatEmptyState = ({ prompts, onSelectPrompt }: ChatEmptyStateProps) => (
+  <div className="m-auto flex flex-col items-center gap-6 py-12">
+    <StellaMark className="text-foreground size-10" />
+    <PromptSuggestions onSelect={onSelectPrompt} prompts={prompts} />
+  </div>
+);
 
 const noop = () => {
   /* placeholder handler — replaced when the panel hydrates */


### PR DESCRIPTION
## Summary
- Refreshes the empty chat landing screen with Stella branding, matter context, prompt, and recent chat entry points.
- Renames chat history surfaces and updates slash-skill/context hints across composers.
- Keeps chat composers editable while responses stream and focuses new sidebar chat tabs.