### PR TITLE
fix: sync folio upstream fixes

### DIFF
--- a/packages/folio/NOTICE.md
+++ b/packages/folio/NOTICE.md
@@ -1,7 +1,8 @@
 # Third-Party Notice
 
-This package contains code originally from [Eigenpal docx-editor](https://github.com/eigenpal/docx-editor),
-licensed under the MIT License.
+This package contains code originally from [Eigenpal docx-editor](https://github.com/eigenpal/docx-editor).
+The upstream Eigenpal code was originally licensed under the MIT License;
+the original license text is reproduced below.
 
 ## Original MIT License
 

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -3045,8 +3045,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
         },
         getCurrentPage: () => scrollPageInfo.currentPage,
         getTotalPages: () => scrollPageInfo.totalPages,
-        scrollToPage: (_pageNumber: number) => {
-          // TODO: Implement page navigation in ProseMirror
+        scrollToPage: (pageNumber: number) => {
+          pagedEditorRef.current?.scrollToPage(pageNumber);
         },
         openPrintPreview: handleDirectPrint,
         print: handleDirectPrint,
@@ -3693,6 +3693,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                         commentsSidebarOpen={showCommentsSidebar}
                         anchorPositionMode="comments"
                         onAnchorPositionsChange={setAnchorPositions}
+                        onTotalPagesChange={(totalPages) => {
+                          setScrollPageInfo((previous) => ({
+                            ...previous,
+                            totalPages,
+                          }));
+                        }}
                         scrollContainerRef={scrollContainerRef}
                         sidebarOverlay={
                           showCommentsSidebar ? (

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -202,6 +202,8 @@ import { useHyperlinkHandlers } from "./hooks/useHyperlinkHandlers";
 import { useImageHandlers } from "./hooks/useImageHandlers";
 import { InlineHeaderFooterEditor } from "./InlineHeaderFooterEditor";
 import type { InlineHeaderFooterEditorRef } from "./InlineHeaderFooterEditor";
+import { updateScrollPageTotal } from "./scrollPageInfo";
+import type { ScrollPageInfo } from "./scrollPageInfo";
 import { TextContextMenu } from "./TextContextMenu";
 import type { TextContextAction, TextContextMenuItem } from "./TextContextMenu";
 import { ToolbarButton, ToolbarSeparator } from "./Toolbar";
@@ -1136,11 +1138,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     }, []);
 
     // Scroll-based page indicator (Google Docs style)
-    const [scrollPageInfo, setScrollPageInfo] = useState<{
-      currentPage: number;
-      totalPages: number;
-      visible: boolean;
-    }>({ currentPage: 1, totalPages: 1, visible: false });
+    const [scrollPageInfo, setScrollPageInfo] = useState<ScrollPageInfo>({
+      currentPage: 1,
+      totalPages: 1,
+      visible: false,
+    });
     const [bodyHistoryAvailability, setBodyHistoryAvailability] = useState({
       canRedo: false,
       canUndo: false,
@@ -3694,10 +3696,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                         anchorPositionMode="comments"
                         onAnchorPositionsChange={setAnchorPositions}
                         onTotalPagesChange={(totalPages) => {
-                          setScrollPageInfo((previous) => ({
-                            ...previous,
-                            totalPages,
-                          }));
+                          setScrollPageInfo((previous) =>
+                            updateScrollPageTotal(previous, totalPages),
+                          );
                         }}
                         scrollContainerRef={scrollContainerRef}
                         sidebarOverlay={

--- a/packages/folio/src/components/scrollPageInfo.test.ts
+++ b/packages/folio/src/components/scrollPageInfo.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { updateScrollPageTotal } from "./scrollPageInfo";
+
+describe("scroll page info", () => {
+  test("clamps current page when the document shrinks", () => {
+    expect(
+      updateScrollPageTotal(
+        { currentPage: 10, totalPages: 10, visible: true },
+        3,
+      ),
+    ).toEqual({ currentPage: 3, totalPages: 3, visible: true });
+  });
+
+  test("preserves current page when it remains in range", () => {
+    expect(
+      updateScrollPageTotal(
+        { currentPage: 2, totalPages: 5, visible: true },
+        4,
+      ),
+    ).toEqual({ currentPage: 2, totalPages: 4, visible: true });
+  });
+});

--- a/packages/folio/src/components/scrollPageInfo.ts
+++ b/packages/folio/src/components/scrollPageInfo.ts
@@ -1,0 +1,14 @@
+export type ScrollPageInfo = {
+  currentPage: number;
+  totalPages: number;
+  visible: boolean;
+};
+
+export const updateScrollPageTotal = (
+  previous: ScrollPageInfo,
+  totalPages: number,
+): ScrollPageInfo => ({
+  ...previous,
+  currentPage: Math.min(previous.currentPage, totalPages),
+  totalPages,
+});

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Page, ParagraphBlock } from "../layout-engine/types";
 import type { BlockLookup } from "./index";
-import { computePageFingerprint } from "./renderPage";
+import { computePageFingerprint, getDefaultPageFontFamily } from "./renderPage";
 
 const page: Page = {
   number: 1,
@@ -53,6 +53,14 @@ describe("render page fingerprint", () => {
   test("changes when comment annotations change without layout geometry changing", () => {
     expect(computePageFingerprint(page, lookup(blockWithComment()))).not.toBe(
       computePageFingerprint(page, lookup(blockWithComment(123))),
+    );
+  });
+});
+
+describe("page font fallback", () => {
+  test("uses the same metric-compatible Calibri fallback as text measurement", () => {
+    expect(getDefaultPageFontFamily()).toBe(
+      "Calibri, Carlito, Arial, Helvetica, sans-serif",
     );
   });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -28,6 +28,7 @@ import type {
   TextBoxFragment,
 } from "../layout-engine/types";
 import type { BorderSpec, Theme } from "../types/document";
+import { resolveFontFamily } from "../utils/fontResolver";
 import { borderToStyle } from "../utils/formatToStyle";
 import type { BlockLookup } from "./index";
 import { renderFragment } from "./renderFragment";
@@ -105,6 +106,9 @@ export const PAGE_CLASS_NAMES = {
 
 // RenderContext is re-exported from renderUtils
 export type { RenderContext } from "./renderUtils";
+
+export const getDefaultPageFontFamily = (): string =>
+  resolveFontFamily("Calibri").cssFallback;
 
 /**
  * Header/footer content for rendering
@@ -210,9 +214,10 @@ function applyPageStyles(
   element.style.boxShadow = "none";
   element.style.outline = "none";
 
-  // Set default font styles (matches Word default: 11pt Calibri)
-  // Individual runs will override these with their own font settings
-  element.style.fontFamily = 'Calibri, "Segoe UI", Arial, sans-serif';
+  // Set default font styles (matches Word default: 11pt Calibri).
+  // Keep this fallback chain aligned with canvas measurement so text widths
+  // do not drift when Calibri is unavailable and Carlito is used instead.
+  element.style.fontFamily = getDefaultPageFontFamily();
   // Use pixels to match Canvas-based measurements (11pt = 11 * 96/72 ≈ 14.67px)
   element.style.fontSize = `${(11 * 96) / 72}px`;
   element.style.color = "var(--doc-canvas-text, #000)";

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -42,6 +42,7 @@ import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
+import { suppressHiddenEditorScrollToSelection } from "./hiddenEditorScroll";
 import { isReadOnlyEditKey } from "./readOnlyEditAttempt";
 // Import ProseMirror CSS
 import "prosemirror-view/style/prosemirror.css";
@@ -306,6 +307,7 @@ const HiddenProseMirrorComponent = forwardRef<
 
         return onKeyDownRef.current?.(view, event) ?? false;
       },
+      handleScrollToSelection: suppressHiddenEditorScrollToSelection,
       // Prevent focus handling from interfering with visual layer
       handleDOMEvents: {
         focus: () => false,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -132,6 +132,10 @@ import {
 // Selection sync
 import { LayoutSelectionGate } from "./LayoutSelectionGate";
 import { isReadOnlyEditKey } from "./readOnlyEditAttempt";
+import {
+  getPageScrollTarget,
+  isValidPmScrollPosition,
+} from "./scrollNavigation";
 import { SelectionOverlay } from "./SelectionOverlay";
 import { getTransactionDirtyRange } from "./transactionDirtyRange";
 import { useDragAutoScroll } from "./useDragAutoScroll";
@@ -209,6 +213,8 @@ export type PagedEditorProps = {
   }) => void;
   /** Callback with pre-computed Y positions for comment/tracked-change anchors (for sidebar positioning without DOM queries). */
   onAnchorPositionsChange?: (positions: Map<string, number>) => void;
+  /** Callback when layout reports a different total page count. */
+  onTotalPagesChange?: (totalPages: number) => void;
   /** Which mark anchors should be mapped for sidebars/margin markers. */
   anchorPositionMode?: "comments" | "comments-and-revisions";
 };
@@ -244,6 +250,8 @@ export type PagedEditorRef = {
   relayout(): void;
   /** Scroll the visible pages to bring a PM position into view. */
   scrollToPosition(pmPos: number): void;
+  /** Scroll the visible pages to bring a page into view. */
+  scrollToPage(pageNumber: number): void;
 };
 
 // =============================================================================
@@ -1854,6 +1862,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onHyperlinkClick,
       onContextMenu,
       onAnchorPositionsChange,
+      onTotalPagesChange,
       anchorPositionMode = "comments-and-revisions",
     } = props;
 
@@ -1887,10 +1896,13 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // when parent passes unstable callback references
     const onSelectionChangeRef = useRef(onSelectionChange);
     const onDocumentChangeRef = useRef(onDocumentChange);
+    const onTotalPagesChangeRef = useRef(onTotalPagesChange);
+    const lastTotalPagesRef = useRef<number | null>(null);
 
     // Keep refs in sync with latest props
     onSelectionChangeRef.current = onSelectionChange;
     onDocumentChangeRef.current = onDocumentChange;
+    onTotalPagesChangeRef.current = onTotalPagesChange;
 
     // State
     const [layout, setLayout] = useState<Layout | null>(null);
@@ -3162,6 +3174,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
     /** Scroll visible pages to a ProseMirror position. */
     const scrollToPositionImpl = useCallback((pmPos: number) => {
+      if (!isValidPmScrollPosition(pmPos)) {
+        return;
+      }
+
       const pageContainer = pagesContainerRef.current;
       if (!pageContainer) {
         return;
@@ -3265,6 +3281,27 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       };
       requestAnimationFrame(refine);
     }, []);
+
+    const scrollToPageImpl = useCallback(
+      (pageNumber: number) => {
+        const target = getPageScrollTarget(layout, pageNumber);
+        if (!target) {
+          return;
+        }
+
+        if (target.type === "position") {
+          scrollToPositionImpl(target.pmPos);
+          return;
+        }
+
+        const pageContainer = pagesContainerRef.current;
+        const shell = pageContainer?.querySelector<HTMLElement>(
+          `[data-page-number="${String(target.pageIndex + 1)}"]`,
+        );
+        shell?.scrollIntoView({ block: "center", inline: "nearest" });
+      },
+      [layout, scrollToPositionImpl],
+    );
 
     const focusHiddenEditor = useCallback(() => {
       if (readOnly) {
@@ -4827,9 +4864,24 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           }
         },
         scrollToPosition: scrollToPositionImpl,
+        scrollToPage: scrollToPageImpl,
       }),
-      [layout, runLayoutPipeline, scrollToPositionImpl],
+      [layout, runLayoutPipeline, scrollToPageImpl, scrollToPositionImpl],
     );
+
+    useEffect(() => {
+      if (!layout) {
+        return;
+      }
+
+      const totalPages = layout.pages.length;
+      if (lastTotalPagesRef.current === totalPages) {
+        return;
+      }
+
+      lastTotalPagesRef.current = totalPages;
+      onTotalPagesChangeRef.current?.(totalPages);
+    }, [layout]);
 
     // Update selection overlay when layout changes
     // This is needed because handleEditorViewReady calls runLayoutPipeline which

--- a/packages/folio/src/paged-editor/hiddenEditorScroll.test.ts
+++ b/packages/folio/src/paged-editor/hiddenEditorScroll.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from "bun:test";
+
+import { suppressHiddenEditorScrollToSelection } from "./hiddenEditorScroll";
+
+describe("hidden editor scroll handling", () => {
+  test("claims selection scrolling so ProseMirror does not move visible ancestors", () => {
+    expect(suppressHiddenEditorScrollToSelection()).toBe(true);
+  });
+});

--- a/packages/folio/src/paged-editor/hiddenEditorScroll.ts
+++ b/packages/folio/src/paged-editor/hiddenEditorScroll.ts
@@ -1,0 +1,1 @@
+export const suppressHiddenEditorScrollToSelection = (): true => true;

--- a/packages/folio/src/paged-editor/scrollNavigation.test.ts
+++ b/packages/folio/src/paged-editor/scrollNavigation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Layout } from "../core/layout-engine/types";
+import {
+  getPageScrollTarget,
+  isValidPmScrollPosition,
+} from "./scrollNavigation";
+
+const layout = {
+  pages: [
+    {
+      number: 1,
+      margins: { top: 72, right: 72, bottom: 72, left: 72 },
+      size: { w: 816, h: 1056 },
+      fragments: [
+        {
+          kind: "paragraph",
+          blockId: "p1",
+          x: 72,
+          y: 72,
+          width: 672,
+          height: 24,
+          fromLine: 0,
+          toLine: 1,
+          pmStart: 4,
+          pmEnd: 20,
+        },
+      ],
+    },
+    {
+      number: 2,
+      margins: { top: 72, right: 72, bottom: 72, left: 72 },
+      size: { w: 816, h: 1056 },
+      fragments: [],
+    },
+  ],
+} satisfies Layout;
+
+describe("paged editor scroll navigation", () => {
+  test("uses the first fragment position for page navigation", () => {
+    expect(getPageScrollTarget(layout, 1)).toEqual({
+      type: "position",
+      pmPos: 4,
+    });
+  });
+
+  test("falls back to the page shell when a page has no positioned content", () => {
+    expect(getPageScrollTarget(layout, 2)).toEqual({
+      type: "pageShell",
+      pageIndex: 1,
+    });
+  });
+
+  test("rejects invalid page numbers", () => {
+    expect(getPageScrollTarget(layout, 0)).toBeNull();
+    expect(getPageScrollTarget(layout, 1.5)).toBeNull();
+    expect(getPageScrollTarget(layout, 3)).toBeNull();
+    expect(getPageScrollTarget(null, 1)).toBeNull();
+  });
+
+  test("rejects non-document positions before querying the DOM", () => {
+    expect(isValidPmScrollPosition(0)).toBe(true);
+    expect(isValidPmScrollPosition(42)).toBe(true);
+    expect(isValidPmScrollPosition(-1)).toBe(false);
+    expect(isValidPmScrollPosition(1.5)).toBe(false);
+    expect(isValidPmScrollPosition(Number.NaN)).toBe(false);
+  });
+});

--- a/packages/folio/src/paged-editor/scrollNavigation.ts
+++ b/packages/folio/src/paged-editor/scrollNavigation.ts
@@ -1,0 +1,40 @@
+import type { Layout } from "../core/layout-engine/types";
+
+export type PageScrollTarget =
+  | {
+      type: "position";
+      pmPos: number;
+    }
+  | {
+      type: "pageShell";
+      pageIndex: number;
+    };
+
+export const isValidPmScrollPosition = (pmPos: number): boolean =>
+  Number.isInteger(pmPos) && pmPos >= 0;
+
+export const getPageScrollTarget = (
+  layout: Layout | null,
+  pageNumber: number,
+): PageScrollTarget | null => {
+  if (!layout || !Number.isInteger(pageNumber) || pageNumber < 1) {
+    return null;
+  }
+
+  const pageIndex = pageNumber - 1;
+  const page = layout.pages[pageIndex];
+  if (!page) {
+    return null;
+  }
+
+  const pmStart = page.fragments.at(0)?.pmStart;
+  if (
+    typeof pmStart === "number" &&
+    Number.isInteger(pmStart) &&
+    pmStart >= 0
+  ) {
+    return { type: "position", pmPos: pmStart };
+  }
+
+  return { type: "pageShell", pageIndex };
+};


### PR DESCRIPTION

note: upstream, MIT licensed, code ported from https://github.com/eigenpal/docx-editor into our fork



## Summary
- align Folio page rendering font fallback with layout measurement
- suppress hidden ProseMirror selection scrolling
- wire page-count updates and page navigation through the editor API
- add regression coverage for the copied upstream behaviors