### PR TITLE
fix(release): skip migration-hash check during smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
           SMTP_PORT: "1025"
           TRANSACTIONAL_EMAIL_FROM: "noreply@example.com"
           USE_MOCK_AI: "true"
+          # Smoke test only verifies the binary boots; the database
+          # is empty so the startup migration-hash check would
+          # fail-closed and abort the build. Skip it here — the
+          # check stays active in real deploys via the production
+          # task definition env.
+          SKIP_MIGRATION_CHECK: "true"
         run: |
           cleanup_smoke() {
             docker rm -f stella-api-smoke >/dev/null 2>&1 || true
@@ -188,6 +194,7 @@ jobs:
             --env SMTP_PORT \
             --env TRANSACTIONAL_EMAIL_FROM \
             --env USE_MOCK_AI \
+            --env SKIP_MIGRATION_CHECK \
             stella-api:smoke
 
           for _ in {1..60}; do


### PR DESCRIPTION
## Summary
The release-build smoke step boots the compiled API container against an empty Postgres just to confirm the binary starts. The startup migration-hash check queries \`drizzle.__drizzle_migrations\` and fail-closes when the table doesn't exist — which the smoke DB by definition lacks, breaking the build.

Set \`SKIP_MIGRATION_CHECK=true\` for the smoke env. The check stays active in actual deploys via the production task-def env.

## Test plan
- [x] Smoke step now passes a fresh \`SKIP_MIGRATION_CHECK=true\` to the container
- [ ] After merge: rebuild v0.0.5 / next release; smoke step succeeds