### PR TITLE
feat(observability): include error.message and first stack frame in safe-handler logs

### DIFF
--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -258,6 +258,18 @@ const logAndCaptureSafeError = ({
     "error.type": errorTag(error),
   };
 
+  if (error instanceof Error) {
+    attributes["error.message"] = error.message.slice(0, 512);
+    if (error.stack) {
+      const firstFrame = error.stack
+        .split("\n")
+        .find((line) => line.trim().startsWith("at "));
+      if (firstFrame) {
+        attributes["error.frame"] = firstFrame.trim().slice(0, 256);
+      }
+    }
+  }
+
   if (reqCtx?.posthogDistinctId) {
     attributes["posthogDistinctId"] = reqCtx.posthogDistinctId;
   }


### PR DESCRIPTION
Adds `error.message` (truncated 512) and the first `at` stack frame (truncated 256) as attributes on the `request.failed` log record. Lets the runtime log stream show the actionable text inline.