### PR TITLE
fix: allow sharing personal matters

### DIFF
--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -386,9 +386,9 @@ export const workspaces = p.pgTable(
     name: p.varchar({ length: 256 }).notNull(),
     reference: p.varchar({ length: 64 }).notNull(),
     // Nullable: a null client_id encodes a personal matter (visible
-    // only to workspace_members). A non-null client_id is a normal
-    // client matter. Personal -> client is a one-way promotion
-    // handled by the update endpoint.
+    // only to the creator via workspace_members). A non-null client_id
+    // is a normal client matter. Personal -> client is a one-way
+    // promotion handled by the update endpoint.
     clientId: safeUuid<"contact">("client_id").references(() => contacts.id, {
       onDelete: "restrict",
     }),

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -386,9 +386,9 @@ export const workspaces = p.pgTable(
     name: p.varchar({ length: 256 }).notNull(),
     reference: p.varchar({ length: 64 }).notNull(),
     // Nullable: a null client_id encodes a personal matter (visible
-    // only to the creator via workspace_members). A non-null client_id
-    // is a normal client matter. Personal -> client is a one-way
-    // promotion handled by the update endpoint.
+    // only to workspace_members). A non-null client_id is a normal
+    // client matter. Personal -> client is a one-way promotion
+    // handled by the update endpoint.
     clientId: safeUuid<"contact">("client_id").references(() => contacts.id, {
       onDelete: "restrict",
     }),

--- a/apps/api/src/handlers/workspaces/create.ts
+++ b/apps/api/src/handlers/workspaces/create.ts
@@ -37,9 +37,9 @@ import { upsertWorkspaceSearchDocument } from "@/api/lib/search/index-global";
 
 const config = {
   permissions: { workspace: ["create"] },
-  // A request without `clientId` creates a personal matter (visible
-  // only to the creator). With `clientId`, it's a normal client
-  // matter and `memberUserIds` may add additional members.
+  // A request without `clientId` creates a personal matter (initially
+  // visible only to the creator). With `clientId`, it's a normal
+  // client matter and `memberUserIds` may add additional members.
   body: t.Object({
     id: tSafeId("workspace"),
     clientId: t.Optional(tSafeId("contact")),
@@ -59,9 +59,9 @@ const createWorkspaces = createSafeRootHandler(
     const txResult = yield* Result.await(
       safeDb(async (tx) => {
         const organizationId = session.activeOrganizationId;
-        // Personal matters (no clientId) always have exactly one
-        // member: the creator. Additional members can only be
-        // attached via promotion through the update endpoint.
+        // New personal matters (no clientId) start with exactly one
+        // member: the creator. Additional members can be attached
+        // through the workspace members endpoint after creation.
         const requestedMemberUserIds =
           body.clientId !== undefined && body.memberUserIds !== undefined
             ? Array.from(new Set(body.memberUserIds))
@@ -136,8 +136,8 @@ const createWorkspaces = createSafeRootHandler(
 
         // Membership verified above — brand each requested user ID.
         // Combined with the session user.id, this gives a typed list
-        // of org-validated members for the insert below. Personal
-        // matters always have exactly one member: the creator.
+        // of org-validated members for the insert below. New personal
+        // matters start with exactly one member: the creator.
         const workspaceMemberUserIds = Array.from(
           new Set([
             user.id,

--- a/apps/api/src/handlers/workspaces/workspace-members-add.test.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-add.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { auditLogs, workspaceMembers } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { createScopedDbMock } from "@/api/tests/scoped-db-mock";
 
@@ -36,23 +37,55 @@ const createContext = ({
       "ws_test123" as SafeId<"workspace">,
   }) as Parameters<typeof addWorkspaceMember.handler>[0];
 
-const workspaceSelect = (rows: { clientId: string | null }[]) => ({
-  from: () => ({
-    where: () => ({
-      for: async () => rows,
+const selectRowsInOrder = (rowsByCall: unknown[][]) => {
+  let callIndex = 0;
+
+  return () => ({
+    from: () => ({
+      where: () => ({
+        for: async () => rowsByCall.at(callIndex++) ?? [],
+      }),
     }),
-  }),
-});
+  });
+};
 
 describe("addWorkspaceMember", () => {
-  test("rejects adding a member to a personal matter", async () => {
+  test("adds a member to a personal matter", async () => {
+    const createdAt = new Date("2026-01-01T00:00:00.000Z");
+    const createdWorkspaceMemberId =
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- branded test value
+      Bun.randomUUIDv7() as SafeId<"workspaceMember">;
+    const insertedWorkspaceMembers: unknown[] = [];
+    const insertedAuditLogs: unknown[] = [];
     const { safeDb, scopedDb } = createScopedDbMock({
       query: {
         member: {
           findFirst: async () => ({ id: "member_existing" }),
         },
       },
-      select: () => workspaceSelect([{ clientId: null }]),
+      select: selectRowsInOrder([[{ id: "ws_test123" }], []]),
+      insert: (table: unknown) => ({
+        values: (value: unknown) => {
+          if (table === workspaceMembers) {
+            insertedWorkspaceMembers.push(value);
+            return {
+              returning: async () => [
+                {
+                  id: createdWorkspaceMemberId,
+                  userId: "user_invitee",
+                  createdAt,
+                },
+              ],
+            };
+          }
+
+          if (table === auditLogs) {
+            insertedAuditLogs.push(value);
+          }
+
+          return undefined;
+        },
+      }),
     });
 
     const result = await addWorkspaceMember.handler(
@@ -64,9 +97,17 @@ describe("addWorkspaceMember", () => {
     );
 
     expect(result).toEqual({
-      code: 400,
-      response: { message: "Assign a client before adding members" },
+      id: createdWorkspaceMemberId,
+      userId: "user_invitee",
+      createdAt,
     });
+    expect(insertedWorkspaceMembers).toEqual([
+      {
+        workspaceId: "ws_test123",
+        userId: "user_invitee",
+      },
+    ]);
+    expect(insertedAuditLogs).toHaveLength(1);
   });
 
   test("rejects when the workspace cannot be found", async () => {
@@ -76,7 +117,7 @@ describe("addWorkspaceMember", () => {
           findFirst: async () => ({ id: "member_existing" }),
         },
       },
-      select: () => workspaceSelect([]),
+      select: selectRowsInOrder([[]]),
     });
 
     const result = await addWorkspaceMember.handler(

--- a/apps/api/src/handlers/workspaces/workspace-members-add.test.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-add.test.ts
@@ -49,6 +49,11 @@ const selectRowsInOrder = (rowsByCall: unknown[][]) => {
   });
 };
 
+const isArrayWithLength = (
+  value: unknown,
+  length: number,
+): value is unknown[] => Array.isArray(value) && value.length === length;
+
 describe("addWorkspaceMember", () => {
   test("adds a member to a personal matter", async () => {
     const createdAt = new Date("2026-01-01T00:00:00.000Z");
@@ -108,6 +113,30 @@ describe("addWorkspaceMember", () => {
       },
     ]);
     expect(insertedAuditLogs).toHaveLength(1);
+    const auditBatch = insertedAuditLogs.at(0);
+    expect(isArrayWithLength(auditBatch, 1)).toBe(true);
+    if (!isArrayWithLength(auditBatch, 1)) {
+      throw new Error("Expected one audit log insert");
+    }
+    expect(auditBatch.at(0)).toEqual({
+      action: "update",
+      changes: {
+        membersAdded: {
+          old: null,
+          new: ["user_invitee"],
+        },
+      },
+      metadata: {
+        forwardedFor: null,
+        ipAddress: null,
+        userAgent: null,
+      },
+      organizationId: "org_test123",
+      resourceId: "ws_test123",
+      resourceType: "workspace",
+      userId: "user_test123",
+      workspaceId: "ws_test123",
+    });
   });
 
   test("rejects when the workspace cannot be found", async () => {

--- a/apps/api/src/handlers/workspaces/workspace-members-add.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-add.ts
@@ -5,6 +5,12 @@ import { t } from "elysia";
 import { workspaceMembers, workspaces } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createAuditContext,
+  writeAuditLog,
+} from "@/api/lib/audit-log";
 import { tUserId } from "@/api/lib/custom-schema";
 import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
@@ -21,7 +27,7 @@ const config = {
 
 const addWorkspaceMember = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, body }) {
+  async function* ({ safeDb, session, workspaceId, user, request, body }) {
     // Verify user is a member of the organization.
     // `member` is an org-level auth table (no RLS policy);
     // safeDb works for querying it.
@@ -47,14 +53,10 @@ const addWorkspaceMember = createSafeHandler(
     }
 
     const txResult = await safeDb(async (tx) => {
-      // Lock the workspace row first so a concurrent promote
-      // can't change clientId between this read and the insert.
-      // Personal matters (clientId IS NULL) are creator-only by
-      // contract; the frontend hides the "add member" affordance,
-      // but enforce it here too so the endpoint cannot be used to
-      // bypass that gate (defense in depth, SOC 2).
+      // Lock the workspace row first so concurrent workspace
+      // deletion or promotion cannot race this membership insert.
       const workspaceRows = await tx
-        .select({ clientId: workspaces.clientId })
+        .select({ id: workspaces.id })
         .from(workspaces)
         .where(eq(workspaces.id, workspaceId))
         .for("update");
@@ -62,10 +64,6 @@ const addWorkspaceMember = createSafeHandler(
 
       if (!workspace) {
         return { ok: false as const, reason: "not_found" as const };
-      }
-
-      if (workspace.clientId === null) {
-        return { ok: false as const, reason: "personal" as const };
       }
 
       // Lock workspace_members rows then count to serialize concurrent adds.
@@ -93,6 +91,27 @@ const addWorkspaceMember = createSafeHandler(
           createdAt: workspaceMembers.createdAt,
         });
 
+      await writeAuditLog(
+        {
+          ...createAuditContext({
+            organizationId: session.activeOrganizationId,
+            workspaceId,
+            userId: user.id,
+            request,
+          }),
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,
+          resourceId: workspaceId,
+          changes: {
+            membersAdded: {
+              old: null,
+              new: [body.userId],
+            },
+          },
+        },
+        tx,
+      );
+
       return { ok: true as const, rows };
     });
 
@@ -115,14 +134,6 @@ const addWorkspaceMember = createSafeHandler(
       if (txResult.value.reason === "not_found") {
         return Result.err(
           new HandlerError({ status: 404, message: "Workspace not found" }),
-        );
-      }
-      if (txResult.value.reason === "personal") {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Assign a client before adding members",
-          }),
         );
       }
       return Result.err(

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -619,9 +619,8 @@ export const resolveAccessibleWorkspaces = async (
   if (ADMIN_BYPASS_ROLES.includes(memberRole)) {
     // Admins see every client matter in the org, plus any personal
     // matter (clientId IS NULL) they themselves are a member of.
-    // Without this gate, an org owner could open another user's
-    // personal scratchpad by URL — violates the "creator-only"
-    // contract enforced for personal matters.
+    // Without this gate, an org owner could open a personal
+    // scratchpad they were not explicitly added to by URL.
     const accessibleWorkspaces = await db
       .select({
         id: workspaces.id,

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -479,7 +479,6 @@ const MatterItem = ({
                 <MenuSeparator />
                 <MatterMenuItems
                   isArchived={false}
-                  isPersonal={!ws.client}
                   isPinned={isPinned}
                   onAddMember={() => setAddMemberOpen(true)}
                   onArchive={() =>

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -64,7 +64,6 @@ export const MatterCard = ({
 
   return (
     <MatterContextMenu
-      isPersonal={!workspace.client}
       workspaceId={workspace.id}
       workspaceName={workspace.name ?? t("workspaces.defaultName")}
     >

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -78,9 +78,6 @@ export type MatterMenuCallbacks = {
   onDelete: () => void;
   isPinned: boolean;
   isArchived: boolean;
-  // Personal matters are creator-only until promoted; the backend
-  // rejects member adds with 400, so hide the affordance here.
-  isPersonal: boolean;
 };
 
 /**
@@ -98,7 +95,6 @@ export const MatterMenuItems = ({
   onDelete,
   isPinned,
   isArchived,
-  isPersonal,
 }: MatterMenuCallbacks) => {
   const t = useTranslations();
 
@@ -112,12 +108,10 @@ export const MatterMenuItems = ({
         <PenLineIcon />
         {t("common.rename")}
       </MenuItem>
-      {!isPersonal && (
-        <MenuItem onClick={onAddMember}>
-          <UserPlusIcon />
-          {t("workspaces.members.addMember")}
-        </MenuItem>
-      )}
+      <MenuItem onClick={onAddMember}>
+        <UserPlusIcon />
+        {t("workspaces.members.addMember")}
+      </MenuItem>
       <MenuItem onClick={onCopyLink}>
         <ClipboardCopyIcon />
         {t("common.copyLink")}
@@ -159,7 +153,6 @@ type MatterContextMenuProps = {
   workspaceId: string;
   workspaceName: string;
   isArchived?: boolean;
-  isPersonal: boolean;
   children: React.ReactNode | ((rename: RenameState) => React.ReactNode);
 };
 
@@ -167,7 +160,6 @@ export const MatterContextMenu = ({
   workspaceId,
   workspaceName,
   isArchived = false,
-  isPersonal,
   children,
 }: MatterContextMenuProps) => {
   const t = useTranslations();
@@ -293,7 +285,6 @@ export const MatterContextMenu = ({
         <MenuPopup anchor={menuAnchor ?? undefined} className="z-50">
           <MatterMenuItems
             isArchived={isArchived}
-            isPersonal={isPersonal}
             isPinned={pinned}
             onAddMember={() => setAddMemberOpen(true)}
             onOpenInNewTab={() => {

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -11,9 +11,9 @@ import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 const DEFAULT_FILE_PROPERTY_NAME = "Documents";
 
 type CreateWorkspaceVars = {
-  // Omit `clientId` to create a personal matter (visible only to
-  // the creator). With `clientId`, `memberUserIds` may add other
-  // members; for personal matters that field is ignored.
+  // Omit `clientId` to create a personal matter (initially visible
+  // only to the creator). With `clientId`, `memberUserIds` may add
+  // other members; for personal matters that field is ignored.
   clientId?: string;
   memberUserIds?: string[];
   name: string;


### PR DESCRIPTION
jk: reason:: for betatesting it is easiest to create "personal" matters without the levle of client above. as such, lets allow sharing them, personal as in "no client" and not "mine only [not shared with team]"


## Summary
- Allow adding organization members to matters without an assigned client.
- Keep workspace permission and organization membership checks, and audit member additions.
- Show Add member consistently in matter menus.