### PR TITLE
fix: lowercase transactional email sender

### DIFF
--- a/apps/api/src/lib/email/from.test.ts
+++ b/apps/api/src/lib/email/from.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatTransactionalEmailFrom } from "./from";
+
+describe("formatTransactionalEmailFrom", () => {
+  test("adds the stella sender name to bare addresses", () => {
+    expect(formatTransactionalEmailFrom("noreply@example.com")).toBe(
+      "stella <noreply@example.com>",
+    );
+  });
+
+  test("replaces an existing sender name while preserving the address", () => {
+    expect(formatTransactionalEmailFrom("Stella <noreply@example.com>")).toBe(
+      "stella <noreply@example.com>",
+    );
+  });
+});

--- a/apps/api/src/lib/email/from.ts
+++ b/apps/api/src/lib/email/from.ts
@@ -1,0 +1,13 @@
+const TRANSACTIONAL_EMAIL_SENDER_NAME = "stella";
+
+export const formatTransactionalEmailFrom = (fromAddress: string): string => {
+  const trimmedAddress = fromAddress.trim();
+  const addressStart = trimmedAddress.lastIndexOf("<");
+
+  if (addressStart !== -1 && trimmedAddress.endsWith(">")) {
+    const address = trimmedAddress.slice(addressStart + 1, -1).trim();
+    return `${TRANSACTIONAL_EMAIL_SENDER_NAME} <${address}>`;
+  }
+
+  return `${TRANSACTIONAL_EMAIL_SENDER_NAME} <${trimmedAddress}>`;
+};

--- a/apps/api/src/lib/email/index.tsx
+++ b/apps/api/src/lib/email/index.tsx
@@ -7,6 +7,7 @@ import { panic } from "better-result";
 import { env } from "@/api/env";
 import type { SupportedLang } from "@/api/lib/locale";
 
+import { formatTransactionalEmailFrom } from "./from";
 import { createSESTransport } from "./ses";
 import { createSMTPTransport } from "./smtp";
 import type { EmailTransport } from "./transport";
@@ -56,6 +57,9 @@ const getTransport = (): EmailTransport => {
   return cachedTransport;
 };
 
+const getTransactionalEmailFrom = () =>
+  formatTransactionalEmailFrom(env.TRANSACTIONAL_EMAIL_FROM);
+
 type SendOTPEmailProps = {
   email: string;
   otp: string;
@@ -76,7 +80,7 @@ export const sendOTPEmail = async ({
   ]);
 
   await getTransport().send({
-    from: env.TRANSACTIONAL_EMAIL_FROM,
+    from: getTransactionalEmailFrom(),
     to: email,
     subject: BetterAuthOTP.subject(lang),
     html,
@@ -116,7 +120,7 @@ export const sendNewDeviceLoginEmail = async ({
   ]);
 
   await getTransport().send({
-    from: env.TRANSACTIONAL_EMAIL_FROM,
+    from: getTransactionalEmailFrom(),
     to: email,
     subject: NewDeviceLogin.subject(lang),
     html,
@@ -153,7 +157,7 @@ export const sendOrganizationInvitation = async ({
   ]);
 
   await getTransport().send({
-    from: env.TRANSACTIONAL_EMAIL_FROM,
+    from: getTransactionalEmailFrom(),
     to: email,
     subject: OrganizationInvitation.subject(lang, {
       organizationName,


### PR DESCRIPTION
## Summary

- Format transactional email `From` headers with the display name `stella`
- Preserve the configured sender address for SES and SMTP delivery
- Cover bare and already-formatted sender addresses with a focused test
