### PR TITLE
fix: localize expired one-time code error

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -75,6 +75,7 @@
       "title": "Pozvánka do organizace"
     },
     "lastUsed": "Naposledy použito",
+    "oneTimeCodeExpired": "Platnost jednorázového kódu vypršela. Požádejte o nový kód.",
     "openInProvider": "Otevřít {provider}",
     "orSignInWithEmail": "nebo se přihlaste e-mailem",
     "organizationNamePlaceholder": "Moje organizace",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -75,6 +75,7 @@
       "title": "Einladung zur Organisation"
     },
     "lastUsed": "Zuletzt verwendet",
+    "oneTimeCodeExpired": "Ihr Einmalcode ist abgelaufen. Fordern Sie einen neuen Code an.",
     "openInProvider": "{provider} öffnen",
     "orSignInWithEmail": "oder mit E-Mail anmelden",
     "organizationNamePlaceholder": "Meine Organisation",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -75,6 +75,7 @@
       "title": "Organization invitation"
     },
     "lastUsed": "Last used",
+    "oneTimeCodeExpired": "Your one-time code has expired. Request a new code.",
     "openInProvider": "Open {provider}",
     "orSignInWithEmail": "or sign in with email",
     "organizationNamePlaceholder": "My organization",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -75,6 +75,7 @@
       "title": "Invitación a la organización"
     },
     "lastUsed": "Último utilizado",
+    "oneTimeCodeExpired": "Tu código de un solo uso ha caducado. Solicita un código nuevo.",
     "openInProvider": "Abrir {provider}",
     "orSignInWithEmail": "o inicia sesión con el correo electrónico",
     "organizationNamePlaceholder": "Mi Organización",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -75,6 +75,7 @@
       "title": "Kutse organisatsiooni"
     },
     "lastUsed": "Viimati kasutatud",
+    "oneTimeCodeExpired": "Sinu ühekordne kood on aegunud. Küsi uus kood.",
     "openInProvider": "Ava {provider}",
     "orSignInWithEmail": "või logi sisse e-postiga",
     "organizationNamePlaceholder": "Minu organisatsioon",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -75,6 +75,7 @@
       "title": "Invitation à l'organisation"
     },
     "lastUsed": "Dernière utilisation",
+    "oneTimeCodeExpired": "Votre code à usage unique a expiré. Demandez un nouveau code.",
     "openInProvider": "Ouvrir {provider}",
     "orSignInWithEmail": "ou connectez-vous avec l'e-mail",
     "organizationNamePlaceholder": "Mon organisation",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -75,6 +75,7 @@
       "title": "Szervezeti meghívó"
     },
     "lastUsed": "Legutóbb használt",
+    "oneTimeCodeExpired": "Az egyszer használatos kód lejárt. Kérjen új kódot.",
     "openInProvider": "{provider} megnyitása",
     "orSignInWithEmail": "vagy jelentkezz be e-maillel",
     "organizationNamePlaceholder": "Szervezetem",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -75,6 +75,7 @@
       "title": "Kvietimas į organizaciją"
     },
     "lastUsed": "Paskutinį kartą naudotas",
+    "oneTimeCodeExpired": "Jūsų vienkartinio kodo galiojimas baigėsi. Paprašykite naujo kodo.",
     "openInProvider": "Atverti {provider}",
     "orSignInWithEmail": "arba prisijunkite el. paštu",
     "organizationNamePlaceholder": "Mano organizacija",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -75,6 +75,7 @@
       "title": "Uzaicinājums organizācijā"
     },
     "lastUsed": "Pēdējoreiz izmantots",
+    "oneTimeCodeExpired": "Jūsu vienreizējā koda derīguma termiņš ir beidzies. Pieprasiet jaunu kodu.",
     "openInProvider": "Atvērt {provider}",
     "orSignInWithEmail": "vai pierakstieties ar e-pastu",
     "organizationNamePlaceholder": "Mana organizācija",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -78,6 +78,7 @@ type Messages = {
       "title": "Organization invitation";
     };
     "lastUsed": "Last used";
+    "oneTimeCodeExpired": "Your one-time code has expired. Request a new code.";
     "openInProvider": "Open {provider}";
     "orSignInWithEmail": "or sign in with email";
     "organizationNamePlaceholder": "My organization";
@@ -1171,12 +1172,11 @@ type Messages = {
       "apiKey": "API key";
       "apiKeyConfiguredPlaceholder": "Configured: {key}. Enter a new key to replace it.";
       "apiKeyPlaceholder": "Enter your API key";
-      "chooseModelsSubtitle": "Pick a model for each role. Prices update on the right.";
-      "chooseModelsTitle": "Choose models";
-      "editProviders": "Edit providers";
       "apiKeySaved": "Saved key {key}";
       "apiKeyUpdatePlaceholder": "Enter new key to update";
       "baseUrl": "Base URL";
+      "chooseModelsSubtitle": "Pick a model for each role. Prices update on the right.";
+      "chooseModelsTitle": "Choose models";
       "configure": "Configure";
       "credentialsPanel": "Key";
       "customModelBadge": "Custom · {provider}";
@@ -1188,6 +1188,7 @@ type Messages = {
       "defaultModel": "Default: {model}";
       "defaultModelOption": "Default";
       "description": "Bring your own API key or configure data sovereignty region.";
+      "editProviders": "Edit providers";
       "keepSavedKey": "Keep saved key";
       "modelForRole": "{role} model";
       "modelIdPlaceholder": "Search models";
@@ -1199,8 +1200,6 @@ type Messages = {
       "noModelResults": "No matching offered models";
       "overrideRoles": "Override roles";
       "overrideRolesDescription": "Choose which roles use this key, then choose a model for each role. Unselected roles use the platform default.";
-      "provider": "Provider";
-      "providerForRole": "{role} provider";
       "prices": {
         "empty": "Add a provider to see model prices";
         "emptyHint": "Pick a provider on the left and we will show pricing for its models here.";
@@ -1213,6 +1212,8 @@ type Messages = {
         "title": "Model prices";
         "typicalCallHint": "Per-1M-token rates · per-call estimate uses {input} in / {output} out";
       };
+      "provider": "Provider";
+      "providerForRole": "{role} provider";
       "providerKeyInvalid": "{provider} rejected the key. Double-check it before saving.";
       "providerKeyInvalidShort": "Invalid";
       "providers": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -75,6 +75,7 @@
       "title": "Zaproszenie do organizacji"
     },
     "lastUsed": "Ostatnio użyte",
+    "oneTimeCodeExpired": "Twój kod jednorazowy wygasł. Poproś o nowy kod.",
     "openInProvider": "Otwórz {provider}",
     "orSignInWithEmail": "lub zaloguj się e-mailem",
     "organizationNamePlaceholder": "Moja organizacja",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -75,6 +75,7 @@
       "title": "Pozvánka do organizácie"
     },
     "lastUsed": "Naposledy použité",
+    "oneTimeCodeExpired": "Platnosť jednorazového kódu vypršala. Požiadajte o nový kód.",
     "openInProvider": "Otvoriť {provider}",
     "orSignInWithEmail": "alebo sa prihláste e-mailom",
     "organizationNamePlaceholder": "Moja organizácia",

--- a/apps/web/src/routes/auth/otp.tsx
+++ b/apps/web/src/routes/auth/otp.tsx
@@ -30,6 +30,7 @@ import { COMMON_TIMEZONES } from "@/lib/timezones";
 import { InboxQuickJump } from "./-components/inbox-quick-jump";
 
 const OTP_LENGTH = 6;
+const OTP_EXPIRED_MESSAGE = "OTP expired";
 
 const searchSchema = v.strictObject({
   email: emailSchema(),
@@ -107,7 +108,10 @@ function OTP() {
         setOtp("");
         if (signInError.status !== HTTP_TOO_MANY_REQUESTS) {
           toastManager.add({
-            title: signInError.message ?? t("errors.actionFailed"),
+            title:
+              signInError.message === OTP_EXPIRED_MESSAGE
+                ? t("auth.oneTimeCodeExpired")
+                : (signInError.message ?? t("errors.actionFailed")),
             type: "error",
           });
         }


### PR DESCRIPTION
Localizes the expired one-time code error shown during email-code sign-in and adds translations for all web locales.