### PR TITLE
fix(folio): stabilize folio document preview search

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -184,8 +184,9 @@ import {
 import type { CommentMarkRange } from "./commentAnchors";
 import { CommentsSidebar } from "./CommentsSidebar";
 import type { TrackedChangeEntry } from "./CommentsSidebar";
-import { useHyperlinkDialog } from "./dialogs/HyperlinkDialog";
 // Dialog hooks and utilities (static imports — lightweight, no UI)
+import type { FindMatch } from "./dialogs/findReplaceUtils";
+import { useHyperlinkDialog } from "./dialogs/HyperlinkDialog";
 import { useFindReplace as useFindReplaceState } from "./dialogs/useFindReplace";
 import {
   DefaultLoadingIndicator,
@@ -194,6 +195,7 @@ import {
 } from "./DocxEditorHelpers";
 import { ErrorBoundary, ErrorProvider } from "./ErrorBoundary";
 import { FormattingBar } from "./FormattingBar";
+import { resolveFindMatchRange } from "./hooks/findReplaceSelection";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 import { useDocumentLoader } from "./hooks/useDocumentLoader";
 import { useFindReplace } from "./hooks/useFindReplace";
@@ -1541,6 +1543,25 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       [replaceComments],
     );
 
+    const selectFindMatch = useCallback((match: FindMatch): boolean => {
+      const editor = pagedEditorRef.current;
+      const view = editor?.getView();
+      if (!editor || !view) {
+        return false;
+      }
+
+      const range = resolveFindMatchRange(view.state.doc, match);
+      if (!range) {
+        return false;
+      }
+
+      editor.setSelection(range.from, range.to);
+      requestAnimationFrame(() => {
+        editor.scrollToPosition(range.from);
+      });
+      return true;
+    }, []);
+
     // Find/Replace handlers (depends on handleDocumentChange)
     const {
       findResultRef,
@@ -1550,10 +1571,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       handleReplace,
       handleReplaceAll,
     } = useFindReplace({
-      documentState: history.state,
+      getDocumentState: buildCurrentDocument,
       containerRef,
       handleDocumentChange,
       findReplace,
+      selectMatch: selectFindMatch,
     });
 
     // Handle selection changes from ProseMirror
@@ -1939,6 +1961,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
 
     // Keyboard shortcuts for Find/Replace (Ctrl+F, Ctrl+H) and delete table selection
     useEffect(() => {
+      const openFindFromSelection = () => {
+        const selection = window.getSelection();
+        const selectedText =
+          selection && !selection.isCollapsed ? selection.toString() : "";
+        findReplace.openFind(selectedText);
+      };
+
       const handleKeyDown = (e: KeyboardEvent) => {
         // Check for Ctrl+F (Find) or Ctrl+H (Replace)
         const isMac = navigator.platform.toUpperCase().includes("MAC");
@@ -1995,20 +2024,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
         }
 
         if (cmdOrCtrl && !e.shiftKey && !e.altKey) {
-          if (e.key.toLowerCase() === "f") {
+          if (e.key.toLowerCase() === "f" || e.key.toLowerCase() === "h") {
             e.preventDefault();
-            // Get selected text if any
-            const selection = window.getSelection();
-            const selectedText =
-              selection && !selection.isCollapsed ? selection.toString() : "";
-            findReplace.openFind(selectedText);
-          } else if (e.key.toLowerCase() === "h") {
-            e.preventDefault();
-            // Get selected text if any
-            const selection = window.getSelection();
-            const selectedText =
-              selection && !selection.isCollapsed ? selection.toString() : "";
-            findReplace.openReplace(selectedText);
+            openFindFromSelection();
           } else if (e.key.toLowerCase() === "p" && !e.repeat) {
             e.preventDefault();
             handleDirectPrint();
@@ -4069,7 +4087,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                   onReplace={handleReplace}
                   onReplaceAll={handleReplaceAll}
                   initialSearchText={findReplace.state.searchText}
-                  replaceMode={findReplace.state.dialog.mode === "replace"}
                   currentResult={findResultRef.current}
                 />
               )}

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -23,6 +23,8 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { getFindReplaceOverlayStyle } from "./findReplaceDialogLayout";
+import { getFindEnterAction } from "./findReplaceInteraction";
 import type { FindOptions, FindResult, FindMatch } from "./findReplaceUtils";
 
 // Re-export types and utilities so existing imports still work
@@ -109,12 +111,9 @@ export function FindReplaceDialog({
   onFind,
   onFindNext,
   onFindPrevious,
-  onReplace,
-  onReplaceAll,
   onHighlightMatches,
   onClearHighlights,
   initialSearchText = "",
-  replaceMode = false,
   currentResult,
   className,
   style,
@@ -122,15 +121,12 @@ export function FindReplaceDialog({
   const t = useTranslations("folio");
   // State
   const [searchText, setSearchText] = useState("");
-  const [replaceText, setReplaceText] = useState("");
-  const [showReplace, setShowReplace] = useState(replaceMode);
   const [matchCase, setMatchCase] = useState(false);
   const [matchWholeWord, setMatchWholeWord] = useState(false);
   const [result, setResult] = useState<FindResult | null>(null);
 
   // Refs
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const replaceInputRef = useRef<HTMLInputElement>(null);
 
   // Sync with external result if provided
   useEffect(() => {
@@ -143,8 +139,6 @@ export function FindReplaceDialog({
   useEffect(() => {
     if (isOpen) {
       setSearchText(initialSearchText);
-      setReplaceText("");
-      setShowReplace(replaceMode);
       setResult(null);
 
       setTimeout(() => {
@@ -166,7 +160,7 @@ export function FindReplaceDialog({
       onClearHighlights();
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, initialSearchText, replaceMode]);
+  }, [isOpen, initialSearchText]);
 
   const performSearch = useCallback(() => {
     if (!searchText.trim()) {
@@ -201,40 +195,50 @@ export function FindReplaceDialog({
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [matchCase, matchWholeWord]);
 
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    if (!searchText.trim()) {
+      setResult(null);
+      onClearHighlights?.();
+      return undefined;
+    }
+
+    const timeout = setTimeout(performSearch, 120);
+    return () => clearTimeout(timeout);
+  }, [isOpen, searchText, performSearch, onClearHighlights]);
+
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setSearchText(e.target.value);
+    setResult(null);
   }, []);
 
   const handleSearchKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
       if (e.key === "Enter") {
         e.preventDefault();
-        if (e.shiftKey) {
-          handleFindPrevious();
-        } else if (!result) {
+        const action = getFindEnterAction({
+          searchText,
+          result,
+          shiftKey: e.shiftKey,
+        });
+        if (action === "search") {
           performSearch();
-        } else {
-          handleFindNext();
+          return;
         }
+        if (action === "previous") {
+          handleFindPrevious();
+          return;
+        }
+        handleFindNext();
       } else if (e.key === "Escape") {
         onClose();
       }
     },
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [result, performSearch, onClose],
-  );
-
-  const handleReplaceKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        handleReplace();
-      } else if (e.key === "Escape") {
-        onClose();
-      }
-    },
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-    [onClose],
+    [searchText, result, performSearch, onClose],
   );
 
   const handleFindNext = useCallback(() => {
@@ -243,7 +247,7 @@ export function FindReplaceDialog({
       return;
     }
 
-    if (!result) {
+    if (!result || result.totalCount === 0) {
       performSearch();
       return;
     }
@@ -264,7 +268,7 @@ export function FindReplaceDialog({
       return;
     }
 
-    if (!result) {
+    if (!result || result.totalCount === 0) {
       performSearch();
       return;
     }
@@ -281,68 +285,6 @@ export function FindReplaceDialog({
       });
     }
   }, [searchText, result, performSearch, onFindPrevious]);
-
-  const handleReplace = useCallback(() => {
-    if (!result || result.totalCount === 0) {
-      return;
-    }
-
-    const success = onReplace(replaceText);
-    if (success) {
-      const newResult = onFind(searchText, { matchCase, matchWholeWord });
-      setResult(newResult);
-      if (newResult?.matches && onHighlightMatches) {
-        onHighlightMatches(newResult.matches);
-      }
-    }
-  }, [
-    result,
-    replaceText,
-    searchText,
-    matchCase,
-    matchWholeWord,
-    onReplace,
-    onFind,
-    onHighlightMatches,
-  ]);
-
-  const handleReplaceAll = useCallback(() => {
-    if (!searchText.trim()) {
-      return;
-    }
-
-    const count = onReplaceAll(searchText, replaceText, {
-      matchCase,
-      matchWholeWord,
-    });
-    if (count > 0) {
-      setResult({
-        matches: [],
-        totalCount: 0,
-        currentIndex: -1,
-      });
-      if (onClearHighlights) {
-        onClearHighlights();
-      }
-    }
-  }, [
-    searchText,
-    replaceText,
-    matchCase,
-    matchWholeWord,
-    onReplaceAll,
-    onClearHighlights,
-  ]);
-
-  const toggleReplaceMode = useCallback(() => {
-    setShowReplace((prev) => {
-      const newValue = !prev;
-      if (newValue) {
-        setTimeout(() => replaceInputRef.current?.focus(), 100);
-      }
-      return newValue;
-    });
-  }, []);
 
   const handleOverlayClick = useCallback((e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -365,18 +307,19 @@ export function FindReplaceDialog({
 
   const hasMatches = result && result.totalCount > 0;
   const noMatches = result && result.totalCount === 0 && searchText.trim();
+  const overlayStyle = getFindReplaceOverlayStyle(style);
 
   return (
     <div
       role="presentation"
-      className={`docx-find-replace-dialog-overlay pointer-events-none fixed inset-0 z-[10000] flex items-start justify-end bg-transparent ${className || ""}`}
-      style={style}
+      className={`docx-find-replace-dialog-overlay pointer-events-none fixed end-0 bottom-0 z-[10002] flex items-start justify-end bg-transparent ${className || ""}`}
+      style={overlayStyle}
       data-slot="folio-find-replace-overlay"
       onClick={handleOverlayClick}
       onKeyDown={handleDialogKeyDown}
     >
       <div
-        className="docx-find-replace-dialog bg-popover text-popover-foreground pointer-events-auto me-5 mt-15 w-[min(440px,calc(100vw-40px))] rounded-lg border shadow-xl"
+        className="docx-find-replace-dialog bg-popover text-popover-foreground pointer-events-auto me-4 mt-3 w-[min(440px,calc(100vw-var(--folio-find-replace-left,5.5rem)-2rem))] rounded-lg border shadow-xl"
         data-testid="find-replace-dialog"
         role="dialog"
         aria-modal="false"
@@ -388,11 +331,7 @@ export function FindReplaceDialog({
             className="flex min-w-0 items-center gap-2 text-sm font-medium"
           >
             <SearchIcon className="text-muted-foreground size-4 shrink-0" />
-            <span className="truncate">
-              {showReplace
-                ? t("findReplace.findAndReplace")
-                : t("findReplace.find")}
-            </span>
+            <span className="truncate">{t("findReplace.find")}</span>
           </h2>
           <Button
             onClick={onClose}
@@ -469,50 +408,6 @@ export function FindReplaceDialog({
             </div>
           )}
 
-          {showReplace && (
-            <div className="grid grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-2">
-              <label
-                className="text-muted-foreground text-xs font-medium"
-                htmlFor="replace-text"
-              >
-                {t("findReplace.replace")}
-              </label>
-              <Input
-                ref={replaceInputRef}
-                id="replace-text"
-                nativeInput
-                type="text"
-                className="h-8"
-                size="sm"
-                value={replaceText}
-                onChange={(e) => setReplaceText(e.target.value)}
-                onKeyDown={handleReplaceKeyDown}
-                placeholder={t("findReplace.replacePlaceholder")}
-                aria-label={t("findReplace.replaceText")}
-              />
-              <div className="flex items-center gap-1">
-                <Button
-                  onClick={handleReplace}
-                  disabled={!hasMatches}
-                  size="xs"
-                  title={t("findReplace.replaceCurrent")}
-                  variant="outline"
-                >
-                  {t("findReplace.replace")}
-                </Button>
-                <Button
-                  onClick={handleReplaceAll}
-                  disabled={!hasMatches}
-                  size="xs"
-                  title={t("findReplace.replaceAll")}
-                  variant="outline"
-                >
-                  {t("findReplace.replaceAll")}
-                </Button>
-              </div>
-            </div>
-          )}
-
           <div className="ms-20 flex flex-wrap items-center gap-x-4 gap-y-2">
             <label className="text-muted-foreground flex items-center gap-2 text-xs">
               <Checkbox checked={matchCase} onCheckedChange={setMatchCase} />
@@ -525,11 +420,6 @@ export function FindReplaceDialog({
               />
               {t("findReplace.wholeWords")}
             </label>
-            {!showReplace && (
-              <Button onClick={toggleReplaceMode} size="xs" variant="ghost">
-                {t("findReplace.showReplace")}
-              </Button>
-            )}
           </div>
         </div>
       </div>

--- a/packages/folio/src/components/dialogs/findReplaceDialogLayout.test.ts
+++ b/packages/folio/src/components/dialogs/findReplaceDialogLayout.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  FIND_REPLACE_DIALOG_LEFT,
+  FIND_REPLACE_DIALOG_TOP,
+  getFindReplaceOverlayStyle,
+} from "./findReplaceDialogLayout";
+
+describe("find and replace dialog placement", () => {
+  test("starts below the host editor chrome by default", () => {
+    expect(getFindReplaceOverlayStyle(undefined).top).toBe(
+      FIND_REPLACE_DIALOG_TOP,
+    );
+  });
+
+  test("stays inside the document viewer rail by default", () => {
+    expect(getFindReplaceOverlayStyle(undefined).left).toBe(
+      FIND_REPLACE_DIALOG_LEFT,
+    );
+  });
+
+  test("allows hosts to override the top offset", () => {
+    expect(getFindReplaceOverlayStyle({ top: "12rem" }).top).toBe("12rem");
+  });
+
+  test("allows hosts to override the left rail", () => {
+    expect(getFindReplaceOverlayStyle({ left: "8rem" }).left).toBe("8rem");
+  });
+});

--- a/packages/folio/src/components/dialogs/findReplaceDialogLayout.ts
+++ b/packages/folio/src/components/dialogs/findReplaceDialogLayout.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from "react";
+
+export const FIND_REPLACE_DIALOG_TOP = "var(--folio-find-replace-top, 7rem)";
+export const FIND_REPLACE_DIALOG_LEFT =
+  "var(--folio-find-replace-left, 5.5rem)";
+
+export function getFindReplaceOverlayStyle(
+  style: CSSProperties | undefined,
+): CSSProperties {
+  return {
+    top: FIND_REPLACE_DIALOG_TOP,
+    left: FIND_REPLACE_DIALOG_LEFT,
+    ...style,
+  };
+}

--- a/packages/folio/src/components/dialogs/findReplaceInteraction.test.ts
+++ b/packages/folio/src/components/dialogs/findReplaceInteraction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getAdjacentFindIndex,
+  getFindEnterAction,
+} from "./findReplaceInteraction";
+import type { FindResult } from "./findReplaceUtils";
+
+const emptyResult: FindResult = {
+  matches: [],
+  totalCount: 0,
+  currentIndex: 0,
+};
+
+const matchResult: FindResult = {
+  matches: [
+    {
+      paragraphIndex: 0,
+      contentIndex: 0,
+      startOffset: 0,
+      endOffset: 5,
+      text: "stock",
+    },
+  ],
+  totalCount: 1,
+  currentIndex: 0,
+};
+
+describe("Folio find dialog keyboard interaction", () => {
+  test("reruns search when Enter follows a stale zero-result state", () => {
+    expect(
+      getFindEnterAction({
+        searchText: "stock",
+        result: emptyResult,
+        shiftKey: false,
+      }),
+    ).toBe("search");
+  });
+
+  test("navigates only after the current query has matches", () => {
+    expect(
+      getFindEnterAction({
+        searchText: "stock",
+        result: matchResult,
+        shiftKey: false,
+      }),
+    ).toBe("next");
+
+    expect(
+      getFindEnterAction({
+        searchText: "stock",
+        result: matchResult,
+        shiftKey: true,
+      }),
+    ).toBe("previous");
+  });
+
+  test("advances through matches without resetting to the first hit", () => {
+    expect(getAdjacentFindIndex(0, 107, "next")).toBe(1);
+    expect(getAdjacentFindIndex(1, 107, "next")).toBe(2);
+    expect(getAdjacentFindIndex(106, 107, "next")).toBe(0);
+  });
+
+  test("moves backward through matches with wraparound", () => {
+    expect(getAdjacentFindIndex(2, 107, "previous")).toBe(1);
+    expect(getAdjacentFindIndex(0, 107, "previous")).toBe(106);
+  });
+});

--- a/packages/folio/src/components/dialogs/findReplaceInteraction.ts
+++ b/packages/folio/src/components/dialogs/findReplaceInteraction.ts
@@ -1,0 +1,38 @@
+import type { FindResult } from "./findReplaceUtils";
+
+export type FindEnterAction = "search" | "next" | "previous";
+export type FindDirection = "next" | "previous";
+
+type GetFindEnterActionOptions = {
+  searchText: string;
+  result: FindResult | null;
+  shiftKey: boolean;
+};
+
+export function getFindEnterAction({
+  searchText,
+  result,
+  shiftKey,
+}: GetFindEnterActionOptions): FindEnterAction {
+  if (!searchText.trim() || !result || result.totalCount === 0) {
+    return "search";
+  }
+
+  return shiftKey ? "previous" : "next";
+}
+
+export function getAdjacentFindIndex(
+  currentIndex: number,
+  totalCount: number,
+  direction: FindDirection,
+): number {
+  if (totalCount <= 0) {
+    return 0;
+  }
+
+  if (direction === "previous") {
+    return currentIndex === 0 ? totalCount - 1 : currentIndex - 1;
+  }
+
+  return (currentIndex + 1) % totalCount;
+}

--- a/packages/folio/src/components/dialogs/findReplaceUtils.test.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.test.ts
@@ -61,6 +61,41 @@ describe("Folio find and replace", () => {
     expect(matches[0]?.startOffset).toBe(0);
   });
 
+  test("reports match offsets relative to the whole paragraph", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Series " }],
+                },
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Stock" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const matches = findInDocument(
+      document,
+      "stock",
+      createDefaultFindOptions(),
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.contentIndex).toBe(1);
+    expect(matches[0]?.startOffset).toBe(7);
+    expect(matches[0]?.endOffset).toBe(12);
+  });
+
   test("replaces matches inside table cells", () => {
     const document = createTableDocument();
     const match = findInDocument(

--- a/packages/folio/src/components/dialogs/findReplaceUtils.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.ts
@@ -432,8 +432,8 @@ export function findInParagraph(
     matches.push({
       paragraphIndex,
       contentIndex: contentInfo.contentIndex,
-      startOffset: contentInfo.offsetInContent,
-      endOffset: contentInfo.offsetInContent + (match.end - match.start),
+      startOffset: match.start,
+      endOffset: match.end,
       text: paragraphText.slice(match.start, match.end),
     });
   }

--- a/packages/folio/src/components/hooks/findReplaceSelection.test.ts
+++ b/packages/folio/src/components/hooks/findReplaceSelection.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+
+import { resolveFindMatchRange } from "./findReplaceSelection";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "text*" },
+    text: { group: "inline" },
+  },
+});
+
+describe("Folio find match selection", () => {
+  test("maps paragraph-relative find offsets to ProseMirror positions", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Preferred stock")]),
+      schema.node("paragraph", null, [schema.text("Common stock")]),
+    ]);
+
+    expect(
+      resolveFindMatchRange(doc, {
+        paragraphIndex: 1,
+        contentIndex: 0,
+        startOffset: 7,
+        endOffset: 12,
+        text: "stock",
+      }),
+    ).toEqual({ from: 25, to: 30 });
+  });
+});

--- a/packages/folio/src/components/hooks/findReplaceSelection.test.ts
+++ b/packages/folio/src/components/hooks/findReplaceSelection.test.ts
@@ -5,8 +5,15 @@ import { resolveFindMatchRange } from "./findReplaceSelection";
 
 const schema = new Schema({
   nodes: {
-    doc: { content: "block+" },
-    paragraph: { group: "block", content: "text*" },
+    doc: { content: "(paragraph | table | textBox)+" },
+    paragraph: { group: "block", content: "inline*" },
+    table: { group: "block", content: "tableRow+" },
+    tableRow: { content: "(tableCell | tableHeader)+" },
+    tableCell: { content: "(paragraph | table)+" },
+    tableHeader: { content: "(paragraph | table)+" },
+    textBox: { group: "block", content: "(paragraph | table)+" },
+    tab: { group: "inline", inline: true },
+    hardBreak: { group: "inline", inline: true },
     text: { group: "inline" },
   },
 });
@@ -27,5 +34,47 @@ describe("Folio find match selection", () => {
         text: "stock",
       }),
     ).toEqual({ from: 25, to: 30 });
+  });
+
+  test("skips text box paragraphs to match document search traversal", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Preferred stock")]),
+      schema.node("textBox", null, [
+        schema.node("paragraph", null, [schema.text("stock in text box")]),
+      ]),
+      schema.node("paragraph", null, [schema.text("Common stock")]),
+    ]);
+
+    expect(
+      resolveFindMatchRange(doc, {
+        paragraphIndex: 1,
+        contentIndex: 0,
+        startOffset: 7,
+        endOffset: 12,
+        text: "stock",
+      }),
+    ).toEqual({ from: 46, to: 51 });
+  });
+
+  test("maps offsets after inline search tokens", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("pre"),
+        schema.node("tab"),
+        schema.text("stock"),
+        schema.node("hardBreak"),
+        schema.text("tail"),
+      ]),
+    ]);
+
+    expect(
+      resolveFindMatchRange(doc, {
+        paragraphIndex: 0,
+        contentIndex: 0,
+        startOffset: 4,
+        endOffset: 9,
+        text: "stock",
+      }),
+    ).toEqual({ from: 5, to: 10 });
   });
 });

--- a/packages/folio/src/components/hooks/findReplaceSelection.ts
+++ b/packages/folio/src/components/hooks/findReplaceSelection.ts
@@ -14,17 +14,13 @@ export function resolveFindMatchRange(
   let paragraphIndex = 0;
   let resolved: FindMatchRange | null = null;
 
-  doc.descendants((node, pos) => {
+  const visitParagraph = (node: ProseMirrorNode, pos: number): boolean => {
     if (resolved) {
       return false;
     }
-    if (node.type.name !== "paragraph") {
-      return true;
-    }
-
     if (paragraphIndex !== match.paragraphIndex) {
       paragraphIndex++;
-      return false;
+      return true;
     }
 
     resolved = resolveTextRangeInParagraph({
@@ -34,7 +30,63 @@ export function resolveFindMatchRange(
       endOffset: match.endOffset,
     });
     return false;
-  });
+  };
+
+  const walkBlocks = (
+    container: ProseMirrorNode,
+    contentStart: number,
+  ): boolean => {
+    let offset = 0;
+    for (let childIndex = 0; childIndex < container.childCount; childIndex++) {
+      const child = container.child(childIndex);
+      const childPos = contentStart + offset;
+      if (child.type.name === "paragraph") {
+        if (!visitParagraph(child, childPos)) {
+          return false;
+        }
+      } else if (child.type.name === "table" && !walkTable(child, childPos)) {
+        return false;
+      }
+
+      offset += child.nodeSize;
+    }
+    return true;
+  };
+
+  const walkTable = (table: ProseMirrorNode, tablePos: number): boolean => {
+    let rowOffset = 0;
+    for (let rowIndex = 0; rowIndex < table.childCount; rowIndex++) {
+      const row = table.child(rowIndex);
+      if (row.type.name !== "tableRow") {
+        rowOffset += row.nodeSize;
+        continue;
+      }
+
+      const rowPos = tablePos + 1 + rowOffset;
+      let cellOffset = 0;
+      for (let cellIndex = 0; cellIndex < row.childCount; cellIndex++) {
+        const cell = row.child(cellIndex);
+        if (
+          cell.type.name !== "tableCell" &&
+          cell.type.name !== "tableHeader"
+        ) {
+          cellOffset += cell.nodeSize;
+          continue;
+        }
+
+        const cellPos = rowPos + 1 + cellOffset;
+        if (!walkBlocks(cell, cellPos + 1)) {
+          return false;
+        }
+        cellOffset += cell.nodeSize;
+      }
+
+      rowOffset += row.nodeSize;
+    }
+    return true;
+  };
+
+  walkBlocks(doc, 0);
 
   return resolved;
 }
@@ -57,19 +109,20 @@ function resolveTextRangeInParagraph({
   let to: number | null = null;
 
   paragraph.descendants((node, pos) => {
-    if (!node.isText) {
+    const tokenLength = getSearchTextTokenLength(node);
+    if (tokenLength === 0) {
       return true;
     }
 
-    const text = node.text ?? "";
     const textStart = textOffset;
-    const textEnd = textStart + text.length;
+    const textEnd = textStart + tokenLength;
+    const nodeStart = paragraphPos + 1 + pos;
 
     if (from === null && startOffset >= textStart && startOffset <= textEnd) {
-      from = paragraphPos + 1 + pos + (startOffset - textStart);
+      from = nodeStart + Math.min(startOffset - textStart, node.nodeSize);
     }
     if (to === null && endOffset >= textStart && endOffset <= textEnd) {
-      to = paragraphPos + 1 + pos + (endOffset - textStart);
+      to = nodeStart + Math.min(endOffset - textStart, node.nodeSize);
     }
 
     textOffset = textEnd;
@@ -81,4 +134,16 @@ function resolveTextRangeInParagraph({
   }
 
   return { from, to };
+}
+
+function getSearchTextTokenLength(node: ProseMirrorNode): number {
+  if (node.isText) {
+    return node.text?.length ?? 0;
+  }
+
+  if (node.type.name === "tab" || node.type.name === "hardBreak") {
+    return 1;
+  }
+
+  return 0;
 }

--- a/packages/folio/src/components/hooks/findReplaceSelection.ts
+++ b/packages/folio/src/components/hooks/findReplaceSelection.ts
@@ -1,0 +1,84 @@
+import type { Node as ProseMirrorNode } from "prosemirror-model";
+
+import type { FindMatch } from "../dialogs/findReplaceUtils";
+
+export type FindMatchRange = {
+  from: number;
+  to: number;
+};
+
+export function resolveFindMatchRange(
+  doc: ProseMirrorNode,
+  match: FindMatch,
+): FindMatchRange | null {
+  let paragraphIndex = 0;
+  let resolved: FindMatchRange | null = null;
+
+  doc.descendants((node, pos) => {
+    if (resolved) {
+      return false;
+    }
+    if (node.type.name !== "paragraph") {
+      return true;
+    }
+
+    if (paragraphIndex !== match.paragraphIndex) {
+      paragraphIndex++;
+      return false;
+    }
+
+    resolved = resolveTextRangeInParagraph({
+      paragraph: node,
+      paragraphPos: pos,
+      startOffset: match.startOffset,
+      endOffset: match.endOffset,
+    });
+    return false;
+  });
+
+  return resolved;
+}
+
+type ResolveTextRangeInParagraphOptions = {
+  paragraph: ProseMirrorNode;
+  paragraphPos: number;
+  startOffset: number;
+  endOffset: number;
+};
+
+function resolveTextRangeInParagraph({
+  paragraph,
+  paragraphPos,
+  startOffset,
+  endOffset,
+}: ResolveTextRangeInParagraphOptions): FindMatchRange | null {
+  let textOffset = 0;
+  let from: number | null = null;
+  let to: number | null = null;
+
+  paragraph.descendants((node, pos) => {
+    if (!node.isText) {
+      return true;
+    }
+
+    const text = node.text ?? "";
+    const textStart = textOffset;
+    const textEnd = textStart + text.length;
+
+    if (from === null && startOffset >= textStart && startOffset <= textEnd) {
+      from = paragraphPos + 1 + pos + (startOffset - textStart);
+    }
+    if (to === null && endOffset >= textStart && endOffset <= textEnd) {
+      to = paragraphPos + 1 + pos + (endOffset - textStart);
+    }
+
+    textOffset = textEnd;
+    return to === null;
+  });
+
+  if (from === null || to === null || from >= to) {
+    return null;
+  }
+
+  return { from, to };
+}

--- a/packages/folio/src/components/hooks/useFindReplace.ts
+++ b/packages/folio/src/components/hooks/useFindReplace.ts
@@ -11,6 +11,7 @@ import { useRef, useCallback } from "react";
 
 import type { Document } from "../../core/types/document";
 import { replaceTextInDocument } from "../../core/utils/replaceText";
+import { getAdjacentFindIndex } from "../dialogs/findReplaceInteraction";
 import { findInDocument, scrollToMatch } from "../dialogs/findReplaceUtils";
 import type {
   FindMatch,
@@ -24,14 +25,18 @@ import type { UseFindReplaceReturn as FindReplaceStateReturn } from "../dialogs/
 // ============================================================================
 
 type UseFindReplaceParams = {
-  /** Current document state from history */
-  documentState: Document | null;
+  /** Current document state fallback for existing mounted callers during HMR */
+  documentState?: Document | null;
+  /** Returns the current live document state from the editor */
+  getDocumentState?: () => Document | null;
   /** Ref to the scrollable container for scrollToMatch */
   containerRef: React.RefObject<HTMLDivElement | null>;
   /** Callback to push a new document state */
   handleDocumentChange: (newDoc: Document) => void;
   /** Dialog state manager from useFindReplace (dialogs) */
   findReplace: FindReplaceStateReturn;
+  /** Select and reveal a match in the live editor */
+  selectMatch?: (match: FindMatch) => boolean;
 };
 
 export type UseFindReplaceReturn = {
@@ -59,22 +64,31 @@ export type UseFindReplaceReturn = {
 
 export function useFindReplace({
   documentState,
+  getDocumentState,
   containerRef,
   handleDocumentChange,
   findReplace,
+  selectMatch,
 }: UseFindReplaceParams): UseFindReplaceReturn {
   // Store the current find result for navigation
   const findResultRef = useRef<FindResult | null>(null);
+  const { setMatches, goToMatch } = findReplace;
+
+  const readDocumentState = useCallback(
+    () => getDocumentState?.() ?? documentState ?? null,
+    [getDocumentState, documentState],
+  );
 
   // Handle find operation
   const handleFind = useCallback(
     (searchText: string, options: FindOptions): FindResult | null => {
-      if (!documentState || !searchText.trim()) {
+      const currentDocument = readDocumentState();
+      if (!currentDocument || !searchText.trim()) {
         findResultRef.current = null;
         return null;
       }
 
-      const matches = findInDocument(documentState, searchText, options);
+      const matches = findInDocument(currentDocument, searchText, options);
       const result: FindResult = {
         matches,
         totalCount: matches.length,
@@ -82,66 +96,82 @@ export function useFindReplace({
       };
 
       findResultRef.current = result;
-      findReplace.setMatches(matches, 0);
+      setMatches(matches, 0);
 
       // Scroll to first match
-      if (matches.length > 0 && containerRef.current) {
+      if (matches.length > 0) {
         // SAFETY: length > 0 guarantees index 0 exists
-        scrollToMatch(containerRef.current, matches[0]!);
+        const firstMatch = matches[0]!;
+        if (!selectMatch?.(firstMatch) && containerRef.current) {
+          scrollToMatch(containerRef.current, firstMatch);
+        }
       }
 
       return result;
     },
-    [documentState, findReplace, containerRef],
+    [readDocumentState, setMatches, containerRef, selectMatch],
   );
 
   // Handle find next
   const handleFindNext = useCallback((): FindMatch | null => {
-    if (!findResultRef.current || findResultRef.current.matches.length === 0) {
+    const currentResult = findResultRef.current;
+    if (!currentResult || currentResult.matches.length === 0) {
       return null;
     }
 
-    const newIndex = findReplace.goToNextMatch();
-    const match = findResultRef.current.matches[newIndex];
+    const newIndex = getAdjacentFindIndex(
+      currentResult.currentIndex,
+      currentResult.matches.length,
+      "next",
+    );
+    const match = currentResult.matches[newIndex];
     findResultRef.current = {
-      ...findResultRef.current,
+      ...currentResult,
       currentIndex: newIndex,
     };
+    goToMatch(newIndex);
 
     // Scroll to the match
-    if (match && containerRef.current) {
+    if (match && !selectMatch?.(match) && containerRef.current) {
       scrollToMatch(containerRef.current, match);
     }
 
     return match || null;
-  }, [findReplace, containerRef]);
+  }, [goToMatch, containerRef, selectMatch]);
 
   // Handle find previous
   const handleFindPrevious = useCallback((): FindMatch | null => {
-    if (!findResultRef.current || findResultRef.current.matches.length === 0) {
+    const currentResult = findResultRef.current;
+    if (!currentResult || currentResult.matches.length === 0) {
       return null;
     }
 
-    const newIndex = findReplace.goToPreviousMatch();
-    const match = findResultRef.current.matches[newIndex];
+    const newIndex = getAdjacentFindIndex(
+      currentResult.currentIndex,
+      currentResult.matches.length,
+      "previous",
+    );
+    const match = currentResult.matches[newIndex];
     findResultRef.current = {
-      ...findResultRef.current,
+      ...currentResult,
       currentIndex: newIndex,
     };
+    goToMatch(newIndex);
 
     // Scroll to the match
-    if (match && containerRef.current) {
+    if (match && !selectMatch?.(match) && containerRef.current) {
       scrollToMatch(containerRef.current, match);
     }
 
     return match || null;
-  }, [findReplace, containerRef]);
+  }, [goToMatch, containerRef, selectMatch]);
 
   // Handle replace current match
   const handleReplace = useCallback(
     (replaceText: string): boolean => {
+      const currentDocument = readDocumentState();
       if (
-        !documentState ||
+        !currentDocument ||
         !findResultRef.current ||
         findResultRef.current.matches.length === 0
       ) {
@@ -157,7 +187,7 @@ export function useFindReplace({
       // Execute replace command
       try {
         const newDoc = replaceTextInDocument(
-          documentState,
+          currentDocument,
           {
             start: {
               paragraphIndex: currentMatch.paragraphIndex,
@@ -177,24 +207,25 @@ export function useFindReplace({
         return false;
       }
     },
-    [documentState, handleDocumentChange],
+    [readDocumentState, handleDocumentChange],
   );
 
   // Handle replace all matches
   const handleReplaceAll = useCallback(
     (searchText: string, replaceText: string, options: FindOptions): number => {
-      if (!documentState || !searchText.trim()) {
+      const currentDocument = readDocumentState();
+      if (!currentDocument || !searchText.trim()) {
         return 0;
       }
 
       // Find all matches first
-      const matches = findInDocument(documentState, searchText, options);
+      const matches = findInDocument(currentDocument, searchText, options);
       if (matches.length === 0) {
         return 0;
       }
 
       // Replace from end to start to maintain correct indices
-      let doc = documentState;
+      let doc = currentDocument;
       const sortedMatches = [...matches].toSorted((a, b) => {
         if (a.paragraphIndex !== b.paragraphIndex) {
           return b.paragraphIndex - a.paragraphIndex;
@@ -225,11 +256,11 @@ export function useFindReplace({
 
       handleDocumentChange(doc);
       findResultRef.current = null;
-      findReplace.setMatches([], 0);
+      setMatches([], 0);
 
       return matches.length;
     },
-    [documentState, handleDocumentChange, findReplace],
+    [readDocumentState, handleDocumentChange, setMatches],
   );
 
   return {

--- a/packages/folio/src/core/layout-painter/documentColors.test.ts
+++ b/packages/folio/src/core/layout-painter/documentColors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAutomaticTextColorForBackground } from "./documentColors";
+
+describe("document automatic text color", () => {
+  test("uses black automatic text on explicit white document shading", () => {
+    expect(getAutomaticTextColorForBackground("#FFFFFF")).toBe("#000000");
+  });
+
+  test("uses white automatic text on explicit dark document shading", () => {
+    expect(getAutomaticTextColorForBackground("#111111")).toBe("#FFFFFF");
+  });
+
+  test("leaves automatic text theme-adaptive when shading is not a concrete color", () => {
+    expect(getAutomaticTextColorForBackground("auto")).toBeUndefined();
+    expect(getAutomaticTextColorForBackground(undefined)).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-painter/documentColors.ts
+++ b/packages/folio/src/core/layout-painter/documentColors.ts
@@ -1,0 +1,44 @@
+const HEX_COLOR_RE = /^#?[0-9a-f]{6}$/i;
+
+function normalizeHexColor(color: string): string | null {
+  const trimmed = color.trim();
+  if (!HEX_COLOR_RE.test(trimmed)) {
+    return null;
+  }
+  return `#${trimmed.replace(/^#/, "").toUpperCase()}`;
+}
+
+function relativeLuminance(hexColor: string): number | null {
+  const normalized = normalizeHexColor(hexColor);
+  if (!normalized) {
+    return null;
+  }
+
+  const hex = normalized.slice(1);
+  const channels = [0, 2, 4].map((offset) => {
+    const value = Number.parseInt(hex.slice(offset, offset + 2), 16) / 255;
+    return value <= 0.039_28 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+  });
+
+  const [red, green, blue] = channels;
+  if (red === undefined || green === undefined || blue === undefined) {
+    return null;
+  }
+
+  return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
+}
+
+export function getAutomaticTextColorForBackground(
+  backgroundColor: string | undefined,
+): string | undefined {
+  if (!backgroundColor) {
+    return undefined;
+  }
+
+  const luminance = relativeLuminance(backgroundColor);
+  if (luminance === null) {
+    return undefined;
+  }
+
+  return luminance > 0.45 ? "#000000" : "#FFFFFF";
+}

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -28,6 +28,7 @@ import type {
 } from "../prosemirror/utils/tabCalculator";
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
 import { resolveFontFamily } from "../utils/fontResolver";
+import { getAutomaticTextColorForBackground } from "./documentColors";
 import { isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
 
@@ -1133,6 +1134,12 @@ export function renderParagraphFragment(
   // Apply shading (background color)
   if (block.attrs?.shading) {
     fragmentEl.style.backgroundColor = block.attrs.shading;
+    const automaticTextColor = getAutomaticTextColorForBackground(
+      block.attrs.shading,
+    );
+    if (automaticTextColor) {
+      fragmentEl.style.color = automaticTextColor;
+    }
   }
 
   // Calculate available width for justify

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -21,6 +21,7 @@ import type {
   ParagraphFragment,
   ImageRun,
 } from "../layout-engine/types";
+import { getAutomaticTextColorForBackground } from "./documentColors";
 import { renderParagraphFragment } from "./renderParagraph";
 import { emuToPixels, isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
@@ -520,6 +521,12 @@ function renderTableCell(
   // Background color
   if (cell.background) {
     cellEl.style.backgroundColor = cell.background;
+    const automaticTextColor = getAutomaticTextColorForBackground(
+      cell.background,
+    );
+    if (automaticTextColor) {
+      cellEl.style.color = automaticTextColor;
+    }
   }
 
   // Vertical alignment

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -115,6 +115,7 @@ import type {
   SectionProperties,
   HeaderFooter,
 } from "../core/types/document";
+import { computeEffectiveHeaderFooterMargins } from "./headerFooterMargins";
 // Internal components
 import { HiddenProseMirror } from "./HiddenProseMirror";
 import type { HiddenProseMirrorRef } from "./HiddenProseMirror";
@@ -2151,46 +2152,13 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               )
             : undefined;
 
-          // Adjust margins if header/footer content exceeds available space
-          // (Word and Google Docs push body content down when header grows).
-          // Only the DEFAULT header/footer heights drive the margin adjustment;
-          // first-page variants only appear on page 1 and must not inflate the
-          // margins for every page (which could eliminate the content area).
-          const headerDistance = margins.header ?? 48;
-          const footerDistance = margins.footer ?? 48;
-          const availableHeaderSpace = margins.top - headerDistance;
-          const availableFooterSpace = margins.bottom - footerDistance;
-          const hfHeight = (hf: HeaderFooterContent | undefined) =>
-            hf ? (hf.visualBottom ?? hf.height) : 0;
-          const hfFooterHeight = (hf: HeaderFooterContent | undefined) =>
-            hf
-              ? Math.max(
-                  (hf.visualBottom ?? hf.height) - (hf.visualTop ?? 0),
-                  hf.height,
-                )
-              : 0;
-          const headerContentHeight = hfHeight(headerContentForRender);
-          const footerContentHeight = hfFooterHeight(footerContentForRender);
-
-          let effectiveMargins = margins;
-          if (
-            headerContentHeight > availableHeaderSpace ||
-            footerContentHeight > availableFooterSpace
-          ) {
-            effectiveMargins = { ...margins };
-            if (headerContentHeight > availableHeaderSpace) {
-              effectiveMargins.top = Math.max(
-                margins.top,
-                headerDistance + headerContentHeight,
-              );
-            }
-            if (footerContentHeight > availableFooterSpace) {
-              effectiveMargins.bottom = Math.max(
-                margins.bottom,
-                footerDistance + footerContentHeight,
-              );
-            }
-          }
+          const effectiveMargins = computeEffectiveHeaderFooterMargins({
+            margins,
+            headerContent: headerContentForRender,
+            footerContent: footerContentForRender,
+            firstPageHeaderContent: firstPageHeaderForRender,
+            firstPageFooterContent: firstPageFooterForRender,
+          });
 
           // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
           let newLayout: Layout;

--- a/packages/folio/src/paged-editor/headerFooterMargins.test.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HeaderFooterContent } from "../core/layout-painter/renderPage";
+import { computeEffectiveHeaderFooterMargins } from "./headerFooterMargins";
+
+const content = (height: number): HeaderFooterContent => ({
+  blocks: [],
+  measures: [],
+  height,
+  visualBottom: height,
+});
+
+describe("header and footer margin reservation", () => {
+  test("reserves body space for a tall first-page header", () => {
+    const margins = {
+      top: 96,
+      right: 72,
+      bottom: 96,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+
+    expect(
+      computeEffectiveHeaderFooterMargins({
+        margins,
+        headerContent: content(20),
+        firstPageHeaderContent: content(78),
+      }).top,
+    ).toBe(126);
+  });
+
+  test("keeps margins unchanged when header and footer fit", () => {
+    const margins = {
+      top: 96,
+      right: 72,
+      bottom: 96,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+
+    expect(
+      computeEffectiveHeaderFooterMargins({
+        margins,
+        headerContent: content(40),
+        footerContent: content(40),
+      }),
+    ).toBe(margins);
+  });
+});

--- a/packages/folio/src/paged-editor/headerFooterMargins.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.ts
@@ -1,0 +1,67 @@
+import type { PageMargins } from "../core/layout-engine/types";
+import type { HeaderFooterContent } from "../core/layout-painter/renderPage";
+
+type EffectiveHeaderFooterMarginsInput = {
+  margins: PageMargins;
+  headerContent?: HeaderFooterContent | undefined;
+  footerContent?: HeaderFooterContent | undefined;
+  firstPageHeaderContent?: HeaderFooterContent | undefined;
+  firstPageFooterContent?: HeaderFooterContent | undefined;
+};
+
+function headerHeight(content: HeaderFooterContent | undefined): number {
+  return content ? (content.visualBottom ?? content.height) : 0;
+}
+
+function footerHeight(content: HeaderFooterContent | undefined): number {
+  if (!content) {
+    return 0;
+  }
+  return Math.max(
+    (content.visualBottom ?? content.height) - (content.visualTop ?? 0),
+    content.height,
+  );
+}
+
+export function computeEffectiveHeaderFooterMargins({
+  margins,
+  headerContent,
+  footerContent,
+  firstPageHeaderContent,
+  firstPageFooterContent,
+}: EffectiveHeaderFooterMarginsInput): PageMargins {
+  const headerDistance = margins.header ?? 48;
+  const footerDistance = margins.footer ?? 48;
+  const availableHeaderSpace = margins.top - headerDistance;
+  const availableFooterSpace = margins.bottom - footerDistance;
+  const headerContentHeight = Math.max(
+    headerHeight(headerContent),
+    headerHeight(firstPageHeaderContent),
+  );
+  const footerContentHeight = Math.max(
+    footerHeight(footerContent),
+    footerHeight(firstPageFooterContent),
+  );
+
+  if (
+    headerContentHeight <= availableHeaderSpace &&
+    footerContentHeight <= availableFooterSpace
+  ) {
+    return margins;
+  }
+
+  const effectiveMargins = { ...margins };
+  if (headerContentHeight > availableHeaderSpace) {
+    effectiveMargins.top = Math.max(
+      margins.top,
+      headerDistance + headerContentHeight,
+    );
+  }
+  if (footerContentHeight > availableFooterSpace) {
+    effectiveMargins.bottom = Math.max(
+      margins.bottom,
+      footerDistance + footerContentHeight,
+    );
+  }
+  return effectiveMargins;
+}


### PR DESCRIPTION
Summary:
- Fix Folio document contrast and first-page header/footer layout reservations.
- Stabilize find navigation against the live editor document.
- Hide replace controls until replacement is reliable and keep the find dialog inside host chrome.