### PR TITLE
feat(web): banner when API version exceeds the loaded SPA version

### DIFF
--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -18,7 +18,7 @@ const healthSchema = v.object({
 
 export const ApiVersionMismatchBanner = () => {
   const t = useTranslations();
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 
   // Selfhost has its own GitHub-release-driven banner. Skip there
   // so the two don't fight for the same slot.
@@ -57,14 +57,13 @@ export const ApiVersionMismatchBanner = () => {
   // Per-version dismissal so dismissing 0.0.8 doesn't suppress
   // the banner when 0.0.9 ships.
   const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion}`;
+  if (dismissedVersion === serverVersion) {
+    return null;
+  }
   if (
-    !dismissed &&
     typeof localStorage !== "undefined" &&
     localStorage.getItem(dismissedKey) === "1"
   ) {
-    return null;
-  }
-  if (dismissed) {
     return null;
   }
 
@@ -72,7 +71,7 @@ export const ApiVersionMismatchBanner = () => {
     if (typeof localStorage !== "undefined") {
       localStorage.setItem(dismissedKey, "1");
     }
-    setDismissed(true);
+    setDismissedVersion(serverVersion);
   };
 
   const handleRefresh = () => {

--- a/apps/web/src/components/api-version-mismatch-banner.tsx
+++ b/apps/web/src/components/api-version-mismatch-banner.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { RefreshCwIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
+import { env } from "@/env";
+import { compareSemver } from "@/lib/semver-compare";
+
+const FIVE_MIN_MS = 5 * 60 * 1000;
+const DISMISSED_KEY_PREFIX = "stella:api-version-mismatch-dismissed:";
+
+const healthSchema = v.object({
+  status: v.literal("ok"),
+  version: v.pipe(v.string(), v.minLength(1)),
+});
+
+export const ApiVersionMismatchBanner = () => {
+  const t = useTranslations();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Selfhost has its own GitHub-release-driven banner. Skip there
+  // so the two don't fight for the same slot.
+  const enabled = !env.VITE_SELFHOST;
+  const installedVersion = __APP_VERSION__;
+
+  const { data: serverVersion } = useQuery({
+    queryKey: ["api-version-check"],
+    enabled,
+    staleTime: FIVE_MIN_MS,
+    refetchInterval: FIVE_MIN_MS,
+    refetchIntervalInBackground: false,
+    retry: false,
+    queryFn: async (): Promise<string | null> => {
+      const response = await fetch(`${env.VITE_API_URL}/health`, {
+        cache: "no-store",
+        signal: AbortSignal.timeout(8000),
+      });
+      if (!response.ok) {
+        return null;
+      }
+      const json: unknown = await response.json();
+      const parsed = v.safeParse(healthSchema, json);
+      return parsed.success ? parsed.output.version : null;
+    },
+  });
+
+  if (!enabled || !serverVersion) {
+    return null;
+  }
+
+  if (compareSemver(serverVersion, installedVersion) <= 0) {
+    return null;
+  }
+
+  // Per-version dismissal so dismissing 0.0.8 doesn't suppress
+  // the banner when 0.0.9 ships.
+  const dismissedKey = `${DISMISSED_KEY_PREFIX}${serverVersion}`;
+  if (
+    !dismissed &&
+    typeof localStorage !== "undefined" &&
+    localStorage.getItem(dismissedKey) === "1"
+  ) {
+    return null;
+  }
+  if (dismissed) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(dismissedKey, "1");
+    }
+    setDismissed(true);
+  };
+
+  const handleRefresh = () => {
+    window.location.reload();
+  };
+
+  return (
+    <div className="border-b bg-blue-50 px-4 py-2 text-sm text-blue-900 dark:bg-blue-950/40 dark:text-blue-200">
+      <div className="flex items-center justify-between gap-3">
+        <span>
+          {t("app.versionMismatch.message", {
+            installed: installedVersion,
+            latest: serverVersion,
+          })}{" "}
+          <button
+            className="inline-flex items-center gap-1 underline underline-offset-2 hover:no-underline"
+            onClick={handleRefresh}
+            type="button"
+          >
+            <RefreshCwIcon className="size-3" />
+            {t("app.versionMismatch.refresh")}
+          </button>
+        </span>
+        <button
+          aria-label={t("app.versionMismatch.dismiss")}
+          className="-me-1 rounded-sm p-1 hover:bg-blue-100 dark:hover:bg-blue-900/40"
+          onClick={handleDismiss}
+          type="button"
+        >
+          <XIcon className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/components/selfhost-update-banner.tsx
+++ b/apps/web/src/components/selfhost-update-banner.tsx
@@ -8,6 +8,7 @@ import * as v from "valibot";
 import { env } from "@/env";
 import { logDevError } from "@/lib/errors/utils";
 import { sanitizeHref } from "@/lib/sanitize-href";
+import { compareSemver } from "@/lib/semver-compare";
 
 const RELEASES_API_URL =
   "https://api.github.com/repos/stella/stella/releases/latest";
@@ -22,34 +23,6 @@ const releaseSchema = v.object({
 });
 
 type Release = v.InferOutput<typeof releaseSchema>;
-
-// Compare semver strings like "0.0.2" or "0.0.2-rc.1". Returns
-// negative if `a < b`, positive if `a > b`, zero if equal. Treats
-// any prerelease as strictly older than its stable counterpart, so
-// `0.0.1` > `0.0.1-rc.5`. Good enough for the "should we show the
-// banner" decision; not a full semver compare (no build metadata).
-const compareSemver = (a: string, b: string): number => {
-  const [aCore, aPre] = a.split("-", 2);
-  const [bCore, bPre] = b.split("-", 2);
-  const aNums = (aCore ?? "0.0.0").split(".").map((n) => Number(n) || 0);
-  const bNums = (bCore ?? "0.0.0").split(".").map((n) => Number(n) || 0);
-  for (let i = 0; i < 3; i++) {
-    const diff = (aNums[i] ?? 0) - (bNums[i] ?? 0);
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  if (aPre === bPre) {
-    return 0;
-  }
-  if (!aPre) {
-    return 1;
-  }
-  if (!bPre) {
-    return -1;
-  }
-  return aPre < bPre ? -1 : 1;
-};
 
 const stripPrefix = (tag: string): string =>
   tag.startsWith("v") ? tag.slice(1) : tag;

--- a/apps/web/src/components/selfhost-update-banner.tsx
+++ b/apps/web/src/components/selfhost-update-banner.tsx
@@ -29,7 +29,7 @@ const stripPrefix = (tag: string): string =>
 
 export const SelfhostUpdateBanner = () => {
   const t = useTranslations();
-  const [dismissed, setDismissed] = useState(false);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 
   const enabled = env.VITE_SELFHOST;
   const installedVersion = __APP_VERSION__;
@@ -71,14 +71,13 @@ export const SelfhostUpdateBanner = () => {
   // banner for v0.0.3 later. Stored in localStorage so it survives
   // tab refreshes within the same install.
   const dismissedKey = `${DISMISSED_KEY_PREFIX}${latestVersion}`;
+  if (dismissedVersion === latestVersion) {
+    return null;
+  }
   if (
-    !dismissed &&
     typeof localStorage !== "undefined" &&
     localStorage.getItem(dismissedKey) === "1"
   ) {
-    return null;
-  }
-  if (dismissed) {
     return null;
   }
 
@@ -86,7 +85,7 @@ export const SelfhostUpdateBanner = () => {
     if (typeof localStorage !== "undefined") {
       localStorage.setItem(dismissedKey, "1");
     }
-    setDismissed(true);
+    setDismissedVersion(latestVersion);
   };
 
   // GitHub's API only ever returns http(s) URLs, but route through

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Zavřít oznámení o aktualizaci",
+      "message": "Je dostupná nová verze (v{latest}). Používáte v{installed}.",
+      "refresh": "Obnovit a aktualizovat"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Zadejte slova k vyhledání…",
     "title": "Kontrola anonymizace"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Studené",
     "dark": "Tmavý",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Wörter zum Suchen eingeben…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Kühl",
     "dark": "Dunkel",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Update-Hinweis schließen",
+      "message": "Eine neue Version ist verfügbar (v{latest}). Sie verwenden v{installed}.",
+      "refresh": "Zum Aktualisieren neu laden"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Type word(s) to find…",
     "title": "Anonymization review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Cool",
     "dark": "Dark",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Escriba palabras a buscar…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Frío",
     "dark": "Oscuro",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Descartar aviso de actualización",
+      "message": "Hay una nueva versión disponible (v{latest}). Estás usando v{installed}.",
+      "refresh": "Actualizar la página"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Sulge uuendusteade",
+      "message": "Saadaval on uus versioon (v{latest}). Kasutusel on v{installed}.",
+      "refresh": "Värskenda uuendamiseks"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Sisestage otsitavad sõnad…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Jahe",
     "dark": "Tume",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Ignorer l'avis de mise à jour",
+      "message": "Une nouvelle version est disponible (v{latest}). Vous utilisez v{installed}.",
+      "refresh": "Actualiser pour mettre à jour"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Saisissez des mots à rechercher…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Froid",
     "dark": "Sombre",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Frissítési értesítés elvetése",
+      "message": "Új verzió érhető el (v{latest}). Jelenlegi verzió: v{installed}.",
+      "refresh": "Frissítés újratöltéssel"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Írjon be keresendő szavakat…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Hűvös",
     "dark": "Sötét",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Atmesti atnaujinimo pranešimą",
+      "message": "Yra nauja versija (v{latest}). Naudojate v{installed}.",
+      "refresh": "Atnaujinti įkeliant iš naujo"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Įveskite žodžius paieškai…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Vėsūs",
     "dark": "Tamsus",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Noraidīt atjauninājuma paziņojumu",
+      "message": "Ir pieejama jauna versija (v{latest}). Jūs izmantojat v{installed}.",
+      "refresh": "Pārlādēt, lai atjauninātu"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Ievadiet meklējamos vārdus…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Vēss",
     "dark": "Tumšs",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -43,6 +43,13 @@ type Messages = {
     "searchPlaceholder": "Type word(s) to find…";
     "title": "Anonymization review";
   };
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice";
+      "message": "A new version is available (v{latest}). You're on v{installed}.";
+      "refresh": "Refresh to update";
+    };
+  };
   "appearance": {
     "cool": "Cool";
     "dark": "Dark";
@@ -1171,12 +1178,11 @@ type Messages = {
       "apiKey": "API key";
       "apiKeyConfiguredPlaceholder": "Configured: {key}. Enter a new key to replace it.";
       "apiKeyPlaceholder": "Enter your API key";
-      "chooseModelsSubtitle": "Pick a model for each role. Prices update on the right.";
-      "chooseModelsTitle": "Choose models";
-      "editProviders": "Edit providers";
       "apiKeySaved": "Saved key {key}";
       "apiKeyUpdatePlaceholder": "Enter new key to update";
       "baseUrl": "Base URL";
+      "chooseModelsSubtitle": "Pick a model for each role. Prices update on the right.";
+      "chooseModelsTitle": "Choose models";
       "configure": "Configure";
       "credentialsPanel": "Key";
       "customModelBadge": "Custom · {provider}";
@@ -1188,6 +1194,7 @@ type Messages = {
       "defaultModel": "Default: {model}";
       "defaultModelOption": "Default";
       "description": "Bring your own API key or configure data sovereignty region.";
+      "editProviders": "Edit providers";
       "keepSavedKey": "Keep saved key";
       "modelForRole": "{role} model";
       "modelIdPlaceholder": "Search models";
@@ -1199,8 +1206,6 @@ type Messages = {
       "noModelResults": "No matching offered models";
       "overrideRoles": "Override roles";
       "overrideRolesDescription": "Choose which roles use this key, then choose a model for each role. Unselected roles use the platform default.";
-      "provider": "Provider";
-      "providerForRole": "{role} provider";
       "prices": {
         "empty": "Add a provider to see model prices";
         "emptyHint": "Pick a provider on the left and we will show pricing for its models here.";
@@ -1213,6 +1218,8 @@ type Messages = {
         "title": "Model prices";
         "typicalCallHint": "Per-1M-token rates · per-call estimate uses {input} in / {output} out";
       };
+      "provider": "Provider";
+      "providerForRole": "{role} provider";
       "providerKeyInvalid": "{provider} rejected the key. Double-check it before saving.";
       "providerKeyInvalidShort": "Invalid";
       "providers": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Wpisz słowa do wyszukania…",
     "title": "Przegląd anonimizacji"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Chłodne",
     "dark": "Ciemny",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Zamknij powiadomienie o aktualizacji",
+      "message": "Dostępna jest nowa wersja (v{latest}). Używasz v{installed}.",
+      "refresh": "Odśwież, aby zaktualizować"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -42,9 +42,9 @@
   },
   "app": {
     "versionMismatch": {
-      "dismiss": "Dismiss update notice",
-      "message": "A new version is available (v{latest}). You're on v{installed}.",
-      "refresh": "Refresh to update"
+      "dismiss": "Zavrieť oznámenie o aktualizácii",
+      "message": "Je dostupná nová verzia (v{latest}). Používate v{installed}.",
+      "refresh": "Obnoviť a aktualizovať"
     }
   },
   "appearance": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -40,6 +40,13 @@
     "searchPlaceholder": "Zadajte slová na vyhľadanie…",
     "title": "Anonymisation review"
   },
+  "app": {
+    "versionMismatch": {
+      "dismiss": "Dismiss update notice",
+      "message": "A new version is available (v{latest}). You're on v{installed}.",
+      "refresh": "Refresh to update"
+    }
+  },
   "appearance": {
     "cool": "Studené",
     "dark": "Tmavý",

--- a/apps/web/src/lib/semver-compare.test.ts
+++ b/apps/web/src/lib/semver-compare.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+
+import { compareSemver } from "./semver-compare";
+
+describe("semver comparison", () => {
+  it("orders major, minor, and patch segments numerically", () => {
+    expect(compareSemver("1.0.0", "0.9.9")).toBeGreaterThan(0);
+    expect(compareSemver("1.2.0", "1.10.0")).toBeLessThan(0);
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  it("treats prereleases as older than their stable version", () => {
+    expect(compareSemver("1.2.3", "1.2.3-rc.1")).toBeGreaterThan(0);
+    expect(compareSemver("1.2.3-beta.2", "1.2.3")).toBeLessThan(0);
+  });
+
+  it("keeps prerelease ordering deterministic", () => {
+    expect(compareSemver("1.2.3-rc.2", "1.2.3-beta.1")).toBeGreaterThan(0);
+    expect(compareSemver("1.2.3-beta.1", "1.2.3-rc.2")).toBeLessThan(0);
+  });
+});

--- a/apps/web/src/lib/semver-compare.ts
+++ b/apps/web/src/lib/semver-compare.ts
@@ -1,0 +1,32 @@
+/**
+ * Compare semver strings like `0.0.2` or `0.0.2-rc.1`.
+ *
+ * Returns negative if `a < b`, positive if `a > b`, zero if equal.
+ * Treats any prerelease as strictly older than its stable
+ * counterpart, so `0.0.1` > `0.0.1-rc.5`. Good enough for the
+ * "should we show this banner" decision; not a full semver compare
+ * (no build metadata, no numeric prerelease ordering beyond
+ * lexicographic).
+ */
+export const compareSemver = (a: string, b: string): number => {
+  const [aCore, aPre] = a.split("-", 2);
+  const [bCore, bPre] = b.split("-", 2);
+  const aNums = (aCore ?? "0.0.0").split(".").map((n) => Number(n) || 0);
+  const bNums = (bCore ?? "0.0.0").split(".").map((n) => Number(n) || 0);
+  for (let i = 0; i < 3; i++) {
+    const diff = (aNums[i] ?? 0) - (bNums[i] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  if (aPre === bPre) {
+    return 0;
+  }
+  if (!aPre) {
+    return 1;
+  }
+  if (!bPre) {
+    return -1;
+  }
+  return aPre < bPre ? -1 : 1;
+};

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -32,6 +32,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
 import { AppSidebar } from "@/components/app-sidebar";
 import { AppBreadcrumbs } from "@/components/breadcrumbs/app-breadcrumbs";
 import { ChatEditorProvider } from "@/components/chat-editor-provider";
@@ -335,6 +336,7 @@ function ProtectedContent({
 
   return (
     <SidebarInset className="flex flex-col">
+      <ApiVersionMismatchBanner />
       <SelfhostUpdateBanner />
       <header
         className="flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"


### PR DESCRIPTION
The SPA bundle is cached in browser tabs indefinitely; users keep an old build open while the API rolls forward, and stale clients send requests against newer schemas. Add a small TanStack-Query poll against `/health` every five minutes; when the reported API version is newer than the bundle's compiled version, show a non-blocking banner inviting the user to refresh.

Selfhost installs already have their own update banner driven off the GitHub releases API; the new banner short-circuits when `VITE_SELFHOST` is set so the two don't fight for the same slot.

Both banners share a small semver comparator now extracted to `lib/semver-compare.ts`.

## Test plan
- [x] Local: bundle reports v0.0.7; mock `/health` to return `0.0.8`; banner appears with refresh + dismiss buttons
- [ ] Selfhost build (VITE_SELFHOST=true): banner does not render
- [ ] Dismiss persists per-version in localStorage