### PR TITLE
fix(desktop): allow hosted SPA origins by default in bridge

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -21,9 +21,16 @@ The root `bun run dev:desktop` runner sets `STELLA_WEB_PORT`,
 `STELLA_DESKTOP_VIEW_PORT`, and `STELLA_DESKTOP_BRIDGE_PORT`
 automatically so multiple worktrees can coexist without port clashes.
 
-### Release configuration
+### Configuration
 
 Packaged builds should set these environment variables before building:
+
+- `STELLA_DESKTOP_RELEASE_BASE_URL`
+  - Base URL hosting Tauri release metadata and update artifacts (the
+    channel-rooted directory containing `latest.json`)
+  - Required to enable update checks in packaged builds
+
+Runtime bridge configuration:
 
 - `STELLA_DESKTOP_ALLOWED_ORIGINS`
   - Comma-separated exact web origins allowed to call the privileged localhost bridge
@@ -33,15 +40,10 @@ Packaged builds should set these environment variables before building:
   - Optional override for the localhost bridge port during development
 - `STELLA_DESKTOP_VIEW_PORT`
   - Optional override for the desktop Vite dev server during development
-- `STELLA_DESKTOP_RELEASE_BASE_URL`
-  - Base URL hosting Tauri release metadata and update artifacts (the
-    channel-rooted directory containing `latest.json`)
-  - Required to enable update checks in packaged builds
 
 Example:
 
 ```bash
-export STELLA_DESKTOP_ALLOWED_ORIGINS="https://my.stll.app"
 export STELLA_DESKTOP_RELEASE_BASE_URL="https://downloads.stll.app/desktop/prod"
 bun --cwd apps/desktop run build
 ```

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -10,10 +10,12 @@ bun --cwd apps/desktop run dev
 bun run dev:desktop
 ```
 
-The desktop bridge only allows loopback origins by default:
+The desktop bridge allows these origins by default:
 
 - `http://localhost:${STELLA_WEB_PORT:-3000}`
 - `http://127.0.0.1:${STELLA_WEB_PORT:-3000}`
+- `https://my.stll.app`
+- `https://app.stll.app`
 
 The root `bun run dev:desktop` runner sets `STELLA_WEB_PORT`,
 `STELLA_DESKTOP_VIEW_PORT`, and `STELLA_DESKTOP_BRIDGE_PORT`
@@ -25,8 +27,8 @@ Packaged builds should set these environment variables before building:
 
 - `STELLA_DESKTOP_ALLOWED_ORIGINS`
   - Comma-separated exact web origins allowed to call the privileged localhost bridge
-  - Example: `https://my.stll.app`
-  - Keep this explicit; the default loopback-only allowlist is intentional
+  - Read at runtime; appended to the built-in defaults (loopback + hosted SPA)
+  - Use this for selfhost or staging origins
 - `STELLA_DESKTOP_BRIDGE_PORT`
   - Optional override for the localhost bridge port during development
 - `STELLA_DESKTOP_VIEW_PORT`

--- a/apps/desktop/src-tauri/src/config.rs
+++ b/apps/desktop/src-tauri/src/config.rs
@@ -4,6 +4,8 @@ use crate::types::DEFAULT_BRIDGE_PORT;
 
 const DEFAULT_WEB_PORT: u16 = 3000;
 
+const DEFAULT_PROD_ORIGINS: &[&str] = &["https://my.stll.app", "https://app.stll.app"];
+
 fn parse_port(value: Option<String>, fallback: u16) -> u16 {
   value
     .and_then(|v| v.parse::<u16>().ok())
@@ -33,6 +35,10 @@ pub fn resolve_allowed_origins() -> HashSet<String> {
   let mut origins = HashSet::new();
   origins.insert(format!("http://127.0.0.1:{web_port}"));
   origins.insert(format!("http://localhost:{web_port}"));
+
+  for origin in DEFAULT_PROD_ORIGINS {
+    origins.insert((*origin).to_string());
+  }
 
   for origin in parse_origins(std::env::var("STELLA_DESKTOP_ALLOWED_ORIGINS").ok()) {
     origins.insert(origin);


### PR DESCRIPTION
## Summary

- Bake `https://my.stll.app` and `https://app.stll.app` into the desktop bridge's default allowlist
- Update README to match what the code actually does

## Why

The bridge reads `STELLA_DESKTOP_ALLOWED_ORIGINS` at runtime via `std::env::var()`. Setting it during `bun --cwd apps/desktop run build` does not flow into the packaged binary — the user's machine never has that env var set, so the var is always empty in production. 

The env var continues to layer on top of the defaults for selfhost or staging origins.

## Test plan

- [ ] Run packaged desktop app locally; hit `http://127.0.0.1:45901/health` from `https://my.stll.app` and confirm 200 + correct `Access-Control-Allow-Origin`
- [ ] Loopback dev origin still works (`http://localhost:3000`)
- [ ] `STELLA_DESKTOP_ALLOWED_ORIGINS=https://staging.example.com` still adds to the allowlist