### PR TITLE
fix: bundle runtime assets for compiled API

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -30,6 +30,15 @@ RUN bun build \
     --target bun \
     --outfile /app/server \
     apps/api/src/index.ts
+RUN mkdir -p /app/runtime-workers && \
+    bun build \
+      --target bun \
+      --outfile /app/runtime-workers/pdf-worker.js \
+      apps/api/src/handlers/files/pdf-worker.ts && \
+    bun build \
+      --target bun \
+      --outfile /app/runtime-workers/extraction-worker.js \
+      apps/api/src/lib/search/extraction-worker.ts
 
 # Run the compiled API as non-root.
 #
@@ -44,11 +53,13 @@ FROM deps AS runner
 # Defaults to "dev" for local `docker build` outside the release flow.
 ARG STELLA_VERSION=dev
 ENV STELLA_VERSION=${STELLA_VERSION}
+ENV STELLA_WORKER_DIR=/\$bunfs/root/workers
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella
 COPY --chown=stella:stella --from=pruner /app/out/full/ .
 COPY --chown=stella:stella --from=builder /app/server /app/server
 RUN mkdir -p '/$bunfs/root'
+COPY --chown=stella:stella --from=builder /app/runtime-workers /\$bunfs/root/workers
 COPY --chown=stella:stella --from=builder /app/apps/api/src/lib/file-scan/yara /\$bunfs/root/yara
 COPY --chown=stella:stella --from=deps \
     /app/node_modules/@stll/aho-corasick-wasm/dist/*.wasm \

--- a/apps/api/src/handlers/files/pdf-utils.artifact.test.ts
+++ b/apps/api/src/handlers/files/pdf-utils.artifact.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "../../../../..");
+
+describe("PDF worker runtime artifact", () => {
+  test("bundled parent process finds the bundled PDF worker", async () => {
+    const testDir = mkdtempSync(path.join(REPO_ROOT, ".tmp-pdf-worker-"));
+    const workerDir = path.join(testDir, "workers");
+    const parentDir = path.join(testDir, "parent");
+    const entrypoint = path.join(testDir, "entrypoint.ts");
+
+    try {
+      mkdirSync(workerDir);
+      mkdirSync(parentDir);
+
+      writeFileSync(
+        entrypoint,
+        `import { Result } from "better-result";
+import { isEncryptedPdf } from ${JSON.stringify(path.join(import.meta.dir, "pdf-utils.ts"))};
+
+const result = await isEncryptedPdf(new ArrayBuffer(0));
+if (!Result.isError(result)) {
+  throw new Error("Expected empty PDF to fail parsing");
+}
+if (result.error.message.includes("Module not found")) {
+  throw new Error(result.error.message);
+}
+if (!result.error.message.includes("pdf-worker error")) {
+  throw new Error(result.error.message);
+}
+`,
+      );
+
+      const workerBuild = await Bun.build({
+        entrypoints: [path.join(import.meta.dir, "pdf-worker.ts")],
+        naming: "pdf-worker.js",
+        outdir: workerDir,
+        target: "bun",
+      });
+      expect(workerBuild.success).toBe(true);
+
+      const parentBuild = await Bun.build({
+        entrypoints: [entrypoint],
+        outdir: parentDir,
+        target: "bun",
+      });
+      expect(parentBuild.success).toBe(true);
+
+      const result = Bun.spawnSync({
+        cmd: ["bun", path.join(parentDir, "entrypoint.js")],
+        env: {
+          PATH: process.env["PATH"] ?? "",
+          STELLA_WORKER_DIR: workerDir,
+        },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+
+      expect(result.exitCode).toBe(0);
+    } finally {
+      rmSync(testDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/api/src/handlers/files/pdf-utils.ts
+++ b/apps/api/src/handlers/files/pdf-utils.ts
@@ -1,14 +1,18 @@
 import { Result, TaggedError } from "better-result";
-import { resolve } from "node:path";
 
 import { LIMITS } from "@/api/lib/limits";
+import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
 import { spawnWorker } from "@/api/lib/subprocess";
 
 class CorruptedPdfError extends TaggedError("CorruptedPdfError")<{
   message: string;
 }>() {}
 
-const WORKER_PATH = resolve(import.meta.dir, "pdf-worker.ts");
+const WORKER_PATH = resolveRuntimeWorkerPath({
+  outputFile: "pdf-worker.js",
+  sourceDir: import.meta.dir,
+  sourceFile: "pdf-worker.ts",
+});
 
 export const isEncryptedPdf = async (buffer: ArrayBuffer) => {
   const result = await spawnWorker({

--- a/apps/api/src/lib/runtime-worker-path.test.ts
+++ b/apps/api/src/lib/runtime-worker-path.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
+
+const WORKER_DIR_ENV = "STELLA_WORKER_DIR";
+const originalWorkerDir = process.env[WORKER_DIR_ENV];
+
+afterEach(() => {
+  if (originalWorkerDir === undefined) {
+    process.env[WORKER_DIR_ENV] = "";
+    return;
+  }
+
+  process.env[WORKER_DIR_ENV] = originalWorkerDir;
+});
+
+describe("runtime worker paths", () => {
+  test("uses source worker path when no runtime worker directory is configured", () => {
+    process.env[WORKER_DIR_ENV] = "";
+
+    expect(
+      resolveRuntimeWorkerPath({
+        outputFile: "worker.js",
+        sourceDir: "/repo/apps/api/src/lib/search",
+        sourceFile: "worker.ts",
+      }),
+    ).toBe(resolve("/repo/apps/api/src/lib/search", "worker.ts"));
+  });
+
+  test("uses bundled worker artifact when runtime worker directory is configured", () => {
+    process.env[WORKER_DIR_ENV] = "/runtime/workers";
+
+    expect(
+      resolveRuntimeWorkerPath({
+        outputFile: "worker.js",
+        sourceDir: "/repo/apps/api/src/lib/search",
+        sourceFile: "worker.ts",
+      }),
+    ).toBe(resolve("/runtime/workers", "worker.js"));
+  });
+});

--- a/apps/api/src/lib/runtime-worker-path.ts
+++ b/apps/api/src/lib/runtime-worker-path.ts
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+
+const WORKER_DIR_ENV = "STELLA_WORKER_DIR";
+
+export const resolveRuntimeWorkerPath = ({
+  outputFile,
+  sourceDir,
+  sourceFile,
+}: {
+  outputFile: string;
+  sourceDir: string;
+  sourceFile: string;
+}): string => {
+  const workerDir = process.env[WORKER_DIR_ENV];
+  if (workerDir) {
+    return resolve(workerDir, outputFile);
+  }
+
+  return resolve(sourceDir, sourceFile);
+};

--- a/apps/api/src/lib/search/extract-content.ts
+++ b/apps/api/src/lib/search/extract-content.ts
@@ -8,15 +8,19 @@
  */
 
 import { Result } from "better-result";
-import { resolve } from "node:path";
 
 import { captureError } from "@/api/lib/analytics";
 import { ExtractionWorkerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import { resolveRuntimeWorkerPath } from "@/api/lib/runtime-worker-path";
 import { spawnWorker } from "@/api/lib/subprocess";
 import { DOCX_MIME_TYPE, PDF_MIME_TYPE } from "@/api/mime-types";
 
-const WORKER_PATH = resolve(import.meta.dir, "extraction-worker.ts");
+const WORKER_PATH = resolveRuntimeWorkerPath({
+  outputFile: "extraction-worker.js",
+  sourceDir: import.meta.dir,
+  sourceFile: "extraction-worker.ts",
+});
 
 const SUPPORTED_MIMES = new Set<string>([PDF_MIME_TYPE, DOCX_MIME_TYPE]);
 

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
-    "test": "bun test src",
+    "generate": "bun scripts/generate-manifest.ts",
+    "test": "bun scripts/generate-manifest.ts --check && bun test src",
     "typecheck": "tsgo --noEmit",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/skills",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/skills",

--- a/packages/skills/scripts/generate-manifest.ts
+++ b/packages/skills/scripts/generate-manifest.ts
@@ -1,0 +1,165 @@
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const packageRoot = path.join(import.meta.dirname, "..");
+const skillsRoot = path.join(packageRoot, "skills");
+const outputPath = path.join(packageRoot, "src", "skills.gen.ts");
+const skillFileName = "SKILL.md";
+const resourceRoots = ["knowledge", "prompts"] as const;
+const resourceExtensions = [".md", ".prompt.md"] as const;
+
+type ResourceEntry = {
+  importName: string;
+  kind: "knowledge" | "prompt";
+  path: string;
+  sourcePath: string;
+};
+
+type SkillEntry = {
+  id: string;
+  importName: string;
+  resources: ResourceEntry[];
+  sourcePath: string;
+};
+
+const skillEntries = readdirSync(skillsRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .filter((skillId) =>
+    existsSync(path.join(skillsRoot, skillId, skillFileName)),
+  )
+  .sort((a, b) => a.localeCompare(b))
+  .map((skillId, index): SkillEntry => {
+    const skillDir = path.join(skillsRoot, skillId);
+    return {
+      id: skillId,
+      importName: `skill${index}`,
+      resources: listResources(skillDir, index),
+      sourcePath: toImportPath(path.join(skillDir, skillFileName)),
+    };
+  });
+
+const imports = skillEntries.flatMap((skill) => [
+  `import ${skill.importName} from "${skill.sourcePath}" with { type: "text" };`,
+  ...skill.resources.map(
+    (resource) =>
+      `import ${resource.importName} from "${resource.sourcePath}" with { type: "text" };`,
+  ),
+]);
+
+const output = `// eslint-disable-next-line typescript-eslint/triple-slash-reference
+/// <reference path="./markdown.d.ts" />
+
+${imports.join("\n")}
+
+export const GENERATED_SKILLS = [
+${skillEntries.map(formatSkillEntry).join(",\n")}
+] as const;
+`;
+
+if (process.argv.includes("--check")) {
+  const currentOutput = readFileSync(outputPath, "utf-8");
+  if (currentOutput !== output) {
+    throw new Error("Generated skills manifest is out of date");
+  }
+} else {
+  writeFileSync(outputPath, output);
+}
+
+function listResources(skillDir: string, skillIndex: number): ResourceEntry[] {
+  const resources: ResourceEntry[] = [];
+
+  for (const rootName of resourceRoots) {
+    const rootDir = path.join(skillDir, rootName);
+    if (!existsSync(rootDir)) {
+      continue;
+    }
+
+    collectResources({
+      baseDir: skillDir,
+      currentDir: rootDir,
+      importPrefix: `skill${skillIndex}Resource`,
+      kind: rootName === "knowledge" ? "knowledge" : "prompt",
+      resources,
+    });
+  }
+
+  return resources
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((resource, resourceIndex) => ({
+      importName: `skill${skillIndex}Resource${resourceIndex}`,
+      kind: resource.kind,
+      path: resource.path,
+      sourcePath: resource.sourcePath,
+    }));
+}
+
+function collectResources({
+  baseDir,
+  currentDir,
+  importPrefix,
+  kind,
+  resources,
+}: {
+  baseDir: string;
+  currentDir: string;
+  importPrefix: string;
+  kind: ResourceEntry["kind"];
+  resources: ResourceEntry[];
+}) {
+  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
+    const entryPath = path.join(currentDir, entry.name);
+
+    if (entry.isDirectory()) {
+      collectResources({
+        baseDir,
+        currentDir: entryPath,
+        importPrefix,
+        kind,
+        resources,
+      });
+      continue;
+    }
+
+    if (!entry.isFile() || !hasAllowedResourceExtension(entry.name)) {
+      continue;
+    }
+
+    resources.push({
+      importName: importPrefix,
+      kind,
+      path: path.relative(baseDir, entryPath).split(path.sep).join("/"),
+      sourcePath: toImportPath(entryPath),
+    });
+  }
+}
+
+function formatSkillEntry(skill: SkillEntry): string {
+  const resources = skill.resources
+    .map(
+      (resource) =>
+        `      { kind: ${JSON.stringify(resource.kind)}, path: ${JSON.stringify(resource.path)}, source: ${resource.importName} }`,
+    )
+    .join(",\n");
+
+  return `  {
+    id: ${JSON.stringify(skill.id)},
+    source: ${skill.importName},
+    resources: [
+${resources}
+    ],
+  }`;
+}
+
+function toImportPath(filePath: string): string {
+  const relativePath = path.relative(path.dirname(outputPath), filePath);
+  return relativePath.startsWith(".")
+    ? relativePath.split(path.sep).join("/")
+    : `./${relativePath.split(path.sep).join("/")}`;
+}
+
+function hasAllowedResourceExtension(resourcePath: string): boolean {
+  return resourceExtensions.some((extension) =>
+    resourcePath.endsWith(extension),
+  );
+}

--- a/packages/skills/src/bundled-loader.test.ts
+++ b/packages/skills/src/bundled-loader.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+describe("bundled Stella skill loader", () => {
+  test("loads skills after bundling without a neighboring skills directory", async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), "stella-skills-bundle-"));
+    const entrypoint = path.join(testDir, "entrypoint.ts");
+    const outfile = path.join(testDir, "entrypoint.js");
+
+    writeFileSync(
+      entrypoint,
+      `import { listSkillMetadata, readSkillResource } from ${JSON.stringify(path.join(import.meta.dirname, "loader.ts"))};
+
+const skill = listSkillMetadata().find((candidate) => candidate.name === "legal-interpretation");
+if (!skill) {
+  throw new Error("Bundled skill metadata missing");
+}
+
+const resource = readSkillResource({
+  skillId: "legal-interpretation",
+  resourcePath: "knowledge/01-interpretation-methods.md",
+});
+if (!resource.includes("##")) {
+  throw new Error("Bundled skill resource missing");
+}
+`,
+    );
+
+    const build = await Bun.build({
+      entrypoints: [entrypoint],
+      naming: path.basename(outfile),
+      outdir: testDir,
+      target: "bun",
+    });
+
+    expect(build.success).toBe(true);
+
+    const process = Bun.spawnSync({
+      cmd: ["bun", outfile],
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    expect(process.exitCode).toBe(0);
+  });
+});

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -1,5 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import path from "node:path";
+import { GENERATED_SKILLS } from "./skills.gen";
 
 export type SkillMetadata = {
   description: string;
@@ -17,11 +16,10 @@ export type StellaSkill = SkillMetadata & {
   resources: SkillResource[];
 };
 
-const SKILLS_ROOT = path.join(import.meta.dirname, "..", "skills");
-const SKILL_FILE_NAME = "SKILL.md";
-const RESOURCE_ROOTS = ["knowledge", "prompts"] as const;
 const RESOURCE_EXTENSIONS = [".md", ".prompt.md"] as const;
-const skillResourcesCache = new Map<string, SkillResource[]>();
+const skillsById: ReadonlyMap<string, GeneratedSkill> = new Map(
+  GENERATED_SKILLS.map((skill) => [skill.id, skill]),
+);
 
 type Frontmatter = {
   description?: string | undefined;
@@ -29,14 +27,16 @@ type Frontmatter = {
   version?: string | undefined;
 };
 
+type GeneratedSkill = (typeof GENERATED_SKILLS)[number];
+
 export const listSkillMetadata = (): SkillMetadata[] =>
-  listSkillIds()
-    .map((skillId) => readSkillMetadata(skillId))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  GENERATED_SKILLS.map((skill) => readSkillMetadata(skill.id)).sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
 
 export const loadSkill = (skillId: string): StellaSkill => {
-  const skillPath = getSkillFilePath(skillId);
-  const parsed = parseSkillFile(readFileSync(skillPath, "utf-8"));
+  const skill = getSkill(skillId);
+  const parsed = parseSkillFile(skill.source);
 
   return {
     ...parsed.metadata,
@@ -46,33 +46,8 @@ export const loadSkill = (skillId: string): StellaSkill => {
 };
 
 export const listSkillResources = (skillId: string): SkillResource[] => {
-  const cachedResources = skillResourcesCache.get(skillId);
-  if (cachedResources) {
-    return cachedResources;
-  }
-
-  const skillDir = getSkillDir(skillId);
-  const resources: SkillResource[] = [];
-
-  for (const rootName of RESOURCE_ROOTS) {
-    const rootDir = path.join(skillDir, rootName);
-    if (!existsSync(rootDir)) {
-      continue;
-    }
-
-    collectResourcePaths({
-      baseDir: skillDir,
-      currentDir: rootDir,
-      kind: rootName === "knowledge" ? "knowledge" : "prompt",
-      resources,
-    });
-  }
-
-  const sortedResources = resources.sort((a, b) =>
-    a.path.localeCompare(b.path),
-  );
-  skillResourcesCache.set(skillId, sortedResources);
-  return sortedResources;
+  const skill = getSkill(skillId);
+  return skill.resources.map(({ kind, path }) => ({ kind, path }));
 };
 
 export const readSkillResource = ({
@@ -83,52 +58,36 @@ export const readSkillResource = ({
   skillId: string;
 }): string => {
   const normalizedPath = normalizeResourcePath(resourcePath);
-  const skillDir = getSkillDir(skillId);
-  const resolvedPath = path.resolve(skillDir, normalizedPath);
-  const resolvedSkillDir = path.resolve(skillDir);
-
-  if (!resolvedPath.startsWith(`${resolvedSkillDir}${path.sep}`)) {
-    throw new Error("Skill resource path escapes the skill directory");
-  }
-
+  const skill = getSkill(skillId);
   if (!isAllowedResourcePath(normalizedPath)) {
     throw new Error("Skill resource path is not a whitelisted resource");
   }
 
-  if (!existsSync(resolvedPath) || !statSync(resolvedPath).isFile()) {
+  const resource = skill.resources.find(
+    (candidate) => candidate.path === normalizedPath,
+  );
+  if (!resource) {
     throw new Error("Skill resource not found");
   }
 
-  return readFileSync(resolvedPath, "utf-8");
+  return resource.source;
 };
 
-const listSkillIds = (): string[] =>
-  readdirSync(SKILLS_ROOT, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .filter((skillId) =>
-      existsSync(path.join(SKILLS_ROOT, skillId, SKILL_FILE_NAME)),
-    )
-    .sort((a, b) => a.localeCompare(b));
-
 const readSkillMetadata = (skillId: string): SkillMetadata =>
-  parseSkillFile(readFileSync(getSkillFilePath(skillId), "utf-8")).metadata;
+  parseSkillFile(getSkill(skillId).source).metadata;
 
-const getSkillDir = (skillId: string): string => {
+const getSkill = (skillId: string) => {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(skillId)) {
     throw new Error("Invalid skill id");
   }
 
-  const skillDir = path.join(SKILLS_ROOT, skillId);
-  if (!existsSync(path.join(skillDir, SKILL_FILE_NAME))) {
+  const skill = skillsById.get(skillId);
+  if (!skill) {
     throw new Error(`Unknown skill: ${skillId}`);
   }
 
-  return skillDir;
+  return skill;
 };
-
-const getSkillFilePath = (skillId: string): string =>
-  path.join(getSkillDir(skillId), SKILL_FILE_NAME);
 
 const parseSkillFile = (
   source: string,
@@ -189,47 +148,12 @@ const stripYamlString = (value: string): string => {
   return trimmed.replace(/^["']|["']$/g, "");
 };
 
-const collectResourcePaths = ({
-  baseDir,
-  currentDir,
-  kind,
-  resources,
-}: {
-  baseDir: string;
-  currentDir: string;
-  kind: SkillResource["kind"];
-  resources: SkillResource[];
-}) => {
-  for (const entry of readdirSync(currentDir, { withFileTypes: true })) {
-    const entryPath = path.join(currentDir, entry.name);
-
-    if (entry.isDirectory()) {
-      collectResourcePaths({
-        baseDir,
-        currentDir: entryPath,
-        kind,
-        resources,
-      });
-      continue;
-    }
-
-    if (!entry.isFile() || !hasAllowedResourceExtension(entry.name)) {
-      continue;
-    }
-
-    resources.push({
-      kind,
-      path: path.relative(baseDir, entryPath).split(path.sep).join("/"),
-    });
-  }
-};
-
 const normalizeResourcePath = (resourcePath: string): string => {
-  if (path.isAbsolute(resourcePath)) {
+  if (resourcePath.startsWith("/")) {
     throw new Error("Skill resource path must be relative");
   }
 
-  const normalized = path.posix.normalize(resourcePath.replaceAll("\\", "/"));
+  const normalized = normalizePosixPath(resourcePath.replaceAll("\\", "/"));
   if (
     normalized === "." ||
     normalized === ".." ||
@@ -252,3 +176,30 @@ const isAllowedResourcePath = (resourcePath: string): boolean => {
 
 const hasAllowedResourceExtension = (resourcePath: string): boolean =>
   RESOURCE_EXTENSIONS.some((extension) => resourcePath.endsWith(extension));
+
+const normalizePosixPath = (resourcePath: string): string => {
+  const segments: string[] = [];
+
+  for (const segment of resourcePath.split("/")) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+
+    if (segment === "..") {
+      if (segments.length === 0) {
+        return "..";
+      }
+
+      segments.pop();
+      continue;
+    }
+
+    segments.push(segment);
+  }
+
+  if (segments.length === 0) {
+    return ".";
+  }
+
+  return segments.join("/");
+};

--- a/packages/skills/src/loader.ts
+++ b/packages/skills/src/loader.ts
@@ -1,5 +1,8 @@
 import { GENERATED_SKILLS } from "./skills.gen";
 
+// TODO: This is a temporary toy implementation for Stella-provided skills.
+// Replace it with importable, persisted skill packs before user-managed
+// skills become a runtime feature.
 export type SkillMetadata = {
   description: string;
   name: string;

--- a/packages/skills/src/markdown.d.ts
+++ b/packages/skills/src/markdown.d.ts
@@ -1,0 +1,4 @@
+declare module "*.md" {
+  const source: string;
+  export default source;
+}

--- a/packages/skills/src/skills.gen.ts
+++ b/packages/skills/src/skills.gen.ts
@@ -1,0 +1,80 @@
+// eslint-disable-next-line typescript-eslint/triple-slash-reference
+/// <reference path="./markdown.d.ts" />
+
+import skill0 from "../skills/case-briefing/SKILL.md" with { type: "text" };
+import skill0Resource0 from "../skills/case-briefing/knowledge/01-structural-elements.md" with { type: "text" };
+import skill0Resource1 from "../skills/case-briefing/prompts/brief-case.prompt.md" with { type: "text" };
+import skill0Resource2 from "../skills/case-briefing/prompts/extract-ratio.prompt.md" with { type: "text" };
+import skill1 from "../skills/contract-analysis/SKILL.md" with { type: "text" };
+import skill1Resource0 from "../skills/contract-analysis/knowledge/01-structural-components.md" with { type: "text" };
+import skill1Resource1 from "../skills/contract-analysis/knowledge/02-analysis-patterns.md" with { type: "text" };
+import skill1Resource2 from "../skills/contract-analysis/prompts/decompose-contract.prompt.md" with { type: "text" };
+import skill1Resource3 from "../skills/contract-analysis/prompts/extract-contract-type.prompt.md" with { type: "text" };
+import skill1Resource4 from "../skills/contract-analysis/prompts/extract-risk-allocation.prompt.md" with { type: "text" };
+import skill2 from "../skills/data-protection/SKILL.md" with { type: "text" };
+import skill2Resource0 from "../skills/data-protection/knowledge/01-data-protection-framework.md" with { type: "text" };
+import skill2Resource1 from "../skills/data-protection/knowledge/02-lawful-basis-analysis.md" with { type: "text" };
+import skill2Resource2 from "../skills/data-protection/knowledge/03-transparency-and-notices.md" with { type: "text" };
+import skill2Resource3 from "../skills/data-protection/knowledge/04-processor-agreements.md" with { type: "text" };
+import skill2Resource4 from "../skills/data-protection/knowledge/05-breach-assessment.md" with { type: "text" };
+import skill2Resource5 from "../skills/data-protection/knowledge/06-cross-cutting-considerations.md" with { type: "text" };
+import skill2Resource6 from "../skills/data-protection/prompts/assess-breach.prompt.md" with { type: "text" };
+import skill2Resource7 from "../skills/data-protection/prompts/assess-processing.prompt.md" with { type: "text" };
+import skill2Resource8 from "../skills/data-protection/prompts/review-dpa.prompt.md" with { type: "text" };
+import skill2Resource9 from "../skills/data-protection/prompts/review-privacy-notice.prompt.md" with { type: "text" };
+import skill3 from "../skills/legal-interpretation/SKILL.md" with { type: "text" };
+import skill3Resource0 from "../skills/legal-interpretation/knowledge/01-interpretation-methods.md" with { type: "text" };
+import skill3Resource1 from "../skills/legal-interpretation/knowledge/02-reasoning-structure.md" with { type: "text" };
+import skill3Resource2 from "../skills/legal-interpretation/knowledge/03-examples.md" with { type: "text" };
+import skill3Resource3 from "../skills/legal-interpretation/knowledge/04-domain-rules.md" with { type: "text" };
+import skill3Resource4 from "../skills/legal-interpretation/prompts/analyze-statute.prompt.md" with { type: "text" };
+
+export const GENERATED_SKILLS = [
+  {
+    id: "case-briefing",
+    source: skill0,
+    resources: [
+      { kind: "knowledge", path: "knowledge/01-structural-elements.md", source: skill0Resource0 },
+      { kind: "prompt", path: "prompts/brief-case.prompt.md", source: skill0Resource1 },
+      { kind: "prompt", path: "prompts/extract-ratio.prompt.md", source: skill0Resource2 }
+    ],
+  },
+  {
+    id: "contract-analysis",
+    source: skill1,
+    resources: [
+      { kind: "knowledge", path: "knowledge/01-structural-components.md", source: skill1Resource0 },
+      { kind: "knowledge", path: "knowledge/02-analysis-patterns.md", source: skill1Resource1 },
+      { kind: "prompt", path: "prompts/decompose-contract.prompt.md", source: skill1Resource2 },
+      { kind: "prompt", path: "prompts/extract-contract-type.prompt.md", source: skill1Resource3 },
+      { kind: "prompt", path: "prompts/extract-risk-allocation.prompt.md", source: skill1Resource4 }
+    ],
+  },
+  {
+    id: "data-protection",
+    source: skill2,
+    resources: [
+      { kind: "knowledge", path: "knowledge/01-data-protection-framework.md", source: skill2Resource0 },
+      { kind: "knowledge", path: "knowledge/02-lawful-basis-analysis.md", source: skill2Resource1 },
+      { kind: "knowledge", path: "knowledge/03-transparency-and-notices.md", source: skill2Resource2 },
+      { kind: "knowledge", path: "knowledge/04-processor-agreements.md", source: skill2Resource3 },
+      { kind: "knowledge", path: "knowledge/05-breach-assessment.md", source: skill2Resource4 },
+      { kind: "knowledge", path: "knowledge/06-cross-cutting-considerations.md", source: skill2Resource5 },
+      { kind: "prompt", path: "prompts/assess-breach.prompt.md", source: skill2Resource6 },
+      { kind: "prompt", path: "prompts/assess-processing.prompt.md", source: skill2Resource7 },
+      { kind: "prompt", path: "prompts/review-dpa.prompt.md", source: skill2Resource8 },
+      { kind: "prompt", path: "prompts/review-privacy-notice.prompt.md", source: skill2Resource9 }
+    ],
+  },
+  {
+    id: "legal-interpretation",
+    source: skill3,
+    resources: [
+      { kind: "knowledge", path: "knowledge/01-interpretation-methods.md", source: skill3Resource0 },
+      { kind: "knowledge", path: "knowledge/02-reasoning-structure.md", source: skill3Resource1 },
+      { kind: "knowledge", path: "knowledge/03-examples.md", source: skill3Resource2 },
+      { kind: "knowledge", path: "knowledge/04-domain-rules.md", source: skill3Resource3 },
+      { kind: "prompt", path: "prompts/analyze-statute.prompt.md", source: skill3Resource4 }
+    ],
+  }
+] as const;


### PR DESCRIPTION
jk: note::: the skills implementation is very rough and this is just a hotfix to unblock hosted app, cleaning of skills and allowing users to add their own arbitrary ones is to be added as a prio, tracked in #25


## Summary

- embed built-in skill files through a generated static manifest
- build subprocess worker artifacts and resolve them from a configured runtime worker directory
- add bundled artifact regression tests for skills and worker path resolution

## Checks

- bun --filter @stll/skills test && bun --filter @stll/skills typecheck && bun --filter @stll/skills lint
- bun --cwd apps/api test src/handlers/files/pdf-utils.artifact.test.ts src/lib/runtime-worker-path.test.ts src/lib/subprocess.test.ts && bun --filter @stll/api typecheck && bun --filter @stll/api lint
- pre-push: i18n, format, typecheck, lint
