### PR TITLE
fix(chat): stop empty-completion auto-resubmit storm

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -26,10 +26,17 @@ import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-regi
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import {
+  getModelForRole,
+  getModelInfoForRole,
+  getTemperatureForRole,
+} from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  ChatEmptyCompletionError,
+  HandlerError,
+} from "@/api/lib/errors/tagged-errors";
 
 const MAX_TOOL_STEPS = 8;
 
@@ -122,6 +129,7 @@ export const streamChat = async ({
       return "error";
     },
     execute: ({ writer }) => {
+      const modelInfo = getModelInfoForRole("chat", orgAIConfig);
       const result = streamText({
         abortSignal,
         model: getModelForRole("chat", orgAIConfig),
@@ -137,6 +145,26 @@ export const streamChat = async ({
         },
         stopWhen: [stepCountIs(MAX_TOOL_STEPS), hasToolCall("ask-user")],
         messages: modelMessages,
+        onFinish: ({ finishReason, totalUsage }) => {
+          // Some providers (notably gemini-2.5-flash-lite on cached
+          // prefixes) return finish_reason=stop with zero output
+          // tokens. The frontend predicate guards against the
+          // resulting auto-resubmit storm, but the failure is
+          // otherwise invisible — capture it so we can track which
+          // models regress.
+          if (finishReason === "stop" && (totalUsage.outputTokens ?? 0) === 0) {
+            captureError(
+              new ChatEmptyCompletionError({
+                message: "Model returned finish_reason=stop with zero output",
+              }),
+              {
+                threadId,
+                provider: modelInfo.provider,
+                modelId: modelInfo.modelId,
+              },
+            );
+          }
+        },
       });
 
       const uiStream = result.toUIMessageStream<ChatMessage>();

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -152,7 +152,10 @@ export const streamChat = async ({
           // resulting auto-resubmit storm, but the failure is
           // otherwise invisible — capture it so we can track which
           // models regress.
-          if (finishReason === "stop" && (totalUsage.outputTokens ?? 0) === 0) {
+          // `outputTokens` is `number | undefined` — only fire when
+          // explicitly zero, otherwise providers that omit usage
+          // metadata would all be misclassified as empty.
+          if (finishReason === "stop" && totalUsage.outputTokens === 0) {
             captureError(
               new ChatEmptyCompletionError({
                 message: "Model returned finish_reason=stop with zero output",

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -85,6 +85,18 @@ export class ChatToolError extends TaggedError("ChatToolError")<{
   cause?: unknown;
 }>() {}
 
+/**
+ * Chat stream finished with finish_reason=stop and zero output
+ * tokens. Observed with small Gemini variants (notably 2.5-flash-lite)
+ * on cached prefix replays. Surfaced as a tagged error for telemetry
+ * so we can track which models cause it.
+ */
+export class ChatEmptyCompletionError extends TaggedError(
+  "ChatEmptyCompletionError",
+)<{
+  message: string;
+}>() {}
+
 /** Sandbox execution failure: transpile, runtime, limit, or marshalling. */
 export class SandboxError extends TaggedError("SandboxError")<{
   reason:

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -243,23 +243,26 @@ export const buildSendRequestBody = ({
 // with cached prefixes on small Gemini variants), the AI SDK does
 // not append a new assistant message, so the same tool-result tail
 // keeps satisfying the predicate and useChat resubmits at ~1.5 Hz
-// until the user reloads. Requiring the message count to grow since
-// the last fire breaks the loop without affecting the legitimate
-// post-tool-result resubmit.
+// until the user reloads. Tracking the id of the message that last
+// triggered an automatic send breaks the loop without affecting the
+// legitimate post-tool-result resubmit. Id is more robust than
+// length: deleting and re-adding a message reuses no id, so the
+// predicate cannot accidentally lock out a future fire.
 const createSendAutomaticallyPredicate = () => {
-  let lastFiredAtCount = 0;
+  let lastFiredMessageId: string | null = null;
   return ({ messages }: { messages: PersistedChatMessage[] }) => {
     if (hasApprovedActiveDocxEditAwaitingClientOutput({ messages })) {
       return false;
     }
-    if (messages.length <= lastFiredAtCount) {
+    const lastMessage = messages.at(-1);
+    if (!lastMessage || lastMessage.id === lastFiredMessageId) {
       return false;
     }
     const shouldFire =
       lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
       lastAssistantMessageIsCompleteWithToolCalls({ messages });
     if (shouldFire) {
-      lastFiredAtCount = messages.length;
+      lastFiredMessageId = lastMessage.id;
     }
     return shouldFire;
   };

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -238,14 +238,32 @@ export const buildSendRequestBody = ({
   return body;
 };
 
-const shouldSendAutomaticallyAfterToolResponse = ({
-  messages,
-}: {
-  messages: PersistedChatMessage[];
-}) =>
-  !hasApprovedActiveDocxEditAwaitingClientOutput({ messages }) &&
-  (lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
-    lastAssistantMessageIsCompleteWithToolCalls({ messages }));
+// Per-thread guard against empty-completion auto-resubmit storms.
+// When a model returns finish_reason=stop with zero tokens (observed
+// with cached prefixes on small Gemini variants), the AI SDK does
+// not append a new assistant message, so the same tool-result tail
+// keeps satisfying the predicate and useChat resubmits at ~1.5 Hz
+// until the user reloads. Requiring the message count to grow since
+// the last fire breaks the loop without affecting the legitimate
+// post-tool-result resubmit.
+const createSendAutomaticallyPredicate = () => {
+  let lastFiredAtCount = 0;
+  return ({ messages }: { messages: PersistedChatMessage[] }) => {
+    if (hasApprovedActiveDocxEditAwaitingClientOutput({ messages })) {
+      return false;
+    }
+    if (messages.length <= lastFiredAtCount) {
+      return false;
+    }
+    const shouldFire =
+      lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
+      lastAssistantMessageIsCompleteWithToolCalls({ messages });
+    if (shouldFire) {
+      lastFiredAtCount = messages.length;
+    }
+    return shouldFire;
+  };
+};
 
 export type ChatThreadFetched = {
   chat: Chat<PersistedChatMessage>;
@@ -287,7 +305,7 @@ export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
             }),
           }),
         }),
-        sendAutomaticallyWhen: shouldSendAutomaticallyAfterToolResponse,
+        sendAutomaticallyWhen: createSendAutomaticallyPredicate(),
       });
 
       return { chat, contextMatterIds };


### PR DESCRIPTION
## Summary

- Empty completions (model finishes with `finish_reason=stop` and zero output tokens) caused `useChat` to auto-resubmit at ~1.5 Hz indefinitely, producing storms of ~95 single-step runs in <1 minute.
- Repro: `gemini-2.5-flash-lite` after a tool result whose prompt prefix is largely cached. Provider returns stop+empty, AI SDK does not append a new assistant message, the auto-resubmit predicate keeps matching the same tool-result tail.
- Frontend: harden the `sendAutomaticallyWhen` predicate with a per-thread last-fired message count so it only fires once per conversation growth. The legitimate post-tool-result resubmit still works; the same predicate state cannot fire twice without the conversation extending.
- Backend: capture empty completions as a tagged `ChatEmptyCompletionError` so the failure is visible in analytics with `provider` + `modelId` correlation. The frontend guard alone stops the storm; this just makes future regressions traceable.

## Test plan

- [ ] Reproduce the storm on `main` against an org BYOK'd to `gemini-2.5-flash-lite`: send a chat message that triggers `ask-user`, submit empty answers, observe the AI SDK Devtools panel for repeated single-step runs at the same timestamp.
- [ ] Same flow on this branch: predicate fires once, no resubmit storm.
- [ ] Normal chat flow: tool call → tool result → assistant continuation still resumes automatically.
- [ ] PostHog: `ChatEmptyCompletionError` event fires once per empty completion with `provider` and `modelId` properties.

## Notes

- The dev "Chat Model" picker (`apps/web/src/components/dev-sidebar-group.tsx:48`) is dead code — `chatModelId` is written but never read on the request path. Out of scope for this PR; needs a separate change to thread it through `prepareSendMessagesRequest` and validate against the org's model allowlist on the API side.