### PR TITLE
fix: repair matter rename surfaces

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -260,6 +260,7 @@ const MatterItem = ({
   const isPinned = usePinnedStore((s) => s.isPinned(ws.id));
   const t = useTranslations();
   const lang = useI18nStore((s) => s.lang);
+  const { state, setOpen, isMobile } = useSidebar();
   const [isRenaming, setIsRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(ws.name);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -273,6 +274,7 @@ const MatterItem = ({
   const [isDropTarget, setIsDropTarget] = useState(false);
 
   const canDrag = isPinned && !!onReorder;
+  const isCollapsed = state === "collapsed" && !isMobile;
 
   const onReorderRef = useRef(onReorder);
   onReorderRef.current = onReorder;
@@ -313,6 +315,21 @@ const MatterItem = ({
   const cancelRename = () => {
     setIsRenaming(false);
     setRenameValue(ws.name);
+  };
+
+  const startRename = () => {
+    escapedRef.current = false;
+    setMenuOpen(false);
+    setCtxAnchor(null);
+    setRenameValue(ws.name);
+
+    if (isCollapsed) {
+      setOpen(true);
+      window.requestAnimationFrame(() => setIsRenaming(true));
+      return;
+    }
+
+    setIsRenaming(true);
   };
 
   const handleRename = () => {
@@ -502,8 +519,7 @@ const MatterItem = ({
                     void window.open(`/workspaces/${ws.id}`, "_blank");
                   }}
                   onRename={() => {
-                    setRenameValue(ws.name);
-                    setIsRenaming(true);
+                    startRename();
                   }}
                   onTogglePin={() => onTogglePin(ws.id)}
                 />

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -285,19 +285,17 @@ export const WorkspaceBreadcrumb = ({
                 onChange={(e) => setValue(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") {
-                    handleSaveProjectName();
+                    e.currentTarget.blur();
                   }
                   if (e.key === "Escape") {
                     escapedNameRef.current = true;
                     e.currentTarget.blur();
                   }
                 }}
-                ref={(el) => {
-                  el?.focus();
-                }}
+                autoFocus
                 size="sm"
                 unstyled
-                value={value || displayName}
+                value={value}
               />
             </>
           ) : (
@@ -380,19 +378,17 @@ export const WorkspaceBreadcrumb = ({
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
-                handleSaveProjectName();
+                e.currentTarget.blur();
               }
               if (e.key === "Escape") {
                 escapedNameRef.current = true;
                 e.currentTarget.blur();
               }
             }}
-            ref={(el) => {
-              el?.focus();
-            }}
+            autoFocus
             size="sm"
             unstyled
-            value={value || displayName}
+            value={value}
           />
           {referenceSegment}
           {referenceHint}

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   BreadcrumbItem,
@@ -44,6 +44,7 @@ export const WorkspaceBreadcrumb = ({
   });
   const [value, setValue] = useState("");
   const [isEditing, setIsEditing] = useState(false);
+  const escapedNameRef = useRef(false);
   const [refValue, setRefValue] = useState("");
   const [isEditingRef, setIsEditingRef] = useState(false);
   const [refError, setRefError] = useState("");
@@ -63,7 +64,20 @@ export const WorkspaceBreadcrumb = ({
 
   const displayName = workspace.name ?? workspaceId;
 
+  const startEditingName = () => {
+    escapedNameRef.current = false;
+    setValue(displayName);
+    setIsEditing(true);
+  };
+
   const handleSaveProjectName = () => {
+    if (escapedNameRef.current) {
+      escapedNameRef.current = false;
+      setValue(displayName);
+      setIsEditing(false);
+      return;
+    }
+
     setIsEditing(false);
 
     const workspaceName = value.trim();
@@ -248,39 +262,88 @@ export const WorkspaceBreadcrumb = ({
       <>
         {clientSegment}
         <BreadcrumbItem className="shrink-0">
-          <Link
-            activeOptions={{ exact: true, includeSearch: false }}
-            activeProps={{ className: "text-foreground font-semibold" }}
-            className="hover:text-foreground inline-flex max-w-80 items-center gap-1.5 font-semibold transition-colors"
-            params={{ workspaceId }}
-            title={displayName}
-            to="/workspaces/$workspaceId"
-          >
-            <span
-              className="flex shrink-0"
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setColorPickerOpen(true);
-              }}
-              ref={setIconAnchor}
-            >
-              <LayersIcon className="size-3.5" style={{ color: activeColor }} />
-            </span>
-            <span className="truncate">{displayName}</span>
-            {workspace.reference && !isEditingRef ? (
+          {isEditing ? (
+            <>
               <span
-                className="text-muted-foreground/60 shrink-0 text-sm"
+                className="flex shrink-0"
                 onContextMenu={(e) => {
                   e.preventDefault();
-                  setRefValue(workspace.reference ?? "");
-                  setRefError("");
-                  setIsEditingRef(true);
+                  e.stopPropagation();
+                  setColorPickerOpen(true);
                 }}
+                ref={setIconAnchor}
               >
-                {workspace.reference}
+                <LayersIcon
+                  className="size-3.5"
+                  style={{ color: activeColor }}
+                />
               </span>
-            ) : null}
-          </Link>
+              <Input
+                className={`${matterNameInputClassName} w-fit`}
+                disabled={updateWorkspace.isPending}
+                onBlur={() => handleSaveProjectName()}
+                onChange={(e) => setValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    handleSaveProjectName();
+                  }
+                  if (e.key === "Escape") {
+                    escapedNameRef.current = true;
+                    e.currentTarget.blur();
+                  }
+                }}
+                ref={(el) => {
+                  el?.focus();
+                }}
+                size="sm"
+                unstyled
+                value={value || displayName}
+              />
+            </>
+          ) : (
+            <Link
+              activeOptions={{ exact: true, includeSearch: false }}
+              activeProps={{ className: "text-foreground font-semibold" }}
+              className="hover:text-foreground inline-flex max-w-80 items-center gap-1.5 font-semibold transition-colors"
+              onContextMenu={(e) => {
+                e.preventDefault();
+                startEditingName();
+              }}
+              params={{ workspaceId }}
+              title={displayName}
+              to="/workspaces/$workspaceId"
+            >
+              <span
+                className="flex shrink-0"
+                onContextMenu={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setColorPickerOpen(true);
+                }}
+                ref={setIconAnchor}
+              >
+                <LayersIcon
+                  className="size-3.5"
+                  style={{ color: activeColor }}
+                />
+              </span>
+              <span className="truncate">{displayName}</span>
+              {workspace.reference && !isEditingRef ? (
+                <span
+                  className="text-muted-foreground/60 shrink-0 text-sm"
+                  onContextMenu={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setRefValue(workspace.reference ?? "");
+                    setRefError("");
+                    setIsEditingRef(true);
+                  }}
+                >
+                  {workspace.reference}
+                </span>
+              ) : null}
+            </Link>
+          )}
           {isEditingRef ? referenceSegment : null}
           {referenceHint}
         </BreadcrumbItem>
@@ -319,6 +382,10 @@ export const WorkspaceBreadcrumb = ({
               if (e.key === "Enter") {
                 handleSaveProjectName();
               }
+              if (e.key === "Escape") {
+                escapedNameRef.current = true;
+                e.currentTarget.blur();
+              }
             }}
             ref={(el) => {
               el?.focus();
@@ -343,16 +410,15 @@ export const WorkspaceBreadcrumb = ({
           activeOptions={{ exact: true, includeSearch: false }}
           activeProps={{ className: "text-foreground font-semibold" }}
           className="hover:text-foreground max-w-80 truncate font-semibold transition-colors"
-          title={displayName}
           onClick={() => {
-            setIsEditing(true);
+            startEditingName();
           }}
           onContextMenu={(e) => {
             e.preventDefault();
-            setValue(displayName);
-            setIsEditing(true);
+            startEditingName();
           }}
           params={{ workspaceId }}
+          title={displayName}
           to="/workspaces/$workspaceId"
         >
           {displayName}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
@@ -61,6 +61,8 @@ export const MatterMetadataSheet = ({
   const queryClient = useQueryClient();
   const [isOpen, setIsOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [nameValue, setNameValue] = useState("");
+  const escapedNameRef = useRef(false);
   const [referenceValue, setReferenceValue] = useState("");
   const [referenceError, setReferenceError] = useState("");
 
@@ -68,6 +70,37 @@ export const MatterMetadataSheet = ({
   const deleteWorkspace = useDeleteWorkspace();
   const canDeleteWorkspace = usePermissions({ workspace: ["delete"] });
   const updateWorkspace = useUpdateWorkspace();
+
+  const handleSaveName = () => {
+    if (escapedNameRef.current) {
+      escapedNameRef.current = false;
+      setNameValue(workspace.name);
+      return;
+    }
+
+    const trimmed = nameValue.trim();
+    if (!trimmed || trimmed === workspace.name) {
+      setNameValue(workspace.name);
+      return;
+    }
+
+    updateWorkspace.mutate(
+      {
+        workspaceId,
+        name: trimmed,
+      },
+      {
+        onError: (error) => {
+          const message =
+            APIError.is(error) && error.status < 500
+              ? error.message
+              : t("errors.actionFailed");
+          toastManager.add({ title: message, type: "error" });
+          setNameValue(workspace.name);
+        },
+      },
+    );
+  };
 
   const handleSaveReference = () => {
     const trimmed = referenceValue.trim();
@@ -145,6 +178,8 @@ export const MatterMetadataSheet = ({
         onOpenChange={(open) => {
           setIsOpen(open);
           if (open) {
+            escapedNameRef.current = false;
+            setNameValue(workspace.name);
             setReferenceValue(workspace.reference ?? "");
           }
         }}
@@ -159,6 +194,30 @@ export const MatterMetadataSheet = ({
             <SheetDescription />
           </SheetHeader>
           <SheetPanel className="flex flex-1 flex-col gap-4">
+            {/* Name */}
+            <section className="px-4">
+              <span className="text-muted-foreground mb-1.5 block text-sm font-medium">
+                {t("common.name")}
+              </span>
+              <Input
+                disabled={updateWorkspace.isPending}
+                onBlur={handleSaveName}
+                onChange={(e) => setNameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.currentTarget.blur();
+                  }
+                  if (e.key === "Escape") {
+                    escapedNameRef.current = true;
+                    e.currentTarget.blur();
+                  }
+                }}
+                value={nameValue}
+              />
+            </section>
+
+            <Separator />
+
             {/* Reference */}
             <section className="px-4">
               <span className="text-muted-foreground mb-1.5 block text-sm font-medium">

--- a/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+
+describe("workspace update cache invalidation", () => {
+  test("includes the navigation cache used by the sidebar", async () => {
+    process.env["VITE_API_URL"] = "http://localhost:3006";
+
+    const { workspaceUpdateInvalidationKeys } =
+      await import("@/routes/_protected.workspaces/-mutations");
+    const { workspacesKeys } =
+      await import("@/routes/_protected.workspaces/-queries");
+    const workspaceId = "workspace-1";
+
+    expect(workspaceUpdateInvalidationKeys(workspaceId)).toContainEqual(
+      workspacesKeys.navigation(),
+    );
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
@@ -1,17 +1,19 @@
 import { describe, expect, test } from "bun:test";
 
 describe("workspace update cache invalidation", () => {
-  test("includes the navigation cache used by the sidebar", async () => {
+  test("invalidates the root workspace cache that covers sidebar navigation", async () => {
     process.env["VITE_API_URL"] = "http://localhost:3006";
 
     const { workspaceUpdateInvalidationKeys } =
       await import("@/routes/_protected.workspaces/-mutations");
     const { workspacesKeys } =
       await import("@/routes/_protected.workspaces/-queries");
-    const workspaceId = "workspace-1";
 
-    expect(workspaceUpdateInvalidationKeys(workspaceId)).toContainEqual(
-      workspacesKeys.navigation(),
+    expect(workspaceUpdateInvalidationKeys()).toContainEqual(
+      workspacesKeys.all,
     );
+    expect(
+      workspacesKeys.navigation().slice(0, workspacesKeys.all.length),
+    ).toEqual(workspacesKeys.all);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -73,11 +73,7 @@ type UpdateWorkspaceVars = {
   };
 };
 
-export const workspaceUpdateInvalidationKeys = (workspaceId: string) => [
-  workspacesKeys.byId(workspaceId),
-  workspacesKeys.navigation(),
-  workspacesKeys.all,
-];
+export const workspaceUpdateInvalidationKeys = () => [workspacesKeys.all];
 
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
@@ -108,10 +104,8 @@ export const useUpdateWorkspace = () => {
         throw toAPIError(response.error);
       }
     },
-    onSuccess: (_data, variables) => {
-      for (const queryKey of workspaceUpdateInvalidationKeys(
-        variables.workspaceId,
-      )) {
+    onSuccess: () => {
+      for (const queryKey of workspaceUpdateInvalidationKeys()) {
         void queryClient.invalidateQueries({ queryKey });
       }
     },

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -73,8 +73,15 @@ type UpdateWorkspaceVars = {
   };
 };
 
+export const workspaceUpdateInvalidationKeys = (workspaceId: string) => [
+  workspacesKeys.byId(workspaceId),
+  workspacesKeys.navigation(),
+  workspacesKeys.all,
+];
+
 export const useUpdateWorkspace = () => {
   const analytics = useAnalytics();
+  const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({ workspaceId, ...body }: UpdateWorkspaceVars) => {
@@ -99,6 +106,13 @@ export const useUpdateWorkspace = () => {
 
       if (response.error) {
         throw toAPIError(response.error);
+      }
+    },
+    onSuccess: (_data, variables) => {
+      for (const queryKey of workspaceUpdateInvalidationKeys(
+        variables.workspaceId,
+      )) {
+        void queryClient.invalidateQueries({ queryKey });
       }
     },
     onError: (error) => {


### PR DESCRIPTION
Summary:
- keep sidebar matter rename usable when the left rail is collapsed
- add matter rename entry points in breadcrumbs and metadata
- refresh workspace navigation data after matter updates