### PR TITLE
chore: polish chat entry and matter menus

### DIFF
--- a/apps/web/src/components/chat/chat-matter-picker.tsx
+++ b/apps/web/src/components/chat/chat-matter-picker.tsx
@@ -147,6 +147,12 @@ export const ChatMatterPicker = ({
   const triggerSwatch = selected[0]
     ? resolveMatterColor(selected[0].id, selected[0].color)
     : null;
+  const extraCountStyle = triggerSwatch
+    ? {
+        backgroundColor: `color-mix(in srgb, ${triggerSwatch} 14%, transparent)`,
+        color: triggerSwatch,
+      }
+    : undefined;
 
   const toggle = (matterId: string) => {
     if (matterIds.includes(matterId)) {
@@ -183,7 +189,10 @@ export const ChatMatterPicker = ({
         />
         <span className="truncate">{triggerLabel}</span>
         {extraCount > 0 && (
-          <span className="bg-muted text-foreground rounded-sm px-1 text-[10px] font-medium tabular-nums">
+          <span
+            className="bg-muted text-foreground rounded-sm px-1 text-[10px] font-medium tabular-nums"
+            style={extraCountStyle}
+          >
             +{extraCount}
           </span>
         )}

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Naposledy otevřené spisy",
       "noMatters": "Zatím žádné spisy",
-      "noPrompts": "Zatím žádné prompty",
+      "noPrompts": "Zatím žádné dovednosti",
       "noRecentChats": "Zatím žádné nedávné chaty",
       "pinnedMatters": "Připnuté spisy",
-      "prompts": "Prompty",
+      "prompts": "Dovednosti",
       "recentChats": "Nedávné chaty"
     },
     "maxAttachmentsReached": "Maximálně {count} souborů na zprávu",
@@ -373,12 +373,12 @@
     "noThreads": "Zatím žádné konverzace",
     "placeholder": "Zde napište svůj dotaz, / pro dovednosti, @ pro přidání kontextu",
     "prompts": {
-      "noResults": "Žádné odpovídající promty",
+      "noResults": "Žádné odpovídající dovednosti",
       "noShortcuts": "Zatím žádné dovednosti. Přidejte je v části Znalosti → Dovednosti.",
       "scope": {
-        "private": "Vaše promty",
+        "private": "Vaše dovednosti",
         "stock": "Vestavěné",
-        "team": "Týmové promty"
+        "team": "Týmové dovednosti"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Konektory"
       },
       "skills": {
-        "description": "Vlastní AI dovednosti a prompty",
+        "description": "Vlastní AI dovednosti",
         "title": "Dovednosti"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Zuletzt geöffnete Sachen",
       "noMatters": "Noch keine Sachen",
-      "noPrompts": "Noch keine Prompts",
+      "noPrompts": "Noch keine Skills",
       "noRecentChats": "Keine letzten Chats",
       "pinnedMatters": "Angeheftete Sachen",
-      "prompts": "Prompts",
+      "prompts": "Skills",
       "recentChats": "Letzte Chats"
     },
     "maxAttachmentsReached": "Maximal {count} Dateien pro Nachricht",
@@ -373,12 +373,12 @@
     "noThreads": "Noch keine Konversationen",
     "placeholder": "Geben Sie hier Ihre Frage ein, / für Skills, @ für Kontext",
     "prompts": {
-      "noResults": "Keine passenden Prompts",
+      "noResults": "Keine passenden Skills",
       "noShortcuts": "Noch keine Skills. Fügen Sie welche unter Wissen → Skills hinzu.",
       "scope": {
-        "private": "Eigene Prompts",
+        "private": "Eigene Skills",
         "stock": "Vorgegeben",
-        "team": "Team-Prompts"
+        "team": "Team-Skills"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Konnektoren"
       },
       "skills": {
-        "description": "Benutzerdefinierte KI-Skills und Prompts",
+        "description": "Benutzerdefinierte KI-Skills",
         "title": "Fähigkeiten"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Last accessed matters",
       "noMatters": "No matters yet",
-      "noPrompts": "No prompts yet",
+      "noPrompts": "No skills yet",
       "noRecentChats": "No recent chats",
       "pinnedMatters": "Pinned matters",
-      "prompts": "Prompts",
+      "prompts": "Skills",
       "recentChats": "Recent chats"
     },
     "maxAttachmentsReached": "Maximum {count} files per message",
@@ -373,12 +373,12 @@
     "noThreads": "No conversations yet",
     "placeholder": "Type your question here, / for skills, @ to add context",
     "prompts": {
-      "noResults": "No matching prompts",
+      "noResults": "No matching skills",
       "noShortcuts": "No skills yet. Add some in Knowledge → Skills.",
       "scope": {
-        "private": "Your prompts",
+        "private": "Your skills",
         "stock": "Built-in",
-        "team": "Team prompts"
+        "team": "Team skills"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Connectors"
       },
       "skills": {
-        "description": "Custom AI skills and prompts",
+        "description": "Custom AI skills",
         "title": "Skills"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Asuntos abiertos recientemente",
       "noMatters": "Aún no hay asuntos",
-      "noPrompts": "Aún no hay prompts",
+      "noPrompts": "Aún no hay habilidades",
       "noRecentChats": "No hay chats recientes",
       "pinnedMatters": "Asuntos fijados",
-      "prompts": "Prompts",
+      "prompts": "Habilidades",
       "recentChats": "Chats recientes"
     },
     "maxAttachmentsReached": "Máximo {count} archivos por mensaje",
@@ -373,12 +373,12 @@
     "noThreads": "Aún no hay conversaciones",
     "placeholder": "Escriba su pregunta aquí, / para skills, @ para añadir contexto",
     "prompts": {
-      "noResults": "Sin prompts coincidentes",
+      "noResults": "Sin habilidades coincidentes",
       "noShortcuts": "Aún no hay skills. Añádalas en Conocimiento → Skills.",
       "scope": {
-        "private": "Tus prompts",
+        "private": "Tus habilidades",
         "stock": "Predefinidos",
-        "team": "Prompts del equipo"
+        "team": "Habilidades del equipo"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Conectores"
       },
       "skills": {
-        "description": "Habilidades y prompts personalizados de IA",
+        "description": "Habilidades de IA personalizadas",
         "title": "Habilidades"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Viimati avatud asjad",
       "noMatters": "Asju veel pole",
-      "noPrompts": "Prompte veel pole",
+      "noPrompts": "Oskusi veel pole",
       "noRecentChats": "Hiljutisi vestlusi pole",
       "pinnedMatters": "Kinnitatud asjad",
-      "prompts": "Promptid",
+      "prompts": "Oskused",
       "recentChats": "Hiljutised vestlused"
     },
     "maxAttachmentsReached": "Maksimaalselt {count} faili sõnumi kohta",
@@ -373,12 +373,12 @@
     "noThreads": "Vestlusi pole veel",
     "placeholder": "Kirjutage oma küsimus siia, / oskuste jaoks, @ konteksti lisamiseks",
     "prompts": {
-      "noResults": "Sobivaid küsimusi pole",
+      "noResults": "Sobivaid oskusi pole",
       "noShortcuts": "Oskusi veel pole. Lisage need jaotises Teadmised → Oskused.",
       "scope": {
-        "private": "Sinu küsimused",
+        "private": "Sinu oskused",
         "stock": "Sisseehitatud",
-        "team": "Tiimi küsimused"
+        "team": "Tiimi oskused"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Konnektorid"
       },
       "skills": {
-        "description": "Kohandatud tehisintellekti oskused ja päringud",
+        "description": "Kohandatud tehisintellekti oskused",
         "title": "Oskused"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Dossiers consultés récemment",
       "noMatters": "Aucun dossier pour le moment",
-      "noPrompts": "Aucun prompt pour le moment",
+      "noPrompts": "Aucun skill pour le moment",
       "noRecentChats": "Aucun chat récent",
       "pinnedMatters": "Dossiers épinglés",
-      "prompts": "Prompts",
+      "prompts": "Skills",
       "recentChats": "Chats récents"
     },
     "maxAttachmentsReached": "Maximum {count} fichiers par message",
@@ -373,12 +373,12 @@
     "noThreads": "Aucune conversation",
     "placeholder": "Saisissez votre question ici, / pour les skills, @ pour ajouter du contexte",
     "prompts": {
-      "noResults": "Aucun prompt correspondant",
+      "noResults": "Aucun skill correspondant",
       "noShortcuts": "Aucun skill pour le moment. Ajoutez-en dans Connaissances → Skills.",
       "scope": {
-        "private": "Vos prompts",
+        "private": "Vos skills",
         "stock": "Intégrés",
-        "team": "Prompts d'équipe"
+        "team": "Skills d'équipe"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Connecteurs"
       },
       "skills": {
-        "description": "Compétences et prompts IA personnalisés",
+        "description": "Skills IA personnalisés",
         "title": "Compétences"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Legutóbb megnyitott ügyek",
       "noMatters": "Még nincsenek ügyek",
-      "noPrompts": "Még nincsenek promptok",
+      "noPrompts": "Még nincsenek skillek",
       "noRecentChats": "Nincsenek legutóbbi chatek",
       "pinnedMatters": "Kitűzött ügyek",
-      "prompts": "Promptok",
+      "prompts": "Skillek",
       "recentChats": "Legutóbbi chatek"
     },
     "maxAttachmentsReached": "Üzenetenként legfeljebb {count} fájl",
@@ -373,12 +373,12 @@
     "noThreads": "Még nincsenek beszélgetések",
     "placeholder": "Írja ide a kérdését, / a skillekhez, @ kontextus hozzáadásához",
     "prompts": {
-      "noResults": "Nincs egyező prompt",
+      "noResults": "Nincs egyező skill",
       "noShortcuts": "Még nincsenek skillek. Adjon hozzá a Tudás → Skillek részen.",
       "scope": {
-        "private": "Saját promptok",
+        "private": "Saját skillek",
         "stock": "Beépített",
-        "team": "Csapat promptjai"
+        "team": "Csapat skillek"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Csatlakozók"
       },
       "skills": {
-        "description": "Egyéni MI-képességek és promptok",
+        "description": "Egyéni MI-skillek",
         "title": "Képességek"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Paskutinės atidarytos bylos",
       "noMatters": "Bylų dar nėra",
-      "noPrompts": "Raginimų dar nėra",
+      "noPrompts": "Įgūdžių dar nėra",
       "noRecentChats": "Nėra naujausių pokalbių",
       "pinnedMatters": "Prisegtos bylos",
-      "prompts": "Raginimai",
+      "prompts": "Įgūdžiai",
       "recentChats": "Neseniai naudoti pokalbiai"
     },
     "maxAttachmentsReached": "Daugiausiai {count} failų vienoje žinutėje",
@@ -373,12 +373,12 @@
     "noThreads": "Pokalbių dar nėra",
     "placeholder": "Čia įveskite klausimą, / įgūdžiams, @ kontekstui pridėti",
     "prompts": {
-      "noResults": "Nėra atitinkančių raginimų",
+      "noResults": "Nėra atitinkančių įgūdžių",
       "noShortcuts": "Įgūdžių dar nėra. Pridėkite juos skiltyje Žinios → Įgūdžiai.",
       "scope": {
-        "private": "Jūsų raginimai",
+        "private": "Jūsų įgūdžiai",
         "stock": "Įmontuoti",
-        "team": "Komandos raginimai"
+        "team": "Komandos įgūdžiai"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Jungtys"
       },
       "skills": {
-        "description": "Individualūs AI įgūdžiai ir užklausos",
+        "description": "Individualūs AI įgūdžiai",
         "title": "Įgūdžiai"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Pēdējās atvērtās lietas",
       "noMatters": "Lietu vēl nav",
-      "noPrompts": "Promptu vēl nav",
+      "noPrompts": "Prasmju vēl nav",
       "noRecentChats": "Nav nesenu čatu",
       "pinnedMatters": "Piespraustās lietas",
-      "prompts": "Prompti",
+      "prompts": "Prasmes",
       "recentChats": "Nesenie čati"
     },
     "maxAttachmentsReached": "Maksimāli {count} faili vienā ziņojumā",
@@ -373,12 +373,12 @@
     "noThreads": "Sarunu vēl nav",
     "placeholder": "Ierakstiet jautājumu šeit, / prasmēm, @ konteksta pievienošanai",
     "prompts": {
-      "noResults": "Nav atbilstošu uzvedņu",
+      "noResults": "Nav atbilstošu prasmju",
       "noShortcuts": "Prasmju vēl nav. Pievienojiet tās sadaļā Zināšanas → Prasmes.",
       "scope": {
-        "private": "Jūsu uzvednes",
+        "private": "Jūsu prasmes",
         "stock": "Iebūvētas",
-        "team": "Komandas uzvednes"
+        "team": "Komandas prasmes"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Savienotāji"
       },
       "skills": {
-        "description": "Pielāgotas AI prasmes un uzvednes",
+        "description": "Pielāgotas AI prasmes",
         "title": "Prasmes"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -352,10 +352,10 @@ type Messages = {
     "landing": {
       "lastAccessedMatters": "Last accessed matters";
       "noMatters": "No matters yet";
-      "noPrompts": "No prompts yet";
+      "noPrompts": "No skills yet";
       "noRecentChats": "No recent chats";
       "pinnedMatters": "Pinned matters";
-      "prompts": "Prompts";
+      "prompts": "Skills";
       "recentChats": "Recent chats";
     };
     "maxAttachmentsReached": "Maximum {count} files per message";
@@ -376,12 +376,12 @@ type Messages = {
     "noThreads": "No conversations yet";
     "placeholder": "Type your question here, / for skills, @ to add context";
     "prompts": {
-      "noResults": "No matching prompts";
+      "noResults": "No matching skills";
       "noShortcuts": "No skills yet. Add some in Knowledge → Skills.";
       "scope": {
-        "private": "Your prompts";
+        "private": "Your skills";
         "stock": "Built-in";
-        "team": "Team prompts";
+        "team": "Team skills";
       };
       "stock": {
         "compareVersions": {
@@ -1069,7 +1069,7 @@ type Messages = {
         "title": "Connectors";
       };
       "skills": {
-        "description": "Custom AI skills and prompts";
+        "description": "Custom AI skills";
         "title": "Skills";
       };
       "templates": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Ostatnio otwarte sprawy",
       "noMatters": "Nie ma jeszcze spraw",
-      "noPrompts": "Nie ma jeszcze promptów",
+      "noPrompts": "Nie ma jeszcze umiejętności",
       "noRecentChats": "Brak ostatnich chatów",
       "pinnedMatters": "Przypięte sprawy",
-      "prompts": "Prompty",
+      "prompts": "Umiejętności",
       "recentChats": "Ostatnie chaty"
     },
     "maxAttachmentsReached": "Maksymalnie {count} plików na wiadomość",
@@ -373,12 +373,12 @@
     "noThreads": "Brak rozmów",
     "placeholder": "Wpisz pytanie tutaj, / dla umiejętności, @ aby dodać kontekst",
     "prompts": {
-      "noResults": "Brak pasujących promptów",
+      "noResults": "Brak pasujących umiejętności",
       "noShortcuts": "Nie ma jeszcze umiejętności. Dodaj je w Wiedza → Umiejętności.",
       "scope": {
-        "private": "Twoje prompty",
+        "private": "Twoje umiejętności",
         "stock": "Wbudowane",
-        "team": "Prompty zespołu"
+        "team": "Umiejętności zespołu"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Konektory"
       },
       "skills": {
-        "description": "Niestandardowe umiejętności AI i prompty",
+        "description": "Niestandardowe umiejętności AI",
         "title": "Umiejętności"
       },
       "templates": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -349,10 +349,10 @@
     "landing": {
       "lastAccessedMatters": "Naposledy otvorené spisy",
       "noMatters": "Zatiaľ žiadne spisy",
-      "noPrompts": "Zatiaľ žiadne prompty",
+      "noPrompts": "Zatiaľ žiadne zručnosti",
       "noRecentChats": "Zatiaľ žiadne nedávne chaty",
       "pinnedMatters": "Pripnuté spisy",
-      "prompts": "Prompty",
+      "prompts": "Zručnosti",
       "recentChats": "Nedávne chaty"
     },
     "maxAttachmentsReached": "Maximálne {count} súborov na správu",
@@ -373,12 +373,12 @@
     "noThreads": "Zatiaľ žiadne konverzácie",
     "placeholder": "Sem napíšte svoju otázku, / pre zručnosti, @ na pridanie kontextu",
     "prompts": {
-      "noResults": "Žiadne zhodné prompty",
+      "noResults": "Žiadne zhodné zručnosti",
       "noShortcuts": "Zatiaľ žiadne zručnosti. Pridajte ich v časti Znalosti → Zručnosti.",
       "scope": {
-        "private": "Vaše prompty",
+        "private": "Vaše zručnosti",
         "stock": "Vstavané",
-        "team": "Tímové prompty"
+        "team": "Tímové zručnosti"
       },
       "stock": {
         "compareVersions": {
@@ -1066,7 +1066,7 @@
         "title": "Konektory"
       },
       "skills": {
-        "description": "Vlastné AI zručnosti a prompty",
+        "description": "Vlastné AI zručnosti",
         "title": "Zručnosti"
       },
       "templates": {

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -28,6 +28,7 @@ import {
   useSetChatAnonymized,
 } from "@/lib/chat-anonymized-store";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
+import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
 import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
@@ -73,12 +74,12 @@ function ChatIndex() {
   const openInspectorChat = useInspectorStore((s) => s.openChat);
   const [contextMatterIds, setContextMatterIds] = useState<string[]>([]);
   const getContextMatterIds = useEffectEvent(() => contextMatterIds);
-  const [isComposerFocused, setIsComposerFocused] = useState(false);
 
   const pinnedMatters = useMemo(() => {
     const workspaceById = new Map<string, PinnedMatter>();
     for (const workspace of workspaces ?? []) {
       workspaceById.set(workspace.id, {
+        color: workspace.color,
         id: workspace.id,
         lastActivityAt: workspace.lastActivityAt,
         name: workspace.name,
@@ -104,6 +105,7 @@ function ChatIndex() {
         )
         .slice(0, 5)
         .map((workspace) => ({
+          color: workspace.color,
           id: workspace.id,
           lastActivityAt: workspace.lastActivityAt,
           name: workspace.name,
@@ -187,12 +189,7 @@ function ChatIndex() {
       </div>
       <div className="flex flex-1 flex-col items-center overflow-y-auto px-4 pb-16">
         <div className="flex min-h-[22rem] w-full max-w-2xl shrink-0 flex-col items-center justify-center gap-8">
-          <div
-            className={cn(
-              "flex flex-col items-center gap-4 text-center transition-opacity duration-150",
-              isComposerFocused && "opacity-60",
-            )}
-          >
+          <div className="flex flex-col items-center gap-4 text-center">
             <div className="border-border bg-background text-foreground flex size-12 items-center justify-center rounded-lg border shadow-sm">
               <StellaMark className="size-7" />
             </div>
@@ -204,7 +201,6 @@ function ChatIndex() {
             <ChatInputSurface
               autoFocus
               controller={controller}
-              onFocusChange={setIsComposerFocused}
               onSubmit={async (draft) => {
                 if (!(await ensureAIAvailable())) {
                   return;
@@ -242,12 +238,7 @@ function ChatIndex() {
             />
           </div>
         </div>
-        <div
-          className={cn(
-            "grid min-h-52 w-full gap-8 transition-opacity duration-150 md:grid-cols-3",
-            isComposerFocused && "opacity-55",
-          )}
-        >
+        <div className="grid min-h-52 w-full gap-8 md:grid-cols-3">
           <LandingSection
             heading={
               <Link
@@ -260,20 +251,29 @@ function ChatIndex() {
             }
           >
             {visibleMatters.length > 0 ? (
-              visibleMatters.map((matter) => (
-                <Link
-                  className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
-                  key={matter.id}
-                  params={{ workspaceId: matter.id }}
-                  to="/workspaces/$workspaceId"
-                >
-                  <LandingItemText
-                    icon={<LayersIcon className="size-4" />}
-                    meta={formatRelativeTime(matter.lastActivityAt, lang)}
-                    title={matter.name}
-                  />
-                </Link>
-              ))
+              visibleMatters.map((matter) => {
+                const matterColor = resolveMatterColor(matter.id, matter.color);
+                return (
+                  <Link
+                    className="group hover:bg-accent/50 focus-visible:ring-ring rounded-md px-2 py-1.5 text-start transition-colors outline-none focus-visible:ring-2"
+                    key={matter.id}
+                    params={{ workspaceId: matter.id }}
+                    to="/workspaces/$workspaceId"
+                  >
+                    <LandingItemText
+                      icon={
+                        <LayersIcon
+                          className="size-4"
+                          style={{ color: matterColor }}
+                        />
+                      }
+                      iconTone="matter"
+                      meta={formatRelativeTime(matter.lastActivityAt, lang)}
+                      title={matter.name}
+                    />
+                  </Link>
+                );
+              })
             ) : (
               <LandingEmpty>{t("chat.landing.noMatters")}</LandingEmpty>
             )}
@@ -356,6 +356,7 @@ function ChatIndex() {
 }
 
 type PinnedMatter = {
+  color: string | null;
   id: string;
   lastActivityAt: string | Date;
   name: string;
@@ -420,13 +421,21 @@ const LandingButton = ({ icon, meta, onClick, title }: LandingButtonProps) => (
 
 type LandingItemTextProps = {
   icon?: ReactElement;
+  iconTone?: "muted" | "matter" | undefined;
   meta?: string | undefined;
   title: string;
 };
 
-const LandingItemText = ({ icon, meta, title }: LandingItemTextProps) => (
+const LandingItemText = ({
+  icon,
+  iconTone = "muted",
+  meta,
+  title,
+}: LandingItemTextProps) => (
   <span className="flex min-w-0 items-start gap-2">
-    {icon !== undefined && <LandingRowIcon>{icon}</LandingRowIcon>}
+    {icon !== undefined && (
+      <LandingRowIcon tone={iconTone}>{icon}</LandingRowIcon>
+    )}
     <span className="min-w-0 flex-1">
       <span className="text-foreground block truncate text-sm font-medium">
         {title}
@@ -442,10 +451,17 @@ const LandingItemText = ({ icon, meta, title }: LandingItemTextProps) => (
 
 type LandingRowIconProps = {
   children: ReactElement;
+  tone?: "muted" | "matter" | undefined;
 };
 
-const LandingRowIcon = ({ children }: LandingRowIconProps) => (
-  <span className="text-muted-foreground/55 group-hover:text-muted-foreground mt-0.5 flex size-4 shrink-0 items-center justify-center transition-colors">
+const LandingRowIcon = ({ children, tone = "muted" }: LandingRowIconProps) => (
+  <span
+    className={cn(
+      "mt-0.5 flex size-4 shrink-0 items-center justify-center transition-colors",
+      tone === "muted" &&
+        "text-muted-foreground/55 group-hover:text-muted-foreground",
+    )}
+  >
     {children}
   </span>
 );

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -32,12 +32,14 @@ const DAY_MS = 86_400_000;
 
 type MatterCardProps = {
   workspace: Workspace;
+  canCreateMatter?: boolean | undefined;
   focused: boolean;
   hideClientName?: boolean;
 };
 
 export const MatterCard = ({
   workspace,
+  canCreateMatter = false,
   focused,
   hideClientName,
 }: MatterCardProps) => {
@@ -64,6 +66,7 @@ export const MatterCard = ({
 
   return (
     <MatterContextMenu
+      canCreateMatter={canCreateMatter}
       isPersonal={!workspace.client}
       workspaceId={workspace.id}
       workspaceName={workspace.name ?? t("workspaces.defaultName")}

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -44,12 +44,14 @@ import {
   PenLineIcon,
   PinIcon,
   PinOffIcon,
+  PlusIcon,
   Trash2Icon,
   UserPlusIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { UserIdentity } from "@/components/user-avatar";
+import { usePermissions } from "@/hooks/use-permissions";
 import { usePinnedStore } from "@/lib/pinned-store";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";
 import { useAddWorkspaceMember } from "@/routes/_protected.workspaces/$workspaceId/-mutations/workspace-members";
@@ -62,11 +64,16 @@ import {
   useUnarchiveWorkspace,
   useUpdateWorkspace,
 } from "@/routes/_protected.workspaces/-mutations";
-import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
+import {
+  workspacesKeys,
+  workspacesOptions,
+} from "@/routes/_protected.workspaces/-queries";
+import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 
 // ── Shared menu items ────────────────────────────────────────
 
 type MatterMenuBaseCallbacks = {
+  onCreateMatter?: (() => void) | undefined;
   onOpenInNewTab: () => void;
   onRename: () => void;
   onAddMember: () => void;
@@ -99,6 +106,15 @@ export const MatterMenuItems = (props: MatterMenuCallbacks) => {
 
   return (
     <>
+      {props.onCreateMatter && (
+        <>
+          <MenuItem onClick={props.onCreateMatter}>
+            <PlusIcon />
+            {t("workspaces.createNewWorkspace")}
+          </MenuItem>
+          <MenuSeparator />
+        </>
+      )}
       <MenuItem onClick={props.onOpenInNewTab}>
         <ExternalLinkIcon />
         {t("common.openInNewTab")}
@@ -168,11 +184,14 @@ export const MatterContextMenu = ({
   const t = useTranslations();
   const { togglePin, isPinned } = usePinnedStore();
   const pinned = isPinned(workspaceId);
+  const canCreateMatter = usePermissions({ workspace: ["create"] });
+  const openCreateMatter = useCreateMatterStore((s) => s.openDialog);
 
   const queryClient = useQueryClient();
   const updateWorkspace = useUpdateWorkspace();
   const unarchiveWorkspace = useUnarchiveWorkspace();
   const deleteWorkspace = useDeleteWorkspace();
+  const { data: workspacesData } = useQuery(workspacesOptions);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<{
@@ -270,6 +289,12 @@ export const MatterContextMenu = ({
   const matterMenuCallbacks = {
     isPersonal,
     isPinned: pinned,
+    onCreateMatter:
+      canCreateMatter &&
+      workspacesData &&
+      workspacesData.workspaces.length < workspacesData.workspacesCountLimit
+        ? () => openCreateMatter()
+        : undefined,
     onAddMember: () => setAddMemberOpen(true),
     onCopyLink: () => {
       void handleCopyLink();

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -51,7 +51,6 @@ import {
 import { useTranslations } from "use-intl";
 
 import { UserIdentity } from "@/components/user-avatar";
-import { usePermissions } from "@/hooks/use-permissions";
 import { usePinnedStore } from "@/lib/pinned-store";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";
 import { useAddWorkspaceMember } from "@/routes/_protected.workspaces/$workspaceId/-mutations/workspace-members";
@@ -64,10 +63,7 @@ import {
   useUnarchiveWorkspace,
   useUpdateWorkspace,
 } from "@/routes/_protected.workspaces/-mutations";
-import {
-  workspacesKeys,
-  workspacesOptions,
-} from "@/routes/_protected.workspaces/-queries";
+import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 
 // ── Shared menu items ────────────────────────────────────────
@@ -169,6 +165,7 @@ export type RenameState =
 type MatterContextMenuProps = {
   workspaceId: string;
   workspaceName: string;
+  canCreateMatter?: boolean | undefined;
   isArchived?: boolean;
   isPersonal: boolean;
   children: React.ReactNode | ((rename: RenameState) => React.ReactNode);
@@ -177,6 +174,7 @@ type MatterContextMenuProps = {
 export const MatterContextMenu = ({
   workspaceId,
   workspaceName,
+  canCreateMatter = false,
   isArchived = false,
   isPersonal,
   children,
@@ -184,14 +182,12 @@ export const MatterContextMenu = ({
   const t = useTranslations();
   const { togglePin, isPinned } = usePinnedStore();
   const pinned = isPinned(workspaceId);
-  const canCreateMatter = usePermissions({ workspace: ["create"] });
   const openCreateMatter = useCreateMatterStore((s) => s.openDialog);
 
   const queryClient = useQueryClient();
   const updateWorkspace = useUpdateWorkspace();
   const unarchiveWorkspace = useUnarchiveWorkspace();
   const deleteWorkspace = useDeleteWorkspace();
-  const { data: workspacesData } = useQuery(workspacesOptions);
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<{
@@ -289,12 +285,7 @@ export const MatterContextMenu = ({
   const matterMenuCallbacks = {
     isPersonal,
     isPinned: pinned,
-    onCreateMatter:
-      canCreateMatter &&
-      workspacesData &&
-      workspacesData.workspaces.length < workspacesData.workspacesCountLimit
-        ? () => openCreateMatter()
-        : undefined,
+    onCreateMatter: canCreateMatter ? () => openCreateMatter() : undefined,
     onAddMember: () => setAddMemberOpen(true),
     onCopyLink: () => {
       void handleCopyLink();

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -142,6 +142,7 @@ function RouteComponent() {
               </div>
             ) : (
               <MattersContentView
+                canCreateMatter={canOpenCreateMatter}
                 displayed={displayed}
                 focusIndex={focusIndex}
                 groups={groups}
@@ -185,6 +186,9 @@ const MattersPageContextMenu = ({
     <div
       className="contents"
       onContextMenu={(event) => {
+        if (event.defaultPrevented) {
+          return;
+        }
         event.preventDefault();
         const x = event.clientX;
         const y = event.clientY;
@@ -220,12 +224,14 @@ const MattersPageContextMenu = ({
 };
 
 type MattersContentViewProps = {
+  canCreateMatter: boolean;
   displayed: Workspace[];
   groups: WorkspaceGroup[] | null;
   focusIndex: number;
 };
 
 const MattersContentView = ({
+  canCreateMatter,
   displayed,
   groups,
   focusIndex,
@@ -264,6 +270,7 @@ const MattersContentView = ({
                 {!collapsed &&
                   group.workspaces.map((workspace, i) => (
                     <MatterCard
+                      canCreateMatter={canCreateMatter}
                       focused={focusIndex === baseIndex + i}
                       hideClientName
                       key={workspace.id}
@@ -278,6 +285,7 @@ const MattersContentView = ({
         <div className="grid auto-rows-min gap-3 md:grid-cols-3" ref={gridRef}>
           {displayed.map((workspace, i) => (
             <MatterCard
+              canCreateMatter={canCreateMatter}
               focused={focusIndex === i}
               key={workspace.id}
               workspace={workspace}

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -1,11 +1,20 @@
 import { Fragment, useEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
+import { usePermissions } from "@/hooks/use-permissions";
 import { pageTitle } from "@/lib/page-title";
 import { AlphabetIndex } from "@/routes/_protected.workspaces/-components/alphabet-index";
 import { ClientGroupHeader } from "@/routes/_protected.workspaces/-components/client-group-header";
@@ -13,6 +22,7 @@ import { MatterCard } from "@/routes/_protected.workspaces/-components/matter-ca
 import { MattersTable } from "@/routes/_protected.workspaces/-components/matters-table";
 import { MattersToolbar } from "@/routes/_protected.workspaces/-components/matters-toolbar";
 import { workspacesOptions } from "@/routes/_protected.workspaces/-queries";
+import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 import type {
   Workspace,
   WorkspaceGroup,
@@ -40,6 +50,7 @@ export const Route = createFileRoute("/_protected/workspaces/")({
 function RouteComponent() {
   const t = useTranslations();
   const { data } = useSuspenseQuery(workspacesOptions);
+  const canCreateMatter = usePermissions({ workspace: ["create"] });
 
   const { sortKey, sortDesc, groupBy, collapsedGroups } = useConfigStore(
     useShallow((s) => ({
@@ -56,6 +67,8 @@ function RouteComponent() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const workspaces = data.workspaces;
+  const canOpenCreateMatter =
+    canCreateMatter && workspaces.length < data.workspacesCountLimit;
 
   const filtered = workspaces.filter((w) => {
     if (!search.trim()) {
@@ -111,40 +124,100 @@ function RouteComponent() {
   });
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <MattersToolbar
-        onSearchChange={setSearch}
-        search={search}
-        searchRef={searchRef}
-      />
+    <MattersPageContextMenu canCreateMatter={canOpenCreateMatter}>
+      <div className="flex min-h-0 flex-1 flex-col">
+        <MattersToolbar
+          onSearchChange={setSearch}
+          search={search}
+          searchRef={searchRef}
+        />
 
-      <div className="relative flex-1">
-        <div className="absolute inset-0 overflow-y-auto" ref={scrollRef}>
-          {sorted.length === 0 ? (
-            <div className="text-muted-foreground flex flex-1 items-center justify-center p-8 text-sm">
-              {workspaces.length === 0
-                ? t("workspaces.noMatters")
-                : t("common.empty")}
-            </div>
-          ) : (
-            <MattersContentView
-              displayed={displayed}
-              focusIndex={focusIndex}
+        <div className="relative flex-1">
+          <div className="absolute inset-0 overflow-y-auto" ref={scrollRef}>
+            {sorted.length === 0 ? (
+              <div className="text-muted-foreground flex flex-1 items-center justify-center p-8 text-sm">
+                {workspaces.length === 0
+                  ? t("workspaces.noMatters")
+                  : t("common.empty")}
+              </div>
+            ) : (
+              <MattersContentView
+                displayed={displayed}
+                focusIndex={focusIndex}
+                groups={groups}
+              />
+            )}
+          </div>
+          {groups && groups.length > 0 && (
+            <AlphabetIndex
+              collapsedGroups={collapsedGroups}
               groups={groups}
+              scrollContainerRef={scrollRef}
             />
           )}
         </div>
-        {groups && groups.length > 0 && (
-          <AlphabetIndex
-            collapsedGroups={collapsedGroups}
-            groups={groups}
-            scrollContainerRef={scrollRef}
-          />
-        )}
       </div>
-    </div>
+    </MattersPageContextMenu>
   );
 }
+
+type MattersPageContextMenuProps = {
+  canCreateMatter: boolean;
+  children: ReactNode;
+};
+
+const MattersPageContextMenu = ({
+  canCreateMatter,
+  children,
+}: MattersPageContextMenuProps): ReactNode => {
+  const t = useTranslations();
+  const openCreateMatter = useCreateMatterStore((s) => s.openDialog);
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState<{
+    getBoundingClientRect: () => DOMRect;
+  } | null>(null);
+
+  if (!canCreateMatter) {
+    return children;
+  }
+
+  return (
+    <div
+      className="contents"
+      onContextMenu={(event) => {
+        event.preventDefault();
+        const x = event.clientX;
+        const y = event.clientY;
+        setAnchor({
+          getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+        });
+        setOpen(true);
+      }}
+    >
+      {children}
+      <Menu
+        onOpenChange={(nextOpen) => {
+          setOpen(nextOpen);
+          if (!nextOpen) {
+            setAnchor(null);
+          }
+        }}
+        open={open}
+      >
+        <MenuTrigger
+          nativeButton={false}
+          render={<span className="sr-only" />}
+        />
+        <MenuPopup anchor={anchor ?? undefined}>
+          <MenuItem onClick={() => openCreateMatter()}>
+            <PlusIcon />
+            {t("workspaces.createNewWorkspace")}
+          </MenuItem>
+        </MenuPopup>
+      </Menu>
+    </div>
+  );
+};
 
 type MattersContentViewProps = {
   displayed: Workspace[];

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,9 +1,7 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 
-import { api } from "@/lib/api";
-
 export const Route = createFileRoute("/")({
-  beforeLoad: async ({ context }) => {
+  beforeLoad: ({ context }) => {
     if (!context.session) {
       throw redirect({ to: "/auth", replace: true });
     }
@@ -15,17 +13,6 @@ export const Route = createFileRoute("/")({
       });
     }
 
-    const { data } = await api.workspaces.active.get();
-    const lastActiveWorkspaceId = data?.lastActiveWorkspaceId;
-
-    if (lastActiveWorkspaceId) {
-      throw redirect({
-        to: "/workspaces/$workspaceId",
-        params: { workspaceId: lastActiveWorkspaceId },
-        replace: true,
-      });
-    }
-
-    throw redirect({ to: "/workspaces", replace: true });
+    throw redirect({ to: "/chat", replace: true });
   },
 });


### PR DESCRIPTION
## Summary
- route authenticated home to the global chat entry screen
- keep matter colors visible on chat landing and chat matter picker badges
- rename prompt-facing chat labels to Skills and add create-matter context menus on Matters

## Checks
- bun run lint
- bun run format
- bun run typecheck
- bun run test