### PR TITLE
chore(release): promote via manifest job, stop passing image digest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,7 @@ jobs:
     # production by accident if the upstream validation regex changes.
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [resolve, build-arm64, smoke]
+    needs: [resolve, manifest, smoke]
     if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
     permissions:
       contents: read
@@ -430,7 +430,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
-          IMAGE_DIGEST: ${{ needs.build-arm64.outputs.digest }}
           INFRA_REPO: ${{ github.repository_owner }}/stella-infra
         run: |
           dispatched_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -438,7 +437,6 @@ jobs:
             gh workflow run promote-release.yml \
               --repo "$INFRA_REPO" \
               --field release_ref="$RELEASE_REF" \
-              --field image_digest="$IMAGE_DIGEST" \
               --field run_migrations=true \
               --field frontend=true 2>&1
           )"


### PR DESCRIPTION
## Summary

Promote now waits for the \`manifest\` job and dispatches \`promote-release.yml\` with only \`release_ref\`. The infra side reads the digest directly from \`release-manifest.json\` on the GitHub Release (per stella/stella-infra#134).

## Why

The previous attempt (#175) had \`promote\` wait only on \`build-arm64 + smoke\` and pass the per-arch arm64 digest. But \`promote-release.yml\` verifies the input digest against \`release-manifest.json.image.digest\` (the multi-arch manifest list digest). Mismatch → every promote since v0.0.10 failed.

Eliminates the bug class entirely: there's no longer two digest contracts that have to agree across repos.

## Pipeline shape

\`\`\`
resolve ─┬─ smoke (arm64 native)         ─┐
         ├─ build-arm64 (native)         ─┤
         ├─ build-amd64 (native)         ─┤
         └→ manifest (needs all 3)        ─┴→ promote
\`\`\`

Critical-path effect: ~+1 min vs the previous (broken) attempt because promote now waits for the slower of arm64/amd64 + the manifest stitch (~30-60s). Net ~12-13 min vs ~14-15 baseline before parallelization. Worth the cost: no more cross-repo digest contract.

## Dependency

Requires stella/stella-infra#134 to land first (otherwise \`promote-release.yml\` rejects the dispatch with a missing required \`image_digest\`).

## Test plan

- [ ] Tag a prerelease (e.g., \`v0.0.11-rc.1\`) to verify the publish path including manifest works end-to-end. Promote skips on prereleases so this exercises the new dependency without deploying.
- [ ] Watch the next stable tag — \`promote\` should fire once \`manifest\` completes and succeed without passing a digest.