### PR TITLE
fix: scope folio dialog control ids

### DIFF
--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -118,6 +118,7 @@ export function FindReplaceDialog({
   className,
   style,
 }: FindReplaceDialogProps): React.ReactElement | null {
+  const id = React.useId();
   const t = useTranslations("folio");
   // State
   const [searchText, setSearchText] = useState("");
@@ -308,6 +309,8 @@ export function FindReplaceDialog({
   const hasMatches = result && result.totalCount > 0;
   const noMatches = result && result.totalCount === 0 && searchText.trim();
   const overlayStyle = getFindReplaceOverlayStyle(style);
+  const titleId = `${id}-find-replace-dialog-title`;
+  const findTextId = `${id}-find-text`;
 
   return (
     <div
@@ -323,12 +326,12 @@ export function FindReplaceDialog({
         data-testid="find-replace-dialog"
         role="dialog"
         aria-modal="false"
-        aria-labelledby="find-replace-dialog-title"
+        aria-labelledby={titleId}
       >
         <div className="bg-muted/30 flex items-center justify-between gap-3 border-b px-3 py-2">
           <h2
-            id="find-replace-dialog-title"
             className="flex min-w-0 items-center gap-2 text-sm font-medium"
+            id={titleId}
           >
             <SearchIcon className="text-muted-foreground size-4 shrink-0" />
             <span className="truncate">{t("findReplace.find")}</span>
@@ -348,13 +351,13 @@ export function FindReplaceDialog({
           <div className="grid grid-cols-[4.5rem_minmax(0,1fr)_auto] items-center gap-2">
             <label
               className="text-muted-foreground text-xs font-medium"
-              htmlFor="find-text"
+              htmlFor={findTextId}
             >
               {t("findReplace.find")}
             </label>
             <Input
               ref={searchInputRef}
-              id="find-text"
+              id={findTextId}
               nativeInput
               type="text"
               className="h-8"

--- a/packages/folio/src/components/dialogs/FootnotePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/FootnotePropertiesDialog.tsx
@@ -4,7 +4,7 @@
  * Edits position, numbering format, start number, and restart rules.
  */
 
-import { useState } from "react";
+import { useId, useState } from "react";
 
 import {
   Dialog,
@@ -63,6 +63,7 @@ export function FootnotePropertiesDialog({
   footnotePr,
   endnotePr,
 }: FootnotePropertiesDialogProps) {
+  const id = useId();
   const [fnPosition, setFnPosition] = useState<FootnotePosition>(
     footnotePr?.position ?? "pageBottom",
   );
@@ -113,6 +114,16 @@ export function FootnotePropertiesDialog({
   const inputCls =
     "border-input bg-background text-foreground w-[60px] rounded border px-2 py-1 text-[13px] outline-none";
   const sectionCls = "mb-4 rounded border p-3";
+  const fieldIds = {
+    fnPosition: `${id}-fn-position`,
+    fnNumFmt: `${id}-fn-num-fmt`,
+    fnStartAt: `${id}-fn-start-at`,
+    fnNumbering: `${id}-fn-numbering`,
+    enPosition: `${id}-en-position`,
+    enNumFmt: `${id}-en-num-fmt`,
+    enStartAt: `${id}-en-start-at`,
+    enNumbering: `${id}-en-numbering`,
+  };
 
   return (
     <Dialog
@@ -135,11 +146,11 @@ export function FootnotePropertiesDialog({
             <div className={sectionCls}>
               <h4 className="mb-2 text-sm font-semibold">Footnotes</h4>
 
-              <label htmlFor="fn-position" className={labelCls}>
+              <label htmlFor={fieldIds.fnPosition} className={labelCls}>
                 Position
               </label>
               <select
-                id="fn-position"
+                id={fieldIds.fnPosition}
                 className={selectCls}
                 value={fnPosition}
                 onChange={(e) =>
@@ -150,11 +161,11 @@ export function FootnotePropertiesDialog({
                 <option value="beneathText">Below text</option>
               </select>
 
-              <label htmlFor="fn-num-fmt" className={labelCls}>
+              <label htmlFor={fieldIds.fnNumFmt} className={labelCls}>
                 Number format
               </label>
               <select
-                id="fn-num-fmt"
+                id={fieldIds.fnNumFmt}
                 className={selectCls}
                 value={fnNumFmt}
                 onChange={(e) => setFnNumFmt(e.target.value as NumberFormat)}
@@ -168,11 +179,11 @@ export function FootnotePropertiesDialog({
 
               <div className="flex items-center gap-3">
                 <div>
-                  <label htmlFor="fn-start-at" className={labelCls}>
+                  <label htmlFor={fieldIds.fnStartAt} className={labelCls}>
                     Start at
                   </label>
                   <input
-                    id="fn-start-at"
+                    id={fieldIds.fnStartAt}
                     type="number"
                     min={1}
                     className={inputCls}
@@ -183,11 +194,11 @@ export function FootnotePropertiesDialog({
                   />
                 </div>
                 <div className="flex-1">
-                  <label htmlFor="fn-numbering" className={labelCls}>
+                  <label htmlFor={fieldIds.fnNumbering} className={labelCls}>
                     Numbering
                   </label>
                   <select
-                    id="fn-numbering"
+                    id={fieldIds.fnNumbering}
                     className={selectCls}
                     value={fnRestart}
                     onChange={(e) =>
@@ -206,11 +217,11 @@ export function FootnotePropertiesDialog({
             <div className={sectionCls}>
               <h4 className="mb-2 text-sm font-semibold">Endnotes</h4>
 
-              <label htmlFor="en-position" className={labelCls}>
+              <label htmlFor={fieldIds.enPosition} className={labelCls}>
                 Position
               </label>
               <select
-                id="en-position"
+                id={fieldIds.enPosition}
                 className={selectCls}
                 value={enPosition}
                 onChange={(e) =>
@@ -221,11 +232,11 @@ export function FootnotePropertiesDialog({
                 <option value="sectEnd">End of section</option>
               </select>
 
-              <label htmlFor="en-num-fmt" className={labelCls}>
+              <label htmlFor={fieldIds.enNumFmt} className={labelCls}>
                 Number format
               </label>
               <select
-                id="en-num-fmt"
+                id={fieldIds.enNumFmt}
                 className={selectCls}
                 value={enNumFmt}
                 onChange={(e) => setEnNumFmt(e.target.value as NumberFormat)}
@@ -239,11 +250,11 @@ export function FootnotePropertiesDialog({
 
               <div className="flex items-center gap-3">
                 <div>
-                  <label htmlFor="en-start-at" className={labelCls}>
+                  <label htmlFor={fieldIds.enStartAt} className={labelCls}>
                     Start at
                   </label>
                   <input
-                    id="en-start-at"
+                    id={fieldIds.enStartAt}
                     type="number"
                     min={1}
                     className={inputCls}
@@ -254,11 +265,11 @@ export function FootnotePropertiesDialog({
                   />
                 </div>
                 <div className="flex-1">
-                  <label htmlFor="en-numbering" className={labelCls}>
+                  <label htmlFor={fieldIds.enNumbering} className={labelCls}>
                     Numbering
                   </label>
                   <select
-                    id="en-numbering"
+                    id={fieldIds.enNumbering}
                     className={selectCls}
                     value={enRestart}
                     onChange={(e) =>

--- a/packages/folio/src/components/dialogs/HyperlinkDialog.tsx
+++ b/packages/folio/src/components/dialogs/HyperlinkDialog.tsx
@@ -13,7 +13,7 @@
  * - Validation and error handling
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import type { FormEvent, KeyboardEvent } from "react";
 
 import {
@@ -144,6 +144,7 @@ export function HyperlinkDialog({
   isEditing = false,
   bookmarks = [],
 }: HyperlinkDialogProps) {
+  const id = useId();
   // State
   const [linkType, setLinkType] = useState<LinkType>("url");
   const [url, setUrl] = useState("");
@@ -276,6 +277,14 @@ export function HyperlinkDialog({
   const inputErrorCls =
     "border-destructive bg-background text-foreground w-full rounded border px-3 py-2.5 text-sm outline-none";
   const hintCls = "text-muted-foreground mt-1 text-xs";
+  const fieldIds = {
+    url: `${id}-hyperlink-url`,
+    urlError: `${id}-url-error`,
+    urlHint: `${id}-url-hint`,
+    bookmark: `${id}-hyperlink-bookmark`,
+    displayText: `${id}-hyperlink-display-text`,
+    tooltip: `${id}-hyperlink-tooltip`,
+  };
 
   return (
     <Dialog
@@ -338,12 +347,12 @@ export function HyperlinkDialog({
             {/* URL input */}
             {linkType === "url" && (
               <div className="mb-4">
-                <label htmlFor="hyperlink-url" className={labelCls}>
+                <label htmlFor={fieldIds.url} className={labelCls}>
                   URL
                 </label>
                 <input
                   ref={urlInputRef}
-                  id="hyperlink-url"
+                  id={fieldIds.url}
                   type="text"
                   className={urlError && touched ? inputErrorCls : inputCls}
                   value={url}
@@ -359,15 +368,20 @@ export function HyperlinkDialog({
                   }}
                   placeholder="https://example.com"
                   aria-invalid={!!urlError}
-                  aria-describedby={urlError ? "url-error" : "url-hint"}
+                  aria-describedby={
+                    urlError ? fieldIds.urlError : fieldIds.urlHint
+                  }
                 />
                 {urlError && touched && (
-                  <div id="url-error" className="text-destructive mt-1 text-xs">
+                  <div
+                    id={fieldIds.urlError}
+                    className="text-destructive mt-1 text-xs"
+                  >
                     {urlError}
                   </div>
                 )}
                 {!urlError && (
-                  <div id="url-hint" className={hintCls}>
+                  <div id={fieldIds.urlHint} className={hintCls}>
                     Enter a web address, email (mailto:), or phone (tel:)
                   </div>
                 )}
@@ -377,12 +391,12 @@ export function HyperlinkDialog({
             {/* Bookmark select */}
             {linkType === "bookmark" && (
               <div className="mb-4">
-                <label htmlFor="hyperlink-bookmark" className={labelCls}>
+                <label htmlFor={fieldIds.bookmark} className={labelCls}>
                   Bookmark
                 </label>
                 <select
                   ref={bookmarkSelectRef}
-                  id="hyperlink-bookmark"
+                  id={fieldIds.bookmark}
                   className={`${inputCls} cursor-pointer`}
                   value={bookmark}
                   onChange={(e) => setBookmark(e.target.value)}
@@ -399,11 +413,11 @@ export function HyperlinkDialog({
 
             {/* Display text */}
             <div className="mb-4">
-              <label htmlFor="hyperlink-display-text" className={labelCls}>
+              <label htmlFor={fieldIds.displayText} className={labelCls}>
                 Display Text
               </label>
               <input
-                id="hyperlink-display-text"
+                id={fieldIds.displayText}
                 type="text"
                 className={inputCls}
                 value={displayText}
@@ -417,11 +431,11 @@ export function HyperlinkDialog({
 
             {/* Tooltip */}
             <div className="mb-4">
-              <label htmlFor="hyperlink-tooltip" className={labelCls}>
+              <label htmlFor={fieldIds.tooltip} className={labelCls}>
                 Tooltip (optional)
               </label>
               <input
-                id="hyperlink-tooltip"
+                id={fieldIds.tooltip}
                 type="text"
                 className={inputCls}
                 value={tooltip}

--- a/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
+++ b/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
@@ -7,7 +7,7 @@
  * - Distance from text (top/bottom/left/right)
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import {
   Dialog,
@@ -56,6 +56,7 @@ export function ImagePositionDialog({
   onApply,
   currentData,
 }: ImagePositionDialogProps) {
+  const id = useId();
   const [hMode, setHMode] = useState<"align" | "offset">("align");
   const [hAlign, setHAlign] = useState("center");
   const [hRelativeTo, setHRelativeTo] = useState("column");
@@ -128,6 +129,20 @@ export function ImagePositionDialog({
     "border-input bg-background text-foreground flex-1 rounded border px-1.5 py-1 text-xs outline-none";
   const sectionLabelCls = "text-foreground text-[13px] font-semibold";
   const distLabelCls = "w-[45px] text-muted-foreground text-xs";
+  const fieldIds = {
+    hMode: `${id}-img-pos-h-mode`,
+    hAlign: `${id}-img-pos-h-align`,
+    hOffset: `${id}-img-pos-h-offset`,
+    hRelativeTo: `${id}-img-pos-h-rel`,
+    vMode: `${id}-img-pos-v-mode`,
+    vAlign: `${id}-img-pos-v-align`,
+    vOffset: `${id}-img-pos-v-offset`,
+    vRelativeTo: `${id}-img-pos-v-rel`,
+    distTop: `${id}-img-pos-dist-top`,
+    distBottom: `${id}-img-pos-dist-bottom`,
+    distLeft: `${id}-img-pos-dist-left`,
+    distRight: `${id}-img-pos-dist-right`,
+  };
 
   return (
     <Dialog
@@ -150,12 +165,12 @@ export function ImagePositionDialog({
             <div className="flex flex-col gap-2">
               <div className={sectionLabelCls}>Horizontal</div>
               <div className="flex items-center gap-2">
-                <label className={labelCls} htmlFor="img-pos-h-mode">
+                <label className={labelCls} htmlFor={fieldIds.hMode}>
                   Position
                 </label>
                 <select
-                  id="img-pos-h-mode"
                   className={inputCls}
+                  id={fieldIds.hMode}
                   value={hMode}
                   onChange={(e) =>
                     setHMode(e.target.value as "align" | "offset")
@@ -167,12 +182,12 @@ export function ImagePositionDialog({
               </div>
               {hMode === "align" ? (
                 <div className="flex items-center gap-2">
-                  <label className={labelCls} htmlFor="img-pos-h-align">
+                  <label className={labelCls} htmlFor={fieldIds.hAlign}>
                     Align
                   </label>
                   <select
-                    id="img-pos-h-align"
                     className={inputCls}
+                    id={fieldIds.hAlign}
                     value={hAlign}
                     onChange={(e) => setHAlign(e.target.value)}
                   >
@@ -183,25 +198,25 @@ export function ImagePositionDialog({
                 </div>
               ) : (
                 <div className="flex items-center gap-2">
-                  <label className={labelCls} htmlFor="img-pos-h-offset">
+                  <label className={labelCls} htmlFor={fieldIds.hOffset}>
                     Offset (px)
                   </label>
                   <input
-                    id="img-pos-h-offset"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.hOffset}
+                    type="number"
                     value={hOffset}
                     onChange={(e) => setHOffset(Number(e.target.value) || 0)}
                   />
                 </div>
               )}
               <div className="flex items-center gap-2">
-                <label className={labelCls} htmlFor="img-pos-h-rel">
+                <label className={labelCls} htmlFor={fieldIds.hRelativeTo}>
                   Relative to
                 </label>
                 <select
-                  id="img-pos-h-rel"
                   className={inputCls}
+                  id={fieldIds.hRelativeTo}
                   value={hRelativeTo}
                   onChange={(e) => setHRelativeTo(e.target.value)}
                 >
@@ -217,12 +232,12 @@ export function ImagePositionDialog({
             <div className="flex flex-col gap-2">
               <div className={sectionLabelCls}>Vertical</div>
               <div className="flex items-center gap-2">
-                <label className={labelCls} htmlFor="img-pos-v-mode">
+                <label className={labelCls} htmlFor={fieldIds.vMode}>
                   Position
                 </label>
                 <select
-                  id="img-pos-v-mode"
                   className={inputCls}
+                  id={fieldIds.vMode}
                   value={vMode}
                   onChange={(e) =>
                     setVMode(e.target.value as "align" | "offset")
@@ -234,12 +249,12 @@ export function ImagePositionDialog({
               </div>
               {vMode === "align" ? (
                 <div className="flex items-center gap-2">
-                  <label className={labelCls} htmlFor="img-pos-v-align">
+                  <label className={labelCls} htmlFor={fieldIds.vAlign}>
                     Align
                   </label>
                   <select
-                    id="img-pos-v-align"
                     className={inputCls}
+                    id={fieldIds.vAlign}
                     value={vAlign}
                     onChange={(e) => setVAlign(e.target.value)}
                   >
@@ -250,25 +265,25 @@ export function ImagePositionDialog({
                 </div>
               ) : (
                 <div className="flex items-center gap-2">
-                  <label className={labelCls} htmlFor="img-pos-v-offset">
+                  <label className={labelCls} htmlFor={fieldIds.vOffset}>
                     Offset (px)
                   </label>
                   <input
-                    id="img-pos-v-offset"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.vOffset}
+                    type="number"
                     value={vOffset}
                     onChange={(e) => setVOffset(Number(e.target.value) || 0)}
                   />
                 </div>
               )}
               <div className="flex items-center gap-2">
-                <label className={labelCls} htmlFor="img-pos-v-rel">
+                <label className={labelCls} htmlFor={fieldIds.vRelativeTo}>
                   Relative to
                 </label>
                 <select
-                  id="img-pos-v-rel"
                   className={inputCls}
+                  id={fieldIds.vRelativeTo}
                   value={vRelativeTo}
                   onChange={(e) => setVRelativeTo(e.target.value)}
                 >
@@ -285,53 +300,53 @@ export function ImagePositionDialog({
               <div className={sectionLabelCls}>Distance from text (px)</div>
               <div className="grid grid-cols-2 gap-2">
                 <div className="flex items-center gap-2">
-                  <label className={distLabelCls} htmlFor="img-pos-dist-top">
+                  <label className={distLabelCls} htmlFor={fieldIds.distTop}>
                     Top
                   </label>
                   <input
-                    id="img-pos-dist-top"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.distTop}
                     min={0}
+                    type="number"
                     value={distTop}
                     onChange={(e) => setDistTop(Number(e.target.value) || 0)}
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label className={distLabelCls} htmlFor="img-pos-dist-bottom">
+                  <label className={distLabelCls} htmlFor={fieldIds.distBottom}>
                     Bottom
                   </label>
                   <input
-                    id="img-pos-dist-bottom"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.distBottom}
                     min={0}
+                    type="number"
                     value={distBottom}
                     onChange={(e) => setDistBottom(Number(e.target.value) || 0)}
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label className={distLabelCls} htmlFor="img-pos-dist-left">
+                  <label className={distLabelCls} htmlFor={fieldIds.distLeft}>
                     Left
                   </label>
                   <input
-                    id="img-pos-dist-left"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.distLeft}
                     min={0}
+                    type="number"
                     value={distLeft}
                     onChange={(e) => setDistLeft(Number(e.target.value) || 0)}
                   />
                 </div>
                 <div className="flex items-center gap-2">
-                  <label className={distLabelCls} htmlFor="img-pos-dist-right">
+                  <label className={distLabelCls} htmlFor={fieldIds.distRight}>
                     Right
                   </label>
                   <input
-                    id="img-pos-dist-right"
-                    type="number"
                     className={inputCls}
+                    id={fieldIds.distRight}
                     min={0}
+                    type="number"
                     value={distRight}
                     onChange={(e) => setDistRight(Number(e.target.value) || 0)}
                   />

--- a/packages/folio/src/components/dialogs/ImagePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/ImagePropertiesDialog.tsx
@@ -6,7 +6,7 @@
  * - Border/outline style, color, and width
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import {
   Dialog,
@@ -45,6 +45,7 @@ export function ImagePropertiesDialog({
   onApply,
   currentData,
 }: ImagePropertiesDialogProps) {
+  const id = useId();
   const [alt, setAlt] = useState("");
   const [borderWidth, setBorderWidth] = useState(0);
   const [borderColor, setBorderColor] = useState("#000000");
@@ -72,6 +73,11 @@ export function ImagePropertiesDialog({
   const inputCls =
     "border-input bg-background text-foreground flex-1 rounded border px-1.5 py-1 text-xs outline-none";
   const sectionLabelCls = "text-foreground text-[13px] font-semibold";
+  const fieldIds = {
+    borderWidth: `${id}-img-border-width`,
+    borderStyle: `${id}-img-border-style`,
+    borderColor: `${id}-img-border-color`,
+  };
 
   return (
     <Dialog
@@ -105,11 +111,11 @@ export function ImagePropertiesDialog({
             <div className="flex flex-col gap-2">
               <div className={sectionLabelCls}>Border</div>
               <div className="flex items-center gap-2">
-                <label htmlFor="img-border-width" className={labelCls}>
+                <label htmlFor={fieldIds.borderWidth} className={labelCls}>
                   Width
                 </label>
                 <input
-                  id="img-border-width"
+                  id={fieldIds.borderWidth}
                   type="number"
                   className={`${inputCls} max-w-[80px]`}
                   min={0}
@@ -121,11 +127,11 @@ export function ImagePropertiesDialog({
                 <span className="text-muted-foreground text-xs">px</span>
               </div>
               <div className="flex items-center gap-2">
-                <label htmlFor="img-border-style" className={labelCls}>
+                <label htmlFor={fieldIds.borderStyle} className={labelCls}>
                   Style
                 </label>
                 <select
-                  id="img-border-style"
+                  id={fieldIds.borderStyle}
                   className={inputCls}
                   value={borderStyle}
                   onChange={(e) => setBorderStyle(e.target.value)}
@@ -141,11 +147,11 @@ export function ImagePropertiesDialog({
                 </select>
               </div>
               <div className="flex items-center gap-2">
-                <label htmlFor="img-border-color" className={labelCls}>
+                <label htmlFor={fieldIds.borderColor} className={labelCls}>
                   Color
                 </label>
                 <input
-                  id="img-border-color"
+                  id={fieldIds.borderColor}
                   type="color"
                   value={borderColor}
                   onChange={(e) => setBorderColor(e.target.value)}

--- a/packages/folio/src/components/dialogs/PageSetupDialog.tsx
+++ b/packages/folio/src/components/dialogs/PageSetupDialog.tsx
@@ -7,7 +7,7 @@
  * - Margins (top, bottom, left, right) in inches
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useId, useState } from "react";
 
 import {
   Dialog,
@@ -80,6 +80,7 @@ export function PageSetupDialog({
   onApply,
   currentProps,
 }: PageSetupDialogProps) {
+  const id = useId();
   const [pageWidth, setPageWidth] = useState(DEFAULT_WIDTH);
   const [pageHeight, setPageHeight] = useState(DEFAULT_HEIGHT);
   const [orientation, setOrientation] = useState<"portrait" | "landscape">(
@@ -156,6 +157,14 @@ export function PageSetupDialog({
     "border-input bg-background text-foreground flex-1 rounded border px-2 py-1.5 text-[13px] outline-none";
   const sectionLabelCls =
     "text-muted-foreground text-xs font-semibold uppercase tracking-wide";
+  const fieldIds = {
+    size: `${id}-ps-size`,
+    orientation: `${id}-ps-orientation`,
+    marginTop: `${id}-ps-margin-top`,
+    marginBottom: `${id}-ps-margin-bottom`,
+    marginLeft: `${id}-ps-margin-left`,
+    marginRight: `${id}-ps-margin-right`,
+  };
 
   return (
     <Dialog
@@ -178,11 +187,11 @@ export function PageSetupDialog({
             <div className={sectionLabelCls}>Page Size</div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-size" className={labelCls}>
+              <label htmlFor={fieldIds.size} className={labelCls}>
                 Size
               </label>
               <select
-                id="ps-size"
+                id={fieldIds.size}
                 className={inputCls}
                 value={sizeIndex}
                 onChange={(e) => handlePageSizeChange(Number(e.target.value))}
@@ -197,11 +206,11 @@ export function PageSetupDialog({
             </div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-orientation" className={labelCls}>
+              <label htmlFor={fieldIds.orientation} className={labelCls}>
                 Orientation
               </label>
               <select
-                id="ps-orientation"
+                id={fieldIds.orientation}
                 className={inputCls}
                 value={orientation}
                 onChange={(e) =>
@@ -219,11 +228,11 @@ export function PageSetupDialog({
             <div className={`${sectionLabelCls} mt-1`}>Margins</div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-margin-top" className={labelCls}>
+              <label htmlFor={fieldIds.marginTop} className={labelCls}>
                 Top
               </label>
               <input
-                id="ps-margin-top"
+                id={fieldIds.marginTop}
                 type="number"
                 className={inputCls}
                 min={0}
@@ -238,11 +247,11 @@ export function PageSetupDialog({
             </div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-margin-bottom" className={labelCls}>
+              <label htmlFor={fieldIds.marginBottom} className={labelCls}>
                 Bottom
               </label>
               <input
-                id="ps-margin-bottom"
+                id={fieldIds.marginBottom}
                 type="number"
                 className={inputCls}
                 min={0}
@@ -257,11 +266,11 @@ export function PageSetupDialog({
             </div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-margin-left" className={labelCls}>
+              <label htmlFor={fieldIds.marginLeft} className={labelCls}>
                 Left
               </label>
               <input
-                id="ps-margin-left"
+                id={fieldIds.marginLeft}
                 type="number"
                 className={inputCls}
                 min={0}
@@ -276,11 +285,11 @@ export function PageSetupDialog({
             </div>
 
             <div className="flex items-center gap-3">
-              <label htmlFor="ps-margin-right" className={labelCls}>
+              <label htmlFor={fieldIds.marginRight} className={labelCls}>
                 Right
               </label>
               <input
-                id="ps-margin-right"
+                id={fieldIds.marginRight}
                 type="number"
                 className={inputCls}
                 min={0}

--- a/packages/folio/src/components/dialogs/TablePropertiesDialog.tsx
+++ b/packages/folio/src/components/dialogs/TablePropertiesDialog.tsx
@@ -2,7 +2,7 @@
  * Table Properties Dialog — width type, width value, alignment.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 
 import {
   Dialog,
@@ -36,6 +36,7 @@ export function TablePropertiesDialog({
   onApply,
   currentProps,
 }: TablePropertiesDialogProps) {
+  const id = useId();
   const [width, setWidth] = useState(currentProps?.width ?? 0);
   const [widthType, setWidthType] = useState(currentProps?.widthType ?? "auto");
   const [justification, setJustification] = useState(
@@ -74,6 +75,11 @@ export function TablePropertiesDialog({
   const labelCls = "w-20 text-muted-foreground text-[13px]";
   const inputCls =
     "border-input bg-background text-foreground flex-1 rounded border px-2 py-1.5 text-[13px] outline-none";
+  const fieldIds = {
+    widthType: `${id}-tp-width-type`,
+    width: `${id}-tp-width`,
+    align: `${id}-tp-align`,
+  };
 
   return (
     <Dialog
@@ -93,12 +99,12 @@ export function TablePropertiesDialog({
 
           <div className="flex flex-col gap-3 px-5 py-4">
             <div className="flex items-center gap-3">
-              <label className={labelCls} htmlFor="tp-width-type">
+              <label className={labelCls} htmlFor={fieldIds.widthType}>
                 Width type
               </label>
               <select
                 className={inputCls}
-                id="tp-width-type"
+                id={fieldIds.widthType}
                 onChange={(e) => setWidthType(e.target.value)}
                 value={widthType}
               >
@@ -110,12 +116,12 @@ export function TablePropertiesDialog({
 
             {widthType !== "auto" && (
               <div className="flex items-center gap-3">
-                <label className={labelCls} htmlFor="tp-width">
+                <label className={labelCls} htmlFor={fieldIds.width}>
                   Width
                 </label>
                 <input
                   className={inputCls}
-                  id="tp-width"
+                  id={fieldIds.width}
                   min={0}
                   onChange={(e) => setWidth(Number(e.target.value) || 0)}
                   step={widthType === "pct" ? 5 : 100}
@@ -129,12 +135,12 @@ export function TablePropertiesDialog({
             )}
 
             <div className="flex items-center gap-3">
-              <label className={labelCls} htmlFor="tp-align">
+              <label className={labelCls} htmlFor={fieldIds.align}>
                 Alignment
               </label>
               <select
                 className={inputCls}
-                id="tp-align"
+                id={fieldIds.align}
                 onChange={(e) => setJustification(e.target.value)}
                 value={justification}
               >


### PR DESCRIPTION
## Summary
- Scope Folio dialog form control IDs with React-generated instance IDs
- Preserve label, description, and dialog title associations for accessibility
- Remove duplicate form field IDs when multiple editor instances are mounted