### PR TITLE
fix: table property and grid UI

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -32,7 +32,7 @@ export const BottomRow = ({
         // oxlint-disable-next-line jsx_a11y/prefer-tag-over-role
         <WorkspaceGridRow className="cursor-pointer" role="button">
           <WorkspaceGridCell
-            className="z-10 flex items-center justify-center"
+            className="z-10 flex items-center justify-center border-t-2"
             style={{
               left: table.getColumn(selectColId)?.getStart("left"),
               right: table.getColumn(selectColId)?.getStart("right"),
@@ -42,7 +42,7 @@ export const BottomRow = ({
             <PlusIcon className="size-4" />
           </WorkspaceGridCell>
           <WorkspaceGridCell
-            className="z-10 flex items-center border-e-0"
+            className="z-10 flex items-center border-e-0 border-t-2"
             style={{
               left: table.getColumn(selectColId)?.getSize(),
               right: table.getColumn(selectColId)?.getSize(),
@@ -53,6 +53,7 @@ export const BottomRow = ({
           </WorkspaceGridCell>
           <WorkspaceGridCell
             aria-hidden="true"
+            className="border-t-2"
             role="presentation"
             style={{ gridColumn: "3 / -1" }}
           />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -2,40 +2,63 @@ import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu";
+import type { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import {
   WorkspaceGridCell,
   WorkspaceGridRow,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid";
+import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
+
+const selectColId = getInternalColId("select");
 
 type BottomRowProps = {
   workspaceId: string;
+  table: WorkspaceTable;
   onFolderCreated?: ((entityId: string) => void) | undefined;
 };
 
-export const BottomRow = ({ workspaceId, onFolderCreated }: BottomRowProps) => {
+export const BottomRow = ({
+  workspaceId,
+  table,
+  onFolderCreated,
+}: BottomRowProps) => {
   const t = useTranslations();
 
   return (
-    <WorkspaceGridRow className="sticky bottom-0 z-10">
-      <WorkspaceGridCell
-        className="z-10 border-t-2 transition-colors"
-        style={{ gridColumn: "1 / -1" }}
-      >
-        <AddEntityMenu
-          onFolderCreated={onFolderCreated}
-          uploadOnly
-          render={
-            <button
-              className="flex items-center gap-2"
-              title={t("workspaces.newDocument")}
-            >
-              <PlusIcon className="size-4" />
-              {t("workspaces.newDocument")}
-            </button>
-          }
-          workspaceId={workspaceId}
-        />
-      </WorkspaceGridCell>
-    </WorkspaceGridRow>
+    <AddEntityMenu
+      onFolderCreated={onFolderCreated}
+      uploadOnly
+      render={
+        // oxlint-disable-next-line jsx_a11y/prefer-tag-over-role
+        <WorkspaceGridRow className="cursor-pointer" role="button">
+          <WorkspaceGridCell
+            className="z-10 flex items-center justify-center"
+            style={{
+              left: table.getColumn(selectColId)?.getStart("left"),
+              right: table.getColumn(selectColId)?.getStart("right"),
+              position: "sticky",
+            }}
+          >
+            <PlusIcon className="size-4" />
+          </WorkspaceGridCell>
+          <WorkspaceGridCell
+            className="z-10 flex items-center border-e-0"
+            style={{
+              left: table.getColumn(selectColId)?.getSize(),
+              right: table.getColumn(selectColId)?.getSize(),
+              position: "sticky",
+            }}
+          >
+            {t("workspaces.newDocument")}
+          </WorkspaceGridCell>
+          <WorkspaceGridCell
+            aria-hidden="true"
+            role="presentation"
+            style={{ gridColumn: "3 / -1" }}
+          />
+        </WorkspaceGridRow>
+      }
+      workspaceId={workspaceId}
+    />
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/bottom-row.tsx
@@ -1,98 +1,41 @@
-import { Button } from "@stll/ui/components/button";
 import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu";
-import type { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import {
   WorkspaceGridCell,
   WorkspaceGridRow,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid";
-import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
-
-const selectColId = getInternalColId("select");
-const addPropertyColId = getInternalColId("add-property");
 
 type BottomRowProps = {
   workspaceId: string;
-  table: WorkspaceTable;
   onFolderCreated?: ((entityId: string) => void) | undefined;
 };
 
-export const BottomRow = ({
-  workspaceId,
-  table,
-  onFolderCreated,
-}: BottomRowProps) => {
+export const BottomRow = ({ workspaceId, onFolderCreated }: BottomRowProps) => {
   const t = useTranslations();
-  const addPropertyColumn = table.getColumn(addPropertyColId);
 
   return (
-    <WorkspaceGridRow className="bg-muted/40 hover:bg-muted sticky bottom-0 z-10 transition-colors">
+    <WorkspaceGridRow className="sticky bottom-0 z-10">
       <WorkspaceGridCell
-        className="relative z-10 min-w-12 shrink-0 border-e-0 border-t-2 p-0"
-        style={{
-          left: table.getColumn(selectColId)?.getStart("left"),
-          position: "sticky",
-        }}
-      >
-        <AddEntityMenu
-          onFolderCreated={onFolderCreated}
-          uploadOnly
-          render={
-            <Button
-              className="absolute inset-0 z-10 flex size-auto! min-w-12 shrink-0 rounded-none bg-transparent"
-              size="icon"
-              type="button"
-              variant="ghost"
-            >
-              <PlusIcon className="size-4" />
-            </Button>
-          }
-          workspaceId={workspaceId}
-        />
-      </WorkspaceGridCell>
-      <WorkspaceGridCell
-        className="text-muted-foreground relative z-10 border-e-0 border-t-2"
-        style={{
-          left: table.getColumn(selectColId)?.getSize(),
-          position: "sticky",
-        }}
+        className="z-10 border-t-2 transition-colors"
+        style={{ gridColumn: "1 / -1" }}
       >
         <AddEntityMenu
           onFolderCreated={onFolderCreated}
           uploadOnly
           render={
             <button
-              className="absolute inset-0 cursor-pointer text-start"
-              type="button"
-            />
-          }
-          workspaceId={workspaceId}
-        />
-        {t("workspaces.newDocument")}
-      </WorkspaceGridCell>
-      <WorkspaceGridCell
-        className="relative border-e-0 border-t-2 p-0"
-        style={{ gridColumn: addPropertyColumn ? "3 / -2" : "3 / -1" }}
-      >
-        <AddEntityMenu
-          onFolderCreated={onFolderCreated}
-          uploadOnly
-          render={
-            <button className="absolute inset-0 cursor-pointer" type="button" />
+              className="flex items-center gap-2"
+              title={t("workspaces.newDocument")}
+            >
+              <PlusIcon className="size-4" />
+              {t("workspaces.newDocument")}
+            </button>
           }
           workspaceId={workspaceId}
         />
       </WorkspaceGridCell>
-      {addPropertyColumn && (
-        <WorkspaceGridCell
-          aria-hidden="true"
-          className="bg-muted/40 sticky end-0 z-10 border-s border-t-2 p-0"
-          role="presentation"
-          style={{ gridColumn: "-2 / -1" }}
-        />
-      )}
     </WorkspaceGridRow>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -1,5 +1,6 @@
 import { Result } from "better-result";
 import { SquareMinusIcon } from "lucide-react";
+import type { ReactNode } from "react";
 import { useLocale, useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
@@ -153,7 +154,7 @@ const FileCell = ({
         content={fileName}
         render={
           <button
-            className="bg-muted grid min-w-0 max-w-full cursor-pointer grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start"
+            className="bg-muted grid max-w-full min-w-0 cursor-pointer grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start"
             onClick={() =>
               openPdf({
                 id: fieldId,
@@ -179,7 +180,7 @@ const FileCell = ({
     <Tooltip
       content={fileName}
       render={
-        <span className="bg-muted grid min-w-0 max-w-full grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start opacity-60" />
+        <span className="bg-muted grid max-w-full min-w-0 grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start opacity-60" />
       }
     >
       <DocumentIcon className="size-3.5 shrink-0" mimeType={mimeType} />
@@ -242,9 +243,19 @@ type IntCellProps = {
   currency: string | null;
 };
 
+const IntCellContainer = ({ children }: { children: ReactNode }) => (
+  <div className="min-w-0 max-w-full truncate tabular-nums text-start">
+    {children}
+  </div>
+);
+
 const IntCell = ({ value, currency }: IntCellProps) => {
   if (!currency) {
-    return <div>{new Intl.NumberFormat().format(value)}</div>;
+    return (
+      <IntCellContainer>
+        {new Intl.NumberFormat().format(value)}
+      </IntCellContainer>
+    );
   }
 
   const formattedResult = Result.try(() =>
@@ -257,11 +268,11 @@ const IntCell = ({ value, currency }: IntCellProps) => {
 
   if (formattedResult.isErr()) {
     return (
-      <div>
+      <IntCellContainer>
         {new Intl.NumberFormat().format(value)} {currency}
-      </div>
+      </IntCellContainer>
     );
   }
 
-  return <div>{formattedResult.value}</div>;
+  return <IntCellContainer>{formattedResult.value}</IntCellContainer>;
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -1,6 +1,7 @@
+import type { ReactNode } from "react";
+
 import { Result } from "better-result";
 import { SquareMinusIcon } from "lucide-react";
-import type { ReactNode } from "react";
 import { useLocale, useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
@@ -244,7 +245,7 @@ type IntCellProps = {
 };
 
 const IntCellContainer = ({ children }: { children: ReactNode }) => (
-  <div className="min-w-0 max-w-full truncate tabular-nums text-start">
+  <div className="max-w-full min-w-0 truncate text-start tabular-nums">
     {children}
   </div>
 );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -153,7 +153,7 @@ const FileCell = ({
         content={fileName}
         render={
           <button
-            className="bg-muted grid max-w-full cursor-pointer grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5"
+            className="bg-muted grid min-w-0 max-w-full cursor-pointer grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start"
             onClick={() =>
               openPdf({
                 id: fieldId,
@@ -170,7 +170,7 @@ const FileCell = ({
         }
       >
         <DocumentIcon className="size-3.5 shrink-0" mimeType={mimeType} />
-        <span className="truncate">{fileName}</span>
+        <span className="min-w-0 truncate text-start">{fileName}</span>
       </Tooltip>
     );
   }
@@ -179,11 +179,11 @@ const FileCell = ({
     <Tooltip
       content={fileName}
       render={
-        <span className="bg-muted grid max-w-full grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 opacity-60" />
+        <span className="bg-muted grid min-w-0 max-w-full grid-cols-[1rem_minmax(0,1fr)] items-center gap-1 rounded px-1 py-0.5 text-start opacity-60" />
       }
     >
       <DocumentIcon className="size-3.5 shrink-0" mimeType={mimeType} />
-      <span className="truncate">{fileName}</span>
+      <span className="min-w-0 truncate text-start">{fileName}</span>
     </Tooltip>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -375,7 +375,7 @@ const InlineIntEditor = ({
   if (!editing) {
     return (
       <button
-        className="hover:bg-muted w-full rounded px-2 py-1 text-start text-sm transition-colors"
+        className="hover:bg-muted block w-full min-w-0 rounded px-2 py-1 text-start text-sm transition-colors"
         onClick={() => {
           setDraft(String(value));
           setEditing(true);
@@ -415,6 +415,9 @@ const InlineIntEditor = ({
 
 // -- Shared display helpers --
 
+const intDisplayClass =
+  "block min-w-0 max-w-full truncate tabular-nums text-start text-sm";
+
 const IntDisplay = ({
   value,
   currency,
@@ -424,7 +427,9 @@ const IntDisplay = ({
 }) => {
   if (!currency) {
     return (
-      <span className="text-sm">{new Intl.NumberFormat().format(value)}</span>
+      <span className={intDisplayClass}>
+        {new Intl.NumberFormat().format(value)}
+      </span>
     );
   }
 
@@ -434,10 +439,10 @@ const IntDisplay = ({
       currency,
       minimumFractionDigits: 0,
     }).format(value);
-    return <span className="text-sm">{formatted}</span>;
+    return <span className={intDisplayClass}>{formatted}</span>;
   } catch {
     return (
-      <span className="text-sm">
+      <span className={intDisplayClass}>
         {new Intl.NumberFormat().format(value)} {currency}
       </span>
     );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -167,10 +167,10 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
     columnDefs.push({
       id: addPropertyColId,
       accessorKey: addPropertyColId,
-      header: () => <CreateProperty workspaceId={workspaceId} />,
-      cell: () => (
-        <CreateProperty triggerVariant="blank-cell" workspaceId={workspaceId} />
+      header: () => (
+        <CreateProperty triggerVariant="icon" workspaceId={workspaceId} />
       ),
+      cell: () => null,
       enableResizing: false,
       enablePinning: false,
       enableSorting: false,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.test.ts
@@ -64,19 +64,19 @@ describe("workspace grid column ordering", () => {
       rightColumns: [],
     });
 
-    expect(getGridTemplateColumns(orderedColumns, 0)).toBe(
-      "48px 240px 200px 160px 0px",
+    expect(getGridTemplateColumns(orderedColumns)).toBe(
+      "48px 240px 200px 160px",
     );
   });
 
-  test("places the filler before end-pinned utility columns", () => {
+  test("keeps end utility columns as real columns", () => {
     expect(
-      getGridTemplateColumns(
-        [column("select", 48), column("documents", 240)],
-        120,
-        [column("add-property", 48)],
-      ),
-    ).toBe("48px 240px 120px 48px");
+      getGridTemplateColumns([
+        column("select", 48),
+        column("documents", 240),
+        column("add-property", 40),
+      ]),
+    ).toBe("48px 240px 40px");
   });
 
   test("moves a dragged column before the targeted column", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order.ts
@@ -44,16 +44,8 @@ export const getOrderedCells = <TCell extends CellLike>(
   return orderedCells;
 };
 
-export const getGridTemplateColumns = (
-  columns: readonly ColumnLike[],
-  trailingFillerWidth: number,
-  endColumns: readonly ColumnLike[] = [],
-) =>
-  [
-    ...columns.map((column) => `${column.getSize()}px`),
-    `${trailingFillerWidth}px`,
-    ...endColumns.map((column) => `${column.getSize()}px`),
-  ].join(" ");
+export const getGridTemplateColumns = (columns: readonly ColumnLike[]) =>
+  columns.map((column) => `${column.getSize()}px`).join(" ");
 
 type ReorderColumnIdsOptions = {
   ids: readonly string[];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -463,7 +463,10 @@ export const WorkspaceTable = ({
         </div>
         <div>
           {paddingTop > 0 && (
-            <WorkspaceGridRow aria-hidden="true" className="pointer-events-none">
+            <WorkspaceGridRow
+              aria-hidden="true"
+              className="pointer-events-none"
+            >
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
@@ -527,7 +530,10 @@ export const WorkspaceTable = ({
             );
           })}
           {paddingBottom > 0 && (
-            <WorkspaceGridRow aria-hidden="true" className="pointer-events-none">
+            <WorkspaceGridRow
+              aria-hidden="true"
+              className="pointer-events-none"
+            >
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
@@ -544,6 +550,7 @@ export const WorkspaceTable = ({
             </WorkspaceGridRow>
           )}
           <BottomRow
+            table={table}
             onFolderCreated={setEditingEntityId}
             workspaceId={workspaceId}
           />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -251,7 +251,7 @@ export const WorkspaceTable = ({
     leftColumns: table.getLeftLeafColumns(),
     centerColumns: table.getCenterLeafColumns(),
     rightColumns: table.getRightLeafColumns(),
-  });
+  }).filter((column) => column.getIsVisible());
   const addPropertyColumn =
     orderedColumns.find((column) => column.id === addPropertyColId) ?? null;
   const renderColumns = orderedColumns.filter(
@@ -262,20 +262,12 @@ export const WorkspaceTable = ({
     (sum, column) => sum + column.getSize(),
     0,
   );
-  const leftoverWidth = Math.max(0, wrapperWidth - tableWidth);
-  const trailingFillerWidth = leftoverWidth;
   const gridStyle: WorkspaceGridStyle = {
-    "--workspace-table-columns": getGridTemplateColumns(
-      renderColumns,
-      trailingFillerWidth,
-      addPropertyColumn ? [addPropertyColumn] : [],
-    ),
-    minWidth: tableWidth + trailingFillerWidth,
+    "--workspace-table-columns": getGridTemplateColumns(orderedColumns),
+    minWidth: tableWidth,
+    width: tableWidth,
   };
-  const horizontalMaxScroll = Math.max(
-    0,
-    tableWidth + trailingFillerWidth - wrapperWidth,
-  );
+  const horizontalMaxScroll = Math.max(0, tableWidth - wrapperWidth);
   const handleColumnReorder = useCallback(
     (sourceId: string, targetId: string, edge: ColumnDropEdge) => {
       const sourceColumn = table.getColumn(sourceId);
@@ -433,7 +425,7 @@ export const WorkspaceTable = ({
       <div
         aria-colcount={visibleColumnCount}
         aria-rowcount={rowModel.rows.length}
-        className="relative min-h-full w-full text-sm"
+        className="relative min-h-full text-sm"
         role="grid"
         style={gridStyle}
       >
@@ -453,11 +445,6 @@ export const WorkspaceTable = ({
                   />
                 ),
               )}
-              <WorkspaceGridHead
-                aria-hidden="true"
-                className="border-e-0"
-                role="presentation"
-              />
               {addPropertyColumn && (
                 <DraggableHeaderCell
                   addColumnHovered={isAddColumnHovered}
@@ -476,7 +463,7 @@ export const WorkspaceTable = ({
         </div>
         <div>
           {paddingTop > 0 && (
-            <WorkspaceGridRow aria-hidden="true">
+            <WorkspaceGridRow aria-hidden="true" className="pointer-events-none">
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
@@ -540,7 +527,7 @@ export const WorkspaceTable = ({
             );
           })}
           {paddingBottom > 0 && (
-            <WorkspaceGridRow aria-hidden="true">
+            <WorkspaceGridRow aria-hidden="true" className="pointer-events-none">
               <WorkspaceGridFillerCell
                 className="border-b-0"
                 style={{
@@ -558,7 +545,6 @@ export const WorkspaceTable = ({
           )}
           <BottomRow
             onFolderCreated={setEditingEntityId}
-            table={table}
             workspaceId={workspaceId}
           />
         </div>
@@ -1308,9 +1294,6 @@ const DraggableRow = ({
           )}
         </WorkspaceGridCell>
       ))}
-      <WorkspaceGridFillerCell
-        className={cn(isAddColumnHoverRow && "group-hover/row:bg-background")}
-      />
       <AddPropertyCell
         addColumnHovered={addColumnHovered}
         cell={addPropertyCell}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -88,8 +88,6 @@ const TABLE_ROW_ESTIMATE_PX = 41;
 const TABLE_ROW_OVERSCAN = 16;
 const EXPANDED_ROW_MAX_HEIGHT_PX = 192;
 const TABLE_COLUMN_DRAG_TYPE = "workspace-table-column";
-const ADD_COLUMN_HOVER_COLOR =
-  "color-mix(in srgb, var(--color-foreground) 4%, var(--color-background))";
 
 type WorkspaceGridStyle = CSSProperties & {
   "--workspace-table-columns": string;
@@ -131,10 +129,6 @@ export const WorkspaceTable = ({
   const lastColumnDropPosition = useRef<ColumnDropPosition | null>(null);
   const [editingEntityId, setEditingEntityId] = useState<string | null>(null);
   const [wrapperWidth, setWrapperWidth] = useState(0);
-  const [addColumnHoverRowId, setAddColumnHoverRowId] = useState<string | null>(
-    null,
-  );
-  const [isAddColumnHovered, setIsAddColumnHovered] = useState(false);
   const expandedTableRowEntityId = useWorkspaceStore(
     (s) => s.expandedTableRowEntityId,
   );
@@ -435,11 +429,13 @@ export const WorkspaceTable = ({
               {getOrderedHeaders(headerGroup.headers, renderColumns).map(
                 (header, index) => (
                   <DraggableHeaderCell
-                    addColumnHovered={isAddColumnHovered}
+                    collapseEndBorder={
+                      Boolean(addPropertyColumn) &&
+                      index === renderColumns.length - 1
+                    }
                     header={header}
                     index={index}
                     key={header.id}
-                    onAddColumnHoverChange={setIsAddColumnHovered}
                     onToggleSelectAll={handleToggleSelectAll}
                     selectAllState={selectAllState}
                   />
@@ -447,13 +443,11 @@ export const WorkspaceTable = ({
               )}
               {addPropertyColumn && (
                 <DraggableHeaderCell
-                  addColumnHovered={isAddColumnHovered}
                   header={getRequiredHeader(
                     headerGroup.headers,
                     addPropertyColumn.id,
                   )}
                   index={renderColumns.length}
-                  onAddColumnHoverChange={setIsAddColumnHovered}
                   onToggleSelectAll={handleToggleSelectAll}
                   selectAllState={selectAllState}
                 />
@@ -475,10 +469,7 @@ export const WorkspaceTable = ({
                 }}
               />
               {addPropertyColumn && (
-                <AddPropertyRailSpacer
-                  addColumnHovered={isAddColumnHovered}
-                  height={paddingTop}
-                />
+                <AddPropertyRailSpacer height={paddingTop} />
               )}
             </WorkspaceGridRow>
           )}
@@ -493,8 +484,6 @@ export const WorkspaceTable = ({
                 activeEntityId={activeEntityId}
                 activePropertyId={activePropertyId}
                 activeTaskId={activeTaskId}
-                addColumnHoverRowId={addColumnHoverRowId}
-                addColumnHovered={isAddColumnHovered}
                 editingEntityId={editingEntityId}
                 expanded={expandedTableRowEntityId === row.original.entityId}
                 index={virtualRow.index}
@@ -510,10 +499,6 @@ export const WorkspaceTable = ({
                 }}
                 onStartEditing={setEditingEntityId}
                 onStopEditing={() => setEditingEntityId(null)}
-                onAddColumnHoverChange={(hovered) => {
-                  setIsAddColumnHovered(hovered);
-                  setAddColumnHoverRowId(hovered ? row.id : null);
-                }}
                 onToggleExpanded={(entityId) => {
                   setExpandedTableRowEntityId(
                     expandedTableRowEntityId === entityId ? null : entityId,
@@ -542,10 +527,7 @@ export const WorkspaceTable = ({
                 }}
               />
               {addPropertyColumn && (
-                <AddPropertyRailSpacer
-                  addColumnHovered={isAddColumnHovered}
-                  height={paddingBottom}
-                />
+                <AddPropertyRailSpacer height={paddingBottom} />
               )}
             </WorkspaceGridRow>
           )}
@@ -563,8 +545,7 @@ export const WorkspaceTable = ({
 type DraggableHeaderCellProps = {
   header: Header<TableTreeNode, unknown>;
   index: number;
-  addColumnHovered: boolean;
-  onAddColumnHoverChange: (hovered: boolean) => void;
+  collapseEndBorder?: boolean;
   onToggleSelectAll: () => void;
   selectAllState: SelectAllState;
 };
@@ -572,8 +553,7 @@ type DraggableHeaderCellProps = {
 const DraggableHeaderCell = ({
   header,
   index,
-  addColumnHovered,
-  onAddColumnHoverChange,
+  collapseEndBorder = false,
   onToggleSelectAll,
   selectAllState,
 }: DraggableHeaderCellProps) => {
@@ -664,24 +644,15 @@ const DraggableHeaderCell = ({
       className={cn(
         "relative",
         isAddPropertyColumn && "border-s",
+        collapseEndBorder && "border-e-0",
         isDragging && "opacity-50",
         closestEdge && "overflow-visible",
         header.column.getIsResizing() &&
           "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
       )}
       ref={headerRef}
-      onPointerEnter={
-        isAddPropertyColumn ? () => onAddColumnHoverChange(true) : undefined
-      }
-      onPointerDown={
-        isAddPropertyColumn ? () => onAddColumnHoverChange(false) : undefined
-      }
-      onPointerLeave={
-        isAddPropertyColumn ? () => onAddColumnHoverChange(false) : undefined
-      }
       style={{
         ...getGridPinningStyles(header.column),
-        ...getAddColumnHoverStyles(isAddPropertyColumn && addColumnHovered),
       }}
     >
       <PinnedBoundary column={header.column} />
@@ -808,17 +779,6 @@ const getGridPinningStyles = (column: Column<TableTreeNode>): CSSProperties => {
     left: `${column.getStart("left")}px`,
     position: "sticky",
     zIndex: column.id === selectColId ? 3 : 2,
-  };
-};
-
-const getAddColumnHoverStyles = (hovered: boolean): CSSProperties => {
-  if (!hovered) {
-    return {};
-  }
-
-  return {
-    backgroundColor: ADD_COLUMN_HOVER_COLOR,
-    borderBottomColor: ADD_COLUMN_HOVER_COLOR,
   };
 };
 
@@ -972,13 +932,10 @@ type DraggableRowProps = {
   activeEntityId: string | null;
   activePropertyId: string | null;
   activeTaskId: string | null;
-  addColumnHoverRowId: string | null;
-  addColumnHovered: boolean;
   editingEntityId: string | null;
   expanded: boolean;
   lastSelectedIndex: React.RefObject<number | null>;
   measureElement: (element: Element | null) => void;
-  onAddColumnHoverChange: (hovered: boolean) => void;
   onRename: (entityId: string, newName: string) => void;
   onStartEditing: (entityId: string) => void;
   onStopEditing: () => void;
@@ -997,13 +954,10 @@ const DraggableRow = ({
   activeEntityId,
   activePropertyId,
   activeTaskId,
-  addColumnHoverRowId,
-  addColumnHovered,
   editingEntityId,
   expanded,
   lastSelectedIndex,
   measureElement,
-  onAddColumnHoverChange,
   onRename,
   onStartEditing,
   onStopEditing,
@@ -1025,7 +979,6 @@ const DraggableRow = ({
   const entity = row.original;
   const isFolder = entity.kind === "folder";
   const isTask = entity.kind === "task";
-  const isAddColumnHoverRow = addColumnHoverRowId === row.id;
   const visibleCells = getOrderedCells(row.getVisibleCells(), renderColumns);
   const addPropertyCell = addPropertyColumn
     ? row
@@ -1228,11 +1181,9 @@ const DraggableRow = ({
           onClick={() => row.toggleExpanded()}
           style={{ gridColumn: addPropertyCell ? "3 / -2" : "3 / -1" }}
         />
-        <FolderAddPropertyCell
-          addColumnHovered={addColumnHovered}
+        <AddPropertyCell
           cell={addPropertyCell}
           columnIndex={renderColumns.length + 1}
-          onAddColumnHoverChange={onAddColumnHoverChange}
           selected={row.getIsSelected()}
         />
       </WorkspaceGridRow>
@@ -1258,36 +1209,20 @@ const DraggableRow = ({
           aria-colindex={cellIndex + 1}
           className={cn(
             "relative",
-            isAddColumnHoverRow && "group-hover/row:bg-background",
             cell.column.id === selectColId && "min-w-12 shrink-0",
             cell.column.columnDef.meta?.muted && "text-muted-foreground",
             expanded &&
-              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:overflow-visible [&_.truncate]:whitespace-normal",
+              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:whitespace-normal [&_.truncate]:wrap-break-word",
             cell.column.getIsResizing() &&
               "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
+            addPropertyColumn &&
+              cellIndex === visibleCells.length - 1 &&
+              "border-e-0",
           )}
           data-state={cell.row.getIsSelected() ? "selected" : undefined}
           key={cell.id}
-          onPointerEnter={
-            cell.column.id === addPropertyColId
-              ? () => onAddColumnHoverChange(true)
-              : undefined
-          }
-          onPointerDown={
-            cell.column.id === addPropertyColId
-              ? () => onAddColumnHoverChange(false)
-              : undefined
-          }
-          onPointerLeave={
-            cell.column.id === addPropertyColId
-              ? () => onAddColumnHoverChange(false)
-              : undefined
-          }
           style={{
             ...getGridPinningStyles(cell.column),
-            ...getAddColumnHoverStyles(
-              cell.column.id === addPropertyColId && addColumnHovered,
-            ),
             maxHeight: expanded ? EXPANDED_ROW_MAX_HEIGHT_PX : undefined,
           }}
         >
@@ -1302,47 +1237,25 @@ const DraggableRow = ({
         </WorkspaceGridCell>
       ))}
       <AddPropertyCell
-        addColumnHovered={addColumnHovered}
         cell={addPropertyCell}
         columnIndex={renderColumns.length + 1}
-        onAddColumnHoverChange={onAddColumnHoverChange}
         selected={row.getIsSelected()}
       />
     </WorkspaceGridRow>
   );
 };
 
-type FolderAddPropertyCellProps = {
+type AddPropertyCellProps = {
   cell: Cell<TableTreeNode, unknown> | undefined;
   columnIndex: number;
   selected: boolean;
-  addColumnHovered: boolean;
-  onAddColumnHoverChange: (hovered: boolean) => void;
 };
-
-const FolderAddPropertyCell = ({
-  cell,
-  columnIndex,
-  selected,
-  addColumnHovered,
-  onAddColumnHoverChange,
-}: FolderAddPropertyCellProps) => (
-  <AddPropertyCell
-    addColumnHovered={addColumnHovered}
-    cell={cell}
-    columnIndex={columnIndex}
-    onAddColumnHoverChange={onAddColumnHoverChange}
-    selected={selected}
-  />
-);
 
 const AddPropertyCell = ({
   cell,
   columnIndex,
   selected,
-  addColumnHovered,
-  onAddColumnHoverChange,
-}: FolderAddPropertyCellProps) => {
+}: AddPropertyCellProps) => {
   if (!cell) {
     return null;
   }
@@ -1350,14 +1263,10 @@ const AddPropertyCell = ({
   return (
     <WorkspaceGridCell
       aria-colindex={columnIndex}
-      className="group-hover/row:bg-background group-data-[state=selected]/row:bg-background group-data-[state=selected]/row:group-hover/row:bg-background border-s p-0"
+      className="border-s p-0"
       data-state={selected ? "selected" : undefined}
-      onPointerEnter={() => onAddColumnHoverChange(true)}
-      onPointerDown={() => onAddColumnHoverChange(false)}
-      onPointerLeave={() => onAddColumnHoverChange(false)}
       style={{
         ...getGridPinningStyles(cell.column),
-        ...getAddColumnHoverStyles(addColumnHovered),
       }}
     >
       {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -1366,17 +1275,13 @@ const AddPropertyCell = ({
 };
 
 type AddPropertyRailSpacerProps = {
-  addColumnHovered: boolean;
   height: number;
 };
 
-const AddPropertyRailSpacer = ({
-  addColumnHovered,
-  height,
-}: AddPropertyRailSpacerProps) => (
+const AddPropertyRailSpacer = ({ height }: AddPropertyRailSpacerProps) => (
   <WorkspaceGridCell
     aria-hidden="true"
-    className="group-hover/row:bg-background border-s border-b-0 p-0"
+    className="border-s border-b-0 p-0"
     role="presentation"
     style={{
       gridColumn: "-2 / -1",
@@ -1384,7 +1289,6 @@ const AddPropertyRailSpacer = ({
       position: "sticky",
       right: 0,
       zIndex: 2,
-      ...getAddColumnHoverStyles(addColumnHovered),
     }}
   />
 );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -1212,7 +1212,7 @@ const DraggableRow = ({
             cell.column.id === selectColId && "min-w-12 shrink-0",
             cell.column.columnDef.meta?.muted && "text-muted-foreground",
             expanded &&
-              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:whitespace-normal [&_.truncate]:wrap-break-word",
+              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:wrap-break-word [&_.truncate]:whitespace-normal",
             cell.column.getIsResizing() &&
               "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
             addPropertyColumn &&

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
@@ -32,7 +32,15 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
   const updateView = useUpdateView(workspaceId);
 
   const storedColumnSizing = useTableStore(
-    useShallow((s) => s.columnSizing.get(viewId) ?? {}),
+    useShallow((s) => {
+      const sizing = s.columnSizing.get(viewId) ?? {};
+      const {
+        [selectColId]: _selectSize,
+        [addPropertyColId]: _addPropertySize,
+        ...propertySizing
+      } = sizing;
+      return propertySizing;
+    }),
   );
   const setStoredColumnSizing = useTableStore((s) => s.setColumnSizing);
   const [columnSizing, setColumnSizing] = useState(storedColumnSizing);

--- a/packages/ui/src/components/date-picker-popover.tsx
+++ b/packages/ui/src/components/date-picker-popover.tsx
@@ -395,7 +395,7 @@ function DatePickerPopover({
           <button
             aria-label={value ? displayLabel : undefined}
             className={cn(
-              "flex min-h-7 h-auto w-full min-w-0 items-center gap-1.5",
+              "flex h-auto min-h-7 w-full min-w-0 items-center gap-1.5",
               "rounded-md px-1.5 text-sm",
               "hover:bg-muted transition-colors",
               isOverdue
@@ -409,7 +409,7 @@ function DatePickerPopover({
         }
       >
         <CalendarIcon className="size-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 text-start wrap-break-word overflow-hidden text-ellipsis">
+        <span className="min-w-0 flex-1 overflow-hidden text-start wrap-break-word text-ellipsis">
           {displayLabel}
         </span>
         {isOverdue && overdueLabel && (

--- a/packages/ui/src/components/date-picker-popover.tsx
+++ b/packages/ui/src/components/date-picker-popover.tsx
@@ -395,7 +395,7 @@ function DatePickerPopover({
           <button
             aria-label={value ? displayLabel : undefined}
             className={cn(
-              "flex h-7 w-full items-center gap-1.5",
+              "flex min-h-7 h-auto w-full min-w-0 items-center gap-1.5",
               "rounded-md px-1.5 text-sm",
               "hover:bg-muted transition-colors",
               isOverdue
@@ -409,7 +409,9 @@ function DatePickerPopover({
         }
       >
         <CalendarIcon className="size-3.5 shrink-0" />
-        <span>{displayLabel}</span>
+        <span className="min-w-0 flex-1 text-start wrap-break-word overflow-hidden text-ellipsis">
+          {displayLabel}
+        </span>
         {isOverdue && overdueLabel && (
           <span className="text-xs text-red-500">{overdueLabel}</span>
         )}


### PR DESCRIPTION
## Proposed change
creating new property now only works on the header col, because it was clashing with expending the row

<img width="2246" height="567" alt="image" src="https://github.com/user-attachments/assets/3edcd25b-43e2-4da4-b6b0-8f4ab5749a33" />
<img width="2105" height="604" alt="image" src="https://github.com/user-attachments/assets/967e6843-b75e-43f6-922e-0b39eef2f4a3" />
<img width="1434" height="595" alt="image" src="https://github.com/user-attachments/assets/1db888a7-824b-4c34-a6c0-bf82dc06d5fd" />

<!--
  Brief description of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

- [ ] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [ ] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [ ] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [ ] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [ ] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)
