### PR TITLE
fix: block docx chat submit before snapshot ready

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -841,7 +841,7 @@ const FileChatOverlayInner = ({
 
       <PromptBar
         attentionPulseSeq={attentionPulseSeq}
-        canSubmitNow={() => canSubmitWithCurrentDocxSnapshot()}
+        canSubmitNow={canSubmitWithCurrentDocxSnapshot}
         editorController={editorController}
         emptyPlaceholder={
           activeFile && filePlaceholderAction ? (

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -720,6 +720,21 @@ const FileChatOverlayInner = ({
     placeholder: filePlaceholder,
     threadRef,
   });
+  const canSubmitWithCurrentDocxSnapshot = useEffectEvent(() => {
+    if (!activeFile || !docxEditorRef) {
+      return true;
+    }
+
+    const snapshot = docxEditorRef.current?.createAIEditSnapshot() ?? null;
+    if (snapshot) {
+      lastSentDocxEditSnapshotRef.current = snapshot;
+      return true;
+    }
+
+    lastSentDocxEditSnapshotRef.current = null;
+    setEditorReady(false);
+    return false;
+  });
 
   const handleApproveWithDocxUnlock = async (
     approvalId: string,
@@ -826,6 +841,7 @@ const FileChatOverlayInner = ({
 
       <PromptBar
         attentionPulseSeq={attentionPulseSeq}
+        canSubmitNow={() => canSubmitWithCurrentDocxSnapshot()}
         editorController={editorController}
         emptyPlaceholder={
           activeFile && filePlaceholderAction ? (

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1015,6 +1015,7 @@ function computeVisibleRange(
 type PromptBarProps = {
   layout: FileAIChatLayout;
   status: FileAIChatStatus;
+  canSubmitNow?: (() => boolean) | undefined;
   onSubmit: (input: { prompt: string }) => void;
   onNewThread?: (() => void) | undefined;
   newThreadLabel?: string | undefined;
@@ -1126,6 +1127,7 @@ export function PromptBar(props: PromptBarProps) {
     pendingCount,
     panelOpen,
     showThreadToggle,
+    canSubmitNow,
     onSubmit,
     onStop,
     onNewThread,
@@ -1180,10 +1182,13 @@ export function PromptBar(props: PromptBarProps) {
     if (submitDisabled) {
       return;
     }
+    if (canSubmitNow && !canSubmitNow()) {
+      return;
+    }
     await submit((draft) => {
       onSubmit({ prompt: draft.html });
     });
-  }, [onSubmit, submit, submitDisabled]);
+  }, [canSubmitNow, onSubmit, submit, submitDisabled]);
 
   // Register Enter handler — TipTap's keymap delegates Enter to
   // the `setSubmitHandler` registered here. Without this, Enter


### PR DESCRIPTION
Prevents DOCX file chat from submitting when the editor has temporarily lost its AI edit snapshot. The prompt stays in the composer, the bar returns to the loading state, and the backend does not receive incomplete DOCX edit context.

Checks run:
- bun test apps/web/src/components/chat/chat-ui-tools.test.ts apps/web/src/components/ai-suggestions/review-store.test.ts
- bun --filter @stll/web typecheck
- bun --filter @stll/web lint
- bun --filter @stll/web format -- --check