### PR TITLE
fix: classify BYOK quota telemetry

### DIFF
--- a/apps/api/src/lib/analytics/ai.test.ts
+++ b/apps/api/src/lib/analytics/ai.test.ts
@@ -657,7 +657,7 @@ describe("createAIAnalyticsCallbacks", () => {
           message:
             "Quota exceeded for quota metric 'Generate requests per day per project per model'",
           responseBody:
-            '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"quotaId":"GenerateRequestsPerDayPerProjectPerModel-FreeTier"}]}}',
+            '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"quotaId":"GenerateRequestsPerDayPerProjectPerModel"}]}}',
           statusCode: 429,
         }),
       ),
@@ -669,6 +669,103 @@ describe("createAIAnalyticsCallbacks", () => {
       throw new Error("Expected aggregate AI failure event");
     }
     expect(event.properties.failure_reason).toBe("byok_quota");
+  });
+
+  test("keeps shared-capacity Gemini resource exhaustion classified as rate limit", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      modelRole: "fast",
+      orgAIConfig: createGoogleOrgAIConfig(),
+      traceId: "trace_shared_capacity",
+    });
+
+    callbacks.captureError(
+      createErrorWithCause(
+        "Failed after 3 attempts. Last error: server capacity",
+        createTransportError({
+          message: "Resource exhausted, please try again later.",
+          responseBody:
+            '{"error":{"code":429,"message":"Resource exhausted, please try again later.","status":"RESOURCE_EXHAUSTED"}}',
+          statusCode: 429,
+        }),
+      ),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.failure_reason).toBe("rate_limit");
+  });
+
+  test("keeps response body serialization failures from breaking classification", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const circularResponseBody: Record<string, unknown> = {
+      status: "RESOURCE_EXHAUSTED",
+    };
+    circularResponseBody["self"] = circularResponseBody;
+
+    const cases = [
+      {
+        message: "circular response body",
+        responseBody: circularResponseBody,
+      },
+      {
+        message: "bigint response body",
+        responseBody: {
+          remainingQuota: 0n,
+          status: "RESOURCE_EXHAUSTED",
+        },
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const events: Parameters<Analytics["capture"]>[0][] = [];
+
+      const analytics: Analytics = {
+        capture: (event) => {
+          events.push(event);
+        },
+        flush: async () => void 0,
+      };
+
+      const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+        analytics,
+        feature: "analysis.basic",
+        modelRole: "fast",
+        orgAIConfig: createGoogleOrgAIConfig(),
+        traceId: `trace_${testCase.message}`,
+      });
+
+      callbacks.captureError(
+        createTransportError({
+          message: "Too many requests",
+          responseBody: testCase.responseBody,
+          statusCode: 429,
+        }),
+      );
+
+      const event = events.at(0);
+      expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+      if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+        throw new Error("Expected aggregate AI failure event");
+      }
+      expect(event.properties.failure_reason).toBe("rate_limit");
+    }
   });
 
   test("keeps platform Gemini quota exhaustion classified as rate limit", async () => {

--- a/apps/api/src/lib/analytics/ai.test.ts
+++ b/apps/api/src/lib/analytics/ai.test.ts
@@ -5,6 +5,8 @@ import type {
 } from "ai";
 import { describe, expect, test } from "bun:test";
 
+import type { OrgAIConfig } from "@/api/lib/ai-models";
+
 import { SERVER_ANALYTICS_EVENTS } from "./types";
 import type { Analytics } from "./types";
 
@@ -18,6 +20,57 @@ process.env["SMTP_HOST"] ??= "localhost";
 process.env["SMTP_PORT"] ??= "1025";
 
 const loadAIAnalytics = async () => await import("./ai");
+
+const setErrorCause = (error: Error, cause: unknown): Error => {
+  Object.defineProperty(error, "cause", {
+    configurable: true,
+    value: cause,
+  });
+  return error;
+};
+
+const createErrorWithCause = (message: string, cause: unknown): Error =>
+  setErrorCause(new Error(message), cause);
+
+type TransportErrorOptions = {
+  cause?: unknown;
+  message: string;
+  responseBody?: unknown;
+  statusCode?: number;
+};
+
+const createTransportError = ({
+  cause,
+  message,
+  responseBody,
+  statusCode,
+}: TransportErrorOptions): Error => {
+  const error = Object.assign(new Error(message), {
+    ...(responseBody === undefined ? {} : { responseBody }),
+    ...(statusCode === undefined ? {} : { statusCode }),
+  });
+
+  if (cause !== undefined) {
+    setErrorCause(error, cause);
+  }
+
+  return error;
+};
+
+const createGoogleOrgAIConfig = (): OrgAIConfig => ({
+  providers: [
+    {
+      apiKey: "org-google-secret",
+      provider: "google",
+    },
+  ],
+  overrideModels: {
+    chat: { provider: "google", modelId: "gemini-2.5-flash" },
+    fast: { provider: "google", modelId: "gemini-2.5-flash" },
+    reasoning: { provider: "google", modelId: "gemini-2.5-pro" },
+    pdf: { provider: "google", modelId: "gemini-2.5-flash" },
+  },
+});
 
 describe("sanitizeForAIAnalytics", () => {
   test("replaces binary payloads with summaries", async () => {
@@ -428,6 +481,273 @@ describe("createAIAnalyticsCallbacks", () => {
     });
     expect(JSON.stringify(event.properties)).not.toContain("secret client");
     expect(JSON.stringify(event.properties)).not.toContain("trace_should_not");
+  });
+
+  test("captures safe provider messages from wrapped causes", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      traceId: "trace_wrapped_message",
+    });
+
+    callbacks.captureError(
+      createErrorWithCause(
+        "Failed after 3 attempts. Last error: quota failed",
+        new Error("RESOURCE_EXHAUSTED: Quota exceeded for metric: requests"),
+      ),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.error_message).toStartWith("RESOURCE_EXHAUSTED");
+    expect(event.properties).not.toHaveProperty("error_message_kind");
+  });
+
+  test("captures the deepest safe provider message within three cause levels", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      traceId: "trace_deep_message",
+    });
+
+    const fourthCause = new Error("UNAUTHENTICATED: outside search depth");
+    const thirdCause = createErrorWithCause(
+      "INVALID_ARGUMENT: deepest captured message",
+      fourthCause,
+    );
+    const secondCause = createErrorWithCause(
+      "RESOURCE_EXHAUSTED: shallower captured message",
+      thirdCause,
+    );
+    const firstCause = createErrorWithCause(
+      "PERMISSION_DENIED: shallow captured message",
+      secondCause,
+    );
+
+    callbacks.captureError(
+      createErrorWithCause("Failed after 3 attempts", firstCause),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.error_message).toBe(
+      "INVALID_ARGUMENT: deepest captured message",
+    );
+  });
+
+  test("ignores safe provider messages beyond three cause levels", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      traceId: "trace_too_deep_message",
+    });
+
+    const fourthCause = new Error("RESOURCE_EXHAUSTED: outside search depth");
+    const thirdCause = createErrorWithCause("wrapped", fourthCause);
+    const secondCause = createErrorWithCause("wrapped", thirdCause);
+    const firstCause = createErrorWithCause("wrapped", secondCause);
+
+    callbacks.captureError(
+      createErrorWithCause("Failed after 3 attempts", firstCause),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.error_message_kind).toBe("non_standard");
+    expect(event.properties).not.toHaveProperty("error_message");
+  });
+
+  test("terminates provider message classification on cause cycles", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      traceId: "trace_cycle_message",
+    });
+
+    const cyclicError = new Error("Failed after 3 attempts");
+    setErrorCause(cyclicError, cyclicError);
+    callbacks.captureError(cyclicError);
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.error_message_kind).toBe("non_standard");
+    expect(event.properties).not.toHaveProperty("error_message");
+  });
+
+  test("classifies wrapped Gemini BYOK quota exhaustion separately", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      modelRole: "fast",
+      orgAIConfig: createGoogleOrgAIConfig(),
+      traceId: "trace_byok_quota",
+    });
+
+    callbacks.captureError(
+      createErrorWithCause(
+        "Failed after 3 attempts. Last error: quota failed",
+        createTransportError({
+          message:
+            "Quota exceeded for quota metric 'Generate requests per day per project per model'",
+          responseBody:
+            '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"quotaId":"GenerateRequestsPerDayPerProjectPerModel-FreeTier"}]}}',
+          statusCode: 429,
+        }),
+      ),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.failure_reason).toBe("byok_quota");
+  });
+
+  test("keeps platform Gemini quota exhaustion classified as rate limit", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      modelRole: "fast",
+      traceId: "trace_platform_quota",
+    });
+
+    callbacks.captureError(
+      createErrorWithCause(
+        "Failed after 3 attempts. Last error: quota failed",
+        createTransportError({
+          message:
+            "Quota exceeded for quota metric 'Generate requests per day per project per model'",
+          responseBody:
+            '{"error":{"code":429,"status":"RESOURCE_EXHAUSTED","details":[{"quotaId":"GenerateRequestsPerDayPerProjectPerModel-FreeTier"}]}}',
+          statusCode: 429,
+        }),
+      ),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.failure_reason).toBe("rate_limit");
+  });
+
+  test("keeps non-quota 429 failures classified as rate limit", async () => {
+    const aiAnalyticsModule = await loadAIAnalytics();
+
+    const events: Parameters<Analytics["capture"]>[0][] = [];
+
+    const analytics: Analytics = {
+      capture: (event) => {
+        events.push(event);
+      },
+      flush: async () => void 0,
+    };
+
+    const callbacks = aiAnalyticsModule.createAIAnalyticsCallbacks({
+      analytics,
+      feature: "analysis.basic",
+      modelRole: "fast",
+      orgAIConfig: createGoogleOrgAIConfig(),
+      traceId: "trace_non_quota_429",
+    });
+
+    callbacks.captureError(
+      createErrorWithCause(
+        "Failed after 3 attempts. Last error: rate limit",
+        createTransportError({
+          message: "Too many requests",
+          responseBody: '{"error":{"code":429,"status":"RATE_LIMITED"}}',
+          statusCode: 429,
+        }),
+      ),
+    );
+
+    const event = events.at(0);
+    expect(event?.event).toBe(SERVER_ANALYTICS_EVENTS.aiGenerationFailed);
+    if (event?.event !== SERVER_ANALYTICS_EVENTS.aiGenerationFailed) {
+      throw new Error("Expected aggregate AI failure event");
+    }
+    expect(event.properties.failure_reason).toBe("rate_limit");
   });
 
   test("classifies AI SDK statusCode transport failures", async () => {

--- a/apps/api/src/lib/analytics/ai.ts
+++ b/apps/api/src/lib/analytics/ai.ts
@@ -53,7 +53,7 @@ const ONE_SECOND_MS = 1000;
 const SERVER_DISTINCT_ID = "server";
 const ERROR_CAUSE_MAX_DEPTH = 3;
 const RESOURCE_EXHAUSTED_CODE = "RESOURCE_EXHAUSTED";
-const GEMINI_FREE_TIER_QUOTA_MARKER = "FreeTier";
+const GEMINI_QUOTA_PATTERN = /quota/i;
 const isLocalPostHogDebugEnabled = (): boolean =>
   env.isDev && env.POSTHOG_LOCAL_DEBUG;
 
@@ -216,22 +216,27 @@ const getResponseBodyText = (error: unknown): string | undefined => {
     return undefined;
   }
 
-  const serialized = JSON.stringify(responseBody);
-  return serialized;
+  try {
+    return JSON.stringify(responseBody);
+  } catch {
+    return undefined;
+  }
 };
 
-const isGeminiFreeTierQuotaError = (error: unknown): boolean => {
+const hasGeminiQuotaSignal = (text: string | undefined): boolean =>
+  text !== undefined &&
+  text.includes(RESOURCE_EXHAUSTED_CODE) &&
+  GEMINI_QUOTA_PATTERN.test(text);
+
+const isGeminiQuotaError = (error: unknown): boolean => {
   const message = error instanceof Error ? error.message : "";
-  if (
-    message.includes(RESOURCE_EXHAUSTED_CODE) &&
-    message.includes(GEMINI_FREE_TIER_QUOTA_MARKER)
-  ) {
+  if (hasGeminiQuotaSignal(message)) {
     return true;
   }
 
   return (
     getErrorStatusCode(error) === 429 &&
-    (getResponseBodyText(error)?.includes(RESOURCE_EXHAUSTED_CODE) ?? false)
+    hasGeminiQuotaSignal(getResponseBodyText(error))
   );
 };
 
@@ -241,7 +246,7 @@ const isBYOKGeminiQuotaError = (
 ): boolean =>
   modelKeySource === "byok" &&
   findInErrorCauseChain(error, (candidate) =>
-    isGeminiFreeTierQuotaError(candidate) ? true : undefined,
+    isGeminiQuotaError(candidate) ? true : undefined,
   ) === true;
 
 // Provider error messages we feel safe surfacing as raw text.

--- a/apps/api/src/lib/analytics/ai.ts
+++ b/apps/api/src/lib/analytics/ai.ts
@@ -19,6 +19,7 @@ import type {
   AnalyticsPrimitive,
   CountBucket,
   LatencyBucket,
+  ModelKeySource,
   SafeAIAnalyticsMetadata,
   TokenBucket,
 } from "./types";
@@ -50,6 +51,9 @@ const MAX_STRING_LENGTH = 2000;
 const TRUNCATION_MARKER = " [truncated]";
 const ONE_SECOND_MS = 1000;
 const SERVER_DISTINCT_ID = "server";
+const ERROR_CAUSE_MAX_DEPTH = 3;
+const RESOURCE_EXHAUSTED_CODE = "RESOURCE_EXHAUSTED";
+const GEMINI_FREE_TIER_QUOTA_MARKER = "FreeTier";
 const isLocalPostHogDebugEnabled = (): boolean =>
   env.isDev && env.POSTHOG_LOCAL_DEBUG;
 
@@ -152,12 +156,102 @@ const getErrorStatusCode = (error: unknown): number | undefined => {
   return undefined;
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const getErrorCause = (error: unknown): unknown => {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return error["cause"];
+};
+
+const findInErrorCauseChain = <T>(
+  error: unknown,
+  match: (candidate: unknown) => T | undefined,
+): T | undefined => {
+  let candidate = error;
+  let remainingCauseDepth = ERROR_CAUSE_MAX_DEPTH;
+  const seen = new WeakSet<object>();
+
+  while (candidate !== undefined) {
+    if (isRecord(candidate)) {
+      if (seen.has(candidate)) {
+        return undefined;
+      }
+      seen.add(candidate);
+    }
+
+    const result = match(candidate);
+    if (result !== undefined) {
+      return result;
+    }
+
+    if (remainingCauseDepth === 0) {
+      return undefined;
+    }
+
+    candidate = getErrorCause(candidate);
+    remainingCauseDepth -= 1;
+  }
+
+  return undefined;
+};
+
+const sanitizeProviderMessage = (message: string, maxLength: number): string =>
+  String(sanitizeForAIAnalytics(message.trim())).slice(0, maxLength);
+
+const getResponseBodyText = (error: unknown): string | undefined => {
+  if (!isRecord(error) || !("responseBody" in error)) {
+    return undefined;
+  }
+
+  const responseBody = error["responseBody"];
+  if (typeof responseBody === "string") {
+    return responseBody;
+  }
+
+  if (responseBody === undefined) {
+    return undefined;
+  }
+
+  const serialized = JSON.stringify(responseBody);
+  return serialized;
+};
+
+const isGeminiFreeTierQuotaError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : "";
+  if (
+    message.includes(RESOURCE_EXHAUSTED_CODE) &&
+    message.includes(GEMINI_FREE_TIER_QUOTA_MARKER)
+  ) {
+    return true;
+  }
+
+  return (
+    getErrorStatusCode(error) === 429 &&
+    (getResponseBodyText(error)?.includes(RESOURCE_EXHAUSTED_CODE) ?? false)
+  );
+};
+
+const isBYOKGeminiQuotaError = (
+  error: unknown,
+  modelKeySource: ModelKeySource | undefined,
+): boolean =>
+  modelKeySource === "byok" &&
+  findInErrorCauseChain(error, (candidate) =>
+    isGeminiFreeTierQuotaError(candidate) ? true : undefined,
+  ) === true;
+
 // Provider error messages we feel safe surfacing as raw text.
 // Google Generative AI and most other AI gateways return errors
 // prefixed with an UPPER_SNAKE_CASE code (PERMISSION_DENIED,
 // RESOURCE_EXHAUSTED, INVALID_ARGUMENT, ...). Anything else may
 // echo request bodies, prompt fragments, or file names, so we
 // drop the message text and only keep the bucketed reason.
+// Wrapped provider errors are common, so we look for that enum-style
+// code in the cause chain without broadening the allowlist.
 const SAFE_PROVIDER_MESSAGE_PATTERN = /^[A-Z][A-Z_]+(:|\s)/;
 
 type ClassifiedErrorMessage =
@@ -168,20 +262,64 @@ const classifyErrorMessage = (
   error: unknown,
   maxLength: number,
 ): ClassifiedErrorMessage | undefined => {
-  if (!(error instanceof Error) || !error.message) {
+  if (!(error instanceof Error)) {
     return undefined;
   }
+
   const trimmed = error.message.trim();
-  if (!SAFE_PROVIDER_MESSAGE_PATTERN.test(trimmed)) {
-    return { kind: "non_standard" };
+  if (SAFE_PROVIDER_MESSAGE_PATTERN.test(trimmed)) {
+    return {
+      kind: "safe",
+      message: sanitizeProviderMessage(trimmed, maxLength),
+    };
   }
-  return {
-    kind: "safe",
-    message: String(sanitizeForAIAnalytics(trimmed)).slice(0, maxLength),
-  };
+
+  let safeCauseMessage: string | undefined;
+  let candidate = getErrorCause(error);
+  let remainingCauseDepth = ERROR_CAUSE_MAX_DEPTH;
+  const seen = new WeakSet<object>();
+  seen.add(error);
+
+  while (candidate !== undefined && remainingCauseDepth > 0) {
+    if (isRecord(candidate)) {
+      if (seen.has(candidate)) {
+        break;
+      }
+      seen.add(candidate);
+    }
+
+    if (candidate instanceof Error) {
+      const causeMessage = candidate.message.trim();
+      if (SAFE_PROVIDER_MESSAGE_PATTERN.test(causeMessage)) {
+        safeCauseMessage = causeMessage;
+      }
+    }
+
+    candidate = getErrorCause(candidate);
+    remainingCauseDepth -= 1;
+  }
+
+  if (safeCauseMessage) {
+    return {
+      kind: "safe",
+      message: sanitizeProviderMessage(safeCauseMessage, maxLength),
+    };
+  }
+
+  return { kind: "non_standard" };
 };
 
-const classifyFailureReason = (error: unknown): AIFailureReason => {
+const getErrorStatusCodeFromChain = (error: unknown): number | undefined =>
+  findInErrorCauseChain(error, getErrorStatusCode);
+
+const classifyFailureReason = (
+  error: unknown,
+  modelKeySource?: ModelKeySource,
+): AIFailureReason => {
+  if (isBYOKGeminiQuotaError(error, modelKeySource)) {
+    return "byok_quota";
+  }
+
   const tag = errorTag(error);
   if (tag.includes("Validation")) {
     return "validation";
@@ -193,7 +331,7 @@ const classifyFailureReason = (error: unknown): AIFailureReason => {
     return "timeout";
   }
 
-  const statusCode = getErrorStatusCode(error);
+  const statusCode = getErrorStatusCodeFromChain(error);
   if (statusCode === 401 || statusCode === 403) {
     return "auth";
   }
@@ -530,12 +668,14 @@ export const createAIAnalyticsCallbacks = ({
 
     hasCapturedGenerationError = true;
     const activeStep = [...stepState.values()].at(-1);
+    const modelKeySource = resolvedModelInfo?.keySource;
+    const failureReason = classifyFailureReason(error, modelKeySource);
 
     const cwMessage = classifyErrorMessage(error, 256);
     logger.error("ai.generation.failed", {
       "error.type": errorTag(error),
       "ai.feature": config.feature,
-      "ai.failure_reason": classifyFailureReason(error),
+      "ai.failure_reason": failureReason,
       ...(resolvedModelInfo?.provider
         ? { "ai.provider": resolvedModelInfo.provider }
         : {}),
@@ -558,7 +698,7 @@ export const createAIAnalyticsCallbacks = ({
           ...(phMessage?.kind === "safe"
             ? { error_message: phMessage.message }
             : { error_message_kind: "non_standard" }),
-          failure_reason: classifyFailureReason(error),
+          failure_reason: failureReason,
           feature: config.feature,
           ...(activeStep
             ? {

--- a/apps/api/src/lib/analytics/types.ts
+++ b/apps/api/src/lib/analytics/types.ts
@@ -16,6 +16,7 @@ export type CountBucket = "0" | "1" | "2_3" | "4_plus";
 export type ModelKeySource = ResolvedModelInfo["keySource"] | "unknown";
 export type AIFailureReason =
   | "auth"
+  | "byok_quota"
   | "configuration"
   | "provider"
   | "rate_limit"
@@ -53,6 +54,8 @@ export type AIGenerationCompletedProperties = AIModelTelemetryProperties &
   };
 
 export type AIGenerationFailedProperties = SafeAIAnalyticsMetadata & {
+  error_message?: string;
+  error_message_kind?: "non_standard";
   error_type: string;
   failure_reason: AIFailureReason;
   feature: string;


### PR DESCRIPTION
## Summary

- classify wrapped Gemini BYOK quota exhaustion under a dedicated telemetry bucket
- walk wrapped provider error causes for allowlisted enum-style messages
- add regression coverage for wrapped quota errors, cause depth limits, and cycles

## Validation

- `bun --filter @stll/api test src/lib/analytics/ai.test.ts`
- `bun --filter @stll/api typecheck`
- `bun --filter @stll/api lint`
- `bun run lint && bun run format && bun run typecheck && bun run test`