### PR TITLE
fix: allow renaming clients

### DIFF
--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -19,6 +19,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
   ArrowLeftIcon,
@@ -51,6 +52,7 @@ import {
   PARTY_ROLE_LABEL_KEYS,
   toPartyRole,
 } from "@/routes/_protected.workspaces/$workspaceId/-party-roles";
+import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 import { useCreateMatterStore } from "@/routes/_protected.workspaces/-store/create-matter-store";
 
 export const Route = createFileRoute("/_protected/contacts/$contactId")({
@@ -174,6 +176,12 @@ function ContactDetailPage() {
             <div className="space-y-2 text-sm">
               <EditableRow
                 contact={contact}
+                field="displayName"
+                label={t("contacts.fields.displayName")}
+                value={contact.displayName}
+              />
+              <EditableRow
+                contact={contact}
                 field="prefix"
                 label={t("contacts.fields.prefix")}
                 value={contact.prefix}
@@ -205,12 +213,20 @@ function ContactDetailPage() {
             </div>
           )}
           {contact.type === "organization" && (
-            <EditableRow
-              contact={contact}
-              field="organizationName"
-              label={t("common.organizationName")}
-              value={contact.organizationName}
-            />
+            <div className="space-y-2 text-sm">
+              <EditableRow
+                contact={contact}
+                field="displayName"
+                label={t("contacts.fields.displayName")}
+                value={contact.displayName}
+              />
+              <EditableRow
+                contact={contact}
+                field="organizationName"
+                label={t("common.organizationName")}
+                value={contact.organizationName}
+              />
+            </div>
           )}
         </section>
 
@@ -507,20 +523,32 @@ const getContactMetadata = (contact: ContactData): ContactMetadata => {
   };
 };
 
+const invalidateContactCaches = (
+  queryClient: QueryClient,
+  contactId: string,
+) => {
+  // eslint-disable-next-line typescript/no-floating-promises
+  queryClient.invalidateQueries({
+    queryKey: contactsKeys.byId(contactId),
+  });
+  // eslint-disable-next-line typescript/no-floating-promises
+  queryClient.invalidateQueries({
+    queryKey: contactsKeys.list(),
+  });
+  // Client contact fields are embedded in workspace list/detail/navigation data.
+  // eslint-disable-next-line typescript/no-floating-promises
+  queryClient.invalidateQueries({
+    queryKey: workspacesKeys.all,
+  });
+};
+
 const useContactPatch = (contact: ContactData) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const updateContact = useUpdateContact();
 
   const handleSuccess = () => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    queryClient.invalidateQueries({
-      queryKey: contactsKeys.byId(contact.id),
-    });
-    // eslint-disable-next-line typescript/no-floating-promises
-    queryClient.invalidateQueries({
-      queryKey: contactsKeys.list(),
-    });
+    invalidateContactCaches(queryClient, contact.id);
   };
 
   const handleError = (onError?: () => void) => {
@@ -1178,14 +1206,7 @@ const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.byId(contact.id),
-          });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.list(),
-          });
+          invalidateContactCaches(queryClient, contact.id);
         },
         onError: () => {
           stellaToast.add({
@@ -1385,14 +1406,7 @@ const ContactNotesEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.byId(contact.id),
-          });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.list(),
-          });
+          invalidateContactCaches(queryClient, contact.id);
         },
         onError: () => {
           stellaToast.add({
@@ -1471,6 +1485,16 @@ const EditableRow = ({
         return;
       }
       payload = { [field]: parsed };
+    } else if (field === "displayName") {
+      if (!trimmed) {
+        stellaToast.add({
+          title: t("errors.actionFailed"),
+          type: "error",
+        });
+        setInputValue(value ?? "");
+        return;
+      }
+      payload = { displayName: trimmed };
     } else {
       payload = { [field]: trimmed || null };
     }
@@ -1479,14 +1503,7 @@ const EditableRow = ({
       { contactId: contact.id, ...payload },
       {
         onSuccess: () => {
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.byId(contact.id),
-          });
-          // eslint-disable-next-line typescript/no-floating-promises
-          queryClient.invalidateQueries({
-            queryKey: contactsKeys.list(),
-          });
+          invalidateContactCaches(queryClient, contact.id);
         },
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -523,23 +523,33 @@ const getContactMetadata = (contact: ContactData): ContactMetadata => {
   };
 };
 
-const invalidateContactCaches = (
+type InvalidateContactCachesOptions = {
+  invalidateWorkspaces?: boolean;
+};
+
+const invalidateContactCaches = async (
   queryClient: QueryClient,
   contactId: string,
+  { invalidateWorkspaces = false }: InvalidateContactCachesOptions = {},
 ) => {
-  // eslint-disable-next-line typescript/no-floating-promises
-  queryClient.invalidateQueries({
-    queryKey: contactsKeys.byId(contactId),
-  });
-  // eslint-disable-next-line typescript/no-floating-promises
-  queryClient.invalidateQueries({
-    queryKey: contactsKeys.list(),
-  });
-  // Client contact fields are embedded in workspace list/detail/navigation data.
-  // eslint-disable-next-line typescript/no-floating-promises
-  queryClient.invalidateQueries({
-    queryKey: workspacesKeys.all,
-  });
+  const promises = [
+    queryClient.invalidateQueries({
+      queryKey: contactsKeys.byId(contactId),
+    }),
+    queryClient.invalidateQueries({
+      queryKey: contactsKeys.lists(),
+    }),
+  ];
+
+  if (invalidateWorkspaces) {
+    promises.push(
+      queryClient.invalidateQueries({
+        queryKey: workspacesKeys.all,
+      }),
+    );
+  }
+
+  await Promise.all(promises);
 };
 
 const useContactPatch = (contact: ContactData) => {
@@ -548,7 +558,7 @@ const useContactPatch = (contact: ContactData) => {
   const updateContact = useUpdateContact();
 
   const handleSuccess = () => {
-    invalidateContactCaches(queryClient, contact.id);
+    void invalidateContactCaches(queryClient, contact.id);
   };
 
   const handleError = (onError?: () => void) => {
@@ -571,10 +581,8 @@ const useContactPatch = (contact: ContactData) => {
 
   const saveContactPatchAsync = async (patch: ContactPatch) => {
     try {
-      await updateContact.mutateAsync(
-        { contactId: contact.id, ...patch },
-        { onSuccess: handleSuccess },
-      );
+      await updateContact.mutateAsync({ contactId: contact.id, ...patch });
+      await invalidateContactCaches(queryClient, contact.id);
       return true;
     } catch {
       handleError();
@@ -1206,7 +1214,9 @@ const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          invalidateContactCaches(queryClient, contact.id);
+          void invalidateContactCaches(queryClient, contact.id, {
+            invalidateWorkspaces: field === "responsibleAttorneyId",
+          });
         },
         onError: () => {
           stellaToast.add({
@@ -1406,7 +1416,7 @@ const ContactNotesEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          invalidateContactCaches(queryClient, contact.id);
+          void invalidateContactCaches(queryClient, contact.id);
         },
         onError: () => {
           stellaToast.add({
@@ -1503,7 +1513,9 @@ const EditableRow = ({
       { contactId: contact.id, ...payload },
       {
         onSuccess: () => {
-          invalidateContactCaches(queryClient, contact.id);
+          void invalidateContactCaches(queryClient, contact.id, {
+            invalidateWorkspaces: field === "displayName",
+          });
         },
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/routes/_protected.contacts/-queries.ts
+++ b/apps/web/src/routes/_protected.contacts/-queries.ts
@@ -5,10 +5,11 @@ import { toAPIError } from "@/lib/errors";
 
 export const contactsKeys = {
   all: ["contacts"],
+  lists: () => [...contactsKeys.all, "list"],
   list: (filters?: {
     type?: "person" | "organization" | undefined;
     q?: string | undefined;
-  }) => [...contactsKeys.all, "list", filters],
+  }) => [...contactsKeys.lists(), filters],
   byId: (contactId: string) => [...contactsKeys.all, contactId],
 };
 


### PR DESCRIPTION
Adds editable display-name support on the contact detail page so existing client contacts can be renamed. Also invalidates workspace caches after contact updates so embedded client names refresh across matter views.