### PR TITLE
fix(tag-on-version-bump): use exact-match git ref endpoint

### DIFF
--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -69,7 +69,11 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
-          if gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+          # /git/ref/{ref} is the EXACT-match endpoint. The plural
+          # /git/refs/{ref} does prefix matching: a check for
+          # `v0.1.0` would also match `v0.1.0-rc.1` and skip the
+          # real tag push.
+          if gh api "repos/${{ github.repository }}/git/ref/tags/$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists; nothing to do."
             echo "skip=true" >> "$GITHUB_ENV"
           fi


### PR DESCRIPTION
Switch from `/git/refs/tags/$TAG` to `/git/ref/tags/$TAG`. The plural endpoint does prefix matching: an existence check for `vX.Y.Z` matches `vX.Y.Z-rc.N` and silently skips the tag push, leaving the merge unreleased.

Surfaced today during the v0.1.0 stable cut: VERSION bump merged, but tag-on-VERSION-bump's existence check returned the prerelease `v0.1.0-rc.1` ref and the workflow no-op'd. Manual `git push origin v0.1.0` was needed to trigger the release pipeline.

comment block flags the foot-gun for future readers.