### PR TITLE
chore(landing): unify page titles to "stella | <page>"

### DIFF
--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -6,7 +6,7 @@ type Props = {
 };
 
 const {
-  title = "stella — Legal Workspace",
+  title = "stella | open source legal workspace",
   description = "Open source legal workspace for documents, matters, review, and research. Self-host or use our cloud. Usage-based AI, no lock-in.",
 } = Astro.props;
 

--- a/apps/landing/src/pages/404.astro
+++ b/apps/landing/src/pages/404.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
 ---
 
-<Base title="Not found — stella" description="Page not found.">
+<Base title="stella | not found" description="Page not found.">
   <div class="flex min-h-dvh flex-col">
     <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">

--- a/apps/landing/src/pages/imprint.astro
+++ b/apps/landing/src/pages/imprint.astro
@@ -5,7 +5,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 const appUrl = "https://my.stll.app";
 ---
 
-<Base title="Imprint — stella" description="Legal information.">
+<Base title="stella | imprint" description="Legal information.">
   <div class="flex min-h-dvh flex-col">
     <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">

--- a/apps/landing/src/pages/security.astro
+++ b/apps/landing/src/pages/security.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
 ---
 
-<Base title="Security — stella" description="How stella protects your data. Security controls and data handling.">
+<Base title="stella | security" description="How stella protects your data. Security controls and data handling.">
   <div class="flex min-h-dvh flex-col">
     <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">

--- a/apps/landing/src/pages/terms.astro
+++ b/apps/landing/src/pages/terms.astro
@@ -81,7 +81,7 @@ const sections = [
 ];
 ---
 
-<Base title="Terms of Service — stella" description="Terms of Service for stella.">
+<Base title="stella | terms of service" description="Terms of Service for stella.">
   <div class="flex min-h-dvh flex-col">
     <nav class="mx-auto flex w-full max-w-300 items-center justify-between px-6 py-5">
       <a href="/">


### PR DESCRIPTION
## Summary

- Replace mixed `X — stella` / `stella — Legal Workspace` titles with a consistent lowercase pipe-separated form.
- Applies to the `Base.astro` default and per-page overrides on 404, terms, security, imprint.