### PR TITLE
chore(ci): defer release latest flag until desktop build, drop private-repo gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,10 +260,9 @@ jobs:
           TRUST_RESULT="${{ needs.trust-check.result }}"
           EVENT="${{ github.event_name }}"
 
-          # When the trust-check job was skipped (private repo
-          # visibility gate or irrelevant label event), all
-          # downstream jobs are also skipped. This is expected
-          # and should not block the PR.
+          # When the trust-check job was skipped (draft PR or
+          # irrelevant label event), all downstream jobs are also
+          # skipped. This is expected and should not block the PR.
           if [[ "$TRUST_RESULT" == "skipped" ]]; then
             echo "Trust-check skipped. Passing."
             exit 0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,9 +17,8 @@ permissions:
 jobs:
   analyze:
     if: >-
-      github.event.repository.visibility == 'public'
-      && (github.event_name != 'pull_request'
-          || github.event.pull_request.draft != true)
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,12 +30,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # Dependency Review needs Dependency Graph + GitHub Advanced Security on
-    # private repos, but is available for public repositories. Keep it wired up
-    # for launch while avoiding a hard failure before the repository is public.
-    if: >-
-      github.event.repository.visibility == 'public'
-      && github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -606,3 +606,17 @@ jobs:
             --distribution-id "$DIST_ID" \
             --paths "/$key" \
             --no-cli-pager > /dev/null
+
+      # Promote the release to "latest" only after the signed
+      # installers are attached. release.yml creates the release
+      # with --latest=false so /releases/latest/download/Stella-*
+      # keeps pointing at the previous fully-built release while
+      # this workflow is still building. Prereleases never get the
+      # latest flag (GitHub excludes them from /releases/latest by
+      # default) so we only flip for stable tags.
+      - name: Promote release to latest
+        if: ${{ !contains(needs.resolve.outputs.release_ref, '-') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
+        run: gh release edit "$RELEASE_REF" --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,7 +255,6 @@ jobs:
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
 
       - name: Attest image provenance
-        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -306,7 +305,6 @@ jobs:
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
 
       - name: Attest image provenance
-        continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -390,15 +388,26 @@ jobs:
           RELEASE_REF: ${{ needs.resolve.outputs.release_ref }}
         run: |
           if ! gh release view "$RELEASE_REF" >/dev/null 2>&1; then
-            prerelease_args=()
+            extra_args=()
             if [[ "$RELEASE_REF" == *-rc.* ]]; then
-              prerelease_args+=(--prerelease)
+              extra_args+=(--prerelease)
+            else
+              # Defer the "latest" flag until release-desktop.yml has
+              # uploaded the signed installers. Without this, GitHub
+              # auto-promotes the new stable release on creation, but
+              # the desktop build runs as a workflow_run trigger and
+              # takes another ~25 min — during that window
+              # /releases/latest/download/Stella-macos-universal.dmg
+              # 404s for end users. release-desktop.yml flips the
+              # flag in its final step, after both Mac + Windows
+              # signed installers are attached to the release.
+              extra_args+=(--latest=false)
             fi
             gh release create "$RELEASE_REF" \
               --title "$RELEASE_REF" \
               --notes-file NOTES.md \
               --verify-tag \
-              "${prerelease_args[@]}"
+              "${extra_args[@]}"
           fi
           gh release upload "$RELEASE_REF" release-manifest.json --clobber
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,10 +13,6 @@ permissions: read-all
 
 jobs:
   scorecard:
-    # OpenSSF Scorecard publishing is intended for the public repository.
-    # While private, the action cannot access the repository metadata it
-    # needs through GITHUB_TOKEN and fails on push-to-main.
-    if: github.event.repository.visibility == 'public'
     runs-on: ubuntu-latest
     permissions:
       # Required to checkout the repository


### PR DESCRIPTION

- **Defer \`latest=true\` until desktop build finishes.** \`release.yml\` now creates stable releases with \`--latest=false\`; \`release-desktop.yml\` flips \`--latest\` in a final step after both signed installers are attached. Closes the ~25 min window where \`/releases/latest/download/Stella-macos-universal.dmg\` 404s because the GH Release exists but the DMG isn't uploaded yet.
- **Drop \"if visibility == 'public'\" gates.** Repo is public