### PR TITLE
feat: add table cell metadata flags

### DIFF
--- a/apps/api/drizzle/20260506100000_cell-metadata/migration.sql
+++ b/apps/api/drizzle/20260506100000_cell-metadata/migration.sql
@@ -1,0 +1,41 @@
+CREATE TABLE "cell_metadata" (
+	"workspace_id" uuid NOT NULL,
+	"entity_version_id" uuid NOT NULL,
+	"property_id" uuid NOT NULL,
+	"metadata" jsonb NOT NULL,
+	"created_by" text,
+	"updated_by" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "cell_metadata_entity_version_id_property_id_pk" PRIMARY KEY("entity_version_id","property_id")
+);
+--> statement-breakpoint
+ALTER TABLE "cell_metadata" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "cell_metadata" ADD CONSTRAINT "cell_metadata_entity_version_id_entity_versions_id_fk" FOREIGN KEY ("entity_version_id") REFERENCES "entity_versions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "cell_metadata" ADD CONSTRAINT "cell_metadata_property_id_workspace_id_properties_id_workspace_id_fk" FOREIGN KEY ("property_id","workspace_id") REFERENCES "properties"("id","workspace_id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "cell_metadata" ADD CONSTRAINT "cell_metadata_created_by_user_id_fk" FOREIGN KEY ("created_by") REFERENCES "user"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "cell_metadata" ADD CONSTRAINT "cell_metadata_updated_by_user_id_fk" FOREIGN KEY ("updated_by") REFERENCES "user"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+CREATE INDEX "cell_metadata_workspace_id_idx" ON "cell_metadata" ("workspace_id");
+--> statement-breakpoint
+CREATE INDEX "cell_metadata_entity_version_id_idx" ON "cell_metadata" ("entity_version_id");
+--> statement-breakpoint
+CREATE POLICY "workspace_select" ON "cell_metadata" AS PERMISSIVE FOR SELECT TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_insert" ON "cell_metadata" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_update" ON "cell_metadata" AS PERMISSIVE FOR UPDATE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_delete" ON "cell_metadata" AS PERMISSIVE FOR DELETE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));

--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -195,6 +195,24 @@ export const fieldContentSchema = t.Union([
 
 export type FieldContent = Static<typeof fieldContentSchema>;
 
+export const cellMetadataSchema = t.Object({
+  version: v1,
+  manualFlags: t.Array(t.String({ minLength: 1, maxLength: 64 }), {
+    maxItems: 16,
+  }),
+  flagProvenance: t.Optional(
+    t.Record(
+      t.String({ minLength: 1, maxLength: 64 }),
+      t.Object({
+        addedBy: t.String({ minLength: 1 }),
+        addedAt: t.String({ format: "date-time" }),
+      }),
+    ),
+  ),
+});
+
+export type CellMetadata = Static<typeof cellMetadataSchema>;
+
 export const boundingBoxesSchema = t.Object({
   version: v1,
   boxes: t.Array(

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -23,6 +23,7 @@ import type {
   BankAccount,
   BillingAddress,
   BoundingBoxes,
+  CellMetadata,
   ContactAddress,
   ContactEmail,
   ContactPersistedMetadata,
@@ -1114,6 +1115,41 @@ export const fields = p.pgTable(
       .onDelete("cascade"),
     p.index("fields_workspace_id_idx").on(table.workspaceId),
     p.unique("fields_id_ws_unq").on(table.id, table.workspaceId),
+    ...wsPolicies(),
+  ],
+);
+
+export const cellMetadata = p.pgTable(
+  "cell_metadata",
+  {
+    workspaceId: safeWorkspaceId("workspace_id").notNull(),
+    entityVersionId: safeUuid<"entityVersion">("entity_version_id")
+      .notNull()
+      .references(() => entityVersions.id, { onDelete: "cascade" }),
+    propertyId: safeUuid<"property">("property_id").notNull(),
+    metadata: jsonb().$type<CellMetadata>().notNull(),
+    createdBy: p
+      .text("created_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    updatedBy: p
+      .text("updated_by")
+      .references(() => user.id, { onDelete: "set null" }),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p.timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p.primaryKey({
+      columns: [table.entityVersionId, table.propertyId],
+      name: "cell_metadata_entity_version_id_property_id_pk",
+    }),
+    p
+      .foreignKey({
+        columns: [table.propertyId, table.workspaceId],
+        foreignColumns: [properties.id, properties.workspaceId],
+      })
+      .onDelete("cascade"),
+    p.index("cell_metadata_workspace_id_idx").on(table.workspaceId),
+    p.index("cell_metadata_entity_version_id_idx").on(table.entityVersionId),
     ...wsPolicies(),
   ],
 );

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -6,13 +6,18 @@ import { alias } from "drizzle-orm/pg-core";
 import type { SafeDb, Transaction } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";
 import {
+  cellMetadata,
   desktopEditSessions,
   entities,
   entityVersions,
   fields,
   searchDocuments,
 } from "@/api/db/schema";
-import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
+import type {
+  CellMetadata,
+  EntityKind,
+  FieldContent,
+} from "@/api/db/schema-validators";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   AGENDA_ITEM_KIND,
@@ -30,6 +35,17 @@ import type { ViewFilterCondition, ViewSort } from "@/api/lib/views-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
 export type QueryEntitiesFieldMode = "full" | "visible";
+
+type CellMetadataFlagProvenanceResult = {
+  addedBy: string;
+  addedAt: string;
+  addedByName: string | null;
+  addedByImage: string | null;
+};
+
+type CellMetadataResult = Omit<CellMetadata, "flagProvenance"> & {
+  flagProvenance?: Record<string, CellMetadataFlagProvenanceResult>;
+};
 
 export type QueryEntityResult = {
   entityId: string;
@@ -72,6 +88,10 @@ export type QueryEntityResult = {
     entityId: string;
     content: FieldContent;
   }[];
+  cellMetadata: {
+    propertyId: string;
+    metadata: CellMetadataResult;
+  }[];
 };
 
 type QueryEntitiesProps = {
@@ -103,6 +123,100 @@ const organizationMemberIdsSubquery = (
     .where(eq(member.organizationId, organizationId))
     .groupBy(member.userId)
     .as(aliasName);
+
+type VersionScopedRow = {
+  entityVersionId: string;
+};
+
+const groupByEntityVersionId = <TRow extends VersionScopedRow>(
+  rows: TRow[],
+) => {
+  const byVersionId = new Map<string, TRow[]>();
+  for (const row of rows) {
+    const list = byVersionId.get(row.entityVersionId);
+    if (list) {
+      list.push(row);
+    } else {
+      byVersionId.set(row.entityVersionId, [row]);
+    }
+  }
+  return byVersionId;
+};
+
+const getCellMetadataActorIds = (
+  rows: { metadata: CellMetadata }[],
+): string[] => {
+  const userIds = new Set<string>();
+  for (const row of rows) {
+    for (const provenance of Object.values(row.metadata.flagProvenance ?? {})) {
+      userIds.add(provenance.addedBy);
+    }
+  }
+  return [...userIds];
+};
+
+type CellMetadataActor = {
+  id: string;
+  name: string | null;
+  image: string | null;
+};
+
+const enrichCellMetadata = (
+  metadata: CellMetadata,
+  actorMap: Map<string, CellMetadataActor>,
+): CellMetadataResult => {
+  const provenanceEntries = Object.entries(metadata.flagProvenance ?? {});
+  if (provenanceEntries.length === 0) {
+    return {
+      manualFlags: metadata.manualFlags,
+      version: metadata.version,
+    };
+  }
+
+  return {
+    ...metadata,
+    flagProvenance: Object.fromEntries(
+      provenanceEntries.map(([flag, provenance]) => {
+        const actor = actorMap.get(provenance.addedBy);
+        return [
+          flag,
+          {
+            ...provenance,
+            addedByName: actor?.name ?? null,
+            addedByImage: actor?.image ?? null,
+          },
+        ];
+      }),
+    ),
+  };
+};
+
+const buildCellMetadataPredicates = ({
+  fieldIds,
+  fieldMode,
+  idFilter,
+}: {
+  fieldIds: SafeId<"property">[];
+  fieldMode: QueryEntitiesFieldMode;
+  idFilter: SQL;
+}) => {
+  const predicates = [
+    eq(cellMetadata.entityVersionId, entities.currentVersionId),
+    idFilter,
+  ];
+  if (fieldMode !== "visible") {
+    return predicates;
+  }
+
+  const uniqueFieldIds = [...new Set(fieldIds)];
+  if (uniqueFieldIds.length === 0) {
+    predicates.push(sql`false`);
+    return predicates;
+  }
+
+  predicates.push(inArray(cellMetadata.propertyId, uniqueFieldIds));
+  return predicates;
+};
 
 const queryEntitiesGenerator = async function* ({
   safeDb,
@@ -206,11 +320,17 @@ const queryEntitiesGenerator = async function* ({
       }
     }
   }
+  const cellMetadataPredicates = buildCellMetadataPredicates({
+    fieldIds,
+    fieldMode,
+    idFilter,
+  });
 
   const [
     entityRowsResult,
     versionCountsResult,
     fieldRowsResult,
+    cellMetadataRowsResult,
     activeSessionsResult,
   ] = await Promise.all([
     safeDb((tx) => {
@@ -306,6 +426,16 @@ const queryEntitiesGenerator = async function* ({
         .from(fields)
         .innerJoin(entities, and(...fieldPredicates)),
     ),
+    safeDb((tx) =>
+      tx
+        .select({
+          entityVersionId: cellMetadata.entityVersionId,
+          propertyId: cellMetadata.propertyId,
+          metadata: cellMetadata.metadata,
+        })
+        .from(cellMetadata)
+        .innerJoin(entities, and(...cellMetadataPredicates)),
+    ),
     safeDb((tx) => {
       const sessionEditorMembers = organizationMemberIdsSubquery(
         tx,
@@ -342,7 +472,41 @@ const queryEntitiesGenerator = async function* ({
   const entityRows = yield* entityRowsResult;
   const versionCounts = yield* versionCountsResult;
   const fieldRows = yield* fieldRowsResult;
+  const cellMetadataRows = yield* cellMetadataRowsResult;
   const activeSessions = yield* activeSessionsResult;
+  const cellMetadataActorIds = getCellMetadataActorIds(cellMetadataRows);
+  const cellMetadataActors =
+    cellMetadataActorIds.length > 0
+      ? yield* Result.await(
+          safeDb((tx) => {
+            const actorMembers = tx
+              .select({ userId: member.userId })
+              .from(member)
+              .where(
+                and(
+                  eq(member.organizationId, currentOrganizationId),
+                  inArray(member.userId, cellMetadataActorIds),
+                ),
+              )
+              .groupBy(member.userId)
+              .as("cell_metadata_actor_members");
+
+            return tx
+              .select({
+                id: user.id,
+                name: sql<
+                  string | null
+                >`coalesce(nullif(trim(${user.name}), ''), ${user.email})`,
+                image: user.image,
+              })
+              .from(actorMembers)
+              .innerJoin(user, eq(actorMembers.userId, user.id));
+          }),
+        )
+      : [];
+  const cellMetadataActorMap = new Map(
+    cellMetadataActors.map((actor) => [actor.id, actor]),
+  );
 
   const versionCountMap = new Map(
     versionCounts.map((v) => [v.entityId, v.versionCount]),
@@ -362,15 +526,8 @@ const queryEntitiesGenerator = async function* ({
     }
   }
 
-  const fieldsByVersionId = new Map<string, typeof fieldRows>();
-  for (const field of fieldRows) {
-    const list = fieldsByVersionId.get(field.entityVersionId);
-    if (list) {
-      list.push(field);
-    } else {
-      fieldsByVersionId.set(field.entityVersionId, [field]);
-    }
-  }
+  const fieldsByVersionId = groupByEntityVersionId(fieldRows);
+  const cellMetadataByVersionId = groupByEntityVersionId(cellMetadataRows);
 
   const entityMap = new Map(entityRows.map((e) => [e.id, e]));
 
@@ -387,6 +544,7 @@ const queryEntitiesGenerator = async function* ({
     }
 
     const entityFields = fieldsByVersionId.get(versionId) ?? [];
+    const entityCellMetadata = cellMetadataByVersionId.get(versionId) ?? [];
 
     result.push({
       entityId: entity.id,
@@ -428,6 +586,10 @@ const queryEntitiesGenerator = async function* ({
         propertyId: field.propertyId,
         entityId: entity.id,
         content: field.content,
+      })),
+      cellMetadata: entityCellMetadata.map((entry) => ({
+        propertyId: entry.propertyId,
+        metadata: enrichCellMetadata(entry.metadata, cellMetadataActorMap),
       })),
     });
   }

--- a/apps/api/src/handlers/fields/routes.ts
+++ b/apps/api/src/handlers/fields/routes.ts
@@ -1,5 +1,6 @@
 import Elysia from "elysia";
 
+import updateCellMetadata from "@/api/handlers/fields/update-cell-metadata";
 import upsertField from "@/api/handlers/fields/upsert-by-id";
 import { workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
@@ -12,5 +13,9 @@ export const fieldsRoute = new Elysia({ prefix: "/fields/:workspaceId" })
   })
   .post("/", upsertField.handler, {
     body: upsertField.config.body,
+    invalidateQuery: true,
+  })
+  .patch("/metadata", updateCellMetadata.handler, {
+    body: updateCellMetadata.config.body,
     invalidateQuery: true,
   });

--- a/apps/api/src/handlers/fields/update-cell-metadata.ts
+++ b/apps/api/src/handlers/fields/update-cell-metadata.ts
@@ -1,0 +1,151 @@
+import { Result, panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { cellMetadata } from "@/api/db/schema";
+import type { CellMetadata } from "@/api/db/schema-validators";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const config = {
+  permissions: {
+    entity: ["update"],
+  },
+  body: t.Object({
+    propertyId: tSafeId("property"),
+    entityId: tSafeId("entity"),
+    manualFlags: t.Array(t.String({ minLength: 1, maxLength: 64 }), {
+      maxItems: 16,
+    }),
+  }),
+} satisfies HandlerConfig;
+
+const updateCellMetadata = createSafeHandler(
+  config,
+  async function* ({ safeDb, workspaceId, body, user }) {
+    const entity = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.entities.findFirst({
+          columns: { id: true, currentVersionId: true },
+          where: {
+            id: { eq: body.entityId },
+            workspaceId: { eq: workspaceId },
+          },
+        }),
+      ),
+    );
+
+    if (!entity) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Entity not found in workspace",
+        }),
+      );
+    }
+
+    const property = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.properties.findFirst({
+          columns: { id: true },
+          where: {
+            id: { eq: body.propertyId },
+            workspaceId: { eq: workspaceId },
+          },
+        }),
+      ),
+    );
+
+    if (!property) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Property not found in workspace",
+        }),
+      );
+    }
+
+    if (!entity.currentVersionId) {
+      panic("Entity has no current version");
+    }
+
+    const manualFlags = [...new Set(body.manualFlags)].toSorted();
+    const entityVersionId = entity.currentVersionId;
+    const existingMetadata = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({ metadata: cellMetadata.metadata })
+          .from(cellMetadata)
+          .where(
+            and(
+              eq(cellMetadata.entityVersionId, entityVersionId),
+              eq(cellMetadata.propertyId, property.id),
+            ),
+          )
+          .limit(1),
+      ),
+    );
+
+    if (manualFlags.length === 0) {
+      yield* Result.await(
+        safeDb((tx) =>
+          tx
+            .delete(cellMetadata)
+            .where(
+              and(
+                eq(cellMetadata.entityVersionId, entityVersionId),
+                eq(cellMetadata.propertyId, property.id),
+              ),
+            ),
+        ),
+      );
+      return Result.ok({ success: true });
+    }
+
+    const existingProvenance =
+      existingMetadata.at(0)?.metadata.flagProvenance ?? {};
+    const addedAt = new Date().toISOString();
+    const metadata: CellMetadata = {
+      version: 1,
+      manualFlags,
+      flagProvenance: Object.fromEntries(
+        manualFlags.map((flag) => [
+          flag,
+          existingProvenance[flag] ?? {
+            addedBy: user.id,
+            addedAt,
+          },
+        ]),
+      ),
+    };
+
+    yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .insert(cellMetadata)
+          .values({
+            workspaceId,
+            entityVersionId,
+            propertyId: property.id,
+            metadata,
+            createdBy: user.id,
+            updatedBy: user.id,
+          })
+          .onConflictDoUpdate({
+            target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
+            set: {
+              metadata,
+              updatedBy: user.id,
+              updatedAt: new Date(),
+            },
+          }),
+      ),
+    );
+
+    return Result.ok({ success: true });
+  },
+);
+
+export default updateCellMetadata;

--- a/apps/api/src/handlers/fields/update-cell-metadata.ts
+++ b/apps/api/src/handlers/fields/update-cell-metadata.ts
@@ -2,12 +2,16 @@ import { Result, panic } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
-import { cellMetadata } from "@/api/db/schema";
+import { cellMetadata, entities, properties } from "@/api/db/schema";
 import type { CellMetadata } from "@/api/db/schema-validators";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const manualFlagsSchema = t.Array(t.String({ minLength: 1, maxLength: 64 }), {
+  maxItems: 16,
+});
 
 const config = {
   permissions: {
@@ -16,66 +20,89 @@ const config = {
   body: t.Object({
     propertyId: tSafeId("property"),
     entityId: tSafeId("entity"),
-    manualFlags: t.Array(t.String({ minLength: 1, maxLength: 64 }), {
-      maxItems: 16,
-    }),
+    baseManualFlags: t.Optional(manualFlagsSchema),
+    manualFlags: manualFlagsSchema,
   }),
 } satisfies HandlerConfig;
+
+type UpdateCellMetadataResult =
+  | { status: "ok" }
+  | { status: "entity-not-found" }
+  | { status: "property-not-found" };
+
+const normalizeManualFlags = (flags: string[]) =>
+  [...new Set(flags)].toSorted();
+
+const mergeManualFlags = ({
+  baseManualFlags,
+  currentManualFlags,
+  requestedManualFlags,
+}: {
+  baseManualFlags: string[];
+  currentManualFlags: string[];
+  requestedManualFlags: string[];
+}) => {
+  const requestedFlagSet = new Set(requestedManualFlags);
+  const baseFlagSet = new Set(baseManualFlags);
+  const removedFlagSet = new Set(
+    baseManualFlags.filter((flag) => !requestedFlagSet.has(flag)),
+  );
+  const addedFlags = requestedManualFlags.filter(
+    (flag) => !baseFlagSet.has(flag),
+  );
+
+  return normalizeManualFlags([
+    ...currentManualFlags.filter((flag) => !removedFlagSet.has(flag)),
+    ...addedFlags,
+  ]);
+};
 
 const updateCellMetadata = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, body, user }) {
-    const entity = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.entities.findFirst({
-          columns: { id: true, currentVersionId: true },
-          where: {
-            id: { eq: body.entityId },
-            workspaceId: { eq: workspaceId },
-          },
-        }),
-      ),
-    );
+    const txResult = yield* Result.await(
+      safeDb(async (tx): Promise<UpdateCellMetadataResult> => {
+        const entityRows = await tx
+          .select({
+            id: entities.id,
+            currentVersionId: entities.currentVersionId,
+          })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.id, body.entityId),
+              eq(entities.workspaceId, workspaceId),
+            ),
+          )
+          .for("update");
+        const entity = entityRows.at(0);
 
-    if (!entity) {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Entity not found in workspace",
-        }),
-      );
-    }
+        if (!entity) {
+          return { status: "entity-not-found" };
+        }
 
-    const property = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.properties.findFirst({
-          columns: { id: true },
-          where: {
-            id: { eq: body.propertyId },
-            workspaceId: { eq: workspaceId },
-          },
-        }),
-      ),
-    );
+        if (!entity.currentVersionId) {
+          panic("Entity has no current version");
+        }
 
-    if (!property) {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Property not found in workspace",
-        }),
-      );
-    }
+        const propertyRows = await tx
+          .select({ id: properties.id })
+          .from(properties)
+          .where(
+            and(
+              eq(properties.id, body.propertyId),
+              eq(properties.workspaceId, workspaceId),
+            ),
+          )
+          .limit(1);
+        const property = propertyRows.at(0);
 
-    if (!entity.currentVersionId) {
-      panic("Entity has no current version");
-    }
+        if (!property) {
+          return { status: "property-not-found" };
+        }
 
-    const manualFlags = [...new Set(body.manualFlags)].toSorted();
-    const entityVersionId = entity.currentVersionId;
-    const existingMetadata = yield* Result.await(
-      safeDb((tx) =>
-        tx
+        const entityVersionId = entity.currentVersionId;
+        const existingMetadataRows = await tx
           .select({ metadata: cellMetadata.metadata })
           .from(cellMetadata)
           .where(
@@ -84,46 +111,52 @@ const updateCellMetadata = createSafeHandler(
               eq(cellMetadata.propertyId, property.id),
             ),
           )
-          .limit(1),
-      ),
-    );
+          .limit(1)
+          .for("update");
+        const existingMetadata = existingMetadataRows.at(0)?.metadata;
+        const currentManualFlags = normalizeManualFlags(
+          existingMetadata?.manualFlags ?? [],
+        );
+        const requestedManualFlags = normalizeManualFlags(body.manualFlags);
+        const baseManualFlags =
+          body.baseManualFlags === undefined
+            ? currentManualFlags
+            : normalizeManualFlags(body.baseManualFlags);
+        const manualFlags = mergeManualFlags({
+          baseManualFlags,
+          currentManualFlags,
+          requestedManualFlags,
+        });
 
-    if (manualFlags.length === 0) {
-      yield* Result.await(
-        safeDb((tx) =>
-          tx
+        if (manualFlags.length === 0) {
+          await tx
             .delete(cellMetadata)
             .where(
               and(
                 eq(cellMetadata.entityVersionId, entityVersionId),
                 eq(cellMetadata.propertyId, property.id),
               ),
-            ),
-        ),
-      );
-      return Result.ok({ success: true });
-    }
+            );
+          return { status: "ok" };
+        }
 
-    const existingProvenance =
-      existingMetadata.at(0)?.metadata.flagProvenance ?? {};
-    const addedAt = new Date().toISOString();
-    const metadata: CellMetadata = {
-      version: 1,
-      manualFlags,
-      flagProvenance: Object.fromEntries(
-        manualFlags.map((flag) => [
-          flag,
-          existingProvenance[flag] ?? {
-            addedBy: user.id,
-            addedAt,
-          },
-        ]),
-      ),
-    };
+        const existingProvenance = existingMetadata?.flagProvenance ?? {};
+        const addedAt = new Date().toISOString();
+        const metadata: CellMetadata = {
+          version: 1,
+          manualFlags,
+          flagProvenance: Object.fromEntries(
+            manualFlags.map((flag) => [
+              flag,
+              existingProvenance[flag] ?? {
+                addedBy: user.id,
+                addedAt,
+              },
+            ]),
+          ),
+        };
 
-    yield* Result.await(
-      safeDb((tx) =>
-        tx
+        await tx
           .insert(cellMetadata)
           .values({
             workspaceId,
@@ -140,9 +173,29 @@ const updateCellMetadata = createSafeHandler(
               updatedBy: user.id,
               updatedAt: new Date(),
             },
-          }),
-      ),
+          });
+
+        return { status: "ok" };
+      }),
     );
+
+    if (txResult.status === "entity-not-found") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Entity not found in workspace",
+        }),
+      );
+    }
+
+    if (txResult.status === "property-not-found") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Property not found in workspace",
+        }),
+      );
+    }
 
     return Result.ok({ success: true });
   },

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -230,6 +230,9 @@ const NavBadge = ({ digit }: { digit: number }) => (
 );
 
 type AppSidebarProps = React.ComponentProps<typeof Sidebar>;
+type AppSidebarStyle = React.CSSProperties & {
+  "--matter-sidebar-tint"?: string;
+};
 
 type MatterItemProps = {
   workspace: MatterIdentity & {
@@ -634,6 +637,17 @@ export function AppSidebar(props: AppSidebarProps) {
     from: "/_protected/workspaces/$workspaceId",
     shouldThrow: false,
   });
+  const activeWorkspaceId = workspaceMatch?.params.workspaceId;
+  const activeWorkspace = workspaces?.find((ws) => ws.id === activeWorkspaceId);
+  const activeMatterColor =
+    activeWorkspaceId && activeWorkspace
+      ? resolveMatterColor(activeWorkspaceId, activeWorkspace.color)
+      : null;
+  const sidebarStyle: AppSidebarStyle | undefined = activeMatterColor
+    ? {
+        "--matter-sidebar-tint": `color-mix(in srgb, ${activeMatterColor} 2%, var(--sidebar))`,
+      }
+    : undefined;
 
   const handleCreateWorkspace = () => {
     if (!canCreateMatter) {
@@ -884,7 +898,16 @@ export function AppSidebar(props: AppSidebarProps) {
   }, [showNavBadges]);
 
   return (
-    <Sidebar {...props} collapsible="icon">
+    <Sidebar
+      {...props}
+      className={cn(
+        activeMatterColor &&
+          "[&_[data-slot=sidebar-inner]]:bg-[var(--matter-sidebar-tint)]",
+        props.className,
+      )}
+      collapsible="icon"
+      style={{ ...sidebarStyle, ...props.style }}
+    >
       {/* Stella logo header */}
       <SidebarHeader>
         <div

--- a/apps/web/src/components/chat-mention-helpers.test.ts
+++ b/apps/web/src/components/chat-mention-helpers.test.ts
@@ -70,6 +70,7 @@ describe("buildEntityMentionOption", () => {
       readOnly: false,
       sortOrder: null,
       activeEditBy: null,
+      cellMetadata: {},
       fields: {
         file: {
           id: "field_1",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1933,7 +1933,23 @@
       "parties": "Strany"
     },
     "table": {
-      "reorderReadOnly": "Řádky tabulky se řídí aktuálním řazením"
+      "clearFlags": "Vymazat označení",
+      "flagCell": "Označit buňku",
+      "flags": {
+        "contradiction": "Rozpor",
+        "contradictionDescription": "Může být v rozporu s jinými údaji.",
+        "followUp": "Navázat",
+        "followUpDescription": "Vyžaduje následný krok.",
+        "important": "Důležité",
+        "importantDescription": "Zvýrazňuje klíčovou hodnotu.",
+        "needsReview": "Zkontrolovat",
+        "needsReviewDescription": "Vyžaduje ruční kontrolu.",
+        "verified": "Ověřeno",
+        "verifiedDescription": "Ručně potvrzeno."
+      },
+      "reorderReadOnly": "Řádky tabulky se řídí aktuálním řazením",
+      "tightContent": "Těsně",
+      "wrapContent": "Obtékat text"
     },
     "tasksCount": "{count, plural, one {# položka agendy} few {# položky agendy} other {# položek agendy}}",
     "tools": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1933,7 +1933,23 @@
       "parties": "Parteien"
     },
     "table": {
-      "reorderReadOnly": "Tabellenzeilen folgen der aktuellen Sortierung"
+      "clearFlags": "Markierungen löschen",
+      "flagCell": "Zelle markieren",
+      "flags": {
+        "contradiction": "Widerspruch",
+        "contradictionDescription": "Kann anderen Daten widersprechen.",
+        "followUp": "Nachfassen",
+        "followUpDescription": "Erfordert eine nächste Aktion.",
+        "important": "Wichtig",
+        "importantDescription": "Kennzeichnet einen Schlüsselwert.",
+        "needsReview": "Zu prüfen",
+        "needsReviewDescription": "Erfordert manuelle Prüfung.",
+        "verified": "Verifiziert",
+        "verifiedDescription": "Manuell bestätigt."
+      },
+      "reorderReadOnly": "Tabellenzeilen folgen der aktuellen Sortierung",
+      "tightContent": "Kompakt",
+      "wrapContent": "Text umbrechen"
     },
     "tasksCount": "{count, plural, one {# Agendaeintrag} other {# Agendaeinträge}}",
     "tools": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1933,7 +1933,23 @@
       "parties": "Parties"
     },
     "table": {
-      "reorderReadOnly": "Table rows follow the current sort"
+      "clearFlags": "Clear flags",
+      "flagCell": "Flag cell",
+      "flags": {
+        "contradiction": "Contradiction",
+        "contradictionDescription": "May conflict with other data.",
+        "followUp": "Follow up",
+        "followUpDescription": "Needs a next action.",
+        "important": "Important",
+        "importantDescription": "Marks a key value.",
+        "needsReview": "Needs review",
+        "needsReviewDescription": "Requires manual review.",
+        "verified": "Verified",
+        "verifiedDescription": "Manually confirmed."
+      },
+      "reorderReadOnly": "Table rows follow the current sort",
+      "tightContent": "Tight",
+      "wrapContent": "Wrap content"
     },
     "tasksCount": "{count, plural, one {# agenda item} other {# agenda items}}",
     "tools": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1933,7 +1933,23 @@
       "parties": "Partes"
     },
     "table": {
-      "reorderReadOnly": "Las filas de la tabla siguen el orden actual"
+      "clearFlags": "Borrar marcas",
+      "flagCell": "Marcar celda",
+      "flags": {
+        "contradiction": "Contradicción",
+        "contradictionDescription": "Puede entrar en conflicto con otros datos.",
+        "followUp": "Seguimiento",
+        "followUpDescription": "Necesita una acción siguiente.",
+        "important": "Importante",
+        "importantDescription": "Marca un valor clave.",
+        "needsReview": "Revisar",
+        "needsReviewDescription": "Requiere revisión manual.",
+        "verified": "Verificado",
+        "verifiedDescription": "Confirmado manualmente."
+      },
+      "reorderReadOnly": "Las filas de la tabla siguen el orden actual",
+      "tightContent": "Compacto",
+      "wrapContent": "Ajustar texto"
     },
     "tasksCount": "{count, plural, one {# elemento de agenda} other {# elementos de agenda}}",
     "tools": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1933,7 +1933,23 @@
       "parties": "Osapooled"
     },
     "table": {
-      "reorderReadOnly": "Tabeliread järgivad praegust sortimist"
+      "clearFlags": "Eemalda märgised",
+      "flagCell": "Märgista lahter",
+      "flags": {
+        "contradiction": "Vastuolu",
+        "contradictionDescription": "Võib olla vastuolus teiste andmetega.",
+        "followUp": "Järeltegevus",
+        "followUpDescription": "Vajab järgmist tegevust.",
+        "important": "Tähtis",
+        "importantDescription": "Märgib võtmeväärtuse.",
+        "needsReview": "Vajab ülevaatust",
+        "needsReviewDescription": "Vajab käsitsi ülevaatust.",
+        "verified": "Kinnitatud",
+        "verifiedDescription": "Käsitsi kinnitatud."
+      },
+      "reorderReadOnly": "Tabeliread järgivad praegust sortimist",
+      "tightContent": "Kompaktne",
+      "wrapContent": "Murra tekst"
     },
     "tasksCount": "{count, plural, one {# agenda kirje} other {# agenda kirjet}}",
     "tools": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1933,7 +1933,23 @@
       "parties": "Parties"
     },
     "table": {
-      "reorderReadOnly": "Les lignes du tableau suivent le tri actuel"
+      "clearFlags": "Effacer les marqueurs",
+      "flagCell": "Marquer la cellule",
+      "flags": {
+        "contradiction": "Contradiction",
+        "contradictionDescription": "Peut contredire d’autres données.",
+        "followUp": "Suivi",
+        "followUpDescription": "Nécessite une prochaine action.",
+        "important": "Important",
+        "importantDescription": "Signale une valeur clé.",
+        "needsReview": "À vérifier",
+        "needsReviewDescription": "Nécessite une vérification manuelle.",
+        "verified": "Vérifié",
+        "verifiedDescription": "Confirmé manuellement."
+      },
+      "reorderReadOnly": "Les lignes du tableau suivent le tri actuel",
+      "tightContent": "Compact",
+      "wrapContent": "Retour à la ligne"
     },
     "tasksCount": "{count, plural, one {# élément d'agenda} other {# éléments d'agenda}}",
     "tools": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1933,7 +1933,23 @@
       "parties": "Felek"
     },
     "table": {
-      "reorderReadOnly": "A táblázatsorok az aktuális rendezést követik"
+      "clearFlags": "Jelölések törlése",
+      "flagCell": "Cella megjelölése",
+      "flags": {
+        "contradiction": "Ellentmondás",
+        "contradictionDescription": "Más adatokkal ütközhet.",
+        "followUp": "Utánkövetés",
+        "followUpDescription": "Következő lépést igényel.",
+        "important": "Fontos",
+        "importantDescription": "Kulcsértéket jelöl.",
+        "needsReview": "Ellenőrizendő",
+        "needsReviewDescription": "Kézi ellenőrzést igényel.",
+        "verified": "Ellenőrizve",
+        "verifiedDescription": "Kézzel megerősítve."
+      },
+      "reorderReadOnly": "A táblázatsorok az aktuális rendezést követik",
+      "tightContent": "Kompakt",
+      "wrapContent": "Szöveg tördelése"
     },
     "tasksCount": "{count, plural, one {# agendatétel} other {# agendatétel}}",
     "tools": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1933,7 +1933,23 @@
       "parties": "Šalys"
     },
     "table": {
-      "reorderReadOnly": "Lentelės eilutės laikosi dabartinio rūšiavimo"
+      "clearFlags": "Išvalyti žymas",
+      "flagCell": "Pažymėti langelį",
+      "flags": {
+        "contradiction": "Prieštara",
+        "contradictionDescription": "Gali prieštarauti kitiems duomenims.",
+        "followUp": "Tolesnis veiksmas",
+        "followUpDescription": "Reikia kito veiksmo.",
+        "important": "Svarbu",
+        "importantDescription": "Pažymi esminę reikšmę.",
+        "needsReview": "Reikia peržiūros",
+        "needsReviewDescription": "Reikia rankinės peržiūros.",
+        "verified": "Patvirtinta",
+        "verifiedDescription": "Patvirtinta rankiniu būdu."
+      },
+      "reorderReadOnly": "Lentelės eilutės laikosi dabartinio rūšiavimo",
+      "tightContent": "Kompaktiškai",
+      "wrapContent": "Laužyti tekstą"
     },
     "tasksCount": "{count, plural, one {# agendos elementas} few {# agendos elementai} other {# agendos elementų}}",
     "tools": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1933,7 +1933,23 @@
       "parties": "Puses"
     },
     "table": {
-      "reorderReadOnly": "Tabulas rindas seko pašreizējai kārtošanai"
+      "clearFlags": "Notīrīt atzīmes",
+      "flagCell": "Atzīmēt šūnu",
+      "flags": {
+        "contradiction": "Pretruna",
+        "contradictionDescription": "Var būt pretrunā ar citiem datiem.",
+        "followUp": "Turpmāka darbība",
+        "followUpDescription": "Nepieciešama nākamā darbība.",
+        "important": "Svarīgi",
+        "importantDescription": "Atzīmē būtisku vērtību.",
+        "needsReview": "Jāpārskata",
+        "needsReviewDescription": "Nepieciešama manuāla pārbaude.",
+        "verified": "Pārbaudīts",
+        "verifiedDescription": "Manuāli apstiprināts."
+      },
+      "reorderReadOnly": "Tabulas rindas seko pašreizējai kārtošanai",
+      "tightContent": "Kompakti",
+      "wrapContent": "Aplauzt tekstu"
     },
     "tasksCount": "{count, plural, one {# agendas vienums} other {# agendas vienumi}}",
     "tools": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1936,7 +1936,23 @@ type Messages = {
       "parties": "Parties";
     };
     "table": {
+      "clearFlags": "Clear flags";
+      "flagCell": "Flag cell";
+      "flags": {
+        "contradiction": "Contradiction";
+        "contradictionDescription": "May conflict with other data.";
+        "followUp": "Follow up";
+        "followUpDescription": "Needs a next action.";
+        "important": "Important";
+        "importantDescription": "Marks a key value.";
+        "needsReview": "Needs review";
+        "needsReviewDescription": "Requires manual review.";
+        "verified": "Verified";
+        "verifiedDescription": "Manually confirmed.";
+      };
       "reorderReadOnly": "Table rows follow the current sort";
+      "tightContent": "Tight";
+      "wrapContent": "Wrap content";
     };
     "tasksCount": "{count, plural, one {# agenda item} other {# agenda items}}";
     "tools": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1933,7 +1933,23 @@
       "parties": "Strony"
     },
     "table": {
-      "reorderReadOnly": "Wiersze tabeli są zgodne z bieżącym sortowaniem"
+      "clearFlags": "Wyczyść oznaczenia",
+      "flagCell": "Oznacz komórkę",
+      "flags": {
+        "contradiction": "Sprzeczność",
+        "contradictionDescription": "Może być sprzeczne z innymi danymi.",
+        "followUp": "Dalsze działania",
+        "followUpDescription": "Wymaga kolejnego działania.",
+        "important": "Ważne",
+        "importantDescription": "Oznacza kluczową wartość.",
+        "needsReview": "Do sprawdzenia",
+        "needsReviewDescription": "Wymaga ręcznej weryfikacji.",
+        "verified": "Zweryfikowane",
+        "verifiedDescription": "Potwierdzone ręcznie."
+      },
+      "reorderReadOnly": "Wiersze tabeli są zgodne z bieżącym sortowaniem",
+      "tightContent": "Kompaktowo",
+      "wrapContent": "Zawijaj tekst"
     },
     "tasksCount": "{count, plural, one {# pozycja agendy} few {# pozycje agendy} other {# pozycji agendy}}",
     "tools": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1933,7 +1933,23 @@
       "parties": "Strany"
     },
     "table": {
-      "reorderReadOnly": "Riadky tabuľky sa riadia aktuálnym zoradením"
+      "clearFlags": "Vymazať označenia",
+      "flagCell": "Označiť bunku",
+      "flags": {
+        "contradiction": "Rozpor",
+        "contradictionDescription": "Môže byť v rozpore s inými údajmi.",
+        "followUp": "Nadviazať",
+        "followUpDescription": "Vyžaduje následný krok.",
+        "important": "Dôležité",
+        "importantDescription": "Zvýrazňuje kľúčovú hodnotu.",
+        "needsReview": "Skontrolovať",
+        "needsReviewDescription": "Vyžaduje ručnú kontrolu.",
+        "verified": "Overené",
+        "verifiedDescription": "Ručne potvrdené."
+      },
+      "reorderReadOnly": "Riadky tabuľky sa riadia aktuálnym zoradením",
+      "tightContent": "Tesne",
+      "wrapContent": "Zalomiť text"
     },
     "tasksCount": "{count, plural, one {# položka agendy} few {# položky agendy} other {# položiek agendy}}",
     "tools": {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -172,6 +172,20 @@ export type WorkspaceField = {
   content: WorkspaceFieldContent;
 };
 
+export type WorkspaceCellMetadata = {
+  version: 1;
+  manualFlags: string[];
+  flagProvenance?: Record<
+    string,
+    {
+      addedBy: string;
+      addedAt: string;
+      addedByName: string | null;
+      addedByImage: string | null;
+    }
+  >;
+};
+
 export type EntityField = {
   id: string;
   propertyId: string;
@@ -214,6 +228,7 @@ export type WorkspaceEntity = {
   sortOrder: string | null;
   activeEditBy: { name: string; image: string | null; isMe: boolean } | null;
   fields: Record<string, WorkspaceField>;
+  cellMetadata: Record<string, WorkspaceCellMetadata>;
 };
 
 export type WorkspaceView<T extends ViewLayoutType = ViewLayoutType> = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -1,0 +1,401 @@
+import { useMemo } from "react";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuSeparator,
+} from "@stll/ui/components/menu";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { LucideIcon } from "lucide-react";
+import {
+  CheckIcon,
+  CheckCircle2Icon,
+  HelpCircleIcon,
+  MessageSquareWarningIcon,
+  ShieldAlertIcon,
+  StarIcon,
+} from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
+import Tooltip from "@/components/tooltip";
+import { UserAvatar } from "@/components/user-avatar";
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import { formatRelativeTime } from "@/lib/relative-time";
+import { toSafeId } from "@/lib/safe-id";
+import type { WorkspaceCellMetadata } from "@/lib/types";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+
+const CELL_FLAG_IDS = [
+  "needs-review",
+  "important",
+  "follow-up",
+  "contradiction",
+  "verified",
+] as const;
+
+type CellFlagId = (typeof CELL_FLAG_IDS)[number];
+
+const VERIFIED_FLAG_ID = "verified";
+
+type CellFlagDefinition = {
+  id: CellFlagId;
+  icon: LucideIcon;
+  color: string;
+  background: string;
+};
+
+const VERIFIED_CELL_FLAG = {
+  id: VERIFIED_FLAG_ID,
+  icon: CheckCircle2Icon,
+  color: "var(--option-emerald)",
+  background: "var(--option-emerald-bg)",
+} as const satisfies CellFlagDefinition;
+
+const CELL_FLAGS = [
+  {
+    id: "needs-review",
+    icon: HelpCircleIcon,
+    color: "var(--option-amber)",
+    background: "var(--option-amber-bg)",
+  },
+  {
+    id: "important",
+    icon: StarIcon,
+    color: "var(--option-blue)",
+    background: "var(--option-blue-bg)",
+  },
+  {
+    id: "follow-up",
+    icon: MessageSquareWarningIcon,
+    color: "var(--option-violet)",
+    background: "var(--option-violet-bg)",
+  },
+  {
+    id: "contradiction",
+    icon: ShieldAlertIcon,
+    color: "var(--option-red)",
+    background: "var(--option-red-bg)",
+  },
+  VERIFIED_CELL_FLAG,
+] as const satisfies readonly CellFlagDefinition[];
+
+const cellFlagsById = new Map<string, CellFlagDefinition>(
+  CELL_FLAGS.map((flag) => [flag.id, flag]),
+);
+
+const FLAG_LABEL_KEYS = {
+  "needs-review": "workspaces.table.flags.needsReview",
+  important: "workspaces.table.flags.important",
+  "follow-up": "workspaces.table.flags.followUp",
+  contradiction: "workspaces.table.flags.contradiction",
+  verified: "workspaces.table.flags.verified",
+} as const;
+
+type FlagProvenance = NonNullable<
+  WorkspaceCellMetadata["flagProvenance"]
+>[string];
+
+const useFlagLabel = () => {
+  const t = useTranslations();
+  return (flagId: CellFlagId) => t(FLAG_LABEL_KEYS[flagId]);
+};
+
+type CellMetadataFlagsProps = {
+  workspaceId: string;
+  entityId: string;
+  propertyId: string;
+  metadata: WorkspaceCellMetadata | undefined;
+};
+
+export const CellMetadataFlags = ({
+  workspaceId,
+  entityId,
+  propertyId,
+  metadata,
+}: CellMetadataFlagsProps) => {
+  const getFlagLabel = useFlagLabel();
+  const { decorativeFlags, hasVerifiedFlag, toggleFlag } = useCellMetadataFlags(
+    {
+      entityId,
+      metadata,
+      propertyId,
+      workspaceId,
+    },
+  );
+  const cornerFlag = decorativeFlags.at(0);
+  const verifiedProvenance = metadata?.flagProvenance?.[VERIFIED_FLAG_ID];
+
+  return (
+    <>
+      {cornerFlag ? (
+        <CellCornerFlag
+          flags={decorativeFlags}
+          metadata={metadata}
+          onDrop={toggleFlag}
+        />
+      ) : (
+        <Tooltip
+          className="max-w-72 text-wrap"
+          content={
+            <FlagProvenanceTooltip
+              flag={VERIFIED_CELL_FLAG}
+              metadata={verifiedProvenance}
+            />
+          }
+          render={
+            <button
+              aria-label={getFlagLabel(VERIFIED_FLAG_ID)}
+              className={cn(
+                "bg-background/55 focus-visible:ring-ring absolute end-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px] transition-opacity outline-none focus-visible:ring-1",
+                hasVerifiedFlag
+                  ? "opacity-100"
+                  : "text-muted-foreground/70 opacity-0 group-hover/cell-content:opacity-100",
+              )}
+              onClick={(event) => {
+                event.stopPropagation();
+                toggleFlag(VERIFIED_FLAG_ID);
+              }}
+              style={
+                hasVerifiedFlag
+                  ? {
+                      color: VERIFIED_CELL_FLAG.color,
+                    }
+                  : undefined
+              }
+              type="button"
+            />
+          }
+        >
+          <span
+            className="size-1.5 rounded-full bg-current"
+            style={{
+              backgroundColor: hasVerifiedFlag
+                ? VERIFIED_CELL_FLAG.color
+                : "currentColor",
+            }}
+          />
+        </Tooltip>
+      )}
+    </>
+  );
+};
+
+type CellCornerFlagProps = {
+  flags: CellFlagDefinition[];
+  metadata: WorkspaceCellMetadata | undefined;
+  onDrop: (flag: CellFlagId) => void;
+};
+
+const CellCornerFlag = ({ flags, metadata, onDrop }: CellCornerFlagProps) => {
+  const getFlagLabel = useFlagLabel();
+  const flag = flags.at(0);
+  if (!flag) {
+    return null;
+  }
+
+  const Icon = flag.icon;
+  const label = flags.map((item) => getFlagLabel(item.id)).join(", ");
+  const provenance = metadata?.flagProvenance?.[flag.id];
+
+  return (
+    <Tooltip
+      className="max-w-72 text-wrap"
+      content={<FlagProvenanceTooltip flag={flag} metadata={provenance} />}
+      render={
+        <button
+          aria-label={label}
+          className="bg-background/55 focus-visible:ring-ring absolute end-1 top-1 z-20 flex size-3 items-center justify-center rounded-full opacity-100 backdrop-blur-[2px] outline-none focus-visible:ring-1"
+          data-row-expansion-ignore
+          onClick={(event) => {
+            event.stopPropagation();
+            onDrop(flag.id);
+          }}
+          style={{ color: flag.color }}
+          type="button"
+        />
+      }
+    >
+      <Icon className="size-2.5" strokeWidth={2.5} />
+    </Tooltip>
+  );
+};
+
+type FlagProvenanceTooltipProps = {
+  flag: CellFlagDefinition;
+  metadata: FlagProvenance | undefined;
+};
+
+const FlagProvenanceTooltip = ({
+  flag,
+  metadata,
+}: FlagProvenanceTooltipProps) => {
+  const getFlagLabel = useFlagLabel();
+  const locale = useLocale();
+  const displayName = metadata?.addedByName ?? null;
+  const relativeTime = metadata
+    ? formatRelativeTime(metadata.addedAt, locale)
+    : null;
+  const label = getFlagLabel(flag.id);
+
+  if (!metadata) {
+    return <span>{label}</span>;
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-2">
+      <UserAvatar
+        className="size-5 shrink-0 text-[8px]"
+        image={metadata.addedByImage}
+        name={displayName}
+      />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">{label}</span>
+        <span className="text-muted-foreground block truncate text-xs">
+          {displayName ? `${displayName} · ${relativeTime}` : relativeTime}
+        </span>
+      </span>
+    </span>
+  );
+};
+
+export const CellMetadataMenuSection = ({
+  workspaceId,
+  entityId,
+  propertyId,
+  metadata,
+}: CellMetadataFlagsProps) => {
+  const t = useTranslations();
+  const { activeFlags, clearFlags, toggleFlag } = useCellMetadataFlags({
+    entityId,
+    metadata,
+    propertyId,
+    workspaceId,
+  });
+
+  return (
+    <>
+      <MenuGroup>
+        <MenuGroupLabel>{t("workspaces.table.flagCell")}</MenuGroupLabel>
+        {CELL_FLAGS.map((flag) => {
+          const Icon = flag.icon;
+          const checked = metadata?.manualFlags.includes(flag.id) ?? false;
+          return (
+            <MenuItem
+              className="min-h-7 py-0.5 text-sm"
+              closeOnClick={false}
+              key={flag.id}
+              onClick={() => toggleFlag(flag.id)}
+            >
+              <Icon
+                className="size-3.5 shrink-0 opacity-75"
+                style={{ color: flag.color }}
+              />
+              <span className="min-w-0 flex-1 truncate">
+                {t(FLAG_LABEL_KEYS[flag.id])}
+              </span>
+              {checked && (
+                <CheckIcon className="text-muted-foreground ms-3 size-3.5 shrink-0" />
+              )}
+            </MenuItem>
+          );
+        })}
+      </MenuGroup>
+      {activeFlags.length > 0 && (
+        <>
+          <MenuSeparator />
+          <Button
+            className="mx-1 mb-1 w-[calc(100%-0.5rem)] justify-start"
+            onClick={(event) => {
+              event.stopPropagation();
+              clearFlags();
+            }}
+            size="xs"
+            variant="ghost"
+          >
+            {t("workspaces.table.clearFlags")}
+          </Button>
+        </>
+      )}
+    </>
+  );
+};
+
+const useCellMetadataFlags = ({
+  workspaceId,
+  entityId,
+  propertyId,
+  metadata,
+}: CellMetadataFlagsProps) => {
+  const t = useTranslations();
+  const queryClient = useQueryClient();
+  const activeFlags = useMemo(
+    () =>
+      (metadata?.manualFlags ?? []).flatMap((flagId) => {
+        const flag = cellFlagsById.get(flagId);
+        return flag === undefined ? [] : [flag];
+      }),
+    [metadata],
+  );
+  const decorativeFlags = activeFlags.filter(
+    (flag) => flag.id !== VERIFIED_FLAG_ID,
+  );
+  const hasVerifiedFlag =
+    metadata?.manualFlags.includes(VERIFIED_FLAG_ID) ?? false;
+
+  const updateMetadata = useMutation({
+    mutationFn: async (manualFlags: string[]) => {
+      const response = await api
+        .fields({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        .metadata.patch({
+          queryKey: entitiesKeys.all(workspaceId),
+          entityId: toSafeId<"entity">(entityId),
+          propertyId: toSafeId<"property">(propertyId),
+          manualFlags,
+        });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(workspaceId),
+      });
+    },
+    onError: (error) => {
+      stellaToast.add({
+        title: t("errors.actionFailed"),
+        description:
+          error instanceof Error ? error.message : t("common.unexpectedError"),
+        type: "error",
+      });
+    },
+  });
+
+  const toggleFlag = (flagId: CellFlagId) => {
+    const current = metadata?.manualFlags ?? [];
+    const next = current.includes(flagId)
+      ? current.filter((id) => id !== flagId)
+      : [...current, flagId];
+    updateMetadata.mutate(next);
+  };
+
+  const clearFlags = () => {
+    updateMetadata.mutate([]);
+  };
+
+  return {
+    activeFlags,
+    clearFlags,
+    decorativeFlags,
+    hasVerifiedFlag,
+    toggleFlag,
+  };
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@stll/ui/components/button";
 import {
@@ -104,6 +104,12 @@ const useFlagLabel = () => {
   const t = useTranslations();
   return (flagId: CellFlagId) => t(FLAG_LABEL_KEYS[flagId]);
 };
+
+const normalizeManualFlags = (flags: string[]) =>
+  [...new Set(flags)].toSorted();
+
+const haveSameFlags = (a: string[], b: string[]) =>
+  a.length === b.length && a.every((flag, index) => flag === b[index]);
 
 type CellMetadataFlagsProps = {
   workspaceId: string;
@@ -333,19 +339,38 @@ const useCellMetadataFlags = ({
 }: CellMetadataFlagsProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const [pendingManualFlags, setPendingManualFlags] = useState<string[] | null>(
+    null,
+  );
+  const pendingManualFlagsRef = useRef<string[] | null>(null);
+  const metadataManualFlags = useMemo(
+    () => normalizeManualFlags(metadata?.manualFlags ?? []),
+    [metadata?.manualFlags],
+  );
+  const currentManualFlags = pendingManualFlags ?? metadataManualFlags;
+
+  useEffect(() => {
+    if (
+      pendingManualFlags !== null &&
+      haveSameFlags(pendingManualFlags, metadataManualFlags)
+    ) {
+      pendingManualFlagsRef.current = null;
+      setPendingManualFlags(null);
+    }
+  }, [metadataManualFlags, pendingManualFlags]);
+
   const activeFlags = useMemo(
     () =>
-      (metadata?.manualFlags ?? []).flatMap((flagId) => {
+      currentManualFlags.flatMap((flagId) => {
         const flag = cellFlagsById.get(flagId);
         return flag === undefined ? [] : [flag];
       }),
-    [metadata],
+    [currentManualFlags],
   );
   const decorativeFlags = activeFlags.filter(
     (flag) => flag.id !== VERIFIED_FLAG_ID,
   );
-  const hasVerifiedFlag =
-    metadata?.manualFlags.includes(VERIFIED_FLAG_ID) ?? false;
+  const hasVerifiedFlag = currentManualFlags.includes(VERIFIED_FLAG_ID);
 
   const updateMetadata = useMutation({
     mutationFn: async (manualFlags: string[]) => {
@@ -370,6 +395,8 @@ const useCellMetadataFlags = ({
       });
     },
     onError: (error) => {
+      pendingManualFlagsRef.current = null;
+      setPendingManualFlags(null);
       stellaToast.add({
         title: t("errors.actionFailed"),
         description:
@@ -380,14 +407,20 @@ const useCellMetadataFlags = ({
   });
 
   const toggleFlag = (flagId: CellFlagId) => {
-    const current = metadata?.manualFlags ?? [];
-    const next = current.includes(flagId)
-      ? current.filter((id) => id !== flagId)
-      : [...current, flagId];
+    const current = pendingManualFlagsRef.current ?? metadataManualFlags;
+    const next = normalizeManualFlags(
+      current.includes(flagId)
+        ? current.filter((id) => id !== flagId)
+        : [...current, flagId],
+    );
+    pendingManualFlagsRef.current = next;
+    setPendingManualFlags(next);
     updateMetadata.mutate(next);
   };
 
   const clearFlags = () => {
+    pendingManualFlagsRef.current = [];
+    setPendingManualFlags([]);
     updateMetadata.mutate([]);
   };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -111,6 +111,11 @@ const normalizeManualFlags = (flags: string[]) =>
 const haveSameFlags = (a: string[], b: string[]) =>
   a.length === b.length && a.every((flag, index) => flag === b[index]);
 
+type UpdateCellMetadataVariables = {
+  baseManualFlags: string[];
+  manualFlags: string[];
+};
+
 type CellMetadataFlagsProps = {
   workspaceId: string;
   entityId: string;
@@ -373,13 +378,17 @@ const useCellMetadataFlags = ({
   const hasVerifiedFlag = currentManualFlags.includes(VERIFIED_FLAG_ID);
 
   const updateMetadata = useMutation({
-    mutationFn: async (manualFlags: string[]) => {
+    mutationFn: async ({
+      baseManualFlags,
+      manualFlags,
+    }: UpdateCellMetadataVariables) => {
       const response = await api
         .fields({ workspaceId: toSafeId<"workspace">(workspaceId) })
         .metadata.patch({
           queryKey: entitiesKeys.all(workspaceId),
           entityId: toSafeId<"entity">(entityId),
           propertyId: toSafeId<"property">(propertyId),
+          baseManualFlags,
           manualFlags,
         });
 
@@ -389,6 +398,7 @@ const useCellMetadataFlags = ({
 
       return response.data;
     },
+    scope: { id: `cell-metadata:${workspaceId}:${entityId}:${propertyId}` },
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: entitiesKeys.all(workspaceId),
@@ -415,13 +425,14 @@ const useCellMetadataFlags = ({
     );
     pendingManualFlagsRef.current = next;
     setPendingManualFlags(next);
-    updateMetadata.mutate(next);
+    updateMetadata.mutate({ baseManualFlags: current, manualFlags: next });
   };
 
   const clearFlags = () => {
+    const current = pendingManualFlagsRef.current ?? metadataManualFlags;
     pendingManualFlagsRef.current = [];
     setPendingManualFlags([]);
-    updateMetadata.mutate([]);
+    updateMetadata.mutate({ baseManualFlags: current, manualFlags: [] });
   };
 
   return {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-virtualization.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-virtualization.test.ts
@@ -44,6 +44,7 @@ const entity = (
   readOnly: false,
   sortOrder: null,
   activeEditBy: null,
+  cellMetadata: {},
   fields: {},
   children,
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.logic.test.ts
@@ -46,6 +46,7 @@ const entity = (
   readOnly: false,
   sortOrder: null,
   activeEditBy: null,
+  cellMetadata: {},
   fields: {},
 });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -1072,6 +1072,7 @@ const OverviewRow = ({ entity, workspaceId, lang }: OverviewRowProps) => {
       readOnly: false,
       sortOrder: null,
       activeEditBy: null,
+      cellMetadata: {},
       fields,
     };
   }, [entity]);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -49,8 +49,9 @@ import { DOCX_MIME } from "@/lib/consts";
 import { openDocxInDesktop } from "@/lib/desktop-bridge";
 import { ClientOperationError, isUnauthorizedError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
-import type { WorkspaceEntity } from "@/lib/types";
+import type { WorkspaceCellMetadata, WorkspaceEntity } from "@/lib/types";
 import { isFileDisplayable } from "@/lib/types";
+import { CellMetadataMenuSection } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { getPdfDownloadFileName } from "@/routes/_protected.workspaces/$workspaceId/-components/row-actions.logic";
 import { downloadFile } from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
@@ -86,6 +87,10 @@ type RowActionsProps = {
   anchor?: VirtualAnchor | null | undefined;
   /** Extra entities included in bulk actions. */
   selectedEntities?: WorkspaceEntity[] | undefined;
+  cellMetadataTarget?:
+    | { propertyId: string; metadata: WorkspaceCellMetadata | undefined }
+    | null
+    | undefined;
 };
 
 export const RowActions = ({
@@ -100,6 +105,7 @@ export const RowActions = ({
   triggerTabIndex,
   anchor,
   selectedEntities,
+  cellMetadataTarget,
 }: RowActionsProps) => {
   const t = useTranslations();
   const navigate = useNavigate();
@@ -109,6 +115,8 @@ export const RowActions = ({
   const name = getEntityName(entity);
   const isFolder = entity.kind === "folder";
   const isBulk = selectedEntities !== undefined && selectedEntities.length > 1;
+  const isCellContext =
+    !isBulk && cellMetadataTarget !== null && cellMetadataTarget !== undefined;
   const isDocx = !isBulk && file?.mimeType === DOCX_MIME;
   const isLockedByMe =
     isDocx && entity.activeEditBy !== null && entity.activeEditBy.isMe;
@@ -457,14 +465,25 @@ export const RowActions = ({
             {t("common.rename")}
           </MenuItem>
         )}
-        {!isBulk && isFolder && onSubfolderCreated && (
+        {!isBulk && cellMetadataTarget && (
+          <>
+            <MenuSeparator />
+            <CellMetadataMenuSection
+              entityId={entity.entityId}
+              metadata={cellMetadataTarget.metadata}
+              propertyId={cellMetadataTarget.propertyId}
+              workspaceId={workspaceId}
+            />
+          </>
+        )}
+        {!isCellContext && !isBulk && isFolder && onSubfolderCreated && (
           <CreateSubfolderMenuItem
             entity={entity}
             onSubfolderCreated={onSubfolderCreated}
             workspaceId={workspaceId}
           />
         )}
-        {canOpenInDesktop && (
+        {!isCellContext && canOpenInDesktop && (
           <MenuItem
             onClick={() => {
               void handleOpenInDesktop();
@@ -474,7 +493,7 @@ export const RowActions = ({
             {t("workspaces.files.desktopEdit.action")}
           </MenuItem>
         )}
-        {isLockedByOther && (
+        {!isCellContext && isLockedByOther && (
           <MenuItem
             onClick={() => {
               void handleReleaseLock();
@@ -504,105 +523,111 @@ export const RowActions = ({
           {t("chat.chatAbout")}
         </MenuItem>
 
-        <MenuSeparator />
+        {!isCellContext && (
+          <>
+            <MenuSeparator />
 
-        {/* --- File operations --- */}
-        {hasAnyFile && (isBulk || !hasPdfConversion) && (
-          <MenuItem
-            onClick={() => {
-              void handleDownload();
-            }}
-          >
-            <DownloadIcon />
-            {t("common.download")}
-          </MenuItem>
-        )}
-        {!isBulk && hasPdfConversion && (
-          <MenuSub>
-            <MenuSubTrigger>
-              <DownloadIcon />
-              {t("common.download")}
-            </MenuSubTrigger>
-            <MenuSubPopup>
+            {/* --- File operations --- */}
+            {hasAnyFile && (isBulk || !hasPdfConversion) && (
               <MenuItem
                 onClick={() => {
                   void handleDownload();
                 }}
               >
                 <DownloadIcon />
-                {t("workspaces.files.downloadOriginal")}
+                {t("common.download")}
               </MenuItem>
+            )}
+            {!isBulk && hasPdfConversion && (
+              <MenuSub>
+                <MenuSubTrigger>
+                  <DownloadIcon />
+                  {t("common.download")}
+                </MenuSubTrigger>
+                <MenuSubPopup>
+                  <MenuItem
+                    onClick={() => {
+                      void handleDownload();
+                    }}
+                  >
+                    <DownloadIcon />
+                    {t("workspaces.files.downloadOriginal")}
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => {
+                      void handleDownload(true);
+                    }}
+                  >
+                    <FileOutputIcon />
+                    {t("workspaces.files.downloadPdf")}
+                  </MenuItem>
+                </MenuSubPopup>
+              </MenuSub>
+            )}
+            {hasAnyFolder && (
               <MenuItem
                 onClick={() => {
-                  void handleDownload(true);
+                  void handleZipDownload();
                 }}
               >
-                <FileOutputIcon />
-                {t("workspaces.files.downloadPdf")}
+                <ArchiveIcon />
+                {t("workspaces.files.downloadAsZip")}
               </MenuItem>
-            </MenuSubPopup>
-          </MenuSub>
-        )}
-        {hasAnyFolder && (
-          <MenuItem
-            onClick={() => {
-              void handleZipDownload();
-            }}
-          >
-            <ArchiveIcon />
-            {t("workspaces.files.downloadAsZip")}
-          </MenuItem>
-        )}
-        <MenuItem
-          onClick={() => {
-            void handleDuplicate();
-          }}
-        >
-          <CopyIcon />
-          {t("common.duplicate")}
-        </MenuItem>
+            )}
+            <MenuItem
+              onClick={() => {
+                void handleDuplicate();
+              }}
+            >
+              <CopyIcon />
+              {t("common.duplicate")}
+            </MenuItem>
 
-        <MenuSeparator />
+            <MenuSeparator />
 
-        {/* --- Destructive --- */}
-        <AlertDialog>
-          <AlertDialogTrigger
-            render={<MenuItem closeOnClick={false} variant="destructive" />}
-          >
-            <Trash2Icon />
-            {t("common.delete")}
-          </AlertDialogTrigger>
-          <AlertDialogPopup>
-            <AlertDialogHeader>
-              <AlertDialogTitle>
-                {isBulk
-                  ? t("workspaces.deleteItems", {
-                      count: selectedEntities.length,
-                    })
-                  : t("workspaces.deleteItem")}
-              </AlertDialogTitle>
-              <AlertDialogDescription>
-                {isBulk
-                  ? t("workspaces.deleteItemsDescription", {
-                      count: selectedEntities.length,
-                    })
-                  : t("common.deleteConfirmDescription", {
-                      name,
-                    })}
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogClose render={<Button variant="ghost" />}>
-                {t("common.cancel")}
-              </AlertDialogClose>
-              <AlertDialogClose
-                render={<Button onClick={handleDelete} variant="destructive" />}
+            {/* --- Destructive --- */}
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={<MenuItem closeOnClick={false} variant="destructive" />}
               >
+                <Trash2Icon />
                 {t("common.delete")}
-              </AlertDialogClose>
-            </AlertDialogFooter>
-          </AlertDialogPopup>
-        </AlertDialog>
+              </AlertDialogTrigger>
+              <AlertDialogPopup>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {isBulk
+                      ? t("workspaces.deleteItems", {
+                          count: selectedEntities.length,
+                        })
+                      : t("workspaces.deleteItem")}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {isBulk
+                      ? t("workspaces.deleteItemsDescription", {
+                          count: selectedEntities.length,
+                        })
+                      : t("common.deleteConfirmDescription", {
+                          name,
+                        })}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogClose render={<Button variant="ghost" />}>
+                    {t("common.cancel")}
+                  </AlertDialogClose>
+                  <AlertDialogClose
+                    render={
+                      <Button onClick={handleDelete} variant="destructive" />
+                    }
+                  >
+                    {t("common.delete")}
+                  </AlertDialogClose>
+                </AlertDialogFooter>
+              </AlertDialogPopup>
+            </AlertDialog>
+          </>
+        )}
       </MenuPopup>
     </Menu>
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -1,7 +1,12 @@
 import type { PropsWithChildren } from "react";
 
+import { Button } from "@stll/ui/components/button";
+import { EyeIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { WorkspaceEntity, WorkspaceProperty } from "@/lib/types";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
+import { CellMetadataFlags } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { CellResult } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-result";
 import { EditableField } from "@/routes/_protected.workspaces/$workspaceId/-components/editable-field";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
@@ -32,6 +37,7 @@ const PropertyCell = ({
 }) => {
   const field = entity.fields[property.id];
   const fieldContent = field?.content;
+  const cellMetadata = entity.cellMetadata[property.id];
 
   const justification = useWorkspaceStore((s) =>
     s.justifications.find((j) => j.fieldId === field?.id),
@@ -55,6 +61,12 @@ const PropertyCell = ({
   if (property.content.type === "file" || fieldContent?.type === "file") {
     return (
       <span className="flex min-w-0 items-center gap-1.5">
+        <CellMetadataFlags
+          entityId={entity.entityId}
+          metadata={cellMetadata}
+          propertyId={property.id}
+          workspaceId={property.workspaceId}
+        />
         <CellResult field={field} property={property} />
         {entity.activeEditBy && (
           <ActiveEditBadge
@@ -69,14 +81,22 @@ const PropertyCell = ({
 
   if (property.tool.type === "manual-input") {
     return (
-      <EditableField
-        content={fieldContent}
-        entityId={entity.entityId}
-        entityKind={entity.kind}
-        property={property}
-        propertyId={property.id}
-        workspaceId={property.workspaceId}
-      />
+      <>
+        <CellMetadataFlags
+          entityId={entity.entityId}
+          metadata={cellMetadata}
+          propertyId={property.id}
+          workspaceId={property.workspaceId}
+        />
+        <EditableField
+          content={fieldContent}
+          entityId={entity.entityId}
+          entityKind={entity.kind}
+          property={property}
+          propertyId={property.id}
+          workspaceId={property.workspaceId}
+        />
+      </>
     );
   }
 
@@ -124,13 +144,29 @@ const PropertyCell = ({
           propertyId={property.id}
           workspaceId={property.workspaceId}
         >
+          <CellMetadataFlags
+            entityId={entity.entityId}
+            metadata={cellMetadata}
+            propertyId={property.id}
+            workspaceId={property.workspaceId}
+          />
           <CellResult field={field} property={property} />
         </WithOpenEntityButton>
       );
     }
   }
 
-  return <CellResult field={field} property={property} />;
+  return (
+    <>
+      <CellMetadataFlags
+        entityId={entity.entityId}
+        metadata={cellMetadata}
+        propertyId={property.id}
+        workspaceId={property.workspaceId}
+      />
+      <CellResult field={field} property={property} />
+    </>
+  );
 };
 
 type WithOpenEntityButtonProps = {
@@ -144,8 +180,7 @@ type WithOpenEntityButtonProps = {
   workspaceId: string;
 };
 
-/** Makes the cell clickable to open the peek PDF viewer
- *  in the inspector with the AI justification visible. */
+/** Shows a peek PDF preview in the inspector with the AI justification visible. */
 const WithOpenEntityButton = ({
   fieldId,
   entityId,
@@ -157,26 +192,37 @@ const WithOpenEntityButton = ({
   workspaceId,
   children,
 }: PropsWithChildren<WithOpenEntityButtonProps>) => {
+  const t = useTranslations();
   const openPdf = useInspectorStore((s) => s.openPdf);
+  const handleOpenPreview = () => {
+    openPdf({
+      id: fieldId,
+      entityId,
+      label,
+      mimeType,
+      pdfFileId: pdfFileId ?? null,
+      justificationFieldId,
+      propertyId,
+      workspaceId,
+    });
+  };
 
   return (
-    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
-    <div
-      className="w-full min-w-0 cursor-pointer text-start"
-      onClick={() =>
-        openPdf({
-          id: fieldId,
-          entityId,
-          label,
-          mimeType,
-          pdfFileId: pdfFileId ?? null,
-          justificationFieldId,
-          propertyId,
-          workspaceId,
-        })
-      }
-    >
+    <div className="w-full min-w-0 text-start">
       {children}
+      <Button
+        className="text-muted-foreground/70 hover:text-foreground absolute end-1.5 bottom-1.5 hidden h-6 gap-1 px-1.5 text-xs opacity-70 group-data-[expanded-cell]/cell-content:flex hover:opacity-100"
+        data-row-expansion-ignore
+        onClick={(event) => {
+          event.stopPropagation();
+          handleOpenPreview();
+        }}
+        size="xs"
+        variant="ghost"
+      >
+        <EyeIcon className="size-3.5" />
+        {t("common.preview")}
+      </Button>
     </div>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -217,6 +217,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
         fetchNextPage();
       }}
       table={table}
+      contentMode={tableState.contentMode}
       workspaceId={workspaceId}
     />
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -72,9 +72,9 @@ import {
   reorderColumnIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order";
 import type { ColumnDropEdge } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-grid-order";
+import type { TableContentMode } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useInspectorFlash } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-inspector-flash";
 import { useRenameEntity } from "@/routes/_protected.workspaces/$workspaceId/-mutations/entities";
-import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 import {
   countDescendants,
   getEntityName,
@@ -86,7 +86,6 @@ const selectColId = getInternalColId("select");
 const addPropertyColId = getInternalColId("add-property");
 const TABLE_ROW_ESTIMATE_PX = 41;
 const TABLE_ROW_OVERSCAN = 16;
-const EXPANDED_ROW_MAX_HEIGHT_PX = 192;
 const TABLE_COLUMN_DRAG_TYPE = "workspace-table-column";
 const TABLE_END_FILLER_LINE =
   "color-mix(in srgb, var(--color-border) 60%, transparent)";
@@ -114,6 +113,7 @@ const tableEndFillerCellStyle: CSSProperties = {
 type WorkspaceTableProps = {
   workspaceId: string;
   table: WorkspaceTableType;
+  contentMode: TableContentMode;
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
@@ -133,9 +133,15 @@ type ColumnDropPosition = {
   edge: ColumnDropEdge;
 };
 
+type ExpandedTableCell = {
+  entityId: string;
+  columnId: string;
+};
+
 export const WorkspaceTable = ({
   workspaceId,
   table,
+  contentMode,
   hasNextPage = false,
   isFetchingNextPage = false,
   onLoadMore,
@@ -146,13 +152,9 @@ export const WorkspaceTable = ({
   const previousHorizontalMaxScroll = useRef<number | null>(null);
   const lastColumnDropPosition = useRef<ColumnDropPosition | null>(null);
   const [editingEntityId, setEditingEntityId] = useState<string | null>(null);
+  const [expandedTableCell, setExpandedTableCell] =
+    useState<ExpandedTableCell | null>(null);
   const [wrapperWidth, setWrapperWidth] = useState(0);
-  const expandedTableRowEntityId = useWorkspaceStore(
-    (s) => s.expandedTableRowEntityId,
-  );
-  const setExpandedTableRowEntityId = useWorkspaceStore(
-    (s) => s.setExpandedTableRowEntityId,
-  );
 
   const renameEntity = useRenameEntity();
 
@@ -451,10 +453,7 @@ export const WorkspaceTable = ({
               {getOrderedHeaders(headerGroup.headers, renderColumns).map(
                 (header, index) => (
                   <DraggableHeaderCell
-                    collapseEndBorder={
-                      Boolean(addPropertyColumn) &&
-                      index === renderColumns.length - 1
-                    }
+                    expandedColumnId={expandedTableCell?.columnId ?? null}
                     header={header}
                     index={index}
                     key={header.id}
@@ -469,6 +468,7 @@ export const WorkspaceTable = ({
               />
               {addPropertyColumn && (
                 <DraggableHeaderCell
+                  expandedColumnId={expandedTableCell?.columnId ?? null}
                   header={getRequiredHeader(
                     headerGroup.headers,
                     addPropertyColumn.id,
@@ -511,7 +511,13 @@ export const WorkspaceTable = ({
                 activePropertyId={activePropertyId}
                 activeTaskId={activeTaskId}
                 editingEntityId={editingEntityId}
-                expanded={expandedTableRowEntityId === row.original.entityId}
+                expandedCellId={
+                  expandedTableCell?.entityId === row.original.entityId
+                    ? expandedTableCell.columnId
+                    : null
+                }
+                contentMode={contentMode}
+                hasExpandedTableCell={expandedTableCell !== null}
                 index={virtualRow.index}
                 key={row.id}
                 lastSelectedIndex={lastSelectedIndex}
@@ -525,10 +531,17 @@ export const WorkspaceTable = ({
                 }}
                 onStartEditing={setEditingEntityId}
                 onStopEditing={() => setEditingEntityId(null)}
-                onToggleExpanded={(entityId) => {
-                  setExpandedTableRowEntityId(
-                    expandedTableRowEntityId === entityId ? null : entityId,
-                  );
+                onToggleExpandedCell={(entityId, columnId) => {
+                  setExpandedTableCell((current) => {
+                    if (
+                      current?.entityId === entityId &&
+                      current.columnId === columnId
+                    ) {
+                      return null;
+                    }
+
+                    return { entityId, columnId };
+                  });
                 }}
                 addPropertyColumn={addPropertyColumn}
                 row={row}
@@ -588,12 +601,7 @@ const TableEndFiller = ({
   >
     {renderColumns.map((column, index) => (
       <WorkspaceGridCell
-        className={cn(
-          "border-b-0",
-          addPropertyColumn &&
-            index === renderColumns.length - 1 &&
-            "border-e-0",
-        )}
+        className="border-b-0"
         key={column.id}
         role="presentation"
         style={{
@@ -671,6 +679,7 @@ type DraggableHeaderCellProps = {
   header: Header<TableTreeNode, unknown>;
   index: number;
   collapseEndBorder?: boolean;
+  expandedColumnId: string | null;
   onToggleSelectAll: () => void;
   selectAllState: SelectAllState;
 };
@@ -679,6 +688,7 @@ const DraggableHeaderCell = ({
   header,
   index,
   collapseEndBorder = false,
+  expandedColumnId,
   onToggleSelectAll,
   selectAllState,
 }: DraggableHeaderCellProps) => {
@@ -770,6 +780,9 @@ const DraggableHeaderCell = ({
         "relative",
         isAddPropertyColumn && "border-s",
         collapseEndBorder && "border-e-0",
+        expandedColumnId !== null &&
+          expandedColumnId !== header.column.id &&
+          "opacity-80 transition-opacity duration-150 hover:opacity-95",
         isDragging && "opacity-50",
         closestEdge && "overflow-visible",
         header.column.getIsResizing() &&
@@ -999,6 +1012,18 @@ const shouldIgnoreRowExpansionClick = (target: EventTarget) => {
   );
 };
 
+const getContextPropertyId = (target: EventTarget) => {
+  if (!(target instanceof HTMLElement)) {
+    return null;
+  }
+
+  return (
+    target.closest<HTMLElement>("[data-table-property-id]")?.dataset[
+      "tablePropertyId"
+    ] ?? null
+  );
+};
+
 type ActiveCellFlashInput = {
   activeCellPropertyId: string | null;
   activationSeq: number;
@@ -1078,14 +1103,16 @@ type DraggableRowProps = {
   activeEntityId: string | null;
   activePropertyId: string | null;
   activeTaskId: string | null;
+  contentMode: TableContentMode;
   editingEntityId: string | null;
-  expanded: boolean;
+  expandedCellId: string | null;
+  hasExpandedTableCell: boolean;
   lastSelectedIndex: React.RefObject<number | null>;
   measureElement: (element: Element | null) => void;
   onRename: (entityId: string, newName: string) => void;
   onStartEditing: (entityId: string) => void;
   onStopEditing: () => void;
-  onToggleExpanded: (entityId: string) => void;
+  onToggleExpandedCell: (entityId: string, columnId: string) => void;
 };
 
 const DraggableRow = ({
@@ -1100,14 +1127,16 @@ const DraggableRow = ({
   activeEntityId,
   activePropertyId,
   activeTaskId,
+  contentMode,
   editingEntityId,
-  expanded,
+  expandedCellId,
+  hasExpandedTableCell,
   lastSelectedIndex,
   measureElement,
   onRename,
   onStartEditing,
   onStopEditing,
-  onToggleExpanded,
+  onToggleExpandedCell,
 }: DraggableRowProps) => {
   const rowRef = useRef<HTMLDivElement>(null);
   const setRowRef = useCallback(
@@ -1122,9 +1151,14 @@ const DraggableRow = ({
   const [contextAnchor, setContextAnchor] = useState<VirtualAnchor | null>(
     null,
   );
+  const [contextPropertyId, setContextPropertyId] = useState<string | null>(
+    null,
+  );
   const entity = row.original;
   const isFolder = entity.kind === "folder";
   const isTask = entity.kind === "task";
+  const isFocusedExpansionRow = expandedCellId !== null;
+  const isMutedByExpandedCell = hasExpandedTableCell && !isFocusedExpansionRow;
   const visibleCells = getOrderedCells(row.getVisibleCells(), renderColumns);
   const addPropertyCell = addPropertyColumn
     ? row
@@ -1165,6 +1199,7 @@ const DraggableRow = ({
     e.preventDefault();
     e.stopPropagation();
     bulkEntitiesRef.current = getBulkSelectedEntities();
+    setContextPropertyId(getContextPropertyId(e.target));
     setContextAnchor({
       getBoundingClientRect: () => new DOMRect(e.clientX, e.clientY, 0, 0),
     });
@@ -1172,18 +1207,28 @@ const DraggableRow = ({
   };
 
   const handleRowClick = (e: React.MouseEvent) => {
-    if (shouldIgnoreRowExpansionClick(e.target)) {
+    if (!isTask || shouldIgnoreRowExpansionClick(e.target)) {
       return;
     }
 
-    if (isTask) {
-      useInspectorStore.getState().openTask(entity.entityId, name);
+    useInspectorStore.getState().openTask(entity.entityId, name);
+  };
+
+  const toggleExpandedCell = (columnId: string) => {
+    onToggleExpandedCell(entity.entityId, columnId);
+  };
+
+  const handleCellClick = (
+    event: React.MouseEvent,
+    columnId: string,
+    canExpandCell: boolean,
+  ) => {
+    if (!canExpandCell || shouldIgnoreRowExpansionClick(event.target)) {
       return;
     }
 
-    if (!isFolder) {
-      onToggleExpanded(entity.entityId);
-    }
+    event.stopPropagation();
+    toggleExpandedCell(columnId);
   };
 
   const selectCellContent = (
@@ -1207,12 +1252,21 @@ const DraggableRow = ({
         setContextOpen(open);
         if (!open) {
           setContextAnchor(null);
+          setContextPropertyId(null);
           bulkEntitiesRef.current = undefined;
         }
       }}
       onRename={isFolder ? () => onStartEditing(entity.entityId) : undefined}
       open={contextOpen}
       selectedEntities={contextOpen ? bulkEntitiesRef.current : undefined}
+      cellMetadataTarget={
+        contextPropertyId
+          ? {
+              propertyId: contextPropertyId,
+              metadata: entity.cellMetadata[contextPropertyId],
+            }
+          : null
+      }
       triggerClassName="opacity-0! transition-opacity group-hover/row:opacity-100! focus-visible:opacity-100!"
       workspaceId={workspaceId}
     />
@@ -1233,7 +1287,7 @@ const DraggableRow = ({
     if (rowRef.current) {
       measureElement(rowRef.current);
     }
-  }, [expanded, measureElement]);
+  }, [contentMode, expandedCellId, measureElement]);
 
   useEffect(() => {
     const el = rowRef.current;
@@ -1272,78 +1326,37 @@ const DraggableRow = ({
   }, [entity.entityId, entity.kind, entity.parentId, name, file?.mimeType]);
 
   if (isFolder && visibleCells.length > 2) {
-    const selectCell = visibleCells[0];
-    const nameCell = visibleCells[1];
-    if (!selectCell || !nameCell) {
-      return null;
-    }
     return (
-      <WorkspaceGridRow
-        aria-rowindex={virtualIndex + 2}
-        aria-selected={row.getIsSelected()}
-        data-active={entity.entityId === activeEntityId || undefined}
-        data-index={virtualIndex}
-        data-state={row.getIsSelected() ? "selected" : undefined}
-        key={row.id}
+      <FolderTableRow
+        activeEntityId={activeEntityId}
+        addPropertyCell={addPropertyCell}
+        editingEntityId={editingEntityId}
+        entity={entity}
+        isMutedByExpandedCell={isMutedByExpandedCell}
         onContextMenu={handleContextMenu}
+        onRename={onRename}
+        onStartEditing={onStartEditing}
+        onStopEditing={onStopEditing}
         ref={setRowRef}
-      >
-        <WorkspaceGridCell
-          aria-colindex={1}
-          data-state={row.getIsSelected() ? "selected" : undefined}
-          key={selectCell.id}
-          style={{
-            gridColumn: 1,
-            ...getGridPinningStyles(selectCell.column),
-          }}
-        >
-          <PinnedBoundary column={selectCell.column} />
-          {selectCellWithActions}
-        </WorkspaceGridCell>
-        <WorkspaceGridCell
-          aria-colindex={2}
-          className="cursor-pointer"
-          data-state={row.getIsSelected() ? "selected" : undefined}
-          key={nameCell.id}
-          onClick={() => row.toggleExpanded()}
-          style={{
-            gridColumn: 2,
-            ...getGridPinningStyles(nameCell.column),
-          }}
-        >
-          <PinnedBoundary column={nameCell.column} />
-          <FolderCell
-            depth={row.depth}
-            editingEntityId={editingEntityId}
-            entity={entity}
-            isExpanded={row.getIsExpanded()}
-            onRename={onRename}
-            onStopEditing={onStopEditing}
-            startEditing={() => onStartEditing(entity.entityId)}
-          />
-        </WorkspaceGridCell>
-        <WorkspaceGridCell
-          aria-colindex={3}
-          className="cursor-pointer border-e-0"
-          data-state={row.getIsSelected() ? "selected" : undefined}
-          onClick={() => row.toggleExpanded()}
-          style={{ gridColumn: addPropertyCell ? "3 / -2" : "3 / -1" }}
-        />
-        <AddPropertyCell
-          cell={addPropertyCell}
-          columnIndex={renderColumns.length + 1}
-          selected={row.getIsSelected()}
-        />
-      </WorkspaceGridRow>
+        renderColumns={renderColumns}
+        row={row}
+        selectCellWithActions={selectCellWithActions}
+        virtualIndex={virtualIndex}
+        visibleCells={visibleCells}
+      />
     );
   }
 
   return (
     <WorkspaceGridRow
-      aria-expanded={expanded}
       aria-rowindex={virtualIndex + 2}
       aria-selected={row.getIsSelected()}
-      className={cn((isTask || !isFolder) && "cursor-pointer")}
+      className={cn(
+        "transition-opacity duration-150",
+        isTask && "cursor-pointer",
+        isFocusedExpansionRow && "relative z-20",
+        isMutedByExpandedCell && "opacity-[0.78] hover:opacity-95",
+      )}
       data-active={activeRow || undefined}
       data-index={virtualIndex}
       data-state={row.getIsSelected() ? "selected" : undefined}
@@ -1352,39 +1365,14 @@ const DraggableRow = ({
       onContextMenu={handleContextMenu}
       ref={setRowRef}
     >
-      {visibleCells.map((cell, cellIndex) => (
-        <WorkspaceGridCell
-          aria-colindex={cellIndex + 1}
-          className={cn(
-            "relative",
-            cell.column.id === selectColId && "min-w-12 shrink-0",
-            cell.column.columnDef.meta?.muted && "text-muted-foreground",
-            expanded &&
-              "max-h-48 overflow-y-auto whitespace-normal [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:wrap-break-word [&_.truncate]:whitespace-normal",
-            cell.column.getIsResizing() &&
-              "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
-            addPropertyColumn &&
-              cellIndex === visibleCells.length - 1 &&
-              "border-e-0",
-          )}
-          data-state={cell.row.getIsSelected() ? "selected" : undefined}
-          key={cell.id}
-          style={{
-            gridColumn: cellIndex + 1,
-            ...getGridPinningStyles(cell.column),
-            maxHeight: expanded ? EXPANDED_ROW_MAX_HEIGHT_PX : undefined,
-          }}
-        >
-          <PinnedBoundary column={cell.column} />
-          {cell.column.id === selectColId ? (
-            selectCellWithActions
-          ) : (
-            <span className="flex w-full min-w-0 items-center gap-1.5">
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </span>
-          )}
-        </WorkspaceGridCell>
-      ))}
+      <DataRowCells
+        expandedCellId={expandedCellId}
+        contentMode={contentMode}
+        hasExpandedCell={isFocusedExpansionRow}
+        onCellClick={handleCellClick}
+        selectCellWithActions={selectCellWithActions}
+        visibleCells={visibleCells}
+      />
       <RowEndFillerCell
         addPropertyColumn={addPropertyColumn}
         renderColumns={renderColumns}
@@ -1398,6 +1386,188 @@ const DraggableRow = ({
     </WorkspaceGridRow>
   );
 };
+
+type FolderTableRowProps = {
+  activeEntityId: string | null;
+  addPropertyCell: Cell<TableTreeNode, unknown> | undefined;
+  editingEntityId: string | null;
+  entity: TableTreeNode;
+  isMutedByExpandedCell: boolean;
+  onContextMenu: (event: React.MouseEvent) => void;
+  onRename: (entityId: string, newName: string) => void;
+  onStartEditing: (entityId: string) => void;
+  onStopEditing: () => void;
+  ref: (element: HTMLDivElement | null) => void;
+  renderColumns: Column<TableTreeNode>[];
+  row: Row<TableTreeNode>;
+  selectCellWithActions: React.ReactNode;
+  virtualIndex: number;
+  visibleCells: Cell<TableTreeNode, unknown>[];
+};
+
+const FolderTableRow = ({
+  activeEntityId,
+  addPropertyCell,
+  editingEntityId,
+  entity,
+  isMutedByExpandedCell,
+  onContextMenu,
+  onRename,
+  onStartEditing,
+  onStopEditing,
+  ref,
+  renderColumns,
+  row,
+  selectCellWithActions,
+  virtualIndex,
+  visibleCells,
+}: FolderTableRowProps) => {
+  const selectCell = visibleCells[0];
+  const nameCell = visibleCells[1];
+  if (!selectCell || !nameCell) {
+    return null;
+  }
+
+  return (
+    <WorkspaceGridRow
+      aria-rowindex={virtualIndex + 2}
+      aria-selected={row.getIsSelected()}
+      className={cn(
+        "transition-opacity duration-150",
+        isMutedByExpandedCell && "opacity-[0.78] hover:opacity-95",
+      )}
+      data-active={entity.entityId === activeEntityId || undefined}
+      data-index={virtualIndex}
+      data-state={row.getIsSelected() ? "selected" : undefined}
+      key={row.id}
+      onContextMenu={onContextMenu}
+      ref={ref}
+    >
+      <WorkspaceGridCell
+        aria-colindex={1}
+        data-state={row.getIsSelected() ? "selected" : undefined}
+        key={selectCell.id}
+        style={{
+          gridColumn: 1,
+          ...getGridPinningStyles(selectCell.column),
+        }}
+      >
+        <PinnedBoundary column={selectCell.column} />
+        {selectCellWithActions}
+      </WorkspaceGridCell>
+      <WorkspaceGridCell
+        aria-colindex={2}
+        className="cursor-pointer"
+        data-state={row.getIsSelected() ? "selected" : undefined}
+        key={nameCell.id}
+        onClick={() => row.toggleExpanded()}
+        style={{
+          gridColumn: 2,
+          ...getGridPinningStyles(nameCell.column),
+        }}
+      >
+        <PinnedBoundary column={nameCell.column} />
+        <FolderCell
+          depth={row.depth}
+          editingEntityId={editingEntityId}
+          entity={entity}
+          isExpanded={row.getIsExpanded()}
+          onRename={onRename}
+          onStopEditing={onStopEditing}
+          startEditing={() => onStartEditing(entity.entityId)}
+        />
+      </WorkspaceGridCell>
+      <WorkspaceGridCell
+        aria-colindex={3}
+        className="cursor-pointer border-e-0"
+        data-state={row.getIsSelected() ? "selected" : undefined}
+        onClick={() => row.toggleExpanded()}
+        style={{ gridColumn: addPropertyCell ? "3 / -2" : "3 / -1" }}
+      />
+      <AddPropertyCell
+        cell={addPropertyCell}
+        columnIndex={renderColumns.length + 1}
+        selected={row.getIsSelected()}
+      />
+    </WorkspaceGridRow>
+  );
+};
+
+type DataRowCellsProps = {
+  expandedCellId: string | null;
+  contentMode: TableContentMode;
+  hasExpandedCell: boolean;
+  onCellClick: (
+    event: React.MouseEvent,
+    columnId: string,
+    canExpandCell: boolean,
+  ) => void;
+  selectCellWithActions: React.ReactNode;
+  visibleCells: Cell<TableTreeNode, unknown>[];
+};
+
+const DataRowCells = ({
+  expandedCellId,
+  contentMode,
+  hasExpandedCell,
+  onCellClick,
+  selectCellWithActions,
+  visibleCells,
+}: DataRowCellsProps) =>
+  visibleCells.map((cell, cellIndex) => {
+    const isSelectCell = cell.column.id === selectColId;
+    const isAddPropertyCell = cell.column.id === addPropertyColId;
+    const canExpandCell = !isSelectCell && !isAddPropertyCell;
+    const canFlagCell = canExpandCell && !cell.column.id.startsWith("_");
+    const isExpandedCell = expandedCellId === cell.column.id;
+
+    return (
+      <WorkspaceGridCell
+        aria-colindex={cellIndex + 1}
+        className={cn(
+          "relative",
+          canExpandCell && "cursor-pointer",
+          isSelectCell && "min-w-12 shrink-0",
+          cell.column.columnDef.meta?.muted && "text-muted-foreground",
+          contentMode === "fit-content" &&
+            "whitespace-normal! [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:wrap-break-word [&_.truncate]:whitespace-normal",
+          hasExpandedCell &&
+            !isExpandedCell &&
+            !isSelectCell &&
+            "opacity-70 transition-opacity duration-150",
+          isExpandedCell &&
+            "z-30 overflow-visible! whitespace-normal! [&_.line-clamp-2]:line-clamp-none [&_.truncate]:min-w-0 [&_.truncate]:overflow-visible [&_.truncate]:wrap-break-word [&_.truncate]:whitespace-normal",
+          cell.column.getIsResizing() &&
+            "after:bg-info after:pointer-events-none after:absolute after:top-0 after:right-0 after:bottom-0 after:z-50 after:w-px",
+        )}
+        data-expanded-cell={isExpandedCell || undefined}
+        data-state={cell.row.getIsSelected() ? "selected" : undefined}
+        data-table-property-id={canFlagCell ? cell.column.id : undefined}
+        key={cell.id}
+        onClick={(event) => onCellClick(event, cell.column.id, canExpandCell)}
+        style={{
+          gridColumn: cellIndex + 1,
+          ...getGridPinningStyles(cell.column),
+        }}
+      >
+        <PinnedBoundary column={cell.column} />
+        {isSelectCell ? (
+          selectCellWithActions
+        ) : (
+          <span
+            className={cn(
+              "flex w-full min-w-0 items-center gap-1.5",
+              contentMode === "fit-content" && "items-start",
+              isExpandedCell &&
+                "border-border/80 bg-background absolute inset-x-0 top-0 z-40 max-h-96 items-start overflow-y-auto border p-2 pb-8 shadow-lg",
+            )}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </span>
+        )}
+      </WorkspaceGridCell>
+    );
+  });
 
 type AddPropertyCellProps = {
   cell: Cell<TableTreeNode, unknown> | undefined;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -1,3 +1,4 @@
+import type { ComponentType } from "react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@stll/ui/components/button";
@@ -17,8 +18,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
+import { cn } from "@stll/ui/lib/utils";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import {
+  AlignJustifyIcon,
   CalendarIcon,
   ClockIcon,
   EyeIcon,
@@ -28,9 +31,11 @@ import {
   Rows3Icon,
   SparklesIcon,
   UserIcon,
+  WrapTextIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import Tooltip from "@/components/tooltip";
 import type { TranslationKey } from "@/i18n/types";
 import type { ViewLayout, WorkspaceProperty, WorkspaceView } from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";
@@ -38,6 +43,8 @@ import { ExistingFileOrganizerDialog } from "@/routes/_protected.workspaces/$wor
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
 import { FilterChips } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters";
 import { SortChips } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts";
+import type { TableContentMode } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
+import { useTableStore } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useUpdateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
 import {
   workspaceFilesOptions,
@@ -192,6 +199,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
       {view.layout.type === "table" && (
         <>
           <span className="bg-border mx-1 h-4 w-px" />
+          <TableContentModeControl viewId={view.id} />
           <CreateProperty triggerVariant="labelled" workspaceId={workspaceId} />
         </>
       )}
@@ -200,6 +208,64 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
 };
 
 // -- Layout-specific controls --
+
+type TableContentModeControlProps = {
+  viewId: string;
+};
+
+const TABLE_CONTENT_MODE_OPTIONS = [
+  {
+    mode: "tight",
+    icon: AlignJustifyIcon,
+    labelKey: "workspaces.table.tightContent",
+  },
+  {
+    mode: "fit-content",
+    icon: WrapTextIcon,
+    labelKey: "workspaces.table.wrapContent",
+  },
+] as const satisfies readonly {
+  mode: TableContentMode;
+  icon: ComponentType<{ className?: string }>;
+  labelKey: TranslationKey;
+}[];
+
+const TableContentModeControl = ({ viewId }: TableContentModeControlProps) => {
+  const t = useTranslations();
+  const mode = useTableStore((s) => s.contentMode[viewId] ?? "tight");
+  const setMode = useTableStore((s) => s.setContentMode);
+
+  return (
+    <div className="border-border/70 bg-muted/30 inline-flex h-7 shrink-0 items-center overflow-hidden rounded-md border p-0.5">
+      {TABLE_CONTENT_MODE_OPTIONS.map((option) => {
+        const Icon = option.icon;
+        const isActive = mode === option.mode;
+        return (
+          <Tooltip
+            content={t(option.labelKey)}
+            key={option.mode}
+            render={
+              <Button
+                aria-label={t(option.labelKey)}
+                aria-pressed={isActive}
+                className={cn(
+                  "text-muted-foreground h-6 min-h-0 w-7 rounded-[4px] p-0",
+                  isActive && "bg-background text-foreground shadow-xs",
+                )}
+                onClick={() => setMode(viewId, option.mode)}
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              />
+            }
+          >
+            <Icon className="size-3.5" />
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+};
 
 type FilesystemOrganizerActionProps = {
   workspaceId: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.test.ts
@@ -11,9 +11,13 @@ const replacer = (_key: string, value: unknown): unknown => {
 };
 
 type ColumnSizingState = Record<string, number>;
+type TableContentMode = "tight" | "fit-content";
 
 type StorageShape = {
-  state: { columnSizing: Map<string, ColumnSizingState> };
+  state: {
+    columnSizing: Map<string, ColumnSizingState>;
+    contentMode: Record<string, TableContentMode>;
+  };
   version: number;
 };
 
@@ -24,6 +28,10 @@ const StorageSchema = v.strictObject({
         v.tuple([v.string(), v.record(v.string(), v.number())]),
       ),
     }),
+    contentMode: v.optional(
+      v.record(v.string(), v.picklist(["tight", "fit-content"])),
+      {},
+    ),
   }),
   version: v.number(),
 });
@@ -41,7 +49,10 @@ const parseStorage = (json: string): StorageShape | null => {
   }
   const entries = result.output.state.columnSizing[MAP_TAG];
   return {
-    state: { columnSizing: new Map(entries) },
+    state: {
+      columnSizing: new Map(entries),
+      contentMode: result.output.state.contentMode,
+    },
     version: result.output.version,
   };
 };
@@ -57,7 +68,10 @@ const expectParsed = (raw: string): StorageShape => {
 describe("Map serialization roundtrip", () => {
   test("empty Map survives roundtrip", () => {
     const data = {
-      state: { columnSizing: new Map<string, ColumnSizingState>() },
+      state: {
+        columnSizing: new Map<string, ColumnSizingState>(),
+        contentMode: {},
+      },
       version: 0,
     };
     const serialized = JSON.stringify(data, replacer);
@@ -75,6 +89,7 @@ describe("Map serialization roundtrip", () => {
           ["view-1", { col_a: 200, col_b: 150 }],
           ["view-2", { col_x: 300 }],
         ]),
+        contentMode: { "view-1": "fit-content" as const },
       },
       version: 0,
     };
@@ -90,12 +105,14 @@ describe("Map serialization roundtrip", () => {
     expect(parsed.state.columnSizing.get("view-2")).toEqual({
       col_x: 300,
     });
+    expect(parsed.state.contentMode).toEqual({ "view-1": "fit-content" });
   });
 
   test("wire format uses tagged entries", () => {
     const data = {
       state: {
         columnSizing: new Map([["v1", { a: 100 }]]),
+        contentMode: { v1: "tight" as const },
       },
       version: 0,
     };
@@ -104,6 +121,7 @@ describe("Map serialization roundtrip", () => {
     expect(wire).toEqual({
       state: {
         columnSizing: { [MAP_TAG]: [["v1", { a: 100 }]] },
+        contentMode: { v1: "tight" },
       },
       version: 0,
     });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/table-store.ts
@@ -10,6 +10,9 @@ import type { PersistStorage, StorageValue } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
 const MAP_TAG = "__map";
+const TABLE_CONTENT_MODES = ["tight", "fit-content"] as const;
+
+export type TableContentMode = (typeof TABLE_CONTENT_MODES)[number];
 
 const replacer = (_key: string, value: unknown): unknown => {
   if (value instanceof Map) {
@@ -20,6 +23,7 @@ const replacer = (_key: string, value: unknown): unknown => {
 
 type PersistedState = {
   columnSizing: Map<string, ColumnSizingState>;
+  contentMode: Record<string, TableContentMode>;
 };
 
 const StorageSchema = v.strictObject({
@@ -29,6 +33,12 @@ const StorageSchema = v.strictObject({
         v.tuple([v.string(), v.record(v.string(), v.number())]),
       ),
     }),
+    contentMode: v.optional(
+      v.record(v.string(), v.picklist(TABLE_CONTENT_MODES)),
+    ),
+    columnWidthMode: v.optional(
+      v.record(v.string(), v.picklist(TABLE_CONTENT_MODES)),
+    ),
   }),
   version: v.optional(v.number(), 0),
 });
@@ -49,7 +59,16 @@ const parsePersistedStorage = (
   }
   const entries = result.output.state.columnSizing[MAP_TAG];
   const columnSizing = new Map<string, ColumnSizingState>(entries);
-  return { state: { columnSizing }, version: result.output.version };
+  return {
+    state: {
+      columnSizing,
+      contentMode:
+        result.output.state.contentMode ??
+        result.output.state.columnWidthMode ??
+        {},
+    },
+    version: result.output.version,
+  };
 };
 
 const mapStorage: PersistStorage<PersistedState> = {
@@ -70,6 +89,8 @@ const mapStorage: PersistStorage<PersistedState> = {
 
 type TableStore = {
   columnSizing: Map<string, ColumnSizingState>;
+  contentMode: Record<string, TableContentMode>;
+  setContentMode: (viewId: string, mode: TableContentMode) => void;
   setColumnSizing: (
     viewId: string,
     updater: Updater<ColumnSizingState>,
@@ -86,7 +107,14 @@ export const useTableStore = create<TableStore>()(
   persist(
     immer((set) => ({
       columnSizing: new Map<string, ColumnSizingState>(),
+      contentMode: {},
       rowSelection: {},
+
+      setContentMode: (viewId, mode) => {
+        set((state) => {
+          state.contentMode[viewId] = mode;
+        });
+      },
 
       setColumnSizing: (viewId, updater) => {
         set((state) => {
@@ -112,6 +140,13 @@ export const useTableStore = create<TableStore>()(
               state.columnSizing.delete(viewId);
             }
           }
+          const prunedContentMode: Record<string, TableContentMode> = {};
+          for (const [vid, mode] of Object.entries(state.contentMode)) {
+            if (active.has(vid)) {
+              prunedContentMode[vid] = mode;
+            }
+          }
+          state.contentMode = prunedContentMode;
           const pruned: Record<string, RowSelectionState> = {};
           for (const [vid, sel] of Object.entries(state.rowSelection)) {
             if (active.has(vid)) {
@@ -127,6 +162,7 @@ export const useTableStore = create<TableStore>()(
       storage: mapStorage,
       partialize: (state) => ({
         columnSizing: state.columnSizing,
+        contentMode: state.contentMode,
       }),
     },
   ),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state.ts
@@ -13,6 +13,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { useShallow } from "zustand/shallow";
 
 import type { WorkspaceView } from "@/lib/types";
+import type { TableContentMode } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useTableStore } from "@/routes/_protected.workspaces/$workspaceId/-hooks/table-store";
 import { useUpdateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
 import { getInternalColId } from "@/routes/_protected.workspaces/$workspaceId/-utils";
@@ -43,6 +44,8 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
     }),
   );
   const setStoredColumnSizing = useTableStore((s) => s.setColumnSizing);
+  const contentMode = useTableStore((s) => s.contentMode[viewId] ?? "tight");
+  const setContentMode = useTableStore((s) => s.setContentMode);
   const [columnSizing, setColumnSizing] = useState(storedColumnSizing);
 
   const debouncedSetStoredColumnSizing = useDebouncedCallback(
@@ -152,6 +155,10 @@ export const useTableState = ({ workspaceId, view }: UseTableStateProps) => {
 
   return {
     view,
+    contentMode,
+    setContentMode: (mode: TableContentMode) => {
+      setContentMode(viewId, mode);
+    },
     state: {
       columnSizing,
       columnOrder,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -28,7 +28,7 @@ type KanbanGroupOptionsInput = QueryOptionsInput<KanbanGroupKey>;
 
 type RawWorkspaceEntity = Omit<
   WorkspaceEntity,
-  "entityId" | "parentId" | "fields"
+  "entityId" | "parentId" | "fields" | "cellMetadata"
 > & {
   entityId: string;
   parentId: string | null;
@@ -37,6 +37,10 @@ type RawWorkspaceEntity = Omit<
     propertyId: string;
     entityId: string;
     content: WorkspaceField["content"];
+  }[];
+  cellMetadata: {
+    propertyId: string;
+    metadata: WorkspaceEntity["cellMetadata"][string];
   }[];
 };
 
@@ -49,6 +53,10 @@ const toWorkspaceEntity = (entity: RawWorkspaceEntity): WorkspaceEntity => {
       entityId: toSafeId<"entity">(field.entityId),
       content: field.content,
     };
+  }
+  const cellMetadata: WorkspaceEntity["cellMetadata"] = {};
+  for (const entry of entity.cellMetadata) {
+    cellMetadata[entry.propertyId] = entry.metadata;
   }
   return {
     entityId: toSafeId<"entity">(entity.entityId),
@@ -87,6 +95,7 @@ const toWorkspaceEntity = (entity: RawWorkspaceEntity): WorkspaceEntity => {
     sortOrder: entity.sortOrder,
     activeEditBy: entity.activeEditBy,
     fields,
+    cellMetadata,
   };
 };
 


### PR DESCRIPTION
## Summary
- Add cell metadata persistence and a workspace-scoped endpoint for manual table cell flags with server-side provenance.
- Render subtle per-cell flag markers, a right-click flag menu, and avatar/timestamp provenance tooltips.
- Add single-cell expansion plus tight/wrap content controls for table cells.