### PR TITLE
feat(table): distinguish loading state, broaden flag tooltips, ESC-to-collapse

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -204,35 +204,44 @@ type CellCornerFlagProps = {
 
 const CellCornerFlag = ({ flags, metadata, onDrop }: CellCornerFlagProps) => {
   const getFlagLabel = useFlagLabel();
-  const flag = flags.at(0);
-  if (!flag) {
+  if (flags.length === 0) {
     return null;
   }
 
-  const Icon = flag.icon;
-  const label = flags.map((item) => getFlagLabel(item.id)).join(", ");
-  const provenance = metadata?.flagProvenance?.[flag.id];
-
   return (
-    <Tooltip
-      className="max-w-72 text-wrap"
-      content={<FlagProvenanceTooltip flag={flag} metadata={provenance} />}
-      render={
-        <button
-          aria-label={label}
-          className="bg-background/55 focus-visible:ring-ring absolute end-1 top-1 z-20 flex size-3 items-center justify-center rounded-full opacity-100 backdrop-blur-[2px] outline-none focus-visible:ring-1"
-          data-row-expansion-ignore
-          onClick={(event) => {
-            event.stopPropagation();
-            onDrop(flag.id);
-          }}
-          style={{ color: flag.color }}
-          type="button"
-        />
-      }
+    <div
+      className="absolute end-1 top-1 z-20 flex items-center gap-1"
+      data-row-expansion-ignore
     >
-      <Icon className="size-2.5" strokeWidth={2.5} />
-    </Tooltip>
+      {flags.map((flag) => {
+        const Icon = flag.icon;
+        const provenance = metadata?.flagProvenance?.[flag.id];
+        return (
+          <Tooltip
+            className="max-w-72 text-wrap"
+            content={
+              <FlagProvenanceTooltip flag={flag} metadata={provenance} />
+            }
+            key={flag.id}
+            render={
+              <button
+                aria-label={getFlagLabel(flag.id)}
+                className="bg-background/55 focus-visible:ring-ring flex size-3 items-center justify-center rounded-full opacity-100 backdrop-blur-[2px] outline-none focus-visible:ring-1"
+                data-row-expansion-ignore
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDrop(flag.id);
+                }}
+                style={{ color: flag.color }}
+                type="button"
+              />
+            }
+          >
+            <Icon className="size-2.5" strokeWidth={2.5} />
+          </Tooltip>
+        );
+      })}
+    </div>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Result } from "better-result";
-import { SquareMinusIcon } from "lucide-react";
+import { Loader2Icon, SquareMinusIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
@@ -43,7 +43,11 @@ export const CellResult = ({
         <span className={hasPreview ? "line-clamp-2" : "truncate"}>
           {hasPreview ? preview : t("workspaces.fields.calculating")}
         </span>
-        <span className="bg-muted-foreground size-2 shrink-0 animate-pulse rounded-full" />
+        <Loader2Icon
+          aria-hidden="true"
+          className="text-muted-foreground size-3 shrink-0 animate-spin"
+          strokeWidth={2.25}
+        />
       </div>
     );
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -156,6 +156,24 @@ export const WorkspaceTable = ({
     useState<ExpandedTableCell | null>(null);
   const [wrapperWidth, setWrapperWidth] = useState(0);
 
+  useEffect(() => {
+    if (!expandedTableCell) {
+      return undefined;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      setExpandedTableCell(null);
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+    };
+  }, [expandedTableCell]);
+
   const renameEntity = useRenameEntity();
 
   const activeEntityId = useInspectorStore((s) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -161,16 +161,14 @@ export const WorkspaceTable = ({
       return undefined;
     }
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== "Escape") {
+      if (event.key !== "Escape" || event.defaultPrevented) {
         return;
       }
-      event.preventDefault();
-      event.stopPropagation();
       setExpandedTableCell(null);
     };
-    document.addEventListener("keydown", onKeyDown, true);
+    document.addEventListener("keydown", onKeyDown);
     return () => {
-      document.removeEventListener("keydown", onKeyDown, true);
+      document.removeEventListener("keydown", onKeyDown);
     };
   }, [expandedTableCell]);
 


### PR DESCRIPTION
## Summary

- Pending-cell indicator switches from a grey pulsing dot to a spinner (`Loader2Icon` + `animate-spin`) so it can no longer be confused with the verified flag dot.
- `CellCornerFlag` now renders each decorative flag as its own tooltip target. Previously every active flag collapsed into a single icon, so only the first flag's provenance was reachable on hover.
- `WorkspaceTable` listens for `Escape` while a cell is expanded and clears `expandedTableCell`.