### PR TITLE
fix(api): run migrations on boot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .claude
 .turbo
 .cache
+apps/desktop/src-tauri/target
 dist
 node_modules
 **/.env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,12 +160,6 @@ jobs:
           SMTP_PORT: "1025"
           TRANSACTIONAL_EMAIL_FROM: "noreply@example.com"
           USE_MOCK_AI: "true"
-          # Smoke test only verifies the binary boots; the database
-          # is empty so the startup migration-hash check would
-          # fail-closed and abort the build. Skip it here — the
-          # check stays active in real deploys via the production
-          # task definition env.
-          SKIP_MIGRATION_CHECK: "true"
         run: |
           cleanup_smoke() {
             docker rm -f stella-api-smoke >/dev/null 2>&1 || true
@@ -194,7 +188,6 @@ jobs:
             --env SMTP_PORT \
             --env TRANSACTIONAL_EMAIL_FROM \
             --env USE_MOCK_AI \
-            --env SKIP_MIGRATION_CHECK \
             stella-api:smoke
 
           for _ in {1..60}; do

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -44,6 +44,7 @@ import { workspacesRoute } from "@/api/handlers/workspaces/routes";
 import { captureRequestError, getAnalytics } from "@/api/lib/analytics";
 import { getAuth } from "@/api/lib/auth";
 import { assertMigrationsApplied } from "@/api/lib/db/assert-migrations-applied";
+import { migrateOnBoot } from "@/api/lib/db/migrate-on-boot";
 import { DEV_INSPECTOR_ORIGINS } from "@/api/lib/dev-origins";
 import { httpError } from "@/api/lib/errors/http-error";
 import { errorTag } from "@/api/lib/errors/utils";
@@ -347,9 +348,9 @@ const startS3RefreshLoop = () => {
   timer.unref();
 };
 
-// Schema-drift fail-fast. If the runtime expects migrations
-// the database has not received, exit before serving any
-// request against a stale schema.
+// Apply the runtime image's migrations, then fail fast if the
+// database still does not match the local migration files.
+await migrateOnBoot();
 await assertMigrationsApplied();
 
 await refreshS3();

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -1,12 +1,17 @@
 import { sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import { db } from "@/api/db/root";
+import {
+  assertMigrationsDirectoryPresent,
+  DRIZZLE_MIGRATIONS_SCHEMA,
+  DRIZZLE_MIGRATIONS_TABLE,
+  MIGRATIONS_DIR,
+} from "@/api/lib/db/migration-config";
 import { logger } from "@/api/lib/observability/logger";
 
-const MIGRATIONS_DIR = resolve(process.cwd(), "drizzle");
 const ESCAPE_HATCH_ENV = "SKIP_MIGRATION_CHECK";
 
 type LocalMigration = { name: string; hash: string };
@@ -30,7 +35,7 @@ const queryAppliedHashes = async (): Promise<Set<string>> => {
   // of the migration.sql contents at apply time, so a mismatch
   // also catches a file edited after it was applied.
   const result = await db.execute<AppliedMigrationRow>(
-    sql`SELECT hash FROM drizzle.__drizzle_migrations`,
+    sql`SELECT hash FROM ${sql.identifier(DRIZZLE_MIGRATIONS_SCHEMA)}.${sql.identifier(DRIZZLE_MIGRATIONS_TABLE)}`,
   );
   return new Set(result.map((row) => row.hash));
 };
@@ -42,6 +47,8 @@ export const assertMigrationsApplied = async (): Promise<void> => {
     });
     return;
   }
+
+  assertMigrationsDirectoryPresent();
 
   const local = listLocalMigrations();
   if (local.length === 0) {

--- a/apps/api/src/lib/db/migrate-on-boot.test.ts
+++ b/apps/api/src/lib/db/migrate-on-boot.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { SQL, is } from "drizzle-orm";
+import type { SQLWrapper } from "drizzle-orm";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { runBootMigrations } from "@/api/lib/db/migrate-on-boot";
+
+describe("boot migrations", () => {
+  test("holds the advisory lock before running migrations", async () => {
+    const events: string[] = [];
+    const dialect = new PgDialect();
+    const tx = {
+      execute: async (query: SQLWrapper | string): Promise<void> => {
+        if (!is(query, SQL)) {
+          throw new Error("expected advisory lock query");
+        }
+
+        events.push(dialect.sqlToQuery(query).sql);
+      },
+    };
+    const database = {
+      transaction: async <T>(fn: (transaction: typeof tx) => Promise<T>) => {
+        events.push("transaction:start");
+        const result = await fn(tx);
+        events.push("transaction:end");
+        return result;
+      },
+    };
+
+    await runBootMigrations(database, async () => {
+      events.push("migrate");
+    });
+
+    expect(events).toEqual([
+      "transaction:start",
+      "SELECT pg_advisory_xact_lock($1, $2)",
+      "migrate",
+      "transaction:end",
+    ]);
+  });
+});

--- a/apps/api/src/lib/db/migrate-on-boot.ts
+++ b/apps/api/src/lib/db/migrate-on-boot.ts
@@ -1,0 +1,70 @@
+import { panic } from "better-result";
+import { sql } from "drizzle-orm";
+import type { SQLWrapper } from "drizzle-orm";
+import { migrate } from "drizzle-orm/bun-sql/migrator";
+
+import { db } from "@/api/db/root";
+import type { Transaction } from "@/api/db/root";
+import {
+  assertMigrationsDirectoryPresent,
+  DRIZZLE_MIGRATIONS_SCHEMA,
+  DRIZZLE_MIGRATIONS_TABLE,
+  MIGRATIONS_DIR,
+} from "@/api/lib/db/migration-config";
+import { logger } from "@/api/lib/observability/logger";
+
+const MIGRATION_LOCK_NAMESPACE = 1_398_031_692;
+const MIGRATION_LOCK_ID = 1_296_648_018;
+
+type BootMigrationTransaction = {
+  execute: (query: SQLWrapper | string) => PromiseLike<unknown>;
+};
+
+type BootMigrationDatabase<TTransaction extends BootMigrationTransaction> = {
+  transaction: <TResult>(
+    fn: (tx: TTransaction) => Promise<TResult>,
+  ) => Promise<TResult>;
+};
+
+type MigrationRunner<TTransaction extends BootMigrationTransaction> = (
+  tx: TTransaction,
+) => Promise<void>;
+
+const runDrizzleMigrations = async (tx: Transaction): Promise<void> => {
+  const result = await migrate(tx, {
+    migrationsFolder: MIGRATIONS_DIR,
+    migrationsSchema: DRIZZLE_MIGRATIONS_SCHEMA,
+    migrationsTable: DRIZZLE_MIGRATIONS_TABLE,
+  });
+
+  if (!result) {
+    return;
+  }
+
+  panic(`Unexpected Drizzle migration init result: ${result.exitCode}`);
+};
+
+export const runBootMigrations = async <
+  TTransaction extends BootMigrationTransaction,
+>(
+  database: BootMigrationDatabase<TTransaction>,
+  runMigrations: MigrationRunner<TTransaction>,
+): Promise<void> => {
+  assertMigrationsDirectoryPresent();
+
+  logger.info("startup.migrations_begin");
+
+  await database.transaction(async (tx) => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(${MIGRATION_LOCK_NAMESPACE}, ${MIGRATION_LOCK_ID})`,
+    );
+
+    await runMigrations(tx);
+  });
+
+  logger.info("startup.migrations_complete");
+};
+
+export const migrateOnBoot = async (): Promise<void> => {
+  await runBootMigrations(db, runDrizzleMigrations);
+};

--- a/apps/api/src/lib/db/migration-config.ts
+++ b/apps/api/src/lib/db/migration-config.ts
@@ -1,0 +1,17 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+export const DRIZZLE_MIGRATIONS_SCHEMA = "drizzle";
+export const DRIZZLE_MIGRATIONS_TABLE = "__drizzle_migrations";
+export const MIGRATIONS_DIR = resolve(process.cwd(), "drizzle");
+
+export const assertMigrationsDirectoryPresent = (): void => {
+  if (existsSync(MIGRATIONS_DIR)) {
+    return;
+  }
+
+  throw new Error(
+    `[startup] No migration files at ${MIGRATIONS_DIR}; refusing to start. ` +
+      "The runtime image must include apps/api/drizzle/.",
+  );
+};


### PR DESCRIPTION
Runs API migrations during startup under a Postgres advisory lock, then keeps the schema check as a guard.