### PR TITLE
fix(dev-runner): detect foreign Compose containers on shared infra ports

### DIFF
--- a/packages/scripts/src/dev-runner.test.ts
+++ b/packages/scripts/src/dev-runner.test.ts
@@ -16,6 +16,7 @@ import {
   isWorktreeCheckout,
   parseDockerComposePsJson,
   parseArgs,
+  parseForeignPortOwners,
   portsForOffset,
   requiredPortsForMode,
   resolveMainRootFromCommonDir,
@@ -306,6 +307,106 @@ describe("shared Docker service readiness", () => {
     ).toBe("minio-setup has not completed yet (state=running)");
 
     expect(getSharedDockerServicesWaitFailure(readyStatuses)).toBeUndefined();
+  });
+});
+
+describe("parseForeignPortOwners", () => {
+  const sharedPorts = [5432, 6379, 9000, 9001, 3003] as const;
+
+  test("returns nothing when output is empty", () => {
+    expect(
+      parseForeignPortOwners({
+        expectedProject: "stella-dev",
+        output: "",
+        sharedPorts,
+      }),
+    ).toEqual([]);
+  });
+
+  test("ignores containers from the expected compose project", () => {
+    const output = [
+      "stella-dev-postgres-1\tstella-dev\t0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp",
+      "stella-dev-valkey-1\tstella-dev\t0.0.0.0:6379->6379/tcp",
+    ].join("\n");
+
+    expect(
+      parseForeignPortOwners({
+        expectedProject: "stella-dev",
+        output,
+        sharedPorts,
+      }),
+    ).toEqual([]);
+  });
+
+  test("flags foreign compose project containers holding shared ports", () => {
+    const output = [
+      "stella-1-table-export-postgres-1\tstella-1-table-export\t0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp",
+      "stella-1-table-export-valkey-1\tstella-1-table-export\t0.0.0.0:6379->6379/tcp",
+      "stella-1-table-export-gotenberg-1\tstella-1-table-export\t0.0.0.0:3003->3000/tcp",
+      "snoopy-brewing-music-db-1\tsnoopy-brewing-music\t127.0.0.1:5434->5432/tcp",
+    ].join("\n");
+
+    expect(
+      parseForeignPortOwners({
+        expectedProject: "stella-dev",
+        output,
+        sharedPorts,
+      }),
+    ).toEqual([
+      {
+        composeProject: "stella-1-table-export",
+        containerName: "stella-1-table-export-postgres-1",
+        hostPort: 5432,
+      },
+      {
+        composeProject: "stella-1-table-export",
+        containerName: "stella-1-table-export-valkey-1",
+        hostPort: 6379,
+      },
+      {
+        composeProject: "stella-1-table-export",
+        containerName: "stella-1-table-export-gotenberg-1",
+        hostPort: 3003,
+      },
+    ]);
+  });
+
+  test("flags containers without a compose project label", () => {
+    const output =
+      "rogue-postgres\t\t0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp";
+
+    expect(
+      parseForeignPortOwners({
+        expectedProject: "stella-dev",
+        output,
+        sharedPorts,
+      }),
+    ).toEqual([
+      {
+        composeProject: "",
+        containerName: "rogue-postgres",
+        hostPort: 5432,
+      },
+    ]);
+  });
+
+  test("only counts each host port once per container even with dual-stack mappings", () => {
+    const output =
+      "other-pg\tother-project\t0.0.0.0:5432->5432/tcp, [::]:5432->5432/tcp";
+
+    expect(
+      parseForeignPortOwners({
+        expectedProject: "stella-dev",
+        output,
+        sharedPorts,
+      }),
+    ).toEqual([
+      {
+        composeProject: "other-project",
+        containerName: "other-pg",
+        hostPort: 5432,
+      },
+    ]);
   });
 });
 

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -520,6 +520,78 @@ const areSharedDockerPortsFree = async (infraPorts: InfraPorts) => {
   return availability.every(Boolean);
 };
 
+export type ForeignPortOwner = {
+  composeProject: string;
+  containerName: string;
+  hostPort: number;
+};
+
+export const parseForeignPortOwners = ({
+  expectedProject,
+  output,
+  sharedPorts,
+}: {
+  expectedProject: string;
+  output: string;
+  sharedPorts: readonly number[];
+}): ForeignPortOwner[] => {
+  const portSet = new Set(sharedPorts);
+  const foreign: ForeignPortOwner[] = [];
+
+  for (const line of output.split("\n")) {
+    if (!line) {
+      continue;
+    }
+    const [containerName, composeProject, portsField] = line.split("\t");
+    if (!containerName || composeProject === expectedProject) {
+      continue;
+    }
+
+    const seen = new Set<number>();
+    for (const match of (portsField ?? "").matchAll(/:(\d+)->/g)) {
+      const hostPort = Number.parseInt(match[1] ?? "", 10);
+      if (
+        Number.isNaN(hostPort) ||
+        !portSet.has(hostPort) ||
+        seen.has(hostPort)
+      ) {
+        continue;
+      }
+      seen.add(hostPort);
+      foreign.push({
+        composeProject: composeProject ?? "",
+        containerName,
+        hostPort,
+      });
+    }
+  }
+
+  return foreign;
+};
+
+const findForeignContainersOnSharedPorts = ({
+  infraOffset,
+  infraPorts,
+  rootDir,
+}: {
+  infraOffset: number;
+  infraPorts: InfraPorts;
+  rootDir: string;
+}) =>
+  parseForeignPortOwners({
+    expectedProject: dockerProjectName(infraOffset),
+    output: runCommandText({
+      cmd: [
+        resolveCommandPath("docker"),
+        "ps",
+        "--format",
+        '{{.Names}}\t{{.Label "com.docker.compose.project"}}\t{{.Ports}}',
+      ],
+      cwd: rootDir,
+    }),
+    sharedPorts: sharedInfraPortList(infraPorts),
+  });
+
 const dockerComposeEnv = (infraPorts: InfraPorts) => ({
   ...process.env,
   STELLA_GOTENBERG_HOST_PORT: String(infraPorts.gotenberg),
@@ -718,6 +790,23 @@ const ensureDockerServices = async ({
   infraPorts: InfraPorts;
   rootDir: string;
 }) => {
+  const foreignOwners = findForeignContainersOnSharedPorts({
+    infraOffset,
+    infraPorts,
+    rootDir,
+  });
+  if (foreignOwners.length > 0) {
+    const detail = foreignOwners
+      .map(
+        ({ composeProject, containerName, hostPort }) =>
+          `  - host port ${String(hostPort)}: ${containerName} (project ${composeProject || "<none>"})`,
+      )
+      .join("\n");
+    throw new Error(
+      `Shared Docker ports are held by containers from another Compose project:\n${detail}\nStop the conflicting stack, or use --infra-offset to shift Stella's infra ports.`,
+    );
+  }
+
   if (await areSharedDockerServicesHealthy(infraPorts)) {
     const currentFailure = getSharedDockerServicesWaitFailure(
       readSharedDockerServiceStatuses({


### PR DESCRIPTION
## Summary

- Shared-services health probe in `dev-runner.ts` only checked port liveness, so a foreign Compose project (e.g. another worktree's stack) listening on Stella's standard infra ports made the probe pass.
- The runner then took the "reconcile" branch and attempted `docker compose -p stella-dev up -d`, which failed at the kernel-level port bind.
- New ownership check lists each container's `com.docker.compose.project` label alongside published ports, throws fast with a clear message when any shared infra port is held by a container outside the expected project.

## Test plan

- [x] `bun test packages/scripts/src/dev-runner.test.ts` — 37 pass (4 new cases for `parseForeignPortOwners`)
- [x] `bun run lint`, `bun run format`, `bun run typecheck`
- [x] `bun run dev --dry-run --infra-offset 236` still resolves correctly