### PR TITLE
feat: add chat prompt history navigation via arrows

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -436,6 +436,10 @@ export const useChatEditor = ({
   }, [onDraftStart, threadKey]);
   markDraftStartedRef.current = markDraftStarted;
 
+  useEffect(() => {
+    messageHistoryIndexRef.current = null;
+  }, [sentMessageHistoryHtml, threadKey]);
+
   const fetchWorkspaceEntities = useCallback(
     async (workspace: ChatMentionOption, query: string) => {
       if (!workspace.sourceViewId) {

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -182,6 +182,9 @@ const isSuggestionPluginActive = (state: EditorState): boolean =>
 const areDocsEqual = (left: JSONContent, right: JSONContent) =>
   JSON.stringify(left) === JSON.stringify(right);
 
+const getEditorHtml = (editor: Editor) =>
+  editor.isEmpty ? "" : editor.getHTML().trim();
+
 export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const registrationsRef = useRef(new Map<string, RegisteredExtension>());
   const activeEditorRef = useRef<ActiveChatEditorHandle | null>(null);
@@ -366,10 +369,12 @@ export const useChatEditorManager = () => {
 export const useChatEditor = ({
   onDraftStart,
   placeholder,
+  sentMessageHistoryHtml,
   threadRef,
 }: {
   onDraftStart?: (() => void) | undefined;
   placeholder?: string | undefined;
+  sentMessageHistoryHtml?: readonly string[] | undefined;
   threadRef: ChatThreadRef;
 }): ChatEditorController => {
   const t = useTranslations();
@@ -382,8 +387,17 @@ export const useChatEditor = ({
   const submitHandlerRef = useRef<(() => Promise<void>) | null>(null);
   const fileIdCounterRef = useRef(0);
   const activePluginKeysRef = useRef<(string | PluginKey)[]>([]);
+  const editorRef = useRef<Editor | null>(null);
   const isApplyingStoredDraftRef = useRef(false);
+  const isNavigatingHistoryRef = useRef(false);
   const draftStartedThreadKeyRef = useRef<string | null>(null);
+  const sentMessageHistoryHtmlRef = useRef<readonly string[]>([]);
+  const messageHistoryIndexRef = useRef<number | null>(null);
+  const markDraftStartedRef = useRef<(() => void) | null>(null);
+  sentMessageHistoryHtmlRef.current =
+    sentMessageHistoryHtml
+      ?.map((message) => message.trim())
+      .filter((message) => message.length > 0) ?? [];
   const threadKey = getChatThreadKey(threadRef);
   const {
     extensionVersion,
@@ -417,6 +431,7 @@ export const useChatEditor = ({
     draftStartedThreadKeyRef.current = threadKey;
     onDraftStart?.();
   }, [onDraftStart, threadKey]);
+  markDraftStartedRef.current = markDraftStarted;
 
   const fetchWorkspaceEntities = useCallback(
     async (workspace: ChatMentionOption, query: string) => {
@@ -566,6 +581,10 @@ export const useChatEditor = ({
       return;
     }
 
+    if (!isNavigatingHistoryRef.current) {
+      messageHistoryIndexRef.current = null;
+    }
+
     setDraft(
       threadKey,
       createChatDraftState({
@@ -593,6 +612,68 @@ export const useChatEditor = ({
   );
   const promptsRef = useRef(allPrompts);
   promptsRef.current = allPrompts;
+
+  const handleMessageHistoryKeyDown = useCallback(
+    (state: EditorState, event: KeyboardEvent) => {
+      if (
+        (event.key !== "ArrowUp" && event.key !== "ArrowDown") ||
+        event.isComposing
+      ) {
+        return false;
+      }
+
+      if (isSuggestionPluginActive(state)) {
+        return false;
+      }
+
+      if (attachmentsRef.current.length > 0) {
+        return false;
+      }
+
+      const targetEditor = editorRef.current;
+      if (targetEditor === null) {
+        return false;
+      }
+
+      const history = sentMessageHistoryHtmlRef.current;
+      const currentIndex = messageHistoryIndexRef.current;
+      if (history.length === 0) {
+        return false;
+      }
+
+      if (event.key === "ArrowDown" && currentIndex === null) {
+        return false;
+      }
+
+      const currentHtml = getEditorHtml(targetEditor);
+      if (currentIndex === null && currentHtml !== "") {
+        return false;
+      }
+
+      let nextIndex: number | null = null;
+      if (event.key === "ArrowUp") {
+        nextIndex = Math.min((currentIndex ?? -1) + 1, history.length - 1);
+      } else if (currentIndex !== null && currentIndex > 0) {
+        nextIndex = currentIndex - 1;
+      }
+      const nextHtml = nextIndex === null ? "" : (history.at(nextIndex) ?? "");
+
+      event.preventDefault();
+      isNavigatingHistoryRef.current = true;
+      try {
+        targetEditor.commands.setContent(nextHtml);
+        targetEditor.commands.focus("end");
+      } finally {
+        isNavigatingHistoryRef.current = false;
+      }
+      messageHistoryIndexRef.current = nextIndex;
+      if (nextHtml !== "") {
+        markDraftStartedRef.current?.();
+      }
+      return true;
+    },
+    [],
+  );
 
   const editor = useEditor({
     autofocus: false,
@@ -634,6 +715,7 @@ export const useChatEditor = ({
       }),
     ],
     onCreate: ({ editor: nextEditor }) => {
+      editorRef.current = nextEditor;
       setIsEmpty(nextEditor.isEmpty);
     },
     onUpdate: ({ editor: nextEditor }) => {
@@ -645,6 +727,10 @@ export const useChatEditor = ({
           "field-sizing-content max-h-48 min-h-10 overflow-y-auto text-sm focus-visible:outline-none",
       },
       handleKeyDown: (view, event) => {
+        if (handleMessageHistoryKeyDown(view.state, event)) {
+          return true;
+        }
+
         // Submit on Enter or Cmd/Ctrl+Enter. Shift+Enter falls
         // through to the HardBreak extension (newline). The
         // mention-suggestion plugin owns Enter while its popup is
@@ -666,6 +752,8 @@ export const useChatEditor = ({
       },
     },
   });
+
+  editorRef.current = editor;
 
   const syncEditorPlugins = useCallback(
     (targetEditor: Editor) => {

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -185,6 +185,12 @@ const areDocsEqual = (left: JSONContent, right: JSONContent) =>
 const getEditorHtml = (editor: Editor) =>
   editor.isEmpty ? "" : editor.getHTML().trim();
 
+const isSelectionAtStart = ({ selection }: EditorState) =>
+  selection.empty && selection.from <= 1;
+
+const isSelectionAtEnd = ({ doc, selection }: EditorState) =>
+  selection.empty && selection.to >= doc.content.size - 1;
+
 export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const registrationsRef = useRef(new Map<string, RegisteredExtension>());
   const activeEditorRef = useRef<ActiveChatEditorHandle | null>(null);
@@ -394,10 +400,7 @@ export const useChatEditor = ({
   const sentMessageHistoryHtmlRef = useRef<readonly string[]>([]);
   const messageHistoryIndexRef = useRef<number | null>(null);
   const markDraftStartedRef = useRef<(() => void) | null>(null);
-  sentMessageHistoryHtmlRef.current =
-    sentMessageHistoryHtml
-      ?.map((message) => message.trim())
-      .filter((message) => message.length > 0) ?? [];
+  sentMessageHistoryHtmlRef.current = sentMessageHistoryHtml ?? [];
   const threadKey = getChatThreadKey(threadRef);
   const {
     extensionVersion,
@@ -648,6 +651,16 @@ export const useChatEditor = ({
       const currentHtml = getEditorHtml(targetEditor);
       if (currentIndex === null && currentHtml !== "") {
         return false;
+      }
+
+      if (currentIndex !== null) {
+        const isAtHistoryBoundary =
+          event.key === "ArrowUp"
+            ? isSelectionAtStart(state)
+            : isSelectionAtEnd(state);
+        if (!isAtHistoryBoundary) {
+          return false;
+        }
       }
 
       let nextIndex: number | null = null;

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatPart } from "@/components/chat/chat-ui-tools";
 import {
   getChatToolTitleKey,
+  getUserMessageHtmlHistory,
   hasApprovedActiveDocxEditAwaitingClientOutput,
   isApprovalPart,
 } from "@/components/chat/chat-ui-tools";
@@ -98,5 +99,53 @@ describe("hasApprovedActiveDocxEditAwaitingClientOutput", () => {
         ],
       }),
     ).toBe(false);
+  });
+});
+
+describe("getUserMessageHtmlHistory", () => {
+  test("returns user message HTML from newest to oldest", () => {
+    expect(
+      getUserMessageHtmlHistory([
+        {
+          id: "message-1",
+          parts: [{ text: "Older prompt", type: "text" }],
+          role: "user",
+        },
+        {
+          id: "message-2",
+          parts: [{ text: "Assistant response", type: "text" }],
+          role: "assistant",
+        },
+        {
+          id: "message-3",
+          parts: [{ text: "Latest prompt", type: "text" }],
+          role: "user",
+        },
+      ]),
+    ).toEqual(["Latest prompt", "Older prompt"]);
+  });
+
+  test("skips user messages without text", () => {
+    expect(
+      getUserMessageHtmlHistory([
+        {
+          id: "message-1",
+          parts: [{ text: "Reusable prompt", type: "text" }],
+          role: "user",
+        },
+        {
+          id: "message-2",
+          parts: [
+            {
+              filename: "contract.pdf",
+              mediaType: "application/pdf",
+              type: "file",
+              url: "https://example.com/contract.pdf",
+            },
+          ],
+          role: "user",
+        },
+      ]),
+    ).toEqual(["Reusable prompt"]);
   });
 });

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -148,4 +148,21 @@ describe("getUserMessageHtmlHistory", () => {
       ]),
     ).toEqual(["Reusable prompt"]);
   });
+
+  test("trims history entries and skips whitespace-only text", () => {
+    expect(
+      getUserMessageHtmlHistory([
+        {
+          id: "message-1",
+          parts: [{ text: "   ", type: "text" }],
+          role: "user",
+        },
+        {
+          id: "message-2",
+          parts: [{ text: "\n<p>Clean prompt</p>\n", type: "text" }],
+          role: "user",
+        },
+      ]),
+    ).toEqual(["<p>Clean prompt</p>"]);
+  });
 });

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -106,3 +106,29 @@ export const hasApprovedActiveDocxEditAwaitingClientOutput = ({
 
   return message.parts.some(isApprovedActiveDocxEditPart);
 };
+
+export const getUserMessageHtmlHistory = (
+  messages: readonly PersistedChatMessage[],
+) => {
+  const history: string[] = [];
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages.at(index);
+    if (!message || message.role !== "user") {
+      continue;
+    }
+
+    const textParts: string[] = [];
+    for (const part of message.parts) {
+      if (part.type === "text" && part.text.trim()) {
+        textParts.push(part.text);
+      }
+    }
+
+    if (textParts.length > 0) {
+      history.push(textParts.join("\n\n"));
+    }
+  }
+
+  return history;
+};

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -125,8 +125,9 @@ export const getUserMessageHtmlHistory = (
       }
     }
 
-    if (textParts.length > 0) {
-      history.push(textParts.join("\n\n"));
+    const content = textParts.join("\n\n").trim();
+    if (content) {
+      history.push(content);
     }
   }
 

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -15,6 +15,7 @@ import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
+import { getUserMessageHtmlHistory } from "@/components/chat/chat-ui-tools";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import Tooltip from "@/components/tooltip";
@@ -51,7 +52,6 @@ export const ChatThreadPage = ({
   const userContext = useChatUserContext();
   const getUserContext = useEffectEvent(() => userContext);
   const showToolCalls = useDevStore((state) => state.showToolCalls);
-  const controller = useChatEditor({ threadRef });
   const prompts = useSavedPrompts();
 
   // Local copy of the persisted contextMatterIds, seeded from the
@@ -110,6 +110,10 @@ export const ChatThreadPage = ({
     streamdownComponents,
     approvalPendingMessageId,
   } = useChatSession({ chat, workspaceId });
+  const controller = useChatEditor({
+    sentMessageHistoryHtml: getUserMessageHtmlHistory(messages),
+    threadRef,
+  });
 
   const openInspectorChat = useInspectorStore((s) => s.openChat);
   const navigate = useNavigate();

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -1,4 +1,4 @@
-import { useEffectEvent, useState } from "react";
+import { useEffectEvent, useMemo, useState } from "react";
 
 import { Button, buttonVariants } from "@stll/ui/components/button";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
@@ -110,8 +110,12 @@ export const ChatThreadPage = ({
     streamdownComponents,
     approvalPendingMessageId,
   } = useChatSession({ chat, workspaceId });
+  const sentMessageHistoryHtml = useMemo(
+    () => getUserMessageHtmlHistory(messages),
+    [messages],
+  );
   const controller = useChatEditor({
-    sentMessageHistoryHtml: getUserMessageHtmlHistory(messages),
+    sentMessageHistoryHtml,
     threadRef,
   });
 


### PR DESCRIPTION
Adds keyboard history navigation to the chat composer so users can recall prior prompts with ArrowUp and move forward again with ArrowDown. The behavior stays inactive while suggestions are open, attachments are present, or the composer contains a manually edited draft.