### PR TITLE
fix: make search dialog escape control clickable

### DIFF
--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -362,6 +362,14 @@ export const SearchDialog = ({
     summarizeSearchMutation.reset();
   };
 
+  const handleEscapeAction = () => {
+    if (query.trim() || debouncedQuery.trim()) {
+      clearSearchQuery();
+      return;
+    }
+    onOpenChange(false);
+  };
+
   const handleSummarizeResults = () => {
     const trimmedQuery = searchQuery.trim();
     if (!trimmedQuery || summarizeSearchMutation.isPending) {
@@ -712,9 +720,16 @@ export const SearchDialog = ({
                 <WandSparklesIcon className="size-4" />
               )}
             </Button>
-            <kbd className="bg-muted text-muted-foreground hidden rounded border px-1.5 py-0.5 text-[0.625rem] sm:inline-flex">
+            <Button
+              aria-keyshortcuts="Escape"
+              aria-label={t("search.escKey")}
+              className="bg-muted text-muted-foreground hover:bg-muted/80 hidden h-auto rounded border px-1.5 py-0.5 text-[0.625rem] leading-none sm:inline-flex"
+              onClick={handleEscapeAction}
+              title={t("search.escKey")}
+              variant="ghost"
+            >
               {t("search.escKey")}
-            </kbd>
+            </Button>
           </div>
 
           {/* Content area */}

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -613,7 +613,7 @@ export const SearchDialog = ({
     if (e.key === "Escape" && (query.trim() || debouncedQuery.trim())) {
       e.preventDefault();
       e.stopPropagation();
-      clearSearchQuery();
+      handleEscapeAction();
     }
   };
 
@@ -723,7 +723,7 @@ export const SearchDialog = ({
             <Button
               aria-keyshortcuts="Escape"
               aria-label={t("search.escKey")}
-              className="bg-muted text-muted-foreground hover:bg-muted/80 hidden h-auto rounded border px-1.5 py-0.5 text-[0.625rem] leading-none sm:inline-flex"
+              className="border-border bg-muted text-muted-foreground hover:bg-muted/80 hidden h-auto rounded border px-1.5 py-0.5 text-[0.625rem] leading-none sm:inline-flex"
               onClick={handleEscapeAction}
               title={t("search.escKey")}
               variant="ghost"


### PR DESCRIPTION
## Summary
- Replace the search dialog's static ESC hint with a clickable button.
- Reuse the same Escape behavior: clear a non-empty search first, otherwise close the dialog.