### PR TITLE
chore: add markdown version of webpage

### DIFF
--- a/apps/landing/public/index.md
+++ b/apps/landing/public/index.md
@@ -1,0 +1,32 @@
+# stella
+
+> Open-source legal workspace for mid-size law firms. Documents, matters, review, and research in one place.
+
+stella is built for firms that need control. Matters, documents, and search are free to use. AI-powered review, research, and drafting are billed by usage. stella is open source, self-hostable, exportable, and designed for privileged legal work.
+
+## Key facts
+
+- Apache-2.0 for open-source use; commercial licensing arrangements (support, indemnity, custom terms) are available alongside.
+- AI outputs are grounded by citations and traceable to source material.
+- Sensitive text can be anonymized before AI workflows.
+- The AI layer uses the AI SDK and remains provider-agnostic.
+- No lock-in: standard files, full export, and no per-seat pricing on the core workspace.
+
+## Start here
+
+- [Website](https://stll.app): Product overview and pricing.
+- [Application](https://my.stll.app): Start using stella in the cloud.
+- [Documentation](https://stll.app/docs): Product and self-hosting documentation.
+- [Contact](mailto:contact@stll.app): Deployment, pilots, and general questions.
+
+## Open source
+
+- [Repository](https://github.com/stella/stella): Source code, issues, and contributions.
+- [Manifesto](https://github.com/stella/stella/blob/main/MANIFESTO.md): Product principles and positioning.
+- [License](https://github.com/stella/stella/blob/main/LICENSE): Apache-2.0 license text.
+
+## Trust
+
+- [Security](https://stll.app/security): Security posture and deployment options.
+- [Imprint](https://stll.app/imprint): Company details and legal contact.
+


### PR DESCRIPTION
Adds a Markdown copy of the landing homepage at `/index.md`.