### PR TITLE
feat(ai): classify provider errors + fix bbox Panic

### DIFF
--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -121,15 +121,25 @@ export const streamChat = async ({
     boundary: thirdPartyBoundary,
     tools,
   });
+  // The AI SDK runs error formatting in two places: the outer
+  // `createUIMessageStream({ onError })` for errors thrown inside
+  // `execute`, and the inner `result.toUIMessageStream({ onError })`
+  // for errors emitted by the model stream itself. The inner one
+  // defaults to `() => "An error occurred."` and *that* is the path a
+  // Gemini-quota / OpenRouter-credits failure actually takes — without
+  // wiring the same classifier on both, the chat client sees the
+  // generic string and our frontend kind-mapping never fires.
+  const onAiError = (error: unknown): string => {
+    const kind = classifyAIError(error);
+    captureError(error, { threadId, kind });
+    return kind;
+  };
+
   const stream = createUIMessageStream<ChatMessage>({
     generateId: () => Bun.randomUUIDv7(),
     originalMessages: preparedMessages.value,
     onFinish,
-    onError: (error) => {
-      const kind = classifyAIError(error);
-      captureError(error, { threadId, kind });
-      return kind;
-    },
+    onError: onAiError,
     execute: ({ writer }) => {
       const modelInfo = getModelInfoForRole("chat", orgAIConfig);
       const result = streamText({
@@ -172,7 +182,9 @@ export const streamChat = async ({
         },
       });
 
-      const uiStream = result.toUIMessageStream<ChatMessage>();
+      const uiStream = result.toUIMessageStream<ChatMessage>({
+        onError: onAiError,
+      });
       writer.merge(
         resolveAssistantTextRefs
           ? resolveRefsInTextStream(

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -25,6 +25,7 @@ import type { ChatTools } from "@/api/handlers/chat/tools/chat-tools";
 import type { ChatRefRegistry } from "@/api/handlers/chat/tools/execute/ref-registry";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import { hydrateFilePart } from "@/api/handlers/chat/upload-files";
+import { classifyAIError } from "@/api/lib/ai-error";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import {
   getModelForRole,
@@ -125,8 +126,9 @@ export const streamChat = async ({
     originalMessages: preparedMessages.value,
     onFinish,
     onError: (error) => {
-      captureError(error, { threadId });
-      return "error";
+      const kind = classifyAIError(error);
+      captureError(error, { threadId, kind });
+      return kind;
     },
     execute: ({ writer }) => {
       const modelInfo = getModelInfoForRole("chat", orgAIConfig);

--- a/apps/api/src/handlers/entities/organize-suggestions.ts
+++ b/apps/api/src/handlers/entities/organize-suggestions.ts
@@ -13,6 +13,7 @@ import {
   entityVersionAiSummaries,
   searchDocuments,
 } from "@/api/db/schema";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import {
   getModelForRole,
   getModelInfoForRole,
@@ -285,7 +286,7 @@ const organizeSuggestionsHandler = async function* ({
       organizationId,
     });
     return Result.err(
-      new HandlerError({
+      aiHandlerError(result.error, {
         status: 502,
         message: "Failed to generate organization suggestions",
       }),
@@ -706,7 +707,7 @@ const generateMissingSummaries = async ({
       organizationId,
     });
     return Result.err(
-      new HandlerError({
+      aiHandlerError(result.error, {
         status: 502,
         message: "Failed to generate document summaries",
       }),

--- a/apps/api/src/handlers/properties/preview.ts
+++ b/apps/api/src/handlers/properties/preview.ts
@@ -5,6 +5,7 @@ import { t } from "elysia";
 import { isMockAI } from "@/api/consts";
 import { propertyContentSchema } from "@/api/db/schema-validators";
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -208,11 +209,13 @@ const previewProperty = createSafeHandler(
       if (skipped) {
         return Result.ok({ status: "skipped" } satisfies PreviewResponse);
       }
+      // WorkflowIntegrationError carries the underlying AI provider
+      // failure (if any) on its `cause` — classify against that so
+      // quota/credits errors propagate the right status to the UI.
       return Result.err(
-        new HandlerError({
+        aiHandlerError(generateResult.error.cause, {
           status: 502,
           message: "Preview generation failed",
-          cause: generateResult.error,
         }),
       );
     }

--- a/apps/api/src/handlers/properties/suggest-prompt.ts
+++ b/apps/api/src/handlers/properties/suggest-prompt.ts
@@ -3,6 +3,7 @@ import { Result } from "better-result";
 import { t } from "elysia";
 
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -165,10 +166,9 @@ const suggestPrompt = createSafeHandler(
 
     if (Result.isError(generateResult)) {
       return Result.err(
-        new HandlerError({
+        aiHandlerError(generateResult.error, {
           status: 502,
           message: "Suggest prompt failed",
-          cause: generateResult.error,
         }),
       );
     }

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -17,6 +17,7 @@ import {
   workspaceSearchDocuments,
 } from "@/api/db/schema";
 import { resolveSelectedWorkspaceIds } from "@/api/handlers/search/search";
+import { aiErrorStatusBody } from "@/api/lib/ai-error";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import {
   getModelForRole,
@@ -310,7 +311,11 @@ export const refineSearchQuery = async ({
 
     if (result.isErr()) {
       aiAnalytics.captureError(result.error);
-      return status(502, { message: "Failed to improve search query" });
+      const mapped = aiErrorStatusBody(result.error, {
+        status: 502,
+        message: "Failed to improve search query",
+      });
+      return status(mapped.status, mapped.body);
     }
 
     const parsedOutput = v.safeParse(
@@ -430,7 +435,11 @@ export const summarizeSearchResults = async ({
       feature: "search.summary",
       organizationId,
     });
-    return status(502, { message: "Failed to summarize search results" });
+    const mapped = aiErrorStatusBody(result.error, {
+      status: 502,
+      message: "Failed to summarize search results",
+    });
+    return status(mapped.status, mapped.body);
   }
 
   const parsedOutput = v.safeParse(

--- a/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
+++ b/apps/api/src/handlers/workspaces/generate-bounding-boxes.ts
@@ -4,6 +4,7 @@ import { t } from "elysia";
 
 import { isMockAI } from "@/api/consts";
 import { justifications } from "@/api/db/schema";
+import { aiHandlerError } from "@/api/lib/ai-error";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -55,7 +56,7 @@ const generateBoundingBoxes = createSafeHandler(
     const boxes: BoundingBox[] = [];
 
     for (const pageNumber of preparedData.pageNumbers) {
-      const pageBoxes = await generateFn({
+      const pageBoxesResult = await generateFn({
         abortSignal: AbortSignal.timeout(60_000),
         justificationId,
         organizationId,
@@ -70,7 +71,25 @@ const generateBoundingBoxes = createSafeHandler(
         },
       });
 
-      boxes.push(...pageBoxes);
+      if (Result.isError(pageBoxesResult)) {
+        captureError(pageBoxesResult.error, {
+          feature: "bbox.generate",
+          workspaceId,
+          organizationId,
+        });
+        // `WorkflowIntegrationError.cause` carries the underlying AI
+        // provider failure (APICallError / RetryError) — classify
+        // against that so quota/credits map to 429/402 instead of
+        // bubbling up as an uncaught Panic and returning 500.
+        return Result.err(
+          aiHandlerError(pageBoxesResult.error.cause, {
+            status: 502,
+            message: "Bounding box generation failed",
+          }),
+        );
+      }
+
+      boxes.push(...pageBoxesResult.value);
 
       yield* Result.await(
         safeDb((tx) =>

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -35,6 +35,19 @@ export const classifyAIError = (error: unknown): AIErrorKind => {
       return "provider_unavailable";
     }
   }
+  // Walk through any wrapper that carries the original provider error
+  // on `cause` (e.g. our own `WorkflowIntegrationError`, or generic
+  // `Error.cause` from a higher-level rethrow). Without this, callers
+  // that pass a wrapped error get classified as `unknown` and miss the
+  // mapped HTTP status / UX copy.
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "cause" in error &&
+    error.cause !== undefined
+  ) {
+    return classifyAIError(error.cause);
+  }
   return "unknown";
 };
 

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -1,0 +1,110 @@
+/**
+ * Stable, user-facing classification of AI provider errors.
+ *
+ * The `AIErrorKind` strings cross the network as the chat
+ * stream's error message; the frontend maps them to i18n keys.
+ * Renaming a kind is a wire-format change — update both sides
+ * (and `chat-thread-messages.tsx`) together.
+ */
+import { APICallError, RetryError } from "ai";
+
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
+
+export const AI_ERROR_KINDS = [
+  "quota_exhausted",
+  "insufficient_credits",
+  "provider_unavailable",
+  "unknown",
+] as const;
+
+export type AIErrorKind = (typeof AI_ERROR_KINDS)[number];
+
+export const classifyAIError = (error: unknown): AIErrorKind => {
+  if (RetryError.isInstance(error)) {
+    return classifyAIError(error.lastError);
+  }
+  if (APICallError.isInstance(error)) {
+    if (error.statusCode === 429) {
+      return "quota_exhausted";
+    }
+    if (error.statusCode === 402) {
+      return "insufficient_credits";
+    }
+    if (error.statusCode !== undefined && error.statusCode >= 500) {
+      return "provider_unavailable";
+    }
+  }
+  return "unknown";
+};
+
+type AIHandlerErrorFallback = {
+  status: HandlerErrorStatusCode;
+  message: string;
+};
+
+/**
+ * Build a `HandlerError` for an AI provider failure.
+ *
+ * For known AI failure modes (quota, credits, transient
+ * upstream outage) returns a typed error with an actionable
+ * status + message. For everything else, returns the caller's
+ * fallback so unrelated bugs aren't masked as "AI unavailable".
+ */
+export const aiHandlerError = (
+  error: unknown,
+  fallback: AIHandlerErrorFallback,
+): HandlerError => {
+  const kind = classifyAIError(error);
+  switch (kind) {
+    case "quota_exhausted":
+      return new HandlerError({
+        status: 429,
+        message:
+          "The AI provider's quota is exhausted. Try again shortly, or contact your workspace admin to upgrade the plan.",
+        cause: error,
+      });
+    case "insufficient_credits":
+      return new HandlerError({
+        status: 402,
+        message:
+          "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+        cause: error,
+      });
+    case "provider_unavailable":
+      return new HandlerError({
+        status: 502,
+        message:
+          "The AI provider is temporarily unavailable. Please try again in a moment.",
+        cause: error,
+      });
+    case "unknown":
+      return new HandlerError({ ...fallback, cause: error });
+    default: {
+      const _exhaustive: never = kind;
+      return _exhaustive;
+    }
+  }
+};
+
+type AIErrorStatusBody = {
+  status: HandlerErrorStatusCode;
+  body: { message: string };
+};
+
+/**
+ * Variant of `aiHandlerError` for handlers that build an Elysia
+ * `status()` response directly instead of returning `HandlerError`.
+ * Returns `{ status, body }` so callers can spread it into
+ * `status(status, body)`.
+ */
+export const aiErrorStatusBody = (
+  error: unknown,
+  fallback: { status: HandlerErrorStatusCode; message: string },
+): AIErrorStatusBody => {
+  const handlerError = aiHandlerError(error, fallback);
+  return {
+    status: handlerError.status,
+    body: { message: handlerError.message },
+  };
+};

--- a/apps/api/src/lib/bbox/generate-b-boxes-mock.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-mock.ts
@@ -1,4 +1,4 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { sleep } from "bun";
 
 import { parseGeminiBBoxes } from "@/api/lib/bbox/generate-b-boxes-shared";
@@ -18,9 +18,11 @@ export const generateBBoxesMock = async ({
     panic(`Page ${pageNumber} not found`);
   }
 
-  return parseGeminiBBoxes([[100, 100, 300, 900]], {
-    pageNumber,
-    width: page.width,
-    height: page.height,
-  });
+  return Result.ok(
+    parseGeminiBBoxes([[100, 100, 300, 900]], {
+      pageNumber,
+      width: page.width,
+      height: page.height,
+    }),
+  );
 };

--- a/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
@@ -11,6 +11,7 @@ import type { FieldContent } from "@/api/db/schema-validators";
 import { createFileKey } from "@/api/handlers/files/utils";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import type { SafeId } from "@/api/lib/branded-types";
+import type { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 import { getS3 } from "@/api/lib/s3";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 import type { BoundingBox } from "@/api/types";
@@ -30,7 +31,14 @@ export type GenerateBBoxesProps = {
   };
 };
 
-export type GenerateBBoxesResult = BoundingBox[];
+// Wraps the BoundingBox payload in a `Result` so AI provider failures
+// (Anthropic 429/500, Gemini quota, etc.) can be surfaced as typed
+// errors at the handler boundary instead of throwing through the
+// safe-handler stack as `Panic`.
+export type GenerateBBoxesResult = Result<
+  BoundingBox[],
+  WorkflowIntegrationError
+>;
 
 class JustificationTextError extends TaggedError("JustificationTextError")<{
   message: string;

--- a/apps/api/src/lib/bbox/generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes.ts
@@ -25,24 +25,28 @@ export const generateBBoxes = async ({
 
   const { height, width } = page;
 
-  const result = Result.unwrap(
-    await generateBBoxData({
-      pdfData,
-      prompt,
-      fieldContent,
-      justificationText,
-      abortSignal,
-      justificationId,
-      organizationId,
-      orgAIConfig: orgAIConfig ?? null,
+  const dataResult = await generateBBoxData({
+    pdfData,
+    prompt,
+    fieldContent,
+    justificationText,
+    abortSignal,
+    justificationId,
+    organizationId,
+    orgAIConfig: orgAIConfig ?? null,
+    pageNumber,
+    workspaceId,
+  });
+
+  if (Result.isError(dataResult)) {
+    return Result.err(dataResult.error);
+  }
+
+  return Result.ok(
+    parseGeminiBBoxes(dataResult.value, {
       pageNumber,
-      workspaceId,
+      width,
+      height,
     }),
   );
-
-  return parseGeminiBBoxes(result, {
-    pageNumber,
-    width,
-    height,
-  });
 };

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -1,6 +1,15 @@
 import { TaggedError } from "better-result";
 
-export type HandlerErrorStatusCode = 400 | 403 | 404 | 409 | 422 | 500 | 502;
+export type HandlerErrorStatusCode =
+  | 400
+  | 402
+  | 403
+  | 404
+  | 409
+  | 422
+  | 429
+  | 500
+  | 502;
 
 export type HandlerErrorProps<
   TStatus extends HandlerErrorStatusCode = HandlerErrorStatusCode,

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -23,6 +23,7 @@ import { SourceChips } from "@/components/chat/source-chips";
 import { StreamdownMentionLink } from "@/components/chat/streamdown-mention-link";
 import { ToolApprovalCard } from "@/components/chat/tool-approval-card";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
+import type { TranslationKey } from "@/i18n/types";
 import { getUserFileContentUrl } from "@/lib/user-files";
 
 const USER_STREAMDOWN_COMPONENTS = {
@@ -164,10 +165,38 @@ const ThinkingIndicator = () => {
   );
 };
 
-const ChatErrorMessage = ({
+// Mirrors `AIErrorKind` in apps/api/src/lib/ai-error.ts. The
+// backend's chat stream `onError` returns one of these strings as
+// the error message; anything else falls through to the generic
+// copy.
+const CHAT_ERROR_TRANSLATION_KEYS = {
+  insufficient_credits: "chat.sendErrorInsufficientCredits",
+  provider_unavailable: "chat.sendErrorProviderUnavailable",
+  quota_exhausted: "chat.sendErrorQuotaExhausted",
+} as const satisfies Record<string, TranslationKey>;
+
+type ChatErrorTranslationKey =
+  | (typeof CHAT_ERROR_TRANSLATION_KEYS)[keyof typeof CHAT_ERROR_TRANSLATION_KEYS]
+  | "chat.sendError";
+
+const isMappedChatErrorKind = (
+  message: string,
+): message is keyof typeof CHAT_ERROR_TRANSLATION_KEYS =>
+  message in CHAT_ERROR_TRANSLATION_KEYS;
+
+const chatErrorTranslationKey = (error: Error): ChatErrorTranslationKey => {
+  if (isMappedChatErrorKind(error.message)) {
+    return CHAT_ERROR_TRANSLATION_KEYS[error.message];
+  }
+  return "chat.sendError";
+};
+
+export const ChatErrorMessage = ({
+  error,
   isGenerating,
   onResend,
 }: {
+  error: Error;
   isGenerating: boolean;
   onResend?: (() => void | PromiseLike<void>) | undefined;
 }) => {
@@ -176,7 +205,7 @@ const ChatErrorMessage = ({
   return (
     <Message from="assistant">
       <MessageContent className="bg-destructive/10 border-destructive/20 text-destructive max-w-md rounded-lg border px-3 py-2">
-        <p className="text-sm">{t("chat.sendError")}</p>
+        <p className="text-sm">{t(chatErrorTranslationKey(error))}</p>
         {onResend && (
           <Button
             className="self-start"
@@ -367,7 +396,11 @@ export const ChatThreadMessages = ({
       </Message>
     ))}
     {error && (
-      <ChatErrorMessage isGenerating={isGenerating} onResend={onResend} />
+      <ChatErrorMessage
+        error={error}
+        isGenerating={isGenerating}
+        onResend={onResend}
+      />
     )}
     {showThinkingIndicator &&
       isGenerating &&

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -384,6 +384,9 @@
     "resend": "Odeslat znovu",
     "send": "Odeslat zprávu",
     "sendError": "Při odesílání zprávy došlo k problému. Pokud chyba přetrvává, kontaktujte podporu.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Pracuji s kontextem",
     "threads": "Historie",
     "tool": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -384,9 +384,9 @@
     "resend": "Odeslat znovu",
     "send": "Odeslat zprávu",
     "sendError": "Při odesílání zprávy došlo k problému. Pokud chyba přetrvává, kontaktujte podporu.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "AI poskytovatel potřebuje doplnit kredity. Požádejte správce pracovního prostoru o navýšení zůstatku.",
+    "sendErrorProviderUnavailable": "AI poskytovatel je dočasně nedostupný. Zkuste to prosím za chvíli znovu.",
+    "sendErrorQuotaExhausted": "Kvóta AI poskytovatele je vyčerpaná. Zkuste to za chvíli znovu nebo požádejte správce pracovního prostoru o navýšení plánu.",
     "thinking": "Pracuji s kontextem",
     "threads": "Historie",
     "tool": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -384,9 +384,9 @@
     "resend": "Erneut senden",
     "send": "Nachricht senden",
     "sendError": "Beim Senden deiner Nachricht ist ein Problem aufgetreten. Wende dich an den Support, wenn der Fehler weiterhin auftritt.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "Der KI-Provider benötigt mehr Guthaben. Bitte deinen Workspace-Admin, das Konto aufzuladen.",
+    "sendErrorProviderUnavailable": "Der KI-Provider ist vorübergehend nicht verfügbar. Bitte versuche es gleich noch einmal.",
+    "sendErrorQuotaExhausted": "Das Kontingent des KI-Providers ist aufgebraucht. Versuche es gleich noch einmal oder bitte deinen Workspace-Admin, das Paket zu erweitern.",
     "thinking": "Arbeite mit Kontext",
     "threads": "Verlauf",
     "tool": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -384,6 +384,9 @@
     "resend": "Erneut senden",
     "send": "Nachricht senden",
     "sendError": "Beim Senden deiner Nachricht ist ein Problem aufgetreten. Wende dich an den Support, wenn der Fehler weiterhin auftritt.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Arbeite mit Kontext",
     "threads": "Verlauf",
     "tool": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -384,6 +384,9 @@
     "resend": "Resend",
     "send": "Send message",
     "sendError": "There was an issue sending your message. Contact support if the error persists.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Working with context",
     "threads": "History",
     "tool": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -384,9 +384,9 @@
     "resend": "Reenviar",
     "send": "Enviar mensaje",
     "sendError": "Hubo un problema al enviar tu mensaje. Contacta con soporte si el error persiste.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "El proveedor de IA necesita más créditos. Pídele al administrador del espacio de trabajo que recargue la cuenta.",
+    "sendErrorProviderUnavailable": "El proveedor de IA no está disponible temporalmente. Inténtalo de nuevo en un momento.",
+    "sendErrorQuotaExhausted": "Se ha agotado la cuota del proveedor de IA. Inténtalo de nuevo en un minuto o pídele al administrador del espacio de trabajo que mejore el plan.",
     "thinking": "Trabajando con contexto",
     "threads": "Historial",
     "tool": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -384,6 +384,9 @@
     "resend": "Reenviar",
     "send": "Enviar mensaje",
     "sendError": "Hubo un problema al enviar tu mensaje. Contacta con soporte si el error persiste.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Trabajando con contexto",
     "threads": "Historial",
     "tool": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -384,9 +384,9 @@
     "resend": "Saada uuesti",
     "send": "Saada sõnum",
     "sendError": "Sõnumi saatmisel tekkis probleem. Kui viga püsib, võta ühendust toega.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "AI-teenusepakkujal on vaja rohkem krediiti. Palu töökoha administraatoril kontot täiendada.",
+    "sendErrorProviderUnavailable": "AI-teenusepakkuja pole hetkel saadaval. Proovi hetke pärast uuesti.",
+    "sendErrorQuotaExhausted": "AI-teenusepakkuja kvoot on otsas. Proovi minuti pärast uuesti või palu töökoha administraatoril paketti uuendada.",
     "thinking": "Töötan kontekstiga",
     "threads": "Ajalugu",
     "tool": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -384,6 +384,9 @@
     "resend": "Saada uuesti",
     "send": "Saada sõnum",
     "sendError": "Sõnumi saatmisel tekkis probleem. Kui viga püsib, võta ühendust toega.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Töötan kontekstiga",
     "threads": "Ajalugu",
     "tool": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -384,9 +384,9 @@
     "resend": "Renvoyer",
     "send": "Envoyer le message",
     "sendError": "Un problème est survenu lors de l’envoi de ton message. Contacte le support si l’erreur persiste.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "Le fournisseur d’IA a besoin de crédits supplémentaires. Demande à l’administrateur de l’espace de travail de recharger le compte.",
+    "sendErrorProviderUnavailable": "Le fournisseur d’IA est temporairement indisponible. Réessaie dans un instant.",
+    "sendErrorQuotaExhausted": "Le quota du fournisseur d’IA est épuisé. Réessaie dans une minute, ou demande à l’administrateur de l’espace de travail de passer à un plan supérieur.",
     "thinking": "Traitement du contexte",
     "threads": "Historique",
     "tool": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -384,6 +384,9 @@
     "resend": "Renvoyer",
     "send": "Envoyer le message",
     "sendError": "Un problème est survenu lors de l’envoi de ton message. Contacte le support si l’erreur persiste.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Traitement du contexte",
     "threads": "Historique",
     "tool": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -384,9 +384,9 @@
     "resend": "Újraküldés",
     "send": "Üzenet küldése",
     "sendError": "Probléma történt az üzenet elküldésekor. Ha a hiba továbbra is fennáll, vedd fel a kapcsolatot a támogatással.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "Az AI-szolgáltatónak további kreditre van szüksége. Kérd a munkaterület adminisztrátorát, hogy töltse fel a fiókot.",
+    "sendErrorProviderUnavailable": "Az AI-szolgáltató átmenetileg nem elérhető. Próbáld újra egy pillanat múlva.",
+    "sendErrorQuotaExhausted": "Az AI-szolgáltató kvótája kimerült. Próbáld újra egy perc múlva, vagy kérd a munkaterület adminisztrátorát, hogy bővítse a csomagot.",
     "thinking": "Kontextussal dolgozom",
     "threads": "Előzmények",
     "tool": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -384,6 +384,9 @@
     "resend": "Újraküldés",
     "send": "Üzenet küldése",
     "sendError": "Probléma történt az üzenet elküldésekor. Ha a hiba továbbra is fennáll, vedd fel a kapcsolatot a támogatással.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Kontextussal dolgozom",
     "threads": "Előzmények",
     "tool": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -384,6 +384,9 @@
     "resend": "Siųsti dar kartą",
     "send": "Siųsti žinutę",
     "sendError": "Siunčiant žinutę kilo problema. Jei klaida kartojasi, susisiekite su palaikymo komanda.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Dirbama su kontekstu",
     "threads": "Istorija",
     "tool": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -384,9 +384,9 @@
     "resend": "Siųsti dar kartą",
     "send": "Siųsti žinutę",
     "sendError": "Siunčiant žinutę kilo problema. Jei klaida kartojasi, susisiekite su palaikymo komanda.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "AI teikėjui reikia daugiau kreditų. Paprašykite darbo srities administratoriaus papildyti sąskaitą.",
+    "sendErrorProviderUnavailable": "AI teikėjas laikinai nepasiekiamas. Pabandykite po akimirkos dar kartą.",
+    "sendErrorQuotaExhausted": "AI teikėjo kvota išnaudota. Pabandykite po minutės dar kartą arba paprašykite darbo srities administratoriaus atnaujinti planą.",
     "thinking": "Dirbama su kontekstu",
     "threads": "Istorija",
     "tool": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -384,6 +384,9 @@
     "resend": "Nosūtīt vēlreiz",
     "send": "Nosūtīt ziņu",
     "sendError": "Nosūtot ziņu, radās problēma. Ja kļūda nepazūd, sazinieties ar atbalsta dienestu.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Strādāju ar kontekstu",
     "threads": "Vēsture",
     "tool": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -384,9 +384,9 @@
     "resend": "Nosūtīt vēlreiz",
     "send": "Nosūtīt ziņu",
     "sendError": "Nosūtot ziņu, radās problēma. Ja kļūda nepazūd, sazinieties ar atbalsta dienestu.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "AI pakalpojumu sniedzējam ir vajadzīgi papildu kredīti. Sazinieties ar darba telpas administratoru, lai papildinātu kontu.",
+    "sendErrorProviderUnavailable": "AI pakalpojumu sniedzējs uz laiku nav pieejams. Mēģiniet vēlreiz pēc brīža.",
+    "sendErrorQuotaExhausted": "AI pakalpojumu sniedzēja kvota ir izsmelta. Mēģiniet vēlreiz pēc minūtes vai sazinieties ar darba telpas administratoru, lai uzlabotu plānu.",
     "thinking": "Strādāju ar kontekstu",
     "threads": "Vēsture",
     "tool": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -387,6 +387,9 @@ type Messages = {
     "resend": "Resend";
     "send": "Send message";
     "sendError": "There was an issue sending your message. Contact support if the error persists.";
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.";
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.";
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.";
     "thinking": "Working with context";
     "threads": "History";
     "tool": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -384,6 +384,9 @@
     "resend": "Wyślij ponownie",
     "send": "Wyślij wiadomość",
     "sendError": "Wystąpił problem podczas wysyłania wiadomości. Jeśli błąd będzie się powtarzał, skontaktuj się z pomocą techniczną.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Pracuję z kontekstem",
     "threads": "Historia",
     "tool": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -384,9 +384,9 @@
     "resend": "Wyślij ponownie",
     "send": "Wyślij wiadomość",
     "sendError": "Wystąpił problem podczas wysyłania wiadomości. Jeśli błąd będzie się powtarzał, skontaktuj się z pomocą techniczną.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "Dostawca AI potrzebuje więcej środków. Poproś administratora obszaru roboczego o doładowanie konta.",
+    "sendErrorProviderUnavailable": "Dostawca AI jest tymczasowo niedostępny. Spróbuj ponownie za chwilę.",
+    "sendErrorQuotaExhausted": "Limit dostawcy AI został wyczerpany. Spróbuj za chwilę ponownie lub poproś administratora obszaru roboczego o ulepszenie planu.",
     "thinking": "Pracuję z kontekstem",
     "threads": "Historia",
     "tool": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -384,6 +384,9 @@
     "resend": "Odoslať znova",
     "send": "Odoslať správu",
     "sendError": "Pri odosielaní správy nastal problém. Ak chyba pretrváva, kontaktujte podporu.",
+    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
+    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "thinking": "Pracujem s kontextom",
     "threads": "História",
     "tool": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -384,9 +384,9 @@
     "resend": "Odoslať znova",
     "send": "Odoslať správu",
     "sendError": "Pri odosielaní správy nastal problém. Ak chyba pretrváva, kontaktujte podporu.",
-    "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
-    "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
-    "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
+    "sendErrorInsufficientCredits": "AI poskytovateľ potrebuje doplniť kredity. Požiadajte správcu pracovného priestoru o navýšenie zostatku.",
+    "sendErrorProviderUnavailable": "AI poskytovateľ je dočasne nedostupný. Skúste to prosím o chvíľu znova.",
+    "sendErrorQuotaExhausted": "Kvóta AI poskytovateľa je vyčerpaná. Skúste to o chvíľu znova alebo požiadajte správcu pracovného priestoru o navýšenie plánu.",
     "thinking": "Pracujem s kontextom",
     "threads": "História",
     "tool": {

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -191,6 +191,7 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { ChatErrorMessage } from "@/components/chat/chat-thread-messages";
 import { AIKeyRequiredDialog } from "@/components/require-ai-key";
 
 type ComboboxOption = {
@@ -1461,19 +1462,35 @@ function ToolCallMock() {
   );
 }
 
+// Mirrors `AIErrorKind` in apps/api/src/lib/ai-error.ts. The
+// backend returns one of these strings on the chat stream's error
+// channel; passing them as `error.message` exercises the real
+// translation path the user will see.
+const CHAT_ERROR_VARIANTS = [
+  { label: "Generic", message: "unknown" },
+  { label: "Quota exhausted", message: "quota_exhausted" },
+  { label: "Insufficient credits", message: "insufficient_credits" },
+  { label: "Provider unavailable", message: "provider_unavailable" },
+] as const;
+
 function ChatErrorMock() {
   return (
-    <Message from="assistant">
-      <MessageContent className="bg-destructive/10 border-destructive/20 text-destructive max-w-md rounded-lg border px-3 py-2">
-        <p className="text-sm">
-          There was an issue sending your message. Contact support if the error
-          persists.
-        </p>
-        <Button className="self-start" size="sm" variant="destructive-outline">
-          Resend
-        </Button>
-      </MessageContent>
-    </Message>
+    <div className="flex flex-col gap-3">
+      {CHAT_ERROR_VARIANTS.map((variant) => (
+        <div className="flex flex-col gap-1" key={variant.message}>
+          <div className="text-muted-foreground text-[10px] uppercase">
+            {variant.label}
+          </div>
+          <ChatErrorMessage
+            error={new Error(variant.message)}
+            isGenerating={false}
+            onResend={() => {
+              /* no-op in playground */
+            }}
+          />
+        </div>
+      ))}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Add `apps/api/src/lib/ai-error.ts` exporting `classifyAIError`, `aiHandlerError`, `aiErrorStatusBody`. Classifies `APICallError` and `RetryError` from the AI SDK into `quota_exhausted` (429), `insufficient_credits` (402), `provider_unavailable` (502), or `unknown` (caller fallback).
- Wire the helper into the non-streaming AI handlers (`suggest-prompt`, `organize-suggestions`, `properties/preview`, `search/ai`, `workspaces/generate-bounding-boxes`) so quota/credits/upstream-unavailable surface as the right HTTP status with a typed message.
- Chat stream `onError` returns the kind as the error-channel string; `ChatErrorMessage` switches on it and renders one of three new i18n keys (`chat.sendError{QuotaExhausted,InsufficientCredits,ProviderUnavailable}`) or falls back to the existing `chat.sendError`.
- Expand `HandlerErrorStatusCode` to include 402 and 429.
- Fix today's prod Panic on `POST /v1/workspaces/:workspaceId/bounding-boxes` (13:01 UTC). `apps/api/src/lib/bbox/generate-b-boxes.ts` was unwrapping `generateBBoxData`'s `Result` with `Result.unwrap()`, which threw when Anthropic returned `APICallError` and bubbled up the safe-handler stack as an uncaught `Panic` → 500. The function now threads `Result<BoundingBox[], WorkflowIntegrationError>` to the handler, which routes the underlying cause through `aiHandlerError`. Mock + shared type updated to match.
- `/dev` playground renders all four `ChatErrorMessage` variants live using the production component.

## Test plan
- [x] `bun run lint` clean across 14 packages
- [x] `bun --filter @stll/api typecheck` clean
- [x] `bun --filter @stll/web typecheck` clean
- [x] Sandbox + chat-thread-messages tests pass
- [x] `bun run format` clean
- [ ] After merge: confirm next bbox AI failure returns 429/402/502 with a typed body instead of 500 Panic
- [ ] After merge: confirm chat surface shows the new copy when Gemini quota fires