### PR TITLE
chore: add upstream docx-editor changes + few additional docx fidelity slips

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -69,6 +69,7 @@ import type {
 import type { DocxCompatibility } from "../core/docx/compatibility";
 import { repackDocx } from "../core/docx/rezip";
 import { attemptSelectiveSave } from "../core/docx/selectiveSave";
+import { findBodyPmAnchors } from "../core/layout-bridge/findBodyPmSpans";
 // ProseMirror editor
 import {
   TextSelection,
@@ -537,9 +538,7 @@ function findSelectionYPosition(
   if (!pagesEl) {
     return null;
   }
-  const elements = pagesEl.querySelectorAll("[data-pm-start]");
-  for (const node of elements) {
-    const el = node as HTMLElement;
+  for (const el of findBodyPmAnchors(pagesEl)) {
     const pmStart = Number(el.dataset["pmStart"]);
     const pmEnd = Number(el.dataset["pmEnd"]);
     if (pmPos >= pmStart && pmPos <= pmEnd) {

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.test.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  DocumentBody,
+  Paragraph,
+  SectionProperties,
+} from "../../core/types/document";
+import { resolveEffectiveSectionProperties } from "./useHeaderFooterEditor";
+
+const paragraph: Paragraph = {
+  type: "paragraph",
+  content: [],
+};
+
+describe("resolveEffectiveSectionProperties", () => {
+  test("uses the first content section instead of an empty final section", () => {
+    const firstSection: SectionProperties = {
+      marginTop: 1296,
+      headerDistance: 288,
+      titlePg: true,
+    };
+    const emptyFinalSection: SectionProperties = {
+      marginTop: 1728,
+      headerDistance: 1872,
+      titlePg: true,
+    };
+    const body: DocumentBody = {
+      content: [paragraph],
+      sections: [
+        {
+          properties: firstSection,
+          content: [paragraph],
+        },
+        {
+          properties: emptyFinalSection,
+          content: [],
+        },
+      ],
+      finalSectionProperties: emptyFinalSection,
+    };
+
+    expect(resolveEffectiveSectionProperties(body, true)).toBe(firstSection);
+  });
+
+  test("preserves title-page mode when inherited from header references", () => {
+    const firstSection: SectionProperties = {
+      headerDistance: 288,
+    };
+    const body: DocumentBody = {
+      content: [paragraph],
+      sections: [
+        {
+          properties: firstSection,
+          content: [paragraph],
+        },
+      ],
+    };
+
+    expect(resolveEffectiveSectionProperties(body, true)).toEqual({
+      headerDistance: 288,
+      titlePg: true,
+    });
+  });
+});

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -9,6 +9,7 @@ import type { RefObject } from "react";
 import { proseDocToBlocks } from "../../core/prosemirror/conversion/fromProseDoc";
 import type {
   Document,
+  DocumentBody,
   HeaderFooter,
   SectionProperties,
   Paragraph,
@@ -60,6 +61,21 @@ type UseHeaderFooterEditorReturn = {
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
+
+export function resolveEffectiveSectionProperties(
+  documentBody: DocumentBody | undefined,
+  hasTitlePg: boolean,
+): SectionProperties | undefined {
+  const firstContentSection = documentBody?.sections?.find(
+    (section) => section.content.length > 0,
+  );
+  const base =
+    firstContentSection?.properties ?? documentBody?.finalSectionProperties;
+  if (!hasTitlePg || base?.titlePg) {
+    return base;
+  }
+  return base ? { ...base, titlePg: true } : base;
+}
 
 export const useHeaderFooterEditor = ({
   history,
@@ -215,13 +231,14 @@ export const useHeaderFooterEditor = ({
   // Effective section properties (titlePg merged)
   // -------------------------------------------------------------------------
 
-  const effectiveSectionProperties = useMemo(() => {
-    const final = history.state?.package.document?.finalSectionProperties;
-    if (!hasTitlePg || final?.titlePg) {
-      return final;
-    }
-    return final ? { ...final, titlePg: true } : final;
-  }, [history.state?.package.document?.finalSectionProperties, hasTitlePg]);
+  const effectiveSectionProperties = useMemo(
+    () =>
+      resolveEffectiveSectionProperties(
+        history.state?.package.document,
+        hasTitlePg,
+      ),
+    [history.state?.package.document, hasTitlePg],
+  );
 
   // -------------------------------------------------------------------------
   // Callbacks

--- a/packages/folio/src/core/docx/footnoteParser-table.test.ts
+++ b/packages/folio/src/core/docx/footnoteParser-table.test.ts
@@ -31,6 +31,34 @@ const ENDNOTE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   </w:endnote>
 </w:endnotes>`;
 
+const ALT_PREFIX_FOOTNOTE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<n:footnotes xmlns:n="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <n:footnote n:id="1">
+    <n:p><n:r><n:t>intro paragraph</n:t></n:r></n:p>
+    <n:tbl>
+      <n:tr>
+        <n:tc>
+          <n:p><n:r><n:t>cell text</n:t></n:r></n:p>
+        </n:tc>
+      </n:tr>
+    </n:tbl>
+  </n:footnote>
+</n:footnotes>`;
+
+const ALT_PREFIX_ENDNOTE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<n:endnotes xmlns:n="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <n:endnote n:id="1">
+    <n:p><n:r><n:t>endnote intro</n:t></n:r></n:p>
+    <n:tbl>
+      <n:tr>
+        <n:tc>
+          <n:p><n:r><n:t>endnote cell</n:t></n:r></n:p>
+        </n:tc>
+      </n:tr>
+    </n:tbl>
+  </n:endnote>
+</n:endnotes>`;
+
 describe("footnoteParser table content", () => {
   test("preserves footnote tables in document order", () => {
     const map = parseFootnotes(FOOTNOTE_XML);
@@ -46,6 +74,28 @@ describe("footnoteParser table content", () => {
 
   test("preserves endnote tables in document order", () => {
     const map = parseEndnotes(ENDNOTE_XML);
+    const endnote = map.byId.get(1);
+
+    expect(endnote).toBeDefined();
+    expect(endnote?.content.map((block) => block.type)).toEqual([
+      "paragraph",
+      "table",
+    ]);
+  });
+
+  test("parses footnote block content with alternate namespace prefixes", () => {
+    const map = parseFootnotes(ALT_PREFIX_FOOTNOTE_XML);
+    const footnote = map.byId.get(1);
+
+    expect(footnote).toBeDefined();
+    expect(footnote?.content.map((block) => block.type)).toEqual([
+      "paragraph",
+      "table",
+    ]);
+  });
+
+  test("parses endnote block content with alternate namespace prefixes", () => {
+    const map = parseEndnotes(ALT_PREFIX_ENDNOTE_XML);
     const endnote = map.byId.get(1);
 
     expect(endnote).toBeDefined();

--- a/packages/folio/src/core/docx/footnoteParser-table.test.ts
+++ b/packages/folio/src/core/docx/footnoteParser-table.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseEndnotes, parseFootnotes } from "./footnoteParser";
+
+const FOOTNOTE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:footnote w:id="1">
+    <w:p><w:r><w:t>intro paragraph</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr>
+        <w:tc>
+          <w:p><w:r><w:t>cell text</w:t></w:r></w:p>
+        </w:tc>
+      </w:tr>
+    </w:tbl>
+    <w:p><w:r><w:t>after table</w:t></w:r></w:p>
+  </w:footnote>
+</w:footnotes>`;
+
+const ENDNOTE_XML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:endnote w:id="1">
+    <w:p><w:r><w:t>endnote intro</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr>
+        <w:tc>
+          <w:p><w:r><w:t>endnote cell</w:t></w:r></w:p>
+        </w:tc>
+      </w:tr>
+    </w:tbl>
+  </w:endnote>
+</w:endnotes>`;
+
+describe("footnoteParser table content", () => {
+  test("preserves footnote tables in document order", () => {
+    const map = parseFootnotes(FOOTNOTE_XML);
+    const footnote = map.byId.get(1);
+
+    expect(footnote).toBeDefined();
+    expect(footnote?.content.map((block) => block.type)).toEqual([
+      "paragraph",
+      "table",
+      "paragraph",
+    ]);
+  });
+
+  test("preserves endnote tables in document order", () => {
+    const map = parseEndnotes(ENDNOTE_XML);
+    const endnote = map.byId.get(1);
+
+    expect(endnote).toBeDefined();
+    expect(endnote?.content.map((block) => block.type)).toEqual([
+      "paragraph",
+      "table",
+    ]);
+  });
+});

--- a/packages/folio/src/core/docx/footnoteParser.ts
+++ b/packages/folio/src/core/docx/footnoteParser.ts
@@ -34,9 +34,9 @@ import { parseTable } from "./tableParser";
 import {
   parseXml,
   findChildren,
-  getAttribute,
   getChildElements,
-  parseNumericAttribute,
+  getAttributes,
+  getLocalName,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
@@ -118,6 +118,29 @@ function parseNoteType(
   }
 }
 
+function getNoteAttribute(
+  element: XmlElement,
+  localName: "id" | "type",
+): string | null {
+  for (const [name, value] of Object.entries(getAttributes(element))) {
+    if (getLocalName(name) === localName) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function parseNoteId(element: XmlElement): number {
+  const id = getNoteAttribute(element, "id");
+  if (id === null) {
+    return 0;
+  }
+
+  const parsed = Number.parseInt(id, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
 // ============================================================================
 // FOOTNOTE PARSING
 // ============================================================================
@@ -133,9 +156,10 @@ function parseNoteBlockContent(
   const blocks: (Paragraph | Table)[] = [];
 
   for (const child of getChildElements(element)) {
-    if (child.name === "w:p") {
+    const localName = getLocalName(child.name ?? "");
+    if (localName === "p") {
       blocks.push(parseParagraph(child, styles, theme, numbering, rels));
-    } else if (child.name === "w:tbl") {
+    } else if (localName === "tbl") {
       blocks.push(parseTable(child, styles, theme, numbering, rels, media));
     }
   }
@@ -154,8 +178,8 @@ function parseFootnote(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
 ): Footnote {
-  const id = parseNumericAttribute(element, "w", "id") ?? 0;
-  const typeAttr = getAttribute(element, "w", "type");
+  const id = parseNoteId(element);
+  const typeAttr = getNoteAttribute(element, "type");
   const noteType = parseNoteType(typeAttr);
 
   const content = parseNoteBlockContent(
@@ -277,8 +301,8 @@ function parseEndnote(
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
 ): Endnote {
-  const id = parseNumericAttribute(element, "w", "id") ?? 0;
-  const typeAttr = getAttribute(element, "w", "type");
+  const id = parseNoteId(element);
+  const typeAttr = getNoteAttribute(element, "type");
   const noteType = parseNoteType(typeAttr);
 
   const content = parseNoteBlockContent(

--- a/packages/folio/src/core/docx/footnoteParser.ts
+++ b/packages/folio/src/core/docx/footnoteParser.ts
@@ -22,6 +22,7 @@ import type {
   Footnote,
   Endnote,
   Paragraph,
+  Table,
   Theme,
   RelationshipMap,
   MediaFile,
@@ -29,10 +30,12 @@ import type {
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
 import type { StyleMap } from "./styleParser";
+import { parseTable } from "./tableParser";
 import {
   parseXml,
   findChildren,
   getAttribute,
+  getChildElements,
   parseNumericAttribute,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
@@ -119,6 +122,27 @@ function parseNoteType(
 // FOOTNOTE PARSING
 // ============================================================================
 
+function parseNoteBlockContent(
+  element: XmlElement,
+  styles: StyleMap | null,
+  theme: Theme | null,
+  numbering: NumberingMap | null,
+  rels: RelationshipMap | null,
+  media: Map<string, MediaFile> | null,
+): (Paragraph | Table)[] {
+  const blocks: (Paragraph | Table)[] = [];
+
+  for (const child of getChildElements(element)) {
+    if (child.name === "w:p") {
+      blocks.push(parseParagraph(child, styles, theme, numbering, rels));
+    } else if (child.name === "w:tbl") {
+      blocks.push(parseTable(child, styles, theme, numbering, rels, media));
+    }
+  }
+
+  return blocks;
+}
+
 /**
  * Parse a single footnote element (w:footnote)
  */
@@ -128,16 +152,19 @@ function parseFootnote(
   theme: Theme | null,
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
-  _media: Map<string, MediaFile> | null,
+  media: Map<string, MediaFile> | null,
 ): Footnote {
   const id = parseNumericAttribute(element, "w", "id") ?? 0;
   const typeAttr = getAttribute(element, "w", "type");
   const noteType = parseNoteType(typeAttr);
 
-  // Parse content paragraphs
-  const paragraphElements = findChildren(element, "w", "p");
-  const content: Paragraph[] = paragraphElements.map((pEl) =>
-    parseParagraph(pEl, styles, theme, numbering, rels),
+  const content = parseNoteBlockContent(
+    element,
+    styles,
+    theme,
+    numbering,
+    rels,
+    media,
   );
 
   return {
@@ -248,16 +275,19 @@ function parseEndnote(
   theme: Theme | null,
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
-  _media: Map<string, MediaFile> | null,
+  media: Map<string, MediaFile> | null,
 ): Endnote {
   const id = parseNumericAttribute(element, "w", "id") ?? 0;
   const typeAttr = getAttribute(element, "w", "type");
   const noteType = parseNoteType(typeAttr);
 
-  // Parse content paragraphs
-  const paragraphElements = findChildren(element, "w", "p");
-  const content: Paragraph[] = paragraphElements.map((pEl) =>
-    parseParagraph(pEl, styles, theme, numbering, rels),
+  const content = parseNoteBlockContent(
+    element,
+    styles,
+    theme,
+    numbering,
+    rels,
+    media,
   );
 
   return {
@@ -373,6 +403,9 @@ export function getFootnoteText(footnote: Footnote): string {
   const texts: string[] = [];
 
   for (const para of footnote.content) {
+    if (para.type !== "paragraph") {
+      continue;
+    }
     const paraTexts: string[] = [];
     for (const content of para.content) {
       if (content.type === "run") {
@@ -396,6 +429,9 @@ export function getEndnoteText(endnote: Endnote): string {
   const texts: string[] = [];
 
   for (const para of endnote.content) {
+    if (para.type !== "paragraph") {
+      continue;
+    }
     const paraTexts: string[] = [];
     for (const content of para.content) {
       if (content.type === "run") {

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -264,46 +264,64 @@ export function serializeTextFormatting(
   }
 
   // Caps
-  if (formatting.allCaps) {
+  if (formatting.allCaps === true) {
     parts.push("<w:caps/>");
+  } else if (formatting.allCaps === false) {
+    parts.push('<w:caps w:val="0"/>');
   }
 
-  if (formatting.smallCaps) {
+  if (formatting.smallCaps === true) {
     parts.push("<w:smallCaps/>");
+  } else if (formatting.smallCaps === false) {
+    parts.push('<w:smallCaps w:val="0"/>');
   }
 
   // Strike
-  if (formatting.strike) {
+  if (formatting.strike === true) {
     parts.push("<w:strike/>");
+  } else if (formatting.strike === false) {
+    parts.push('<w:strike w:val="0"/>');
   }
 
-  if (formatting.doubleStrike) {
+  if (formatting.doubleStrike === true) {
     parts.push("<w:dstrike/>");
+  } else if (formatting.doubleStrike === false) {
+    parts.push('<w:dstrike w:val="0"/>');
   }
 
   // Outline
-  if (formatting.outline) {
+  if (formatting.outline === true) {
     parts.push("<w:outline/>");
+  } else if (formatting.outline === false) {
+    parts.push('<w:outline w:val="0"/>');
   }
 
   // Shadow
-  if (formatting.shadow) {
+  if (formatting.shadow === true) {
     parts.push("<w:shadow/>");
+  } else if (formatting.shadow === false) {
+    parts.push('<w:shadow w:val="0"/>');
   }
 
   // Emboss
-  if (formatting.emboss) {
+  if (formatting.emboss === true) {
     parts.push("<w:emboss/>");
+  } else if (formatting.emboss === false) {
+    parts.push('<w:emboss w:val="0"/>');
   }
 
   // Imprint
-  if (formatting.imprint) {
+  if (formatting.imprint === true) {
     parts.push("<w:imprint/>");
+  } else if (formatting.imprint === false) {
+    parts.push('<w:imprint w:val="0"/>');
   }
 
   // Hidden
-  if (formatting.hidden) {
+  if (formatting.hidden === true) {
     parts.push("<w:vanish/>");
+  } else if (formatting.hidden === false) {
+    parts.push('<w:vanish w:val="0"/>');
   }
 
   // Color

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -56,6 +56,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
     ...(run.letterSpacing !== undefined
       ? { letterSpacing: run.letterSpacing }
       : {}),
+    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -57,6 +57,9 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -57,6 +57,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
     ...(run.horizontalScale !== undefined
       ? { horizontalScale: run.horizontalScale }
       : {}),

--- a/packages/folio/src/core/layout-bridge/findBodyPmSpans.test.ts
+++ b/packages/folio/src/core/layout-bridge/findBodyPmSpans.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findBodyEmptyRuns,
+  findBodyPmAnchor,
+  findBodyPmAnchors,
+  findBodyPmSpans,
+} from "./findBodyPmSpans";
+
+const bodyParagraph = { dataset: { pmStart: "1", pmEnd: "8" } };
+const bodySpan = { dataset: { pmStart: "2", pmEnd: "5" }, textContent: "body" };
+const bodyEmptyRun = { dataset: { pmStart: "7", pmEnd: "7" } };
+const bodyImage = { dataset: { pmStart: "9", pmEnd: "10" } };
+
+const createContainer = (): ParentNode =>
+  ({
+    querySelectorAll(selector: string) {
+      switch (selector) {
+        case ".layout-page-content span[data-pm-start][data-pm-end]":
+          return [bodySpan];
+        case ".layout-page-content .layout-empty-run":
+          return [bodyEmptyRun];
+        case ".layout-page-content [data-pm-start]":
+          return [bodyParagraph, bodySpan, bodyEmptyRun, bodyImage];
+        default:
+          return [];
+      }
+    },
+    querySelector(selector: string) {
+      if (selector === '.layout-page-content [data-pm-start="2"]') {
+        return bodySpan;
+      }
+      return null;
+    },
+  }) as unknown as ParentNode;
+
+describe("body-scoped PM DOM lookups", () => {
+  test("finds only body run spans", () => {
+    const spans = findBodyPmSpans(createContainer());
+
+    expect(spans.map((span) => span.textContent?.trim())).toEqual(["body"]);
+  });
+
+  test("finds body anchors without matching overlapping header/footer positions", () => {
+    const anchors = findBodyPmAnchors(createContainer());
+
+    expect(anchors.map((anchor) => anchor.dataset["pmStart"])).toEqual([
+      "1",
+      "2",
+      "7",
+      "9",
+    ]);
+    expect(findBodyPmAnchor(createContainer(), 2)?.textContent?.trim()).toBe(
+      "body",
+    );
+  });
+
+  test("finds only body empty runs", () => {
+    const emptyRuns = findBodyEmptyRuns(createContainer());
+
+    expect(emptyRuns).toHaveLength(1);
+    expect(emptyRuns[0]?.dataset["pmStart"]).toBe("7");
+  });
+});

--- a/packages/folio/src/core/layout-bridge/findBodyPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findBodyPmSpans.ts
@@ -1,0 +1,33 @@
+const BODY_SCOPE = ".layout-page-content";
+
+export function findBodyPmSpans(container: ParentNode): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      `${BODY_SCOPE} span[data-pm-start][data-pm-end]`,
+    ),
+  );
+}
+
+export function findBodyEmptyRuns(container: ParentNode): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(`${BODY_SCOPE} .layout-empty-run`),
+  );
+}
+
+export function findBodyPmAnchors(container: ParentNode): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(`${BODY_SCOPE} [data-pm-start]`),
+  );
+}
+
+export function findBodyPmAnchor(
+  container: ParentNode,
+  pmStart: number,
+): HTMLElement | null {
+  if (!Number.isFinite(pmStart)) {
+    return null;
+  }
+  return container.querySelector<HTMLElement>(
+    `${BODY_SCOPE} [data-pm-start="${String(pmStart)}"]`,
+  );
+}

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -66,6 +66,78 @@ const emptyFootnoteWithTable: Footnote = {
   ],
 };
 
+const footnoteWithRowSpanTable: Footnote = {
+  type: "footnote",
+  id: 9,
+  noteType: "normal",
+  content: [
+    {
+      type: "table",
+      columnWidths: [1440, 2880],
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { vMerge: "restart" },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "A" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "B" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { vMerge: "continue" },
+              content: [{ type: "paragraph", content: [] }],
+            },
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "C" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 function withFakeTextMeasure(runTest: () => void): void {
   const originalDocument = globalThis.document;
   const fakeDocument = {
@@ -157,6 +229,26 @@ describe("footnote layout", () => {
         throw new Error("Expected footnote table to have a table measure");
       }
       expect(tableMeasure.totalHeight).toBeGreaterThan(0);
+    });
+  });
+
+  test("skips row-spanned columns while measuring footnote table rows", () => {
+    withFakeTextMeasure(() => {
+      const content = convertFootnoteToContent(
+        footnoteWithRowSpanTable,
+        4,
+        400,
+      );
+      const tableMeasure = content.measures.at(1);
+
+      expect(tableMeasure?.kind).toBe("table");
+      if (tableMeasure?.kind !== "table") {
+        throw new Error("Expected footnote table to have a table measure");
+      }
+
+      expect(tableMeasure.rows.at(0)?.cells.at(0)?.rowSpan).toBe(2);
+      expect(tableMeasure.rows.at(0)?.cells.at(0)?.width).toBeCloseTo(96);
+      expect(tableMeasure.rows.at(1)?.cells.at(0)?.width).toBeCloseTo(192);
     });
   });
 

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
+import type { FlowBlock } from "../layout-engine/types";
 import type { Footnote } from "../types/document";
-import { convertFootnoteToContent } from "./footnoteLayout";
+import {
+  applyFootnotePresentation,
+  convertFootnoteToContent,
+} from "./footnoteLayout";
 
 const footnoteWithTable: Footnote = {
   type: "footnote",
@@ -39,6 +43,28 @@ const footnoteWithTable: Footnote = {
   ],
 };
 
+const emptyFootnoteWithTable: Footnote = {
+  type: "footnote",
+  id: 8,
+  noteType: "normal",
+  content: [
+    {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [{ type: "paragraph", content: [] }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 describe("footnote layout", () => {
   test("routes footnotes through the body pipeline so tables survive", () => {
     const content = convertFootnoteToContent(footnoteWithTable, 3, 400, {
@@ -62,5 +88,64 @@ describe("footnote layout", () => {
       "table",
     ]);
     expect(content.height).toBe(36);
+  });
+
+  test("measures table footnotes without a caller-provided measurement hook", () => {
+    const content = convertFootnoteToContent(emptyFootnoteWithTable, 3, 400);
+
+    expect(content.blocks.map((block) => block.kind)).toEqual(["table"]);
+    expect(Number.isNaN(content.height)).toBe(false);
+    expect(content.height).toBeGreaterThan(0);
+
+    const tableMeasure = content.measures.at(0);
+    expect(tableMeasure?.kind).toBe("table");
+    if (tableMeasure?.kind !== "table") {
+      throw new Error("Expected footnote table to have a table measure");
+    }
+    expect(tableMeasure.totalHeight).toBeGreaterThan(0);
+  });
+
+  test("applies footnote font size to nested table paragraphs and field runs", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "table",
+        id: "table-1",
+        rows: [
+          {
+            id: "row-1",
+            cells: [
+              {
+                id: "cell-1",
+                blocks: [
+                  {
+                    kind: "paragraph",
+                    id: "cell-p-1",
+                    runs: [
+                      { kind: "text", text: "Cell" },
+                      { kind: "field", fieldType: "PAGE", fallback: "1" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const table = applyFootnotePresentation(blocks, 4).at(0);
+    expect(table?.kind).toBe("table");
+    if (table?.kind !== "table") {
+      throw new Error("Expected a table block");
+    }
+
+    const paragraph = table.rows.at(0)?.cells.at(0)?.blocks.at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected nested paragraph block");
+    }
+
+    expect(paragraph.runs.at(0)?.fontSize).toBe(8);
+    expect(paragraph.runs.at(1)?.fontSize).toBe(8);
   });
 });

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -6,6 +6,7 @@ import {
   applyFootnotePresentation,
   convertFootnoteToContent,
 } from "./footnoteLayout";
+import { resetCanvasContext } from "./measuring/measureContainer";
 
 const footnoteWithTable: Footnote = {
   type: "footnote",
@@ -65,6 +66,44 @@ const emptyFootnoteWithTable: Footnote = {
   ],
 };
 
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              return {
+                width: text.length * 5,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
 describe("footnote layout", () => {
   test("routes footnotes through the body pipeline so tables survive", () => {
     const content = convertFootnoteToContent(footnoteWithTable, 3, 400, {
@@ -91,18 +130,34 @@ describe("footnote layout", () => {
   });
 
   test("measures table footnotes without a caller-provided measurement hook", () => {
-    const content = convertFootnoteToContent(emptyFootnoteWithTable, 3, 400);
+    withFakeTextMeasure(() => {
+      const content = convertFootnoteToContent(emptyFootnoteWithTable, 3, 400);
 
-    expect(content.blocks.map((block) => block.kind)).toEqual(["table"]);
-    expect(Number.isNaN(content.height)).toBe(false);
-    expect(content.height).toBeGreaterThan(0);
+      expect(content.blocks.map((block) => block.kind)).toEqual([
+        "paragraph",
+        "table",
+      ]);
+      expect(Number.isNaN(content.height)).toBe(false);
+      expect(content.height).toBeGreaterThan(0);
 
-    const tableMeasure = content.measures.at(0);
-    expect(tableMeasure?.kind).toBe("table");
-    if (tableMeasure?.kind !== "table") {
-      throw new Error("Expected footnote table to have a table measure");
-    }
-    expect(tableMeasure.totalHeight).toBeGreaterThan(0);
+      const numberBlock = content.blocks.at(0);
+      expect(numberBlock?.kind).toBe("paragraph");
+      if (numberBlock?.kind !== "paragraph") {
+        throw new Error("Expected footnote number paragraph");
+      }
+      expect(numberBlock.runs.at(0)).toMatchObject({
+        kind: "text",
+        text: "3  ",
+        superscript: true,
+      });
+
+      const tableMeasure = content.measures.at(1);
+      expect(tableMeasure?.kind).toBe("table");
+      if (tableMeasure?.kind !== "table") {
+        throw new Error("Expected footnote table to have a table measure");
+      }
+      expect(tableMeasure.totalHeight).toBeGreaterThan(0);
+    });
   });
 
   test("applies footnote font size to nested table paragraphs and field runs", () => {
@@ -133,7 +188,7 @@ describe("footnote layout", () => {
       },
     ];
 
-    const table = applyFootnotePresentation(blocks, 4).at(0);
+    const table = applyFootnotePresentation(blocks, 4).at(1);
     expect(table?.kind).toBe("table");
     if (table?.kind !== "table") {
       throw new Error("Expected a table block");

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Footnote } from "../types/document";
+import { convertFootnoteToContent } from "./footnoteLayout";
+
+const footnoteWithTable: Footnote = {
+  type: "footnote",
+  id: 7,
+  noteType: "normal",
+  content: [
+    {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "Intro" }] }],
+    },
+    {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "Cell" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe("footnote layout", () => {
+  test("routes footnotes through the body pipeline so tables survive", () => {
+    const content = convertFootnoteToContent(footnoteWithTable, 3, 400, {
+      measureBlocks(blocks) {
+        return blocks.map((block) =>
+          block.kind === "table"
+            ? {
+                kind: "table",
+                rows: [],
+                columnWidths: [400],
+                totalWidth: 400,
+                totalHeight: 24,
+              }
+            : { kind: "paragraph", lines: [], totalHeight: 12 },
+        );
+      },
+    });
+
+    expect(content.blocks.map((block) => block.kind)).toEqual([
+      "paragraph",
+      "table",
+    ]);
+    expect(content.height).toBe(36);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -11,19 +11,30 @@ import type {
   Measure,
   Page,
   ParagraphBlock,
-  Run,
   TextRun,
-  RunFormatting,
   FootnoteContent,
 } from "../layout-engine/types";
-import type { Footnote } from "../types/document";
+import { footnoteToProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type { Footnote, StyleDefinitions, Theme } from "../types/document";
 import { measureParagraph } from "./measuring";
+import { toFlowBlocks } from "./toFlowBlocks";
 
 /** Separator line height + padding in pixels */
 const SEPARATOR_HEIGHT = 12;
 
 /** Default footnote font size in points */
 const FOOTNOTE_FONT_SIZE = 8;
+
+export type MeasureBlocksFn = (
+  blocks: FlowBlock[],
+  contentWidth: number,
+) => Measure[];
+
+export type ConvertFootnoteOptions = {
+  styles?: StyleDefinitions | null;
+  theme?: Theme | null;
+  measureBlocks?: MeasureBlocksFn;
+};
 
 // ============================================================================
 // 1. Scan FlowBlocks for footnote references
@@ -119,126 +130,41 @@ export function convertFootnoteToContent(
   footnote: Footnote,
   displayNumber: number,
   contentWidth: number,
+  options: ConvertFootnoteOptions = {},
 ): FootnoteContent {
-  const blocks: FlowBlock[] = [];
-
-  for (let i = 0; i < footnote.content.length; i++) {
-    // SAFETY: i < footnote.content.length in for loop
-    const para = footnote.content[i]!;
-    const runs: Run[] = [];
-
-    // For the first paragraph, prepend the footnote number
-    if (i === 0) {
-      const numberRun: TextRun = {
-        kind: "text",
-        text: `${displayNumber}  `,
-        fontSize: FOOTNOTE_FONT_SIZE,
-        superscript: true,
-      };
-      runs.push(numberRun);
-    }
-
-    // Convert paragraph content to runs
-    for (const content of para.content) {
-      const contentObj = content as unknown as Record<string, unknown>;
-
-      if (
-        contentObj["type"] === "run" &&
-        Array.isArray(contentObj["content"])
-      ) {
-        const formatting = contentObj["formatting"] as
-          | Record<string, unknown>
-          | undefined;
-        const runFormatting: RunFormatting = {};
-
-        if (formatting) {
-          if (formatting["bold"]) {
-            runFormatting.bold = true;
-          }
-          if (formatting["italic"]) {
-            runFormatting.italic = true;
-          }
-          if (formatting["underline"]) {
-            runFormatting.underline = true;
-          }
-          if (formatting["strike"]) {
-            runFormatting.strike = true;
-          }
-          if (formatting["color"]) {
-            const color = formatting["color"] as Record<string, unknown>;
-            if (color["val"]) {
-              runFormatting.color = `#${color["val"]}`;
-            } else if (color["rgb"]) {
-              runFormatting.color = `#${color["rgb"]}`;
-            }
-          }
-          if (formatting["fontSize"]) {
-            runFormatting.fontSize = (formatting["fontSize"] as number) / 2; // half-points to points
-          }
-          if (formatting["fontFamily"]) {
-            const ff = formatting["fontFamily"] as Record<string, unknown>;
-            runFormatting.fontFamily = (ff["ascii"] || ff["hAnsi"]) as string;
-          }
-        }
-
-        // If no fontSize specified, use footnote default
-        if (!runFormatting.fontSize) {
-          runFormatting.fontSize = FOOTNOTE_FONT_SIZE;
-        }
-
-        for (const rc of contentObj["content"] as unknown[]) {
-          const rcObj = rc as Record<string, unknown>;
-          if (rcObj["type"] === "text" && typeof rcObj["text"] === "string") {
-            runs.push({
-              kind: "text",
-              text: rcObj["text"],
-              ...runFormatting,
-            });
-          } else if (rcObj["type"] === "tab") {
-            runs.push({ kind: "tab", ...runFormatting });
-          } else if (rcObj["type"] === "break") {
-            runs.push({ kind: "lineBreak" });
-          } else if (rcObj["type"] === "footnoteRef") {
-            // Self-reference marker - skip (we prepend the number ourselves)
-          }
-        }
-      }
-    }
-
-    // If no runs were generated, add an empty text run to ensure the paragraph renders
-    if (runs.length === 0) {
-      runs.push({ kind: "text", text: "", fontSize: FOOTNOTE_FONT_SIZE });
-    }
-
-    const paragraphBlock: ParagraphBlock = {
-      kind: "paragraph",
-      id: `fn-${footnote.id}-p${i}`,
-      runs,
-    };
-    blocks.push(paragraphBlock);
+  const proseOptions: Parameters<typeof footnoteToProseDoc>[1] = {};
+  if (options.styles) {
+    proseOptions.styles = options.styles;
   }
-
-  if (blocks.length === 0) {
-    blocks.push({
-      kind: "paragraph",
-      id: `fn-${footnote.id}-empty`,
-      runs: [{ kind: "text", text: "", fontSize: FOOTNOTE_FONT_SIZE }],
-    });
+  if (options.theme !== undefined) {
+    proseOptions.theme = options.theme;
   }
-
-  // Measure blocks
-  const measures: Measure[] = [];
-  for (const block of blocks) {
-    if (block.kind === "paragraph") {
-      const m = measureParagraph(block, contentWidth);
-      measures.push(m);
-    }
+  const pmDoc = footnoteToProseDoc(footnote.content, proseOptions);
+  const flowOptions: Parameters<typeof toFlowBlocks>[1] = {};
+  if (options.theme !== undefined) {
+    flowOptions.theme = options.theme;
   }
+  const blocks = applyFootnotePresentation(
+    toFlowBlocks(pmDoc, flowOptions),
+    displayNumber,
+  );
+
+  const measures = options.measureBlocks
+    ? options.measureBlocks(blocks, contentWidth)
+    : blocks.map((block) =>
+        block.kind === "paragraph"
+          ? measureParagraph(block, contentWidth)
+          : ({ kind: block.kind } as Measure),
+      );
 
   let totalHeight = 0;
   for (const measure of measures) {
     if (measure.kind === "paragraph") {
       totalHeight += measure.totalHeight;
+    } else if (measure.kind === "table") {
+      totalHeight += measure.totalHeight;
+    } else if (measure.kind === "image" || measure.kind === "textBox") {
+      totalHeight += measure.height;
     }
   }
 
@@ -249,6 +175,59 @@ export function convertFootnoteToContent(
     measures,
     height: totalHeight,
   };
+}
+
+export function applyFootnotePresentation(
+  blocks: FlowBlock[],
+  displayNumber: number,
+): FlowBlock[] {
+  if (blocks.length === 0) {
+    return [
+      {
+        kind: "paragraph",
+        id: `fn-empty-${displayNumber}`,
+        runs: [
+          {
+            kind: "text",
+            text: `${displayNumber}  `,
+            fontSize: FOOTNOTE_FONT_SIZE,
+            superscript: true,
+          },
+        ],
+      } satisfies ParagraphBlock,
+    ];
+  }
+
+  const output = blocks.map((block) => {
+    if (block.kind !== "paragraph") {
+      return block;
+    }
+    return {
+      ...block,
+      runs: block.runs.map((run) => {
+        if ((run.kind === "text" || run.kind === "tab") && !run.fontSize) {
+          return { ...run, fontSize: FOOTNOTE_FONT_SIZE };
+        }
+        return run;
+      }),
+    };
+  });
+
+  const first = output[0];
+  if (first?.kind === "paragraph") {
+    const numberRun: TextRun = {
+      kind: "text",
+      text: `${displayNumber}  `,
+      fontSize: FOOTNOTE_FONT_SIZE,
+      superscript: true,
+    };
+    output[0] = {
+      ...first,
+      runs: [numberRun, ...first.runs],
+    };
+  }
+
+  return output;
 }
 
 // ============================================================================
@@ -263,6 +242,7 @@ export function buildFootnoteContentMap(
   footnotes: Footnote[],
   footnoteRefs: { footnoteId: number }[],
   contentWidth: number,
+  options: ConvertFootnoteOptions = {},
 ): Map<number, FootnoteContent> {
   const contentMap = new Map<number, FootnoteContent>();
   const footnoteById = new Map<number, Footnote>();
@@ -292,6 +272,7 @@ export function buildFootnoteContentMap(
       footnote,
       displayNumber,
       contentWidth,
+      options,
     );
     contentMap.set(ref.footnoteId, content);
     displayNumber++;

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -409,6 +409,19 @@ export function applyFootnotePresentation(
       ...first,
       runs: [numberRun, ...first.runs],
     };
+  } else {
+    output.unshift({
+      kind: "paragraph",
+      id: `fn-number-${displayNumber}`,
+      runs: [
+        {
+          kind: "text",
+          text: `${displayNumber}  `,
+          fontSize: FOOTNOTE_FONT_SIZE,
+          superscript: true,
+        },
+      ],
+    });
   }
 
   return output;

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -11,8 +11,17 @@ import type {
   Measure,
   Page,
   ParagraphBlock,
+  Run,
+  TableBlock,
+  TableCellMeasure,
+  TableMeasure,
+  TableRowMeasure,
   TextRun,
   FootnoteContent,
+} from "../layout-engine/types";
+import {
+  DEFAULT_TEXTBOX_MARGINS as TEXTBOX_MARGINS,
+  DEFAULT_TEXTBOX_WIDTH as TEXTBOX_WIDTH,
 } from "../layout-engine/types";
 import { footnoteToProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type { Footnote, StyleDefinitions, Theme } from "../types/document";
@@ -151,11 +160,7 @@ export function convertFootnoteToContent(
 
   const measures = options.measureBlocks
     ? options.measureBlocks(blocks, contentWidth)
-    : blocks.map((block) =>
-        block.kind === "paragraph"
-          ? measureParagraph(block, contentWidth)
-          : ({ kind: block.kind } as Measure),
-      );
+    : measureFootnoteBlocks(blocks, contentWidth);
 
   let totalHeight = 0;
   for (const measure of measures) {
@@ -175,6 +180,198 @@ export function convertFootnoteToContent(
     measures,
     height: totalHeight,
   };
+}
+
+function measureFootnoteBlocks(
+  blocks: FlowBlock[],
+  contentWidth: number,
+): Measure[] {
+  return blocks.map((block) => measureFootnoteBlock(block, contentWidth));
+}
+
+function measureFootnoteBlock(block: FlowBlock, contentWidth: number): Measure {
+  switch (block.kind) {
+    case "paragraph":
+      return measureParagraph(block, contentWidth);
+
+    case "table":
+      return measureFootnoteTable(block, contentWidth);
+
+    case "image":
+      return {
+        kind: "image",
+        width: block.width,
+        height: block.height,
+      };
+
+    case "textBox": {
+      const margins = block.margins ?? TEXTBOX_MARGINS;
+      const width = block.width ?? TEXTBOX_WIDTH;
+      const innerWidth = Math.max(1, width - margins.left - margins.right);
+      const innerMeasures = block.content.map((paragraph) =>
+        measureParagraph(paragraph, innerWidth),
+      );
+      let contentHeight = 0;
+      for (const measure of innerMeasures) {
+        contentHeight += measure.totalHeight;
+      }
+
+      return {
+        kind: "textBox",
+        width,
+        height: block.height ?? contentHeight + margins.top + margins.bottom,
+        innerMeasures,
+      };
+    }
+
+    case "pageBreak":
+      return { kind: "pageBreak" };
+
+    case "columnBreak":
+      return { kind: "columnBreak" };
+
+    case "sectionBreak":
+      return { kind: "sectionBreak" };
+
+    default: {
+      const exhaustive: never = block;
+      return exhaustive;
+    }
+  }
+}
+
+function resolveFootnoteTableWidth(
+  width: number | undefined,
+  widthType: string | undefined,
+  contentWidth: number,
+): number | undefined {
+  if (!width) {
+    return undefined;
+  }
+  if (widthType === "pct") {
+    return (contentWidth * width) / 5000;
+  }
+  if (widthType === "dxa" || !widthType || widthType === "auto") {
+    return (width / 1440) * 96;
+  }
+  return undefined;
+}
+
+function measureFootnoteTable(
+  tableBlock: TableBlock,
+  contentWidth: number,
+): TableMeasure {
+  let columnWidths = tableBlock.columnWidths ?? [];
+  const explicitWidth = resolveFootnoteTableWidth(
+    tableBlock.width,
+    tableBlock.widthType,
+    contentWidth,
+  );
+
+  if (columnWidths.length === 0) {
+    const firstRow = tableBlock.rows.at(0);
+    let colCount = 0;
+    for (const cell of firstRow?.cells ?? []) {
+      colCount += cell.colSpan ?? 1;
+    }
+    const totalWidth = explicitWidth ?? contentWidth;
+    const equalWidth = totalWidth / Math.max(1, colCount);
+    columnWidths = Array.from(
+      { length: Math.max(1, colCount) },
+      () => equalWidth,
+    );
+  } else if (explicitWidth) {
+    const totalWidth = sumColumnWidths(columnWidths);
+    if (totalWidth > 0 && Math.abs(totalWidth - explicitWidth) > 1) {
+      const scale = explicitWidth / totalWidth;
+      columnWidths = columnWidths.map((width) => width * scale);
+    }
+  }
+
+  const rows: TableRowMeasure[] = tableBlock.rows.map((row) => {
+    let columnIndex = 0;
+    const cells: TableCellMeasure[] = row.cells.map((cell) => {
+      const colSpan = cell.colSpan ?? 1;
+      let cellWidth = 0;
+      for (
+        let offset = 0;
+        offset < colSpan && columnIndex + offset < columnWidths.length;
+        offset++
+      ) {
+        cellWidth += columnWidths[columnIndex + offset] ?? 0;
+      }
+      if (cellWidth === 0) {
+        cellWidth = cell.width ?? 100;
+      }
+      columnIndex += colSpan;
+
+      const padding = cell.padding ?? { top: 0, right: 7, bottom: 0, left: 7 };
+      const innerWidth = Math.max(1, cellWidth - padding.left - padding.right);
+      const blocks = measureFootnoteBlocks(cell.blocks, innerWidth);
+      let height = padding.top + padding.bottom;
+      for (const measure of blocks) {
+        height += getMeasureHeight(measure);
+      }
+
+      const cellMeasure: TableCellMeasure = {
+        blocks,
+        width: cellWidth,
+        height,
+      };
+      if (cell.colSpan !== undefined) {
+        cellMeasure.colSpan = cell.colSpan;
+      }
+      if (cell.rowSpan !== undefined) {
+        cellMeasure.rowSpan = cell.rowSpan;
+      }
+      return cellMeasure;
+    });
+
+    let contentHeight = 0;
+    for (const cell of cells) {
+      contentHeight = Math.max(contentHeight, cell.height);
+    }
+    const explicitHeight = row.height;
+    let height = contentHeight;
+    if (explicitHeight !== undefined && row.heightRule === "exact") {
+      height = explicitHeight;
+    } else if (explicitHeight !== undefined) {
+      height = Math.max(contentHeight, explicitHeight);
+    }
+
+    return { cells, height };
+  });
+
+  let totalHeight = 0;
+  for (const row of rows) {
+    totalHeight += row.height;
+  }
+
+  return {
+    kind: "table",
+    rows,
+    columnWidths,
+    totalWidth: sumColumnWidths(columnWidths) || explicitWidth || contentWidth,
+    totalHeight,
+  };
+}
+
+function sumColumnWidths(columnWidths: number[]): number {
+  let total = 0;
+  for (const width of columnWidths) {
+    total += width;
+  }
+  return total;
+}
+
+function getMeasureHeight(measure: Measure): number {
+  if (measure.kind === "paragraph" || measure.kind === "table") {
+    return measure.totalHeight;
+  }
+  if (measure.kind === "image" || measure.kind === "textBox") {
+    return measure.height;
+  }
+  return 0;
 }
 
 export function applyFootnotePresentation(
@@ -198,20 +395,7 @@ export function applyFootnotePresentation(
     ];
   }
 
-  const output = blocks.map((block) => {
-    if (block.kind !== "paragraph") {
-      return block;
-    }
-    return {
-      ...block,
-      runs: block.runs.map((run) => {
-        if ((run.kind === "text" || run.kind === "tab") && !run.fontSize) {
-          return { ...run, fontSize: FOOTNOTE_FONT_SIZE };
-        }
-        return run;
-      }),
-    };
-  });
+  const output = blocks.map(applyFootnoteBlockPresentation);
 
   const first = output[0];
   if (first?.kind === "paragraph") {
@@ -228,6 +412,50 @@ export function applyFootnotePresentation(
   }
 
   return output;
+}
+
+function applyFootnoteBlockPresentation(block: FlowBlock): FlowBlock {
+  if (block.kind === "paragraph") {
+    return applyFootnoteParagraphPresentation(block);
+  }
+  if (block.kind === "table") {
+    return {
+      ...block,
+      rows: block.rows.map((row) => ({
+        ...row,
+        cells: row.cells.map((cell) => ({
+          ...cell,
+          blocks: cell.blocks.map(applyFootnoteBlockPresentation),
+        })),
+      })),
+    };
+  }
+  if (block.kind === "textBox") {
+    return {
+      ...block,
+      content: block.content.map(applyFootnoteParagraphPresentation),
+    };
+  }
+  return block;
+}
+
+function applyFootnoteParagraphPresentation(
+  block: ParagraphBlock,
+): ParagraphBlock {
+  return {
+    ...block,
+    runs: block.runs.map(applyFootnoteRunPresentation),
+  };
+}
+
+function applyFootnoteRunPresentation(run: Run): Run {
+  if (
+    (run.kind === "text" || run.kind === "tab" || run.kind === "field") &&
+    run.fontSize === undefined
+  ) {
+    return { ...run, fontSize: FOOTNOTE_FONT_SIZE };
+  }
+  return run;
 }
 
 // ============================================================================

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -288,9 +288,14 @@ function measureFootnoteTable(
     }
   }
 
-  const rows: TableRowMeasure[] = tableBlock.rows.map((row) => {
+  const rowSpanEnds: number[] = [];
+  const rows: TableRowMeasure[] = tableBlock.rows.map((row, rowIndex) => {
     let columnIndex = 0;
     const cells: TableCellMeasure[] = row.cells.map((cell) => {
+      while ((rowSpanEnds[columnIndex] ?? 0) > rowIndex) {
+        columnIndex++;
+      }
+
       const colSpan = cell.colSpan ?? 1;
       let cellWidth = 0;
       for (
@@ -323,6 +328,12 @@ function measureFootnoteTable(
       }
       if (cell.rowSpan !== undefined) {
         cellMeasure.rowSpan = cell.rowSpan;
+      }
+      if ((cell.rowSpan ?? 1) > 1) {
+        const rowSpanEnd = rowIndex + (cell.rowSpan ?? 1);
+        for (let offset = 0; offset < colSpan; offset++) {
+          rowSpanEnds[columnIndex - colSpan + offset] = rowSpanEnd;
+        }
       }
       return cellMeasure;
     });

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -279,7 +279,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}`,
+        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -314,6 +314,25 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
     if (attrs.defaultFontFamily != null) {
       parts.push(`dff:${attrs.defaultFontFamily}`);
     }
+    if (attrs.suppressEmptyParagraphHeight) {
+      parts.push("sup");
+    }
+    const borders = attrs.borders;
+    if (borders) {
+      const signature = (border?: {
+        width?: number;
+        style?: string;
+        color?: string;
+      }): string =>
+        border
+          ? `${border.width ?? ""},${border.style ?? ""},${border.color ?? ""}`
+          : "";
+      parts.push(
+        `bdr:${signature(borders.top)}|${signature(borders.bottom)}|${signature(
+          borders.left,
+        )}|${signature(borders.right)}`,
+      );
+    }
   }
 
   return parts.join("||");

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -279,7 +279,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.horizontalScale}`,
+        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -279,7 +279,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}`,
+        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.smallCaps}|${run.horizontalScale}|${run.letterSpacing}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -279,7 +279,7 @@ export function hashParagraphBlock(block: ParagraphBlock): string {
   for (const run of block.runs) {
     if (run.kind === "text") {
       parts.push(
-        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}`,
+        `t:${run.text}|${run.fontFamily}|${run.fontSize}|${run.bold}|${run.italic}|${run.allCaps}|${run.horizontalScale}`,
       );
     } else if (run.kind === "tab") {
       parts.push(`tab:${run.width}`);

--- a/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
@@ -12,6 +12,7 @@
  */
 
 import { resolveFontFamily } from "../../utils/fontResolver";
+import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
 
 // Constants for OOXML unit conversions
 const TWIPS_PER_INCH = 1440;
@@ -149,7 +150,7 @@ function getResolvedFallback(fontFamily: string): string {
  *
  * @example
  * buildFontString({ fontFamily: "Arial", fontSize: 12, bold: true })
- * // Returns: "bold 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
+ * // Returns: "800 16px Arial, Arimo, Helvetica, sans-serif" (12pt = 16px)
  */
 export function buildFontString(style: FontStyle): string {
   const parts: string[] = [];
@@ -161,7 +162,7 @@ export function buildFontString(style: FontStyle): string {
     parts.push(style.fontVariant);
   }
   if (style.bold) {
-    parts.push("bold");
+    parts.push(DOCX_BOLD_FONT_WEIGHT);
   }
 
   // Convert points to pixels for canvas measurement

--- a/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
@@ -34,6 +34,7 @@ export type FontStyle = {
   bold?: boolean;
   italic?: boolean;
   letterSpacing?: number; // in pixels
+  textTransform?: "uppercase";
 };
 
 /**
@@ -241,11 +242,12 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   if (!text) {
     return 0;
   }
+  const measuredText = applyTextTransform(text, style);
 
   const ctx = getCanvasContext();
   ctx.font = buildFontString(style);
 
-  const metrics = ctx.measureText(text);
+  const metrics = ctx.measureText(measuredText);
 
   // Use advance width for line breaking — this is the standard metric for text flow.
   // Painted width (actualBoundingBox) includes glyph overhang which is visual only
@@ -253,8 +255,8 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   let width = metrics.width;
 
   // Apply letter spacing if specified
-  if (style.letterSpacing && text.length > 1) {
-    width += style.letterSpacing * (text.length - 1);
+  if (style.letterSpacing && measuredText.length > 1) {
+    width += style.letterSpacing * (measuredText.length - 1);
   }
 
   return width;
@@ -303,7 +305,7 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
   // Measure each character individually for click positioning
   for (let i = 0; i < text.length; i++) {
     // SAFETY: i < text.length in for loop
-    const char = text[i]!;
+    const char = applyTextTransform(text[i]!, style);
     const charMetrics = ctx.measureText(char);
 
     // Use advance width for individual characters
@@ -323,6 +325,13 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
     charWidths,
     metrics,
   };
+}
+
+function applyTextTransform(text: string, style: FontStyle): string {
+  if (style.textTransform === "uppercase") {
+    return text.toLocaleUpperCase();
+  }
+  return text;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
@@ -35,6 +35,7 @@ export type FontStyle = {
   italic?: boolean;
   letterSpacing?: number; // in pixels
   textTransform?: "uppercase";
+  horizontalScale?: number;
 };
 
 /**
@@ -259,7 +260,7 @@ export function measureTextWidth(text: string, style: FontStyle): number {
     width += style.letterSpacing * (measuredText.length - 1);
   }
 
-  return width;
+  return width * getHorizontalScaleFactor(style);
 }
 
 /**
@@ -316,6 +317,7 @@ export function measureRun(text: string, style: FontStyle): RunMeasurement {
       charWidth += letterSpacing;
     }
 
+    charWidth *= getHorizontalScaleFactor(style);
     charWidths.push(charWidth);
     totalWidth += charWidth;
   }
@@ -332,6 +334,10 @@ function applyTextTransform(text: string, style: FontStyle): string {
     return text.toLocaleUpperCase();
   }
   return text;
+}
+
+function getHorizontalScaleFactor(style: FontStyle): number {
+  return (style.horizontalScale ?? 100) / 100;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
@@ -35,6 +35,7 @@ export type FontStyle = {
   italic?: boolean;
   letterSpacing?: number; // in pixels
   textTransform?: "uppercase";
+  fontVariant?: "small-caps";
   horizontalScale?: number;
 };
 
@@ -155,6 +156,9 @@ export function buildFontString(style: FontStyle): string {
 
   if (style.italic) {
     parts.push("italic");
+  }
+  if (style.fontVariant) {
+    parts.push(style.fontVariant);
   }
   if (style.bold) {
     parts.push("bold");

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -214,6 +214,32 @@ describe("inline image paragraph measurement", () => {
   });
 });
 
+describe("paragraph indentation measurement", () => {
+  test("negative side indents widen the measured line box", () => {
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "negative-indent",
+        runs: [
+          {
+            kind: "text" as const,
+            text: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+            fontSize: 11,
+          },
+        ],
+        attrs: {
+          indent: {
+            left: -20,
+            right: -10,
+          },
+        },
+      };
+
+      expect(measureParagraph(block, 100).lines).toHaveLength(1);
+    });
+  });
+});
+
 describe("all-caps paragraph measurement", () => {
   test("measures all-caps runs using uppercase glyph widths", () => {
     withFakeTextMeasure(() => {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { resetCanvasContext } from "./measureContainer";
 import { measureParagraph } from "./measureParagraph";
 
 const PT_TO_PX = 96 / 72;
@@ -123,5 +124,58 @@ describe("inline image paragraph measurement", () => {
     expect(measure.lines[0]?.lineHeight).toBeGreaterThan(imageHeight);
     expect(measure.lines[0]?.ascent).toBeGreaterThan(imageHeight);
     expect(measure.lines[0]?.descent).toBeGreaterThan(0);
+  });
+});
+
+describe("all-caps paragraph measurement", () => {
+  test("measures all-caps runs using uppercase glyph widths", () => {
+    const originalDocument = globalThis.document;
+    const fakeDocument = {
+      createElement() {
+        return {
+          getContext() {
+            return {
+              font: "",
+              measureText(text: string) {
+                let width = 0;
+                for (const char of text) {
+                  width += char >= "A" && char <= "Z" ? 10 : 5;
+                }
+                return {
+                  width,
+                  actualBoundingBoxAscent: 8,
+                  actualBoundingBoxDescent: 2,
+                };
+              },
+            };
+          },
+        };
+      },
+    } as unknown as Document;
+
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: fakeDocument,
+    });
+    resetCanvasContext();
+
+    try {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "caps",
+          runs: [{ kind: "text", text: "iiii", allCaps: true }],
+        },
+        25,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+    } finally {
+      resetCanvasContext();
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
   });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -44,4 +44,84 @@ describe("empty paragraph line-height floor", () => {
 
     expect(measure.totalHeight).toBeCloseTo(8, 1);
   });
+
+  test("empty paragraph includes authored spacing", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "t3",
+        pmStart: 0,
+        pmEnd: 0,
+        runs: [],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Arial Narrow",
+          spacing: {
+            before: 5,
+            after: 7,
+            line: 1,
+            lineUnit: "multiplier",
+            lineRule: "auto",
+          },
+        },
+      },
+      600,
+    );
+
+    expect(measure.totalHeight).toBeCloseTo(11 * PT_TO_PX * 1.15 + 12, 1);
+  });
+
+  test("suppressed empty paragraph keeps a zero-height anchor", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "t4",
+        pmStart: 0,
+        pmEnd: 0,
+        runs: [],
+        attrs: {
+          suppressEmptyParagraphHeight: true,
+          defaultFontSize: 11,
+          defaultFontFamily: "Arial Narrow",
+        },
+      },
+      600,
+    );
+
+    expect(measure.totalHeight).toBe(0);
+    expect(measure.lines[0]?.lineHeight).toBe(0);
+  });
+});
+
+describe("inline image paragraph measurement", () => {
+  test("image-only line reserves descender room above and below image", () => {
+    const imageHeight = 29;
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "img1",
+        pmStart: 0,
+        pmEnd: 1,
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 186,
+            height: imageHeight,
+            pmStart: 0,
+            pmEnd: 1,
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    expect(measure.lines[0]?.lineHeight).toBeGreaterThan(imageHeight);
+    expect(measure.lines[0]?.ascent).toBeGreaterThan(imageHeight);
+    expect(measure.lines[0]?.descent).toBeGreaterThan(0);
+  });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { hashParagraphBlock } from "./cache";
-import { resetCanvasContext } from "./measureContainer";
+import { buildFontString, resetCanvasContext } from "./measureContainer";
 import { getRunCharWidths, measureParagraph } from "./measureParagraph";
 
 const PT_TO_PX = 96 / 72;
@@ -241,6 +241,17 @@ describe("paragraph indentation measurement", () => {
 });
 
 describe("all-caps paragraph measurement", () => {
+  test("builds canvas font strings with the rendered DOCX bold weight", () => {
+    const font = buildFontString({
+      fontFamily: "Arial",
+      fontSize: 12,
+      bold: true,
+    });
+
+    expect(font).toContain("800");
+    expect(font).not.toContain("bold");
+  });
+
   test("measures all-caps runs using uppercase glyph widths", () => {
     withFakeTextMeasure(() => {
       const measure = measureParagraph(

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -5,6 +5,48 @@ import { measureParagraph } from "./measureParagraph";
 
 const PT_TO_PX = 96 / 72;
 
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              let width = 0;
+              for (const char of text) {
+                width += char >= "A" && char <= "Z" ? 10 : 5;
+              }
+              return {
+                width,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
 describe("empty paragraph line-height floor", () => {
   test("empty paragraph with line=1.0 auto is floored to 1.15 times fontSize", () => {
     const measure = measureParagraph(
@@ -125,51 +167,44 @@ describe("inline image paragraph measurement", () => {
     expect(measure.lines[0]?.ascent).toBeGreaterThan(imageHeight);
     expect(measure.lines[0]?.descent).toBeGreaterThan(0);
   });
+
+  test("advances floating-zone y offsets by image-inflated line height", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "img-float",
+          runs: [
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 35,
+              height: 90,
+            },
+            { kind: "text", text: "iiii" },
+          ],
+        },
+        40,
+        {
+          floatingZones: [
+            {
+              leftMargin: 35,
+              rightMargin: 0,
+              topY: 20,
+              bottomY: 80,
+            },
+          ],
+        },
+      );
+
+      expect(measure.lines).toHaveLength(2);
+      expect(measure.lines.at(1)?.leftOffset).toBeUndefined();
+      expect(measure.lines.at(1)?.width).toBe(20);
+    });
+  });
 });
 
 describe("all-caps paragraph measurement", () => {
-  function withFakeTextMeasure(runTest: () => void): void {
-    const originalDocument = globalThis.document;
-    const fakeDocument = {
-      createElement() {
-        return {
-          getContext() {
-            return {
-              font: "",
-              measureText(text: string) {
-                let width = 0;
-                for (const char of text) {
-                  width += char >= "A" && char <= "Z" ? 10 : 5;
-                }
-                return {
-                  width,
-                  actualBoundingBoxAscent: 8,
-                  actualBoundingBoxDescent: 2,
-                };
-              },
-            };
-          },
-        };
-      },
-    } as unknown as Document;
-
-    Object.defineProperty(globalThis, "document", {
-      configurable: true,
-      value: fakeDocument,
-    });
-    resetCanvasContext();
-
-    try {
-      runTest();
-    } finally {
-      resetCanvasContext();
-      Object.defineProperty(globalThis, "document", {
-        configurable: true,
-        value: originalDocument,
-      });
-    }
-  }
-
   test("measures all-caps runs using uppercase glyph widths", () => {
     withFakeTextMeasure(() => {
       const measure = measureParagraph(

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -128,7 +128,7 @@ describe("inline image paragraph measurement", () => {
 });
 
 describe("all-caps paragraph measurement", () => {
-  test("measures all-caps runs using uppercase glyph widths", () => {
+  function withFakeTextMeasure(runTest: () => void): void {
     const originalDocument = globalThis.document;
     const fakeDocument = {
       createElement() {
@@ -160,6 +160,18 @@ describe("all-caps paragraph measurement", () => {
     resetCanvasContext();
 
     try {
+      runTest();
+    } finally {
+      resetCanvasContext();
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: originalDocument,
+      });
+    }
+  }
+
+  test("measures all-caps runs using uppercase glyph widths", () => {
+    withFakeTextMeasure(() => {
       const measure = measureParagraph(
         {
           kind: "paragraph",
@@ -170,12 +182,21 @@ describe("all-caps paragraph measurement", () => {
       );
 
       expect(measure.lines).toHaveLength(2);
-    } finally {
-      resetCanvasContext();
-      Object.defineProperty(globalThis, "document", {
-        configurable: true,
-        value: originalDocument,
-      });
-    }
+    });
+  });
+
+  test("measures horizontally scaled runs using scaled glyph widths", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "scaled",
+          runs: [{ kind: "text", text: "iiii", horizontalScale: 150 }],
+        },
+        25,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+    });
   });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
+import { hashParagraphBlock } from "./cache";
 import { resetCanvasContext } from "./measureContainer";
-import { measureParagraph } from "./measureParagraph";
+import { getRunCharWidths, measureParagraph } from "./measureParagraph";
 
 const PT_TO_PX = 96 / 72;
 
@@ -13,10 +14,19 @@ function withFakeTextMeasure(runTest: () => void): void {
         getContext() {
           return {
             font: "",
-            measureText(text: string) {
+            measureText(this: { font: string }, text: string) {
               let width = 0;
+              const isSmallCaps = this.font.includes("small-caps");
               for (const char of text) {
-                width += char >= "A" && char <= "Z" ? 10 : 5;
+                const isUppercase = char >= "A" && char <= "Z";
+                const isLowercase = char >= "a" && char <= "z";
+                if (isUppercase) {
+                  width += 10;
+                } else if (isSmallCaps && isLowercase) {
+                  width += 8;
+                } else {
+                  width += 5;
+                }
               }
               return {
                 width,
@@ -233,5 +243,38 @@ describe("all-caps paragraph measurement", () => {
 
       expect(measure.lines).toHaveLength(2);
     });
+  });
+
+  test("measures small-caps runs using small-caps glyph widths", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "small-caps",
+          runs: [{ kind: "text", text: "iiii", smallCaps: true }],
+        },
+        25,
+      );
+
+      expect(measure.lines).toHaveLength(2);
+      expect(
+        getRunCharWidths({ kind: "text", text: "ii", smallCaps: true }),
+      ).toEqual([8, 8]);
+    });
+  });
+
+  test("includes small-caps formatting in paragraph cache keys", () => {
+    const plainHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "plain",
+      runs: [{ kind: "text", text: "iiii" }],
+    });
+    const smallCapsHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "small-caps",
+      runs: [{ kind: "text", text: "iiii", smallCaps: true }],
+    });
+
+    expect(smallCapsHash).not.toBe(plainHash);
   });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -303,4 +303,19 @@ describe("all-caps paragraph measurement", () => {
 
     expect(smallCapsHash).not.toBe(plainHash);
   });
+
+  test("includes character spacing in paragraph cache keys", () => {
+    const plainHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "plain",
+      runs: [{ kind: "text", text: "iiii" }],
+    });
+    const spacedHash = hashParagraphBlock({
+      kind: "paragraph",
+      id: "spaced",
+      runs: [{ kind: "text", text: "iiii", letterSpacing: 1.5 }],
+    });
+
+    expect(spacedHash).not.toBe(plainHash);
+  });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -526,7 +526,7 @@ export function measureParagraph(
     lines.push(line);
 
     // Update cumulative height for next line's floating zone calculation
-    cumulativeHeight += typography.lineHeight;
+    cumulativeHeight += finalTypography.lineHeight;
   };
 
   /**

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -151,6 +151,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
     ...(run.horizontalScale !== undefined
       ? { horizontalScale: run.horizontalScale }
       : {}),
@@ -689,6 +690,14 @@ export function measureParagraph(
         fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
         ...(run.bold !== undefined ? { bold: run.bold } : {}),
         ...(run.italic !== undefined ? { italic: run.italic } : {}),
+        ...(run.letterSpacing !== undefined
+          ? { letterSpacing: run.letterSpacing }
+          : {}),
+        ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+        ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
+        ...(run.horizontalScale !== undefined
+          ? { horizontalScale: run.horizontalScale }
+          : {}),
       };
       updateMaxFont(style);
 

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -150,6 +150,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
     ...(run.letterSpacing !== undefined
       ? { letterSpacing: run.letterSpacing }
       : {}),
+    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -383,6 +383,25 @@ export function measureParagraph(
 
   // Handle empty paragraph
   if (runs.length === 0) {
+    if (attrs?.suppressEmptyParagraphHeight) {
+      lines.push({
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 0,
+        width: 0,
+        ascent: 0,
+        descent: 0,
+        lineHeight: 0,
+      });
+
+      return {
+        kind: "paragraph",
+        lines,
+        totalHeight: 0,
+      };
+    }
+
     const emptyFontSize = attrs?.defaultFontSize ?? DEFAULT_FONT_SIZE;
     const emptyFontFamily = attrs?.defaultFontFamily ?? DEFAULT_FONT_FAMILY;
     const emptyMetrics = calculateEmptyParagraphMetrics(
@@ -399,10 +418,18 @@ export function measureParagraph(
       ...emptyMetrics,
     });
 
+    let totalHeight = emptyMetrics.lineHeight;
+    if (spacing?.before) {
+      totalHeight += spacing.before;
+    }
+    if (spacing?.after) {
+      totalHeight += spacing.after;
+    }
+
     return {
       kind: "paragraph",
       lines,
-      totalHeight: emptyMetrics.lineHeight,
+      totalHeight,
     };
   }
 
@@ -465,13 +492,14 @@ export function measureParagraph(
       currentLine.maxFontMetrics,
     );
 
-    // If an inline image is taller than the text-based line height,
-    // use the image height directly (it's already in pixels — no pt→px conversion needed)
+    // If an inline image is taller than the text-based line height, reserve
+    // descender room on both sides to avoid clipping image-only table rows.
     const finalTypography = { ...typography };
     if (currentLine.maxImageHeightPx > finalTypography.lineHeight) {
-      finalTypography.lineHeight = currentLine.maxImageHeightPx;
-      finalTypography.ascent = currentLine.maxImageHeightPx * 0.8;
-      finalTypography.descent = currentLine.maxImageHeightPx * 0.2;
+      const imageHeight = currentLine.maxImageHeightPx;
+      const buffer = finalTypography.descent;
+      finalTypography.lineHeight = imageHeight + buffer * 2;
+      finalTypography.ascent = imageHeight + buffer;
     }
 
     const line: MeasuredLine = {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -151,6 +151,9 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -79,6 +79,9 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -78,6 +78,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
     ...(run.letterSpacing !== undefined
       ? { letterSpacing: run.letterSpacing }
       : {}),
+    ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
   };
 }
 

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -79,6 +79,7 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       ? { letterSpacing: run.letterSpacing }
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
+    ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
     ...(run.horizontalScale !== undefined
       ? { horizontalScale: run.horizontalScale }
       : {}),

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+
+import type { ParagraphBlock, TextRun } from "../layout-engine/types";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+      attrs: {
+        styleId: { default: null },
+        defaultTextFormatting: { default: null },
+      },
+    },
+    text: { group: "inline" },
+  },
+  marks: {
+    allCaps: {},
+    smallCaps: {},
+    emboss: {},
+    imprint: {},
+    textShadow: {},
+    textOutline: {},
+    emphasisMark: {
+      attrs: { type: { default: "dot" } },
+    },
+    characterSpacing: {
+      attrs: {
+        spacing: { default: null },
+        position: { default: null },
+        scale: { default: null },
+        kerning: { default: null },
+      },
+    },
+  },
+});
+
+function buildSingleRunDoc(
+  text: string,
+  markName: string,
+  attrs?: Record<string, unknown>,
+) {
+  const mark = schema.marks[markName]?.create(attrs);
+  if (!mark) {
+    throw new Error(`Unknown mark: ${markName}`);
+  }
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [schema.text(text, [mark])]),
+  ]);
+}
+
+function firstRun(blocks: unknown[]): TextRun {
+  const paragraph = blocks.find(
+    (block) => (block as ParagraphBlock).kind === "paragraph",
+  ) as ParagraphBlock;
+  return paragraph.runs[0] as TextRun;
+}
+
+describe("toFlowBlocks run-level OOXML marks", () => {
+  test("propagates caps and text effect marks to run formatting", () => {
+    for (const markName of [
+      "allCaps",
+      "smallCaps",
+      "emboss",
+      "imprint",
+      "textShadow",
+      "textOutline",
+    ] as const) {
+      const blocks = toFlowBlocks(buildSingleRunDoc("text", markName), {});
+      expect(firstRun(blocks)[markName]).toBe(true);
+    }
+  });
+
+  test("propagates character spacing position, scale, and kerning", () => {
+    const blocks = toFlowBlocks(
+      buildSingleRunDoc("text", "characterSpacing", {
+        spacing: 16,
+        position: 12,
+        scale: 90,
+        kerning: 16,
+      }),
+      {},
+    );
+    const run = firstRun(blocks);
+
+    expect(run.letterSpacing).toBeCloseTo(1.0667, 3);
+    expect(run.positionPx).toBeCloseTo(8, 3);
+    expect(run.horizontalScale).toBe(90);
+    expect(run.kerningMinPt).toBe(8);
+  });
+
+  test("does not emit no-op character spacing values", () => {
+    const blocks = toFlowBlocks(
+      buildSingleRunDoc("text", "characterSpacing", {
+        spacing: 0,
+        position: 0,
+        scale: 100,
+        kerning: 0,
+      }),
+      {},
+    );
+    const run = firstRun(blocks);
+
+    expect(run.letterSpacing).toBeUndefined();
+    expect(run.positionPx).toBeUndefined();
+    expect(run.horizontalScale).toBeUndefined();
+    expect(run.kerningMinPt).toBeUndefined();
+  });
+
+  test("propagates emphasis mark variants", () => {
+    for (const variant of ["dot", "comma", "circle", "underDot"] as const) {
+      const blocks = toFlowBlocks(
+        buildSingleRunDoc("text", "emphasisMark", { type: variant }),
+        {},
+      );
+      expect(firstRun(blocks).emphasisMark).toBe(variant);
+    }
+  });
+
+  test("cascades paragraph default text formatting to unmarked runs", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
+            fontSize: 22,
+          },
+        },
+        [schema.text("body text")],
+      ),
+    ]);
+    const run = firstRun(toFlowBlocks(doc, {}));
+
+    expect(run.fontFamily).toBe("Arial Narrow");
+    expect(run.fontSize).toBe(11);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -128,6 +128,10 @@ describe("toFlowBlocks run-level OOXML marks", () => {
           defaultTextFormatting: {
             fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" },
             fontSize: 22,
+            bold: true,
+            color: { rgb: "C00000" },
+            underline: { style: "single" },
+            smallCaps: true,
           },
         },
         [schema.text("body text")],
@@ -137,5 +141,9 @@ describe("toFlowBlocks run-level OOXML marks", () => {
 
     expect(run.fontFamily).toBe("Arial Narrow");
     expect(run.fontSize).toBe(11);
+    expect(run.bold).toBe(true);
+    expect(run.color).toBe("#C00000");
+    expect(run.underline).toEqual({ style: "single" });
+    expect(run.smallCaps).toBe(true);
   });
 });

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -281,6 +281,67 @@ describe("toFlowBlocks style cascade", () => {
     }
   });
 
+  test("default table style supplies conditional formatting when table has no style ID", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "DefaultGrid",
+          type: "table",
+          default: true,
+          name: "Default Grid",
+          tblStylePr: [
+            {
+              type: "wholeTable",
+              tcPr: { shading: { fill: { rgb: "D9EAF7" } } },
+              rPr: { bold: true },
+            },
+          ],
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "default styled" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+        styles,
+      },
+    };
+
+    const tableBlock = toFlowBlocks(toProseDoc(document, { styles }), {})[0];
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind === "table") {
+      const cell = tableBlock.rows.at(0)?.cells.at(0);
+      const paragraph = cell?.blocks.at(0) as ParagraphBlock | undefined;
+      const run = paragraph?.runs.at(0) as TextRun | undefined;
+
+      expect(cell?.background).toBe("#D9EAF7");
+      expect(run?.bold).toBe(true);
+    }
+  });
+
   test("style-less tables use built-in TableNormal side padding", () => {
     const table: Table = {
       type: "table",

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import type { ParagraphBlock, TextRun } from "../layout-engine/types";
+import type {
+  ParagraphBlock,
+  TableBlock as LayoutTableBlock,
+  TextRun,
+} from "../layout-engine/types";
 import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type {
   Document,
@@ -27,6 +31,14 @@ function firstParagraph(blocks: unknown[]): ParagraphBlock {
 
 function firstRun(blocks: unknown[]): TextRun {
   return firstParagraph(blocks).runs[0] as TextRun;
+}
+
+function firstTableRun(blocks: unknown[]): TextRun {
+  const table = blocks.find(
+    (block) => (block as LayoutTableBlock).kind === "table",
+  ) as LayoutTableBlock;
+  const paragraph = table.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
+  return paragraph.runs[0] as TextRun;
 }
 
 describe("toFlowBlocks style cascade", () => {
@@ -130,6 +142,79 @@ describe("toFlowBlocks style cascade", () => {
     );
 
     expect(firstRun(blocks).fontFamily).toBe("Cambria");
+  });
+
+  test("table conditionals without rPr do not override paragraph run defaults", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Arial", hAnsi: "Arial" } },
+        },
+        {
+          styleId: "FontePadrao",
+          type: "character",
+          default: true,
+          name: "Default Paragraph Font",
+          rPr: { fontFamily: { ascii: "Cambria", hAnsi: "Cambria" } },
+        },
+        {
+          styleId: "BandedTable",
+          type: "table",
+          name: "Banded Table",
+          tblStylePr: [
+            {
+              type: "firstRow",
+              tcPr: { shading: { fill: { rgb: "EEEEEE" } } },
+            },
+          ],
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "BandedTable", look: { firstRow: true } },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  formatting: { styleId: "Normal" },
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "first row" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc(
+        {
+          package: {
+            document: { content: [table] },
+            styles,
+          },
+        },
+        { styles },
+      ),
+      {},
+    );
+
+    expect(firstTableRun(blocks).fontFamily).toBe("Arial");
   });
 
   test("default table style supplies cell margins when table has no style ID", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -323,6 +323,81 @@ describe("toFlowBlocks style cascade", () => {
     }
   });
 
+  test("explicit table styles do not fall back to the default table style borders or margins", () => {
+    const gridBorder = {
+      style: "single" as const,
+      size: 4,
+      color: { rgb: "000000" },
+    };
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "DefaultGrid",
+          type: "table",
+          default: true,
+          name: "Default Grid",
+          tblPr: {
+            borders: {
+              top: gridBorder,
+              bottom: gridBorder,
+              left: gridBorder,
+              right: gridBorder,
+              insideH: gridBorder,
+              insideV: gridBorder,
+            },
+            cellMargins: {
+              left: { value: 144, type: "dxa" },
+              right: { value: 288, type: "dxa" },
+            },
+          },
+        },
+        {
+          styleId: "Borderless",
+          type: "table",
+          name: "Borderless",
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      formatting: { styleId: "Borderless" },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "cell" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+        styles,
+      },
+    };
+
+    const tableNode = toProseDoc(document, { styles }).firstChild;
+    const rowNode = tableNode?.firstChild;
+    const cellNode = rowNode?.firstChild;
+
+    expect(tableNode?.attrs["cellMargins"]).toBeNull();
+    expect(cellNode?.attrs["borders"]).toBeNull();
+  });
+
   test("default table style supplies conditional formatting when table has no style ID", () => {
     const styles: StyleDefinitions = {
       styles: [

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock, TextRun } from "../layout-engine/types";
+import { toProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type {
+  Document,
+  Paragraph,
+  StyleDefinitions,
+  Table,
+} from "../types/document";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+function makeDoc(paragraph: Paragraph, styles?: StyleDefinitions): Document {
+  return {
+    package: {
+      document: { content: [paragraph] },
+      ...(styles ? { styles } : {}),
+    },
+  };
+}
+
+function firstParagraph(blocks: unknown[]): ParagraphBlock {
+  return blocks.find(
+    (block) => (block as ParagraphBlock).kind === "paragraph",
+  ) as ParagraphBlock;
+}
+
+function firstRun(blocks: unknown[]): TextRun {
+  return firstParagraph(blocks).runs[0] as TextRun;
+}
+
+describe("toFlowBlocks style cascade", () => {
+  test("paragraph style rFonts reaches runs without explicit font marks", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" } },
+        },
+        {
+          styleId: "Clauses",
+          type: "paragraph",
+          basedOn: "Normal",
+          name: "Clauses",
+          rPr: { fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Clauses" },
+      content: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "clause one" }],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc(makeDoc(paragraph, styles), { styles }),
+      {},
+    );
+
+    expect(firstRun(blocks).fontFamily).toBe("Arial Narrow");
+  });
+
+  test("run with partial rFonts inherits ascii font from paragraph defaults", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+          rPr: { fontFamily: { ascii: "Arial Narrow", hAnsi: "Arial Narrow" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Normal" },
+      content: [
+        {
+          type: "run",
+          formatting: { fontFamily: { eastAsia: "Calibri" } },
+          content: [{ type: "text", text: "mixed" }],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc(makeDoc(paragraph, styles), { styles }),
+      {},
+    );
+
+    expect(firstRun(blocks).fontFamily).toBe("Arial Narrow");
+  });
+
+  test("default character style reaches runs without rStyle", () => {
+    const styles: StyleDefinitions = {
+      docDefaults: { rPr: { fontSize: 22 } },
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          default: true,
+          name: "Normal",
+        },
+        {
+          styleId: "FontePadrao",
+          type: "character",
+          default: true,
+          name: "Default Paragraph Font",
+          rPr: { fontFamily: { ascii: "Cambria", hAnsi: "Cambria" } },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text: "plain" }] }],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc(makeDoc(paragraph, styles), { styles }),
+      {},
+    );
+
+    expect(firstRun(blocks).fontFamily).toBe("Cambria");
+  });
+
+  test("default table style supplies cell margins when table has no style ID", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "TableNormal",
+          type: "table",
+          default: true,
+          name: "Normal Table",
+          tblPr: {
+            cellMargins: {
+              left: { value: 144, type: "dxa" },
+              right: { value: 288, type: "dxa" },
+            },
+          },
+        },
+      ],
+    };
+    const table: Table = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "cell" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+        styles,
+      },
+    };
+
+    const pmDoc = toProseDoc(document, { styles });
+    const tableNode = pmDoc.firstChild;
+
+    expect(tableNode?.attrs["cellMargins"]).toEqual({
+      left: 144,
+      right: 288,
+    });
+
+    const tableBlock = toFlowBlocks(pmDoc, {})[0];
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind === "table") {
+      expect(tableBlock.rows[0]?.cells[0]?.padding?.left).toBeCloseTo(9.6, 1);
+      expect(tableBlock.rows[0]?.cells[0]?.padding?.right).toBeCloseTo(19.2, 1);
+    }
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -112,6 +112,48 @@ describe("toFlowBlocks style cascade", () => {
     expect(firstRun(blocks).fontFamily).toBe("Arial Narrow");
   });
 
+  test("explicit run formatting toggles override paragraph style defaults", () => {
+    const styles: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Heading",
+          type: "paragraph",
+          name: "Heading",
+          rPr: {
+            bold: true,
+            italic: true,
+            allCaps: true,
+          },
+        },
+      ],
+    };
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { styleId: "Heading" },
+      content: [
+        {
+          type: "run",
+          formatting: {
+            bold: false,
+            italic: false,
+            allCaps: false,
+          },
+          content: [{ type: "text", text: "Keep mixed case" }],
+        },
+      ],
+    };
+
+    const blocks = toFlowBlocks(
+      toProseDoc(makeDoc(paragraph, styles), { styles }),
+      {},
+    );
+    const run = firstRun(blocks);
+
+    expect(run.bold).toBe(false);
+    expect(run.italic).toBe(false);
+    expect(run.allCaps).toBe(false);
+  });
+
   test("default character style reaches runs without rStyle", () => {
     const styles: StyleDefinitions = {
       docDefaults: { rPr: { fontSize: 22 } },

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -195,4 +195,98 @@ describe("toFlowBlocks style cascade", () => {
       expect(tableBlock.rows[0]?.cells[0]?.padding?.right).toBeCloseTo(19.2, 1);
     }
   });
+
+  test("style-less tables use built-in TableNormal side padding", () => {
+    const table: Table = {
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "cell" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+      },
+    };
+
+    const tableBlock = toFlowBlocks(toProseDoc(document), {})[0];
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind === "table") {
+      const padding = tableBlock.rows.at(0)?.cells.at(0)?.padding;
+      expect(padding?.top).toBe(0);
+      expect(padding?.right).toBeCloseTo(7.2, 1);
+      expect(padding?.bottom).toBe(0);
+      expect(padding?.left).toBeCloseTo(7.2, 1);
+    }
+  });
+
+  test("explicit zero cell margins fall through to table defaults", () => {
+    const table: Table = {
+      type: "table",
+      formatting: {
+        cellMargins: {
+          left: { value: 144, type: "dxa" },
+          right: { value: 288, type: "dxa" },
+        },
+      },
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: {
+                margins: {
+                  left: { value: 0, type: "dxa" },
+                  right: { value: 0, type: "dxa" },
+                },
+              },
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "cell" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const document: Document = {
+      package: {
+        document: { content: [table] },
+      },
+    };
+
+    const tableBlock = toFlowBlocks(toProseDoc(document), {})[0];
+    expect(tableBlock?.kind).toBe("table");
+    if (tableBlock?.kind === "table") {
+      const padding = tableBlock.rows.at(0)?.cells.at(0)?.padding;
+      expect(padding?.left).toBeCloseTo(9.6, 1);
+      expect(padding?.right).toBeCloseTo(19.2, 1);
+    }
+  });
 });

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -443,6 +443,10 @@ function extractRunFormatting(
         formatting.textOutline = true;
         break;
 
+      case "runFormattingOverride":
+        applyRunFormattingOverrides(formatting, mark);
+        break;
+
       case "emphasisMark": {
         const type = mark.attrs["type"] as string | undefined;
         formatting.emphasisMark =
@@ -519,6 +523,42 @@ function extractRunFormatting(
   }
 
   return formatting;
+}
+
+function applyRunFormattingOverrides(
+  formatting: RunFormatting,
+  mark: Mark,
+): void {
+  if (mark.attrs["bold"] === false) {
+    formatting.bold = false;
+  }
+  if (mark.attrs["italic"] === false) {
+    formatting.italic = false;
+  }
+  if (mark.attrs["underline"] === "none") {
+    formatting.underline = false;
+  }
+  if (mark.attrs["strike"] === false) {
+    formatting.strike = false;
+  }
+  if (mark.attrs["allCaps"] === false) {
+    formatting.allCaps = false;
+  }
+  if (mark.attrs["smallCaps"] === false) {
+    formatting.smallCaps = false;
+  }
+  if (mark.attrs["emboss"] === false) {
+    formatting.emboss = false;
+  }
+  if (mark.attrs["imprint"] === false) {
+    formatting.imprint = false;
+  }
+  if (mark.attrs["shadow"] === false) {
+    formatting.textShadow = false;
+  }
+  if (mark.attrs["outline"] === false) {
+    formatting.textOutline = false;
+  }
 }
 
 function paragraphRunDefaults(

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -43,7 +43,11 @@ import type {
 import type { ParagraphAttrs as PMParagraphAttrs } from "../prosemirror/schema/nodes";
 import type { Theme, SectionProperties, NumberFormat } from "../types/document";
 import { resolveColor, resolveHighlightToCss } from "../utils/colorResolver";
-import { pointsToPixels } from "../utils/units";
+import {
+  pointsToPixels,
+  halfPointsToPixels,
+  halfPointsToPoints,
+} from "../utils/units";
 
 /**
  * Options for the conversion.
@@ -381,6 +385,64 @@ function extractRunFormatting(
         break;
       }
 
+      case "characterSpacing": {
+        const attrs = mark.attrs as {
+          spacing: number | null;
+          position: number | null;
+          scale: number | null;
+          kerning: number | null;
+        };
+        if (attrs.spacing != null && attrs.spacing !== 0) {
+          formatting.letterSpacing = twipsToPixels(attrs.spacing);
+        }
+        if (attrs.position != null && attrs.position !== 0) {
+          formatting.positionPx = halfPointsToPixels(attrs.position);
+        }
+        if (attrs.scale != null && attrs.scale !== 100) {
+          formatting.horizontalScale = attrs.scale;
+        }
+        if (attrs.kerning != null && attrs.kerning > 0) {
+          formatting.kerningMinPt = halfPointsToPoints(attrs.kerning);
+        }
+        break;
+      }
+
+      case "allCaps":
+        formatting.allCaps = true;
+        break;
+
+      case "smallCaps":
+        formatting.smallCaps = true;
+        break;
+
+      case "emboss":
+        formatting.emboss = true;
+        break;
+
+      case "imprint":
+        formatting.imprint = true;
+        break;
+
+      case "textShadow":
+        formatting.textShadow = true;
+        break;
+
+      case "textOutline":
+        formatting.textOutline = true;
+        break;
+
+      case "emphasisMark": {
+        const type = mark.attrs["type"] as string | undefined;
+        formatting.emphasisMark =
+          type === "dot" ||
+          type === "comma" ||
+          type === "circle" ||
+          type === "underDot"
+            ? type
+            : "dot";
+        break;
+      }
+
       case "superscript":
         formatting.superscript = true;
         break;
@@ -447,6 +509,33 @@ function extractRunFormatting(
   return formatting;
 }
 
+function paragraphRunDefaults(pmAttrs: PMParagraphAttrs): {
+  fontFamily?: string;
+  fontSize?: number;
+} {
+  const defaultTextFormatting = pmAttrs.defaultTextFormatting as
+    | {
+        fontSize?: number;
+        fontFamily?: { ascii?: string; hAnsi?: string };
+      }
+    | undefined;
+  if (!defaultTextFormatting) {
+    return {};
+  }
+
+  const result: { fontFamily?: string; fontSize?: number } = {};
+  const fontFamily =
+    defaultTextFormatting.fontFamily?.ascii ??
+    defaultTextFormatting.fontFamily?.hAnsi;
+  if (fontFamily) {
+    result.fontFamily = fontFamily;
+  }
+  if (defaultTextFormatting.fontSize !== undefined) {
+    result.fontSize = defaultTextFormatting.fontSize / 2;
+  }
+  return result;
+}
+
 /**
  * Build an ImageRun from ProseMirror node attrs, applying conditional property assignment
  * to satisfy exactOptionalPropertyTypes.
@@ -509,6 +598,7 @@ function paragraphToRuns(
   const runs: Run[] = [];
   const offset = startPos + 1; // +1 for opening tag
   const theme = _options.theme;
+  const paraDefaults = paragraphRunDefaults(node.attrs as PMParagraphAttrs);
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, childOffset) => {
@@ -520,6 +610,7 @@ function paragraphToRuns(
       const run: TextRun = {
         kind: "text",
         text: child.text,
+        ...paraDefaults,
         ...formatting,
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
@@ -538,6 +629,7 @@ function paragraphToRuns(
       const formatting = extractRunFormatting(child.marks, theme);
       const run: TabRun = {
         kind: "tab",
+        ...paraDefaults,
         ...formatting,
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
@@ -603,6 +695,7 @@ function paragraphToRuns(
           const run: TextRun = {
             kind: "text",
             text: sdtChild.text,
+            ...paraDefaults,
             ...formatting,
             pmStart: sdtChildPos,
             pmEnd: sdtChildPos + sdtChild.nodeSize,
@@ -619,6 +712,7 @@ function paragraphToRuns(
           const formatting = extractRunFormatting(sdtChild.marks, theme);
           const run: TabRun = {
             kind: "tab",
+            ...paraDefaults,
             ...formatting,
             pmStart: sdtChildPos,
             pmEnd: sdtChildPos + sdtChild.nodeSize,
@@ -1076,6 +1170,12 @@ function convertTableCell(
   node: PMNode,
   startPos: number,
   options: ToFlowBlocksOptions,
+  tableCellMargins?: {
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+  },
 ): TableCell {
   const blocks: FlowBlock[] = [];
   let offset = startPos + 1; // +1 for opening tag
@@ -1098,11 +1198,26 @@ function convertTableCell(
   const margins = attrs["margins"] as
     | { top?: number; bottom?: number; left?: number; right?: number }
     | undefined;
+  const resolvePaddingSide = (
+    cellTwips: number | undefined,
+    tableTwips: number | undefined,
+  ): number => {
+    if (cellTwips !== undefined) {
+      const px = twipsToPixels(cellTwips);
+      if (px > 0) {
+        return px;
+      }
+    }
+    if (tableTwips !== undefined) {
+      return twipsToPixels(tableTwips);
+    }
+    return 0;
+  };
   const padding = {
-    top: margins?.top !== undefined ? twipsToPixels(margins.top) : 0,
-    right: margins?.right !== undefined ? twipsToPixels(margins.right) : 7,
-    bottom: margins?.bottom !== undefined ? twipsToPixels(margins.bottom) : 0,
-    left: margins?.left !== undefined ? twipsToPixels(margins.left) : 7,
+    top: resolvePaddingSide(margins?.top, tableCellMargins?.top),
+    right: resolvePaddingSide(margins?.right, tableCellMargins?.right),
+    bottom: resolvePaddingSide(margins?.bottom, tableCellMargins?.bottom),
+    left: resolvePaddingSide(margins?.left, tableCellMargins?.left),
   };
 
   const cell: TableCell = {
@@ -1138,6 +1253,12 @@ function convertTableRow(
   node: PMNode,
   startPos: number,
   options: ToFlowBlocksOptions,
+  tableCellMargins?: {
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+  },
 ): TableRow {
   const cells: TableCell[] = [];
   let offset = startPos + 1; // +1 for opening tag
@@ -1145,7 +1266,7 @@ function convertTableRow(
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "tableCell" || child.type.name === "tableHeader") {
-      cells.push(convertTableCell(child, offset, options));
+      cells.push(convertTableCell(child, offset, options, tableCellMargins));
     }
     offset += child.nodeSize;
   });
@@ -1177,11 +1298,14 @@ function convertTable(
 ): TableBlock {
   const rows: TableRow[] = [];
   let offset = startPos + 1; // +1 for opening tag
+  const tableCellMargins = node.attrs["cellMargins"] as
+    | { top?: number; bottom?: number; left?: number; right?: number }
+    | undefined;
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
     if (child.type.name === "tableRow") {
-      rows.push(convertTableRow(child, offset, options));
+      rows.push(convertTableRow(child, offset, options, tableCellMargins));
     }
     offset += child.nodeSize;
   });

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -70,6 +70,13 @@ export type ToFlowBlocksOptions = {
 };
 
 const DEFAULT_FONT = "Calibri";
+const DEFAULT_TABLE_CELL_MARGIN_TWIPS = {
+  top: 0,
+  right: 108,
+  bottom: 0,
+  left: 108,
+} as const;
+type TablePaddingSide = keyof typeof DEFAULT_TABLE_CELL_MARGIN_TWIPS;
 
 /**
  * Constrain image dimensions to fit within the page content area.
@@ -1199,6 +1206,7 @@ function convertTableCell(
     | { top?: number; bottom?: number; left?: number; right?: number }
     | undefined;
   const resolvePaddingSide = (
+    side: TablePaddingSide,
     cellTwips: number | undefined,
     tableTwips: number | undefined,
   ): number => {
@@ -1211,13 +1219,17 @@ function convertTableCell(
     if (tableTwips !== undefined) {
       return twipsToPixels(tableTwips);
     }
-    return 0;
+    return twipsToPixels(DEFAULT_TABLE_CELL_MARGIN_TWIPS[side]);
   };
   const padding = {
-    top: resolvePaddingSide(margins?.top, tableCellMargins?.top),
-    right: resolvePaddingSide(margins?.right, tableCellMargins?.right),
-    bottom: resolvePaddingSide(margins?.bottom, tableCellMargins?.bottom),
-    left: resolvePaddingSide(margins?.left, tableCellMargins?.left),
+    top: resolvePaddingSide("top", margins?.top, tableCellMargins?.top),
+    right: resolvePaddingSide("right", margins?.right, tableCellMargins?.right),
+    bottom: resolvePaddingSide(
+      "bottom",
+      margins?.bottom,
+      tableCellMargins?.bottom,
+    ),
+    left: resolvePaddingSide("left", margins?.left, tableCellMargins?.left),
   };
 
   const cell: TableCell = {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -41,7 +41,12 @@ import type {
   FontFamilyAttrs,
 } from "../prosemirror/schema/marks";
 import type { ParagraphAttrs as PMParagraphAttrs } from "../prosemirror/schema/nodes";
-import type { Theme, SectionProperties, NumberFormat } from "../types/document";
+import type {
+  Theme,
+  SectionProperties,
+  NumberFormat,
+  TextFormatting,
+} from "../types/document";
 import { resolveColor, resolveHighlightToCss } from "../utils/colorResolver";
 import {
   pointsToPixels,
@@ -516,21 +521,18 @@ function extractRunFormatting(
   return formatting;
 }
 
-function paragraphRunDefaults(pmAttrs: PMParagraphAttrs): {
-  fontFamily?: string;
-  fontSize?: number;
-} {
+function paragraphRunDefaults(
+  pmAttrs: PMParagraphAttrs,
+  theme?: Theme | null,
+): RunFormatting {
   const defaultTextFormatting = pmAttrs.defaultTextFormatting as
-    | {
-        fontSize?: number;
-        fontFamily?: { ascii?: string; hAnsi?: string };
-      }
+    | TextFormatting
     | undefined;
   if (!defaultTextFormatting) {
     return {};
   }
 
-  const result: { fontFamily?: string; fontSize?: number } = {};
+  const result: RunFormatting = {};
   const fontFamily =
     defaultTextFormatting.fontFamily?.ascii ??
     defaultTextFormatting.fontFamily?.hAnsi;
@@ -539,6 +541,93 @@ function paragraphRunDefaults(pmAttrs: PMParagraphAttrs): {
   }
   if (defaultTextFormatting.fontSize !== undefined) {
     result.fontSize = defaultTextFormatting.fontSize / 2;
+  }
+  if (defaultTextFormatting.bold !== undefined) {
+    result.bold = defaultTextFormatting.bold;
+  }
+  if (defaultTextFormatting.italic !== undefined) {
+    result.italic = defaultTextFormatting.italic;
+  }
+  if (
+    defaultTextFormatting.underline &&
+    defaultTextFormatting.underline.style !== "none"
+  ) {
+    result.underline = {};
+    if (defaultTextFormatting.underline.style) {
+      result.underline.style = defaultTextFormatting.underline.style;
+    }
+    if (defaultTextFormatting.underline.color) {
+      result.underline.color = resolveColor(
+        defaultTextFormatting.underline.color,
+        theme,
+      );
+    }
+  }
+  if (defaultTextFormatting.strike !== undefined) {
+    result.strike = defaultTextFormatting.strike;
+  }
+  if (defaultTextFormatting.color) {
+    result.color = resolveColor(defaultTextFormatting.color, theme);
+  }
+  if (defaultTextFormatting.highlight) {
+    const highlight = resolveHighlightToCss(defaultTextFormatting.highlight);
+    if (highlight) {
+      result.highlight = highlight;
+    }
+  }
+  if (defaultTextFormatting.vertAlign === "superscript") {
+    result.superscript = true;
+  }
+  if (defaultTextFormatting.vertAlign === "subscript") {
+    result.subscript = true;
+  }
+  if (defaultTextFormatting.allCaps !== undefined) {
+    result.allCaps = defaultTextFormatting.allCaps;
+  }
+  if (defaultTextFormatting.smallCaps !== undefined) {
+    result.smallCaps = defaultTextFormatting.smallCaps;
+  }
+  if (
+    defaultTextFormatting.spacing !== undefined &&
+    defaultTextFormatting.spacing !== 0
+  ) {
+    result.letterSpacing = twipsToPixels(defaultTextFormatting.spacing);
+  }
+  if (
+    defaultTextFormatting.position !== undefined &&
+    defaultTextFormatting.position !== 0
+  ) {
+    result.positionPx = halfPointsToPixels(defaultTextFormatting.position);
+  }
+  if (
+    defaultTextFormatting.scale !== undefined &&
+    defaultTextFormatting.scale !== 100
+  ) {
+    result.horizontalScale = defaultTextFormatting.scale;
+  }
+  if (
+    defaultTextFormatting.kerning !== undefined &&
+    defaultTextFormatting.kerning > 0
+  ) {
+    result.kerningMinPt = halfPointsToPoints(defaultTextFormatting.kerning);
+  }
+  if (defaultTextFormatting.emboss !== undefined) {
+    result.emboss = defaultTextFormatting.emboss;
+  }
+  if (defaultTextFormatting.imprint !== undefined) {
+    result.imprint = defaultTextFormatting.imprint;
+  }
+  if (defaultTextFormatting.shadow !== undefined) {
+    result.textShadow = defaultTextFormatting.shadow;
+  }
+  if (defaultTextFormatting.outline !== undefined) {
+    result.textOutline = defaultTextFormatting.outline;
+  }
+  if (
+    defaultTextFormatting.emphasisMark &&
+    defaultTextFormatting.emphasisMark !== "none"
+  ) {
+    result.emphasisMark = defaultTextFormatting.emphasisMark;
   }
   return result;
 }
@@ -605,7 +694,10 @@ function paragraphToRuns(
   const runs: Run[] = [];
   const offset = startPos + 1; // +1 for opening tag
   const theme = _options.theme;
-  const paraDefaults = paragraphRunDefaults(node.attrs as PMParagraphAttrs);
+  const paraDefaults = paragraphRunDefaults(
+    node.attrs as PMParagraphAttrs,
+    theme,
+  );
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, childOffset) => {

--- a/packages/folio/src/core/layout-engine/integration.test.ts
+++ b/packages/folio/src/core/layout-engine/integration.test.ts
@@ -160,6 +160,22 @@ describe("Layout Engine - Page Production", () => {
       expect(fragment.blockId).toBe(0);
     });
 
+    test("first paragraph on a page honors explicit spaceBefore", () => {
+      const blocks: FlowBlock[] = [
+        {
+          ...makeParagraphBlock(0, "Starts lower", 1),
+          attrs: { spacing: { before: 18, after: 0 } },
+        },
+      ];
+      const measures: Measure[] = [
+        makeParagraphMeasure([makeLine(0, 0, 0, 12, 100, 24)]),
+      ];
+
+      const layout = layoutDocument(blocks, measures, makeLayoutOptions());
+
+      expect(layout.pages[0].fragments[0]?.y).toBe(DEFAULT_MARGINS.top + 18);
+    });
+
     test("multiple paragraphs fit on one page", () => {
       const blocks: FlowBlock[] = [
         makeParagraphBlock(0, "First paragraph", 1),

--- a/packages/folio/src/core/layout-engine/paginator.test.ts
+++ b/packages/folio/src/core/layout-engine/paginator.test.ts
@@ -50,3 +50,41 @@ describe("paginator forcePageBreak", () => {
     expect(state.contentBottom).toBe(nextSize.h - nextMargins.bottom);
   });
 });
+
+describe("paginator block spacing", () => {
+  test("does not carry trailing spacing to the top of a new page", () => {
+    const paginator = createPaginator({
+      pageSize: { w: 100, h: 100 },
+      margins: { top: 10, right: 10, bottom: 10, left: 10 },
+    });
+
+    paginator.addFragment({ kind: "paragraph" } as never, 70, 0, 20);
+    const result = paginator.addFragment(
+      { kind: "paragraph" } as never,
+      20,
+      0,
+      0,
+    );
+
+    expect(paginator.pages.length).toBe(2);
+    expect(result.y).toBe(10);
+  });
+
+  test("preserves explicit spaceBefore at the top of a new page", () => {
+    const paginator = createPaginator({
+      pageSize: { w: 100, h: 100 },
+      margins: { top: 10, right: 10, bottom: 10, left: 10 },
+    });
+
+    paginator.addFragment({ kind: "paragraph" } as never, 70, 0, 20);
+    const result = paginator.addFragment(
+      { kind: "paragraph" } as never,
+      20,
+      5,
+      0,
+    );
+
+    expect(paginator.pages.length).toBe(2);
+    expect(result.y).toBe(15);
+  });
+});

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -279,17 +279,24 @@ export function createPaginator(options: PaginatorOptions) {
     spaceBefore: number = 0,
     spaceAfter: number = 0,
   ): { state: PageState; x: number; y: number } {
+    const initialState = getCurrentState();
+    const initialColumnIndex = initialState.columnIndex;
+
     // Collapse space before with trailing spacing from previous block
     const effectiveSpaceBefore = Math.max(
       spaceBefore,
-      getCurrentState().trailingSpacing,
+      initialState.trailingSpacing,
     );
     const totalHeight = effectiveSpaceBefore + height;
 
     // Ensure we have space
     const state = ensureFits(totalHeight);
 
-    const actualSpaceBefore = effectiveSpaceBefore;
+    const isSameFlowRegion =
+      state === initialState && state.columnIndex === initialColumnIndex;
+    const actualSpaceBefore = isSameFlowRegion
+      ? effectiveSpaceBefore
+      : spaceBefore;
 
     // Calculate position
     const x = getColumnX(state.columnIndex);

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -289,9 +289,7 @@ export function createPaginator(options: PaginatorOptions) {
     // Ensure we have space
     const state = ensureFits(totalHeight);
 
-    // If we moved to a new page/column, no space before needed
-    const isAtTop = state.cursorY === state.topMargin;
-    const actualSpaceBefore = isAtTop ? 0 : effectiveSpaceBefore;
+    const actualSpaceBefore = effectiveSpaceBefore;
 
     // Calculate position
     const x = getColumnX(state.columnIndex);

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -30,6 +30,21 @@ export type RunFormatting = {
   letterSpacing?: number;
   superscript?: boolean;
   subscript?: boolean;
+  /** Render glyphs as uppercase regardless of source case. */
+  allCaps?: boolean;
+  /** Render lowercase glyphs as small uppercase. */
+  smallCaps?: boolean;
+  /** Vertical baseline shift in CSS pixels. */
+  positionPx?: number;
+  /** Horizontal text scale as a percentage. */
+  horizontalScale?: number;
+  /** Minimum font size in points at which kerning is enabled. */
+  kerningMinPt?: number;
+  imprint?: boolean;
+  emboss?: boolean;
+  textShadow?: boolean;
+  textOutline?: boolean;
+  emphasisMark?: "dot" | "comma" | "circle" | "underDot";
   /** Hyperlink info if this run is a link */
   hyperlink?: { href: string; tooltip?: string };
   /** Footnote reference ID (if this run contains a footnote reference) */
@@ -243,6 +258,8 @@ export type ParagraphAttrs = {
   borders?: ParagraphBorders;
   shading?: string; // CSS background color
   tabs?: TabStop[]; // Custom tab stops
+  /** Render structural empty paragraphs as zero-height anchors. */
+  suppressEmptyParagraphHeight?: boolean;
   // List properties
   numPr?: ListNumPr;
   listMarker?: string; // Pre-computed marker text (e.g., "1.", "•", "a)")

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type {
   Page,
   ParagraphBlock,
+  ParagraphMeasure,
   TableBlock,
   TableMeasure,
 } from "../layout-engine/types";
@@ -178,6 +179,59 @@ describe("header and footer rendering", () => {
 });
 
 describe("footnote rendering", () => {
+  test("renders structured footnote fields with the page render context", () => {
+    const footnoteParagraph: ParagraphBlock = {
+      kind: "paragraph",
+      id: "fn-page-field",
+      runs: [
+        { kind: "text", text: "Page " },
+        { kind: "field", fieldType: "PAGE", fallback: "0" },
+        { kind: "text", text: " of " },
+        { kind: "field", fieldType: "NUMPAGES", fallback: "0" },
+      ],
+    };
+    const footnoteMeasure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 3,
+          toChar: 1,
+          width: 72,
+          ascent: 8,
+          descent: 2,
+          lineHeight: 12,
+        },
+      ],
+      totalHeight: 12,
+    };
+
+    const pageEl = renderPage(
+      {
+        ...page,
+        footnoteReservedHeight: 24,
+        fragments: [],
+      },
+      { pageNumber: 7, totalPages: 9, section: "body" },
+      {
+        document: fakeDocument,
+        footnoteArea: [
+          {
+            displayNumber: "1",
+            content: {
+              blocks: [footnoteParagraph],
+              measures: [footnoteMeasure],
+              height: 12,
+            },
+          },
+        ],
+      },
+    );
+
+    expect(pageEl.textContent).toContain("Page 7 of 9");
+  });
+
   test("renders structured table footnote content without body PM anchors", () => {
     const tableBlock: TableBlock = {
       kind: "table",

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -61,6 +61,19 @@ const fakeDocument = {
   },
 } as unknown as Document;
 
+function collectPmAnchors(element: FakeElement): FakeElement[] {
+  const ownAnchorKeys = Object.keys(element.dataset).filter((key) =>
+    key.toLowerCase().includes("pm"),
+  );
+  const anchors = ownAnchorKeys.length > 0 ? [element] : [];
+
+  for (const child of element.children) {
+    anchors.push(...collectPmAnchors(child));
+  }
+
+  return anchors;
+}
+
 const page: Page = {
   number: 1,
   margins: { top: 72, right: 72, bottom: 72, left: 72 },
@@ -123,10 +136,12 @@ describe("page font fallback", () => {
 });
 
 describe("footnote rendering", () => {
-  test("renders structured table footnote content", () => {
+  test("renders structured table footnote content without body PM anchors", () => {
     const tableBlock: TableBlock = {
       kind: "table",
       id: "fn-table",
+      pmStart: 1,
+      pmEnd: 20,
       rows: [
         {
           id: "row-1",
@@ -137,7 +152,9 @@ describe("footnote rendering", () => {
                 {
                   kind: "paragraph",
                   id: "cell-p-1",
-                  runs: [{ kind: "text", text: "Cell" }],
+                  pmStart: 2,
+                  pmEnd: 8,
+                  runs: [{ kind: "text", text: "Cell", pmStart: 3, pmEnd: 7 }],
                 },
               ],
               padding: { top: 0, right: 7, bottom: 0, left: 7 },
@@ -199,5 +216,8 @@ describe("footnote rendering", () => {
     );
 
     expect(footnoteArea.textContent).toContain("Cell");
+    expect(collectPmAnchors(footnoteArea as unknown as FakeElement)).toEqual(
+      [],
+    );
   });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -1,8 +1,65 @@
 import { describe, expect, test } from "bun:test";
 
-import type { Page, ParagraphBlock } from "../layout-engine/types";
+import type {
+  Page,
+  ParagraphBlock,
+  TableBlock,
+  TableMeasure,
+} from "../layout-engine/types";
 import type { BlockLookup } from "./index";
-import { computePageFingerprint, getDefaultPageFontFamily } from "./renderPage";
+import {
+  computePageFingerprint,
+  getDefaultPageFontFamily,
+  renderFootnoteArea,
+} from "./renderPage";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  private ownText = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  get textContent(): string {
+    return (
+      this.ownText + this.children.map((child) => child.textContent).join("")
+    );
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = text;
+    return node;
+  },
+} as unknown as Document;
 
 const page: Page = {
   number: 1,
@@ -62,5 +119,85 @@ describe("page font fallback", () => {
     expect(getDefaultPageFontFamily()).toBe(
       "Calibri, Carlito, Arial, Helvetica, sans-serif",
     );
+  });
+});
+
+describe("footnote rendering", () => {
+  test("renders structured table footnote content", () => {
+    const tableBlock: TableBlock = {
+      kind: "table",
+      id: "fn-table",
+      rows: [
+        {
+          id: "row-1",
+          cells: [
+            {
+              id: "cell-1",
+              blocks: [
+                {
+                  kind: "paragraph",
+                  id: "cell-p-1",
+                  runs: [{ kind: "text", text: "Cell" }],
+                },
+              ],
+              padding: { top: 0, right: 7, bottom: 0, left: 7 },
+            },
+          ],
+        },
+      ],
+      columnWidths: [100],
+    };
+    const tableMeasure: TableMeasure = {
+      kind: "table",
+      rows: [
+        {
+          cells: [
+            {
+              blocks: [
+                {
+                  kind: "paragraph",
+                  lines: [
+                    {
+                      fromRun: 0,
+                      fromChar: 0,
+                      toRun: 0,
+                      toChar: 4,
+                      width: 24,
+                      ascent: 8,
+                      descent: 2,
+                      lineHeight: 12,
+                    },
+                  ],
+                  totalHeight: 12,
+                },
+              ],
+              width: 100,
+              height: 12,
+            },
+          ],
+          height: 12,
+        },
+      ],
+      columnWidths: [100],
+      totalWidth: 100,
+      totalHeight: 12,
+    };
+
+    const footnoteArea = renderFootnoteArea(
+      [
+        {
+          displayNumber: "1",
+          content: {
+            blocks: [tableBlock],
+            measures: [tableMeasure],
+            height: 12,
+          },
+        },
+      ],
+      400,
+      fakeDocument,
+    );
+
+    expect(footnoteArea.textContent).toContain("Cell");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -10,6 +10,7 @@ import type { BlockLookup } from "./index";
 import {
   computePageFingerprint,
   getDefaultPageFontFamily,
+  renderPage,
   renderFootnoteArea,
 } from "./renderPage";
 
@@ -48,6 +49,10 @@ class FakeElement {
   getContext(): null {
     return null;
   }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
 }
 
 const fakeDocument = {
@@ -72,6 +77,24 @@ function collectPmAnchors(element: FakeElement): FakeElement[] {
   }
 
   return anchors;
+}
+
+function findByClass(
+  element: FakeElement,
+  className: string,
+): FakeElement | undefined {
+  if (element.className.split(" ").includes(className)) {
+    return element;
+  }
+
+  for (const child of element.children) {
+    const match = findByClass(child, className);
+    if (match) {
+      return match;
+    }
+  }
+
+  return undefined;
 }
 
 const page: Page = {
@@ -132,6 +155,25 @@ describe("page font fallback", () => {
     expect(getDefaultPageFontFamily()).toBe(
       "Calibri, Carlito, Arial, Helvetica, sans-serif",
     );
+  });
+});
+
+describe("header and footer rendering", () => {
+  test("dims header and footer chrome while editing body content", () => {
+    const pageElement = renderPage(
+      { ...page, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+
+    expect(
+      findByClass(pageElement as unknown as FakeElement, "layout-page-header")
+        ?.style.opacity,
+    ).toBe("0.62");
+    expect(
+      findByClass(pageElement as unknown as FakeElement, "layout-page-footer")
+        ?.style.opacity,
+    ).toBe("0.62");
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -807,6 +807,7 @@ export function renderFootnoteArea(
   footnotes: FootnoteRenderItem[],
   contentWidth: number,
   doc: Document,
+  context?: RenderContext,
 ): HTMLElement {
   const container = doc.createElement("div");
   container.className = "layout-footnote-area";
@@ -828,7 +829,7 @@ export function renderFootnoteArea(
     fnEl.style.color = "var(--doc-canvas-text, #000)";
 
     if (fn.content) {
-      const contentEl = renderFootnoteContent(fn, contentWidth, doc);
+      const contentEl = renderFootnoteContent(fn, contentWidth, doc, context);
       fnEl.append(contentEl);
     } else {
       fnEl.style.fontSize = "10px";
@@ -854,6 +855,7 @@ function renderFootnoteContent(
   footnote: FootnoteRenderItem,
   contentWidth: number,
   doc: Document,
+  context?: RenderContext,
 ): HTMLElement {
   const content = footnote.content;
   if (!content) {
@@ -866,10 +868,10 @@ function renderFootnoteContent(
   wrapper.style.width = `${contentWidth}px`;
   wrapper.style.height = `${content.height}px`;
 
-  const context: RenderContext = {
-    pageNumber: 0,
-    totalPages: 0,
-    section: "body",
+  const renderContext: RenderContext = {
+    pageNumber: context?.pageNumber ?? 0,
+    totalPages: context?.totalPages ?? 0,
+    section: context?.section ?? "body",
     contentWidth,
   };
 
@@ -886,7 +888,7 @@ function renderFootnoteContent(
       measure,
       contentWidth,
       y,
-      context,
+      renderContext,
       doc,
     );
     if (!blockEl) {
@@ -1396,6 +1398,7 @@ export function renderPage(
       options.footnoteArea,
       contentWidth,
       doc,
+      context,
     );
     fnAreaEl.style.position = "absolute";
     // Position at page bottom minus bottom margin (bottom of content area)

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -17,12 +17,15 @@ import type {
   ParagraphFragment,
   ParagraphBorders,
   TableBlock,
+  TableCell,
   TableMeasure,
   TableFragment,
+  TableRow,
   ImageBlock,
   ImageMeasure,
   ImageFragment,
   ImageRun,
+  Run,
   TextBoxBlock,
   TextBoxMeasure,
   TextBoxFragment,
@@ -904,83 +907,186 @@ function renderFootnoteBlock(
   context: RenderContext,
   doc: Document,
 ): HTMLElement | null {
-  if (block.kind === "paragraph" && measure.kind === "paragraph") {
+  const renderBlock = stripFootnotePmAnchors(block);
+
+  if (renderBlock.kind === "paragraph" && measure.kind === "paragraph") {
     const fragment: ParagraphFragment = {
       kind: "paragraph",
-      blockId: block.id,
+      blockId: renderBlock.id,
       x: 0,
       y,
       width: contentWidth,
       height: measure.totalHeight,
       fromLine: 0,
       toLine: measure.lines.length,
-      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
-      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
-    const element = renderParagraphFragment(fragment, block, measure, context, {
-      document: doc,
-    });
+    const element = renderParagraphFragment(
+      fragment,
+      renderBlock,
+      measure,
+      context,
+      {
+        document: doc,
+      },
+    );
     positionFootnoteBlock(element, y, contentWidth, measure.totalHeight);
     return element;
   }
 
-  if (block.kind === "table" && measure.kind === "table") {
+  if (renderBlock.kind === "table" && measure.kind === "table") {
     const fragment: TableFragment = {
       kind: "table",
-      blockId: block.id,
+      blockId: renderBlock.id,
       x: 0,
       y,
       width: measure.totalWidth,
       height: measure.totalHeight,
       fromRow: 0,
-      toRow: block.rows.length,
-      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
-      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+      toRow: renderBlock.rows.length,
     };
-    const element = renderTableFragment(fragment, block, measure, context, {
-      document: doc,
-    });
+    const element = renderTableFragment(
+      fragment,
+      renderBlock,
+      measure,
+      context,
+      {
+        document: doc,
+      },
+    );
     positionFootnoteBlock(element, y, measure.totalWidth, measure.totalHeight);
     return element;
   }
 
-  if (block.kind === "image" && measure.kind === "image") {
+  if (renderBlock.kind === "image" && measure.kind === "image") {
     const fragment: ImageFragment = {
       kind: "image",
-      blockId: block.id,
+      blockId: renderBlock.id,
       x: 0,
       y,
       width: measure.width,
       height: measure.height,
-      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
-      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
-    const element = renderImageFragment(fragment, block, measure, context, {
-      document: doc,
-    });
+    const element = renderImageFragment(
+      fragment,
+      renderBlock,
+      measure,
+      context,
+      {
+        document: doc,
+      },
+    );
     positionFootnoteBlock(element, y, measure.width, measure.height);
     return element;
   }
 
-  if (block.kind === "textBox" && measure.kind === "textBox") {
+  if (renderBlock.kind === "textBox" && measure.kind === "textBox") {
     const fragment: TextBoxFragment = {
       kind: "textBox",
-      blockId: block.id,
+      blockId: renderBlock.id,
       x: 0,
       y,
       width: measure.width,
       height: measure.height,
-      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
-      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     };
-    const element = renderTextBoxFragment(fragment, block, measure, context, {
-      document: doc,
-    });
+    const element = renderTextBoxFragment(
+      fragment,
+      renderBlock,
+      measure,
+      context,
+      {
+        document: doc,
+      },
+    );
     positionFootnoteBlock(element, y, measure.width, measure.height);
     return element;
   }
 
   return null;
+}
+
+function stripFootnotePmAnchors(block: FlowBlock): FlowBlock {
+  switch (block.kind) {
+    case "paragraph":
+      return stripFootnoteParagraphPmAnchors(block);
+    case "table": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...table } = block;
+      return {
+        ...table,
+        rows: table.rows.map(stripFootnoteTableRowPmAnchors),
+      };
+    }
+    case "image": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...image } = block;
+      return image;
+    }
+    case "textBox": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...textBox } = block;
+      return {
+        ...textBox,
+        content: textBox.content.map(stripFootnoteParagraphPmAnchors),
+      };
+    }
+    case "pageBreak":
+    case "columnBreak": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...breakBlock } = block;
+      return breakBlock;
+    }
+    case "sectionBreak":
+      return block;
+    default:
+      return block;
+  }
+}
+
+function stripFootnoteTableRowPmAnchors(row: TableRow): TableRow {
+  return {
+    ...row,
+    cells: row.cells.map(stripFootnoteTableCellPmAnchors),
+  };
+}
+
+function stripFootnoteTableCellPmAnchors(cell: TableCell): TableCell {
+  return {
+    ...cell,
+    blocks: cell.blocks.map(stripFootnotePmAnchors),
+  };
+}
+
+function stripFootnoteParagraphPmAnchors(
+  block: ParagraphBlock,
+): ParagraphBlock {
+  const { pmStart: _pmStart, pmEnd: _pmEnd, ...paragraph } = block;
+  return {
+    ...paragraph,
+    runs: paragraph.runs.map(stripFootnoteRunPmAnchors),
+  };
+}
+
+function stripFootnoteRunPmAnchors(run: Run): Run {
+  switch (run.kind) {
+    case "text": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...textRun } = run;
+      return textRun;
+    }
+    case "tab": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...tabRun } = run;
+      return tabRun;
+    }
+    case "image": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...imageRun } = run;
+      return imageRun;
+    }
+    case "lineBreak": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...lineBreakRun } = run;
+      return lineBreakRun;
+    }
+    case "field": {
+      const { pmStart: _pmStart, pmEnd: _pmEnd, ...fieldRun } = run;
+      return fieldRun;
+    }
+    default:
+      return run;
+  }
 }
 
 function positionFootnoteBlock(

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -1442,6 +1442,7 @@ export function renderPage(
     headerEl.style.width = `${headerContentWidth}px`;
     headerEl.style.height = `${actualHeaderHeight}px`;
     headerEl.style.minHeight = `${actualHeaderHeight}px`;
+    headerEl.style.opacity = "0.62";
 
     let shouldClipHeader = !headerOverflows;
     if (options.headerContent && options.headerContent.blocks.length > 0) {
@@ -1526,6 +1527,7 @@ export function renderPage(
     footerEl.style.width = `${footerContentWidth}px`;
     footerEl.style.height = `${actualFooterHeight}px`;
     footerEl.style.minHeight = `${actualFooterHeight}px`;
+    footerEl.style.opacity = "0.62";
 
     let shouldClipFooter = !footerOverflows;
     if (options.footerContent && options.footerContent.blocks.length > 0) {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -26,6 +26,7 @@ import type {
   TextBoxBlock,
   TextBoxMeasure,
   TextBoxFragment,
+  FootnoteContent,
 } from "../layout-engine/types";
 import type { BorderSpec, Theme } from "../types/document";
 import { resolveFontFamily } from "../utils/fontResolver";
@@ -133,7 +134,9 @@ export type FootnoteRenderItem = {
   /** Display number (e.g. "1", "2") */
   displayNumber: string;
   /** Plain text content */
-  text: string;
+  text?: string;
+  /** Pre-measured structured footnote content. */
+  content?: Pick<FootnoteContent, "blocks" | "measures" | "height">;
 };
 
 /**
@@ -797,7 +800,7 @@ function renderHeaderFooterContent(
  * Render the footnote area at the bottom of a page.
  * Includes a separator line (33% width) and footnote entries.
  */
-function renderFootnoteArea(
+export function renderFootnoteArea(
   footnotes: FootnoteRenderItem[],
   contentWidth: number,
   doc: Document,
@@ -818,24 +821,189 @@ function renderFootnoteArea(
   // Render each footnote
   for (const fn of footnotes) {
     const fnEl = doc.createElement("div");
-    fnEl.style.fontSize = "10px";
-    fnEl.style.lineHeight = "1.3";
     fnEl.style.marginBottom = "4px";
     fnEl.style.color = "var(--doc-canvas-text, #000)";
 
-    const sup = doc.createElement("sup");
-    sup.textContent = fn.displayNumber;
-    sup.style.fontSize = "7px";
-    sup.style.marginRight = "2px";
-    fnEl.append(sup);
+    if (fn.content) {
+      const contentEl = renderFootnoteContent(fn, contentWidth, doc);
+      fnEl.append(contentEl);
+    } else {
+      fnEl.style.fontSize = "10px";
+      fnEl.style.lineHeight = "1.3";
 
-    const textNode = doc.createTextNode(` ${fn.text}`);
-    fnEl.append(textNode);
+      const sup = doc.createElement("sup");
+      sup.textContent = fn.displayNumber;
+      sup.style.fontSize = "7px";
+      sup.style.marginRight = "2px";
+      fnEl.append(sup);
+
+      const textNode = doc.createTextNode(` ${fn.text ?? ""}`);
+      fnEl.append(textNode);
+    }
 
     container.append(fnEl);
   }
 
   return container;
+}
+
+function renderFootnoteContent(
+  footnote: FootnoteRenderItem,
+  contentWidth: number,
+  doc: Document,
+): HTMLElement {
+  const content = footnote.content;
+  if (!content) {
+    throw new Error("Missing structured footnote content");
+  }
+
+  const wrapper = doc.createElement("div");
+  wrapper.className = "layout-footnote-content";
+  wrapper.style.position = "relative";
+  wrapper.style.width = `${contentWidth}px`;
+  wrapper.style.height = `${content.height}px`;
+
+  const context: RenderContext = {
+    pageNumber: 0,
+    totalPages: 0,
+    section: "body",
+    contentWidth,
+  };
+
+  let y = 0;
+  for (let index = 0; index < content.blocks.length; index++) {
+    const block = content.blocks[index];
+    const measure = content.measures[index];
+    if (!block || !measure) {
+      continue;
+    }
+
+    const blockEl = renderFootnoteBlock(
+      block,
+      measure,
+      contentWidth,
+      y,
+      context,
+      doc,
+    );
+    if (!blockEl) {
+      continue;
+    }
+    wrapper.append(blockEl);
+    y += getFootnoteMeasureHeight(measure);
+  }
+
+  return wrapper;
+}
+
+function renderFootnoteBlock(
+  block: FlowBlock,
+  measure: Measure,
+  contentWidth: number,
+  y: number,
+  context: RenderContext,
+  doc: Document,
+): HTMLElement | null {
+  if (block.kind === "paragraph" && measure.kind === "paragraph") {
+    const fragment: ParagraphFragment = {
+      kind: "paragraph",
+      blockId: block.id,
+      x: 0,
+      y,
+      width: contentWidth,
+      height: measure.totalHeight,
+      fromLine: 0,
+      toLine: measure.lines.length,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    const element = renderParagraphFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+    positionFootnoteBlock(element, y, contentWidth, measure.totalHeight);
+    return element;
+  }
+
+  if (block.kind === "table" && measure.kind === "table") {
+    const fragment: TableFragment = {
+      kind: "table",
+      blockId: block.id,
+      x: 0,
+      y,
+      width: measure.totalWidth,
+      height: measure.totalHeight,
+      fromRow: 0,
+      toRow: block.rows.length,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    const element = renderTableFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+    positionFootnoteBlock(element, y, measure.totalWidth, measure.totalHeight);
+    return element;
+  }
+
+  if (block.kind === "image" && measure.kind === "image") {
+    const fragment: ImageFragment = {
+      kind: "image",
+      blockId: block.id,
+      x: 0,
+      y,
+      width: measure.width,
+      height: measure.height,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    const element = renderImageFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+    positionFootnoteBlock(element, y, measure.width, measure.height);
+    return element;
+  }
+
+  if (block.kind === "textBox" && measure.kind === "textBox") {
+    const fragment: TextBoxFragment = {
+      kind: "textBox",
+      blockId: block.id,
+      x: 0,
+      y,
+      width: measure.width,
+      height: measure.height,
+      ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+      ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+    };
+    const element = renderTextBoxFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+    positionFootnoteBlock(element, y, measure.width, measure.height);
+    return element;
+  }
+
+  return null;
+}
+
+function positionFootnoteBlock(
+  element: HTMLElement,
+  top: number,
+  width: number,
+  height: number,
+): void {
+  element.style.position = "absolute";
+  element.style.left = "0";
+  element.style.top = `${top}px`;
+  element.style.width = `${width}px`;
+  element.style.height = `${height}px`;
+}
+
+function getFootnoteMeasureHeight(measure: Measure): number {
+  if (measure.kind === "paragraph" || measure.kind === "table") {
+    return measure.totalHeight;
+  }
+  if (measure.kind === "image" || measure.kind === "textBox") {
+    return measure.height;
+  }
+  return 0;
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImageRun,
+  MeasuredLine,
+  ParagraphBlock,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+describe("renderLine inline image handling", () => {
+  test("pins image dimensions and centers an image-only line", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 186,
+      height: 29,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [imageRun],
+      pmStart: 0,
+      pmEnd: 3,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 186,
+      ascent: 32,
+      descent: 3,
+      lineHeight: 35,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const imageEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(lineEl.style.display).toBe("flex");
+    expect(lineEl.style.alignItems).toBe("center");
+    expect(imageEl?.style.width).toBe("186px");
+    expect(imageEl?.style.height).toBe("29px");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -114,6 +114,37 @@ describe("renderLine scaled text handling", () => {
   });
 });
 
+describe("renderLine text styling", () => {
+  test("paints DOCX bold runs with the calibrated browser weight", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "SECURITIES ACT",
+          bold: true,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 14,
+      width: 80,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.fontWeight).toBe("800");
+  });
+});
+
 describe("renderParagraphFragment indentation handling", () => {
   test("negative side indents shift and widen line boxes", () => {
     const block: ParagraphBlock = {

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -145,6 +145,35 @@ describe("renderLine text styling", () => {
   });
 });
 
+describe("renderLine tab tracking", () => {
+  test("includes preceding run letter spacing when sizing tabs", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        { kind: "text", text: "AA", letterSpacing: 10 },
+        { kind: "tab" },
+        { kind: "text", text: "B" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 55,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const tabEl = lineEl.children[1] as HTMLElement | undefined;
+
+    expect(tabEl?.style.width).toBe("24px");
+  });
+});
+
 describe("renderParagraphFragment indentation handling", () => {
   test("negative side indents shift and widen line boxes", () => {
     const block: ParagraphBlock = {

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -33,8 +33,22 @@ class FakeElement {
     return child;
   }
 
-  getContext(): null {
-    return null;
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+
+    return {
+      font: "",
+      measureText(text: string) {
+        return {
+          width: text.length * 7 + (this.font.includes("800") ? 10 : 0),
+        };
+      },
+    };
   }
 }
 
@@ -146,6 +160,33 @@ describe("renderLine text styling", () => {
 });
 
 describe("renderLine tab tracking", () => {
+  test("measures preceding bold text with the rendered DOCX bold weight", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        { kind: "text", text: "AA", bold: true },
+        { kind: "tab" },
+        { kind: "text", text: "B" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 55,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const tabEl = lineEl.children[1] as HTMLElement | undefined;
+
+    expect(tabEl?.style.width).toBe("24px");
+  });
+
   test("includes preceding run letter spacing when sizing tabs", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -4,8 +4,10 @@ import type {
   ImageRun,
   MeasuredLine,
   ParagraphBlock,
+  ParagraphFragment,
+  ParagraphMeasure,
 } from "../layout-engine/types";
-import { renderLine } from "./renderParagraph";
+import { renderLine, renderParagraphFragment } from "./renderParagraph";
 
 class FakeElement {
   className = "";
@@ -109,5 +111,59 @@ describe("renderLine scaled text handling", () => {
 
     expect(textEl?.style.transform).toBe("scaleX(1.5)");
     expect(textEl?.style.width).toBe("42px");
+  });
+});
+
+describe("renderParagraphFragment indentation handling", () => {
+  test("negative side indents shift and widen line boxes", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "wide" }],
+      attrs: {
+        indent: {
+          left: -20,
+          right: -10,
+        },
+      },
+    };
+    const measure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 4,
+          width: 20,
+          ascent: 10,
+          descent: 2,
+          lineHeight: 12,
+        },
+      ],
+      totalHeight: 12,
+    };
+    const fragment: ParagraphFragment = {
+      kind: "paragraph",
+      blockId: "p1",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 12,
+      fromLine: 0,
+      toLine: 1,
+    };
+
+    const fragmentEl = renderParagraphFragment(
+      fragment,
+      block,
+      measure,
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument },
+    );
+    const lineEl = fragmentEl.children[0] as HTMLElement | undefined;
+
+    expect(lineEl?.style.marginLeft).toBe("-20px");
+    expect(lineEl?.style.width).toBe("130px");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -79,3 +79,35 @@ describe("renderLine inline image handling", () => {
     expect(imageEl?.style.height).toBe("29px");
   });
 });
+
+describe("renderLine scaled text handling", () => {
+  test("reserves scaled advance for horizontally scaled text runs", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "abcd",
+          horizontalScale: 150,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 4,
+      width: 42,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.transform).toBe("scaleX(1.5)");
+    expect(textEl?.style.width).toBe("42px");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -45,6 +45,8 @@ export const PARAGRAPH_CLASS_NAMES = {
   lineBreak: "layout-run-linebreak",
 };
 
+const DOCX_BOLD_FONT_WEIGHT = "800";
+
 // Text wrapping around floating images is implemented via measurement-time
 // per-line leftOffset/rightOffset. renderPage.ts re-measures paragraphs with
 // FloatingImageZone[] when floating images are present on the page.
@@ -118,7 +120,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.fontSize = `${fontSizePx}px`;
   }
   if (run.bold) {
-    element.style.fontWeight = "bold";
+    element.style.fontWeight = DOCX_BOLD_FONT_WEIGHT;
   }
   if (run.italic) {
     element.style.fontStyle = "italic";

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -305,6 +305,17 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   }
 }
 
+function reserveScaledAdvance(
+  element: HTMLElement,
+  unscaledWidth: number,
+  horizontalScale: number | undefined,
+): void {
+  if (horizontalScale === undefined || horizontalScale === 100) {
+    return;
+  }
+  element.style.width = `${unscaledWidth * (horizontalScale / 100)}px`;
+}
+
 /**
  * Apply PM position data attributes
  */
@@ -964,6 +975,7 @@ export function renderLine(
           ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
         },
       );
+      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
       currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
     } else if (isImageRun(run)) {
       // Skip floating images - they're rendered separately at page level.
@@ -1001,20 +1013,18 @@ export function renderLine(
       }
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
-      currentX +=
-        measureText(
-          run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
-          fontSize,
-          fontFamily,
-          {
-            ...(run.bold !== undefined ? { bold: run.bold } : {}),
-            ...(run.italic !== undefined ? { italic: run.italic } : {}),
-            ...(run.smallCaps !== undefined
-              ? { smallCaps: run.smallCaps }
-              : {}),
-          },
-        ) *
-        ((run.horizontalScale ?? 100) / 100);
+      const measuredWidth = measureText(
+        run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
+        fontSize,
+        fontFamily,
+        {
+          ...(run.bold !== undefined ? { bold: run.bold } : {}),
+          ...(run.italic !== undefined ? { italic: run.italic } : {}),
+          ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
+        },
+      );
+      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
+      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
     } else {
       // Fallback for unknown run types
       const runEl = renderRun(run, doc, options?.context);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1157,17 +1157,17 @@ export function renderParagraphFragment(
     // Track indent values for line-level application
     // For RTL paragraphs, swap left/right indentation
     if (isBidi) {
-      if (indent.left && indent.left > 0) {
+      if (indent.left !== undefined) {
         indentRight = indent.left;
       }
-      if (indent.right && indent.right > 0) {
+      if (indent.right !== undefined) {
         indentLeft = indent.right;
       }
     } else {
-      if (indent.left && indent.left > 0) {
+      if (indent.left !== undefined) {
         indentLeft = indent.left;
       }
-      if (indent.right && indent.right > 0) {
+      if (indent.right !== undefined) {
         indentRight = indent.right;
       }
     }
@@ -1358,10 +1358,14 @@ export function renderParagraphFragment(
 
     // Apply left offset from floating images (lines start after the floating image)
     // Also constrain width so text doesn't overflow into the image area
-    if (lineLeftOffset > 0 || lineRightOffset > 0) {
-      if (lineLeftOffset > 0) {
-        lineEl.style.marginLeft = `${lineLeftOffset}px`;
-      }
+    const lineMarginLeft = Math.min(indentLeft, 0) + lineLeftOffset;
+    if (
+      lineMarginLeft !== 0 ||
+      lineRightOffset > 0 ||
+      indentLeft < 0 ||
+      indentRight < 0
+    ) {
+      lineEl.style.marginLeft = `${lineMarginLeft}px`;
       if (lineRightOffset > 0) {
         lineEl.style.marginRight = `${lineRightOffset}px`;
       }
@@ -1383,13 +1387,13 @@ export function renderParagraphFragment(
 
     if (isFirstLine) {
       // First line handling
-      if (indentLeft > 0 && hasHanging) {
+      if (indentLeft !== 0 && hasHanging) {
         // Hanging indent: first line starts at (indentLeft - hanging)
-        lineEl.style.paddingLeft = `${indentLeft}px`;
+        lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
         lineEl.style.textIndent = `-${indent?.hanging ?? 0}px`;
-      } else if (indentLeft > 0 && hasFirstLine) {
+      } else if (indentLeft !== 0 && hasFirstLine) {
         // First line indent: first line starts at (indentLeft + firstLine)
-        lineEl.style.paddingLeft = `${indentLeft}px`;
+        lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
         lineEl.style.textIndent = `${indent?.firstLine ?? 0}px`;
       } else if (indentLeft > 0) {
         // Just left indent, no special first line treatment

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -761,8 +761,21 @@ function getTextAfterTab(
 type TextMeasureStyle = {
   bold?: boolean;
   italic?: boolean;
+  letterSpacing?: number;
   smallCaps?: boolean;
 };
+
+function applyLetterSpacingToMeasuredWidth(
+  width: number,
+  text: string,
+  letterSpacing: number | undefined,
+): number {
+  if (!letterSpacing || text.length <= 1) {
+    return width;
+  }
+
+  return width + letterSpacing * (text.length - 1);
+}
 
 function createTextMeasurer(
   doc: Document,
@@ -782,7 +795,11 @@ function createTextMeasurer(
     style: TextMeasureStyle = {},
   ) => {
     if (!ctx) {
-      return text.length * 7;
+      return applyLetterSpacingToMeasuredWidth(
+        text.length * 7,
+        text,
+        style.letterSpacing,
+      );
     } // Fallback estimate
     // Use font resolver for category-appropriate fallback stacks,
     // matching measureContainer.ts
@@ -801,7 +818,11 @@ function createTextMeasurer(
     }
     fontParts.push(`${fontSizePx}px`, cssFallback);
     ctx.font = fontParts.join(" ");
-    return ctx.measureText(text).width;
+    return applyLetterSpacingToMeasuredWidth(
+      ctx.measureText(text).width,
+      text,
+      style.letterSpacing,
+    );
   };
 }
 
@@ -974,6 +995,9 @@ export function renderLine(
         {
           ...(run.bold !== undefined ? { bold: run.bold } : {}),
           ...(run.italic !== undefined ? { italic: run.italic } : {}),
+          ...(run.letterSpacing !== undefined
+            ? { letterSpacing: run.letterSpacing }
+            : {}),
           ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
         },
       );
@@ -1022,6 +1046,9 @@ export function renderLine(
         {
           ...(run.bold !== undefined ? { bold: run.bold } : {}),
           ...(run.italic !== undefined ? { italic: run.italic } : {}),
+          ...(run.letterSpacing !== undefined
+            ? { letterSpacing: run.letterSpacing }
+            : {}),
           ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
         },
       );

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -139,6 +139,66 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     element.style.letterSpacing = `${run.letterSpacing}px`;
   }
 
+  if (run.allCaps) {
+    element.style.textTransform = "uppercase";
+  }
+  if (run.smallCaps) {
+    element.style.fontVariant = "small-caps";
+  }
+  if (run.positionPx) {
+    element.style.verticalAlign = `${run.positionPx}px`;
+  }
+  if (run.horizontalScale && run.horizontalScale !== 100) {
+    element.style.display = "inline-block";
+    element.style.transform = `scaleX(${run.horizontalScale / 100})`;
+    element.style.transformOrigin = "left center";
+  }
+  if (run.kerningMinPt && run.kerningMinPt > 0) {
+    const fontSizePt = run.fontSize ?? 11;
+    if (fontSizePt >= run.kerningMinPt) {
+      element.style.fontKerning = "normal";
+    }
+  }
+  if (run.emboss) {
+    element.style.textShadow =
+      "1px 1px 1px rgba(255,255,255,0.5), -1px -1px 1px rgba(0,0,0,0.3)";
+  }
+  if (run.imprint) {
+    element.style.textShadow =
+      "-1px -1px 1px rgba(255,255,255,0.5), 1px 1px 1px rgba(0,0,0,0.3)";
+  }
+  if (run.textShadow && !run.emboss && !run.imprint) {
+    element.style.textShadow = "1px 1px 2px rgba(0,0,0,0.3)";
+  }
+  if (run.textOutline) {
+    element.style.webkitTextStroke = "1px currentColor";
+    (
+      element.style as CSSStyleDeclaration & {
+        webkitTextFillColor?: string;
+      }
+    ).webkitTextFillColor = "transparent";
+  }
+  if (run.emphasisMark) {
+    const variant =
+      run.emphasisMark === "comma"
+        ? "filled sesame"
+        : run.emphasisMark === "circle"
+          ? "filled circle"
+          : "filled dot";
+    const position =
+      run.emphasisMark === "underDot" ? "under right" : "over right";
+    element.style.textEmphasis = variant;
+    element.style.textEmphasisPosition = position;
+    (
+      element.style as CSSStyleDeclaration & { webkitTextEmphasis?: string }
+    ).webkitTextEmphasis = variant;
+    (
+      element.style as CSSStyleDeclaration & {
+        webkitTextEmphasisPosition?: string;
+      }
+    ).webkitTextEmphasisPosition = position;
+  }
+
   // Highlight (background color)
   if (run.highlight) {
     element.style.backgroundColor = run.highlight;
@@ -367,6 +427,8 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   img.src = run.src;
   img.width = run.width;
   img.height = run.height;
+  img.style.width = `${run.width}px`;
+  img.style.height = `${run.height}px`;
   if (run.alt) {
     img.alt = run.alt;
   }
@@ -488,6 +550,25 @@ function renderFieldRun(
     ...(run.highlight !== undefined ? { highlight: run.highlight } : {}),
     ...(run.fontFamily !== undefined ? { fontFamily: run.fontFamily } : {}),
     ...(run.fontSize !== undefined ? { fontSize: run.fontSize } : {}),
+    ...(run.letterSpacing !== undefined
+      ? { letterSpacing: run.letterSpacing }
+      : {}),
+    ...(run.allCaps !== undefined ? { allCaps: run.allCaps } : {}),
+    ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
+    ...(run.positionPx !== undefined ? { positionPx: run.positionPx } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
+    ...(run.kerningMinPt !== undefined
+      ? { kerningMinPt: run.kerningMinPt }
+      : {}),
+    ...(run.imprint !== undefined ? { imprint: run.imprint } : {}),
+    ...(run.emboss !== undefined ? { emboss: run.emboss } : {}),
+    ...(run.textShadow !== undefined ? { textShadow: run.textShadow } : {}),
+    ...(run.textOutline !== undefined ? { textOutline: run.textOutline } : {}),
+    ...(run.emphasisMark !== undefined
+      ? { emphasisMark: run.emphasisMark }
+      : {}),
     ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
     ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
   };
@@ -710,6 +791,10 @@ export function renderLine(
 
   // Get runs for this line
   const runsForLine = sliceRunsForLine(block, line);
+  if (runsForLine.length === 1 && isImageRun(runsForLine[0]!)) {
+    lineEl.style.display = "flex";
+    lineEl.style.alignItems = "center";
+  }
 
   // Handle empty lines
   if (runsForLine.length === 0) {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -28,6 +28,7 @@ import type {
 } from "../prosemirror/utils/tabCalculator";
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
 import { resolveFontFamily } from "../utils/fontResolver";
+import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
@@ -44,8 +45,6 @@ export const PARAGRAPH_CLASS_NAMES = {
   image: "layout-run-image",
   lineBreak: "layout-run-linebreak",
 };
-
-const DOCX_BOLD_FONT_WEIGHT = "800";
 
 // Text wrapping around floating images is implemented via measurement-time
 // per-line leftOffset/rightOffset. renderPage.ts re-measures paragraphs with
@@ -814,7 +813,7 @@ function createTextMeasurer(
       fontParts.push("small-caps");
     }
     if (style.bold) {
-      fontParts.push("bold");
+      fontParts.push(DOCX_BOLD_FONT_WEIGHT);
     }
     fontParts.push(`${fontSizePx}px`, cssFallback);
     ctx.font = fontParts.join(" ");

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -927,7 +927,11 @@ export function renderLine(
       // Measure text width for accurate tab position tracking
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
-      currentX += measureText(run.text, fontSize, fontFamily);
+      currentX += measureText(
+        run.allCaps ? run.text.toLocaleUpperCase() : run.text,
+        fontSize,
+        fontFamily,
+      );
     } else if (isImageRun(run)) {
       // Skip floating images - they're rendered separately at page level.
       // Exception: inside table cells, floating images must render in-flow

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -745,13 +745,29 @@ function getTextAfterTab(
  * Create a text measurement function using a temporary canvas
  * Uses the same font fallback chain as measureContainer.ts
  */
+type TextMeasureStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  smallCaps?: boolean;
+};
+
 function createTextMeasurer(
   doc: Document,
-): (text: string, fontSize?: number, fontFamily?: string) => number {
+): (
+  text: string,
+  fontSize?: number,
+  fontFamily?: string,
+  style?: TextMeasureStyle,
+) => number {
   const canvas = doc.createElement("canvas");
   const ctx = canvas.getContext("2d");
 
-  return (text: string, fontSize = 11, fontFamily = "Calibri") => {
+  return (
+    text: string,
+    fontSize = 11,
+    fontFamily = "Calibri",
+    style: TextMeasureStyle = {},
+  ) => {
     if (!ctx) {
       return text.length * 7;
     } // Fallback estimate
@@ -760,7 +776,18 @@ function createTextMeasurer(
     const cssFallback = resolveFontFamily(fontFamily).cssFallback;
     // Convert pt to px for canvas (1pt = 96/72 px)
     const fontSizePx = (fontSize * 96) / 72;
-    ctx.font = `${fontSizePx}px ${cssFallback}`;
+    const fontParts: string[] = [];
+    if (style.italic) {
+      fontParts.push("italic");
+    }
+    if (style.smallCaps) {
+      fontParts.push("small-caps");
+    }
+    if (style.bold) {
+      fontParts.push("bold");
+    }
+    fontParts.push(`${fontSizePx}px`, cssFallback);
+    ctx.font = fontParts.join(" ");
     return ctx.measureText(text).width;
   };
 }
@@ -931,6 +958,11 @@ export function renderLine(
         run.allCaps ? run.text.toLocaleUpperCase() : run.text,
         fontSize,
         fontFamily,
+        {
+          ...(run.bold !== undefined ? { bold: run.bold } : {}),
+          ...(run.italic !== undefined ? { italic: run.italic } : {}),
+          ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
+        },
       );
       currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
     } else if (isImageRun(run)) {
@@ -969,7 +1001,20 @@ export function renderLine(
       }
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
-      currentX += measureText(fieldText, fontSize, fontFamily);
+      currentX +=
+        measureText(
+          run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
+          fontSize,
+          fontFamily,
+          {
+            ...(run.bold !== undefined ? { bold: run.bold } : {}),
+            ...(run.italic !== undefined ? { italic: run.italic } : {}),
+            ...(run.smallCaps !== undefined
+              ? { smallCaps: run.smallCaps }
+              : {}),
+          },
+        ) *
+        ((run.horizontalScale ?? 100) / 100);
     } else {
       // Fallback for unknown run types
       const runEl = renderRun(run, doc, options?.context);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -927,11 +927,12 @@ export function renderLine(
       // Measure text width for accurate tab position tracking
       const fontSize = run.fontSize || 11;
       const fontFamily = run.fontFamily || "Calibri";
-      currentX += measureText(
+      const measuredWidth = measureText(
         run.allCaps ? run.text.toLocaleUpperCase() : run.text,
         fontSize,
         fontFamily,
       );
+      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
     } else if (isImageRun(run)) {
       // Skip floating images - they're rendered separately at page level.
       // Exception: inside table cells, floating images must render in-flow

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -55,6 +55,7 @@ import type {
   CellMargins,
 } from "../../types/document";
 import { pixelsToEmu } from "../../utils/units";
+import { applyRunFormattingOverrideMark } from "../extensions/marks/RunFormattingOverrideExtension";
 import type { ShapeAttrs } from "../extensions/nodes/ShapeExtension";
 import type { TextBoxAttrs } from "../extensions/nodes/TextBoxExtension";
 import type {
@@ -1261,6 +1262,10 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
 
       case "textOutline":
         formatting.outline = true;
+        break;
+
+      case "runFormattingOverride":
+        applyRunFormattingOverrideMark(formatting, mark);
         break;
 
       // hyperlink is handled separately

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -4,6 +4,142 @@ import type { Document } from "../../types/document";
 import { toProseDoc } from "./toProseDoc";
 
 describe("toProseDoc", () => {
+  test("applies oneNDA paragraph mark defaults to unformatted visible text like Word", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  bold: true,
+                  fontSize: 21,
+                  fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {},
+                  content: [{ type: "text", text: "TERMS" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(true);
+    expect(text?.marks.some((mark) => mark.type.name === "italic")).toBe(false);
+    expect(
+      text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size,
+    ).toBe(21);
+    expect(
+      text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii,
+    ).toBe("Arial");
+  });
+
+  test("keeps oneNDA heading direct run formatting ahead of paragraph mark defaults", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  italic: true,
+                  fontSize: 18,
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    bold: true,
+                    fontSize: 20,
+                  },
+                  content: [{ type: "text", text: "PARTIES AND " }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(true);
+    expect(text?.marks.some((mark) => mark.type.name === "italic")).toBe(false);
+    expect(
+      text?.marks.find((mark) => mark.type.name === "fontSize")?.attrs.size,
+    ).toBe(20);
+  });
+
+  test("applies oneNDA table style run properties before direct run properties", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "TableStyle",
+              type: "table",
+              rPr: {
+                bold: true,
+                fontFamily: {
+                  ascii: "Open Sans Light",
+                  hAnsi: "Open Sans Light",
+                },
+              },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "table",
+              formatting: { styleId: "TableStyle" },
+              rows: [
+                {
+                  cells: [
+                    {
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Styled cell" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const text = doc.firstChild?.firstChild?.firstChild?.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(true);
+    expect(
+      text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii,
+    ).toBe("Open Sans Light");
+  });
+
   test("applies built-in Word Normal defaults when styles.xml is absent", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -31,6 +31,97 @@ describe("toProseDoc", () => {
     expect(paragraph?.attrs.lineSpacingRule).toBe("auto");
   });
 
+  test("keeps paragraph style run defaults above default character style", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+              rPr: {
+                fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+              },
+            },
+            {
+              styleId: "DefaultChar",
+              type: "character",
+              default: true,
+              rPr: {
+                fontFamily: { ascii: "Cambria", hAnsi: "Cambria" },
+              },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "Normal" },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Plain paragraph" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const defaultTextFormatting = doc.firstChild?.attrs.defaultTextFormatting;
+
+    expect(defaultTextFormatting?.fontFamily?.ascii).toBe("Arial");
+    expect(defaultTextFormatting?.fontFamily?.hAnsi).toBe("Arial");
+  });
+
+  test("uses default character style when paragraph style has no run defaults", () => {
+    const document: Document = {
+      package: {
+        styles: {
+          styles: [
+            {
+              styleId: "Normal",
+              type: "paragraph",
+              default: true,
+            },
+            {
+              styleId: "DefaultChar",
+              type: "character",
+              default: true,
+              rPr: {
+                fontFamily: { ascii: "Cambria", hAnsi: "Cambria" },
+              },
+            },
+          ],
+        },
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: { styleId: "Normal" },
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Plain paragraph" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document, { styles: document.package.styles });
+    const defaultTextFormatting = doc.firstChild?.attrs.defaultTextFormatting;
+
+    expect(defaultTextFormatting?.fontFamily?.ascii).toBe("Cambria");
+    expect(defaultTextFormatting?.fontFamily?.hAnsi).toBe("Cambria");
+  });
+
   test("preserves DOCX field instruction and cached display text", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -763,18 +763,19 @@ function convertTable(
     ? styleResolver?.getStyle(tableStyleId)
     : undefined;
   const defaultTableStyle = styleResolver?.getDefaultTableStyle();
+  const fallbackTableStyle = tableStyleId ? undefined : defaultTableStyle;
   const conditionalTableStyleId =
-    tableStyle?.styleId ?? defaultTableStyle?.styleId;
+    tableStyle?.styleId ?? fallbackTableStyle?.styleId;
   const resolvedTableBorders =
     table.formatting?.borders ??
     tableStyle?.tblPr?.borders ??
-    defaultTableStyle?.tblPr?.borders;
+    fallbackTableStyle?.tblPr?.borders;
 
   // Resolve default cell margins through the same table-style cascade.
   const tableCellMargins =
     table.formatting?.cellMargins ??
     tableStyle?.tblPr?.cellMargins ??
-    defaultTableStyle?.tblPr?.cellMargins;
+    fallbackTableStyle?.tblPr?.cellMargins;
   let cellMarginsAttr:
     | { top?: number; bottom?: number; left?: number; right?: number }
     | undefined;

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -366,7 +366,6 @@ function paragraphFormattingToAttrs(
   if (styleResolver) {
     const resolved = styleResolver.resolveParagraphStyle(styleId);
     const stylePpr = resolved.paragraphFormatting;
-    const styleRpr = resolved.runFormatting;
 
     // Apply style-based values as defaults (inline overrides)
     set("alignment", formatting?.alignment ?? stylePpr?.alignment);
@@ -407,18 +406,9 @@ function paragraphFormattingToAttrs(
     // Text direction
     set("bidi", formatting?.bidi ?? stylePpr?.bidi);
 
-    // Default run properties (pPr/rPr)
-    const defaultCharStyleRpr = styleResolver.getDefaultCharacterStyle()?.rPr;
-    const styleRprWithDefaultChar = defaultCharStyleRpr
-      ? mergeTextFormatting(styleRpr, defaultCharStyleRpr)
-      : styleRpr;
-    const resolvedRunProps = resolveTextFormatting(
-      formatting?.runProperties,
-      styleResolver,
-    );
     set(
       "defaultTextFormatting",
-      mergeTextFormatting(styleRprWithDefaultChar, resolvedRunProps),
+      resolveParagraphDefaultTextFormatting(styleId, formatting, styleResolver),
     );
 
     // If style defines numPr but inline doesn't, use style's numPr
@@ -592,6 +582,32 @@ function resolveTextFormatting(
 
   const styleFormatting = styleResolver.resolveRunStyle(formatting.styleId);
   return mergeTextFormatting(styleFormatting, formatting);
+}
+
+function resolveParagraphDefaultTextFormatting(
+  styleId: string | undefined,
+  formatting: Paragraph["formatting"] | undefined,
+  styleResolver: StyleResolver,
+): TextFormatting | undefined {
+  const style = styleId
+    ? (styleResolver.getStyle(styleId) ??
+      styleResolver.getDefaultParagraphStyle())
+    : styleResolver.getDefaultParagraphStyle();
+  const paragraphStyleRpr = style?.type === "paragraph" ? style.rPr : undefined;
+  const paragraphRunProperties = formatting?.runProperties
+    ? resolveTextFormatting(formatting.runProperties, styleResolver)
+    : undefined;
+
+  return mergeTextFormatting(
+    mergeTextFormatting(
+      mergeTextFormatting(
+        styleResolver.getDocDefaults()?.rPr,
+        styleResolver.getDefaultCharacterStyle()?.rPr,
+      ),
+      paragraphStyleRpr,
+    ),
+    paragraphRunProperties,
+  );
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -39,6 +39,7 @@ import type {
   MoveFrom,
   MoveTo,
   MathEquation,
+  Theme,
 } from "../../types/document";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
@@ -58,6 +59,8 @@ import type { StyleResolver } from "../styles";
 export type ToProseDocOptions = {
   /** Style definitions for resolving paragraph styles */
   styles?: StyleDefinitions;
+  /** Theme used when converting themed table/cell values in nested content. */
+  theme?: Theme | null;
 };
 
 /**
@@ -405,13 +408,17 @@ function paragraphFormattingToAttrs(
     set("bidi", formatting?.bidi ?? stylePpr?.bidi);
 
     // Default run properties (pPr/rPr)
+    const defaultCharStyleRpr = styleResolver.getDefaultCharacterStyle()?.rPr;
+    const styleRprWithDefaultChar = defaultCharStyleRpr
+      ? mergeTextFormatting(styleRpr, defaultCharStyleRpr)
+      : styleRpr;
     const resolvedRunProps = resolveTextFormatting(
       formatting?.runProperties,
       styleResolver,
     );
     set(
       "defaultTextFormatting",
-      mergeTextFormatting(styleRpr, resolvedRunProps),
+      mergeTextFormatting(styleRprWithDefaultChar, resolvedRunProps),
     );
 
     // If style defines numPr but inline doesn't, use style's numPr
@@ -577,9 +584,9 @@ function resolveTextFormatting(
   styleResolver: StyleResolver | null,
 ): TextFormatting | undefined {
   if (!formatting) {
-    return undefined;
+    return styleResolver?.resolveRunStyle(null);
   }
-  if (!formatting.styleId || !styleResolver) {
+  if (!styleResolver) {
     return formatting;
   }
 
@@ -666,16 +673,21 @@ function convertTable(
   const tableStyleId = table.formatting?.styleId;
   const look = table.formatting?.look;
 
-  // Resolve table borders: prefer table's own borders, fall back to table style's borders
+  // Resolve table borders through inline style, table style, then default table style.
   const tableStyle = tableStyleId
     ? styleResolver?.getStyle(tableStyleId)
     : undefined;
+  const defaultTableStyle = styleResolver?.getDefaultTableStyle();
   const resolvedTableBorders =
-    table.formatting?.borders ?? tableStyle?.tblPr?.borders;
+    table.formatting?.borders ??
+    tableStyle?.tblPr?.borders ??
+    defaultTableStyle?.tblPr?.borders;
 
-  // Resolve default cell margins: table's own cellMargins > table style's cellMargins
+  // Resolve default cell margins through the same table-style cascade.
   const tableCellMargins =
-    table.formatting?.cellMargins ?? tableStyle?.tblPr?.cellMargins;
+    table.formatting?.cellMargins ??
+    tableStyle?.tblPr?.cellMargins ??
+    defaultTableStyle?.tblPr?.cellMargins;
   let cellMarginsAttr:
     | { top?: number; bottom?: number; left?: number; right?: number }
     | undefined;
@@ -2072,6 +2084,13 @@ export function headerFooterToProseDoc(
   }
 
   return schema.node("doc", null, nodes);
+}
+
+export function footnoteToProseDoc(
+  content: (Paragraph | Table)[],
+  options?: ToProseDocOptions,
+): PMNode {
+  return headerFooterToProseDoc(content, options);
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -43,6 +43,7 @@ import type {
 } from "../../types/document";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
+import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
 import { schema } from "../schema";
 import type {
   ParagraphAttrs,
@@ -1792,6 +1793,11 @@ function textFormattingToMarks(
   }
 
   const marks: ReturnType<typeof schema.mark>[] = [];
+  const overrideAttrs = buildRunFormattingOverrideAttrs(formatting);
+
+  if (overrideAttrs) {
+    marks.push(schema.mark("runFormattingOverride", overrideAttrs));
+  }
 
   // Bold
   if (formatting.bold) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -63,6 +63,10 @@ export type ToProseDocOptions = {
   theme?: Theme | null;
 };
 
+type RunFormattingResolver = (
+  formatting: TextFormatting | undefined,
+) => TextFormatting | undefined;
+
 /**
  * Convert a Document to a ProseMirror document
  *
@@ -146,15 +150,23 @@ function convertParagraph(
     styleRunFormatting = resolved.runFormatting;
   }
 
-  // NOTE: paragraph.formatting?.runProperties is the paragraph mark formatting (pPr/rPr).
-  // Per ECMA-376, this only applies to the paragraph mark glyph (¶), NOT to text runs.
-  // Style-level rPr (from styleResolver) already provides default run formatting.
-
-  // Merge in extra formatting (e.g., table style conditional rPr)
-  const mergedStyleRunFormatting = mergeTextFormatting(
+  const paragraphRunFormatting = paragraph.formatting?.runProperties
+    ? resolveTextFormatting(paragraph.formatting.runProperties, styleResolver)
+    : undefined;
+  const baseRunFormatting = mergeTextFormatting(
     styleRunFormatting,
     extraRunFormatting,
   );
+  const defaultRunFormatting = mergeTextFormatting(
+    baseRunFormatting,
+    paragraphRunFormatting,
+  );
+  const getInheritedRunFormatting = (
+    formatting: TextFormatting | undefined,
+  ): TextFormatting | undefined =>
+    hasDirectRunFormatting(formatting)
+      ? baseRunFormatting
+      : defaultRunFormatting;
   const emitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
     markType: "insertion" | "deletion",
@@ -163,7 +175,7 @@ function convertParagraph(
       convertTrackedChange(
         change,
         markType,
-        mergedStyleRunFormatting,
+        getInheritedRunFormatting,
         styleResolver,
       ),
     );
@@ -178,20 +190,24 @@ function convertParagraph(
       anchorPointComment(inlineNodes, content.id);
     } else if (content.type === "run") {
       emitInlineNodes(
-        convertRun(content, mergedStyleRunFormatting, styleResolver),
+        convertRun(
+          content,
+          getInheritedRunFormatting(content.formatting),
+          styleResolver,
+        ),
       );
     } else if (content.type === "hyperlink") {
       emitInlineNodes(
-        convertHyperlink(content, mergedStyleRunFormatting, styleResolver),
+        convertHyperlink(content, getInheritedRunFormatting, styleResolver),
       );
     } else if (
       content.type === "simpleField" ||
       content.type === "complexField"
     ) {
-      emitInlineNode(convertField(content, mergedStyleRunFormatting));
+      emitInlineNode(convertField(content, getInheritedRunFormatting));
     } else if (content.type === "inlineSdt") {
       emitInlineNode(
-        convertInlineSdt(content, mergedStyleRunFormatting, styleResolver),
+        convertInlineSdt(content, getInheritedRunFormatting, styleResolver),
       );
     } else if (content.type === "insertion" || content.type === "moveTo") {
       emitTrackedChange(content, "insertion");
@@ -261,15 +277,23 @@ function anchorPointComment(nodes: PMNode[], commentId: number): void {
 function convertTrackedChange(
   change: Insertion | Deletion | MoveFrom | MoveTo,
   markType: "insertion" | "deletion",
-  styleRunFormatting?: TextFormatting,
+  getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleResolver | null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
   for (const item of change.content) {
     if (item.type === "run") {
-      nodes.push(...convertRun(item, styleRunFormatting, styleResolver));
+      nodes.push(
+        ...convertRun(
+          item,
+          getInheritedRunFormatting(item.formatting),
+          styleResolver,
+        ),
+      );
     } else if (item.type === "hyperlink") {
-      nodes.push(...convertHyperlink(item, styleRunFormatting, styleResolver));
+      nodes.push(
+        ...convertHyperlink(item, getInheritedRunFormatting, styleResolver),
+      );
     }
   }
 
@@ -514,6 +538,37 @@ function resolveTableStyleConditional(
   return result;
 }
 
+function resolveTableBaseStyle(
+  styleResolver: StyleResolver | null,
+  tableStyleId: string | undefined,
+): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
+  if (!styleResolver || !tableStyleId) {
+    return undefined;
+  }
+
+  const style = styleResolver.getStyle(tableStyleId);
+  if (!style) {
+    return undefined;
+  }
+
+  const runPropsFromPpr = style.pPr?.runProperties
+    ? resolveTextFormatting(style.pPr.runProperties, styleResolver)
+    : undefined;
+  const resolvedRpr = style.rPr
+    ? resolveTextFormatting(style.rPr, styleResolver)
+    : undefined;
+  const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
+
+  const result: { tcPr?: TableCellFormatting; rPr?: TextFormatting } = {};
+  if (style.tcPr) {
+    result.tcPr = style.tcPr;
+  }
+  if (mergedRunProps) {
+    result.rPr = mergedRunProps;
+  }
+  return result.tcPr || result.rPr ? result : undefined;
+}
+
 function mergeConditionalStyles(
   base?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
   override?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
@@ -568,6 +623,18 @@ function mergeConditionalStyles(
   }
 
   return merged;
+}
+
+function hasDirectRunFormatting(
+  formatting: TextFormatting | undefined,
+): boolean {
+  if (!formatting) {
+    return false;
+  }
+
+  return Object.entries(formatting).some(
+    ([key, value]) => key !== "styleId" && value !== undefined,
+  );
 }
 
 function resolveTextFormatting(
@@ -778,6 +845,13 @@ function convertTable(
     }
   };
   setCS("wholeTable", "wholeTable");
+  const wholeTableStyle = mergeConditionalStyles(
+    resolveTableBaseStyle(styleResolver, tableStyleId),
+    conditionalStyles.wholeTable,
+  );
+  if (wholeTableStyle) {
+    conditionalStyles.wholeTable = wholeTableStyle;
+  }
   setCS("firstRow", "firstRow");
   setCS("lastRow", "lastRow");
   setCS("firstCol", "firstCol");
@@ -1250,12 +1324,12 @@ function convertTableCell(
 /**
  * Convert a SimpleField or ComplexField to a ProseMirror field node.
  * Preserves run formatting (bold, fontSize, color, etc.) as PM marks.
- * Accepts styleFormatting so fields inherit paragraph-level formatting
- * (same as convertRun does for regular text runs).
+ * Accepts a run formatting resolver so fields inherit paragraph-level
+ * formatting the same way regular text runs do.
  */
 function convertField(
   field: SimpleField | ComplexField,
-  styleFormatting?: TextFormatting,
+  getInheritedRunFormatting: RunFormattingResolver,
 ): PMNode | null {
   // Extract display text and formatting from field content/result
   let displayText = "";
@@ -1278,8 +1352,9 @@ function convertField(
   }
 
   // Merge style formatting with field run formatting (inline takes precedence)
+  const inheritedFormatting = getInheritedRunFormatting(fieldFormatting);
   const mergedFormatting = mergeTextFormatting(
-    styleFormatting,
+    inheritedFormatting,
     fieldFormatting,
   );
   const marks = textFormattingToMarks(mergedFormatting);
@@ -1315,7 +1390,7 @@ function convertMathEquation(math: MathEquation): PMNode | null {
  */
 function convertInlineSdt(
   sdt: InlineSdt,
-  styleRunFormatting?: TextFormatting,
+  getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleResolver | null,
 ): PMNode | null {
   const props = sdt.properties;
@@ -1323,12 +1398,16 @@ function convertInlineSdt(
 
   for (const content of sdt.content) {
     if (content.type === "run") {
-      const runNodes = convertRun(content, styleRunFormatting, styleResolver);
+      const runNodes = convertRun(
+        content,
+        getInheritedRunFormatting(content.formatting),
+        styleResolver,
+      );
       inlineNodes.push(...runNodes);
     } else if (content.type === "hyperlink") {
       const linkNodes = convertHyperlink(
         content,
-        styleRunFormatting,
+        getInheritedRunFormatting,
         styleResolver,
       );
       inlineNodes.push(...linkNodes);
@@ -1652,11 +1731,11 @@ function convertImage(image: Image): PMNode {
  * Convert a Hyperlink to ProseMirror nodes with link mark
  *
  * @param hyperlink - The hyperlink to convert
- * @param styleFormatting - Text formatting from the paragraph's style
+ * @param getInheritedRunFormatting - Formatting inherited by each child run
  */
 function convertHyperlink(
   hyperlink: Hyperlink,
-  styleFormatting?: TextFormatting,
+  getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleResolver | null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
@@ -1674,10 +1753,11 @@ function convertHyperlink(
     if (child.type === "run") {
       // Merge style formatting with run's inline formatting
       const runStyleFormatting = child.formatting?.styleId
-        ? styleResolver?.resolveRunStyle(child.formatting.styleId)
+        ? styleResolver?.getRunStyleOwnProperties(child.formatting.styleId)
         : undefined;
+      const inheritedFormatting = getInheritedRunFormatting(child.formatting);
       const mergedFormatting = mergeTextFormatting(
-        mergeTextFormatting(styleFormatting, runStyleFormatting),
+        mergeTextFormatting(inheritedFormatting, runStyleFormatting),
         child.formatting,
       );
       const runMarks = textFormattingToMarks(mergedFormatting);

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -762,6 +762,8 @@ function convertTable(
     ? styleResolver?.getStyle(tableStyleId)
     : undefined;
   const defaultTableStyle = styleResolver?.getDefaultTableStyle();
+  const conditionalTableStyleId =
+    tableStyle?.styleId ?? defaultTableStyle?.styleId;
   const resolvedTableBorders =
     table.formatting?.borders ??
     tableStyle?.tblPr?.borders ??
@@ -839,14 +841,18 @@ function convertTable(
     seCell?: CondStyle;
   } = {};
   const setCS = (key: keyof typeof conditionalStyles, type: string): void => {
-    const val = resolveTableStyleConditional(styleResolver, tableStyleId, type);
+    const val = resolveTableStyleConditional(
+      styleResolver,
+      conditionalTableStyleId,
+      type,
+    );
     if (val) {
       conditionalStyles[key] = val;
     }
   };
   setCS("wholeTable", "wholeTable");
   const wholeTableStyle = mergeConditionalStyles(
-    resolveTableBaseStyle(styleResolver, tableStyleId),
+    resolveTableBaseStyle(styleResolver, conditionalTableStyleId),
     conditionalStyles.wholeTable,
   );
   if (wholeTableStyle) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -496,11 +496,12 @@ function resolveTableStyleConditional(
     return undefined;
   }
 
-  const runPropsFromPpr = resolveTextFormatting(
-    conditional.pPr?.runProperties,
-    styleResolver,
-  );
-  const resolvedRpr = resolveTextFormatting(conditional.rPr, styleResolver);
+  const runPropsFromPpr = conditional.pPr?.runProperties
+    ? resolveTextFormatting(conditional.pPr.runProperties, styleResolver)
+    : undefined;
+  const resolvedRpr = conditional.rPr
+    ? resolveTextFormatting(conditional.rPr, styleResolver)
+    : undefined;
   const mergedRunProps = mergeTextFormatting(runPropsFromPpr, resolvedRpr);
 
   const result: { tcPr?: TableCellFormatting; rPr?: TextFormatting } = {};

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -36,6 +36,7 @@ import { FootnoteRefExtension } from "./marks/FootnoteRefExtension";
 import { HighlightExtension } from "./marks/HighlightExtension";
 import { HyperlinkExtension } from "./marks/HyperlinkExtension";
 import { ItalicExtension } from "./marks/ItalicExtension";
+import { RunFormattingOverrideExtension } from "./marks/RunFormattingOverrideExtension";
 import { SmallCapsExtension } from "./marks/SmallCapsExtension";
 import { StrikeExtension } from "./marks/StrikeExtension";
 import { SubscriptExtension } from "./marks/SubscriptExtension";
@@ -131,6 +132,7 @@ export function createStarterKit(
   add("textShadow", TextShadowExtension());
   add("emphasisMark", EmphasisMarkExtension());
   add("textOutline", TextOutlineExtension());
+  add("runFormattingOverride", RunFormattingOverrideExtension());
   add("comment", CommentExtension());
   add("insertion", InsertionExtension());
   add("deletion", DeletionExtension());

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
@@ -1,0 +1,153 @@
+/**
+ * Run formatting override mark.
+ *
+ * OOXML can explicitly turn inherited boolean/defaultable run properties off
+ * (for example <w:b w:val="0"/>). Plain PM marks cannot distinguish "inherit"
+ * from "explicitly off", so this mark carries those negative overrides.
+ */
+
+import type { Mark } from "prosemirror-model";
+
+import type { TextFormatting } from "../../../types/document";
+import { createMarkExtension } from "../create";
+
+type RunFormattingOverrideAttrs = Record<string, false | "none">;
+
+export function buildRunFormattingOverrideAttrs(
+  formatting: TextFormatting | undefined,
+): RunFormattingOverrideAttrs | undefined {
+  if (!formatting) {
+    return undefined;
+  }
+
+  const attrs: RunFormattingOverrideAttrs = {};
+
+  if (formatting.bold === false) {
+    attrs["bold"] = false;
+  }
+  if (formatting.italic === false) {
+    attrs["italic"] = false;
+  }
+  if (formatting.underline?.style === "none") {
+    attrs["underline"] = "none";
+  }
+  if (formatting.strike === false) {
+    attrs["strike"] = false;
+  }
+  if (formatting.doubleStrike === false) {
+    attrs["doubleStrike"] = false;
+  }
+  if (formatting.allCaps === false) {
+    attrs["allCaps"] = false;
+  }
+  if (formatting.smallCaps === false) {
+    attrs["smallCaps"] = false;
+  }
+  if (formatting.hidden === false) {
+    attrs["hidden"] = false;
+  }
+  if (formatting.emboss === false) {
+    attrs["emboss"] = false;
+  }
+  if (formatting.imprint === false) {
+    attrs["imprint"] = false;
+  }
+  if (formatting.shadow === false) {
+    attrs["shadow"] = false;
+  }
+  if (formatting.outline === false) {
+    attrs["outline"] = false;
+  }
+
+  return Object.keys(attrs).length > 0 ? attrs : undefined;
+}
+
+export function applyRunFormattingOverrideMark(
+  formatting: TextFormatting,
+  mark: Mark,
+): void {
+  if (mark.attrs["bold"] === false) {
+    formatting.bold = false;
+  }
+  if (mark.attrs["italic"] === false) {
+    formatting.italic = false;
+  }
+  if (mark.attrs["underline"] === "none") {
+    formatting.underline = { style: "none" };
+  }
+  if (mark.attrs["strike"] === false) {
+    formatting.strike = false;
+  }
+  if (mark.attrs["doubleStrike"] === false) {
+    formatting.doubleStrike = false;
+  }
+  if (mark.attrs["allCaps"] === false) {
+    formatting.allCaps = false;
+  }
+  if (mark.attrs["smallCaps"] === false) {
+    formatting.smallCaps = false;
+  }
+  if (mark.attrs["hidden"] === false) {
+    formatting.hidden = false;
+  }
+  if (mark.attrs["emboss"] === false) {
+    formatting.emboss = false;
+  }
+  if (mark.attrs["imprint"] === false) {
+    formatting.imprint = false;
+  }
+  if (mark.attrs["shadow"] === false) {
+    formatting.shadow = false;
+  }
+  if (mark.attrs["outline"] === false) {
+    formatting.outline = false;
+  }
+}
+
+export const RunFormattingOverrideExtension = createMarkExtension({
+  name: "runFormattingOverride",
+  schemaMarkName: "runFormattingOverride",
+  markSpec: {
+    attrs: {
+      bold: { default: null },
+      italic: { default: null },
+      underline: { default: null },
+      strike: { default: null },
+      doubleStrike: { default: null },
+      allCaps: { default: null },
+      smallCaps: { default: null },
+      hidden: { default: null },
+      emboss: { default: null },
+      imprint: { default: null },
+      shadow: { default: null },
+      outline: { default: null },
+    },
+    toDOM(mark) {
+      const styles: string[] = [];
+
+      if (mark.attrs["bold"] === false) {
+        styles.push("font-weight: normal");
+      }
+      if (mark.attrs["italic"] === false) {
+        styles.push("font-style: normal");
+      }
+      if (
+        mark.attrs["underline"] === "none" ||
+        mark.attrs["strike"] === false
+      ) {
+        styles.push("text-decoration: none");
+      }
+      if (mark.attrs["allCaps"] === false) {
+        styles.push("text-transform: none");
+      }
+      if (mark.attrs["smallCaps"] === false) {
+        styles.push("font-variant-caps: normal");
+      }
+      if (mark.attrs["hidden"] === false) {
+        styles.push("visibility: visible");
+      }
+
+      return ["span", styles.length > 0 ? { style: styles.join("; ") } : {}, 0];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
@@ -12,6 +12,10 @@ import type {
   UnderlineStyle,
   ThemeColorSlot,
 } from "../../../types/document";
+import {
+  applyRunFormattingOverrideMark,
+  buildRunFormattingOverrideAttrs,
+} from "./RunFormattingOverrideExtension";
 
 type MarkAttrs = Record<string, unknown>;
 
@@ -104,6 +108,9 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
       case "subscript":
         formatting.vertAlign = "subscript";
+        break;
+      case "runFormattingOverride":
+        applyRunFormattingOverrideMark(formatting, mark);
         break;
       default:
         break;
@@ -297,6 +304,11 @@ export function textFormattingToMarks(
   schema: Schema,
 ): Mark[] {
   const marks: Mark[] = [];
+  const overrideAttrs = buildRunFormattingOverrideAttrs(formatting);
+
+  if (overrideAttrs && schema.marks["runFormattingOverride"]) {
+    marks.push(schema.marks["runFormattingOverride"].create(overrideAttrs));
+  }
 
   if (formatting.bold && schema.marks["bold"]) {
     marks.push(schema.marks["bold"].create());

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
@@ -237,6 +237,88 @@ describe("StyleResolver", () => {
       expect(result?.fontSize).toBe(22); // From docDefaults
       expect(result?.bold).toBe(true); // From Strong style
     });
+
+    test("applies the default character style when no style ID is given", () => {
+      const styleDefinitions: StyleDefinitions = {
+        docDefaults: {
+          rPr: { fontSize: 22 },
+        },
+        styles: [
+          {
+            styleId: "FontePadrao",
+            type: "character",
+            default: true,
+            rPr: { fontFamily: { ascii: "Cambria", hAnsi: "Cambria" } },
+          },
+        ],
+      };
+
+      const resolver = createStyleResolver(styleDefinitions);
+      const result = resolver.resolveRunStyle(null);
+
+      expect(result?.fontSize).toBe(22);
+      expect(result?.fontFamily?.ascii).toBe("Cambria");
+    });
+
+    test("explicit character style overrides the default character style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        docDefaults: { rPr: { fontSize: 22 } },
+        styles: [
+          {
+            styleId: "FontePadrao",
+            type: "character",
+            default: true,
+            rPr: { fontFamily: { ascii: "Cambria", hAnsi: "Cambria" } },
+          },
+          {
+            styleId: "Code",
+            type: "character",
+            rPr: { fontFamily: { ascii: "Consolas", hAnsi: "Consolas" } },
+          },
+        ],
+      };
+
+      const resolver = createStyleResolver(styleDefinitions);
+      const result = resolver.resolveRunStyle("Code");
+
+      expect(result?.fontSize).toBe(22);
+      expect(result?.fontFamily?.ascii).toBe("Consolas");
+    });
+
+    test("exposes the default character style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "FontePadrao",
+            type: "character",
+            default: true,
+            rPr: {},
+          },
+          { styleId: "Code", type: "character", rPr: {} },
+        ],
+      };
+
+      const resolver = createStyleResolver(styleDefinitions);
+
+      expect(resolver.getDefaultCharacterStyle()?.styleId).toBe("FontePadrao");
+    });
+
+    test("exposes the default table style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "TableNormal",
+            type: "table",
+            default: true,
+            tblPr: {},
+          },
+        ],
+      };
+
+      const resolver = createStyleResolver(styleDefinitions);
+
+      expect(resolver.getDefaultTableStyle()?.styleId).toBe("TableNormal");
+    });
   });
 
   describe("getParagraphStyles", () => {

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -54,6 +54,8 @@ export class StyleResolver {
   private readonly stylesById: Map<string, Style>;
   private readonly docDefaults: DocDefaults | undefined;
   private readonly defaultParagraphStyle: Style | undefined;
+  private readonly defaultCharacterStyle: Style | undefined;
+  private readonly defaultTableStyle: Style | undefined;
 
   constructor(styleDefinitions: StyleDefinitions | undefined) {
     this.stylesById = new Map();
@@ -70,6 +72,8 @@ export class StyleResolver {
 
     // Find default paragraph style
     this.defaultParagraphStyle = this.findDefaultStyle("paragraph");
+    this.defaultCharacterStyle = this.findDefaultStyle("character");
+    this.defaultTableStyle = this.findDefaultStyle("table");
   }
 
   /**
@@ -178,13 +182,13 @@ export class StyleResolver {
       result = { ...this.docDefaults.rPr };
     }
 
-    // If no styleId, return defaults
-    if (!styleId) {
-      return Object.keys(result).length > 0 ? result : undefined;
+    const defaultCharacterRpr = this.defaultCharacterStyle?.rPr;
+    if (defaultCharacterRpr) {
+      result = mergeTextFormatting(result, defaultCharacterRpr) ?? {};
     }
 
     // Get the requested style
-    const style = this.stylesById.get(styleId);
+    const style = styleId ? this.stylesById.get(styleId) : undefined;
     if (!style?.rPr) {
       return Object.keys(result).length > 0 ? result : undefined;
     }
@@ -230,6 +234,20 @@ export class StyleResolver {
   }
 
   /**
+   * Get default character style.
+   */
+  getDefaultCharacterStyle(): Style | undefined {
+    return this.defaultCharacterStyle;
+  }
+
+  /**
+   * Get default table style.
+   */
+  getDefaultTableStyle(): Style | undefined {
+    return this.defaultTableStyle;
+  }
+
+  /**
    * Check if a style exists
    */
   hasStyle(styleId: string): boolean {
@@ -240,7 +258,9 @@ export class StyleResolver {
   // Private helpers
   // ============================================================================
 
-  private findDefaultStyle(type: "paragraph" | "character"): Style | undefined {
+  private findDefaultStyle(
+    type: "paragraph" | "character" | "table",
+  ): Style | undefined {
     // First try to find explicitly marked default
     for (const style of this.stylesById.values()) {
       if (style.type === type && style.default) {

--- a/packages/folio/src/core/types/content.ts
+++ b/packages/folio/src/core/types/content.ts
@@ -1274,7 +1274,7 @@ export type Footnote = {
     | "continuationSeparator"
     | "continuationNotice";
   /** Content */
-  content: Paragraph[];
+  content: (Paragraph | Table)[];
 };
 
 /**
@@ -1291,7 +1291,7 @@ export type Endnote = {
     | "continuationSeparator"
     | "continuationNotice";
   /** Content */
-  content: Paragraph[];
+  content: (Paragraph | Table)[];
 };
 
 // ============================================================================

--- a/packages/folio/src/core/types/styles.ts
+++ b/packages/folio/src/core/types/styles.ts
@@ -75,7 +75,8 @@ export type Style = {
       | "neCell"
       | "nwCell"
       | "seCell"
-      | "swCell";
+      | "swCell"
+      | "wholeTable";
     pPr?: ParagraphFormatting;
     rPr?: TextFormatting;
     tblPr?: TableFormatting;

--- a/packages/folio/src/core/utils/fontWeights.ts
+++ b/packages/folio/src/core/utils/fontWeights.ts
@@ -1,0 +1,1 @@
+export const DOCX_BOLD_FONT_WEIGHT = "800";

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -91,6 +91,7 @@ import type {
   ParagraphBorders,
   ParagraphSpacing,
   TextBoxBlock,
+  FootnoteContent,
 } from "../core/layout-engine/types";
 import {
   DEFAULT_TEXTBOX_MARGINS,
@@ -1737,7 +1738,7 @@ function convertHeaderFooterToContent(
  */
 function buildFootnoteRenderItems(
   pageFootnoteMap: Map<number, number[]>,
-  footnoteContentMap: Map<number, { displayNumber: number }>,
+  footnoteContentMap: Map<number, FootnoteContent>,
   doc: Document | null,
 ): Map<number, FootnoteRenderItem[]> {
   const result = new Map<number, FootnoteRenderItem[]>();
@@ -1770,6 +1771,15 @@ function buildFootnoteRenderItems(
       items.push({
         displayNumber: String(displayNum),
         text,
+        ...(content
+          ? {
+              content: {
+                blocks: content.blocks,
+                measures: content.measures,
+                height: content.height,
+              },
+            }
+          : {}),
       });
     }
 
@@ -2125,10 +2135,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
           let newLayout: Layout;
           let pageFootnoteMap = new Map<number, number[]>();
-          let footnoteContentMap = new Map<
-            number,
-            { displayNumber: number; height: number }
-          >();
+          let footnoteContentMap = new Map<number, FootnoteContent>();
 
           // Common layout options for all passes
           const bodyBreakType = sectionProperties?.sectionStart as

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -35,6 +35,12 @@ import { getFootnoteText } from "../core/docx/footnoteParser";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
 import {
+  findBodyEmptyRuns,
+  findBodyPmAnchor,
+  findBodyPmAnchors,
+  findBodyPmSpans,
+} from "../core/layout-bridge/findBodyPmSpans";
+import {
   collectFootnoteRefs,
   mapFootnotesToPages,
   buildFootnoteContentMap,
@@ -2163,6 +2169,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               document!.package.footnotes!,
               footnoteRefs,
               contentWidth,
+              (() => {
+                const footnoteOptions: Parameters<
+                  typeof buildFootnoteContentMap
+                >[3] = { measureBlocks };
+                if (styles) {
+                  footnoteOptions.styles = styles;
+                }
+                if (_theme !== undefined) {
+                  footnoteOptions.theme = _theme;
+                }
+                return footnoteOptions;
+              })(),
             );
 
             // Calculate per-page reserved heights
@@ -2436,12 +2454,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         const overlayRect = overlay.getBoundingClientRect();
 
         // Find spans with PM position data
-        const spans = pagesContainerRef.current.querySelectorAll(
-          "span[data-pm-start][data-pm-end]",
-        );
+        const spans = findBodyPmSpans(pagesContainerRef.current);
 
-        for (const span of Array.from(spans)) {
-          const spanEl = span as HTMLElement;
+        for (const spanEl of spans) {
           const pmStart = Number(spanEl.dataset["pmStart"]);
           const pmEnd = Number(spanEl.dataset["pmEnd"]);
 
@@ -2496,9 +2511,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           if (
             pmPos >= pmStart &&
             pmPos <= pmEnd &&
-            span.firstChild?.nodeType === Node.TEXT_NODE
+            spanEl.firstChild?.nodeType === Node.TEXT_NODE
           ) {
-            const textNode = span.firstChild as Text;
+            const textNode = spanEl.firstChild as Text;
             const charIndex = Math.min(pmPos - pmStart, textNode.length);
 
             // Create a range at the exact character position
@@ -2562,9 +2577,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         }
 
         // Fallback: try to find position in empty paragraphs (they have empty runs)
-        const emptyRuns =
-          pagesContainerRef.current.querySelectorAll(".layout-empty-run");
-        for (const emptyRun of Array.from(emptyRuns)) {
+        const emptyRuns = findBodyEmptyRuns(pagesContainerRef.current);
+        for (const emptyRun of emptyRuns) {
           const paragraph = emptyRun.closest(
             ".layout-paragraph",
           ) as HTMLElement;
@@ -2708,12 +2722,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             const domRects: SelectionRect[] = [];
 
             // Find spans that intersect with the selection range
-            const spans = pagesContainerRef.current.querySelectorAll(
-              "span[data-pm-start][data-pm-end]",
-            );
+            const spans = findBodyPmSpans(pagesContainerRef.current);
 
-            for (const span of Array.from(spans)) {
-              const spanEl = span as HTMLElement;
+            for (const spanEl of spans) {
               const pmStart = Number(spanEl.dataset["pmStart"]);
               const pmEnd = Number(spanEl.dataset["pmEnd"]);
 
@@ -2739,14 +2750,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
                 // Find the text node — may be a direct child or inside an <a> for hyperlinks
                 let textNode: Text | null = null;
-                if (span.firstChild?.nodeType === Node.TEXT_NODE) {
-                  textNode = span.firstChild as Text;
+                if (spanEl.firstChild?.nodeType === Node.TEXT_NODE) {
+                  textNode = spanEl.firstChild as Text;
                 } else if (
-                  span.firstChild?.nodeType === Node.ELEMENT_NODE &&
-                  (span.firstChild as HTMLElement).tagName === "A" &&
-                  span.firstChild.firstChild?.nodeType === Node.TEXT_NODE
+                  spanEl.firstChild?.nodeType === Node.ELEMENT_NODE &&
+                  (spanEl.firstChild as HTMLElement).tagName === "A" &&
+                  spanEl.firstChild.firstChild?.nodeType === Node.TEXT_NODE
                 ) {
-                  textNode = span.firstChild.firstChild as Text;
+                  textNode = spanEl.firstChild.firstChild as Text;
                 }
                 if (!textNode) {
                   continue;
@@ -2931,9 +2942,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           const { selection: sel } = view.state;
           if (sel instanceof NodeSelection && sel.node.type.name === "image") {
             const pmPos = sel.from;
-            const imgEl = pagesContainerRef.current?.querySelector(
-              `[data-pm-start="${pmPos}"]`,
-            ) as HTMLElement | null;
+            const imgEl = pagesContainerRef.current
+              ? findBodyPmAnchor(pagesContainerRef.current, pmPos)
+              : null;
             if (imgEl) {
               setSelectedImageInfo(buildImageSelectionInfo(imgEl, pmPos));
               return;
@@ -3113,9 +3124,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       // virtualized doc only sees runs in the currently-rendered
       // buffer, so each click stepped one buffer-width forward
       // instead of jumping straight to the target.
-      const exact: HTMLElement | null = pageContainer.querySelector(
-        `[data-pm-start="${pmPos}"]`,
-      );
+      const exact = findBodyPmAnchor(pageContainer, pmPos);
       if (exact) {
         exact.scrollIntoView({ behavior: "smooth", block: "center" });
         return;
@@ -3125,9 +3134,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       // inside one of them (block-node positions never match
       // exactly but usually live inside a known run).
       let runMatch: HTMLElement | null = null;
-      for (const el of pageContainer.querySelectorAll<HTMLElement>(
-        "[data-pm-start]",
-      )) {
+      for (const el of findBodyPmAnchors(pageContainer)) {
         const start = Number(el.dataset["pmStart"]);
         if (Number.isNaN(start)) {
           continue;
@@ -3164,18 +3171,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       let attempts = 0;
       const refine = () => {
         attempts++;
-        const exactInShell = shell.querySelector<HTMLElement>(
-          `[data-pm-start="${pmPos}"]`,
-        );
+        const exactInShell = findBodyPmAnchor(shell, pmPos);
         if (exactInShell) {
           exactInShell.scrollIntoView({ behavior: "smooth", block: "center" });
           return;
         }
         let bestEl: HTMLElement | null = null;
         let bestStart = Number.NEGATIVE_INFINITY;
-        for (const el of shell.querySelectorAll<HTMLElement>(
-          "[data-pm-start]",
-        )) {
+        for (const el of findBodyPmAnchors(shell)) {
           const start = Number(el.dataset["pmStart"]);
           if (Number.isNaN(start)) {
             continue;

--- a/packages/folio/src/paged-editor/useVisualLineNavigation.ts
+++ b/packages/folio/src/paged-editor/useVisualLineNavigation.ts
@@ -16,6 +16,11 @@ import { useCallback, useRef } from "react";
 import { Selection, TextSelection } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import {
+  findBodyEmptyRuns,
+  findBodyPmSpans,
+} from "../core/layout-bridge/findBodyPmSpans";
+
 /** Only match lines inside page body content, skipping header/footer lines. */
 const CONTENT_LINE_SELECTOR = ".layout-page-content .layout-line";
 
@@ -77,11 +82,8 @@ export function useVisualLineNavigation({
         return null;
       }
 
-      const spans = pagesContainerRef.current.querySelectorAll(
-        "span[data-pm-start][data-pm-end]",
-      );
-      for (const span of Array.from(spans)) {
-        const spanEl = span as HTMLElement;
+      const spans = findBodyPmSpans(pagesContainerRef.current);
+      for (const spanEl of spans) {
         const pmStart = Number(spanEl.dataset["pmStart"]);
         const pmEnd = Number(spanEl.dataset["pmEnd"]);
 
@@ -95,9 +97,9 @@ export function useVisualLineNavigation({
         if (
           pmPos >= pmStart &&
           pmPos <= pmEnd &&
-          span.firstChild?.nodeType === Node.TEXT_NODE
+          spanEl.firstChild?.nodeType === Node.TEXT_NODE
         ) {
-          const textNode = span.firstChild as Text;
+          const textNode = spanEl.firstChild as Text;
           const charIndex = Math.min(pmPos - pmStart, textNode.length);
           const ownerDoc = spanEl.ownerDocument;
           if (!ownerDoc) {
@@ -115,9 +117,8 @@ export function useVisualLineNavigation({
       }
 
       // Check empty paragraphs
-      const emptyRuns =
-        pagesContainerRef.current.querySelectorAll(".layout-empty-run");
-      for (const emptyRun of Array.from(emptyRuns)) {
+      const emptyRuns = findBodyEmptyRuns(pagesContainerRef.current);
+      for (const emptyRun of emptyRuns) {
         const paragraph = emptyRun.closest(".layout-paragraph") as HTMLElement;
         if (!paragraph) {
           continue;

--- a/packages/folio/src/styles/font-aliases.css
+++ b/packages/folio/src/styles/font-aliases.css
@@ -11,28 +11,28 @@
 /* Calibri → Carlito */
 @font-face {
   font-family: "Calibri";
-  src: local("Carlito"), local("Calibri");
+  src: local("Carlito"), local("Carlito Regular"), local("Calibri");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Calibri";
-  src: local("Carlito"), local("Calibri");
+  src: local("Carlito Italic"), local("Calibri Italic");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: "Calibri";
-  src: local("Carlito"), local("Calibri");
+  src: local("Carlito Bold"), local("Calibri Bold");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Calibri";
-  src: local("Carlito"), local("Calibri");
+  src: local("Carlito Bold Italic"), local("Calibri Bold Italic");
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -41,28 +41,28 @@
 /* Cambria → Caladea */
 @font-face {
   font-family: "Cambria";
-  src: local("Caladea"), local("Cambria");
+  src: local("Caladea"), local("Caladea Regular"), local("Cambria");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Cambria";
-  src: local("Caladea"), local("Cambria");
+  src: local("Caladea Italic"), local("Cambria Italic");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: "Cambria";
-  src: local("Caladea"), local("Cambria");
+  src: local("Caladea Bold"), local("Cambria Bold");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Cambria";
-  src: local("Caladea"), local("Cambria");
+  src: local("Caladea Bold Italic"), local("Cambria Bold Italic");
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -71,28 +71,28 @@
 /* Arial → Arimo */
 @font-face {
   font-family: "Arial";
-  src: local("Arimo"), local("Arial");
+  src: local("Arimo"), local("Arimo Regular"), local("Arial");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Arial";
-  src: local("Arimo"), local("Arial");
+  src: local("Arimo Italic"), local("Arial Italic");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: "Arial";
-  src: local("Arimo"), local("Arial");
+  src: local("Arimo Bold"), local("Arial Bold");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Arial";
-  src: local("Arimo"), local("Arial");
+  src: local("Arimo Bold Italic"), local("Arial Bold Italic");
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -101,28 +101,28 @@
 /* Times New Roman → Tinos */
 @font-face {
   font-family: "Times New Roman";
-  src: local("Tinos"), local("Times New Roman");
+  src: local("Tinos"), local("Tinos Regular"), local("Times New Roman");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Times New Roman";
-  src: local("Tinos"), local("Times New Roman");
+  src: local("Tinos Italic"), local("Times New Roman Italic");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: "Times New Roman";
-  src: local("Tinos"), local("Times New Roman");
+  src: local("Tinos Bold"), local("Times New Roman Bold");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Times New Roman";
-  src: local("Tinos"), local("Times New Roman");
+  src: local("Tinos Bold Italic"), local("Times New Roman Bold Italic");
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -131,28 +131,28 @@
 /* Courier New → Cousine */
 @font-face {
   font-family: "Courier New";
-  src: local("Cousine"), local("Courier New");
+  src: local("Cousine"), local("Cousine Regular"), local("Courier New");
   font-weight: 400;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Courier New";
-  src: local("Cousine"), local("Courier New");
+  src: local("Cousine Italic"), local("Courier New Italic");
   font-weight: 400;
   font-style: italic;
   font-display: swap;
 }
 @font-face {
   font-family: "Courier New";
-  src: local("Cousine"), local("Courier New");
+  src: local("Cousine Bold"), local("Courier New Bold");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Courier New";
-  src: local("Cousine"), local("Courier New");
+  src: local("Cousine Bold Italic"), local("Courier New Bold Italic");
   font-weight: 700;
   font-style: italic;
   font-display: swap;

--- a/packages/folio/src/styles/font-aliases.test.ts
+++ b/packages/folio/src/styles/font-aliases.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("font aliases", () => {
+  test("do not map bold Office aliases to regular local font faces", () => {
+    const css = readFileSync(
+      new URL("font-aliases.css", import.meta.url),
+      "utf-8",
+    );
+    const boldBlocks = css.match(
+      /@font-face\s*{[^}]*font-weight:\s*700;[^}]*}/g,
+    );
+
+    expect(boldBlocks).not.toBeNull();
+    for (const block of boldBlocks ?? []) {
+      expect(block).not.toContain('local("Tinos")');
+      expect(block).not.toContain('local("Caladea")');
+      expect(block).not.toContain('local("Carlito")');
+      expect(block).not.toContain('local("Arimo")');
+      expect(block).not.toContain('local("Cousine")');
+    }
+  });
+});


### PR DESCRIPTION
Syncs applicable upstream docx-editor fixes into Folio, including DOCX style cascade handling, body-scoped PM position lookups, footnote table rendering, run-level OOXML mark propagation, and layout fidelity fixes.