### PR TITLE
feat: add chat response actions

### DIFF
--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -100,6 +100,53 @@ describe("chat thread messages", () => {
     expect(html.match(/>Retry<\/button>/g)?.length).toBe(1);
   });
 
+  test("hides retry when a later user message is the final turn", () => {
+    const chatMessages: PersistedChatMessage[] = [
+      {
+        id: "message-A",
+        parts: [{ type: "text", text: "Answer before retry" }],
+        role: "assistant",
+      },
+      {
+        id: "message-B",
+        parts: [{ type: "text", text: "Follow-up prompt" }],
+        role: "user",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <IntlProvider
+        locale="en"
+        // SAFETY: this mirrors the app provider boundary; locale
+        // files are checked separately, while use-intl preserves
+        // English literal values in the generated Messages type.
+        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        messages={messages as Messages}
+        timeZone="UTC"
+      >
+        <ChatThreadMessages
+          approvalPendingMessageId={null}
+          autoApprovedTools={new Set()}
+          handleAlwaysAllow={() => {}}
+          handleApprove={() => {}}
+          handleDeny={() => {}}
+          messages={chatMessages}
+          onAskUserSubmit={() => {}}
+          onResend={() => {}}
+          showToolCalls={false}
+          streamdownComponents={{
+            a: ({ children, ...props }) => <a {...props}>{children}</a>,
+          }}
+        />
+      </IntlProvider>,
+    );
+
+    expect(html).toContain("Answer before retry");
+    expect(html).toContain("Follow-up prompt");
+    expect(html.match(/>Copy<\/button>/g)?.length).toBe(1);
+    expect(html).not.toContain(">Retry</button>");
+  });
+
   test("shows a resendable chat message when the chat runtime errors", () => {
     const html = renderToStaticMarkup(
       <IntlProvider

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, test } from "bun:test";
 import { IntlProvider } from "use-intl";
 
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import messages from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
 
@@ -12,6 +13,93 @@ const { ChatThreadMessages } =
   await import("@/components/chat/chat-thread-messages");
 
 describe("chat thread messages", () => {
+  test("shows a copy action at the end of assistant responses", () => {
+    const chatMessages: PersistedChatMessage[] = [
+      {
+        id: "message-A",
+        parts: [{ type: "text", text: "Draft answer" }],
+        role: "assistant",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <IntlProvider
+        locale="en"
+        // SAFETY: this mirrors the app provider boundary; locale
+        // files are checked separately, while use-intl preserves
+        // English literal values in the generated Messages type.
+        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        messages={messages as Messages}
+        timeZone="UTC"
+      >
+        <ChatThreadMessages
+          approvalPendingMessageId={null}
+          autoApprovedTools={new Set()}
+          handleAlwaysAllow={() => {}}
+          handleApprove={() => {}}
+          handleDeny={() => {}}
+          messages={chatMessages}
+          onAskUserSubmit={() => {}}
+          showToolCalls={false}
+          streamdownComponents={{
+            a: ({ children, ...props }) => <a {...props}>{children}</a>,
+          }}
+        />
+      </IntlProvider>,
+    );
+
+    expect(html).toContain("Draft answer");
+    expect(html).toContain('aria-label="Copy"');
+    expect(html).toContain(">Copy</button>");
+  });
+
+  test("shows retry only on the latest assistant response", () => {
+    const chatMessages: PersistedChatMessage[] = [
+      {
+        id: "message-A",
+        parts: [{ type: "text", text: "First answer" }],
+        role: "assistant",
+      },
+      {
+        id: "message-B",
+        parts: [{ type: "text", text: "Second answer" }],
+        role: "assistant",
+      },
+    ];
+
+    const html = renderToStaticMarkup(
+      <IntlProvider
+        locale="en"
+        // SAFETY: this mirrors the app provider boundary; locale
+        // files are checked separately, while use-intl preserves
+        // English literal values in the generated Messages type.
+        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        messages={messages as Messages}
+        timeZone="UTC"
+      >
+        <ChatThreadMessages
+          approvalPendingMessageId={null}
+          autoApprovedTools={new Set()}
+          handleAlwaysAllow={() => {}}
+          handleApprove={() => {}}
+          handleDeny={() => {}}
+          messages={chatMessages}
+          onAskUserSubmit={() => {}}
+          onResend={() => {}}
+          showToolCalls={false}
+          streamdownComponents={{
+            a: ({ children, ...props }) => <a {...props}>{children}</a>,
+          }}
+        />
+      </IntlProvider>,
+    );
+
+    expect(html).toContain("First answer");
+    expect(html).toContain("Second answer");
+    expect(html.match(/>Copy<\/button>/g)?.length).toBe(2);
+    expect(html.match(/>Retry<\/button>/g)?.length).toBe(1);
+  });
+
   test("shows a resendable chat message when the chat runtime errors", () => {
     const html = renderToStaticMarkup(
       <IntlProvider

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -1,10 +1,11 @@
 import type { ComponentProps } from "react";
 
 import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 import { isToolUIPart } from "ai";
 import type { FileUIPart } from "ai";
-import { FileTextIcon } from "lucide-react";
+import { CopyIcon, FileTextIcon, RotateCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import {
@@ -252,6 +253,93 @@ const hasVisibleContent = (
   return false;
 };
 
+const getMessageText = (message: PersistedChatMessage) => {
+  const textParts: string[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text" && part.text.trim()) {
+      textParts.push(part.text);
+    }
+  }
+
+  return textParts.join("\n\n").trim();
+};
+
+const AssistantMessageActions = ({
+  isGenerating,
+  isLatestAssistantMessage,
+  message,
+  onResend,
+}: {
+  isGenerating: boolean;
+  isLatestAssistantMessage: boolean;
+  message: PersistedChatMessage;
+  onResend?: (() => void | PromiseLike<void>) | undefined;
+}) => {
+  const t = useTranslations();
+  const text = getMessageText(message);
+  const canRetry = Boolean(onResend && isLatestAssistantMessage);
+
+  if (!text && !canRetry) {
+    return null;
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      stellaToast.add({ title: t("common.copied"), type: "success" });
+    } catch {
+      stellaToast.add({ title: t("errors.actionFailed"), type: "error" });
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      {text && (
+        <Button
+          aria-label={t("common.copy")}
+          className="text-muted-foreground h-6 px-1.5 text-xs"
+          onClick={() => {
+            void handleCopy();
+          }}
+          size="xs"
+          variant="ghost"
+        >
+          <CopyIcon className="size-3.5" />
+          {t("common.copy")}
+        </Button>
+      )}
+      {canRetry && (
+        <Button
+          aria-label={t("common.retry")}
+          className="text-muted-foreground h-6 px-1.5 text-xs"
+          disabled={isGenerating}
+          onClick={() => {
+            void onResend?.();
+          }}
+          size="xs"
+          variant="ghost"
+        >
+          <RotateCcwIcon className="size-3.5" />
+          {t("common.retry")}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+const getLatestAssistantMessageId = (
+  messages: readonly PersistedChatMessage[],
+) => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages.at(index);
+    if (message?.role === "assistant") {
+      return message.id;
+    }
+  }
+
+  return null;
+};
+
 type ChatThreadMessagesProps = {
   approvalPendingMessageId: string | null;
   autoApprovedTools: ReadonlySet<ApprovalToolName>;
@@ -294,116 +382,128 @@ export const ChatThreadMessages = ({
   showToolCalls,
   streamdownComponents,
   workspaceId,
-}: ChatThreadMessagesProps) => (
-  <>
-    {messages.map((message) => (
-      <Message
-        className={cn(
-          "transition-opacity duration-200",
-          approvalPendingMessageId &&
-            approvalPendingMessageId !== message.id &&
-            "opacity-40",
-        )}
-        from={message.role}
-        key={message.id}
-      >
-        <MessageContent>
-          {message.role === "assistant" ? (
-            <>
-              {message.parts.map((part, index) => {
-                if (part.type === "text") {
-                  return (
-                    <MessageResponse
-                      components={streamdownComponents}
-                      key={`${message.id}-text-${index}`}
-                    >
-                      {part.text}
-                    </MessageResponse>
-                  );
-                }
+}: ChatThreadMessagesProps) => {
+  const latestAssistantMessageId = getLatestAssistantMessageId(messages);
 
-                if (part.type === "tool-ask-user") {
-                  return (
-                    <AskUserCard
-                      key={part.toolCallId}
-                      onSubmit={(toolCallId, output) => {
-                        void onAskUserSubmit(toolCallId, output);
-                      }}
-                      part={part}
-                      workspaceId={workspaceId}
-                    />
-                  );
-                }
-
-                if (isApprovalPart(part)) {
-                  return (
-                    <ToolApprovalCard
-                      autoApprovedTools={autoApprovedTools}
-                      blockedApprovalTools={blockedApprovalTools}
-                      key={part.toolCallId}
-                      onAlwaysAllow={handleAlwaysAllow}
-                      onApprove={handleApprove}
-                      onDeny={handleDeny}
-                      part={part}
-                      workspaceId={workspaceId}
-                    />
-                  );
-                }
-
-                if (isToolUIPart(part) && showToolCalls) {
-                  return (
-                    <ToolCallCard
-                      key={part.toolCallId}
-                      part={part}
-                      showDetails
-                    />
-                  );
-                }
-
-                return null;
-              })}
-              <SourceChips
-                messageId={message.id}
-                parts={message.parts}
-                workspaceId={workspaceId}
-              />
-            </>
-          ) : (
-            <>
-              {(() => {
-                const fileParts: FileUIPart[] = [];
-                for (const part of message.parts) {
-                  if (part.type === "file") {
-                    fileParts.push(part);
-                  }
-                }
-
-                return <UserAttachments parts={fileParts} />;
-              })()}
-              {message.parts.map((part, index) =>
-                part.type === "text" ? (
-                  <MessageResponse
-                    components={USER_STREAMDOWN_COMPONENTS}
-                    key={`${message.id}-user-text-${index}`}
-                  >
-                    {normalizeUserMessageTextForDisplay(part.text)}
-                  </MessageResponse>
-                ) : null,
-              )}
-            </>
+  return (
+    <>
+      {messages.map((message) => (
+        <Message
+          className={cn(
+            "transition-opacity duration-200",
+            approvalPendingMessageId &&
+              approvalPendingMessageId !== message.id &&
+              "opacity-40",
           )}
-        </MessageContent>
-      </Message>
-    ))}
-    {error && (
-      <ChatErrorMessage
-        error={error}
-        isGenerating={isGenerating}
-        onResend={onResend}
-      />
-    )}
-    {showThinkingIndicator &&
-      isGenerating &&
-      !hasVisibleContent(messages, showToolCalls) && <ThinkingIndicator />}
-  </>
-);
+          from={message.role}
+          key={message.id}
+        >
+          <MessageContent>
+            {message.role === "assistant" ? (
+              <>
+                {message.parts.map((part, index) => {
+                  if (part.type === "text") {
+                    return (
+                      <MessageResponse
+                        components={streamdownComponents}
+                        key={`${message.id}-text-${index}`}
+                      >
+                        {part.text}
+                      </MessageResponse>
+                    );
+                  }
+
+                  if (part.type === "tool-ask-user") {
+                    return (
+                      <AskUserCard
+                        key={part.toolCallId}
+                        onSubmit={(toolCallId, output) => {
+                          void onAskUserSubmit(toolCallId, output);
+                        }}
+                        part={part}
+                        workspaceId={workspaceId}
+                      />
+                    );
+                  }
+
+                  if (isApprovalPart(part)) {
+                    return (
+                      <ToolApprovalCard
+                        autoApprovedTools={autoApprovedTools}
+                        blockedApprovalTools={blockedApprovalTools}
+                        key={part.toolCallId}
+                        onAlwaysAllow={handleAlwaysAllow}
+                        onApprove={handleApprove}
+                        onDeny={handleDeny}
+                        part={part}
+                        workspaceId={workspaceId}
+                      />
+                    );
+                  }
+
+                  if (isToolUIPart(part) && showToolCalls) {
+                    return (
+                      <ToolCallCard
+                        key={part.toolCallId}
+                        part={part}
+                        showDetails
+                      />
+                    );
+                  }
+
+                  return null;
+                })}
+                <SourceChips
+                  messageId={message.id}
+                  parts={message.parts}
+                  workspaceId={workspaceId}
+                />
+                <AssistantMessageActions
+                  isGenerating={isGenerating}
+                  isLatestAssistantMessage={
+                    message.id === latestAssistantMessageId
+                  }
+                  message={message}
+                  onResend={onResend}
+                />
+              </>
+            ) : (
+              <>
+                {(() => {
+                  const fileParts: FileUIPart[] = [];
+                  for (const part of message.parts) {
+                    if (part.type === "file") {
+                      fileParts.push(part);
+                    }
+                  }
+
+                  return <UserAttachments parts={fileParts} />;
+                })()}
+                {message.parts.map((part, index) =>
+                  part.type === "text" ? (
+                    <MessageResponse
+                      components={USER_STREAMDOWN_COMPONENTS}
+                      key={`${message.id}-user-text-${index}`}
+                    >
+                      {normalizeUserMessageTextForDisplay(part.text)}
+                    </MessageResponse>
+                  ) : null,
+                )}
+              </>
+            )}
+          </MessageContent>
+        </Message>
+      ))}
+      {error && (
+        <ChatErrorMessage
+          error={error}
+          isGenerating={isGenerating}
+          onResend={onResend}
+        />
+      )}
+      {showThinkingIndicator &&
+        isGenerating &&
+        !hasVisibleContent(messages, showToolCalls) && <ThinkingIndicator />}
+    </>
+  );
+};

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { ComponentProps } from "react";
 
 import { Button } from "@stll/ui/components/button";
@@ -276,7 +277,7 @@ const AssistantMessageActions = ({
   onResend?: (() => void | PromiseLike<void>) | undefined;
 }) => {
   const t = useTranslations();
-  const text = getMessageText(message);
+  const text = useMemo(() => getMessageText(message), [message]);
   const canRetry = Boolean(onResend && isLatestAssistantMessage);
 
   if (!text && !canRetry) {
@@ -327,14 +328,12 @@ const AssistantMessageActions = ({
   );
 };
 
-const getLatestAssistantMessageId = (
+const getRetryableAssistantMessageId = (
   messages: readonly PersistedChatMessage[],
 ) => {
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages.at(index);
-    if (message?.role === "assistant") {
-      return message.id;
-    }
+  const message = messages.at(-1);
+  if (message?.role === "assistant") {
+    return message.id;
   }
 
   return null;
@@ -383,7 +382,10 @@ export const ChatThreadMessages = ({
   streamdownComponents,
   workspaceId,
 }: ChatThreadMessagesProps) => {
-  const latestAssistantMessageId = getLatestAssistantMessageId(messages);
+  const retryableAssistantMessageId = useMemo(
+    () => getRetryableAssistantMessageId(messages),
+    [messages],
+  );
 
   return (
     <>
@@ -461,7 +463,7 @@ export const ChatThreadMessages = ({
                 <AssistantMessageActions
                   isGenerating={isGenerating}
                   isLatestAssistantMessage={
-                    message.id === latestAssistantMessageId
+                    message.id === retryableAssistantMessageId
                   }
                   message={message}
                   onResend={onResend}

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Ztratili jsme spojení se serverem. Automaticky opakujeme.",
     "convertTo": "Převést na",
     "copied": "Zkopírováno do schránky",
+    "copy": "Kopírovat",
     "copyLink": "Kopírovat odkaz",
     "createdAt": "Vytvořeno {date}",
     "currency": "Měna",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Die Verbindung zum Server wurde unterbrochen. Automatische Wiederholung.",
     "convertTo": "Konvertieren zu",
     "copied": "Copied to clipboard",
+    "copy": "Kopieren",
     "copyLink": "Link kopieren",
     "createdAt": "Erstellt am {date}",
     "currency": "Währung",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "We lost the connection to the server. Retrying automatically.",
     "convertTo": "Convert to",
     "copied": "Copied to clipboard",
+    "copy": "Copy",
     "copyLink": "Copy link",
     "createdAt": "Created at {date}",
     "currency": "Currency",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Se perdió la conexión con el servidor. Reintentando automáticamente.",
     "convertTo": "Convertir a",
     "copied": "Copied to clipboard",
+    "copy": "Copiar",
     "copyLink": "Copiar enlace",
     "createdAt": "Creado el {date}",
     "currency": "Moneda",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Kaotasime ühenduse serveriga. Proovime automaatselt uuesti.",
     "convertTo": "Teisenda",
     "copied": "Copied to clipboard",
+    "copy": "Kopeeri",
     "copyLink": "Kopeeri link",
     "createdAt": "Loodud {date}",
     "currency": "Valuuta",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "La connexion au serveur a été perdue. Nouvelle tentative automatique.",
     "convertTo": "Convertir en",
     "copied": "Copied to clipboard",
+    "copy": "Copier",
     "copyLink": "Copier le lien",
     "createdAt": "Créé le {date}",
     "currency": "Devise",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Megszakadt a kapcsolat a szerverrel. Automatikus újrapróbálkozás.",
     "convertTo": "Konvertálás",
     "copied": "Copied to clipboard",
+    "copy": "Másolás",
     "copyLink": "Hivatkozás másolása",
     "createdAt": "Létrehozva: {date}",
     "currency": "Pénznem",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Praradome ryšį su serveriu. Bandoma automatiškai iš naujo.",
     "convertTo": "Konvertuoti į",
     "copied": "Copied to clipboard",
+    "copy": "Kopijuoti",
     "copyLink": "Kopijuoti nuorodą",
     "createdAt": "Sukurta {date}",
     "currency": "Valiuta",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Zaudējām savienojumu ar serveri. Automātiska atkārtota mēģināšana.",
     "convertTo": "Pārvērst par",
     "copied": "Copied to clipboard",
+    "copy": "Kopēt",
     "copyLink": "Kopēt saiti",
     "createdAt": "Izveidots {date}",
     "currency": "Valūta",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -526,6 +526,7 @@ type Messages = {
     "connectionLostDescription": "We lost the connection to the server. Retrying automatically.";
     "convertTo": "Convert to";
     "copied": "Copied to clipboard";
+    "copy": "Copy";
     "copyLink": "Copy link";
     "createdAt": "Created at {date}";
     "currency": "Currency";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Utracono połączenie z serwerem. Automatyczne ponowne łączenie.",
     "convertTo": "Konwertuj na",
     "copied": "Skopiowano do schowka",
+    "copy": "Kopiuj",
     "copyLink": "Kopiuj link",
     "createdAt": "Utworzono {date}",
     "currency": "Waluta",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Perdemos a conexão com o servidor. Tentando novamente automaticamente.",
     "convertTo": "Converter para",
     "copied": "Copiado para a área de transferência",
+    "copy": "Copiar",
     "copyLink": "Copiar link",
     "createdAt": "Criado em {date}",
     "currency": "Moeda",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -523,6 +523,7 @@
     "connectionLostDescription": "Stratili sme spojenie so serverom. Automaticky opakujeme.",
     "convertTo": "Previesť na",
     "copied": "Skopírované do schránky",
+    "copy": "Kopírovať",
     "copyLink": "Kopírovať odkaz",
     "createdAt": "Vytvorené {date}",
     "currency": "Mena",

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -191,7 +191,11 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
-import { ChatErrorMessage } from "@/components/chat/chat-thread-messages";
+import {
+  ChatErrorMessage,
+  ChatThreadMessages,
+} from "@/components/chat/chat-thread-messages";
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import { AIKeyRequiredDialog } from "@/components/require-ai-key";
 
 type ComboboxOption = {
@@ -308,7 +312,7 @@ export function UiPlayground() {
           </p>
         </header>
 
-        <Tabs defaultValue="actions">
+        <Tabs defaultValue="chat">
           <TabsList className="bg-background/96 sticky top-0 z-20 py-2 backdrop-blur">
             <TabsTab value="actions">Actions</TabsTab>
             <TabsTab value="forms">Forms</TabsTab>
@@ -1162,6 +1166,12 @@ export function UiPlayground() {
           <TabsPanel value="chat">
             <PlaygroundGrid>
               <PlaygroundSection
+                description="Production chat renderer sample. Use this to review shared assistant response controls."
+                title="Shared renderer"
+              >
+                <SharedChatRendererSample />
+              </PlaygroundSection>
+              <PlaygroundSection
                 description="Existing assistant + user bubble types from the standalone chat panel. We need to lift each into the unified file-anchored chat (Phase C)."
                 title="Chat bubbles"
               >
@@ -1221,6 +1231,88 @@ function Metric({
         <div className="text-lg leading-none font-semibold">{value}</div>
         <div className="text-muted-foreground mt-1 text-xs">{label}</div>
       </div>
+    </div>
+  );
+}
+
+const SHARED_CHAT_RENDERER_MESSAGES = [
+  {
+    id: "dev-user-copy-1",
+    parts: [
+      {
+        type: "text",
+        text: "Give me a quick first read on indemnity exposure.",
+      },
+    ],
+    role: "user",
+  },
+  {
+    id: "dev-assistant-copy-1",
+    parts: [
+      {
+        type: "text",
+        text: "The first read is medium exposure: broad carve-outs, a short survival period, and a relatively small escrow.",
+      },
+    ],
+    role: "assistant",
+  },
+  {
+    id: "dev-user-copy-2",
+    parts: [
+      {
+        type: "text",
+        text: "Now make that client-ready.",
+      },
+    ],
+    role: "user",
+  },
+  {
+    id: "dev-assistant-copy-2",
+    parts: [
+      {
+        type: "text",
+        text: [
+          "**Indemnity position.** The draft creates a medium exposure profile.",
+          "",
+          "- Tax and environmental carve-outs sit outside the main cap.",
+          "- The survival period is 24 months, shorter than the playbook standard.",
+          "- The escrow covers only 10% of the purchase price.",
+          "",
+          "Recommended next step: ask for a 36-month survival period and bring tax claims back under a negotiated sub-cap.",
+        ].join("\n"),
+      },
+    ],
+    role: "assistant",
+  },
+] satisfies PersistedChatMessage[];
+
+function SharedChatRendererSample() {
+  return (
+    <div className="bg-popover/40 flex flex-col gap-4 rounded-2xl border p-4">
+      <ChatThreadMessages
+        approvalPendingMessageId={null}
+        autoApprovedTools={new Set()}
+        handleAlwaysAllow={() => {
+          /* no-op in playground */
+        }}
+        handleApprove={() => {
+          /* no-op in playground */
+        }}
+        handleDeny={() => {
+          /* no-op in playground */
+        }}
+        messages={SHARED_CHAT_RENDERER_MESSAGES}
+        onAskUserSubmit={() => {
+          /* no-op in playground */
+        }}
+        onResend={() => {
+          /* no-op in playground */
+        }}
+        showToolCalls={false}
+        streamdownComponents={{
+          a: ({ children, ...props }) => <a {...props}>{children}</a>,
+        }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Adds copy and retry controls to assistant chat responses. Retry is only shown for the latest assistant response, while copy remains available on assistant responses with text.

Also adds a /dev shared renderer sample so the response actions can be reviewed in the UI playground.