### PR TITLE
fix: polish external previews

### DIFF
--- a/apps/api/src/handlers/external-preview/preview.test.ts
+++ b/apps/api/src/handlers/external-preview/preview.test.ts
@@ -5,6 +5,7 @@ import {
   extractReadableTextFromHtml,
   isPdfBytes,
   isPdfPreview,
+  isPdfPreviewResponse,
 } from "@/api/handlers/external-preview/preview";
 
 describe("external source preview", () => {
@@ -78,5 +79,34 @@ describe("external source preview", () => {
     expect(isPdfBytes(new TextEncoder().encode("<html></html>").buffer)).toBe(
       false,
     );
+  });
+
+  test("preserves PDF detection when redirects hide the original extension", () => {
+    expect(
+      isPdfPreviewResponse({
+        body: new TextEncoder().encode("%PDF-1.4\n").buffer,
+        contentType: "application/octet-stream",
+        requestedUrl: new URL("https://example.test/document.pdf"),
+        responseUrl: new URL("https://cdn.example.test/signed-token"),
+      }),
+    ).toBe(true);
+
+    expect(
+      isPdfPreviewResponse({
+        body: new TextEncoder().encode("<html></html>").buffer,
+        contentType: "application/octet-stream",
+        requestedUrl: new URL("https://example.test/document.pdf"),
+        responseUrl: new URL("https://cdn.example.test/signed-token"),
+      }),
+    ).toBe(true);
+
+    expect(
+      isPdfPreviewResponse({
+        body: new TextEncoder().encode("<html></html>").buffer,
+        contentType: "application/octet-stream",
+        requestedUrl: new URL("https://example.test/document"),
+        responseUrl: new URL("https://cdn.example.test/signed-token"),
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/handlers/external-preview/preview.ts
+++ b/apps/api/src/handlers/external-preview/preview.ts
@@ -53,10 +53,17 @@ const previewExternalSource = createSafeRootHandler(
     const previewFetch = yield* Result.await(
       fetchPreviewUrl(target, { maxBytes: MAX_PREVIEW_BYTES }),
     );
-    const { response, url } = previewFetch;
+    const { requestedUrl, response, url } = previewFetch;
     const contentType = getContentType(response.headers);
 
-    if (isPdfPreview(contentType, url)) {
+    if (
+      isPdfPreviewResponse({
+        body: response.body,
+        contentType,
+        requestedUrl,
+        responseUrl: url,
+      })
+    ) {
       const preview: ExternalPreviewResponse = {
         contentType,
         format: "pdf" as const,
@@ -122,10 +129,18 @@ export const previewExternalFile = createSafeRootHandler(
     const previewFetch = yield* Result.await(
       fetchPreviewUrl(target, { maxBytes: MAX_FILE_PREVIEW_BYTES }),
     );
-    const { response, url } = previewFetch;
+    const { requestedUrl, response, url } = previewFetch;
     const contentType = getContentType(response.headers);
+    const body = response.body;
 
-    if (!isPdfPreview(contentType, url)) {
+    if (
+      !isPdfPreviewResponse({
+        body,
+        contentType,
+        requestedUrl,
+        responseUrl: url,
+      })
+    ) {
       return Result.err(
         new HandlerError({
           status: 422,
@@ -133,8 +148,6 @@ export const previewExternalFile = createSafeRootHandler(
         }),
       );
     }
-
-    const body = response.body;
 
     if (!isPdfBytes(body)) {
       return Result.err(
@@ -369,6 +382,7 @@ type FetchPreviewUrlOptions = {
 };
 
 type FetchPreviewUrlResult = {
+  requestedUrl: URL;
   response: SafeOutboundFetchResponse;
   url: URL;
 };
@@ -440,7 +454,11 @@ const fetchPreviewUrl = async (
           });
         }
 
-        return { response: response.value, url: currentTarget.url };
+        return {
+          requestedUrl: target.url,
+          response: response.value,
+          url: currentTarget.url,
+        };
       }
 
       throw new HandlerError({
@@ -572,6 +590,21 @@ export const isPdfPreview = (contentType: string | null, url: URL): boolean =>
   (contentType !== null && PDF_CONTENT_TYPES.has(contentType)) ||
   ((contentType === null || GENERIC_BINARY_CONTENT_TYPES.has(contentType)) &&
     url.pathname.toLowerCase().endsWith(".pdf"));
+
+export const isPdfPreviewResponse = ({
+  body,
+  contentType,
+  requestedUrl,
+  responseUrl,
+}: {
+  body: ArrayBuffer;
+  contentType: string | null;
+  requestedUrl: URL;
+  responseUrl: URL;
+}): boolean =>
+  isPdfPreview(contentType, responseUrl) ||
+  isPdfPreview(contentType, requestedUrl) ||
+  isPdfBytes(body);
 
 export const isPdfBytes = (body: ArrayBuffer): boolean => {
   if (body.byteLength < PDF_MAGIC_BYTES.length) {

--- a/apps/api/src/handlers/external-preview/preview.ts
+++ b/apps/api/src/handlers/external-preview/preview.ts
@@ -20,6 +20,7 @@ const MAX_URL_LENGTH = 2048;
 const MAX_PREVIEW_BYTES = 1_000_000;
 const MAX_FILE_PREVIEW_BYTES = 20_000_000;
 const MAX_PREVIEW_CHARS = 80_000;
+const MAX_PREVIEW_REDIRECTS = 5;
 const MIN_READABLE_TEXT_CHARS = 80;
 
 const HTML_CONTENT_TYPES = new Set(["application/xhtml+xml", "text/html"]);
@@ -49,10 +50,10 @@ const previewExternalSource = createSafeRootHandler(
   config,
   async function* ({ query }) {
     const target = yield* Result.await(validatePreviewUrl(query.url));
-    const { url } = target;
-    const response = yield* Result.await(
+    const previewFetch = yield* Result.await(
       fetchPreviewUrl(target, { maxBytes: MAX_PREVIEW_BYTES }),
     );
+    const { response, url } = previewFetch;
     const contentType = getContentType(response.headers);
 
     if (isPdfPreview(contentType, url)) {
@@ -118,10 +119,10 @@ export const previewExternalFile = createSafeRootHandler(
   config,
   async function* ({ query }) {
     const target = yield* Result.await(validatePreviewUrl(query.url));
-    const { url } = target;
-    const response = yield* Result.await(
+    const previewFetch = yield* Result.await(
       fetchPreviewUrl(target, { maxBytes: MAX_FILE_PREVIEW_BYTES }),
     );
+    const { response, url } = previewFetch;
     const contentType = getContentType(response.headers);
 
     if (!isPdfPreview(contentType, url)) {
@@ -310,6 +311,12 @@ const extractHtmlTitle = (html: string): string | null => {
 const validatePreviewUrl = async (
   rawUrl: string,
 ): Promise<Result<ValidatedPreviewUrl, HandlerError>> => {
+  if (rawUrl.length > MAX_URL_LENGTH) {
+    return Result.err(
+      new HandlerError({ status: 400, message: "Source URL is too long" }),
+    );
+  }
+
   let url: URL;
   try {
     url = new URL(rawUrl);
@@ -361,43 +368,85 @@ type FetchPreviewUrlOptions = {
   maxBytes: number;
 };
 
+type FetchPreviewUrlResult = {
+  response: SafeOutboundFetchResponse;
+  url: URL;
+};
+
 const fetchPreviewUrl = async (
   target: ValidatedPreviewUrl,
   { maxBytes }: FetchPreviewUrlOptions,
-): Promise<Result<SafeOutboundFetchResponse, HandlerError>> =>
+): Promise<Result<FetchPreviewUrlResult, HandlerError>> =>
   await Result.tryPromise({
     try: async () => {
-      const response = await fetchWithResolvedAddress({
-        addresses: target.addresses,
-        headers: {
-          Accept:
-            "application/pdf, text/html, application/xhtml+xml, text/plain;q=0.9",
-          "User-Agent": "Stella external source preview",
-        },
-        maxBytes,
-        timeoutMs: PREVIEW_TIMEOUT_MS,
-        url: target.url,
+      let currentTarget = target;
+
+      for (let redirects = 0; redirects <= MAX_PREVIEW_REDIRECTS; redirects++) {
+        const response = await fetchWithResolvedAddress({
+          addresses: currentTarget.addresses,
+          headers: {
+            Accept:
+              "application/pdf, text/html, application/xhtml+xml, text/plain;q=0.9",
+            "User-Agent": "Stella external source preview",
+          },
+          maxBytes,
+          redirect: "manual",
+          timeoutMs: PREVIEW_TIMEOUT_MS,
+          url: currentTarget.url,
+        });
+        if (Result.isError(response)) {
+          throw response.error;
+        }
+
+        if (isRedirectStatus(response.value.status)) {
+          if (redirects === MAX_PREVIEW_REDIRECTS) {
+            throw new HandlerError({
+              status: 502,
+              message: "Source redirected too many times",
+            });
+          }
+
+          const location = response.value.headers.get("location");
+          if (!location) {
+            throw new HandlerError({
+              status: 502,
+              message: "Source redirected without a location",
+            });
+          }
+
+          const nextTarget = await validatePreviewUrl(
+            new URL(location, currentTarget.url).toString(),
+          );
+          if (Result.isError(nextTarget)) {
+            throw nextTarget.error;
+          }
+
+          currentTarget = nextTarget.value;
+          continue;
+        }
+
+        if (!response.value.ok) {
+          throw new HandlerError({
+            status: 502,
+            message: `Source returned HTTP ${response.value.status}`,
+          });
+        }
+
+        const contentLength = response.value.headers.get("content-length");
+        if (contentLength && Number(contentLength) > maxBytes) {
+          throw new HandlerError({
+            status: 422,
+            message: "This source is too large to preview",
+          });
+        }
+
+        return { response: response.value, url: currentTarget.url };
+      }
+
+      throw new HandlerError({
+        status: 502,
+        message: "Source redirected too many times",
       });
-      if (Result.isError(response)) {
-        throw response.error;
-      }
-
-      if (!response.value.ok) {
-        throw new HandlerError({
-          status: 502,
-          message: `Source returned HTTP ${response.value.status}`,
-        });
-      }
-
-      const contentLength = response.value.headers.get("content-length");
-      if (contentLength && Number(contentLength) > maxBytes) {
-        throw new HandlerError({
-          status: 422,
-          message: "This source is too large to preview",
-        });
-      }
-
-      return response.value;
     },
     catch: (cause) =>
       HandlerError.is(cause)
@@ -408,6 +457,9 @@ const fetchPreviewUrl = async (
             cause,
           }),
   });
+
+const isRedirectStatus = (status: number): boolean =>
+  status >= 300 && status < 400;
 
 const readResponseText = (response: SafeOutboundFetchResponse): string =>
   new TextDecoder().decode(response.body.slice(0, MAX_PREVIEW_BYTES));

--- a/apps/api/src/lib/safe-outbound-fetch.test.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.test.ts
@@ -52,6 +52,51 @@ describe("fetchWithResolvedAddress", () => {
     );
   });
 
+  test("rejects redirects by default", async () => {
+    await withHttpServer(
+      (_request, response) => {
+        response.writeHead(302, { Location: "/target" });
+        response.end();
+      },
+      async (port) => {
+        const result = await fetchWithResolvedAddress({
+          addresses: [{ address: "127.0.0.1", family: 4 }],
+          maxBytes: 1024,
+          timeoutMs: 1000,
+          url: new URL(`http://example.test:${port}/redirect`),
+        });
+
+        expect(Result.isError(result)).toBe(true);
+      },
+    );
+  });
+
+  test("can return redirects for callers that revalidate each hop", async () => {
+    await withHttpServer(
+      (_request, response) => {
+        response.writeHead(302, { Location: "/target" });
+        response.end();
+      },
+      async (port) => {
+        const result = await fetchWithResolvedAddress({
+          addresses: [{ address: "127.0.0.1", family: 4 }],
+          maxBytes: 1024,
+          redirect: "manual",
+          timeoutMs: 1000,
+          url: new URL(`http://example.test:${port}/redirect`),
+        });
+
+        expect(Result.isOk(result)).toBe(true);
+        if (Result.isError(result)) {
+          throw result.error;
+        }
+
+        expect(result.value.status).toBe(302);
+        expect(result.value.headers.get("location")).toBe("/target");
+      },
+    );
+  });
+
   test("returns streaming responses before the server closes the body", async () => {
     await withHttpServer(
       (_request, response) => {

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -36,12 +36,15 @@ export type SafeOutboundFetchStreamResponse = {
   status: number;
 };
 
+type SafeOutboundRedirectMode = "error" | "manual";
+
 export const fetchWithResolvedAddress = async ({
   addresses,
   body,
   headers,
   maxBytes,
   method = "GET",
+  redirect = "error",
   timeoutMs,
   url,
 }: {
@@ -50,6 +53,7 @@ export const fetchWithResolvedAddress = async ({
   headers?: SafeOutboundHeaders | undefined;
   maxBytes: number;
   method?: string | undefined;
+  redirect?: SafeOutboundRedirectMode | undefined;
   timeoutMs: number;
   url: URL;
 }): Promise<Result<SafeOutboundFetchResponse, SafeOutboundFetchError>> => {
@@ -100,7 +104,7 @@ export const fetchWithResolvedAddress = async ({
             const status = response.statusCode ?? 0;
             const responseHeaders = headersFromIncoming(response.headers);
 
-            if (status >= 300 && status < 400) {
+            if (status >= 300 && status < 400 && redirect === "error") {
               response.resume();
               clearTimeout(timeout);
               reject(

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -142,6 +142,40 @@ describe("chat thread messages", () => {
     expect(html).not.toContain(">Retry</button>");
   });
 
+  test("hides retry while the latest assistant response is generating", () => {
+    const chatMessages: PersistedChatMessage[] = [
+      {
+        id: "message-A",
+        parts: [{ type: "text", text: "Streaming answer" }],
+        role: "assistant",
+      },
+    ];
+
+    const html = renderWithProviders(
+      <ChatThreadMessages
+        alwaysApprovedTools={new Set()}
+        approvalPendingMessageId={null}
+        conversationApprovedTools={new Set()}
+        handleAllowInConversation={() => {}}
+        handleAlwaysAllow={() => {}}
+        handleApprove={() => {}}
+        handleDeny={() => {}}
+        isGenerating
+        messages={chatMessages}
+        onAskUserSubmit={() => {}}
+        onResend={() => {}}
+        showToolCalls={false}
+        streamdownComponents={{
+          a: ({ children, ...props }) => <a {...props}>{children}</a>,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Streaming answer");
+    expect(html).toContain(">Copy</button>");
+    expect(html).not.toContain(">Retry</button>");
+  });
+
   test("shows a resendable chat message when the chat runtime errors", () => {
     const html = renderWithProviders(
       <ChatThreadMessages

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -279,7 +279,9 @@ const AssistantMessageActions = ({
 }) => {
   const t = useTranslations();
   const text = useMemo(() => getMessageText(message), [message]);
-  const canRetry = Boolean(onResend && isLatestAssistantMessage);
+  const canRetry = Boolean(
+    onResend && isLatestAssistantMessage && !isGenerating,
+  );
 
   if (!text && !canRetry) {
     return null;
@@ -314,7 +316,6 @@ const AssistantMessageActions = ({
         <Button
           aria-label={t("common.retry")}
           className="text-muted-foreground h-6 px-1.5 text-xs"
-          disabled={isGenerating}
           onClick={() => {
             void onResend?.(message.id);
           }}

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -8,6 +8,7 @@ import {
   getUserMessageHtmlHistory,
   hasApprovalResponseAwaitingModelStep,
   hasApprovedActiveDocxEditAwaitingClientOutput,
+  hasRunningToolCallInLatestAssistantMessage,
   isApprovalPart,
   isPublicOfficialChatToolName,
   isToolApprovedByGrant,
@@ -220,6 +221,84 @@ describe("hasApprovalResponseAwaitingModelStep", () => {
         ],
       }),
     ).toBe(true);
+  });
+});
+
+describe("hasRunningToolCallInLatestAssistantMessage", () => {
+  test("treats in-flight tool input as an active assistant response", () => {
+    const messages = [
+      {
+        id: "message-1",
+        parts: [
+          {
+            input: { query: "consumer credit" },
+            state: "input-available",
+            toolCallId: "tool-call-1",
+            toolName: "mcp__salvia__search_decisions",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+    ] satisfies Parameters<
+      typeof hasRunningToolCallInLatestAssistantMessage
+    >[0]["messages"];
+
+    expect(hasRunningToolCallInLatestAssistantMessage({ messages })).toBe(true);
+  });
+
+  test("ignores completed tool output", () => {
+    const messages = [
+      {
+        id: "message-1",
+        parts: [
+          {
+            input: { query: "consumer credit" },
+            output: { content: [] },
+            state: "output-available",
+            toolCallId: "tool-call-1",
+            toolName: "mcp__salvia__search_decisions",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+    ] satisfies Parameters<
+      typeof hasRunningToolCallInLatestAssistantMessage
+    >[0]["messages"];
+
+    expect(hasRunningToolCallInLatestAssistantMessage({ messages })).toBe(
+      false,
+    );
+  });
+
+  test("ignores stale running tool parts from older messages", () => {
+    const messages = [
+      {
+        id: "message-1",
+        parts: [
+          {
+            input: { query: "consumer credit" },
+            state: "input-available",
+            toolCallId: "tool-call-1",
+            toolName: "mcp__salvia__search_decisions",
+            type: "dynamic-tool",
+          },
+        ],
+        role: "assistant",
+      },
+      {
+        id: "message-2",
+        parts: [{ text: "new prompt", type: "text" }],
+        role: "user",
+      },
+    ] satisfies Parameters<
+      typeof hasRunningToolCallInLatestAssistantMessage
+    >[0]["messages"];
+
+    expect(hasRunningToolCallInLatestAssistantMessage({ messages })).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/web/src/components/chat/chat-ui-tools.test.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.test.ts
@@ -272,6 +272,29 @@ describe("hasRunningToolCallInLatestAssistantMessage", () => {
     );
   });
 
+  test("ignores ask-user prompts waiting for a user answer", () => {
+    const messages = [
+      {
+        id: "message-1",
+        parts: [
+          {
+            input: { analysis: "Need the user's answer.", questions: [] },
+            state: "input-available",
+            toolCallId: "tool-call-1",
+            type: "tool-ask-user",
+          },
+        ],
+        role: "assistant",
+      },
+    ] satisfies Parameters<
+      typeof hasRunningToolCallInLatestAssistantMessage
+    >[0]["messages"];
+
+    expect(hasRunningToolCallInLatestAssistantMessage({ messages })).toBe(
+      false,
+    );
+  });
+
   test("ignores stale running tool parts from older messages", () => {
     const messages = [
       {

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -34,6 +34,10 @@ type PublicOfficialToolName = Extract<
   BuiltInApprovalToolName,
   "ares_lookup_company" | "ares_search_companies"
 >;
+const RUNNING_TOOL_STATES = {
+  "input-available": true,
+  "input-streaming": true,
+} as const satisfies Record<string, true>;
 
 const CHAT_TOOL_TITLE_KEYS = {
   "apply-active-docx-edits": "chat.tool.apply-active-docx-edits",
@@ -250,6 +254,38 @@ export const hasApprovalResponseAwaitingModelStep = ({
   }
 
   return message.parts.some(isApprovalRespondedPart);
+};
+
+export const isRunningToolPart = (part: unknown): boolean => {
+  if (
+    typeof part !== "object" ||
+    part === null ||
+    !("type" in part) ||
+    !("state" in part) ||
+    typeof part.type !== "string" ||
+    typeof part.state !== "string"
+  ) {
+    return false;
+  }
+
+  if (!(part.state in RUNNING_TOOL_STATES)) {
+    return false;
+  }
+
+  return part.type === "dynamic-tool" || part.type.startsWith("tool-");
+};
+
+export const hasRunningToolCallInLatestAssistantMessage = ({
+  messages,
+}: {
+  messages: PersistedChatMessage[];
+}) => {
+  const message = messages.at(-1);
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+
+  return message.parts.some(isRunningToolPart);
 };
 
 export const getUserMessageHtmlHistory = (

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -272,6 +272,10 @@ export const isRunningToolPart = (part: unknown): boolean => {
     return false;
   }
 
+  if (part.type === "tool-ask-user") {
+    return false;
+  }
+
   return part.type === "dynamic-tool" || part.type.startsWith("tool-");
 };
 

--- a/apps/web/src/components/chat/external-source-store.ts
+++ b/apps/web/src/components/chat/external-source-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 export type ExternalSourceReference = {
   connectorSlug?: string | undefined;
+  iconHref?: string | undefined;
   provider?: string | undefined;
   snippet?: string | undefined;
   sourceToolName?: string | undefined;

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -141,13 +141,24 @@ export const SourceChips = ({
     ...mcpConnectorsOptions(),
     enabled: hasMcpExternalSources,
   });
+  const uniqueExternalSourcesWithIcons = uniqueExternalSources.map((source) => {
+    if (source.connectorSlug === undefined) {
+      return source;
+    }
+
+    const iconHref = findMcpConnectorIconHref({
+      connectorSlug: source.connectorSlug,
+      connectors: mcpConnectorsData?.connectors ?? [],
+    });
+    return iconHref === undefined ? source : { ...source, iconHref };
+  });
   const registerSources = useExternalSourceStore(
     (state) => state.registerSources,
   );
 
   useEffect(() => {
-    registerSources(uniqueExternalSources);
-  }, [registerSources, uniqueExternalSources]);
+    registerSources(uniqueExternalSourcesWithIcons);
+  }, [registerSources, uniqueExternalSourcesWithIcons]);
 
   if (uniqueSources.length === 0 && uniqueExternalSources.length === 0) {
     return null;
@@ -162,9 +173,8 @@ export const SourceChips = ({
           workspaceId={workspaceId}
         />
       ))}
-      {uniqueExternalSources.map((source) => (
+      {uniqueExternalSourcesWithIcons.map((source) => (
         <ExternalSourceChip
-          connectors={mcpConnectorsData?.connectors ?? []}
           key={`${messageId}-external-source-${source.url}`}
           source={source}
         />
@@ -191,28 +201,11 @@ const SourceIcon = ({
   return <FileTextIcon className={cn(cls, "text-muted-foreground")} />;
 };
 
-const ExternalSourceChip = ({
-  connectors,
-  source,
-}: {
-  connectors: {
-    iconUrl: string | null;
-    slug: string;
-    url: string;
-  }[];
-  source: ExternalSourceEntry;
-}) => {
-  const iconHref =
-    source.connectorSlug === undefined
-      ? undefined
-      : findMcpConnectorIconHref({
-          connectorSlug: source.connectorSlug,
-          connectors,
-        });
-
+const ExternalSourceChip = ({ source }: { source: ExternalSourceEntry }) => {
   const handleClick = () => {
     useInspectorStore.getState().openExternal({
       connectorSlug: source.connectorSlug,
+      iconHref: source.iconHref,
       label: source.title,
       provider: source.provider,
       snippet: source.snippet,
@@ -232,7 +225,7 @@ const ExternalSourceChip = ({
       onClick={handleClick}
       type="button"
     >
-      <ExternalSourceIcon iconHref={iconHref} />
+      <ExternalSourceIcon iconHref={source.iconHref} />
       <span className="max-w-[20ch] truncate">{source.title}</span>
     </button>
   );

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import type {
   ChatMessage,
@@ -80,6 +80,69 @@ export const SourceChips = ({
   parts,
   workspaceId,
 }: SourceChipsProps) => {
+  const { uniqueExternalSources, uniqueSources } = useMemo(
+    () => collectSourceChipEntries(parts),
+    [parts],
+  );
+  const hasMcpExternalSources = uniqueExternalSources.some(
+    (source) => source.connectorSlug !== undefined,
+  );
+  const { data: mcpConnectorsData } = useQuery({
+    ...mcpConnectorsOptions(),
+    enabled: hasMcpExternalSources,
+  });
+  const uniqueExternalSourcesWithIcons = useMemo(
+    () =>
+      uniqueExternalSources.map((source) => {
+        if (source.connectorSlug === undefined) {
+          return source;
+        }
+
+        const iconHref = findMcpConnectorIconHref({
+          connectorSlug: source.connectorSlug,
+          connectors: mcpConnectorsData?.connectors ?? [],
+        });
+        return iconHref === undefined ? source : { ...source, iconHref };
+      }),
+    [mcpConnectorsData?.connectors, uniqueExternalSources],
+  );
+  const registerSources = useExternalSourceStore(
+    (state) => state.registerSources,
+  );
+
+  useEffect(() => {
+    registerSources(uniqueExternalSourcesWithIcons);
+  }, [registerSources, uniqueExternalSourcesWithIcons]);
+
+  if (uniqueSources.length === 0 && uniqueExternalSources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      {uniqueSources.map((part) => (
+        <SourceChip
+          key={`${messageId}-source-${part.id ?? part.data.entityId}`}
+          sourceDocument={part.data}
+          workspaceId={workspaceId}
+        />
+      ))}
+      {uniqueExternalSourcesWithIcons.map((source) => (
+        <ExternalSourceChip
+          key={`${messageId}-external-source-${source.url}`}
+          source={source}
+        />
+      ))}
+    </div>
+  );
+};
+
+const collectSourceChipEntries = (
+  parts: ChatMessage["parts"],
+): {
+  uniqueExternalSources: ExternalSourceEntry[];
+  uniqueSources: SourceDocumentEntry[];
+} => {
   const sources: SourceDocumentEntry[] = [];
   const externalSources: ExternalSourceEntry[] = [];
   for (const part of parts) {
@@ -123,6 +186,7 @@ export const SourceChips = ({
       existing
         ? {
             connectorSlug: source.connectorSlug ?? existing.connectorSlug,
+            iconHref: source.iconHref ?? existing.iconHref,
             provider: source.provider ?? existing.provider,
             snippet: source.snippet ?? existing.snippet,
             sourceToolName: source.sourceToolName ?? existing.sourceToolName,
@@ -133,54 +197,11 @@ export const SourceChips = ({
         : source,
     );
   }
-  const uniqueExternalSources = Array.from(externalSourcesByUrl.values());
-  const hasMcpExternalSources = uniqueExternalSources.some(
-    (source) => source.connectorSlug !== undefined,
-  );
-  const { data: mcpConnectorsData } = useQuery({
-    ...mcpConnectorsOptions(),
-    enabled: hasMcpExternalSources,
-  });
-  const uniqueExternalSourcesWithIcons = uniqueExternalSources.map((source) => {
-    if (source.connectorSlug === undefined) {
-      return source;
-    }
 
-    const iconHref = findMcpConnectorIconHref({
-      connectorSlug: source.connectorSlug,
-      connectors: mcpConnectorsData?.connectors ?? [],
-    });
-    return iconHref === undefined ? source : { ...source, iconHref };
-  });
-  const registerSources = useExternalSourceStore(
-    (state) => state.registerSources,
-  );
-
-  useEffect(() => {
-    registerSources(uniqueExternalSourcesWithIcons);
-  }, [registerSources, uniqueExternalSourcesWithIcons]);
-
-  if (uniqueSources.length === 0 && uniqueExternalSources.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      {uniqueSources.map((part) => (
-        <SourceChip
-          key={`${messageId}-source-${part.id ?? part.data.entityId}`}
-          sourceDocument={part.data}
-          workspaceId={workspaceId}
-        />
-      ))}
-      {uniqueExternalSourcesWithIcons.map((source) => (
-        <ExternalSourceChip
-          key={`${messageId}-external-source-${source.url}`}
-          source={source}
-        />
-      ))}
-    </div>
-  );
+  return {
+    uniqueExternalSources: Array.from(externalSourcesByUrl.values()),
+    uniqueSources,
+  };
 };
 
 const cls = "size-3 shrink-0";

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -446,6 +446,7 @@ export const StreamdownMentionLink = ({
           useInspectorStore.getState().openExternal({
             url: httpUrl.toString(),
             connectorSlug: source?.connectorSlug,
+            iconHref: source?.iconHref,
             label: getPlainText(children) ?? source?.title ?? httpUrl.hostname,
             provider: source?.provider,
             snippet: source?.snippet,

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -14,7 +14,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { getChatToolTitleKey } from "@/components/chat/chat-ui-tools";
+import {
+  getChatToolTitleKey,
+  isRunningToolPart,
+} from "@/components/chat/chat-ui-tools";
 import { sanitizeHref } from "@/lib/sanitize-href";
 import { mcpConnectorsOptions } from "@/routes/_protected.knowledge/-queries";
 
@@ -188,8 +191,7 @@ export const ToolCallCard = ({
     toolName: name,
   });
 
-  const isLoading =
-    part.state === "input-streaming" || part.state === "input-available";
+  const isLoading = isRunningToolPart(part);
   const hasOutput = part.state === "output-available";
   const hasError = part.state === "output-error";
   const toolInput = getToolInput(part);

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Otevřít externí odkaz?",
       "openLink": "Otevřít odkaz",
       "openOriginal": "Otevřít originál",
-      "unavailable": "Tento web nepovoluje bezpečný náhled uvnitř Stelly. Pokud nástroj vrátil text dokumentu, zobrazí se tady; jinak otevřete originál."
+      "unavailable": "Odkazovaný web nepovoluje bezpečný náhled. Pokud nástroj vrátil text dokumentu, zobrazí se tady; jinak otevřete originál."
     },
     "facet": {
       "preview": "Náhled",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Externen Link öffnen?",
       "openLink": "Link öffnen",
       "openOriginal": "Original öffnen",
-      "unavailable": "Diese Website erlaubt keine sichere Vorschau in Stella. Wenn das Tool Dokumenttext zurückgegeben hat, erscheint er hier; andernfalls öffnen Sie das Original."
+      "unavailable": "Die verlinkte Website erlaubt keine sichere Vorschau. Wenn das Tool Dokumenttext zurückgegeben hat, erscheint er hier; andernfalls öffnen Sie das Original."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Open external link?",
       "openLink": "Open link",
       "openOriginal": "Open original",
-      "unavailable": "This site does not allow a safe in-app preview. If the tool returned document text, it appears here; otherwise open the original."
+      "unavailable": "The referenced site does not allow a safe preview. If the tool returned document text, it appears here; otherwise open the original."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "¿Abrir enlace externo?",
       "openLink": "Abrir enlace",
       "openOriginal": "Abrir original",
-      "unavailable": "Este sitio no permite una vista previa segura dentro de Stella. Si la herramienta devolvió el texto del documento, aparecerá aquí; si no, abra el original."
+      "unavailable": "El sitio referenciado no permite una vista previa segura. Si la herramienta devolvió el texto del documento, aparecerá aquí; si no, abra el original."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Ava väline link?",
       "openLink": "Ava link",
       "openOriginal": "Ava originaal",
-      "unavailable": "See sait ei luba Stellas turvalist eelvaadet. Kui tööriist tagastas dokumendi teksti, kuvatakse see siin; muul juhul avage originaal."
+      "unavailable": "Viidatud sait ei luba turvalist eelvaadet. Kui tööriist tagastas dokumendi teksti, kuvatakse see siin; muul juhul avage originaal."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Ouvrir le lien externe ?",
       "openLink": "Ouvrir le lien",
       "openOriginal": "Ouvrir l’original",
-      "unavailable": "Ce site n’autorise pas un aperçu sécurisé dans Stella. Si l’outil a renvoyé le texte du document, il s’affiche ici ; sinon, ouvrez l’original."
+      "unavailable": "Le site référencé n’autorise pas un aperçu sécurisé. Si l’outil a renvoyé le texte du document, il s’affiche ici ; sinon, ouvrez l’original."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Külső hivatkozás megnyitása?",
       "openLink": "Hivatkozás megnyitása",
       "openOriginal": "Eredeti megnyitása",
-      "unavailable": "Ez a webhely nem engedélyez biztonságos előnézetet a Stellában. Ha az eszköz visszaadta a dokumentum szövegét, az itt jelenik meg; ellenkező esetben nyissa meg az eredetit."
+      "unavailable": "A hivatkozott webhely nem engedélyez biztonságos előnézetet. Ha az eszköz visszaadta a dokumentum szövegét, az itt jelenik meg; ellenkező esetben nyissa meg az eredetit."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Atidaryti išorinę nuorodą?",
       "openLink": "Atidaryti nuorodą",
       "openOriginal": "Atidaryti originalą",
-      "unavailable": "Ši svetainė neleidžia saugios peržiūros Stella viduje. Jei įrankis grąžino dokumento tekstą, jis bus rodomas čia; kitu atveju atidarykite originalą."
+      "unavailable": "Nurodyta svetainė neleidžia saugios peržiūros. Jei įrankis grąžino dokumento tekstą, jis bus rodomas čia; kitu atveju atidarykite originalą."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Atvērt ārēju saiti?",
       "openLink": "Atvērt saiti",
       "openOriginal": "Atvērt oriģinālu",
-      "unavailable": "Šī vietne neļauj drošu priekšskatījumu Stellā. Ja rīks atgrieza dokumenta tekstu, tas parādīsies šeit; pretējā gadījumā atveriet oriģinālu."
+      "unavailable": "Norādītā vietne neļauj drošu priekšskatījumu. Ja rīks atgrieza dokumenta tekstu, tas parādīsies šeit; pretējā gadījumā atveriet oriģinālu."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1044,7 +1044,7 @@ type Messages = {
       "confirmTitle": "Open external link?";
       "openLink": "Open link";
       "openOriginal": "Open original";
-      "unavailable": "This site does not allow a safe in-app preview. If the tool returned document text, it appears here; otherwise open the original.";
+      "unavailable": "The referenced site does not allow a safe preview. If the tool returned document text, it appears here; otherwise open the original.";
     };
     "facet": {
       "preview": "Preview";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Otworzyć link zewnętrzny?",
       "openLink": "Otwórz link",
       "openOriginal": "Otwórz oryginał",
-      "unavailable": "Ta strona nie pozwala na bezpieczny podgląd w Stelli. Jeśli narzędzie zwróciło tekst dokumentu, pojawi się tutaj; w przeciwnym razie otwórz oryginał."
+      "unavailable": "Wskazana strona nie pozwala na bezpieczny podgląd. Jeśli narzędzie zwróciło tekst dokumentu, pojawi się tutaj; w przeciwnym razie otwórz oryginał."
     },
     "facet": {
       "preview": "Preview",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Abrir link externo?",
       "openLink": "Abrir link",
       "openOriginal": "Abrir original",
-      "unavailable": "Este site não permite uma pré-visualização segura dentro da Stella. Se a ferramenta retornou o texto do documento, ele aparece aqui; caso contrário, abra o original."
+      "unavailable": "O site referenciado não permite uma pré-visualização segura. Se a ferramenta retornou o texto do documento, ele aparece aqui; caso contrário, abra o original."
     },
     "facet": {
       "preview": "Visualização",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1041,7 +1041,7 @@
       "confirmTitle": "Otvoriť externý odkaz?",
       "openLink": "Otvoriť odkaz",
       "openOriginal": "Otvoriť originál",
-      "unavailable": "Tento web nepovoľuje bezpečný náhľad v Stelle. Ak nástroj vrátil text dokumentu, zobrazí sa tu; inak otvorte originál."
+      "unavailable": "Odkazovaný web nepovoľuje bezpečný náhľad. Ak nástroj vrátil text dokumentu, zobrazí sa tu; inak otvorte originál."
     },
     "facet": {
       "preview": "Náhľad",

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -23,6 +23,7 @@ import {
   getExternalMcpConnectorApprovalGrant,
   getExternalMcpConnectorSlugFromToolName,
   getToolApprovalGrant,
+  hasRunningToolCallInLatestAssistantMessage,
   isApprovalToolName,
   isExternalMcpToolName,
   isToolApprovalGrant,
@@ -175,7 +176,12 @@ export const useChatSession = ({
     [messages],
   );
 
-  const isGenerating = status === "submitted" || status === "streaming";
+  const hasRunningToolCall = useMemo(
+    () => hasRunningToolCallInLatestAssistantMessage({ messages }),
+    [messages],
+  );
+  const isGenerating =
+    status === "submitted" || status === "streaming" || hasRunningToolCall;
 
   useEffect(() => {
     setConversationApprovedTools(readConversationApprovedTools(conversationId));

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -5,6 +5,7 @@ import { toChatThreadId } from "@/lib/chat-thread-ref";
 import {
   buildSendRequestBody,
   chatKeys,
+  createSendAutomaticallyPredicate,
   matchesChatThreadAcrossScopes,
 } from "@/routes/_protected.chat/-queries";
 
@@ -105,5 +106,52 @@ describe("buildSendRequestBody", () => {
       anonymized: true,
       threadId: "thread-A",
     });
+  });
+});
+
+describe("createSendAutomaticallyPredicate", () => {
+  test("allows sequential auto sends inside the same assistant message", () => {
+    const shouldSendAutomatically = createSendAutomaticallyPredicate();
+    const baseMessage = {
+      id: "message-A",
+      role: "assistant",
+    } satisfies Pick<PersistedChatMessage, "id" | "role">;
+    const firstToolResult = {
+      ...baseMessage,
+      parts: [
+        { type: "step-start" },
+        {
+          input: {},
+          output: { content: [] },
+          state: "output-available",
+          toolCallId: "tool-call-1",
+          toolName: "mcp__legaldatahunter-com__discover_countries",
+          type: "dynamic-tool",
+        },
+      ],
+    } satisfies PersistedChatMessage;
+    const secondApprovalResponse = {
+      ...baseMessage,
+      parts: [
+        ...firstToolResult.parts,
+        { type: "step-start" },
+        {
+          approval: { approved: true, id: "approval-1" },
+          input: { query: "derecho al olvido" },
+          state: "approval-responded",
+          toolCallId: "tool-call-2",
+          toolName: "mcp__legaldatahunter-com__search",
+          type: "dynamic-tool",
+        },
+      ],
+    } satisfies PersistedChatMessage;
+
+    expect(shouldSendAutomatically({ messages: [firstToolResult] })).toBeTrue();
+    expect(
+      shouldSendAutomatically({ messages: [firstToolResult] }),
+    ).toBeFalse();
+    expect(
+      shouldSendAutomatically({ messages: [secondApprovalResponse] }),
+    ).toBeTrue();
   });
 });

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -281,19 +281,19 @@ export const buildSendRequestBody = ({
 // with cached prefixes on small Gemini variants), the AI SDK does
 // not append a new assistant message, so the same tool-result tail
 // keeps satisfying the predicate and useChat resubmits at ~1.5 Hz
-// until the user reloads. Tracking the id of the message that last
-// triggered an automatic send breaks the loop without affecting the
-// legitimate post-tool-result resubmit. Id is more robust than
-// length: deleting and re-adding a message reuses no id, so the
-// predicate cannot accidentally lock out a future fire.
-const createSendAutomaticallyPredicate = () => {
-  let lastFiredMessageId: string | null = null;
+// until the user reloads. Tracking the latest assistant message's
+// tool-state fingerprint breaks that loop while still allowing the
+// same assistant message to advance through multiple sequential
+// tool calls.
+export const createSendAutomaticallyPredicate = () => {
+  let lastFiredFingerprint: string | null = null;
   return ({ messages }: { messages: PersistedChatMessage[] }) => {
     if (hasApprovedActiveDocxEditAwaitingClientOutput({ messages })) {
       return false;
     }
     const lastMessage = messages.at(-1);
-    if (!lastMessage || lastMessage.id === lastFiredMessageId) {
+    const fingerprint = getAutoSendFingerprint(lastMessage);
+    if (!fingerprint || fingerprint === lastFiredFingerprint) {
       return false;
     }
     const shouldFire =
@@ -301,10 +301,45 @@ const createSendAutomaticallyPredicate = () => {
       lastAssistantMessageIsCompleteWithApprovalResponses({ messages }) ||
       lastAssistantMessageIsCompleteWithToolCalls({ messages });
     if (shouldFire) {
-      lastFiredMessageId = lastMessage.id;
+      lastFiredFingerprint = fingerprint;
     }
     return shouldFire;
   };
+};
+
+const getAutoSendFingerprint = (
+  message: PersistedChatMessage | undefined,
+): string | null => {
+  if (!message || message.role !== "assistant") {
+    return null;
+  }
+
+  const segments = [message.id];
+  for (const part of message.parts) {
+    if (typeof part !== "object" || part === null || !("type" in part)) {
+      continue;
+    }
+
+    const type = typeof part.type === "string" ? part.type : "";
+    const state =
+      "state" in part && typeof part.state === "string" ? part.state : "";
+    const toolCallId =
+      "toolCallId" in part && typeof part.toolCallId === "string"
+        ? part.toolCallId
+        : "";
+    const approved =
+      "approval" in part &&
+      typeof part.approval === "object" &&
+      part.approval !== null &&
+      "approved" in part.approval &&
+      typeof part.approval.approved === "boolean"
+        ? String(part.approval.approved)
+        : "";
+
+    segments.push(`${type}:${toolCallId}:${state}:${approved}`);
+  }
+
+  return segments.join("|");
 };
 
 export type ChatThreadFetched = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -2584,6 +2584,7 @@ const ExternalReferencePanel = ({
   const previewSnippet = tab.snippet ?? storedSource?.snippet;
   const provider = tab.provider ?? storedSource?.provider;
   const connectorSlug = tab.connectorSlug ?? storedSource?.connectorSlug;
+  const storedIconHref = tab.iconHref ?? storedSource?.iconHref;
   const sourceToolName = tab.sourceToolName ?? storedSource?.sourceToolName;
   const externalFilePreviewUrl =
     safeHref === undefined
@@ -2644,12 +2645,13 @@ const ExternalReferencePanel = ({
     enabled: connectorSlug !== undefined,
   });
   const iconHref =
-    connectorSlug === undefined
+    storedIconHref ??
+    (connectorSlug === undefined
       ? undefined
       : findMcpConnectorIconHref({
           connectorSlug,
           connectors: mcpConnectorsData?.connectors ?? [],
-        });
+        }));
   const requestOpenExternal = useCallback((href: string) => {
     setConfirmHref(href);
   }, []);
@@ -2992,17 +2994,22 @@ const VerticalTab = ({
   const tabQueryClient = useQueryClient();
   const externalConnectorSlug =
     tab.type === "external" ? tab.connectorSlug : undefined;
+  const storedExternalIconHref =
+    tab.type === "external" ? tab.iconHref : undefined;
   const { data: mcpConnectorsData } = useQuery({
     ...mcpConnectorsOptions(),
-    enabled: externalConnectorSlug !== undefined,
+    enabled:
+      externalConnectorSlug !== undefined &&
+      storedExternalIconHref === undefined,
   });
   const externalIconHref =
-    externalConnectorSlug === undefined
+    storedExternalIconHref ??
+    (externalConnectorSlug === undefined
       ? undefined
       : findMcpConnectorIconHref({
           connectorSlug: externalConnectorSlug,
           connectors: mcpConnectorsData?.connectors ?? [],
-        });
+        }));
 
   const contextMenu = useTabContextMenu({
     tabId: tab.id,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -2538,6 +2538,81 @@ const fallbackIconUrl = (rawUrl: string): string | undefined => {
   }
 };
 
+const useExternalPdfObjectUrl = ({
+  enabled,
+  url,
+}: {
+  enabled: boolean;
+  url?: string | undefined;
+}): string | undefined => {
+  const [objectUrl, setObjectUrl] = useState<string | undefined>();
+
+  useEffect(() => {
+    setObjectUrl(undefined);
+    if (!enabled || url === undefined) {
+      return undefined;
+    }
+
+    let nextObjectUrl: string | undefined;
+    const controller = new AbortController();
+
+    void (async () => {
+      const response = await fetch(url, {
+        credentials: "include",
+        signal: controller.signal,
+      });
+
+      if (!response.ok || controller.signal.aborted) {
+        return;
+      }
+
+      const blob = await response.blob();
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      nextObjectUrl = URL.createObjectURL(blob);
+      setObjectUrl(nextObjectUrl);
+    })().catch(() => {
+      if (!controller.signal.aborted) {
+        setObjectUrl(undefined);
+      }
+    });
+
+    return () => {
+      controller.abort();
+      if (nextObjectUrl !== undefined) {
+        URL.revokeObjectURL(nextObjectUrl);
+      }
+    };
+  }, [enabled, url]);
+
+  return objectUrl;
+};
+
+const ExternalPdfPreview = ({
+  objectUrl,
+  title,
+}: {
+  objectUrl?: string | undefined;
+  title: string;
+}) => {
+  if (objectUrl === undefined) {
+    return (
+      <div className="space-y-3 p-4">
+        <Skeleton className="h-4 w-2/3" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-4/5" />
+      </div>
+    );
+  }
+
+  return (
+    <iframe className="min-h-0 flex-1 border-0" src={objectUrl} title={title} />
+  );
+};
+
 const ExternalReferencePanel = ({
   onClose,
   tab,
@@ -2590,6 +2665,12 @@ const ExternalReferencePanel = ({
     safeHref === undefined
       ? undefined
       : `${env.VITE_API_URL}/v1/external-preview/file?url=${encodeURIComponent(safeHref)}`;
+  const shouldLoadExternalPdf =
+    fetchedPreview?.format === "pdf" && externalFilePreviewUrl !== undefined;
+  const externalPdfObjectUrl = useExternalPdfObjectUrl({
+    enabled: shouldLoadExternalPdf,
+    url: externalFilePreviewUrl,
+  });
   const externalChatThreadId =
     tab.chatThreadId ?? fallbackChatThreadIdRef.current;
   const hasMetadata =
@@ -2863,10 +2944,9 @@ const ExternalReferencePanel = ({
               <Skeleton className="h-4 w-5/6" />
               <Skeleton className="h-4 w-4/5" />
             </div>
-          ) : fetchedPreview?.format === "pdf" && externalFilePreviewUrl ? (
-            <iframe
-              className="min-h-0 flex-1 border-0"
-              src={externalFilePreviewUrl}
+          ) : shouldLoadExternalPdf ? (
+            <ExternalPdfPreview
+              objectUrl={externalPdfObjectUrl}
               title={tab.label}
             />
           ) : previewText || tab.snippet ? (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -2544,15 +2544,23 @@ const useExternalPdfObjectUrl = ({
 }: {
   enabled: boolean;
   url?: string | undefined;
-}): string | undefined => {
+}): {
+  objectUrl: string | undefined;
+  status: "error" | "idle" | "loading" | "ready";
+} => {
   const [objectUrl, setObjectUrl] = useState<string | undefined>();
+  const [status, setStatus] = useState<"error" | "idle" | "loading" | "ready">(
+    "idle",
+  );
 
   useEffect(() => {
     setObjectUrl(undefined);
     if (!enabled || url === undefined) {
+      setStatus("idle");
       return undefined;
     }
 
+    setStatus("loading");
     let nextObjectUrl: string | undefined;
     const controller = new AbortController();
 
@@ -2563,6 +2571,9 @@ const useExternalPdfObjectUrl = ({
       });
 
       if (!response.ok || controller.signal.aborted) {
+        if (!controller.signal.aborted) {
+          setStatus("error");
+        }
         return;
       }
 
@@ -2573,9 +2584,11 @@ const useExternalPdfObjectUrl = ({
 
       nextObjectUrl = URL.createObjectURL(blob);
       setObjectUrl(nextObjectUrl);
+      setStatus("ready");
     })().catch(() => {
       if (!controller.signal.aborted) {
         setObjectUrl(undefined);
+        setStatus("error");
       }
     });
 
@@ -2587,17 +2600,30 @@ const useExternalPdfObjectUrl = ({
     };
   }, [enabled, url]);
 
-  return objectUrl;
+  return { objectUrl, status };
 };
 
 const ExternalPdfPreview = ({
   objectUrl,
+  onOpenOriginal,
+  status,
   title,
 }: {
   objectUrl?: string | undefined;
+  onOpenOriginal: () => void;
+  status: "error" | "idle" | "loading" | "ready";
   title: string;
 }) => {
-  if (objectUrl === undefined) {
+  if (status === "error") {
+    return (
+      <ExternalPreviewUnavailable
+        canOpenOriginal
+        onOpenOriginal={onOpenOriginal}
+      />
+    );
+  }
+
+  if (objectUrl === undefined || status === "loading" || status === "idle") {
     return (
       <div className="space-y-3 p-4">
         <Skeleton className="h-4 w-2/3" />
@@ -2610,6 +2636,39 @@ const ExternalPdfPreview = ({
 
   return (
     <iframe className="min-h-0 flex-1 border-0" src={objectUrl} title={title} />
+  );
+};
+
+const ExternalPreviewUnavailable = ({
+  canOpenOriginal,
+  onOpenOriginal,
+}: {
+  canOpenOriginal: boolean;
+  onOpenOriginal: () => void;
+}) => {
+  const t = useTranslations();
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <div className="max-w-sm text-center">
+        <ExternalLinkIcon className="text-muted-foreground mx-auto size-6" />
+        <p className="text-muted-foreground mt-3 text-sm">
+          {t("inspector.external.unavailable")}
+        </p>
+        {canOpenOriginal && (
+          <Button
+            className="mt-4"
+            aria-label={t("inspector.external.openOriginal")}
+            onClick={onOpenOriginal}
+            size="sm"
+            variant="outline"
+          >
+            <ExternalLinkIcon className="size-3.5" />
+            {t("inspector.external.openOriginal")}
+          </Button>
+        )}
+      </div>
+    </div>
   );
 };
 
@@ -2667,7 +2726,7 @@ const ExternalReferencePanel = ({
       : `${env.VITE_API_URL}/v1/external-preview/file?url=${encodeURIComponent(safeHref)}`;
   const shouldLoadExternalPdf =
     fetchedPreview?.format === "pdf" && externalFilePreviewUrl !== undefined;
-  const externalPdfObjectUrl = useExternalPdfObjectUrl({
+  const externalPdfPreview = useExternalPdfObjectUrl({
     enabled: shouldLoadExternalPdf,
     url: externalFilePreviewUrl,
   });
@@ -2736,6 +2795,13 @@ const ExternalReferencePanel = ({
   const requestOpenExternal = useCallback((href: string) => {
     setConfirmHref(href);
   }, []);
+  const requestSafeExternalOpen = useCallback(() => {
+    if (safeHref === undefined) {
+      return;
+    }
+
+    requestOpenExternal(safeHref);
+  }, [requestOpenExternal, safeHref]);
   const openConfirmedExternal = useCallback(() => {
     if (confirmHref === undefined) {
       return;
@@ -2946,7 +3012,9 @@ const ExternalReferencePanel = ({
             </div>
           ) : shouldLoadExternalPdf ? (
             <ExternalPdfPreview
-              objectUrl={externalPdfObjectUrl}
+              objectUrl={externalPdfPreview.objectUrl}
+              onOpenOriginal={requestSafeExternalOpen}
+              status={externalPdfPreview.status}
               title={tab.label}
             />
           ) : previewText || tab.snippet ? (
@@ -2974,28 +3042,10 @@ const ExternalReferencePanel = ({
               </article>
             </ScrollArea>
           ) : (
-            <div className="flex flex-1 items-center justify-center p-6">
-              <div className="max-w-sm text-center">
-                <ExternalLinkIcon className="text-muted-foreground mx-auto size-6" />
-                <p className="text-muted-foreground mt-3 text-sm">
-                  {t("inspector.external.unavailable")}
-                </p>
-                {canPreview && (
-                  <Button
-                    className="mt-4"
-                    aria-label={t("inspector.external.openOriginal")}
-                    onClick={() => {
-                      requestOpenExternal(safeHref);
-                    }}
-                    size="sm"
-                    variant="outline"
-                  >
-                    <ExternalLinkIcon className="size-3.5" />
-                    {t("inspector.external.openOriginal")}
-                  </Button>
-                )}
-              </div>
-            </div>
+            <ExternalPreviewUnavailable
+              canOpenOriginal={canPreview}
+              onOpenOriginal={requestSafeExternalOpen}
+            />
           )}
         </div>
       </FileViewerWithAI>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
@@ -72,6 +72,34 @@ describe("openChat", () => {
   });
 });
 
+describe("openExternal", () => {
+  test("preserves the source connector icon on the external tab", () => {
+    useInspectorStore.getState().openExternal({
+      connectorSlug: "salvia",
+      iconHref: "https://salvia.example/favicon.ico",
+      label: "Decision",
+      url: "https://example.test/decision",
+    });
+
+    useInspectorStore.getState().openExternal({
+      label: "Decision",
+      url: "https://example.test/decision",
+    });
+
+    const tab = useInspectorStore
+      .getState()
+      .tabs.find(
+        (item) => item.id === "external:https://example.test/decision",
+      );
+    if (tab?.type !== "external") {
+      throw new Error("expected external tab");
+    }
+
+    expect(tab.connectorSlug).toBe("salvia");
+    expect(tab.iconHref).toBe("https://salvia.example/favicon.ico");
+  });
+});
+
 describe("replacePdfFieldId", () => {
   test("re-opening an existing pdf tab refreshes the file label", () => {
     useInspectorStore.getState().openPdf({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
@@ -102,6 +102,7 @@ export type ExternalTab = {
   label: string;
   url: string;
   connectorSlug?: string | undefined;
+  iconHref?: string | undefined;
   provider?: string | undefined;
   snippet?: string | undefined;
   sourceToolName?: string | undefined;
@@ -159,6 +160,7 @@ type Actions = {
   openExternal: (args: {
     url: string;
     connectorSlug?: string | undefined;
+    iconHref?: string | undefined;
     label?: string | undefined;
     provider?: string | undefined;
     snippet?: string | undefined;
@@ -374,6 +376,7 @@ export const useInspectorStore = create<State & Actions>()(
 
     openExternal: ({
       connectorSlug,
+      iconHref,
       label,
       provider,
       snippet,
@@ -397,6 +400,7 @@ export const useInspectorStore = create<State & Actions>()(
             chatThreadId: createChatThreadId(),
             label: label ?? fallbackLabel,
             connectorSlug,
+            iconHref,
             provider,
             snippet,
             sourceToolName,
@@ -406,6 +410,7 @@ export const useInspectorStore = create<State & Actions>()(
         } else if (existing.type === "external") {
           existing.label = label ?? existing.label;
           existing.connectorSlug = connectorSlug ?? existing.connectorSlug;
+          existing.iconHref = iconHref ?? existing.iconHref;
           existing.provider = provider ?? existing.provider;
           existing.snippet = snippet ?? existing.snippet;
           existing.sourceToolName = sourceToolName ?? existing.sourceToolName;

--- a/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
+++ b/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
@@ -55,6 +55,27 @@ const PROVIDERS: readonly Provider[] = [
 const isFallbackProvider = (name: ProviderName) =>
   name === "Gmail" || name === "Outlook";
 
+const getProductIconUrl = (name: ProviderName) => {
+  if (name === "Gmail") {
+    return "https://upload.wikimedia.org/wikipedia/commons/7/7e/Gmail_icon_%282020%29.svg";
+  }
+
+  if (name === "Outlook") {
+    return "https://upload.wikimedia.org/wikipedia/commons/c/cc/Microsoft_Outlook_Icon_%282025%E2%80%93present%29.svg";
+  }
+
+  return null;
+};
+
+const ProviderIcon = ({ name }: { name: ProviderName }) => {
+  const iconUrl = getProductIconUrl(name);
+  if (!iconUrl) {
+    return null;
+  }
+
+  return <img alt="" className="size-4" src={iconUrl} />;
+};
+
 const getProvidersForEmail = (email: string): readonly Provider[] => {
   const domain = email.split("@").at(1)?.toLowerCase() ?? "";
   const exact = PROVIDERS.find((p) => p.domains.includes(domain));
@@ -78,6 +99,7 @@ export const InboxQuickJump = ({ email }: { email: string }) => {
               rel="noopener noreferrer"
               target="_blank"
             >
+              <ProviderIcon name={p.name} />
               {t("auth.openInProvider", { provider: p.name })}
             </a>
           }


### PR DESCRIPTION
## Summary

- follow safe external-preview redirects after revalidating each hop
- preserve source connector icons on external inspector tabs
- hide Retry while a response is still generating
- shorten the external-preview fallback copy across locales
