### PR TITLE
feat: add Mistral BYOK support

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -35,6 +35,7 @@
     "@ai-sdk/google": "^3.0.67",
     "@ai-sdk/google-vertex": "^4.0.118",
     "@ai-sdk/mcp": "^1.0.39",
+    "@ai-sdk/mistral": "^3.0.35",
     "@ai-sdk/openai": "^3.0.58",
     "@ai-sdk/valibot": "^2.0.27",
     "@aws-sdk/client-sesv2": "^3.1041.0",

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -23,6 +23,7 @@ const envApi = createEnv({
         "openai",
         "azure_foundry",
         "anthropic",
+        "mistral",
         "openai_compatible",
       ]),
     ),
@@ -50,6 +51,7 @@ const envApi = createEnv({
     AZURE_BASE_URL: v.optional(v.pipe(v.string(), v.url())),
     AZURE_API_VERSION: v.optional(v.string()),
     ANTHROPIC_API_KEY: v.optional(v.string()),
+    MISTRAL_API_KEY: v.optional(v.string()),
     GOOGLE_AI_API_KEY_EU: v.optional(v.string()),
     GOOGLE_AI_API_KEY_CH: v.optional(v.string()),
     /**

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -36,6 +36,7 @@ const BYOK_PROVIDER_VALUES = [
   "openai",
   "azure_foundry",
   "anthropic",
+  "mistral",
 ] as const satisfies readonly AIProvider[];
 type BYOKProvider = (typeof BYOK_PROVIDER_VALUES)[number];
 

--- a/apps/api/src/lib/ai-config-crypto.test.ts
+++ b/apps/api/src/lib/ai-config-crypto.test.ts
@@ -82,6 +82,23 @@ describe("isOrgAIConfig", () => {
     ).toBe(true);
   });
 
+  test("accepts Mistral org AI config", () => {
+    expect(
+      isOrgAIConfig({
+        providers: [{ provider: "mistral", apiKey: "sk-test" }],
+        overrideModels: {
+          chat: { provider: "mistral", modelId: "mistral-large-latest" },
+          fast: { provider: "mistral", modelId: "mistral-small-latest" },
+          reasoning: {
+            provider: "mistral",
+            modelId: "magistral-medium-latest",
+          },
+          pdf: { provider: "mistral", modelId: "mistral-large-latest" },
+        },
+      }),
+    ).toBe(true);
+  });
+
   test("rejects Azure Foundry configs without endpoint metadata", () => {
     expect(
       isOrgAIConfig({

--- a/apps/api/src/lib/ai-config-crypto.ts
+++ b/apps/api/src/lib/ai-config-crypto.ts
@@ -19,6 +19,7 @@ const standardProviderSchema = v.picklist([
   "openrouter",
   "openai",
   "anthropic",
+  "mistral",
 ]);
 
 const modelSelectionSchema = v.strictObject({
@@ -28,6 +29,7 @@ const modelSelectionSchema = v.strictObject({
     "openai",
     "azure_foundry",
     "anthropic",
+    "mistral",
   ]),
   modelId: v.pipe(v.string(), v.minLength(1)),
 });

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -26,6 +26,7 @@ type AIProvider =
   | "openai"
   | "azure_foundry"
   | "anthropic"
+  | "mistral"
   | "openai_compatible";
 
 describe("supportsRegion", () => {
@@ -39,6 +40,7 @@ describe("supportsRegion", () => {
       "openai",
       "azure_foundry",
       "anthropic",
+      "mistral",
       "openai_compatible",
     ];
 
@@ -59,6 +61,8 @@ describe("isAllowedBYOKModel", () => {
   test("accepts curated catalog models", () => {
     expect(isAllowedBYOKModel("anthropic", "claude-opus-4-7")).toBe(true);
     expect(isAllowedBYOKModel("google", "gemini-3-pro-preview")).toBe(true);
+    expect(isAllowedBYOKModel("mistral", "mistral-medium-3-5")).toBe(true);
+    expect(isAllowedBYOKModel("mistral", "mistral-large-latest")).toBe(true);
     expect(isAllowedBYOKModel("openai", "gpt-5.4")).toBe(true);
     expect(isAllowedBYOKModel("azure_foundry", "customer-gpt-5")).toBe(true);
     expect(isAllowedBYOKModel("openrouter", "anthropic/claude-opus-4.5")).toBe(
@@ -70,6 +74,8 @@ describe("isAllowedBYOKModel", () => {
     expect(isAllowedBYOKModel("openrouter", "x-ai/grok-4")).toBe(false);
     expect(isAllowedBYOKModel("anthropic", "claude-2")).toBe(false);
     expect(isAllowedBYOKModel("google", "gemini-1.5-pro")).toBe(false);
+    expect(isAllowedBYOKModel("mistral", "pixtral-large-latest")).toBe(false);
+    expect(isAllowedBYOKModel("mistral", "mistral-tiny")).toBe(false);
     expect(isAllowedBYOKModel("openai", "gpt-4o")).toBe(false);
     expect(isAllowedBYOKModel("azure_foundry", "")).toBe(false);
   });
@@ -181,6 +187,44 @@ describe("BYOK model overrides", () => {
       expect(getModelInfoForRole(role, orgConfig)).toMatchObject({
         keySource: "byok",
         provider: "openrouter",
+        modelId: orgConfig.overrideModels[role].modelId,
+      });
+      expect(() => getModelForRole(role, orgConfig)).not.toThrow();
+    }
+  });
+
+  test("routes every Stella role through configured Mistral models", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org-mistral",
+          provider: "mistral",
+        },
+      ],
+      overrideModels: {
+        fast: {
+          provider: "mistral",
+          modelId: "mistral-small-latest",
+        },
+        chat: {
+          provider: "mistral",
+          modelId: "mistral-large-latest",
+        },
+        reasoning: {
+          provider: "mistral",
+          modelId: "magistral-medium-latest",
+        },
+        pdf: {
+          provider: "mistral",
+          modelId: "mistral-large-latest",
+        },
+      },
+    };
+
+    for (const role of ["fast", "chat", "reasoning", "pdf"] as const) {
+      expect(getModelInfoForRole(role, orgConfig)).toMatchObject({
+        keySource: "byok",
+        provider: "mistral",
         modelId: orgConfig.overrideModels[role].modelId,
       });
       expect(() => getModelForRole(role, orgConfig)).not.toThrow();

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -11,11 +11,12 @@
  * - "azure_foundry": Azure AI Foundry / Azure OpenAI
  *   (AZURE_API_KEY + AZURE_RESOURCE_NAME or AZURE_BASE_URL)
  * - "anthropic": Anthropic (ANTHROPIC_API_KEY)
+ * - "mistral": Mistral AI (MISTRAL_API_KEY)
  * - "openai_compatible": Any OpenAI-compatible endpoint
  *   (OPENAI_API_KEY + AI_PROVIDER_BASE_URL)
  *
  * When AI_PROVIDER is not set, auto-detects from available
- * API keys: OPENROUTER → Google → OpenAI → Azure → Anthropic.
+ * API keys: OPENROUTER → Google → OpenAI → Azure → Anthropic → Mistral.
  */
 
 import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
@@ -23,6 +24,7 @@ import { createAzure } from "@ai-sdk/azure";
 import { devToolsMiddleware } from "@ai-sdk/devtools";
 import { createGoogleGenerativeAI, google } from "@ai-sdk/google";
 import { createVertex } from "@ai-sdk/google-vertex";
+import { createMistral, mistral } from "@ai-sdk/mistral";
 import { createOpenAI, openai } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { wrapLanguageModel } from "ai";
@@ -62,6 +64,7 @@ export type AIProvider =
   | "openai"
   | "azure_foundry"
   | "anthropic"
+  | "mistral"
   | "openai_compatible";
 
 // -- Default model IDs per provider -----------------------------
@@ -97,6 +100,12 @@ export const DEFAULT_MODELS = {
     reasoning: "claude-sonnet-4-6",
     pdf: "claude-sonnet-4-6",
   },
+  mistral: {
+    fast: "mistral-small-latest",
+    chat: "mistral-large-latest",
+    reasoning: "magistral-medium-latest",
+    pdf: "mistral-large-latest",
+  },
   openai_compatible: {
     fast: "default",
     chat: "default",
@@ -127,6 +136,13 @@ export const BYOK_MODEL_OPTIONS = {
     "claude-sonnet-4-6",
     "claude-opus-4-6",
     "claude-haiku-4-5-20251001",
+  ],
+  mistral: [
+    "mistral-medium-3-5",
+    "mistral-large-latest",
+    "mistral-small-latest",
+    "magistral-medium-latest",
+    "magistral-small-latest",
   ],
   openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
   azure_foundry: [],
@@ -238,12 +254,15 @@ const resolveProvider = (): AIProvider => {
   if (env.ANTHROPIC_API_KEY) {
     return "anthropic";
   }
+  if (env.MISTRAL_API_KEY) {
+    return "mistral";
+  }
 
   return panic(
     "No AI provider configured. Set AI_PROVIDER or " +
       "provide at least one API key: " +
       "GOOGLE_GENERATIVE_AI_API_KEY, OPENROUTER_API_KEY, " +
-      "OPENAI_API_KEY, AZURE_API_KEY, or ANTHROPIC_API_KEY.",
+      "OPENAI_API_KEY, AZURE_API_KEY, ANTHROPIC_API_KEY, or MISTRAL_API_KEY.",
   );
 };
 
@@ -272,7 +291,8 @@ export const hasInstanceProvider = (): boolean => {
     env.GOOGLE_AI_API_KEY_CH ||
     env.OPENAI_API_KEY ||
     (env.AZURE_API_KEY && (env.AZURE_RESOURCE_NAME || env.AZURE_BASE_URL)) ||
-    env.ANTHROPIC_API_KEY
+    env.ANTHROPIC_API_KEY ||
+    env.MISTRAL_API_KEY
   );
   if (!env.AI_PROVIDER) {
     return hasAnyKey;
@@ -298,6 +318,8 @@ export const hasInstanceProvider = (): boolean => {
       );
     case "anthropic":
       return !!env.ANTHROPIC_API_KEY;
+    case "mistral":
+      return !!env.MISTRAL_API_KEY;
     case "openai_compatible":
       return !!(env.OPENAI_API_KEY && env.AI_PROVIDER_BASE_URL);
     default:
@@ -460,6 +482,13 @@ const createModelFactory = ({
         return (id) => client(id);
       }
       return (id) => anthropic(id);
+    }
+    case "mistral": {
+      if (apiKey) {
+        const client = createMistral({ apiKey });
+        return (id) => client(id);
+      }
+      return (id) => mistral(id);
     }
     case "openai_compatible": {
       const key =

--- a/apps/api/src/lib/ai-provider-probe.ts
+++ b/apps/api/src/lib/ai-provider-probe.ts
@@ -19,6 +19,7 @@ export const PROVIDER_PROBE_VALUES = [
   "openai",
   "azure_foundry",
   "anthropic",
+  "mistral",
 ] as const;
 
 export type ProviderProbeValue = (typeof PROVIDER_PROBE_VALUES)[number];
@@ -54,6 +55,10 @@ const PROBE_TARGETS: Record<
     url: "https://openrouter.ai/api/v1/auth/key",
     init: { headers: { Authorization: `Bearer ${apiKey}` } },
   }),
+  mistral: (apiKey) => ({
+    url: "https://api.mistral.ai/v1/models",
+    init: { headers: { Authorization: `Bearer ${apiKey}` } },
+  }),
 };
 
 const PROVIDER_LABELS: Record<ProviderProbeValue, string> = {
@@ -62,6 +67,7 @@ const PROVIDER_LABELS: Record<ProviderProbeValue, string> = {
   openai: "OpenAI",
   azure_foundry: "Azure Foundry",
   openrouter: "OpenRouter",
+  mistral: "Mistral",
 };
 
 const extractDetail = async (response: Response): Promise<string | undefined> =>

--- a/apps/web/src/components/ai-config-providers-editor.tsx
+++ b/apps/web/src/components/ai-config-providers-editor.tsx
@@ -30,6 +30,7 @@ import type {
 const API_KEY_PLACEHOLDER = {
   google: "AIza...",
   anthropic: "sk-ant-...",
+  mistral: "...",
   openai: "sk-proj-...",
   azure_foundry: "0123456789abcdef...",
   openrouter: "sk-or-v1-...",

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -90,21 +90,48 @@ describe("BYOK provider and model configuration", () => {
 
   test("builds model options from the union of configured providers", () => {
     expect(
-      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+      getAvailableModelOptions([
+        "anthropic",
+        "mistral",
+        "openai",
+        "openrouter",
+      ]),
     ).toContainEqual({
       provider: "anthropic",
       modelId: "claude-opus-4-7",
       value: "anthropic::claude-opus-4-7",
     });
     expect(
-      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+      getAvailableModelOptions([
+        "anthropic",
+        "mistral",
+        "openai",
+        "openrouter",
+      ]),
+    ).toContainEqual({
+      provider: "mistral",
+      modelId: "mistral-large-latest",
+      value: "mistral::mistral-large-latest",
+    });
+    expect(
+      getAvailableModelOptions([
+        "anthropic",
+        "mistral",
+        "openai",
+        "openrouter",
+      ]),
     ).toContainEqual({
       provider: "openai",
       modelId: "gpt-5.4",
       value: "openai::gpt-5.4",
     });
     expect(
-      getAvailableModelOptions(["anthropic", "openai", "openrouter"]),
+      getAvailableModelOptions([
+        "anthropic",
+        "mistral",
+        "openai",
+        "openrouter",
+      ]),
     ).toContainEqual({
       provider: "openrouter",
       modelId: "google/gemini-3-flash-preview",
@@ -116,6 +143,7 @@ describe("BYOK provider and model configuration", () => {
     const modelOptions = getAvailableModelOptions([
       "anthropic",
       "google",
+      "mistral",
       "openai",
     ]);
 
@@ -128,6 +156,16 @@ describe("BYOK provider and model configuration", () => {
       provider: "google",
       modelId: "gemini-3-pro-preview",
       value: "google::gemini-3-pro-preview",
+    });
+    expect(modelOptions).toContainEqual({
+      provider: "mistral",
+      modelId: "magistral-medium-latest",
+      value: "mistral::magistral-medium-latest",
+    });
+    expect(modelOptions).toContainEqual({
+      provider: "mistral",
+      modelId: "mistral-medium-3-5",
+      value: "mistral::mistral-medium-3-5",
     });
     expect(modelOptions).toContainEqual({
       provider: "openai",
@@ -143,6 +181,16 @@ describe("BYOK provider and model configuration", () => {
       provider: "google",
       modelId: "gemini-1.5-pro",
       value: "google::gemini-1.5-pro",
+    });
+    expect(modelOptions).not.toContainEqual({
+      provider: "mistral",
+      modelId: "mistral-tiny",
+      value: "mistral::mistral-tiny",
+    });
+    expect(modelOptions).not.toContainEqual({
+      provider: "mistral",
+      modelId: "pixtral-large-latest",
+      value: "mistral::pixtral-large-latest",
     });
     expect(modelOptions).not.toContainEqual({
       provider: "openai",
@@ -272,6 +320,15 @@ describe("BYOK provider and model configuration", () => {
         },
       ]),
     ).toBe(true);
+  });
+
+  test("creates Mistral role defaults", () => {
+    expect(createDefaultRoleModels(["mistral"])).toEqual({
+      chat: { provider: "mistral", modelId: "mistral-large-latest" },
+      fast: { provider: "mistral", modelId: "mistral-small-latest" },
+      reasoning: { provider: "mistral", modelId: "magistral-medium-latest" },
+      pdf: { provider: "mistral", modelId: "mistral-large-latest" },
+    });
   });
 
   test("accepts saved provider drafts without requiring key replacement", () => {

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -1,6 +1,7 @@
 export const PROVIDER_KEYS = [
   "google",
   "anthropic",
+  "mistral",
   "openai",
   "azure_foundry",
   "openrouter",
@@ -83,6 +84,12 @@ export const DEFAULT_MODELS_BY_PROVIDER = {
     reasoning: "claude-sonnet-4-6",
     pdf: "claude-sonnet-4-6",
   },
+  mistral: {
+    chat: "mistral-large-latest",
+    fast: "mistral-small-latest",
+    reasoning: "magistral-medium-latest",
+    pdf: "mistral-large-latest",
+  },
   openai: {
     chat: "gpt-5.4-mini",
     fast: "gpt-5.4-nano",
@@ -110,6 +117,13 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
     "claude-sonnet-4-6",
     "claude-opus-4-6",
     "claude-haiku-4-5-20251001",
+  ],
+  mistral: [
+    "mistral-medium-3-5",
+    "mistral-large-latest",
+    "mistral-small-latest",
+    "magistral-medium-latest",
+    "magistral-small-latest",
   ],
   openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
   azure_foundry: [],

--- a/apps/web/src/components/ai-provider-icons.tsx
+++ b/apps/web/src/components/ai-provider-icons.tsx
@@ -41,6 +41,7 @@ const OpenAIIcon = (props: IconProps) => (
 const PROVIDER_ICONS = {
   google: GeminiIcon,
   anthropic: AnthropicIcon,
+  mistral: SparklesIcon,
   openai: OpenAIIcon,
   azure_foundry: CloudIcon,
   openrouter: SparklesIcon,

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1330,6 +1330,7 @@ type Messages = {
         "anthropic": "Anthropic";
         "azure_foundry": "Azure Foundry";
         "google": "Google";
+        "mistral": "Mistral";
         "openai": "ChatGPT";
         "openrouter": "OpenRouter";
       };

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1327,6 +1327,7 @@
         "anthropic": "Anthropic",
         "azure_foundry": "Azure Foundry",
         "google": "Google",
+        "mistral": "Mistral",
         "openai": "ChatGPT",
         "openrouter": "OpenRouter"
       },

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -67,6 +67,7 @@ type RowStateMap = Record<ProviderValue, RowState>;
 const INITIAL_ROW_STATES: RowStateMap = {
   google: { status: "idle" },
   anthropic: { status: "idle" },
+  mistral: { status: "idle" },
   openai: { status: "idle" },
   azure_foundry: { status: "idle" },
   openrouter: { status: "idle" },
@@ -274,6 +275,7 @@ export const AIStep = ({
       anthropic: stillPresent.has("anthropic")
         ? prev.anthropic
         : { status: "idle" },
+      mistral: stillPresent.has("mistral") ? prev.mistral : { status: "idle" },
       openai: stillPresent.has("openai") ? prev.openai : { status: "idle" },
       azure_foundry: stillPresent.has("azure_foundry")
         ? prev.azure_foundry

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@ai-sdk/google": "^3.0.67",
         "@ai-sdk/google-vertex": "^4.0.118",
         "@ai-sdk/mcp": "^1.0.39",
+        "@ai-sdk/mistral": "^3.0.35",
         "@ai-sdk/openai": "^3.0.58",
         "@ai-sdk/valibot": "^2.0.27",
         "@aws-sdk/client-sesv2": "^3.1041.0",
@@ -511,6 +512,8 @@
     "@ai-sdk/google-vertex": ["@ai-sdk/google-vertex@4.0.118", "", { "dependencies": { "@ai-sdk/anthropic": "3.0.74", "@ai-sdk/google": "3.0.67", "@ai-sdk/openai-compatible": "2.0.45", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "google-auth-library": "^10.5.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jmXAi5n+vixA3ig/RhkjV8k/YuFD8uTnd3+yr2pnYEQVe3Ocp3hn0mS99S5yKgn+6cGNGbG0CWJH44oSwSOs8w=="],
 
     "@ai-sdk/mcp": ["@ai-sdk/mcp@1.0.39", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "pkce-challenge": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-x31r0Xs6bOpFCMuc+mjA+sEk3Nd+tnY1H43p1BV29jI9ZuOQmehpfQ+yiFeTPDeOwTRdp+8nZ4PfsqAlj7DnhQ=="],
+
+    "@ai-sdk/mistral": ["@ai-sdk/mistral@3.0.35", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8BCt8pOWjvfIFZOVFz+koFcbydVv7Q8WM24J0gVJWDw1eOEn3Muugw4py+TuaQc8KdjP7d1HR9E4gIMN55zBgQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.58", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2+5xGMROmrBboJuoOwqLL3b/o3i56+NRdxXDNVAiTyYjLiBj6KzembeuyuBT217be1X+zkEfAqD1H0irJlGIyw=="],
 


### PR DESCRIPTION
## Summary
- add Mistral as a first-class AI provider for instance and BYOK configuration
- expose Mistral provider/model choices in organization settings and onboarding
- validate Mistral keys and encrypted organization AI configs with the existing BYOK flow