### PR TITLE
chore(analytics): drop posthog exception noise

### DIFF
--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -134,6 +134,53 @@ describe("PostHog browser analytics adapter", () => {
     expect(initOptions?.before_send({ event: "$heatmap" })).toBeNull();
   });
 
+  test("drops known browser-noise exceptions", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const noise = [
+      "ResizeObserver loop completed with undelivered notifications.",
+      "Script error.",
+      "undefined",
+      "Non-Error promise rejection captured with value: undefined",
+    ];
+    for (const value of noise) {
+      expect(
+        initOptions?.before_send({
+          event: WEB_ANALYTICS_EVENTS.exception,
+          properties: { $exception_list: [{ type: "Error", value }] },
+        }),
+      ).toBeNull();
+    }
+  });
+
+  test("keeps real exceptions with messages and stacks", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const event = {
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [
+          {
+            type: "TypeError",
+            value: "Cannot read properties of undefined (reading 'foo')",
+            stacktrace: { frames: [{ filename: "app.js", lineno: 42 }] },
+          },
+        ],
+      },
+    };
+    expect(initOptions?.before_send(event)).toEqual(event);
+  });
+
+  test("captureError ignores null and undefined", () => {
+    const { analytics } = createPostHogAnalytics(
+      "phc_test",
+      "https://posthog.test",
+    );
+    analytics.captureError(null);
+    analytics.captureError(undefined);
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
   test("captures sanitized page view payloads", () => {
     const { analytics } = createPostHogAnalytics(
       "phc_test",

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -153,6 +153,24 @@ describe("PostHog browser analytics adapter", () => {
     }
   });
 
+  test("keeps non-Error promise rejections that carry a useful value", () => {
+    createPostHogAnalytics("phc_test", "https://posthog.test");
+
+    const event = {
+      event: WEB_ANALYTICS_EVENTS.exception,
+      properties: {
+        $exception_list: [
+          {
+            type: "UnhandledRejection",
+            value:
+              "Non-Error promise rejection captured with value: API_TIMEOUT",
+          },
+        ],
+      },
+    };
+    expect(initOptions?.before_send(event)).toEqual(event);
+  });
+
   test("keeps real exceptions with messages and stacks", () => {
     createPostHogAnalytics("phc_test", "https://posthog.test");
 

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -27,7 +27,10 @@ const EXCEPTION_NOISE_PATTERNS: readonly RegExp[] = [
   /^ResizeObserver loop/i,
   /^Script error\.?$/i,
   /^(?:Error: )?undefined$/i,
-  /Non-Error promise rejection/i,
+  // Match only the empty form, not rejections that carry a useful
+  // string (e.g. `Promise.reject("API_TIMEOUT")`) which we want to
+  // keep capturing.
+  /^Non-Error promise rejection captured with value: (?:undefined|null)$/i,
 ];
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -11,6 +11,53 @@ const isWebAnalyticsEvent = (event: string): event is WebAnalyticsEvent =>
   event === WEB_ANALYTICS_EVENTS.identify ||
   event === WEB_ANALYTICS_EVENTS.pageViewed;
 
+// Browser-noise patterns we drop client-side before they hit
+// PostHog ingest. PostHog has no built-in `ignoreErrors` analogue
+// to Sentry's, so the canonical filter point is `before_send`.
+//
+// - `ResizeObserver loop ...`: benign Chromium/Firefox quirk that
+//   fires when a ResizeObserver callback queues another resize.
+// - `Script error.`: W3C-mandated cross-origin sanitization with
+//   no payload — not actionable.
+// - Empty / `undefined` rejection values: produced by
+//   `capture_unhandled_rejections: true` catching a
+//   `Promise.reject()` that carries no reason. No stack, no
+//   message — filtering loses zero debuggable signal.
+const EXCEPTION_NOISE_PATTERNS: readonly RegExp[] = [
+  /^ResizeObserver loop/i,
+  /^Script error\.?$/i,
+  /^(?:Error: )?undefined$/i,
+  /Non-Error promise rejection/i,
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readStringField = (entry: unknown, key: string): string => {
+  if (!isRecord(entry)) {
+    return "";
+  }
+  const value = entry[key];
+  return typeof value === "string" ? value : "";
+};
+
+const isNoiseException = (event: {
+  properties?: Record<string, unknown>;
+}): boolean => {
+  const list = event.properties?.["$exception_list"];
+  if (!Array.isArray(list) || list.length === 0) {
+    return false;
+  }
+  const entries: unknown[] = list;
+  return entries.some((entry) => {
+    const value = readStringField(entry, "value");
+    const type = readStringField(entry, "type");
+    return EXCEPTION_NOISE_PATTERNS.some(
+      (pattern) => pattern.test(value) || pattern.test(type),
+    );
+  });
+};
+
 /**
  * Initialize PostHog and return an Analytics adapter.
  *
@@ -55,8 +102,16 @@ export const createPostHogAnalytics = (
       if (import.meta.env.DEV && !localDebugEnabled) {
         return null;
       }
-
-      return event && isWebAnalyticsEvent(event.event) ? event : null;
+      if (!event || !isWebAnalyticsEvent(event.event)) {
+        return null;
+      }
+      if (
+        event.event === WEB_ANALYTICS_EVENTS.exception &&
+        isNoiseException(event)
+      ) {
+        return null;
+      }
+      return event;
     },
   });
 
@@ -66,7 +121,15 @@ export const createPostHogAnalytics = (
 
   const analytics: Analytics = {
     captureError: (error) => {
-      if (error instanceof CancelledError) {
+      // Cheap guards before the SDK call: a stray `captureError(null)`
+      // or `captureError(undefined)` would otherwise reach PostHog as
+      // `Error: "undefined"` noise that the `before_send` filter then
+      // has to clean up.
+      if (
+        error === null ||
+        error === undefined ||
+        error instanceof CancelledError
+      ) {
         return;
       }
       logDevError(error);


### PR DESCRIPTION
Drop `$exception` events that carry no actionable signal:
- \`ResizeObserver loop ...\` (Chromium/Firefox quirk)
- \`Script error.\` (W3C cross-origin sanitisation; payload-stripped, never actionable)
- empty / \`undefined\` rejection values from \`capture_unhandled_rejections\` catching \`Promise.reject()\` with no reason

posthog-js has no built-in \`ignoreErrors\` analogue  \`before_send\` is the canonical filter point. Source-fix isn't an option for the first two (browser internals / third-party scripts) and loses no debuggable signal for the third (no stack, no message).

Also early-return in \`captureError\` for \`null\`/\`undefined\` so a stray call from app code can't feed the same noise.

## Test plan
- [x] \`bun --filter @stll/web typecheck\` clean
- [x] \`bun --filter @stll/web lint\` clean
- [x] \`bun --filter @stll/web test -- src/lib/analytics/posthog\` — 13/13 pass, including 4 new noise-pattern cases and 1 case asserting real exceptions still pass through