### PR TITLE
fix: redirect MCP OAuth callback to SPA so popup can close

### DIFF
--- a/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildCallbackRedirectUrl } from "@/api/handlers/mcp-connectors/oauth-callback";
+
+describe("buildCallbackRedirectUrl", () => {
+  test("encodes a connected slug onto the SPA terminal route", () => {
+    const url = buildCallbackRedirectUrl("https://my.stll.app", {
+      status: "connected",
+      slug: "linear",
+    });
+
+    expect(url).toBe(
+      "https://my.stll.app/mcp/oauth-callback?status=connected&slug=linear",
+    );
+  });
+
+  test("encodes an error reason onto the SPA terminal route", () => {
+    const url = buildCallbackRedirectUrl("https://my.stll.app", {
+      status: "error",
+      reason: "expired-state",
+    });
+
+    expect(url).toBe(
+      "https://my.stll.app/mcp/oauth-callback?status=error&reason=expired-state",
+    );
+  });
+
+  test("preserves trailing path segments and percent-encodes slug", () => {
+    const url = buildCallbackRedirectUrl("https://example.test/", {
+      status: "connected",
+      slug: "with space",
+    });
+
+    expect(url).toBe(
+      "https://example.test/mcp/oauth-callback?status=connected&slug=with+space",
+    );
+  });
+});

--- a/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth-callback.test.ts
@@ -25,7 +25,7 @@ describe("buildCallbackRedirectUrl", () => {
     );
   });
 
-  test("preserves trailing path segments and percent-encodes slug", () => {
+  test("percent-encodes slugs that contain whitespace", () => {
     const url = buildCallbackRedirectUrl("https://example.test/", {
       status: "connected",
       slug: "with space",

--- a/apps/api/src/handlers/mcp-connectors/oauth-callback.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth-callback.ts
@@ -29,39 +29,41 @@ const config = {
   query: requestQuery,
 } satisfies HandlerConfig;
 
-const htmlResponse = (body: string, status = 200) =>
-  new Response(body, {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-    status,
+type CallbackRedirectInput =
+  | { status: "connected"; slug: string }
+  | { status: "error"; reason: string };
+
+// The popup lands on a SPA route that does the postMessage + close.
+// Returning HTML with an inline <script> from api.stll.app is blocked
+// by the API's CSP (`script-src 'self' 'unsafe-eval'`) and its
+// `Cross-Origin-Opener-Policy: same-origin` would also detach
+// `window.opener`, so the SPA host is the only place the terminal
+// page can run.
+export const buildCallbackRedirectUrl = (
+  frontendUrl: string,
+  input: CallbackRedirectInput,
+): string => {
+  const url = new URL("/mcp/oauth-callback", frontendUrl);
+  url.searchParams.set("status", input.status);
+  if (input.status === "connected") {
+    url.searchParams.set("slug", input.slug);
+  } else {
+    url.searchParams.set("reason", input.reason);
+  }
+  return url.toString();
+};
+
+const redirect = (input: CallbackRedirectInput) =>
+  new Response(null, {
+    status: 302,
+    headers: { Location: buildCallbackRedirectUrl(env.FRONTEND_URL, input) },
   });
-
-const mcpSettingsUrl = () =>
-  new URL("/knowledge/mcp", env.FRONTEND_URL).toString();
-
-const callbackHtml = (message: string) => `<!doctype html>
-<html>
-  <head><meta charset="utf-8"><title>MCP connection</title></head>
-  <body>
-    <script>
-      if (window.opener) {
-        window.opener.postMessage(${JSON.stringify(message)}, ${JSON.stringify(
-          env.FRONTEND_URL,
-        )});
-        window.close();
-      } else {
-        window.location.replace(${JSON.stringify(mcpSettingsUrl())});
-      }
-    </script>
-  </body>
-</html>`;
 
 const mcpOAuthCallback = createSafeRootHandler(
   config,
   async function* ({ query: input, safeDb, session, user }) {
     if (!input.code || !input.state) {
-      return Result.ok(
-        htmlResponse(callbackHtml("mcp:error:missing-code"), 400),
-      );
+      return Result.ok(redirect({ status: "error", reason: "missing-code" }));
     }
     const code = input.code;
     const state = input.state;
@@ -87,12 +89,12 @@ const mcpOAuthCallback = createSafeRootHandler(
 
       if (!row || row.createdAt < cutoff) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:expired-state"), 400),
+          redirect({ status: "error", reason: "expired-state" }),
         );
       }
       if (!row.connector) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:missing-connector"), 400),
+          redirect({ status: "error", reason: "missing-connector" }),
         );
       }
       if (
@@ -100,7 +102,7 @@ const mcpOAuthCallback = createSafeRootHandler(
         row.userId !== user.id
       ) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:user-mismatch"), 403),
+          redirect({ status: "error", reason: "user-mismatch" }),
         );
       }
 
@@ -123,7 +125,7 @@ const mcpOAuthCallback = createSafeRootHandler(
 
       if (!client) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:missing-client"), 400),
+          redirect({ status: "error", reason: "missing-client" }),
         );
       }
 
@@ -150,7 +152,7 @@ const mcpOAuthCallback = createSafeRootHandler(
 
       if (Result.isError(token)) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:token-exchange"), 400),
+          redirect({ status: "error", reason: "token-exchange" }),
         );
       }
 
@@ -228,16 +230,16 @@ const mcpOAuthCallback = createSafeRootHandler(
       );
 
       return Result.ok(
-        htmlResponse(callbackHtml(`mcp:connected:${row.connector.slug}`)),
+        redirect({ status: "connected", slug: row.connector.slug }),
       );
     } catch (error) {
       if (HandlerError.is(error)) {
         return Result.ok(
-          htmlResponse(callbackHtml("mcp:error:invalid-secret"), 400),
+          redirect({ status: "error", reason: "invalid-secret" }),
         );
       }
 
-      return Result.ok(htmlResponse(callbackHtml("mcp:error:unexpected"), 500));
+      return Result.ok(redirect({ status: "error", reason: "unexpected" }));
     }
   },
 );

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as OnboardingRouteRouteImport } from './routes/onboarding/route'
 import { Route as AuthRouteRouteImport } from './routes/auth/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthIndexRouteImport } from './routes/auth/index'
+import { Route as McpOauthCallbackRouteImport } from './routes/mcp.oauth-callback'
 import { Route as AuthOtpRouteImport } from './routes/auth/otp'
 import { Route as AuthOrganizationRouteImport } from './routes/auth/organization'
 import { Route as ProtectedSettingsRouteRouteImport } from './routes/_protected.settings/route'
@@ -91,6 +92,11 @@ const AuthIndexRoute = AuthIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => AuthRouteRoute,
+} as any)
+const McpOauthCallbackRoute = McpOauthCallbackRouteImport.update({
+  id: '/mcp/oauth-callback',
+  path: '/mcp/oauth-callback',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const AuthOtpRoute = AuthOtpRouteImport.update({
   id: '/otp',
@@ -337,6 +343,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof ProtectedSettingsRouteRouteWithChildren
   '/auth/organization': typeof AuthOrganizationRoute
   '/auth/otp': typeof AuthOtpRoute
+  '/mcp/oauth-callback': typeof McpOauthCallbackRoute
   '/auth/': typeof AuthIndexRoute
   '/knowledge/case': typeof ProtectedKnowledgeCaseRouteRouteWithChildren
   '/settings/organization': typeof ProtectedSettingsOrganizationRouteRouteWithChildren
@@ -382,6 +389,7 @@ export interface FileRoutesByTo {
   '/dev': typeof DevRoute
   '/auth/organization': typeof AuthOrganizationRoute
   '/auth/otp': typeof AuthOtpRoute
+  '/mcp/oauth-callback': typeof McpOauthCallbackRoute
   '/auth': typeof AuthIndexRoute
   '/chat/$threadId': typeof ProtectedChatThreadIdRoute
   '/chat/new': typeof ProtectedChatNewRoute
@@ -429,6 +437,7 @@ export interface FileRoutesById {
   '/_protected/settings': typeof ProtectedSettingsRouteRouteWithChildren
   '/auth/organization': typeof AuthOrganizationRoute
   '/auth/otp': typeof AuthOtpRoute
+  '/mcp/oauth-callback': typeof McpOauthCallbackRoute
   '/auth/': typeof AuthIndexRoute
   '/_protected/knowledge/case': typeof ProtectedKnowledgeCaseRouteRouteWithChildren
   '/_protected/settings/organization': typeof ProtectedSettingsOrganizationRouteRouteWithChildren
@@ -480,6 +489,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/auth/organization'
     | '/auth/otp'
+    | '/mcp/oauth-callback'
     | '/auth/'
     | '/knowledge/case'
     | '/settings/organization'
@@ -525,6 +535,7 @@ export interface FileRouteTypes {
     | '/dev'
     | '/auth/organization'
     | '/auth/otp'
+    | '/mcp/oauth-callback'
     | '/auth'
     | '/chat/$threadId'
     | '/chat/new'
@@ -571,6 +582,7 @@ export interface FileRouteTypes {
     | '/_protected/settings'
     | '/auth/organization'
     | '/auth/otp'
+    | '/mcp/oauth-callback'
     | '/auth/'
     | '/_protected/knowledge/case'
     | '/_protected/settings/organization'
@@ -617,6 +629,7 @@ export interface RootRouteChildren {
   ProtectedRoute: typeof ProtectedRouteWithChildren
   ConsentRoute: typeof ConsentRoute
   DevRoute: typeof DevRoute
+  McpOauthCallbackRoute: typeof McpOauthCallbackRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -669,6 +682,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/auth/'
       preLoaderRoute: typeof AuthIndexRouteImport
       parentRoute: typeof AuthRouteRoute
+    }
+    '/mcp/oauth-callback': {
+      id: '/mcp/oauth-callback'
+      path: '/mcp/oauth-callback'
+      fullPath: '/mcp/oauth-callback'
+      preLoaderRoute: typeof McpOauthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/auth/otp': {
       id: '/auth/otp'
@@ -1182,6 +1202,7 @@ const rootRouteChildren: RootRouteChildren = {
   ProtectedRoute: ProtectedRouteWithChildren,
   ConsentRoute: ConsentRoute,
   DevRoute: DevRoute,
+  McpOauthCallbackRoute: McpOauthCallbackRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -30,7 +30,6 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { env } from "@/env";
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
@@ -101,7 +100,6 @@ const sortCatalogItems = <
 function McpPage() {
   const t = useTranslations();
   const queryClient = useQueryClient();
-  const apiOrigin = new URL(env.VITE_API_URL).origin;
 
   const { data: connectorsData, isLoading: connectorsLoading } = useQuery(
     mcpConnectorsOptions(),
@@ -116,27 +114,39 @@ function McpPage() {
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== apiOrigin) {
+      // Popup terminal page lives on the SPA host, so it posts back
+      // to its own origin. The previous flow posted from the API
+      // host (api.stll.app), but CloudFront's CSP blocks the inline
+      // postMessage script there.
+      if (event.origin !== window.location.origin) {
         return;
       }
 
-      if (
-        typeof event.data !== "string" ||
-        !event.data.startsWith("mcp:connected:")
-      ) {
+      if (typeof event.data !== "string") {
         return;
       }
 
-      stellaToast.add({
-        title: t("knowledge.mcp.connectedToast"),
-        type: "success",
-      });
-      void queryClient.invalidateQueries({ queryKey: knowledgeKeys.mcp.all });
+      if (event.data.startsWith("mcp:connected:")) {
+        stellaToast.add({
+          title: t("knowledge.mcp.connectedToast"),
+          type: "success",
+        });
+        void queryClient.invalidateQueries({ queryKey: knowledgeKeys.mcp.all });
+        return;
+      }
+
+      if (event.data.startsWith("mcp:error:")) {
+        stellaToast.add({
+          title: t("knowledge.mcp.errorTitle"),
+          description: t("knowledge.mcp.errorDescription"),
+          type: "error",
+        });
+      }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [apiOrigin, queryClient, t]);
+  }, [queryClient, t]);
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto p-6">

--- a/apps/web/src/routes/mcp.oauth-callback.tsx
+++ b/apps/web/src/routes/mcp.oauth-callback.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Frame,
+  FrameDescription,
+  FrameHeader,
+  FramePanel,
+  FrameTitle,
+} from "@stll/ui/components/frame";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
+import { pageTitle } from "@/lib/page-title";
+
+const searchSchema = v.object({
+  status: v.picklist(["connected", "error"]),
+  slug: v.optional(v.string()),
+  reason: v.optional(v.string()),
+});
+
+export const Route = createFileRoute("/mcp/oauth-callback")({
+  validateSearch: searchSchema,
+  head: () => ({
+    meta: [{ title: pageTitle("knowledge.sections.mcp.title") }],
+  }),
+  component: McpOAuthCallbackPage,
+});
+
+function McpOAuthCallbackPage() {
+  const t = useTranslations();
+  const status = Route.useSearch({ select: (search) => search.status });
+  const slug = Route.useSearch({ select: (search) => search.slug });
+  const reason = Route.useSearch({ select: (search) => search.reason });
+
+  useEffect(() => {
+    const message =
+      status === "connected"
+        ? `mcp:connected:${slug ?? ""}`
+        : `mcp:error:${reason ?? "unexpected"}`;
+
+    // SAFETY: lib.dom types `window.opener` as `any` because the
+    // opener may be a Window from any origin. We post to our own
+    // origin only, so narrowing to the postMessage surface is safe.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const opener = window.opener as Pick<Window, "postMessage"> | null;
+    if (opener !== null) {
+      opener.postMessage(message, window.location.origin);
+      window.close();
+    }
+  }, [status, slug, reason]);
+
+  const isError = status === "error";
+
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <Frame className="w-full max-w-sm">
+        <FrameHeader>
+          <FrameTitle>
+            {isError
+              ? t("knowledge.mcp.errorTitle")
+              : t("knowledge.mcp.connectedToast")}
+          </FrameTitle>
+          {isError ? (
+            <FrameDescription>
+              {t("knowledge.mcp.errorDescription")}
+            </FrameDescription>
+          ) : null}
+        </FrameHeader>
+        <FramePanel>
+          <Link to="/knowledge/mcp">
+            <Button className="w-full" type="button">
+              {t("common.close")}
+            </Button>
+          </Link>
+        </FramePanel>
+      </Frame>
+    </div>
+  );
+}


### PR DESCRIPTION
he MCP OAuth popup that ships in v0.1.4 hangs in prod and the connectors list doesn't refresh. Token exchange and DB upsert succeed, but the popup never closes and no toast fires.
- Fix: `/v1/mcp/oauth/callback` now 302s to a new SPA route `/mcp/oauth-callback`. The SPA route posts the existing `mcp:connected:` / `mcp:error:` messages from the SPA's own origin and closes the window. The settings-page listener is switched to `window.location.origin` and now surfaces the error branch.
