### PR TITLE
feat: add release-specific changelog previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,10 @@ jobs:
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun run i18n:check
 
+      - name: Release changelog guard
+        if: github.event_name == 'pull_request'
+        run: bash scripts/check-release-changelog.sh --base "origin/${{ github.base_ref || 'main' }}"
+
       - name: Lint
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun run lint -- ${{ steps.affected.outputs.flag }}
@@ -215,7 +219,7 @@ jobs:
           run=false
           for file in "${changed_files[@]}"; do
             case "$file" in
-              apps/landing/*|packages/*|bun.lock|package.json|.github/workflows/ci.yml)
+              apps/landing/*|docs/changelog/*|VERSION|packages/*|bun.lock|package.json|.github/workflows/ci.yml)
                 run=true
                 break
                 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,7 +444,7 @@ jobs:
         run: |
           if ! gh release view "$RELEASE_REF" >/dev/null 2>&1; then
             extra_args=()
-            if [[ "$RELEASE_REF" == *-rc.* ]]; then
+            if [[ "$RELEASE_REF" == *-* ]]; then
               extra_args+=(--prerelease)
             else
               # Defer the "latest" flag until release-desktop.yml has

--- a/.github/workflows/tag-on-version-bump.yml
+++ b/.github/workflows/tag-on-version-bump.yml
@@ -63,6 +63,10 @@ jobs:
             exit 1
           fi
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Require release changelog file
+        run: bash scripts/check-release-changelog.sh --version "${{ steps.version.outputs.value }}"
 
       - name: Skip if tag already exists
         env:

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -3,15 +3,19 @@ import "../styles/global.css";
 type Props = {
   title?: string;
   description?: string;
+  socialImage?: string;
+  socialImageAlt?: string;
 };
 
 const {
   title = "stella | open source legal workspace",
   description = "Open source legal workspace for documents, matters, review, and research. Self-host or use our cloud. Usage-based AI, no lock-in.",
+  socialImage = "/images/og-card.png",
+  socialImageAlt = description,
 } = Astro.props;
 
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site);
-const socialImageUrl = new URL("/images/og-card.png", Astro.site);
+const socialImageUrl = new URL(socialImage, Astro.site);
 ---
 
 <!--
@@ -46,7 +50,7 @@ const socialImageUrl = new URL("/images/og-card.png", Astro.site);
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={socialImageUrl.href} />
-    <meta name="twitter:image:alt" content={description} />
+    <meta name="twitter:image:alt" content={socialImageAlt} />
 
     <!-- Favicons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/apps/landing/src/lib/changelog-og.ts
+++ b/apps/landing/src/lib/changelog-og.ts
@@ -1,0 +1,288 @@
+import { Resvg } from "@resvg/resvg-js";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { ChangelogRelease } from "./changelog";
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+const TEXT_X = 84;
+const TEXT_MAX_WIDTH = 980;
+const HEADING_MAX_LINES = 3;
+const HEADING_PREFERRED_FONT_SIZE = 116;
+const HEADING_MIN_FONT_SIZE = 76;
+
+const fontPath = resolveLandingPath(
+  "public",
+  "fonts",
+  "CabinetGrotesk-Regular.otf",
+);
+const logoSvg = readFileSync(
+  resolveLandingPath("public", "images", "stella-logo.svg"),
+  "utf-8",
+);
+const logoSvgBase64 = Buffer.from(logoSvg).toString("base64");
+const gradientPngBase64 = readFileSync(
+  resolveLandingPath("public", "images", "gradient-hero.png"),
+).toString("base64");
+
+export const renderChangelogOgImage = (release: ChangelogRelease) => {
+  const versionLabel = release.tagName.startsWith("v")
+    ? release.tagName.slice(1)
+    : release.tagName;
+  if (!release.heading) {
+    return renderVersionOnlyOgImage(versionLabel);
+  }
+
+  const heading = fitLines(
+    release.heading,
+    HEADING_PREFERRED_FONT_SIZE,
+    HEADING_MAX_LINES,
+  );
+  const headingLineHeight = Math.round(heading.fontSize * 0.9);
+  const firstHeadingY =
+    380 -
+    Math.max(0, heading.lines.length - 1) * Math.round(headingLineHeight / 2);
+  const headingMarkup = renderTextLines({
+    className: "display",
+    fontSize: heading.fontSize,
+    lineHeight: headingLineHeight,
+    lines: heading.lines,
+    x: TEXT_X,
+    y: firstHeadingY,
+  });
+
+  const sourceSvg = String.raw`<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .display {
+        font-family: "Cabinet Grotesk", sans-serif;
+        fill: #111827;
+        font-weight: 400;
+      }
+
+    </style>
+  </defs>
+
+  <image href="data:image/png;base64,${gradientPngBase64}" x="0" y="0" width="${WIDTH}" height="${HEIGHT}" preserveAspectRatio="xMidYMid slice" />
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#F7FAFF" fill-opacity="0.04" />
+
+  <image
+    href="data:image/svg+xml;base64,${logoSvgBase64}"
+    x="84"
+    y="72"
+    width="236"
+    height="62"
+    preserveAspectRatio="xMinYMin meet"
+  />
+
+  <text x="1116" y="122" text-anchor="end" class="display" font-size="58">${escapeXml(versionLabel)}</text>
+  ${headingMarkup}
+</svg>`;
+
+  return new Resvg(sourceSvg, {
+    fitTo: {
+      mode: "width",
+      value: WIDTH,
+    },
+    font: {
+      fontFiles: [fontPath],
+      loadSystemFonts: false,
+    },
+  })
+    .render()
+    .asPng();
+};
+
+const renderVersionOnlyOgImage = (versionLabel: string) => {
+  const sourceSvg = String.raw`<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <style>
+      .display {
+        font-family: "Cabinet Grotesk", sans-serif;
+        fill: #111827;
+        font-weight: 400;
+      }
+    </style>
+  </defs>
+
+  <image href="data:image/png;base64,${gradientPngBase64}" x="0" y="0" width="${WIDTH}" height="${HEIGHT}" preserveAspectRatio="xMidYMid slice" />
+  <rect width="${WIDTH}" height="${HEIGHT}" fill="#F7FAFF" fill-opacity="0.04" />
+
+  <image
+    href="data:image/svg+xml;base64,${logoSvgBase64}"
+    x="84"
+    y="72"
+    width="236"
+    height="62"
+    preserveAspectRatio="xMinYMin meet"
+  />
+
+  <text x="${TEXT_X}" y="392" class="display" font-size="164">${escapeXml(versionLabel)}</text>
+</svg>`;
+
+  return new Resvg(sourceSvg, {
+    fitTo: {
+      mode: "width",
+      value: WIDTH,
+    },
+    font: {
+      fontFiles: [fontPath],
+      loadSystemFonts: false,
+    },
+  })
+    .render()
+    .asPng();
+};
+
+type TextLinesInput = {
+  className: string;
+  fontSize: number;
+  lineHeight: number;
+  lines: string[];
+  x: number;
+  y: number;
+};
+
+const renderTextLines = ({
+  className,
+  fontSize,
+  lineHeight,
+  lines,
+  x,
+  y,
+}: TextLinesInput) =>
+  `<text x="${x}" y="${y}" class="${className}" font-size="${fontSize}">${lines
+    .map((line, index) => {
+      const dy = index === 0 ? 0 : lineHeight;
+      return `<tspan x="${x}" dy="${dy}">${escapeXml(line)}</tspan>`;
+    })
+    .join("")}</text>`;
+
+const fitLines = (
+  text: string,
+  preferredFontSize: number,
+  maxLines: number,
+) => {
+  for (
+    let fontSize = preferredFontSize;
+    fontSize >= HEADING_MIN_FONT_SIZE;
+    fontSize -= 8
+  ) {
+    const lines = wrapText(text, TEXT_MAX_WIDTH, fontSize, maxLines);
+    const didFit = lines.length <= maxLines && !lastLineWasTruncated(lines);
+    if (didFit || fontSize === HEADING_MIN_FONT_SIZE) {
+      return { fontSize, lines };
+    }
+  }
+
+  return {
+    fontSize: HEADING_MIN_FONT_SIZE,
+    lines: wrapText(text, TEXT_MAX_WIDTH, HEADING_MIN_FONT_SIZE, maxLines),
+  };
+};
+
+const wrapText = (
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  maxLines: number,
+) => {
+  const words = text.trim().split(/\s+/);
+  const lines: string[] = [];
+  let currentLine = "";
+
+  for (const word of words) {
+    const candidate = currentLine ? `${currentLine} ${word}` : word;
+    if (measureText(candidate, fontSize) <= maxWidth) {
+      currentLine = candidate;
+      continue;
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+    currentLine = word;
+
+    if (lines.length === maxLines) {
+      return truncateLastLine(lines, maxWidth, fontSize);
+    }
+  }
+
+  if (currentLine) {
+    lines.push(currentLine);
+  }
+
+  if (lines.length <= maxLines) {
+    return lines;
+  }
+
+  return truncateLastLine(lines.slice(0, maxLines), maxWidth, fontSize);
+};
+
+const truncateLastLine = (
+  lines: string[],
+  maxWidth: number,
+  fontSize: number,
+) => {
+  const truncatedLines = [...lines];
+  let lastLine = truncatedLines.at(-1) ?? "";
+
+  while (
+    lastLine.length > 0 &&
+    measureText(`${lastLine}...`, fontSize) > maxWidth
+  ) {
+    lastLine = lastLine.slice(0, -1).trimEnd();
+  }
+
+  truncatedLines[truncatedLines.length - 1] = `${lastLine}...`;
+  return truncatedLines;
+};
+
+const lastLineWasTruncated = (lines: string[]) =>
+  lines.at(-1)?.endsWith("...") ?? false;
+
+const measureText = (text: string, fontSize: number) => {
+  let width = 0;
+
+  for (const character of text) {
+    width += fontSize * characterWidthRatio(character);
+  }
+
+  return width;
+};
+
+const characterWidthRatio = (character: string) => {
+  if (character === " ") {
+    return 0.28;
+  }
+  if (/[,.:;|!]/.test(character)) {
+    return 0.22;
+  }
+  if (/[ijlI]/.test(character)) {
+    return 0.28;
+  }
+  if (/[mwMW]/.test(character)) {
+    return 0.78;
+  }
+  if (/[A-Z]/.test(character)) {
+    return 0.62;
+  }
+  return 0.52;
+};
+
+const escapeXml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+function resolveLandingPath(...segments: string[]) {
+  const fromLanding = join(process.cwd(), ...segments);
+  if (existsSync(fromLanding)) {
+    return fromLanding;
+  }
+
+  return join(process.cwd(), "apps", "landing", ...segments);
+}

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -10,7 +10,7 @@ export type ChangelogRelease = {
 };
 
 const CHANGELOG_DIR = resolveRepoPath("docs", "changelog");
-const CHANGELOG_FILE_PATTERN = /^v[\w.-]+\.md$/;
+const STABLE_CHANGELOG_FILE_PATTERN = /^v\d+\.\d+\.\d+\.md$/;
 
 export const releaseAnchorId = (tagName: string) =>
   tagName
@@ -26,7 +26,7 @@ export const getChangelogReleases = (): ChangelogRelease[] => {
   }
 
   return readdirSync(CHANGELOG_DIR)
-    .filter((fileName) => CHANGELOG_FILE_PATTERN.test(fileName))
+    .filter((fileName) => STABLE_CHANGELOG_FILE_PATTERN.test(fileName))
     .map((fileName) => {
       const tagName = fileName.replace(/\.md$/, "");
       const markdown = readFileSync(join(CHANGELOG_DIR, fileName), "utf-8");

--- a/apps/landing/src/lib/changelog.ts
+++ b/apps/landing/src/lib/changelog.ts
@@ -1,0 +1,111 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type ChangelogRelease = {
+  description: string;
+  displayName: string;
+  heading: string | null;
+  slug: string;
+  tagName: string;
+};
+
+const CHANGELOG_DIR = resolveRepoPath("docs", "changelog");
+const CHANGELOG_FILE_PATTERN = /^v[\w.-]+\.md$/;
+
+export const releaseAnchorId = (tagName: string) =>
+  tagName
+    .toLowerCase()
+    .replaceAll(".", "-")
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+export const getChangelogReleases = (): ChangelogRelease[] => {
+  if (!existsSync(CHANGELOG_DIR)) {
+    return [];
+  }
+
+  return readdirSync(CHANGELOG_DIR)
+    .filter((fileName) => CHANGELOG_FILE_PATTERN.test(fileName))
+    .map((fileName) => {
+      const tagName = fileName.replace(/\.md$/, "");
+      const markdown = readFileSync(join(CHANGELOG_DIR, fileName), "utf-8");
+      const heading = findHeading(markdown, 1);
+      const description =
+        findHeading(markdown, 2) ??
+        `Release notes for ${formatReleaseName(tagName)}.`;
+
+      return {
+        description,
+        displayName: formatReleaseName(tagName),
+        heading,
+        slug: releaseAnchorId(tagName),
+        tagName,
+      };
+    })
+    .sort((left, right) =>
+      right.tagName.localeCompare(left.tagName, "en", { numeric: true }),
+    );
+};
+
+const findHeading = (markdown: string, level: 1 | 2) => {
+  const marker = "#".repeat(level);
+  const heading = markdown
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line.startsWith(`${marker} `));
+
+  if (!heading) {
+    return null;
+  }
+
+  return normalizeMarkdownText(heading.slice(marker.length + 1));
+};
+
+const normalizeMarkdownText = (text: string) =>
+  stripMarkdownLinks(text).replace(/[*_`]/g, "").replace(/\s+/g, " ").trim();
+
+const stripMarkdownLinks = (text: string) => {
+  let output = "";
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const openLabel = text.indexOf("[", cursor);
+    if (openLabel === -1) {
+      output += text.slice(cursor);
+      break;
+    }
+
+    const closeLabel = text.indexOf("](", openLabel);
+    if (closeLabel === -1) {
+      output += text.slice(cursor);
+      break;
+    }
+
+    const closeTarget = text.indexOf(")", closeLabel + 2);
+    if (closeTarget === -1) {
+      output += text.slice(cursor);
+      break;
+    }
+
+    output += text.slice(cursor, openLabel);
+    output += text.slice(openLabel + 1, closeLabel);
+    cursor = closeTarget + 1;
+  }
+
+  return output;
+};
+
+const formatReleaseName = (tagName: string) => {
+  const version = tagName.startsWith("v") ? tagName.slice(1) : tagName;
+  return `stella ${version}`;
+};
+
+function resolveRepoPath(...segments: string[]) {
+  const fromRoot = join(process.cwd(), ...segments);
+  if (existsSync(fromRoot)) {
+    return fromRoot;
+  }
+
+  return join(process.cwd(), "..", "..", ...segments);
+}

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -1,9 +1,11 @@
 ---
 import Base from "../layouts/Base.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
+import { getChangelogReleases } from "../lib/changelog";
 
 const githubUrl = "https://github.com/stella/stella";
 const releasesUrl = `${githubUrl}/releases`;
+const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug);
 ---
 
 <Base
@@ -134,6 +136,13 @@ const releasesUrl = `${githubUrl}/releases`;
     </footer>
   </div>
 
+  <script
+    is:inline
+    id="changelog-preview-release-slugs"
+    type="application/json"
+    set:html={JSON.stringify(previewReleaseSlugs)}
+  />
+
   <style>
     :global(.changelog-entry) {
       background: var(--card);
@@ -233,6 +242,22 @@ const releasesUrl = `${githubUrl}/releases`;
       `${releasesApiBase}?per_page=${GITHUB_RELEASES_PER_PAGE}`;
     const releasesContainer = document.getElementById("changelog-releases");
     const paginationContainer = document.getElementById("changelog-pagination");
+    const previewReleaseSlugsElement = document.getElementById(
+      "changelog-preview-release-slugs",
+    );
+    const readPreviewReleaseSlugs = () => {
+      if (!previewReleaseSlugsElement?.textContent) {
+        return [];
+      }
+
+      const parsed = JSON.parse(previewReleaseSlugsElement.textContent);
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed.filter((value): value is string => typeof value === "string");
+    };
+    const previewReleaseSlugs = new Set<string>(readPreviewReleaseSlugs());
 
     let currentPage = (() => {
       const page = Number(new URLSearchParams(window.location.search).get("page"));
@@ -446,7 +471,9 @@ const releasesUrl = `${githubUrl}/releases`;
 
       const title = document.createElement("h2");
       const titleLink = document.createElement("a");
-      titleLink.href = `#${article.id}`;
+      titleLink.href = previewReleaseSlugs.has(article.id)
+        ? `/changelog/${article.id}`
+        : `#${article.id}`;
       titleLink.className =
         "font-display text-3xl font-medium transition-opacity hover:opacity-70 sm:text-4xl";
       titleLink.style.color = "var(--foreground)";
@@ -536,6 +563,7 @@ const releasesUrl = `${githubUrl}/releases`;
 
     const updatePageUrl = () => {
       const url = new URL(window.location.href);
+      url.pathname = "/changelog";
       if (currentPage === 1) {
         url.searchParams.delete("page");
       } else {
@@ -661,6 +689,7 @@ const releasesUrl = `${githubUrl}/releases`;
         releasesContainer.replaceChildren(
           ...releasePage.releases.map(renderRelease),
         );
+        scrollToCurrentHash();
       } catch {
         hasNextPage = false;
         renderPagination();
@@ -668,6 +697,13 @@ const releasesUrl = `${githubUrl}/releases`;
           renderMessage("Release notes could not be loaded right now. Read them directly on"),
         );
       }
+    };
+
+    const scrollToCurrentHash = () => {
+      const id = decodeURIComponent(window.location.hash.slice(1));
+      if (!id) return;
+
+      document.getElementById(id)?.scrollIntoView({ block: "start" });
     };
 
     loadReleases();

--- a/apps/landing/src/pages/changelog.astro
+++ b/apps/landing/src/pages/changelog.astro
@@ -471,13 +471,23 @@ const previewReleaseSlugs = getChangelogReleases().map((release) => release.slug
 
       const title = document.createElement("h2");
       const titleLink = document.createElement("a");
-      titleLink.href = previewReleaseSlugs.has(article.id)
-        ? `/changelog/${article.id}`
-        : `#${article.id}`;
+      const hasPreviewPage = previewReleaseSlugs.has(article.id);
+      titleLink.href = hasPreviewPage ? `/changelog/${article.id}` : `#${article.id}`;
       titleLink.className =
         "font-display text-3xl font-medium transition-opacity hover:opacity-70 sm:text-4xl";
       titleLink.style.color = "var(--foreground)";
       titleLink.textContent = release.name || release.tag_name;
+      if (hasPreviewPage) {
+        titleLink.addEventListener("click", (event) => {
+          if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+            return;
+          }
+
+          event.preventDefault();
+          window.history.pushState(null, "", `#${article.id}`);
+          article.scrollIntoView({ block: "start", behavior: "smooth" });
+        });
+      }
       title.append(titleLink);
       meta.append(title);
 

--- a/apps/landing/src/pages/changelog/[release].astro
+++ b/apps/landing/src/pages/changelog/[release].astro
@@ -1,0 +1,48 @@
+---
+import Base from "../../layouts/Base.astro";
+import { getChangelogReleases } from "../../lib/changelog";
+
+export const getStaticPaths = () =>
+  getChangelogReleases().map((release, index) => ({
+    params: { release: release.slug },
+    props: { page: Math.floor(index / 5) + 1, release },
+  }));
+
+const { page, release } = Astro.props;
+const changelogHref =
+  page === 1 ? `/changelog#${release.slug}` : `/changelog?page=${page}#${release.slug}`;
+const pageTitle = release.heading
+  ? `${release.displayName}: ${release.heading}`
+  : release.displayName;
+const socialImage = `/images/changelog/${release.slug}.png`;
+---
+
+<Base
+  title={pageTitle}
+  description={release.description}
+  socialImage={socialImage}
+  socialImageAlt={pageTitle}
+>
+  <main
+    class="grid min-h-dvh place-items-center px-6 text-center"
+    style="background: var(--background); color: var(--foreground)"
+  >
+    <div class="max-w-xl">
+      <p class="font-display text-3xl font-medium">{pageTitle}</p>
+      <p class="mt-4 text-sm leading-[1.8]" style="color: var(--muted-foreground)">
+        Redirecting to the changelog entry.
+      </p>
+      <a
+        href={changelogHref}
+        class="mt-6 inline-flex h-10 items-center justify-center rounded-[0.625rem] px-4 text-sm font-medium transition-opacity hover:opacity-80"
+        style="background: var(--card); border: 1px solid var(--border); color: var(--foreground)"
+      >
+        Open changelog
+      </a>
+    </div>
+  </main>
+
+  <script is:inline define:vars={{ changelogHref }}>
+    window.location.replace(changelogHref);
+  </script>
+</Base>

--- a/apps/landing/src/pages/images/changelog/[release].png.ts
+++ b/apps/landing/src/pages/images/changelog/[release].png.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import type { ChangelogRelease } from "../../../lib/changelog";
 import { getChangelogReleases } from "../../../lib/changelog";
 import { renderChangelogOgImage } from "../../../lib/changelog-og";
 
@@ -9,16 +10,12 @@ export const getStaticPaths = () =>
     props: { release },
   }));
 
-export const GET: APIRoute = ({ params }) => {
-  const release = getChangelogReleases().find(
-    (changelogRelease) => changelogRelease.slug === params.release,
-  );
-
-  if (!release) {
+export const GET: APIRoute<{ release?: ChangelogRelease }> = ({ props }) => {
+  if (props.release === undefined) {
     return new Response(null, { status: 404 });
   }
 
-  return new Response(new Uint8Array(renderChangelogOgImage(release)), {
+  return new Response(new Uint8Array(renderChangelogOgImage(props.release)), {
     headers: {
       "Cache-Control": "public, max-age=31536000, immutable",
       "Content-Type": "image/png",

--- a/apps/landing/src/pages/images/changelog/[release].png.ts
+++ b/apps/landing/src/pages/images/changelog/[release].png.ts
@@ -1,0 +1,27 @@
+import type { APIRoute } from "astro";
+
+import { getChangelogReleases } from "../../../lib/changelog";
+import { renderChangelogOgImage } from "../../../lib/changelog-og";
+
+export const getStaticPaths = () =>
+  getChangelogReleases().map((release) => ({
+    params: { release: release.slug },
+    props: { release },
+  }));
+
+export const GET: APIRoute = ({ params }) => {
+  const release = getChangelogReleases().find(
+    (changelogRelease) => changelogRelease.slug === params.release,
+  );
+
+  if (!release) {
+    return new Response(null, { status: 404 });
+  }
+
+  return new Response(new Uint8Array(renderChangelogOgImage(release)), {
+    headers: {
+      "Cache-Control": "public, max-age=31536000, immutable",
+      "Content-Type": "image/png",
+    },
+  });
+};

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -1,7 +1,9 @@
 # Manual Changelog Notes
 
-Add one Markdown file per release when the generated git-cliff notes need a
-human-written summary. Commit it together with the matching `VERSION` bump:
+Add one Markdown file per release and commit it together with the matching
+`VERSION` bump. The file may be blank for minor releases with no handwritten
+notes; the landing site still uses its presence to generate release-specific
+link preview pages and version-only fallback images.
 
 ```text
 docs/changelog/vX.Y.Z.md
@@ -10,14 +12,15 @@ docs/changelog/vX.Y.Z-rc.N.md
 
 ```bash
 printf "X.Y.Z\n" > VERSION
-$EDITOR docs/changelog/vX.Y.Z.md
+touch docs/changelog/vX.Y.Z.md
 git add VERSION docs/changelog/vX.Y.Z.md
 git commit -m "chore: release vX.Y.Z"
 ```
 
-The release workflow prepends the matching file to the generated release notes,
-adds a `## Changes` heading, then appends the categorized git-cliff commit list
-below it. Keep the manual section short and product-facing.
+When the file contains manual notes, the release workflow prepends the matching
+file to the generated release notes, adds a `## Changes` heading, then appends
+the categorized git-cliff commit list below it. Keep the manual section short
+and product-facing.
 
 Example:
 

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -1,13 +1,15 @@
 # Manual Changelog Notes
 
-Add one Markdown file per release and commit it together with the matching
-`VERSION` bump. The file may be blank for minor releases with no handwritten
-notes; the landing site still uses its presence to generate release-specific
-link preview pages and version-only fallback images.
+Add one Markdown file per stable release and commit it together with the
+matching `VERSION` bump. The file may be blank for minor releases with no
+handwritten notes; the landing site still uses its presence to generate
+release-specific link preview pages and version-only fallback images.
+
+Prereleases (`vX.Y.Z-rc.N`, `vX.Y.Z-beta.N`, `vX.Y.Z-alpha.N`) stay off the
+public changelog page. Their generated GitHub release notes are enough.
 
 ```text
 docs/changelog/vX.Y.Z.md
-docs/changelog/vX.Y.Z-rc.N.md
 ```
 
 ```bash
@@ -43,6 +45,5 @@ PR comment, or release description draft, then copy the generated
 Keep videos short and compressed; the website embeds the file responsively.
 
 Stable releases (`vX.Y.Z`) generate their commit list from the previous stable
-tag, so the first non-RC release includes the changes shipped through earlier
-RC tags for that version. RC releases continue to use the latest tag as their
-base.
+tag, so the stable release includes the changes shipped through earlier
+prerelease tags for that version.

--- a/scripts/check-release-changelog.sh
+++ b/scripts/check-release-changelog.sh
@@ -42,6 +42,11 @@ if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; th
   exit 1
 fi
 
+if [[ "$version" == *-* ]]; then
+  echo "VERSION $version is a prerelease; public changelog preview file not required."
+  exit 0
+fi
+
 changelog_file="docs/changelog/v${version}.md"
 if [[ ! -f "$changelog_file" ]]; then
   cat >&2 <<EOF

--- a/scripts/check-release-changelog.sh
+++ b/scripts/check-release-changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_ref=""
+version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      base_ref="${2:-}"
+      shift 2
+      ;;
+    --version)
+      version="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "::error::Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$version" ]]; then
+  if [[ ! -f VERSION ]]; then
+    echo "::error::VERSION file is missing" >&2
+    exit 1
+  fi
+  version="$(tr -d '[:space:]' < VERSION)"
+fi
+
+if [[ -n "$base_ref" ]]; then
+  previous_version="$(git show "$base_ref:VERSION" 2>/dev/null | tr -d '[:space:]' || true)"
+  if [[ "$previous_version" == "$version" ]]; then
+    echo "VERSION unchanged ($version); changelog release file not required."
+    exit 0
+  fi
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)\.[0-9]+)?$ ]]; then
+  echo "::error::VERSION must look like 1.2.3, 1.2.3-rc.1, 1.2.3-beta.1, or 1.2.3-alpha.1; got '$version'" >&2
+  exit 1
+fi
+
+changelog_file="docs/changelog/v${version}.md"
+if [[ ! -f "$changelog_file" ]]; then
+  cat >&2 <<EOF
+::error file=VERSION::VERSION was bumped to $version, but $changelog_file is missing.
+Create the file even for minor releases with no handwritten notes; it may be blank. The landing site uses it to generate release-specific link preview pages and version-only fallback images.
+EOF
+  exit 1
+fi
+
+echo "Found $changelog_file for VERSION $version."


### PR DESCRIPTION
## Summary

- generate release-specific changelog preview images and share pages from committed changelog files
- redirect release share pages back to the matching changelog entry
- require a matching docs/changelog/vX.Y.Z.md file when VERSION changes so preview routes exist for every release