### PR TITLE
fix(folio): port upstream eigenpal batch + multi-section / footnote fidelity

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -8,7 +8,16 @@ import type {
 } from "@stll/folio";
 import { Button } from "@stll/ui/components/button";
 import { Separator } from "@stll/ui/components/separator";
-import { PenLineIcon, EyeIcon } from "lucide-react";
+import { EyeIcon, MinusIcon, PenLineIcon, PlusIcon } from "lucide-react";
+
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 2;
+const ZOOM_STEP = 0.1;
+const ZOOM_INITIAL = 1;
+
+function clampZoom(zoom: number): number {
+  return Math.min(Math.max(zoom, ZOOM_MIN), ZOOM_MAX);
+}
 
 declare global {
   var __folioPlayground:
@@ -64,6 +73,7 @@ export function App() {
   const [fileName, setFileName] = useState("Untitled.docx");
   const [status, setStatus] = useState("");
   const [editorMode, setEditorMode] = useState<EditorMode>("editing");
+  const [zoom, setZoom] = useState(ZOOM_INITIAL);
 
   // Load fixture from ?file= query param (for visual regression tests)
   // or from /fixtures/*.docx (served by Vite's public dir)
@@ -158,6 +168,24 @@ export function App() {
     setStatus(`Error: ${error.message}`);
   }, []);
 
+  const applyZoom = useCallback((next: number) => {
+    const clamped = clampZoom(next);
+    setZoom(clamped);
+    editorRef.current?.setZoom(clamped);
+  }, []);
+  const handleZoomIn = useCallback(
+    () => applyZoom(zoom + ZOOM_STEP),
+    [applyZoom, zoom],
+  );
+  const handleZoomOut = useCallback(
+    () => applyZoom(zoom - ZOOM_STEP),
+    [applyZoom, zoom],
+  );
+  const handleZoomReset = useCallback(
+    () => applyZoom(ZOOM_INITIAL),
+    [applyZoom],
+  );
+
   const toggleDarkMode = useCallback(() => {
     document.documentElement.classList.toggle("dark");
   }, []);
@@ -183,6 +211,7 @@ export function App() {
           author="Folio User"
           onError={handleError}
           showToolbar={true}
+          initialZoom={ZOOM_INITIAL}
           mode={editorMode}
           onModeChange={setEditorMode}
         />
@@ -226,14 +255,44 @@ export function App() {
           id="file-input"
           type="file"
           accept=".docx"
-          onChange={handleFileSelect}
+          onChange={(e) => void handleFileSelect(e)}
           className="hidden"
         />
         <Button variant="ghost" size="sm" onClick={handleNewDocument}>
           New
         </Button>
-        <Button variant="ghost" size="sm" onClick={handleSave}>
+        <Button variant="ghost" size="sm" onClick={() => void handleSave()}>
           Save
+        </Button>
+
+        <Separator orientation="vertical" className="h-5" />
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleZoomOut}
+          disabled={zoom <= ZOOM_MIN}
+          title="Zoom out"
+        >
+          <MinusIcon />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleZoomReset}
+          title="Reset zoom"
+          className="min-w-12 font-mono text-xs"
+        >
+          {Math.round(zoom * 100)}%
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={handleZoomIn}
+          disabled={zoom >= ZOOM_MAX}
+          title="Zoom in"
+        >
+          <PlusIcon />
         </Button>
 
         <Separator orientation="vertical" className="h-5" />

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -163,7 +163,14 @@ export const useHeaderFooterEditor = ({
           continue;
         }
         lastHeader = candidate;
-        const hasFirstRef = sp.headerReferences.some((r) => r.type === "first");
+        // Word only honors `first` references when `<w:titlePg/>` is
+        // set on the section (ECMA-376 §17.10.6). A stale `first`
+        // reference on a section without titlePg should be ignored —
+        // gating on `sp.titlePg` keeps this resolution consistent with
+        // the first-page resolution below and with Word's behavior.
+        const hasFirstRef =
+          sp.titlePg === true &&
+          sp.headerReferences.some((r) => r.type === "first");
         if (hasFirstRef && !primaryHeaderFromTitleSection) {
           primaryHeaderFromTitleSection = candidate;
         }
@@ -204,7 +211,11 @@ export const useHeaderFooterEditor = ({
           continue;
         }
         lastFooter = candidate;
-        const hasFirstRef = sp.footerReferences.some((r) => r.type === "first");
+        // Same titlePg gate as headers above — ignore `first` refs in
+        // sections that don't enable title-page mode.
+        const hasFirstRef =
+          sp.titlePg === true &&
+          sp.footerReferences.some((r) => r.type === "first");
         if (hasFirstRef && !primaryFooterFromTitleSection) {
           primaryFooterFromTitleSection = candidate;
         }

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -292,13 +292,18 @@ export const useHeaderFooterEditor = ({
       }
     }
 
-    // When titlePg is not set but only 'first' headers exist, use them as default
+    // When titlePg is not set but only 'first' headers exist, use them as default.
+    // Mirror the rId fallback so save/remove targets the rId actually
+    // rendered — otherwise the active default rId stays null and edits to
+    // the displayed header/footer silently no-op (Codex PR #258 review).
     if (!titlePg) {
       if (!header && firstHeader) {
         header = firstHeader;
+        resolvedHeaderRId = resolvedFirstHeaderRId;
       }
       if (!footer && firstFooter) {
         footer = firstFooter;
+        resolvedFooterRId = resolvedFirstFooterRId;
       }
     }
 

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -142,7 +142,12 @@ export const useHeaderFooterEditor = ({
 
     // Resolve default headers/footers: use the last section that defines them
     // (typically the final section properties)
+    // Same title-page-section preference as footers below — pages 2+
+    // should use the body section's default header, not a later signature
+    // section's empty/different one.
     if (headers) {
+      let primaryHeaderFromTitleSection: HeaderFooter | null = null;
+      let lastHeader: HeaderFooter | null = null;
       for (const sp of allSectionProps) {
         if (!sp.headerReferences) {
           continue;
@@ -150,13 +155,40 @@ export const useHeaderFooterEditor = ({
         const defaultRef = sp.headerReferences.find(
           (r) => r.type === "default",
         );
-        if (defaultRef?.rId) {
-          header = headers.get(defaultRef.rId) ?? header;
+        if (!defaultRef?.rId) {
+          continue;
+        }
+        const candidate = headers.get(defaultRef.rId);
+        if (!candidate) {
+          continue;
+        }
+        lastHeader = candidate;
+        const hasFirstRef = sp.headerReferences.some((r) => r.type === "first");
+        if (hasFirstRef && !primaryHeaderFromTitleSection) {
+          primaryHeaderFromTitleSection = candidate;
         }
       }
+      header = primaryHeaderFromTitleSection ?? lastHeader ?? header;
     }
 
     if (footers) {
+      // Per ECMA-376 §17.10, each section has its own header/footer
+      // references. Folio's HF model is currently flat (one default per
+      // document) — the closest spec-conformant approximation is "the
+      // section that hosts the title page's first-page references". That's
+      // section 1 in NVCA-style multi-section docs (sec 1: title page +
+      // body, sec 2..N: signature pages with different / empty footers).
+      // Picking the LAST section's default (the previous behavior) silently
+      // dropped the body footer's PAGE field on pages 2+ when later
+      // sections override `default` with a stripped-down footer.
+      //
+      // Algorithm: pick the default from the FIRST section that has both
+      // a first-page reference AND a default — that's the title-page
+      // section, whose default applies to pages 2+ within that section
+      // (and, since folio's HF is flat, to pages 2+ globally). Fall back
+      // to the last default if no section has both.
+      let primaryFooterFromTitleSection: HeaderFooter | null = null;
+      let lastFooter: HeaderFooter | null = null;
       for (const sp of allSectionProps) {
         if (!sp.footerReferences) {
           continue;
@@ -164,10 +196,20 @@ export const useHeaderFooterEditor = ({
         const defaultRef = sp.footerReferences.find(
           (r) => r.type === "default",
         );
-        if (defaultRef?.rId) {
-          footer = footers.get(defaultRef.rId) ?? footer;
+        if (!defaultRef?.rId) {
+          continue;
+        }
+        const candidate = footers.get(defaultRef.rId);
+        if (!candidate) {
+          continue;
+        }
+        lastFooter = candidate;
+        const hasFirstRef = sp.footerReferences.some((r) => r.type === "first");
+        if (hasFirstRef && !primaryFooterFromTitleSection) {
+          primaryFooterFromTitleSection = candidate;
         }
       }
+      footer = primaryFooterFromTitleSection ?? lastFooter ?? footer;
     }
 
     // Resolve first-page headers/footers: find the first section with titlePg

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -101,12 +101,20 @@ export const useHeaderFooterEditor = ({
     firstPageHeaderContent,
     firstPageFooterContent,
     hasTitlePg,
+    activeHeaderRId,
+    activeFooterRId,
+    activeFirstHeaderRId,
+    activeFirstFooterRId,
   } = useMemo<{
     headerContent: HeaderFooter | null;
     footerContent: HeaderFooter | null;
     firstPageHeaderContent: HeaderFooter | null;
     firstPageFooterContent: HeaderFooter | null;
     hasTitlePg: boolean;
+    activeHeaderRId: string | null;
+    activeFooterRId: string | null;
+    activeFirstHeaderRId: string | null;
+    activeFirstFooterRId: string | null;
   }>(() => {
     if (!history.state?.package) {
       return {
@@ -115,6 +123,10 @@ export const useHeaderFooterEditor = ({
         firstPageHeaderContent: null,
         firstPageFooterContent: null,
         hasTitlePg: false,
+        activeHeaderRId: null,
+        activeFooterRId: null,
+        activeFirstHeaderRId: null,
+        activeFirstFooterRId: null,
       };
     }
 
@@ -145,9 +157,16 @@ export const useHeaderFooterEditor = ({
     // Same title-page-section preference as footers below — pages 2+
     // should use the body section's default header, not a later signature
     // section's empty/different one.
+    let resolvedHeaderRId: string | null = null;
+    let resolvedFooterRId: string | null = null;
+    let resolvedFirstHeaderRId: string | null = null;
+    let resolvedFirstFooterRId: string | null = null;
+
     if (headers) {
       let primaryHeaderFromTitleSection: HeaderFooter | null = null;
+      let primaryHeaderRId: string | null = null;
       let lastHeader: HeaderFooter | null = null;
+      let lastHeaderRId: string | null = null;
       for (const sp of allSectionProps) {
         if (!sp.headerReferences) {
           continue;
@@ -163,6 +182,7 @@ export const useHeaderFooterEditor = ({
           continue;
         }
         lastHeader = candidate;
+        lastHeaderRId = defaultRef.rId;
         // Word only honors `first` references when `<w:titlePg/>` is
         // set on the section (ECMA-376 §17.10.6). A stale `first`
         // reference on a section without titlePg should be ignored —
@@ -173,9 +193,11 @@ export const useHeaderFooterEditor = ({
           sp.headerReferences.some((r) => r.type === "first");
         if (hasFirstRef && !primaryHeaderFromTitleSection) {
           primaryHeaderFromTitleSection = candidate;
+          primaryHeaderRId = defaultRef.rId;
         }
       }
       header = primaryHeaderFromTitleSection ?? lastHeader ?? header;
+      resolvedHeaderRId = primaryHeaderRId ?? lastHeaderRId;
     }
 
     if (footers) {
@@ -195,7 +217,9 @@ export const useHeaderFooterEditor = ({
       // (and, since folio's HF is flat, to pages 2+ globally). Fall back
       // to the last default if no section has both.
       let primaryFooterFromTitleSection: HeaderFooter | null = null;
+      let primaryFooterRId: string | null = null;
       let lastFooter: HeaderFooter | null = null;
+      let lastFooterRId: string | null = null;
       for (const sp of allSectionProps) {
         if (!sp.footerReferences) {
           continue;
@@ -211,6 +235,7 @@ export const useHeaderFooterEditor = ({
           continue;
         }
         lastFooter = candidate;
+        lastFooterRId = defaultRef.rId;
         // Same titlePg gate as headers above — ignore `first` refs in
         // sections that don't enable title-page mode.
         const hasFirstRef =
@@ -218,9 +243,11 @@ export const useHeaderFooterEditor = ({
           sp.footerReferences.some((r) => r.type === "first");
         if (hasFirstRef && !primaryFooterFromTitleSection) {
           primaryFooterFromTitleSection = candidate;
+          primaryFooterRId = defaultRef.rId;
         }
       }
       footer = primaryFooterFromTitleSection ?? lastFooter ?? footer;
+      resolvedFooterRId = primaryFooterRId ?? lastFooterRId;
     }
 
     // Resolve first-page headers/footers: find the first section with titlePg
@@ -231,12 +258,14 @@ export const useHeaderFooterEditor = ({
           const firstRef = sp.headerReferences.find((r) => r.type === "first");
           if (firstRef?.rId) {
             firstHeader = headers.get(firstRef.rId) ?? null;
+            resolvedFirstHeaderRId = firstRef.rId;
           }
         }
         if (footers && sp.footerReferences) {
           const firstRef = sp.footerReferences.find((r) => r.type === "first");
           if (firstRef?.rId) {
             firstFooter = footers.get(firstRef.rId) ?? null;
+            resolvedFirstFooterRId = firstRef.rId;
           }
         }
         break; // first section with titlePg wins
@@ -251,6 +280,7 @@ export const useHeaderFooterEditor = ({
       const firstRef = refs?.find((r) => r.type === "first");
       if (firstRef?.rId) {
         firstHeader = headers.get(firstRef.rId) ?? null;
+        resolvedFirstHeaderRId = firstRef.rId;
       }
     }
     if (!titlePg && footers) {
@@ -258,6 +288,7 @@ export const useHeaderFooterEditor = ({
       const firstRef = refs?.find((r) => r.type === "first");
       if (firstRef?.rId) {
         firstFooter = footers.get(firstRef.rId) ?? null;
+        resolvedFirstFooterRId = firstRef.rId;
       }
     }
 
@@ -277,6 +308,15 @@ export const useHeaderFooterEditor = ({
       firstPageHeaderContent: firstHeader,
       firstPageFooterContent: firstFooter,
       hasTitlePg: titlePg,
+      // Active rIds for the *displayed* H/F. Save/remove must target
+      // these — not finalSectionProperties — otherwise edits to a
+      // multi-section doc's title-page footer end up in the
+      // (hidden) final section's rId and the visible footer never
+      // updates (Codex PR #258 review).
+      activeHeaderRId: resolvedHeaderRId,
+      activeFooterRId: resolvedFooterRId,
+      activeFirstHeaderRId: resolvedFirstHeaderRId,
+      activeFirstFooterRId: resolvedFirstFooterRId,
     };
   }, [history.state]);
 
@@ -381,30 +421,35 @@ export const useHeaderFooterEditor = ({
       }
 
       const pkg = history.state.package;
-      const sectionProps = pkg.document?.finalSectionProperties;
-      const refs =
-        hfEditPosition === "header"
-          ? sectionProps?.headerReferences
-          : sectionProps?.footerReferences;
-      const targetType = hfEditIsFirstPage ? "first" : "default";
-      const activeRef =
-        refs?.find((r) => r.type === targetType) ??
-        refs?.find((r) => r.type === "default") ??
-        refs?.find((r) => r.type === "first") ??
-        refs?.[0];
+      // Save into the rId resolved by the SAME algorithm that picks
+      // the displayed H/F (see the resolver useMemo above). Routing
+      // saves through `pkg.document?.finalSectionProperties` would
+      // write into the *last* section's rId, which can be different
+      // from the rendered one in multi-section docs (NVCA-style:
+      // title-page section has the body H/F; signature sections
+      // override default with stripped-down rIds). Codex PR #258
+      // review.
+      const activeRId = hfEditIsFirstPage
+        ? hfEditPosition === "header"
+          ? activeFirstHeaderRId
+          : activeFirstFooterRId
+        : hfEditPosition === "header"
+          ? activeHeaderRId
+          : activeFooterRId;
+      const refType = hfEditIsFirstPage ? "first" : "default";
       const mapKey = hfEditPosition === "header" ? "headers" : "footers";
       const map = pkg[mapKey];
 
-      if (activeRef?.rId && map) {
-        const existing = map.get(activeRef.rId);
+      if (activeRId && map) {
+        const existing = map.get(activeRId);
         const updated: HeaderFooter = {
           type: hfEditPosition,
-          hdrFtrType: activeRef.type as "default" | "first" | "even",
+          hdrFtrType: refType,
           ...existing,
           content,
         };
         const newMap = new Map(map);
-        newMap.set(activeRef.rId, updated);
+        newMap.set(activeRId, updated);
 
         const newDoc: Document = {
           ...history.state,
@@ -418,7 +463,16 @@ export const useHeaderFooterEditor = ({
 
       setHfEditPosition(null);
     },
-    [hfEditPosition, hfEditIsFirstPage, history, pushDocument],
+    [
+      hfEditPosition,
+      hfEditIsFirstPage,
+      activeHeaderRId,
+      activeFooterRId,
+      activeFirstHeaderRId,
+      activeFirstFooterRId,
+      history,
+      pushDocument,
+    ],
   );
 
   const handleBodyClick = useCallback(() => {
@@ -442,45 +496,76 @@ export const useHeaderFooterEditor = ({
     }
 
     const pkg = history.state.package;
-    const sectionProps = pkg.document?.finalSectionProperties;
     const refKey =
       hfEditPosition === "header" ? "headerReferences" : "footerReferences";
     const mapKey = hfEditPosition === "header" ? "headers" : "footers";
-    const refs = sectionProps?.[refKey];
-    const delTargetType = hfEditIsFirstPage ? "first" : "default";
-    const activeRef =
-      refs?.find((r) => r.type === delTargetType) ??
-      refs?.find((r) => r.type === "default") ??
-      refs?.find((r) => r.type === "first") ??
-      refs?.[0];
 
-    if (activeRef?.rId) {
+    // Same active-rId resolution as save: target the rId actually
+    // rendered, not whatever lives in `finalSectionProperties` (Codex
+    // PR #258 review). Drop the ref from every section that points at
+    // this rId so we don't leave a dangling reference behind.
+    const activeRId = hfEditIsFirstPage
+      ? hfEditPosition === "header"
+        ? activeFirstHeaderRId
+        : activeFirstFooterRId
+      : hfEditPosition === "header"
+        ? activeHeaderRId
+        : activeFooterRId;
+
+    if (activeRId) {
       const newMap = new Map(pkg[mapKey]);
-      newMap.delete(activeRef.rId);
+      newMap.delete(activeRId);
 
-      const newRefs = (refs ?? []).filter((r) => r.rId !== activeRef.rId);
+      const stripRef = (sp: SectionProperties): SectionProperties => {
+        const refs = sp[refKey];
+        if (!refs?.some((r) => r.rId === activeRId)) {
+          return sp;
+        }
+        return {
+          ...sp,
+          [refKey]: refs.filter((r) => r.rId !== activeRId),
+        };
+      };
+
+      const oldDoc = pkg.document;
+      const newSections = oldDoc?.sections?.map((s) => ({
+        ...s,
+        properties: stripRef(s.properties),
+      }));
+      const newFinalProps = oldDoc?.finalSectionProperties
+        ? stripRef(oldDoc.finalSectionProperties)
+        : oldDoc?.finalSectionProperties;
 
       const newDoc: Document = {
         ...history.state,
         package: {
           ...pkg,
           [mapKey]: newMap,
-          document: pkg.document
+          document: oldDoc
             ? {
-                ...pkg.document,
-                finalSectionProperties: {
-                  ...sectionProps,
-                  [refKey]: newRefs,
-                },
+                ...oldDoc,
+                ...(newSections !== undefined ? { sections: newSections } : {}),
+                ...(newFinalProps !== undefined
+                  ? { finalSectionProperties: newFinalProps }
+                  : {}),
               }
-            : pkg.document,
+            : oldDoc,
         },
       };
       pushDocument(newDoc);
     }
 
     setHfEditPosition(null);
-  }, [hfEditPosition, hfEditIsFirstPage, history, pushDocument]);
+  }, [
+    hfEditPosition,
+    hfEditIsFirstPage,
+    activeHeaderRId,
+    activeFooterRId,
+    activeFirstHeaderRId,
+    activeFirstFooterRId,
+    history,
+    pushDocument,
+  ]);
 
   return {
     hfEditPosition,

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -732,6 +732,15 @@ export function parseParagraphProperties(
     if (runPropsResult !== undefined) {
       formatting.runProperties = runPropsResult;
     }
+    // Run-in heading marker: `<w:specVanish/>` on the paragraph
+    // mark's rPr (ECMA-376 §17.3.1.32). Word treats the paragraph
+    // break as a soft break and flows the next paragraph inline on
+    // the same line — used by run-in heading styles in legal
+    // templates (NVCA "6.11 Severability" → body merges).
+    const specVanish = findChild(rPr, "w", "specVanish");
+    if (specVanish && parseBooleanElement(specVanish)) {
+      formatting.runInWithNext = true;
+    }
   }
 
   return Object.keys(formatting).length > 0 ? formatting : undefined;

--- a/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+
+import { createEmptyDocument } from "../../utils/createDocument";
+import { serializeDocument } from "./documentSerializer";
+
+// Issue #417 (eigenpal): integer-typed twip attributes (page size, margins,
+// columns, borders, line numbers) must never appear as fractional values in
+// the XML, or Microsoft Word rejects the file as corrupt. Callers commonly
+// compute twips as `inches * 1440`, which produces drift like
+// `0.7 * 1440 === 1008.0000000000001`.
+const ANY_DECIMAL_IN_TWIPS_ATTR =
+  /w:(top|right|bottom|left|header|footer|gutter|w|h|sz|space|num|countBy|start|distance)="-?\d+\.\d+"/;
+
+describe("document section properties are integer-only (issue #417)", () => {
+  test("createEmptyDocument with fractional inches produces no float twips", () => {
+    const doc = createEmptyDocument({
+      pageWidth: 8.5 * 1440,
+      pageHeight: 11 * 1440,
+      marginTop: 0.7 * 1440,
+      marginBottom: 0.5 * 1440,
+      marginLeft: 1.25 * 1440,
+      marginRight: 1.25 * 1440,
+    });
+
+    const xml = serializeDocument(doc);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_TWIPS_ATTR);
+    expect(xml).toContain('<w:pgSz w:w="12240" w:h="15840"');
+    expect(xml).toContain('w:top="1008"');
+    expect(xml).toContain('w:bottom="720"');
+    expect(xml).toContain('w:left="1800"');
+    expect(xml).toContain('w:right="1800"');
+  });
+
+  test("serializer-side defense catches drift even if the model carries floats", () => {
+    // Bypass the createEmptyDocument input guard by mutating the model
+    // directly — proves the serializer's intAttr() defense works on its own.
+    const doc = createEmptyDocument();
+    const sectionProps = doc.package.document.finalSectionProperties;
+    if (!sectionProps) {
+      throw new Error("expected finalSectionProperties on empty document");
+    }
+    sectionProps.marginTop = 1008.000_000_000_000_1;
+    sectionProps.marginLeft = 1800.000_000_1;
+
+    const xml = serializeDocument(doc);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_TWIPS_ATTR);
+    expect(xml).toContain('w:top="1008"');
+    expect(xml).toContain('w:left="1800"');
+  });
+});

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -36,7 +36,7 @@ import type {
 // oxlint-disable-next-line import/no-cycle
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
-import { escapeXml } from "./xmlUtils";
+import { escapeXml, intAttr } from "./xmlUtils";
 
 // ============================================================================
 // BORDER SERIALIZATION
@@ -56,11 +56,11 @@ function serializeBorder(
   const attrs: string[] = [`w:val="${border.style}"`];
 
   if (border.size !== undefined) {
-    attrs.push(`w:sz="${border.size}"`);
+    attrs.push(`w:sz="${intAttr(border.size)}"`);
   }
 
   if (border.space !== undefined) {
-    attrs.push(`w:space="${border.space}"`);
+    attrs.push(`w:space="${intAttr(border.space)}"`);
   }
 
   // Color
@@ -226,7 +226,7 @@ function serializeTabStops(tabs: TabStop[] | undefined): string {
   const tabElements = tabs.map((tab) => {
     const attrs: string[] = [
       `w:val="${tab.alignment}"`,
-      `w:pos="${tab.position}"`,
+      `w:pos="${intAttr(tab.position)}"`,
     ];
 
     if (tab.leader && tab.leader !== "none") {
@@ -250,15 +250,15 @@ function serializeSpacing(formatting: ParagraphFormatting): string {
   const attrs: string[] = [];
 
   if (formatting.spaceBefore !== undefined) {
-    attrs.push(`w:before="${formatting.spaceBefore}"`);
+    attrs.push(`w:before="${intAttr(formatting.spaceBefore)}"`);
   }
 
   if (formatting.spaceAfter !== undefined) {
-    attrs.push(`w:after="${formatting.spaceAfter}"`);
+    attrs.push(`w:after="${intAttr(formatting.spaceAfter)}"`);
   }
 
   if (formatting.lineSpacing !== undefined) {
-    attrs.push(`w:line="${formatting.lineSpacing}"`);
+    attrs.push(`w:line="${intAttr(formatting.lineSpacing)}"`);
   }
 
   if (formatting.lineSpacingRule) {
@@ -291,19 +291,21 @@ function serializeIndentation(formatting: ParagraphFormatting): string {
   const attrs: string[] = [];
 
   if (formatting.indentLeft !== undefined) {
-    attrs.push(`w:left="${formatting.indentLeft}"`);
+    attrs.push(`w:left="${intAttr(formatting.indentLeft)}"`);
   }
 
   if (formatting.indentRight !== undefined) {
-    attrs.push(`w:right="${formatting.indentRight}"`);
+    attrs.push(`w:right="${intAttr(formatting.indentRight)}"`);
   }
 
   if (formatting.indentFirstLine !== undefined) {
     if (formatting.hangingIndent) {
       // Hanging indent is stored as positive value but uses w:hanging attribute
-      attrs.push(`w:hanging="${Math.abs(formatting.indentFirstLine)}"`);
+      attrs.push(
+        `w:hanging="${intAttr(Math.abs(formatting.indentFirstLine))}"`,
+      );
     } else if (formatting.indentFirstLine !== 0) {
-      attrs.push(`w:firstLine="${formatting.indentFirstLine}"`);
+      attrs.push(`w:firstLine="${intAttr(formatting.indentFirstLine)}"`);
     }
   }
 
@@ -329,11 +331,11 @@ function serializeNumbering(numPr: ParagraphFormatting["numPr"]): string {
   const parts: string[] = [];
 
   if (numPr.ilvl !== undefined) {
-    parts.push(`<w:ilvl w:val="${numPr.ilvl}"/>`);
+    parts.push(`<w:ilvl w:val="${intAttr(numPr.ilvl)}"/>`);
   }
 
   if (numPr.numId !== undefined) {
-    parts.push(`<w:numId w:val="${numPr.numId}"/>`);
+    parts.push(`<w:numId w:val="${intAttr(numPr.numId)}"/>`);
   }
 
   if (parts.length === 0) {
@@ -358,11 +360,11 @@ function serializeFrameProperties(frame: ParagraphFormatting["frame"]): string {
   const attrs: string[] = [];
 
   if (frame.width !== undefined) {
-    attrs.push(`w:w="${frame.width}"`);
+    attrs.push(`w:w="${intAttr(frame.width)}"`);
   }
 
   if (frame.height !== undefined) {
-    attrs.push(`w:h="${frame.height}"`);
+    attrs.push(`w:h="${intAttr(frame.height)}"`);
   }
 
   if (frame.hAnchor) {

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -513,10 +513,21 @@ export function serializeParagraphFormatting(
     }
 
     // Run properties (default run formatting for paragraph)
-    if (formatting.runProperties) {
-      const rPrXml = serializeTextFormatting(formatting.runProperties);
-      if (rPrXml) {
-        parts.push(rPrXml);
+    // Round-trip `<w:specVanish/>` (run-in heading marker, ECMA-376
+    // §17.3.1.32) by injecting it into the paragraph mark's rPr.
+    // The parser populates `formatting.runInWithNext` from this
+    // element; the layout engine consumes it via toFlowBlocks'
+    // run-in merge. Without serializing it back, saving a doc
+    // through Folio loses the soft paragraph break and the heading
+    // becomes a normal separate paragraph in Word.
+    if (formatting.runProperties || formatting.runInWithNext) {
+      const innerRPr = formatting.runProperties
+        ? extractRPrInner(serializeTextFormatting(formatting.runProperties))
+        : "";
+      const specVanishXml = formatting.runInWithNext ? "<w:specVanish/>" : "";
+      const fullInner = `${innerRPr}${specVanishXml}`;
+      if (fullInner.length > 0) {
+        parts.push(`<w:rPr>${fullInner}</w:rPr>`);
       }
     }
   }
@@ -541,6 +552,18 @@ function extractPPrInner(pPrXml: string): string {
     return "";
   }
   return pPrXml.slice("<w:pPr>".length, -"</w:pPr>".length);
+}
+
+/**
+ * Strip the outer `<w:rPr>...</w:rPr>` wrapper so callers can splice
+ * additional rPr children (e.g. `<w:specVanish/>`) and re-emit a
+ * single rPr element.
+ */
+function extractRPrInner(rPrXml: string): string {
+  if (!rPrXml.startsWith("<w:rPr>") || !rPrXml.endsWith("</w:rPr>")) {
+    return "";
+  }
+  return rPrXml.slice("<w:rPr>".length, -"</w:rPr>".length);
 }
 
 function serializeParagraphPropertyChange(

--- a/packages/folio/src/core/docx/serializer/runSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Run } from "../../types/document";
+import { serializeRun } from "./runSerializer";
+
+// Issue #417 (eigenpal): image and shape dimension/offset attributes leaked
+// floating-point IEEE-754 drift (e.g. cy="495299.99999999994") which Word
+// rejects as a corrupt document. The model layer rounds via pixelsToEmu, but
+// the serializer must also coerce so a caller that hands us a float can never
+// produce an unopenable file.
+
+const FLOAT_INLINE_IMAGE: Run = {
+  type: "run",
+  content: [
+    {
+      type: "drawing",
+      image: {
+        type: "image",
+        rId: "rId7",
+        size: { width: 5_610_225, height: 495_299.999_999_999_94 },
+        wrap: { type: "inline" },
+        padding: { top: 0.4, bottom: 0.6, left: 0, right: 0 },
+      },
+    },
+  ],
+};
+
+const FLOAT_FLOATING_IMAGE: Run = {
+  type: "run",
+  content: [
+    {
+      type: "drawing",
+      image: {
+        type: "image",
+        rId: "rId8",
+        size: { width: 1_905_000.000_000_000_2, height: 933_449.999_999_999_9 },
+        wrap: {
+          type: "square",
+          distT: 114_299.999_999_99,
+          distB: 0,
+          distL: 0,
+          distR: 0,
+        },
+        position: {
+          horizontal: {
+            relativeTo: "column",
+            posOffset: 238_125.000_000_000_03,
+          },
+          vertical: {
+            relativeTo: "paragraph",
+            posOffset: 962_024.999_999_999_9,
+          },
+        },
+      },
+    },
+  ],
+};
+
+const FLOAT_BEHIND_IMAGE: Run = {
+  type: "run",
+  content: [
+    {
+      type: "drawing",
+      image: {
+        type: "image",
+        rId: "rId9",
+        size: { width: 495_299.999_999_999_94, height: 495_299.999_999_999_94 },
+        wrap: { type: "behind" },
+        position: {
+          horizontal: { relativeTo: "page", posOffset: -50.7 },
+          vertical: { relativeTo: "page", posOffset: 0 },
+        },
+      },
+    },
+  ],
+};
+
+const FLOAT_INLINE_SHAPE: Run = {
+  type: "run",
+  content: [
+    {
+      type: "shape",
+      shape: {
+        type: "shape",
+        shapeType: "rect",
+        size: { width: 1_234_567.89, height: 987_654.321 },
+      },
+    },
+  ],
+};
+
+const FLOAT_FLOATING_TEXTBOX: Run = {
+  type: "run",
+  content: [
+    {
+      type: "shape",
+      shape: {
+        type: "shape",
+        shapeType: "textBox",
+        size: { width: 2_540_000.000_000_1, height: 1_270_000.5 },
+        wrap: {
+          type: "square",
+          distT: 91_440.7,
+          distB: 91_440.3,
+          distL: 0,
+          distR: 0,
+        },
+        position: {
+          horizontal: { relativeTo: "margin", posOffset: 100_000.5 },
+          vertical: { relativeTo: "paragraph", posOffset: 200_000.5 },
+        },
+        textBody: {
+          content: [{ type: "paragraph", content: [] }],
+          margins: {
+            left: 91_440.5,
+            top: 45_720.3,
+            right: 91_440.5,
+            bottom: 45_720.3,
+          },
+        },
+      },
+    },
+  ],
+};
+
+const ANY_DECIMAL_IN_EMU_ATTR =
+  /(?:cx|cy|distT|distB|distL|distR|lIns|tIns|rIns|bIns)="-?\d+\.\d+"/;
+const POSOFFSET_DECIMAL = /<wp:posOffset>-?\d+\.\d+<\/wp:posOffset>/;
+
+describe("image EMU attributes are integer-only (issue #417)", () => {
+  test("inline image with float dimensions serializes integer cx/cy/distT/distB", () => {
+    const xml = serializeRun(FLOAT_INLINE_IMAGE);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
+    expect(xml).toContain('<wp:extent cx="5610225" cy="495300"/>');
+    expect(xml).toContain('<a:ext cx="5610225" cy="495300"/>');
+    expect(xml).toContain('distT="0" distB="1"');
+  });
+
+  test("floating image with float position/extent serializes integer attrs", () => {
+    const xml = serializeRun(FLOAT_FLOATING_IMAGE);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
+    expect(xml).not.toMatch(POSOFFSET_DECIMAL);
+    expect(xml).toContain('<wp:extent cx="1905000" cy="933450"/>');
+    expect(xml).toContain("<wp:posOffset>238125</wp:posOffset>");
+    expect(xml).toContain("<wp:posOffset>962025</wp:posOffset>");
+    expect(xml).toContain('distT="114300"');
+  });
+
+  test("behind-wrapped image with negative offset rounds correctly", () => {
+    const xml = serializeRun(FLOAT_BEHIND_IMAGE);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
+    expect(xml).not.toMatch(POSOFFSET_DECIMAL);
+    expect(xml).toContain('behindDoc="1"');
+    expect(xml).toContain('<wp:extent cx="495300" cy="495300"/>');
+    expect(xml).toContain("<wp:posOffset>-51</wp:posOffset>");
+  });
+});
+
+describe("shape EMU attributes are integer-only (issue #417)", () => {
+  test("inline shape with float size serializes integer cx/cy", () => {
+    const xml = serializeRun(FLOAT_INLINE_SHAPE);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
+    expect(xml).toContain('<a:ext cx="1234568" cy="987654"/>');
+    expect(xml).toContain('<wp:extent cx="1234568" cy="987654"/>');
+  });
+
+  test("floating textbox with float dimensions/position/margins is fully integer", () => {
+    const xml = serializeRun(FLOAT_FLOATING_TEXTBOX);
+
+    expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
+    expect(xml).not.toMatch(POSOFFSET_DECIMAL);
+    expect(xml).toContain('<wp:extent cx="2540000" cy="1270001"/>');
+    expect(xml).toContain('<a:ext cx="2540000" cy="1270001"/>');
+    expect(xml).toContain('distT="91441" distB="91440"');
+    expect(xml).toContain("<wp:posOffset>100001</wp:posOffset>");
+    expect(xml).toContain("<wp:posOffset>200001</wp:posOffset>");
+    expect(xml).toContain('lIns="91441"');
+    expect(xml).toContain('tIns="45720"');
+    expect(xml).toContain('rIns="91441"');
+    expect(xml).toContain('bIns="45720"');
+  });
+});
+
+describe("run formatting integer attributes (issue #417)", () => {
+  test("font size, character spacing, scale, kern, position render as integers", () => {
+    const run: Run = {
+      type: "run",
+      content: [{ type: "text", text: "x" }],
+      formatting: {
+        fontSize: 22.000_000_1,
+        fontSizeCs: 21.999_999,
+        spacing: 19.999_999_998,
+        scale: 99.999_99,
+        kerning: 18.000_000_3,
+        position: -6.000_000_1,
+      },
+    };
+
+    const xml = serializeRun(run);
+
+    expect(xml).not.toMatch(/w:val="-?\d+\.\d+"/);
+    expect(xml).toContain('<w:sz w:val="22"/>');
+    expect(xml).toContain('<w:szCs w:val="22"/>');
+    expect(xml).toContain('<w:spacing w:val="20"/>');
+    expect(xml).toContain('<w:w w:val="100"/>');
+    expect(xml).toContain('<w:kern w:val="18"/>');
+    expect(xml).toContain('<w:position w:val="-6"/>');
+  });
+});

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -37,7 +37,7 @@ import type {
 } from "../../types/document";
 // oxlint-disable-next-line import/no-cycle
 import { serializeParagraph } from "./paragraphSerializer";
-import { escapeXml } from "./xmlUtils";
+import { escapeXml, intAttr } from "./xmlUtils";
 
 // ============================================================================
 // CONSTANTS
@@ -332,31 +332,31 @@ export function serializeTextFormatting(
 
   // Spacing
   if (formatting.spacing !== undefined) {
-    parts.push(`<w:spacing w:val="${formatting.spacing}"/>`);
+    parts.push(`<w:spacing w:val="${intAttr(formatting.spacing)}"/>`);
   }
 
   // Scale (w:w)
   if (formatting.scale !== undefined) {
-    parts.push(`<w:w w:val="${formatting.scale}"/>`);
+    parts.push(`<w:w w:val="${intAttr(formatting.scale)}"/>`);
   }
 
   // Kerning
   if (formatting.kerning !== undefined) {
-    parts.push(`<w:kern w:val="${formatting.kerning}"/>`);
+    parts.push(`<w:kern w:val="${intAttr(formatting.kerning)}"/>`);
   }
 
   // Position
   if (formatting.position !== undefined) {
-    parts.push(`<w:position w:val="${formatting.position}"/>`);
+    parts.push(`<w:position w:val="${intAttr(formatting.position)}"/>`);
   }
 
   // Font size
   if (formatting.fontSize !== undefined) {
-    parts.push(`<w:sz w:val="${formatting.fontSize}"/>`);
+    parts.push(`<w:sz w:val="${intAttr(formatting.fontSize)}"/>`);
   }
 
   if (formatting.fontSizeCs !== undefined) {
-    parts.push(`<w:szCs w:val="${formatting.fontSizeCs}"/>`);
+    parts.push(`<w:szCs w:val="${intAttr(formatting.fontSizeCs)}"/>`);
   }
 
   // Highlight — emit valid OOXML named colors via w:highlight,
@@ -642,7 +642,7 @@ function serializeFill(fill: ShapeFill | undefined): string {
       .join("");
     const direction =
       g.type === "linear"
-        ? `<a:lin ang="${(g.angle || 0) * 60_000}" scaled="1"/>`
+        ? `<a:lin ang="${(g.angle ?? 0) * 60_000}" scaled="1"/>`
         : "";
     return `<a:gradFill><a:gsLst>${stops}</a:gsLst>${direction}</a:gradFill>`;
   }
@@ -698,7 +698,7 @@ function serializePosition(pos: ImagePosition): string {
   if (h.alignment) {
     parts.push(`<wp:align>${h.alignment}</wp:align>`);
   } else {
-    parts.push(`<wp:posOffset>${h.posOffset || 0}</wp:posOffset>`);
+    parts.push(`<wp:posOffset>${intAttr(h.posOffset)}</wp:posOffset>`);
   }
   parts.push("</wp:positionH>");
 
@@ -708,7 +708,7 @@ function serializePosition(pos: ImagePosition): string {
   if (v.alignment) {
     parts.push(`<wp:align>${v.alignment}</wp:align>`);
   } else {
-    parts.push(`<wp:posOffset>${v.posOffset || 0}</wp:posOffset>`);
+    parts.push(`<wp:posOffset>${intAttr(v.posOffset)}</wp:posOffset>`);
   }
   parts.push("</wp:positionV>");
 
@@ -771,7 +771,7 @@ function serializePicGraphic(image: Image, sharedId: string): string {
     "<pic:spPr>",
     `<a:xfrm${xfrmAttrs}>`,
     '<a:off x="0" y="0"/>',
-    `<a:ext cx="${cx}" cy="${cy}"/>`,
+    `<a:ext cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     "</a:xfrm>",
     '<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>',
     image.outline ? serializeOutline(image.outline) : "",
@@ -803,8 +803,8 @@ function serializeDrawingContent(content: DrawingContent): string {
     // Inline image
     return [
       "<w:drawing>",
-      `<wp:inline distT="${distT}" distB="${distB}" distL="${distL}" distR="${distR}">`,
-      `<wp:extent cx="${cx}" cy="${cy}"/>`,
+      `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
+      `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
       '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
       `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}${image.decorative ? ' hidden="1"' : ""}/>`,
       '<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/></wp:cNvGraphicFramePr>',
@@ -823,10 +823,10 @@ function serializeDrawingContent(content: DrawingContent): string {
 
   return [
     "<w:drawing>",
-    `<wp:anchor distT="${distT}" distB="${distB}" distL="${distL}" distR="${distR}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
+    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
     '<wp:simplePos x="0" y="0"/>',
     position,
-    `<wp:extent cx="${cx}" cy="${cy}"/>`,
+    `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
     wrap,
     `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}/>`,
@@ -876,7 +876,7 @@ function serializeShapeContent(content: ShapeContent): string {
     "<wps:spPr>",
     `<a:xfrm${xfrmAttrs}>`,
     '<a:off x="0" y="0"/>',
-    `<a:ext cx="${cx}" cy="${cy}"/>`,
+    `<a:ext cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     "</a:xfrm>",
     `<a:prstGeom prst="${shape.shapeType === "textBox" ? "rect" : shape.shapeType}"><a:avLst/></a:prstGeom>`,
     serializeFill(shape.fill),
@@ -896,17 +896,17 @@ function serializeShapeContent(content: ShapeContent): string {
       bpAttrs.push('anchorCtr="1"');
     }
     if (tb.margins) {
-      if (tb.margins.left !== null) {
-        bpAttrs.push(`lIns="${tb.margins.left}"`);
+      if (tb.margins.left != null) {
+        bpAttrs.push(`lIns="${intAttr(tb.margins.left)}"`);
       }
-      if (tb.margins.top !== null) {
-        bpAttrs.push(`tIns="${tb.margins.top}"`);
+      if (tb.margins.top != null) {
+        bpAttrs.push(`tIns="${intAttr(tb.margins.top)}"`);
       }
-      if (tb.margins.right !== null) {
-        bpAttrs.push(`rIns="${tb.margins.right}"`);
+      if (tb.margins.right != null) {
+        bpAttrs.push(`rIns="${intAttr(tb.margins.right)}"`);
       }
-      if (tb.margins.bottom !== null) {
-        bpAttrs.push(`bIns="${tb.margins.bottom}"`);
+      if (tb.margins.bottom != null) {
+        bpAttrs.push(`bIns="${intAttr(tb.margins.bottom)}"`);
       }
     }
 
@@ -943,8 +943,8 @@ function serializeShapeContent(content: ShapeContent): string {
   if (!isFloating) {
     return [
       "<w:drawing>",
-      `<wp:inline distT="${distT}" distB="${distB}" distL="${distL}" distR="${distR}">`,
-      `<wp:extent cx="${cx}" cy="${cy}"/>`,
+      `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
+      `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
       '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
       `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"/>`,
       "<wp:cNvGraphicFramePr/>",
@@ -966,10 +966,10 @@ function serializeShapeContent(content: ShapeContent): string {
 
   return [
     "<w:drawing>",
-    `<wp:anchor distT="${distT}" distB="${distB}" distL="${distL}" distR="${distR}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
+    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
     '<wp:simplePos x="0" y="0"/>',
     position,
-    `<wp:extent cx="${cx}" cy="${cy}"/>`,
+    `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
     '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
     wrap,
     `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"/>`,

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -6,6 +6,7 @@ import type {
   HeaderReference,
   SectionProperties,
 } from "../../types/document";
+import { intAttr } from "./xmlUtils";
 
 function serializeBorder(
   border: BorderSpec | undefined,
@@ -18,10 +19,10 @@ function serializeBorder(
   const attrs: string[] = [`w:val="${border.style}"`];
 
   if (border.size !== undefined) {
-    attrs.push(`w:sz="${border.size}"`);
+    attrs.push(`w:sz="${intAttr(border.size)}"`);
   }
   if (border.space !== undefined) {
-    attrs.push(`w:space="${border.space}"`);
+    attrs.push(`w:space="${intAttr(border.space)}"`);
   }
   if (border.color) {
     if (border.color.auto) {
@@ -70,7 +71,7 @@ function serializeFootnoteProperties(
     parts.push(`<w:numFmt w:val="${props.numFmt}"/>`);
   }
   if (props.numStart !== undefined) {
-    parts.push(`<w:numStart w:val="${props.numStart}"/>`);
+    parts.push(`<w:numStart w:val="${intAttr(props.numStart)}"/>`);
   }
   if (props.numRestart) {
     parts.push(`<w:numRestart w:val="${props.numRestart}"/>`);
@@ -96,7 +97,7 @@ function serializeEndnoteProperties(
     parts.push(`<w:numFmt w:val="${props.numFmt}"/>`);
   }
   if (props.numStart !== undefined) {
-    parts.push(`<w:numStart w:val="${props.numStart}"/>`);
+    parts.push(`<w:numStart w:val="${intAttr(props.numStart)}"/>`);
   }
   if (props.numRestart) {
     parts.push(`<w:numRestart w:val="${props.numRestart}"/>`);
@@ -108,10 +109,10 @@ function serializeEndnoteProperties(
 function serializePageSize(props: SectionProperties): string {
   const attrs: string[] = [];
   if (props.pageWidth !== undefined) {
-    attrs.push(`w:w="${props.pageWidth}"`);
+    attrs.push(`w:w="${intAttr(props.pageWidth)}"`);
   }
   if (props.pageHeight !== undefined) {
-    attrs.push(`w:h="${props.pageHeight}"`);
+    attrs.push(`w:h="${intAttr(props.pageHeight)}"`);
   }
   if (props.orientation === "landscape") {
     attrs.push('w:orient="landscape"');
@@ -122,25 +123,25 @@ function serializePageSize(props: SectionProperties): string {
 function serializePageMargins(props: SectionProperties): string {
   const attrs: string[] = [];
   if (props.marginTop !== undefined) {
-    attrs.push(`w:top="${props.marginTop}"`);
+    attrs.push(`w:top="${intAttr(props.marginTop)}"`);
   }
   if (props.marginRight !== undefined) {
-    attrs.push(`w:right="${props.marginRight}"`);
+    attrs.push(`w:right="${intAttr(props.marginRight)}"`);
   }
   if (props.marginBottom !== undefined) {
-    attrs.push(`w:bottom="${props.marginBottom}"`);
+    attrs.push(`w:bottom="${intAttr(props.marginBottom)}"`);
   }
   if (props.marginLeft !== undefined) {
-    attrs.push(`w:left="${props.marginLeft}"`);
+    attrs.push(`w:left="${intAttr(props.marginLeft)}"`);
   }
   if (props.headerDistance !== undefined) {
-    attrs.push(`w:header="${props.headerDistance}"`);
+    attrs.push(`w:header="${intAttr(props.headerDistance)}"`);
   }
   if (props.footerDistance !== undefined) {
-    attrs.push(`w:footer="${props.footerDistance}"`);
+    attrs.push(`w:footer="${intAttr(props.footerDistance)}"`);
   }
   if (props.gutter !== undefined) {
-    attrs.push(`w:gutter="${props.gutter}"`);
+    attrs.push(`w:gutter="${intAttr(props.gutter)}"`);
   }
   return attrs.length > 0 ? `<w:pgMar ${attrs.join(" ")}/>` : "";
 }
@@ -148,10 +149,10 @@ function serializePageMargins(props: SectionProperties): string {
 function serializePaperSource(props: SectionProperties): string {
   const attrs: string[] = [];
   if (props.paperSrcFirst !== undefined) {
-    attrs.push(`w:first="${props.paperSrcFirst}"`);
+    attrs.push(`w:first="${intAttr(props.paperSrcFirst)}"`);
   }
   if (props.paperSrcOther !== undefined) {
-    attrs.push(`w:other="${props.paperSrcOther}"`);
+    attrs.push(`w:other="${intAttr(props.paperSrcOther)}"`);
   }
   return attrs.length > 0 ? `<w:paperSrc ${attrs.join(" ")}/>` : "";
 }
@@ -163,10 +164,10 @@ function serializeColumns(props: SectionProperties): string {
 
   const attrs: string[] = [];
   if (props.columnCount !== undefined && props.columnCount > 1) {
-    attrs.push(`w:num="${props.columnCount}"`);
+    attrs.push(`w:num="${intAttr(props.columnCount)}"`);
   }
   if (props.columnSpace !== undefined) {
-    attrs.push(`w:space="${props.columnSpace}"`);
+    attrs.push(`w:space="${intAttr(props.columnSpace)}"`);
   }
   if (props.equalWidth !== undefined) {
     attrs.push(`w:equalWidth="${props.equalWidth ? "1" : "0"}"`);
@@ -179,10 +180,10 @@ function serializeColumns(props: SectionProperties): string {
     .map((col) => {
       const colAttrs: string[] = [];
       if (col.width !== undefined) {
-        colAttrs.push(`w:w="${col.width}"`);
+        colAttrs.push(`w:w="${intAttr(col.width)}"`);
       }
       if (col.space !== undefined) {
-        colAttrs.push(`w:space="${col.space}"`);
+        colAttrs.push(`w:space="${intAttr(col.space)}"`);
       }
       return `<w:col ${colAttrs.join(" ")}/>`;
     })
@@ -204,13 +205,13 @@ function serializeLineNumbers(props: SectionProperties): string {
   const attrs: string[] = [];
   const ln = props.lineNumbers;
   if (ln.countBy !== undefined) {
-    attrs.push(`w:countBy="${ln.countBy}"`);
+    attrs.push(`w:countBy="${intAttr(ln.countBy)}"`);
   }
   if (ln.start !== undefined) {
-    attrs.push(`w:start="${ln.start}"`);
+    attrs.push(`w:start="${intAttr(ln.start)}"`);
   }
   if (ln.distance !== undefined) {
-    attrs.push(`w:distance="${ln.distance}"`);
+    attrs.push(`w:distance="${intAttr(ln.distance)}"`);
   }
   if (ln.restart) {
     attrs.push(`w:restart="${ln.restart}"`);
@@ -267,10 +268,10 @@ function serializeDocGrid(props: SectionProperties): string {
     attrs.push(`w:type="${dg.type}"`);
   }
   if (dg.linePitch !== undefined) {
-    attrs.push(`w:linePitch="${dg.linePitch}"`);
+    attrs.push(`w:linePitch="${intAttr(dg.linePitch)}"`);
   }
   if (dg.charSpace !== undefined) {
-    attrs.push(`w:charSpace="${dg.charSpace}"`);
+    attrs.push(`w:charSpace="${intAttr(dg.charSpace)}"`);
   }
   return attrs.length > 0 ? `<w:docGrid ${attrs.join(" ")}/>` : "";
 }

--- a/packages/folio/src/core/docx/serializer/tableSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/tableSerializer.ts
@@ -36,7 +36,7 @@ import type {
   Paragraph,
 } from "../../types/document";
 import { serializeParagraph } from "./paragraphSerializer";
-import { escapeXml } from "./xmlUtils";
+import { escapeXml, intAttr } from "./xmlUtils";
 
 function normalizeTrackedChangeInfo(info: {
   id: number;
@@ -96,7 +96,7 @@ function serializeMeasurement(
   }
 
   const attrs: string[] = [
-    `w:w="${measurement.value}"`,
+    `w:w="${intAttr(measurement.value)}"`,
     `w:type="${measurement.type}"`,
   ];
 
@@ -121,11 +121,11 @@ function serializeBorder(
   const attrs: string[] = [`w:val="${border.style}"`];
 
   if (border.size !== undefined) {
-    attrs.push(`w:sz="${border.size}"`);
+    attrs.push(`w:sz="${intAttr(border.size)}"`);
   }
 
   if (border.space !== undefined) {
-    attrs.push(`w:space="${border.space}"`);
+    attrs.push(`w:space="${intAttr(border.space)}"`);
   }
 
   // Color
@@ -387,7 +387,7 @@ function serializeFloatingTableProperties(
   }
 
   if (floating.tblpX !== undefined) {
-    attrs.push(`w:tblpX="${floating.tblpX}"`);
+    attrs.push(`w:tblpX="${intAttr(floating.tblpX)}"`);
   }
 
   if (floating.tblpXSpec) {
@@ -395,7 +395,7 @@ function serializeFloatingTableProperties(
   }
 
   if (floating.tblpY !== undefined) {
-    attrs.push(`w:tblpY="${floating.tblpY}"`);
+    attrs.push(`w:tblpY="${intAttr(floating.tblpY)}"`);
   }
 
   if (floating.tblpYSpec) {
@@ -403,19 +403,19 @@ function serializeFloatingTableProperties(
   }
 
   if (floating.topFromText !== undefined) {
-    attrs.push(`w:topFromText="${floating.topFromText}"`);
+    attrs.push(`w:topFromText="${intAttr(floating.topFromText)}"`);
   }
 
   if (floating.bottomFromText !== undefined) {
-    attrs.push(`w:bottomFromText="${floating.bottomFromText}"`);
+    attrs.push(`w:bottomFromText="${intAttr(floating.bottomFromText)}"`);
   }
 
   if (floating.leftFromText !== undefined) {
-    attrs.push(`w:leftFromText="${floating.leftFromText}"`);
+    attrs.push(`w:leftFromText="${intAttr(floating.leftFromText)}"`);
   }
 
   if (floating.rightFromText !== undefined) {
-    attrs.push(`w:rightFromText="${floating.rightFromText}"`);
+    attrs.push(`w:rightFromText="${intAttr(floating.rightFromText)}"`);
   }
 
   if (attrs.length === 0) {
@@ -579,7 +579,7 @@ export function serializeTableRowFormatting(
 
     // Row height
     if (formatting.height) {
-      const attrs: string[] = [`w:val="${formatting.height.value}"`];
+      const attrs: string[] = [`w:val="${intAttr(formatting.height.value)}"`];
 
       if (formatting.heightRule) {
         attrs.push(`w:hRule="${formatting.heightRule}"`);
@@ -719,7 +719,7 @@ export function serializeTableCellFormatting(
 
     // Grid span (horizontal merge)
     if (formatting.gridSpan && formatting.gridSpan > 1) {
-      parts.push(`<w:gridSpan w:val="${formatting.gridSpan}"/>`);
+      parts.push(`<w:gridSpan w:val="${intAttr(formatting.gridSpan)}"/>`);
     }
 
     // Vertical merge
@@ -841,7 +841,7 @@ function serializeTableGrid(columnWidths: number[] | undefined): string {
     return "";
   }
 
-  const cols = columnWidths.map((w) => `<w:gridCol w:w="${w}"/>`);
+  const cols = columnWidths.map((w) => `<w:gridCol w:w="${intAttr(w)}"/>`);
 
   return `<w:tblGrid>${cols.join("")}</w:tblGrid>`;
 }

--- a/packages/folio/src/core/docx/serializer/xmlUtils.ts
+++ b/packages/folio/src/core/docx/serializer/xmlUtils.ts
@@ -10,3 +10,22 @@ export function escapeXml(text: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;");
 }
+
+/**
+ * Format a numeric value as an integer XML attribute.
+ *
+ * OOXML measure types (twips, EMU, half-points, eighths-of-point) are
+ * integer-typed in the schema (xs:unsignedInt / xs:long / xs:int). Word
+ * rejects floating-point values (e.g. `0.7 * 1440 === 1008.0000000000001`
+ * from `inches * TWIPS_PER_INCH`), even though tolerant readers accept them.
+ * Coerce to a finite integer at every serialization site.
+ *
+ * `NaN`/`Infinity`/`null`/`undefined` collapse to `'0'` rather than leaking
+ * literal `"NaN"` or `"Infinity"` into the XML.
+ */
+export function intAttr(value: number | undefined | null): string {
+  if (value == null || !Number.isFinite(value)) {
+    return "0";
+  }
+  return String(Math.round(value));
+}

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -287,10 +287,17 @@ function findNearestSpan(
   _zoom: number,
 ): number | null {
   // Get all text spans on this page
-  const spans = pageEl.querySelectorAll("span[data-pm-start][data-pm-end]");
+  // Scope to body content — `pageEl` is the whole `.layout-page` and
+  // includes header/footer subtrees whose `data-pm-start` collides with body
+  // PM positions (HF content is a separate ProseMirror doc). Without scoping,
+  // a click outside any body span could resolve to an HF position.
+  const spans = pageEl.querySelectorAll(
+    ".layout-page-content span[data-pm-start][data-pm-end]",
+  );
   if (spans.length === 0) {
-    // No text spans - return position based on paragraph
-    const paragraphs = pageEl.querySelectorAll(".layout-paragraph");
+    const paragraphs = pageEl.querySelectorAll(
+      ".layout-page-content .layout-paragraph",
+    );
     if (paragraphs.length > 0) {
       const firstP = paragraphs[0] as HTMLElement;
       return Number(firstP.dataset["pmStart"]) || 0;
@@ -299,7 +306,7 @@ function findNearestSpan(
   }
 
   // Find the closest line to the click Y
-  const lines = pageEl.querySelectorAll(".layout-line");
+  const lines = pageEl.querySelectorAll(".layout-page-content .layout-line");
   let closestLine: HTMLElement | null = null;
   let closestLineDistance = Infinity;
 
@@ -396,7 +403,14 @@ export function getSelectionRectsFromDom(
   const rects: DomSelectionRect[] = [];
 
   // Find all spans that intersect with the selection
-  const spans = container.querySelectorAll("span[data-pm-start][data-pm-end]");
+  // Scope the query to body content. Headers and footers go through a
+  // separate ProseMirror document whose positions also start at 1, so an
+  // HF span can carry the same `data-pm-start` as a body run — without the
+  // scope, body selections paint phantom rects on HF text and clicks in
+  // body coords could resolve to HF positions.
+  const spans = container.querySelectorAll(
+    ".layout-page-content span[data-pm-start][data-pm-end]",
+  );
 
   for (const span of Array.from(spans)) {
     const spanEl = span as HTMLElement;
@@ -476,7 +490,14 @@ export function getCaretPositionFromDom(
   overlayRect: DOMRect,
 ): DomCaretPosition | null {
   // Find span containing this position
-  const spans = container.querySelectorAll("span[data-pm-start][data-pm-end]");
+  // Scope the query to body content. Headers and footers go through a
+  // separate ProseMirror document whose positions also start at 1, so an
+  // HF span can carry the same `data-pm-start` as a body run — without the
+  // scope, body selections paint phantom rects on HF text and clicks in
+  // body coords could resolve to HF positions.
+  const spans = container.querySelectorAll(
+    ".layout-page-content span[data-pm-start][data-pm-end]",
+  );
 
   for (const span of Array.from(spans)) {
     const spanEl = span as HTMLElement;

--- a/packages/folio/src/core/layout-bridge/clickToPositionDomScope.test.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDomScope.test.ts
@@ -11,8 +11,7 @@ import { describe, expect, test } from "bun:test";
 // mode is a regression that drops the prefix and re-introduces the HF
 // bleed at the page-container or page-element level.
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 const SOURCE = readFileSync(
   join(import.meta.dirname, "clickToPositionDom.ts"),

--- a/packages/folio/src/core/layout-bridge/clickToPositionDomScope.test.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDomScope.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+// Issue #406 (eigenpal): headers and footers go through a separate
+// ProseMirror document whose positions also start at 1, so an HF run can
+// carry the same `data-pm-start` as a body run. Pre-PR, the DOM-based
+// selection painter and caret resolver in clickToPositionDom queried every
+// span on the page, matched both trees, and painted phantom selection rects
+// on header/footer text. Scope must be `.layout-page-content`.
+//
+// We can't easily exercise the full DOM-range path under bun:test (no DOM,
+// no Range), so this test asserts the *call site* is scoped — the failure
+// mode is a regression that drops the prefix and re-introduces the HF
+// bleed at the page-container or page-element level.
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SOURCE = readFileSync(
+  join(import.meta.dirname, "clickToPositionDom.ts"),
+  "utf-8",
+);
+
+describe("clickToPositionDom selector scope (issue #406)", () => {
+  test("page-container span queries are scoped to body content", () => {
+    // The two functions whose queries traverse the WHOLE pages container
+    // (getSelectionRectsFromDom and getCaretPositionFromDom) must use the
+    // body scope. Search for the bare selector with `container.` as the
+    // receiver — that's the dangerous form that hits HF spans.
+    const dangerous = SOURCE.match(
+      /container\.querySelectorAll\([^)]*"span\[data-pm-start\]\[data-pm-end\]"/g,
+    );
+
+    expect(dangerous).toBeNull();
+  });
+
+  test("page-element span queries are scoped to body content", () => {
+    // findNearestSpan walks `pageEl.querySelectorAll(...)`. `pageEl` is the
+    // whole `.layout-page` and contains header/footer subtrees, so the
+    // bare selector form is also dangerous here.
+    const dangerous = SOURCE.match(
+      /pageEl\.querySelectorAll\([^)]*"span\[data-pm-start\]\[data-pm-end\]"/g,
+    );
+
+    expect(dangerous).toBeNull();
+  });
+
+  test("page-container .layout-line query is scoped to body content", () => {
+    // `pageEl.querySelectorAll('.layout-line')` would also match HF lines
+    // and lead the click resolver to an HF position; scope it.
+    const dangerous = SOURCE.match(
+      /pageEl\.querySelectorAll\(\s*"\.layout-line"/g,
+    );
+
+    expect(dangerous).toBeNull();
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/emptyParagraphFloor.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/emptyParagraphFloor.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock } from "../../layout-engine/types";
+import { measureParagraph } from "./measureParagraph";
+
+// Issue #391/#394 (eigenpal): Word renders an empty paragraph as a single
+// readable line — its line height never collapses below 1.15 × font size,
+// even when the doc explicitly writes `<w:line w:val="240"/>` (1.0×). The
+// floor is scoped to `auto`/`atLeast` line rules; `exact` means exact.
+
+const ARIAL_PT = 11;
+const ARIAL_PX = (ARIAL_PT * 96) / 72; // ≈ 14.667
+
+const emptyPara = (
+  spacing?: ParagraphBlock["attrs"] extends infer A
+    ? A extends { spacing?: infer S }
+      ? S
+      : never
+    : never,
+): ParagraphBlock => ({
+  kind: "paragraph",
+  id: 0,
+  runs: [],
+  attrs: {
+    defaultFontSize: ARIAL_PT,
+    defaultFontFamily: "Arial",
+    ...(spacing ? { spacing } : {}),
+  },
+});
+
+describe("empty-paragraph 1.15× line-height floor (eigenpal #391/#394)", () => {
+  test("auto rule with line=240 (1.0×) is floored to 1.15× font size", () => {
+    const measure = measureParagraph(
+      emptyPara({ line: 1, lineUnit: "multiplier", lineRule: "auto" }),
+      600,
+    );
+    const expected = ARIAL_PX * 1.15;
+    expect(measure.lines).toHaveLength(1);
+    expect(measure.lines[0]!.lineHeight).toBeGreaterThanOrEqual(
+      expected - 0.01,
+    );
+  });
+
+  test("atLeast rule below the floor is also floored", () => {
+    const measure = measureParagraph(
+      emptyPara({ line: 8, lineUnit: "px", lineRule: "atLeast" }),
+      600,
+    );
+    const expected = ARIAL_PX * 1.15;
+    expect(measure.lines[0]!.lineHeight).toBeGreaterThanOrEqual(
+      expected - 0.01,
+    );
+  });
+
+  test("exact rule is NOT floored — exact means exact per OOXML", () => {
+    const measure = measureParagraph(
+      emptyPara({ line: 8, lineUnit: "px", lineRule: "exact" }),
+      600,
+    );
+    expect(measure.lines[0]!.lineHeight).toBe(8);
+  });
+
+  test("auto rule above the floor is unchanged", () => {
+    // 2.0× line spacing with Arial's natural metrics is well above the
+    // 1.15× floor — the floor must NOT shrink it back to 1.15.
+    const measure = measureParagraph(
+      emptyPara({ line: 2, lineUnit: "multiplier", lineRule: "auto" }),
+      600,
+    );
+    const floor = ARIAL_PX * 1.15;
+    expect(measure.lines[0]!.lineHeight).toBeGreaterThan(floor + 5);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/firstLineListMarker.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/firstLineListMarker.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock } from "../../layout-engine/types";
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+// First-line-indent list paragraphs (`<w:ind w:left="0" w:firstLine="N"/>`,
+// no hanging) put the marker inline at the start of the first line. The
+// painter prepends a marker span (with a 12 px tab-after) — so the
+// first line's available text width must be measured *minus* the
+// marker box, otherwise the line breaker over-allocates and the
+// trailing punctuation/text wraps to the next line.
+//
+// NVCA-style legal templates trigger this: section heads like
+// "4.10 Voting Agreement.  The Company..." rendered "4.10Voting
+// Agreement" then ". The Company..." on the next line because the
+// measurement assumed the full first-line width was available for
+// text that the painter then had to share with a 30+12 px marker box.
+
+function withFakeTextMeasure(runTest: () => void): void {
+  // Each character reports 5 px (uppercase 10 px) — same shape as
+  // measureParagraph.test.ts so the line-break math is predictable.
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              let width = 0;
+              for (const char of text) {
+                width += char >= "A" && char <= "Z" ? 10 : 5;
+              }
+              return {
+                width,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    resetCanvasContext();
+  }
+}
+
+describe("measureParagraph — first-line list marker reservation", () => {
+  test("first-line text width on a list paragraph excludes marker + tab-after", () => {
+    withFakeTextMeasure(() => {
+      // Total content width 200 px. firstLine indent = 50 px.
+      // Marker "4.10" = 5+5+5+5 = 20 px @ 11pt fake metrics.
+      // Tab-after = 12 px.
+      // Without the fix: first-line width = 200 - 50 = 150.
+      // With the fix:    first-line width = 200 - 50 - (20 + 12) = 118.
+      const para: ParagraphBlock = {
+        kind: "paragraph",
+        id: 0,
+        runs: [
+          {
+            kind: "text",
+            text: "abcdefghijklmnopqrstuvwxyz",
+            pmStart: 1,
+            pmEnd: 27,
+          },
+        ],
+        attrs: {
+          indent: { left: 0, firstLine: 50 },
+          listMarker: "4.10",
+          defaultFontSize: 11,
+          defaultFontFamily: "TestFont",
+          listMarkerFontSize: 11,
+          listMarkerFontFamily: "TestFont",
+        },
+        pmStart: 1,
+        pmEnd: 28,
+      };
+
+      const m = measureParagraph(para, 200);
+      expect(m.kind).toBe("paragraph");
+
+      // Without fix the first line would claim 150 px and fit 30
+      // characters (5 px each) — the entire 26-char string + tail.
+      // With the fix only 118 px fits → 23 chars on first line, the
+      // rest wraps. Two-line output proves marker reservation took
+      // effect.
+      expect(m.lines.length).toBeGreaterThanOrEqual(2);
+      expect(m.lines[0]!.toChar).toBeLessThanOrEqual(24);
+    });
+  });
+
+  test("hanging-indent lists do NOT also subtract a marker reservation", () => {
+    withFakeTextMeasure(() => {
+      // Hanging-indent: marker box already sits in the hanging space
+      // (painter sets `min-width: hanging`), so the line's text width
+      // shouldn't be reduced again. With left=50, hanging=50:
+      //   bodyContentWidth = 200 - 50 = 150
+      //   firstLineOffset  = 0 - 50 = -50  (hanging gives more width)
+      //   baseFirstLineWidth = 150 - (-50) = 200 — full content width.
+      // Subtracting the marker again here would shrink first line
+      // text width below 200 and overcount.
+      const para: ParagraphBlock = {
+        kind: "paragraph",
+        id: 0,
+        runs: [{ kind: "text", text: "Body text", pmStart: 1, pmEnd: 10 }],
+        attrs: {
+          indent: { left: 50, hanging: 50 },
+          listMarker: "1.",
+          defaultFontSize: 11,
+          defaultFontFamily: "TestFont",
+        },
+        pmStart: 1,
+        pmEnd: 11,
+      };
+
+      const m = measureParagraph(para, 200);
+      expect(m.kind).toBe("paragraph");
+      // Hanging case: the first line's measured *text* width should
+      // match the full content width (200 in this fake), not be
+      // reduced by the marker reservation. The text "Body text" is
+      // short, so we just check the line's total width is well below
+      // the limit (proxy: a single line) — combined with the body
+      // calculation that hanging branch is taken (no extra
+      // subtraction). The negative assertion is that there's no extra
+      // wrap from a phantom marker subtraction.
+      expect(m.lines.length).toBe(1);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -220,7 +220,21 @@ function calculateTypographyMetrics(
 }
 
 /**
- * Calculate metrics for an empty paragraph
+ * Word's "single line spacing" floor (≈ 1.15×) applied to empty paragraphs
+ * with `auto`/`atLeast` line rules. Without this, narrow-metric fonts
+ * (Arial Narrow, OS/2 ratio ≈ 1.117) collapse empty rows visibly tighter
+ * than Word renders them. See eigenpal #391/#394.
+ */
+const WORD_SINGLE_LINE_FLOOR = 1.15;
+
+/**
+ * Calculate metrics for an empty paragraph.
+ *
+ * Word renders an empty paragraph as a single readable line — its line
+ * height never collapses below 1.15 × font size, even when the doc
+ * explicitly writes `<w:line w:val="240"/>` (1.0×). The floor is scoped to
+ * `auto`/`atLeast` line rules; `exact` means exact (per OOXML §17.3.1.33)
+ * and stays untouched.
  */
 function calculateEmptyParagraphMetrics(
   fontSize: number,
@@ -231,7 +245,17 @@ function calculateEmptyParagraphMetrics(
     fontSize,
     fontFamily: fontFamily ?? DEFAULT_FONT_FAMILY,
   });
-  return calculateTypographyMetrics(fontSize, spacing, metrics);
+  const result = calculateTypographyMetrics(fontSize, spacing, metrics);
+
+  const lineRule = spacing?.lineRule ?? "auto";
+  if (lineRule === "auto" || lineRule === "atLeast") {
+    const fontSizePx = ptToPx(fontSize);
+    const floor = fontSizePx * WORD_SINGLE_LINE_FLOOR;
+    if (result.lineHeight < floor) {
+      return { ...result, lineHeight: floor };
+    }
+  }
+  return result;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -386,7 +386,39 @@ export function measureParagraph(
   const bodyContentWidth = Math.max(1, maxWidth - indentLeft - indentRight);
   // First line offset: positive = first-line indent (less space), negative = hanging (more space)
   // Subtracting gives correct width in both cases
-  const baseFirstLineWidth = Math.max(1, bodyContentWidth - firstLineOffset);
+  let baseFirstLineWidth = Math.max(1, bodyContentWidth - firstLineOffset);
+
+  // List marker on first-line-indent paragraphs: the marker is rendered
+  // inline at the start of the first line and takes its own width. Word's
+  // measurement includes the marker in the first line's content; folio
+  // renders the marker as a separately-prepended span that's *not* in the
+  // run list, so we must subtract its width here. Without this, the line
+  // breaker thinks the first line has a full `bodyWidth - firstLine` of
+  // text room, the painter then pushes some text past the right margin,
+  // and a trailing run (e.g. ". The Company...") wraps to the next line.
+  // Hanging-indent lists already account for the marker via the hanging
+  // gap (see baseFirstLineWidth shrinking through firstLineOffset).
+  if (
+    attrs?.listMarker &&
+    !attrs.listMarkerHidden &&
+    !((indent?.hanging ?? 0) > 0)
+  ) {
+    const markerFontSize =
+      attrs.listMarkerFontSize ?? attrs.defaultFontSize ?? DEFAULT_FONT_SIZE;
+    const markerFontFamily =
+      attrs.listMarkerFontFamily ??
+      attrs.defaultFontFamily ??
+      DEFAULT_FONT_FAMILY;
+    const markerStyle: FontStyle = {
+      fontFamily: markerFontFamily,
+      fontSize: markerFontSize,
+    };
+    const markerTextWidth = measureTextWidth(attrs.listMarker, markerStyle);
+    // 12 px tab-after gap, matching the painter's `paddingRight: 12px`
+    // on the marker box for first-line-indent lists.
+    const markerSlotWidth = markerTextWidth + 12;
+    baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerSlotWidth);
+  }
 
   // Track cumulative height for floating zone calculations
   let cumulativeHeight = 0;

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -680,13 +680,25 @@ export function measureParagraph(
 
     if (isImageRun(run)) {
       const wrapType = run.wrapType;
+      // Match the painter's `isFloatingImageRun` classification —
+      // including `behind` / `inFront` (wrapNone). These images are
+      // anchored at absolute coordinates and the painter lifts them
+      // out of the paragraph flow, so the measurer must also skip
+      // them: otherwise the line reserves the image's inline width
+      // and height while the painter renders it as an overlay,
+      // leaving phantom gaps in the body text (Codex PR #258 review).
+      // Drop the `run.position` precondition too — wrapNone images
+      // can be authored without an explicit `<wp:positionH>` and
+      // still shouldn't contribute to inline metrics.
       const isFloating =
         run.displayMode === "float" ||
-        (wrapType && ["square", "tight", "through"].includes(wrapType));
+        wrapType === "square" ||
+        wrapType === "tight" ||
+        wrapType === "through" ||
+        wrapType === "behind" ||
+        wrapType === "inFront";
 
-      // Skip truly floating images - they don't contribute to line height
-      // (they are positioned absolutely and text wraps around them)
-      if (run.position && isFloating) {
+      if (isFloating) {
         currentLine.toRun = runIndex;
         currentLine.toChar = 1;
         continue;

--- a/packages/folio/src/core/layout-bridge/runInChain.test.ts
+++ b/packages/folio/src/core/layout-bridge/runInChain.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock } from "../layout-engine/types";
+import { schema } from "../prosemirror/schema";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+// Run-in heading chains (`<w:specVanish/>` on the paragraph mark of
+// every heading in a sequence). Word collapses the whole chain into
+// the first body paragraph that lacks specVanish — see ECMA-376
+// §17.3.1.32 and Codex's PR #258 review.
+//
+// `mergeRunInParagraphs` must keep folding while the merged block
+// still carries `runInWithNext`. A previous version stopped after one
+// fold, so chained run-in headings followed by body produced two
+// visual lines instead of one.
+
+describe("toFlowBlocks — chained run-in heading paragraphs", () => {
+  test("two consecutive run-in headings merge with the body paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { runInWithNext: true }, [
+        schema.text("Heading A"),
+      ]),
+      schema.node("paragraph", { runInWithNext: true }, [
+        schema.text(" Heading B"),
+      ]),
+      schema.node("paragraph", null, [
+        schema.text(". Body text continues here."),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+
+    // All three paragraphs should collapse into a single block.
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    expect(paragraphs.length).toBe(1);
+
+    const merged = paragraphs[0] as ParagraphBlock;
+    // Combined runs preserve the document order.
+    const text = merged.runs
+      .filter((r) => r.kind === "text")
+      .map((r) => (r as { text?: string }).text ?? "")
+      .join("");
+    expect(text).toBe("Heading A Heading B. Body text continues here.");
+    // The merged block does not carry `runInWithNext` — the chain
+    // terminates at the body paragraph that lacks specVanish.
+    expect(merged.attrs?.runInWithNext).toBeUndefined();
+  });
+
+  test("single run-in heading still merges with the next paragraph", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { runInWithNext: true }, [
+        schema.text("Severability"),
+      ]),
+      schema.node("paragraph", null, [schema.text(". The invalidity ...")]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    expect(paragraphs.length).toBe(1);
+  });
+
+  test("run-in heading at end-of-doc with no following paragraph stays standalone", () => {
+    // Defensive: a doc that ends with a specVanish paragraph (no
+    // body to merge with) must still emit one paragraph block.
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { runInWithNext: true }, [
+        schema.text("Trailing heading"),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    expect(paragraphs.length).toBe(1);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1882,47 +1882,55 @@ export function toFlowBlocks(
 function mergeRunInParagraphs(blocks: FlowBlock[]): FlowBlock[] {
   const out: FlowBlock[] = [];
   for (let i = 0; i < blocks.length; i++) {
-    const current = blocks[i];
+    let current = blocks[i];
     if (!current) {
       continue;
     }
-    if (
-      current.kind === "paragraph" &&
-      (current as ParagraphBlock).attrs?.runInWithNext
+    // Chain merge: keep folding consecutive paragraphs while the
+    // *current* (possibly already-merged) block carries
+    // `runInWithNext` and the next block is also a paragraph. Per
+    // ECMA-376 §17.3.1.32 and Word's behaviour, a sequence of
+    // `<w:specVanish/>` paragraphs flows inline through the first
+    // body paragraph that lacks it (Codex PR #258 review).
+    while (
+      current?.kind === "paragraph" &&
+      (current as ParagraphBlock).attrs?.runInWithNext &&
+      i + 1 < blocks.length
     ) {
       const next = blocks[i + 1];
-      if (next && next.kind === "paragraph") {
-        const a = current as ParagraphBlock;
-        const b = next as ParagraphBlock;
-        const mergedAttrs: ParagraphAttrs = { ...a.attrs };
-        // Heading typically has no spaceAfter; the body's spaceAfter
-        // governs the merged paragraph's trailing gap.
-        if (b.attrs?.spacing?.after !== undefined) {
-          mergedAttrs.spacing = {
-            ...mergedAttrs.spacing,
-            after: b.attrs.spacing.after,
-          };
-        }
-        // Drop the run-in flag unless the second para is also
-        // specVanish (rare); then a future iteration would chain.
-        if (b.attrs?.runInWithNext) {
-          mergedAttrs.runInWithNext = true;
-        } else {
-          delete mergedAttrs.runInWithNext;
-        }
-        const merged: ParagraphBlock = {
-          ...a,
-          runs: [...a.runs, ...b.runs],
-          attrs: mergedAttrs,
-        };
-        const mergedPmEnd = b.pmEnd ?? a.pmEnd;
-        if (mergedPmEnd !== undefined) {
-          merged.pmEnd = mergedPmEnd;
-        }
-        out.push(merged);
-        i += 1; // consumed `next`
-        continue;
+      if (!next || next.kind !== "paragraph") {
+        break;
       }
+      const a = current as ParagraphBlock;
+      const b = next as ParagraphBlock;
+      const mergedAttrs: ParagraphAttrs = { ...a.attrs };
+      // Heading typically has no spaceAfter; the body's spaceAfter
+      // governs the merged paragraph's trailing gap.
+      if (b.attrs?.spacing?.after !== undefined) {
+        mergedAttrs.spacing = {
+          ...mergedAttrs.spacing,
+          after: b.attrs.spacing.after,
+        };
+      }
+      // Carry forward `runInWithNext` only if the *consumed* second
+      // paragraph itself was specVanish — the while condition above
+      // then triggers another fold against the paragraph after it.
+      if (b.attrs?.runInWithNext) {
+        mergedAttrs.runInWithNext = true;
+      } else {
+        delete mergedAttrs.runInWithNext;
+      }
+      const merged: ParagraphBlock = {
+        ...a,
+        runs: [...a.runs, ...b.runs],
+        attrs: mergedAttrs,
+      };
+      const mergedPmEnd = b.pmEnd ?? a.pmEnd;
+      if (mergedPmEnd !== undefined) {
+        merged.pmEnd = mergedPmEnd;
+      }
+      current = merged;
+      i += 1; // consumed `next`; fold further if the merged block still has the flag
     }
     out.push(current);
   }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -924,6 +924,25 @@ function convertParagraphAttrs(
     if (typeof spaceAfter === "number") {
       attrs.spacing.after = twipsToPixels(spaceAfter);
     }
+    // Propagate the `spacingExplicit` flag the PM schema carries — empty
+    // paragraphs inherit zero spacing unless the side was set inline (Word
+    // fidelity, eigenpal #402).
+    const pmSpacingExplicit = pmAttrs.spacingExplicit as
+      | { before?: boolean; after?: boolean }
+      | null
+      | undefined;
+    if (pmSpacingExplicit) {
+      const explicit: { before?: boolean; after?: boolean } = {};
+      if (pmSpacingExplicit.before) {
+        explicit.before = true;
+      }
+      if (pmSpacingExplicit.after) {
+        explicit.after = true;
+      }
+      if (explicit.before !== undefined || explicit.after !== undefined) {
+        attrs.spacingExplicit = explicit;
+      }
+    }
     if (typeof lineSpacing === "number") {
       // Line spacing in twips - convert to multiplier or exact
       if (

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -790,7 +790,14 @@ function paragraphToRuns(
       );
       runs.push(run);
     } else if (child.type.name === "field") {
-      // Field node — convert to FieldRun for render-time substitution
+      // Field node — convert to FieldRun for render-time substitution.
+      //
+      // Marks on the field node (bold/italic/underline applied to the field
+      // result inside `<w:fldChar separate>...</w:fldChar end>`) must
+      // propagate to the run formatting, otherwise complex REF fields whose
+      // visible text was authored as underlined (e.g. cross-references like
+      // "Exhibit A" / "Section 1.3" in NVCA-style templates) render with no
+      // underline. Reuse the same extractor text runs use.
       const ft = child.attrs["fieldType"] as string;
       const mappedType: FieldRun["fieldType"] =
         ft === "PAGE"
@@ -802,12 +809,14 @@ function paragraphToRuns(
               : ft === "TIME"
                 ? "TIME"
                 : "OTHER";
+      const fieldFormatting = extractRunFormatting(child.marks, theme);
       const run: FieldRun = {
         kind: "field",
         fieldType: mappedType,
         fallback: (child.attrs["displayText"] as string) || "",
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
+        ...fieldFormatting,
       };
       runs.push(run);
     } else if (child.type.name === "math") {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1072,9 +1072,16 @@ function convertParagraphAttrs(
     }
   }
 
-  // Shading (background color)
-  if (pmAttrs.shading?.fill?.rgb) {
-    attrs.shading = `#${pmAttrs.shading.fill.rgb}`;
+  // Shading (background color). Word's `Normal` paragraph style commonly
+  // sets `<w:shd val="clear" fill="FFFFFF"/>` — semantically a no-op on
+  // a white page, but folio's dark mode draws the literal `#FFFFFF`
+  // fill as a visible white block over the dark canvas. Treat any white
+  // shading as transparent (= page background) so it renders the same as
+  // "no shading" in both modes. Other shading colors are preserved
+  // verbatim so authored highlights stay visible.
+  const shadingRgb = pmAttrs.shading?.fill?.rgb?.toUpperCase();
+  if (shadingRgb && shadingRgb !== "FFFFFF" && shadingRgb !== "FFFFFE") {
+    attrs.shading = `#${pmAttrs.shading?.fill?.rgb}`;
   }
 
   // Tab stops

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1111,6 +1111,9 @@ function convertParagraphAttrs(
   if (pmAttrs.contextualSpacing) {
     attrs.contextualSpacing = true;
   }
+  if (pmAttrs.runInWithNext) {
+    attrs.runInWithNext = true;
+  }
   if (pmAttrs.bidi) {
     attrs.bidi = true;
   }
@@ -1855,5 +1858,73 @@ export function toFlowBlocks(
     }
   });
 
-  return blocks;
+  return mergeRunInParagraphs(blocks);
+}
+
+/**
+ * Merge consecutive paragraph blocks where the first carries
+ * `runInWithNext` (`<w:specVanish/>` on the paragraph mark).
+ *
+ * Word's run-in heading feature renders the next paragraph inline on
+ * the same line, so for layout we collapse the pair into one
+ * ParagraphBlock with combined runs. The merged block keeps the first
+ * paragraph's attrs (heading formatting, list marker, indent) and
+ * extends pmEnd to the second paragraph's range so click-to-position
+ * resolution still maps both ranges back to body content.
+ *
+ * Chains: runInWithNext on the merged block is dropped because the
+ * second paragraph's mark wasn't `specVanish`. If a chain of
+ * specVanish paragraphs needs collapsing (rare in practice), the loop
+ * naturally handles it by re-inspecting the merged block's flag (we
+ * preserve runInWithNext only when the second paragraph itself has
+ * specVanish).
+ */
+function mergeRunInParagraphs(blocks: FlowBlock[]): FlowBlock[] {
+  const out: FlowBlock[] = [];
+  for (let i = 0; i < blocks.length; i++) {
+    const current = blocks[i];
+    if (!current) {
+      continue;
+    }
+    if (
+      current.kind === "paragraph" &&
+      (current as ParagraphBlock).attrs?.runInWithNext
+    ) {
+      const next = blocks[i + 1];
+      if (next && next.kind === "paragraph") {
+        const a = current as ParagraphBlock;
+        const b = next as ParagraphBlock;
+        const mergedAttrs: ParagraphAttrs = { ...a.attrs };
+        // Heading typically has no spaceAfter; the body's spaceAfter
+        // governs the merged paragraph's trailing gap.
+        if (b.attrs?.spacing?.after !== undefined) {
+          mergedAttrs.spacing = {
+            ...mergedAttrs.spacing,
+            after: b.attrs.spacing.after,
+          };
+        }
+        // Drop the run-in flag unless the second para is also
+        // specVanish (rare); then a future iteration would chain.
+        if (b.attrs?.runInWithNext) {
+          mergedAttrs.runInWithNext = true;
+        } else {
+          delete mergedAttrs.runInWithNext;
+        }
+        const merged: ParagraphBlock = {
+          ...a,
+          runs: [...a.runs, ...b.runs],
+          attrs: mergedAttrs,
+        };
+        const mergedPmEnd = b.pmEnd ?? a.pmEnd;
+        if (mergedPmEnd !== undefined) {
+          merged.pmEnd = mergedPmEnd;
+        }
+        out.push(merged);
+        i += 1; // consumed `next`
+        continue;
+      }
+    }
+    out.push(current);
+  }
+  return out;
 }

--- a/packages/folio/src/core/layout-engine/emptyParagraphSpacing.test.ts
+++ b/packages/folio/src/core/layout-engine/emptyParagraphSpacing.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type {
+  FlowBlock,
+  LayoutOptions,
+  Measure,
+  ParagraphAttrs,
+  ParagraphBlock,
+  ParagraphMeasure,
+  PageMargins,
+} from "./types";
+
+// Issue #402 (eigenpal): Word collapses style-inherited spacing on empty
+// paragraphs (only direct `<w:pPr><w:spacing>` formatting survives). The
+// engine consults `attrs.spacingExplicit` to distinguish: if the field for
+// `before`/`after` is falsy, an empty paragraph carries no spacing on that
+// side regardless of what the inherited style would have set.
+
+const PAGE_SIZE = { w: 600, h: 1200 };
+const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
+
+function makePara(
+  id: number,
+  text: string,
+  attrs: ParagraphAttrs,
+): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id,
+    runs: [{ kind: "text", text, pmStart: 1, pmEnd: 1 + text.length }],
+    attrs,
+    pmStart: 1,
+    pmEnd: 1 + text.length + 1,
+  };
+}
+
+function makeMeasure(lineHeight: number): ParagraphMeasure {
+  return {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 0,
+        width: 100,
+        ascent: lineHeight * 0.8,
+        descent: lineHeight * 0.2,
+        lineHeight,
+      },
+    ],
+    totalHeight: lineHeight,
+  };
+}
+
+const layoutOptions: LayoutOptions = {
+  pageSize: PAGE_SIZE,
+  margins: MARGINS,
+  pageGap: 20,
+};
+
+describe("empty-paragraph spacing collapse (issue #402)", () => {
+  test("inherited spacing on an empty paragraph does not push the next paragraph", () => {
+    // Empty paragraph with style-inherited before:80, after:80 (no
+    // spacingExplicit). The engine zeroes both sides for this one only.
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      // Empty paragraph — runs is a single empty TextRun. spacingExplicit absent.
+      makePara(1, "", { spacing: { before: 80, after: 80 } }),
+      makePara(2, "Body", { spacing: { before: 0 } }),
+    ];
+    const measures: Measure[] = [
+      makeMeasure(16),
+      makeMeasure(16),
+      makeMeasure(16),
+    ];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+    expect(fragments).toHaveLength(3);
+
+    // p0: y=0; p1: y=16 (no inherited before applied); p2: y=32 (no
+    // inherited after carried forward by p1).
+    expect(fragments[0]!.y).toBe(0);
+    expect(fragments[1]!.y).toBe(16);
+    expect(fragments[2]!.y).toBe(32);
+  });
+
+  test("explicit inline spacing on an empty paragraph IS honored", () => {
+    // The user authored <w:p><w:pPr><w:spacing w:before="80"/></w:pPr></w:p>
+    // (typed a blank line with explicit spacing). spacingExplicit.before=true,
+    // so the value survives the empty-paragraph collapse.
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      makePara(1, "", {
+        spacing: { before: 80, after: 0 },
+        spacingExplicit: { before: true },
+      }),
+      makePara(2, "Body", { spacing: { before: 0 } }),
+    ];
+    const measures: Measure[] = [
+      makeMeasure(16),
+      makeMeasure(16),
+      makeMeasure(16),
+    ];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+
+    // p1's explicit before:80 honored, so p1 starts at y=16+80=96 and
+    // p2 follows at y=96+16=112.
+    expect(fragments[1]!.y).toBe(96);
+    expect(fragments[2]!.y).toBe(112);
+  });
+
+  test("non-empty paragraphs always carry their inherited spacing", () => {
+    // Sanity: the collapse only applies to empty paragraphs.
+    const blocks: FlowBlock[] = [
+      makePara(0, "Heading", { spacing: { after: 0 } }),
+      makePara(1, "Body line", { spacing: { before: 80, after: 0 } }),
+    ];
+    const measures: Measure[] = [makeMeasure(16), makeMeasure(16)];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    const fragments = layout.pages[0]!.fragments;
+
+    // p1 has visible content, so its inherited before:80 applies.
+    expect(fragments[1]!.y).toBe(96);
+  });
+});

--- a/packages/folio/src/core/layout-engine/footnoteLineReservation.test.ts
+++ b/packages/folio/src/core/layout-engine/footnoteLineReservation.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type {
+  FlowBlock,
+  LayoutOptions,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  PageMargins,
+  TextRun,
+} from "./types";
+
+// Single-pass footnote layout: each body line carrying a footnote ref
+// reserves space for that fn's content on the same page. Replaces the
+// earlier static-reservation + iterative-convergence loop, which
+// produced either body-overflow into the footer or large gaps above
+// the fn area on documents with multiple long footnotes per page.
+
+const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
+
+function makePara(
+  id: number,
+  runs: TextRun[],
+  lineCount: number,
+  lineHeight: number,
+  fromRunPerLine: number[] = Array.from({ length: lineCount }, () => 0),
+  toRunPerLine: number[] = Array.from(
+    { length: lineCount },
+    () => runs.length - 1,
+  ),
+): { block: ParagraphBlock; measure: ParagraphMeasure } {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id,
+    runs,
+    attrs: {},
+    pmStart: 1,
+    pmEnd: 100,
+  };
+  const lines = Array.from({ length: lineCount }, (_, i) => ({
+    fromRun: fromRunPerLine[i] ?? 0,
+    fromChar: 0,
+    toRun: toRunPerLine[i] ?? runs.length - 1,
+    toChar: 0,
+    width: 100,
+    ascent: lineHeight * 0.8,
+    descent: lineHeight * 0.2,
+    lineHeight,
+  }));
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines,
+    totalHeight: lineHeight * lineCount,
+  };
+  return { block, measure };
+}
+
+function textRun(
+  pmStart: number,
+  text: string,
+  footnoteRefId?: number,
+): TextRun {
+  const run: TextRun = {
+    kind: "text",
+    text,
+    pmStart,
+    pmEnd: pmStart + text.length,
+  };
+  if (footnoteRefId !== undefined) {
+    run.footnoteRefId = footnoteRefId;
+  }
+  return run;
+}
+
+describe("footnote line-level reservation", () => {
+  test("page reserves fn-content space for each line carrying a fn ref", () => {
+    // Page 100 px tall. Line height 10 px. Fn 1 height 30 px.
+    // A 5-line para where line 3 carries fn ref 1 should keep all
+    // five lines on page 1: 5*10 + 30 = 80 ≤ 100.
+    const { block, measure } = makePara(
+      0,
+      [textRun(1, "Line1Line2"), textRun(20, "fn", 1), textRun(22, "moretext")],
+      5,
+      10,
+      [0, 0, 0, 1, 2],
+      [0, 0, 1, 2, 2],
+    );
+    // Line 2 (index 2) covers runs 0..1 — the fn ref run is in line 2.
+
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[1, 30]]),
+    };
+
+    const blocks: FlowBlock[] = [block];
+    const measures: Measure[] = [measure];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+
+    // All 5 lines must be on page 1 (50 px body + 30 px fn = 80 px ≤ 100).
+    const page1 = layout.pages[0]!;
+    const para = page1.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 0,
+    );
+    expect(para).toBeDefined();
+    expect(page1.footnoteReservedHeight).toBeGreaterThanOrEqual(30);
+  });
+
+  test("page advances when a fn-bearing line cannot fit alongside its fn", () => {
+    // Page 50 px tall. 5 lines × 10 px = 50 px = full page (no fn).
+    // Add fn ref of height 40 px to line 4. Line 4 + fn don't fit on
+    // page 1 alongside lines 1-3 (3*10 + 10 + 40 = 80 > 50). The line
+    // (and the fn) must move to page 2.
+    const { block, measure } = makePara(
+      0,
+      [textRun(1, "Line1"), textRun(10, "fn", 7)],
+      5,
+      10,
+      [0, 0, 0, 0, 1],
+      [0, 0, 0, 0, 1],
+    );
+
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 50 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[7, 40]]),
+    };
+
+    const layout = layoutDocument([block], [measure], layoutOptions);
+
+    expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+    // Page 1 has no fn reservation (no fn-bearing line landed there).
+    expect(layout.pages[0]!.footnoteReservedHeight ?? 0).toBe(0);
+    // Page 2 carries the fn for the moved line.
+    const p2Fn = layout.pages[1]!.footnoteReservedHeight ?? 0;
+    expect(p2Fn).toBeGreaterThanOrEqual(40);
+  });
+
+  test("ignored when footnoteHeightById is not provided", () => {
+    // Without the fn-height table, the engine falls back to the static
+    // (pre-fix) behaviour: fn refs are treated as ordinary text runs
+    // and contribute zero reservation. Layout fits all lines on one
+    // page with no `footnoteReservedHeight` set.
+    const { block, measure } = makePara(0, [textRun(1, "x", 1)], 3, 10);
+
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    const layout = layoutDocument([block], [measure], layoutOptions);
+
+    expect(layout.pages.length).toBe(1);
+    expect(layout.pages[0]!.footnoteReservedHeight).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-engine/footnoteSplitParagraph.test.ts
+++ b/packages/folio/src/core/layout-engine/footnoteSplitParagraph.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type {
+  FlowBlock,
+  LayoutOptions,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  PageMargins,
+  TextRun,
+} from "./types";
+
+// Regression: when a paragraph is split across pages and the
+// footnote ref lives in a continuation fragment, the fn must be
+// attributed to the page where the ref-bearing *line* actually
+// landed — not to the page hosting the first fragment of the
+// paragraph.
+//
+// Pre-fix the engine reserved space correctly per line, but the
+// post-layout `mapFootnotesToPages` looked at fragment-level
+// pmStart/pmEnd. Both halves of a split paragraph carry the full
+// paragraph span, so a ref in the second half could be reported as
+// belonging to the first half's page (Codex PR #258 review).
+
+const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
+
+function textRun(
+  pmStart: number,
+  text: string,
+  footnoteRefId?: number,
+): TextRun {
+  const run: TextRun = {
+    kind: "text",
+    text,
+    pmStart,
+    pmEnd: pmStart + text.length,
+  };
+  if (footnoteRefId !== undefined) {
+    run.footnoteRefId = footnoteRefId;
+  }
+  return run;
+}
+
+function makeMultiLinePara(
+  id: number,
+  lineCount: number,
+  lineHeight: number,
+  fnRefAtLineIndex: number,
+  fnId: number,
+): { block: ParagraphBlock; measure: ParagraphMeasure } {
+  // One run per line so the per-line `[fromRun..toRun]` mapping is
+  // trivial; the fn ref sits on the run for `fnRefAtLineIndex`.
+  const runs: TextRun[] = Array.from({ length: lineCount }, (_, i) =>
+    textRun(1 + i * 10, `line${i}`, i === fnRefAtLineIndex ? fnId : undefined),
+  );
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id,
+    runs,
+    attrs: {},
+    pmStart: 1,
+    pmEnd: 1 + lineCount * 10,
+  };
+  const lines = Array.from({ length: lineCount }, (_, i) => ({
+    fromRun: i,
+    fromChar: 0,
+    toRun: i,
+    toChar: 0,
+    width: 100,
+    ascent: lineHeight * 0.8,
+    descent: lineHeight * 0.2,
+    lineHeight,
+  }));
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines,
+    totalHeight: lineHeight * lineCount,
+  };
+  return { block, measure };
+}
+
+describe("footnote routing across split paragraphs", () => {
+  test("fn ref in continuation fragment is attributed to its host page", () => {
+    // Page content area = 50 px, line height = 10. A 10-line paragraph
+    // splits 5 lines on page 1, 5 lines on page 2. Put the fn ref on
+    // line index 7 (second half) — it should land on page 2, not on
+    // page 1. The fn content height is 30 px, comfortably fitting
+    // alongside lines 5-9 on page 2 (50 - 30 = 20 px slack).
+    const { block, measure } = makeMultiLinePara(0, 10, 10, 7, 99);
+
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 50 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[99, 30]]),
+    };
+
+    const layout = layoutDocument(
+      [block as FlowBlock],
+      [measure as Measure],
+      layoutOptions,
+    );
+
+    expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+    // Page 1 should NOT have fn 99 attributed to it.
+    const p1Ids = layout.pages[0]!.footnoteIds ?? [];
+    expect(p1Ids).not.toContain(99);
+    // Page 2 (or wherever the ref-bearing line actually landed) is
+    // the host page; assert fn 99 is attributed there.
+    const hostPage = layout.pages.find((p) =>
+      (p.footnoteIds ?? []).includes(99),
+    );
+    expect(hostPage).toBeDefined();
+    expect(hostPage!.number).toBeGreaterThanOrEqual(2);
+  });
+
+  test("fn ref in first fragment is attributed to page 1", () => {
+    // Sanity: ref on line 1 (first half) → page 1.
+    const { block, measure } = makeMultiLinePara(0, 10, 10, 1, 42);
+
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 60 },
+      margins: MARGINS,
+      pageGap: 0,
+      footnoteHeightById: new Map([[42, 20]]),
+    };
+
+    const layout = layoutDocument(
+      [block as FlowBlock],
+      [measure as Measure],
+      layoutOptions,
+    );
+    expect(layout.pages[0]!.footnoteIds).toContain(42);
+  });
+});

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -10,7 +10,7 @@ import {
   getMidChainIndices,
   hasPageBreakBefore,
 } from "./keep-together";
-import { createPaginator } from "./paginator";
+import { FOOTNOTE_SEPARATOR_HEIGHT, createPaginator } from "./paginator";
 import type {
   FlowBlock,
   Measure,
@@ -528,8 +528,19 @@ function layoutParagraph(
     // onto a page that has only a hair of body space left — body fits
     // by itself but `addFootnoteHeight` afterwards drops contentBottom
     // below cursorY, producing an overlap with the fn area.
+    //
+    // If this would be the *first* footnote on the host page, also
+    // include `FOOTNOTE_SEPARATOR_HEIGHT` in the fit check —
+    // `addFootnoteHeight` reserves it on the first call, and missing
+    // it here lets a boundary-case line slip onto a page where the
+    // separator's 13 px shrinks contentBottom past cursorY (Codex
+    // PR #258 — same overlap class as the linesFnHeight gap).
     if (linesFnHeight > 0) {
-      paginator.ensureFits(effectiveSpaceBefore + linesHeight + linesFnHeight);
+      const isFirstFnOnPage = paginator.getCurrentState().footnoteHeight === 0;
+      const separatorOverhead = isFirstFnOnPage ? FOOTNOTE_SEPARATOR_HEIGHT : 0;
+      paginator.ensureFits(
+        effectiveSpaceBefore + linesHeight + linesFnHeight + separatorOverhead,
+      );
     }
 
     const result = paginator.addFragment(

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -376,18 +376,25 @@ export function layoutDocument(
 }
 
 /**
- * Sum of footnote content heights for refs whose run sits in line `j`.
- * Empty when the engine isn't tracking dynamic fn demand.
+ * Footnote refs whose run sits in line `[fromRun..toRun]`, with their
+ * pre-measured content heights. Empty when the engine isn't tracking
+ * dynamic fn demand. Used by `layoutParagraph` to (a) reserve fn
+ * height per line and (b) record the IDs on the host page so the
+ * painter renders the fn on the page where the ref-bearing line
+ * actually landed — even when the paragraph splits across pages
+ * (fragment pmStart/pmEnd is paragraph-wide and cannot disambiguate
+ * between split halves).
  */
-function getLineFootnoteHeight(
+function getLineFootnoteRefs(
   block: ParagraphBlock,
   fromRun: number,
   toRun: number,
   fnHeights: Map<number, number> | undefined,
-): number {
+): { ids: number[]; height: number } {
   if (!fnHeights) {
-    return 0;
+    return { ids: [], height: 0 };
   }
+  const ids: number[] = [];
   let height = 0;
   for (let r = fromRun; r <= toRun; r++) {
     const run = block.runs[r];
@@ -400,10 +407,11 @@ function getLineFootnoteHeight(
     }
     const h = fnHeights.get(id);
     if (h !== undefined) {
+      ids.push(id);
       height += h;
     }
   }
-  return height;
+  return { ids, height };
 }
 
 /**
@@ -465,6 +473,7 @@ function layoutParagraph(
     // Calculate how many lines fit
     let linesHeight = 0;
     let linesFnHeight = 0;
+    const linesFnIds: number[] = [];
     let fittingLines = 0;
 
     // The first fragment of a paragraph eats `spaceBefore` from the
@@ -482,7 +491,7 @@ function layoutParagraph(
     for (let j = currentLineIndex; j < lines.length; j++) {
       const line = lines[j]!; // SAFETY: j < lines.length
       const lineHeight = line.lineHeight;
-      const lineFnHeight = getLineFootnoteHeight(
+      const lineRefs = getLineFootnoteRefs(
         block,
         line.fromRun,
         line.toRun,
@@ -490,11 +499,17 @@ function layoutParagraph(
       );
       const totalWithLine = linesHeight + lineHeight;
       const withSpacing =
-        totalWithLine + firstFragmentSpaceBefore + linesFnHeight + lineFnHeight;
+        totalWithLine +
+        firstFragmentSpaceBefore +
+        linesFnHeight +
+        lineRefs.height;
 
       if (withSpacing <= availableHeight || fittingLines === 0) {
         linesHeight = totalWithLine;
-        linesFnHeight += lineFnHeight;
+        linesFnHeight += lineRefs.height;
+        for (const id of lineRefs.ids) {
+          linesFnIds.push(id);
+        }
         fittingLines++;
       } else {
         break;
@@ -552,11 +567,14 @@ function layoutParagraph(
     fragment.y = result.y;
 
     // Now that the lines have committed to this page, grow the page's
-    // footnote reservation for any fn refs they carry. Subsequent body
-    // (in this paragraph or the next block) will see the reduced
-    // `getAvailableHeight()` and split correctly.
+    // footnote reservation for any fn refs they carry, and record the
+    // IDs on the host page directly. Page → fn-ID mapping is driven by
+    // line-level placement here (not by post-layout pmRange mapping)
+    // so a fn ref that lives in a continuation fragment of a split
+    // paragraph is correctly attributed to the page where the
+    // ref-bearing line landed (Codex PR #258 review).
     if (linesFnHeight > 0) {
-      paginator.addFootnoteHeight(linesFnHeight);
+      paginator.addFootnoteHeight(linesFnHeight, linesFnIds);
     }
 
     currentLineIndex += fittingLines;

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -249,6 +249,9 @@ export function layoutDocument(
   const paginator = createPaginator({
     pageSize: initialConfig.pageSize,
     margins: initialConfig.margins,
+    ...(options.firstPageMargins !== undefined
+      ? { firstPageMargins: options.firstPageMargins }
+      : {}),
     columns: initialConfig.columns ?? DEFAULT_COLUMNS,
     ...(options.footnoteReservedHeights !== undefined
       ? { footnoteReservedHeights: options.footnoteReservedHeights }

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -544,22 +544,31 @@ function layoutParagraph(
     // by itself but `addFootnoteHeight` afterwards drops contentBottom
     // below cursorY, producing an overlap with the fn area.
     //
-    // Always include `FOOTNOTE_SEPARATOR_HEIGHT` in the fit check.
-    // We can't gate on the *current* page's `isFirstFnOnPage` flag —
-    // `ensureFits` may advance to a fresh page where this would be
-    // the first footnote, and the separator that `addFootnoteHeight`
-    // then reserves would push contentBottom past the just-committed
-    // line (Codex PR #258 review). Over-reserving 13 px on a page
-    // that already has a footnote is harmless; under-reserving on a
-    // freshly-advanced page reintroduces the overlap class this
-    // preflight is meant to prevent.
+    // Two-phase check (Codex PR #258 reviews — both edges):
+    //
+    // 1. Try without the separator overhead. The current page may
+    //    already host a footnote — in that case `addFootnoteHeight`
+    //    will *not* reserve another separator, so adding 13 px here
+    //    would force an unnecessary page advance and split the
+    //    paragraph between pages even though the line + fn still fit.
+    //
+    // 2. After the first `ensureFits`, re-read the page state. If we
+    //    landed on a *fresh* page (`footnoteHeight === 0`), the next
+    //    `addFootnoteHeight` call *will* reserve a separator — so we
+    //    need to verify the line + fn + separator all still fit on
+    //    that page. Otherwise the post-commit `addFootnoteHeight`
+    //    drops contentBottom past the just-committed line.
     if (linesFnHeight > 0) {
-      paginator.ensureFits(
-        effectiveSpaceBefore +
-          linesHeight +
-          linesFnHeight +
-          FOOTNOTE_SEPARATOR_HEIGHT,
-      );
+      paginator.ensureFits(effectiveSpaceBefore + linesHeight + linesFnHeight);
+      const stateAfter = paginator.getCurrentState();
+      if (stateAfter.footnoteHeight === 0) {
+        paginator.ensureFits(
+          effectiveSpaceBefore +
+            linesHeight +
+            linesFnHeight +
+            FOOTNOTE_SEPARATOR_HEIGHT,
+        );
+      }
     }
 
     const result = paginator.addFragment(

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -306,6 +306,7 @@ export function layoutDocument(
           measure as ParagraphMeasure,
           paginator,
           paginator.getContentWidth(),
+          options.footnoteHeightById,
         );
         break;
 
@@ -375,13 +376,52 @@ export function layoutDocument(
 }
 
 /**
+ * Sum of footnote content heights for refs whose run sits in line `j`.
+ * Empty when the engine isn't tracking dynamic fn demand.
+ */
+function getLineFootnoteHeight(
+  block: ParagraphBlock,
+  fromRun: number,
+  toRun: number,
+  fnHeights: Map<number, number> | undefined,
+): number {
+  if (!fnHeights) {
+    return 0;
+  }
+  let height = 0;
+  for (let r = fromRun; r <= toRun; r++) {
+    const run = block.runs[r];
+    if (!run || run.kind !== "text") {
+      continue;
+    }
+    const id = (run as { footnoteRefId?: number }).footnoteRefId;
+    if (id === undefined) {
+      continue;
+    }
+    const h = fnHeights.get(id);
+    if (h !== undefined) {
+      height += h;
+    }
+  }
+  return height;
+}
+
+/**
  * Layout a paragraph block onto pages.
+ *
+ * When `footnoteHeightById` is provided, each line carrying a footnote
+ * ref additionally reserves space on its host page for the fn's
+ * content. Pagination decisions look at the line's effective height
+ * (`lineHeight + lineFnHeight`) so a line cannot land on a page that
+ * lacks room for both — preventing footnote overflow without the
+ * static-reservation iteration loop.
  */
 function layoutParagraph(
   block: ParagraphBlock,
   measure: ParagraphMeasure,
   paginator: ReturnType<typeof createPaginator>,
   contentWidth: number,
+  footnoteHeightById?: Map<number, number>,
 ): void {
   if (measure.kind !== "paragraph") {
     throw new Error(`layoutParagraph: expected paragraph measure`);
@@ -424,6 +464,7 @@ function layoutParagraph(
 
     // Calculate how many lines fit
     let linesHeight = 0;
+    let linesFnHeight = 0;
     let fittingLines = 0;
 
     // The first fragment of a paragraph eats `spaceBefore` from the
@@ -439,12 +480,21 @@ function layoutParagraph(
     const firstFragmentSpaceBefore = currentLineIndex === 0 ? spaceBefore : 0;
 
     for (let j = currentLineIndex; j < lines.length; j++) {
-      const lineHeight = lines[j]!.lineHeight; // SAFETY: j < lines.length
+      const line = lines[j]!; // SAFETY: j < lines.length
+      const lineHeight = line.lineHeight;
+      const lineFnHeight = getLineFootnoteHeight(
+        block,
+        line.fromRun,
+        line.toRun,
+        footnoteHeightById,
+      );
       const totalWithLine = linesHeight + lineHeight;
-      const withSpacing = totalWithLine + firstFragmentSpaceBefore;
+      const withSpacing =
+        totalWithLine + firstFragmentSpaceBefore + linesFnHeight + lineFnHeight;
 
       if (withSpacing <= availableHeight || fittingLines === 0) {
         linesHeight = totalWithLine;
+        linesFnHeight += lineFnHeight;
         fittingLines++;
       } else {
         break;
@@ -472,6 +522,16 @@ function layoutParagraph(
       ...(!isLastFragment ? { continuesOnNext: true } : {}),
     };
 
+    // Ensure the page can accommodate body lines + footnote demand
+    // *together* before placing. Without this, the `fittingLines === 0`
+    // fallback in the loop above may force a line carrying a fn ref
+    // onto a page that has only a hair of body space left — body fits
+    // by itself but `addFootnoteHeight` afterwards drops contentBottom
+    // below cursorY, producing an overlap with the fn area.
+    if (linesFnHeight > 0) {
+      paginator.ensureFits(effectiveSpaceBefore + linesHeight + linesFnHeight);
+    }
+
     const result = paginator.addFragment(
       fragment,
       linesHeight,
@@ -479,6 +539,14 @@ function layoutParagraph(
       effectiveSpaceAfter,
     );
     fragment.y = result.y;
+
+    // Now that the lines have committed to this page, grow the page's
+    // footnote reservation for any fn refs they carry. Subsequent body
+    // (in this paragraph or the next block) will see the reduced
+    // `getAvailableHeight()` and split correctly.
+    if (linesFnHeight > 0) {
+      paginator.addFootnoteHeight(linesFnHeight);
+    }
 
     currentLineIndex += fittingLines;
 

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -88,17 +88,45 @@ export function collectSectionConfigs(
 }
 
 /**
- * Get spacing before a paragraph block.
+ * Whether a paragraph block has no visible content (no runs, or a single
+ * empty text run). Word collapses style-inherited spacing on empty
+ * paragraphs (only direct `<w:pPr><w:spacing>` formatting survives) — see
+ * eigenpal #402.
  */
-function getSpacingBefore(block: ParagraphBlock): number {
-  return block.attrs?.spacing?.before ?? 0;
+function isEmptyParagraph(block: ParagraphBlock): boolean {
+  if (block.runs.length === 0) {
+    return true;
+  }
+  if (block.runs.length !== 1) {
+    return false;
+  }
+  const r = block.runs[0];
+  return r?.kind === "text" && ((r as { text?: string }).text ?? "") === "";
 }
 
 /**
- * Get spacing after a paragraph block.
+ * Get spacing before a paragraph block. Empty paragraphs whose
+ * `before` was inherited from a paragraph style (not set inline) collapse
+ * to zero — Word fidelity for incidental empty separators.
+ */
+function getSpacingBefore(block: ParagraphBlock): number {
+  const value = block.attrs?.spacing?.before ?? 0;
+  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.before) {
+    return 0;
+  }
+  return value;
+}
+
+/**
+ * Get spacing after a paragraph block. Same empty-paragraph collapse rule
+ * as `getSpacingBefore`.
  */
 function getSpacingAfter(block: ParagraphBlock): number {
-  return block.attrs?.spacing?.after ?? 0;
+  const value = block.attrs?.spacing?.after ?? 0;
+  if (isEmptyParagraph(block) && !block.attrs?.spacingExplicit?.after) {
+    return 0;
+  }
+  return value;
 }
 
 /**

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -544,17 +544,21 @@ function layoutParagraph(
     // by itself but `addFootnoteHeight` afterwards drops contentBottom
     // below cursorY, producing an overlap with the fn area.
     //
-    // If this would be the *first* footnote on the host page, also
-    // include `FOOTNOTE_SEPARATOR_HEIGHT` in the fit check —
-    // `addFootnoteHeight` reserves it on the first call, and missing
-    // it here lets a boundary-case line slip onto a page where the
-    // separator's 13 px shrinks contentBottom past cursorY (Codex
-    // PR #258 — same overlap class as the linesFnHeight gap).
+    // Always include `FOOTNOTE_SEPARATOR_HEIGHT` in the fit check.
+    // We can't gate on the *current* page's `isFirstFnOnPage` flag —
+    // `ensureFits` may advance to a fresh page where this would be
+    // the first footnote, and the separator that `addFootnoteHeight`
+    // then reserves would push contentBottom past the just-committed
+    // line (Codex PR #258 review). Over-reserving 13 px on a page
+    // that already has a footnote is harmless; under-reserving on a
+    // freshly-advanced page reintroduces the overlap class this
+    // preflight is meant to prevent.
     if (linesFnHeight > 0) {
-      const isFirstFnOnPage = paginator.getCurrentState().footnoteHeight === 0;
-      const separatorOverhead = isFirstFnOnPage ? FOOTNOTE_SEPARATOR_HEIGHT : 0;
       paginator.ensureFits(
-        effectiveSpaceBefore + linesHeight + linesFnHeight + separatorOverhead,
+        effectiveSpaceBefore +
+          linesHeight +
+          linesFnHeight +
+          FOOTNOTE_SEPARATOR_HEIGHT,
       );
     }
 

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -426,15 +426,22 @@ function layoutParagraph(
     let linesHeight = 0;
     let fittingLines = 0;
 
+    // The first fragment of a paragraph eats `spaceBefore` from the
+    // available height for *every* line check, not only the first one.
+    // Pre-fix the loop checked `linesHeight + lineHeight + spaceBefore`
+    // only when `j === currentLineIndex`; subsequent lines compared bare
+    // line totals against the full available height. That let the loop
+    // claim more lines than would actually fit, then `addFragment` (which
+    // correctly sums `spaceBefore + linesHeight`) refused the placement
+    // and bumped the *whole* fragment to the next page. Result: page-end
+    // paragraphs with multi-line content didn't split — they jumped the
+    // page boundary, leaving a chunk of empty space above.
+    const firstFragmentSpaceBefore = currentLineIndex === 0 ? spaceBefore : 0;
+
     for (let j = currentLineIndex; j < lines.length; j++) {
       const lineHeight = lines[j]!.lineHeight; // SAFETY: j < lines.length
       const totalWithLine = linesHeight + lineHeight;
-
-      // Add space before only for first fragment
-      const withSpacing =
-        currentLineIndex === 0 && j === currentLineIndex
-          ? totalWithLine + spaceBefore
-          : totalWithLine;
+      const withSpacing = totalWithLine + firstFragmentSpaceBefore;
 
       if (withSpacing <= availableHeight || fittingLines === 0) {
         linesHeight = totalWithLine;

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -13,7 +13,7 @@ import type { Page, PageMargins, Fragment, ColumnLayout } from "./types";
  * footnote-bearing page above the fn content. Must match the painter
  * (`renderFootnoteArea`).
  */
-const FOOTNOTE_SEPARATOR_HEIGHT = 13;
+export const FOOTNOTE_SEPARATOR_HEIGHT = 13;
 
 /**
  * Current state of a page being laid out.

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -8,6 +8,14 @@
 import type { Page, PageMargins, Fragment, ColumnLayout } from "./types";
 
 /**
+ * Height of the footnote separator (a 0.5 px divider line + 6 px top
+ * + 6 px bottom margin = 12.5 px, rounded up). Reserved once per
+ * footnote-bearing page above the fn content. Must match the painter
+ * (`renderFootnoteArea`).
+ */
+const FOOTNOTE_SEPARATOR_HEIGHT = 13;
+
+/**
  * Current state of a page being laid out.
  */
 export type PageState = {
@@ -19,8 +27,16 @@ export type PageState = {
   columnIndex: number;
   /** Top margin of content area. */
   topMargin: number;
-  /** Bottom boundary of content area (page height - bottom margin). */
+  /**
+   * Bottom boundary of usable body content area.
+   * Equals `pageBottom - footnoteHeight`. Recomputed when footnote
+   * demand grows (a line carrying a fn ref is placed on this page).
+   */
   contentBottom: number;
+  /** Raw bottom of content area (page height - bottom margin); excludes fn area. */
+  rawContentBottom: number;
+  /** Total height reserved for footnotes on this page (grows as refs are placed). */
+  footnoteHeight: number;
   /** Accumulated trailing spacing (space after previous block). */
   trailingSpacing: number;
 };
@@ -179,7 +195,11 @@ export function createPaginator(options: PaginatorOptions) {
     const topMargin = pageMargins.top;
     const contentBottom = pageSize.h - pageMargins.bottom;
 
-    // Reduce content bottom by footnote reserved height for this page
+    // Reduce content bottom by footnote reserved height for this page.
+    // Used as a static reservation only when the layout engine isn't
+    // tracking footnote demand dynamically per line. The dynamic path
+    // (see `addFootnoteHeight`) starts at zero and grows as fn-ref-
+    // carrying lines are placed.
     const footnoteHeight =
       options.footnoteReservedHeights?.get(pageNumber) ?? 0;
     const pageContentBottom = contentBottom - footnoteHeight;
@@ -200,6 +220,8 @@ export function createPaginator(options: PaginatorOptions) {
       columnIndex: 0,
       topMargin,
       contentBottom: pageContentBottom,
+      rawContentBottom: contentBottom,
+      footnoteHeight,
       trailingSpacing: 0,
     };
 
@@ -334,6 +356,38 @@ export function createPaginator(options: PaginatorOptions) {
   }
 
   /**
+   * Reserve additional footnote area on the current page.
+   *
+   * Called by the layout engine each time a body line carrying a
+   * footnote ref is placed: the page must shrink its body area by
+   * the fn content's height so the fn can render below without
+   * overflowing into the footer. Updates both `state.contentBottom`
+   * (so subsequent line-fitting checks see the reduced space) and
+   * `state.page.footnoteReservedHeight` (so the painter draws the fn
+   * area at the correct top).
+   *
+   * On the first fn added to a page, additionally reserves
+   * `FOOTNOTE_SEPARATOR_HEIGHT` for the divider line + its margins so
+   * the separator stays inside the reserved slot.
+   *
+   * Caller is responsible for ensuring the line itself fits *with*
+   * `additionalHeight` already accounted for; if the line should have
+   * advanced to the next page, the engine must check that *before*
+   * committing the line + reservation.
+   */
+  function addFootnoteHeight(additionalHeight: number): void {
+    if (!Number.isFinite(additionalHeight) || additionalHeight <= 0) {
+      return;
+    }
+    const state = getCurrentState();
+    const separatorOverhead =
+      state.footnoteHeight === 0 ? FOOTNOTE_SEPARATOR_HEIGHT : 0;
+    state.footnoteHeight += additionalHeight + separatorOverhead;
+    state.contentBottom = state.rawContentBottom - state.footnoteHeight;
+    state.page.footnoteReservedHeight = state.footnoteHeight;
+  }
+
+  /**
    * Force a page break - move to a new page.
    */
   function forcePageBreak(breakOptions: ForcePageBreakOptions = {}): PageState {
@@ -447,6 +501,8 @@ export function createPaginator(options: PaginatorOptions) {
     ensureFits,
     /** Add a fragment to current page. */
     addFragment,
+    /** Reserve additional footnote area on the current page. */
+    addFootnoteHeight,
     /** Force a page break. */
     forcePageBreak,
     /** Force a column break. */

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -33,6 +33,13 @@ export type PaginatorOptions = {
   pageSize: { w: number; h: number };
   /** Page margins. */
   margins: PageMargins;
+  /**
+   * Margins applied only to the very first page (page 1) of the paginator.
+   * Used when a `<w:titlePg/>`-enabled section needs different margins for
+   * its title page (typically extended top margin to clear an overflowing
+   * first-page header) vs. its body pages. Pages 2+ use `margins`.
+   */
+  firstPageMargins?: PageMargins;
   /** Column configuration (optional). */
   columns?: ColumnLayout;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
@@ -159,8 +166,18 @@ export function createPaginator(options: PaginatorOptions) {
     }
 
     const pageNumber = pages.length + 1;
-    const topMargin = margins.top;
-    const contentBottom = getContentBottom();
+    // Page 1 of the document may use first-page margins (extended top to
+    // clear an overflowing first-page header on a titlePg section) while
+    // pages 2+ use the regular section margins. Without this distinction
+    // every page in the section would inherit page 1's title-page top
+    // margin, leaving large empty space at the top of pages 2+ on
+    // first-page-header docs (NVCA-style templates).
+    const pageMargins =
+      pageNumber === 1 && options.firstPageMargins
+        ? { ...options.firstPageMargins }
+        : { ...margins };
+    const topMargin = pageMargins.top;
+    const contentBottom = pageSize.h - pageMargins.bottom;
 
     // Reduce content bottom by footnote reserved height for this page
     const footnoteHeight =
@@ -170,7 +187,7 @@ export function createPaginator(options: PaginatorOptions) {
     const page: Page = {
       number: pageNumber,
       fragments: [],
-      margins: { ...margins },
+      margins: pageMargins,
       size: { ...pageSize },
       ...(footnoteHeight > 0 ? { footnoteReservedHeight: footnoteHeight } : {}),
       // Set initial columns; may be overwritten by updateColumns() for continuous section breaks

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -375,7 +375,10 @@ export function createPaginator(options: PaginatorOptions) {
    * advanced to the next page, the engine must check that *before*
    * committing the line + reservation.
    */
-  function addFootnoteHeight(additionalHeight: number): void {
+  function addFootnoteHeight(
+    additionalHeight: number,
+    footnoteIds?: number[],
+  ): void {
     if (!Number.isFinite(additionalHeight) || additionalHeight <= 0) {
       return;
     }
@@ -385,6 +388,20 @@ export function createPaginator(options: PaginatorOptions) {
     state.footnoteHeight += additionalHeight + separatorOverhead;
     state.contentBottom = state.rawContentBottom - state.footnoteHeight;
     state.page.footnoteReservedHeight = state.footnoteHeight;
+    // Record which fn IDs landed on *this* page. Driven by the
+    // line-level placement in the engine (not by post-layout
+    // pmRange mapping) so a fn ref in a continuation fragment of a
+    // split paragraph is correctly attributed to the page where the
+    // ref-bearing line actually lives — Codex PR #258 review.
+    if (footnoteIds && footnoteIds.length > 0) {
+      const existing = state.page.footnoteIds ?? [];
+      for (const id of footnoteIds) {
+        if (!existing.includes(id)) {
+          existing.push(id);
+        }
+      }
+      state.page.footnoteIds = existing;
+    }
   }
 
   /**

--- a/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
+++ b/packages/folio/src/core/layout-engine/paragraphSplitWithSpaceBefore.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+
+import { layoutDocument } from "./index";
+import type {
+  FlowBlock,
+  LayoutOptions,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  PageMargins,
+} from "./types";
+
+// Regression: a multi-line paragraph with `spaceBefore` whose first
+// fragment lands near the bottom of a page must split at the page
+// boundary — *not* jump entirely to the next page.
+//
+// Pre-fix the line-fitting loop only added `spaceBefore` to the
+// `withSpacing <= availableHeight` check on the very first iteration
+// (`j === currentLineIndex`). Subsequent iterations compared a bare
+// `linesHeight + lineHeight` against the full available height, so the
+// loop claimed more lines than would actually fit. `addFragment` then
+// summed `spaceBefore + linesHeight` and refused the placement,
+// punting the *whole* fragment to the next page. The visible symptom
+// was a gap at the bottom of one page and the entire next paragraph
+// starting fresh on the page after — even though several of its lines
+// could have fit. Hit hard on NVCA-style legal templates with long
+// numbered list items (e.g. (iii) Shortfall Closing) sitting after a
+// dense (ii) item.
+
+const MARGINS: PageMargins = { top: 0, right: 0, bottom: 0, left: 0 };
+
+function makePara(
+  id: number,
+  text: string,
+  spacing: { before?: number; after?: number },
+  lineCount: number,
+  lineHeight: number,
+): { block: ParagraphBlock; measure: ParagraphMeasure } {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id,
+    runs: [{ kind: "text", text, pmStart: 1, pmEnd: 1 + text.length }],
+    attrs: { spacing },
+    pmStart: 1,
+    pmEnd: 1 + text.length + 1,
+  };
+  const lines = Array.from({ length: lineCount }, () => ({
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 0,
+    width: 100,
+    ascent: lineHeight * 0.8,
+    descent: lineHeight * 0.2,
+    lineHeight,
+  }));
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines,
+    totalHeight: lineHeight * lineCount,
+  };
+  return { block, measure };
+}
+
+describe("paragraph split with spaceBefore", () => {
+  test("multi-line paragraph splits at page boundary and fills page-end space", () => {
+    // Page content area = 200 px. First paragraph fills 180 px, leaving
+    // 20 px below it. Second paragraph has spaceBefore=10 and 5 lines of
+    // 10 px each (50 px total). With spaceBefore consumed, 10 px remain
+    // for lines — exactly one line fits on the same page; the rest
+    // continue on page 2. Pre-fix the engine bumped the entire 5-line
+    // paragraph to page 2, leaving the 20 px tail of page 1 empty.
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 200 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    const first = makePara(0, "filler", { after: 0 }, 18, 10);
+    const second = makePara(1, "splitMe", { before: 10 }, 5, 10);
+
+    const blocks: FlowBlock[] = [first.block, second.block];
+    const measures: Measure[] = [first.measure, second.measure];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+
+    const page1 = layout.pages[0]!;
+    const page1SecondPara = page1.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    expect(page1SecondPara).toBeDefined();
+    // The first fragment of paragraph 1 must land on page 1, not page 2.
+    expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+    const page2 = layout.pages[1]!;
+    const page2SecondPara = page2.fragments.find(
+      (f) => f.kind === "paragraph" && f.blockId === 1,
+    );
+    // Continuation must exist on page 2.
+    expect(page2SecondPara).toBeDefined();
+  });
+
+  test("paragraph that does not fit at all still splits a single line on the current page when forced", () => {
+    // Sanity: existing `fittingLines === 0` fallback still places at
+    // least one line on the current page even when nothing fits, to
+    // prevent infinite advancing.
+    const layoutOptions: LayoutOptions = {
+      pageSize: { w: 600, h: 100 },
+      margins: MARGINS,
+      pageGap: 0,
+    };
+
+    const tall = makePara(0, "tall", {}, 8, 20);
+    const blocks: FlowBlock[] = [tall.block];
+    const measures: Measure[] = [tall.measure];
+
+    const layout = layoutDocument(blocks, measures, layoutOptions);
+    expect(layout.pages.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -247,6 +247,15 @@ export type ListNumPr = {
 export type ParagraphAttrs = {
   alignment?: "left" | "center" | "right" | "justify";
   spacing?: ParagraphSpacing;
+  /**
+   * Tracks which `spacing` sides came from inline (`<w:pPr><w:spacing>`)
+   * formatting versus inherited via paragraph style. Word collapses
+   * style-inherited spacing on empty paragraphs (only direct formatting
+   * survives), so the layout engine consults this flag in
+   * `getSpacingBefore`/`getSpacingAfter`. Both sides default to false (style
+   * inheritance assumed) when the field is absent.
+   */
+  spacingExplicit?: { before?: boolean; after?: boolean };
   indent?: ParagraphIndent;
   keepNext?: boolean;
   keepLines?: boolean;

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -845,6 +845,18 @@ export type LayoutOptions = {
   evenAndOddHeaders?: boolean;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
   footnoteReservedHeights?: Map<number, number>;
+  /**
+   * Footnote content heights keyed by internal footnote id (the OOXML
+   * `<w:footnoteReference w:id>`). When provided, the layout engine
+   * tracks footnote demand per body line: each line carrying a fn ref
+   * grows its page's reservation by that fn's height before the next
+   * line is fitted. This single-pass approach avoids the static-
+   * reservation + iterative-convergence loop that produced oscillation
+   * (and either body-overflow into the footer or large empty gaps
+   * above the fn area) on documents with multiple long footnotes per
+   * page.
+   */
+  footnoteHeightById?: Map<number, number>;
   /** Section break type for the body-level (final) section (for section transition logic). */
   bodyBreakType?: "continuous" | "nextPage" | "evenPage" | "oddPage";
 };

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -818,6 +818,13 @@ export type LayoutOptions = {
   pageSize: { w: number; h: number };
   /** Initial page margins. */
   margins: PageMargins;
+  /**
+   * Margins applied only to page 1 (the title page) when the first
+   * section has `<w:titlePg/>`. Used to extend the top margin for an
+   * overflowing first-page header without forcing pages 2+ to inherit the
+   * same extension.
+   */
+  firstPageMargins?: PageMargins;
   /** Body-level final section page size. */
   finalPageSize?: { w: number; h: number };
   /** Body-level final section margins. */

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -262,6 +262,13 @@ export type ParagraphAttrs = {
   pageBreakBefore?: boolean;
   styleId?: string;
   contextualSpacing?: boolean;
+  /**
+   * Run-in heading: paragraph mark carries `<w:specVanish/>` and the
+   * next paragraph should flow inline on the same line. The layout
+   * stage merges the next paragraph's runs into this paragraph's
+   * fragment (keeping pmStart/pmEnd intact for editing).
+   */
+  runInWithNext?: boolean;
   /** Right-to-left paragraph direction */
   bidi?: boolean;
   borders?: ParagraphBorders;

--- a/packages/folio/src/core/layout-painter/floatingImageClassification.test.ts
+++ b/packages/folio/src/core/layout-painter/floatingImageClassification.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ImageRun } from "../layout-engine/types";
+import {
+  isFloatingImageRun,
+  isTextWrappingFloatingImageRun,
+} from "./renderUtils";
+
+// Issue #418 (eigenpal): wrapNone images (behind/inFront) are anchored floats
+// but must NOT shrink line widths — text paints over or under them. Folio's
+// previous classifier excluded behind/inFront from "floating" entirely, so
+// they fell back to inline rendering and pushed paragraph flow.
+
+const baseImage = (
+  wrapType: string | undefined,
+  extras: Partial<ImageRun> = {},
+): ImageRun => {
+  const base: ImageRun = {
+    kind: "image",
+    src: "img.png",
+    width: 100,
+    height: 100,
+  };
+  if (wrapType !== undefined) {
+    base.wrapType = wrapType;
+  }
+  return { ...base, ...extras };
+};
+
+describe("isFloatingImageRun (issue #418)", () => {
+  test("recognizes behind as floating", () => {
+    expect(isFloatingImageRun(baseImage("behind"))).toBe(true);
+  });
+
+  test("recognizes inFront as floating", () => {
+    expect(isFloatingImageRun(baseImage("inFront"))).toBe(true);
+  });
+
+  test("recognizes square/tight/through as floating", () => {
+    expect(isFloatingImageRun(baseImage("square"))).toBe(true);
+    expect(isFloatingImageRun(baseImage("tight"))).toBe(true);
+    expect(isFloatingImageRun(baseImage("through"))).toBe(true);
+  });
+
+  test("inline image is not floating", () => {
+    expect(isFloatingImageRun(baseImage("inline"))).toBe(false);
+  });
+
+  test("topAndBottom is not floating (it's a block image)", () => {
+    expect(isFloatingImageRun(baseImage("topAndBottom"))).toBe(false);
+  });
+
+  test("explicit displayMode='float' overrides missing wrapType", () => {
+    expect(
+      isFloatingImageRun(
+        baseImage(undefined, { displayMode: "float", cssFloat: "left" }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("isTextWrappingFloatingImageRun (issue #418)", () => {
+  test("behind images do not wrap text", () => {
+    expect(isTextWrappingFloatingImageRun(baseImage("behind"))).toBe(false);
+  });
+
+  test("inFront images do not wrap text", () => {
+    expect(isTextWrappingFloatingImageRun(baseImage("inFront"))).toBe(false);
+  });
+
+  test("topAndBottom does not wrap text (block, not side-wrapped)", () => {
+    expect(isTextWrappingFloatingImageRun(baseImage("topAndBottom"))).toBe(
+      false,
+    );
+  });
+
+  test("square/tight/through wrap text", () => {
+    expect(isTextWrappingFloatingImageRun(baseImage("square"))).toBe(true);
+    expect(isTextWrappingFloatingImageRun(baseImage("tight"))).toBe(true);
+    expect(isTextWrappingFloatingImageRun(baseImage("through"))).toBe(true);
+  });
+
+  test("explicit cssFloat without wrap type wraps text", () => {
+    expect(
+      isTextWrappingFloatingImageRun(
+        baseImage(undefined, { displayMode: "float", cssFloat: "left" }),
+      ),
+    ).toBe(true);
+  });
+
+  test("inline images don't wrap text (they aren't floating in the first place)", () => {
+    expect(isTextWrappingFloatingImageRun(baseImage("inline"))).toBe(false);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -785,9 +785,26 @@ function renderHeaderFooterContent(
         { document: doc },
       );
 
-      // Position the fragment
+      // Position the fragment in flow and visualize the paragraph's spacing
+      // as padding so HF paragraphs separate the way Word renders them.
+      // Body content gets paragraph spacing via the paginator's absolute
+      // fragment.y positioning; HF rendering uses relative-flow stacking,
+      // so without padding here the paragraph's `spaceBefore`/`spaceAfter`
+      // would advance `cursorY` for the layout-engine but never appear in
+      // the DOM (visible regression on first-page header docs whose
+      // last-paragraph spaceAfter pushes the body content's first line
+      // down by one line in Word).
       fragEl.style.position = "relative";
       fragEl.style.marginBottom = "0";
+      fragEl.style.boxSizing = "border-box";
+      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+      const spaceAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
+      if (spaceBefore > 0) {
+        fragEl.style.paddingTop = `${spaceBefore}px`;
+      }
+      if (spaceAfter > 0) {
+        fragEl.style.paddingBottom = `${spaceAfter}px`;
+      }
 
       containerEl.append(fragEl);
       cursorY += paragraphMeasure.totalHeight;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -40,7 +40,11 @@ import { renderImageFragment } from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTableFragment } from "./renderTable";
 import { renderTextBoxFragment } from "./renderTextBox";
-import { emuToPixels, isFloatingImageRun } from "./renderUtils";
+import {
+  emuToPixels,
+  isFloatingImageRun,
+  isTextWrappingFloatingImageRun,
+} from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
 
 /**
@@ -70,8 +74,19 @@ type PageFloatingImage = {
   pmEnd?: number;
   /** OOXML wrapText: which side(s) TEXT flows on */
   wrapText?: "bothSides" | "left" | "right" | "largest";
-  /** Wrap type (square, tight, through, topAndBottom) */
+  /** Wrap type (square, tight, through, topAndBottom, behind, inFront) */
   wrapType?: string;
+  /**
+   * Whether this image creates a text-wrap exclusion zone (line widths shrink
+   * around it). False for `behind`/`inFront` (wrapNone) and `topAndBottom`.
+   */
+  affectsTextWrap: boolean;
+  /**
+   * Whether this image paints behind body text. True only for `wrapType ===
+   * "behind"` — the page-level layer is split into a behind-text and
+   * above-text layer so wrapNone semantics survive in the DOM.
+   */
+  behindDoc: boolean;
 };
 
 /**
@@ -534,6 +549,8 @@ function extractFloatingImagesFromParagraph(
       ...(imgRun.pmEnd !== undefined ? { pmEnd: imgRun.pmEnd } : {}),
       wrapText,
       ...(imgRun.wrapType !== undefined ? { wrapType: imgRun.wrapType } : {}),
+      affectsTextWrap: isTextWrappingFloatingImageRun(imgRun),
+      behindDoc: imgRun.wrapType === "behind",
     });
   }
 
@@ -587,21 +604,33 @@ function rectsToFloatingZones(
 }
 
 /**
- * Render floating images into a page-level layer
+ * Render floating images into a page-level layer.
+ *
+ * `layerMode === "behind"` paints below body text (used for `behindDoc`
+ * wrapNone images, e.g. full-page letterhead backgrounds). `"front"` paints
+ * above text (default for `inFront` wrapNone and side-wrapping images).
  */
 function renderFloatingImagesLayer(
   floatingImages: PageFloatingImage[],
   doc: Document,
+  layerMode: "front" | "behind" = "front",
 ): HTMLElement {
   const layer = doc.createElement("div");
-  layer.className = "layout-floating-images-layer";
+  layer.className =
+    layerMode === "behind"
+      ? "layout-floating-images-layer layout-floating-images-layer-behind"
+      : "layout-floating-images-layer";
   layer.style.position = "absolute";
   layer.style.top = "0";
   layer.style.left = "0";
   layer.style.right = "0";
   layer.style.bottom = "0";
   layer.style.pointerEvents = "none"; // Allow clicks to pass through
-  layer.style.zIndex = "10";
+  // Behind layer: leave default stacking so content (rendered after) paints
+  // above. Front layer: lift above content fragments.
+  if (layerMode === "front") {
+    layer.style.zIndex = "10";
+  }
 
   for (const floatImg of floatingImages) {
     const container = doc.createElement("div");
@@ -1168,8 +1197,14 @@ export function renderPage(
     }
   }
 
-  // Collect floating image exclusion rectangles
+  // Collect floating image exclusion rectangles. wrapNone images (`behind`,
+  // `inFront`) and `topAndBottom` block images do NOT shrink line widths —
+  // they're filtered out here so text measurement ignores them. Without this,
+  // a behindDoc letterhead would carve a vertical column out of body text.
   for (const img of allFloatingImages) {
+    if (!img.affectsTextWrap) {
+      continue;
+    }
     floatingRects.push({
       side: img.side,
       x: img.x,
@@ -1231,10 +1266,19 @@ export function renderPage(
       ? rectsToFloatingZones(floatingRects, contentWidth)
       : [];
 
-  // PHASE 3: Render floating images in a page-level layer
-  if (allFloatingImages.length > 0) {
-    const floatingLayer = renderFloatingImagesLayer(allFloatingImages, doc);
-    contentEl.append(floatingLayer);
+  // PHASE 3a: Render behindDoc images first so they paint below body text.
+  // Front-layer images (everything else) are appended after fragments below
+  // so they overlay content as Word does for `inFront` and side-wrapped
+  // images.
+  const behindFloatingImages = allFloatingImages.filter((img) => img.behindDoc);
+  const frontFloatingImages = allFloatingImages.filter((img) => !img.behindDoc);
+  if (behindFloatingImages.length > 0) {
+    const behindLayer = renderFloatingImagesLayer(
+      behindFloatingImages,
+      doc,
+      "behind",
+    );
+    contentEl.append(behindLayer);
   }
 
   // PHASE 4: Render each fragment with floating image awareness
@@ -1369,6 +1413,18 @@ export function renderPage(
       top: page.margins.top,
     });
     contentEl.append(fragmentEl);
+  }
+
+  // PHASE 3b: Render front-layer floating images after text fragments so
+  // wrapNone `inFront` images and side-wrapped images paint above body text
+  // — matching Word's anchor stacking semantics.
+  if (frontFloatingImages.length > 0) {
+    const frontLayer = renderFloatingImagesLayer(
+      frontFloatingImages,
+      doc,
+      "front",
+    );
+    contentEl.append(frontLayer);
   }
 
   // Render column separator lines between columns (when w:sep is set)

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1453,9 +1453,31 @@ export function renderParagraphFragment(
       block.attrs?.listMarker &&
       !block.attrs?.listMarkerHidden
     ) {
-      // Override padding for list first lines
-      // Marker position = indentLeft - hanging (where first line content starts)
-      const markerPos = Math.max(0, indentLeft - (indent?.hanging ?? 0));
+      // Override padding for list first lines.
+      //
+      // Two list-indent shapes are common in OOXML:
+      //
+      // 1. Hanging — `<w:ind w:left="X" w:hanging="Y"/>`. Body text
+      //    wraps at X, marker sits at X-Y (further left). The marker
+      //    box fills the Y-px hanging space and the body text picks
+      //    up at indentLeft.
+      //
+      // 2. First-line — `<w:ind w:left="X" w:firstLine="Y"/>`. Body
+      //    text wraps at X, the FIRST line is shifted right by Y.
+      //    Marker sits at X+Y; body text on subsequent lines wraps to
+      //    the page margin (indentLeft). NVCA-style legal templates
+      //    use this shape — the body of "(i) Tranche Closing..."
+      //    wraps to the page margin, only the first line's marker is
+      //    indented.
+      const markerHasHanging =
+        indent?.hanging !== undefined && indent.hanging > 0;
+      const markerHasFirstLine =
+        indent?.firstLine !== undefined && indent.firstLine > 0;
+      const markerPos = markerHasHanging
+        ? Math.max(0, indentLeft - (indent?.hanging ?? 0))
+        : markerHasFirstLine
+          ? indentLeft + (indent?.firstLine ?? 0)
+          : indentLeft;
       lineEl.style.paddingLeft = `${markerPos}px`;
       lineEl.style.textIndent = "0"; // Don't use textIndent for lists
 
@@ -1532,19 +1554,31 @@ function renderListMarker(
     span.style.fontSize = `${fontSizePx}px`;
   }
 
-  // In Word, the marker character is followed by a tab that extends to the
-  // text indent position. We emulate this by left-aligning the marker within
-  // the hanging indent box — the marker sits at the start and the remaining
-  // space acts as the tab gap, just like Word.
   span.textContent = marker;
-
-  // The marker box fills the hanging indent space
-  const hanging = indent?.hanging ?? 24; // Default 24px if not specified
-
-  // min-width so short markers fill the space; long markers can extend
-  span.style.minWidth = `${hanging}px`;
   span.style.textAlign = "left";
   span.style.boxSizing = "border-box";
+
+  // ECMA-376 §17.9.30: `<w:suff>` selects what follows the marker —
+  // `tab` (default), `space`, or `nothing`. We don't currently parse
+  // `<w:suff>` and fall back to the default (tab) behaviour.
+  //
+  // Hanging-indent lists bake the tab gap into the hanging space:
+  // marker fills `[indentLeft - hanging, indentLeft]`, body text
+  // picks up at `indentLeft`. Set `min-width: hanging` so short
+  // markers don't collapse against the body text.
+  //
+  // First-line-indent lists (`firstLine > 0` and no hanging) place
+  // the marker at `indentLeft + firstLine` with body text wrapping
+  // at `indentLeft`; the marker box has no implicit gap, so we add
+  // an explicit padding-right to emulate the marker's tab-after.
+  // Without this, NVCA-style lists rendered "(i)Tranche Closing"
+  // and "4.10Voting Agreement" with the marker flush against the
+  // text.
+  if (indent?.hanging !== undefined && indent.hanging > 0) {
+    span.style.minWidth = `${indent.hanging}px`;
+  } else if (indent?.firstLine !== undefined && indent.firstLine > 0) {
+    span.style.paddingRight = "12px";
+  }
 
   return span;
 }

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -32,21 +32,61 @@ export function emuToPixels(emu: number | undefined): number {
 }
 
 /**
- * Check if an image run is a floating image (should be positioned at page level)
+ * Check if an image run is a floating image (positioned at page level rather
+ * than participating in inline flow).
+ *
+ * Includes wrapNone variants (`behind` / `inFront`) — those are anchored at
+ * absolute coordinates but do not interact with line measurement; text paints
+ * over or under them. They still need to be lifted out of the paragraph flow.
  */
 export function isFloatingImageRun(run: ImageRun): boolean {
   const wrapType = run.wrapType;
   const displayMode = run.displayMode;
 
-  // Floating images have specific wrap types that allow text to flow around them
-  if (wrapType && ["square", "tight", "through"].includes(wrapType)) {
+  if (
+    wrapType === "square" ||
+    wrapType === "tight" ||
+    wrapType === "through" ||
+    wrapType === "behind" ||
+    wrapType === "inFront"
+  ) {
     return true;
   }
 
-  // Or explicit float display mode (but not topAndBottom — those are block images)
+  // Explicit float display mode (covers callers that set displayMode without a
+  // wrapType, e.g. legacy ProseMirror nodes pre-dating the wrap-type roundtrip).
   if (displayMode === "float") {
     return true;
   }
 
   return false;
+}
+
+/**
+ * Check if a floating image should create a text-wrap exclusion zone.
+ *
+ * `behind` / `inFront` (wrapNone) and `topAndBottom` images do *not* shrink
+ * line widths in Word: text either flows above/below them as a block (TaB) or
+ * paints over/under them (wrapNone). Only `square` / `tight` / `through`
+ * actually divert lines around the image.
+ *
+ * `displayMode === "float"` with a CSS float direction is treated as wrapping
+ * for ProseMirror nodes that don't carry a wrap type but do float.
+ */
+export function isTextWrappingFloatingImageRun(run: ImageRun): boolean {
+  const wrapType = run.wrapType;
+
+  if (
+    wrapType === "behind" ||
+    wrapType === "inFront" ||
+    wrapType === "topAndBottom"
+  ) {
+    return false;
+  }
+
+  if (wrapType === "square" || wrapType === "tight" || wrapType === "through") {
+    return true;
+  }
+
+  return run.displayMode === "float" && run.cssFloat !== "none";
 }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -893,20 +893,19 @@ function createImageRun(node: PMNode): Run {
 
   // Determine wrap type from attrs (default: inline)
   const wrapType = attrs.wrapType || "inline";
-  const PX_TO_EMU = 914_400 / 96;
 
   const wrap: ImageWrap = { type: wrapType };
   if (attrs.distTop !== undefined) {
-    wrap.distT = Math.round(attrs.distTop * PX_TO_EMU);
+    wrap.distT = pixelsToEmu(attrs.distTop);
   }
   if (attrs.distBottom !== undefined) {
-    wrap.distB = Math.round(attrs.distBottom * PX_TO_EMU);
+    wrap.distB = pixelsToEmu(attrs.distBottom);
   }
   if (attrs.distLeft !== undefined) {
-    wrap.distL = Math.round(attrs.distLeft * PX_TO_EMU);
+    wrap.distL = pixelsToEmu(attrs.distLeft);
   }
   if (attrs.distRight !== undefined) {
-    wrap.distR = Math.round(attrs.distRight * PX_TO_EMU);
+    wrap.distR = pixelsToEmu(attrs.distRight);
   }
 
   // Restore wrapText from PM attr
@@ -996,8 +995,7 @@ function createImageRun(node: PMNode): Run {
       outset: "solid",
     };
     const outline: ShapeOutline = {
-      // Convert pixels back to EMU (1 px = 914400/96 EMU)
-      width: Math.round(attrs.borderWidth * (914_400 / 96)),
+      width: pixelsToEmu(attrs.borderWidth),
       style: attrs.borderStyle
         ? (cssToOoxmlStyle[attrs.borderStyle] as ShapeOutline["style"]) ||
           "solid"
@@ -1035,8 +1033,8 @@ function createShapeRun(node: PMNode): Run {
     type: "shape",
     shapeType: (attrs.shapeType || "rect") as Shape["shapeType"],
     size: {
-      width: attrs.width ? Math.round(attrs.width * (914_400 / 96)) : 0,
-      height: attrs.height ? Math.round(attrs.height * (914_400 / 96)) : 0,
+      width: attrs.width ? pixelsToEmu(attrs.width) : 0,
+      height: attrs.height ? pixelsToEmu(attrs.height) : 0,
     },
   };
   if (attrs.shapeId) {
@@ -1091,7 +1089,7 @@ function createShapeRun(node: PMNode): Run {
       dashed: "dash",
     };
     const shapeOutline: ShapeOutline = {
-      width: Math.round(attrs.outlineWidth * (914_400 / 96)),
+      width: pixelsToEmu(attrs.outlineWidth),
       style: attrs.outlineStyle
         ? (cssToOoxml[attrs.outlineStyle] as ShapeOutline["style"]) || "solid"
         : "solid",
@@ -1743,8 +1741,8 @@ function convertPMTextBox(node: PMNode): Paragraph {
     type: "shape",
     shapeType: "rect",
     size: {
-      width: attrs.width ? Math.round(attrs.width * (914_400 / 96)) : 0,
-      height: attrs.height ? Math.round(attrs.height * (914_400 / 96)) : 0,
+      width: attrs.width ? pixelsToEmu(attrs.width) : 0,
+      height: attrs.height ? pixelsToEmu(attrs.height) : 0,
     },
     textBody: {
       content:
@@ -1759,16 +1757,16 @@ function convertPMTextBox(node: PMNode): Paragraph {
           right?: number;
         } = {};
         if (attrs.marginTop !== null && attrs.marginTop !== undefined) {
-          m.top = Math.round(attrs.marginTop * (914_400 / 96));
+          m.top = pixelsToEmu(attrs.marginTop);
         }
         if (attrs.marginBottom !== null && attrs.marginBottom !== undefined) {
-          m.bottom = Math.round(attrs.marginBottom * (914_400 / 96));
+          m.bottom = pixelsToEmu(attrs.marginBottom);
         }
         if (attrs.marginLeft !== null && attrs.marginLeft !== undefined) {
-          m.left = Math.round(attrs.marginLeft * (914_400 / 96));
+          m.left = pixelsToEmu(attrs.marginLeft);
         }
         if (attrs.marginRight !== null && attrs.marginRight !== undefined) {
-          m.right = Math.round(attrs.marginRight * (914_400 / 96));
+          m.right = pixelsToEmu(attrs.marginRight);
         }
         return m;
       })(),
@@ -1795,7 +1793,7 @@ function convertPMTextBox(node: PMNode): Paragraph {
       dashed: "dash",
     };
     const tbOutline: ShapeOutline = {
-      width: Math.round(attrs.outlineWidth * (914_400 / 96)),
+      width: pixelsToEmu(attrs.outlineWidth),
       style: attrs.outlineStyle
         ? (cssToOoxmlOutline[attrs.outlineStyle] as ShapeOutline["style"]) ||
           "solid"

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1605,14 +1605,26 @@ function convertImage(image: Image): PMNode {
     cssFloat = "none";
   }
 
-  // Determine display mode for CSS
+  // Determine display mode for CSS.
+  //
+  // - inline           → inline run, participates in flow
+  // - topAndBottom     → block image, takes its own line
+  // - behind / inFront → float (anchored at absolute coords; the page-level
+  //   layer paints them, so they must be lifted out of the paragraph flow
+  //   even though they don't carve a text-wrap exclusion zone)
+  // - square / tight / through with cssFloat → float
+  // - everything else (centered etc.) → block
   let displayMode: "inline" | "block" | "float" = "inline";
   if (wrapType === "inline") {
     displayMode = "inline";
+  } else if (wrapType === "topAndBottom") {
+    displayMode = "block";
+  } else if (wrapType === "behind" || wrapType === "inFront") {
+    displayMode = "float";
   } else if (cssFloat && cssFloat !== "none") {
     displayMode = "float";
   } else {
-    displayMode = "block"; // TopAndBottom or centered
+    displayMode = "block";
   }
 
   // Build transform string if needed (rotation, flip)

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -424,6 +424,9 @@ function paragraphFormattingToAttrs(
       "contextualSpacing",
       formatting?.contextualSpacing ?? stylePpr?.contextualSpacing,
     );
+    // Run-in heading (`<w:specVanish/>` on the paragraph mark) — see
+    // ParagraphAttrs.runInWithNext.
+    set("runInWithNext", formatting?.runInWithNext ?? stylePpr?.runInWithNext);
 
     // Outline level (for TOC)
     set("outlineLevel", formatting?.outlineLevel ?? stylePpr?.outlineLevel);
@@ -461,6 +464,7 @@ function paragraphFormattingToAttrs(
     set("pageBreakBefore", formatting?.pageBreakBefore);
     set("keepNext", formatting?.keepNext);
     set("keepLines", formatting?.keepLines);
+    set("runInWithNext", formatting?.runInWithNext);
 
     // Outline level
     set("outlineLevel", formatting?.outlineLevel);

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -335,6 +335,7 @@ const paragraphNodeSpec: NodeSpec = {
     keepNext: { default: null },
     keepLines: { default: null },
     contextualSpacing: { default: null },
+    runInWithNext: { default: null },
     defaultTextFormatting: { default: null },
     sectionBreakType: { default: null },
     bidi: { default: null },

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -116,6 +116,14 @@ export type ParagraphAttrs = {
   // Bookmarks on this paragraph (for TOC anchors, cross-references)
   bookmarks?: { id: number; name: string }[];
 
+  /**
+   * Run-in heading flag: this paragraph's mark carries
+   * `<w:specVanish/>` and the next paragraph should flow inline on
+   * the same line (NVCA-style "6.11 Severability" → "The
+   * invalidity..." merges). Layout consumes this in toFlowBlocks.
+   */
+  runInWithNext?: boolean;
+
   /** Original inline paragraph formatting from DOCX (pre-style-resolution).
    *  Used by fromProseDoc for lossless round-trip serialization. */
   _originalFormatting?: ParagraphFormatting;

--- a/packages/folio/src/core/types/formatting.ts
+++ b/packages/folio/src/core/types/formatting.ts
@@ -343,6 +343,16 @@ export type ParagraphFormatting = {
   // Default run properties for this paragraph
   /** Run properties to apply to all runs (w:rPr) */
   runProperties?: TextFormatting;
+
+  /**
+   * Run-in heading: this paragraph's mark carries `<w:specVanish/>`
+   * (ECMA-376 §17.3.1.32) and the paragraph break should be treated
+   * as a soft break — Word renders the next paragraph inline on the
+   * same line. Used by NVCA-style legal templates where heading
+   * paragraphs (e.g. "6.11 Severability") visually merge into the
+   * body paragraph that follows.
+   */
+  runInWithNext?: boolean;
 };
 
 // ============================================================================

--- a/packages/folio/src/core/utils/createDocument.ts
+++ b/packages/folio/src/core/utils/createDocument.ts
@@ -264,27 +264,29 @@ export function createEmptyDocument(
 ): Document {
   const sectionProps = getDefaultSectionProperties();
 
-  // Apply custom options
+  // Twips are integer-typed in OOXML, and callers typically compute them as
+  // `inches * 1440` which produces drift like `0.7 * 1440 === 1008.0000000000001`.
+  // Round at the API boundary so the model never carries a fractional twip.
   if (options.pageWidth !== undefined) {
-    sectionProps.pageWidth = options.pageWidth;
+    sectionProps.pageWidth = Math.round(options.pageWidth);
   }
   if (options.pageHeight !== undefined) {
-    sectionProps.pageHeight = options.pageHeight;
+    sectionProps.pageHeight = Math.round(options.pageHeight);
   }
   if (options.orientation !== undefined) {
     sectionProps.orientation = options.orientation;
   }
   if (options.marginTop !== undefined) {
-    sectionProps.marginTop = options.marginTop;
+    sectionProps.marginTop = Math.round(options.marginTop);
   }
   if (options.marginBottom !== undefined) {
-    sectionProps.marginBottom = options.marginBottom;
+    sectionProps.marginBottom = Math.round(options.marginBottom);
   }
   if (options.marginLeft !== undefined) {
-    sectionProps.marginLeft = options.marginLeft;
+    sectionProps.marginLeft = Math.round(options.marginLeft);
   }
   if (options.marginRight !== undefined) {
-    sectionProps.marginRight = options.marginRight;
+    sectionProps.marginRight = Math.round(options.marginRight);
   }
 
   // Create initial paragraph content

--- a/packages/folio/src/core/utils/units.test.ts
+++ b/packages/folio/src/core/utils/units.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { emuToPixels, emuToTwips, pixelsToEmu, twipsToEmu } from "./units";
+
+// Microsoft Word treats EMU/twip attributes as integer-typed (xs:long /
+// xs:unsignedInt). IEEE-754 drift such as `(52 / 96) * 914400 ===
+// 495299.99999999994` makes Word reject the file as corrupt while WPS,
+// LibreOffice, and Google Docs tolerate it. Upstream eigenpal/docx-editor
+// fixed this in #422 — port the same defense.
+describe("EMU/twip conversions return integers", () => {
+  test("pixelsToEmu rounds the IEEE-754 drift cases from issue #417", () => {
+    // 52 px → 495299.99999999994 unrounded
+    expect(pixelsToEmu(52)).toBe(495_300);
+    // 98 px → 933449.9999999999 unrounded
+    expect(pixelsToEmu(98)).toBe(933_450);
+    // 25 px → 238125.00000000003 unrounded
+    expect(pixelsToEmu(25)).toBe(238_125);
+    // 200 px → 1905000.0000000002 unrounded
+    expect(pixelsToEmu(200)).toBe(1_905_000);
+  });
+
+  test("pixelsToEmu always returns an integer", () => {
+    for (let px = 1; px <= 800; px += 1) {
+      expect(Number.isInteger(pixelsToEmu(px))).toBe(true);
+    }
+    expect(Number.isInteger(pixelsToEmu(123.456))).toBe(true);
+  });
+
+  test("twipsToEmu and emuToTwips round to integers", () => {
+    expect(Number.isInteger(twipsToEmu(720))).toBe(true);
+    expect(Number.isInteger(emuToTwips(914_400))).toBe(true);
+    expect(twipsToEmu(1440)).toBe(914_400);
+    expect(emuToTwips(914_400)).toBe(1440);
+  });
+
+  test("emuToPixels still rounds and tolerates null/NaN", () => {
+    expect(emuToPixels(914_400)).toBe(96);
+    expect(emuToPixels(null)).toBe(0);
+    expect(emuToPixels(undefined)).toBe(0);
+    expect(emuToPixels(Number.NaN)).toBe(0);
+  });
+});

--- a/packages/folio/src/core/utils/units.ts
+++ b/packages/folio/src/core/utils/units.ts
@@ -75,24 +75,27 @@ export function emuToPixels(emu: number | undefined | null): number {
 }
 
 /**
- * Convert pixels to EMUs
+ * Convert pixels to EMUs.
+ *
+ * EMU coordinates in OOXML are integer-typed (xs:long); rounding here keeps
+ * floating-point drift (e.g. 52 px → 495299.99999999994) out of the document.
  */
 export function pixelsToEmu(px: number): number {
-  return (px / PIXELS_PER_INCH) * EMUS_PER_INCH;
+  return Math.round((px / PIXELS_PER_INCH) * EMUS_PER_INCH);
 }
 
 /**
- * Convert EMUs to twips
+ * Convert EMUs to twips. Twips are integer-typed in OOXML; round here.
  */
 export function emuToTwips(emu: number): number {
-  return (emu / EMUS_PER_INCH) * TWIPS_PER_INCH;
+  return Math.round((emu / EMUS_PER_INCH) * TWIPS_PER_INCH);
 }
 
 /**
- * Convert twips to EMUs
+ * Convert twips to EMUs. EMUs are integer-typed in OOXML; round here.
  */
 export function twipsToEmu(twips: number): number {
-  return (twips / TWIPS_PER_INCH) * EMUS_PER_INCH;
+  return Math.round((twips / TWIPS_PER_INCH) * EMUS_PER_INCH);
 }
 
 // ============================================================================

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1688,7 +1688,15 @@ function convertHeaderFooterToContent(
                 | "decimal"
                 | "bar"
                 | "clear",
-              pos: twipsToPixels(tab.position),
+              // Keep twips. The layout-bridge measurer (`computeTabWidth`)
+              // and renderer treat `tabStop.pos` as twips and call
+              // `twipsToPx` themselves — body content stores tabs in twips
+              // (see `toFlowBlocks`). Pre-converting to pixels here was
+              // double-converting (4770 twips → 318 px → treated as twips →
+              // ~21 px stop), collapsing the center tab back to a default
+              // narrow tab and pushing footer content (page number,
+              // centered text) to the wrong x.
+              pos: tab.position,
             };
             if (tab.leader) {
               tabStop.leader = tab.leader as NonNullable<typeof tabStop.leader>;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -113,6 +113,8 @@ import type {
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "../core/prosemirror";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { createStyleResolver } from "../core/prosemirror/styles/styleResolver";
+import type { StyleResolver } from "../core/prosemirror/styles/styleResolver";
 import type { Footnote } from "../core/types/content";
 // Types
 import type {
@@ -1534,6 +1536,7 @@ function convertHeaderFooterToContent(
   headerFooter: HeaderFooter | null | undefined,
   contentWidth: number,
   metrics: HeaderFooterMetrics,
+  styleResolver?: StyleResolver | null,
 ): HeaderFooterContent | undefined {
   if (
     !headerFooter ||
@@ -1554,6 +1557,18 @@ function convertHeaderFooterToContent(
         | Record<string, unknown>
         | undefined;
       const attrs: ParagraphAttrs = {};
+
+      // Resolve the paragraph style cascade so HF paragraphs inherit
+      // spacing/alignment/etc from `Normal` (or whatever pStyle they
+      // reference). HF parsing skips this cascade — without it,
+      // spaceBefore/spaceAfter inherited from a paragraph style is silently
+      // lost in headers/footers. Reuses the same StyleResolver the body uses.
+      const styleId =
+        typeof formatting?.["styleId"] === "string"
+          ? (formatting["styleId"] as string)
+          : undefined;
+      const resolvedStyle = styleResolver?.resolveParagraphStyle(styleId);
+      const styledPpr = resolvedStyle?.paragraphFormatting;
 
       if (formatting) {
         if (formatting["alignment"]) {
@@ -1593,26 +1608,57 @@ function convertHeaderFooterToContent(
             attrs.borders = converted;
           }
         }
-        // Convert spacing for measurement.
-        // NOTE: Only convert lineSpacing (affects line height). Skip spaceBefore/
-        // spaceAfter — these are typically style-resolved artifacts (e.g., from
-        // Normal style) inlined during the PM->document round-trip, not intentional
-        // header/footer formatting. The layout painter renders header/footer
-        // paragraphs without inter-paragraph margins, so measurement must match.
-        if (formatting["lineSpacing"] !== undefined) {
+        // Convert spacing for measurement and rendering. lineSpacing affects
+        // line height; spaceBefore/spaceAfter are visualized as fragment
+        // padding by `renderHeaderFooterContent`. Word renders style-inherited
+        // paragraph spacing in headers/footers the same way as in body
+        // (NVCA-style first-page header: each paragraph has Normal's
+        // spaceAfter=240twips inherited, which produces the visible blank row
+        // above the body's first paragraph). Without these, last-paragraph
+        // spaceAfter is silently dropped and body content butts flush against
+        // the last header line.
+        // Inline pPr first, then fall back to the resolved style cascade.
+        const inlineLineSpacing = formatting["lineSpacing"];
+        const inlineSpaceBefore = formatting["spaceBefore"];
+        const inlineSpaceAfter = formatting["spaceAfter"];
+        const inlineLineRule = formatting["lineSpacingRule"] as
+          | string
+          | undefined;
+        const lineSpacing =
+          typeof inlineLineSpacing === "number"
+            ? inlineLineSpacing
+            : styledPpr?.lineSpacing;
+        const lineRule = inlineLineRule ?? styledPpr?.lineSpacingRule;
+        const spaceBeforeTwips =
+          typeof inlineSpaceBefore === "number"
+            ? inlineSpaceBefore
+            : styledPpr?.spaceBefore;
+        const spaceAfterTwips =
+          typeof inlineSpaceAfter === "number"
+            ? inlineSpaceAfter
+            : styledPpr?.spaceAfter;
+        if (
+          typeof lineSpacing === "number" ||
+          typeof spaceBeforeTwips === "number" ||
+          typeof spaceAfterTwips === "number"
+        ) {
           const spacingAttrs: ParagraphSpacing = {};
-          const rule = formatting["lineSpacingRule"] as string | undefined;
-          if (rule === "exact" || rule === "atLeast") {
-            spacingAttrs.line = twipsToPixels(
-              formatting["lineSpacing"] as number,
-            );
-            spacingAttrs.lineUnit = "px";
-            spacingAttrs.lineRule = rule;
-          } else {
-            // Auto — line spacing is in 240ths of a line
-            spacingAttrs.line = (formatting["lineSpacing"] as number) / 240;
-            spacingAttrs.lineUnit = "multiplier";
-            spacingAttrs.lineRule = "auto";
+          if (typeof lineSpacing === "number") {
+            if (lineRule === "exact" || lineRule === "atLeast") {
+              spacingAttrs.line = twipsToPixels(lineSpacing);
+              spacingAttrs.lineUnit = "px";
+              spacingAttrs.lineRule = lineRule;
+            } else {
+              spacingAttrs.line = lineSpacing / 240;
+              spacingAttrs.lineUnit = "multiplier";
+              spacingAttrs.lineRule = "auto";
+            }
+          }
+          if (typeof spaceBeforeTwips === "number") {
+            spacingAttrs.before = twipsToPixels(spaceBeforeTwips);
+          }
+          if (typeof spaceAfterTwips === "number") {
+            spacingAttrs.after = twipsToPixels(spaceAfterTwips);
           }
           attrs.spacing = spacingAttrs;
         }
@@ -2099,15 +2145,20 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             pageSize,
             margins,
           };
+          const headerFooterStyleResolver = styles
+            ? createStyleResolver(styles)
+            : null;
           const headerContentForRender = convertHeaderFooterToContent(
             headerContent,
             contentWidth,
             hfMetricsHeader,
+            headerFooterStyleResolver,
           );
           const footerContentForRender = convertHeaderFooterToContent(
             footerContent,
             contentWidth,
             hfMetricsFooter,
+            headerFooterStyleResolver,
           );
           const hasTitlePg = sectionProperties?.titlePg === true;
           const firstPageHeaderForRender = hasTitlePg
@@ -2115,6 +2166,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 firstPageHeaderContent,
                 contentWidth,
                 hfMetricsHeader,
+                headerFooterStyleResolver,
               )
             : undefined;
           const firstPageFooterForRender = hasTitlePg
@@ -2122,6 +2174,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 firstPageFooterContent,
                 contentWidth,
                 hfMetricsFooter,
+                headerFooterStyleResolver,
               )
             : undefined;
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -44,7 +44,6 @@ import {
   collectFootnoteRefs,
   mapFootnotesToPages,
   buildFootnoteContentMap,
-  calculateFootnoteReservedHeights,
 } from "../core/layout-bridge/footnoteLayout";
 import {
   hitTestFragment,
@@ -2257,20 +2256,10 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           }
 
           if (hasFootnotes) {
-            // Pass 1: Layout without footnote space to determine page assignments
-            const pass1Layout = layoutDocument(
-              newBlocks,
-              newMeasures,
-              layoutOpts,
-            );
-
-            // Map footnote refs to pages
-            pageFootnoteMap = mapFootnotesToPages(
-              pass1Layout.pages,
-              footnoteRefs,
-            );
-
-            // Build footnote content and measure heights
+            // Build footnote content and measure heights up front. The
+            // per-fn height table feeds into the layout engine so each
+            // body line carrying an fn ref reserves space for that fn
+            // on its host page in a single pass — no convergence loop.
             footnoteContentMap = buildFootnoteContentMap(
               // oxlint-disable-next-line typescript/no-non-null-assertion
               document!.package.footnotes!,
@@ -2290,108 +2279,41 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               })(),
             );
 
-            // Calculate per-page reserved heights
-            const footnoteReservedHeights = calculateFootnoteReservedHeights(
-              pageFootnoteMap,
-              footnoteContentMap,
+            const footnoteHeightById = new Map<number, number>();
+            // Per-fn vertical margin applied by the painter
+            // (`renderFootnoteArea` sets `marginBottom: 4px` on each
+            // fn entry). Reserved alongside content height so the page
+            // accounts for inter-fn whitespace.
+            const FOOTNOTE_ENTRY_MARGIN = 4;
+            for (const [id, content] of footnoteContentMap) {
+              footnoteHeightById.set(
+                id,
+                content.height + FOOTNOTE_ENTRY_MARGIN,
+              );
+            }
+            // Note: the layout engine adds the divider's height once
+            // per fn-bearing page (in paginator.addFootnoteHeight); we
+            // pass per-fn (content + entry margin) here.
+
+            newLayout = layoutDocument(newBlocks, newMeasures, {
+              ...layoutOpts,
+              footnoteHeightById,
+            });
+
+            pageFootnoteMap = mapFootnotesToPages(
+              newLayout.pages,
+              footnoteRefs,
             );
 
-            // Pass 2: Layout with reserved heights. Then iterate until
-            // the footnote-to-page mapping is stable (or we hit the
-            // convergence cap). Word's algorithm iterates similarly: on a
-            // page where reserving footnote space pushes its triggering
-            // body content to the next page, the next pass un-reserves
-            // that footnote, opening up room for more body — so a fresh
-            // pass may pull subsequent body up. Stops when the per-page
-            // footnote ID set stops changing (or after 4 iterations to
-            // bound worst-case cost on pathological docs).
-            if (footnoteReservedHeights.size > 0) {
-              let reservedHeights = footnoteReservedHeights;
-              // Per-page upper bound: the largest reservation seen for
-              // each page across all convergence passes. Used to seed
-              // the final pass when the loop oscillates so that body
-              // content cannot grow past what the final fn area
-              // requires. Without this, hitting the convergence cap
-              // produced layouts where page.footnoteReservedHeight
-              // recorded a smaller-than-needed value (the last pass's
-              // input), but the final pageFootnoteMap mapped more
-              // footnotes onto that page — the painter then drew a tall
-              // fn area on top of body content (NVCA page 3: fn 9 + 10
-              // overflowed past contentBottom into the footer).
-              const upperBound = new Map<number, number>(
-                footnoteReservedHeights,
-              );
-              const mergeUpper = (m: Map<number, number>) => {
-                for (const [pageNum, h] of m) {
-                  const prev = upperBound.get(pageNum) ?? 0;
-                  if (h > prev) {
-                    upperBound.set(pageNum, h);
-                  }
-                }
-              };
-
-              let prevMapKey = "";
-              const MAX_PASSES = 4;
-              newLayout = pass1Layout;
-              let stable = false;
-              for (let pass = 0; pass < MAX_PASSES; pass += 1) {
-                newLayout = layoutDocument(newBlocks, newMeasures, {
-                  ...layoutOpts,
-                  footnoteReservedHeights: reservedHeights,
-                });
-
-                pageFootnoteMap = mapFootnotesToPages(
-                  newLayout.pages,
-                  footnoteRefs,
-                );
-
-                // Stable when (page → footnoteIds) hasn't changed since
-                // last pass.
-                const mapKey = [...pageFootnoteMap.entries()]
-                  .map(([p, ids]) => `${p}:${ids.join(",")}`)
-                  .sort()
-                  .join("|");
-                if (mapKey === prevMapKey) {
-                  stable = true;
-                  break;
-                }
-                prevMapKey = mapKey;
-
-                reservedHeights = calculateFootnoteReservedHeights(
-                  pageFootnoteMap,
-                  footnoteContentMap,
-                );
-                mergeUpper(reservedHeights);
+            // Store footnoteIds on each page for rendering. The page's
+            // `footnoteReservedHeight` was already set incrementally by
+            // the engine via `addFootnoteHeight` and matches the actual
+            // fns that landed on the page.
+            for (const [pageNum, fnIds] of pageFootnoteMap) {
+              const page = newLayout.pages.find((p) => p.number === pageNum);
+              if (page) {
+                page.footnoteIds = fnIds;
               }
-
-              // If the convergence loop hit MAX_PASSES without
-              // stabilising, do one final layout pass with the
-              // per-page upper bound. Body content is conservatively
-              // sized so that whatever footnotes the final mapping
-              // assigns to a page always fit in its reserved area —
-              // never overflowing into the footer. Word's heuristic is
-              // the same: in pathological cases it prefers a slightly
-              // shorter body to a footnote that breaks the page frame.
-              if (!stable) {
-                newLayout = layoutDocument(newBlocks, newMeasures, {
-                  ...layoutOpts,
-                  footnoteReservedHeights: upperBound,
-                });
-                pageFootnoteMap = mapFootnotesToPages(
-                  newLayout.pages,
-                  footnoteRefs,
-                );
-              }
-
-              // Store footnoteIds on each page for rendering
-              for (const [pageNum, fnIds] of pageFootnoteMap) {
-                const page = newLayout.pages.find((p) => p.number === pageNum);
-                if (page) {
-                  page.footnoteIds = fnIds;
-                }
-              }
-            } else {
-              newLayout = pass1Layout;
             }
           } else {
             // No footnotes — single pass

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2272,18 +2272,47 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               footnoteContentMap,
             );
 
-            // Pass 2: Layout with reserved heights
+            // Pass 2: Layout with reserved heights. Then iterate until
+            // the footnote-to-page mapping is stable (or we hit the
+            // convergence cap). Word's algorithm iterates similarly: on a
+            // page where reserving footnote space pushes its triggering
+            // body content to the next page, the next pass un-reserves
+            // that footnote, opening up room for more body — so a fresh
+            // pass may pull subsequent body up. Stops when the per-page
+            // footnote ID set stops changing (or after 4 iterations to
+            // bound worst-case cost on pathological docs).
             if (footnoteReservedHeights.size > 0) {
-              newLayout = layoutDocument(newBlocks, newMeasures, {
-                ...layoutOpts,
-                footnoteReservedHeights,
-              });
+              let reservedHeights = footnoteReservedHeights;
+              let prevMapKey = "";
+              const MAX_PASSES = 4;
+              newLayout = pass1Layout;
+              for (let pass = 0; pass < MAX_PASSES; pass += 1) {
+                newLayout = layoutDocument(newBlocks, newMeasures, {
+                  ...layoutOpts,
+                  footnoteReservedHeights: reservedHeights,
+                });
 
-              // Re-map footnotes to pages (assignments may have shifted)
-              pageFootnoteMap = mapFootnotesToPages(
-                newLayout.pages,
-                footnoteRefs,
-              );
+                pageFootnoteMap = mapFootnotesToPages(
+                  newLayout.pages,
+                  footnoteRefs,
+                );
+
+                // Stable when (page → footnoteIds) hasn't changed since
+                // last pass.
+                const mapKey = [...pageFootnoteMap.entries()]
+                  .map(([p, ids]) => `${p}:${ids.join(",")}`)
+                  .sort()
+                  .join("|");
+                if (mapKey === prevMapKey) {
+                  break;
+                }
+                prevMapKey = mapKey;
+
+                reservedHeights = calculateFootnoteReservedHeights(
+                  pageFootnoteMap,
+                  footnoteContentMap,
+                );
+              }
 
               // Store footnoteIds on each page for rendering
               for (const [pageNum, fnIds] of pageFootnoteMap) {

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -42,7 +42,6 @@ import {
 } from "../core/layout-bridge/findBodyPmSpans";
 import {
   collectFootnoteRefs,
-  mapFootnotesToPages,
   buildFootnoteContentMap,
 } from "../core/layout-bridge/footnoteLayout";
 import {
@@ -2317,19 +2316,17 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               footnoteHeightById,
             });
 
-            pageFootnoteMap = mapFootnotesToPages(
-              newLayout.pages,
-              footnoteRefs,
-            );
-
-            // Store footnoteIds on each page for rendering. The page's
-            // `footnoteReservedHeight` was already set incrementally by
-            // the engine via `addFootnoteHeight` and matches the actual
-            // fns that landed on the page.
-            for (const [pageNum, fnIds] of pageFootnoteMap) {
-              const page = newLayout.pages.find((p) => p.number === pageNum);
-              if (page) {
-                page.footnoteIds = fnIds;
+            // The layout engine assigned `page.footnoteIds` line-by-
+            // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
+            // ref in a continuation fragment of a split paragraph
+            // lands on the page where the ref-bearing line actually
+            // is. Build pageFootnoteMap from those page records (not
+            // from `mapFootnotesToPages`'s pmRange scan, which can't
+            // disambiguate split-paragraph halves; Codex PR #258).
+            pageFootnoteMap = new Map<number, number[]>();
+            for (const page of newLayout.pages) {
+              if (page.footnoteIds && page.footnoteIds.length > 0) {
+                pageFootnoteMap.set(page.number, page.footnoteIds);
               }
             }
           } else {

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -550,18 +550,35 @@ function getColumns(
 }
 
 /**
- * Check if an image run is a floating image (should affect text wrapping)
+ * Check if an image run is a *text-wrapping* floating image — it
+ * occupies an exclusion zone the body text should flow around.
+ *
+ * `wrapType: "behind"` and `wrapType: "inFront"` are anchored
+ * (out-of-flow) but Word's wrapNone semantics put them behind /
+ * over the text without shrinking the body. They render as
+ * `displayMode: "float"` in the prose model so the painter knows
+ * they're out of normal flow, but `extractFloatingZones` must skip
+ * them — including them here would make the line breaker wrap text
+ * around a background letterhead or a foreground overlay (Codex
+ * PR #258 review).
  */
 function isFloatingImageRun(run: ImageRun): boolean {
   const wrapType = run.wrapType;
   const displayMode = run.displayMode;
+
+  // wrapNone (behind / inFront): never an exclusion zone, regardless
+  // of displayMode.
+  if (wrapType === "behind" || wrapType === "inFront") {
+    return false;
+  }
 
   // Floating images have specific wrap types that allow text to flow around them
   if (wrapType && ["square", "tight", "through"].includes(wrapType)) {
     return true;
   }
 
-  // Or explicit float display mode
+  // Or explicit float display mode (only when no wrapNone semantics —
+  // already filtered above).
   if (displayMode === "float") {
     return true;
   }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2307,9 +2307,33 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             // bound worst-case cost on pathological docs).
             if (footnoteReservedHeights.size > 0) {
               let reservedHeights = footnoteReservedHeights;
+              // Per-page upper bound: the largest reservation seen for
+              // each page across all convergence passes. Used to seed
+              // the final pass when the loop oscillates so that body
+              // content cannot grow past what the final fn area
+              // requires. Without this, hitting the convergence cap
+              // produced layouts where page.footnoteReservedHeight
+              // recorded a smaller-than-needed value (the last pass's
+              // input), but the final pageFootnoteMap mapped more
+              // footnotes onto that page — the painter then drew a tall
+              // fn area on top of body content (NVCA page 3: fn 9 + 10
+              // overflowed past contentBottom into the footer).
+              const upperBound = new Map<number, number>(
+                footnoteReservedHeights,
+              );
+              const mergeUpper = (m: Map<number, number>) => {
+                for (const [pageNum, h] of m) {
+                  const prev = upperBound.get(pageNum) ?? 0;
+                  if (h > prev) {
+                    upperBound.set(pageNum, h);
+                  }
+                }
+              };
+
               let prevMapKey = "";
               const MAX_PASSES = 4;
               newLayout = pass1Layout;
+              let stable = false;
               for (let pass = 0; pass < MAX_PASSES; pass += 1) {
                 newLayout = layoutDocument(newBlocks, newMeasures, {
                   ...layoutOpts,
@@ -2328,6 +2352,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                   .sort()
                   .join("|");
                 if (mapKey === prevMapKey) {
+                  stable = true;
                   break;
                 }
                 prevMapKey = mapKey;
@@ -2335,6 +2360,26 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 reservedHeights = calculateFootnoteReservedHeights(
                   pageFootnoteMap,
                   footnoteContentMap,
+                );
+                mergeUpper(reservedHeights);
+              }
+
+              // If the convergence loop hit MAX_PASSES without
+              // stabilising, do one final layout pass with the
+              // per-page upper bound. Body content is conservatively
+              // sized so that whatever footnotes the final mapping
+              // assigns to a page always fit in its reserved area —
+              // never overflowing into the footer. Word's heuristic is
+              // the same: in pathological cases it prefers a slightly
+              // shorter body to a footnote that breaks the page frame.
+              if (!stable) {
+                newLayout = layoutDocument(newBlocks, newMeasures, {
+                  ...layoutOpts,
+                  footnoteReservedHeights: upperBound,
+                });
+                pageFootnoteMap = mapFootnotesToPages(
+                  newLayout.pages,
+                  footnoteRefs,
                 );
               }
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -90,6 +90,7 @@ import type {
   ParagraphAttrs,
   ParagraphBorders,
   ParagraphSpacing,
+  SectionBreakBlock,
   TextBoxBlock,
   FootnoteContent,
 } from "../core/layout-engine/types";
@@ -121,7 +122,7 @@ import type {
   SectionProperties,
   HeaderFooter,
 } from "../core/types/document";
-import { computeEffectiveHeaderFooterMargins } from "./headerFooterMargins";
+import { computeHeaderFooterMarginExtender } from "./headerFooterMargins";
 // Internal components
 import { HiddenProseMirror } from "./HiddenProseMirror";
 import type { HiddenProseMirrorRef } from "./HiddenProseMirror";
@@ -2124,13 +2125,27 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               )
             : undefined;
 
-          const effectiveMargins = computeEffectiveHeaderFooterMargins({
-            margins,
+          const extendForHfOverflow = computeHeaderFooterMarginExtender({
             headerContent: headerContentForRender,
             footerContent: footerContentForRender,
             firstPageHeaderContent: firstPageHeaderForRender,
             firstPageFooterContent: firstPageFooterForRender,
           });
+          const effectiveMargins = extendForHfOverflow(margins);
+          // Section-break blocks carry their own `sb.margins` from
+          // `<w:sectPr>` and the layout engine prefers those over the
+          // body-level fallback. Apply the extension to each one too,
+          // otherwise a footer that overflows on one section silently
+          // re-overlaps body text on the next. (Eigenpal #400.)
+          for (const block of newBlocks) {
+            if (block.kind !== "sectionBreak") {
+              continue;
+            }
+            const sb = block as SectionBreakBlock;
+            if (sb.margins) {
+              sb.margins = extendForHfOverflow(sb.margins);
+            }
+          }
 
           // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
           let newLayout: Layout;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -124,7 +124,10 @@ import type {
   SectionProperties,
   HeaderFooter,
 } from "../core/types/document";
-import { computeHeaderFooterMarginExtender } from "./headerFooterMargins";
+import {
+  computeFirstPageHeaderFooterMarginExtender,
+  computeHeaderFooterMarginExtender,
+} from "./headerFooterMargins";
 // Internal components
 import { HiddenProseMirror } from "./HiddenProseMirror";
 import type { HiddenProseMirrorRef } from "./HiddenProseMirror";
@@ -2186,13 +2189,31 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               )
             : undefined;
 
+          // Default extender — applied to pages 2+ of every section. It
+          // ignores firstPage H/F so a `<w:titlePg/>` section's
+          // overflowing first-page header doesn't push body content down
+          // on every subsequent page.
           const extendForHfOverflow = computeHeaderFooterMarginExtender({
             headerContent: headerContentForRender,
             footerContent: footerContentForRender,
             firstPageHeaderContent: firstPageHeaderForRender,
             firstPageFooterContent: firstPageFooterForRender,
           });
+          // First-page extender — used only for page 1 of a titlePg
+          // section so the title page's larger header reservation is
+          // honored without leaking onto pages 2+.
+          const extendForFirstPage = computeFirstPageHeaderFooterMarginExtender(
+            {
+              headerContent: headerContentForRender,
+              footerContent: footerContentForRender,
+              firstPageHeaderContent: firstPageHeaderForRender,
+              firstPageFooterContent: firstPageFooterForRender,
+            },
+          );
           const effectiveMargins = extendForHfOverflow(margins);
+          const effectiveFirstPageMargins = hasTitlePg
+            ? extendForFirstPage(margins)
+            : undefined;
           // Section-break blocks carry their own `sb.margins` from
           // `<w:sectPr>` and the layout engine prefers those over the
           // body-level fallback. Apply the extension to each one too,
@@ -2225,6 +2246,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             margins: effectiveMargins,
             pageGap,
           };
+          if (effectiveFirstPageMargins !== undefined) {
+            layoutOpts.firstPageMargins = effectiveFirstPageMargins;
+          }
           if (columns !== undefined) {
             layoutOpts.columns = columns;
           }

--- a/packages/folio/src/paged-editor/headerFooterMargins.test.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import type { HeaderFooterContent } from "../core/layout-painter/renderPage";
 import {
   computeEffectiveHeaderFooterMargins,
+  computeFirstPageHeaderFooterMarginExtender,
   computeHeaderFooterMarginExtender,
 } from "./headerFooterMargins";
 
@@ -14,7 +15,35 @@ const content = (height: number): HeaderFooterContent => ({
 });
 
 describe("header and footer margin reservation", () => {
-  test("reserves body space for a tall first-page header", () => {
+  test("default mode IGNORES first-page header (page 2+ margins)", () => {
+    // Page 2+ of a `<w:titlePg/>` section must not inherit the
+    // first-page header's reservation — only the regular header
+    // counts. Otherwise body content sits artificially low on every
+    // page that follows the title page.
+    const margins = {
+      top: 96,
+      right: 72,
+      bottom: 96,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+
+    // Regular header (20 px) fits within the 96 - 48 = 48 px slot, so
+    // top stays 96. The first-page header (78 px) must NOT be considered.
+    expect(
+      computeEffectiveHeaderFooterMargins({
+        margins,
+        headerContent: content(20),
+        firstPageHeaderContent: content(78),
+      }).top,
+    ).toBe(96);
+  });
+
+  test("first-page extender RESPECTS first-page header (page 1 margins)", () => {
+    // Page 1 of a titlePg section uses the larger of regular and
+    // first-page header heights — the first-page extender is applied
+    // only to that page's margins.
     const margins = {
       top: 96,
       right: 72,
@@ -25,11 +54,10 @@ describe("header and footer margin reservation", () => {
     };
 
     expect(
-      computeEffectiveHeaderFooterMargins({
-        margins,
+      computeFirstPageHeaderFooterMarginExtender({
         headerContent: content(20),
         firstPageHeaderContent: content(78),
-      }).top,
+      })(margins).top,
     ).toBe(126);
   });
 

--- a/packages/folio/src/paged-editor/headerFooterMargins.test.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { HeaderFooterContent } from "../core/layout-painter/renderPage";
-import { computeEffectiveHeaderFooterMargins } from "./headerFooterMargins";
+import {
+  computeEffectiveHeaderFooterMargins,
+  computeHeaderFooterMarginExtender,
+} from "./headerFooterMargins";
 
 const content = (height: number): HeaderFooterContent => ({
   blocks: [],
@@ -47,5 +50,83 @@ describe("header and footer margin reservation", () => {
         footerContent: content(40),
       }),
     ).toBe(margins);
+  });
+});
+
+describe("HF margin extender across multiple section margins (issue #400)", () => {
+  test("returned extender extends every section's margins, not just the body", () => {
+    // Pre-PR a section break with its own w:sectPr margins (40 px bottom)
+    // would silently override the body's extension and the footer would
+    // overlap body text on that section.
+    const extend = computeHeaderFooterMarginExtender({
+      footerContent: content(70),
+    });
+
+    const bodyMargins = {
+      top: 60,
+      right: 72,
+      bottom: 60,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+    const sectionMargins = {
+      top: 60,
+      right: 72,
+      bottom: 40,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+
+    const extendedBody = extend(bodyMargins);
+    const extendedSection = extend(sectionMargins);
+
+    // Footer is 70 px, footerDistance is 48, so bottom must be at least
+    // 48 + 70 = 118 in BOTH margin sets.
+    expect(extendedBody.bottom).toBe(118);
+    expect(extendedSection.bottom).toBe(118);
+  });
+
+  test("extender returns input unchanged when neither header nor footer overflow", () => {
+    const extend = computeHeaderFooterMarginExtender({
+      headerContent: content(20),
+      footerContent: content(20),
+    });
+
+    const margins = {
+      top: 96,
+      right: 72,
+      bottom: 96,
+      left: 72,
+      header: 48,
+      footer: 48,
+    };
+
+    expect(extend(margins)).toBe(margins);
+  });
+
+  test("extender uses the input margins' header/footer distances, not the body's", () => {
+    // A section authored with w:header=24 has more available header space
+    // than one with w:header=48 — the extender must read distances from
+    // the *input* margins to honor that.
+    const extend = computeHeaderFooterMarginExtender({
+      headerContent: content(60),
+    });
+
+    const tightHeaderDistance = {
+      top: 80,
+      right: 72,
+      bottom: 96,
+      left: 72,
+      header: 24,
+      footer: 48,
+    };
+    const looseHeaderDistance = { ...tightHeaderDistance, header: 48 };
+
+    // available = 80 - 24 = 56 < 60, must extend to 24 + 60 = 84.
+    expect(extend(tightHeaderDistance).top).toBe(84);
+    // available = 80 - 48 = 32 < 60, must extend to 48 + 60 = 108.
+    expect(extend(looseHeaderDistance).top).toBe(108);
   });
 });

--- a/packages/folio/src/paged-editor/headerFooterMargins.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.ts
@@ -45,20 +45,45 @@ function footerHeight(content: HeaderFooterContent | undefined): number {
  * paragraph's section margins), not the body's, so each section's authored
  * `w:header`/`w:footer` distances are honored.
  */
-export function computeHeaderFooterMarginExtender({
+/**
+ * Build an extender that pushes body margins clear of HF content.
+ *
+ * `mode === "default"` ignores `firstPageHeaderContent` /
+ * `firstPageFooterContent`. The first-page H/F only renders on page 1 of
+ * a `<w:titlePg/>`-enabled section, so margins for pages 2+ within the
+ * same section must NOT be extended for first-page overflow — extending
+ * them would push body content down on every page even though only page
+ * 1 actually carries the overflowing header. This produced visible
+ * regressions on NVCA-style first-page-header docs, where pages 2+
+ * inherited page 1's title-page header reservation.
+ *
+ * `mode === "firstPage"` uses the larger of the default and first-page
+ * H/F heights — applied only to the first-page margins of a titlePg
+ * section.
+ */
+function buildExtender({
   headerContent,
   footerContent,
   firstPageHeaderContent,
   firstPageFooterContent,
-}: Omit<EffectiveHeaderFooterMarginsInput, "margins">): PageMarginsExtender {
-  const headerContentHeight = Math.max(
-    headerHeight(headerContent),
-    headerHeight(firstPageHeaderContent),
-  );
-  const footerContentHeight = Math.max(
-    footerHeight(footerContent),
-    footerHeight(firstPageFooterContent),
-  );
+  mode,
+}: Omit<EffectiveHeaderFooterMarginsInput, "margins"> & {
+  mode: "default" | "firstPage";
+}): PageMarginsExtender {
+  const headerContentHeight =
+    mode === "firstPage"
+      ? Math.max(
+          headerHeight(headerContent),
+          headerHeight(firstPageHeaderContent),
+        )
+      : headerHeight(headerContent);
+  const footerContentHeight =
+    mode === "firstPage"
+      ? Math.max(
+          footerHeight(footerContent),
+          footerHeight(firstPageFooterContent),
+        )
+      : footerHeight(footerContent);
 
   return (margins: PageMargins): PageMargins => {
     const headerDistance = margins.header ?? 48;
@@ -85,6 +110,23 @@ export function computeHeaderFooterMarginExtender({
     }
     return out;
   };
+}
+
+export function computeHeaderFooterMarginExtender(
+  input: Omit<EffectiveHeaderFooterMarginsInput, "margins">,
+): PageMarginsExtender {
+  return buildExtender({ ...input, mode: "default" });
+}
+
+/**
+ * Like `computeHeaderFooterMarginExtender` but also accounts for the
+ * first-page header/footer content. Apply this only to the margins used
+ * for page 1 of a `<w:titlePg/>`-enabled section.
+ */
+export function computeFirstPageHeaderFooterMarginExtender(
+  input: Omit<EffectiveHeaderFooterMarginsInput, "margins">,
+): PageMarginsExtender {
+  return buildExtender({ ...input, mode: "firstPage" });
 }
 
 export function computeEffectiveHeaderFooterMargins({

--- a/packages/folio/src/paged-editor/headerFooterMargins.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.ts
@@ -9,6 +9,19 @@ type EffectiveHeaderFooterMarginsInput = {
   firstPageFooterContent?: HeaderFooterContent | undefined;
 };
 
+/**
+ * A function that extends a `PageMargins` to clear the HF overflow computed
+ * from a given set of header/footer content. Returned by
+ * `computeHeaderFooterMarginExtender` and applied at every margins site:
+ * the body fallback, `finalMargins`, and per-section `sectionBreak.margins`.
+ *
+ * Eigenpal #400 — pre-PR the extension only applied to the body fallback,
+ * so a section break carrying its own `sb.margins` from `<w:sectPr>`
+ * silently overrode the extension and the footer rendered on top of body
+ * text.
+ */
+export type PageMarginsExtender = (margins: PageMargins) => PageMargins;
+
 function headerHeight(content: HeaderFooterContent | undefined): number {
   return content ? (content.visualBottom ?? content.height) : 0;
 }
@@ -23,17 +36,21 @@ function footerHeight(content: HeaderFooterContent | undefined): number {
   );
 }
 
-export function computeEffectiveHeaderFooterMargins({
-  margins,
+/**
+ * Build a function that, applied to any `PageMargins`, extends `top`/`bottom`
+ * to clear the same header/footer content the body's effective margins do.
+ * Returns the identity function when no extension is needed.
+ *
+ * Header/footer distances are taken from the *given* margins (the source
+ * paragraph's section margins), not the body's, so each section's authored
+ * `w:header`/`w:footer` distances are honored.
+ */
+export function computeHeaderFooterMarginExtender({
   headerContent,
   footerContent,
   firstPageHeaderContent,
   firstPageFooterContent,
-}: EffectiveHeaderFooterMarginsInput): PageMargins {
-  const headerDistance = margins.header ?? 48;
-  const footerDistance = margins.footer ?? 48;
-  const availableHeaderSpace = margins.top - headerDistance;
-  const availableFooterSpace = margins.bottom - footerDistance;
+}: Omit<EffectiveHeaderFooterMarginsInput, "margins">): PageMarginsExtender {
   const headerContentHeight = Math.max(
     headerHeight(headerContent),
     headerHeight(firstPageHeaderContent),
@@ -43,25 +60,44 @@ export function computeEffectiveHeaderFooterMargins({
     footerHeight(firstPageFooterContent),
   );
 
-  if (
-    headerContentHeight <= availableHeaderSpace &&
-    footerContentHeight <= availableFooterSpace
-  ) {
-    return margins;
-  }
+  return (margins: PageMargins): PageMargins => {
+    const headerDistance = margins.header ?? 48;
+    const footerDistance = margins.footer ?? 48;
+    const availableHeaderSpace = margins.top - headerDistance;
+    const availableFooterSpace = margins.bottom - footerDistance;
 
-  const effectiveMargins = { ...margins };
-  if (headerContentHeight > availableHeaderSpace) {
-    effectiveMargins.top = Math.max(
-      margins.top,
-      headerDistance + headerContentHeight,
-    );
-  }
-  if (footerContentHeight > availableFooterSpace) {
-    effectiveMargins.bottom = Math.max(
-      margins.bottom,
-      footerDistance + footerContentHeight,
-    );
-  }
-  return effectiveMargins;
+    if (
+      headerContentHeight <= availableHeaderSpace &&
+      footerContentHeight <= availableFooterSpace
+    ) {
+      return margins;
+    }
+
+    const out = { ...margins };
+    if (headerContentHeight > availableHeaderSpace) {
+      out.top = Math.max(margins.top, headerDistance + headerContentHeight);
+    }
+    if (footerContentHeight > availableFooterSpace) {
+      out.bottom = Math.max(
+        margins.bottom,
+        footerDistance + footerContentHeight,
+      );
+    }
+    return out;
+  };
+}
+
+export function computeEffectiveHeaderFooterMargins({
+  margins,
+  headerContent,
+  footerContent,
+  firstPageHeaderContent,
+  firstPageFooterContent,
+}: EffectiveHeaderFooterMarginsInput): PageMargins {
+  return computeHeaderFooterMarginExtender({
+    headerContent,
+    footerContent,
+    firstPageHeaderContent,
+    firstPageFooterContent,
+  })(margins);
 }


### PR DESCRIPTION
## Summary

- Port the small/focused fixes from eigenpal/docx-editor `6a0b9a9e8..0636a9d13` (skipping the two big upstream refactors `1259fa0` HF unification and `5fddb75` image layout modes for separate PRs).
- Stack on top: a series of folio-specific HF/spacing fixes surfaced while testing against the NVCA Series A SPA template (multi-section doc with first-page header, paginated footnotes, complex REF cross-reference fields, etc.).

CC on behalf of @jan-kubica.

## Test plan

- [x] All 558 folio unit tests pass.
- [x] Manual verification on `apps/playground/public/fixtures/yc-safe-uncapped-mfn.docx` (existing fixture).
- [x] Manual verification on the NVCA Series A SPA template (longer multi-section doc):
  - boilerplate first-page header renders with correct gap before body
  - "Preliminary Note" / "SERIES" heading no longer collide
  - body paragraph spacing matches Word
  - cross-reference fields (`Exhibit A`, `Section 1.3`) render with their authored underline
  - footer page numbers appear on every page (was missing on pages 2+)
  - default-footer tab stops route the page number to the centered position
  - body content (`(a)`, `(b)`, `(c)` of section 1.2) all fit on one page
  - white paragraph shading from `Normal` style no longer renders as visible block in dark mode
- [ ] Visual regression / Playwright suite (haven't re-run yet).