### PR TITLE
fix(inspector): render external PDFs with Stella's viewer

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -2540,29 +2540,30 @@ const fallbackIconUrl = (rawUrl: string): string | undefined => {
   }
 };
 
+type ExternalPdfState =
+  | {
+      status: "idle" | "loading" | "error";
+      buffer?: undefined;
+      token?: undefined;
+    }
+  | { status: "ready"; buffer: ArrayBuffer; token: string };
+
 const useExternalPdfBuffer = ({
   enabled,
   url,
 }: {
   enabled: boolean;
   url?: string | undefined;
-}): {
-  buffer: ArrayBuffer | undefined;
-  status: "error" | "idle" | "loading" | "ready";
-} => {
-  const [buffer, setBuffer] = useState<ArrayBuffer | undefined>();
-  const [status, setStatus] = useState<"error" | "idle" | "loading" | "ready">(
-    "idle",
-  );
+}): ExternalPdfState => {
+  const [state, setState] = useState<ExternalPdfState>({ status: "idle" });
 
   useEffect(() => {
-    setBuffer(undefined);
     if (!enabled || url === undefined) {
-      setStatus("idle");
+      setState({ status: "idle" });
       return undefined;
     }
 
-    setStatus("loading");
+    setState({ status: "loading" });
     const controller = new AbortController();
 
     void (async () => {
@@ -2573,7 +2574,7 @@ const useExternalPdfBuffer = ({
 
       if (!response.ok || controller.signal.aborted) {
         if (!controller.signal.aborted) {
-          setStatus("error");
+          setState({ status: "error" });
         }
         return;
       }
@@ -2583,12 +2584,15 @@ const useExternalPdfBuffer = ({
         return;
       }
 
-      setBuffer(next);
-      setStatus("ready");
+      // The PDF document cache (`usePDFDocument`) keys only by
+      // `fileId` and ignores the buffer, so a same-URL refetch with
+      // new bytes would otherwise return the stale parsed document.
+      // The token rotates per buffer fetch and is folded into the
+      // `fileId` so each new buffer parses from scratch.
+      setState({ status: "ready", buffer: next, token: crypto.randomUUID() });
     })().catch(() => {
       if (!controller.signal.aborted) {
-        setBuffer(undefined);
-        setStatus("error");
+        setState({ status: "error" });
       }
     });
 
@@ -2597,30 +2601,30 @@ const useExternalPdfBuffer = ({
     };
   }, [enabled, url]);
 
-  return { buffer, status };
+  return state;
 };
 
-const externalPdfFallback: PDFPageFallback = {
-  suspense: (
-    <div className="space-y-3 p-4">
-      <Skeleton className="h-4 w-2/3" />
-      <Skeleton className="h-4 w-full" />
-      <Skeleton className="h-4 w-5/6" />
-      <Skeleton className="h-4 w-4/5" />
-    </div>
-  ),
-};
+const externalPdfSuspenseFallback = (
+  <div className="space-y-3 p-4">
+    <Skeleton className="h-4 w-2/3" />
+    <Skeleton className="h-4 w-full" />
+    <Skeleton className="h-4 w-5/6" />
+    <Skeleton className="h-4 w-4/5" />
+  </div>
+);
 
 const ExternalPdfPreview = ({
   buffer,
-  fileId,
   onOpenOriginal,
   status,
+  url,
+  token,
 }: {
   buffer: ArrayBuffer | undefined;
-  fileId: string;
   onOpenOriginal: () => void;
   status: "error" | "idle" | "loading" | "ready";
+  url: string;
+  token: string | undefined;
 }) => {
   if (status === "error") {
     return (
@@ -2631,21 +2635,29 @@ const ExternalPdfPreview = ({
     );
   }
 
-  if (buffer === undefined || status === "loading" || status === "idle") {
-    return (
-      <div className="space-y-3 p-4">
-        <Skeleton className="h-4 w-2/3" />
-        <Skeleton className="h-4 w-full" />
-        <Skeleton className="h-4 w-5/6" />
-        <Skeleton className="h-4 w-4/5" />
-      </div>
-    );
+  if (buffer === undefined || token === undefined || status !== "ready") {
+    return externalPdfSuspenseFallback;
   }
+
+  // Token rotates per buffer fetch so the PDF document cache (which
+  // keys by fileId only) parses fresh bytes instead of returning the
+  // stale parsed document. The `key` on MeasuredPdfProvider forces
+  // the underlying store to remount whenever a new buffer arrives.
+  const fileId = `external:${url}:${token}`;
+  const fallback: PDFPageFallback = {
+    suspense: externalPdfSuspenseFallback,
+    error: (
+      <ExternalPreviewUnavailable
+        canOpenOriginal
+        onOpenOriginal={onOpenOriginal}
+      />
+    ),
+  };
 
   return (
     <MeasuredPdfProvider
       active
-      fallback={externalPdfFallback}
+      fallback={fallback}
       fieldId={fileId}
       initialScaleOffset={0}
       key={fileId}
@@ -3035,9 +3047,10 @@ const ExternalReferencePanel = ({
           ) : shouldLoadExternalPdf && externalFilePreviewUrl !== undefined ? (
             <ExternalPdfPreview
               buffer={externalPdfPreview.buffer}
-              fileId={`external:${externalFilePreviewUrl}`}
               onOpenOriginal={requestSafeExternalOpen}
               status={externalPdfPreview.status}
+              token={externalPdfPreview.token}
+              url={externalFilePreviewUrl}
             />
           ) : previewText || tab.snippet ? (
             <ScrollArea className="min-h-0 flex-1">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -76,7 +76,9 @@ import {
   getPDFPageIdByNumber,
   useOptionalPDFStore,
 } from "@/lib/pdf/pdf-context";
+import { PDFPage } from "@/lib/pdf/pdf-page";
 import type { PDFPageFallback } from "@/lib/pdf/pdf-page";
+import { PDFViewport } from "@/lib/pdf/pdf-viewport";
 import { renderJustificationContent } from "@/lib/render-justification-content";
 import { toSafeId } from "@/lib/safe-id";
 import { sanitizeHref } from "@/lib/sanitize-href";
@@ -2538,30 +2540,29 @@ const fallbackIconUrl = (rawUrl: string): string | undefined => {
   }
 };
 
-const useExternalPdfObjectUrl = ({
+const useExternalPdfBuffer = ({
   enabled,
   url,
 }: {
   enabled: boolean;
   url?: string | undefined;
 }): {
-  objectUrl: string | undefined;
+  buffer: ArrayBuffer | undefined;
   status: "error" | "idle" | "loading" | "ready";
 } => {
-  const [objectUrl, setObjectUrl] = useState<string | undefined>();
+  const [buffer, setBuffer] = useState<ArrayBuffer | undefined>();
   const [status, setStatus] = useState<"error" | "idle" | "loading" | "ready">(
     "idle",
   );
 
   useEffect(() => {
-    setObjectUrl(undefined);
+    setBuffer(undefined);
     if (!enabled || url === undefined) {
       setStatus("idle");
       return undefined;
     }
 
     setStatus("loading");
-    let nextObjectUrl: string | undefined;
     const controller = new AbortController();
 
     void (async () => {
@@ -2577,42 +2578,49 @@ const useExternalPdfObjectUrl = ({
         return;
       }
 
-      const blob = await response.blob();
+      const next = await response.arrayBuffer();
       if (controller.signal.aborted) {
         return;
       }
 
-      nextObjectUrl = URL.createObjectURL(blob);
-      setObjectUrl(nextObjectUrl);
+      setBuffer(next);
       setStatus("ready");
     })().catch(() => {
       if (!controller.signal.aborted) {
-        setObjectUrl(undefined);
+        setBuffer(undefined);
         setStatus("error");
       }
     });
 
     return () => {
       controller.abort();
-      if (nextObjectUrl !== undefined) {
-        URL.revokeObjectURL(nextObjectUrl);
-      }
     };
   }, [enabled, url]);
 
-  return { objectUrl, status };
+  return { buffer, status };
+};
+
+const externalPdfFallback: PDFPageFallback = {
+  suspense: (
+    <div className="space-y-3 p-4">
+      <Skeleton className="h-4 w-2/3" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-5/6" />
+      <Skeleton className="h-4 w-4/5" />
+    </div>
+  ),
 };
 
 const ExternalPdfPreview = ({
-  objectUrl,
+  buffer,
+  fileId,
   onOpenOriginal,
   status,
-  title,
 }: {
-  objectUrl?: string | undefined;
+  buffer: ArrayBuffer | undefined;
+  fileId: string;
   onOpenOriginal: () => void;
   status: "error" | "idle" | "loading" | "ready";
-  title: string;
 }) => {
   if (status === "error") {
     return (
@@ -2623,7 +2631,7 @@ const ExternalPdfPreview = ({
     );
   }
 
-  if (objectUrl === undefined || status === "loading" || status === "idle") {
+  if (buffer === undefined || status === "loading" || status === "idle") {
     return (
       <div className="space-y-3 p-4">
         <Skeleton className="h-4 w-2/3" />
@@ -2635,7 +2643,21 @@ const ExternalPdfPreview = ({
   }
 
   return (
-    <iframe className="min-h-0 flex-1 border-0" src={objectUrl} title={title} />
+    <MeasuredPdfProvider
+      active
+      fallback={externalPdfFallback}
+      fieldId={fileId}
+      initialScaleOffset={0}
+      key={fileId}
+    >
+      <PDFViewport
+        buffer={buffer}
+        className="document-preview-surface h-full"
+        contentClassName="relative space-y-2 px-2 pt-2"
+        fileId={fileId}
+        renderPage={(props) => <PDFPage {...props} />}
+      />
+    </MeasuredPdfProvider>
   );
 };
 
@@ -2726,7 +2748,7 @@ const ExternalReferencePanel = ({
       : `${env.VITE_API_URL}/v1/external-preview/file?url=${encodeURIComponent(safeHref)}`;
   const shouldLoadExternalPdf =
     fetchedPreview?.format === "pdf" && externalFilePreviewUrl !== undefined;
-  const externalPdfPreview = useExternalPdfObjectUrl({
+  const externalPdfPreview = useExternalPdfBuffer({
     enabled: shouldLoadExternalPdf,
     url: externalFilePreviewUrl,
   });
@@ -3010,12 +3032,12 @@ const ExternalReferencePanel = ({
               <Skeleton className="h-4 w-5/6" />
               <Skeleton className="h-4 w-4/5" />
             </div>
-          ) : shouldLoadExternalPdf ? (
+          ) : shouldLoadExternalPdf && externalFilePreviewUrl !== undefined ? (
             <ExternalPdfPreview
-              objectUrl={externalPdfPreview.objectUrl}
+              buffer={externalPdfPreview.buffer}
+              fileId={`external:${externalFilePreviewUrl}`}
               onOpenOriginal={requestSafeExternalOpen}
               status={externalPdfPreview.status}
-              title={tab.label}
             />
           ) : previewText || tab.snippet ? (
             <ScrollArea className="min-h-0 flex-1">


### PR DESCRIPTION
## Summary

- External-source previews were rendering PDFs through \`<iframe src=blob:...>\`, which means the browser's built-in PDF chrome shows up instead of Stella's PDF UI. That diverges from in-workspace previews and is also why the SPA CSP needed \`frame-src 'self' blob:\`.
- Swap to the existing \`PDFViewport\` + \`PDFPage\` stack already used by the workspace and peek viewers. Wrapped in \`MeasuredPdfProvider\` so it picks up the same fit-to-width behavior.
- The blob-URL hook is replaced with one that returns a raw \`ArrayBuffer\`; \`PDFViewport\` reads buffers directly via \`usePDFDocument\`.

## Test plan

- [x] \`bun run lint\`
- [x] \`bunx tsgo --noEmit\` (web)
- [ ] In dev, open an external source whose preview resolves to a PDF and confirm it renders with Stella's viewer (no native browser PDF toolbar visible)
- [ ] Verify zoom +/- and the fit-to-width baseline match the peek viewer
- [ ] Confirm the loading skeleton still appears while the buffer fetches