### PR TITLE
fix: expose build commit metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-arm64,mode=max
           build-args: |
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
+            STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
@@ -315,6 +316,7 @@ jobs:
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-amd64,mode=max
           build-args: |
             STELLA_VERSION=${{ needs.resolve.outputs.version }}
+            STELLA_COMMIT_SHA=${{ needs.resolve.outputs.release_sha }}
 
       - name: Attest image provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -49,10 +49,12 @@ RUN mkdir -p /app/runtime-workers && \
 # node_modules at runtime.
 FROM deps AS runner
 # Stamp the running container with the release version so the API can
-# return it from /health and tag PostHog events with `app_version`.
+# return it from /health and tag PostHog events with build metadata.
 # Defaults to "dev" for local `docker build` outside the release flow.
 ARG STELLA_VERSION=dev
+ARG STELLA_COMMIT_SHA=dev
 ENV STELLA_VERSION=${STELLA_VERSION}
+ENV STELLA_COMMIT_SHA=${STELLA_COMMIT_SHA}
 ENV STELLA_WORKER_DIR=/\$bunfs/root/workers
 RUN groupadd --system --gid 1001 stella && \
     useradd --system --uid 1001 --gid stella --no-create-home stella

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -5,6 +5,11 @@ import { HealthCheckError } from "@/api/lib/errors/tagged-errors";
 import { probeDatabase } from "@/api/lib/health/probe-database";
 
 const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
+const APP_COMMIT_SHA = process.env["STELLA_COMMIT_SHA"] ?? "dev";
+const BUILD_METADATA = {
+  version: APP_VERSION,
+  commit: APP_COMMIT_SHA,
+};
 
 export const healthRoute = new Elysia().get("/health", async ({ set }) => {
   const probe = probeDatabase();
@@ -23,9 +28,9 @@ export const healthRoute = new Elysia().get("/health", async ({ set }) => {
     return {
       status: "error" as const,
       message: "Database unreachable",
-      version: APP_VERSION,
+      ...BUILD_METADATA,
     };
   }
 
-  return { status: "ok" as const, version: APP_VERSION };
+  return { status: "ok" as const, ...BUILD_METADATA };
 });

--- a/apps/api/src/lib/analytics/posthog.test.ts
+++ b/apps/api/src/lib/analytics/posthog.test.ts
@@ -51,6 +51,7 @@ describe("PostHog server analytics adapter", () => {
       event: SERVER_ANALYTICS_EVENTS.exception,
       properties: {
         $exception_type: "HandlerError",
+        app_commit: "dev",
         app_version: "dev",
         organization_id: "org_123",
       },

--- a/apps/api/src/lib/analytics/posthog.ts
+++ b/apps/api/src/lib/analytics/posthog.ts
@@ -7,6 +7,7 @@ import type {
 } from "@/api/lib/analytics/types";
 
 const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
+const APP_COMMIT_SHA = process.env["STELLA_COMMIT_SHA"] ?? "dev";
 const ALLOWED_EVENTS = new Set<ServerAnalyticsCaptureParams["event"]>(
   Object.values(SERVER_ANALYTICS_EVENTS),
 );
@@ -26,7 +27,11 @@ export const createPostHogAnalytics = (
       client.capture({
         event,
         ...rest,
-        properties: { ...properties, app_version: APP_VERSION },
+        properties: {
+          ...properties,
+          app_commit: APP_COMMIT_SHA,
+          app_version: APP_VERSION,
+        },
       });
     },
     // eslint-disable-next-line promise-function-async

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1201,7 +1201,7 @@ export function AppSidebar(props: AppSidebarProps) {
                   {t("common.signOut")}
                 </MenuItem>
                 <div className="text-foreground-ghost px-2 pt-1.5 pb-1 text-[0.6875rem] tabular-nums">
-                  v{__APP_VERSION__}
+                  v{__APP_VERSION__} · {__APP_COMMIT_SHA__.slice(0, 12)}
                 </div>
               </MenuPopup>
             </Menu>

--- a/apps/web/src/lib/analytics/posthog.test.ts
+++ b/apps/web/src/lib/analytics/posthog.test.ts
@@ -67,6 +67,10 @@ Object.defineProperty(globalThis, "__APP_VERSION__", {
   configurable: true,
   value: "test",
 });
+Object.defineProperty(globalThis, "__APP_COMMIT_SHA__", {
+  configurable: true,
+  value: "abc123",
+});
 
 void mock.module("@/env", () => ({
   env: {

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -118,9 +118,12 @@ export const createPostHogAnalytics = (
     },
   });
 
-  // Attach app_version as a super-property so every captured event
-  // carries the build's version. Set once here so call sites don't have to.
-  posthog.register({ app_version: __APP_VERSION__ });
+  // Attach build metadata as super-properties so every captured
+  // event carries the exact deployed build.
+  posthog.register({
+    app_commit: __APP_COMMIT_SHA__,
+    app_version: __APP_VERSION__,
+  });
 
   const analytics: Analytics = {
     captureError: (error) => {

--- a/apps/web/src/types/app-version.d.ts
+++ b/apps/web/src/types/app-version.d.ts
@@ -5,3 +5,4 @@
  * env var that callers can override at runtime).
  */
 declare const __APP_VERSION__: string;
+declare const __APP_COMMIT_SHA__: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { visualizer } from "rollup-plugin-visualizer";
@@ -15,12 +16,31 @@ const APP_VERSION = readFileSync(
   "utf-8",
 ).trim();
 
+const readCommitSha = () => {
+  const explicitSha = process.env["STELLA_COMMIT_SHA"];
+  if (explicitSha) {
+    return explicitSha;
+  }
+
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: resolve(APP_ROOT, "../.."),
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    return "dev";
+  }
+};
+
+const APP_COMMIT_SHA = readCommitSha();
+
 export default defineConfig(({ mode }) => {
   const shouldAnalyze = mode === ANALYZE_MODE || process.env["ANALYZE"] === "1";
 
   return {
     root: APP_ROOT,
     define: {
+      __APP_COMMIT_SHA__: JSON.stringify(APP_COMMIT_SHA),
       __APP_VERSION__: JSON.stringify(APP_VERSION),
     },
     server: {


### PR DESCRIPTION
Expose the build commit alongside the app version in the API health response and app shell.