### PR TITLE
feat(i18n): added trls for markup view options at document edit

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/web",
     "format": "oxfmt -c ../../.oxfmtrc.json .",
     "i18n:check": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs --check && bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs",
+    "i18n:sync": "bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs --sync && bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,7 @@
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware apps/web",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/web",
     "format": "oxfmt -c ../../.oxfmtrc.json .",
-    "i18n:check": "bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs",
+    "i18n:check": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs --check && bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs",
     "test": "bun test"
   },
   "dependencies": {

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Načítání dokumentu…",
     "loadingEditor": "Načítání editoru...",
     "lockFile": "Zamknout soubor",
+    "markupView": {
+      "allMarkup": "Všechny revize",
+      "noMarkup": "Žádná revize",
+      "original": "Původní",
+      "simple": "Jednoduché revize"
+    },
     "moreFormatting": "Další formátování",
     "networkError": "Chyba sítě. Zkontrolujte připojení k internetu a zkuste to znovu.",
     "nextChange": "Následující změna",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Editor wird geladen...",
     "lockFile": "Datei sperren",
+    "markupView": {
+      "allMarkup": "Das gesamte Markup",
+      "noMarkup": "Kein Markup",
+      "original": "Original",
+      "simple": "Einfaches Markup"
+    },
     "moreFormatting": "Weitere Formatierung",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Loading editor...",
     "lockFile": "Lock file",
+    "markupView": {
+      "allMarkup": "All Markup",
+      "noMarkup": "No Markup",
+      "original": "Original",
+      "simple": "Simple Markup"
+    },
     "moreFormatting": "More formatting",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Cargando editor...",
     "lockFile": "Bloquear archivo",
+    "markupView": {
+      "allMarkup": "Todas las revisiones",
+      "noMarkup": "Ninguna revisión",
+      "original": "Original",
+      "simple": "Revisión sencilla"
+    },
     "moreFormatting": "Más formato",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Redaktori laadimine...",
     "lockFile": "Lukusta fail",
+    "markupView": {
+      "allMarkup": "Kogu märgistus",
+      "noMarkup": "Märgistust pole",
+      "original": "Algne",
+      "simple": "Lihtmärgistus"
+    },
     "moreFormatting": "Veel vormindust",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -988,7 +988,7 @@
       "allMarkup": "Toutes les marques",
       "noMarkup": "Aucune marque",
       "original": "Original",
-      "simple": "Le balisage simple"
+      "simple": "Marques simples"
     },
     "moreFormatting": "Plus de mise en forme",
     "networkError": "Network error. Please check your internet connection and try again.",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Chargement de l’éditeur...",
     "lockFile": "Verrouiller le fichier",
+    "markupView": {
+      "allMarkup": "Toutes les marques",
+      "noMarkup": "Aucune marque",
+      "original": "Original",
+      "simple": "Le balisage simple"
+    },
     "moreFormatting": "Plus de mise en forme",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Szerkesztő betöltése...",
     "lockFile": "Fájl zárolása",
+    "markupView": {
+      "allMarkup": "Az összes korrektúra",
+      "noMarkup": "Nincs korrektúra",
+      "original": "Az eredeti",
+      "simple": "Az egyszerű korrektúra"
+    },
     "moreFormatting": "További formázás",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Įkeliamas redaktorius...",
     "lockFile": "Užrakinti failą",
+    "markupView": {
+      "allMarkup": "Visi keitimai",
+      "noMarkup": "Nėra keitimų",
+      "original": "Pradinis",
+      "simple": "Supaprastintas žymėjimas"
+    },
     "moreFormatting": "Daugiau formatavimo",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Loading document...",
     "loadingEditor": "Ielādē redaktoru...",
     "lockFile": "Bloķēt failu",
+    "markupView": {
+      "allMarkup": "Visas atzīmes",
+      "noMarkup": "Bez atzīmēm",
+      "original": "Oriģināls",
+      "simple": "Vienkāršas atzīmes"
+    },
     "moreFormatting": "Papildu formatēšana",
     "networkError": "Network error. Please check your internet connection and try again.",
     "nextChange": "Next Change",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -989,9 +989,9 @@ type Messages = {
     "lockFile": "Lock file";
     "markupView": {
       "allMarkup": "All Markup";
-      "simple": "Simple";
       "noMarkup": "No Markup";
       "original": "Original";
+      "simple": "Simple Markup";
     };
     "moreFormatting": "More formatting";
     "networkError": "Network error. Please check your internet connection and try again.";

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -987,6 +987,12 @@ type Messages = {
     "loadingDocument": "Loading document...";
     "loadingEditor": "Loading editor...";
     "lockFile": "Lock file";
+    "markupView": {
+      "allMarkup": "All Markup";
+      "simple": "Simple";
+      "noMarkup": "No Markup";
+      "original": "Original";
+    };
     "moreFormatting": "More formatting";
     "networkError": "Network error. Please check your internet connection and try again.";
     "nextChange": "Next Change";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Ładowanie dokumentu...",
     "loadingEditor": "Ładowanie edytora...",
     "lockFile": "Zablokuj plik",
+    "markupView": {
+      "allMarkup": "Cała adiustacja",
+      "noMarkup": "Bez adiustacji",
+      "original": "Oryginał",
+      "simple": "Prosta adiustacja"
+    },
     "moreFormatting": "Więcej formatowania",
     "networkError": "Błąd sieci. Sprawdź połączenie z internetem i spróbuj ponownie.",
     "nextChange": "Następna zmiana",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Carregando documento...",
     "loadingEditor": "Carregando editor...",
     "lockFile": "Bloquear arquivo",
+    "markupView": {
+      "allMarkup": "Toda Marcação",
+      "noMarkup": "Nenhuma Marcação",
+      "original": "Original",
+      "simple": "Marcação Simples"
+    },
     "moreFormatting": "Mais formatação",
     "networkError": "Erro de rede. Verifique sua conexão com a Internet e tente novamente.",
     "nextChange": "Próxima alteração",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -984,6 +984,12 @@
     "loadingDocument": "Načitávanie dokumentu...",
     "loadingEditor": "Načítava sa editor...",
     "lockFile": "Zamknúť súbor",
+    "markupView": {
+      "allMarkup": "Všetky revízie",
+      "noMarkup": "Žiadna značka",
+      "original": "Pôvodný",
+      "simple": "Jednoduché označenie revízie"
+    },
     "moreFormatting": "Ďalšie formátovanie",
     "networkError": "Chyba siete. Skontrolujte internetové pripojenie a skúste znova.",
     "nextChange": "Ďalšia zmena",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -986,9 +986,9 @@
     "lockFile": "Zamknúť súbor",
     "markupView": {
       "allMarkup": "Všetky revízie",
-      "noMarkup": "Žiadna značka",
+      "noMarkup": "Bez revízií",
       "original": "Pôvodný",
-      "simple": "Jednoduché označenie revízie"
+      "simple": "Jednoduché revízie"
     },
     "moreFormatting": "Ďalšie formátovanie",
     "networkError": "Chyba siete. Skontrolujte internetové pripojenie a skúste znova.",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:fix": "turbo run lint:fix",
     "lint:ws": "sherif -r unsync-similar-dependencies && bun packages/scripts/src/workspace-hygiene.ts",
     "i18n:check": "turbo run i18n:check --",
-    "i18n:sync": "turbo run i18n:check -- --sync",
+    "i18n:sync": "turbo run i18n:sync --",
     "test": "turbo run test",
     "clean": "turbo run clean && git clean -xdf node_modules",
     "sync:well-known": "cp -r .well-known apps/web/public/",

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -3235,10 +3235,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     }
 
     const DISPLAY_MODE_LABELS = {
-      "all-markup": "All Markup",
-      "simple-markup": "Simple",
-      "no-markup": "No Markup",
-      original: "Original",
+      "all-markup": t("markupView.allMarkup"),
+      "simple-markup": t("markupView.simple"),
+      "no-markup": t("markupView.noMarkup"),
+      original: t("markupView.original"),
     } as const satisfies Record<DisplayMode, string>;
 
     const toolbarChildren = toolbarExtra ?? null;

--- a/packages/scripts/src/i18n-typegen.ts
+++ b/packages/scripts/src/i18n-typegen.ts
@@ -5,7 +5,11 @@
  * use-intl to parse ICU variables at the type level and
  * enforce interpolation parameters.
  *
- * Usage: i18n-typegen <langs-dir>
+ * Usage: i18n-typegen <langs-dir> [--check]
+ *
+ * --check  Verify the on-disk messages.gen.ts matches what
+ *          would be generated from en.json. Exits non-zero on
+ *          drift without writing.
  */
 import { resolve } from "node:path";
 
@@ -35,10 +39,12 @@ const parseMessages = (json: string): JsonObject => {
   return parsed;
 };
 
-const langsDir = process.argv[2];
+const args = process.argv.slice(2);
+const langsDir = args.find((a) => !a.startsWith("--"));
+const checkOnly = args.includes("--check");
 
 if (!langsDir) {
-  console.error("Usage: i18n-typegen <langs-dir>");
+  console.error("Usage: i18n-typegen <langs-dir> [--check]");
   process.exit(1);
 }
 
@@ -81,6 +87,18 @@ type Messages = ${toLiteral(messages, 0)};
 export type { Messages as default };
 `;
 
-await Bun.write(outputPath, declaration);
-
-console.log(`Generated ${outputPath} (${keyCount} keys)`);
+if (checkOnly) {
+  const existing = await Bun.file(outputPath)
+    .text()
+    .catch(() => "");
+  if (existing !== declaration) {
+    console.error(
+      `Error: ${outputPath} is out of sync with en.json. Run \`bun run typegen\`.`,
+    );
+    process.exit(1);
+  }
+  console.log(`${outputPath} is in sync (${keyCount} keys)`);
+} else {
+  await Bun.write(outputPath, declaration);
+  console.log(`Generated ${outputPath} (${keyCount} keys)`);
+}

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -15,7 +15,7 @@
     "start": "email start -p 3002",
     "typecheck": "tsgo --noEmit",
     "typegen": "bun ../scripts/src/i18n-typegen.ts i18n/langs",
-    "i18n:check": "bun ../scripts/src/i18n-check.ts i18n/langs",
+    "i18n:check": "bun ../scripts/src/i18n-typegen.ts i18n/langs --check && bun ../scripts/src/i18n-check.ts i18n/langs",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/transactional",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/transactional",
     "format": "oxfmt ."

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsgo --noEmit",
     "typegen": "bun ../scripts/src/i18n-typegen.ts i18n/langs",
     "i18n:check": "bun ../scripts/src/i18n-typegen.ts i18n/langs --check && bun ../scripts/src/i18n-check.ts i18n/langs",
+    "i18n:sync": "bun ../scripts/src/i18n-check.ts i18n/langs --sync && bun ../scripts/src/i18n-typegen.ts i18n/langs",
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/transactional",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/transactional",
     "format": "oxfmt ."

--- a/turbo.json
+++ b/turbo.json
@@ -40,6 +40,10 @@
       "dependsOn": ["transit"],
       "cache": false
     },
+    "i18n:sync": {
+      "dependsOn": ["transit"],
+      "cache": false
+    },
     "test": {
       "dependsOn": [],
       "inputs": ["$TURBO_DEFAULT$"]


### PR DESCRIPTION
## Proposed change
Added translations from MSFT docs for all languages #57 
To double check replace [pl-pl] with needed locale.
https://support.microsoft.com/pl-pl/office/śledzenie-zmian-w-programie-word-197ba630-0f5f-4a8e-9a77-3712475e806a

<img width="672" height="237" alt="image" src="https://github.com/user-attachments/assets/73c1c7be-71b5-40d4-bdb7-95b221139bba" />
<!--
  Brief description of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

## Checklist

<!--
  Put into **bold** for each item the appropriate option.
  Then mark the item with an `x` like so:
  `- [ ] BUILD ASSURANCE | Confirm that your code builds correctly and without any errors or warnings.
-->

- [X] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [X] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [X] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [X] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [X] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)
