### PR TITLE
fix(api): widen BYOK validation timeout to 20 s

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -391,6 +391,12 @@ const getValidationRole = (
     `validateProviderKey called for ${provider} but no role is bound to it`,
   );
 
+// Provider first-call latency can exceed 10 s and we don't want a
+// healthy key flagged invalid by a slow upstream. Validations run in
+// parallel, so the worst-case settings-save wait is bounded by this
+// single ceiling regardless of how many providers are configured.
+const VALIDATION_TIMEOUT_MS = 20_000;
+
 /**
  * Validate a provider API key by making a minimal API call.
  * Uses a tiny prompt to minimize cost. Always exercises a
@@ -415,7 +421,7 @@ const validateProviderKey = async (
         temperature: getTemperatureForRole(role),
         prompt: "Say OK",
         maxOutputTokens: 3,
-        abortSignal: AbortSignal.timeout(10_000),
+        abortSignal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
       });
     },
     catch: (error: unknown) =>


### PR DESCRIPTION
## Summary

- The provider validation call in \`updateAIConfig\` used a 10 s \`AbortSignal\` ceiling. Provider first-call latency can exceed that on a real-world network path, surfacing as a handled \`"API key validation failed: The operation timed out."\` for users whose key is actually fine.
- Validations run in parallel via \`Promise.all\`, so the worst-case settings-save wait is bounded by this single ceiling regardless of how many providers are configured. Going 10 s → 20 s grows the worst case linearly only in the slowest-provider case.
- Extracted to a named constant so future tuning lives in one place.

## Test plan

- [x] \`bunx tsgo --noEmit\` (api)
- [x] \`bun run lint\`
- [ ] After merge + release, watch the BYOK validation-timeout exception rate drop from the recurring background level