### PR TITLE
fix(web): broadcast MCP OAuth outcome via BroadcastChannel

### DIFF
--- a/apps/web/src/lib/mcp-oauth-channel.ts
+++ b/apps/web/src/lib/mcp-oauth-channel.ts
@@ -1,0 +1,66 @@
+import * as v from "valibot";
+
+const CHANNEL_NAME = "mcp-oauth";
+
+export const mcpOAuthOutcomeSchema = v.union([
+  v.strictObject({
+    status: v.literal("connected"),
+  }),
+  v.strictObject({
+    status: v.literal("error"),
+    reason: v.string(),
+  }),
+]);
+
+export type McpOAuthOutcome = v.InferOutput<typeof mcpOAuthOutcomeSchema>;
+
+export function broadcastMcpOAuthOutcome(outcome: McpOAuthOutcome): void {
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  // BroadcastChannel.postMessage takes no targetOrigin; messages are
+  // confined to the same origin by the browser's BroadcastChannel
+  // contract.
+  // eslint-disable-next-line unicorn/require-post-message-target-origin
+  channel.postMessage(outcome);
+  channel.close();
+
+  // Belt-and-braces: some browsers preserve `window.opener` across
+  // the OAuth round-trip, others sever it via COOP. BroadcastChannel
+  // covers same-origin tabs regardless; postMessage is a fallback
+  // for environments without BroadcastChannel support.
+  // SAFETY: lib.dom types `window.opener` as `any` because the
+  // opener may be a Window from any origin. We post to our own
+  // origin only, so narrowing to the postMessage surface is safe.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const opener = window.opener as Pick<Window, "postMessage"> | null;
+  if (opener !== null) {
+    opener.postMessage(outcome, window.location.origin);
+  }
+}
+
+export function subscribeToMcpOAuthOutcome(
+  handler: (outcome: McpOAuthOutcome) => void,
+): () => void {
+  const onMessage = (event: MessageEvent) => {
+    const result = v.safeParse(mcpOAuthOutcomeSchema, event.data);
+    if (result.success) {
+      handler(result.output);
+    }
+  };
+
+  const channel = new BroadcastChannel(CHANNEL_NAME);
+  channel.addEventListener("message", onMessage);
+
+  const onWindowMessage = (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) {
+      return;
+    }
+    onMessage(event);
+  };
+  window.addEventListener("message", onWindowMessage);
+
+  return () => {
+    channel.removeEventListener("message", onMessage);
+    channel.close();
+    window.removeEventListener("message", onWindowMessage);
+  };
+}

--- a/apps/web/src/lib/mcp-oauth-channel.ts
+++ b/apps/web/src/lib/mcp-oauth-channel.ts
@@ -15,18 +15,21 @@ export const mcpOAuthOutcomeSchema = v.union([
 export type McpOAuthOutcome = v.InferOutput<typeof mcpOAuthOutcomeSchema>;
 
 export function broadcastMcpOAuthOutcome(outcome: McpOAuthOutcome): void {
-  const channel = new BroadcastChannel(CHANNEL_NAME);
-  // BroadcastChannel.postMessage takes no targetOrigin; messages are
-  // confined to the same origin by the browser's BroadcastChannel
-  // contract.
-  // eslint-disable-next-line unicorn/require-post-message-target-origin
-  channel.postMessage(outcome);
-  channel.close();
+  // Prefer BroadcastChannel (covers same-origin tabs even when COOP
+  // severs `window.opener`). Fall back to `opener.postMessage` only
+  // when BroadcastChannel is unavailable, so the subscriber on the
+  // opener page receives the outcome exactly once.
+  if (typeof BroadcastChannel !== "undefined") {
+    const channel = new BroadcastChannel(CHANNEL_NAME);
+    // BroadcastChannel.postMessage takes no targetOrigin; messages are
+    // confined to the same origin by the browser's BroadcastChannel
+    // contract.
+    // eslint-disable-next-line unicorn/require-post-message-target-origin
+    channel.postMessage(outcome);
+    channel.close();
+    return;
+  }
 
-  // Belt-and-braces: some browsers preserve `window.opener` across
-  // the OAuth round-trip, others sever it via COOP. BroadcastChannel
-  // covers same-origin tabs regardless; postMessage is a fallback
-  // for environments without BroadcastChannel support.
   // SAFETY: lib.dom types `window.opener` as `any` because the
   // opener may be a Window from any origin. We post to our own
   // origin only, so narrowing to the postMessage surface is safe.
@@ -47,8 +50,11 @@ export function subscribeToMcpOAuthOutcome(
     }
   };
 
-  const channel = new BroadcastChannel(CHANNEL_NAME);
-  channel.addEventListener("message", onMessage);
+  const channel =
+    typeof BroadcastChannel === "undefined"
+      ? null
+      : new BroadcastChannel(CHANNEL_NAME);
+  channel?.addEventListener("message", onMessage);
 
   const onWindowMessage = (event: MessageEvent) => {
     if (event.origin !== window.location.origin) {
@@ -59,8 +65,8 @@ export function subscribeToMcpOAuthOutcome(
   window.addEventListener("message", onWindowMessage);
 
   return () => {
-    channel.removeEventListener("message", onMessage);
-    channel.close();
+    channel?.removeEventListener("message", onMessage);
+    channel?.close();
     window.removeEventListener("message", onWindowMessage);
   };
 }

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -32,6 +32,7 @@ import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
+import { subscribeToMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { toSafeId } from "@/lib/safe-id";
 import { sanitizeHref } from "@/lib/sanitize-href";
 import {
@@ -112,41 +113,27 @@ function McpPage() {
   const canManageCustomConnectors =
     connectorsData?.canManageCustomConnectors ?? false;
 
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      // Popup terminal page lives on the SPA host, so it posts back
-      // to its own origin. The previous flow posted from the API
-      // host (api.stll.app), but CloudFront's CSP blocks the inline
-      // postMessage script there.
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-
-      if (typeof event.data !== "string") {
-        return;
-      }
-
-      if (event.data.startsWith("mcp:connected:")) {
-        stellaToast.add({
-          title: t("knowledge.mcp.connectedToast"),
-          type: "success",
-        });
-        void queryClient.invalidateQueries({ queryKey: knowledgeKeys.mcp.all });
-        return;
-      }
-
-      if (event.data.startsWith("mcp:error:")) {
+  useEffect(
+    () =>
+      subscribeToMcpOAuthOutcome((outcome) => {
+        if (outcome.status === "connected") {
+          stellaToast.add({
+            title: t("knowledge.mcp.connectedToast"),
+            type: "success",
+          });
+          void queryClient.invalidateQueries({
+            queryKey: knowledgeKeys.mcp.all,
+          });
+          return;
+        }
         stellaToast.add({
           title: t("knowledge.mcp.errorTitle"),
           description: t("knowledge.mcp.errorDescription"),
           type: "error",
         });
-      }
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [queryClient, t]);
+      }),
+    [queryClient, t],
+  );
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto p-6">

--- a/apps/web/src/routes/mcp.oauth-callback.tsx
+++ b/apps/web/src/routes/mcp.oauth-callback.tsx
@@ -8,10 +8,12 @@ import {
   FramePanel,
   FrameTitle,
 } from "@stll/ui/components/frame";
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
+import type { McpOAuthOutcome } from "@/lib/mcp-oauth-channel";
+import { broadcastMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { pageTitle } from "@/lib/page-title";
 
 const searchSchema = v.object({
@@ -31,25 +33,16 @@ export const Route = createFileRoute("/mcp/oauth-callback")({
 function McpOAuthCallbackPage() {
   const t = useTranslations();
   const status = Route.useSearch({ select: (search) => search.status });
-  const slug = Route.useSearch({ select: (search) => search.slug });
   const reason = Route.useSearch({ select: (search) => search.reason });
 
   useEffect(() => {
-    const message =
+    const outcome: McpOAuthOutcome =
       status === "connected"
-        ? `mcp:connected:${slug ?? ""}`
-        : `mcp:error:${reason ?? "unexpected"}`;
-
-    // SAFETY: lib.dom types `window.opener` as `any` because the
-    // opener may be a Window from any origin. We post to our own
-    // origin only, so narrowing to the postMessage surface is safe.
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-    const opener = window.opener as Pick<Window, "postMessage"> | null;
-    if (opener !== null) {
-      opener.postMessage(message, window.location.origin);
-      window.close();
-    }
-  }, [status, slug, reason]);
+        ? { status: "connected" }
+        : { status: "error", reason: reason ?? "unexpected" };
+    broadcastMcpOAuthOutcome(outcome);
+    window.close();
+  }, [status, reason]);
 
   const isError = status === "error";
 
@@ -69,11 +62,13 @@ function McpOAuthCallbackPage() {
           ) : null}
         </FrameHeader>
         <FramePanel>
-          <Link to="/knowledge/mcp">
-            <Button className="w-full" type="button">
-              {t("common.close")}
-            </Button>
-          </Link>
+          <Button
+            className="w-full"
+            onClick={() => window.close()}
+            type="button"
+          >
+            {t("common.close")}
+          </Button>
         </FramePanel>
       </Frame>
     </div>

--- a/apps/web/src/routes/mcp.oauth-callback.tsx
+++ b/apps/web/src/routes/mcp.oauth-callback.tsx
@@ -8,13 +8,16 @@ import {
   FramePanel,
   FrameTitle,
 } from "@stll/ui/components/frame";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
 import type { McpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { broadcastMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { pageTitle } from "@/lib/page-title";
+
+const KNOWLEDGE_MCP_PATH = "/knowledge/mcp";
+const FALLBACK_NAVIGATE_DELAY_MS = 150;
 
 const searchSchema = v.object({
   status: v.picklist(["connected", "error"]),
@@ -32,6 +35,7 @@ export const Route = createFileRoute("/mcp/oauth-callback")({
 
 function McpOAuthCallbackPage() {
   const t = useTranslations();
+  const navigate = useNavigate();
   const status = Route.useSearch({ select: (search) => search.status });
   const reason = Route.useSearch({ select: (search) => search.reason });
 
@@ -42,7 +46,15 @@ function McpOAuthCallbackPage() {
         : { status: "error", reason: reason ?? "unexpected" };
     broadcastMcpOAuthOutcome(outcome);
     window.close();
-  }, [status, reason]);
+    // `window.close()` is a no-op for tabs the user navigated to
+    // themselves (the popup-blocked fallback path uses
+    // `window.location.assign`). If we're still here after a tick,
+    // route back to the MCP settings page so the user is not stranded.
+    const fallback = window.setTimeout(() => {
+      void navigate({ to: KNOWLEDGE_MCP_PATH });
+    }, FALLBACK_NAVIGATE_DELAY_MS);
+    return () => window.clearTimeout(fallback);
+  }, [status, reason, navigate]);
 
   const isError = status === "error";
 
@@ -64,7 +76,10 @@ function McpOAuthCallbackPage() {
         <FramePanel>
           <Button
             className="w-full"
-            onClick={() => window.close()}
+            onClick={() => {
+              window.close();
+              void navigate({ to: KNOWLEDGE_MCP_PATH });
+            }}
             type="button"
           >
             {t("common.close")}


### PR DESCRIPTION
## Summary
- OAuth callback popup now broadcasts via `BroadcastChannel` (with `postMessage` fallback), so the parent learns the outcome even when COOP severs `window.opener`.
- Manual "close" button calls `window.close()` instead of navigating the popup to `/knowledge/mcp`.
- Wire format moved to a shared `McpOAuthOutcome` discriminated union (Valibot) consumed by both ends.

## Test plan
- [ ] Manual: trigger MCP OAuth flow against a provider that strips opener — popup closes, parent toasts and refetches without manual reload
- [ ] Manual: simulate BroadcastChannel message in DevTools and confirm parent toast + query invalidation
- [ ] `bun run typecheck`, `bun run lint`