### PR TITLE
feat: share inspector tabs via BroadcastChannel

### DIFF
--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -57,7 +57,10 @@ import { roleOptions } from "@/routes/-queries";
 import { useGlobalChatMentionRegistration } from "@/routes/_protected.chat/-hooks/use-global-chat-mention-registration";
 import { CaseSearchTrigger } from "@/routes/_protected.knowledge/case/-components/case-viewer/case-search-trigger";
 import { DecisionMetadataSheet } from "@/routes/_protected.knowledge/case/-components/case-viewer/decision-metadata-sheet";
-import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+import {
+  initializeInspectorTabBroadcast,
+  useInspectorStore,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import type { InspectorTab } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { MatterMetadataSheet } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet";
 import { CreateMatterDialog } from "@/routes/_protected.workspaces/-components/create-matter-dialog";
@@ -113,6 +116,12 @@ export const Route = createFileRoute("/_protected")({
 });
 
 function ProtectedComponent() {
+  const inspectorBroadcastUserId = Route.useRouteContext({
+    select: (ctx) => ctx.user.id,
+  });
+  const inspectorBroadcastOrganizationId = Route.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const workspaceMatch = useMatch({
     from: "/_protected/workspaces/$workspaceId",
     shouldThrow: false,
@@ -124,6 +133,15 @@ function ProtectedComponent() {
     shouldThrow: false,
   });
   const activeDecisionId = decisionMatch?.params.decisionId;
+
+  useEffect(
+    () =>
+      initializeInspectorTabBroadcast({
+        organizationId: inspectorBroadcastOrganizationId,
+        userId: inspectorBroadcastUserId,
+      }),
+    [inspectorBroadcastOrganizationId, inspectorBroadcastUserId],
+  );
 
   // Mod+J — toggles the inspector pane. With tabs already open it
   // restores or hides the pane regardless of route, so users can

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
@@ -8,11 +8,16 @@ import {
 } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 
 let cleanupInspectorBroadcast: (() => void) | null = null;
+let previousDateNow: (() => number) | undefined;
 let previousWindowDescriptor: PropertyDescriptor | undefined;
 
 afterEach(() => {
   cleanupInspectorBroadcast?.();
   cleanupInspectorBroadcast = null;
+  if (previousDateNow !== undefined) {
+    Date.now = previousDateNow;
+    previousDateNow = undefined;
+  }
   FakeBroadcastChannel.reset();
   if (previousWindowDescriptor) {
     Object.defineProperty(globalThis, "window", previousWindowDescriptor);
@@ -114,6 +119,11 @@ const installFakeBroadcastChannel = () => {
     configurable: true,
     value: { BroadcastChannel: FakeBroadcastChannel },
   });
+};
+
+const freezeDateNow = (updatedAt: number) => {
+  previousDateNow = Date.now;
+  Date.now = () => updatedAt;
 };
 
 describe("openChat", () => {
@@ -460,6 +470,85 @@ describe("Inspector tab broadcast", () => {
         type: "chat",
         id: localThreadId,
         label: "Local chat renamed elsewhere",
+        contextMatterIds: [],
+      },
+    ]);
+  });
+
+  test("uses sender id as deterministic tie-breaker for same-ms updates", () => {
+    freezeDateNow(100);
+    installFakeBroadcastChannel();
+    const scope = { organizationId: "org-1", userId: "user-1" };
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName(scope),
+    );
+    const received: unknown[] = [];
+    peer.addEventListener("message", (event) => {
+      received.push(event.data);
+    });
+
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast(scope);
+
+    const localThreadId = toChatThreadId("thread-local");
+    useInspectorStore.getState().openChat({
+      id: localThreadId,
+      label: "Local chat",
+    });
+
+    const syncMessage = received.findLast(
+      (message) =>
+        typeof message === "object" &&
+        message !== null &&
+        Reflect.get(message, "type") === "inspector-tabs:sync",
+    );
+    const localSenderId = Reflect.get(syncMessage ?? {}, "senderId");
+    expect(typeof localSenderId).toBe("string");
+    if (typeof localSenderId !== "string") {
+      throw new TypeError("expected local sender id");
+    }
+
+    const lowerPeerThreadId = toChatThreadId("thread-lower-peer");
+    peer.emit({
+      type: "inspector-tabs:sync",
+      senderId: "00000000-0000-0000-0000-000000000000",
+      updatedAt: 100,
+      tabs: [
+        {
+          type: "chat",
+          id: lowerPeerThreadId,
+          label: "Lower peer chat",
+          contextMatterIds: [],
+        },
+      ],
+    });
+    expect(useInspectorStore.getState().tabs).toEqual([
+      {
+        type: "chat",
+        id: localThreadId,
+        label: "Local chat",
+        contextMatterIds: [],
+      },
+    ]);
+
+    const higherPeerThreadId = toChatThreadId("thread-higher-peer");
+    peer.emit({
+      type: "inspector-tabs:sync",
+      senderId: "zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz",
+      updatedAt: 100,
+      tabs: [
+        {
+          type: "chat",
+          id: higherPeerThreadId,
+          label: "Higher peer chat",
+          contextMatterIds: [],
+        },
+      ],
+    });
+    expect(useInspectorStore.getState().tabs).toEqual([
+      {
+        type: "chat",
+        id: higherPeerThreadId,
+        label: "Higher peer chat",
         contextMatterIds: [],
       },
     ]);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
@@ -1,17 +1,120 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import { toChatThreadId } from "@/lib/chat-thread-ref";
-import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+import {
+  getInspectorTabsBroadcastChannelName,
+  initializeInspectorTabBroadcast,
+  useInspectorStore,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+
+let cleanupInspectorBroadcast: (() => void) | null = null;
+let previousWindowDescriptor: PropertyDescriptor | undefined;
 
 afterEach(() => {
+  cleanupInspectorBroadcast?.();
+  cleanupInspectorBroadcast = null;
+  FakeBroadcastChannel.reset();
+  if (previousWindowDescriptor) {
+    Object.defineProperty(globalThis, "window", previousWindowDescriptor);
+    previousWindowDescriptor = undefined;
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
   useInspectorStore.setState({
     tabs: [],
     activeId: null,
     activationSeq: 0,
     pendingRenameTabId: null,
     minimized: false,
+    pendingBlockScroll: null,
   });
 });
+
+class FakeBroadcastChannel {
+  static channels = new Map<string, Set<FakeBroadcastChannel>>();
+
+  readonly name: string;
+
+  private readonly listeners = new Set<
+    (event: MessageEvent<unknown>) => void
+  >();
+
+  constructor(name: string) {
+    this.name = name;
+    const peers = FakeBroadcastChannel.channels.get(name) ?? new Set();
+    peers.add(this);
+    FakeBroadcastChannel.channels.set(name, peers);
+  }
+
+  postMessage(message: unknown) {
+    this.dispatchToPeers(message);
+  }
+
+  emit(message: unknown) {
+    this.dispatchToPeers(message);
+  }
+
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent<unknown>) => void,
+  ) {
+    if (type === "message") {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(
+    type: "message",
+    listener: (event: MessageEvent<unknown>) => void,
+  ) {
+    if (type === "message") {
+      this.listeners.delete(listener);
+    }
+  }
+
+  private dispatchToPeers(message: unknown) {
+    const peers = FakeBroadcastChannel.channels.get(this.name);
+    if (!peers) {
+      return;
+    }
+
+    for (const peer of peers) {
+      if (peer === this) {
+        continue;
+      }
+      peer.dispatch(message);
+    }
+  }
+
+  private dispatch(message: unknown) {
+    const event = new MessageEvent("message", {
+      data: structuredClone(message),
+    });
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  close() {
+    const peers = FakeBroadcastChannel.channels.get(this.name);
+    peers?.delete(this);
+  }
+
+  static reset() {
+    FakeBroadcastChannel.channels.clear();
+  }
+}
+
+const installFakeBroadcastChannel = () => {
+  previousWindowDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "window",
+  );
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { BroadcastChannel: FakeBroadcastChannel },
+  });
+};
 
 describe("openChat", () => {
   test("creates a workspace-scoped tab when workspaceId is provided", () => {
@@ -221,5 +324,229 @@ describe("replacePdfFieldId", () => {
 
     expect(after.renderId).toBe(before.renderId);
     expect(useInspectorStore.getState().activeId).toBe("field-new");
+  });
+});
+
+describe("Inspector tab broadcast", () => {
+  test("publishes tab set metadata without sharing local active state", () => {
+    installFakeBroadcastChannel();
+    const scope = { organizationId: "org-1", userId: "user-1" };
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName(scope),
+    );
+    const received: unknown[] = [];
+    peer.addEventListener("message", (event) => {
+      received.push(event.data);
+    });
+
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast(scope);
+
+    useInspectorStore.getState().openPdf({
+      id: "field-1",
+      entityId: "entity-1",
+      label: "Contract.docx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      pdfFileId: null,
+      propertyId: "property-1",
+      workspaceId: "workspace-1",
+    });
+    useInspectorStore.getState().setPdfFacet("field-1", "versions", {
+      pulse: true,
+    });
+
+    const syncMessage = received.findLast(
+      (message) =>
+        typeof message === "object" &&
+        message !== null &&
+        Reflect.get(message, "type") === "inspector-tabs:sync",
+    );
+    expect(syncMessage).toBeDefined();
+    expect(Reflect.get(syncMessage ?? {}, "tabs")).toEqual(
+      useInspectorStore.getState().tabs,
+    );
+    expect(Reflect.get(syncMessage ?? {}, "activeId")).toBeUndefined();
+    expect(Reflect.get(syncMessage ?? {}, "minimized")).toBeUndefined();
+  });
+
+  test("hydrates tab set from another browser tab and chooses a local active tab", () => {
+    installFakeBroadcastChannel();
+    const scope = { organizationId: "org-1", userId: "user-1" };
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName(scope),
+    );
+
+    peer.addEventListener("message", (event) => {
+      const message = event.data;
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        Reflect.get(message, "type") !== "inspector-tabs:request"
+      ) {
+        return;
+      }
+
+      peer.emit({
+        type: "inspector-tabs:sync",
+        senderId: "peer-tab",
+        recipientId: Reflect.get(message, "senderId"),
+        updatedAt: 1,
+        tabs: [
+          {
+            type: "chat",
+            id: toChatThreadId("thread-1"),
+            label: "Shared chat",
+            workspaceId: "workspace-1",
+            contextMatterIds: ["workspace-1"],
+          },
+        ],
+      });
+    });
+
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast(scope);
+
+    expect(useInspectorStore.getState().tabs).toEqual([
+      {
+        type: "chat",
+        id: toChatThreadId("thread-1"),
+        label: "Shared chat",
+        workspaceId: "workspace-1",
+        contextMatterIds: ["workspace-1"],
+      },
+    ]);
+    expect(useInspectorStore.getState().activeId).toBe("thread-1");
+  });
+
+  test("keeps local active tab when the shared tab set still contains it", () => {
+    installFakeBroadcastChannel();
+    const scope = { organizationId: "org-1", userId: "user-1" };
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName(scope),
+    );
+
+    const localThreadId = toChatThreadId("thread-local");
+    useInspectorStore.getState().openChat({ id: localThreadId });
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast(scope);
+
+    peer.emit({
+      type: "inspector-tabs:sync",
+      senderId: "peer-tab",
+      updatedAt: 1,
+      tabs: [
+        {
+          type: "chat",
+          id: toChatThreadId("thread-remote"),
+          label: "Remote chat",
+          contextMatterIds: [],
+        },
+        {
+          type: "chat",
+          id: localThreadId,
+          label: "Local chat renamed elsewhere",
+          contextMatterIds: [],
+        },
+      ],
+    });
+
+    expect(useInspectorStore.getState().activeId).toBe(localThreadId);
+    expect(useInspectorStore.getState().tabs).toEqual([
+      {
+        type: "chat",
+        id: toChatThreadId("thread-remote"),
+        label: "Remote chat",
+        contextMatterIds: [],
+      },
+      {
+        type: "chat",
+        id: localThreadId,
+        label: "Local chat renamed elsewhere",
+        contextMatterIds: [],
+      },
+    ]);
+  });
+
+  test("hydrates external tabs from another browser tab", () => {
+    installFakeBroadcastChannel();
+    const scope = { organizationId: "org-1", userId: "user-1" };
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName(scope),
+    );
+    const chatThreadId = toChatThreadId("thread-external");
+
+    peer.addEventListener("message", (event) => {
+      const message = event.data;
+      if (
+        typeof message !== "object" ||
+        message === null ||
+        Reflect.get(message, "type") !== "inspector-tabs:request"
+      ) {
+        return;
+      }
+
+      peer.emit({
+        type: "inspector-tabs:sync",
+        senderId: "peer-tab",
+        recipientId: Reflect.get(message, "senderId"),
+        updatedAt: 1,
+        tabs: [
+          {
+            type: "external",
+            id: "external:https://example.test/decision",
+            chatThreadId,
+            label: "External decision",
+            url: "https://example.test/decision",
+            connectorSlug: "salvia",
+            iconHref: "https://example.test/favicon.ico",
+            provider: "example",
+            snippet: "Holding excerpt",
+            sourceToolName: "search_decisions",
+            text: "Decision text",
+          },
+        ],
+      });
+    });
+
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast(scope);
+
+    expect(useInspectorStore.getState().tabs).toEqual([
+      {
+        type: "external",
+        id: "external:https://example.test/decision",
+        chatThreadId,
+        label: "External decision",
+        url: "https://example.test/decision",
+        connectorSlug: "salvia",
+        iconHref: "https://example.test/favicon.ico",
+        provider: "example",
+        snippet: "Holding excerpt",
+        sourceToolName: "search_decisions",
+        text: "Decision text",
+      },
+    ]);
+    expect(useInspectorStore.getState().activeId).toBe(
+      "external:https://example.test/decision",
+    );
+  });
+
+  test("does not exchange tabs across organization scopes", () => {
+    installFakeBroadcastChannel();
+    const peer = new FakeBroadcastChannel(
+      getInspectorTabsBroadcastChannelName({
+        organizationId: "org-2",
+        userId: "user-1",
+      }),
+    );
+    const received: unknown[] = [];
+    peer.addEventListener("message", (event) => {
+      received.push(event.data);
+    });
+
+    cleanupInspectorBroadcast = initializeInspectorTabBroadcast({
+      organizationId: "org-1",
+      userId: "user-1",
+    });
+    useInspectorStore.getState().openChat({ id: toChatThreadId("thread-1") });
+
+    expect(received).toEqual([]);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
@@ -257,6 +257,11 @@ type InspectorBroadcastSession = {
   scopeKey: string;
 };
 
+type InspectorBroadcastClock = {
+  senderId: string;
+  updatedAt: number;
+};
+
 const INSPECTOR_TABS_CHANNEL_PREFIX = "stella:inspector-tabs:v1";
 const noopInspectorBroadcastCleanup = () => undefined;
 
@@ -270,6 +275,35 @@ const postInspectorBroadcastMessage = (
   channel.postMessage(message);
 };
 /* eslint-enable unicorn/require-post-message-target-origin */
+
+const compareInspectorBroadcastClocks = (
+  left: InspectorBroadcastClock,
+  right: InspectorBroadcastClock,
+) => {
+  if (left.updatedAt !== right.updatedAt) {
+    return left.updatedAt - right.updatedAt;
+  }
+
+  return left.senderId.localeCompare(right.senderId);
+};
+
+const getNextInspectorBroadcastClock = (
+  previousClock: InspectorBroadcastClock | null,
+  senderId: string,
+): InspectorBroadcastClock => {
+  const now = Date.now();
+  if (previousClock === null) {
+    return { senderId, updatedAt: now };
+  }
+
+  const updatedAt = Math.max(now, previousClock.updatedAt);
+  const nextClock = { senderId, updatedAt };
+  if (compareInspectorBroadcastClocks(nextClock, previousClock) > 0) {
+    return nextClock;
+  }
+
+  return { senderId, updatedAt: previousClock.updatedAt + 1 };
+};
 
 export const getInspectorTabsBroadcastChannelName = ({
   userId,
@@ -307,19 +341,20 @@ const createInspectorBroadcastSession = (
   const clientId = uuidv7();
   let consumers = 1;
   let applyingRemote = false;
-  let lastTabsUpdatedAt = 0;
+  let lastTabsClock: InspectorBroadcastClock | null = null;
 
   const postTabs = (recipientId?: string) => {
     const tabs = useInspectorStore.getState().tabs;
     if (recipientId !== undefined && tabs.length === 0) {
       return;
     }
+    const clock = lastTabsClock ?? { senderId: clientId, updatedAt: 0 };
 
     postInspectorBroadcastMessage(channel, {
       type: "inspector-tabs:sync",
       senderId: clientId,
       recipientId,
-      updatedAt: lastTabsUpdatedAt,
+      updatedAt: clock.updatedAt,
       tabs,
     });
   };
@@ -329,7 +364,7 @@ const createInspectorBroadcastSession = (
       return;
     }
 
-    lastTabsUpdatedAt = Date.now();
+    lastTabsClock = getNextInspectorBroadcastClock(lastTabsClock, clientId);
     postTabs();
   });
 
@@ -351,13 +386,20 @@ const createInspectorBroadcastSession = (
       return;
     }
 
-    if (message.updatedAt < lastTabsUpdatedAt) {
+    const messageClock = {
+      senderId: message.senderId,
+      updatedAt: message.updatedAt,
+    };
+    if (
+      lastTabsClock !== null &&
+      compareInspectorBroadcastClocks(messageClock, lastTabsClock) <= 0
+    ) {
       return;
     }
 
     applyingRemote = true;
     try {
-      lastTabsUpdatedAt = message.updatedAt;
+      lastTabsClock = messageClock;
       applySharedInspectorTabs(message.tabs);
     } finally {
       applyingRemote = false;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
@@ -228,6 +228,322 @@ type Actions = {
   clearPendingBlockScroll: () => void;
 };
 
+type InspectorBroadcastScope = {
+  userId: string;
+  organizationId: string;
+};
+
+type InspectorTabsRequestMessage = {
+  type: "inspector-tabs:request";
+  senderId: string;
+};
+
+type InspectorTabsSyncMessage = {
+  type: "inspector-tabs:sync";
+  senderId: string;
+  recipientId?: string | undefined;
+  updatedAt: number;
+  tabs: InspectorTab[];
+};
+
+type InspectorBroadcastMessage =
+  | InspectorTabsRequestMessage
+  | InspectorTabsSyncMessage;
+
+type InspectorBroadcastSession = {
+  dispose: () => void;
+  release: () => void;
+  retain: () => void;
+  scopeKey: string;
+};
+
+const INSPECTOR_TABS_CHANNEL_PREFIX = "stella:inspector-tabs:v1";
+const noopInspectorBroadcastCleanup = () => undefined;
+
+let inspectorBroadcastSession: InspectorBroadcastSession | null = null;
+
+/* eslint-disable unicorn/require-post-message-target-origin -- BroadcastChannel.postMessage does not accept targetOrigin. */
+const postInspectorBroadcastMessage = (
+  channel: BroadcastChannel,
+  message: InspectorBroadcastMessage,
+) => {
+  channel.postMessage(message);
+};
+/* eslint-enable unicorn/require-post-message-target-origin */
+
+export const getInspectorTabsBroadcastChannelName = ({
+  userId,
+  organizationId,
+}: InspectorBroadcastScope) =>
+  `${INSPECTOR_TABS_CHANNEL_PREFIX}:${organizationId}:${userId}`;
+
+export const initializeInspectorTabBroadcast = (
+  scope: InspectorBroadcastScope,
+) => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.BroadcastChannel !== "function"
+  ) {
+    return noopInspectorBroadcastCleanup;
+  }
+
+  const scopeKey = `${scope.organizationId}:${scope.userId}`;
+  if (inspectorBroadcastSession?.scopeKey === scopeKey) {
+    inspectorBroadcastSession.retain();
+    return inspectorBroadcastSession.release;
+  }
+
+  inspectorBroadcastSession?.dispose();
+  inspectorBroadcastSession = createInspectorBroadcastSession(scope);
+  return inspectorBroadcastSession.release;
+};
+
+const createInspectorBroadcastSession = (
+  scope: InspectorBroadcastScope,
+): InspectorBroadcastSession => {
+  const channel = new window.BroadcastChannel(
+    getInspectorTabsBroadcastChannelName(scope),
+  );
+  const clientId = uuidv7();
+  let consumers = 1;
+  let applyingRemote = false;
+  let lastTabsUpdatedAt = 0;
+
+  const postTabs = (recipientId?: string) => {
+    const tabs = useInspectorStore.getState().tabs;
+    if (recipientId !== undefined && tabs.length === 0) {
+      return;
+    }
+
+    postInspectorBroadcastMessage(channel, {
+      type: "inspector-tabs:sync",
+      senderId: clientId,
+      recipientId,
+      updatedAt: lastTabsUpdatedAt,
+      tabs,
+    });
+  };
+
+  const unsubscribe = useInspectorStore.subscribe((state, previousState) => {
+    if (applyingRemote || state.tabs === previousState.tabs) {
+      return;
+    }
+
+    lastTabsUpdatedAt = Date.now();
+    postTabs();
+  });
+
+  const handleMessage = (event: MessageEvent<unknown>) => {
+    const message = event.data;
+    if (
+      !isInspectorBroadcastMessage(message) ||
+      message.senderId === clientId
+    ) {
+      return;
+    }
+
+    if (message.type === "inspector-tabs:request") {
+      postTabs(message.senderId);
+      return;
+    }
+
+    if (message.recipientId !== undefined && message.recipientId !== clientId) {
+      return;
+    }
+
+    if (message.updatedAt < lastTabsUpdatedAt) {
+      return;
+    }
+
+    applyingRemote = true;
+    try {
+      lastTabsUpdatedAt = message.updatedAt;
+      applySharedInspectorTabs(message.tabs);
+    } finally {
+      applyingRemote = false;
+    }
+  };
+  channel.addEventListener("message", handleMessage);
+
+  postInspectorBroadcastMessage(channel, {
+    type: "inspector-tabs:request",
+    senderId: clientId,
+  });
+
+  const dispose = () => {
+    unsubscribe();
+    channel.removeEventListener("message", handleMessage);
+    channel.close();
+    if (inspectorBroadcastSession?.scopeKey === scopeKey) {
+      inspectorBroadcastSession = null;
+    }
+  };
+
+  const scopeKey = `${scope.organizationId}:${scope.userId}`;
+  return {
+    scopeKey,
+    dispose,
+    retain: () => {
+      consumers += 1;
+    },
+    release: () => {
+      consumers -= 1;
+      if (consumers > 0) {
+        return;
+      }
+      dispose();
+    },
+  };
+};
+
+const applySharedInspectorTabs = (tabs: InspectorTab[]) => {
+  const current = useInspectorStore.getState();
+  const activeId =
+    current.activeId !== null && tabs.some((tab) => tab.id === current.activeId)
+      ? current.activeId
+      : (tabs.at(0)?.id ?? null);
+  const pendingRenameTabId =
+    current.pendingRenameTabId !== null &&
+    tabs.some((tab) => tab.id === current.pendingRenameTabId)
+      ? current.pendingRenameTabId
+      : null;
+  const pendingBlockScroll =
+    current.pendingBlockScroll !== null &&
+    tabs.some((tab) => tab.id === current.pendingBlockScroll?.tabId)
+      ? current.pendingBlockScroll
+      : null;
+
+  useInspectorStore.setState({
+    tabs,
+    activeId,
+    pendingRenameTabId,
+    pendingBlockScroll,
+    activationSeq:
+      activeId === current.activeId
+        ? current.activationSeq
+        : current.activationSeq + 1,
+  });
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string");
+
+const isOptionalString = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === "string";
+
+const isOptionalNumber = (value: unknown): value is number | undefined =>
+  value === undefined || typeof value === "number";
+
+const isPdfFacet = (
+  value: unknown,
+): value is NonNullable<PdfTab["facet"]> | undefined =>
+  value === undefined ||
+  value === "preview" ||
+  value === "metadata" ||
+  value === "versions" ||
+  value === "suggestions";
+
+const isMetadataLane = (value: unknown): value is PdfTab["metadataLane"] =>
+  value === undefined || value === "closed" || value === "expanded";
+
+const isInspectorTab = (value: unknown): value is InspectorTab => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const type = value["type"];
+  const id = value["id"];
+  const label = value["label"];
+
+  if (typeof type !== "string" || typeof id !== "string") {
+    return false;
+  }
+
+  if (type === "task") {
+    const status = value["status"];
+    return (
+      typeof label === "string" &&
+      typeof value["isNew"] === "boolean" &&
+      (status === undefined || status === null || typeof status === "string")
+    );
+  }
+
+  if (type === "chat") {
+    return (
+      typeof label === "string" &&
+      isOptionalString(value["workspaceId"]) &&
+      isStringArray(value["contextMatterIds"]) &&
+      isOptionalString(value["activeDecisionId"])
+    );
+  }
+
+  if (type === "external") {
+    return (
+      typeof label === "string" &&
+      typeof value["chatThreadId"] === "string" &&
+      typeof value["url"] === "string" &&
+      isOptionalString(value["connectorSlug"]) &&
+      isOptionalString(value["iconHref"]) &&
+      isOptionalString(value["provider"]) &&
+      isOptionalString(value["snippet"]) &&
+      isOptionalString(value["sourceToolName"]) &&
+      isOptionalString(value["text"])
+    );
+  }
+
+  if (type !== "pdf") {
+    return false;
+  }
+
+  const pdfFileId = value["pdfFileId"];
+  return (
+    typeof label === "string" &&
+    typeof value["entityId"] === "string" &&
+    typeof value["workspaceId"] === "string" &&
+    (pdfFileId === null || typeof pdfFileId === "string") &&
+    isOptionalString(value["renderId"]) &&
+    isOptionalString(value["mimeType"]) &&
+    isOptionalString(value["justificationFieldId"]) &&
+    isOptionalString(value["propertyId"]) &&
+    isMetadataLane(value["metadataLane"]) &&
+    isPdfFacet(value["facet"]) &&
+    isOptionalNumber(value["facetPulseSeq"])
+  );
+};
+
+const isInspectorBroadcastMessage = (
+  value: unknown,
+): value is InspectorBroadcastMessage => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const type = value["type"];
+  const senderId = value["senderId"];
+  if (typeof type !== "string" || typeof senderId !== "string") {
+    return false;
+  }
+
+  if (type === "inspector-tabs:request") {
+    return true;
+  }
+
+  if (type !== "inspector-tabs:sync") {
+    return false;
+  }
+
+  const tabs = value["tabs"];
+  return (
+    isOptionalString(value["recipientId"]) &&
+    typeof value["updatedAt"] === "number" &&
+    Array.isArray(tabs) &&
+    tabs.every(isInspectorTab)
+  );
+};
+
 export const useInspectorStore = create<State & Actions>()(
   immer((set) => ({
     tabs: [],


### PR DESCRIPTION
## Summary

Share the Inspector tab set across same-browser Stella tabs using BroadcastChannel. The sync is scoped by organization and user, hydrates newly opened browser tabs from an existing tab, and keeps local-only UI state such as the active tab and minimized state out of the broadcast payload.

The broadcast validator now accepts all current Inspector tab variants, including external tabs.

## Validation

- bun test apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
- bun --filter @stll/web typecheck
- bun --filter @stll/web lint
- bun --filter @stll/web format -- --check
- pre-push: i18n, format, typecheck, lint