### PR TITLE
chore(api): coalesce /health database probes behind a TTL cache

### DIFF
--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -20,15 +20,22 @@ const PROBE_TIMEOUT_MS = 5000;
 const PROBE_CACHE_TTL_MS = 5000;
 
 const runDatabaseProbe = async (): Promise<ProbeOutcome<HealthCheckError>> => {
+  let timerId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    setTimeout(
+    timerId = setTimeout(
       () => reject(new HealthCheckError({ message: "DB probe timeout" })),
       PROBE_TIMEOUT_MS,
     );
   });
-  const result = await Result.tryPromise(
-    async () => await Promise.race([probeDatabase(), timeout]),
-  );
+  const result = await Result.tryPromise(async () => {
+    try {
+      return await Promise.race([probeDatabase(), timeout]);
+    } finally {
+      // Whichever side of the race wins, the loser's timer or the
+      // timeout's setTimeout would otherwise hold the event loop open.
+      clearTimeout(timerId);
+    }
+  });
   if (result.isErr()) {
     const cause = result.error;
     return {

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -2,6 +2,8 @@ import { Result } from "better-result";
 import Elysia from "elysia";
 
 import { HealthCheckError } from "@/api/lib/errors/tagged-errors";
+import { createProbeCache } from "@/api/lib/health/probe-cache";
+import type { ProbeOutcome } from "@/api/lib/health/probe-cache";
 import { probeDatabase } from "@/api/lib/health/probe-database";
 
 const APP_VERSION = process.env["STELLA_VERSION"] ?? "dev";
@@ -11,19 +13,42 @@ const BUILD_METADATA = {
   commit: APP_COMMIT_SHA,
 };
 
-export const healthRoute = new Elysia().get("/health", async ({ set }) => {
-  const probe = probeDatabase();
-  const timeout = new Promise((_resolve, reject) => {
+const PROBE_TIMEOUT_MS = 5000;
+// Coalesces concurrent /health calls onto a single in-flight probe and
+// reuses the outcome for this window, so liveness checks (k8s, ALB) and
+// any drive-by traffic don't translate one-to-one into DB round-trips.
+const PROBE_CACHE_TTL_MS = 5000;
+
+const runDatabaseProbe = async (): Promise<ProbeOutcome<HealthCheckError>> => {
+  const timeout = new Promise<never>((_resolve, reject) => {
     setTimeout(
       () => reject(new HealthCheckError({ message: "DB probe timeout" })),
-      5000,
+      PROBE_TIMEOUT_MS,
     );
   });
   const result = await Result.tryPromise(
-    async () => await Promise.race([probe, timeout]),
+    async () => await Promise.race([probeDatabase(), timeout]),
   );
-
   if (result.isErr()) {
+    const cause = result.error;
+    return {
+      ok: false,
+      error: HealthCheckError.is(cause)
+        ? cause
+        : new HealthCheckError({ message: "DB probe failed", cause }),
+    };
+  }
+  return { ok: true };
+};
+
+const probeCache = createProbeCache(runDatabaseProbe, {
+  ttlMs: PROBE_CACHE_TTL_MS,
+});
+
+export const healthRoute = new Elysia().get("/health", async ({ set }) => {
+  const outcome = await probeCache.run();
+
+  if (!outcome.ok) {
     set.status = 503;
     return {
       status: "error" as const,

--- a/apps/api/src/lib/health/probe-cache.test.ts
+++ b/apps/api/src/lib/health/probe-cache.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import { createProbeCache } from "@/api/lib/health/probe-cache";
+import type { ProbeOutcome } from "@/api/lib/health/probe-cache";
+
+class TestError extends Error {
+  override name = "TestError";
+}
+
+const okOutcome: ProbeOutcome<TestError> = { ok: true };
+
+const captureRejection = async <T>(promise: Promise<T>): Promise<unknown> => {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected promise to reject");
+};
+
+describe("createProbeCache", () => {
+  test("returns the underlying outcome on the first call", async () => {
+    let calls = 0;
+    const cache = createProbeCache(
+      async () => {
+        calls++;
+        return okOutcome;
+      },
+      { ttlMs: 1000, now: () => 0 },
+    );
+    expect(await cache.run()).toEqual(okOutcome);
+    expect(calls).toBe(1);
+  });
+
+  test("serves repeat calls from cache within the TTL", async () => {
+    let calls = 0;
+    let clock = 0;
+    const cache = createProbeCache(
+      async () => {
+        calls++;
+        return okOutcome;
+      },
+      { ttlMs: 1000, now: () => clock },
+    );
+    await cache.run();
+    clock = 500;
+    await cache.run();
+    clock = 999;
+    await cache.run();
+    expect(calls).toBe(1);
+  });
+
+  test("re-runs the probe after the TTL expires", async () => {
+    let calls = 0;
+    let clock = 0;
+    const cache = createProbeCache(
+      async () => {
+        calls++;
+        return okOutcome;
+      },
+      { ttlMs: 1000, now: () => clock },
+    );
+    await cache.run();
+    clock = 1500;
+    await cache.run();
+    expect(calls).toBe(2);
+  });
+
+  test("coalesces concurrent calls onto a single in-flight probe", async () => {
+    let calls = 0;
+    let release: () => void = () => {
+      // overwritten before any caller awaits the gate
+    };
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const cache = createProbeCache(
+      async () => {
+        calls++;
+        await gate;
+        return okOutcome;
+      },
+      { ttlMs: 1000, now: () => 0 },
+    );
+
+    const a = cache.run();
+    const b = cache.run();
+    const c = cache.run();
+    expect(calls).toBe(1);
+    release();
+    await Promise.all([a, b, c]);
+    expect(calls).toBe(1);
+  });
+
+  test("caches failure outcomes for the TTL window", async () => {
+    let calls = 0;
+    let clock = 0;
+    const failure: ProbeOutcome<TestError> = {
+      ok: false,
+      error: new TestError("nope"),
+    };
+    const cache = createProbeCache(
+      async () => {
+        calls++;
+        return failure;
+      },
+      { ttlMs: 1000, now: () => clock },
+    );
+
+    expect(await cache.run()).toBe(failure);
+    clock = 100;
+    expect(await cache.run()).toBe(failure);
+    expect(calls).toBe(1);
+    clock = 1500;
+    expect(await cache.run()).toBe(failure);
+    expect(calls).toBe(2);
+  });
+
+  test("releases the in-flight slot when the probe rejects", async () => {
+    let calls = 0;
+    const cache = createProbeCache<TestError>(
+      async () => {
+        calls++;
+        throw new TestError("boom");
+      },
+      { ttlMs: 1000, now: () => 0 },
+    );
+    expect(await captureRejection(cache.run())).toBeInstanceOf(TestError);
+    expect(await captureRejection(cache.run())).toBeInstanceOf(TestError);
+    expect(calls).toBe(2);
+  });
+});

--- a/apps/api/src/lib/health/probe-cache.ts
+++ b/apps/api/src/lib/health/probe-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * Coalesces calls to a slow probe behind a short-lived cache and an
+ * in-flight de-duplication wrapper. Used by `/health` so that a flood
+ * of concurrent requests turns into at most one underlying probe per
+ * cache window, rather than one probe per request.
+ */
+
+export type ProbeOutcome<TError> = { ok: true } | { ok: false; error: TError };
+
+type Cached<TError> = {
+  at: number;
+  outcome: ProbeOutcome<TError>;
+};
+
+export type ProbeCacheOptions = {
+  /** Maximum age of a cached outcome before a fresh probe is run. */
+  ttlMs: number;
+  /** Wall-clock source. Defaults to `Date.now`; injectable for tests. */
+  now?: () => number;
+};
+
+export type ProbeCache<TError> = {
+  /**
+   * Run the probe through the cache. The first caller in a window
+   * triggers the probe; concurrent callers share its in-flight
+   * promise; later callers within the TTL get the cached outcome.
+   */
+  run: () => Promise<ProbeOutcome<TError>>;
+};
+
+export const createProbeCache = <TError>(
+  probe: () => Promise<ProbeOutcome<TError>>,
+  options: ProbeCacheOptions,
+): ProbeCache<TError> => {
+  const ttlMs = options.ttlMs;
+  const now = options.now ?? Date.now;
+
+  let cached: Cached<TError> | null = null;
+  let inflight: Promise<ProbeOutcome<TError>> | null = null;
+
+  const run = async (): Promise<ProbeOutcome<TError>> => {
+    const t = now();
+    if (cached !== null && t - cached.at < ttlMs) {
+      return cached.outcome;
+    }
+    if (inflight !== null) {
+      return await inflight;
+    }
+    inflight = (async () => {
+      try {
+        const outcome = await probe();
+        cached = { at: now(), outcome };
+        return outcome;
+      } finally {
+        inflight = null;
+      }
+    })();
+    return await inflight;
+  };
+
+  return { run };
+};


### PR DESCRIPTION
## Summary
- New `createProbeCache` helper wraps a probe with in-flight
  de-duplication and a short TTL, so concurrent callers share a
  single underlying execution and repeat callers get the cached
  outcome.
- `/health` uses it around `probeDatabase`. Burst traffic now
  produces at most one DB round-trip per cache window; outages stay
  visible because failure outcomes are cached for the same window.
- Public response shape (200 / 503 + build metadata) is unchanged.

## Test plan
- [x] `bun test src/lib/health/probe-cache.test.ts` — 6 passed
- [x] `bun --filter @stll/api typecheck` / `lint` / `format --check`
- [ ] Smoke: hammer `/health` with 50 concurrent requests, verify a
      single DB query in pg logs