### PR TITLE
feat(folio): port upstream eigenpal HF unification + follow-ups

### DIFF
--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import type { FlowBlock, Measure } from "../layout-engine/types";
+import type { HeaderFooterMetrics } from "./headerFooterLayout";
+import { calculateHeaderFooterVisualBounds } from "./headerFooterLayout";
+
+const metrics: HeaderFooterMetrics = {
+  section: "header",
+  pageSize: { w: 600, h: 800 },
+  margins: {
+    top: 100,
+    right: 72,
+    bottom: 100,
+    left: 72,
+    header: 48,
+    footer: 48,
+  },
+};
+
+const tableMeasure = (totalHeight: number): Measure => ({
+  kind: "table",
+  rows: [],
+  columnWidths: [],
+  totalWidth: 120,
+  totalHeight,
+});
+
+describe("calculateHeaderFooterVisualBounds", () => {
+  test("accounts for page-anchored floating table bounds", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "table",
+        id: "floating-table",
+        rows: [],
+        floating: {
+          vertAnchor: "page",
+          tblpYSpec: "bottom",
+        },
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [tableMeasure(50)],
+      0,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 752 });
+  });
+
+  test("defaults floating table bounds to the source cursor position", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "intro",
+        runs: [{ kind: "text", text: "Intro" }],
+      },
+      {
+        kind: "table",
+        id: "floating-table",
+        rows: [],
+        floating: {},
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [
+        {
+          kind: "paragraph",
+          lines: [],
+          totalHeight: 20,
+        },
+        tableMeasure(50),
+      ],
+      20,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 70 });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -281,7 +281,18 @@ export function calculateHeaderFooterVisualBounds(
       visualBottom = Math.max(visualBottom, paragraphBottomY);
 
       for (const run of block.runs) {
-        if (run.kind !== "image" || !run.position) {
+        if (run.kind !== "image") {
+          continue;
+        }
+        // Match the extraction/normalization classification: any image
+        // floating by `position` OR by `wrapType`/`displayMode` is
+        // rendered absolutely and stripped from paragraph measurement,
+        // so its extent must be factored into the visual bounds. Without
+        // this, a wrap-type-only header image would be visible but
+        // `visualBottom` would still equal the stripped paragraph height,
+        // and `computeHeaderFooterMarginExtender` wouldn't reserve enough
+        // body push-down — the image would overlap body text.
+        if (!run.position && !isFloatingImageRun(run)) {
           continue;
         }
         const runTop = resolveHeaderFooterVisualTop(

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -19,10 +19,12 @@
 
 import type {
   FlowBlock,
+  FloatingTablePosition,
   ImageRun,
   Measure,
   PageMargins,
   Run,
+  TableMeasure,
 } from "../layout-engine/types";
 import type { HeaderFooterContent } from "../layout-painter/renderPage";
 import { isFloatingImageRun } from "../layout-painter/renderUtils";
@@ -257,6 +259,41 @@ export function resolveHeaderFooterVisualTop(
   return paragraphY;
 }
 
+function resolveHeaderFooterFloatingTableVisualTop(
+  floating: FloatingTablePosition,
+  measure: TableMeasure,
+  sourceY: number,
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): number {
+  const flowTop =
+    metrics.section === "header"
+      ? (metrics.margins.header ?? 48)
+      : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
+  const vertAnchor = floating.vertAnchor ?? "margin";
+  const vertFrameHeight =
+    vertAnchor === "page"
+      ? metrics.pageSize.h
+      : metrics.pageSize.h - metrics.margins.top - metrics.margins.bottom;
+  const vertFrameOffset =
+    vertAnchor === "page" ? -flowTop : metrics.margins.top - flowTop;
+
+  if (floating.tblpYSpec === "top") {
+    return vertFrameOffset;
+  }
+  if (floating.tblpYSpec === "bottom") {
+    return vertFrameOffset + vertFrameHeight - measure.totalHeight;
+  }
+  if (floating.tblpYSpec === "center") {
+    return vertFrameOffset + (vertFrameHeight - measure.totalHeight) / 2;
+  }
+  if (floating.tblpY !== undefined) {
+    return vertFrameOffset + floating.tblpY;
+  }
+
+  return sourceY;
+}
+
 export function calculateHeaderFooterVisualBounds(
   blocks: FlowBlock[],
   measures: Measure[],
@@ -332,17 +369,20 @@ export function calculateHeaderFooterVisualBounds(
         visualTop = Math.min(visualTop, cursorY);
         visualBottom = Math.max(visualBottom, blockBottomY);
         cursorY = blockBottomY;
-      } else {
-        // Floating table: expand visualBounds conservatively at the
-        // current cursorY, since most floating HF tables anchor near
-        // their source position. Exact (tblpX, tblpY)-resolved bounds
-        // would require duplicating `resolveHeaderFooterFloatingTablePosition`
-        // here; for tables anchored far from the in-flow stream the
-        // bound undercounts. Without this, a floating-table-only
-        // header would have `height = 0` and the table could be lost
-        // from the body push-down calculation entirely.
-        visualTop = Math.min(visualTop, cursorY);
-        visualBottom = Math.max(visualBottom, cursorY + blockHeight);
+      } else if (
+        block.kind === "table" &&
+        block.floating &&
+        measure.kind === "table"
+      ) {
+        const blockTop = resolveHeaderFooterFloatingTableVisualTop(
+          block.floating,
+          measure,
+          cursorY,
+          flowHeight,
+          metrics,
+        );
+        visualTop = Math.min(visualTop, blockTop);
+        visualBottom = Math.max(visualBottom, blockTop + blockHeight);
       }
     }
   }

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -283,10 +283,18 @@ export function calculateHeaderFooterVisualBounds(
       cursorY = paragraphBottomY;
     } else {
       // Tables / images / textBoxes contribute their measured height as a
-      // single block (they don't reflow within the HF area).
+      // single block (they don't reflow within the HF area). Floating
+      // tables (`<w:tblpPr>`) anchor at (tblpX, tblpY) and don't
+      // participate in the cursorY flow — they're positioned absolutely by
+      // the renderer and can overlap surrounding HF content (Word
+      // semantics for unwrapped floating tables).
       let blockHeight = 0;
+      let advancesCursor = true;
       if (block.kind === "table" && measure.kind === "table") {
         blockHeight = measure.totalHeight;
+        if (block.floating) {
+          advancesCursor = false;
+        }
       } else if (block.kind === "image" && measure.kind === "image") {
         blockHeight = measure.height;
       } else if (block.kind === "textBox" && measure.kind === "textBox") {
@@ -294,10 +302,12 @@ export function calculateHeaderFooterVisualBounds(
       } else {
         continue;
       }
-      const blockBottomY = cursorY + blockHeight;
-      visualTop = Math.min(visualTop, cursorY);
-      visualBottom = Math.max(visualBottom, blockBottomY);
-      cursorY = blockBottomY;
+      if (advancesCursor) {
+        const blockBottomY = cursorY + blockHeight;
+        visualTop = Math.min(visualTop, cursorY);
+        visualBottom = Math.max(visualBottom, blockBottomY);
+        cursorY = blockBottomY;
+      }
     }
   }
 
@@ -362,11 +372,20 @@ export function convertHeaderFooterToContent(
   const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks);
   const measures = options.measureBlocks(blocksForMeasure, contentWidth);
   let totalHeight = 0;
-  for (const m of measures) {
+  for (let i = 0; i < measures.length; i++) {
+    const m = measures[i];
+    const b = blocks[i];
+    if (!m || !b) {
+      continue;
+    }
     if (m.kind === "paragraph") {
       totalHeight += m.totalHeight;
     } else if (m.kind === "table") {
-      totalHeight += m.totalHeight;
+      // Floating tables (`<w:tblpPr>`) anchor at (tblpX, tblpY) and don't
+      // contribute to the in-flow height that drives body push-down.
+      if (!(b.kind === "table" && b.floating)) {
+        totalHeight += m.totalHeight;
+      }
     } else if (m.kind === "image") {
       totalHeight += m.height;
     } else if (m.kind === "textBox") {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -94,23 +94,24 @@ function hasAuthoredVisualContent(block: FlowBlock): boolean {
 export function normalizeHeaderFooterMeasureBlocks(
   blocks: FlowBlock[],
 ): FlowBlock[] {
+  // Only the *canonical trailing* OOXML paragraph after the LAST block
+  // qualifies for height suppression. Empty paragraphs used as authored
+  // spacers in the middle of an HF (e.g. `[table, blank, paragraph,
+  // blank, table]`) carry intentional vertical space and must not be
+  // collapsed.
   const trailingEmptyAfterTable = new Set<number>();
-  for (let i = 1; i < blocks.length; i++) {
-    const prev = blocks[i - 1];
-    const cur = blocks[i];
-    if (prev?.kind !== "table") {
-      continue;
+  const lastIndex = blocks.length - 1;
+  if (lastIndex > 0) {
+    const cur = blocks[lastIndex];
+    const prev = blocks[lastIndex - 1];
+    if (
+      prev?.kind === "table" &&
+      cur?.kind === "paragraph" &&
+      cur.runs.length === 0 &&
+      !hasAuthoredVisualContent(cur)
+    ) {
+      trailingEmptyAfterTable.add(lastIndex);
     }
-    if (cur?.kind !== "paragraph") {
-      continue;
-    }
-    if (cur.runs.length > 0) {
-      continue;
-    }
-    if (hasAuthoredVisualContent(cur)) {
-      continue;
-    }
-    trailingEmptyAfterTable.add(i);
   }
 
   return blocks.map((block, index) => {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -1,0 +1,390 @@
+/**
+ * Header / Footer Layout Utilities
+ *
+ * The header/footer rendering pipeline lives here so any rendering adapter
+ * can share the conversion logic and just supply its platform-specific
+ * `MeasureBlocksFn`. Mirrors the footnote pipeline in `footnoteLayout.ts`.
+ *
+ * Pipeline:
+ *   HF.content -> headerFooterToProseDoc -> toFlowBlocks
+ *     -> normalizeHeaderFooterMeasureBlocks (measure copy: drops floats and
+ *        style-inherited spacing the renderer zeroes anyway, marks the
+ *        canonical trailing-empty-paragraph-after-table as zero-height)
+ *     -> measureBlocks (caller-supplied)
+ *     -> HeaderFooterContent (blocks, measures, height, visualTop/Bottom)
+ *
+ * The render side uses the ORIGINAL block list (full data: floating images,
+ * inherited spacing). Measurement uses the normalized copy.
+ */
+
+import type {
+  FlowBlock,
+  ImageRun,
+  Measure,
+  PageMargins,
+  Run,
+} from "../layout-engine/types";
+import type { HeaderFooterContent } from "../layout-painter/renderPage";
+import { headerFooterToProseDoc } from "../prosemirror/conversion/toProseDoc";
+import type { HeaderFooter, StyleDefinitions, Theme } from "../types/document";
+import { emuToPixels } from "../utils/units";
+import type { MeasureBlocksFn } from "./footnoteLayout";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+// =============================================================================
+// 1. Page-level metrics passed in by the caller
+// =============================================================================
+
+export type HeaderFooterMetrics = {
+  section: "header" | "footer";
+  pageSize: { w: number; h: number };
+  margins: PageMargins;
+};
+
+// =============================================================================
+// 2. Measurement-time block normalization
+// =============================================================================
+//
+// Three transforms are applied to the FlowBlock list before measurement:
+//
+// 1. Drop anchored / floating images (#358). They're positioned absolutely
+//    at page level and don't contribute to in-flow paragraph height. The
+//    measurement copy renders only the inline runs.
+//
+// 2. Strip style-inherited paragraph spacing (#380). Word visibly does NOT
+//    honor inherited `spaceBefore` / `spaceAfter` (e.g. Normal's default
+//    8pt-after) inside the HF text frame. Inline `<w:spacing>` set
+//    explicitly on the HF paragraph IS honored. The parser flags inline
+//    spacing via `spacingExplicit.before` / `.after`; anything not flagged
+//    was inherited and is zeroed for measurement.
+//
+// 3. Zero trailing empty paragraph after a table (#381). OOXML requires a
+//    trailing block-level element after the last `<w:tbl>` in any block
+//    container, including `<w:hdr>` / `<w:ftr>`. Word renders that empty
+//    paragraph as a zero-height anchor when it has no runs AND no authored
+//    visual content (no paragraph borders, no explicit spacing). Marking
+//    its measure with `suppressEmptyParagraphHeight` keeps the BLOCK so
+//    click-to-position into the empty space below the table places the
+//    cursor in the trailing paragraph (matching Word) but the measure
+//    returns zero height. Empty paragraphs with authored `pBdr` or
+//    explicit spacing are NOT suppressed — they exist for their visual
+//    side effect, not just as a structural anchor.
+
+function isAnchoredImageRun(run: Run): boolean {
+  return run.kind === "image" && !!run.position;
+}
+
+function hasAuthoredVisualContent(block: FlowBlock): boolean {
+  if (block.kind !== "paragraph") {
+    return false;
+  }
+  const attrs = block.attrs;
+  if (!attrs) {
+    return false;
+  }
+  if (attrs.borders?.top || attrs.borders?.bottom) {
+    return true;
+  }
+  if (attrs.spacingExplicit?.before || attrs.spacingExplicit?.after) {
+    return true;
+  }
+  return false;
+}
+
+export function normalizeHeaderFooterMeasureBlocks(
+  blocks: FlowBlock[],
+): FlowBlock[] {
+  const trailingEmptyAfterTable = new Set<number>();
+  for (let i = 1; i < blocks.length; i++) {
+    const prev = blocks[i - 1];
+    const cur = blocks[i];
+    if (prev?.kind !== "table") {
+      continue;
+    }
+    if (cur?.kind !== "paragraph") {
+      continue;
+    }
+    if (cur.runs.length > 0) {
+      continue;
+    }
+    if (hasAuthoredVisualContent(cur)) {
+      continue;
+    }
+    trailingEmptyAfterTable.add(i);
+  }
+
+  return blocks.map((block, index) => {
+    if (block.kind !== "paragraph") {
+      return block;
+    }
+
+    const isTrailingEmpty = trailingEmptyAfterTable.has(index);
+
+    const explicit = block.attrs?.spacingExplicit;
+    const hasResolvedBefore = block.attrs?.spacing?.before != null;
+    const hasResolvedAfter = block.attrs?.spacing?.after != null;
+    const beforeIsInherited = hasResolvedBefore && !explicit?.before;
+    const afterIsInherited = hasResolvedAfter && !explicit?.after;
+    const stripsSpacing = beforeIsInherited || afterIsInherited;
+
+    const stripsImages = block.runs.some(isAnchoredImageRun);
+
+    if (!stripsSpacing && !stripsImages && !isTrailingEmpty) {
+      return block;
+    }
+
+    let inlineRuns: Run[] = block.runs;
+    if (stripsImages) {
+      inlineRuns = block.runs.filter((r) => !isAnchoredImageRun(r));
+      if (inlineRuns.length === 0) {
+        inlineRuns = [{ kind: "text" as const, text: "" }];
+      }
+    }
+
+    let attrs = block.attrs;
+    if (stripsSpacing && attrs?.spacing) {
+      const newSpacing = { ...attrs.spacing };
+      if (!explicit?.before) {
+        delete newSpacing.before;
+      }
+      if (!explicit?.after) {
+        delete newSpacing.after;
+      }
+      attrs = { ...attrs, spacing: newSpacing };
+    }
+
+    if (isTrailingEmpty) {
+      attrs = { ...attrs, suppressEmptyParagraphHeight: true };
+    }
+
+    return attrs
+      ? { ...block, runs: inlineRuns, attrs }
+      : { ...block, runs: inlineRuns };
+  });
+}
+
+// =============================================================================
+// 3. Visual bounds (account for floating images that paint above/below the
+//    nominal flow rectangle so HF clipping & shadow regions size correctly)
+// =============================================================================
+
+type PositionedAxis = {
+  relativeTo?: string;
+  posOffset?: number;
+  align?: string;
+  alignment?: string;
+};
+
+function getPositionAlignment(
+  axis: PositionedAxis | undefined,
+): string | undefined {
+  return axis?.align ?? axis?.alignment;
+}
+
+export function resolveHeaderFooterVisualTop(
+  run: ImageRun,
+  paragraphY: number,
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): number {
+  const flowTop =
+    metrics.section === "header"
+      ? (metrics.margins.header ?? 48)
+      : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
+  const vertical = run.position?.vertical;
+
+  if (!vertical) {
+    return paragraphY;
+  }
+
+  const align = getPositionAlignment(vertical);
+  const offsetPx =
+    vertical.posOffset !== undefined
+      ? emuToPixels(vertical.posOffset)
+      : undefined;
+
+  if (vertical.relativeTo === "page") {
+    if (offsetPx !== undefined) {
+      return offsetPx - flowTop;
+    }
+    if (align === "top") {
+      return -flowTop;
+    }
+    if (align === "bottom") {
+      return metrics.pageSize.h - run.height - flowTop;
+    }
+    if (align === "center") {
+      return (metrics.pageSize.h - run.height) / 2 - flowTop;
+    }
+  }
+
+  if (vertical.relativeTo === "margin") {
+    const marginTop = metrics.margins.top;
+    const marginHeight =
+      metrics.pageSize.h - metrics.margins.top - metrics.margins.bottom;
+    if (offsetPx !== undefined) {
+      return marginTop + offsetPx - flowTop;
+    }
+    if (align === "top") {
+      return marginTop - flowTop;
+    }
+    if (align === "bottom") {
+      return marginTop + marginHeight - run.height - flowTop;
+    }
+    if (align === "center") {
+      return marginTop + (marginHeight - run.height) / 2 - flowTop;
+    }
+  }
+
+  if (offsetPx !== undefined) {
+    return paragraphY + offsetPx;
+  }
+
+  return paragraphY;
+}
+
+export function calculateHeaderFooterVisualBounds(
+  blocks: FlowBlock[],
+  measures: Measure[],
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): { visualTop: number; visualBottom: number } {
+  let visualTop = 0;
+  let visualBottom = flowHeight;
+  let cursorY = 0;
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    const measure = measures[i];
+    if (!block || !measure) {
+      continue;
+    }
+
+    if (block.kind === "paragraph" && measure.kind === "paragraph") {
+      const paragraphStartY = cursorY;
+      const paragraphBottomY = paragraphStartY + measure.totalHeight;
+      visualTop = Math.min(visualTop, paragraphStartY);
+      visualBottom = Math.max(visualBottom, paragraphBottomY);
+
+      for (const run of block.runs) {
+        if (run.kind !== "image" || !run.position) {
+          continue;
+        }
+        const runTop = resolveHeaderFooterVisualTop(
+          run,
+          paragraphStartY,
+          flowHeight,
+          metrics,
+        );
+        visualTop = Math.min(visualTop, runTop);
+        visualBottom = Math.max(visualBottom, runTop + run.height);
+      }
+
+      cursorY = paragraphBottomY;
+    } else {
+      // Tables / images / textBoxes contribute their measured height as a
+      // single block (they don't reflow within the HF area).
+      let blockHeight = 0;
+      if (block.kind === "table" && measure.kind === "table") {
+        blockHeight = measure.totalHeight;
+      } else if (block.kind === "image" && measure.kind === "image") {
+        blockHeight = measure.height;
+      } else if (block.kind === "textBox" && measure.kind === "textBox") {
+        blockHeight = measure.height;
+      } else {
+        continue;
+      }
+      const blockBottomY = cursorY + blockHeight;
+      visualTop = Math.min(visualTop, cursorY);
+      visualBottom = Math.max(visualBottom, blockBottomY);
+      cursorY = blockBottomY;
+    }
+  }
+
+  return { visualTop, visualBottom };
+}
+
+// =============================================================================
+// 4. HeaderFooter -> HeaderFooterContent (the public entry point)
+// =============================================================================
+
+export type ConvertHeaderFooterOptions = {
+  styles?: StyleDefinitions | null;
+  theme?: Theme | null;
+  measureBlocks: MeasureBlocksFn;
+};
+
+/**
+ * Convert HeaderFooter (document type) to HeaderFooterContent (render type).
+ *
+ * Routes through the same pipeline as the body: HF.content ->
+ * headerFooterToProseDoc -> toFlowBlocks -> measureBlocks. The inline editor
+ * uses the same conversion chain, so block support (paragraph, table, image,
+ * textBox, fields) and the inline editor's content stay in lockstep.
+ *
+ * No result cache — typing in the body shouldn't recompute HF, but the
+ * upstream cache keyed on `HeaderFooter` identity went stale after inline
+ * edits. The HF pipeline runs at most four times per layout pass and the
+ * paragraph-level measurement cache one layer down covers most of the work.
+ */
+export function convertHeaderFooterToContent(
+  headerFooter: HeaderFooter | null | undefined,
+  contentWidth: number,
+  metrics: HeaderFooterMetrics,
+  options: ConvertHeaderFooterOptions,
+): HeaderFooterContent | undefined {
+  if (
+    !headerFooter ||
+    !headerFooter.content ||
+    headerFooter.content.length === 0
+  ) {
+    return undefined;
+  }
+
+  const proseDocOptions: { styles?: StyleDefinitions; theme?: Theme | null } =
+    {};
+  if (options.styles) {
+    proseDocOptions.styles = options.styles;
+  }
+  if (options.theme !== undefined) {
+    proseDocOptions.theme = options.theme;
+  }
+  const pmDoc = headerFooterToProseDoc(headerFooter.content, proseDocOptions);
+  const flowOptions: { theme?: Theme | null } = {};
+  if (options.theme !== undefined) {
+    flowOptions.theme = options.theme;
+  }
+  const blocks = toFlowBlocks(pmDoc, flowOptions);
+  if (blocks.length === 0) {
+    return undefined;
+  }
+
+  const blocksForMeasure = normalizeHeaderFooterMeasureBlocks(blocks);
+  const measures = options.measureBlocks(blocksForMeasure, contentWidth);
+  let totalHeight = 0;
+  for (const m of measures) {
+    if (m.kind === "paragraph") {
+      totalHeight += m.totalHeight;
+    } else if (m.kind === "table") {
+      totalHeight += m.totalHeight;
+    } else if (m.kind === "image") {
+      totalHeight += m.height;
+    } else if (m.kind === "textBox") {
+      totalHeight += m.height;
+    }
+  }
+  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(
+    blocks,
+    measures,
+    totalHeight,
+    metrics,
+  );
+
+  return {
+    blocks,
+    measures,
+    height: totalHeight,
+    visualTop,
+    visualBottom,
+  };
+}

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -25,6 +25,7 @@ import type {
   Run,
 } from "../layout-engine/types";
 import type { HeaderFooterContent } from "../layout-painter/renderPage";
+import { isFloatingImageRun } from "../layout-painter/renderUtils";
 import { headerFooterToProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type { HeaderFooter, StyleDefinitions, Theme } from "../types/document";
 import { emuToPixels } from "../utils/units";
@@ -71,7 +72,19 @@ export type HeaderFooterMetrics = {
 //    side effect, not just as a structural anchor.
 
 function isAnchoredImageRun(run: Run): boolean {
-  return run.kind === "image" && !!run.position;
+  if (run.kind !== "image") {
+    return false;
+  }
+  // Match the renderer's classification: explicit `<wp:positionH>` /
+  // `<wp:positionV>` OR `wrapType` / `displayMode` that the body's
+  // `isFloatingImageRun` recognizes (square, tight, through, behind,
+  // inFront, or `displayMode: "float"`). Without the second arm,
+  // wrapped header images that omit explicit positioning would still
+  // be measured as in-flow, inflating header height.
+  if (run.position) {
+    return true;
+  }
+  return isFloatingImageRun(run);
 }
 
 function hasAuthoredVisualContent(block: FlowBlock): boolean {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -307,6 +307,17 @@ export function calculateHeaderFooterVisualBounds(
         visualTop = Math.min(visualTop, cursorY);
         visualBottom = Math.max(visualBottom, blockBottomY);
         cursorY = blockBottomY;
+      } else {
+        // Floating table: expand visualBounds conservatively at the
+        // current cursorY, since most floating HF tables anchor near
+        // their source position. Exact (tblpX, tblpY)-resolved bounds
+        // would require duplicating `resolveHeaderFooterFloatingTablePosition`
+        // here; for tables anchored far from the in-flow stream the
+        // bound undercounts. Without this, a floating-table-only
+        // header would have `height = 0` and the table could be lost
+        // from the body push-down calculation entirely.
+        visualTop = Math.min(visualTop, cursorY);
+        visualBottom = Math.max(visualBottom, cursorY + blockHeight);
       }
     }
   }

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -1700,19 +1700,29 @@ export function renderPage(
       page.margins.bottom - footerDistance,
       48,
     );
+    const footerFlowHeight = options.footerContent?.height ?? 0;
     const footerVisualTop = options.footerContent?.visualTop ?? 0;
     const footerVisualBottom =
-      options.footerContent?.visualBottom ?? options.footerContent?.height ?? 0;
+      options.footerContent?.visualBottom ?? footerFlowHeight;
     const actualFooterHeight = Math.max(
       footerVisualBottom - footerVisualTop,
       24,
     );
     const footerOverflows = actualFooterHeight > availableFooterHeight;
 
+    // Anchor the footer container at the *flow* origin, then let it stretch
+    // upward (above-flow image overflow via negative visualTop) and downward
+    // (below-flow floating-table overflow via visualBottom > flowHeight).
+    // Anchoring at the flow origin keeps in-flow content rendered at the
+    // natural footer line (page.h - footerDistance - flowHeight) and keeps
+    // the resolver's `flowTop` consistent with where the in-flow first
+    // paragraph actually paints.
+    const footerNaturalTop = page.size.h - footerDistance - footerFlowHeight;
+    const footerContainerTop = footerNaturalTop + footerVisualTop;
     const footerEl = doc.createElement("div");
     footerEl.className = PAGE_CLASS_NAMES.footer;
     footerEl.style.position = "absolute";
-    footerEl.style.top = `${page.size.h - footerDistance - actualFooterHeight}px`;
+    footerEl.style.top = `${footerContainerTop}px`;
     footerEl.style.left = `${page.margins.left}px`;
     footerEl.style.right = `${page.margins.right}px`;
     footerEl.style.width = `${footerContentWidth}px`;
@@ -1727,8 +1737,7 @@ export function renderPage(
         { ...context, section: "footer", contentWidth: footerContentWidth },
         options,
         {
-          flowTop:
-            page.size.h - footerDistance - (options.footerContent?.height ?? 0),
+          flowTop: footerNaturalTop,
           flowLeft: page.margins.left,
           contentWidth: footerContentWidth,
           pageWidth: page.size.w,

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -358,6 +358,7 @@ function resolveHeaderFooterFloatingTablePosition(
   floating: NonNullable<TableBlock["floating"]>,
   measure: TableMeasure,
   layout: HeaderFooterLayoutInfo,
+  sourceY: number,
 ): { left: number; top: number } {
   // Anchor-aware spec resolution: "right"/"bottom"/"center" are computed
   // relative to whichever frame the anchor selects (page vs margin).
@@ -394,7 +395,7 @@ function resolveHeaderFooterFloatingTablePosition(
   }
 
   // Vertical
-  let top = 0;
+  let top = sourceY;
   if (floating.tblpYSpec === "top") {
     top = vertFrameOffset;
   } else if (floating.tblpYSpec === "bottom") {
@@ -895,6 +896,7 @@ function renderHeaderFooterContent(
           block.floating,
           measure,
           layout,
+          cursorY,
         );
         fragEl.style.position = "absolute";
         fragEl.style.top = `${top}px`;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -832,7 +832,16 @@ function renderHeaderFooterContent(
       // `fragment.y = cursorY + spaceBefore` (see core/layout-engine
       // `addFragment`). Mirror that here so authored `w:spacing w:before`
       // visually pushes the first line down instead of being swallowed.
-      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+      // Only honor *explicit* spaceBefore: `normalizeHeaderFooterMeasureBlocks`
+      // strips inherited (style-only) spacing from the measurement copy
+      // (#380), so totalHeight already excludes it; offsetting by inherited
+      // spaceBefore would shift the line below its reserved space and break
+      // cursorY accumulation for following paragraphs.
+      const explicitBefore =
+        paragraphBlock.attrs?.spacingExplicit?.before === true;
+      const spaceBefore = explicitBefore
+        ? (paragraphBlock.attrs?.spacing?.before ?? 0)
+        : 0;
       fragEl.style.position = "absolute";
       fragEl.style.top = `${cursorY + spaceBefore}px`;
       fragEl.style.left = "0";

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -892,9 +892,19 @@ function renderHeaderFooterContent(
         // floating table weren't there (Word semantics for unwrapped
         // floating tables).
       } else {
+        // Honor `w:jc` / `w:tblInd` for inline HF tables, matching the body
+        // pagination path (see core/layout-engine `desiredX` computation).
+        let inlineLeft = 0;
+        if (block.justification === "center") {
+          inlineLeft = (contentWidth - measure.totalWidth) / 2;
+        } else if (block.justification === "right") {
+          inlineLeft = contentWidth - measure.totalWidth;
+        } else if (block.indent) {
+          inlineLeft = block.indent;
+        }
         fragEl.style.position = "absolute";
         fragEl.style.top = `${cursorY}px`;
-        fragEl.style.left = "0";
+        fragEl.style.left = `${inlineLeft}px`;
         containerEl.append(fragEl);
         cursorY += measure.totalHeight;
       }
@@ -902,12 +912,17 @@ function renderHeaderFooterContent(
       // The unified pipeline extracts top-level text boxes inside H/F as
       // their own block. `renderTextBoxFragment` sets `position: absolute`
       // internally; we only supply top/left so it stacks at cursorY.
+      // Use the *measured* width (not contentWidth): measureBlocks computed
+      // `measure.width` and the cached `innerMeasures` against the authored
+      // text box width, so passing contentWidth would cause the outer box
+      // to be the wrong size and force inner re-wrap inconsistent with the
+      // measure cache.
       const syntheticFragment: TextBoxFragment = {
         kind: "textBox",
         blockId: block.id,
         x: 0,
         y: cursorY,
-        width: contentWidth,
+        width: measure.width,
         height: measure.height,
         ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
         ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -377,13 +377,17 @@ function resolveHeaderFooterFloatingTablePosition(
       ? -layout.flowTop
       : layout.margins.top - layout.flowTop;
 
-  // Horizontal
+  // Horizontal. Match the body's `inside`/`outside` handling
+  // (core/layout-engine: `inside` aliases left, `outside` aliases right).
+  // We don't have facing-page context in HF rendering, so the simple
+  // alias is the closest sensible match.
   let left = 0;
-  if (floating.tblpXSpec === "left") {
+  const xSpec = floating.tblpXSpec;
+  if (xSpec === "left" || xSpec === "inside") {
     left = horzFrameOffset;
-  } else if (floating.tblpXSpec === "right") {
+  } else if (xSpec === "right" || xSpec === "outside") {
     left = horzFrameOffset + horzFrameWidth - measure.totalWidth;
-  } else if (floating.tblpXSpec === "center") {
+  } else if (xSpec === "center") {
     left = horzFrameOffset + (horzFrameWidth - measure.totalWidth) / 2;
   } else if (floating.tblpX !== undefined) {
     left = horzFrameOffset + floating.tblpX;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -826,10 +826,15 @@ function renderHeaderFooterContent(
         { document: doc },
       );
 
-      // Stack HF fragments by absolute top within the container.
-      // `paragraphMeasure.totalHeight` already includes spaceBefore/spaceAfter.
+      // `paragraphMeasure.totalHeight` includes `spaceBefore + lines +
+      // spaceAfter`, but `renderParagraphFragment` paints its first line at
+      // the fragment top. The body's layout engine compensates by setting
+      // `fragment.y = cursorY + spaceBefore` (see core/layout-engine
+      // `addFragment`). Mirror that here so authored `w:spacing w:before`
+      // visually pushes the first line down instead of being swallowed.
+      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
       fragEl.style.position = "absolute";
-      fragEl.style.top = `${cursorY}px`;
+      fragEl.style.top = `${cursorY + spaceBefore}px`;
       fragEl.style.left = "0";
       fragEl.style.width = `${contentWidth}px`;
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -348,6 +348,50 @@ function resolveHeaderFooterFloatTop(
   return floatImg.paragraphY;
 }
 
+/**
+ * Resolve the on-page position of a floating header/footer table
+ * (`<w:tbl><w:tblpPr ...>`). ECMA-376 §17.4.57. Returns coordinates
+ * relative to the HF container (which itself is positioned at the page's
+ * header or footer slot).
+ */
+function resolveHeaderFooterFloatingTablePosition(
+  floating: NonNullable<TableBlock["floating"]>,
+  measure: TableMeasure,
+  layout: HeaderFooterLayoutInfo,
+): { left: number; top: number } {
+  // Horizontal
+  let left = 0;
+  if (floating.tblpXSpec === "left") {
+    left = 0;
+  } else if (floating.tblpXSpec === "right") {
+    left = layout.contentWidth - measure.totalWidth;
+  } else if (floating.tblpXSpec === "center") {
+    left = (layout.contentWidth - measure.totalWidth) / 2;
+  } else if (floating.tblpX !== undefined) {
+    left =
+      floating.horzAnchor === "page"
+        ? floating.tblpX - layout.flowLeft
+        : floating.tblpX;
+  }
+
+  // Vertical
+  let top = 0;
+  if (floating.tblpYSpec === "top") {
+    top = 0;
+  } else if (floating.tblpYSpec === "bottom") {
+    top = layout.pageHeight - measure.totalHeight - layout.flowTop;
+  } else if (floating.tblpYSpec === "center") {
+    top = (layout.pageHeight - measure.totalHeight) / 2 - layout.flowTop;
+  } else if (floating.tblpY !== undefined) {
+    top =
+      floating.vertAnchor === "page"
+        ? floating.tblpY - layout.flowTop
+        : floating.tblpY;
+  }
+
+  return { left, top };
+}
+
 function applyHeaderFooterFloatHorizontalPosition(
   img: HTMLImageElement,
   floatImg: {
@@ -706,14 +750,21 @@ function renderHeaderFooterContent(
   }[] = [];
 
   let cursorY = 0;
+  // Pass `positioning: 'absolute'` so renderers (and downstream readers of
+  // RenderContext) know the HF caller is supplying its own top/left, rather
+  // than the body case where the layout engine assigns fragment coordinates.
+  const hfContext: RenderContext = { ...context, positioning: "absolute" };
 
   for (let i = 0; i < content.blocks.length; i++) {
     const block = content.blocks[i];
     const measure = content.measures[i];
+    if (!block || !measure) {
+      continue;
+    }
 
-    if (block?.kind === "paragraph" && measure?.kind === "paragraph") {
-      const paragraphBlock = block as ParagraphBlock;
-      const paragraphMeasure = measure as ParagraphMeasure;
+    if (block.kind === "paragraph" && measure.kind === "paragraph") {
+      const paragraphBlock = block;
+      const paragraphMeasure = measure;
 
       // Track the Y position where this paragraph starts
       const paragraphStartY = cursorY;
@@ -722,35 +773,14 @@ function renderHeaderFooterContent(
       const inlineRuns: typeof paragraphBlock.runs = [];
       for (const run of paragraphBlock.runs) {
         if (run.kind === "image" && "position" in run && run.position) {
-          const imgRun = run as {
-            kind: "image";
-            src: string;
-            width: number;
-            height: number;
-            alt?: string;
-            position: {
-              horizontal?: {
-                relativeTo?: string;
-                posOffset?: number;
-                align?: string;
-                alignment?: string;
-              };
-              vertical?: {
-                relativeTo?: string;
-                posOffset?: number;
-                align?: string;
-                alignment?: string;
-              };
-            };
-          };
           floatingImages.push({
-            src: imgRun.src,
-            width: imgRun.width,
-            height: imgRun.height,
-            ...(imgRun.alt !== undefined ? { alt: imgRun.alt } : {}),
-            paragraphY: paragraphStartY, // Store where this paragraph starts
-            behindDoc: (run as Record<string, unknown>)["behindDoc"] === true,
-            position: imgRun.position,
+            src: run.src,
+            width: run.width,
+            height: run.height,
+            ...(run.alt !== undefined ? { alt: run.alt } : {}),
+            paragraphY: paragraphStartY,
+            behindDoc: run.wrapType === "behind",
+            position: run.position,
           });
         } else {
           // Keep non-floating runs for inline rendering
@@ -776,38 +806,66 @@ function renderHeaderFooterContent(
         toLine: paragraphMeasure.lines.length,
       };
 
-      // Render paragraph fragment (with floating images filtered out)
       const fragEl = renderParagraphFragment(
         syntheticFragment,
         inlineBlock,
         paragraphMeasure,
-        context,
+        hfContext,
         { document: doc },
       );
 
-      // Position the fragment in flow and visualize the paragraph's spacing
-      // as padding so HF paragraphs separate the way Word renders them.
-      // Body content gets paragraph spacing via the paginator's absolute
-      // fragment.y positioning; HF rendering uses relative-flow stacking,
-      // so without padding here the paragraph's `spaceBefore`/`spaceAfter`
-      // would advance `cursorY` for the layout-engine but never appear in
-      // the DOM (visible regression on first-page header docs whose
-      // last-paragraph spaceAfter pushes the body content's first line
-      // down by one line in Word).
-      fragEl.style.position = "relative";
-      fragEl.style.marginBottom = "0";
-      fragEl.style.boxSizing = "border-box";
-      const spaceBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
-      const spaceAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
-      if (spaceBefore > 0) {
-        fragEl.style.paddingTop = `${spaceBefore}px`;
-      }
-      if (spaceAfter > 0) {
-        fragEl.style.paddingBottom = `${spaceAfter}px`;
-      }
+      // Stack HF fragments by absolute top within the container.
+      // `paragraphMeasure.totalHeight` already includes spaceBefore/spaceAfter.
+      fragEl.style.position = "absolute";
+      fragEl.style.top = `${cursorY}px`;
+      fragEl.style.left = "0";
+      fragEl.style.width = `${contentWidth}px`;
 
       containerEl.append(fragEl);
       cursorY += paragraphMeasure.totalHeight;
+    } else if (block.kind === "table" && measure.kind === "table") {
+      // HF tables don't paginate — synthetic fragment covers all rows.
+      const syntheticFragment: TableFragment = {
+        kind: "table",
+        blockId: block.id,
+        x: 0,
+        y: cursorY,
+        width: measure.totalWidth,
+        height: measure.totalHeight,
+        fromRow: 0,
+        toRow: measure.rows.length,
+        ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+        ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+      };
+      const fragEl = renderTableFragment(
+        syntheticFragment,
+        block,
+        measure,
+        hfContext,
+        { document: doc },
+      );
+
+      // Floating tables (`<w:tblpPr>`) opt out of the cursorY flow. They
+      // anchor at (tblpX, tblpY) per ECMA-376 §17.4.57 and don't advance
+      // cursorY. Inline tables stack within the HF container at cursorY.
+      if (block.floating) {
+        const { left, top } = resolveHeaderFooterFloatingTablePosition(
+          block.floating,
+          measure,
+          layout,
+        );
+        fragEl.style.top = `${top}px`;
+        fragEl.style.left = `${left}px`;
+        containerEl.append(fragEl);
+        // No cursorY advance — surrounding HF blocks flow as if the
+        // floating table weren't there (Word semantics for unwrapped
+        // floating tables).
+      } else {
+        fragEl.style.top = `${cursorY}px`;
+        fragEl.style.left = "0";
+        containerEl.append(fragEl);
+        cursorY += measure.totalHeight;
+      }
     }
   }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -884,6 +884,31 @@ function renderHeaderFooterContent(
         containerEl.append(fragEl);
         cursorY += measure.totalHeight;
       }
+    } else if (block.kind === "textBox" && measure.kind === "textBox") {
+      // The unified pipeline extracts top-level text boxes inside H/F as
+      // their own block. `renderTextBoxFragment` sets `position: absolute`
+      // internally; we only supply top/left so it stacks at cursorY.
+      const syntheticFragment: TextBoxFragment = {
+        kind: "textBox",
+        blockId: block.id,
+        x: 0,
+        y: cursorY,
+        width: contentWidth,
+        height: measure.height,
+        ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
+        ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+      };
+      const fragEl = renderTextBoxFragment(
+        syntheticFragment,
+        block,
+        measure,
+        hfContext,
+        { document: doc },
+      );
+      fragEl.style.top = `${cursorY}px`;
+      fragEl.style.left = "0";
+      containerEl.append(fragEl);
+      cursorY += measure.height;
     }
   }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -785,10 +785,18 @@ function renderHeaderFooterContent(
       // Track the Y position where this paragraph starts
       const paragraphStartY = cursorY;
 
-      // Extract floating images and filter them from runs
+      // Extract floating images and filter them from runs. Match the
+      // body's classification (`isFloatingImageRun`) so images that are
+      // floating by `wrapType`/`displayMode` alone — without an explicit
+      // `<wp:positionH>`/`<wp:positionV>` — are still lifted out.
+      // `renderParagraphFragment` skips them inline; without the matching
+      // extraction here, a wrapped or behind header image without
+      // explicit positioning would never render. Synthesize an empty
+      // `position` for those runs; the float helpers fall through to a
+      // paragraph-relative default.
       const inlineRuns: typeof paragraphBlock.runs = [];
       for (const run of paragraphBlock.runs) {
-        if (run.kind === "image" && "position" in run && run.position) {
+        if (run.kind === "image" && (isFloatingImageRun(run) || run.position)) {
           floatingImages.push({
             src: run.src,
             width: run.width,
@@ -796,7 +804,7 @@ function renderHeaderFooterContent(
             ...(run.alt !== undefined ? { alt: run.alt } : {}),
             paragraphY: paragraphStartY,
             behindDoc: run.wrapType === "behind",
-            position: run.position,
+            position: run.position ?? {},
           });
         } else {
           // Keep non-floating runs for inline rendering

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -359,34 +359,46 @@ function resolveHeaderFooterFloatingTablePosition(
   measure: TableMeasure,
   layout: HeaderFooterLayoutInfo,
 ): { left: number; top: number } {
+  // Anchor-aware spec resolution: "right"/"bottom"/"center" are computed
+  // relative to whichever frame the anchor selects (page vs margin).
+  // Coordinates are returned relative to the HF container, so the page
+  // anchor subtracts the HF flow origin (`flowLeft` / `flowTop`).
+  const horzAnchor = floating.horzAnchor ?? "margin";
+  const vertAnchor = floating.vertAnchor ?? "margin";
+  const horzFrameWidth =
+    horzAnchor === "page" ? layout.pageWidth : layout.contentWidth;
+  const horzFrameOffset = horzAnchor === "page" ? -layout.flowLeft : 0;
+  const vertFrameHeight =
+    vertAnchor === "page"
+      ? layout.pageHeight
+      : layout.pageHeight - layout.margins.top - layout.margins.bottom;
+  const vertFrameOffset =
+    vertAnchor === "page"
+      ? -layout.flowTop
+      : layout.margins.top - layout.flowTop;
+
   // Horizontal
   let left = 0;
   if (floating.tblpXSpec === "left") {
-    left = 0;
+    left = horzFrameOffset;
   } else if (floating.tblpXSpec === "right") {
-    left = layout.contentWidth - measure.totalWidth;
+    left = horzFrameOffset + horzFrameWidth - measure.totalWidth;
   } else if (floating.tblpXSpec === "center") {
-    left = (layout.contentWidth - measure.totalWidth) / 2;
+    left = horzFrameOffset + (horzFrameWidth - measure.totalWidth) / 2;
   } else if (floating.tblpX !== undefined) {
-    left =
-      floating.horzAnchor === "page"
-        ? floating.tblpX - layout.flowLeft
-        : floating.tblpX;
+    left = horzFrameOffset + floating.tblpX;
   }
 
   // Vertical
   let top = 0;
   if (floating.tblpYSpec === "top") {
-    top = 0;
+    top = vertFrameOffset;
   } else if (floating.tblpYSpec === "bottom") {
-    top = layout.pageHeight - measure.totalHeight - layout.flowTop;
+    top = vertFrameOffset + vertFrameHeight - measure.totalHeight;
   } else if (floating.tblpYSpec === "center") {
-    top = (layout.pageHeight - measure.totalHeight) / 2 - layout.flowTop;
+    top = vertFrameOffset + (vertFrameHeight - measure.totalHeight) / 2;
   } else if (floating.tblpY !== undefined) {
-    top =
-      floating.vertAnchor === "page"
-        ? floating.tblpY - layout.flowTop
-        : floating.tblpY;
+    top = vertFrameOffset + floating.tblpY;
   }
 
   return { left, top };
@@ -848,12 +860,17 @@ function renderHeaderFooterContent(
       // Floating tables (`<w:tblpPr>`) opt out of the cursorY flow. They
       // anchor at (tblpX, tblpY) per ECMA-376 §17.4.57 and don't advance
       // cursorY. Inline tables stack within the HF container at cursorY.
+      // `renderTableFragment` already sets `position: absolute` on its
+      // returned element; we re-assert it here for parity with the
+      // paragraph branch and so future changes to renderTableFragment
+      // don't silently break HF positioning.
       if (block.floating) {
         const { left, top } = resolveHeaderFooterFloatingTablePosition(
           block.floating,
           measure,
           layout,
         );
+        fragEl.style.position = "absolute";
         fragEl.style.top = `${top}px`;
         fragEl.style.left = `${left}px`;
         containerEl.append(fragEl);
@@ -861,6 +878,7 @@ function renderHeaderFooterContent(
         // floating table weren't there (Word semantics for unwrapped
         // floating tables).
       } else {
+        fragEl.style.position = "absolute";
         fragEl.style.top = `${cursorY}px`;
         fragEl.style.left = "0";
         containerEl.append(fragEl);

--- a/packages/folio/src/core/layout-painter/renderUtils.ts
+++ b/packages/folio/src/core/layout-painter/renderUtils.ts
@@ -19,6 +19,15 @@ export type RenderContext = {
   contentWidth?: number;
   /** When true, floating images render in-flow instead of being skipped (for table cells) */
   insideTableCell?: boolean;
+  /**
+   * How the renderer should position its outer element. The body lays
+   * fragments at absolute (x, y) on the page (`'absolute'`), while
+   * headers/footers stack blocks vertically inside their own container
+   * (`'absolute'` with caller-supplied top/left). The default is
+   * undefined; renderers fall back to `position: relative` and let the
+   * caller override styles.
+   */
+  positioning?: "absolute" | "flow";
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2186,7 +2186,11 @@ function convertTextBox(
 
 /**
  * Convert HeaderFooter content (array of Paragraph/Table blocks) to a ProseMirror document.
- * Used for editing headers/footers in their own ProseMirror editor.
+ * Used for editing headers/footers in their own ProseMirror editor and for
+ * the unified header/footer render pipeline (see
+ * `core/layout-bridge/headerFooterLayout.ts`). `theme` lives in
+ * `ToProseDocOptions` for future themeColor cell-shading resolution; folio's
+ * `convertTable` does not yet thread it (orthogonal upstream divergence).
  */
 export function headerFooterToProseDoc(
   content: (Paragraph | Table)[],

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -44,6 +44,8 @@ import {
   collectFootnoteRefs,
   buildFootnoteContentMap,
 } from "../core/layout-bridge/footnoteLayout";
+import { convertHeaderFooterToContent } from "../core/layout-bridge/headerFooterLayout";
+import type { HeaderFooterMetrics } from "../core/layout-bridge/headerFooterLayout";
 import {
   hitTestFragment,
   hitTestTableCell,
@@ -66,10 +68,7 @@ import type {
   CaretPosition,
 } from "../core/layout-bridge/selectionRects";
 // Layout bridge
-import {
-  toFlowBlocks,
-  convertBorderSpecToLayout,
-} from "../core/layout-bridge/toFlowBlocks";
+import { toFlowBlocks } from "../core/layout-bridge/toFlowBlocks";
 // Layout engine
 import { layoutDocument } from "../core/layout-engine";
 import type { ColumnLayout, SectionLayoutConfig } from "../core/layout-engine";
@@ -83,11 +82,6 @@ import type {
   ImageBlock,
   ImageRun,
   PageMargins,
-  Run,
-  RunFormatting,
-  ParagraphAttrs,
-  ParagraphBorders,
-  ParagraphSpacing,
   SectionBreakBlock,
   TextBoxBlock,
   FootnoteContent,
@@ -105,14 +99,11 @@ import {
 } from "../core/layout-painter/renderPage";
 import type {
   RenderPageOptions,
-  HeaderFooterContent,
   FootnoteRenderItem,
 } from "../core/layout-painter/renderPage";
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "../core/prosemirror";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
-import { createStyleResolver } from "../core/prosemirror/styles/styleResolver";
-import type { StyleResolver } from "../core/prosemirror/styles/styleResolver";
 import type { Footnote } from "../core/types/content";
 // Types
 import type {
@@ -1164,644 +1155,6 @@ function measureSingleBlockWithoutFloatingZones(
   return measureBlock(block, blockWidth);
 }
 
-/**
- * Convert document Run content to FlowBlock runs.
- * Handles text, tabs, fields (PAGE, NUMPAGES), etc.
- *
- * Fields like PAGE and NUMPAGES are converted to FieldRun which gets
- * substituted with actual values at render time (in renderParagraph).
- *
- * @param content - Array of ParagraphContent from document
- */
-function convertDocumentRunsToFlowRuns(content: unknown[]): Run[] {
-  const runs: Run[] = [];
-
-  for (const item of content) {
-    const itemObj = item as Record<string, unknown>;
-
-    // Handle Run type (from Document)
-    if (itemObj["type"] === "run" && Array.isArray(itemObj["content"])) {
-      const formatting = itemObj["formatting"] as
-        | Record<string, unknown>
-        | undefined;
-      const runFormatting: RunFormatting = {};
-
-      if (formatting) {
-        if (formatting["bold"]) {
-          runFormatting.bold = true;
-        }
-        if (formatting["italic"]) {
-          runFormatting.italic = true;
-        }
-        if (formatting["underline"]) {
-          runFormatting.underline = true;
-        }
-        if (formatting["strike"]) {
-          runFormatting.strike = true;
-        }
-        if (formatting["color"]) {
-          const color = formatting["color"] as Record<string, unknown>;
-          if (color["val"]) {
-            runFormatting.color = `#${color["val"]}`;
-          } else if (color["rgb"]) {
-            runFormatting.color = `#${color["rgb"]}`;
-          }
-        }
-        if (formatting["fontSize"]) {
-          runFormatting.fontSize = (formatting["fontSize"] as number) / 2; // half-points to points
-        }
-        if (formatting["fontFamily"]) {
-          const ff = formatting["fontFamily"] as Record<string, unknown>;
-          runFormatting.fontFamily = (ff["ascii"] || ff["hAnsi"]) as string;
-        }
-      }
-
-      // Process run content
-      for (const runContent of itemObj["content"] as unknown[]) {
-        const rc = runContent as Record<string, unknown>;
-
-        if (rc["type"] === "text" && typeof rc["text"] === "string") {
-          runs.push({
-            kind: "text",
-            text: rc["text"],
-            ...runFormatting,
-          });
-        } else if (rc["type"] === "tab") {
-          runs.push({
-            kind: "tab",
-            ...runFormatting,
-          });
-        } else if (rc["type"] === "break") {
-          runs.push({
-            kind: "lineBreak",
-          });
-        } else if (rc["type"] === "drawing" && rc["image"]) {
-          // Handle images/drawings
-          const image = rc["image"] as Record<string, unknown>;
-          const size = image["size"] as
-            | { width: number; height: number }
-            | undefined;
-          // EMU to pixels: 1 inch = 914400 EMU, 1 inch = 96 pixels
-          const emuToPx = (emu: number) => Math.round((emu / 914_400) * 96);
-          const widthPx = size?.width ? emuToPx(size.width) : 100;
-          const heightPx = size?.height ? emuToPx(size.height) : 100;
-
-          // Check for position (floating/anchored images)
-          const position = image["position"] as
-            | {
-                horizontal?: {
-                  relativeTo?: string;
-                  posOffset?: number;
-                  align?: string;
-                };
-                vertical?: {
-                  relativeTo?: string;
-                  posOffset?: number;
-                  align?: string;
-                };
-              }
-            | undefined;
-
-          // Check for behindDoc (full-page background images)
-          const wrap = image["wrap"] as { type?: string } | undefined;
-          const behindDoc = wrap?.type === "behind";
-
-          runs.push({
-            kind: "image",
-            src: (image["src"] as string) || "",
-            width: widthPx,
-            height: heightPx,
-            alt: (image["alt"] as string) || undefined,
-            // Include position for floating images
-            position: position
-              ? {
-                  horizontal: position.horizontal,
-                  vertical: position.vertical,
-                }
-              : undefined,
-            behindDoc,
-          } as Run);
-        }
-      }
-    }
-
-    // Handle SimpleField (w:fldSimple) - PAGE, NUMPAGES, etc.
-    if (itemObj["type"] === "simpleField") {
-      const fieldType = itemObj["fieldType"] as string;
-
-      // Extract formatting from content runs (same approach as ComplexField)
-      const fieldFormatting: RunFormatting = {};
-      if (Array.isArray(itemObj["content"]) && itemObj["content"].length > 0) {
-        const firstRun = itemObj["content"][0] as Record<string, unknown>;
-        if (firstRun?.["type"] === "run" && firstRun["formatting"]) {
-          const formatting = firstRun["formatting"] as Record<string, unknown>;
-          if (formatting["fontSize"]) {
-            fieldFormatting.fontSize = (formatting["fontSize"] as number) / 2;
-          }
-          if (formatting["fontFamily"]) {
-            const ff = formatting["fontFamily"] as Record<string, unknown>;
-            fieldFormatting.fontFamily = (ff["ascii"] || ff["hAnsi"]) as string;
-          }
-          if (formatting["bold"]) {
-            fieldFormatting.bold = true;
-          }
-          if (formatting["italic"]) {
-            fieldFormatting.italic = true;
-          }
-          if (formatting["color"]) {
-            const c = formatting["color"] as Record<string, unknown>;
-            const val = (c["rgb"] || c["val"]) as string | undefined;
-            if (val) {
-              fieldFormatting.color = val.startsWith("#") ? val : `#${val}`;
-            }
-          }
-        }
-      }
-
-      if (fieldType === "PAGE") {
-        runs.push({
-          kind: "field",
-          fieldType: "PAGE",
-          fallback: "1",
-          ...fieldFormatting,
-        });
-      } else if (fieldType === "NUMPAGES") {
-        runs.push({
-          kind: "field",
-          fieldType: "NUMPAGES",
-          fallback: "1",
-          ...fieldFormatting,
-        });
-      } else if (Array.isArray(itemObj["content"])) {
-        // Use the display content for other fields
-        const displayRuns = convertDocumentRunsToFlowRuns(
-          itemObj["content"] as unknown[],
-        );
-        runs.push(...displayRuns);
-      }
-      continue;
-    }
-
-    // Handle ComplexField (fldChar sequence)
-    if (itemObj["type"] === "complexField") {
-      const fieldType = itemObj["fieldType"] as string;
-
-      // Extract formatting from fieldResult runs if available
-      const fieldFormatting: RunFormatting = {};
-      if (
-        Array.isArray(itemObj["fieldResult"]) &&
-        itemObj["fieldResult"].length > 0
-      ) {
-        const firstRun = itemObj["fieldResult"][0] as Record<string, unknown>;
-        if (firstRun?.["type"] === "run" && firstRun["formatting"]) {
-          const formatting = firstRun["formatting"] as Record<string, unknown>;
-          if (formatting["fontSize"]) {
-            fieldFormatting.fontSize = (formatting["fontSize"] as number) / 2;
-          }
-          if (formatting["fontFamily"]) {
-            const ff = formatting["fontFamily"] as Record<string, unknown>;
-            fieldFormatting.fontFamily = (ff["ascii"] || ff["hAnsi"]) as string;
-          }
-          if (formatting["bold"]) {
-            fieldFormatting.bold = true;
-          }
-          if (formatting["italic"]) {
-            fieldFormatting.italic = true;
-          }
-          if (formatting["color"]) {
-            const c = formatting["color"] as Record<string, unknown>;
-            const val = (c["rgb"] || c["val"]) as string | undefined;
-            if (val) {
-              fieldFormatting.color = val.startsWith("#") ? val : `#${val}`;
-            }
-          }
-        }
-      }
-
-      if (fieldType === "PAGE") {
-        runs.push({
-          kind: "field",
-          fieldType: "PAGE",
-          fallback: "1",
-          ...fieldFormatting,
-        });
-      } else if (fieldType === "NUMPAGES") {
-        runs.push({
-          kind: "field",
-          fieldType: "NUMPAGES",
-          fallback: "1",
-          ...fieldFormatting,
-        });
-      } else if (Array.isArray(itemObj["fieldResult"])) {
-        // Use the fieldResult for other fields
-        const displayRuns = convertDocumentRunsToFlowRuns(
-          itemObj["fieldResult"] as unknown[],
-        );
-        runs.push(...displayRuns);
-      }
-    }
-
-    // Handle Hyperlink
-    if (itemObj["type"] === "hyperlink" && Array.isArray(itemObj["children"])) {
-      const childRuns = convertDocumentRunsToFlowRuns(
-        itemObj["children"] as unknown[],
-      );
-      runs.push(...childRuns);
-    }
-  }
-
-  return runs;
-}
-
-type HeaderFooterMetrics = {
-  section: "header" | "footer";
-  pageSize: { w: number; h: number };
-  margins: PageMargins;
-};
-
-type PositionedAxis = {
-  relativeTo?: string;
-  posOffset?: number;
-  align?: string;
-  alignment?: string;
-};
-
-function getPositionAlignment(
-  axis: PositionedAxis | undefined,
-): string | undefined {
-  return axis?.align ?? axis?.alignment;
-}
-
-function resolveHeaderFooterVisualTop(
-  run: ImageRun,
-  paragraphY: number,
-  flowHeight: number,
-  metrics: HeaderFooterMetrics,
-): number {
-  const flowTop =
-    metrics.section === "header"
-      ? (metrics.margins.header ?? 48)
-      : metrics.pageSize.h - (metrics.margins.footer ?? 48) - flowHeight;
-  const vertical = run.position?.vertical;
-
-  if (!vertical) {
-    return paragraphY;
-  }
-
-  const align = getPositionAlignment(vertical);
-  const offsetPx =
-    vertical.posOffset !== undefined
-      ? emuToPixels(vertical.posOffset)
-      : undefined;
-
-  if (vertical.relativeTo === "page") {
-    if (offsetPx !== undefined) {
-      return offsetPx - flowTop;
-    }
-    if (align === "top") {
-      return -flowTop;
-    }
-    if (align === "bottom") {
-      return metrics.pageSize.h - run.height - flowTop;
-    }
-    if (align === "center") {
-      return (metrics.pageSize.h - run.height) / 2 - flowTop;
-    }
-  }
-
-  if (vertical.relativeTo === "margin") {
-    const marginTop = metrics.margins.top;
-    const marginHeight =
-      metrics.pageSize.h - metrics.margins.top - metrics.margins.bottom;
-    if (offsetPx !== undefined) {
-      return marginTop + offsetPx - flowTop;
-    }
-    if (align === "top") {
-      return marginTop - flowTop;
-    }
-    if (align === "bottom") {
-      return marginTop + marginHeight - run.height - flowTop;
-    }
-    if (align === "center") {
-      return marginTop + (marginHeight - run.height) / 2 - flowTop;
-    }
-  }
-
-  if (offsetPx !== undefined) {
-    return paragraphY + offsetPx;
-  }
-
-  return paragraphY;
-}
-
-function calculateHeaderFooterVisualBounds(
-  blocks: FlowBlock[],
-  measures: Measure[],
-  flowHeight: number,
-  metrics: HeaderFooterMetrics,
-): { visualTop: number; visualBottom: number } {
-  let visualTop = 0;
-  let visualBottom = flowHeight;
-  let cursorY = 0;
-
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i];
-    const measure = measures[i];
-    if (block?.kind !== "paragraph" || measure?.kind !== "paragraph") {
-      continue;
-    }
-
-    const paragraphBlock = block as ParagraphBlock;
-    const paragraphStartY = cursorY;
-    const paragraphBottomY = paragraphStartY + measure.totalHeight;
-    visualTop = Math.min(visualTop, paragraphStartY);
-    visualBottom = Math.max(visualBottom, paragraphBottomY);
-
-    for (const run of paragraphBlock.runs) {
-      if (run.kind !== "image" || !run.position) {
-        continue;
-      }
-      const imageRun = run as ImageRun;
-      const runTop = resolveHeaderFooterVisualTop(
-        imageRun,
-        paragraphStartY,
-        flowHeight,
-        metrics,
-      );
-      visualTop = Math.min(visualTop, runTop);
-      visualBottom = Math.max(visualBottom, runTop + imageRun.height);
-    }
-
-    cursorY = paragraphBottomY;
-  }
-
-  return { visualTop, visualBottom };
-}
-
-/**
- * Convert HeaderFooter (document type) to HeaderFooterContent (render type).
- *
- * This converts parsed header/footer content into FlowBlocks that can be
- * rendered by the layout painter.
- *
- * Fields like PAGE and NUMPAGES are converted to FieldRun which gets
- * substituted with actual values at render time.
- *
- * @param headerFooter - The header/footer document content
- * @param contentWidth - Available width for content
- */
-function convertHeaderFooterToContent(
-  headerFooter: HeaderFooter | null | undefined,
-  contentWidth: number,
-  metrics: HeaderFooterMetrics,
-  styleResolver?: StyleResolver | null,
-): HeaderFooterContent | undefined {
-  if (
-    !headerFooter ||
-    !headerFooter.content ||
-    headerFooter.content.length === 0
-  ) {
-    return undefined;
-  }
-
-  const blocks: FlowBlock[] = [];
-
-  for (const item of headerFooter.content) {
-    const itemObj = item as unknown as Record<string, unknown>;
-
-    // Check for Document Paragraph type
-    if (itemObj["type"] === "paragraph" && Array.isArray(itemObj["content"])) {
-      const formatting = itemObj["formatting"] as
-        | Record<string, unknown>
-        | undefined;
-      const attrs: ParagraphAttrs = {};
-
-      // Resolve the paragraph style cascade so HF paragraphs inherit
-      // spacing/alignment/etc from `Normal` (or whatever pStyle they
-      // reference). HF parsing skips this cascade — without it,
-      // spaceBefore/spaceAfter inherited from a paragraph style is silently
-      // lost in headers/footers. Reuses the same StyleResolver the body uses.
-      const styleId =
-        typeof formatting?.["styleId"] === "string"
-          ? (formatting["styleId"] as string)
-          : undefined;
-      const resolvedStyle = styleResolver?.resolveParagraphStyle(styleId);
-      const styledPpr = resolvedStyle?.paragraphFormatting;
-
-      if (formatting) {
-        if (formatting["alignment"]) {
-          const align = formatting["alignment"] as string;
-          if (align === "both") {
-            attrs.alignment = "justify";
-          } else if (["left", "center", "right", "justify"].includes(align)) {
-            attrs.alignment = align as "left" | "center" | "right" | "justify";
-          }
-        }
-        // Convert paragraph borders (e.g., header bottom line, footer top line)
-        if (formatting["borders"]) {
-          const borders = formatting["borders"] as Record<string, unknown>;
-          const converted: ParagraphBorders = {};
-          for (const side of [
-            "top",
-            "bottom",
-            "left",
-            "right",
-            "between",
-          ] as const) {
-            const b = borders[side] as
-              | {
-                  style?: string;
-                  size?: number;
-                  color?: Record<string, string>;
-                }
-              | undefined;
-            if (b) {
-              const layoutBorder = convertBorderSpecToLayout(b);
-              if (layoutBorder) {
-                converted[side] = layoutBorder;
-              }
-            }
-          }
-          if (Object.keys(converted).length > 0) {
-            attrs.borders = converted;
-          }
-        }
-        // Convert spacing for measurement and rendering. lineSpacing affects
-        // line height; spaceBefore/spaceAfter are visualized as fragment
-        // padding by `renderHeaderFooterContent`. Word renders style-inherited
-        // paragraph spacing in headers/footers the same way as in body
-        // (NVCA-style first-page header: each paragraph has Normal's
-        // spaceAfter=240twips inherited, which produces the visible blank row
-        // above the body's first paragraph). Without these, last-paragraph
-        // spaceAfter is silently dropped and body content butts flush against
-        // the last header line.
-        // Inline pPr first, then fall back to the resolved style cascade.
-        const inlineLineSpacing = formatting["lineSpacing"];
-        const inlineSpaceBefore = formatting["spaceBefore"];
-        const inlineSpaceAfter = formatting["spaceAfter"];
-        const inlineLineRule = formatting["lineSpacingRule"] as
-          | string
-          | undefined;
-        const lineSpacing =
-          typeof inlineLineSpacing === "number"
-            ? inlineLineSpacing
-            : styledPpr?.lineSpacing;
-        const lineRule = inlineLineRule ?? styledPpr?.lineSpacingRule;
-        const spaceBeforeTwips =
-          typeof inlineSpaceBefore === "number"
-            ? inlineSpaceBefore
-            : styledPpr?.spaceBefore;
-        const spaceAfterTwips =
-          typeof inlineSpaceAfter === "number"
-            ? inlineSpaceAfter
-            : styledPpr?.spaceAfter;
-        if (
-          typeof lineSpacing === "number" ||
-          typeof spaceBeforeTwips === "number" ||
-          typeof spaceAfterTwips === "number"
-        ) {
-          const spacingAttrs: ParagraphSpacing = {};
-          if (typeof lineSpacing === "number") {
-            if (lineRule === "exact" || lineRule === "atLeast") {
-              spacingAttrs.line = twipsToPixels(lineSpacing);
-              spacingAttrs.lineUnit = "px";
-              spacingAttrs.lineRule = lineRule;
-            } else {
-              spacingAttrs.line = lineSpacing / 240;
-              spacingAttrs.lineUnit = "multiplier";
-              spacingAttrs.lineRule = "auto";
-            }
-          }
-          if (typeof spaceBeforeTwips === "number") {
-            spacingAttrs.before = twipsToPixels(spaceBeforeTwips);
-          }
-          if (typeof spaceAfterTwips === "number") {
-            spacingAttrs.after = twipsToPixels(spaceAfterTwips);
-          }
-          attrs.spacing = spacingAttrs;
-        }
-        // Convert tab stops (needed for center/right tab alignment in headers/footers)
-        if (
-          Array.isArray(formatting["tabs"]) &&
-          formatting["tabs"].length > 0
-        ) {
-          attrs.tabs = (
-            formatting["tabs"] as {
-              position: number;
-              alignment: string;
-              leader?: string;
-            }[]
-          ).map((tab) => {
-            const align =
-              tab.alignment === "left"
-                ? "start"
-                : tab.alignment === "right"
-                  ? "end"
-                  : tab.alignment;
-            const tabStop: import("../core/layout-engine/types").TabStop = {
-              val: align as
-                | "start"
-                | "end"
-                | "center"
-                | "decimal"
-                | "bar"
-                | "clear",
-              // Keep twips. The layout-bridge measurer (`computeTabWidth`)
-              // and renderer treat `tabStop.pos` as twips and call
-              // `twipsToPx` themselves — body content stores tabs in twips
-              // (see `toFlowBlocks`). Pre-converting to pixels here was
-              // double-converting (4770 twips → 318 px → treated as twips →
-              // ~21 px stop), collapsing the center tab back to a default
-              // narrow tab and pushing footer content (page number,
-              // centered text) to the wrong x.
-              pos: tab.position,
-            };
-            if (tab.leader) {
-              tabStop.leader = tab.leader as NonNullable<typeof tabStop.leader>;
-            }
-            return tabStop;
-          });
-        }
-      }
-
-      const runs = convertDocumentRunsToFlowRuns(
-        itemObj["content"] as unknown[],
-      );
-
-      // Empty paragraphs (blank lines) should still measure — add empty text run
-      if (runs.length === 0) {
-        runs.push({ kind: "text" as const, text: "" });
-      }
-      const paragraphBlock: ParagraphBlock = {
-        kind: "paragraph",
-        id: String(blocks.length),
-        runs,
-      };
-      if (Object.keys(attrs).length > 0) {
-        paragraphBlock.attrs = attrs;
-      }
-      blocks.push(paragraphBlock);
-    }
-  }
-
-  if (blocks.length === 0) {
-    return undefined;
-  }
-
-  // Build blocks for measurement that exclude floating images
-  // (floating images are positioned absolutely, don't affect paragraph height)
-  const blocksForMeasure: FlowBlock[] = blocks.map((block) => {
-    if (block.kind !== "paragraph") {
-      return block;
-    }
-    const pb = block as ParagraphBlock;
-    const hasFloating = pb.runs.some(
-      (r) =>
-        r.kind === "image" &&
-        "position" in r &&
-        (r as Record<string, unknown>)["position"],
-    );
-    if (!hasFloating) {
-      return block;
-    }
-    const inlineRuns = pb.runs.filter(
-      (r) =>
-        !(
-          r.kind === "image" &&
-          "position" in r &&
-          (r as Record<string, unknown>)["position"]
-        ),
-    );
-    // If only floating images remain, add an empty text run so the paragraph still measures
-    if (inlineRuns.length === 0) {
-      inlineRuns.push({ kind: "text" as const, text: "" });
-    }
-    return { ...pb, runs: inlineRuns };
-  });
-
-  const measures = measureBlocks(blocksForMeasure, contentWidth);
-  let totalHeight = 0;
-  for (const measure of measures) {
-    if (measure.kind === "paragraph") {
-      totalHeight += measure.totalHeight;
-    }
-  }
-  const { visualTop, visualBottom } = calculateHeaderFooterVisualBounds(
-    blocks,
-    measures,
-    totalHeight,
-    metrics,
-  );
-
-  return {
-    blocks,
-    measures,
-    height: totalHeight,
-    visualTop,
-    visualBottom,
-  };
-}
-
 // =============================================================================
 // FOOTNOTE HELPERS
 // =============================================================================
@@ -2161,30 +1514,32 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
           // Step 2.75: Prepare header/footer content for rendering (needed before layout
           // to compute effective margins when header content exceeds available space)
-          const hfMetricsHeader = {
-            section: "header" as const,
+          const hfMetricsHeader: HeaderFooterMetrics = {
+            section: "header",
             pageSize,
             margins,
           };
-          const hfMetricsFooter = {
-            section: "footer" as const,
+          const hfMetricsFooter: HeaderFooterMetrics = {
+            section: "footer",
             pageSize,
             margins,
           };
-          const headerFooterStyleResolver = styles
-            ? createStyleResolver(styles)
-            : null;
+          const hfOptions = {
+            ...(styles ? { styles } : {}),
+            ...(_theme !== undefined ? { theme: _theme } : {}),
+            measureBlocks,
+          };
           const headerContentForRender = convertHeaderFooterToContent(
             headerContent,
             contentWidth,
             hfMetricsHeader,
-            headerFooterStyleResolver,
+            hfOptions,
           );
           const footerContentForRender = convertHeaderFooterToContent(
             footerContent,
             contentWidth,
             hfMetricsFooter,
-            headerFooterStyleResolver,
+            hfOptions,
           );
           const hasTitlePg = sectionProperties?.titlePg === true;
           const firstPageHeaderForRender = hasTitlePg
@@ -2192,7 +1547,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 firstPageHeaderContent,
                 contentWidth,
                 hfMetricsHeader,
-                headerFooterStyleResolver,
+                hfOptions,
               )
             : undefined;
           const firstPageFooterForRender = hasTitlePg
@@ -2200,7 +1555,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 firstPageFooterContent,
                 contentWidth,
                 hfMetricsFooter,
-                headerFooterStyleResolver,
+                hfOptions,
               )
             : undefined;
 


### PR DESCRIPTION
## Summary

- Routes header/footer content through the same ProseMirror -> FlowBlock -> measureBlocks chain as the body. New shared `core/layout-bridge/headerFooterLayout.ts` module replaces the legacy paragraph-only converter in `PagedEditor.tsx` (-637 lines of shadow-stack code).
- Adds the table arm to `renderHeaderFooterContent` so HF tables stop being silently dropped, plus the floating-table position resolver and `RenderContext.positioning` field.
- Closes upstream #356/#357/#358 (HF tables in paginated view + shared interaction model + measurement parity) and the #379-#382 follow-ups (positioning context, style-inherited spacing strip, trailing empty-paragraph-after-table suppression, floating tables in HF). `convertTable` theme threading for themeColor cell shading remains orthogonal upstream divergence.

CC on behalf of @jan-kubica.

## Test plan

- [x] Folio typecheck clean.
- [x] Folio lint clean.
- [x] 571/571 folio unit tests pass.
- [x] Web typecheck clean (consumer).
- [ ] Manual playground verification on a DOCX with HF tables (regular + floating), HF anchored images, NVCA Series A SPA template (multi-section + first-page header + paginated footnotes).
- [ ] Visual / Playwright snapshot suite.