### PR TITLE
chore: tighten oxlint config and clean dead disable directives

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -10,7 +10,7 @@
       },
       {
         "groupName": "stella",
-        "elementNamePattern": ["@stella/**"]
+        "elementNamePattern": ["@stll/**"]
       },
       {
         "groupName": "aliases",

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,6 +1,15 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["**/*.gen.*", "**/*.min.*", "sbom.cdx.json", "**/.cache/**", "**/.oxlintrc.json", "**/dist/**", "**/.react-email/**"],
+  "ignorePatterns": [
+    "**/*.gen.*",
+    "**/*.min.*",
+    "sbom.cdx.json",
+    "**/.cache/**",
+    "**/.oxlintrc.json",
+    "**/dist/**",
+    "**/.react-email/**",
+    "apps/api/src/db/schema.ts"
+  ],
   "printWidth": 80,
   "sortImports": {
     "customGroups": [

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,7 +15,7 @@
     "docker:stop-dev": "docker compose --profile dev down",
     "clean": "git clean -xdf .cache .turbo node_modules",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware apps/api",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware apps/api",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/api",
     "format": "oxfmt .",
     "bench:chat-read-surface": "NODE_ENV=development bun scripts/benchmark-chat-read-surface.ts",

--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -10,7 +10,6 @@
  */
 
 import { valibotSchema } from "@ai-sdk/valibot";
-// oxlint-disable-next-line no-restricted-imports
 import { generateText, stepCountIs, tool } from "ai";
 import type { LanguageModel, LanguageModelUsage } from "ai";
 import * as v from "valibot";

--- a/apps/api/scripts/ingest-case-law.ts
+++ b/apps/api/scripts/ingest-case-law.ts
@@ -212,7 +212,6 @@ const ensureSource = async (
     .returning();
 
   // TODO: fix this
-  // oxlint-disable-next-line typescript/strict-boolean-expressions
   if (!created) {
     throw new Error(`Failed to create source row for adapter "${adapterKey}"`);
   }

--- a/apps/api/scripts/seed-case-law.ts
+++ b/apps/api/scripts/seed-case-law.ts
@@ -16,12 +16,13 @@
  *   bun apps/api/scripts/seed-case-law.ts
  */
 
-import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
-import type { DocumentAst } from "@stll/case-law/document-ast";
 import { and, eq, sql } from "drizzle-orm";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import * as v from "valibot";
+
+import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
+import type { DocumentAst } from "@stll/case-law/document-ast";
 
 import { createScopedDb } from "@/api/db";
 import { db } from "@/api/db/root";

--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -4070,7 +4070,6 @@ export async function seed(organizationId?: string, userId?: string) {
   //      - `fields` table (file field + status/date/notes)
   const IV_BYTES = 12;
   let fileCount = 0;
-  // eslint-disable-next-line -- kept for logging
   const pdfTwinCount = 0;
   let extractedCount = 0;
 
@@ -4182,7 +4181,6 @@ export async function seed(organizationId?: string, userId?: string) {
     const ws = at(seedWorkspaces, i);
     const wsLabel = at(WS_LABELS, i);
     const docNames = workspaceDocNames[wsLabel];
-    // oxlint-disable-next-line typescript/strict-boolean-expressions -- docNames may be undefined
     if (docNames) {
       docPlans.push({ wsId: ws.id, wsLabel, docNames });
     }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,11 +1,10 @@
+import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
+import type { DocumentAst } from "@stll/case-law/document-ast";
 import { panic } from "better-result";
 import { defineRelations, isNotNull, isNull, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import * as p from "drizzle-orm/pg-core";
 import { customType } from "drizzle-orm/pg-core";
-
-import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
-import type { DocumentAst } from "@stll/case-law/document-ast";
 
 import { organization, user } from "@/api/db/auth-schema";
 import { jsonb } from "@/api/db/columns";

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,10 +1,11 @@
-import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
-import type { DocumentAst } from "@stll/case-law/document-ast";
 import { panic } from "better-result";
 import { defineRelations, isNotNull, isNull, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import * as p from "drizzle-orm/pg-core";
 import { customType } from "drizzle-orm/pg-core";
+
+import type { PersistedDecisionAnalysis } from "@stll/case-law/analysis";
+import type { DocumentAst } from "@stll/case-law/document-ast";
 
 import { organization, user } from "@/api/db/auth-schema";
 import { jsonb } from "@/api/db/columns";

--- a/apps/api/src/handlers/case-law/analysis/category-catalog.test.ts
+++ b/apps/api/src/handlers/case-law/analysis/category-catalog.test.ts
@@ -1,5 +1,6 @@
-import type { AnalysisHeading } from "@stll/case-law/analysis";
 import { describe, expect, test } from "bun:test";
+
+import type { AnalysisHeading } from "@stll/case-law/analysis";
 
 import {
   buildCategoryCatalogPrompt,

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -7,6 +7,9 @@
  */
 
 import { valibotSchema } from "@ai-sdk/valibot";
+import { Output, streamText } from "ai";
+import { and, eq, isNull } from "drizzle-orm";
+
 import type {
   AnalysisHeading,
   AnalysisInProgress,
@@ -22,8 +25,6 @@ import {
 } from "@stll/case-law/analysis";
 import type { DocumentAst } from "@stll/case-law/document-ast";
 import { hasUsableAst } from "@stll/case-law/document-ast";
-import { Output, streamText } from "ai";
-import { and, eq, isNull } from "drizzle-orm";
 
 import type { ScopedDb } from "@/api/db";
 // SAFETY: rootDb is used only inside runGeneration, which runs in

--- a/apps/api/src/handlers/case-law/decisions/read-by-id.ts
+++ b/apps/api/src/handlers/case-law/decisions/read-by-id.ts
@@ -1,5 +1,6 @@
-import { parsePersistedDecisionAnalysis } from "@stll/case-law/analysis";
 import { status } from "elysia";
+
+import { parsePersistedDecisionAnalysis } from "@stll/case-law/analysis";
 
 import type { ScopedDb } from "@/api/db";
 import { hasUsableAst } from "@/api/handlers/case-law/document-ast";

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-ns.ts
@@ -322,7 +322,6 @@ export const czNsAdapter: SourceAdapter = {
               const raw = `${caseNumber}|${meta["ecli"] ?? ""}|${meta["decisionDate"] ?? ""}`;
 
               // Parse AST from the print page (rich HTML)
-              // oxlint-disable-next-line no-untyped-updates/no-untyped-updates -- AST container, not a DB update
               let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
               let fulltext = meta["fulltext"];
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.test.ts
@@ -1,7 +1,5 @@
 /* eslint-disable typescript-eslint/no-unsafe-type-assertion */
 /* eslint-disable typescript-eslint/promise-function-async */
-/* eslint-disable typescript-eslint/no-unsafe-assignment */
-/* eslint-disable typescript-eslint/no-unsafe-member-access */
 import { Result } from "better-result";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -271,7 +269,6 @@ describe("czUsAdapter.fetchPage", () => {
       (d) => d.caseNumber === "IV.ÚS 1/25",
     );
     expect(decision).toBeDefined();
-    // eslint-disable-next-line unicorn/no-useless-undefined
     expect(decision?.metadata["abstract"]).toEqual(undefined);
   });
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/cz-us.ts
@@ -228,7 +228,6 @@ const parseDecisionPage = (
       ? buildEcli(parsed.caseNumber, decisionYear, ecliCounter)
       : undefined;
 
-  // oxlint-disable-next-line no-untyped-updates/no-untyped-updates -- AST container, not a DB update
   let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
   let resolvedFulltext = fulltext;
 

--- a/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/eu-ecj.test.ts
@@ -1,7 +1,6 @@
 import { Result } from "better-result";
 /* eslint-disable typescript-eslint/no-unsafe-type-assertion */
 /* eslint-disable typescript-eslint/promise-function-async */
-/* eslint-disable unicorn/no-array-sort */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-us.ts
@@ -275,7 +275,6 @@ const parseDocument = async (
   // Fetch and parse PDF
   const pdfBytes = await fetchPdfBytes(doc.documentId, signal);
 
-  // oxlint-disable-next-line no-untyped-updates/no-untyped-updates -- AST container
   let documentAst: DocumentAst | EmptyAst = EMPTY_AST;
   let fulltext: string | undefined;
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-us.ts
@@ -203,7 +203,6 @@ const extractCrossReferences = ($: cheerio.CheerioAPI): CrossReference[] => {
 
 // ── Inline walking (HTML fallback) ────────────────────────
 
-// oxlint-disable-next-line no-unused-vars -- kept for HTML fallback path
 const _walkInlines = (
   $: cheerio.CheerioAPI,
   el: cheerio.Cheerio<AnyNode>,

--- a/apps/api/src/handlers/chat/chat-prompt.ts
+++ b/apps/api/src/handlers/chat/chat-prompt.ts
@@ -5,10 +5,11 @@
  * REST chat endpoint can share the same prompt logic.
  */
 
-import type { SkillMetadata } from "@stll/skills";
 import { panic, Result } from "better-result";
 import * as cheerio from "cheerio";
 import { count, eq } from "drizzle-orm";
+
+import type { SkillMetadata } from "@stll/skills";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
 import { caseLawDecisions, entities, workspaces } from "@/api/db/schema";

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -512,7 +512,6 @@ const anonymizeToolPart = ({
 
     // SAFETY: the tool UI part discriminator fields are preserved. We only
     // anonymize provider-visible text nested in input/output/error/title fields.
-    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
     return Result.ok(prepared as ToolLikePart);
   });
 

--- a/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
+++ b/apps/api/src/handlers/chat/tools/active-docx-edit-tool.ts
@@ -1,5 +1,4 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import * as v from "valibot";
 

--- a/apps/api/src/handlers/chat/tools/ares-tools.ts
+++ b/apps/api/src/handlers/chat/tools/ares-tools.ts
@@ -1,8 +1,8 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-import { lookupByIco, searchByName } from "@stll/ares";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import * as v from "valibot";
+
+import { lookupByIco, searchByName } from "@stll/ares";
 
 export const createAresTools = () => ({
   ares_lookup_company: tool({

--- a/apps/api/src/handlers/chat/tools/authorized-workspace-ids.ts
+++ b/apps/api/src/handlers/chat/tools/authorized-workspace-ids.ts
@@ -34,7 +34,7 @@ type ResolveToolWorkspaceIdsInput = {
 // other code path may construct a value of this brand without
 // going through this function or `intersectAccessibleWorkspaceIds`.
 const brand = (ids: SafeId<"workspace">[]): AuthorizedToolWorkspaceIds =>
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   ids as AuthorizedToolWorkspaceIds;
 
 export const resolveToolWorkspaceIds = ({

--- a/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
+++ b/apps/api/src/handlers/chat/tools/execute/chat-execution-tools.ts
@@ -1,5 +1,4 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import { panic, Result } from "better-result";
 import * as v from "valibot";

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -63,7 +63,6 @@ const dumpVmError = (
       );
       return { message };
     },
-    // oxlint-disable-next-line unicorn/no-useless-undefined
     err: () => undefined,
   });
 

--- a/apps/api/src/handlers/chat/tools/org-tools.ts
+++ b/apps/api/src/handlers/chat/tools/org-tools.ts
@@ -1,5 +1,4 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import * as v from "valibot";
 

--- a/apps/api/src/handlers/chat/tools/skill-tools.ts
+++ b/apps/api/src/handlers/chat/tools/skill-tools.ts
@@ -1,9 +1,9 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-import type { SkillMetadata } from "@stll/skills";
-import { listSkillResources, loadSkill, readSkillResource } from "@stll/skills";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import * as v from "valibot";
+
+import type { SkillMetadata } from "@stll/skills";
+import { listSkillResources, loadSkill, readSkillResource } from "@stll/skills";
 
 import { ChatToolError } from "@/api/lib/errors/tagged-errors";
 

--- a/apps/api/src/handlers/chat/tools/workspace-tools.ts
+++ b/apps/api/src/handlers/chat/tools/workspace-tools.ts
@@ -1,5 +1,4 @@
 import { valibotSchema } from "@ai-sdk/valibot";
-// oxlint-disable-next-line no-restricted-imports
 import { tool } from "ai";
 import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";

--- a/apps/api/src/handlers/contacts/ares-lookup.ts
+++ b/apps/api/src/handlers/contacts/ares-lookup.ts
@@ -1,3 +1,6 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
 import {
   AresAPIError,
   AresRequestError,
@@ -6,8 +9,6 @@ import {
   lookupByIco,
   searchByName,
 } from "@stll/ares";
-import { Result } from "better-result";
-import { t } from "elysia";
 
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -10,8 +10,9 @@
  * (fast-path check via regex on raw XML).
  */
 
-import { evaluateCondition, resolvePath } from "@stll/template-conditions";
 import type * as slimdom from "slimdom";
+
+import { evaluateCondition, resolvePath } from "@stll/template-conditions";
 
 import { isElement, paragraphText, W_NS } from "./ooxml";
 import type {

--- a/apps/api/src/handlers/docx/docx-edge-cases.test.ts
+++ b/apps/api/src/handlers/docx/docx-edge-cases.test.ts
@@ -131,7 +131,6 @@ const pipelineRoundtrip = (
   const accepted = extractAcceptedText(result);
 
   for (const rw of rewrites) {
-    // eslint-disable-next-line vitest/no-standalone-expect
     expect(accepted[rw.paragraphIndex]).toBe(rw.newText);
   }
 };
@@ -428,7 +427,6 @@ describe("run-map vs extract-text consistency", () => {
           `\n    extract: ${JSON.stringify(extractedText)}`,
         );
       }
-      // eslint-disable-next-line vitest/no-standalone-expect
       expect(runMapText).toBe(extractedText);
     }
   };

--- a/apps/api/src/handlers/docx/docx-properties.test.ts
+++ b/apps/api/src/handlers/docx/docx-properties.test.ts
@@ -1324,7 +1324,6 @@ const assertRoundtrip = (oldText: string, newText: string) => {
   const idGen = createIdGenerator(new Set());
   const result = applyEdits(xml, edits, AUTHOR, idGen);
   const accepted = extractAcceptedText(result);
-  // eslint-disable-next-line vitest/no-standalone-expect
   expect(accepted[0]).toBe(newText);
 };
 

--- a/apps/api/src/handlers/docx/ooxml.ts
+++ b/apps/api/src/handlers/docx/ooxml.ts
@@ -5,8 +5,9 @@
  * ones and generate new IDs above the max.
  */
 
-import { OOXML_NS } from "@stll/docx-utils";
 import type * as slimdom from "slimdom";
+
+import { OOXML_NS } from "@stll/docx-utils";
 
 export const W_NS = OOXML_NS.w;
 

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -139,7 +139,6 @@ describe("entity read handlers", () => {
 
   test("page query unwraps the shared entity query result before building pagination", async () => {
     const result = await readEntities.handler(
-      // eslint-disable-next-line typescript/no-unsafe-type-assertion -- read and window handlers use the same safe handler context shape for this test
       createContext({
         body: {
           page: 1,

--- a/apps/api/src/handlers/invoices/add-entries.ts
+++ b/apps/api/src/handlers/invoices/add-entries.ts
@@ -1,7 +1,8 @@
-import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
 import { Result } from "better-result";
 import { and, eq, inArray, isNull } from "drizzle-orm";
 import { t } from "elysia";
+
+import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
 
 import {
   BILLING_STATUS,

--- a/apps/api/src/handlers/invoices/create.ts
+++ b/apps/api/src/handlers/invoices/create.ts
@@ -1,7 +1,8 @@
-import { prorateHourlyCents } from "@stll/money";
 import { Result } from "better-result";
 import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
+
+import { prorateHourlyCents } from "@stll/money";
 
 import {
   BILLING_STATUS,

--- a/apps/api/src/handlers/invoices/remove-entries.ts
+++ b/apps/api/src/handlers/invoices/remove-entries.ts
@@ -1,7 +1,8 @@
-import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
 import { Result } from "better-result";
 import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
+
+import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
 
 import {
   BILLING_STATUS,

--- a/apps/api/src/handlers/time-entries/export-csv.ts
+++ b/apps/api/src/handlers/time-entries/export-csv.ts
@@ -1,7 +1,8 @@
-import { prorateHourlyCents } from "@stll/money";
 import { and, eq, gte, inArray, lte } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
+
+import { prorateHourlyCents } from "@stll/money";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";

--- a/apps/api/src/handlers/time-entries/export-ledes.ts
+++ b/apps/api/src/handlers/time-entries/export-ledes.ts
@@ -1,7 +1,8 @@
-import { prorateHourlyCents } from "@stll/money";
 import { and, eq, gte, inArray, lte } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
+
+import { prorateHourlyCents } from "@stll/money";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";

--- a/apps/api/src/handlers/time-entries/export-pdf.ts
+++ b/apps/api/src/handlers/time-entries/export-pdf.ts
@@ -1,7 +1,8 @@
-import { prorateHourlyCents } from "@stll/money";
 import { and, eq, gte, inArray, lte } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
+
+import { prorateHourlyCents } from "@stll/money";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";

--- a/apps/api/src/handlers/workspaces/infosoud-common.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-common.ts
@@ -1,10 +1,11 @@
+import { t } from "elysia";
+
 import {
   InfoSoudAPIError,
   InfoSoudClient,
   InfoSoudParseError,
   InfoSoudRequestError,
 } from "@stll/infosoud";
-import { t } from "elysia";
 
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 

--- a/apps/api/src/handlers/workspaces/infosoud-courts.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-courts.ts
@@ -1,3 +1,5 @@
+import { Result } from "better-result";
+
 import {
   buildCourtMapFromEntries,
   InfoSoudAPIError,
@@ -5,7 +7,6 @@ import {
   InfoSoudParseError,
   InfoSoudRequestError,
 } from "@stll/infosoud";
-import { Result } from "better-result";
 
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";

--- a/apps/api/src/handlers/workspaces/infosoud-lookup.ts
+++ b/apps/api/src/handlers/workspaces/infosoud-lookup.ts
@@ -1,3 +1,5 @@
+import { Result } from "better-result";
+
 import { getEventLabel, resolveCourtCodeAlias } from "@stll/infosoud";
 import type {
   CaseEvent,
@@ -6,7 +8,6 @@ import type {
   HearingEvent,
   RelatedCase,
 } from "@stll/infosoud";
-import { Result } from "better-result";
 
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";

--- a/apps/api/src/lib/anonymization-blacklist.ts
+++ b/apps/api/src/lib/anonymization-blacklist.ts
@@ -1,6 +1,7 @@
-import type { GazetteerEntry } from "@stll/anonymize-wasm";
 import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
+
+import type { GazetteerEntry } from "@stll/anonymize-wasm";
 
 import type { ScopedDb } from "@/api/db";
 import { anonymizationBlacklistEntries } from "@/api/db/schema";

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -1,5 +1,3 @@
-import type { PermissionInput } from "@stll/permissions";
-import { roles } from "@stll/permissions";
 import type { Err, UnhandledException } from "better-result";
 import { Result } from "better-result";
 import type {
@@ -9,6 +7,9 @@ import type {
   UnwrapRoute,
 } from "elysia";
 import { status } from "elysia";
+
+import type { PermissionInput } from "@stll/permissions";
+import { roles } from "@stll/permissions";
 
 import type { SafeDb, ScopedDb } from "@/api/db";
 import type { OrgAIConfig } from "@/api/lib/ai-models";

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -1,6 +1,4 @@
 import { oauthProvider } from "@better-auth/oauth-provider";
-import { ac, roles } from "@stll/permissions";
-import type { PermissionInput } from "@stll/permissions";
 import type { BetterAuthPlugin } from "better-auth";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
@@ -16,6 +14,9 @@ import { Result } from "better-result";
 import { and, eq, isNotNull, or } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm";
 import Elysia, { t } from "elysia";
+
+import { ac, roles } from "@stll/permissions";
+import type { PermissionInput } from "@stll/permissions";
 
 import { createSafeDb, createScopedDb } from "@/api/db";
 import { authSchema, session as sessionTable } from "@/api/db/auth-schema";
@@ -373,7 +374,6 @@ const createAuth = () => {
       // SAFETY: The oauth-provider plugin's generated OpenAPI metadata
       // is still slightly too wide for Better Auth's plugin type here.
       // The runtime plugin value is valid for betterAuth().
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
       oauthProvider({
         loginPage: "/auth",
         consentPage: "/consent",

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -67,7 +67,7 @@ export type SafeId<T extends SafeIdType> = string & {
 
 // SAFETY: SafeId is a nominal brand; runtime validation happens at call sites
 export const toSafeId = <T extends SafeIdType>(value: string): SafeId<T> =>
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   value as SafeId<T>;
 
 export const createSafeId = <T extends SafeIdType>(): SafeId<T> =>

--- a/apps/api/src/lib/desktop-edit-sessions.ts
+++ b/apps/api/src/lib/desktop-edit-sessions.ts
@@ -1,5 +1,6 @@
-import { roles } from "@stll/permissions";
 import { and, eq } from "drizzle-orm";
+
+import { roles } from "@stll/permissions";
 
 import type { ScopedDb } from "@/api/db";
 import { member, user } from "@/api/db/auth-schema";

--- a/apps/api/src/lib/email/index.tsx
+++ b/apps/api/src/lib/email/index.tsx
@@ -1,8 +1,9 @@
 import { render } from "@react-email/render";
+import { panic } from "better-result";
+
 import * as BetterAuthOTP from "@stll/transactional/emails/better-auth-otp";
 import * as NewDeviceLogin from "@stll/transactional/emails/new-device-login";
 import * as OrganizationInvitation from "@stll/transactional/emails/organization-invitation";
-import { panic } from "better-result";
 
 import { env } from "@/api/env";
 import type { SupportedLang } from "@/api/lib/locale";

--- a/apps/api/src/lib/infosoud/agenda-import.ts
+++ b/apps/api/src/lib/infosoud/agenda-import.ts
@@ -1,10 +1,11 @@
+import { and, eq, inArray, sql } from "drizzle-orm";
+
 import {
   getEventLabel,
   parseInfoSoudDate,
   parseInfoSoudDateTime,
 } from "@stll/infosoud";
 import type { CaseEvent, CaseSearchResult, HearingEvent } from "@stll/infosoud";
-import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
 import { entities, entityVersions, workspaces } from "@/api/db/schema";

--- a/apps/api/src/lib/markdown/ai-tool.ts
+++ b/apps/api/src/lib/markdown/ai-tool.ts
@@ -112,7 +112,6 @@ const ATTR_LABEL = "data-label";
 const ATTR_SUGGESTION_CHAR = "data-mention-suggestion-char";
 
 const replaceMentionsWithAnchors = (html: string): string => {
-  // eslint-disable-next-line no-undef
   const unsafeHtml = new HTMLRewriter()
     .on(MENTION_TAG, {
       element(el) {

--- a/apps/api/src/lib/money.ts
+++ b/apps/api/src/lib/money.ts
@@ -43,7 +43,7 @@ export const cents = (value: number): CentsAmount => {
   }
   // SAFETY: validated to be an integer; brand is nominal so the
   // assertion is sound at runtime.
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return value as CentsAmount;
 };
 
@@ -55,5 +55,5 @@ export const cents = (value: number): CentsAmount => {
  * a valid minor-unit integer.
  */
 export const unsafeCents = (value: number): CentsAmount =>
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   value as CentsAmount;

--- a/apps/api/src/lib/sanitize-filename.ts
+++ b/apps/api/src/lib/sanitize-filename.ts
@@ -42,7 +42,7 @@ export const sanitizeFilename = (name: string): SanitizedFileName => {
   const sanitizedWithoutEdgeDots = stripLeadingAndTrailingDots(sanitized);
 
   // SAFETY: the sanitization above guarantees the result is safe
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return (sanitizedWithoutEdgeDots.slice(0, 255) ||
     "file") as SanitizedFileName;
 };

--- a/apps/api/src/lib/sanitize-url.ts
+++ b/apps/api/src/lib/sanitize-url.ts
@@ -35,11 +35,11 @@ export const sanitizeUrl = (
   }
 
   // SAFETY: URL has been validated as http/https
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return trimmed as SafeHref;
 };
 
 /** Empty-string sentinel typed as `SafeHref` for fallback cases. */
 // SAFETY: empty string is trivially safe (renders as no-op href)
-// eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+// eslint-disable-next-line typescript/no-unsafe-type-assertion
 export const SAFE_HREF_EMPTY = "" as SafeHref;

--- a/apps/api/src/lib/search/index-global.ts
+++ b/apps/api/src/lib/search/index-global.ts
@@ -496,7 +496,6 @@ const buildSearchFilterFragments = ({
   };
 };
 
-// oxlint-disable-next-line sonarjs/cognitive-complexity -- global search composes parallel scoped result queries and facets in one bounded round-trip
 export const searchGlobal = async ({
   query,
   organizationId,

--- a/apps/api/src/lib/validated-org-user-id.ts
+++ b/apps/api/src/lib/validated-org-user-id.ts
@@ -38,6 +38,6 @@ export const validateOrgUserId = async (
   }
 
   // SAFETY: We verified org membership above; the brand attests to that check.
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return row.userId as ValidatedOrgUserId;
 };

--- a/apps/api/src/lib/workflow/ai-prompts.ts
+++ b/apps/api/src/lib/workflow/ai-prompts.ts
@@ -1,5 +1,6 @@
-import type { FolioAIBlock } from "@stll/folio/server";
 import * as v from "valibot";
+
+import type { FolioAIBlock } from "@stll/folio/server";
 
 import { DOCX_REVIEW_MARKUP_EXAMPLES } from "@/api/lib/docx-review-markup";
 import { Unreachable } from "@/api/lib/errors/tagged-errors";

--- a/apps/api/src/lib/workflow/docx-blocks.ts
+++ b/apps/api/src/lib/workflow/docx-blocks.ts
@@ -19,9 +19,10 @@
  *  - tracked insertions/deletions and comments are preserved as inline tags
  */
 
-import type { FolioAIBlock } from "@stll/folio/server";
 import JSZip from "jszip";
 import * as slimdom from "slimdom";
+
+import type { FolioAIBlock } from "@stll/folio/server";
 
 import {
   escapeDocxReviewText,

--- a/apps/api/src/lib/workflow/generate-batch.ts
+++ b/apps/api/src/lib/workflow/generate-batch.ts
@@ -1,6 +1,7 @@
 import { PDF, rgb, Standard14Font, StandardFonts } from "@libpdf/core";
-import type { FolioAIBlock } from "@stll/folio/server";
 import { Result } from "better-result";
+
+import type { FolioAIBlock } from "@stll/folio/server";
 
 import { createFileKey } from "@/api/handlers/files/utils";
 import { createSafeId } from "@/api/lib/branded-types";

--- a/apps/api/src/lib/workflow/utils.test.ts
+++ b/apps/api/src/lib/workflow/utils.test.ts
@@ -13,9 +13,7 @@ import type {
 // Stub registry-only side effects. Avoid mocking `@/api/db`: this test never
 // loads `root.ts`, and Bun's `mock.module` leaks process-wide across files.
 void mock.module("@/api/handlers/registry/utils", () => ({
-  // eslint-disable-next-line no-empty-function
   broadcastEvent: () => {},
-  // eslint-disable-next-line no-empty-function
   resetActorState: () => {},
 }));
 

--- a/apps/api/src/mcp/anonymization-core.ts
+++ b/apps/api/src/mcp/anonymization-core.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 import {
   DEFAULT_ENTITY_LABELS,
   DEFAULT_OPERATOR_CONFIG,
@@ -9,7 +11,6 @@ import type {
   PipelineContext,
   RedactionResult,
 } from "@stll/anonymize-wasm";
-import { panic } from "better-result";
 
 import type { ScopedDb } from "@/api/db";
 import type { SafeId } from "@/api/lib/branded-types";

--- a/apps/api/src/mcp/anonymization.test.ts
+++ b/apps/api/src/mcp/anonymization.test.ts
@@ -1,5 +1,6 @@
-import { createPipelineContext } from "@stll/anonymize-wasm";
 import { describe, expect, mock, test } from "bun:test";
+
+import { createPipelineContext } from "@stll/anonymize-wasm";
 
 import type { ScopedDb } from "@/api/db";
 import { toSafeId } from "@/api/lib/branded-types";

--- a/apps/api/src/scripts/adapter-health.ts
+++ b/apps/api/src/scripts/adapter-health.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console -- CLI script */
 /**
  * Case law adapter health report.
  *

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,7 +11,7 @@
     "dev": "tauri dev",
     "dev:view": "vite --host 127.0.0.1 --strictPort",
     "format": "oxfmt -c ../../.oxfmtrc.json .",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware apps/desktop",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware apps/desktop",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/desktop",
     "test": "bun test --pass-with-no-tests",
     "typecheck": "tsgo --noEmit"

--- a/apps/desktop/src/mainview/App.tsx
+++ b/apps/desktop/src/mainview/App.tsx
@@ -1,5 +1,9 @@
 import { startTransition, useEffect, useState } from "react";
 
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { useTranslations } from "use-intl";
+
 import { Avatar, AvatarFallback } from "@stll/ui/components/avatar";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
@@ -9,9 +13,6 @@ import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { Separator } from "@stll/ui/components/separator";
 import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
 import { cn } from "@stll/ui/lib/utils";
-import { invoke } from "@tauri-apps/api/core";
-import { listen } from "@tauri-apps/api/event";
-import { useTranslations } from "use-intl";
 
 import { isAppSnapshot } from "../shared/rpc";
 import type {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "typegen": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware apps/web",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware apps/web",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/web",
     "format": "oxfmt -c ../../.oxfmtrc.json .",
     "i18n:check": "bun ../../packages/scripts/src/i18n-typegen.ts src/i18n/langs --check && bun ../../packages/scripts/src/i18n-check.ts src/i18n/langs",

--- a/apps/web/src/components/ai-config-providers-editor.tsx
+++ b/apps/web/src/components/ai-config-providers-editor.tsx
@@ -1,3 +1,6 @@
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldDescription, FieldLabel } from "@stll/ui/components/field";
 import { Input } from "@stll/ui/components/input";
@@ -8,8 +11,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import { PlusIcon, Trash2Icon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import {
   createProviderCredentialDraft,

--- a/apps/web/src/components/ai-config-role-model-picker.tsx
+++ b/apps/web/src/components/ai-config-role-model-picker.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "use-intl";
+
 import {
   Combobox,
   ComboboxEmpty,
@@ -15,7 +17,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 import {
   getDefaultModelSelection,

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -3,9 +3,10 @@
 import { useCallback } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
+import { ArrowDownIcon, DownloadIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
-import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 
 import {
   StickToBottomContext,

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -3,12 +3,13 @@
 import { memo } from "react";
 import type { ComponentProps, HTMLAttributes } from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import { cjk } from "@streamdown/cjk";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import type { UIMessage } from "ai";
 import { Streamdown } from "streamdown";
+
+import { cn } from "@stll/ui/lib/utils";
 
 type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"] | "system";

--- a/apps/web/src/components/ai-suggestions/active-docx-store.test.ts
+++ b/apps/web/src/components/ai-suggestions/active-docx-store.test.ts
@@ -11,8 +11,9 @@
 
 import { createRef } from "react";
 
-import type { DocxEditorRef } from "@stll/folio";
 import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { DocxEditorRef } from "@stll/folio";
 
 import { useActiveDocxStore } from "@/components/ai-suggestions/active-docx-store";
 

--- a/apps/web/src/components/ai-suggestions/active-docx-store.ts
+++ b/apps/web/src/components/ai-suggestions/active-docx-store.ts
@@ -12,8 +12,9 @@
 
 import type { RefObject } from "react";
 
-import type { DocxEditorRef } from "@stll/folio";
 import { create } from "zustand";
+
+import type { DocxEditorRef } from "@stll/folio";
 
 export type ActiveDocxRegistration = {
   editorRef: RefObject<DocxEditorRef | null>;

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -24,6 +24,11 @@ import {
 } from "react";
 import type { RefObject } from "react";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { LoaderCircleIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+import { v7 as uuidv7 } from "uuid";
+
 import type {
   DocxEditorRef,
   FolioAIEditOperation,
@@ -31,10 +36,6 @@ import type {
   FolioAIEditSnapshot,
 } from "@stll/folio";
 import { cn } from "@stll/ui/lib/utils";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { LoaderCircleIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
-import { v7 as uuidv7 } from "uuid";
 
 import { PromptBar } from "@/components/ai-suggestions/host";
 import {

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -18,6 +18,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentProps, ReactNode } from "react";
 
 import {
+  ArrowUpIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  LoaderCircleIcon,
+  SquareIcon,
+  SquarePenIcon,
+} from "lucide-react";
+import type { EditorView } from "prosemirror-view";
+import { useTranslations } from "use-intl";
+
+import {
   applySuggestions,
   resolveSuggestionAnchor,
   setActiveCitationMeta,
@@ -42,16 +53,6 @@ import {
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
 import { cn } from "@stll/ui/lib/utils";
-import {
-  ArrowUpIcon,
-  CheckIcon,
-  ChevronDownIcon,
-  LoaderCircleIcon,
-  SquareIcon,
-  SquarePenIcon,
-} from "lucide-react";
-import type { EditorView } from "prosemirror-view";
-import { useTranslations } from "use-intl";
 
 import {
   Message,

--- a/apps/web/src/components/ai-suggestions/review-panel.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.tsx
@@ -8,6 +8,16 @@
 import { useEffect, useMemo, useState } from "react";
 import type { CSSProperties, RefObject } from "react";
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import {
+  ArrowRightIcon,
+  CheckIcon,
+  LoaderCircleIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { diffWordSegments } from "@stll/folio";
 import type { DocxEditorRef, FolioAIBlockPreviewRun } from "@stll/folio";
 import { Avatar, AvatarFallback } from "@stll/ui/components/avatar";
@@ -28,15 +38,6 @@ import {
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
-import {
-  ArrowRightIcon,
-  CheckIcon,
-  LoaderCircleIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import {
   REVIEW_UNSPECIFIED_AREA,
@@ -90,15 +91,11 @@ type SeverityTone = { dot: string; chip: string; chipActive: string };
 // false positive here; suppressed at the constant declarations
 // rather than inside the object so reformatting can't split the
 // suppression away from the value.
-// oxlint-disable-next-line no-inline-style-colors/no-inline-style-colors -- dark: variant present; rule false positive
 const HIGH_DOT = "bg-red-500";
-// oxlint-disable-next-line no-inline-style-colors/no-inline-style-colors -- dark: variant present; rule false positive
 const HIGH_CHIP = "border-red-500/30 text-red-700 dark:text-red-300";
-// oxlint-disable-next-line no-inline-style-colors/no-inline-style-colors -- dark: variant present; rule false positive
 const HIGH_CHIP_ACTIVE =
   "bg-red-500/10 border-red-500 text-red-700 dark:text-red-200";
 
-// oxlint-disable-next-line no-inline-style-colors/no-inline-style-colors -- amber not in named-color blacklist; future-proofing
 const MEDIUM_DOT = "bg-amber-500";
 const MEDIUM_CHIP = "border-amber-500/30 text-amber-700 dark:text-amber-300";
 const MEDIUM_CHIP_ACTIVE =
@@ -958,7 +955,6 @@ const RedlinePreview = ({
   );
   const muted = "text-foreground-strong-muted";
   const contextCls = "text-foreground";
-  // oxlint-disable-next-line no-inline-style-colors/no-inline-style-colors -- emerald not in named-color blacklist
   const insCls =
     "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 px-1 py-0.5 rounded-sm";
   const delCls =

--- a/apps/web/src/components/ai-suggestions/review-store.ts
+++ b/apps/web/src/components/ai-suggestions/review-store.ts
@@ -8,6 +8,8 @@
  * reset".
  */
 
+import { create } from "zustand";
+
 import type {
   FolioAIBlockPreviewRun,
   FolioAIEditApplyMode,
@@ -15,7 +17,6 @@ import type {
   FolioAIEditSeverity,
   FolioAIEditSnapshot,
 } from "@stll/folio";
-import { create } from "zustand";
 
 export const REVIEW_UNSPECIFIED_AREA = "Unspecified";
 export type ReviewSeverityKey = FolioAIEditSeverity | "unspecified";

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -7,29 +7,6 @@ import {
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import {
-  Avatar,
-  AvatarFallback,
-  AvatarImage,
-} from "@stll/ui/components/avatar";
-import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
-import {
-  Menu,
-  MenuGroup,
-  MenuGroupLabel,
-  MenuItem,
-  MenuPopup,
-  MenuRadioGroup,
-  MenuRadioItem,
-  MenuSeparator,
-  MenuSub,
-  MenuSubPopup,
-  MenuSubTrigger,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
-import {
   formatForDisplay,
   useHotkey,
   useKeyHold,
@@ -57,6 +34,30 @@ import {
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
+
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@stll/ui/components/avatar";
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import {
+  Menu,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuSeparator,
+  MenuSub,
+  MenuSubPopup,
+  MenuSubTrigger,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { DevSidebarGroup } from "@/components/dev-sidebar-group";
 import { FeedbackDialog } from "@/components/feedback-dialog";
@@ -204,7 +205,6 @@ const NavContextMenu = ({
             <MenuSeparator />
           )}
           {config.recents?.map((item, i) => (
-            // eslint-disable-next-line react/no-array-index-key
             <MenuItem
               className={
                 item.variant === "destructive" ? "text-destructive" : undefined
@@ -304,7 +304,7 @@ const MatterItem = ({
         onDrop: ({ source }) => {
           setIsDropTarget(false);
           // SAFETY: matterId is always a string; set by our own draggable getInitialData.
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
           const draggedId = source.data["matterId"] as string;
           if (draggedId !== ws.id) {
             onReorderRef.current?.(draggedId, ws.id);

--- a/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
@@ -1,14 +1,15 @@
 import { Fragment, useId, useMemo } from "react";
 
+import { Link, useMatches } from "@tanstack/react-router";
+import type { ResolveParams } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
 import {
   Breadcrumb,
   BreadcrumbItem,
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@stll/ui/components/breadcrumb";
-import { Link, useMatches } from "@tanstack/react-router";
-import type { ResolveParams } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
 
 import { CaseLawBreadcrumb } from "@/components/breadcrumbs/case-law-breadcrumb";
 import { ContactBreadcrumb } from "@/components/breadcrumbs/contact-breadcrumb";
@@ -23,7 +24,7 @@ const serializeKey = (paths: readonly RouterFullPath[]) =>
   paths.join(PATH_SEPARATOR);
 // SAFETY: key comes from breadcrumbMap keys built from RouterFullPath[]
 const deserializeKey = (key: string) =>
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   key.split(PATH_SEPARATOR) as RouterFullPath[];
 
 type BreadcrumbComponent<TPath extends RouterFullPath> = (
@@ -146,7 +147,7 @@ export const AppBreadcrumbs = () => {
         if (parsedKey.some((path) => match.fullPath.startsWith(path))) {
           // SAFETY: match.params from TanStack Router for known route
           const result = breadcrumbMap[key]?.(
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+            // eslint-disable-next-line typescript/no-unsafe-type-assertion
             match.params as ResolveParams<RouterFullPath>,
           );
 
@@ -164,12 +165,7 @@ export const AppBreadcrumbs = () => {
     <Breadcrumb className="min-w-0">
       <BreadcrumbList className="flex-nowrap overflow-hidden">
         {breadcrumbs.map((breadcrumb, index) => (
-          <Fragment
-            key={`${id}-${
-              // eslint-disable-next-line react/no-array-index-key
-              index
-            }`}
-          >
+          <Fragment key={`${id}-${index}`}>
             {index !== 0 && <BreadcrumbSeparator className="shrink-0" />}
             {breadcrumb}
           </Fragment>

--- a/apps/web/src/components/breadcrumbs/case-law-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/case-law-breadcrumb.tsx
@@ -1,7 +1,8 @@
-import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import type { ResolveParams } from "@tanstack/react-router";
 import { BookOpenTextIcon } from "lucide-react";
+
+import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 
 import { getCourtColor } from "@/lib/court-colors";
 import type { SafeId } from "@/lib/safe-id";
@@ -18,12 +19,12 @@ const extractFullRef = (raw: unknown, fallback: string): string => {
   if (raw === null || raw === undefined) {
     return fallback;
   }
-  /* eslint-disable typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion -- SAFETY: raw is either a JSON string or a parsed AST object from the API */
+  /* eslint-disable typescript/no-unsafe-type-assertion -- SAFETY: raw is either a JSON string or a parsed AST object from the API */
   const ast =
     typeof raw === "string"
       ? (JSON.parse(raw) as { blocks?: AstBlock[] })
       : (raw as { blocks?: AstBlock[] });
-  /* eslint-enable typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion */
+  /* eslint-enable typescript/no-unsafe-type-assertion */
   const block = ast.blocks?.find(
     (b) => b.type === "paragraph" && b.role === "case-number",
   );

--- a/apps/web/src/components/breadcrumbs/pdf-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/pdf-breadcrumb.tsx
@@ -1,6 +1,7 @@
-import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useMatch } from "@tanstack/react-router";
+
+import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 
 import { fileMetadataOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
 

--- a/apps/web/src/components/breadcrumbs/shared.tsx
+++ b/apps/web/src/components/breadcrumbs/shared.tsx
@@ -1,7 +1,8 @@
 import type { PropsWithChildren } from "react";
 
-import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 import { Link } from "@tanstack/react-router";
+
+import { BreadcrumbItem } from "@stll/ui/components/breadcrumb";
 
 import type { RouterToPath } from "@/lib/types";
 

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -1,5 +1,11 @@
 import { useRef, useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { Link, useMatch } from "@tanstack/react-router";
+import type { ResolveParams } from "@tanstack/react-router";
+import { LayersIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   BreadcrumbItem,
   BreadcrumbSeparator,
@@ -12,11 +18,6 @@ import {
 import { Input } from "@stll/ui/components/input";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery } from "@tanstack/react-query";
-import { Link, useMatch } from "@tanstack/react-router";
-import type { ResolveParams } from "@tanstack/react-router";
-import { LayersIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { BreadcrumbLink } from "@/components/breadcrumbs/shared";
 import { MatterNumberHint } from "@/components/matter-number-hint";
@@ -173,7 +174,7 @@ export const WorkspaceBreadcrumb = ({
               const parsed: unknown = raw ? JSON.parse(raw) : null;
               const config: Record<string, unknown> =
                 typeof parsed === "object" && parsed !== null
-                  ? // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                  ? // eslint-disable-next-line typescript/no-unsafe-type-assertion
                     (parsed as Record<string, unknown>)
                   : {};
               config["clientFilter"] = workspace.client?.id ?? null;

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -1,10 +1,11 @@
 import "./chat-editor.css";
 import { useCallback, useEffect, useRef } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import { ArrowUpIcon, PaperclipIcon, SquareIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import type {
   ChatEditorController,
@@ -114,7 +115,6 @@ export const ChatInputSurface = ({
   );
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/no-noninteractive-element-interactions
     <div
       className={cn(
         "bg-background rounded-lg border",

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -7,9 +7,6 @@ import {
   useState,
 } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Popover, PopoverPopup } from "@stll/ui/components/popover";
-import { cn } from "@stll/ui/lib/utils";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import {
   ArrowLeftIcon,
@@ -21,6 +18,10 @@ import {
   LoaderIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Popover, PopoverPopup } from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
 
 import type {
   ChatMentionOption,
@@ -222,7 +223,6 @@ export const ChatMentionList = forwardRef<
   }, [safeIndex]);
 
   const selectItem = (index: number) => {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
     const item = activeItems.at(index);
     if (item !== undefined) {
       command(item);
@@ -298,7 +298,6 @@ export const ChatMentionList = forwardRef<
 
       // ArrowRight on a workspace item drills down
       if (event.key === "ArrowRight" && !drillDown) {
-        // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
         const item = activeItems.at(safeIndex);
         if (item?.category === "workspace") {
           handleDrillDown(item);
@@ -435,7 +434,6 @@ export const ChatMentionList = forwardRef<
               );
             })}
 
-          {/* oxlint-disable typescript-eslint/no-unsafe-assignment */}
           {drillDown &&
             !entitiesLoading &&
             drillDownItems?.map((item, i) => (
@@ -459,7 +457,6 @@ export const ChatMentionList = forwardRef<
                 <span className="min-w-0 flex-1 truncate">{item.label}</span>
               </Button>
             ))}
-          {/* oxlint-enable typescript-eslint/no-unsafe-assignment */}
         </div>
       </PopoverPopup>
     </Popover>

--- a/apps/web/src/components/chat-mention-node.tsx
+++ b/apps/web/src/components/chat-mention-node.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@stll/ui/lib/utils";
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import {
@@ -7,6 +6,8 @@ import {
   LandmarkIcon,
   LayersIcon,
 } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { ChatReferenceCategory } from "@/components/chat-mention-extension";
 import { getMatterColor } from "@/lib/matter-colors";
@@ -50,7 +51,7 @@ const CategoryIcon = ({
 
 export const ChatMentionNode = (props: NodeViewProps) => {
   // SAFETY: attrs from our own mention extension schema
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   const attrs = props.node.attrs as {
     id: string;
     label: string;

--- a/apps/web/src/components/chat/ask-user-card.tsx
+++ b/apps/web/src/components/chat/ask-user-card.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import type { ToolUIPart } from "ai";
 import {
   CheckIcon,
@@ -10,6 +9,8 @@ import {
 } from "lucide-react";
 import { Streamdown } from "streamdown";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type {
   AskUserInput,

--- a/apps/web/src/components/chat/chat-draft-attachment-chips.tsx
+++ b/apps/web/src/components/chat/chat-draft-attachment-chips.tsx
@@ -1,6 +1,7 @@
+import { XIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
-import { XIcon } from "lucide-react";
 
 import type { ChatDraftAttachment } from "@/components/chat-editor-provider";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";

--- a/apps/web/src/components/chat/chat-matter-picker.tsx
+++ b/apps/web/src/components/chat/chat-matter-picker.tsx
@@ -1,5 +1,9 @@
 import { useDeferredValue, useMemo, useRef, useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDownIcon, LayersIcon, SearchIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   Menu,
   MenuCheckboxItem,
@@ -7,9 +11,6 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
-import { useQuery } from "@tanstack/react-query";
-import { ChevronDownIcon, LayersIcon, SearchIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -22,7 +22,7 @@ const renderWithProviders = (children: ReactNode) =>
         // SAFETY: this mirrors the app provider boundary; locale
         // files are checked separately, while use-intl preserves
         // English literal values in the generated Messages type.
-        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
         messages={messages as Messages}
         timeZone="UTC"
       >

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -1,13 +1,14 @@
 import { useMemo } from "react";
 import type { ComponentProps } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { isToolUIPart } from "ai";
 import type { FileUIPart } from "ai";
 import { CopyIcon, FileTextIcon, RotateCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   Message,

--- a/apps/web/src/components/chat/entity-link.tsx
+++ b/apps/web/src/components/chat/entity-link.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
   FileTextIcon,
@@ -6,6 +5,8 @@ import {
   LandmarkIcon,
   LayersIcon,
 } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { openCaseLawDecision } from "@/components/chat/case-law-open";
 import type { MentionCategory } from "@/components/chat/chat-mention-href";

--- a/apps/web/src/components/chat/prompt-slash-list.tsx
+++ b/apps/web/src/components/chat/prompt-slash-list.tsx
@@ -6,10 +6,11 @@ import {
   useState,
 } from "react";
 
-import { Popover, PopoverPopup } from "@stll/ui/components/popover";
-import { cn } from "@stll/ui/lib/utils";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { useTranslations } from "use-intl";
+
+import { Popover, PopoverPopup } from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
 
 import type { TranslationKey } from "@/i18n/types";
 import type { ChatPrompt, PromptScope } from "@/lib/prompts/types";

--- a/apps/web/src/components/chat/prompt-suggestions.tsx
+++ b/apps/web/src/components/chat/prompt-suggestions.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { ChatPrompt } from "@/lib/prompts/types";
 

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useRouterState } from "@tanstack/react-router";
+import { getToolName, isDataUIPart, isToolUIPart } from "ai";
+import type { UIDataTypes } from "ai";
+import { ExternalLinkIcon, FileTextIcon, FolderIcon } from "lucide-react";
+
 import type {
   ChatMessage,
   ChatPart,
   ChatSourceDocument,
 } from "@stll/api/types";
 import { cn } from "@stll/ui/lib/utils";
-import { useQuery } from "@tanstack/react-query";
-import { useNavigate, useRouterState } from "@tanstack/react-router";
-import { getToolName, isDataUIPart, isToolUIPart } from "ai";
-import type { UIDataTypes } from "ai";
-import { ExternalLinkIcon, FileTextIcon, FolderIcon } from "lucide-react";
 
 import { openEntityInInspector } from "@/components/chat/entity-open";
 import { useExternalSourceStore } from "@/components/chat/external-source-store";

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -1,7 +1,6 @@
 import type React from "react";
 import { Children } from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import { skipToken, useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import {
@@ -12,6 +11,8 @@ import {
   ListTodoIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { openCaseLawDecision } from "@/components/chat/case-law-open";
 import type { MentionCategory } from "@/components/chat/chat-mention-href";

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRightIcon,
@@ -11,6 +9,9 @@ import {
   XIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { useReviewStore } from "@/components/ai-suggestions/review-store";
 import {

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
 
-import {
-  Popover,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { getToolName } from "ai";
 import {
@@ -18,6 +12,13 @@ import {
   UserIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import {
+  Popover,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   getChatToolTitleKey,

--- a/apps/web/src/components/contact-picker.tsx
+++ b/apps/web/src/components/contact-picker.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import type * as React from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { BuildingIcon, PlusIcon, SearchIcon, UserIcon } from "lucide-react";
+import { useDebouncedCallback } from "use-debounce";
+import { useTranslations } from "use-intl";
+
 import {
   Combobox,
   ComboboxEmpty,
@@ -9,10 +14,6 @@ import {
   ComboboxList,
   ComboboxPopup,
 } from "@stll/ui/components/combobox";
-import { useQuery } from "@tanstack/react-query";
-import { BuildingIcon, PlusIcon, SearchIcon, UserIcon } from "lucide-react";
-import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -1,5 +1,17 @@
 import { useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  DatabaseIcon,
+  ExternalLinkIcon,
+  PlayIcon,
+  RotateCcwIcon,
+  SparklesIcon,
+  Trash2Icon,
+  WrenchIcon,
+} from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+
 import {
   MenuCheckboxItem,
   MenuGroup,
@@ -13,17 +25,6 @@ import {
   MenuSubTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  DatabaseIcon,
-  ExternalLinkIcon,
-  PlayIcon,
-  RotateCcwIcon,
-  SparklesIcon,
-  Trash2Icon,
-  WrenchIcon,
-} from "lucide-react";
-import { useShallow } from "zustand/react/shallow";
 
 import { env } from "@/env";
 import { api } from "@/lib/api";

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ComponentProps, CSSProperties, ReactNode } from "react";
 
-import { Button, buttonVariants } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import {
   CircleHelpIcon,
   ExternalLinkIcon,
@@ -11,6 +9,9 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button, buttonVariants } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { env } from "@/env";
 import { sanitizeHref } from "@/lib/sanitize-href";

--- a/apps/web/src/components/jurisdiction-picker.tsx
+++ b/apps/web/src/components/jurisdiction-picker.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
 
-import { Input } from "@stll/ui/components/input";
-import { cn } from "@stll/ui/lib/utils";
 import { CheckIcon, SearchIcon, StarIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import { Input } from "@stll/ui/components/input";
+import { cn } from "@stll/ui/lib/utils";
 
 import { createCountryOptions, removeJurisdiction } from "@/lib/jurisdictions";
 import type { PracticeJurisdiction } from "@/lib/jurisdictions";

--- a/apps/web/src/components/language-picker.tsx
+++ b/apps/web/src/components/language-picker.tsx
@@ -1,3 +1,5 @@
+import { GlobeIcon } from "lucide-react";
+
 import {
   Menu,
   MenuPopup,
@@ -5,7 +7,6 @@ import {
   MenuRadioItem,
   MenuTrigger,
 } from "@stll/ui/components/menu";
-import { GlobeIcon } from "lucide-react";
 
 import {
   LANG_ENDONYMS,

--- a/apps/web/src/components/matter-number-hint.tsx
+++ b/apps/web/src/components/matter-number-hint.tsx
@@ -1,6 +1,7 @@
-import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { useQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
+
+import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 
 import { matchesPattern, previewReference } from "@/lib/matter-reference";
 import { organizationSettingsOptions } from "@/routes/_protected.organization/-settings-queries";

--- a/apps/web/src/components/prompt-editor.tsx
+++ b/apps/web/src/components/prompt-editor.tsx
@@ -1,13 +1,14 @@
 import "./prompt-editor.css";
 import type React from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import Document from "@tiptap/extension-document";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import type { EditorState } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { EditorContent } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 export const PROMPT_EDITOR_SELECTION_CLASS = "prompt-editor-selection";
 

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -8,6 +8,10 @@ import {
   useState,
 } from "react";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useRouteContext } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -19,9 +23,6 @@ import {
   DialogTitle,
 } from "@stll/ui/components/dialog";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useRouteContext } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
 
 import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
 import { AIConfigRoleModelPicker } from "@/components/ai-config-role-model-picker";

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -6,13 +6,14 @@ import {
   useTransition,
 } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import { CancelledError, useQueryClient } from "@tanstack/react-query";
 import { Navigate } from "@tanstack/react-router";
 import type { ErrorComponentProps } from "@tanstack/react-router";
 import { RefreshCcwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { StellaMark } from "@/components/stella-mark";
 import { useSignOut } from "@/hooks/use-sign-out";

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1,20 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import type { GlobalSearchHit, GlobalSearchResultType } from "@stll/api/types";
-import { Button } from "@stll/ui/components/button";
-import { Checkbox } from "@stll/ui/components/checkbox";
-import {
-  Command,
-  CommandDialog,
-  CommandDialogPopup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@stll/ui/components/command";
-import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
-import { Input } from "@stll/ui/components/input";
-import { Skeleton } from "@stll/ui/components/skeleton";
-import { stellaToast } from "@stll/ui/components/toast";
 import type { UseMutationResult } from "@tanstack/react-query";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouteContext } from "@tanstack/react-router";
@@ -34,6 +19,22 @@ import {
 } from "lucide-react";
 import { useDebouncedCallback } from "use-debounce";
 import { useLocale, useTranslations } from "use-intl";
+
+import type { GlobalSearchHit, GlobalSearchResultType } from "@stll/api/types";
+import { Button } from "@stll/ui/components/button";
+import { Checkbox } from "@stll/ui/components/checkbox";
+import {
+  Command,
+  CommandDialog,
+  CommandDialogPopup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@stll/ui/components/command";
+import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
+import { Input } from "@stll/ui/components/input";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { UserAvatar } from "@/components/user-avatar";
 import type { TranslationKey } from "@/i18n/types";
@@ -842,7 +843,6 @@ export const SearchDialog = ({
               {hasTypedQuery && !hasResults && (!hasQuery || isLoading) && (
                 <div className="space-y-3 px-4 py-3">
                   {Array.from({ length: 4 }).map((_, i) => (
-                    // eslint-disable-next-line react/no-array-index-key
                     <div className="space-y-2" key={`skeleton-${i}`}>
                       <Skeleton className="h-4 w-3/4" />
                       <Skeleton className="h-3 w-1/2" />
@@ -1550,7 +1550,6 @@ const SearchResultItem = ({
         {hit.headline && (
           <p
             className="text-muted-foreground [&_mark]:bg-highlight [&_mark]:text-highlight-foreground mt-0.5 line-clamp-2 text-xs font-normal [&_mark]:font-medium"
-            // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
               __html: hit.headline,
             }}

--- a/apps/web/src/components/shortcut-hints-overlay.tsx
+++ b/apps/web/src/components/shortcut-hints-overlay.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
-import { cn } from "@stll/ui/lib/utils";
 import { useHotkey, useKeyHold } from "@tanstack/react-hotkeys";
 import type { Hotkey } from "@tanstack/react-hotkeys";
 import { useMatch } from "@tanstack/react-router";
 import { useDebouncedCallback } from "use-debounce";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   formatHintKey,

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -6,6 +6,13 @@ import {
   useState,
 } from "react";
 
+import { useHotkey } from "@tanstack/react-hotkeys";
+import { panic } from "better-result";
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+import { PanelLeftIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import { Separator } from "@stll/ui/components/separator";
@@ -24,12 +31,6 @@ import {
 } from "@stll/ui/components/tooltip";
 import { useIsMobile } from "@stll/ui/hooks/use-mobile";
 import { cn } from "@stll/ui/lib/utils";
-import { useHotkey } from "@tanstack/react-hotkeys";
-import { panic } from "better-result";
-import { cva } from "class-variance-authority";
-import type { VariantProps } from "class-variance-authority";
-import { PanelLeftIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { HOTKEYS } from "@/lib/hotkeys";
 import { Slot } from "@/lib/slot";
@@ -147,7 +148,6 @@ function SidebarProvider({
         style={
           // SAFETY: CSS custom properties are valid but
           // not in React's CSSProperties type defs.
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
           {
             "--sidebar-width": SIDEBAR_WIDTH,
             "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
@@ -203,7 +203,6 @@ function Sidebar({
           side={side}
           style={
             // SAFETY: CSS custom properties need CSSWithVars.
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
             } as CSSWithVars
@@ -643,7 +642,6 @@ function SidebarMenuSkeleton({
         data-sidebar="menu-skeleton-text"
         style={
           // SAFETY: CSS custom properties need CSSWithVars.
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
           {
             "--skeleton-width": width,
           } as CSSWithVars

--- a/apps/web/src/components/theme-picker.tsx
+++ b/apps/web/src/components/theme-picker.tsx
@@ -1,3 +1,6 @@
+import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   Menu,
   MenuPopup,
@@ -5,8 +8,6 @@ import {
   MenuRadioItem,
   MenuTrigger,
 } from "@stll/ui/components/menu";
-import { MonitorIcon, MoonIcon, SunIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { THEMES, useTheme } from "@/components/theme-provider";
 

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren } from "react";
 
 import type { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
 import {
   TooltipPopup,
   Tooltip as TooltipRoot,

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -1,5 +1,6 @@
-import type { PermissionInput } from "@stll/permissions";
 import { useSuspenseQuery } from "@tanstack/react-query";
+
+import type { PermissionInput } from "@stll/permissions";
 
 import { authClient } from "@/lib/auth";
 import { roleOptions } from "@/routes/-queries";

--- a/apps/web/src/hooks/use-sign-out.ts
+++ b/apps/web/src/hooks/use-sign-out.ts
@@ -1,7 +1,8 @@
-import { stellaToast } from "@stll/ui/components/toast";
 import { useMutation } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";

--- a/apps/web/src/lib/anonymize/constants.test.ts
+++ b/apps/web/src/lib/anonymize/constants.test.ts
@@ -1,5 +1,6 @@
-import { DEFAULT_ENTITY_LABELS as WASM_DEFAULT_ENTITY_LABELS } from "@stll/anonymize-wasm";
 import { expect, test } from "bun:test";
+
+import { DEFAULT_ENTITY_LABELS as WASM_DEFAULT_ENTITY_LABELS } from "@stll/anonymize-wasm";
 
 import { DEFAULT_ENTITY_LABELS } from "@/lib/anonymize/constants";
 

--- a/apps/web/src/lib/anonymize/gazetteer.ts
+++ b/apps/web/src/lib/anonymize/gazetteer.ts
@@ -1,13 +1,13 @@
-import type { GazetteerEntry } from "@stll/anonymize-wasm";
 // TODO: FIXME — idb's DBSchema resolves as error type, cascading unsafe-* errors
 import { openDB } from "idb";
 import type { DBSchema, IDBPDatabase } from "idb";
+
+import type { GazetteerEntry } from "@stll/anonymize-wasm";
 
 const DB_NAME = "stella-gazetteer";
 const DB_VERSION = 1;
 const STORE_NAME = "entries";
 
-// oxlint-disable-next-line typescript-eslint/no-redundant-type-constituents
 type GazetteerDB = DBSchema & {
   entries: {
     key: string;
@@ -24,17 +24,13 @@ let dbPromise: Promise<IDBPDatabase<GazetteerDB>> | null = null;
 const getDb = (): Promise<IDBPDatabase<GazetteerDB>> => {
   // oxlint-disable-next-line typescript-eslint/prefer-nullish-coalescing
   if (!dbPromise) {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment, typescript-eslint/no-unsafe-call
     dbPromise = openDB<GazetteerDB>(DB_NAME, DB_VERSION, {
       upgrade(db) {
-        // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment, typescript-eslint/no-unsafe-call, typescript-eslint/no-unsafe-member-access
         const store = db.createObjectStore(STORE_NAME, {
           keyPath: "id",
         });
-        // oxlint-disable-next-line typescript-eslint/no-unsafe-call, typescript-eslint/no-unsafe-member-access
         store.createIndex("by-workspace", "workspaceId");
       },
-      // oxlint-disable-next-line typescript-eslint/no-unsafe-member-access
     }).catch((error: unknown) => {
       dbPromise = null;
       throw error;
@@ -49,9 +45,7 @@ const getDb = (): Promise<IDBPDatabase<GazetteerDB>> => {
 export const getEntries = async (
   workspaceId: string,
 ): Promise<GazetteerEntry[]> => {
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
   const db = await getDb();
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-return, typescript-eslint/no-unsafe-call, typescript-eslint/no-unsafe-member-access
   return db.getAllFromIndex(STORE_NAME, "by-workspace", workspaceId);
 };
 
@@ -59,8 +53,6 @@ export const getEntries = async (
  * Add or update a gazetteer entry.
  */
 export const putEntry = async (entry: GazetteerEntry): Promise<void> => {
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-assignment
   const db = await getDb();
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-call, typescript-eslint/no-unsafe-member-access
   await db.put(STORE_NAME, entry);
 };

--- a/apps/web/src/lib/anonymize/pdf-bbox.test.ts
+++ b/apps/web/src/lib/anonymize/pdf-bbox.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access */
 import { describe, expect, it } from "bun:test";
 
 import type { MeasureWidthFn } from "./pdf-bbox";

--- a/apps/web/src/lib/anonymize/pdf-content-stream.ts
+++ b/apps/web/src/lib/anonymize/pdf-content-stream.ts
@@ -86,7 +86,7 @@ const getContentStreams = (
   }
 
   if (contents.type === "stream") {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, typescript/consistent-type-assertions -- discriminated by type check
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- discriminated by type check
     return [contents as PdfStream];
   }
 
@@ -98,7 +98,7 @@ const getContentStreams = (
       if (item) {
         const resolved = item.type === "ref" ? ctx.resolve(item) : item;
         if (resolved?.type === "stream") {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, typescript/consistent-type-assertions -- discriminated by type check
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- discriminated by type check
           streams.push(resolved as PdfStream);
         }
       }

--- a/apps/web/src/lib/anonymize/pdf-redact.ts
+++ b/apps/web/src/lib/anonymize/pdf-redact.ts
@@ -1,4 +1,5 @@
 import { PDF, rgb, Standard14Font, StandardFonts, white } from "@libpdf/core";
+
 import type {
   Entity,
   OperatorConfig,

--- a/apps/web/src/lib/anonymize/redaction-map.ts
+++ b/apps/web/src/lib/anonymize/redaction-map.ts
@@ -1,6 +1,7 @@
-import type { OperatorType } from "@stll/anonymize-wasm";
 import { openDB } from "idb";
 import type { DBSchema, IDBPDatabase } from "idb";
+
+import type { OperatorType } from "@stll/anonymize-wasm";
 
 const DB_NAME = "stella-redaction-maps";
 const DB_VERSION = 1;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,7 @@
 import { treaty } from "@elysiajs/eden";
-import type { API } from "@stll/api/types";
 import { posthog } from "posthog-js";
+
+import type { API } from "@stll/api/types";
 
 import { env } from "@/env";
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,6 +1,4 @@
 import { oauthProviderClient } from "@better-auth/oauth-provider/client";
-import { ac, roles } from "@stll/permissions";
-import { stellaToast } from "@stll/ui/components/toast";
 import type { BetterAuthClientPlugin } from "better-auth/client";
 import {
   emailOTPClient,
@@ -9,6 +7,9 @@ import {
   organizationClient,
 } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
+
+import { ac, roles } from "@stll/permissions";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { env } from "@/env";
 import { getTranslator, useI18nStore } from "@/i18n/i18n-store";

--- a/apps/web/src/lib/desktop-bridge.ts
+++ b/apps/web/src/lib/desktop-bridge.ts
@@ -82,7 +82,6 @@ const launchViaDeepLink = async (): Promise<boolean> => {
 
   // Poll for up to ~6 seconds (the app needs time to start)
   for (let i = 0; i < 6; i++) {
-    // eslint-disable-next-line no-restricted-syntax
     await new Promise<void>((resolve) => {
       setTimeout(resolve, 1000);
     });

--- a/apps/web/src/lib/pdf/hooks/use-pdf-document.ts
+++ b/apps/web/src/lib/pdf/hooks/use-pdf-document.ts
@@ -52,7 +52,7 @@ export const installPDFDocumentCleanup = (queryClient: QueryClient) => {
       return;
     }
     // SAFETY: only usePDFDocument registers this key
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     const data = rawData as PDFDocumentQueryData;
     if (!Result.isOk(data)) {
       return;

--- a/apps/web/src/lib/pdf/pdf-page.tsx
+++ b/apps/web/src/lib/pdf/pdf-page.tsx
@@ -1,9 +1,10 @@
 import { Suspense, use, useDeferredValue } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
-import { Skeleton } from "@stll/ui/components/skeleton";
 import { Result } from "better-result";
 import { useShallow } from "zustand/react/shallow";
+
+import { Skeleton } from "@stll/ui/components/skeleton";
 
 import { PAGE_ID_ATTRIBUTE, TEXT_LAYER_ATTRIBUTE } from "@/lib/pdf/consts";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
@@ -62,7 +63,6 @@ export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
           backgroundColor: "var(--document-preview-page, var(--background))",
           width: `round(down, var(--total-scale-factor) * ${page?.originalWidth ?? 0}px, var(--scale-round-x))`,
           height: `round(down, var(--total-scale-factor) * ${page?.originalHeight ?? 0}px, var(--scale-round-y))`,
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
         } as CSSProperties
       }
     >

--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -9,13 +9,14 @@ import {
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
+import { Result } from "better-result";
+import { useTranslations } from "use-intl";
+import { useShallow } from "zustand/react/shallow";
+
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
 import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
-import { Result } from "better-result";
-import { useTranslations } from "use-intl";
-import { useShallow } from "zustand/react/shallow";
 
 import { useTheme } from "@/components/theme-provider";
 import { usePageVisibility } from "@/lib/pdf/hooks/use-page-visibility";

--- a/apps/web/src/lib/react-query.ts
+++ b/apps/web/src/lib/react-query.ts
@@ -34,7 +34,6 @@ export const ensureCriticalQueryData = async <
 
   return await Promise.race([
     queryClient.ensureQueryData(options),
-    // eslint-disable-next-line no-restricted-syntax
     new Promise<never>((_resolve, reject) => {
       signal.addEventListener(
         "abort",

--- a/apps/web/src/lib/search.ts
+++ b/apps/web/src/lib/search.ts
@@ -1,9 +1,10 @@
-import type { EntityKind, GlobalSearchResultType } from "@stll/api/types";
 import {
   infiniteQueryOptions,
   keepPreviousData,
   queryOptions,
 } from "@tanstack/react-query";
+
+import type { EntityKind, GlobalSearchResultType } from "@stll/api/types";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -102,7 +103,6 @@ export const searchInfiniteOptions = (params: SearchParams) =>
 
       return response.data;
     },
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
     placeholderData: keepPreviousData,

--- a/apps/web/src/lib/slot.tsx
+++ b/apps/web/src/lib/slot.tsx
@@ -19,10 +19,8 @@
  * are not statically known.
  */
 
-/* eslint-disable eslint-plugin-react/no-react-children */
-/* eslint-disable eslint-plugin-react/no-clone-element */
 /* eslint-disable typescript-eslint/no-unsafe-type-assertion */
-/* eslint-disable typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion */
+/* eslint-disable typescript/no-unsafe-type-assertion */
 
 import { Children, Fragment, cloneElement, isValidElement } from "react";
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -28,7 +28,7 @@ export const stripUndefined = <T extends Record<string, unknown>>(
   }
   // SAFETY: result mirrors input with undefined-valued keys
   // removed; the mapped return type reflects this invariant.
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return result as { [K in keyof T]: Exclude<T[K], undefined> };
 };
 
@@ -41,9 +41,7 @@ export const stripUndefined = <T extends Record<string, unknown>>(
 export const includesValue = <T extends string>(
   arr: readonly T[],
   value: string,
-): value is T =>
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
-  (arr as readonly string[]).includes(value);
+): value is T => (arr as readonly string[]).includes(value);
 
 export const shuffleArray = <T>(originalArray: readonly T[]): T[] => {
   const array = [...originalArray];
@@ -53,9 +51,9 @@ export const shuffleArray = <T>(originalArray: readonly T[]): T[] => {
 
     // SAFETY: i is in [1, array.length-1] and randomIndex
     // is in [0, i]; both always in bounds.
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     const a = array[i] as T;
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     const b = array[randomIndex] as T;
     array[randomIndex] = a;
     array[i] = b;

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,13 +1,14 @@
 import type { PropsWithChildren } from "react";
 
-import { ToastProvider } from "@stll/ui/components/toast";
-import { TooltipProvider } from "@stll/ui/components/tooltip";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { QueryClient } from "@tanstack/react-query";
 import { createRouter } from "@tanstack/react-router";
 import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
 import { enableMapSet } from "immer";
 import { IntlProvider } from "use-intl";
+
+import { ToastProvider } from "@stll/ui/components/toast";
+import { TooltipProvider } from "@stll/ui/components/tooltip";
 
 import {
   DefaultErrorComponent,
@@ -43,7 +44,7 @@ const I18nProvider = ({ children }: PropsWithChildren) => {
       // this cast is only at the provider boundary because use-intl's
       // Messages type preserves English literal message values while
       // translated locale JSONs necessarily contain different strings.
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       messages={messages as Messages}
       timeZone={Intl.DateTimeFormat().resolvedOptions().timeZone}
     >

--- a/apps/web/src/routes/_protected.chat/-components/chat-anonymized-toggle.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-anonymized-toggle.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@stll/ui/components/button";
 import { ShieldCheckIcon, ShieldIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import Tooltip from "@/components/tooltip";
 

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -1,10 +1,11 @@
 import { useEffectEvent, useMemo, useState } from "react";
 
-import { Button, buttonVariants } from "@stll/ui/components/button";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { Maximize2Icon, PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button, buttonVariants } from "@stll/ui/components/button";
 
 import {
   Conversation,

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useMatch, useNavigate } from "@tanstack/react-router";
+import { MessageSquareIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Sheet,
@@ -12,10 +17,6 @@ import {
 } from "@stll/ui/components/sheet";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, useMatch, useNavigate } from "@tanstack/react-router";
-import { MessageSquareIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import type { ChatThreadId, ChatThreadRef } from "@/lib/chat-thread-ref";

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -354,7 +354,6 @@ export type ChatThreadFetched = {
 };
 
 export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- runtime getter callbacks configure the Chat transport but are intentionally not part of cache identity.
   queryOptions({
     staleTime: STALE_TIME.FIVETEEN.MINUTES,
     gcTime: STALE_TIME.FIVETEEN.MINUTES,

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -1,8 +1,6 @@
 import { useEffectEvent, useMemo, useRef, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -13,6 +11,9 @@ import {
   PinIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -1,19 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
-import { Input } from "@stll/ui/components/input";
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from "@stll/ui/components/select";
-import { Skeleton } from "@stll/ui/components/skeleton";
-import { Textarea } from "@stll/ui/components/textarea";
-import { stellaToast } from "@stll/ui/components/toast";
 import {
   useQuery,
   useQueryClient,
@@ -35,6 +22,20 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
+
+import { Button } from "@stll/ui/components/button";
+import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
+import { Input } from "@stll/ui/components/input";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { Textarea } from "@stll/ui/components/textarea";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { UserIdentity } from "@/components/user-avatar";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -87,7 +88,6 @@ function ContactDetailPage() {
     await deleteContact.mutateAsync(
       { contactId },
       {
-        // eslint-disable-next-line typescript/no-misused-promises
         onSuccess: () => {
           void (async () => {
             stellaToast.add({
@@ -128,7 +128,6 @@ function ContactDetailPage() {
       {/* Header */}
       <div className="flex items-center gap-3">
         <Button
-          // eslint-disable-next-line typescript/no-misused-promises
           onClick={() => {
             void (async () => await navigate({ to: "/contacts" }))();
           }}

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -1,5 +1,19 @@
 import { useState } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  BuildingIcon,
+  EllipsisVerticalIcon,
+  PlusIcon,
+  SearchIcon,
+  UserIcon,
+} from "lucide-react";
+import { useDebouncedCallback } from "use-debounce";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import {
@@ -36,19 +50,6 @@ import {
   TableRow,
 } from "@stll/ui/components/table";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import {
-  BuildingIcon,
-  EllipsisVerticalIcon,
-  PlusIcon,
-  SearchIcon,
-  UserIcon,
-} from "lucide-react";
-import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { EmptyScreen } from "@/components/empty-screen";
 import Tooltip from "@/components/tooltip";
@@ -477,7 +478,6 @@ const CreateContactDialog = ({
   const form = useForm({
     defaultValues: {
       // SAFETY: widening literal for form discriminant union
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
       type: "person" as "person" | "organization",
       displayName: "",
       firstName: "",

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-body.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-body.tsx
@@ -37,7 +37,6 @@ export const ClauseBody = ({
   return (
     <div className="space-y-0.5 py-2 text-sm">
       {paragraphs.map((p, i) => (
-        // eslint-disable-next-line react/no-array-index-key
         <ClauseParagraphRow key={i} paragraph={p} />
       ))}
     </div>
@@ -83,10 +82,7 @@ const ClauseParagraphRow = ({ paragraph }: { paragraph: ClauseParagraph }) => {
           if (run.italic) {
             content = <em>{content}</em>;
           }
-          return (
-            // eslint-disable-next-line react/no-array-index-key
-            <span key={ri}>{content}</span>
-          );
+          return <span key={ri}>{content}</span>;
         })}
       </p>
     );

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  ArrowLeftIcon,
+  Loader2Icon,
+  MoreHorizontalIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
+
+import {
   AlertDialog,
   AlertDialogClose,
   AlertDialogDescription,
@@ -30,14 +39,6 @@ import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import {
-  ArrowLeftIcon,
-  Loader2Icon,
-  MoreHorizontalIcon,
-  PlusIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
@@ -171,7 +172,7 @@ export const ClauseDetailView = ({
 
     // SAFETY: The API returns body as ClauseParagraph[]
     // but Eden types it as unknown due to JSONB.
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     const detail = data as unknown as ClauseDetail;
     setState({ kind: "ready", detail });
   }, [clauseId, t]);

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-diff-view.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-diff-view.tsx
@@ -18,7 +18,6 @@ export const ClauseDiffView = ({ diffs }: ClauseDiffViewProps) => (
     {diffs.map((para, i) => (
       <p
         className={cn("text-sm leading-relaxed", statusBorder[para.status])}
-        // eslint-disable-next-line react/no-array-index-key
         key={i}
       >
         {para.segments.map((seg, j) => (
@@ -28,7 +27,6 @@ export const ClauseDiffView = ({ diffs }: ClauseDiffViewProps) => (
               seg.type === "removed" &&
                 "bg-red-100 line-through dark:bg-red-900/30",
             )}
-            // eslint-disable-next-line react/no-array-index-key
             key={j}
           >
             {seg.text}

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import Bold from "@tiptap/extension-bold";
 import Document from "@tiptap/extension-document";
 import Heading from "@tiptap/extension-heading";
@@ -18,6 +17,8 @@ import {
   Heading3Icon,
   ItalicIcon,
 } from "lucide-react";
+
+import { Button } from "@stll/ui/components/button";
 
 import "./clause-editor.css";
 import type { ClauseParagraph, ClauseRun } from "./clause-editor-types";
@@ -143,7 +144,6 @@ export const ClauseEditor = ({
   // Sync content when the dialog resets
   const contentKey = content.map((p) => p.text).join("\n");
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     const currentText = editor.getText();
     if (currentText !== contentKey) {
@@ -170,7 +170,6 @@ export const ClauseEditor = ({
   return (
     // Stop modifier key combos from propagating to global
     // hotkeys (e.g., Cmd+B toggles sidebar otherwise).
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className="clause-editor rounded-md border"

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -20,7 +22,6 @@ import {
 } from "@stll/ui/components/select";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-import-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-import-dialog.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useRef, useState } from "react";
 
+import { UploadIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -11,8 +14,6 @@ import {
   DialogTitle,
 } from "@stll/ui/components/dialog";
 import { stellaToast } from "@stll/ui/components/toast";
-import { UploadIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
@@ -62,14 +63,14 @@ export const ClauseImportDialog = ({
             "clauses" in parsed &&
             // SAFETY: `"clauses" in parsed` narrows; Record cast
             // reads the key for Array.isArray and .length.
-            /* eslint-disable typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion */
+            /* eslint-disable typescript/no-unsafe-type-assertion */
             Array.isArray((parsed as Record<string, unknown>)["clauses"])
           ) {
             setPreviewCount(
               ((parsed as Record<string, unknown>)["clauses"] as unknown[])
                 .length,
             );
-            /* eslint-enable typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion */
+            /* eslint-enable typescript/no-unsafe-type-assertion */
           } else {
             setPreviewCount(0);
           }

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -1,6 +1,19 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  DownloadIcon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  SearchIcon,
+  TextQuoteIcon,
+  Trash2Icon,
+  UploadIcon,
+} from "lucide-react";
+import { useDebouncedCallback } from "use-debounce";
+import { useFormatter, useTranslations } from "use-intl";
+
+import {
   AlertDialog,
   AlertDialogClose,
   AlertDialogDescription,
@@ -27,18 +40,6 @@ import {
   DropdownMenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  DownloadIcon,
-  MoreHorizontalIcon,
-  PencilIcon,
-  PlusIcon,
-  SearchIcon,
-  TextQuoteIcon,
-  Trash2Icon,
-  UploadIcon,
-} from "lucide-react";
-import { useDebouncedCallback } from "use-debounce";
-import { useFormatter, useTranslations } from "use-intl";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { SearchIcon, TextQuoteIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -12,9 +16,6 @@ import {
 } from "@stll/ui/components/dialog";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery } from "@tanstack/react-query";
-import { SearchIcon, TextQuoteIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -21,7 +23,6 @@ import {
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
@@ -287,7 +288,7 @@ export const ShortcutFormDialog = ({
               <Select
                 value={form.scope}
                 onValueChange={(v) =>
-                  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                  // eslint-disable-next-line typescript/no-unsafe-type-assertion
                   setForm((f) => ({ ...f, scope: v as ShortcutScope }))
                 }
               >

--- a/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  MoreHorizontalIcon,
+  PencilIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import {
   AlertDialog,
   AlertDialogClose,
   AlertDialogDescription,
@@ -27,13 +35,6 @@ import {
   DropdownMenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  MoreHorizontalIcon,
-  PencilIcon,
-  PlusIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useState } from "react";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangleIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   AlertDialog,
   AlertDialogClose,
@@ -11,14 +20,6 @@ import {
 } from "@stll/ui/components/alert-dialog";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  AlertTriangleIcon,
-  PlusIcon,
-  RefreshCwIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -1,5 +1,8 @@
 import { useCallback, useRef, useState } from "react";
 
+import { AlertTriangleIcon, EyeIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { evaluateCondition } from "@stll/template-conditions";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
@@ -24,8 +27,6 @@ import {
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { AlertTriangleIcon, EyeIcon, PlusIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { DOCX_MIME, PDF_MIME } from "@/lib/consts";
@@ -259,7 +260,7 @@ const FieldRenderer = ({
             value === ""
               ? undefined
               : // SAFETY: inputType discriminates; value is string for select
-                // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                // eslint-disable-next-line typescript/no-unsafe-type-assertion
                 (value as string)
           }
         >
@@ -294,7 +295,7 @@ const FieldRenderer = ({
               onChange={(e) => onChange(field.path, e.target.value)}
               value={
                 // SAFETY: inputType discriminates; value is string for textarea
-                // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                // eslint-disable-next-line typescript/no-unsafe-type-assertion
                 (value as string) ?? ""
               }
             />
@@ -321,7 +322,7 @@ const FieldRenderer = ({
               type="number"
               value={
                 // SAFETY: inputType discriminates; value is string for number input
-                // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                // eslint-disable-next-line typescript/no-unsafe-type-assertion
                 (value as string) ?? ""
               }
             />
@@ -347,7 +348,7 @@ const FieldRenderer = ({
             type={inputType === "date" ? "date" : "text"}
             value={
               // SAFETY: inputType discriminates; value is string for text/date
-              // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+              // eslint-disable-next-line typescript/no-unsafe-type-assertion
               (value as string) ?? ""
             }
           />
@@ -380,7 +381,7 @@ const ArrayFieldRenderer = ({
   const arrayKey = `__array_${field.path}`;
   // SAFETY: __array_* keys hold number[] from form state
   const items =
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     (values[arrayKey] as number[] | undefined) ?? [];
 
   const addItem = () => {
@@ -495,7 +496,7 @@ const buildSubmitValues = (
     if (field.kind === "array") {
       const arrayKey = `__array_${field.path}`;
       // SAFETY: __array_* keys hold number[] from form state
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       const items = (values[arrayKey] as number[] | undefined) ?? [];
       const itemFields: ResolvedField[] = field.itemFields ?? [];
       const arrayValues: Record<string, unknown>[] = [];
@@ -553,7 +554,7 @@ const setNestedValue = (
       current[part] = {};
     }
     // SAFETY: guarded by typeof current[part] === "object" above
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+    // eslint-disable-next-line typescript/no-unsafe-type-assertion
     current = current[part] as Record<string, unknown>;
   }
 
@@ -579,7 +580,7 @@ const collectValidatableFields = (
     if (field.kind === "array") {
       const arrayKey = `__array_${field.path}`;
       // SAFETY: __array_* keys hold number[] from form state
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       const items = (values[arrayKey] as number[] | undefined) ?? [];
       const itemFields: ResolvedField[] = field.itemFields ?? [];
 
@@ -840,7 +841,7 @@ export const TemplateForm = ({
             {
               // SAFETY: the discriminated union guarantees `file`
               // is defined when `templateId` is absent.
-              // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+              // eslint-disable-next-line typescript/no-unsafe-type-assertion
               file: file as File,
               values: valuesJson,
             },
@@ -873,7 +874,7 @@ export const TemplateForm = ({
           : // SAFETY: Eden returns a typed object for the fill
             // endpoint, but the actual response is binary
             // data; the double cast bridges the type mismatch.
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+            // eslint-disable-next-line typescript/no-unsafe-type-assertion
             new Blob([data as unknown as BlobPart], {
               type: mimeType,
             });

--- a/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-list.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useRef, useState } from "react";
 
 import {
+  LayoutTemplateIcon,
+  MoreHorizontalIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useFormatter, useTranslations } from "use-intl";
+
+import {
   AlertDialog,
   AlertDialogClose,
   AlertDialogDescription,
@@ -17,13 +25,6 @@ import {
   DropdownMenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  LayoutTemplateIcon,
-  MoreHorizontalIcon,
-  PlusIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useFormatter, useTranslations } from "use-intl";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { stellaToast } from "@stll/ui/components/toast";
 import { UploadIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { DOCX_MIME } from "@/lib/consts";
@@ -107,8 +108,6 @@ export const TemplateUpload = ({ onDiscovered }: TemplateUploadProps) => {
 
   return (
     <div className="flex flex-1 items-center justify-center p-8">
-      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
-      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         className={`flex w-full max-w-md flex-col items-center gap-4 rounded-xl border-2 border-dashed p-10 transition-[border-color,background-color,box-shadow] duration-200 ${
           isDragOver

--- a/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
@@ -1,10 +1,11 @@
 import { useCallback } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery } from "@tanstack/react-query";
 import { DownloadIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-wizard.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useRef, useState } from "react";
 
+import {
+  AlertTriangleIcon,
+  ArrowLeftIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Field, FieldControl, FieldLabel } from "@stll/ui/components/field";
@@ -12,14 +21,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  AlertTriangleIcon,
-  ArrowLeftIcon,
-  ChevronDownIcon,
-  ChevronRightIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
@@ -208,7 +209,6 @@ export const ConfigureStep = ({
           </div>
         )}
 
-        {/* eslint-disable-next-line typescript/no-misused-promises */}
         <form
           className="flex flex-col gap-5"
           onSubmit={(...args) => {

--- a/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { parseDocumentAst } from "@stll/case-law/document-ast";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { Loader2Icon, SparklesIcon } from "lucide-react";
 import * as v from "valibot";
 import { useShallow } from "zustand/react/shallow";
+
+import { parseDocumentAst } from "@stll/case-law/document-ast";
 
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { useCaseSearchStore } from "@/lib/case-search-store";

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -7,12 +7,13 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import type { DecisionAnalysis } from "@stll/case-law/analysis";
 import {
   isAnalysisInProgress,
   isDecisionAnalysis,
 } from "@stll/case-law/analysis";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { env } from "@/env";
 

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/case-search-trigger.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/case-search-trigger.tsx
@@ -1,8 +1,5 @@
 import { useEffect, useRef } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
-import { Separator } from "@stll/ui/components/separator";
 import { formatForDisplay, useHotkey } from "@tanstack/react-hotkeys";
 import {
   ChevronDownIcon,
@@ -12,6 +9,10 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
+
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import { Separator } from "@stll/ui/components/separator";
 
 import Tooltip from "@/components/tooltip";
 import { useCaseSearchStore } from "@/lib/case-search-store";

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-metadata-sheet.tsx
@@ -1,5 +1,8 @@
 import { Suspense } from "react";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { EllipsisIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Sheet,
@@ -10,8 +13,6 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@stll/ui/components/sheet";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { EllipsisIcon } from "lucide-react";
 
 import type { SafeId } from "@/lib/safe-id";
 import { toSafeId } from "@/lib/safe-id";

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-text.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-text.tsx
@@ -1,10 +1,11 @@
 import { Fragment, useEffect, useMemo, useRef } from "react";
 import type { ReactNode } from "react";
 
+import { useTranslations } from "use-intl";
+
 import type { Block, DocumentAst, Inline } from "@stll/case-law/document-ast";
 import { parseDocumentAst } from "@stll/case-law/document-ast";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 import { sanitizeHref } from "@/lib/sanitize-href";
 

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
@@ -1,8 +1,9 @@
 import { useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { getDocumentAstMetadata } from "@stll/case-law/document-ast";
 import { Button } from "@stll/ui/components/button";
-import { useTranslations } from "use-intl";
 
 import { sanitizeHref } from "@/lib/sanitize-href";
 

--- a/apps/web/src/routes/_protected.knowledge/case/-components/decision-filters.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/decision-filters.tsx
@@ -1,5 +1,8 @@
 import { useCallback } from "react";
 
+import { useDebouncedCallback } from "use-debounce";
+import { useTranslations } from "use-intl";
+
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
 import { Input } from "@stll/ui/components/input";
 import {
@@ -9,8 +12,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
 
 import type {
   DecisionListFilters,

--- a/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
@@ -60,7 +60,6 @@ export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
               {headline && (
                 <p
                   className="text-muted-foreground [&_mark]:text-foreground mt-0.5 line-clamp-2 text-xs [&_mark]:bg-yellow-200/50 [&_mark]:font-medium dark:[&_mark]:bg-yellow-500/20"
-                  // eslint-disable-next-line react/no-danger
                   dangerouslySetInnerHTML={{ __html: headline }}
                 />
               )}

--- a/apps/web/src/routes/_protected.knowledge/case/-queries/decisions.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-queries/decisions.ts
@@ -136,7 +136,6 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
     },
     // SAFETY: TanStack Query needs the initial param typed as
     // string | null; `null` alone infers `null`.
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
   });

--- a/apps/web/src/routes/_protected.knowledge/case/index.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/index.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import { DecisionFilters } from "@/routes/_protected.knowledge/case/-components/decision-filters";
 import { DecisionTable } from "@/routes/_protected.knowledge/case/-components/decision-table";
@@ -30,17 +31,13 @@ function CaseLawIndex() {
 
   // SAFETY: Both list and search branches return the same Decision shape.
   const decisions = useMemo<Decision[]>(
-    () =>
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
-      (data?.pages.flatMap((page) => page.decisions) ?? []) as Decision[],
+    () => (data?.pages.flatMap((page) => page.decisions) ?? []) as Decision[],
     [data],
   );
 
   // SAFETY: facets shape matches SearchFacets across the union.
   const facets = useMemo(
-    () =>
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
-      (data?.pages.at(0)?.facets ?? null) as SearchFacets,
+    () => (data?.pages.at(0)?.facets ?? null) as SearchFacets,
     [data],
   );
 
@@ -62,7 +59,6 @@ function CaseLawIndex() {
         <div className="flex justify-center py-4">
           <Button
             disabled={isFetchingNextPage}
-            // eslint-disable-next-line typescript/no-misused-promises
             onClick={() => {
               void (async () => await fetchNextPage())();
             }}

--- a/apps/web/src/routes/_protected.knowledge/clauses.tsx
+++ b/apps/web/src/routes/_protected.knowledge/clauses.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useRef, useState } from "react";
 
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/index.tsx
+++ b/apps/web/src/routes/_protected.knowledge/index.tsx
@@ -1,5 +1,3 @@
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
   BotIcon,
@@ -9,6 +7,9 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 export const Route = createFileRoute("/_protected/knowledge/")({
   component: KnowledgeLanding,

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -1,15 +1,6 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
-import {
-  Popover,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
@@ -25,6 +16,16 @@ import {
   XIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import {
+  Popover,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.knowledge/skills.tsx
+++ b/apps/web/src/routes/_protected.knowledge/skills.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -12,10 +17,6 @@ import {
 } from "@stll/ui/components/dialog";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import {
   EMPTY_SCREEN_TABLE_PREVIEW,

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -1,9 +1,5 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
-import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
@@ -16,6 +12,11 @@ import {
   PlayIcon,
 } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import { Tabs, TabsList, TabsPanel, TabsTab } from "@stll/ui/components/tabs";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.organization/-components/invite-member-dialog.tsx
+++ b/apps/web/src/routes/_protected.organization/-components/invite-member-dialog.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import type { ComponentProps } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { Result } from "better-result";
+import { UserPlusIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -24,12 +31,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
-import { Result } from "better-result";
-import { UserPlusIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { emailSchema, toFormErrors } from "@/lib/schema";
 import { roleOptions } from "@/routes/-queries";

--- a/apps/web/src/routes/_protected.organization/-mutations.ts
+++ b/apps/web/src/routes/_protected.organization/-mutations.ts
@@ -1,6 +1,7 @@
-import { stellaToast } from "@stll/ui/components/toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";

--- a/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/account/sessions-card.tsx
@@ -1,5 +1,12 @@
 import { useState } from "react";
 
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQueries,
+} from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -21,12 +28,6 @@ import {
   TableRow,
 } from "@stll/ui/components/table";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQueries,
-} from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
 
 import { useI18nStore } from "@/i18n/i18n-store";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Frame, FramePanel } from "@stll/ui/components/frame";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Frame, FramePanel } from "@stll/ui/components/frame";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
 import { AIConfigRoleModelPicker } from "@/components/ai-config-role-model-picker";

--- a/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 
-import { Frame, FramePanel } from "@stll/ui/components/frame";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
+
+import { Frame, FramePanel } from "@stll/ui/components/frame";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { JurisdictionPicker } from "@/components/jurisdiction-picker";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useState } from "react";
 
+import { getRouteApi } from "@tanstack/react-router";
+import { SearchIcon } from "lucide-react";
+import { useDebouncedCallback } from "use-debounce";
+import { useTranslations } from "use-intl";
+
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
 } from "@stll/ui/components/input-group";
-import { getRouteApi } from "@tanstack/react-router";
-import { SearchIcon } from "lucide-react";
-import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
 
 import { InviteMemberDialog } from "@/routes/_protected.organization/-components/invite-member-dialog";
 

--- a/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useDebouncedCallback } from "use-debounce";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldLabel } from "@stll/ui/components/field";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
@@ -12,9 +16,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useDebouncedCallback } from "use-debounce";
-import { useTranslations } from "use-intl";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/profile-card.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
@@ -7,10 +12,6 @@ import { Form } from "@stll/ui/components/form";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { authClient } from "@/lib/auth";

--- a/apps/web/src/routes/_protected.settings/account.desktop.tsx
+++ b/apps/web/src/routes/_protected.settings/account.desktop.tsx
@@ -1,8 +1,9 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
 import { buttonVariants } from "@stll/ui/components/button";
 import { Frame, FramePanel } from "@stll/ui/components/frame";
 import { cn } from "@stll/ui/lib/utils";
-import { createFileRoute } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
 
 import {
   detectDesktopPlatform,

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from "react";
 
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Frame,
@@ -18,13 +26,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
 
 import { authClient } from "@/lib/auth";
 import { toAuthClientError } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.settings/organization.members.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.members.tsx
@@ -1,5 +1,14 @@
 import { useMemo, useState } from "react";
 
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { createFileRoute, useSearch } from "@tanstack/react-router";
+import { ArrowDownIcon, ArrowUpIcon, EllipsisVerticalIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { Frame } from "@stll/ui/components/frame";
@@ -26,14 +35,6 @@ import {
 } from "@stll/ui/components/table";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { createFileRoute, useSearch } from "@tanstack/react-router";
-import { ArrowDownIcon, ArrowUpIcon, EllipsisVerticalIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
 import { UserIdentity } from "@/components/user-avatar";

--- a/apps/web/src/routes/_protected.settings/route.tsx
+++ b/apps/web/src/routes/_protected.settings/route.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
 import {
@@ -10,6 +9,8 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { TranslationKey } from "@/i18n/types";
 import { pageTitle } from "@/lib/page-title";

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -1,13 +1,5 @@
 import { useMemo, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -25,6 +17,15 @@ import {
   PlusIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -169,7 +170,6 @@ function MyTodosPage() {
               {workspaces.workspaces.map((ws) => (
                 <MenuItem
                   key={ws.id}
-                  // eslint-disable-next-line typescript/no-misused-promises
                   onClick={() => {
                     void (async () => {
                       await handleCreateTask(ws.id);
@@ -224,7 +224,6 @@ function MyTodosPage() {
                 {workspaces.workspaces.map((ws) => (
                   <MenuItem
                     key={ws.id}
-                    // eslint-disable-next-line typescript/no-misused-promises
                     onClick={() => {
                       void (async () => {
                         await handleCreateTask(ws.id);

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -8,15 +8,6 @@ import {
 } from "react";
 import type { MouseEvent } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import { Separator } from "@stll/ui/components/separator";
-import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -32,6 +23,16 @@ import {
   PinOffIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { Separator } from "@stll/ui/components/separator";
+import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
 
 import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
 import { AppSidebar } from "@/components/app-sidebar";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -12,18 +12,6 @@ import {
   containsFiles,
   getFiles,
 } from "@atlaskit/pragmatic-drag-and-drop/external/file";
-import type { DocxEditorRef } from "@stll/folio";
-import { Button } from "@stll/ui/components/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogPopup,
-  DialogTitle,
-} from "@stll/ui/components/dialog";
-import { cn } from "@stll/ui/lib/utils";
 import {
   keepPreviousData,
   useQuery,
@@ -37,8 +25,21 @@ import {
 } from "@tanstack/react-router";
 import { UploadIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
-import "@stll/folio/editor.css";
 import * as v from "valibot";
+
+import type { DocxEditorRef } from "@stll/folio";
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import "@stll/folio/editor.css";
+import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.index.tsx
@@ -33,7 +33,7 @@ function RouteComponent() {
       return (
         <TableLayout
           // SAFETY: the switch narrows activeView.layout.type to "table".
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
           view={activeView as WorkspaceView<"table">}
           workspaceId={workspaceId}
         />
@@ -44,7 +44,7 @@ function RouteComponent() {
       return (
         <FilesystemView
           // SAFETY: the switch narrows activeView.layout.type to "filesystem".
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
           view={activeView as WorkspaceView<"filesystem">}
           workspaceId={workspaceId}
         />
@@ -55,7 +55,7 @@ function RouteComponent() {
       return (
         <CalendarView
           // SAFETY: the switch narrows activeView.layout.type to "calendar".
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
           view={activeView as WorkspaceView<"calendar">}
           workspaceId={workspaceId}
         />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -7,6 +6,8 @@ import {
   useMatches,
 } from "@tanstack/react-router";
 import * as v from "valibot";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { getAnalytics } from "@/lib/analytics/provider";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge.tsx
@@ -1,3 +1,5 @@
+import { LockIcon } from "lucide-react";
+
 import {
   Avatar,
   AvatarFallback,
@@ -9,7 +11,6 @@ import {
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
 import { cn } from "@stll/ui/lib/utils";
-import { LockIcon } from "lucide-react";
 
 type ActiveEditBadgeProps = {
   name: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
@@ -1,5 +1,14 @@
 import React, { useRef } from "react";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  FolderPlusIcon,
+  PlusIcon,
+  SquareCheckIcon,
+  UploadIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -9,14 +18,6 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import {
-  FolderPlusIcon,
-  PlusIcon,
-  SquareCheckIcon,
-  UploadIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/batch-action-bar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/batch-action-bar.tsx
@@ -1,5 +1,3 @@
-import { Button } from "@stll/ui/components/button";
-import { stellaToast } from "@stll/ui/components/toast";
 import {
   CheckCheckIcon,
   CircleOffIcon,
@@ -8,6 +6,9 @@ import {
   UndoIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useForm } from "@tanstack/react-form";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
@@ -7,10 +12,6 @@ import { Input } from "@stll/ui/components/input";
 import { Label } from "@stll/ui/components/label";
 import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm } from "@tanstack/react-form";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { PlusIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import {
   useCreateBillingCode,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { Input } from "@stll/ui/components/input";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 const BILLING_INCREMENT = 6;
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import { useForm } from "@tanstack/react-form";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
@@ -14,8 +17,6 @@ import {
 } from "@stll/ui/components/select";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm } from "@tanstack/react-form";
-import { useTranslations } from "use-intl";
 
 import { MatterCombobox } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view.tsx
@@ -1,11 +1,12 @@
 import { useMemo, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { ExpenseForm } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form";
 import type { ExpenseFormValues } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/expense-form";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-row.tsx
@@ -1,7 +1,8 @@
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import { PencilIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/invoice-status-badge.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/invoice-status-badge.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { InvoiceStatus } from "@/routes/_protected.workspaces/$workspaceId/-queries/invoices";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox.tsx
@@ -1,3 +1,6 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
 import {
   Combobox,
   ComboboxInput,
@@ -5,8 +8,6 @@ import {
   ComboboxList,
   ComboboxPopup,
 } from "@stll/ui/components/combobox";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
 
 import { entitySummariesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useForm } from "@tanstack/react-form";
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { ArrowLeftIcon, PlusIcon, StarIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
@@ -14,10 +19,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm } from "@tanstack/react-form";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { ArrowLeftIcon, PlusIcon, StarIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { UserIdentity } from "@/components/user-avatar";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/split-entry-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/split-entry-dialog.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
 import { Input } from "@stll/ui/components/input";
 import { Label } from "@stll/ui/components/label";
 import { stellaToast } from "@stll/ui/components/toast";
-import { PlusIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { MatterCombobox } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox";
 import { useSplitTimeEntry } from "@/routes/_protected.workspaces/$workspaceId/-mutations/time-entries";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-form.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useState } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
@@ -14,9 +18,6 @@ import {
 } from "@stll/ui/components/select";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useQuery } from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
 
 import { DurationInput } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/time-entry-row.tsx
@@ -1,9 +1,5 @@
 import { useState } from "react";
 
-import { prorateHourlyCents } from "@stll/money";
-import { Button } from "@stll/ui/components/button";
-import { Checkbox } from "@stll/ui/components/checkbox";
-import { cn } from "@stll/ui/lib/utils";
 import {
   CheckCheckIcon,
   PencilIcon,
@@ -12,6 +8,11 @@ import {
   UndoIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { prorateHourlyCents } from "@stll/money";
+import { Button } from "@stll/ui/components/button";
+import { Checkbox } from "@stll/ui/components/checkbox";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatMinutes } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/duration-input";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timer-controls.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery } from "@tanstack/react-query";
 import { useRouteContext } from "@tanstack/react-router";
 import { PlayIcon, SquareIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { MatterCombobox } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useMemo, useState } from "react";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import { PlusIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { prorateHourlyCents } from "@stll/money";
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import { Dialog, DialogPopup } from "@stll/ui/components/dialog";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
-import { PlusIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { BatchActionBar } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/batch-action-bar";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 
-import { prorateHourlyCents } from "@stll/money";
-import { cn } from "@stll/ui/lib/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
+
+import { prorateHourlyCents } from "@stll/money";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   formatDecimalHours,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-day-cell.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 
 import { dropTargetForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { PlusIcon, SquareCheckIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   Menu,
   MenuItem,
@@ -8,8 +11,6 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { cn } from "@stll/ui/lib/utils";
-import { PlusIcon, SquareCheckIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { EntityKind } from "@/lib/types";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-entity-chip.tsx
@@ -3,13 +3,14 @@ import { useEffect, useRef } from "react";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { useLocale, useTranslations } from "use-intl";
+
 import {
   Tooltip,
   TooltipPopup,
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
 import { cn } from "@stll/ui/lib/utils";
-import { useLocale, useTranslations } from "use-intl";
 
 import type { DragPreviewData } from "@/components/drag-preview";
 import { renderDragPreview } from "@/components/drag-preview";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-header.tsx
@@ -1,11 +1,12 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Popover,
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
-import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import { getMonthLabels } from "./calendar-utils";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
@@ -1,10 +1,11 @@
 import { useLayoutEffect, useRef, useState } from "react";
 import type { UIEvent } from "react";
 
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { toSafeId } from "@/lib/safe-id";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-year-grid.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-year-grid.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useLocale } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { CalendarDay } from "./calendar-utils";
 import {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -1,14 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import {
-  MenuGroup,
-  MenuGroupLabel,
-  MenuItem,
-  MenuSeparator,
-} from "@stll/ui/components/menu";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -20,6 +11,16 @@ import {
   StarIcon,
 } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuSeparator,
+} from "@stll/ui/components/menu";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import Tooltip from "@/components/tooltip";
 import { UserAvatar } from "@/components/user-avatar";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -1,22 +1,5 @@
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import {
-  Dialog,
-  DialogClose,
-  DialogPopup,
-  DialogTrigger,
-} from "@stll/ui/components/dialog";
-import { Input } from "@stll/ui/components/input";
-import {
-  Popover,
-  PopoverClose,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
-import { Skeleton } from "@stll/ui/components/skeleton";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
 import {
@@ -35,6 +18,24 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogPopup,
+  DialogTrigger,
+} from "@stll/ui/components/dialog";
+import { Input } from "@stll/ui/components/input";
+import {
+  Popover,
+  PopoverClose,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import type {
   PropertyDependency,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -14,6 +14,17 @@ import {
 } from "react";
 import type { CSSProperties, ReactNode, RefObject } from "react";
 
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  CheckCircle2Icon,
+  EyeIcon,
+  LockIcon,
+  LockOpenIcon,
+  PenLineIcon,
+  RefreshCwIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { FormattingBar } from "@stll/folio";
 import type { DocxCompatibility, DocxEditorRef, EditorMode } from "@stll/folio";
 import { Button } from "@stll/ui/components/button";
@@ -26,16 +37,6 @@ import {
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
-import {
-  CheckCircle2Icon,
-  EyeIcon,
-  LockIcon,
-  LockOpenIcon,
-  PenLineIcon,
-  RefreshCwIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 import "@stll/folio/editor.css";
 
 import { useActiveDocxStore } from "@/components/ai-suggestions/active-docx-store";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -1,5 +1,11 @@
 import { useState } from "react";
 
+import { revalidateLogic, useForm } from "@tanstack/react-form";
+import type { AnyFieldApi } from "@tanstack/react-form";
+import { panic } from "better-result";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
 import {
@@ -16,11 +22,6 @@ import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
 import { Form } from "@stll/ui/components/form";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
-import { revalidateLogic, useForm } from "@tanstack/react-form";
-import type { AnyFieldApi } from "@tanstack/react-form";
-import { panic } from "better-result";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { toFormErrors } from "@/lib/schema";
 import type {
@@ -224,7 +225,7 @@ export const EditFieldDialog = ({
                           type="single-select"
                           value={
                             // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
                             field.state.value as FieldFormValue<"single-select">
                           }
                         />
@@ -244,7 +245,7 @@ export const EditFieldDialog = ({
                           type="multi-select"
                           value={
                             // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
                             field.state.value as FieldFormValue<"multi-select">
                           }
                         />
@@ -264,7 +265,7 @@ export const EditFieldDialog = ({
                           onChange={(val) => field.handleChange(val)}
                           value={
                             // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
                             (field.state.value as FieldFormValue<"date">) ?? ""
                           }
                         />
@@ -296,7 +297,7 @@ export const EditFieldDialog = ({
                             )}
                             type="number"
                             // SAFETY: guarded by fieldContent.type check
-                            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+                            // eslint-disable-next-line typescript/no-unsafe-type-assertion
                             value={field.state.value as FieldFormValue<"int">}
                           />
                           <FieldError />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -12,11 +12,12 @@
 
 import { useState } from "react";
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
 import { DatePickerPopover } from "@stll/ui/components/date-picker-popover";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/entity-kind-icon.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/entity-kind-icon.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@stll/ui/lib/utils";
 import { FileIcon, FolderIcon, LinkIcon, MailIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { EntityKind } from "@/lib/types";
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -5,6 +5,19 @@ import {
   draggable,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  ChevronDownIcon,
+  ChevronRightIcon,
+  FolderIcon,
+  LoaderCircleIcon,
+  RotateCcwIcon,
+  Rows3Icon,
+  Trash2Icon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Checkbox } from "@stll/ui/components/checkbox";
 import {
@@ -21,18 +34,6 @@ import { Skeleton } from "@stll/ui/components/skeleton";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  FolderIcon,
-  LoaderCircleIcon,
-  RotateCcwIcon,
-  Rows3Icon,
-  Trash2Icon,
-  TriangleAlertIcon,
-} from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value-select.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value-select.tsx
@@ -1,3 +1,5 @@
+import { useTranslations } from "use-intl";
+
 import {
   Select,
   SelectItem,
@@ -5,7 +7,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import { useTranslations } from "use-intl";
 
 import type { WorkspacePropertyOption } from "@/lib/types";
 import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -14,20 +14,6 @@ import {
   monitorForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbSeparator,
-} from "@stll/ui/components/breadcrumb";
-import {
-  Menu,
-  MenuItem,
-  MenuPopup,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate, useSearch } from "@tanstack/react-router";
@@ -42,6 +28,21 @@ import {
   FolderOpenIcon,
 } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@stll/ui/components/breadcrumb";
+import {
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   renderDragPreview,
@@ -570,7 +571,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       updateView.mutate({
         viewId: view.id,
         // SAFETY: hiddenProperties is part of every layout discriminant.
-        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
         layout: {
           ...view.layout,
           hiddenProperties: [...new Set([...hiddenProperties, propertyId])],
@@ -1516,7 +1516,6 @@ const FilesystemRow = ({
   );
 
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className="group/row relative h-full"
       data-entity-row

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inline-edit.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inline-edit.tsx
@@ -1,6 +1,7 @@
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 type InlineEditProps = {
   value: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -18,7 +18,6 @@
 import { useEffect, useEffectEvent, useMemo, useState } from "react";
 import type { MouseEvent } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import {
   useQuery,
   useQueryClient,
@@ -28,6 +27,8 @@ import { useNavigate } from "@tanstack/react-router";
 import { ArrowUpIcon, Maximize2Icon, SquarePenIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
+
+import { Button } from "@stll/ui/components/button";
 
 import {
   Conversation,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
@@ -1,7 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import {
   useQuery,
   useQueryClient,
@@ -9,6 +8,8 @@ import {
 } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -9,22 +9,6 @@ import {
 } from "react";
 import type { PropsWithChildren, RefObject } from "react";
 
-import type { DocxCompatibility } from "@stll/folio";
-import { Button } from "@stll/ui/components/button";
-import {
-  Dialog,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogPanel,
-  DialogPopup,
-  DialogTitle,
-} from "@stll/ui/components/dialog";
-import { Input } from "@stll/ui/components/input";
-import { ScrollArea } from "@stll/ui/components/scroll-area";
-import { Skeleton } from "@stll/ui/components/skeleton";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import {
   useQuery,
   useQueryClient,
@@ -52,6 +36,23 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
+
+import type { DocxCompatibility } from "@stll/folio";
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { Input } from "@stll/ui/components/input";
+import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { Skeleton } from "@stll/ui/components/skeleton";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { MessageResponse } from "@/components/ai-elements/message";
 import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-tab-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-tab-header.tsx
@@ -1,8 +1,9 @@
 import type { MouseEvent, ReactNode } from "react";
 
+import { LayersIcon, XIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
-import { LayersIcon, XIcon } from "lucide-react";
 
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/suggestions-facet.tsx
@@ -22,8 +22,9 @@
 
 import { useEffect, useRef } from "react";
 
-import type { DocxEditorRef } from "@stll/folio";
 import { useShallow } from "zustand/react/shallow";
+
+import type { DocxEditorRef } from "@stll/folio";
 
 import { useActiveDocxStore } from "@/components/ai-suggestions/active-docx-store";
 import { ReviewPanel } from "@/components/ai-suggestions/review-panel";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-rail-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-rail-context-menu.tsx
@@ -1,6 +1,7 @@
-import { MenuItem } from "@stll/ui/components/menu";
 import { MessageSquarePlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { MenuItem } from "@stll/ui/components/menu";
 
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { useAnchoredMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-anchored-menu";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu.tsx
@@ -1,4 +1,3 @@
-import { MenuItem, MenuSeparator } from "@stll/ui/components/menu";
 import {
   ListXIcon,
   Maximize2Icon,
@@ -8,6 +7,8 @@ import {
   XSquareIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { MenuItem, MenuSeparator } from "@stll/ui/components/menu";
 
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { useAnchoredMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-anchored-menu";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/justification.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/justification.tsx
@@ -1,6 +1,7 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { produce } from "immer";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { Citation } from "@/lib/citations";
 import {
@@ -90,7 +91,6 @@ const PdfChip = ({ workspaceId, justification, citation }: PdfChipProps) => {
         CITATION_CHIP_CLASSES,
         isActive && "bg-primary/25 hover:bg-primary/25",
       )}
-      // eslint-disable-next-line typescript/no-misused-promises
       onClick={() => {
         void (async () => {
           createBoundingBoxes();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -3,14 +3,15 @@ import { useEffect, useRef, useState } from "react";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
+import { CalendarIcon } from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@stll/ui/components/avatar";
 import { cn } from "@stll/ui/lib/utils";
-import { CalendarIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import { isFileDisplayable } from "@/lib/types";
 import type {
@@ -118,7 +119,7 @@ export const KanbanCard = ({
               return;
             }
             // SAFETY: cloneNode of HTMLElement returns HTMLElement
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+            // eslint-disable-next-line typescript/no-unsafe-type-assertion
             const clone = inner.cloneNode(true) as HTMLElement;
             const rect = inner.getBoundingClientRect();
             clone.style.width = `${rect.width}px`;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -16,6 +16,19 @@ import {
   containsFiles,
   getFiles,
 } from "@atlaskit/pragmatic-drag-and-drop/external/file";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  EllipsisVerticalIcon,
+  EyeOffIcon,
+  FileUpIcon,
+  GripVerticalIcon,
+  PaletteIcon,
+  PlusIcon,
+  SquareCheckIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { OptionColor } from "@stll/api/types";
 import {
   AlertDialog,
@@ -45,18 +58,6 @@ import {
   PopoverTrigger,
 } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
-import { useVirtualizer } from "@tanstack/react-virtual";
-import {
-  EllipsisVerticalIcon,
-  EyeOffIcon,
-  FileUpIcon,
-  GripVerticalIcon,
-  PaletteIcon,
-  PlusIcon,
-  SquareCheckIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type {
   EntityKind,
@@ -244,7 +245,7 @@ export const KanbanColumn = ({
           // monitor (forgiving: works even if dropped in gap).
           if (source.data["type"] === ENTITY_DRAG_TYPE) {
             // SAFETY: entityId is always a string; set by our own draggable getInitialData.
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+            // eslint-disable-next-line typescript/no-unsafe-type-assertion
             const entityId = source.data["entityId"] as string;
             onDropRef.current(entityId);
           }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-view.tsx
@@ -7,8 +7,6 @@ import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/clo
 import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import type { OptionColor } from "@stll/api/types";
-import { stellaToast } from "@stll/ui/components/toast";
 import {
   useMutation,
   useInfiniteQuery,
@@ -17,6 +15,9 @@ import {
 } from "@tanstack/react-query";
 import { KanbanIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import type { OptionColor } from "@stll/api/types";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -251,7 +252,7 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
     ? Object.fromEntries(
         TASK_STATUS_ORDER.map((s) => [
           s,
-          // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
           t(`tasks.statusValues.${s}` as "tasks.statusValues.open"),
         ]),
       )
@@ -515,7 +516,6 @@ export const KanbanView = ({ view, workspaceId }: KanbanViewProps) => {
               });
             }}
             onDrop={(entityId) => handleDrop(value, entityId)}
-            // eslint-disable-next-line typescript/no-misused-promises
             onFileUpload={(files) => {
               void (async () => await handleFileUpload(value, files))();
             }}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -1,5 +1,16 @@
 import { useRef, useState } from "react";
 
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  CopyIcon,
+  CopyPlusIcon,
+  EllipsisIcon,
+  LockIcon,
+  TrashIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import { Input } from "@stll/ui/components/input";
@@ -14,16 +25,6 @@ import {
   SheetTrigger,
 } from "@stll/ui/components/sheet";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
-import {
-  CopyIcon,
-  CopyPlusIcon,
-  EllipsisIcon,
-  LockIcon,
-  TrashIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { MatterNumberHint } from "@/components/matter-number-hint";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -155,7 +156,6 @@ export const MatterMetadataSheet = ({
             type: "error",
           });
         },
-        // eslint-disable-next-line typescript/no-misused-promises
         onSuccess: () => {
           void (async () => {
             stellaToast.update(toastId, {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
@@ -1,6 +1,14 @@
 import { useState } from "react";
 import type { ComponentProps } from "react";
 
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { PlusIcon, TrashIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -21,13 +29,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { PlusIcon, TrashIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { UserIdentity } from "@/components/user-avatar";
 import { usePermissions } from "@/hooks/use-permissions";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/metadata-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/metadata-popover.tsx
@@ -1,3 +1,7 @@
+import { EyeOffIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Popover,
@@ -5,9 +9,6 @@ import {
   PopoverTrigger,
 } from "@stll/ui/components/popover";
 import { Separator } from "@stll/ui/components/separator";
-import { EyeOffIcon } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { PinProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property";
 import { SortProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/sort-property";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -4,6 +4,23 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
 import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  CalendarClockIcon,
+  ClockIcon,
+  FolderTreeIcon,
+  PlusIcon,
+  SquareCheckIcon,
+  UploadIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import {
   Avatar,
   AvatarFallback,
   AvatarImage,
@@ -33,22 +50,6 @@ import {
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
 import { cn } from "@stll/ui/lib/utils";
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
-import {
-  CalendarClockIcon,
-  ClockIcon,
-  FolderTreeIcon,
-  PlusIcon,
-  SquareCheckIcon,
-  UploadIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { renderDragPreview } from "@/components/drag-preview";
 import {
@@ -672,7 +673,6 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
                 {Array.from({ length: 7 }, (_, i) => (
                   <span
                     className="text-muted-foreground w-7 text-center text-[0.625rem]"
-                    // eslint-disable-next-line react/no-array-index-key
                     key={i}
                   >
                     {getLocaleDayLabel(i, lang)}
@@ -737,7 +737,6 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
                             return (
                               <div
                                 className="flex w-7 justify-center"
-                                // eslint-disable-next-line react/no-array-index-key
                                 key={dayIdx}
                               >
                                 {cell}
@@ -748,7 +747,6 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
                           return (
                             <div
                               className="flex w-7 justify-center"
-                              // eslint-disable-next-line react/no-array-index-key
                               key={dayIdx}
                             >
                               <Popover>
@@ -1244,7 +1242,6 @@ const OverviewRow = ({ entity, workspaceId, lang }: OverviewRowProps) => {
     // Use a <div> instead of <button> to avoid invalid
     // nested <button> elements (RowActions renders a
     // <button> menu trigger inside).
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className={cn(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -1,5 +1,21 @@
 import { useState } from "react";
 
+import {
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import {
+  BuildingIcon,
+  LockIcon,
+  PlusIcon,
+  TrashIcon,
+  UserIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Dialog,
@@ -20,21 +36,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import {
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import {
-  BuildingIcon,
-  LockIcon,
-  PlusIcon,
-  TrashIcon,
-  UserIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { ContactPicker } from "@/components/contact-picker";
 import { toSafeId } from "@/lib/safe-id";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation.tsx
@@ -1,7 +1,8 @@
 import { useRef } from "react";
 
-import type { BoundingBox } from "@stll/api/types";
 import { useShallow } from "zustand/react/shallow";
+
+import type { BoundingBox } from "@stll/api/types";
 
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -1,5 +1,15 @@
 import { useRef, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+import {
+  CheckIcon,
+  DownloadIcon,
+  HistoryIcon,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import {
   AlertDialog,
   AlertDialogClose,
@@ -19,15 +29,6 @@ import {
 } from "@stll/ui/components/menu";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { cn } from "@stll/ui/lib/utils";
-import { useQueryClient } from "@tanstack/react-query";
-import {
-  CheckIcon,
-  DownloadIcon,
-  HistoryIcon,
-  PlusIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import { UserAvatar } from "@/components/user-avatar";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -9,8 +9,6 @@ import {
 } from "react";
 import type { ReactNode, RefObject } from "react";
 
-import type { DocxEditorRef } from "@stll/folio";
-import { Button } from "@stll/ui/components/button";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   AlertTriangleIcon,
@@ -21,6 +19,9 @@ import {
   UnfoldHorizontalIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import type { DocxEditorRef } from "@stll/folio";
+import { Button } from "@stll/ui/components/button";
 import "@stll/folio/editor.css";
 
 import "./peek-docx.css";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/delete-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/delete-property.tsx
@@ -1,3 +1,6 @@
+import { Trash2Icon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   AlertDialog,
   AlertDialogClose,
@@ -10,8 +13,6 @@ import {
 } from "@stll/ui/components/alert-dialog";
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
-import { Trash2Icon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { WorkspaceProperty } from "@/lib/types";
 import { useDeleteProperty } from "@/routes/_protected.workspaces/$workspaceId/-mutations/properties";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/form.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/form.tsx
@@ -1,8 +1,9 @@
 import type { ComponentProps } from "react";
 
+import type { AnyFieldApi } from "@tanstack/react-form";
+
 import { Field, FieldError } from "@stll/ui/components/field";
 import { cn } from "@stll/ui/lib/utils";
-import type { AnyFieldApi } from "@tanstack/react-form";
 
 type PropertyFormFieldProps = ComponentProps<typeof Field>;
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/inline-option-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/inline-option-editor.tsx
@@ -1,5 +1,8 @@
 import { useState } from "react";
 
+import { PlusIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { OptionColor } from "@stll/api/types";
 import { Button } from "@stll/ui/components/button";
 import {
@@ -8,8 +11,6 @@ import {
   PopoverPopup,
   PopoverTrigger,
 } from "@stll/ui/components/popover";
-import { PlusIcon, XIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { WorkspacePropertyOption } from "@/lib/types";
 import { SelectFallback } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/select-fallback";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@stll/ui/components/button";
 import { PinIcon, PinOffIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import type { TableColumn } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -1,5 +1,9 @@
 import { Fragment } from "react";
 
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { RouteIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { PropertyCondition } from "@stll/api/types";
 import { Button } from "@stll/ui/components/button";
 import {
@@ -20,9 +24,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { Separator } from "@stll/ui/components/separator";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import { RouteIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { getTranslator } from "@/i18n/i18n-store";
 import type {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
@@ -1,21 +1,22 @@
 import { useEffect, useRef } from "react";
 import type React from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { FieldError } from "@stll/ui/components/field";
-import { ScrollArea } from "@stll/ui/components/scroll-area";
-import { cn } from "@stll/ui/lib/utils";
-
-import "./tiptap.css";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
+
+import "./tiptap.css";
 import Text from "@tiptap/extension-text";
 import { useEditor } from "@tiptap/react";
 import type { Editor } from "@tiptap/react";
 import { Loader2Icon, WandSparklesIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { FieldError } from "@stll/ui/components/field";
+import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { cn } from "@stll/ui/lib/utils";
 
 import {
   createPromptEditorDocument,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
@@ -1,10 +1,11 @@
 import { forwardRef, useImperativeHandle, useState } from "react";
 
+import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
-import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
-import { useTranslations } from "use-intl";
 
 import type { MentionOption } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/custom-mention";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-node.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-node.tsx
@@ -1,7 +1,8 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
 
@@ -11,7 +12,7 @@ type MentionNodeProps = NodeViewProps & {
 
 export const MentionNode = ({ workspaceId, ...props }: MentionNodeProps) => {
   // SAFETY: attrs from our mention extension schema
-  // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
   const attributes = props.node.attrs as {
     id: string;
     label: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/select-fallback.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/select-fallback.tsx
@@ -1,3 +1,6 @@
+import { SquareMinusIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { OptionColor } from "@stll/api/types";
 import {
   Select,
@@ -6,8 +9,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import { SquareMinusIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { WorkspacePropertyOption } from "@/lib/types";
 import { SelectColorIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/shared";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/shared.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/shared.tsx
@@ -1,8 +1,9 @@
+import { SquareMinusIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { OptionColor, PropertyContent } from "@stll/api/types";
 import { PopoverTrigger } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
-import { SquareMinusIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
 import type { WorkspaceProperty } from "@/lib/types";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/sort-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/sort-property.tsx
@@ -1,7 +1,8 @@
-import { Button } from "@stll/ui/components/button";
 import type { Column } from "@tanstack/react-table";
 import { ArrowDownIcon, ArrowUpIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import type { TableTreeNode } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-helpers.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-helpers.tsx
@@ -1,7 +1,5 @@
 import type { ComponentProps } from "react";
 
-import type { PropertyContentType } from "@stll/api/types";
-import { cn } from "@stll/ui/lib/utils";
 import {
   AlertCircleIcon,
   CalendarIcon,
@@ -15,6 +13,9 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import type { PropertyContentType } from "@stll/api/types";
+import { cn } from "@stll/ui/lib/utils";
 
 import type { WorkspaceField } from "@/lib/types";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 
+import { EyeOffIcon, PencilLineIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { Separator } from "@stll/ui/components/separator";
 import { stellaToast } from "@stll/ui/components/toast";
-import { EyeOffIcon, PencilLineIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { PropertyDependency, WorkspaceProperty } from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -1,3 +1,22 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Result } from "better-result";
+import {
+  ArchiveIcon,
+  CopyIcon,
+  DownloadIcon,
+  EllipsisVerticalIcon,
+  EyeIcon,
+  FileOutputIcon,
+  FolderPlusIcon,
+  LaptopIcon,
+  LockOpenIcon,
+  Maximize2Icon,
+  MessageSquareIcon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   AlertDialog,
   AlertDialogClose,
@@ -20,24 +39,6 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useNavigate } from "@tanstack/react-router";
-import { Result } from "better-result";
-import {
-  ArchiveIcon,
-  CopyIcon,
-  DownloadIcon,
-  EllipsisVerticalIcon,
-  EyeIcon,
-  FileOutputIcon,
-  FolderPlusIcon,
-  LaptopIcon,
-  LockOpenIcon,
-  Maximize2Icon,
-  MessageSquareIcon,
-  PencilIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { useRequestChatAbout } from "@/components/chat/use-request-chat-about";
 import Tooltip from "@/components/tooltip";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -1,8 +1,9 @@
 import type { PropsWithChildren } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import { EyeIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import type { WorkspaceEntity, WorkspaceProperty } from "@/lib/types";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table.tsx
@@ -21,9 +21,6 @@ import {
   monitorForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { setCustomNativeDragPreview } from "@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview";
-import { Checkbox } from "@stll/ui/components/checkbox";
-import { stellaToast } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 import { flexRender } from "@tanstack/react-table";
 import type {
   Cell,
@@ -42,6 +39,10 @@ import {
   MinusIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Checkbox } from "@stll/ui/components/checkbox";
+import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { renderDragPreview } from "@/components/drag-preview";
 import { BottomRow } from "@/routes/_protected.workspaces/$workspaceId/-components/bottom-row";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-badges.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-badges.tsx
@@ -1,4 +1,3 @@
-import { cn } from "@stll/ui/lib/utils";
 import {
   AlertCircleIcon,
   ArrowDownIcon,
@@ -7,6 +6,8 @@ import {
   MinusIcon,
 } from "lucide-react";
 import { useLocale } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { WorkspaceEntity } from "@/lib/types";
 
@@ -66,7 +67,6 @@ export const TaskBadges = ({ entity, className }: TaskBadgesProps) => {
       )}
       {entity.dueDate && (
         <span
-          // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- dark: variant present; rule false positive
           className={cn(
             "flex items-center gap-0.5",
             overdue && "text-red-500 dark:text-red-400",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import { XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { cn } from "@stll/ui/lib/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useRouteContext } from "@tanstack/react-router";
-import { XIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -1,3 +1,7 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { PlusIcon, XIcon } from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { DatePickerPopover as DatePickerPopoverBase } from "@stll/ui/components/date-picker-popover";
 import type { DatePickerPopoverProps as DatePickerPopoverBaseProps } from "@stll/ui/components/date-picker-popover";
@@ -13,9 +17,6 @@ import {
   SelectTrigger,
 } from "@stll/ui/components/select";
 import { cn } from "@stll/ui/lib/utils";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { PlusIcon, XIcon } from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-subtasks.tsx
@@ -1,6 +1,7 @@
-import { cn } from "@stll/ui/lib/utils";
 import { CheckCircle2Icon, CircleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import { isTaskStatus } from "./task-detail-constants";
 import type { TaskStatus } from "./task-detail-constants";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -5,6 +5,22 @@ import {
   draggable,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import {
+  CalendarIcon,
+  CopyIcon,
+  EllipsisVerticalIcon,
+  FolderTreeIcon,
+  GanttChartIcon,
+  KanbanIcon,
+  LayoutDashboardIcon,
+  PencilIcon,
+  PlusIcon,
+  TableIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import type { ViewLayout, ViewLayoutType } from "@stll/api/types";
 import {
   AlertDialog,
@@ -30,21 +46,6 @@ import {
 import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useSuspenseQuery } from "@tanstack/react-query";
-import {
-  CalendarIcon,
-  CopyIcon,
-  EllipsisVerticalIcon,
-  FolderTreeIcon,
-  GanttChartIcon,
-  KanbanIcon,
-  LayoutDashboardIcon,
-  PencilIcon,
-  PlusIcon,
-  TableIcon,
-  Trash2Icon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import type { TranslationKey } from "@/i18n/types";
@@ -327,7 +328,7 @@ const ViewTab = ({
           setIsDropTarget(false);
           // SAFETY: viewId from our draggable getInitialData
           onReorderRef.current(
-            // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+            // eslint-disable-next-line typescript/no-unsafe-type-assertion
             source.data["viewId"] as string,
             id,
           );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -1,5 +1,17 @@
 import type { PropsWithChildren, ReactNode } from "react";
 
+import type { LucideIcon } from "lucide-react";
+import {
+  CircleDotIcon,
+  FileTextIcon,
+  FilterIcon,
+  FolderIcon,
+  SignalIcon,
+  SquareCheckIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import {
@@ -15,17 +27,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@stll/ui/components/select";
-import type { LucideIcon } from "lucide-react";
-import {
-  CircleDotIcon,
-  FileTextIcon,
-  FilterIcon,
-  FolderIcon,
-  SignalIcon,
-  SquareCheckIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import type { ViewFilterCondition, WorkspaceProperty } from "@/lib/types";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";
@@ -298,9 +299,9 @@ const BuiltinFilterChip = ({
 
   const resolveLabel = (val: string) =>
     isStatus
-      ? // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      ? // eslint-disable-next-line typescript/no-unsafe-type-assertion
         t(`tasks.statusValues.${val}` as "tasks.statusValues.open")
-      : // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      : // eslint-disable-next-line typescript/no-unsafe-type-assertion
         t(`tasks.priorityValues.${val}` as "tasks.priorityValues.none");
 
   const opOptions = [

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-sorts.tsx
@@ -1,3 +1,10 @@
+import {
+  ArrowDownIcon,
+  ArrowUpDownIcon,
+  ArrowUpIcon,
+  XIcon,
+} from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -5,12 +12,6 @@ import {
   MenuPopup,
   MenuTrigger,
 } from "@stll/ui/components/menu";
-import {
-  ArrowDownIcon,
-  ArrowUpDownIcon,
-  ArrowUpIcon,
-  XIcon,
-} from "lucide-react";
 
 import type { ViewLayout, WorkspaceProperty } from "@/lib/types";
 import { PropertyIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/property-helpers";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -1,6 +1,24 @@
 import type { ComponentType } from "react";
 import { useMemo, useState } from "react";
 
+import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { Result } from "better-result";
+import {
+  AlignJustifyIcon,
+  CalendarIcon,
+  ClockIcon,
+  DownloadIcon,
+  EyeIcon,
+  FolderIcon,
+  FolderOpenIcon,
+  HashIcon,
+  Rows3Icon,
+  SparklesIcon,
+  UserIcon,
+  WrapTextIcon,
+} from "lucide-react";
+import { useLocale, useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -20,23 +38,6 @@ import {
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import { Result } from "better-result";
-import {
-  AlignJustifyIcon,
-  CalendarIcon,
-  ClockIcon,
-  DownloadIcon,
-  EyeIcon,
-  FolderIcon,
-  FolderOpenIcon,
-  HashIcon,
-  Rows3Icon,
-  SparklesIcon,
-  UserIcon,
-  WrapTextIcon,
-} from "lucide-react";
-import { useLocale, useTranslations } from "use-intl";
 
 import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
@@ -82,7 +83,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
       viewId: view.id,
       // SAFETY: callers pass subsets matching the current layout
       // discriminant; TS can't verify spread preserves a union.
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       layout: { ...view.layout, ...changes } as ViewLayout,
     });
   };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-b-boxes.ts
@@ -89,7 +89,6 @@ export const useCreateBBoxes = ({
   const mutateRef = useRef(mutation.mutate);
   mutateRef.current = mutation.mutate;
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useCallback(() => {
     if (!aiAvailability?.available) {
       return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 
-import { stellaToast } from "@stll/ui/components/toast";
 import {
   useMutation,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { MAX_PARALLEL_FILE_UPLOADS } from "@/consts";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/properties.ts
@@ -1,5 +1,6 @@
-import type { PropertyContentType } from "@stll/api/types";
 import { useMutation } from "@tanstack/react-query";
+
+import type { PropertyContentType } from "@stll/api/types";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -173,7 +173,6 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
 
       return { ...rest, entities };
     },
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
@@ -217,7 +216,6 @@ export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
 
       return { ...rest, entities };
     },
-    // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
@@ -115,7 +115,7 @@ export const taskDetailOptions = (workspaceId: string, taskId: string) =>
       if (response.error) {
         throw toAPIError(response.error);
       }
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       return response.data as TaskDetail;
     },
     enabled: !!taskId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-store.tsx
@@ -1,6 +1,7 @@
-import type { BoundingBox } from "@stll/api/types";
 import { create } from "zustand";
 import { immer } from "zustand/middleware/immer";
+
+import type { BoundingBox } from "@stll/api/types";
 
 import type { WorkspaceJustification } from "@/lib/types";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/expenses.tsx
@@ -1,9 +1,10 @@
 import { Suspense, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import { createFileRoute } from "@tanstack/react-router";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import { ExpenseListView } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
@@ -1,6 +1,5 @@
 import { Suspense, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
@@ -11,6 +10,8 @@ import {
 } from "@tanstack/react-router";
 import { PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
@@ -117,7 +118,6 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
               <tr
                 className="hover:bg-muted/30 cursor-pointer border-b last:border-0"
                 key={invoice.id}
-                // eslint-disable-next-line typescript/no-misused-promises
                 onClick={() => {
                   void (async () =>
                     await navigate({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices/$invoiceId.tsx
@@ -1,5 +1,24 @@
 import { Suspense, useState } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  ArrowLeftIcon,
+  CheckIcon,
+  EditIcon,
+  SendIcon,
+  Trash2Icon,
+  UndoIcon,
+  XCircleIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { applyMarkupCents, prorateHourlyCents } from "@stll/money";
 import {
   AlertDialog,
@@ -20,24 +39,6 @@ import { Input } from "@stll/ui/components/input";
 import { Label } from "@stll/ui/components/label";
 import { Textarea } from "@stll/ui/components/textarea";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import {
-  useMutation,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import {
-  ArrowLeftIcon,
-  CheckIcon,
-  EditIcon,
-  SendIcon,
-  Trash2Icon,
-  UndoIcon,
-  XCircleIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
 
-import { stellaToast } from "@stll/ui/components/toast";
 import { useHotkey } from "@tanstack/react-hotkeys";
 import type { QueryClient } from "@tanstack/react-query";
 import {
@@ -10,6 +9,8 @@ import {
   redirect,
   useMatch,
 } from "@tanstack/react-router";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { getTranslator } from "@/i18n/i18n-store";
 import { getAnalytics } from "@/lib/analytics/provider";
@@ -220,7 +221,6 @@ function RouteComponent() {
   // they left them. PDF tabs from another matter will refetch
   // with their own workspaceId; chat tabs are workspace-tagged
   // so they only render under the matter they belong to.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(
     () => () => {
       for (const timer of previewClearTimersRef.current.values()) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/timesheets.tsx
@@ -1,5 +1,15 @@
 import { Suspense, useMemo, useState } from "react";
 
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CodeIcon,
+  DownloadIcon,
+  SettingsIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Select,
@@ -10,15 +20,6 @@ import {
 } from "@stll/ui/components/select";
 import { Tabs, TabsList, TabsTab } from "@stll/ui/components/tabs";
 import { stellaToast } from "@stll/ui/components/toast";
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  CodeIcon,
-  DownloadIcon,
-  SettingsIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { api } from "@/lib/api";
 import { ClientOperationError } from "@/lib/errors";
@@ -177,7 +178,7 @@ function TimesheetsPage() {
       }
       // SAFETY: PDF endpoint returns binary; Eden types it
       // as unknown but the response body is an ArrayBuffer
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       const pdfData = response.data as unknown as ArrayBuffer;
       const blob = new Blob([pdfData], {
         type: "application/pdf",

--- a/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/client-group-header.tsx
@@ -1,6 +1,7 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useNavigate } from "@tanstack/react-router";
 import { ChevronRightIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 import type { WorkspaceGroup } from "@/routes/_protected.workspaces/-types";
 

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -1,5 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getRouteApi, useNavigate } from "@tanstack/react-router";
+import { Result } from "better-result";
+import {
+  BuildingIcon,
+  PlusIcon,
+  SearchIcon,
+  UserIcon,
+  XIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+import { useShallow } from "zustand/shallow";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Combobox,
@@ -22,18 +35,6 @@ import { Field, FieldLabel } from "@stll/ui/components/field";
 import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { Result } from "better-result";
-import {
-  BuildingIcon,
-  PlusIcon,
-  SearchIcon,
-  UserIcon,
-  XIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
-import { useShallow } from "zustand/shallow";
 
 import { ContactPicker } from "@/components/contact-picker";
 import { UserIdentity } from "@/components/user-avatar";

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -1,15 +1,16 @@
 import { useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { FileIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import {
   PreviewCard,
   PreviewCardPopup,
   PreviewCardTrigger,
 } from "@stll/ui/components/preview-card";
 import { cn } from "@stll/ui/lib/utils";
-import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
-import { FileIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { useI18nStore } from "@/i18n/i18n-store";
 import { getMatterColor } from "@/lib/matter-colors";

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-context-menu.tsx
@@ -9,6 +9,20 @@
 
 import { useState } from "react";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArchiveRestoreIcon,
+  ClipboardCopyIcon,
+  ExternalLinkIcon,
+  PenLineIcon,
+  PinIcon,
+  PinOffIcon,
+  PlusIcon,
+  Trash2Icon,
+  UserPlusIcon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
 import {
@@ -36,19 +50,6 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  ArchiveRestoreIcon,
-  ClipboardCopyIcon,
-  ExternalLinkIcon,
-  PenLineIcon,
-  PinIcon,
-  PinOffIcon,
-  PlusIcon,
-  Trash2Icon,
-  UserPlusIcon,
-} from "lucide-react";
-import { useTranslations } from "use-intl";
 
 import { UserIdentity } from "@/components/user-avatar";
 import { usePinnedStore } from "@/lib/pinned-store";

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -1,3 +1,8 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import { ArrowDownIcon, ArrowUpIcon, ChevronRightIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+import { useShallow } from "zustand/shallow";
+
 import { Frame } from "@stll/ui/components/frame";
 import {
   Table,
@@ -8,10 +13,6 @@ import {
   TableRow,
 } from "@stll/ui/components/table";
 import { cn } from "@stll/ui/lib/utils";
-import { Link, useNavigate } from "@tanstack/react-router";
-import { ArrowDownIcon, ArrowUpIcon, ChevronRightIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
-import { useShallow } from "zustand/shallow";
 
 import { useI18nStore } from "@/i18n/i18n-store";
 import { getMatterColor } from "@/lib/matter-colors";

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-toolbar.tsx
@@ -1,15 +1,3 @@
-import { Button } from "@stll/ui/components/button";
-import { Input } from "@stll/ui/components/input";
-import {
-  Menu,
-  MenuGroup,
-  MenuGroupLabel,
-  MenuItem,
-  MenuPopup,
-  MenuTrigger,
-} from "@stll/ui/components/menu";
-import { Separator } from "@stll/ui/components/separator";
-import { cn } from "@stll/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
 import {
@@ -23,6 +11,19 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
+
+import { Button } from "@stll/ui/components/button";
+import { Input } from "@stll/ui/components/input";
+import {
+  Menu,
+  MenuGroup,
+  MenuGroupLabel,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+} from "@stll/ui/components/menu";
+import { Separator } from "@stll/ui/components/separator";
+import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";

--- a/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/pdf-viewer-controls.tsx
@@ -1,9 +1,6 @@
 import { useState } from "react";
 import type { ReactNode } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Separator } from "@stll/ui/components/separator";
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { produce } from "immer";
@@ -14,6 +11,10 @@ import {
   PrinterIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Separator } from "@stll/ui/components/separator";
+import { stellaToast } from "@stll/ui/components/toast";
 
 import Tooltip from "@/components/tooltip";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -1,6 +1,12 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
+import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { PlusIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+import { useShallow } from "zustand/shallow";
+
 import {
   Menu,
   MenuItem,
@@ -8,11 +14,6 @@ import {
   MenuTrigger,
 } from "@stll/ui/components/menu";
 import { Skeleton } from "@stll/ui/components/skeleton";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { PlusIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
-import { useShallow } from "zustand/shallow";
 
 import {
   EMPTY_SCREEN_MATTERS_VIDEO,

--- a/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
+++ b/apps/web/src/routes/auth/-components/inbox-quick-jump.tsx
@@ -1,5 +1,6 @@
-import { Button } from "@stll/ui/components/button";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import { sanitizeHref } from "@/lib/sanitize-href";
 

--- a/apps/web/src/routes/auth/accept-invitation.$invitationId.tsx
+++ b/apps/web/src/routes/auth/accept-invitation.$invitationId.tsx
@@ -1,5 +1,14 @@
 import { useState } from "react";
 
+import { useMutation } from "@tanstack/react-query";
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  redirect,
+} from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+
 import { Button, buttonVariants } from "@stll/ui/components/button";
 import {
   Frame,
@@ -10,14 +19,6 @@ import {
 } from "@stll/ui/components/frame";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useMutation } from "@tanstack/react-query";
-import {
-  createFileRoute,
-  Link,
-  notFound,
-  redirect,
-} from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
 
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/auth/index.tsx
+++ b/apps/web/src/routes/auth/index.tsx
@@ -1,15 +1,16 @@
 import { useState } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldError } from "@stll/ui/components/field";
 import { Form } from "@stll/ui/components/form";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
-import { useForm, useStore } from "@tanstack/react-form";
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { env } from "@/env";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/auth/organization.tsx
+++ b/apps/web/src/routes/auth/organization.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Avatar, AvatarFallback } from "@stll/ui/components/avatar";
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
@@ -14,11 +20,6 @@ import {
 import { Input } from "@stll/ui/components/input";
 import { Skeleton } from "@stll/ui/components/skeleton";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/auth/otp.tsx
+++ b/apps/web/src/routes/auth/otp.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Frame,
@@ -14,10 +19,6 @@ import {
   InputOTPSlot,
 } from "@stll/ui/components/input-otp";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useMutation } from "@tanstack/react-query";
-import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { useInvalidateSession } from "@/hooks/use-invalidate-session";
 import { useAnalytics } from "@/lib/analytics/provider";

--- a/apps/web/src/routes/consent.tsx
+++ b/apps/web/src/routes/consent.tsx
@@ -1,5 +1,10 @@
 import { useState } from "react";
 
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Frame,
@@ -9,10 +14,6 @@ import {
   FrameTitle,
 } from "@stll/ui/components/frame";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, redirect } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { authClient } from "@/lib/auth";
 import { toAuthClientError } from "@/lib/errors";

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -2,6 +2,26 @@ import { useState } from "react";
 import type * as React from "react";
 
 import {
+  ArchiveIcon,
+  BellIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  CopyIcon,
+  FileTextIcon,
+  FilterIcon,
+  LinkIcon,
+  LoaderIcon,
+  MailIcon,
+  SearchIcon,
+  SettingsIcon,
+  ShieldIcon,
+  SquarePenIcon,
+  Trash2Icon,
+  UserIcon,
+} from "lucide-react";
+
+import {
   Accordion,
   AccordionItem,
   AccordionPanel,
@@ -166,25 +186,6 @@ import {
   TooltipPopup,
   TooltipTrigger,
 } from "@stll/ui/components/tooltip";
-import {
-  ArchiveIcon,
-  BellIcon,
-  CheckIcon,
-  ChevronDownIcon,
-  ClockIcon,
-  CopyIcon,
-  FileTextIcon,
-  FilterIcon,
-  LinkIcon,
-  LoaderIcon,
-  MailIcon,
-  SearchIcon,
-  SettingsIcon,
-  ShieldIcon,
-  SquarePenIcon,
-  Trash2Icon,
-  UserIcon,
-} from "lucide-react";
 
 import {
   Message,

--- a/apps/web/src/routes/mcp.oauth-callback.tsx
+++ b/apps/web/src/routes/mcp.oauth-callback.tsx
@@ -1,5 +1,9 @@
 import { useEffect } from "react";
 
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Frame,
@@ -8,9 +12,6 @@ import {
   FramePanel,
   FrameTitle,
 } from "@stll/ui/components/frame";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import type { McpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { broadcastMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";

--- a/apps/web/src/routes/onboarding/-components/onboarding-progress.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-progress.tsx
@@ -1,5 +1,6 @@
-import { cn } from "@stll/ui/lib/utils";
 import { useTranslations } from "use-intl";
+
+import { cn } from "@stll/ui/lib/utils";
 
 type OnboardingProgressProps = {
   currentStep: number;

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { stellaToast } from "@stll/ui/components/toast";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import {
   createDefaultRoleModels,

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { stellaToast } from "@stll/ui/components/toast";
-import { useTranslations } from "use-intl";
 
 import { AIConfigProvidersEditor } from "@/components/ai-config-providers-editor";
 import type { ProviderRowStatus } from "@/components/ai-config-providers-editor";

--- a/apps/web/src/routes/onboarding/-components/steps/download-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/download-step.tsx
@@ -1,6 +1,7 @@
+import { useTranslations } from "use-intl";
+
 import { Button, buttonVariants } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
-import { useTranslations } from "use-intl";
 
 import {
   detectDesktopPlatform,

--- a/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/invite-step.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useRef, useState } from "react";
 
+import { AlertTriangleIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import { Input } from "@stll/ui/components/input";
 import { cn } from "@stll/ui/lib/utils";
-import { AlertTriangleIcon, XIcon } from "lucide-react";
-import { useTranslations } from "use-intl";
 
 const DELIMITERS = /[,;\n\t]/;
 

--- a/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/jurisdiction-step.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import createGlobe from "cobe";
 import { XIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 import { JurisdictionPicker } from "@/components/jurisdiction-picker";
 import {

--- a/apps/web/src/routes/onboarding/-components/steps/organization-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/organization-step.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useRef } from "react";
 
+import { useForm, useStore } from "@tanstack/react-form";
+import { useTranslations } from "use-intl";
+import * as v from "valibot";
+
 import { Button } from "@stll/ui/components/button";
 import { Field, FieldError, FieldLabel } from "@stll/ui/components/field";
 import { Form } from "@stll/ui/components/form";
 import { Input } from "@stll/ui/components/input";
-import { useForm, useStore } from "@tanstack/react-form";
-import { useTranslations } from "use-intl";
-import * as v from "valibot";
 
 import { toFormErrors } from "@/lib/schema";
 import { createSlug } from "@/routes/_protected.organization/-utils";

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
       stage_fixed: true
     format:
       glob: "**/*.{ts,tsx,js,jsx,json,css}"
-      run: bun --bun oxfmt -c .oxfmtrc.json {staged_files}
+      run: bun --bun oxfmt -c .oxfmtrc.json --no-error-on-unmatched-pattern {staged_files}
       stage_fixed: true
     i18n:
       glob: "apps/web/src/i18n/langs/*.{json,ts}"

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -49,6 +49,8 @@ export default defineConfig({
     "sonarjs/array-callback-without-return": "error",
     "sonarjs/anchor-precedence": "error",
     "sonarjs/code-eval": "error",
+    "sonarjs/no-array-delete": "error",
+    "sonarjs/no-alphabetical-sort": "error",
     "sonarjs/confidential-information-logging": "error",
     "sonarjs/cognitive-complexity": ["error", 30],
     "sonarjs/existing-groups": "error",

--- a/packages/ares/package.json
+++ b/packages/ares/package.json
@@ -45,7 +45,7 @@
     "pack:dry-run": "bun pm pack --dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/ares",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/ares",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/ares",
     "format": "oxfmt .",
     "prepack": "bun run build"

--- a/packages/docx-utils/package.json
+++ b/packages/docx-utils/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "bun test src",
     "typecheck": "tsc --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts packages/docx-utils",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/docx-utils",
     "format": "oxfmt ."
   },
   "dependencies": {

--- a/packages/docx-utils/src/zip.test.ts
+++ b/packages/docx-utils/src/zip.test.ts
@@ -14,7 +14,7 @@ describe("DOCX ZIP helpers", () => {
     const buffer = await repackZip(zip);
     const loaded = await loadDocx(buffer);
 
-    await expect(extractText(loaded, "word/document.xml")).resolves.toBe(
+    expect(await extractText(loaded, "word/document.xml")).toBe(
       "<w:document>Hello</w:document>",
     );
 
@@ -26,7 +26,7 @@ describe("DOCX ZIP helpers", () => {
   test("returns null for missing text and binary parts", async () => {
     const loaded = await loadDocx(await repackZip(new JSZip()));
 
-    await expect(extractText(loaded, "word/missing.xml")).resolves.toBeNull();
-    await expect(extractBinary(loaded, "word/missing.bin")).resolves.toBeNull();
+    expect(await extractText(loaded, "word/missing.xml")).toBeNull();
+    expect(await extractBinary(loaded, "word/missing.bin")).toBeNull();
   });
 });

--- a/packages/docx-utils/src/zip.ts
+++ b/packages/docx-utils/src/zip.ts
@@ -8,33 +8,33 @@ export const DOCX_COMPRESSION = {
 };
 
 /** Load a DOCX file (ArrayBuffer) into a JSZip instance */
-export const loadDocx = (buffer: ArrayBuffer): Promise<JSZip> =>
-  JSZip.loadAsync(buffer);
+export const loadDocx = async (buffer: ArrayBuffer): Promise<JSZip> =>
+  await JSZip.loadAsync(buffer);
 
 /** Extract a text file from a ZIP */
-export const extractText = (
+export const extractText = async (
   zip: JSZip,
   path: string,
 ): Promise<string | null> => {
   const file = zip.file(path);
   if (!file) {
-    return Promise.resolve(null);
+    return null;
   }
-  return file.async("string");
+  return await file.async("string");
 };
 
 /** Extract a binary file from a ZIP */
-export const extractBinary = (
+export const extractBinary = async (
   zip: JSZip,
   path: string,
 ): Promise<ArrayBuffer | null> => {
   const file = zip.file(path);
   if (!file) {
-    return Promise.resolve(null);
+    return null;
   }
-  return file.async("arraybuffer");
+  return await file.async("arraybuffer");
 };
 
 /** Repack a ZIP to ArrayBuffer with standard DOCX compression */
-export const repackZip = (zip: JSZip): Promise<ArrayBuffer> =>
-  zip.generateAsync(DOCX_COMPRESSION);
+export const repackZip = async (zip: JSZip): Promise<ArrayBuffer> =>
+  await zip.generateAsync(DOCX_COMPRESSION);

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/folio",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/folio",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/folio",
     "format": "oxfmt .",
     "test": "bun test src",

--- a/packages/folio/src/components/CommentsSidebar.tsx
+++ b/packages/folio/src/components/CommentsSidebar.tsx
@@ -736,7 +736,6 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
     replyKey: number,
     submitFn?: (id: number, text: string) => void,
   ) => (
-    // oxlint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
     <div
       onClick={(e) => e.stopPropagation()}
       role="presentation"
@@ -851,7 +850,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
       lastKnownCardPositionsRef.current.get(cardId);
 
     return (
-      // oxlint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+      // oxlint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         key={comment.id}
         ref={(el) => {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -23,6 +23,21 @@ import {
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
+import {
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  EyeIcon,
+  PenLineIcon,
+  SquarePenIcon,
+  StickyNoteIcon,
+  XIcon,
+} from "lucide-react";
+import { Selection } from "prosemirror-state";
+// Paginated editor
+import type { EditorView } from "prosemirror-view";
+import { useTranslations } from "use-intl";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Menu,
@@ -41,20 +56,6 @@ import {
   SelectTrigger as StSelectTrigger,
   SelectValue as StSelectValue,
 } from "@stll/ui/components/select";
-import {
-  CheckIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  EyeIcon,
-  PenLineIcon,
-  SquarePenIcon,
-  StickyNoteIcon,
-  XIcon,
-} from "lucide-react";
-import { Selection } from "prosemirror-state";
-// Paginated editor
-import type { EditorView } from "prosemirror-view";
-import { useTranslations } from "use-intl";
 
 import {
   applyFolioAIEditOperations,

--- a/packages/folio/src/components/ErrorBoundary.tsx
+++ b/packages/folio/src/components/ErrorBoundary.tsx
@@ -16,7 +16,6 @@ import React, {
 } from "react";
 import type { ReactNode, ErrorInfo } from "react";
 
-import { Button } from "@stll/ui/components/button";
 import {
   AlertCircleIcon,
   AlertTriangleIcon,
@@ -25,6 +24,8 @@ import {
   XIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
 
 import { ErrorManager } from "../core/managers/ErrorManager";
 import type { ErrorNotification } from "../core/managers/types";
@@ -302,7 +303,6 @@ export class ErrorBoundary extends Component<
   }
 
   override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    // oxlint-disable-next-line react/no-set-state
     this.setState({ errorInfo });
 
     // Call callback
@@ -312,7 +312,6 @@ export class ErrorBoundary extends Component<
   }
 
   resetError = (): void => {
-    // oxlint-disable-next-line react/no-set-state
     this.setState({
       hasError: false,
       error: null,
@@ -328,7 +327,6 @@ export class ErrorBoundary extends Component<
       // Custom fallback
       if (fallback) {
         if (typeof fallback === "function") {
-          // oxlint-disable-next-line typescript/no-non-null-assertion
           return fallback(error!, this.resetError);
         }
         return fallback;
@@ -337,7 +335,6 @@ export class ErrorBoundary extends Component<
       // Default fallback UI
       return (
         <DefaultErrorFallback
-          // oxlint-disable-next-line typescript/no-non-null-assertion
           error={error!}
           errorInfo={errorInfo}
           showDetails={showDetails}

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -11,9 +11,6 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 
-import { ColorPicker } from "@stll/ui/components/color-picker";
-import type { ColorPreset } from "@stll/ui/components/color-picker";
-import { Menu, MenuPopup, MenuTrigger } from "@stll/ui/components/menu";
 import {
   BaselineIcon,
   BoldIcon,
@@ -25,6 +22,10 @@ import {
   Undo2Icon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { ColorPicker } from "@stll/ui/components/color-picker";
+import type { ColorPreset } from "@stll/ui/components/color-picker";
+import { Menu, MenuPopup, MenuTrigger } from "@stll/ui/components/menu";
 
 import type { ColorValue, ParagraphAlignment } from "../core/types/document";
 import { cn } from "../lib/utils";

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -12,9 +12,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import type { CSSProperties, KeyboardEvent, ChangeEvent } from "react";
 
-import { Button } from "@stll/ui/components/button";
-import { Checkbox } from "@stll/ui/components/checkbox";
-import { Input } from "@stll/ui/components/input";
 import {
   ChevronDownIcon,
   ChevronUpIcon,
@@ -22,6 +19,10 @@ import {
   XIcon,
 } from "lucide-react";
 import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import { Checkbox } from "@stll/ui/components/checkbox";
+import { Input } from "@stll/ui/components/input";
 
 import { getFindReplaceOverlayStyle } from "./findReplaceDialogLayout";
 import { getFindEnterAction } from "./findReplaceInteraction";

--- a/packages/folio/src/components/hooks/useHyperlinkHandlers.ts
+++ b/packages/folio/src/components/hooks/useHyperlinkHandlers.ts
@@ -231,7 +231,6 @@ export const useHyperlinkHandlers = ({
       const nodeEnd = nodeStart + node.nodeSize;
       const hlMark = node.isText
         ? node.marks.find(
-            // oxlint-disable-next-line typescript/no-non-null-assertion
             (m) =>
               m.type === hlType && m.attrs["href"] === linkMark!.attrs["href"],
           )

--- a/packages/folio/src/components/ui/AlignmentButtons.tsx
+++ b/packages/folio/src/components/ui/AlignmentButtons.tsx
@@ -6,18 +6,19 @@
 import type { CSSProperties } from "react";
 
 import {
-  Popover,
-  PopoverClose,
-  PopoverPopup,
-  PopoverTrigger,
-} from "@stll/ui/components/popover";
-import {
   AlignCenterIcon,
   AlignJustifyIcon,
   AlignLeftIcon,
   AlignRightIcon,
   ChevronDownIcon,
 } from "lucide-react";
+
+import {
+  Popover,
+  PopoverClose,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
 
 import type { ParagraphAlignment } from "../../core/types/document";
 import { cn } from "../../lib/utils";

--- a/packages/folio/src/core/docx/__tests__/roundtrip.property.test.ts
+++ b/packages/folio/src/core/docx/__tests__/roundtrip.property.test.ts
@@ -101,7 +101,6 @@ function arbFormattedParagraph(): fc.Arbitrary<PMNode> {
       }
       // Rebuild paragraph with attrs
       const content: PMNode[] = [];
-      // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
       para.forEach((child) => {
         content.push(child);
       });

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -215,7 +215,6 @@ async function readRelsOrStub(zip: JSZip, relsPath: string): Promise<string> {
 
 function findMaxImageNum(zip: JSZip): number {
   let maxImageNum = 0;
-  // oxlint-disable-next-line unicorn/no-array-for-each -- JSZip.forEach is not Array.forEach
   zip.forEach((relativePath) => {
     const m = relativePath.match(/^word\/media\/image(\d+)\./);
     if (m) {

--- a/packages/folio/src/core/docx/xmlParser.ts
+++ b/packages/folio/src/core/docx/xmlParser.ts
@@ -19,8 +19,9 @@
  * - pic: Pictures
  */
 
-import { OOXML_NS } from "@stll/docx-utils";
 import { XMLBuilder, XMLParser } from "fast-xml-parser";
+
+import { OOXML_NS } from "@stll/docx-utils";
 
 /**
  * XML element tree node — drop-in replacement for the `Element` type

--- a/packages/folio/src/core/utils/formatToStyle.ts
+++ b/packages/folio/src/core/utils/formatToStyle.ts
@@ -416,18 +416,15 @@ export function paragraphToStyle(
   // ============================================================================
 
   if (formatting.pageBreakBefore) {
-    // eslint-disable-next-line typescript/no-deprecated -- legacy DOCX renderer uses page-break CSS for print layout compatibility
     style.pageBreakBefore = "always";
   }
 
   // Keep with next / keep lines together
   if (formatting.keepNext) {
-    // eslint-disable-next-line typescript/no-deprecated -- legacy DOCX renderer uses page-break CSS for print layout compatibility
     style.pageBreakAfter = "avoid";
   }
 
   if (formatting.keepLines) {
-    // eslint-disable-next-line typescript/no-deprecated -- legacy DOCX renderer uses page-break CSS for print layout compatibility
     style.pageBreakInside = "avoid";
   }
 

--- a/packages/folio/src/hooks/useHistory.ts
+++ b/packages/folio/src/hooks/useHistory.ts
@@ -519,7 +519,6 @@ export class HistoryManager<T> {
       return undefined;
     }
 
-    // oxlint-disable-next-line typescript/no-non-null-assertion
     const prevEntry = this.undoStack.pop()!;
 
     this.redoStack.push({
@@ -536,7 +535,6 @@ export class HistoryManager<T> {
       return undefined;
     }
 
-    // oxlint-disable-next-line typescript/no-non-null-assertion
     const nextEntry = this.redoStack.pop()!;
 
     this.undoStack.push({

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -669,7 +669,6 @@ function measureTableBlock(
           if (!occupiedColumnsPerRow.has(r)) {
             occupiedColumnsPerRow.set(r, new Set());
           }
-          // oxlint-disable-next-line typescript/no-non-null-assertion
           const occSet = occupiedColumnsPerRow.get(r)!;
           for (let c = 0; c < colSpan; c++) {
             occSet.add(colIdx + c);
@@ -2277,7 +2276,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             // body line carrying an fn ref reserves space for that fn
             // on its host page in a single pass — no convergence loop.
             footnoteContentMap = buildFootnoteContentMap(
-              // oxlint-disable-next-line typescript/no-non-null-assertion
               document!.package.footnotes!,
               footnoteRefs,
               contentWidth,
@@ -4980,7 +4978,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     };
 
     return (
-      // oxlint-disable-next-line jsx-a11y/no-static-element-interactions
       <div
         ref={containerRef}
         className={`folio-root paged-editor ${className ?? ""}`}

--- a/packages/infosoud/package.json
+++ b/packages/infosoud/package.json
@@ -50,7 +50,7 @@
     "release:check": "bun run lint && bun run typecheck && bun run test && bun run build && bun run pack:dry-run",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/infosoud",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/infosoud",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/infosoud",
     "format": "oxfmt .",
     "prepack": "bun run build"

--- a/packages/money/package.json
+++ b/packages/money/package.json
@@ -12,7 +12,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "test": "bun test src",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/money",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/money",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/money",
     "format": "oxfmt ."
   },

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -11,7 +11,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/permissions",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/permissions",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/permissions",
     "format": "oxfmt ."
   },

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -12,7 +12,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/scripts",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/scripts",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/scripts",
     "format": "oxfmt ."
   },

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -16,7 +16,7 @@
     "generate": "bun scripts/generate-manifest.ts",
     "test": "bun scripts/generate-manifest.ts --check && bun test src",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/skills",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/skills",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/skills",
     "format": "oxfmt ."
   },

--- a/packages/template-conditions/package.json
+++ b/packages/template-conditions/package.json
@@ -11,7 +11,7 @@
     "clean": "git clean -xdf .cache .turbo node_modules",
     "test": "bun test",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/template-conditions",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/template-conditions",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/template-conditions",
     "format": "oxfmt ."
   },

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -17,7 +17,7 @@
     "typegen": "bun ../scripts/src/i18n-typegen.ts i18n/langs",
     "i18n:check": "bun ../scripts/src/i18n-typegen.ts i18n/langs --check && bun ../scripts/src/i18n-check.ts i18n/langs",
     "i18n:sync": "bun ../scripts/src/i18n-check.ts i18n/langs --sync && bun ../scripts/src/i18n-typegen.ts i18n/langs",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/transactional",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/transactional",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/transactional",
     "format": "oxfmt ."
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",
     "typecheck": "tsgo --noEmit",
-    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware packages/ui",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware packages/ui",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/ui",
     "format": "oxfmt ."
   },

--- a/packages/ui/src/components/accordion.tsx
+++ b/packages/ui/src/components/accordion.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion";
-import { cn } from "@stll/ui/lib/utils";
 import { ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 function Accordion<Value = unknown>(
   props: AccordionPrimitive.Root.Props<Value>,

--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog";
+
 import { cn } from "@stll/ui/lib/utils";
 
 const AlertDialogCreateHandle = AlertDialogPrimitive.createHandle;

--- a/packages/ui/src/components/avatar.tsx
+++ b/packages/ui/src/components/avatar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Avatar({ className, ...props }: AvatarPrimitive.Root.Props) {

--- a/packages/ui/src/components/breadcrumb.tsx
+++ b/packages/ui/src/components/breadcrumb.tsx
@@ -4,8 +4,9 @@ import type * as React from "react";
 
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
-import { cn } from "@stll/ui/lib/utils";
 import { ChevronRight, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;

--- a/packages/ui/src/components/button.tsx
+++ b/packages/ui/src/components/button.tsx
@@ -4,10 +4,11 @@ import type * as React from "react";
 
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
-import { cn } from "@stll/ui/lib/utils";
 import { cva } from "class-variance-authority";
 import type { VariantProps } from "class-variance-authority";
 import { LoaderIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 const buttonVariants = cva(
   "focus-visible:ring-ring focus-visible:ring-offset-background relative inline-flex shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg border text-base font-medium whitespace-nowrap transition-shadow outline-none before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] focus-visible:ring-2 focus-visible:ring-offset-1 disabled:pointer-events-none disabled:opacity-64 sm:text-sm pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11 [&_svg]:pointer-events-none [&_svg]:-mx-0.5 [&_svg]:shrink-0 [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4",

--- a/packages/ui/src/components/checkbox.tsx
+++ b/packages/ui/src/components/checkbox.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -4,9 +4,10 @@ import { useState } from "react";
 import type * as React from "react";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
 import { HexColorPicker } from "@stll/ui/components/hex-color-picker";
 import { cn } from "@stll/ui/lib/utils";
-import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -3,10 +3,11 @@
 import * as React from "react";
 
 import { Combobox as ComboboxPrimitive } from "@base-ui/react/combobox";
+import { ChevronsUpDownIcon, XIcon } from "lucide-react";
+
 import { Input } from "@stll/ui/components/input";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { cn } from "@stll/ui/lib/utils";
-import { ChevronsUpDownIcon, XIcon } from "lucide-react";
 
 const ComboboxContext = React.createContext<{
   chipsRef: React.RefObject<Element | null> | null;
@@ -352,7 +353,7 @@ function ComboboxChips({
       data-slot="combobox-chips"
       onMouseDown={(e) => {
         // SAFETY: DOM mouse event target is Element for UI interaction
-        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
         const target = e.target as HTMLElement;
         const isChip = target.closest('[data-slot="combobox-chip"]');
         if (isChip || !chipsRef?.current) {
@@ -366,7 +367,7 @@ function ComboboxChips({
         }
       }}
       // SAFETY: chipsRef is HTMLDivElement from ComboboxPrimitive.Chips
-      // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+      // eslint-disable-next-line typescript/no-unsafe-type-assertion
       ref={chipsRef as React.Ref<HTMLDivElement> | null}
       {...props}
     >

--- a/packages/ui/src/components/command.tsx
+++ b/packages/ui/src/components/command.tsx
@@ -4,9 +4,10 @@ import type * as React from "react";
 
 import { Autocomplete as AutocompletePrimitive } from "@base-ui/react/autocomplete";
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { SearchIcon } from "lucide-react";
+
 import { DialogPopup } from "@stll/ui/components/dialog";
 import { cn } from "@stll/ui/lib/utils";
-import { SearchIcon } from "lucide-react";
 
 type CommandProps<ItemValue> = Omit<
   AutocompletePrimitive.Root.Props<ItemValue>,

--- a/packages/ui/src/components/date-picker-popover.tsx
+++ b/packages/ui/src/components/date-picker-popover.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import {
   Popover,
@@ -9,7 +11,6 @@ import {
   PopoverTrigger,
 } from "@stll/ui/components/popover";
 import { cn } from "@stll/ui/lib/utils";
-import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Calendar utilities
@@ -485,7 +486,6 @@ function DatePickerPopover({
                 ))}
               </div>
 
-              {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
               <div
                 aria-label={headerLabel}
                 className="grid grid-cols-7 gap-0"

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { cn } from "@stll/ui/lib/utils";
-import { XIcon } from "lucide-react";
 
 const DialogCreateHandle = DialogPrimitive.createHandle;
 

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Field as FieldPrimitive } from "@base-ui/react/field";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Field({ className, ...props }: FieldPrimitive.Root.Props) {

--- a/packages/ui/src/components/form.tsx
+++ b/packages/ui/src/components/form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Form as FormPrimitive } from "@base-ui/react/form";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Form({ className, ...props }: FormPrimitive.Props) {

--- a/packages/ui/src/components/hex-color-picker.tsx
+++ b/packages/ui/src/components/hex-color-picker.tsx
@@ -304,7 +304,6 @@ const InteractiveArea = ({
     win.addEventListener(endType, handleEnd);
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cleanup only
   useEffect(() => detachListeners, []);
 
   const handleStart = (e: React.MouseEvent | React.TouchEvent) => {

--- a/packages/ui/src/components/input-group.tsx
+++ b/packages/ui/src/components/input-group.tsx
@@ -2,17 +2,17 @@
 
 import type * as React from "react";
 
+import { cva } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
+
 import { Input } from "@stll/ui/components/input";
 import type { InputProps } from "@stll/ui/components/input";
 import { Textarea } from "@stll/ui/components/textarea";
 import type { TextareaProps } from "@stll/ui/components/textarea";
 import { cn } from "@stll/ui/lib/utils";
-import { cva } from "class-variance-authority";
-import type { VariantProps } from "class-variance-authority";
 
 function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
     <div
       className={cn(
         "border-input bg-background text-foreground ring-ring/24 has-autofill:bg-foreground/4 has-[input:focus-visible,textarea:focus-visible]:border-ring has-[input[aria-invalid],textarea[aria-invalid]]:border-destructive/36 has-[input:focus-visible,textarea:focus-visible]:has-[input[aria-invalid],textarea[aria-invalid]]:border-destructive/64 has-[input:focus-visible,textarea:focus-visible]:has-[input[aria-invalid],textarea[aria-invalid]]:ring-destructive/16 dark:bg-input/32 dark:has-autofill:bg-foreground/8 dark:has-[input[aria-invalid],textarea[aria-invalid]]:ring-destructive/24 relative inline-flex w-full min-w-0 items-center rounded-lg border text-base shadow-xs/5 transition-shadow not-dark:bg-clip-padding before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] not-has-[input:disabled,textarea:disabled]:not-has-[input:focus-visible,textarea:focus-visible]:not-has-[input[aria-invalid],textarea[aria-invalid]]:before:shadow-[0_1px_--theme(--color-black/4%)] has-data-[align=block-end]:h-auto has-data-[align=block-end]:flex-col has-data-[align=block-start]:h-auto has-data-[align=block-start]:flex-col has-[input:disabled,textarea:disabled]:opacity-64 has-[input:disabled,textarea:disabled,input:focus-visible,textarea:focus-visible,input[aria-invalid],textarea[aria-invalid]]:shadow-none has-[input:focus-visible,textarea:focus-visible]:ring-[3px] has-[textarea]:h-auto sm:text-sm dark:not-has-[input:disabled,textarea:disabled]:not-has-[input:focus-visible,textarea:focus-visible]:not-has-[input[aria-invalid],textarea[aria-invalid]]:before:shadow-[0_-1px_--theme(--color-white/6%)] has-data-[align=inline-end]:**:[[data-size=sm]_input]:pe-1.5 has-data-[align=inline-start]:**:[[data-size=sm]_input]:ps-1.5 *:[[data-slot=input-control],[data-slot=textarea-control]]:contents *:[[data-slot=input-control],[data-slot=textarea-control]]:before:hidden has-data-[align=block-end]:**:[input]:pt-1.5 has-data-[align=block-start]:**:[input]:pb-1.5 has-data-[align=inline-end]:**:[input]:pe-2 has-data-[align=inline-start]:**:[input]:ps-2 has-[[data-align=block-start],[data-align=block-end]]:**:[input]:h-auto **:[textarea_button]:rounded-[calc(var(--radius-md)-1px)] **:[textarea]:min-h-20.5 **:[textarea]:resize-none **:[textarea]:py-[calc(--spacing(3)-1px)] **:[textarea]:max-sm:min-h-23.5",
@@ -52,7 +52,6 @@ function InputGroupAddon({
   ...props
 }: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
   return (
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions
     <div
       className={cn(inputGroupAddonVariants({ align }), className)}
@@ -60,7 +59,7 @@ function InputGroupAddon({
       data-slot="input-group-addon"
       onMouseDown={(e) => {
         // SAFETY: DOM mouse event target is Element for UI interaction
-        // eslint-disable-next-line typescript/consistent-type-assertions, typescript/no-unsafe-type-assertion
+        // eslint-disable-next-line typescript/no-unsafe-type-assertion
         const target = e.target as HTMLElement;
         const isInteractive = target.closest(
           "button, a, input, select, textarea, [role='button'], [role='combobox'], [role='listbox'], [data-slot='select-trigger']",

--- a/packages/ui/src/components/input-otp.tsx
+++ b/packages/ui/src/components/input-otp.tsx
@@ -2,9 +2,10 @@
 
 import * as React from "react";
 
-import { cn } from "@stll/ui/lib/utils";
 import { OTPInput, OTPInputContext } from "input-otp";
 import { MinusIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 function InputOTP({
   className,
@@ -68,9 +69,6 @@ function InputOTPSlot({
 
 function InputOTPSeparator({ ...props }: React.ComponentProps<"div">) {
   return (
-    // eslint-disable-next-line jsx-a11y/interactive-supports-focus
-    // eslint-disable-next-line jsx-a11y/prefer-tag-over-role
-    // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
     <div data-slot="input-otp-separator" role="separator" {...props}>
       <MinusIcon />
     </div>

--- a/packages/ui/src/components/input.tsx
+++ b/packages/ui/src/components/input.tsx
@@ -3,6 +3,7 @@
 import type * as React from "react";
 
 import { Input as InputPrimitive } from "@base-ui/react/input";
+
 import { cn } from "@stll/ui/lib/utils";
 
 type InputProps = Omit<

--- a/packages/ui/src/components/label.tsx
+++ b/packages/ui/src/components/label.tsx
@@ -2,6 +2,7 @@
 
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Label({

--- a/packages/ui/src/components/menu.tsx
+++ b/packages/ui/src/components/menu.tsx
@@ -3,8 +3,9 @@
 import type * as React from "react";
 
 import { Menu as MenuPrimitive } from "@base-ui/react/menu";
-import { cn } from "@stll/ui/lib/utils";
 import { ChevronRightIcon } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 const MenuCreateHandle = MenuPrimitive.createHandle;
 

--- a/packages/ui/src/components/pagination.tsx
+++ b/packages/ui/src/components/pagination.tsx
@@ -4,14 +4,15 @@ import type * as React from "react";
 
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
-import { buttonVariants } from "@stll/ui/components/button";
-import type { Button } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
   MoreHorizontalIcon,
 } from "lucide-react";
+
+import { buttonVariants } from "@stll/ui/components/button";
+import type { Button } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
   return (

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
+
 import { cn } from "@stll/ui/lib/utils";
 
 const PopoverCreateHandle = PopoverPrimitive.createHandle;

--- a/packages/ui/src/components/preview-card.tsx
+++ b/packages/ui/src/components/preview-card.tsx
@@ -3,6 +3,7 @@
 import type React from "react";
 
 import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card";
+
 import { cn } from "@stll/ui/lib/utils";
 
 export const PreviewCard: typeof PreviewCardPrimitive.Root =

--- a/packages/ui/src/components/scroll-area.tsx
+++ b/packages/ui/src/components/scroll-area.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function ScrollArea({

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -3,12 +3,13 @@
 import * as React from "react";
 
 import { Select as SelectPrimitive } from "@base-ui/react/select";
-import { cn } from "@stll/ui/lib/utils";
 import {
   ChevronDownIcon,
   ChevronsUpDownIcon,
   ChevronUpIcon,
 } from "lucide-react";
+
+import { cn } from "@stll/ui/lib/utils";
 
 type SelectItemProps = SelectPrimitive.Item.Props & {
   label?: string;

--- a/packages/ui/src/components/separator.tsx
+++ b/packages/ui/src/components/separator.tsx
@@ -1,4 +1,5 @@
 import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
+
 import { cn } from "@stll/ui/lib/utils";
 
 function Separator({

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+
 import { Button } from "@stll/ui/components/button";
 import { ScrollArea } from "@stll/ui/components/scroll-area";
 import { cn } from "@stll/ui/lib/utils";
-import { XIcon } from "lucide-react";
 
 const Sheet = SheetPrimitive.Root;
 

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+
 import { cn } from "@stll/ui/lib/utils";
 
 type TabsVariant = "default" | "underline";

--- a/packages/ui/src/components/textarea.tsx
+++ b/packages/ui/src/components/textarea.tsx
@@ -4,6 +4,7 @@ import type * as React from "react";
 
 import { Field as FieldPrimitive } from "@base-ui/react/field";
 import { mergeProps } from "@base-ui/react/merge-props";
+
 import { cn } from "@stll/ui/lib/utils";
 
 type TextareaProps = React.ComponentProps<"textarea"> & {

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -4,8 +4,6 @@ import * as React from "react";
 
 import { Toast } from "@base-ui/react/toast";
 import type { ToastManagerAddOptions } from "@base-ui/react/toast";
-import { buttonVariants } from "@stll/ui/components/button";
-import { cn } from "@stll/ui/lib/utils";
 import {
   CircleAlertIcon,
   CircleCheckIcon,
@@ -14,6 +12,9 @@ import {
   TriangleAlertIcon,
   XIcon,
 } from "lucide-react";
+
+import { buttonVariants } from "@stll/ui/components/button";
+import { cn } from "@stll/ui/lib/utils";
 
 type ToastData = {
   tooltipStyle?: boolean;

--- a/packages/ui/src/components/tooltip.tsx
+++ b/packages/ui/src/components/tooltip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
+
 import { cn } from "@stll/ui/lib/utils";
 
 const TooltipCreateHandle = TooltipPrimitive.createHandle;


### PR DESCRIPTION
## Summary
- Add `--report-unused-disable-directives-severity=error` to all 14 lint scripts; clean 178 stale `eslint-disable` / `oxlint-disable` directives across 102 files.
- Add `sonarjs/no-array-delete` and `sonarjs/no-alphabetical-sort` (0 findings each, pure prevention).
- Fix dead `@stella/**` import group in `.oxfmtrc.json` -> `@stll/**` (workspace prefix typo). Second commit re-sorts 229 files into the activated group.
- Add `--type-aware` to `packages/docx-utils` lint script and fix the 10 surfaced errors (4 `promise-function-async` in `zip.ts`, 3 `await-thenable` + 3 `no-confusing-void-expression` in `zip.test.ts`).

## Test plan
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean (18/18 packages)
- [x] `bun run format:check` clean
- [x] `bun test` in `packages/docx-utils` (2 pass)
- [ ] CI green