### PR TITLE
chore(api): use monotonic time for /health probe TTL accounting

### DIFF
--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -20,6 +20,17 @@ const PROBE_TIMEOUT_MS = 5000;
 // any drive-by traffic don't translate one-to-one into DB round-trips.
 const PROBE_CACHE_TTL_MS = 5000;
 
+const unrefTimer = (timerId: ReturnType<typeof setTimeout>) => {
+  if (
+    typeof timerId === "object" &&
+    timerId !== null &&
+    "unref" in timerId &&
+    typeof timerId.unref === "function"
+  ) {
+    timerId.unref();
+  }
+};
+
 const runDatabaseProbe = async (): Promise<ProbeOutcome<HealthCheckError>> => {
   let timerId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
@@ -30,7 +41,7 @@ const runDatabaseProbe = async (): Promise<ProbeOutcome<HealthCheckError>> => {
     // `unref` keeps a still-pending timeout from holding the event
     // loop open at shutdown if the race resolves before we reach the
     // clearTimeout below.
-    timerId.unref();
+    unrefTimer(timerId);
   });
   const result = await Result.tryPromise(async () => {
     try {

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -14,6 +14,7 @@ const BUILD_METADATA = {
 };
 
 const PROBE_TIMEOUT_MS = 5000;
+
 // Coalesces concurrent /health calls onto a single in-flight probe and
 // reuses the outcome for this window, so liveness checks (k8s, ALB) and
 // any drive-by traffic don't translate one-to-one into DB round-trips.
@@ -26,13 +27,15 @@ const runDatabaseProbe = async (): Promise<ProbeOutcome<HealthCheckError>> => {
       () => reject(new HealthCheckError({ message: "DB probe timeout" })),
       PROBE_TIMEOUT_MS,
     );
+    // `unref` keeps a still-pending timeout from holding the event
+    // loop open at shutdown if the race resolves before we reach the
+    // clearTimeout below.
+    timerId.unref();
   });
   const result = await Result.tryPromise(async () => {
     try {
       return await Promise.race([probeDatabase(), timeout]);
     } finally {
-      // Whichever side of the race wins, the loser's timer or the
-      // timeout's setTimeout would otherwise hold the event loop open.
       clearTimeout(timerId);
     }
   });

--- a/apps/api/src/lib/health/probe-cache.ts
+++ b/apps/api/src/lib/health/probe-cache.ts
@@ -2,20 +2,25 @@
  * Coalesces calls to a slow probe behind a short-lived cache and an
  * in-flight de-duplication wrapper. Used by `/health` so that a flood
  * of concurrent requests turns into at most one underlying probe per
- * cache window, rather than one probe per request.
+ * cache window, rather than one probe per request. Both successful
+ * and failed outcomes are cached for the same TTL so an outage stays
+ * visible to monitoring without thundering against the dependency.
+ *
+ * TTL accounting uses a monotonic time source so an NTP correction or
+ * VM/container resume that moves wall-clock time backward cannot
+ * extend a cached outcome past its intended window.
  */
 
 export type ProbeOutcome<TError> = { ok: true } | { ok: false; error: TError };
 
-type Cached<TError> = {
-  at: number;
-  outcome: ProbeOutcome<TError>;
-};
-
 export type ProbeCacheOptions = {
   /** Maximum age of a cached outcome before a fresh probe is run. */
   ttlMs: number;
-  /** Wall-clock source. Defaults to `Date.now`; injectable for tests. */
+  /**
+   * Monotonic millisecond source. Defaults to `performance.now()`.
+   * Injectable for tests; supplied implementations must be monotonic
+   * non-decreasing — the cache trusts them without re-checking.
+   */
   now?: () => number;
 };
 
@@ -33,14 +38,15 @@ export const createProbeCache = <TError>(
   options: ProbeCacheOptions,
 ): ProbeCache<TError> => {
   const ttlMs = options.ttlMs;
-  const now = options.now ?? Date.now;
+  const now = options.now ?? (() => performance.now());
 
-  let cached: Cached<TError> | null = null;
+  let cached: { monotonicAt: number; outcome: ProbeOutcome<TError> } | null =
+    null;
   let inflight: Promise<ProbeOutcome<TError>> | null = null;
 
   const run = async (): Promise<ProbeOutcome<TError>> => {
     const t = now();
-    if (cached !== null && t - cached.at < ttlMs) {
+    if (cached !== null && t - cached.monotonicAt < ttlMs) {
       return cached.outcome;
     }
     if (inflight !== null) {
@@ -49,7 +55,7 @@ export const createProbeCache = <TError>(
     inflight = (async () => {
       try {
         const outcome = await probe();
-        cached = { at: now(), outcome };
+        cached = { monotonicAt: now(), outcome };
         return outcome;
       } finally {
         inflight = null;


### PR DESCRIPTION
## Summary
Followup to the recently-merged probe cache.

- Default the cache's time source to \`performance.now()\` so an NTP
  correction or VM/container resume that moves wall-clock time
  backward cannot keep a cached outcome valid past its window.
  The test scaffolding still injects its own monotonic clock.
- Rename \`Cached.at\` to \`monotonicAt\` so the contract is visible at
  the use site, and reword the module / \`now\` doc comments to spell
  out the monotonic guarantee.
- Move the cache-window comment in routes.ts next to the constant it
  describes, and \`unref()\` the probe-timeout timer so a missed
  \`clearTimeout\` can never hold the event loop open at shutdown.

## Test plan
- [x] \`bun test src/lib/health/probe-cache.test.ts\` — 6 passed
- [x] \`bun --filter @stll/api typecheck\` / \`lint\` / \`format --check\`