### PR TITLE
feat(folio): port upstream eigenpal TIFF -> PNG image conversion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -328,6 +328,7 @@
         "prosemirror-tables": "^1.8.5",
         "prosemirror-transform": "^1.12.0",
         "prosemirror-view": "^1.41.8",
+        "utif2": "^4.1.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -3562,6 +3563,8 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
@@ -3995,6 +3998,8 @@
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "unstorage/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "utif2/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -43,7 +43,8 @@
     "prosemirror-state": "^1.4.4",
     "prosemirror-tables": "^1.8.5",
     "prosemirror-transform": "^1.12.0",
-    "prosemirror-view": "^1.41.8"
+    "prosemirror-view": "^1.41.8",
+    "utif2": "^4.1.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -33,6 +33,10 @@ import type {
 import { toArrayBuffer } from "../utils/docxInput";
 import type { DocxInput } from "../utils/docxInput";
 import { loadFontsWithMapping } from "../utils/fontLoader";
+import {
+  convertTiffToPngDataUrl,
+  isTiffMimeType,
+} from "../utils/tiffConverter";
 import { parseComments } from "./commentParser";
 import {
   parseDocumentBody,
@@ -338,6 +342,31 @@ function buildMediaMap(
   for (const [path, data] of raw.media.entries()) {
     const filename = path.split("/").pop() || path;
     const mimeType = getMediaMimeType(path);
+
+    // TIFF: browsers don't render TIFF in <img>, so decode + re-encode as
+    // PNG eagerly. This also flips `mimeType` so consumers see the
+    // effective format. On re-export, the image is written as PNG. If
+    // conversion fails (e.g. headless / no Canvas), fall through to lazy
+    // attachment with the original TIFF mimeType — the round-trip survives
+    // even if the in-browser preview is broken.
+    if (isTiffMimeType(mimeType)) {
+      const pngDataUrl = convertTiffToPngDataUrl(data);
+      if (pngDataUrl) {
+        const mediaFile: MediaFile = {
+          path,
+          filename,
+          mimeType: "image/png",
+          data,
+          dataUrl: pngDataUrl,
+        };
+        media.set(path, mediaFile);
+        const normalizedPath = path.replace(/^word\//, "");
+        if (normalizedPath !== path) {
+          media.set(normalizedPath, mediaFile);
+        }
+        continue;
+      }
+    }
 
     const mediaFile: MediaFile = {
       path,

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -344,20 +344,21 @@ function buildMediaMap(
     const mimeType = getMediaMimeType(path);
 
     // TIFF: browsers don't render TIFF in <img>, so decode + re-encode as
-    // PNG eagerly. This also flips `mimeType` so consumers see the
-    // effective format. On re-export, the image is written as PNG. If
-    // conversion fails (e.g. headless / no Canvas), fall through to lazy
-    // attachment with the original TIFF mimeType — the round-trip survives
-    // even if the in-browser preview is broken.
+    // PNG eagerly. The mimeType, data, and filename extension are all
+    // updated together so re-export writes a PNG file matching its
+    // declared type. If conversion fails (e.g. headless / no Canvas, or
+    // dimensions exceed the safety cap), fall through to lazy attachment
+    // with the original TIFF data — the round-trip survives even if the
+    // in-browser preview is broken.
     if (isTiffMimeType(mimeType)) {
-      const pngDataUrl = convertTiffToPngDataUrl(data);
-      if (pngDataUrl) {
+      const converted = convertTiffToPngDataUrl(data);
+      if (converted) {
         const mediaFile: MediaFile = {
           path,
-          filename,
+          filename: filename.replace(/\.tiff?$/i, ".png"),
           mimeType: "image/png",
-          data,
-          dataUrl: pngDataUrl,
+          data: converted.data,
+          dataUrl: converted.dataUrl,
         };
         media.set(path, mediaFile);
         const normalizedPath = path.replace(/^word\//, "");

--- a/packages/folio/src/core/utils/tiffConverter.ts
+++ b/packages/folio/src/core/utils/tiffConverter.ts
@@ -10,11 +10,28 @@
 
 import * as UTIF from "utif2";
 
+/**
+ * Hard cap on the pixel count we'll attempt to decode. Each pixel costs 4 B
+ * for the intermediate RGBA buffer plus another canvas-managed bitmap, so
+ * 64 MP ≈ 256 MB before counting the PNG re-encode. A crafted TIFF whose
+ * declared dimensions exceed this is rejected without allocating the
+ * RGBA buffer, which would otherwise hang or OOM the tab.
+ */
+const MAX_TIFF_PIXELS = 64_000_000;
+
 export function isTiffMimeType(mimeType: string): boolean {
-  return mimeType === "image/tiff" || mimeType === "image/tif";
+  const lower = mimeType.toLowerCase();
+  return lower === "image/tiff" || lower === "image/tif";
 }
 
-export function convertTiffToPngDataUrl(tiffData: ArrayBuffer): string | null {
+export type ConvertedTiff = {
+  dataUrl: string;
+  data: ArrayBuffer;
+};
+
+export function convertTiffToPngDataUrl(
+  tiffData: ArrayBuffer,
+): ConvertedTiff | null {
   try {
     const ifds = UTIF.decode(tiffData);
     const firstImage = ifds[0];
@@ -22,12 +39,19 @@ export function convertTiffToPngDataUrl(tiffData: ArrayBuffer): string | null {
       return null;
     }
 
-    UTIF.decodeImage(tiffData, firstImage);
-    const rgba = UTIF.toRGBA8(firstImage);
-
+    // Validate dimensions BEFORE the eager RGBA allocation.
     const width = firstImage.width;
     const height = firstImage.height;
-    if (!width || !height || rgba.length === 0) {
+    if (!width || !height) {
+      return null;
+    }
+    if (width * height > MAX_TIFF_PIXELS) {
+      return null;
+    }
+
+    UTIF.decodeImage(tiffData, firstImage);
+    const rgba = UTIF.toRGBA8(firstImage);
+    if (rgba.length === 0) {
       return null;
     }
 
@@ -51,7 +75,29 @@ export function convertTiffToPngDataUrl(tiffData: ArrayBuffer): string | null {
     const imageData = new ImageData(clamped, width, height);
     ctx.putImageData(imageData, 0, 0);
 
-    return canvas.toDataURL("image/png");
+    const dataUrl = canvas.toDataURL("image/png");
+    const data = dataUrlToArrayBuffer(dataUrl);
+    if (!data) {
+      return null;
+    }
+    return { dataUrl, data };
+  } catch {
+    return null;
+  }
+}
+
+function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer | null {
+  const base64 = dataUrl.split(",", 2)[1];
+  if (!base64) {
+    return null;
+  }
+  try {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.codePointAt(i) ?? 0;
+    }
+    return bytes.buffer;
   } catch {
     return null;
   }

--- a/packages/folio/src/core/utils/tiffConverter.ts
+++ b/packages/folio/src/core/utils/tiffConverter.ts
@@ -39,19 +39,31 @@ export function convertTiffToPngDataUrl(
       return null;
     }
 
-    // Validate dimensions BEFORE the eager RGBA allocation.
-    const width = firstImage.width;
-    const height = firstImage.height;
-    if (!width || !height) {
+    // `UTIF.decode()` returns IFDs where dimensions are stored as raw
+    // tags (`t256` = ImageWidth, `t257` = ImageLength); the `width` /
+    // `height` properties on the IFD are populated only after
+    // `UTIF.decodeImage()`. Read from the tags so we can enforce the
+    // pixel cap BEFORE the eager `toRGBA8` allocation runs.
+    const declaredWidth = readTiffTagNumber(firstImage["t256"]);
+    const declaredHeight = readTiffTagNumber(firstImage["t257"]);
+    if (!declaredWidth || !declaredHeight) {
       return null;
     }
-    if (width * height > MAX_TIFF_PIXELS) {
+    if (declaredWidth * declaredHeight > MAX_TIFF_PIXELS) {
       return null;
     }
 
     UTIF.decodeImage(tiffData, firstImage);
     const rgba = UTIF.toRGBA8(firstImage);
     if (rgba.length === 0) {
+      return null;
+    }
+
+    // Use the post-decodeImage dimensions for the canvas — they may
+    // differ from the IFD tags after orientation/strip handling.
+    const width = firstImage.width;
+    const height = firstImage.height;
+    if (!width || !height) {
       return null;
     }
 
@@ -84,6 +96,28 @@ export function convertTiffToPngDataUrl(
   } catch {
     return null;
   }
+}
+
+/**
+ * Read a numeric TIFF tag value. utif2 stores tag values as arrays
+ * (typed or plain), so the cap-check helpers only need the first element.
+ */
+function readTiffTagNumber(tag: unknown): number | undefined {
+  if (typeof tag === "number") {
+    return tag;
+  }
+  if (
+    Array.isArray(tag) ||
+    tag instanceof Uint8Array ||
+    tag instanceof Uint16Array ||
+    tag instanceof Uint32Array
+  ) {
+    const first = tag[0];
+    if (typeof first === "number") {
+      return first;
+    }
+  }
+  return undefined;
 }
 
 function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer | null {

--- a/packages/folio/src/core/utils/tiffConverter.ts
+++ b/packages/folio/src/core/utils/tiffConverter.ts
@@ -1,0 +1,58 @@
+/**
+ * TIFF to PNG Converter
+ *
+ * Browsers don't support TIFF in `<img>` tags, so DOCX-embedded TIFFs are
+ * decoded with utif2 and re-encoded as PNG via the Canvas API. Returns
+ * null in environments without Canvas (Node.js parsing); callers fall
+ * back to the raw TIFF data URL, which won't render in browsers but is
+ * fine for headless round-trips.
+ */
+
+import * as UTIF from "utif2";
+
+export function isTiffMimeType(mimeType: string): boolean {
+  return mimeType === "image/tiff" || mimeType === "image/tif";
+}
+
+export function convertTiffToPngDataUrl(tiffData: ArrayBuffer): string | null {
+  try {
+    const ifds = UTIF.decode(tiffData);
+    const firstImage = ifds[0];
+    if (!firstImage) {
+      return null;
+    }
+
+    UTIF.decodeImage(tiffData, firstImage);
+    const rgba = UTIF.toRGBA8(firstImage);
+
+    const width = firstImage.width;
+    const height = firstImage.height;
+    if (!width || !height || rgba.length === 0) {
+      return null;
+    }
+
+    if (
+      typeof document === "undefined" ||
+      typeof document.createElement !== "function"
+    ) {
+      return null;
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      return null;
+    }
+
+    const clamped = new Uint8ClampedArray(rgba.length);
+    clamped.set(rgba);
+    const imageData = new ImageData(clamped, width, height);
+    ctx.putImageData(imageData, 0, 0);
+
+    return canvas.toDataURL("image/png");
+  } catch {
+    return null;
+  }
+}

--- a/packages/folio/src/core/utils/tiffConverter.ts
+++ b/packages/folio/src/core/utils/tiffConverter.ts
@@ -32,6 +32,16 @@ export type ConvertedTiff = {
 export function convertTiffToPngDataUrl(
   tiffData: ArrayBuffer,
 ): ConvertedTiff | null {
+  // Bail out before any decode if Canvas isn't available — without it we
+  // can't produce a PNG anyway, and `UTIF.decodeImage` + `toRGBA8` would
+  // allocate hundreds of MB and burn CPU for nothing in headless parses.
+  if (
+    typeof document === "undefined" ||
+    typeof document.createElement !== "function"
+  ) {
+    return null;
+  }
+
   try {
     const ifds = UTIF.decode(tiffData);
     const firstImage = ifds[0];
@@ -64,13 +74,6 @@ export function convertTiffToPngDataUrl(
     const width = firstImage.width;
     const height = firstImage.height;
     if (!width || !height) {
-      return null;
-    }
-
-    if (
-      typeof document === "undefined" ||
-      typeof document.createElement !== "function"
-    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary

- Ports eigenpal/docx-editor #146 (commits 0c4486718 + 41f923de4): browsers don't render TIFF in \`<img>\`, so DOCX-embedded TIFFs are decoded with utif2 and re-encoded as PNG via the Canvas API at parse time. The mediaFile's mimeType flips to image/png so consumers see the effective format and re-export writes PNG instead of the raw TIFF.
- Falls back to the lazy raw data URL when Canvas is unavailable (headless parsing) so round-trips still survive without an in-browser preview.

Originally part of an "upstream branch sync" bundle covering four fix branches; the other three (\`feat/column-separator-line\`, \`fix/drag-select-autoscroll\`, \`fix/firefox-right-click-selection\`) were already in folio from earlier syncs, so only TIFF support actually needs porting.

CC on behalf of @jan-kubica.

## Test plan

- [x] Folio typecheck clean.
- [x] Folio lint clean.
- [x] 571/571 folio unit tests pass.
- [ ] Manual playground verification on a DOCX containing a TIFF embedded image (e.g. eigenpal's \`tiff-test.docx\` fixture).