### PR TITLE
feat: jurisdiction-defaulted native tool overrides

### DIFF
--- a/apps/api/drizzle/20260510000000_native-tool-overrides/migration.sql
+++ b/apps/api/drizzle/20260510000000_native-tool-overrides/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "organization_settings" ADD COLUMN "native_tool_overrides" jsonb DEFAULT '{}'::jsonb NOT NULL;
+
+-- Keep disabled_native_tools for rolling deploy and rollback compatibility.
+-- A later release can drop it after all live API versions read native_tool_overrides.
+UPDATE "organization_settings"
+SET "native_tool_overrides" = (
+  SELECT coalesce(jsonb_object_agg(value, false), '{}'::jsonb)
+  FROM jsonb_array_elements_text("disabled_native_tools") AS value
+)
+WHERE jsonb_array_length("disabled_native_tools") > 0;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1748,7 +1748,23 @@ export const organizationSettings = p.pgTable(
       .$type<PracticeJurisdiction[]>()
       .notNull()
       .default([]),
-    /** Native tool slugs the org has disabled in chat. */
+    /**
+     * Per-slug overrides for built-in native tools (e.g. ARES). The
+     * effective state of a tool is `overrides[slug] ?? jurisdictionDefault`,
+     * where the jurisdiction default is whether the tool's
+     * recommended jurisdictions intersect the org's practice
+     * jurisdictions. Absent entries mean "use the default".
+     */
+    nativeToolOverrides: jsonb("native_tool_overrides")
+      .$type<Record<string, boolean>>()
+      .notNull()
+      .default({}),
+    /**
+     * Legacy disable list kept for rolling deploy compatibility. New
+     * code reads nativeToolOverrides; keep writes in sync until a later
+     * migration can drop this column after all deployed versions no
+     * longer read it.
+     */
     disabledNativeTools: jsonb("disabled_native_tools")
       .$type<string[]>()
       .notNull()

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -64,6 +64,7 @@ import {
 } from "@/api/handlers/chat/upload-files";
 import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
 import { createFileKey } from "@/api/handlers/files/utils";
+import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { requireAIAvailable } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -333,12 +334,17 @@ const sendMessage = createSafeRootHandler(
           where: {
             organizationId: { eq: session.activeOrganizationId },
           },
-          columns: { disabledNativeTools: true },
+          columns: {
+            practiceJurisdictions: true,
+            nativeToolOverrides: true,
+          },
         }),
       ),
     );
-    const disabledNativeToolSlugs =
-      orgSettingsForChat?.disabledNativeTools ?? [];
+    const disabledNativeToolSlugs = getDisabledNativeToolSlugs({
+      practiceJurisdictions: orgSettingsForChat?.practiceJurisdictions ?? [],
+      nativeToolOverrides: orgSettingsForChat?.nativeToolOverrides ?? {},
+    });
     // Streaming tools mirror the surface the user is on: only the
     // DOCX file-overlay client knows how to satisfy
     // apply-active-docx-edits (it queues into the review store and

--- a/apps/api/src/handlers/contacts/ares-lookup.ts
+++ b/apps/api/src/handlers/contacts/ares-lookup.ts
@@ -10,8 +10,11 @@ import {
   searchByName,
 } from "@stll/ares";
 
+import { isNativeToolEnabledForOrg } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const ARES_NATIVE_TOOL_SLUG = "ares";
 
 const aresQuerySchema = t.Object({
   ico: t.Optional(t.String({ minLength: 1, maxLength: 11 })),
@@ -23,7 +26,7 @@ const aresLookup = createSafeRootHandler(
     permissions: { workspace: ["read"] },
     query: aresQuerySchema,
   },
-  async function* ({ query }) {
+  async function* ({ query, safeDb, session }) {
     const { ico, name } = query;
 
     if (!ico && !name) {
@@ -40,6 +43,31 @@ const aresLookup = createSafeRootHandler(
         new HandlerError({
           status: 400,
           message: "Provide either 'ico' or 'name', not both",
+        }),
+      );
+    }
+
+    const settings = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.organizationSettings.findFirst({
+          where: { organizationId: { eq: session.activeOrganizationId } },
+          columns: {
+            practiceJurisdictions: true,
+            nativeToolOverrides: true,
+          },
+        }),
+      ),
+    );
+    const aresEnabled = isNativeToolEnabledForOrg({
+      slug: ARES_NATIVE_TOOL_SLUG,
+      practiceJurisdictions: settings?.practiceJurisdictions ?? [],
+      nativeToolOverrides: settings?.nativeToolOverrides ?? {},
+    });
+    if (!aresEnabled) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "ARES lookup is disabled for this organization",
         }),
       );
     }

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  getDisabledNativeToolSlugs,
   getNativeToolCatalog,
   isMcpConnectorRecommendedForPractice,
+  isNativeToolEnabledForOrg,
   mcpConnectorCatalogMetadata,
 } from "@/api/handlers/mcp-connectors/catalog-metadata";
 
@@ -59,5 +61,95 @@ describe("mcpConnectorCatalogMetadata", () => {
         recommendedJurisdictions: ["CZ"],
       }),
     );
+  });
+});
+
+describe("isNativeToolEnabledForOrg", () => {
+  it("defaults ARES on for Czech practice", () => {
+    expect(
+      isNativeToolEnabledForOrg({
+        slug: "ares",
+        practiceJurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        nativeToolOverrides: {},
+      }),
+    ).toBe(true);
+  });
+
+  it("defaults ARES off when CZ is not in practice jurisdictions", () => {
+    expect(
+      isNativeToolEnabledForOrg({
+        slug: "ares",
+        practiceJurisdictions: [{ countryCode: "ES", isPrimary: true }],
+        nativeToolOverrides: {},
+      }),
+    ).toBe(false);
+  });
+
+  it("respects an explicit enable override outside the recommended jurisdiction", () => {
+    expect(
+      isNativeToolEnabledForOrg({
+        slug: "ares",
+        practiceJurisdictions: [{ countryCode: "ES", isPrimary: true }],
+        nativeToolOverrides: { ares: true },
+      }),
+    ).toBe(true);
+  });
+
+  it("respects an explicit disable override inside the recommended jurisdiction", () => {
+    expect(
+      isNativeToolEnabledForOrg({
+        slug: "ares",
+        practiceJurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        nativeToolOverrides: { ares: false },
+      }),
+    ).toBe(false);
+  });
+
+  it("treats unknown slugs as disabled", () => {
+    expect(
+      isNativeToolEnabledForOrg({
+        slug: "nonexistent",
+        practiceJurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        nativeToolOverrides: {},
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("getDisabledNativeToolSlugs", () => {
+  it("returns ARES for an org with no Czech jurisdiction and no overrides", () => {
+    expect(
+      getDisabledNativeToolSlugs({
+        practiceJurisdictions: [{ countryCode: "ES", isPrimary: true }],
+        nativeToolOverrides: {},
+      }),
+    ).toContain("ares");
+  });
+
+  it("does not disable ARES for an org with Czech jurisdiction", () => {
+    expect(
+      getDisabledNativeToolSlugs({
+        practiceJurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        nativeToolOverrides: {},
+      }),
+    ).not.toContain("ares");
+  });
+
+  it("disables ARES when an explicit override turns it off in-jurisdiction", () => {
+    expect(
+      getDisabledNativeToolSlugs({
+        practiceJurisdictions: [{ countryCode: "CZ", isPrimary: true }],
+        nativeToolOverrides: { ares: false },
+      }),
+    ).toContain("ares");
+  });
+
+  it("does not disable ARES when an explicit override turns it on out-of-jurisdiction", () => {
+    expect(
+      getDisabledNativeToolSlugs({
+        practiceJurisdictions: [{ countryCode: "ES", isPrimary: true }],
+        nativeToolOverrides: { ares: true },
+      }),
+    ).not.toContain("ares");
   });
 });

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
@@ -39,18 +39,22 @@ export const NATIVE_TOOL_SLUGS: readonly string[] = NATIVE_TOOL_CATALOG.map(
   (tool) => tool.slug,
 );
 
-const intersectsJurisdictions = (
-  recommendedJurisdictions: readonly string[],
+const toPracticeCountryCodeSet = (
   practiceJurisdictions: readonly PracticeJurisdiction[],
-): boolean => {
-  if (recommendedJurisdictions.length === 0) {
-    return true;
-  }
-  const practiceCountryCodes = new Set(
+): ReadonlySet<string> =>
+  new Set(
     practiceJurisdictions.map((jurisdiction) =>
       jurisdiction.countryCode.toUpperCase(),
     ),
   );
+
+const intersectsJurisdictions = (
+  recommendedJurisdictions: readonly string[],
+  practiceCountryCodes: ReadonlySet<string>,
+): boolean => {
+  if (recommendedJurisdictions.length === 0) {
+    return true;
+  }
   return recommendedJurisdictions.some((countryCode) =>
     practiceCountryCodes.has(countryCode.toUpperCase()),
   );
@@ -61,21 +65,30 @@ const intersectsJurisdictions = (
  * org's practice jurisdictions (or the tool has no jurisdiction
  * recommendation, meaning it's globally relevant).
  */
-const isNativeToolDefaultEnabled = ({
-  slug,
-  practiceJurisdictions,
-}: {
-  slug: string;
-  practiceJurisdictions: readonly PracticeJurisdiction[];
-}): boolean => {
+const isNativeToolDefaultEnabledForCodes = (
+  slug: string,
+  practiceCountryCodes: ReadonlySet<string>,
+): boolean => {
   const tool = NATIVE_TOOL_CATALOG.find((entry) => entry.slug === slug);
   if (!tool) {
     return false;
   }
   return intersectsJurisdictions(
     tool.recommendedJurisdictions,
-    practiceJurisdictions,
+    practiceCountryCodes,
   );
+};
+
+const isNativeToolEnabledForCodes = (
+  slug: string,
+  practiceCountryCodes: ReadonlySet<string>,
+  nativeToolOverrides: Readonly<Record<string, boolean>>,
+): boolean => {
+  const override = nativeToolOverrides[slug];
+  if (typeof override === "boolean") {
+    return override;
+  }
+  return isNativeToolDefaultEnabledForCodes(slug, practiceCountryCodes);
 };
 
 /**
@@ -92,13 +105,12 @@ export const isNativeToolEnabledForOrg = ({
   slug: string;
   practiceJurisdictions: readonly PracticeJurisdiction[];
   nativeToolOverrides: Readonly<Record<string, boolean>>;
-}): boolean => {
-  const override = nativeToolOverrides[slug];
-  if (typeof override === "boolean") {
-    return override;
-  }
-  return isNativeToolDefaultEnabled({ slug, practiceJurisdictions });
-};
+}): boolean =>
+  isNativeToolEnabledForCodes(
+    slug,
+    toPracticeCountryCodeSet(practiceJurisdictions),
+    nativeToolOverrides,
+  );
 
 export const getDisabledNativeToolSlugs = ({
   practiceJurisdictions,
@@ -106,15 +118,17 @@ export const getDisabledNativeToolSlugs = ({
 }: {
   practiceJurisdictions: readonly PracticeJurisdiction[];
   nativeToolOverrides: Readonly<Record<string, boolean>>;
-}): readonly string[] =>
-  NATIVE_TOOL_CATALOG.filter(
+}): readonly string[] => {
+  const practiceCountryCodes = toPracticeCountryCodeSet(practiceJurisdictions);
+  return NATIVE_TOOL_CATALOG.filter(
     (tool) =>
-      !isNativeToolEnabledForOrg({
-        slug: tool.slug,
-        practiceJurisdictions,
+      !isNativeToolEnabledForCodes(
+        tool.slug,
+        practiceCountryCodes,
         nativeToolOverrides,
-      }),
+      ),
   ).map((tool) => tool.slug);
+};
 
 export const mcpConnectorCatalogMetadata = (
   _connector: McpConnectorCatalogSource,
@@ -132,14 +146,10 @@ export const isMcpConnectorRecommendedForPractice = ({
     return false;
   }
 
-  const practiceCountryCodes = new Set(
-    practiceJurisdictions.map((jurisdiction) =>
-      jurisdiction.countryCode.toUpperCase(),
-    ),
-  );
+  const practiceCountryCodes = toPracticeCountryCodeSet(practiceJurisdictions);
 
   return metadata.recommendedJurisdictions.some((countryCode) =>
-    practiceCountryCodes.has(countryCode),
+    practiceCountryCodes.has(countryCode.toUpperCase()),
   );
 };
 
@@ -148,11 +158,7 @@ export const getNativeToolCatalog = ({
 }: {
   practiceJurisdictions: readonly PracticeJurisdiction[];
 }) => {
-  const practiceCountryCodes = new Set(
-    practiceJurisdictions.map((jurisdiction) =>
-      jurisdiction.countryCode.toUpperCase(),
-    ),
-  );
+  const practiceCountryCodes = toPracticeCountryCodeSet(practiceJurisdictions);
 
   return NATIVE_TOOL_CATALOG.map((tool) => ({
     description: tool.description,
@@ -160,7 +166,7 @@ export const getNativeToolCatalog = ({
     documentationUrl: tool.documentationUrl,
     iconUrl: tool.iconUrl,
     isRecommended: tool.recommendedJurisdictions.some((countryCode) =>
-      practiceCountryCodes.has(countryCode),
+      practiceCountryCodes.has(countryCode.toUpperCase()),
     ),
     recommendedJurisdictions: tool.recommendedJurisdictions,
     slug: tool.slug,

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
@@ -52,7 +52,7 @@ const intersectsJurisdictions = (
     ),
   );
   return recommendedJurisdictions.some((countryCode) =>
-    practiceCountryCodes.has(countryCode),
+    practiceCountryCodes.has(countryCode.toUpperCase()),
   );
 };
 

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
@@ -39,6 +39,83 @@ export const NATIVE_TOOL_SLUGS: readonly string[] = NATIVE_TOOL_CATALOG.map(
   (tool) => tool.slug,
 );
 
+const intersectsJurisdictions = (
+  recommendedJurisdictions: readonly string[],
+  practiceJurisdictions: readonly PracticeJurisdiction[],
+): boolean => {
+  if (recommendedJurisdictions.length === 0) {
+    return true;
+  }
+  const practiceCountryCodes = new Set(
+    practiceJurisdictions.map((jurisdiction) =>
+      jurisdiction.countryCode.toUpperCase(),
+    ),
+  );
+  return recommendedJurisdictions.some((countryCode) =>
+    practiceCountryCodes.has(countryCode),
+  );
+};
+
+/**
+ * Default-on iff the tool's recommended jurisdictions intersect the
+ * org's practice jurisdictions (or the tool has no jurisdiction
+ * recommendation, meaning it's globally relevant).
+ */
+const isNativeToolDefaultEnabled = ({
+  slug,
+  practiceJurisdictions,
+}: {
+  slug: string;
+  practiceJurisdictions: readonly PracticeJurisdiction[];
+}): boolean => {
+  const tool = NATIVE_TOOL_CATALOG.find((entry) => entry.slug === slug);
+  if (!tool) {
+    return false;
+  }
+  return intersectsJurisdictions(
+    tool.recommendedJurisdictions,
+    practiceJurisdictions,
+  );
+};
+
+/**
+ * Effective enabled state for a native tool. Explicit per-slug
+ * overrides win over the jurisdiction-derived default, so a Czech
+ * lawyer can still disable ARES and a Spanish lawyer can still
+ * enable it on demand.
+ */
+export const isNativeToolEnabledForOrg = ({
+  slug,
+  practiceJurisdictions,
+  nativeToolOverrides,
+}: {
+  slug: string;
+  practiceJurisdictions: readonly PracticeJurisdiction[];
+  nativeToolOverrides: Readonly<Record<string, boolean>>;
+}): boolean => {
+  const override = nativeToolOverrides[slug];
+  if (typeof override === "boolean") {
+    return override;
+  }
+  return isNativeToolDefaultEnabled({ slug, practiceJurisdictions });
+};
+
+export const getDisabledNativeToolSlugs = ({
+  practiceJurisdictions,
+  nativeToolOverrides,
+}: {
+  practiceJurisdictions: readonly PracticeJurisdiction[];
+  nativeToolOverrides: Readonly<Record<string, boolean>>;
+}): readonly string[] =>
+  NATIVE_TOOL_CATALOG.filter(
+    (tool) =>
+      !isNativeToolEnabledForOrg({
+        slug: tool.slug,
+        practiceJurisdictions,
+        nativeToolOverrides,
+      }),
+  ).map((tool) => tool.slug);
+
 export const mcpConnectorCatalogMetadata = (
   _connector: McpConnectorCatalogSource,
 ): McpConnectorCatalogMetadata => ({ recommendedJurisdictions: [] });

--- a/apps/api/src/handlers/mcp-connectors/list-connectors.ts
+++ b/apps/api/src/handlers/mcp-connectors/list-connectors.ts
@@ -5,6 +5,7 @@ import { mcpConnectors } from "@/api/db/schema";
 import {
   getNativeToolCatalog,
   isMcpConnectorRecommendedForPractice,
+  isNativeToolEnabledForOrg,
   mcpConnectorCatalogMetadata,
 } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { mcpConnectorUrlIdentity } from "@/api/handlers/mcp-connectors/url-normalization";
@@ -56,13 +57,13 @@ const listMcpConnectors = createSafeRootHandler(
           },
           columns: {
             practiceJurisdictions: true,
-            disabledNativeTools: true,
+            nativeToolOverrides: true,
           },
         }),
       ),
     );
     const practiceJurisdictions = settings?.practiceJurisdictions ?? [];
-    const disabledNativeTools = new Set(settings?.disabledNativeTools);
+    const nativeToolOverrides = settings?.nativeToolOverrides ?? {};
 
     return Result.ok({
       canManageCustomConnectors: ["admin", "owner"].includes(memberRole.role),
@@ -91,7 +92,11 @@ const listMcpConnectors = createSafeRootHandler(
       }),
       nativeTools: getNativeToolCatalog({ practiceJurisdictions }).map(
         (tool) => {
-          const enabled = !disabledNativeTools.has(tool.slug);
+          const enabled = isNativeToolEnabledForOrg({
+            slug: tool.slug,
+            practiceJurisdictions,
+            nativeToolOverrides,
+          });
           return {
             description: tool.description,
             displayName: tool.displayName,

--- a/apps/api/src/handlers/mcp-connectors/update-native-tool.ts
+++ b/apps/api/src/handlers/mcp-connectors/update-native-tool.ts
@@ -31,16 +31,20 @@ const updateNativeTool = createSafeRootHandler(
       );
     }
 
-    // Atomic upsert: the INSERT carries the post-mutation value as a
-    // one- or zero-element array; the ON CONFLICT branch derives the
-    // next list from the row's current value via JSONB operators
-    // under PG's row lock, so concurrent toggles can't overwrite
-    // each other (no read-modify-write on the application side).
+    // Atomic upsert: the INSERT seeds the overrides map with a
+    // single key; the ON CONFLICT branch merges over the row's
+    // current value via JSONB concatenation under PG's row lock,
+    // so concurrent toggles can't overwrite each other (no
+    // read-modify-write on the application side). Keep the legacy
+    // disabled_native_tools list in sync until the rollout-safe
+    // follow-up migration drops it.
     const slug = params.slug;
-    const insertValue = body.enabled
+    const overrideEntry = sql`jsonb_build_object(${slug}::text, ${body.enabled}::boolean)`;
+    const updateExpr = sql`coalesce("organization_settings"."native_tool_overrides", '{}'::jsonb) || ${overrideEntry}`;
+    const legacyInsertValue = body.enabled
       ? sql`'[]'::jsonb`
       : sql`jsonb_build_array(${slug}::text)`;
-    const updateExpr = body.enabled
+    const legacyUpdateExpr = body.enabled
       ? sql`coalesce("organization_settings"."disabled_native_tools" - ${slug}::text, '[]'::jsonb)`
       : sql`(
           select coalesce(jsonb_agg(distinct value), '[]'::jsonb)
@@ -56,12 +60,14 @@ const updateNativeTool = createSafeRootHandler(
           .insert(organizationSettings)
           .values({
             organizationId: session.activeOrganizationId,
-            disabledNativeTools: insertValue,
+            nativeToolOverrides: overrideEntry,
+            disabledNativeTools: legacyInsertValue,
           })
           .onConflictDoUpdate({
             target: organizationSettings.organizationId,
             set: {
-              disabledNativeTools: updateExpr,
+              nativeToolOverrides: updateExpr,
+              disabledNativeTools: legacyUpdateExpr,
               updatedAt: new Date(),
             },
           })

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -67,6 +67,9 @@ import {
   contactsKeys,
   contactsOptions,
 } from "@/routes/_protected.contacts/-queries";
+import { mcpConnectorsOptions } from "@/routes/_protected.knowledge/-queries";
+
+const ARES_NATIVE_TOOL_SLUG = "ares";
 
 type ContactFilter = "all" | "person" | "organization";
 
@@ -474,6 +477,10 @@ const CreateContactDialog = ({
     useState<BillingAddress | null>(null);
   const createContact = useCreateContact();
   const schema = createContactSchema(t("common.required"));
+  const { data: mcpCatalog } = useQuery(mcpConnectorsOptions());
+  const isAresEnabled =
+    mcpCatalog?.nativeTools.find((tool) => tool.slug === ARES_NATIVE_TOOL_SLUG)
+      ?.enabled ?? false;
 
   const form = useForm({
     defaultValues: {
@@ -729,59 +736,77 @@ const CreateContactDialog = ({
                   )}
                 </form.Field>
 
-                <div className="bg-muted/20 flex flex-col gap-3 rounded-md border p-3">
-                  <div>
-                    <p className="text-sm font-medium">
-                      {t("contacts.create.aresTitle")}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {t("contacts.create.aresHint")}
-                    </p>
+                {isAresEnabled ? (
+                  <div className="bg-muted/20 flex flex-col gap-3 rounded-md border p-3">
+                    <div>
+                      <p className="text-sm font-medium">
+                        {t("contacts.create.aresTitle")}
+                      </p>
+                      <p className="text-muted-foreground text-xs">
+                        {t("contacts.create.aresHint")}
+                      </p>
+                    </div>
+                    <form.Field name="registrationNumber">
+                      {(field) => (
+                        <Field name={field.name}>
+                          <div className="flex gap-2">
+                            <Input
+                              inputMode="numeric"
+                              onBlur={field.handleBlur}
+                              onChange={(e) => {
+                                field.handleChange(
+                                  normalizeIcoInput(e.target.value),
+                                );
+                                setAresBillingAddress(null);
+                              }}
+                              placeholder={t("contacts.create.icoPlaceholder")}
+                              value={field.state.value}
+                            />
+                            <Button
+                              loading={isAresLoading}
+                              onClick={() => {
+                                void handleAresLookup();
+                              }}
+                              type="button"
+                              variant="outline"
+                            >
+                              {t("contacts.create.aresLookup")}
+                            </Button>
+                          </div>
+                          <FieldError />
+                        </Field>
+                      )}
+                    </form.Field>
+                    {aresBillingAddress?.line1 && (
+                      <p className="text-muted-foreground text-xs">
+                        {[
+                          aresBillingAddress.line1,
+                          aresBillingAddress.city,
+                          aresBillingAddress.postalCode,
+                          aresBillingAddress.country,
+                        ]
+                          .filter(Boolean)
+                          .join(", ")}
+                      </p>
+                    )}
                   </div>
+                ) : (
                   <form.Field name="registrationNumber">
                     {(field) => (
                       <Field name={field.name}>
-                        <div className="flex gap-2">
-                          <Input
-                            inputMode="numeric"
-                            onBlur={field.handleBlur}
-                            onChange={(e) => {
-                              field.handleChange(
-                                normalizeIcoInput(e.target.value),
-                              );
-                              setAresBillingAddress(null);
-                            }}
-                            placeholder={t("contacts.create.icoPlaceholder")}
-                            value={field.state.value}
-                          />
-                          <Button
-                            loading={isAresLoading}
-                            onClick={() => {
-                              void handleAresLookup();
-                            }}
-                            type="button"
-                            variant="outline"
-                          >
-                            {t("contacts.create.aresLookup")}
-                          </Button>
-                        </div>
+                        <FieldLabel>
+                          {t("contacts.fields.registrationNumber")}
+                        </FieldLabel>
+                        <Input
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          value={field.state.value}
+                        />
                         <FieldError />
                       </Field>
                     )}
                   </form.Field>
-                  {aresBillingAddress?.line1 && (
-                    <p className="text-muted-foreground text-xs">
-                      {[
-                        aresBillingAddress.line1,
-                        aresBillingAddress.city,
-                        aresBillingAddress.postalCode,
-                        aresBillingAddress.country,
-                      ]
-                        .filter(Boolean)
-                        .join(", ")}
-                    </p>
-                  )}
-                </div>
+                )}
               </>
             )}
 


### PR DESCRIPTION
## Summary
- Replace `disabled_native_tools: string[]` with `native_tool_overrides: Record<slug, boolean>`. Effective state = `override ?? recommendedJurisdictions ∩ practiceJurisdictions ≠ ∅`. ARES defaults on for CZ, off elsewhere; admins can override either way via the existing toggle.
- Gate contacts ARES lookup endpoint + create dialog on the same effective state.
- Drop ARES from the live chat tool set when effectively disabled. Validation tools still include it so prior tool messages parse.

## Test plan
- [ ] Czech-jurisdiction org: ARES card visible in contact create; lookup works; toggling off hides the card and returns 403 from the endpoint.
- [ ] Non-CZ org: ARES card hidden; toggling on in MCP settings re-enables card and endpoint.
- [ ] Chat: ARES tool unavailable when effectively disabled; available after admin opt-in.
- [ ] Existing rows with `disabled_native_tools = ["ares"]` migrate to `native_tool_overrides = {"ares": false}`.