### PR TITLE
chore(api): resolve audit-log client IP via trusted-proxy check

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -110,6 +110,16 @@ const envApi = createEnv({
     ),
     EXTENSION_ORIGIN: v.optional(v.string()),
 
+    /**
+     * Comma-separated CIDRs of proxies the API may trust to set
+     * `cf-connecting-ip`, `x-real-ip`, or `x-forwarded-for` headers.
+     * Typical value covers Cloudflare's published IP ranges and any
+     * load balancers in front of the API. Unset (the default) means
+     * no proxy is trusted and the audit log records the socket peer
+     * directly.
+     */
+    STELLA_TRUSTED_PROXY_CIDRS: v.optional(v.string()),
+
     // Social login — Google
     GOOGLE_AUTH_CLIENT_ID: v.optional(v.string()),
     GOOGLE_AUTH_CLIENT_SECRET: v.optional(v.string()),

--- a/apps/api/src/handlers/entities/create.ts
+++ b/apps/api/src/handlers/entities/create.ts
@@ -200,7 +200,15 @@ const config = {
 
 const createEntities = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* createEntitiesHandler({
       safeDb,
       workspaceId,
@@ -210,6 +218,7 @@ const createEntities = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/entities/delete.ts
+++ b/apps/api/src/handlers/entities/delete.ts
@@ -178,7 +178,15 @@ const config = {
 
 const deleteEntities = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* deleteEntitiesHandler({
       safeDb,
       organizationId: session.activeOrganizationId,
@@ -188,6 +196,7 @@ const deleteEntities = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/entities/duplicate.ts
+++ b/apps/api/src/handlers/entities/duplicate.ts
@@ -455,7 +455,15 @@ const config = {
 
 const duplicateEntity = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* duplicateEntityHandler({
       safeDb,
       workspaceId,
@@ -465,6 +473,7 @@ const duplicateEntity = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/entities/move.ts
+++ b/apps/api/src/handlers/entities/move.ts
@@ -247,7 +247,15 @@ const config = {
 
 const moveEntity = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* moveEntityHandler({
       safeDb,
       workspaceId,
@@ -256,6 +264,7 @@ const moveEntity = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/entities/rename.ts
+++ b/apps/api/src/handlers/entities/rename.ts
@@ -155,7 +155,15 @@ const config = {
 
 const renameEntity = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* renameEntityHandler({
       safeDb,
       workspaceId,
@@ -164,6 +172,7 @@ const renameEntity = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/entities/upload.ts
+++ b/apps/api/src/handlers/entities/upload.ts
@@ -332,7 +332,15 @@ const config = {
 
 const uploadEntity = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     return yield* uploadEntityHandler({
       safeDb,
       organizationId: session.activeOrganizationId,
@@ -343,6 +351,7 @@ const uploadEntity = createSafeHandler(
         workspaceId,
         userId: user.id,
         request,
+        server,
       }),
       body,
     });

--- a/apps/api/src/handlers/organization-settings/update-practice-jurisdictions.ts
+++ b/apps/api/src/handlers/organization-settings/update-practice-jurisdictions.ts
@@ -68,7 +68,7 @@ const normalizePracticeJurisdictions = (
 
 const updatePracticeJurisdictions = createSafeRootHandler(
   config,
-  async function* ({ safeDb, session, user, request, body }) {
+  async function* ({ safeDb, session, user, request, server, body }) {
     const primaryCount = body.practiceJurisdictions.filter(
       (jurisdiction) => jurisdiction.isPrimary,
     ).length;
@@ -114,6 +114,7 @@ const updatePracticeJurisdictions = createSafeRootHandler(
               organizationId: session.activeOrganizationId,
               userId: user.id,
               request,
+              server,
             }),
             action: AUDIT_ACTION.UPDATE,
             resourceType: AUDIT_RESOURCE_TYPE.ORGANIZATION_SETTINGS,

--- a/apps/api/src/handlers/properties/create.ts
+++ b/apps/api/src/handlers/properties/create.ts
@@ -100,7 +100,15 @@ const createDefaultTool = ({
 
 const createProperty = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     let content: PropertyContent | null = null;
     let tool: PropertyTool | null = null;
     const defaultTool = () =>
@@ -255,6 +263,7 @@ const createProperty = createSafeHandler(
               workspaceId,
               userId: user.id,
               request,
+              server,
             }),
             action: AUDIT_ACTION.CREATE,
             resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,

--- a/apps/api/src/handlers/properties/delete-by-id.ts
+++ b/apps/api/src/handlers/properties/delete-by-id.ts
@@ -28,6 +28,7 @@ const deleteProperty = createSafeHandler(
     workspaceId,
     user,
     request,
+    server,
     params: { propertyId },
   }) {
     const deleteResult = await safeDb(async (tx) => {
@@ -90,6 +91,7 @@ const deleteProperty = createSafeHandler(
             workspaceId,
             userId: user.id,
             request,
+            server,
           }),
           action: AUDIT_ACTION.DELETE,
           resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,

--- a/apps/api/src/handlers/properties/update-by-id.ts
+++ b/apps/api/src/handlers/properties/update-by-id.ts
@@ -163,6 +163,7 @@ const updateProperty = createSafeHandler(
     workspaceId,
     user,
     request,
+    server,
     params: { propertyId },
     body,
   }) {
@@ -324,6 +325,7 @@ const updateProperty = createSafeHandler(
               workspaceId,
               userId: user.id,
               request,
+              server,
             }),
             action: AUDIT_ACTION.UPDATE,
             resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,

--- a/apps/api/src/handlers/workspaces/create.ts
+++ b/apps/api/src/handlers/workspaces/create.ts
@@ -55,7 +55,7 @@ const config = {
 
 const createWorkspaces = createSafeRootHandler(
   config,
-  async function* ({ safeDb, session, user, request, body }) {
+  async function* ({ safeDb, session, user, request, server, body }) {
     const txResult = yield* Result.await(
       safeDb(async (tx) => {
         const organizationId = session.activeOrganizationId;
@@ -247,6 +247,7 @@ const createWorkspaces = createSafeRootHandler(
               workspaceId,
               userId: user.id,
               request,
+              server,
             }),
             action: AUDIT_ACTION.CREATE,
             resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,

--- a/apps/api/src/handlers/workspaces/delete-by-id.ts
+++ b/apps/api/src/handlers/workspaces/delete-by-id.ts
@@ -66,7 +66,15 @@ const config = {
 const deleteWorkspace = createSafeHandler(
   config,
   // eslint-disable-next-line require-yield -- manual Result.isError checks preserve rollback semantics
-  async function* ({ scopedDb, safeDb, workspaceId, session, user, request }) {
+  async function* ({
+    scopedDb,
+    safeDb,
+    workspaceId,
+    session,
+    user,
+    request,
+    server,
+  }) {
     const organizationId = session.activeOrganizationId;
 
     // Seal workspace: no new uploads.
@@ -228,6 +236,7 @@ const deleteWorkspace = createSafeHandler(
             workspaceId,
             userId: user.id,
             request,
+            server,
           }),
           action: AUDIT_ACTION.DELETE,
           resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,

--- a/apps/api/src/handlers/workspaces/update-by-id.ts
+++ b/apps/api/src/handlers/workspaces/update-by-id.ts
@@ -47,7 +47,15 @@ const config = {
 
 const updateWorkspace = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     const txResult = await safeDb(async (tx) => {
       const workspaceRows = await tx
         .select({
@@ -223,6 +231,7 @@ const updateWorkspace = createSafeHandler(
             workspaceId,
             userId: user.id,
             request,
+            server,
           }),
           action: AUDIT_ACTION.UPDATE,
           resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,

--- a/apps/api/src/handlers/workspaces/workspace-members-add.ts
+++ b/apps/api/src/handlers/workspaces/workspace-members-add.ts
@@ -27,7 +27,15 @@ const config = {
 
 const addWorkspaceMember = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, request, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    request,
+    server,
+    body,
+  }) {
     // Verify user is a member of the organization.
     // `member` is an org-level auth table (no RLS policy);
     // safeDb works for querying it.
@@ -98,6 +106,7 @@ const addWorkspaceMember = createSafeHandler(
             workspaceId,
             userId: user.id,
             request,
+            server,
           }),
           action: AUDIT_ACTION.UPDATE,
           resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -1,6 +1,11 @@
 import type { Transaction } from "@/api/db";
 import { auditLogs } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
+import { resolveClientIp } from "@/api/lib/client-ip";
+
+type ServerLike = {
+  requestIP: (request: Request) => { address: string } | null;
+};
 
 export const AUDIT_ACTION = {
   CREATE: "create",
@@ -35,6 +40,7 @@ type CreateAuditContextOptions = {
   workspaceId?: SafeId<"workspace"> | null;
   userId: SafeId<"user">;
   request: Request;
+  server: ServerLike | null;
 };
 
 type AuditEntry = AuditContext & {
@@ -42,15 +48,6 @@ type AuditEntry = AuditContext & {
   resourceType: AuditResourceType;
   resourceId: string;
   changes?: AuditChanges | null;
-};
-
-const firstForwardedIp = (forwardedFor: string | null): string | null => {
-  if (!forwardedFor) {
-    return null;
-  }
-
-  const first = forwardedFor.split(",").at(0)?.trim();
-  return first && first.length > 0 ? first : null;
 };
 
 const nullableHeader = (headers: Headers, name: string): string | null => {
@@ -63,22 +60,20 @@ export const createAuditContext = ({
   workspaceId = null,
   userId,
   request,
-}: CreateAuditContextOptions): AuditContext => {
-  const forwardedFor = nullableHeader(request.headers, "x-forwarded-for");
-  const realIp = nullableHeader(request.headers, "x-real-ip");
-  const cloudflareIp = nullableHeader(request.headers, "cf-connecting-ip");
-
-  return {
-    organizationId,
-    workspaceId,
-    userId,
-    metadata: {
-      ipAddress: cloudflareIp ?? realIp ?? firstForwardedIp(forwardedFor),
-      forwardedFor,
-      userAgent: nullableHeader(request.headers, "user-agent"),
-    },
-  };
-};
+  server,
+}: CreateAuditContextOptions): AuditContext => ({
+  organizationId,
+  workspaceId,
+  userId,
+  metadata: {
+    ipAddress: resolveClientIp(request, server),
+    // The raw forwarded-for chain stays in metadata for forensic
+    // inspection, even though `ipAddress` only trusts it when the
+    // socket peer is in the configured proxy set.
+    forwardedFor: nullableHeader(request.headers, "x-forwarded-for"),
+    userAgent: nullableHeader(request.headers, "user-agent"),
+  },
+});
 
 export const writeAuditLog = async (
   entry: AuditEntry | AuditEntry[],

--- a/apps/api/src/lib/client-ip.test.ts
+++ b/apps/api/src/lib/client-ip.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isTrustedProxy,
+  parseTrustedProxies,
+  resolveClientIp,
+} from "@/api/lib/client-ip";
+
+const fakeServer = (peer: string | null) => ({
+  requestIP: () => (peer === null ? null : { address: peer }),
+});
+
+describe("parseTrustedProxies", () => {
+  test("returns an empty block list for an unset value", () => {
+    const trusted = parseTrustedProxies(undefined);
+    expect(isTrustedProxy("1.2.3.4", trusted)).toBe(false);
+    expect(isTrustedProxy("::1", trusted)).toBe(false);
+  });
+
+  test("accepts comma-separated IPv4 CIDRs", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8, 192.168.0.0/16");
+    expect(isTrustedProxy("10.5.5.5", trusted)).toBe(true);
+    expect(isTrustedProxy("192.168.1.1", trusted)).toBe(true);
+    expect(isTrustedProxy("172.16.0.1", trusted)).toBe(false);
+  });
+
+  test("treats a bare IPv4 address as a /32", () => {
+    const trusted = parseTrustedProxies("203.0.113.7");
+    expect(isTrustedProxy("203.0.113.7", trusted)).toBe(true);
+    expect(isTrustedProxy("203.0.113.8", trusted)).toBe(false);
+  });
+
+  test("accepts IPv6 CIDRs and bare addresses", () => {
+    const trusted = parseTrustedProxies("2001:db8::/32, ::1");
+    expect(isTrustedProxy("2001:db8:abcd::1", trusted)).toBe(true);
+    expect(isTrustedProxy("::1", trusted)).toBe(true);
+    expect(isTrustedProxy("fe80::1", trusted)).toBe(false);
+  });
+
+  test("skips malformed entries without crashing", () => {
+    const trusted = parseTrustedProxies("not-an-ip, 10.0.0.0/8, /99");
+    expect(isTrustedProxy("10.1.2.3", trusted)).toBe(true);
+    expect(isTrustedProxy("0.0.0.0", trusted)).toBe(false);
+  });
+});
+
+describe("resolveClientIp", () => {
+  const request = (headers: Record<string, string> = {}) =>
+    new Request("https://example/test", { headers });
+
+  test("returns null when the runtime exposes no socket peer", () => {
+    expect(
+      resolveClientIp(request(), fakeServer(null), {
+        trusted: parseTrustedProxies("10.0.0.0/8"),
+      }),
+    ).toBeNull();
+  });
+
+  test("returns the socket peer when no proxy is trusted", () => {
+    const trusted = parseTrustedProxies(undefined);
+    expect(
+      resolveClientIp(
+        request({ "cf-connecting-ip": "8.8.8.8" }),
+        fakeServer("203.0.113.7"),
+        { trusted },
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  test("ignores forwarded headers when peer is outside the trusted set", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8");
+    expect(
+      resolveClientIp(
+        request({
+          "cf-connecting-ip": "8.8.8.8",
+          "x-real-ip": "9.9.9.9",
+          "x-forwarded-for": "10.10.10.10",
+        }),
+        fakeServer("203.0.113.7"),
+        { trusted },
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  test("trusts cf-connecting-ip when peer is inside the trusted set", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8");
+    expect(
+      resolveClientIp(
+        request({
+          "cf-connecting-ip": "8.8.8.8",
+          "x-real-ip": "9.9.9.9",
+          "x-forwarded-for": "10.10.10.10",
+        }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("8.8.8.8");
+  });
+
+  test("falls back to x-real-ip then x-forwarded-for first hop", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8");
+    expect(
+      resolveClientIp(
+        request({ "x-real-ip": "9.9.9.9" }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("9.9.9.9");
+    expect(
+      resolveClientIp(
+        request({ "x-forwarded-for": "8.8.8.8, 10.0.0.1" }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("8.8.8.8");
+  });
+
+  test("returns the trusted-proxy peer when all forwarded headers are missing", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8");
+    expect(
+      resolveClientIp(request(), fakeServer("10.1.2.3"), { trusted }),
+    ).toBe("10.1.2.3");
+  });
+});

--- a/apps/api/src/lib/client-ip.test.ts
+++ b/apps/api/src/lib/client-ip.test.ts
@@ -38,9 +38,13 @@ describe("parseTrustedProxies", () => {
   });
 
   test("skips malformed entries without crashing", () => {
-    const trusted = parseTrustedProxies("not-an-ip, 10.0.0.0/8, /99");
+    const trusted = parseTrustedProxies(
+      "not-an-ip, 10.0.0.0/8, /24, 1.2.3.4/, 192.168.0.0 / 16",
+    );
     expect(isTrustedProxy("10.1.2.3", trusted)).toBe(true);
+    expect(isTrustedProxy("192.168.1.1", trusted)).toBe(true);
     expect(isTrustedProxy("0.0.0.0", trusted)).toBe(false);
+    expect(isTrustedProxy("8.8.8.8", trusted)).toBe(false);
   });
 });
 
@@ -97,7 +101,7 @@ describe("resolveClientIp", () => {
     ).toBe("8.8.8.8");
   });
 
-  test("falls back to x-real-ip then x-forwarded-for first hop", () => {
+  test("falls back to x-real-ip then the first untrusted x-forwarded-for hop", () => {
     const trusted = parseTrustedProxies("10.0.0.0/8");
     expect(
       resolveClientIp(
@@ -108,11 +112,42 @@ describe("resolveClientIp", () => {
     ).toBe("9.9.9.9");
     expect(
       resolveClientIp(
-        request({ "x-forwarded-for": "8.8.8.8, 10.0.0.1" }),
+        request({ "x-forwarded-for": "9.9.9.9, 198.51.100.23" }),
         fakeServer("10.1.2.3"),
         { trusted },
       ),
-    ).toBe("8.8.8.8");
+    ).toBe("198.51.100.23");
+  });
+
+  test("walks x-forwarded-for backwards through trusted proxies", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8, 192.168.0.0/16");
+    expect(
+      resolveClientIp(
+        request({
+          "x-forwarded-for": "203.0.113.9, 192.168.1.20, 10.2.3.4",
+        }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("203.0.113.9");
+  });
+
+  test("ignores malformed forwarded header values", () => {
+    const trusted = parseTrustedProxies("10.0.0.0/8");
+    expect(
+      resolveClientIp(
+        request({ "cf-connecting-ip": "not-an-ip", "x-real-ip": "also-bad" }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("10.1.2.3");
+    expect(
+      resolveClientIp(
+        request({ "x-forwarded-for": "203.0.113.9, not-an-ip" }),
+        fakeServer("10.1.2.3"),
+        { trusted },
+      ),
+    ).toBe("10.1.2.3");
   });
 
   test("returns the trusted-proxy peer when all forwarded headers are missing", () => {

--- a/apps/api/src/lib/client-ip.ts
+++ b/apps/api/src/lib/client-ip.ts
@@ -15,7 +15,7 @@
  * front of the API). When the variable is unset, no proxy is
  * trusted: forwarded headers are ignored.
  */
-import { BlockList, isIPv6 } from "node:net";
+import { BlockList, isIP, isIPv6 } from "node:net";
 
 import { env } from "@/api/env";
 
@@ -38,12 +38,20 @@ export const parseTrustedProxies = (
     .map((part) => part.trim())
     .filter((part) => part.length > 0)) {
     const slashIndex = entry.indexOf("/");
-    const ip = slashIndex === -1 ? entry : entry.slice(0, slashIndex);
-    const prefixText = slashIndex === -1 ? null : entry.slice(slashIndex + 1);
-    const family: "ipv4" | "ipv6" = isIPv6(ip) ? "ipv6" : "ipv4";
+    const ip = (slashIndex === -1 ? entry : entry.slice(0, slashIndex)).trim();
+    const prefixText =
+      slashIndex === -1 ? null : entry.slice(slashIndex + 1).trim();
+    if (ip.length === 0 || prefixText === "") {
+      continue;
+    }
+    const ipVersion = isIP(ip);
+    if (ipVersion === 0) {
+      continue;
+    }
+    const family: "ipv4" | "ipv6" = ipVersion === 6 ? "ipv6" : "ipv4";
     const defaultPrefix = family === "ipv6" ? 128 : 32;
     const prefix = prefixText === null ? defaultPrefix : Number(prefixText);
-    if (!Number.isFinite(prefix) || prefix < 0 || prefix > defaultPrefix) {
+    if (!Number.isInteger(prefix) || prefix < 0 || prefix > defaultPrefix) {
       continue;
     }
     try {
@@ -77,12 +85,44 @@ const getTrustedProxies = (): TrustedProxies => {
   return cachedTrustedProxies;
 };
 
-const firstForwardedIp = (forwardedFor: string | null): string | null => {
+const nullableIpHeader = (headers: Headers, name: string): string | null => {
+  const value = headers.get(name)?.trim();
+  if (!value || isIP(value) === 0) {
+    return null;
+  }
+  return value;
+};
+
+const clientIpFromForwardedFor = (
+  forwardedFor: string | null,
+  peer: string,
+  trusted: TrustedProxies,
+): string | null => {
   if (!forwardedFor) {
     return null;
   }
-  const first = forwardedFor.split(",").at(0)?.trim();
-  return first && first.length > 0 ? first : null;
+  const ips = forwardedFor
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  if (ips.length === 0) {
+    return null;
+  }
+
+  let clientIp = peer;
+  for (let index = ips.length - 1; index >= 0; index -= 1) {
+    if (!isTrustedProxy(clientIp, trusted)) {
+      break;
+    }
+
+    const nextIp = ips.at(index);
+    if (!nextIp || isIP(nextIp) === 0) {
+      return null;
+    }
+    clientIp = nextIp;
+  }
+
+  return clientIp === peer ? null : clientIp;
 };
 
 /**
@@ -103,15 +143,19 @@ export const resolveClientIp = (
   if (!isTrustedProxy(peer, trusted)) {
     return peer;
   }
-  const cf = request.headers.get("cf-connecting-ip")?.trim();
+  const cf = nullableIpHeader(request.headers, "cf-connecting-ip");
   if (cf) {
     return cf;
   }
-  const real = request.headers.get("x-real-ip")?.trim();
+  const real = nullableIpHeader(request.headers, "x-real-ip");
   if (real) {
     return real;
   }
-  const xff = firstForwardedIp(request.headers.get("x-forwarded-for"));
+  const xff = clientIpFromForwardedFor(
+    request.headers.get("x-forwarded-for"),
+    peer,
+    trusted,
+  );
   if (xff) {
     return xff;
   }

--- a/apps/api/src/lib/client-ip.ts
+++ b/apps/api/src/lib/client-ip.ts
@@ -1,0 +1,119 @@
+/**
+ * Resolves the client IP for a request, refusing to trust
+ * `cf-connecting-ip` / `x-real-ip` / `x-forwarded-for` headers unless
+ * the request actually arrived through a trusted proxy.
+ *
+ * The TCP socket's peer address is the only thing we can rely on by
+ * default: a header value can be set to anything by the caller, but
+ * the socket peer is set by the kernel from the actual handshake.
+ * We therefore only honour forwarded-IP headers when that peer is in
+ * the configured trusted-proxy set; otherwise we record the peer
+ * address itself.
+ *
+ * Operators populate the trusted set via `STELLA_TRUSTED_PROXY_CIDRS`
+ * (comma-separated CIDRs covering the load balancers and CDNs in
+ * front of the API). When the variable is unset, no proxy is
+ * trusted: forwarded headers are ignored.
+ */
+import { BlockList, isIPv6 } from "node:net";
+
+import { env } from "@/api/env";
+
+type ServerLike = {
+  requestIP: (request: Request) => { address: string } | null;
+};
+
+export type TrustedProxies = { blockList: BlockList };
+
+export const parseTrustedProxies = (
+  value: string | null | undefined,
+): TrustedProxies => {
+  const blockList = new BlockList();
+  if (!value) {
+    return { blockList };
+  }
+
+  for (const entry of value
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)) {
+    const slashIndex = entry.indexOf("/");
+    const ip = slashIndex === -1 ? entry : entry.slice(0, slashIndex);
+    const prefixText = slashIndex === -1 ? null : entry.slice(slashIndex + 1);
+    const family: "ipv4" | "ipv6" = isIPv6(ip) ? "ipv6" : "ipv4";
+    const defaultPrefix = family === "ipv6" ? 128 : 32;
+    const prefix = prefixText === null ? defaultPrefix : Number(prefixText);
+    if (!Number.isFinite(prefix) || prefix < 0 || prefix > defaultPrefix) {
+      continue;
+    }
+    try {
+      blockList.addSubnet(ip, prefix, family);
+    } catch {
+      // Malformed entry — skip rather than crash boot. Operators get
+      // visibility via the audit log: a misconfigured trusted set
+      // simply records the socket peer instead of forwarded headers.
+    }
+  }
+
+  return { blockList };
+};
+
+export const isTrustedProxy = (
+  address: string,
+  trusted: TrustedProxies,
+): boolean => {
+  const family: "ipv4" | "ipv6" = isIPv6(address) ? "ipv6" : "ipv4";
+  try {
+    return trusted.blockList.check(address, family);
+  } catch {
+    return false;
+  }
+};
+
+let cachedTrustedProxies: TrustedProxies | null = null;
+
+const getTrustedProxies = (): TrustedProxies => {
+  cachedTrustedProxies ??= parseTrustedProxies(env.STELLA_TRUSTED_PROXY_CIDRS);
+  return cachedTrustedProxies;
+};
+
+const firstForwardedIp = (forwardedFor: string | null): string | null => {
+  if (!forwardedFor) {
+    return null;
+  }
+  const first = forwardedFor.split(",").at(0)?.trim();
+  return first && first.length > 0 ? first : null;
+};
+
+/**
+ * Returns the resolved client IP for an incoming request, or `null`
+ * if the runtime did not expose a socket peer (e.g. the request was
+ * synthesised in-process for tests).
+ */
+export const resolveClientIp = (
+  request: Request,
+  server: ServerLike | null,
+  options?: { trusted?: TrustedProxies },
+): string | null => {
+  const peer = server?.requestIP(request)?.address ?? null;
+  if (!peer) {
+    return null;
+  }
+  const trusted = options?.trusted ?? getTrustedProxies();
+  if (!isTrustedProxy(peer, trusted)) {
+    return peer;
+  }
+  const cf = request.headers.get("cf-connecting-ip")?.trim();
+  if (cf) {
+    return cf;
+  }
+  const real = request.headers.get("x-real-ip")?.trim();
+  if (real) {
+    return real;
+  }
+  const xff = firstForwardedIp(request.headers.get("x-forwarded-for"));
+  if (xff) {
+    return xff;
+  }
+  return peer;
+};


### PR DESCRIPTION
## Summary
- Audit-log IP resolution now derives from the request's actual TCP
  socket peer, not blindly from \`cf-connecting-ip\` /
  \`x-real-ip\` / \`x-forwarded-for\` headers.
- Forwarded headers are only honoured when the socket peer is
  inside a configured trusted-proxy CIDR set, supplied via the new
  \`STELLA_TRUSTED_PROXY_CIDRS\` env variable. With the variable
  unset (the default) no proxy is trusted and the recorded IP is
  the socket peer.
- The full forwarded chain is still kept in audit metadata for
  forensic inspection.

## Test plan
- [x] \`bun run test src/lib/client-ip.test.ts\` — 11 passed
- [x] \`bun --filter @stll/api typecheck\` / \`lint\` / \`format --check\`
- [ ] On a Cloudflare-fronted deployment, set
  \`STELLA_TRUSTED_PROXY_CIDRS\` to the published Cloudflare ranges
  (and any internal load-balancer CIDR) and confirm the audit log
  records the original visitor IP rather than the LB peer.
- [ ] On a self-hosted deployment without a configured trusted
  proxy, confirm the audit log records the socket peer (not a
  spoofable header value).