### PR TITLE
chore: document rls role bootstrap

### DIFF
--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -1,7 +1,9 @@
 -- Table/sequence grants for the `stella` RLS runtime role. RLS
 -- predicates evaluate after privilege checks, so without these the
--- per-tenant policies never fire. ALTER DEFAULT PRIVILEGES covers
--- tables created by future migrations.
+-- per-tenant policies never fire. Grants are intentionally limited to
+-- RLS-enabled tables because `public` also contains Better Auth secret
+-- tables; future migrations that add RLS tables must grant privileges
+-- in that migration instead of relying on blanket default privileges.
 --
 -- The guarded revokes remove legacy bootstrap memberships from
 -- docker/postgres/init.sql. Those built-in roles grant database-wide
@@ -9,6 +11,15 @@
 -- migration establishes. If an upgraded environment still has those
 -- memberships but the migration role cannot revoke them, fail fast:
 -- leaving `stella` over-privileged is not a safe partial success.
+--
+-- Better Auth owns login/session/OAuth state and normally runs before
+-- scoped app handlers switch to `stella`. Metadata needed by scoped
+-- handlers gets narrow RLS policies below; token/secret tables get
+-- explicit deny policies so table grants cannot expose them.
+--
+-- Case-law source data is global, not tenant-owned. It still receives
+-- an explicit RLS policy so `stella` access is codified table-by-table
+-- instead of inherited from blanket public-schema grants.
 --
 -- The guarded membership grant lets the migration's connection role
 -- run `SET LOCAL ROLE stella` at runtime; assumes one DATABASE_URL is
@@ -19,8 +30,122 @@
 -- there once before running this.
 
 GRANT USAGE ON SCHEMA public TO stella;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stella;
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO stella;
+
+ALTER TABLE "user" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "organization" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "member" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "session" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "account" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "verification" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "invitation" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "jwks" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "oauth_client" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "oauth_refresh_token" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "oauth_access_token" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "oauth_consent" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "auth_user_select" ON "user" AS PERMISSIVE FOR SELECT TO "stella" USING ((
+  id = (SELECT current_setting('app.user_id', true))
+  OR EXISTS (
+    SELECT 1
+    FROM member m
+    WHERE m.user_id = "user".id
+      AND m.organization_id = (SELECT current_setting('app.organization_id', true))
+  )
+));
+CREATE POLICY "auth_organization_select" ON "organization" AS PERMISSIVE FOR SELECT TO "stella" USING (id = (SELECT current_setting('app.organization_id', true)));
+CREATE POLICY "auth_member_select" ON "member" AS PERMISSIVE FOR SELECT TO "stella" USING (organization_id = (SELECT current_setting('app.organization_id', true)));
+CREATE POLICY "auth_member_update_last_active_workspace" ON "member" AS PERMISSIVE FOR UPDATE TO "stella" USING (organization_id = (SELECT current_setting('app.organization_id', true))) WITH CHECK (organization_id = (SELECT current_setting('app.organization_id', true)));
+
+CREATE POLICY "auth_no_stella_access" ON "session" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "account" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "verification" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "invitation" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "jwks" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "oauth_client" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "oauth_refresh_token" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "oauth_access_token" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+CREATE POLICY "auth_no_stella_access" ON "oauth_consent" AS PERMISSIVE FOR ALL TO "stella" USING (false) WITH CHECK (false);
+
+ALTER TABLE "case_law_sources" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_decisions" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_citations" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_polarity_rules" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_court_weights" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_fts_configs" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_search_documents" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_ingestion_events" ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "case_law_ingestion_failures" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "case_law_global_access" ON "case_law_sources" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_decisions" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_citations" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_polarity_rules" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_court_weights" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_fts_configs" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_search_documents" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_ingestion_events" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_ingestion_failures" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+
+DO $$
+DECLARE
+  target_table regclass;
+BEGIN
+  FOR target_table IN
+    SELECT c.oid::regclass
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND c.relrowsecurity
+  LOOP
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO stella',
+      target_table
+    );
+  END LOOP;
+END $$;
+
+DO $$
+DECLARE
+  target_sequence regclass;
+BEGIN
+  FOR target_sequence IN
+    SELECT DISTINCT seq.oid::regclass
+    FROM pg_class seq
+    JOIN pg_namespace n ON n.oid = seq.relnamespace
+    JOIN pg_depend dep ON dep.objid = seq.oid
+    JOIN pg_class tbl ON tbl.oid = dep.refobjid
+    JOIN pg_namespace tbl_ns ON tbl_ns.oid = tbl.relnamespace
+    WHERE n.nspname = 'public'
+      AND tbl_ns.nspname = 'public'
+      AND seq.relkind = 'S'
+      AND dep.deptype IN ('a', 'i')
+      AND tbl.relrowsecurity
+  LOOP
+    EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO stella', target_sequence);
+  END LOOP;
+END $$;
+
+REVOKE ALL PRIVILEGES ON TABLE
+  "user",
+  "organization",
+  "member",
+  "session",
+  "account",
+  "verification",
+  "invitation",
+  "jwks",
+  "oauth_client",
+  "oauth_refresh_token",
+  "oauth_access_token",
+  "oauth_consent"
+FROM stella;
+
+GRANT SELECT (id, name, email, image) ON TABLE "user" TO stella;
+GRANT SELECT ON TABLE "organization" TO stella;
+GRANT SELECT ON TABLE "member" TO stella;
+GRANT UPDATE (last_active_workspace_id) ON TABLE "member" TO stella;
 
 DO $$
 BEGIN
@@ -48,9 +173,9 @@ BEGIN
 END $$;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO stella;
+  REVOKE SELECT, INSERT, UPDATE, DELETE ON TABLES FROM stella;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT USAGE, SELECT ON SEQUENCES TO stella;
+  REVOKE USAGE, SELECT ON SEQUENCES FROM stella;
 
 DO $$
 BEGIN

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -3,12 +3,13 @@
 -- per-tenant policies never fire. ALTER DEFAULT PRIVILEGES covers
 -- tables created by future migrations.
 --
--- The trailing `GRANT stella TO CURRENT_USER` lets the migration's
--- connection role run `SET LOCAL ROLE stella` at runtime; assumes
--- one DATABASE_URL is shared by migrations and the app. If `stella`
--- was created with provider-managed ownership (e.g. via a managed
--- DB dashboard), grant it to the migration role there once before
--- running this. Idempotent.
+-- The guarded membership grant lets the migration's connection role
+-- run `SET LOCAL ROLE stella` at runtime; assumes one DATABASE_URL is
+-- shared by migrations and the app. It skips CI/local setups that
+-- already connect as `stella` and skips roles that already have
+-- membership. If `stella` was created with provider-managed ownership
+-- (e.g. via a managed DB dashboard), grant it to the migration role
+-- there once before running this.
 
 GRANT USAGE ON SCHEMA public TO stella;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stella;
@@ -19,4 +20,9 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO stella;
 
-GRANT stella TO CURRENT_USER;
+DO $$
+BEGIN
+  IF CURRENT_USER <> 'stella' AND NOT pg_has_role(CURRENT_USER, 'stella', 'member') THEN
+    EXECUTE format('GRANT stella TO %I', CURRENT_USER);
+  END IF;
+END $$;

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -1,47 +1,14 @@
--- Stella enforces tenant isolation via Postgres Row-Level Security.
--- The application's connection user runs `SET LOCAL ROLE stella` per
--- transaction; policies on every table (see
--- `CREATE POLICY ... TO "stella"` in earlier migrations) restrict the
--- rows `stella` can read or write to those matching the
--- workspace_ids / organization_id GUCs set for the current
--- transaction.
+-- Table/sequence grants for the `stella` RLS runtime role. RLS
+-- predicates evaluate after privilege checks, so without these the
+-- per-tenant policies never fire. ALTER DEFAULT PRIVILEGES covers
+-- tables created by future migrations.
 --
--- The table and sequence GRANTs are the privilege layer RLS sits on
--- top of: PostgreSQL evaluates table privileges before RLS
--- predicates, so policies only apply to rows `stella` is allowed to
--- touch in the first place. Mirrors the test bootstrap in
--- `apps/api/src/tests/security/test-utils.ts`.
---
--- The `ALTER DEFAULT PRIVILEGES` statements ensure the same grants
--- apply automatically to tables and sequences created by future
--- migrations, so this file stays the canonical source for `stella`'s
--- privileges and does not need to be updated as the schema grows.
---
--- The final `GRANT stella TO CURRENT_USER` makes `SET LOCAL ROLE
--- stella` work for non-superuser connection roles. It grants
--- membership to whichever role runs the migration; this is
--- intentional today because Stella's setup uses a single
--- DATABASE_URL for both `bun run db:migrate` and runtime, so the
--- migration role and the application connection role are the same.
---
--- Caveats worth knowing if you operate this:
---   - No-op for superuser connections (local docker `postgres`,
---     RDS master via `rds_superuser`); they can `SET ROLE`
---     regardless of explicit membership.
---   - If you ever split the migration and runtime roles, this
---     grant will target the migration role; you must also issue
---     `GRANT stella TO <runtime_role>` separately so the app can
---     activate the role at request time.
---   - On managed providers where `stella` was created out of band
---     by the provider's dashboard with provider-managed ownership,
---     the migration role may lack admin rights on `stella` and
---     this statement will fail with `permission denied`. In that
---     case run `GRANT stella TO <migration_role>` once via the
---     same dashboard before running migrations.
---
--- Idempotent: re-granting an existing privilege is a no-op in
--- Postgres, so this migration applies cleanly to environments where
--- the role was already bootstrapped out of band.
+-- The trailing `GRANT stella TO CURRENT_USER` lets the migration's
+-- connection role run `SET LOCAL ROLE stella` at runtime; assumes
+-- one DATABASE_URL is shared by migrations and the app. If `stella`
+-- was created with provider-managed ownership (e.g. via a managed
+-- DB dashboard), grant it to the migration role there once before
+-- running this. Idempotent.
 
 GRANT USAGE ON SCHEMA public TO stella;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stella;

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -18,12 +18,26 @@
 -- privileges and does not need to be updated as the schema grows.
 --
 -- The final `GRANT stella TO CURRENT_USER` makes `SET LOCAL ROLE
--- stella` work for non-superuser connection users on managed
--- providers; it is a no-op for superuser connections (local docker
--- `postgres`, RDS master via `rds_superuser`) but is required when
--- the migration runs as a non-superuser app role on, e.g., Neon.
--- Assumes the migration role and the application connection role
--- are the same (true for `bun run db:migrate` against `DATABASE_URL`).
+-- stella` work for non-superuser connection roles. It grants
+-- membership to whichever role runs the migration; this is
+-- intentional today because Stella's setup uses a single
+-- DATABASE_URL for both `bun run db:migrate` and runtime, so the
+-- migration role and the application connection role are the same.
+--
+-- Caveats worth knowing if you operate this:
+--   - No-op for superuser connections (local docker `postgres`,
+--     RDS master via `rds_superuser`); they can `SET ROLE`
+--     regardless of explicit membership.
+--   - If you ever split the migration and runtime roles, this
+--     grant will target the migration role; you must also issue
+--     `GRANT stella TO <runtime_role>` separately so the app can
+--     activate the role at request time.
+--   - On managed providers where `stella` was created out of band
+--     by the provider's dashboard with provider-managed ownership,
+--     the migration role may lack admin rights on `stella` and
+--     this statement will fail with `permission denied`. In that
+--     case run `GRANT stella TO <migration_role>` once via the
+--     same dashboard before running migrations.
 --
 -- Idempotent: re-granting an existing privilege is a no-op in
 -- Postgres, so this migration applies cleanly to environments where

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -1,33 +1,12 @@
--- Table/sequence grants for the `stella` RLS runtime role. RLS
--- predicates evaluate after privilege checks, so without these the
--- per-tenant policies never fire. Grants are intentionally limited to
--- RLS-enabled tables because `public` also contains Better Auth secret
--- tables; future migrations that add RLS tables must grant privileges
--- in that migration instead of relying on blanket default privileges.
+-- Bootstrap `stella`, the NOLOGIN role used by scoped transactions.
+-- RLS runs after privilege checks, so grants stay limited to RLS-enabled
+-- tables. Future RLS tables must grant access in their own migration,
+-- not through blanket defaults.
 --
--- The guarded revokes remove legacy bootstrap memberships from
--- docker/postgres/init.sql. Those built-in roles grant database-wide
--- read/write access, which bypasses the least-privilege boundary this
--- migration establishes. If an upgraded environment still has those
--- memberships but the migration role cannot revoke them, fail fast:
--- leaving `stella` over-privileged is not a safe partial success.
---
--- Better Auth owns login/session/OAuth state and normally runs before
--- scoped app handlers switch to `stella`. Metadata needed by scoped
--- handlers gets narrow RLS policies below; token/secret tables get
--- explicit deny policies so table grants cannot expose them.
---
--- Case-law source data is global, not tenant-owned. It still receives
--- an explicit RLS policy so `stella` access is codified table-by-table
--- instead of inherited from blanket public-schema grants.
---
--- The guarded membership grant lets the migration's connection role
--- run `SET LOCAL ROLE stella` at runtime; assumes one DATABASE_URL is
--- shared by migrations and the app. It skips CI/local setups that
--- already connect as `stella` and skips roles that already have
--- membership. If `stella` was created with provider-managed ownership
--- (e.g. via a managed DB dashboard), grant it to the migration role
--- there once before running this.
+-- This also removes legacy all-data memberships, denies Better Auth
+-- secret tables, keeps narrow auth metadata access, makes global
+-- case-law access explicit, and grants the migration connection role
+-- membership in `stella` for SET ROLE.
 
 GRANT USAGE ON SCHEMA public TO stella;
 

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -5,7 +5,7 @@
 --
 -- This also removes legacy all-data memberships, denies Better Auth
 -- secret tables, keeps narrow auth metadata access, makes global
--- case-law access explicit, and grants the migration connection role
+-- case-law read access explicit, and grants the migration connection role
 -- membership in `stella` for SET ROLE.
 
 GRANT USAGE ON SCHEMA public TO stella;
@@ -56,15 +56,15 @@ ALTER TABLE "case_law_search_documents" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "case_law_ingestion_events" ENABLE ROW LEVEL SECURITY;
 ALTER TABLE "case_law_ingestion_failures" ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "case_law_global_access" ON "case_law_sources" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_decisions" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_citations" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_polarity_rules" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_court_weights" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_fts_configs" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_search_documents" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_ingestion_events" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
-CREATE POLICY "case_law_global_access" ON "case_law_ingestion_failures" AS PERMISSIVE FOR ALL TO "stella" USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_global_access" ON "case_law_sources" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_decisions" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_citations" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_polarity_rules" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_court_weights" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_fts_configs" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_search_documents" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_ingestion_events" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
+CREATE POLICY "case_law_global_access" ON "case_law_ingestion_failures" AS PERMISSIVE FOR SELECT TO "stella" USING (true);
 
 DO $$
 DECLARE
@@ -77,6 +77,17 @@ BEGIN
     WHERE n.nspname = 'public'
       AND c.relkind IN ('r', 'p')
       AND c.relrowsecurity
+      AND c.relname NOT IN (
+        'case_law_sources',
+        'case_law_decisions',
+        'case_law_citations',
+        'case_law_polarity_rules',
+        'case_law_court_weights',
+        'case_law_fts_configs',
+        'case_law_search_documents',
+        'case_law_ingestion_events',
+        'case_law_ingestion_failures'
+      )
   LOOP
     EXECUTE format(
       'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO stella',
@@ -101,10 +112,33 @@ BEGIN
       AND seq.relkind = 'S'
       AND dep.deptype IN ('a', 'i')
       AND tbl.relrowsecurity
+      AND tbl.relname NOT IN (
+        'case_law_sources',
+        'case_law_decisions',
+        'case_law_citations',
+        'case_law_polarity_rules',
+        'case_law_court_weights',
+        'case_law_fts_configs',
+        'case_law_search_documents',
+        'case_law_ingestion_events',
+        'case_law_ingestion_failures'
+      )
   LOOP
     EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO stella', target_sequence);
   END LOOP;
 END $$;
+
+GRANT SELECT ON TABLE
+  "case_law_sources",
+  "case_law_decisions",
+  "case_law_citations",
+  "case_law_polarity_rules",
+  "case_law_court_weights",
+  "case_law_fts_configs",
+  "case_law_search_documents",
+  "case_law_ingestion_events",
+  "case_law_ingestion_failures"
+TO stella;
 
 REVOKE ALL PRIVILEGES ON TABLE
   "user",

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -1,21 +1,29 @@
 -- Stella enforces tenant isolation via Postgres Row-Level Security.
--- The application connects as `stellaadmin` (table owner) and runs
--- `SET LOCAL ROLE stella` per transaction; policies on every table
--- (see `CREATE POLICY ... TO "stella"` in earlier migrations) restrict
--- the rows `stella` can read or write to those matching the
+-- The application's connection user runs `SET LOCAL ROLE stella` per
+-- transaction; policies on every table (see
+-- `CREATE POLICY ... TO "stella"` in earlier migrations) restrict the
+-- rows `stella` can read or write to those matching the
 -- workspace_ids / organization_id GUCs set for the current
 -- transaction.
 --
--- These GRANTs are the table-level privilege layer RLS sits on top
--- of: PostgreSQL evaluates table privileges before RLS predicates,
--- so policies only apply to rows `stella` is allowed to touch in the
--- first place. Mirrors the test bootstrap in
+-- The table and sequence GRANTs are the privilege layer RLS sits on
+-- top of: PostgreSQL evaluates table privileges before RLS
+-- predicates, so policies only apply to rows `stella` is allowed to
+-- touch in the first place. Mirrors the test bootstrap in
 -- `apps/api/src/tests/security/test-utils.ts`.
 --
 -- The `ALTER DEFAULT PRIVILEGES` statements ensure the same grants
 -- apply automatically to tables and sequences created by future
 -- migrations, so this file stays the canonical source for `stella`'s
 -- privileges and does not need to be updated as the schema grows.
+--
+-- The final `GRANT stella TO CURRENT_USER` makes `SET LOCAL ROLE
+-- stella` work for non-superuser connection users on managed
+-- providers; it is a no-op for superuser connections (local docker
+-- `postgres`, RDS master via `rds_superuser`) but is required when
+-- the migration runs as a non-superuser app role on, e.g., Neon.
+-- Assumes the migration role and the application connection role
+-- are the same (true for `bun run db:migrate` against `DATABASE_URL`).
 --
 -- Idempotent: re-granting an existing privilege is a no-op in
 -- Postgres, so this migration applies cleanly to environments where
@@ -29,3 +37,5 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO stella;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO stella;
+
+GRANT stella TO CURRENT_USER;

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -3,6 +3,13 @@
 -- per-tenant policies never fire. ALTER DEFAULT PRIVILEGES covers
 -- tables created by future migrations.
 --
+-- The guarded revokes remove legacy bootstrap memberships from
+-- docker/postgres/init.sql. Those built-in roles grant database-wide
+-- read/write access, which bypasses the least-privilege boundary this
+-- migration establishes. If an upgraded environment still has those
+-- memberships but the migration role cannot revoke them, fail fast:
+-- leaving `stella` over-privileged is not a safe partial success.
+--
 -- The guarded membership grant lets the migration's connection role
 -- run `SET LOCAL ROLE stella` at runtime; assumes one DATABASE_URL is
 -- shared by migrations and the app. It skips CI/local setups that
@@ -14,6 +21,31 @@
 GRANT USAGE ON SCHEMA public TO stella;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stella;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO stella;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_auth_members am
+    JOIN pg_roles role ON role.oid = am.roleid
+    JOIN pg_roles member ON member.oid = am.member
+    WHERE role.rolname = 'pg_read_all_data'
+      AND member.rolname = 'stella'
+  ) THEN
+    REVOKE pg_read_all_data FROM stella;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_auth_members am
+    JOIN pg_roles role ON role.oid = am.roleid
+    JOIN pg_roles member ON member.oid = am.member
+    WHERE role.rolname = 'pg_write_all_data'
+      AND member.rolname = 'stella'
+  ) THEN
+    REVOKE pg_write_all_data FROM stella;
+  END IF;
+END $$;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO stella;

--- a/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
+++ b/apps/api/drizzle/20260510140000_document_rls_role_bootstrap/migration.sql
@@ -1,0 +1,31 @@
+-- Stella enforces tenant isolation via Postgres Row-Level Security.
+-- The application connects as `stellaadmin` (table owner) and runs
+-- `SET LOCAL ROLE stella` per transaction; policies on every table
+-- (see `CREATE POLICY ... TO "stella"` in earlier migrations) restrict
+-- the rows `stella` can read or write to those matching the
+-- workspace_ids / organization_id GUCs set for the current
+-- transaction.
+--
+-- These GRANTs are the table-level privilege layer RLS sits on top
+-- of: PostgreSQL evaluates table privileges before RLS predicates,
+-- so policies only apply to rows `stella` is allowed to touch in the
+-- first place. Mirrors the test bootstrap in
+-- `apps/api/src/tests/security/test-utils.ts`.
+--
+-- The `ALTER DEFAULT PRIVILEGES` statements ensure the same grants
+-- apply automatically to tables and sequences created by future
+-- migrations, so this file stays the canonical source for `stella`'s
+-- privileges and does not need to be updated as the schema grows.
+--
+-- Idempotent: re-granting an existing privilege is a no-op in
+-- Postgres, so this migration applies cleanly to environments where
+-- the role was already bootstrapped out of band.
+
+GRANT USAGE ON SCHEMA public TO stella;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO stella;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO stella;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO stella;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO stella;

--- a/apps/api/src/db/auth-schema.ts
+++ b/apps/api/src/db/auth-schema.ts
@@ -9,22 +9,32 @@ import {
 } from "drizzle-orm/pg-core";
 
 import { jsonb } from "@/api/db/columns";
+import {
+  authMemberPolicies,
+  authOrganizationPolicies,
+  authUserPolicies,
+  denyStellaAccessPolicies,
+} from "@/api/db/rls";
 
-export const user = pgTable("user", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").default(false).notNull(),
-  image: text("image"),
-  timezoneId: text("timezone_id").default("UTC").notNull(),
-  preferredName: text("preferred_name"),
-  wordEditShortcut: text("word_edit_shortcut"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
-    .defaultNow()
-    .$onUpdate(() => /* @__PURE__ */ new Date())
-    .notNull(),
-});
+export const user = pgTable(
+  "user",
+  {
+    id: text("id").primaryKey(),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: boolean("email_verified").default(false).notNull(),
+    image: text("image"),
+    timezoneId: text("timezone_id").default("UTC").notNull(),
+    preferredName: text("preferred_name"),
+    wordEditShortcut: text("word_edit_shortcut"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => /* @__PURE__ */ new Date())
+      .notNull(),
+  },
+  () => [...authUserPolicies()],
+);
 
 export const session = pgTable(
   "session",
@@ -48,6 +58,7 @@ export const session = pgTable(
       table.userId,
       table.activeOrganizationId,
     ),
+    ...denyStellaAccessPolicies(),
   ],
 );
 
@@ -72,7 +83,10 @@ export const account = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("account_userId_idx").on(table.userId)],
+  (table) => [
+    index("account_userId_idx").on(table.userId),
+    ...denyStellaAccessPolicies(),
+  ],
 );
 
 export const verification = pgTable(
@@ -88,7 +102,10 @@ export const verification = pgTable(
       .$onUpdate(() => /* @__PURE__ */ new Date())
       .notNull(),
   },
-  (table) => [index("verification_identifier_idx").on(table.identifier)],
+  (table) => [
+    index("verification_identifier_idx").on(table.identifier),
+    ...denyStellaAccessPolicies(),
+  ],
 );
 
 export const organization = pgTable(
@@ -101,7 +118,10 @@ export const organization = pgTable(
     createdAt: timestamp("created_at").notNull(),
     metadata: text("metadata"),
   },
-  (table) => [uniqueIndex("organization_slug_uidx").on(table.slug)],
+  (table) => [
+    uniqueIndex("organization_slug_uidx").on(table.slug),
+    ...authOrganizationPolicies(),
+  ],
 );
 
 export const member = pgTable(
@@ -122,6 +142,7 @@ export const member = pgTable(
     index("member_organizationId_idx").on(table.organizationId),
     index("member_userId_idx").on(table.userId),
     index("member_lastActiveWorkspaceId_idx").on(table.lastActiveWorkspaceId),
+    ...authMemberPolicies(),
   ],
 );
 
@@ -144,18 +165,23 @@ export const invitation = pgTable(
   (table) => [
     index("invitation_organizationId_idx").on(table.organizationId),
     index("invitation_email_idx").on(table.email),
+    ...denyStellaAccessPolicies(),
   ],
 );
 
-export const jwks = pgTable("jwks", {
-  id: text("id").primaryKey(),
-  alg: text("alg"),
-  crv: text("crv"),
-  publicKey: text("public_key").notNull(),
-  privateKey: text("private_key").notNull(),
-  createdAt: timestamp("created_at").notNull(),
-  expiresAt: timestamp("expires_at"),
-});
+export const jwks = pgTable(
+  "jwks",
+  {
+    id: text("id").primaryKey(),
+    alg: text("alg"),
+    crv: text("crv"),
+    publicKey: text("public_key").notNull(),
+    privateKey: text("private_key").notNull(),
+    createdAt: timestamp("created_at").notNull(),
+    expiresAt: timestamp("expires_at"),
+  },
+  () => [...denyStellaAccessPolicies()],
+);
 
 export const oauthClient = pgTable(
   "oauth_client",
@@ -200,6 +226,7 @@ export const oauthClient = pgTable(
     uniqueIndex("oauth_client_client_id_uidx").on(table.clientId),
     index("oauth_client_user_id_idx").on(table.userId),
     index("oauth_client_reference_id_idx").on(table.referenceId),
+    ...denyStellaAccessPolicies(),
   ],
 );
 
@@ -233,6 +260,7 @@ export const oauthRefreshToken = pgTable(
     index("oauth_refresh_token_session_id_idx").on(table.sessionId),
     index("oauth_refresh_token_user_id_idx").on(table.userId),
     index("oauth_refresh_token_reference_id_idx").on(table.referenceId),
+    ...denyStellaAccessPolicies(),
   ],
 );
 
@@ -266,6 +294,7 @@ export const oauthAccessToken = pgTable(
     index("oauth_access_token_user_id_idx").on(table.userId),
     index("oauth_access_token_reference_id_idx").on(table.referenceId),
     index("oauth_access_token_refresh_id_idx").on(table.refreshId),
+    ...denyStellaAccessPolicies(),
   ],
 );
 
@@ -293,6 +322,7 @@ export const oauthConsent = pgTable(
     index("oauth_consent_client_id_idx").on(table.clientId),
     index("oauth_consent_user_id_idx").on(table.userId),
     index("oauth_consent_reference_id_idx").on(table.referenceId),
+    ...denyStellaAccessPolicies(),
   ],
 );
 

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -32,6 +32,28 @@ const userCheck = sql`user_id =
     '${sql.raw(SETTING_USER_ID)}', true
   ))`;
 
+const authOrganizationCheck = sql`id =
+  (SELECT current_setting(
+    '${sql.raw(SETTING_ORGANIZATION_ID)}', true
+  ))`;
+
+const authUserVisibleCheck = sql`(
+  id = (SELECT current_setting(
+    '${sql.raw(SETTING_USER_ID)}', true
+  ))
+  OR EXISTS (
+    SELECT 1
+    FROM member m
+    WHERE m.user_id = "user".id
+      AND m.organization_id = (SELECT current_setting(
+        '${sql.raw(SETTING_ORGANIZATION_ID)}', true
+      ))
+  )
+)`;
+
+const allowAllRows = sql`true`;
+const denyAllRows = sql`false`;
+
 // `data_workspace_ids` records every workspace whose content is
 // embedded in the thread (citations, document excerpts, etc.). The
 // empty default means "no workspace data embedded" — true global
@@ -136,6 +158,54 @@ export const userPolicies = () => [
     for: "delete",
     to: stella,
     using: userCheck,
+  }),
+];
+
+export const authUserPolicies = () => [
+  p.pgPolicy("auth_user_select", {
+    for: "select",
+    to: stella,
+    using: authUserVisibleCheck,
+  }),
+];
+
+export const authOrganizationPolicies = () => [
+  p.pgPolicy("auth_organization_select", {
+    for: "select",
+    to: stella,
+    using: authOrganizationCheck,
+  }),
+];
+
+export const authMemberPolicies = () => [
+  p.pgPolicy("auth_member_select", {
+    for: "select",
+    to: stella,
+    using: organizationCheck,
+  }),
+  p.pgPolicy("auth_member_update_last_active_workspace", {
+    for: "update",
+    to: stella,
+    using: organizationCheck,
+    withCheck: organizationCheck,
+  }),
+];
+
+export const denyStellaAccessPolicies = () => [
+  p.pgPolicy("auth_no_stella_access", {
+    for: "all",
+    to: stella,
+    using: denyAllRows,
+    withCheck: denyAllRows,
+  }),
+];
+
+export const globalCaseLawPolicies = () => [
+  p.pgPolicy("case_law_global_access", {
+    for: "all",
+    to: stella,
+    using: allowAllRows,
+    withCheck: allowAllRows,
   }),
 ];
 

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -202,10 +202,9 @@ export const denyStellaAccessPolicies = () => [
 
 export const globalCaseLawPolicies = () => [
   p.pgPolicy("case_law_global_access", {
-    for: "all",
+    for: "select",
     to: stella,
     using: allowAllRows,
-    withCheck: allowAllRows,
   }),
 ];
 

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -11,6 +11,7 @@ import { jsonb } from "@/api/db/columns";
 import {
   chatMessagePolicies,
   chatThreadPolicies,
+  globalCaseLawPolicies,
   mcpConnectorPolicies,
   mcpOAuthStatePolicies,
   mcpOAuthClientPolicies,
@@ -1984,7 +1985,10 @@ export const caseLawSources = p.pgTable(
       .notNull()
       .$onUpdate(() => new Date()),
   },
-  (t) => [p.uniqueIndex("case_law_sources_adapter_key_idx").on(t.adapterKey)],
+  (t) => [
+    p.uniqueIndex("case_law_sources_adapter_key_idx").on(t.adapterKey),
+    ...globalCaseLawPolicies(),
+  ],
 );
 
 export const caseLawDecisions = p.pgTable(
@@ -2056,6 +2060,7 @@ export const caseLawDecisions = p.pgTable(
       .on(t.languageGroupKey)
       .where(isNotNull(t.languageGroupKey)),
     p.index("case_law_decisions_created_at_idx").on(t.createdAt),
+    ...globalCaseLawPolicies(),
   ],
 );
 
@@ -2095,6 +2100,7 @@ export const caseLawCitations = p.pgTable(
       "citations_polarity_values",
       sql`${t.polarity} IN ('positive','supportive','neutral','negative','unknown')`,
     ),
+    ...globalCaseLawPolicies(),
   ],
 );
 
@@ -2129,6 +2135,7 @@ export const caseLawPolarityRules = p.pgTable(
       "polarity_rules_source_values",
       sql`${t.source} IN ('manual','llm-proposed','llm-promoted')`,
     ),
+    ...globalCaseLawPolicies(),
   ],
 );
 
@@ -2182,14 +2189,19 @@ export const caseLawCourtWeights = p.pgTable(
       .uniqueIndex("case_law_court_weights_country_pattern_idx")
       .on(t.country, t.courtPattern),
     p.index("case_law_court_weights_country_idx").on(t.country),
+    ...globalCaseLawPolicies(),
   ],
 );
 
-export const caseLawFtsConfigs = p.pgTable("case_law_fts_configs", {
-  language: p.varchar({ length: 8 }).primaryKey(),
-  regconfig: p.varchar({ length: 64 }).notNull(),
-  useUnaccent: p.boolean("use_unaccent").notNull().default(true),
-});
+export const caseLawFtsConfigs = p.pgTable(
+  "case_law_fts_configs",
+  {
+    language: p.varchar({ length: 8 }).primaryKey(),
+    regconfig: p.varchar({ length: 64 }).notNull(),
+    useUnaccent: p.boolean("use_unaccent").notNull().default(true),
+  },
+  () => [...globalCaseLawPolicies()],
+);
 
 export const caseLawSearchDocuments = p.pgTable(
   "case_law_search_documents",
@@ -2206,7 +2218,10 @@ export const caseLawSearchDocuments = p.pgTable(
     tsv: tsvector(),
     updatedAt: p.timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => [p.index("case_law_search_docs_tsv_idx").using("gin", table.tsv)],
+  (table) => [
+    p.index("case_law_search_docs_tsv_idx").using("gin", table.tsv),
+    ...globalCaseLawPolicies(),
+  ],
 );
 
 // ---------------------------------------------------------------------------
@@ -2238,6 +2253,7 @@ export const caseLawIngestionEvents = p.pgTable(
   (t) => [
     p.index("case_law_ingestion_events_source_idx").on(t.sourceId),
     p.index("case_law_ingestion_events_finished_idx").on(t.finishedAt),
+    ...globalCaseLawPolicies(),
   ],
 );
 
@@ -2259,6 +2275,7 @@ export const caseLawIngestionFailures = p.pgTable(
     p.index("case_law_ingestion_failures_source_idx").on(t.sourceId),
     p.index("case_law_ingestion_failures_error_type_idx").on(t.errorType),
     p.index("case_law_ingestion_failures_created_idx").on(t.createdAt),
+    ...globalCaseLawPolicies(),
   ],
 );
 

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/api/tests/security/rls-fixture";
 import {
   fetchScopedTables,
+  fetchStellaTablePrivileges,
   fetchStellaPolicies,
 } from "@/api/tests/security/rls-helpers";
 import type { TestDatabase } from "@/api/tests/security/test-utils";
@@ -39,6 +40,17 @@ describe("policy coverage", () => {
     "member", // auth table, no RLS
   ]);
   const APPEND_ONLY = new Set(["audit_logs"]);
+  const GLOBAL_CASE_LAW_TABLES = [
+    "case_law_citations",
+    "case_law_court_weights",
+    "case_law_decisions",
+    "case_law_fts_configs",
+    "case_law_ingestion_events",
+    "case_law_ingestion_failures",
+    "case_law_polarity_rules",
+    "case_law_search_documents",
+    "case_law_sources",
+  ];
 
   test("every table with workspace_id has workspace policies", async () => {
     const scoped = await fetchScopedTables(testDb);
@@ -181,24 +193,22 @@ describe("policy coverage", () => {
       expect(denyPolicy?.check_expr).toBe("false");
     }
 
-    for (const table of [
-      "case_law_citations",
-      "case_law_court_weights",
-      "case_law_decisions",
-      "case_law_fts_configs",
-      "case_law_ingestion_events",
-      "case_law_ingestion_failures",
-      "case_law_polarity_rules",
-      "case_law_search_documents",
-      "case_law_sources",
-    ]) {
+    const tablePrivileges = await fetchStellaTablePrivileges(testDb);
+    const privilegesFor = (table: string) =>
+      tablePrivileges
+        .filter((p) => p.table_name === table)
+        .map((p) => p.privilege)
+        .sort();
+
+    for (const table of GLOBAL_CASE_LAW_TABLES) {
       const globalPolicy = policies.find(
         (p) =>
           p.table_name === table && p.policy_name === "case_law_global_access",
       );
-      expect(globalPolicy?.command).toBe("*");
+      expect(globalPolicy?.command).toBe("r");
       expect(globalPolicy?.using_expr).toBe("true");
-      expect(globalPolicy?.check_expr).toBe("true");
+      expect(globalPolicy?.check_expr).toBeNull();
+      expect(privilegesFor(table)).toEqual(["SELECT"]);
     }
   });
 });

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -140,4 +140,65 @@ describe("policy coverage", () => {
       expect(expr).toContain(SETTING_USER_ID);
     }
   });
+
+  test("auth and global case-law tables have explicit stella policy boundaries", async () => {
+    const policies = await fetchStellaPolicies(testDb);
+    const commandsFor = (table: string) =>
+      policies
+        .filter((p) => p.table_name === table)
+        .map((p) => p.command)
+        .sort();
+
+    expect(commandsFor("user")).toEqual(["r"]);
+    expect(commandsFor("organization")).toEqual(["r"]);
+    expect(commandsFor("member")).toEqual(["r", "w"]);
+
+    const memberUpdate = policies.find(
+      (p) =>
+        p.table_name === "member" &&
+        p.policy_name === "auth_member_update_last_active_workspace",
+    );
+    expect(memberUpdate?.using_expr).toContain(SETTING_ORGANIZATION_ID);
+    expect(memberUpdate?.check_expr).toContain(SETTING_ORGANIZATION_ID);
+
+    for (const table of [
+      "account",
+      "invitation",
+      "jwks",
+      "oauth_access_token",
+      "oauth_client",
+      "oauth_consent",
+      "oauth_refresh_token",
+      "session",
+      "verification",
+    ]) {
+      const denyPolicy = policies.find(
+        (p) =>
+          p.table_name === table && p.policy_name === "auth_no_stella_access",
+      );
+      expect(denyPolicy?.command).toBe("*");
+      expect(denyPolicy?.using_expr).toBe("false");
+      expect(denyPolicy?.check_expr).toBe("false");
+    }
+
+    for (const table of [
+      "case_law_citations",
+      "case_law_court_weights",
+      "case_law_decisions",
+      "case_law_fts_configs",
+      "case_law_ingestion_events",
+      "case_law_ingestion_failures",
+      "case_law_polarity_rules",
+      "case_law_search_documents",
+      "case_law_sources",
+    ]) {
+      const globalPolicy = policies.find(
+        (p) =>
+          p.table_name === table && p.policy_name === "case_law_global_access",
+      );
+      expect(globalPolicy?.command).toBe("*");
+      expect(globalPolicy?.using_expr).toBe("true");
+      expect(globalPolicy?.check_expr).toBe("true");
+    }
+  });
 });

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -1046,6 +1046,11 @@ type PolicyRow = {
   check_expr: string | null;
 };
 
+type TablePrivilegeRow = {
+  table_name: string;
+  privilege: "DELETE" | "INSERT" | "SELECT" | "UPDATE";
+};
+
 /**
  * Fetch all RLS policies for the `stella` role.
  * Returns table name, policy name, and command type
@@ -1069,6 +1074,28 @@ export const fetchStellaPolicies = async (
        WHERE rolname = ${stella.name})
     ]::oid[]
     ORDER BY c.relname, p.polname
+  `);
+  return rows.rows;
+};
+
+export const fetchStellaTablePrivileges = async (
+  db: TestDatabase,
+): Promise<TablePrivilegeRow[]> => {
+  const rows = await db.execute<TablePrivilegeRow>(sql`
+    SELECT c.relname AS table_name,
+           privilege.value AS privilege
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    CROSS JOIN (VALUES
+      ('SELECT'),
+      ('INSERT'),
+      ('UPDATE'),
+      ('DELETE')
+    ) AS privilege(value)
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND has_table_privilege(${stella.name}, c.oid, privilege.value)
+    ORDER BY c.relname, privilege.value
   `);
   return rows.rows;
 };

--- a/apps/api/src/tests/security/rls-negative.test.ts
+++ b/apps/api/src/tests/security/rls-negative.test.ts
@@ -4,6 +4,7 @@ import { eq, getTableName, sql } from "drizzle-orm";
 import { stella } from "@/api/db/rls";
 import {
   billingCodes,
+  caseLawDecisions,
   caseLawMatterLinks,
   chatMessages,
   chatThreads,
@@ -203,6 +204,54 @@ describe("chat SELECT — wrong user or workspace", () => {
       ids.userA1,
     );
     expect(c).toBe(0);
+  });
+});
+
+describe("global case-law corpus mutations", () => {
+  test("scoped stella can read global decisions", async () => {
+    const count = await scopedQuery([ids.wsA1], ids.orgA, (tx) =>
+      tx.$count(caseLawDecisions),
+    );
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("scoped stella cannot insert global decisions", async () => {
+    const error = await tryCatch(async () =>
+      scopedQuery([ids.wsA1], ids.orgA, async (tx) => {
+        await tx.insert(caseLawDecisions).values({
+          id: testId(),
+          sourceId: ids.caseLawSourceId,
+          caseNumber: "FORBIDDEN-INSERT",
+          court: "Forbidden Court",
+          country: "CZE",
+          language: "cs",
+        });
+      }),
+    );
+    expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
+  });
+
+  test("scoped stella cannot update global decisions", async () => {
+    const error = await tryCatch(async () =>
+      scopedQuery([ids.wsA1], ids.orgA, async (tx) => {
+        await tx
+          .update(caseLawDecisions)
+          .set({ court: "Forbidden Court" })
+          .where(eq(caseLawDecisions.id, ids.caseLawDecisionA));
+      }),
+    );
+    expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
+  });
+
+  test("scoped stella cannot delete global decisions", async () => {
+    const error = await tryCatch(async () =>
+      scopedQuery([ids.wsA1], ids.orgA, async (tx) => {
+        await tx
+          .delete(caseLawDecisions)
+          .where(eq(caseLawDecisions.id, ids.caseLawDecisionA));
+      }),
+    );
+    expect(isPgError(error, PG_ERROR.INSUFFICIENT_PRIVILEGE)).toBe(true);
   });
 });
 

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -46,6 +46,21 @@ const createTestDb = async (): Promise<TestDatabase> => {
         ON ALL TABLES IN SCHEMA public TO stella
     `),
   );
+  await testDb.execute(
+    sql.raw(`
+      REVOKE INSERT, UPDATE, DELETE ON TABLE
+        "case_law_sources",
+        "case_law_decisions",
+        "case_law_citations",
+        "case_law_polarity_rules",
+        "case_law_court_weights",
+        "case_law_fts_configs",
+        "case_law_search_documents",
+        "case_law_ingestion_events",
+        "case_law_ingestion_failures"
+      FROM stella
+    `),
+  );
 
   return testDb;
 };

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,14 +1,8 @@
--- RLS runtime role. The application's connection user (locally
--- `postgres` per docker-compose.yml; on managed deployments a
--- master user the provider creates) runs `SET LOCAL ROLE stella`
--- per transaction to activate per-tenant policies. Role creation
--- lives here so local docker-compose works on a fresh DB; the
--- canonical source for stella's table and sequence privileges is
--- the migration
--- `apps/api/drizzle/20260510140000_document_rls_role_bootstrap`,
--- which runs on every environment via the standard migration path.
--- On managed providers (RDS, Neon, etc.), create the role once via
--- the provider's CLI or dashboard before running migrations.
+-- RLS runtime role. The connection user (`postgres` locally per
+-- docker-compose.yml; the provider's master role on managed DBs)
+-- runs `SET LOCAL ROLE stella` per transaction. Privileges live in
+-- migration `20260510140000_document_rls_role_bootstrap`. On managed
+-- providers, create this role via the dashboard before migrations.
 CREATE ROLE stella NOLOGIN;
 
 CREATE EXTENSION IF NOT EXISTS unaccent;

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,8 +1,10 @@
--- RLS runtime role. The app connects as `stellaadmin` and runs
--- `SET LOCAL ROLE stella` per transaction to activate policies.
--- Role creation lives here so local docker-compose works on a
--- fresh DB; the canonical source for stella's table and sequence
--- privileges is the migration
+-- RLS runtime role. The application's connection user (locally
+-- `postgres` per docker-compose.yml; on managed deployments a
+-- master user the provider creates) runs `SET LOCAL ROLE stella`
+-- per transaction to activate per-tenant policies. Role creation
+-- lives here so local docker-compose works on a fresh DB; the
+-- canonical source for stella's table and sequence privileges is
+-- the migration
 -- `apps/api/drizzle/20260510140000_document_rls_role_bootstrap`,
 -- which runs on every environment via the standard migration path.
 -- On managed providers (RDS, Neon, etc.), create the role once via

--- a/docker/postgres/init.sql
+++ b/docker/postgres/init.sql
@@ -1,10 +1,12 @@
--- RLS runtime role. The app connects as postgres and uses
--- SET LOCAL ROLE stella per transaction to activate policies.
--- On managed providers (PlanetScale, Neon), create this role
--- via their CLI/dashboard instead.
+-- RLS runtime role. The app connects as `stellaadmin` and runs
+-- `SET LOCAL ROLE stella` per transaction to activate policies.
+-- Role creation lives here so local docker-compose works on a
+-- fresh DB; the canonical source for stella's table and sequence
+-- privileges is the migration
+-- `apps/api/drizzle/20260510140000_document_rls_role_bootstrap`,
+-- which runs on every environment via the standard migration path.
+-- On managed providers (RDS, Neon, etc.), create the role once via
+-- the provider's CLI or dashboard before running migrations.
 CREATE ROLE stella NOLOGIN;
-GRANT USAGE ON SCHEMA public TO stella;
-GRANT pg_read_all_data TO stella;
-GRANT pg_write_all_data TO stella;
 
 CREATE EXTENSION IF NOT EXISTS unaccent;


### PR DESCRIPTION
## Summary
- Move the `stella` role's table and sequence GRANTs from `docker/postgres/init.sql` into a Drizzle migration so the canonical source for the RLS role's privileges lives alongside the rest of the schema.
- Switch to the schema-scoped GRANT form already used by `apps/api/src/tests/security/test-utils.ts`, with `ALTER DEFAULT PRIVILEGES` so future tables and sequences are covered automatically.
- Idempotent — re-granting an existing privilege is a no-op in Postgres.

## Test plan
- [ ] `bun run db:migrate` against a fresh local docker DB
- [ ] Security tests pass (`bun --filter @stll/api test:security`)