### PR TITLE
feat: move matter info into inspector

### DIFF
--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -278,17 +278,18 @@ const copyWorkspaceFile = async ({
 };
 
 const copyWorkspaceFiles = async ({
+  copiedS3Keys,
   copies,
   organizationId,
   sourceWorkspaceId,
   targetWorkspaceId,
 }: {
+  copiedS3Keys: string[];
   copies: FileCopy[];
   organizationId: SafeId<"organization">;
   sourceWorkspaceId: SafeId<"workspace">;
   targetWorkspaceId: SafeId<"workspace">;
 }) => {
-  const copiedS3Keys: string[] = [];
   let nextIndex = 0;
 
   const copyNext = async () => {
@@ -315,8 +316,6 @@ const copyWorkspaceFiles = async ({
       copyNext,
     ),
   );
-
-  return copiedS3Keys;
 };
 
 const cleanupCopiedS3Keys = async ({
@@ -446,14 +445,13 @@ const duplicateWorkspace = createSafeHandler(
 
     if (includeContent) {
       const copyResult = await Result.tryPromise(async () => {
-        copiedS3Keys.push(
-          ...(await copyWorkspaceFiles({
-            copies: fileCopies,
-            organizationId,
-            sourceWorkspaceId,
-            targetWorkspaceId,
-          })),
-        );
+        await copyWorkspaceFiles({
+          copiedS3Keys,
+          copies: fileCopies,
+          organizationId,
+          sourceWorkspaceId,
+          targetWorkspaceId,
+        });
       });
 
       if (Result.isError(copyResult)) {

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -1,4 +1,4 @@
-import { Result, panic } from "better-result";
+import { Result } from "better-result";
 import { and, count, eq, ilike, inArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 
@@ -50,6 +50,8 @@ const config = {
     includeContent: t.Boolean(),
   }),
 } satisfies HandlerConfig;
+
+const FILE_COPY_CONCURRENCY = 4;
 
 type FileCopy = {
   sourceFileId: string;
@@ -269,9 +271,52 @@ const copyWorkspaceFile = async ({
     fileId: copy.targetFileId,
     mimeType: copy.mimeType,
   });
-  const bytes = await getS3().file(sourceKey).arrayBuffer();
-  await getS3().write(targetKey, new Uint8Array(bytes));
+  await getS3().write(targetKey, getS3().file(sourceKey), {
+    type: copy.mimeType,
+  });
   return targetKey;
+};
+
+const copyWorkspaceFiles = async ({
+  copies,
+  organizationId,
+  sourceWorkspaceId,
+  targetWorkspaceId,
+}: {
+  copies: FileCopy[];
+  organizationId: SafeId<"organization">;
+  sourceWorkspaceId: SafeId<"workspace">;
+  targetWorkspaceId: SafeId<"workspace">;
+}) => {
+  const copiedS3Keys: string[] = [];
+  let nextIndex = 0;
+
+  const copyNext = async () => {
+    while (nextIndex < copies.length) {
+      const copy = copies[nextIndex];
+      nextIndex++;
+      if (!copy) {
+        return;
+      }
+
+      const key = await copyWorkspaceFile({
+        copy,
+        organizationId,
+        sourceWorkspaceId,
+        targetWorkspaceId,
+      });
+      copiedS3Keys.push(key);
+    }
+  };
+
+  await Promise.all(
+    Array.from(
+      { length: Math.min(FILE_COPY_CONCURRENCY, copies.length) },
+      copyNext,
+    ),
+  );
+
+  return copiedS3Keys;
 };
 
 const duplicateWorkspace = createSafeHandler(
@@ -379,15 +424,14 @@ const duplicateWorkspace = createSafeHandler(
 
     if (includeContent) {
       const copyResult = await Result.tryPromise(async () => {
-        for (const copy of fileCopies) {
-          const key = await copyWorkspaceFile({
-            copy,
+        copiedS3Keys.push(
+          ...(await copyWorkspaceFiles({
+            copies: fileCopies,
             organizationId,
             sourceWorkspaceId,
             targetWorkspaceId,
-          });
-          copiedS3Keys.push(key);
-        }
+          })),
+        );
       });
 
       if (Result.isError(copyResult)) {
@@ -492,7 +536,11 @@ const duplicateWorkspace = createSafeHandler(
           .then((rows) => rows.at(0));
 
         if (!counter) {
-          panic("Failed to create matter counter");
+          return {
+            ok: false as const,
+            status: 500 as const,
+            message: "Failed to create matter counter",
+          };
         }
 
         const reference = toReference({
@@ -640,7 +688,7 @@ const duplicateWorkspace = createSafeHandler(
               parentId: newParentId,
               name: source.name,
               createdBy: user.id,
-              lastEditedBy: source.lastEditedBy,
+              lastEditedBy: user.id,
               docSequence: entityStamp?.docSequence ?? null,
               status: source.status,
               priority: source.priority,

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -310,12 +310,17 @@ const copyWorkspaceFiles = async ({
     }
   };
 
-  await Promise.all(
+  const copyResults = await Promise.allSettled(
     Array.from(
       { length: Math.min(FILE_COPY_CONCURRENCY, copies.length) },
       copyNext,
     ),
   );
+  const failedCopy = copyResults.find((result) => result.status === "rejected");
+
+  if (failedCopy) {
+    throw failedCopy.reason;
+  }
 };
 
 const cleanupCopiedS3Keys = async ({

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -319,6 +319,28 @@ const copyWorkspaceFiles = async ({
   return copiedS3Keys;
 };
 
+const cleanupCopiedS3Keys = async ({
+  copiedS3Keys,
+  targetWorkspaceId,
+}: {
+  copiedS3Keys: string[];
+  targetWorkspaceId: SafeId<"workspace">;
+}) => {
+  if (copiedS3Keys.length === 0) {
+    return;
+  }
+
+  const cleanupResult = await Result.tryPromise(async () => {
+    await Promise.all(
+      copiedS3Keys.map(async (key) => await getS3().delete(key)),
+    );
+  });
+
+  if (Result.isError(cleanupResult)) {
+    captureError(cleanupResult.error, { targetWorkspaceId });
+  }
+};
+
 const duplicateWorkspace = createSafeHandler(
   config,
   async function* ({
@@ -435,10 +457,9 @@ const duplicateWorkspace = createSafeHandler(
       });
 
       if (Result.isError(copyResult)) {
-        await Result.tryPromise(async () => {
-          await Promise.all(
-            copiedS3Keys.map(async (key) => await getS3().delete(key)),
-          );
+        await cleanupCopiedS3Keys({
+          copiedS3Keys,
+          targetWorkspaceId,
         });
         return Result.err(
           new HandlerError({
@@ -450,118 +471,117 @@ const duplicateWorkspace = createSafeHandler(
       }
     }
 
-    const txResult = yield* Result.await(
-      safeDb(async (tx) => {
-        const [countResult, duplicatedNames, settings, orgMembers] =
-          await Promise.all([
-            tx
-              .select({ total: count() })
-              .from(workspaces)
-              .where(eq(workspaces.organizationId, organizationId)),
-            tx
-              .select({ name: workspaces.name })
-              .from(workspaces)
-              .where(
-                and(
-                  eq(workspaces.organizationId, organizationId),
-                  ilike(
-                    workspaces.name,
-                    `${escapeLike(snapshot.workspace.name)}%`,
-                  ),
+    const txResult = await safeDb(async (tx) => {
+      const [countResult, duplicatedNames, settings, orgMembers] =
+        await Promise.all([
+          tx
+            .select({ total: count() })
+            .from(workspaces)
+            .where(eq(workspaces.organizationId, organizationId)),
+          tx
+            .select({ name: workspaces.name })
+            .from(workspaces)
+            .where(
+              and(
+                eq(workspaces.organizationId, organizationId),
+                ilike(
+                  workspaces.name,
+                  `${escapeLike(snapshot.workspace.name)}%`,
                 ),
               ),
-            tx.query.organizationSettings.findFirst({
-              where: { organizationId: { eq: organizationId } },
-              columns: {
-                matterNumberPattern: true,
-                matterNumberPadding: true,
-              },
-            }),
-            snapshot.members.length > 0
-              ? tx
-                  .select({ userId: member.userId })
-                  .from(member)
-                  .where(
-                    and(
-                      eq(member.organizationId, organizationId),
-                      inArray(
-                        member.userId,
-                        snapshot.members.map((m) => m.userId),
-                      ),
+            ),
+          tx.query.organizationSettings.findFirst({
+            where: { organizationId: { eq: organizationId } },
+            columns: {
+              matterNumberPattern: true,
+              matterNumberPadding: true,
+            },
+          }),
+          snapshot.members.length > 0
+            ? tx
+                .select({ userId: member.userId })
+                .from(member)
+                .where(
+                  and(
+                    eq(member.organizationId, organizationId),
+                    inArray(
+                      member.userId,
+                      snapshot.members.map((m) => m.userId),
                     ),
-                  )
-              : Promise.resolve([]),
-          ]);
+                  ),
+                )
+            : Promise.resolve([]),
+        ]);
 
-        const activeCount = countResult.at(0)?.total ?? 0;
-        if (activeCount >= LIMITS.workspacesCount) {
-          return {
-            ok: false as const,
-            status: 400 as const,
-            message: "Workspaces limit reached",
-          };
-        }
+      const activeCount = countResult.at(0)?.total ?? 0;
+      if (activeCount >= LIMITS.workspacesCount) {
+        return {
+          ok: false as const,
+          status: 400 as const,
+          message: "Workspaces limit reached",
+        };
+      }
 
-        if (orgMembers.length !== snapshot.members.length) {
-          return {
-            ok: false as const,
-            status: 400 as const,
-            message: "Some users are not members of this organization",
-          };
-        }
+      if (orgMembers.length !== snapshot.members.length) {
+        return {
+          ok: false as const,
+          status: 400 as const,
+          message: "Some users are not members of this organization",
+        };
+      }
 
-        const newName =
-          duplicatedNames.length > 0
-            ? `${snapshot.workspace.name} (${duplicatedNames.length})`
-            : snapshot.workspace.name;
-        const pattern =
-          settings?.matterNumberPattern ?? DEFAULT_MATTER_NUMBER_PATTERN;
-        const padding =
-          settings?.matterNumberPadding ?? DEFAULT_MATTER_NUMBER_PADDING;
-        const now = new Date();
-        const scopeKey = toScopeKey(pattern, now);
-        const counter = await tx
-          .insert(matterCounters)
-          .values({
-            id: createSafeId<"matterCounter">(),
-            organizationId,
-            scopeKey,
-            lastValue: 1,
-          })
-          .onConflictDoUpdate({
-            target: [matterCounters.organizationId, matterCounters.scopeKey],
-            set: { lastValue: sql`${matterCounters.lastValue} + 1` },
-          })
-          .returning({ lastValue: matterCounters.lastValue })
-          .then((rows) => rows.at(0));
-
-        if (!counter) {
-          return {
-            ok: false as const,
-            status: 500 as const,
-            message: "Failed to create matter counter",
-          };
-        }
-
-        const reference = toReference({
-          pattern,
-          now,
-          seq: counter.lastValue,
-          padding,
-        });
-
-        await tx.insert(workspaces).values({
-          id: targetWorkspaceId,
+      const newName =
+        duplicatedNames.length > 0
+          ? `${snapshot.workspace.name} (${duplicatedNames.length})`
+          : snapshot.workspace.name;
+      const pattern =
+        settings?.matterNumberPattern ?? DEFAULT_MATTER_NUMBER_PATTERN;
+      const padding =
+        settings?.matterNumberPadding ?? DEFAULT_MATTER_NUMBER_PADDING;
+      const now = new Date();
+      const scopeKey = toScopeKey(pattern, now);
+      const counter = await tx
+        .insert(matterCounters)
+        .values({
+          id: createSafeId<"matterCounter">(),
           organizationId,
-          clientId: snapshot.workspace.clientId,
-          billingReference: snapshot.workspace.billingReference,
-          color: snapshot.workspace.color,
-          name: newName,
-          reference,
-        });
+          scopeKey,
+          lastValue: 1,
+        })
+        .onConflictDoUpdate({
+          target: [matterCounters.organizationId, matterCounters.scopeKey],
+          set: { lastValue: sql`${matterCounters.lastValue} + 1` },
+        })
+        .returning({ lastValue: matterCounters.lastValue })
+        .then((rows) => rows.at(0));
 
-        await tx.execute(
-          sql`SELECT set_config(
+      if (!counter) {
+        return {
+          ok: false as const,
+          status: 500 as const,
+          message: "Failed to create matter counter",
+        };
+      }
+
+      const reference = toReference({
+        pattern,
+        now,
+        seq: counter.lastValue,
+        padding,
+      });
+
+      await tx.insert(workspaces).values({
+        id: targetWorkspaceId,
+        organizationId,
+        clientId: snapshot.workspace.clientId,
+        billingReference: snapshot.workspace.billingReference,
+        color: snapshot.workspace.color,
+        name: newName,
+        reference,
+      });
+
+      await tx.execute(
+        sql`SELECT set_config(
             ${SETTING_WORKSPACE_IDS},
             array_append(
               current_setting(${SETTING_WORKSPACE_IDS}, true)::text[],
@@ -569,242 +589,246 @@ const duplicateWorkspace = createSafeHandler(
             )::text,
             true
           )`,
+      );
+
+      if (snapshot.members.length > 0) {
+        await tx.insert(workspaceMembers).values(
+          snapshot.members.map((workspaceMember) => ({
+            workspaceId: targetWorkspaceId,
+            userId: workspaceMember.userId,
+          })),
         );
+      }
 
-        if (snapshot.members.length > 0) {
-          await tx.insert(workspaceMembers).values(
-            snapshot.members.map((workspaceMember) => ({
-              workspaceId: targetWorkspaceId,
-              userId: workspaceMember.userId,
-            })),
+      const propertyIdMap = new Map<string, SafeId<"property">>();
+      if (snapshot.properties.length > 0) {
+        const newProperties = snapshot.properties.map((property) => {
+          const id = createSafeId<"property">();
+          propertyIdMap.set(property.id, id);
+          return {
+            id,
+            workspaceId: targetWorkspaceId,
+            name: property.name,
+            status: property.status,
+            content: property.content,
+            tool: property.tool,
+            system: property.system,
+            kinds: property.kinds,
+          };
+        });
+        await tx.insert(properties).values(newProperties);
+      }
+
+      const newDependencies = snapshot.dependencies
+        .map((dependency) => {
+          const propertyId = propertyIdMap.get(dependency.propertyId);
+          const dependsOnPropertyId = propertyIdMap.get(
+            dependency.dependsOnPropertyId,
           );
-        }
+          if (!propertyId || !dependsOnPropertyId) {
+            return null;
+          }
+          return {
+            id: createSafeId<"propertyDependency">(),
+            workspaceId: targetWorkspaceId,
+            propertyId,
+            dependsOnPropertyId,
+            condition: dependency.condition,
+          };
+        })
+        .filter((dependency) => dependency !== null);
+      if (newDependencies.length > 0) {
+        await tx.insert(propertyDependencies).values(newDependencies);
+      }
 
-        const propertyIdMap = new Map<string, SafeId<"property">>();
-        if (snapshot.properties.length > 0) {
-          const newProperties = snapshot.properties.map((property) => {
-            const id = createSafeId<"property">();
-            propertyIdMap.set(property.id, id);
-            return {
-              id,
-              workspaceId: targetWorkspaceId,
-              name: property.name,
-              status: property.status,
-              content: property.content,
-              tool: property.tool,
-              system: property.system,
-              kinds: property.kinds,
-            };
-          });
-          await tx.insert(properties).values(newProperties);
-        }
-
-        const newDependencies = snapshot.dependencies
-          .map((dependency) => {
-            const propertyId = propertyIdMap.get(dependency.propertyId);
-            const dependsOnPropertyId = propertyIdMap.get(
-              dependency.dependsOnPropertyId,
-            );
-            if (!propertyId || !dependsOnPropertyId) {
-              return null;
-            }
-            return {
-              id: createSafeId<"propertyDependency">(),
-              workspaceId: targetWorkspaceId,
-              propertyId,
-              dependsOnPropertyId,
-              condition: dependency.condition,
-            };
-          })
-          .filter((dependency) => dependency !== null);
-        if (newDependencies.length > 0) {
-          await tx.insert(propertyDependencies).values(newDependencies);
-        }
-
-        if (snapshot.views.length > 0) {
-          await tx.insert(workspaceViews).values(
-            snapshot.views.map((view) => ({
-              id: createSafeId<"workspaceView">(),
-              workspaceId: targetWorkspaceId,
-              name: view.name,
-              layout: remapLayout(view.layout, propertyIdMap),
-              position: view.position,
-            })),
-          );
-        }
-
-        if (snapshot.contacts.length > 0) {
-          await tx.insert(workspaceContacts).values(
-            snapshot.contacts.map((contact) => ({
-              id: createSafeId<"workspaceContact">(),
-              organizationId,
-              workspaceId: targetWorkspaceId,
-              contactId: contact.contactId,
-              role: contact.role,
-              isPrimary: contact.isPrimary,
-              notes: contact.notes,
-            })),
-          );
-        }
-
-        const entityIdMap = new Map<string, SafeId<"entity">>();
-        const duplicatedEntityIds: SafeId<"entity">[] = [];
-        const entitiesToDuplicate = orderEntitiesForDuplicate(
-          snapshot.entities,
+      if (snapshot.views.length > 0) {
+        await tx.insert(workspaceViews).values(
+          snapshot.views.map((view) => ({
+            id: createSafeId<"workspaceView">(),
+            workspaceId: targetWorkspaceId,
+            name: view.name,
+            layout: remapLayout(view.layout, propertyIdMap),
+            position: view.position,
+          })),
         );
+      }
 
-        if (includeContent && entitiesToDuplicate.length > 0) {
-          if (entitiesToDuplicate.length > LIMITS.entitiesCount) {
+      if (snapshot.contacts.length > 0) {
+        await tx.insert(workspaceContacts).values(
+          snapshot.contacts.map((contact) => ({
+            id: createSafeId<"workspaceContact">(),
+            organizationId,
+            workspaceId: targetWorkspaceId,
+            contactId: contact.contactId,
+            role: contact.role,
+            isPrimary: contact.isPrimary,
+            notes: contact.notes,
+          })),
+        );
+      }
+
+      const entityIdMap = new Map<string, SafeId<"entity">>();
+      const duplicatedEntityIds: SafeId<"entity">[] = [];
+      const entitiesToDuplicate = orderEntitiesForDuplicate(snapshot.entities);
+
+      if (includeContent && entitiesToDuplicate.length > 0) {
+        if (entitiesToDuplicate.length > LIMITS.entitiesCount) {
+          return {
+            ok: false as const,
+            status: 400 as const,
+            message: "Entities limit reached",
+          };
+        }
+
+        for (const source of entitiesToDuplicate) {
+          if (!source.currentVersion) {
             return {
               ok: false as const,
               status: 400 as const,
-              message: "Entities limit reached",
+              message: "Entity has no current version",
             };
           }
 
-          for (const source of entitiesToDuplicate) {
-            if (!source.currentVersion) {
-              return {
-                ok: false as const,
-                status: 400 as const,
-                message: "Entity has no current version",
-              };
-            }
-
-            const newEntityId = createSafeId<"entity">();
-            const newVersionId = createSafeId<"entityVersion">();
-            const entityStamp =
-              source.kind === "document"
-                ? await allocateEntityStamp(tx, targetWorkspaceId)
-                : null;
-            const newParentId = source.parentId
-              ? (entityIdMap.get(source.parentId) ?? null)
+          const newEntityId = createSafeId<"entity">();
+          const newVersionId = createSafeId<"entityVersion">();
+          const entityStamp =
+            source.kind === "document"
+              ? await allocateEntityStamp(tx, targetWorkspaceId)
               : null;
+          const newParentId = source.parentId
+            ? (entityIdMap.get(source.parentId) ?? null)
+            : null;
 
-            await tx.insert(entities).values({
-              id: newEntityId,
-              workspaceId: targetWorkspaceId,
-              kind: source.kind,
-              parentId: newParentId,
-              name: source.name,
-              createdBy: user.id,
-              lastEditedBy: user.id,
-              docSequence: entityStamp?.docSequence ?? null,
-              status: source.status,
-              priority: source.priority,
-              dueDate: source.dueDate,
-              agendaKind: source.agendaKind,
-              startAt: source.startAt,
-              endAt: source.endAt,
-              occurredAt: source.occurredAt,
-              remindAt: source.remindAt,
-              allDay: source.allDay,
-              timeZone: source.timeZone,
-              location: source.location,
-              onlineMeetingUrl: source.onlineMeetingUrl,
-              availability: source.availability,
-              sensitivity: source.sensitivity,
-              organizer: source.organizer,
-              attendees: source.attendees,
-              recurrence: source.recurrence,
-              agendaSource: source.agendaSource,
-              externalSource: null,
-              externalId: null,
-              externalChangeKey: null,
-              externalICalUid: null,
-              externalData: null,
-              readOnly: false,
-              sortOrder: source.sortOrder,
-              metadata: source.metadata,
-            });
+          await tx.insert(entities).values({
+            id: newEntityId,
+            workspaceId: targetWorkspaceId,
+            kind: source.kind,
+            parentId: newParentId,
+            name: source.name,
+            createdBy: user.id,
+            lastEditedBy: user.id,
+            docSequence: entityStamp?.docSequence ?? null,
+            status: source.status,
+            priority: source.priority,
+            dueDate: source.dueDate,
+            agendaKind: source.agendaKind,
+            startAt: source.startAt,
+            endAt: source.endAt,
+            occurredAt: source.occurredAt,
+            remindAt: source.remindAt,
+            allDay: source.allDay,
+            timeZone: source.timeZone,
+            location: source.location,
+            onlineMeetingUrl: source.onlineMeetingUrl,
+            availability: source.availability,
+            sensitivity: source.sensitivity,
+            organizer: source.organizer,
+            attendees: source.attendees,
+            recurrence: source.recurrence,
+            agendaSource: source.agendaSource,
+            externalSource: null,
+            externalId: null,
+            externalChangeKey: null,
+            externalICalUid: null,
+            externalData: null,
+            readOnly: false,
+            sortOrder: source.sortOrder,
+            metadata: source.metadata,
+          });
 
-            await tx.insert(entityVersions).values({
-              id: newVersionId,
-              workspaceId: targetWorkspaceId,
-              entityId: newEntityId,
-              versionNumber: 1,
-              stamp: entityStamp?.stamp ?? null,
-              verificationCode: entityStamp?.verificationCode ?? null,
-              createdBy: user.id,
-            });
+          await tx.insert(entityVersions).values({
+            id: newVersionId,
+            workspaceId: targetWorkspaceId,
+            entityId: newEntityId,
+            versionNumber: 1,
+            stamp: entityStamp?.stamp ?? null,
+            verificationCode: entityStamp?.verificationCode ?? null,
+            createdBy: user.id,
+          });
 
-            await tx
-              .update(entities)
-              .set({ currentVersionId: newVersionId })
-              .where(eq(entities.id, newEntityId));
+          await tx
+            .update(entities)
+            .set({ currentVersionId: newVersionId })
+            .where(eq(entities.id, newEntityId));
 
-            const newFields = source.currentVersion.fields.flatMap((field) => {
-              const propertyId = propertyIdMap.get(field.propertyId);
-              if (!propertyId) {
-                return [];
-              }
-              return [
-                {
-                  workspaceId: targetWorkspaceId,
-                  propertyId,
-                  entityVersionId: newVersionId,
-                  content: remapFieldContent(field.content, fileIdMap),
-                },
-              ];
-            });
-            if (newFields.length > 0) {
-              await tx.insert(fields).values(newFields);
+          const newFields = source.currentVersion.fields.flatMap((field) => {
+            const propertyId = propertyIdMap.get(field.propertyId);
+            if (!propertyId) {
+              return [];
             }
-
-            entityIdMap.set(source.id, newEntityId);
-            duplicatedEntityIds.push(newEntityId);
-          }
-        }
-
-        await writeAuditLog(
-          {
-            ...createAuditContext({
-              organizationId,
-              workspaceId: targetWorkspaceId,
-              userId: user.id,
-              request,
-              server,
-            }),
-            action: AUDIT_ACTION.CREATE,
-            resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,
-            resourceId: targetWorkspaceId,
-            changes: {
-              created: {
-                old: { sourceWorkspaceId, includeContent },
-                new: { name: newName, reference },
+            return [
+              {
+                workspaceId: targetWorkspaceId,
+                propertyId,
+                entityVersionId: newVersionId,
+                content: remapFieldContent(field.content, fileIdMap),
               },
+            ];
+          });
+          if (newFields.length > 0) {
+            await tx.insert(fields).values(newFields);
+          }
+
+          entityIdMap.set(source.id, newEntityId);
+          duplicatedEntityIds.push(newEntityId);
+        }
+      }
+
+      await writeAuditLog(
+        {
+          ...createAuditContext({
+            organizationId,
+            workspaceId: targetWorkspaceId,
+            userId: user.id,
+            request,
+            server,
+          }),
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,
+          resourceId: targetWorkspaceId,
+          changes: {
+            created: {
+              old: { sourceWorkspaceId, includeContent },
+              new: { name: newName, reference },
             },
           },
-          tx,
-        );
+        },
+        tx,
+      );
 
-        return {
-          ok: true as const,
-          workspaceId: targetWorkspaceId,
-          entityIds: duplicatedEntityIds,
-        };
-      }),
-    );
+      return {
+        ok: true as const,
+        workspaceId: targetWorkspaceId,
+        entityIds: duplicatedEntityIds,
+      };
+    });
 
-    if (!txResult.ok) {
-      await Result.tryPromise(async () => {
-        await Promise.all(
-          copiedS3Keys.map(async (key) => await getS3().delete(key)),
-        );
+    if (Result.isError(txResult)) {
+      await cleanupCopiedS3Keys({
+        copiedS3Keys,
+        targetWorkspaceId,
+      });
+      return Result.err(txResult.error);
+    }
+
+    if (!txResult.value.ok) {
+      await cleanupCopiedS3Keys({
+        copiedS3Keys,
+        targetWorkspaceId,
       });
       return Result.err(
         new HandlerError({
-          status: txResult.status,
-          message: txResult.message,
+          status: txResult.value.status,
+          message: txResult.value.message,
         }),
       );
     }
 
-    for (const entityId of txResult.entityIds) {
+    for (const entityId of txResult.value.entityIds) {
       processExtraction(entityId).catch(captureError);
     }
 
-    return Result.ok({ workspaceId: txResult.workspaceId });
+    return Result.ok({ workspaceId: txResult.value.workspaceId });
   },
 );
 

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -1,0 +1,763 @@
+import { Result, panic } from "better-result";
+import { and, count, eq, ilike, inArray, sql } from "drizzle-orm";
+import { t } from "elysia";
+
+import { member } from "@/api/db/auth-schema";
+import { SETTING_WORKSPACE_IDS } from "@/api/db/rls";
+import {
+  entities,
+  entityVersions,
+  fields,
+  matterCounters,
+  properties,
+  propertyDependencies,
+  workspaceContacts,
+  workspaceMembers,
+  workspaces,
+  workspaceViews,
+} from "@/api/db/schema";
+import type { FieldContent } from "@/api/db/schema-validators";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createAuditContext,
+  writeAuditLog,
+} from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { escapeLike } from "@/api/lib/escape-like";
+import { LIMITS } from "@/api/lib/limits";
+import {
+  DEFAULT_MATTER_NUMBER_PADDING,
+  DEFAULT_MATTER_NUMBER_PATTERN,
+  toReference,
+  toScopeKey,
+} from "@/api/lib/matter-reference";
+import { getS3 } from "@/api/lib/s3";
+import { processExtraction } from "@/api/lib/search/process-extraction";
+import type { ViewLayout } from "@/api/lib/views-schema";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+
+const config = {
+  permissions: { workspace: ["create"] },
+  body: t.Object({
+    includeContent: t.Boolean(),
+  }),
+} satisfies HandlerConfig;
+
+type FileCopy = {
+  sourceFileId: string;
+  targetFileId: string;
+  mimeType: string;
+};
+
+const remapPropertyId = (
+  propertyId: string,
+  propertyIdMap: Map<string, SafeId<"property">>,
+) => propertyIdMap.get(propertyId) ?? propertyId;
+
+const remapLayout = (
+  layout: ViewLayout,
+  propertyIdMap: Map<string, SafeId<"property">>,
+): ViewLayout => {
+  const remapFilters = layout.filters.map((filter) => {
+    if (filter.field !== "property") {
+      return filter;
+    }
+    return {
+      ...filter,
+      propertyId: remapPropertyId(filter.propertyId, propertyIdMap),
+    };
+  });
+  const remapSorts = layout.sorts.map((sort) => ({
+    ...sort,
+    propertyId: remapPropertyId(sort.propertyId, propertyIdMap),
+  }));
+  const base = {
+    ...layout,
+    filters: remapFilters,
+    sorts: remapSorts,
+    hiddenProperties: layout.hiddenProperties.map((id) =>
+      remapPropertyId(id, propertyIdMap),
+    ),
+  };
+
+  if (base.type === "table") {
+    return {
+      ...base,
+      columnOrder: base.columnOrder.map((id) =>
+        remapPropertyId(id, propertyIdMap),
+      ),
+      columnPinning: base.columnPinning.map((id) =>
+        remapPropertyId(id, propertyIdMap),
+      ),
+    };
+  }
+
+  if (base.type === "kanban") {
+    return {
+      ...base,
+      groupByPropertyId: base.groupByPropertyId
+        ? remapPropertyId(base.groupByPropertyId, propertyIdMap)
+        : undefined,
+    };
+  }
+
+  if (base.type === "calendar") {
+    return {
+      ...base,
+      datePropertyId: remapPropertyId(base.datePropertyId, propertyIdMap),
+      endDatePropertyId: base.endDatePropertyId
+        ? remapPropertyId(base.endDatePropertyId, propertyIdMap)
+        : undefined,
+      additionalDatePropertyIds: base.additionalDatePropertyIds?.map((id) =>
+        remapPropertyId(id, propertyIdMap),
+      ),
+    };
+  }
+
+  if (base.type === "timeline") {
+    return {
+      ...base,
+      startDatePropertyId: remapPropertyId(
+        base.startDatePropertyId,
+        propertyIdMap,
+      ),
+      endDatePropertyId: remapPropertyId(base.endDatePropertyId, propertyIdMap),
+      groupByPropertyId: base.groupByPropertyId
+        ? remapPropertyId(base.groupByPropertyId, propertyIdMap)
+        : undefined,
+    };
+  }
+
+  return base;
+};
+
+const collectFileCopies = (content: FieldContent): FileCopy[] => {
+  if (content.type !== "file") {
+    return [];
+  }
+
+  const copies: FileCopy[] = [
+    {
+      sourceFileId: content.id,
+      targetFileId: Bun.randomUUIDv7(),
+      mimeType: content.mimeType,
+    },
+  ];
+
+  if (content.pdfFileId) {
+    copies.push({
+      sourceFileId: content.pdfFileId,
+      targetFileId: Bun.randomUUIDv7(),
+      mimeType: PDF_MIME_TYPE,
+    });
+  }
+
+  return copies;
+};
+
+const collectUniqueFileCopies = (
+  entitiesToCopy: {
+    currentVersion?: { fields: { content: FieldContent }[] } | null;
+  }[],
+) => {
+  const fileCopiesBySourceId = new Map<string, FileCopy>();
+
+  for (const entity of entitiesToCopy) {
+    for (const field of entity.currentVersion?.fields ?? []) {
+      for (const copy of collectFileCopies(field.content)) {
+        if (fileCopiesBySourceId.has(copy.sourceFileId)) {
+          continue;
+        }
+        fileCopiesBySourceId.set(copy.sourceFileId, copy);
+      }
+    }
+  }
+
+  return [...fileCopiesBySourceId.values()];
+};
+
+const remapFieldContent = (
+  content: FieldContent,
+  fileIdMap: Map<string, string>,
+): FieldContent => {
+  if (content.type !== "file") {
+    return content;
+  }
+
+  return {
+    ...content,
+    id: fileIdMap.get(content.id) ?? content.id,
+    pdfFileId: content.pdfFileId
+      ? (fileIdMap.get(content.pdfFileId) ?? content.pdfFileId)
+      : null,
+  };
+};
+
+const orderEntitiesForDuplicate = <
+  TEntity extends { id: string; parentId: string | null },
+>(
+  entitiesToOrder: TEntity[],
+) => {
+  const entityIds = new Set(entitiesToOrder.map((entity) => entity.id));
+  const childrenByParentId = new Map<string, TEntity[]>();
+  const roots: TEntity[] = [];
+
+  for (const entity of entitiesToOrder) {
+    if (!entity.parentId || !entityIds.has(entity.parentId)) {
+      roots.push(entity);
+      continue;
+    }
+
+    const children = childrenByParentId.get(entity.parentId);
+    if (children) {
+      children.push(entity);
+      continue;
+    }
+    childrenByParentId.set(entity.parentId, [entity]);
+  }
+
+  const ordered: TEntity[] = [];
+  const visited = new Set<string>();
+  const queue = [...roots];
+
+  for (const entity of queue) {
+    if (visited.has(entity.id)) {
+      continue;
+    }
+    visited.add(entity.id);
+    ordered.push(entity);
+    queue.push(...(childrenByParentId.get(entity.id) ?? []));
+  }
+
+  for (const entity of entitiesToOrder) {
+    if (!visited.has(entity.id)) {
+      ordered.push(entity);
+    }
+  }
+
+  return ordered;
+};
+
+const copyWorkspaceFile = async ({
+  copy,
+  organizationId,
+  sourceWorkspaceId,
+  targetWorkspaceId,
+}: {
+  copy: FileCopy;
+  organizationId: SafeId<"organization">;
+  sourceWorkspaceId: SafeId<"workspace">;
+  targetWorkspaceId: SafeId<"workspace">;
+}) => {
+  const sourceKey = createFileKey({
+    organizationId,
+    workspaceId: sourceWorkspaceId,
+    fileId: copy.sourceFileId,
+    mimeType: copy.mimeType,
+  });
+  const targetKey = createFileKey({
+    organizationId,
+    workspaceId: targetWorkspaceId,
+    fileId: copy.targetFileId,
+    mimeType: copy.mimeType,
+  });
+  const bytes = await getS3().file(sourceKey).arrayBuffer();
+  await getS3().write(targetKey, new Uint8Array(bytes));
+  return targetKey;
+};
+
+const duplicateWorkspace = createSafeHandler(
+  config,
+  async function* ({
+    safeDb,
+    session,
+    user,
+    workspaceId: sourceWorkspaceId,
+    request,
+    server,
+    body: { includeContent },
+  }) {
+    const organizationId = session.activeOrganizationId;
+    const targetWorkspaceId = createSafeId<"workspace">();
+
+    const snapshot = yield* Result.await(
+      safeDb(async (tx) => {
+        const workspace = await tx.query.workspaces.findFirst({
+          where: { id: { eq: sourceWorkspaceId } },
+          columns: {
+            id: true,
+            name: true,
+            clientId: true,
+            billingReference: true,
+            color: true,
+          },
+        });
+
+        if (!workspace) {
+          return null;
+        }
+
+        const [
+          workspaceProperties,
+          dependencies,
+          views,
+          members,
+          contacts,
+          sourceEntities,
+        ] = await Promise.all([
+          tx.query.properties.findMany({
+            where: { workspaceId: { eq: sourceWorkspaceId } },
+            orderBy: { createdAt: "asc" },
+          }),
+          tx.query.propertyDependencies.findMany({
+            where: { workspaceId: { eq: sourceWorkspaceId } },
+          }),
+          tx.query.workspaceViews.findMany({
+            where: { workspaceId: { eq: sourceWorkspaceId } },
+            orderBy: { position: "asc" },
+          }),
+          tx.query.workspaceMembers.findMany({
+            where: { workspaceId: { eq: sourceWorkspaceId } },
+            columns: { userId: true },
+          }),
+          tx.query.workspaceContacts.findMany({
+            where: { workspaceId: { eq: sourceWorkspaceId } },
+          }),
+          includeContent
+            ? tx.query.entities.findMany({
+                where: { workspaceId: { eq: sourceWorkspaceId } },
+                orderBy: { createdAt: "asc" },
+                limit: LIMITS.entitiesCount + 1,
+                with: {
+                  currentVersion: {
+                    columns: { id: true },
+                    with: {
+                      fields: {
+                        columns: {
+                          propertyId: true,
+                          content: true,
+                        },
+                      },
+                    },
+                  },
+                },
+              })
+            : Promise.resolve([]),
+        ]);
+
+        return {
+          workspace,
+          properties: workspaceProperties,
+          dependencies,
+          views,
+          members,
+          contacts,
+          entities: sourceEntities,
+        };
+      }),
+    );
+
+    if (!snapshot) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Workspace not found" }),
+      );
+    }
+
+    const fileCopies = collectUniqueFileCopies(snapshot.entities);
+    const fileIdMap = new Map(
+      fileCopies.map((copy) => [copy.sourceFileId, copy.targetFileId]),
+    );
+    const copiedS3Keys: string[] = [];
+
+    if (includeContent) {
+      const copyResult = await Result.tryPromise(async () => {
+        for (const copy of fileCopies) {
+          const key = await copyWorkspaceFile({
+            copy,
+            organizationId,
+            sourceWorkspaceId,
+            targetWorkspaceId,
+          });
+          copiedS3Keys.push(key);
+        }
+      });
+
+      if (Result.isError(copyResult)) {
+        await Result.tryPromise(async () => {
+          await Promise.all(
+            copiedS3Keys.map(async (key) => await getS3().delete(key)),
+          );
+        });
+        return Result.err(
+          new HandlerError({
+            status: 500,
+            message: "Failed to copy matter files",
+            cause: copyResult.error,
+          }),
+        );
+      }
+    }
+
+    const txResult = yield* Result.await(
+      safeDb(async (tx) => {
+        const [countResult, duplicatedNames, settings, orgMembers] =
+          await Promise.all([
+            tx
+              .select({ total: count() })
+              .from(workspaces)
+              .where(eq(workspaces.organizationId, organizationId)),
+            tx
+              .select({ name: workspaces.name })
+              .from(workspaces)
+              .where(
+                and(
+                  eq(workspaces.organizationId, organizationId),
+                  ilike(
+                    workspaces.name,
+                    `${escapeLike(snapshot.workspace.name)}%`,
+                  ),
+                ),
+              ),
+            tx.query.organizationSettings.findFirst({
+              where: { organizationId: { eq: organizationId } },
+              columns: {
+                matterNumberPattern: true,
+                matterNumberPadding: true,
+              },
+            }),
+            snapshot.members.length > 0
+              ? tx
+                  .select({ userId: member.userId })
+                  .from(member)
+                  .where(
+                    and(
+                      eq(member.organizationId, organizationId),
+                      inArray(
+                        member.userId,
+                        snapshot.members.map((m) => m.userId),
+                      ),
+                    ),
+                  )
+              : Promise.resolve([]),
+          ]);
+
+        const activeCount = countResult.at(0)?.total ?? 0;
+        if (activeCount >= LIMITS.workspacesCount) {
+          return {
+            ok: false as const,
+            status: 400 as const,
+            message: "Workspaces limit reached",
+          };
+        }
+
+        if (orgMembers.length !== snapshot.members.length) {
+          return {
+            ok: false as const,
+            status: 400 as const,
+            message: "Some users are not members of this organization",
+          };
+        }
+
+        const newName =
+          duplicatedNames.length > 0
+            ? `${snapshot.workspace.name} (${duplicatedNames.length})`
+            : snapshot.workspace.name;
+        const pattern =
+          settings?.matterNumberPattern ?? DEFAULT_MATTER_NUMBER_PATTERN;
+        const padding =
+          settings?.matterNumberPadding ?? DEFAULT_MATTER_NUMBER_PADDING;
+        const now = new Date();
+        const scopeKey = toScopeKey(pattern, now);
+        const counter = await tx
+          .insert(matterCounters)
+          .values({
+            id: createSafeId<"matterCounter">(),
+            organizationId,
+            scopeKey,
+            lastValue: 1,
+          })
+          .onConflictDoUpdate({
+            target: [matterCounters.organizationId, matterCounters.scopeKey],
+            set: { lastValue: sql`${matterCounters.lastValue} + 1` },
+          })
+          .returning({ lastValue: matterCounters.lastValue })
+          .then((rows) => rows.at(0));
+
+        if (!counter) {
+          panic("Failed to create matter counter");
+        }
+
+        const reference = toReference({
+          pattern,
+          now,
+          seq: counter.lastValue,
+          padding,
+        });
+
+        await tx.insert(workspaces).values({
+          id: targetWorkspaceId,
+          organizationId,
+          clientId: snapshot.workspace.clientId,
+          billingReference: snapshot.workspace.billingReference,
+          color: snapshot.workspace.color,
+          name: newName,
+          reference,
+        });
+
+        await tx.execute(
+          sql`SELECT set_config(
+            ${SETTING_WORKSPACE_IDS},
+            array_append(
+              current_setting(${SETTING_WORKSPACE_IDS}, true)::text[],
+              ${targetWorkspaceId}
+            )::text,
+            true
+          )`,
+        );
+
+        if (snapshot.members.length > 0) {
+          await tx.insert(workspaceMembers).values(
+            snapshot.members.map((workspaceMember) => ({
+              workspaceId: targetWorkspaceId,
+              userId: workspaceMember.userId,
+            })),
+          );
+        }
+
+        const propertyIdMap = new Map<string, SafeId<"property">>();
+        if (snapshot.properties.length > 0) {
+          const newProperties = snapshot.properties.map((property) => {
+            const id = createSafeId<"property">();
+            propertyIdMap.set(property.id, id);
+            return {
+              id,
+              workspaceId: targetWorkspaceId,
+              name: property.name,
+              status: property.status,
+              content: property.content,
+              tool: property.tool,
+              system: property.system,
+              kinds: property.kinds,
+            };
+          });
+          await tx.insert(properties).values(newProperties);
+        }
+
+        const newDependencies = snapshot.dependencies
+          .map((dependency) => {
+            const propertyId = propertyIdMap.get(dependency.propertyId);
+            const dependsOnPropertyId = propertyIdMap.get(
+              dependency.dependsOnPropertyId,
+            );
+            if (!propertyId || !dependsOnPropertyId) {
+              return null;
+            }
+            return {
+              id: createSafeId<"propertyDependency">(),
+              workspaceId: targetWorkspaceId,
+              propertyId,
+              dependsOnPropertyId,
+              condition: dependency.condition,
+            };
+          })
+          .filter((dependency) => dependency !== null);
+        if (newDependencies.length > 0) {
+          await tx.insert(propertyDependencies).values(newDependencies);
+        }
+
+        if (snapshot.views.length > 0) {
+          await tx.insert(workspaceViews).values(
+            snapshot.views.map((view) => ({
+              id: createSafeId<"workspaceView">(),
+              workspaceId: targetWorkspaceId,
+              name: view.name,
+              layout: remapLayout(view.layout, propertyIdMap),
+              position: view.position,
+            })),
+          );
+        }
+
+        if (snapshot.contacts.length > 0) {
+          await tx.insert(workspaceContacts).values(
+            snapshot.contacts.map((contact) => ({
+              id: createSafeId<"workspaceContact">(),
+              organizationId,
+              workspaceId: targetWorkspaceId,
+              contactId: contact.contactId,
+              role: contact.role,
+              isPrimary: contact.isPrimary,
+              notes: contact.notes,
+            })),
+          );
+        }
+
+        const entityIdMap = new Map<string, SafeId<"entity">>();
+        const duplicatedEntityIds: SafeId<"entity">[] = [];
+        const entitiesToDuplicate = orderEntitiesForDuplicate(
+          snapshot.entities,
+        );
+
+        if (includeContent && entitiesToDuplicate.length > 0) {
+          if (entitiesToDuplicate.length > LIMITS.entitiesCount) {
+            return {
+              ok: false as const,
+              status: 400 as const,
+              message: "Entities limit reached",
+            };
+          }
+
+          for (const source of entitiesToDuplicate) {
+            if (!source.currentVersion) {
+              return {
+                ok: false as const,
+                status: 400 as const,
+                message: "Entity has no current version",
+              };
+            }
+
+            const newEntityId = createSafeId<"entity">();
+            const newVersionId = createSafeId<"entityVersion">();
+            const entityStamp =
+              source.kind === "document"
+                ? await allocateEntityStamp(tx, targetWorkspaceId)
+                : null;
+            const newParentId = source.parentId
+              ? (entityIdMap.get(source.parentId) ?? null)
+              : null;
+
+            await tx.insert(entities).values({
+              id: newEntityId,
+              workspaceId: targetWorkspaceId,
+              kind: source.kind,
+              parentId: newParentId,
+              name: source.name,
+              createdBy: user.id,
+              lastEditedBy: source.lastEditedBy,
+              docSequence: entityStamp?.docSequence ?? null,
+              status: source.status,
+              priority: source.priority,
+              dueDate: source.dueDate,
+              agendaKind: source.agendaKind,
+              startAt: source.startAt,
+              endAt: source.endAt,
+              occurredAt: source.occurredAt,
+              remindAt: source.remindAt,
+              allDay: source.allDay,
+              timeZone: source.timeZone,
+              location: source.location,
+              onlineMeetingUrl: source.onlineMeetingUrl,
+              availability: source.availability,
+              sensitivity: source.sensitivity,
+              organizer: source.organizer,
+              attendees: source.attendees,
+              recurrence: source.recurrence,
+              agendaSource: source.agendaSource,
+              externalSource: null,
+              externalId: null,
+              externalChangeKey: null,
+              externalICalUid: null,
+              externalData: null,
+              readOnly: false,
+              sortOrder: source.sortOrder,
+              metadata: source.metadata,
+            });
+
+            await tx.insert(entityVersions).values({
+              id: newVersionId,
+              workspaceId: targetWorkspaceId,
+              entityId: newEntityId,
+              versionNumber: 1,
+              stamp: entityStamp?.stamp ?? null,
+              verificationCode: entityStamp?.verificationCode ?? null,
+              createdBy: user.id,
+            });
+
+            await tx
+              .update(entities)
+              .set({ currentVersionId: newVersionId })
+              .where(eq(entities.id, newEntityId));
+
+            const newFields = source.currentVersion.fields.flatMap((field) => {
+              const propertyId = propertyIdMap.get(field.propertyId);
+              if (!propertyId) {
+                return [];
+              }
+              return [
+                {
+                  workspaceId: targetWorkspaceId,
+                  propertyId,
+                  entityVersionId: newVersionId,
+                  content: remapFieldContent(field.content, fileIdMap),
+                },
+              ];
+            });
+            if (newFields.length > 0) {
+              await tx.insert(fields).values(newFields);
+            }
+
+            entityIdMap.set(source.id, newEntityId);
+            duplicatedEntityIds.push(newEntityId);
+          }
+        }
+
+        await writeAuditLog(
+          {
+            ...createAuditContext({
+              organizationId,
+              workspaceId: targetWorkspaceId,
+              userId: user.id,
+              request,
+              server,
+            }),
+            action: AUDIT_ACTION.CREATE,
+            resourceType: AUDIT_RESOURCE_TYPE.WORKSPACE,
+            resourceId: targetWorkspaceId,
+            changes: {
+              created: {
+                old: { sourceWorkspaceId, includeContent },
+                new: { name: newName, reference },
+              },
+            },
+          },
+          tx,
+        );
+
+        return {
+          ok: true as const,
+          workspaceId: targetWorkspaceId,
+          entityIds: duplicatedEntityIds,
+        };
+      }),
+    );
+
+    if (!txResult.ok) {
+      await Result.tryPromise(async () => {
+        await Promise.all(
+          copiedS3Keys.map(async (key) => await getS3().delete(key)),
+        );
+      });
+      return Result.err(
+        new HandlerError({
+          status: txResult.status,
+          message: txResult.message,
+        }),
+      );
+    }
+
+    for (const entityId of txResult.entityIds) {
+      processExtraction(entityId).catch(captureError);
+    }
+
+    return Result.ok({ workspaceId: txResult.workspaceId });
+  },
+);
+
+export default duplicateWorkspace;

--- a/apps/api/src/handlers/workspaces/duplicate.ts
+++ b/apps/api/src/handlers/workspaces/duplicate.ts
@@ -40,6 +40,7 @@ import {
   toScopeKey,
 } from "@/api/lib/matter-reference";
 import { getS3 } from "@/api/lib/s3";
+import { upsertWorkspaceSearchDocument } from "@/api/lib/search/index-global";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import type { ViewLayout } from "@/api/lib/views-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
@@ -826,6 +827,10 @@ const duplicateWorkspace = createSafeHandler(
         }),
       );
     }
+
+    upsertWorkspaceSearchDocument(txResult.value.workspaceId).catch(
+      captureError,
+    );
 
     for (const entityId of txResult.value.entityIds) {
       processExtraction(entityId).catch(captureError);

--- a/apps/api/src/handlers/workspaces/routes.ts
+++ b/apps/api/src/handlers/workspaces/routes.ts
@@ -200,7 +200,7 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
         .post("/duplicate", duplicateWorkspace.handler, {
           body: duplicateWorkspace.config.body,
           permissions: duplicateWorkspace.config.permissions,
-          invalidateQuery: true,
+          invalidateOrganizationQuery: true,
         })
         .post("/active", updateActiveWorkspace.handler)
         .delete("/", deleteWorkspace.handler, {

--- a/apps/api/src/handlers/workspaces/routes.ts
+++ b/apps/api/src/handlers/workspaces/routes.ts
@@ -4,6 +4,7 @@ import Elysia, { t } from "elysia";
 import archiveWorkspace from "@/api/handlers/workspaces/archive";
 import createWorkspaces from "@/api/handlers/workspaces/create";
 import deleteWorkspace from "@/api/handlers/workspaces/delete-by-id";
+import duplicateWorkspace from "@/api/handlers/workspaces/duplicate";
 import generateBoundingBoxes from "@/api/handlers/workspaces/generate-bounding-boxes";
 import infosoudCourts from "@/api/handlers/workspaces/infosoud-courts";
 import infosoudImportAgenda from "@/api/handlers/workspaces/infosoud-import-agenda";
@@ -194,6 +195,11 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
         .get("/overview", readOverview.handler)
         .post("/", updateWorkspace.handler, {
           body: updateWorkspace.config.body,
+          invalidateQuery: true,
+        })
+        .post("/duplicate", duplicateWorkspace.handler, {
+          body: duplicateWorkspace.config.body,
+          permissions: duplicateWorkspace.config.permissions,
           invalidateQuery: true,
         })
         .post("/active", updateActiveWorkspace.handler)

--- a/apps/api/src/lib/invalidate-query-macro.ts
+++ b/apps/api/src/lib/invalidate-query-macro.ts
@@ -1,6 +1,7 @@
 import Elysia, { t } from "elysia";
 
 import { authMacro } from "@/api/lib/auth";
+import type { SafeId } from "@/api/lib/branded-types";
 import { brandPersistedWorkspaceId } from "@/api/lib/safe-id-boundaries";
 import { broadcast, broadcastToOrganization } from "@/api/lib/sse";
 
@@ -12,6 +13,18 @@ const invalidateQueryBodySchema = t.Object({
 
 const INVALIDATE_QUERY_EVENT_TYPE = "invalidate-query";
 
+const createInvalidateQueryEvent = (queryKey: string[]) => ({
+  type: INVALIDATE_QUERY_EVENT_TYPE,
+  data: queryKey,
+});
+
+export const broadcastQueryInvalidationToOrganization = (
+  organizationId: SafeId<"organization">,
+  queryKey: string[],
+) => {
+  broadcastToOrganization(organizationId, createInvalidateQueryEvent(queryKey));
+};
+
 export const invalidateQuery = new Elysia({ name: "invalidateQueryMacro" })
   .use(authMacro)
   .macro("invalidateQuery", {
@@ -22,11 +35,7 @@ export const invalidateQuery = new Elysia({ name: "invalidateQueryMacro" })
         return;
       }
 
-      const event = {
-        type: INVALIDATE_QUERY_EVENT_TYPE,
-        data: ctx.body.queryKey,
-      };
-
+      const event = createInvalidateQueryEvent(ctx.body.queryKey);
       const workspaceId =
         "workspaceId" in ctx ? String(ctx.workspaceId) : undefined;
 
@@ -35,5 +44,19 @@ export const invalidateQuery = new Elysia({ name: "invalidateQueryMacro" })
       } else {
         broadcastToOrganization(ctx.session.activeOrganizationId, event);
       }
+    },
+  })
+  .macro("invalidateOrganizationQuery", {
+    validateAuth: true,
+    body: invalidateQueryBodySchema,
+    afterHandle: (ctx) => {
+      if (ctx.session === null || ctx.session === undefined) {
+        return;
+      }
+
+      broadcastQueryInvalidationToOrganization(
+        ctx.session.activeOrganizationId,
+        ctx.body.queryKey,
+      );
     },
   });

--- a/apps/web/src/components/matter-number-hint.tsx
+++ b/apps/web/src/components/matter-number-hint.tsx
@@ -1,7 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
-import { Popover, PopoverPopup } from "@stll/ui/components/popover";
+import { Button } from "@stll/ui/components/button";
+import {
+  Popover,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
 
 import { matchesPattern, previewReference } from "@/lib/matter-reference";
 import { organizationSettingsOptions } from "@/routes/_protected.organization/-settings-queries";
@@ -18,25 +26,41 @@ const MatterNumberHintBody = ({
   error,
 }: MatterNumberHintBodyProps) => {
   const t = useTranslations();
-  return (
-    <>
-      <p className="text-muted-foreground text-xs">
-        {t("workspaces.referenceConventionHint", { example })}
-      </p>
-      {error ? (
-        <p className="text-destructive mt-1 text-xs">{error}</p>
-      ) : showWarning ? (
-        <p className="mt-1 text-xs text-amber-600">
+
+  if (error) {
+    return <p className="text-destructive text-xs">{error}</p>;
+  }
+
+  if (showWarning) {
+    return (
+      <div className="space-y-1 text-xs">
+        <p className="text-muted-foreground">
+          {t("workspaces.referenceConventionHint", { example })}
+        </p>
+        <p className="text-amber-600">
           {t("workspaces.referenceFormatWarning")}
         </p>
-      ) : null}
-    </>
+        <Link
+          className="text-foreground inline-flex text-xs font-medium hover:underline"
+          to="/settings/organization/matter-numbering"
+        >
+          {t("settings.organization.matterNumbering")}
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-muted-foreground truncate text-xs">
+      {t("workspaces.referenceConventionHint", { example })}
+    </p>
   );
 };
 
 type InlineProps = {
   variant: "inline";
   value: string;
+  className?: string | undefined;
   error?: string | undefined;
 };
 
@@ -51,6 +75,7 @@ type PopoverProps = {
 export type MatterNumberHintProps = InlineProps | PopoverProps;
 
 export const MatterNumberHint = (props: MatterNumberHintProps) => {
+  const t = useTranslations();
   const { data: settings } = useQuery(organizationSettingsOptions);
 
   if (!settings) {
@@ -65,8 +90,36 @@ export const MatterNumberHint = (props: MatterNumberHintProps) => {
     trimmed.length > 0 && !matchesPattern(trimmed, pattern, padding);
 
   if (props.variant === "inline") {
+    if (showWarning && !props.error) {
+      return (
+        <div className={cn("mt-1", props.className)}>
+          <Popover>
+            <PopoverTrigger
+              render={
+                <Button
+                  aria-label={t("workspaces.referenceFormatWarning")}
+                  className="text-amber-600 hover:text-amber-700"
+                  size="icon-xs"
+                  title={t("workspaces.referenceFormatWarning")}
+                  variant="ghost"
+                />
+              }
+            >
+              <AlertTriangleIcon className="size-3.5" />
+            </PopoverTrigger>
+            <PopoverPopup align="start" className="w-72" side="bottom">
+              <MatterNumberHintBody
+                example={example}
+                showWarning={showWarning}
+              />
+            </PopoverPopup>
+          </Popover>
+        </div>
+      );
+    }
+
     return (
-      <div className="mt-1">
+      <div className={cn("mt-1", props.className)}>
         <MatterNumberHintBody
           error={props.error}
           example={example}

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Role aktualizována",
     "sessionRevoked": "Sezení odhlášeno",
     "taskCreated": "Úkol vytvořen",
-    "workspaceDeletedSuccessfully": "Spis úspěšně smazán"
+    "workspaceDeletedSuccessfully": "Spis úspěšně smazán",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Přidat osobu",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Mazání spisu",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} other {# dokumentů}}",
     "dropToUploadFiles": "Přetáhněte soubory pro nahrání",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplikovat s obsahem",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Nahrajte dokumenty a získejte extrakci tabulek, organizaci dokumentů, úpravy přímo v prohlížeči a vyhledávání napříč tímto spisem.",
       "title": "Nahrajte první dokumenty",

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sezení odhlášeno",
     "taskCreated": "Úkol vytvořen",
     "workspaceDeletedSuccessfully": "Spis úspěšně smazán",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Spis úspěšně duplikován"
   },
   "tasks": {
     "addAssignee": "Přidat osobu",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Mazání spisu",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} other {# dokumentů}}",
     "dropToUploadFiles": "Přetáhněte soubory pro nahrání",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Duplikovat spis",
+    "duplicateMatterDescription": "Duplikujete spis, jeho název, klienta, členy týmu, účastníky a zobrazení.",
+    "duplicateMatterWithContentDescription": "Duplikujete spis, jeho název, klienta, členy týmu, účastníky, zobrazení a obsah.",
     "duplicateWithContent": "Duplikovat s obsahem",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplikování spisu",
     "emptyDocuments": {
       "description": "Nahrajte dokumenty a získejte extrakci tabulek, organizaci dokumentů, úpravy přímo v prohlížeči a vyhledávání napříč tímto spisem.",
       "title": "Nahrajte první dokumenty",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sitzung beendet",
     "taskCreated": "Aufgabe erstellt",
     "workspaceDeletedSuccessfully": "Akte erfolgreich gelöscht",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Akte erfolgreich dupliziert"
   },
   "tasks": {
     "addAssignee": "Person zuweisen",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Akte wird gelöscht",
     "documentsCount": "{count, plural, one {# Dokument} other {# Dokumente}}",
     "dropToUploadFiles": "Dateien zum Hochladen ablegen",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Akte duplizieren",
+    "duplicateMatterDescription": "Sie duplizieren die Akte, ihren Namen, Mandanten, Teammitglieder, Beteiligte und Ansichten.",
+    "duplicateMatterWithContentDescription": "Sie duplizieren die Akte, ihren Namen, Mandanten, Teammitglieder, Beteiligte, Ansichten und Inhalt.",
     "duplicateWithContent": "Mit Inhalt duplizieren",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Akte wird dupliziert",
     "emptyDocuments": {
       "description": "Laden Sie Dokumente hoch, um Tabellenextraktion, Dokumentorganisation, Bearbeitung im Browser und Suche in dieser Akte zu ermöglichen.",
       "title": "Laden Sie Ihre ersten Dokumente hoch",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rolle aktualisiert",
     "sessionRevoked": "Sitzung beendet",
     "taskCreated": "Aufgabe erstellt",
-    "workspaceDeletedSuccessfully": "Akte erfolgreich gelöscht"
+    "workspaceDeletedSuccessfully": "Akte erfolgreich gelöscht",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Person zuweisen",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Akte wird gelöscht",
     "documentsCount": "{count, plural, one {# Dokument} other {# Dokumente}}",
     "dropToUploadFiles": "Dateien zum Hochladen ablegen",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Mit Inhalt duplizieren",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Laden Sie Dokumente hoch, um Tabellenextraktion, Dokumentorganisation, Bearbeitung im Browser und Suche in dieser Akte zu ermöglichen.",
       "title": "Laden Sie Ihre ersten Dokumente hoch",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Role updated",
     "sessionRevoked": "Session revoked",
     "taskCreated": "Task created",
-    "workspaceDeletedSuccessfully": "Matter deleted successfully"
+    "workspaceDeletedSuccessfully": "Matter deleted successfully",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Add assignee",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Deleting matter",
     "documentsCount": "{count, plural, one {# document} other {# documents}}",
     "dropToUploadFiles": "Drop to upload files",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplicate with content",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Upload documents to enable table extraction, document organization, in-browser editing, and search across this matter.",
       "title": "Upload your first documents",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rol actualizado",
     "sessionRevoked": "Sesión cerrada",
     "taskCreated": "Tarea creada",
-    "workspaceDeletedSuccessfully": "Asunto eliminado correctamente"
+    "workspaceDeletedSuccessfully": "Asunto eliminado correctamente",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Añadir asignado",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Eliminando asunto",
     "documentsCount": "{count, plural, one {# documento} other {# documentos}}",
     "dropToUploadFiles": "Suelte para subir archivos",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplicar con contenido",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Suba documentos para habilitar la extracción de tablas, la organización de documentos, la edición en el navegador y la búsqueda en este asunto.",
       "title": "Suba sus primeros documentos",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sesión cerrada",
     "taskCreated": "Tarea creada",
     "workspaceDeletedSuccessfully": "Asunto eliminado correctamente",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Asunto duplicado correctamente"
   },
   "tasks": {
     "addAssignee": "Añadir asignado",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Eliminando asunto",
     "documentsCount": "{count, plural, one {# documento} other {# documentos}}",
     "dropToUploadFiles": "Suelte para subir archivos",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Duplicar asunto",
+    "duplicateMatterDescription": "Duplicarás el asunto, su nombre, cliente, miembros del equipo, partes y vistas.",
+    "duplicateMatterWithContentDescription": "Duplicarás el asunto, su nombre, cliente, miembros del equipo, partes, vistas y contenido.",
     "duplicateWithContent": "Duplicar con contenido",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplicando asunto",
     "emptyDocuments": {
       "description": "Suba documentos para habilitar la extracción de tablas, la organización de documentos, la edición en el navegador y la búsqueda en este asunto.",
       "title": "Suba sus primeros documentos",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Roll uuendatud",
     "sessionRevoked": "Seanss lõpetatud",
     "taskCreated": "Ülesanne loodud",
-    "workspaceDeletedSuccessfully": "Toimik edukalt kustutatud"
+    "workspaceDeletedSuccessfully": "Toimik edukalt kustutatud",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Lisa isik",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Toimiku kustutamine",
     "documentsCount": "{count, plural, one {# dokument} other {# dokumenti}}",
     "dropToUploadFiles": "Lohistage failid üleslaadimiseks siia",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Dubleeri koos sisuga",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Laadige dokumendid üles, et võimaldada tabelite eraldamist, dokumentide korrastamist, brauseris redigeerimist ja otsingut selles asjas.",
       "title": "Laadige üles esimesed dokumendid",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Seanss lõpetatud",
     "taskCreated": "Ülesanne loodud",
     "workspaceDeletedSuccessfully": "Toimik edukalt kustutatud",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Toimik edukalt dubleeritud"
   },
   "tasks": {
     "addAssignee": "Lisa isik",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Toimiku kustutamine",
     "documentsCount": "{count, plural, one {# dokument} other {# dokumenti}}",
     "dropToUploadFiles": "Lohistage failid üleslaadimiseks siia",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Dubleeri toimik",
+    "duplicateMatterDescription": "Dubleerid toimiku, selle nime, kliendi, tiimiliikmed, osapooled ja vaated.",
+    "duplicateMatterWithContentDescription": "Dubleerid toimiku, selle nime, kliendi, tiimiliikmed, osapooled, vaated ja sisu.",
     "duplicateWithContent": "Dubleeri koos sisuga",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Toimiku dubleerimine",
     "emptyDocuments": {
       "description": "Laadige dokumendid üles, et võimaldada tabelite eraldamist, dokumentide korrastamist, brauseris redigeerimist ja otsingut selles asjas.",
       "title": "Laadige üles esimesed dokumendid",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rôle mis à jour",
     "sessionRevoked": "Session révoquée",
     "taskCreated": "Tâche créée",
-    "workspaceDeletedSuccessfully": "Dossier supprimé avec succès"
+    "workspaceDeletedSuccessfully": "Dossier supprimé avec succès",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Ajouter un assigné",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Suppression du dossier",
     "documentsCount": "{count, plural, one {# document} other {# documents}}",
     "dropToUploadFiles": "Déposez pour importer des fichiers",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Dupliquer avec le contenu",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Importez des documents pour activer l’extraction de tableaux, l’organisation des documents, la modification dans le navigateur et la recherche dans ce dossier.",
       "title": "Importez vos premiers documents",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Session révoquée",
     "taskCreated": "Tâche créée",
     "workspaceDeletedSuccessfully": "Dossier supprimé avec succès",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Dossier dupliqué avec succès"
   },
   "tasks": {
     "addAssignee": "Ajouter un assigné",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Suppression du dossier",
     "documentsCount": "{count, plural, one {# document} other {# documents}}",
     "dropToUploadFiles": "Déposez pour importer des fichiers",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Dupliquer le dossier",
+    "duplicateMatterDescription": "Vous allez dupliquer le dossier, son nom, son client, les membres de l'équipe, les parties et les vues.",
+    "duplicateMatterWithContentDescription": "Vous allez dupliquer le dossier, son nom, son client, les membres de l'équipe, les parties, les vues et son contenu.",
     "duplicateWithContent": "Dupliquer avec le contenu",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplication du dossier",
     "emptyDocuments": {
       "description": "Importez des documents pour activer l’extraction de tableaux, l’organisation des documents, la modification dans le navigateur et la recherche dans ce dossier.",
       "title": "Importez vos premiers documents",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Munkamenet visszavonva",
     "taskCreated": "Feladat létrehozva",
     "workspaceDeletedSuccessfully": "Ügy sikeresen törölve",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Ügy sikeresen másolva"
   },
   "tasks": {
     "addAssignee": "Felelős hozzáadása",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Ügy törlése folyamatban",
     "documentsCount": "{count, plural, one {# dokumentum} other {# dokumentum}}",
     "dropToUploadFiles": "Húzza ide a fájlokat a feltöltéshez",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Ügy másolása",
+    "duplicateMatterDescription": "Másolni fogja az ügyet, annak nevét, ügyfelét, csapattagjait, feleit és nézeteit.",
+    "duplicateMatterWithContentDescription": "Másolni fogja az ügyet, annak nevét, ügyfelét, csapattagjait, feleit, nézeteit és tartalmát.",
     "duplicateWithContent": "Másolás tartalommal",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Ügy másolása folyamatban",
     "emptyDocuments": {
       "description": "Töltsön fel dokumentumokat a táblázatok kinyeréséhez, a dokumentumok rendszerezéséhez, a böngészőn belüli szerkesztéshez és az ügyön belüli kereséshez.",
       "title": "Töltse fel az első dokumentumokat",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Szerepkör frissítve",
     "sessionRevoked": "Munkamenet visszavonva",
     "taskCreated": "Feladat létrehozva",
-    "workspaceDeletedSuccessfully": "Ügy sikeresen törölve"
+    "workspaceDeletedSuccessfully": "Ügy sikeresen törölve",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Felelős hozzáadása",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Ügy törlése folyamatban",
     "documentsCount": "{count, plural, one {# dokumentum} other {# dokumentum}}",
     "dropToUploadFiles": "Húzza ide a fájlokat a feltöltéshez",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Másolás tartalommal",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Töltsön fel dokumentumokat a táblázatok kinyeréséhez, a dokumentumok rendszerezéséhez, a böngészőn belüli szerkesztéshez és az ügyön belüli kereséshez.",
       "title": "Töltse fel az első dokumentumokat",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rolė atnaujinta",
     "sessionRevoked": "Sesija baigta",
     "taskCreated": "Užduotis sukurta",
-    "workspaceDeletedSuccessfully": "Byla sėkmingai ištrinta"
+    "workspaceDeletedSuccessfully": "Byla sėkmingai ištrinta",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Priskirti asmenį",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Byla trinama",
     "documentsCount": "{count, plural, one {# dokumentas} few {# dokumentai} many {# dokumento} other {# dokumentų}}",
     "dropToUploadFiles": "Vilkite failus norėdami įkelti",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Dubliuoti su turiniu",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Įkelkite dokumentus, kad galėtumėte išgauti lenteles, tvarkyti dokumentus, redaguoti naršyklėje ir ieškoti šioje byloje.",
       "title": "Įkelkite pirmuosius dokumentus",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sesija baigta",
     "taskCreated": "Užduotis sukurta",
     "workspaceDeletedSuccessfully": "Byla sėkmingai ištrinta",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Byla sėkmingai dubliuota"
   },
   "tasks": {
     "addAssignee": "Priskirti asmenį",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Byla trinama",
     "documentsCount": "{count, plural, one {# dokumentas} few {# dokumentai} many {# dokumento} other {# dokumentų}}",
     "dropToUploadFiles": "Vilkite failus norėdami įkelti",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Dubliuoti bylą",
+    "duplicateMatterDescription": "Dubliuosite bylą, jos pavadinimą, klientą, komandos narius, šalis ir rodinius.",
+    "duplicateMatterWithContentDescription": "Dubliuosite bylą, jos pavadinimą, klientą, komandos narius, šalis, rodinius ir turinį.",
     "duplicateWithContent": "Dubliuoti su turiniu",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Byla dubliuojama",
     "emptyDocuments": {
       "description": "Įkelkite dokumentus, kad galėtumėte išgauti lenteles, tvarkyti dokumentus, redaguoti naršyklėje ir ieškoti šioje byloje.",
       "title": "Įkelkite pirmuosius dokumentus",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sesija beigta",
     "taskCreated": "Uzdevums izveidots",
     "workspaceDeletedSuccessfully": "Lieta veiksmīgi dzēsta",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Lieta veiksmīgi dublēta"
   },
   "tasks": {
     "addAssignee": "Pievienot atbildīgo",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Dzēš lietu",
     "documentsCount": "{count, plural, zero {# dokumentu} one {# dokuments} other {# dokumenti}}",
     "dropToUploadFiles": "Nometiet, lai augšupielādētu failus",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Dublēt lietu",
+    "duplicateMatterDescription": "Jūs dublēsiet lietu, tās nosaukumu, klientu, komandas dalībniekus, puses un skatus.",
+    "duplicateMatterWithContentDescription": "Jūs dublēsiet lietu, tās nosaukumu, klientu, komandas dalībniekus, puses, skatus un saturu.",
     "duplicateWithContent": "Dublēt ar saturu",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Dublē lietu",
     "emptyDocuments": {
       "description": "Augšupielādējiet dokumentus, lai iespējotu tabulu izguvi, dokumentu kārtošanu, rediģēšanu pārlūkā un meklēšanu šajā lietā.",
       "title": "Augšupielādējiet pirmos dokumentus",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Loma atjaunināta",
     "sessionRevoked": "Sesija beigta",
     "taskCreated": "Uzdevums izveidots",
-    "workspaceDeletedSuccessfully": "Lieta veiksmīgi dzēsta"
+    "workspaceDeletedSuccessfully": "Lieta veiksmīgi dzēsta",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Pievienot atbildīgo",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Dzēš lietu",
     "documentsCount": "{count, plural, zero {# dokumentu} one {# dokuments} other {# dokumenti}}",
     "dropToUploadFiles": "Nometiet, lai augšupielādētu failus",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Dublēt ar saturu",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Augšupielādējiet dokumentus, lai iespējotu tabulu izguvi, dokumentu kārtošanu, rediģēšanu pārlūkā un meklēšanu šajā lietā.",
       "title": "Augšupielādējiet pirmos dokumentus",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1516,6 +1516,7 @@ type Messages = {
     "sessionRevoked": "Session revoked";
     "taskCreated": "Task created";
     "workspaceDeletedSuccessfully": "Matter deleted successfully";
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully";
   };
   "tasks": {
     "addAssignee": "Add assignee";
@@ -1672,7 +1673,11 @@ type Messages = {
     "deletingWorkspace": "Deleting matter";
     "documentsCount": "{count, plural, one {# document} other {# documents}}";
     "dropToUploadFiles": "Drop to upload files";
+    "duplicateMatter": "Duplicate matter";
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.";
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.";
     "duplicateWithContent": "Duplicate with content";
+    "duplicatingWorkspace": "Duplicating matter";
     "emptyDocuments": {
       "description": "Upload documents to enable table extraction, document organization, in-browser editing, and search across this matter.";
       "title": "Upload your first documents";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sesja zakończona",
     "taskCreated": "Zadanie utworzone",
     "workspaceDeletedSuccessfully": "Sprawa usunięta pomyślnie",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Sprawa została pomyślnie zduplikowana"
   },
   "tasks": {
     "addAssignee": "Przypisz osobę",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Usuwanie sprawy",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} many {# dokumentów} other {# dokumentu}}",
     "dropToUploadFiles": "Upuść pliki, aby je przesłać",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Duplikuj sprawę",
+    "duplicateMatterDescription": "Zduplikujesz sprawę, jej nazwę, klienta, członków zespołu, strony i widoki.",
+    "duplicateMatterWithContentDescription": "Zduplikujesz sprawę, jej nazwę, klienta, członków zespołu, strony, widoki i treść.",
     "duplicateWithContent": "Duplikuj z zawartością",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplikowanie sprawy",
     "emptyDocuments": {
       "description": "Prześlij dokumenty, aby włączyć wyodrębnianie tabel, porządkowanie dokumentów, edycję w przeglądarce i wyszukiwanie w tej sprawie.",
       "title": "Prześlij pierwsze dokumenty",

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rola zaktualizowana",
     "sessionRevoked": "Sesja zakończona",
     "taskCreated": "Zadanie utworzone",
-    "workspaceDeletedSuccessfully": "Sprawa usunięta pomyślnie"
+    "workspaceDeletedSuccessfully": "Sprawa usunięta pomyślnie",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Przypisz osobę",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Usuwanie sprawy",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} many {# dokumentów} other {# dokumentu}}",
     "dropToUploadFiles": "Upuść pliki, aby je przesłać",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplikuj z zawartością",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Prześlij dokumenty, aby włączyć wyodrębnianie tabel, porządkowanie dokumentów, edycję w przeglądarce i wyszukiwanie w tej sprawie.",
       "title": "Prześlij pierwsze dokumenty",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Sessão revogada",
     "taskCreated": "Tarefa criada",
     "workspaceDeletedSuccessfully": "Caso excluído com sucesso",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Caso duplicado com sucesso"
   },
   "tasks": {
     "addAssignee": "Adicionar responsável",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Excluindo caso",
     "documentsCount": "{count, plural, one {# documento} many {# documentos} other {# documentos}}",
     "dropToUploadFiles": "Solte para fazer upload de arquivos",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Duplicar caso",
+    "duplicateMatterDescription": "Você duplicará o caso, seu nome, cliente, membros da equipe, partes e visualizações.",
+    "duplicateMatterWithContentDescription": "Você duplicará o caso, seu nome, cliente, membros da equipe, partes, visualizações e conteúdo.",
     "duplicateWithContent": "Duplicar com conteúdo",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplicando caso",
     "emptyDocuments": {
       "description": "Envie documentos para habilitar extração de tabelas, organização de documentos, edição no navegador e pesquisa neste caso.",
       "title": "Envie seus primeiros documentos",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Função atualizada",
     "sessionRevoked": "Sessão revogada",
     "taskCreated": "Tarefa criada",
-    "workspaceDeletedSuccessfully": "Caso excluído com sucesso"
+    "workspaceDeletedSuccessfully": "Caso excluído com sucesso",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Adicionar responsável",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Excluindo caso",
     "documentsCount": "{count, plural, one {# documento} many {# documentos} other {# documentos}}",
     "dropToUploadFiles": "Solte para fazer upload de arquivos",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplicar com conteúdo",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Envie documentos para habilitar extração de tabelas, organização de documentos, edição no navegador e pesquisa neste caso.",
       "title": "Envie seus primeiros documentos",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1513,7 +1513,7 @@
     "sessionRevoked": "Relácia bola odhlásená",
     "taskCreated": "Úloha vytvorená",
     "workspaceDeletedSuccessfully": "Spis úspešne vymazaný",
-    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
+    "workspaceDuplicatedSuccessfully": "Spis úspešne duplikovaný"
   },
   "tasks": {
     "addAssignee": "Pridať osobu",
@@ -1670,11 +1670,11 @@
     "deletingWorkspace": "Mazanie spisu",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} other {# dokumentov}}",
     "dropToUploadFiles": "Presuňte súbory pre nahranie",
-    "duplicateMatter": "Duplicate matter",
-    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
-    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
+    "duplicateMatter": "Duplikovať spis",
+    "duplicateMatterDescription": "Duplikujete spis, jeho názov, klienta, členov tímu, strany a zobrazenia.",
+    "duplicateMatterWithContentDescription": "Duplikujete spis, jeho názov, klienta, členov tímu, strany, zobrazenia a obsah.",
     "duplicateWithContent": "Duplikovať s obsahom",
-    "duplicatingWorkspace": "Duplicating matter",
+    "duplicatingWorkspace": "Duplikovanie spisu",
     "emptyDocuments": {
       "description": "Nahrajte dokumenty, aby ste mohli extrahovať tabuľky, organizovať dokumenty, upravovať ich priamo v prehliadači a vyhľadávať v tomto spise.",
       "title": "Nahrajte prvé dokumenty",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1512,7 +1512,8 @@
     "roleUpdated": "Rola aktualizovaná",
     "sessionRevoked": "Relácia bola odhlásená",
     "taskCreated": "Úloha vytvorená",
-    "workspaceDeletedSuccessfully": "Spis úspešne vymazaný"
+    "workspaceDeletedSuccessfully": "Spis úspešne vymazaný",
+    "workspaceDuplicatedSuccessfully": "Matter duplicated successfully"
   },
   "tasks": {
     "addAssignee": "Pridať osobu",
@@ -1669,7 +1670,11 @@
     "deletingWorkspace": "Mazanie spisu",
     "documentsCount": "{count, plural, one {# dokument} few {# dokumenty} other {# dokumentov}}",
     "dropToUploadFiles": "Presuňte súbory pre nahranie",
+    "duplicateMatter": "Duplicate matter",
+    "duplicateMatterDescription": "You will duplicate the matter, its name, client, team members, parties, and views.",
+    "duplicateMatterWithContentDescription": "You will duplicate the matter, its name, client, team members, parties, views, and content.",
     "duplicateWithContent": "Duplikovať s obsahom",
+    "duplicatingWorkspace": "Duplicating matter",
     "emptyDocuments": {
       "description": "Nahrajte dokumenty, aby ste mohli extrahovať tabuľky, organizovať dokumenty, upravovať ich priamo v prehliadači a vyhľadávať v tomto spise.",
       "title": "Nahrajte prvé dokumenty",

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -17,6 +17,7 @@ import {
   useMatch,
 } from "@tanstack/react-router";
 import {
+  LayersIcon,
   MessageSquarePlusIcon,
   PanelRightIcon,
   PinIcon,
@@ -63,7 +64,6 @@ import {
   useInspectorStore,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import type { InspectorTab } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
-import { MatterMetadataSheet } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet";
 import { CreateMatterDialog } from "@/routes/_protected.workspaces/-components/create-matter-dialog";
 import { workspaceOptions } from "@/routes/_protected.workspaces/-queries";
 
@@ -246,6 +246,7 @@ function ProtectedContent({
   const inspectorTabsCount = useInspectorStore((s) => s.tabs.length);
   const toggleInspector = useInspectorStore((s) => s.toggleMinimized);
   const openInspectorChat = useInspectorStore((s) => s.openChat);
+  const openMatterInspector = useInspectorStore((s) => s.openMatter);
   const handleInspectorButtonClick = () => {
     if (inspectorTabsCount === 0) {
       // No tabs yet — open a new chat. With a matter context the
@@ -323,9 +324,23 @@ function ProtectedContent({
               <PinIcon className="size-4" />
             )}
           </Button>
-          <Suspense>
-            <MatterMetadataSheet workspaceId={workspaceId} />
-          </Suspense>
+          <Button
+            onClick={() => {
+              openMatterInspector({
+                workspaceId,
+                label: workspace?.name ?? t("workspaces.matterInfo"),
+                color: workspace?.color ?? null,
+              });
+            }}
+            size="icon-sm"
+            title={t("workspaces.matterInfo")}
+            variant="ghost"
+          >
+            <LayersIcon
+              className="size-4"
+              style={matterColor ? { color: matterColor } : undefined}
+            />
+          </Button>
         </>
       )}
       {activeDecisionId && (
@@ -437,8 +452,8 @@ function WorkspaceInspectorSidePanel() {
   // matter they came from, even after the user navigates away
   // to another matter (or to a non-workspace route like the
   // knowledge / case-law viewer). Resolution order:
-  //   1. Active tab's origin (PDF.workspaceId or started-chat
-  //      contextMatterIds[0])
+  //   1. Active tab's origin (PDF.workspaceId, Matter.workspaceId,
+  //      or started-chat contextMatterIds[0])
   //   2. The current route's matter (for blank chats or task
   //      tabs while inside a workspace)
   //   3. Any other tab's stored workspaceId — keeps the pane
@@ -449,16 +464,23 @@ function WorkspaceInspectorSidePanel() {
   const tabOriginWorkspaceId =
     activeTab?.type === "pdf"
       ? activeTab.workspaceId
-      : activeTab?.type === "chat"
-        ? (activeTab.contextMatterIds.at(0) ?? null)
-        : null;
+      : activeTab?.type === "matter"
+        ? activeTab.workspaceId
+        : activeTab?.type === "chat"
+          ? (activeTab.contextMatterIds.at(0) ?? null)
+          : null;
   // Last-resort: pick *any* tab's stored workspace so the inspector
   // mounts even when the active tab can't dictate one (a task tab,
   // or a chat that hasn't been pinned to a matter yet) and the
   // route is also non-workspace. PDF tabs carry workspaceId
-  // directly; chat tabs surface theirs via contextMatterIds[0].
+  // directly; matter tabs carry workspaceId directly; chat tabs
+  // surface theirs via contextMatterIds[0].
   const fallbackPdfTab = tabs.find(
     (tab): tab is Extract<InspectorTab, { type: "pdf" }> => tab.type === "pdf",
+  );
+  const fallbackMatterTab = tabs.find(
+    (tab): tab is Extract<InspectorTab, { type: "matter" }> =>
+      tab.type === "matter",
   );
   const fallbackChatTab = tabs.find(
     (tab): tab is Extract<InspectorTab, { type: "chat" }> =>
@@ -466,6 +488,7 @@ function WorkspaceInspectorSidePanel() {
   );
   const fallbackTabWorkspaceId =
     fallbackPdfTab?.workspaceId ??
+    fallbackMatterTab?.workspaceId ??
     fallbackChatTab?.contextMatterIds.at(0) ??
     null;
   const activeWorkspaceId =

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -23,6 +23,7 @@ import {
   CopyIcon,
   ExternalLinkIcon,
   FileTextIcon,
+  LayersIcon,
   LoaderCircleIcon,
   LockOpenIcon,
   LaptopIcon,
@@ -109,6 +110,7 @@ import { SuggestionsFacet } from "@/routes/_protected.workspaces/$workspaceId/-c
 import { useRailContextMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-rail-context-menu";
 import { useTabContextMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu";
 import { VersionsFacet } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/versions-facet";
+import { MatterMetadataPanel } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet";
 import {
   PeekPdfControls,
   PeekPdfViewer,
@@ -244,6 +246,10 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   const pdfRouteJustification = pdfRouteMatch?.search.justification ?? null;
 
   const activeTab = tabs.find((tab) => tab.id === activeId);
+  const activeMatterPanelColor =
+    activeTab?.type === "matter"
+      ? resolveMatterColor(activeTab.workspaceId, activeTab.color ?? null)
+      : matterColor;
 
   // -- PDF zoom --
   const [scaleOffsets, setScaleOffsets] = useState<Map<string, number>>(
@@ -792,7 +798,7 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
           }
         >
           <ChatTabPanel
-            matterColor={matterColor}
+            matterColor={activeMatterPanelColor}
             onClose={() => handleCloseTab(activeTab.id)}
             onLabelContextMenu={ribbonContextMenu.openAt}
             tab={activeTab}
@@ -806,6 +812,35 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
           tab={activeTab}
           workspaceId={workspaceId}
         />
+      )}
+
+      {!minimized && activeTab?.type === "matter" && (
+        <div className="bg-background flex flex-1 flex-col overflow-hidden">
+          <InspectorTabHeader
+            label={t("workspaces.matterInfo")}
+            matter={
+              <MatterOriginLink
+                color={activeTab.color ?? null}
+                id={activeTab.workspaceId}
+                name={activeTab.label}
+                onClick={() => {
+                  void navigate({
+                    to: "/workspaces/$workspaceId",
+                    params: { workspaceId: activeTab.workspaceId },
+                  });
+                }}
+              />
+            }
+            matterColor={activeMatterPanelColor}
+            onClose={() => handleCloseTab(activeTab.id)}
+          />
+          <Suspense fallback={<MetadataPanelSkeleton />}>
+            <MatterMetadataPanel
+              onDeleted={() => handleCloseTab(activeTab.id)}
+              workspaceId={activeTab.workspaceId}
+            />
+          </Suspense>
+        </div>
       )}
 
       {/* Document content — render all open document tabs, show only the active one.
@@ -3183,6 +3218,56 @@ const getTabAbbrev = (label: string): string => {
   return stem.slice(0, 3);
 };
 
+type VerticalTabIconProps = {
+  tab: InspectorTab;
+  active: boolean;
+  externalIconHref?: string | undefined;
+};
+
+const VerticalTabIcon = ({
+  tab,
+  active,
+  externalIconHref,
+}: VerticalTabIconProps) => {
+  if (tab.type === "task") {
+    return (
+      <EntityKindIcon className="size-3.5" kind="task" status={tab.status} />
+    );
+  }
+
+  if (tab.type === "chat") {
+    return <MessageSquareIcon className="size-3.5" />;
+  }
+
+  if (tab.type === "matter") {
+    const swatch = resolveMatterColor(tab.workspaceId, tab.color ?? null);
+    return <LayersIcon className="size-3.5" style={{ color: swatch }} />;
+  }
+
+  if (tab.type === "external") {
+    return (
+      <ExternalSourceLogo
+        className="size-3.5 border-0"
+        iconHref={externalIconHref}
+      />
+    );
+  }
+
+  if (active && tab.mimeType) {
+    return <DocumentIcon className="size-3.5" mimeType={tab.mimeType} />;
+  }
+
+  if (active) {
+    return <FileTextIcon className="size-3.5" />;
+  }
+
+  return (
+    <span className="text-[9px] leading-none font-semibold tracking-tight uppercase">
+      {getTabAbbrev(tab.label)}
+    </span>
+  );
+};
+
 type VerticalTabProps = {
   tab: InspectorTab;
   active: boolean;
@@ -3220,6 +3305,7 @@ const VerticalTab = ({
         }));
 
   const contextMenu = useTabContextMenu({
+    canRename: tab.type !== "matter",
     tabId: tab.id,
     onClose,
     onMaximize: buildMaximizeTabAction(tab, {
@@ -3278,28 +3364,11 @@ const VerticalTab = ({
         }
         side="left"
       >
-        {tab.type === "task" ? (
-          <EntityKindIcon
-            className="size-3.5"
-            kind="task"
-            status={tab.status}
-          />
-        ) : tab.type === "chat" ? (
-          <MessageSquareIcon className="size-3.5" />
-        ) : tab.type === "external" ? (
-          <ExternalSourceLogo
-            className="size-3.5 border-0"
-            iconHref={externalIconHref}
-          />
-        ) : active && tab.mimeType ? (
-          <DocumentIcon className="size-3.5" mimeType={tab.mimeType} />
-        ) : active ? (
-          <FileTextIcon className="size-3.5" />
-        ) : (
-          <span className="text-[9px] leading-none font-semibold tracking-tight uppercase">
-            {getTabAbbrev(tab.label)}
-          </span>
-        )}
+        <VerticalTabIcon
+          active={active}
+          externalIconHref={externalIconHref}
+          tab={tab}
+        />
       </Tooltip>
       {contextMenu.element}
     </>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
@@ -95,6 +95,16 @@ export type ChatTab = {
   activeDecisionId?: string | undefined;
 };
 
+export type MatterTabId = `matter:${string}`;
+
+export type MatterTab = {
+  type: "matter";
+  id: MatterTabId;
+  label: string;
+  workspaceId: string;
+  color?: string | null | undefined;
+};
+
 export type ExternalTab = {
   type: "external";
   id: ExternalTabId;
@@ -109,7 +119,7 @@ export type ExternalTab = {
   text?: string | undefined;
 };
 
-export type InspectorTab = PdfTab | TaskTab | ChatTab | ExternalTab;
+export type InspectorTab = PdfTab | TaskTab | ChatTab | MatterTab | ExternalTab;
 
 type State = {
   tabs: InspectorTab[];
@@ -166,6 +176,11 @@ type Actions = {
     snippet?: string | undefined;
     sourceToolName?: string | undefined;
     text?: string | undefined;
+  }) => void;
+  openMatter: (args: {
+    workspaceId: string;
+    label: string;
+    color?: string | null | undefined;
   }) => void;
   /**
    * Open a chat tab. Without args, creates a new (local-only) chat
@@ -536,6 +551,15 @@ const isInspectorTab = (value: unknown): value is InspectorTab => {
     );
   }
 
+  if (type === "matter") {
+    const color = value["color"];
+    return (
+      typeof label === "string" &&
+      typeof value["workspaceId"] === "string" &&
+      (color === undefined || color === null || typeof color === "string")
+    );
+  }
+
   if (type !== "pdf") {
     return false;
   }
@@ -773,6 +797,28 @@ export const useInspectorStore = create<State & Actions>()(
           existing.snippet = snippet ?? existing.snippet;
           existing.sourceToolName = sourceToolName ?? existing.sourceToolName;
           existing.text = text ?? existing.text;
+        }
+        state.activeId = id;
+        state.activationSeq += 1;
+        state.minimized = false;
+      }),
+
+    openMatter: ({ workspaceId, label, color }) =>
+      set((state) => {
+        const id: MatterTabId = `matter:${workspaceId}`;
+        const existing = state.tabs.find((t) => t.id === id);
+        if (!existing) {
+          state.tabs.push({
+            type: "matter",
+            id,
+            label,
+            workspaceId,
+            color,
+          });
+        } else if (existing.type === "matter") {
+          existing.label = label;
+          existing.workspaceId = workspaceId;
+          existing.color = color;
         }
         state.activeId = id;
         state.activationSeq += 1;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/use-tab-context-menu.tsx
@@ -25,10 +25,12 @@ import { useAnchoredMenu } from "@/routes/_protected.workspaces/$workspaceId/-co
  * gesture is reachable from either entry point.
  */
 export const useTabContextMenu = ({
+  canRename = true,
   tabId,
   onClose,
   onMaximize,
 }: {
+  canRename?: boolean;
   tabId: string;
   onClose: () => void;
   onMaximize?: (() => void) | undefined;
@@ -55,10 +57,12 @@ export const useTabContextMenu = ({
           </MenuItem>
         )}
         <MenuSeparator />
-        <MenuItem onClick={() => requestRename(tabId)}>
-          <PenLineIcon />
-          {t("common.rename")}
-        </MenuItem>
+        {canRename && (
+          <MenuItem onClick={() => requestRename(tabId)}>
+            <PenLineIcon />
+            {t("common.rename")}
+          </MenuItem>
+        )}
         <MenuItem onClick={onClose}>
           <XIcon />
           {t("common.close")}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-info-layout.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-info-layout.ts
@@ -1,0 +1,2 @@
+export const MATTER_INFO_ICON_SLOT_CLASS =
+  "flex size-7 shrink-0 items-center justify-center";

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -64,6 +64,7 @@ export const MatterMetadataPanel = ({
   const { data: workspace } = useSuspenseQuery(workspaceOptions(workspaceId));
   const deleteWorkspace = useDeleteWorkspace();
   const duplicateWorkspace = useDuplicateWorkspace();
+  const canCreateWorkspace = usePermissions({ workspace: ["create"] });
   const canDeleteWorkspace = usePermissions({ workspace: ["delete"] });
   const updateWorkspace = useUpdateWorkspace();
 
@@ -176,7 +177,11 @@ export const MatterMetadataPanel = ({
   };
 
   const handleDuplicateWorkspace = () => {
-    if (duplicateMode === null || duplicateWorkspace.isPending) {
+    if (
+      !canCreateWorkspace ||
+      duplicateMode === null ||
+      duplicateWorkspace.isPending
+    ) {
       return;
     }
 
@@ -301,34 +306,36 @@ export const MatterMetadataPanel = ({
 
         <div className="mt-auto">
           {/* Actions */}
-          <div className="flex flex-col">
-            <Button
-              className={cn(
-                "w-full justify-start rounded-none px-3",
-                TOOLBAR_ROW_HEIGHT,
-              )}
-              onClick={() => setDuplicateMode("metadata")}
-              variant="ghost"
-            >
-              <span className={MATTER_INFO_ICON_SLOT_CLASS}>
-                <CopyIcon className="size-4" />
-              </span>
-              {t("common.duplicate")}
-            </Button>
-            <Button
-              className={cn(
-                "w-full justify-start rounded-none px-3",
-                TOOLBAR_ROW_HEIGHT,
-              )}
-              onClick={() => setDuplicateMode("content")}
-              variant="ghost"
-            >
-              <span className={MATTER_INFO_ICON_SLOT_CLASS}>
-                <CopyPlusIcon className="size-4" />
-              </span>
-              {t("workspaces.duplicateWithContent")}
-            </Button>
-          </div>
+          {canCreateWorkspace && (
+            <div className="flex flex-col">
+              <Button
+                className={cn(
+                  "w-full justify-start rounded-none px-3",
+                  TOOLBAR_ROW_HEIGHT,
+                )}
+                onClick={() => setDuplicateMode("metadata")}
+                variant="ghost"
+              >
+                <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+                  <CopyIcon className="size-4" />
+                </span>
+                {t("common.duplicate")}
+              </Button>
+              <Button
+                className={cn(
+                  "w-full justify-start rounded-none px-3",
+                  TOOLBAR_ROW_HEIGHT,
+                )}
+                onClick={() => setDuplicateMode("content")}
+                variant="ghost"
+              >
+                <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+                  <CopyPlusIcon className="size-4" />
+                </span>
+                {t("workspaces.duplicateWithContent")}
+              </Button>
+            </div>
+          )}
 
           {/* Danger zone */}
           {canDeleteWorkspace && (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -1,38 +1,36 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import {
-  CopyIcon,
-  CopyPlusIcon,
-  EllipsisIcon,
-  LockIcon,
-  TrashIcon,
-} from "lucide-react";
+import { CopyIcon, CopyPlusIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
 import { DestructiveConfirmDialog } from "@stll/ui/components/destructive-confirm-dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
 import { Input } from "@stll/ui/components/input";
 import { Separator } from "@stll/ui/components/separator";
-import {
-  Sheet,
-  SheetDescription,
-  SheetHeader,
-  SheetPanel,
-  SheetPopup,
-  SheetTitle,
-  SheetTrigger,
-} from "@stll/ui/components/sheet";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { MatterNumberHint } from "@/components/matter-number-hint";
 import { usePermissions } from "@/hooks/use-permissions";
+import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { APIError } from "@/lib/errors";
+import { MATTER_INFO_ICON_SLOT_CLASS } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-info-layout";
 import { MembersSection } from "@/routes/_protected.workspaces/$workspaceId/-components/members-section";
 import { PartiesSection } from "@/routes/_protected.workspaces/$workspaceId/-components/parties-section";
 import {
   useDeleteWorkspace,
+  useDuplicateWorkspace,
   useUpdateWorkspace,
 } from "@/routes/_protected.workspaces/-mutations";
 import {
@@ -40,25 +38,24 @@ import {
   workspacesKeys,
 } from "@/routes/_protected.workspaces/-queries";
 
-const comingSoon = (label: string) => {
-  stellaToast.add({
-    title: label,
-    type: "neutral",
-  });
-};
-
-type MatterMetadataSheetProps = {
+type MatterMetadataPanelProps = {
   workspaceId: string;
+  onDeleted?: () => void;
 };
 
-export const MatterMetadataSheet = ({
+type DuplicateMode = "metadata" | "content";
+
+export const MatterMetadataPanel = ({
   workspaceId,
-}: MatterMetadataSheetProps) => {
+  onDeleted,
+}: MatterMetadataPanelProps) => {
   const t = useTranslations();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const [isOpen, setIsOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [duplicateMode, setDuplicateMode] = useState<DuplicateMode | null>(
+    null,
+  );
   const [nameValue, setNameValue] = useState("");
   const escapedNameRef = useRef(false);
   const [referenceValue, setReferenceValue] = useState("");
@@ -66,8 +63,16 @@ export const MatterMetadataSheet = ({
 
   const { data: workspace } = useSuspenseQuery(workspaceOptions(workspaceId));
   const deleteWorkspace = useDeleteWorkspace();
+  const duplicateWorkspace = useDuplicateWorkspace();
   const canDeleteWorkspace = usePermissions({ workspace: ["delete"] });
   const updateWorkspace = useUpdateWorkspace();
+
+  useEffect(() => {
+    escapedNameRef.current = false;
+    setNameValue(workspace.name);
+    setReferenceValue(workspace.reference ?? "");
+    setReferenceError("");
+  }, [workspace.name, workspace.reference]);
 
   const handleSaveName = () => {
     if (escapedNameRef.current) {
@@ -162,6 +167,7 @@ export const MatterMetadataSheet = ({
               title: t("success.workspaceDeletedSuccessfully"),
               type: "success",
             });
+            onDeleted?.();
             await navigate({ to: "/workspaces" });
           })();
         },
@@ -169,155 +175,210 @@ export const MatterMetadataSheet = ({
     );
   };
 
+  const handleDuplicateWorkspace = () => {
+    if (duplicateMode === null || duplicateWorkspace.isPending) {
+      return;
+    }
+
+    const toastId = stellaToast.add({
+      title: t("workspaces.duplicatingWorkspace"),
+      type: "loading",
+      timeout: Number.POSITIVE_INFINITY,
+    });
+
+    duplicateWorkspace.mutate(
+      {
+        workspaceId,
+        includeContent: duplicateMode === "content",
+      },
+      {
+        onError: () => {
+          stellaToast.update(toastId, {
+            title: t("errors.actionFailed"),
+            type: "error",
+          });
+        },
+        onSuccess: (data) => {
+          stellaToast.update(toastId, {
+            title: t("success.workspaceDuplicatedSuccessfully"),
+            type: "success",
+          });
+          setDuplicateMode(null);
+          void navigate({
+            to: "/workspaces/$workspaceId",
+            params: { workspaceId: data.workspaceId },
+          });
+        },
+      },
+    );
+  };
+
   return (
     <>
-      <Sheet
-        onOpenChange={(open) => {
-          setIsOpen(open);
-          if (open) {
-            escapedNameRef.current = false;
-            setNameValue(workspace.name);
-            setReferenceValue(workspace.reference ?? "");
-          }
-        }}
-        open={isOpen}
-      >
-        <SheetTrigger render={<Button size="icon-sm" variant="ghost" />}>
-          <EllipsisIcon className="size-5" />
-        </SheetTrigger>
-        <SheetPopup side="right">
-          <SheetHeader>
-            <SheetTitle>{t("workspaces.matterInfo")}</SheetTitle>
-            <SheetDescription />
-          </SheetHeader>
-          <SheetPanel className="flex flex-1 flex-col gap-4">
-            {/* Name */}
-            <section className="px-4">
-              <span className="text-muted-foreground mb-1.5 block text-sm font-medium">
-                {t("common.name")}
-              </span>
-              <Input
-                disabled={updateWorkspace.isPending}
-                onBlur={handleSaveName}
-                onChange={(e) => setNameValue(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.currentTarget.blur();
-                  }
-                  if (e.key === "Escape") {
-                    escapedNameRef.current = true;
-                    e.currentTarget.blur();
-                  }
-                }}
-                value={nameValue}
-              />
-            </section>
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {/* Name */}
+        <section
+          className={cn(
+            "grid shrink-0 grid-cols-[8rem_minmax(0,1fr)] items-center gap-3 border-b px-3",
+            TOOLBAR_ROW_HEIGHT,
+          )}
+        >
+          <span className="text-muted-foreground truncate text-sm font-medium">
+            {t("common.name")}
+          </span>
+          <Input
+            className="rounded-md shadow-none"
+            disabled={updateWorkspace.isPending}
+            onBlur={handleSaveName}
+            onChange={(e) => setNameValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              }
+              if (e.key === "Escape") {
+                escapedNameRef.current = true;
+                e.currentTarget.blur();
+              }
+            }}
+            size="sm"
+            value={nameValue}
+          />
+        </section>
 
-            <Separator />
+        {/* Reference */}
+        <section
+          className={cn(
+            "grid shrink-0 grid-cols-[8rem_minmax(0,1fr)] items-center gap-3 border-b px-3",
+            TOOLBAR_ROW_HEIGHT,
+          )}
+        >
+          <span className="text-muted-foreground truncate text-sm font-medium">
+            {t("workspaces.reference")}
+          </span>
+          <div className="flex min-w-0 items-center gap-2">
+            <Input
+              className="w-36 shrink-0 rounded-md shadow-none"
+              onBlur={handleSaveReference}
+              onChange={(e) => {
+                setReferenceValue(e.target.value);
+                setReferenceError("");
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.currentTarget.blur();
+                }
+              }}
+              placeholder={t("workspaces.referencePlaceholder")}
+              size="sm"
+              value={referenceValue}
+            />
+            <MatterNumberHint
+              className="mt-0 min-w-0 flex-1"
+              error={referenceError}
+              value={referenceValue}
+              variant="inline"
+            />
+          </div>
+        </section>
 
-            {/* Reference */}
-            <section className="px-4">
-              <span className="text-muted-foreground mb-1.5 block text-sm font-medium">
-                {t("workspaces.reference")}
-              </span>
-              <Input
-                onBlur={handleSaveReference}
-                onChange={(e) => {
-                  setReferenceValue(e.target.value);
-                  setReferenceError("");
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.currentTarget.blur();
-                  }
-                }}
-                placeholder={t("workspaces.referencePlaceholder")}
-                value={referenceValue}
-              />
-              <MatterNumberHint
-                error={referenceError}
-                value={referenceValue}
-                variant="inline"
-              />
-            </section>
-
-            <Separator />
-
-            {/* InfoSoud */}
-            {/* TODO: add with proper localization support for CS-only
+        {/* InfoSoud */}
+        {/* TODO: add with proper localization support for CS-only
                 customers. The component is wired and works, but the
                 surface (CZ court IDs, sp. zn. labels, etc.) is
                 Czech-only by design — we hide it from the UX until
                 we have a locale gate that only shows it to CS users
                 or surfaces an EN explainer for non-CS users. */}
-            {/* <InfoSoudSection active={isOpen} workspaceId={workspaceId} /> */}
-            {/* <Separator /> */}
+        {/* <InfoSoudSection active workspaceId={workspaceId} /> */}
+        {/* <Separator /> */}
 
-            {/* Members */}
-            <MembersSection workspaceId={workspaceId} />
+        {/* Members */}
+        <MembersSection workspaceId={workspaceId} />
 
-            <Separator />
+        <Separator />
 
-            {/* Parties */}
-            <PartiesSection workspaceId={workspaceId} />
+        {/* Parties */}
+        <PartiesSection workspaceId={workspaceId} />
 
-            <Separator />
-
-            {/* Actions */}
-            <div className="flex flex-col gap-0.5 px-2">
-              <Button
-                className="justify-start"
-                onClick={() => comingSoon(t("common.comingSoon"))}
-                size="sm"
-                variant="ghost"
-              >
+        <div className="mt-auto">
+          {/* Actions */}
+          <div className="flex flex-col">
+            <Button
+              className={cn(
+                "w-full justify-start rounded-none px-3",
+                TOOLBAR_ROW_HEIGHT,
+              )}
+              onClick={() => setDuplicateMode("metadata")}
+              variant="ghost"
+            >
+              <span className={MATTER_INFO_ICON_SLOT_CLASS}>
                 <CopyIcon className="size-4" />
-                {t("common.duplicate")}
-              </Button>
-              <Button
-                className="justify-start"
-                onClick={() => comingSoon(t("common.comingSoon"))}
-                size="sm"
-                variant="ghost"
-              >
+              </span>
+              {t("common.duplicate")}
+            </Button>
+            <Button
+              className={cn(
+                "w-full justify-start rounded-none px-3",
+                TOOLBAR_ROW_HEIGHT,
+              )}
+              onClick={() => setDuplicateMode("content")}
+              variant="ghost"
+            >
+              <span className={MATTER_INFO_ICON_SLOT_CLASS}>
                 <CopyPlusIcon className="size-4" />
-                {t("workspaces.duplicateWithContent")}
-              </Button>
-            </div>
+              </span>
+              {t("workspaces.duplicateWithContent")}
+            </Button>
+          </div>
 
-            <Separator />
-
-            {/* Status actions */}
-            <div className="flex flex-col gap-0.5 px-2">
-              <Button
-                className="justify-start"
-                onClick={() => comingSoon(t("common.comingSoon"))}
-                size="sm"
-                variant="ghost"
-              >
-                <LockIcon className="size-4" />
-                {t("workspaces.lockMatter")}
-              </Button>
-            </div>
-
-            {/* Danger zone */}
-            {canDeleteWorkspace && (
-              <div className="mt-auto border-t px-2 pt-4">
-                <Button
-                  className="text-destructive justify-start"
-                  disabled={deleteWorkspace.isPending}
-                  onClick={() => setDeleteDialogOpen(true)}
-                  size="sm"
-                  variant="ghost"
-                >
-                  <TrashIcon className="size-4" />
-                  {t("workspaces.deleteWorkspace")}
-                </Button>
-              </div>
-            )}
-          </SheetPanel>
-        </SheetPopup>
-      </Sheet>
+          {/* Danger zone */}
+          {canDeleteWorkspace && (
+            <button
+              className={cn(
+                "text-destructive hover:bg-accent flex w-full shrink-0 items-center gap-2 border-t px-3 text-sm font-medium transition-colors",
+                TOOLBAR_ROW_HEIGHT,
+              )}
+              disabled={deleteWorkspace.isPending}
+              onClick={() => setDeleteDialogOpen(true)}
+              type="button"
+            >
+              <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+                <TrashIcon className="size-4" />
+              </span>
+              {t("workspaces.deleteWorkspace")}
+            </button>
+          )}
+        </div>
+      </div>
+      <Dialog
+        onOpenChange={(open) => {
+          if (!open) {
+            setDuplicateMode(null);
+          }
+        }}
+        open={duplicateMode !== null}
+      >
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{t("workspaces.duplicateMatter")}</DialogTitle>
+            <DialogDescription>
+              {duplicateMode === "content"
+                ? t("workspaces.duplicateMatterWithContentDescription")
+                : t("workspaces.duplicateMatterDescription")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" />}>
+              {t("common.cancel")}
+            </DialogClose>
+            <Button
+              loading={duplicateWorkspace.isPending}
+              onClick={handleDuplicateWorkspace}
+            >
+              {t("common.duplicate")}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
       <DestructiveConfirmDialog
         cancelLabel={t("common.cancel")}
         confirmLabel={t("common.delete")}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
@@ -29,10 +29,13 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { UserIdentity } from "@/components/user-avatar";
 import { usePermissions } from "@/hooks/use-permissions";
+import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { organizationOptions } from "@/routes/_protected.organization/-queries";
+import { MATTER_INFO_ICON_SLOT_CLASS } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-info-layout";
 import {
   useAddWorkspaceMember,
   useRemoveWorkspaceMember,
@@ -53,14 +56,26 @@ export const MembersSection = ({ workspaceId }: MembersSectionProps) => {
 
   return (
     <section>
-      <div className="mb-3 flex items-center justify-between">
+      <div
+        className={cn(
+          "flex items-center justify-between gap-2 px-3",
+          TOOLBAR_ROW_HEIGHT,
+        )}
+      >
         <h3 className="text-muted-foreground text-sm font-medium">
           {t("workspaces.sections.members")}
         </h3>
-        {canUpdate && <AddMemberDialog workspaceId={workspaceId} />}
+        {canUpdate && (
+          <AddMemberDialog
+            showTriggerLabel={false}
+            triggerSize="icon-xs"
+            triggerVariant="ghost"
+            workspaceId={workspaceId}
+          />
+        )}
       </div>
       {members.length > 0 ? (
-        <ul className="space-y-1">
+        <ul>
           {members.map((member) => (
             <MemberRow
               canUpdate={canUpdate}
@@ -130,12 +145,14 @@ const MemberRow = ({
   };
 
   return (
-    <li className="flex items-center gap-2 rounded-md border px-3 py-2">
+    <li className={cn("flex items-center gap-2 px-3", TOOLBAR_ROW_HEIGHT)}>
       <UserIdentity
-        avatarClassName="size-8 shrink-0 text-[0.625rem]"
+        avatarClassName={cn(MATTER_INFO_ICON_SLOT_CLASS, "text-[0.5625rem]")}
         className="min-w-0 flex-1"
         image={member.user?.image}
         name={member.user?.name ?? member.userId}
+        nameClassName="text-sm"
+        secondaryClassName="text-xs"
         secondaryText={member.user?.email ?? null}
       />
       {canUpdate && membersCount > 1 && (
@@ -183,6 +200,7 @@ type AddMemberDialogProps = {
   triggerClassName?: string | undefined;
   triggerSize?: ComponentProps<typeof Button>["size"] | undefined;
   triggerVariant?: ComponentProps<typeof Button>["variant"] | undefined;
+  showTriggerLabel?: boolean | undefined;
 };
 
 export const AddMemberDialog = ({
@@ -190,6 +208,7 @@ export const AddMemberDialog = ({
   triggerClassName,
   triggerSize = "sm",
   triggerVariant = "outline",
+  showTriggerLabel = true,
 }: AddMemberDialogProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
@@ -256,14 +275,16 @@ export const AddMemberDialog = ({
       <DialogTrigger
         render={
           <Button
+            aria-label={t("workspaces.members.addMember")}
             className={triggerClassName}
             size={triggerSize}
+            title={t("workspaces.members.addMember")}
             variant={triggerVariant}
           />
         }
       >
         <PlusIcon className="size-3.5" />
-        {t("workspaces.members.addMember")}
+        {showTriggerLabel ? t("workspaces.members.addMember") : null}
       </DialogTrigger>
       <DialogPopup>
         <DialogHeader>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -36,11 +36,14 @@ import {
   SelectValue,
 } from "@stll/ui/components/select";
 import { stellaToast } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { ContactPicker } from "@/components/contact-picker";
+import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
 import { toSafeId } from "@/lib/safe-id";
 import { useCreateContact } from "@/routes/_protected.contacts/-mutations";
 import { contactsKeys } from "@/routes/_protected.contacts/-queries";
+import { MATTER_INFO_ICON_SLOT_CLASS } from "@/routes/_protected.workspaces/$workspaceId/-components/matter-info-layout";
 import {
   useAddParty,
   useRemoveParty,
@@ -124,8 +127,8 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
   const { client } = workspace;
   if (!client) {
     return (
-      <div className="flex flex-1 flex-col gap-6 overflow-auto p-4">
-        <section className="bg-muted/30 flex flex-col gap-3 rounded-md border p-4">
+      <div className="flex flex-col p-3">
+        <section className="bg-muted/30 flex flex-col gap-2 rounded-md border p-3">
           <div className="flex items-center gap-2">
             <LockIcon className="text-muted-foreground size-4" />
             <h3 className="text-sm font-medium">
@@ -142,45 +145,58 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
   }
 
   return (
-    <div className="flex flex-1 flex-col gap-6 overflow-auto p-4">
+    <div className="flex flex-col">
       {/* Client sub-section */}
       <section>
-        <h3 className="text-muted-foreground mb-3 text-sm font-medium">
-          {t("workspaces.parties.client")}
-        </h3>
-        <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 px-3",
+            TOOLBAR_ROW_HEIGHT,
+          )}
+        >
+          <h3 className="text-muted-foreground text-sm font-medium">
+            {t("workspaces.parties.client")}
+          </h3>
+          <ChangeClientDialog
+            onCreate={handleCreateAndSetClient}
+            onSelect={handleSetClient}
+          />
+        </div>
+        <div className={cn("flex items-center gap-2 px-3", TOOLBAR_ROW_HEIGHT)}>
           {client.type === "person" ? (
-            <UserIcon className="text-muted-foreground size-4" />
+            <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+              <UserIcon className="text-muted-foreground size-4" />
+            </span>
           ) : (
-            <BuildingIcon className="text-muted-foreground size-4" />
+            <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+              <BuildingIcon className="text-muted-foreground size-4" />
+            </span>
           )}
           <Link
-            className="text-sm font-medium hover:underline"
+            className="min-w-0 truncate text-sm font-medium hover:underline"
             params={{ contactId: client.id }}
             to="/contacts/$contactId"
           >
             {client.displayName}
           </Link>
         </div>
-        <div className="mt-2">
-          <ContactPicker
-            onCreate={handleCreateAndSetClient}
-            onSelect={handleSetClient}
-            placeholder={t("workspaces.parties.changeClient")}
-          />
-        </div>
       </section>
 
       {/* Parties sub-section */}
       <section>
-        <div className="mb-3 flex items-center justify-between">
+        <div
+          className={cn(
+            "flex items-center justify-between gap-2 px-3",
+            TOOLBAR_ROW_HEIGHT,
+          )}
+        >
           <h3 className="text-muted-foreground text-sm font-medium">
             {t("workspaces.sections.parties")}
           </h3>
-          <AddPartyDialog workspaceId={workspaceId} />
+          <AddPartyDialog showTriggerLabel={false} workspaceId={workspaceId} />
         </div>
         {parties.length > 0 ? (
-          <ul className="space-y-1">
+          <ul>
             {parties.map((party) => (
               <PartyRow
                 key={party.id}
@@ -190,12 +206,67 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
             ))}
           </ul>
         ) : (
-          <p className="text-muted-foreground text-sm">
+          <p
+            className={cn(
+              "text-muted-foreground flex items-center px-3 text-sm italic",
+              TOOLBAR_ROW_HEIGHT,
+            )}
+          >
             {t("workspaces.parties.noParties")}
           </p>
         )}
       </section>
     </div>
+  );
+};
+
+type ChangeClientDialogProps = {
+  onCreate: (name: string, type: "person" | "organization") => void;
+  onSelect: (contact: { id: string; displayName: string }) => void;
+};
+
+const ChangeClientDialog = ({
+  onCreate,
+  onSelect,
+}: ChangeClientDialogProps) => {
+  const t = useTranslations();
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Dialog onOpenChange={setIsOpen} open={isOpen}>
+      <DialogTrigger
+        render={
+          <Button
+            aria-label={t("workspaces.parties.changeClient")}
+            size="icon-xs"
+            title={t("workspaces.parties.changeClient")}
+            variant="ghost"
+          />
+        }
+      >
+        <PlusIcon className="size-3.5" />
+      </DialogTrigger>
+      <DialogPopup>
+        <DialogHeader>
+          <DialogTitle>{t("workspaces.parties.changeClient")}</DialogTitle>
+          <DialogDescription />
+        </DialogHeader>
+        <DialogPanel>
+          <ContactPicker
+            autoFocus
+            onCreate={(name, type) => {
+              onCreate(name, type);
+              setIsOpen(false);
+            }}
+            onSelect={(contact) => {
+              onSelect(contact);
+              setIsOpen(false);
+            }}
+            placeholder={t("workspaces.parties.changeClient")}
+          />
+        </DialogPanel>
+      </DialogPopup>
+    </Dialog>
   );
 };
 
@@ -406,11 +477,15 @@ const PartyRow = ({ party, workspaceId }: PartyRowProps) => {
     : PARTY_ROLE_LABEL_KEYS.other;
 
   return (
-    <li className="flex items-center gap-2 rounded-md border px-3 py-2">
+    <li className={cn("flex items-center gap-2 px-3", TOOLBAR_ROW_HEIGHT)}>
       {contact.type === "person" ? (
-        <UserIcon className="text-muted-foreground size-4" />
+        <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+          <UserIcon className="text-muted-foreground size-4" />
+        </span>
       ) : (
-        <BuildingIcon className="text-muted-foreground size-4" />
+        <span className={MATTER_INFO_ICON_SLOT_CLASS}>
+          <BuildingIcon className="text-muted-foreground size-4" />
+        </span>
       )}
       <Link
         className="text-sm font-medium hover:underline"
@@ -438,9 +513,13 @@ const PartyRow = ({ party, workspaceId }: PartyRowProps) => {
 
 type AddPartyDialogProps = {
   workspaceId: string;
+  showTriggerLabel?: boolean | undefined;
 };
 
-const AddPartyDialog = ({ workspaceId }: AddPartyDialogProps) => {
+const AddPartyDialog = ({
+  workspaceId,
+  showTriggerLabel = true,
+}: AddPartyDialogProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const addParty = useAddParty();
@@ -506,9 +585,18 @@ const AddPartyDialog = ({ workspaceId }: AddPartyDialogProps) => {
       }}
       open={isOpen}
     >
-      <DialogTrigger render={<Button size="sm" variant="outline" />}>
+      <DialogTrigger
+        render={
+          <Button
+            aria-label={t("workspaces.parties.addParty")}
+            size={showTriggerLabel ? "sm" : "icon-xs"}
+            title={t("workspaces.parties.addParty")}
+            variant={showTriggerLabel ? "outline" : "ghost"}
+          />
+        }
+      >
         <PlusIcon className="size-3.5" />
-        {t("workspaces.parties.addParty")}
+        {showTriggerLabel ? t("workspaces.parties.addParty") : null}
       </DialogTrigger>
       <DialogPopup>
         <DialogHeader>

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -209,3 +209,42 @@ export const useDeleteWorkspace = () => {
     },
   });
 };
+
+type DuplicateWorkspaceVars = {
+  workspaceId: string;
+  includeContent: boolean;
+};
+
+export const useDuplicateWorkspace = () => {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      includeContent,
+      workspaceId,
+    }: DuplicateWorkspaceVars) => {
+      const response = await api
+        .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        .duplicate.post({
+          includeContent,
+          queryKey: workspacesKeys.all,
+        });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
+      void queryClient.invalidateQueries({
+        queryKey: workspacesKeys.navigation(),
+      });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+    },
+  });
+};


### PR DESCRIPTION
Moves matter information into the inspector and adds duplicate matter actions for metadata-only and content duplication. Updates the compact inspector layout for matter metadata, members, client, parties, and bottom actions.