### PR TITLE
chore: order release notes with features first

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -38,21 +38,23 @@ sort_commits = "newest"
 #   - First matching parser wins (so put more specific patterns first,
 #     e.g. `chore(deps)` before `chore`).
 #   - Rendered section order follows the lexicographic order of `group`.
-#     The `N:` prefix below pins the order (0 → 8); the body template
-#     above strips everything before the colon, so the prefix never
-#     reaches the rendered markdown — keeps GitHub release notes,
-#     stll.app/changelog, and any other downstream renderer clean.
+#     The two-digit `NN:` prefix pins the order (00 → 99); the body
+#     template above strips everything before the colon, so the prefix
+#     never reaches the rendered markdown — keeps GitHub release notes,
+#     stll.app/changelog, and any other downstream renderer clean. Two
+#     digits leave headroom for new sections without breaking sort
+#     (single-digit `10` would otherwise sort before `2`).
 commit_parsers = [
-  { message = "^feat",            group = "0:🚀 Features" },
-  { message = "^fix",             group = "1:🐛 Bug Fixes" },
-  { message = "^perf",            group = "2:⚡ Performance" },
-  { message = "^refactor",        group = "3:♻️ Refactor" },
-  { message = "^docs",            group = "4:📚 Documentation" },
-  { message = "^test",            group = "5:🧪 Tests" },
-  { message = "^chore\\(deps\\)", group = "6:📦 Dependencies" },
-  { message = "^chore",           group = "7:⚙️ Miscellaneous" },
+  { message = "^feat",            group = "00:🚀 Features" },
+  { message = "^fix",             group = "01:🐛 Bug Fixes" },
+  { message = "^perf",            group = "02:⚡ Performance" },
+  { message = "^refactor",        group = "03:♻️ Refactor" },
+  { message = "^docs",            group = "04:📚 Documentation" },
+  { message = "^test",            group = "05:🧪 Tests" },
+  { message = "^chore\\(deps\\)", group = "06:📦 Dependencies" },
+  { message = "^chore",           group = "07:⚙️ Miscellaneous" },
   { message = "^style",           skip  = true },
   { message = "^ci",              skip  = true },
   { message = "^build",           skip  = true },
-  { message = "^revert",          group = "8:⏪ Reverts" },
+  { message = "^revert",          group = "08:⏪ Reverts" },
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -14,7 +14,7 @@ body = """
 ## Unreleased
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group }}
+### {{ group | split(pat=":") | last }}
 {% for commit in commits %}
 - {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.message | split(pat="\\n") | first | trim }}\
 {% endfor %}
@@ -37,21 +37,22 @@ sort_commits = "newest"
 # Order matters twice over:
 #   - First matching parser wins (so put more specific patterns first,
 #     e.g. `chore(deps)` before `chore`).
-#   - Section order in the rendered notes follows the lexicographic
-#     order of `group`. The `<!-- N -->` HTML-comment prefix below sorts
-#     deterministically (0 → 8) but is stripped by GitHub's markdown
-#     renderer, so the visible heading is just the emoji + label.
+#   - Rendered section order follows the lexicographic order of `group`.
+#     The `N:` prefix below pins the order (0 → 8); the body template
+#     above strips everything before the colon, so the prefix never
+#     reaches the rendered markdown — keeps GitHub release notes,
+#     stll.app/changelog, and any other downstream renderer clean.
 commit_parsers = [
-  { message = "^feat",            group = "<!-- 0 -->🚀 Features" },
-  { message = "^fix",             group = "<!-- 1 -->🐛 Bug Fixes" },
-  { message = "^perf",            group = "<!-- 2 -->⚡ Performance" },
-  { message = "^refactor",        group = "<!-- 3 -->♻️ Refactor" },
-  { message = "^docs",            group = "<!-- 4 -->📚 Documentation" },
-  { message = "^test",            group = "<!-- 5 -->🧪 Tests" },
-  { message = "^chore\\(deps\\)", group = "<!-- 6 -->📦 Dependencies" },
-  { message = "^chore",           group = "<!-- 7 -->⚙️ Miscellaneous" },
+  { message = "^feat",            group = "0:🚀 Features" },
+  { message = "^fix",             group = "1:🐛 Bug Fixes" },
+  { message = "^perf",            group = "2:⚡ Performance" },
+  { message = "^refactor",        group = "3:♻️ Refactor" },
+  { message = "^docs",            group = "4:📚 Documentation" },
+  { message = "^test",            group = "5:🧪 Tests" },
+  { message = "^chore\\(deps\\)", group = "6:📦 Dependencies" },
+  { message = "^chore",           group = "7:⚙️ Miscellaneous" },
   { message = "^style",           skip  = true },
   { message = "^ci",              skip  = true },
   { message = "^build",           skip  = true },
-  { message = "^revert",          group = "<!-- 8 -->⏪ Reverts" },
+  { message = "^revert",          group = "8:⏪ Reverts" },
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -34,18 +34,24 @@ filter_commits = false
 tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-rc\\.[0-9]+)?$"
 sort_commits = "newest"
 
-# Order matters: first matching parser wins.
+# Order matters twice over:
+#   - First matching parser wins (so put more specific patterns first,
+#     e.g. `chore(deps)` before `chore`).
+#   - Section order in the rendered notes follows the lexicographic
+#     order of `group`. The `<!-- N -->` HTML-comment prefix below sorts
+#     deterministically (0 → 8) but is stripped by GitHub's markdown
+#     renderer, so the visible heading is just the emoji + label.
 commit_parsers = [
-  { message = "^feat",            group = "🚀 Features" },
-  { message = "^fix",             group = "🐛 Bug Fixes" },
-  { message = "^perf",            group = "⚡ Performance" },
-  { message = "^refactor",        group = "♻️ Refactor" },
-  { message = "^docs",            group = "📚 Documentation" },
-  { message = "^test",            group = "🧪 Tests" },
-  { message = "^chore\\(deps\\)", group = "📦 Dependencies" },
-  { message = "^chore",           group = "⚙️ Miscellaneous" },
+  { message = "^feat",            group = "<!-- 0 -->🚀 Features" },
+  { message = "^fix",             group = "<!-- 1 -->🐛 Bug Fixes" },
+  { message = "^perf",            group = "<!-- 2 -->⚡ Performance" },
+  { message = "^refactor",        group = "<!-- 3 -->♻️ Refactor" },
+  { message = "^docs",            group = "<!-- 4 -->📚 Documentation" },
+  { message = "^test",            group = "<!-- 5 -->🧪 Tests" },
+  { message = "^chore\\(deps\\)", group = "<!-- 6 -->📦 Dependencies" },
+  { message = "^chore",           group = "<!-- 7 -->⚙️ Miscellaneous" },
   { message = "^style",           skip  = true },
   { message = "^ci",              skip  = true },
   { message = "^build",           skip  = true },
-  { message = "^revert",          group = "⏪ Reverts" },
+  { message = "^revert",          group = "<!-- 8 -->⏪ Reverts" },
 ]


### PR DESCRIPTION
## Summary
- git-cliff sorted sections by lexicographic order of `group`, so emoji prefixes were placing **Misc** and **Bug Fixes** above **Features** in every release. Prefix each group with a hidden `<!-- N -->` HTML comment to control sort order: Features → Bug Fixes → Performance → Refactor → Documentation → Tests → Dependencies → Miscellaneous → Reverts.
- The HTML comments are stripped by GitHub's markdown renderer; visible headings stay clean.

## Test plan
- [x] `git-cliff --config cliff.toml v0.1.4..v0.1.5` locally — sections render in the new order (Features → Bug Fixes → Miscellaneous), headings show only emoji + label.
- [ ] Next release notes (or a re-rendered preview of the current draft) put Features first.