### PR TITLE
fix: harden CI trust boundaries

### DIFF
--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -33,7 +33,7 @@
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,
-        "allowed_merge_methods": ["merge", "squash", "rebase"],
+        "allowed_merge_methods": ["squash"],
         "required_reviewers": []
       }
     },

--- a/.github/branch-protection/ruleset-main.json
+++ b/.github/branch-protection/ruleset-main.json
@@ -10,7 +10,7 @@
   },
   "bypass_actors": [
     {
-      "actor_id": 1,
+      "actor_id": 5,
       "actor_type": "RepositoryRole",
       "bypass_mode": "pull_request"
     }
@@ -23,7 +23,7 @@
       "type": "non_fast_forward"
     },
     {
-      "type": "required_signatures"
+      "type": "required_linear_history"
     },
     {
       "type": "pull_request",
@@ -32,13 +32,16 @@
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": true,
         "require_last_push_approval": true,
-        "required_review_thread_resolution": true
+        "required_review_thread_resolution": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"],
+        "required_reviewers": []
       }
     },
     {
       "type": "required_status_checks",
       "parameters": {
         "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
             "context": "ci-result"
@@ -48,6 +51,9 @@
           }
         ]
       }
+    },
+    {
+      "type": "required_signatures"
     }
   ]
 }

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   audit:
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@main
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 concurrency:
   # Non-run-ci label events intentionally skip below. Keep them out of
   # the main CI concurrency group so an incidental label cannot cancel
-  # real checks and replace the required status with a skipped pass.
+  # real checks. The ci-result job also changes its check name for
+  # those events so it cannot replace the required status with a pass.
   group: >-
     ${{ github.workflow }}-${{ github.ref }}-${{
       github.event_name == 'pull_request'
@@ -329,6 +330,14 @@ jobs:
   # this check to pass, which ensures untrusted PRs cannot be
   # merged without CI and trusted PRs must pass all checks.
   ci-result:
+    name: >-
+      ${{
+        github.event_name == 'pull_request'
+        && github.event.action == 'labeled'
+        && github.event.label.name != 'run-ci'
+        && format('ci-result-ignored-label-{0}', github.run_id)
+        || 'ci-result'
+      }}
     if: always()
     needs: [trust-check, ci-checks, web-build, landing-build]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,9 @@ jobs:
         if: steps.changed-files.outputs.package_checks_required == 'true'
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # .npmrc references NPM_TOKEN, but PR installs must not expose
+          # the real npm token to dependency lifecycle scripts.
+          NPM_TOKEN: ""
 
       - name: Prepare environment
         if: steps.changed-files.outputs.package_checks_required == 'true'
@@ -315,7 +317,9 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # .npmrc references NPM_TOKEN, but PR installs must not expose
+          # the real npm token to dependency lifecycle scripts.
+          NPM_TOKEN: ""
 
       - name: Build landing
         if: steps.changed.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,24 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Non-run-ci label events intentionally skip below. Keep them out of
+  # the main CI concurrency group so an incidental label cannot cancel
+  # real checks and replace the required status with a skipped pass.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+      github.event_name == 'pull_request'
+      && github.event.action == 'labeled'
+      && github.event.label.name != 'run-ci'
+      && format('label-{0}-{1}', github.event.label.name, github.run_id)
+      || 'checks'
+    }}
   cancel-in-progress: true
 
 jobs:
   trust-check:
     # Skip draft PRs (CI runs when marked ready for review via
     # `reopened`). Also skip irrelevant label events: only the
-    # "run-ci" label matters — without this gate, adding any
-    # label (e.g. priority, triage) would cancel an in-progress
-    # CI run due to cancel-in-progress.
+    # "run-ci" label matters.
     if: >-
       github.event_name == 'workflow_dispatch'
       || (github.event.pull_request.draft != true

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         )
       )
-    uses: stella/.github/.github/workflows/cla.yml@main
+    uses: stella/.github/.github/workflows/cla.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
     with:
       allowlist: dependabot[bot],renovate[bot],github-actions[bot]
     secrets:

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # .npmrc references NPM_TOKEN, but PR installs must not expose
+          # the real npm token to dependency lifecycle scripts.
+          NPM_TOKEN: ""
 
       - name: Check migration coverage
         env:
@@ -93,7 +95,9 @@ jobs:
       - name: Install dependencies
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # .npmrc references NPM_TOKEN, but PR installs must not expose
+          # the real npm token to dependency lifecycle scripts.
+          NPM_TOKEN: ""
 
       - name: Apply all migrations to fresh Postgres
         working-directory: apps/api

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -154,6 +154,7 @@ jobs:
           bun src/index.ts >"$log_file" 2>&1 &
           api_pid=$!
 
+          # shellcheck disable=SC2329
           cleanup() {
             kill "$api_pid" >/dev/null 2>&1 || true
             wait "$api_pid" >/dev/null 2>&1 || true

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -27,5 +27,5 @@ jobs:
     if: >-
       github.event.action != 'labeled'
       || github.event.label.name == 'run-pr-lint'
-    uses: stella/.github/.github/workflows/pr-lint.yml@main
+    uses: stella/.github/.github/workflows/pr-lint.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
     secrets: inherit

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -70,6 +70,7 @@ jobs:
       - name: Checkout workflow scripts
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          fetch-depth: 0
           sparse-checkout: scripts
           sparse-checkout-cone-mode: false
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -141,16 +141,29 @@ jobs:
             exit 1
           fi
 
+          git fetch --no-tags origin "refs/tags/${REF}:refs/tags/${REF}" main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "::error::Release tag $REF is not reachable from protected main"
+            exit 1
+          fi
+
+          if ! gh release view "$REF" >/dev/null 2>&1; then
+            echo "::error::GitHub Release $REF does not exist; refusing to run signing jobs"
+            exit 1
+          fi
+
           # Resolve the channel via the shared script so the
           # in-binary updater endpoint, the manifest mirror path,
           # and the CloudFront invalidation key all derive from
           # exactly the same logic. See scripts/release-channel.sh.
           CHANNEL=$(bash scripts/release-channel.sh "$REF")
 
-          echo "value=$REF" >> "$GITHUB_OUTPUT"
-          echo "sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
-          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
-          echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
+          {
+            echo "value=$REF"
+            echo "sha=$RELEASE_SHA"
+            echo "version=${REF#v}"
+            echo "channel=$CHANNEL"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary
- prevent ignored label events from satisfying the required ci-result check
- withhold npm token from PR dependency installs
- pin reusable workflow refs and verify desktop release tags before signing
- fetch full release history before desktop tag ancestry checks
- align checked-in branch protection expectations with the hardened live ruleset
- restrict the main ruleset to squash-only PR merges

## Validation
- actionlint
- actionlint .github/workflows/release-desktop.yml
- checked .github/branch-protection/ruleset-main.json against the live GitHub ruleset
- verified public npm package reads work with NPM_TOKEN unset
