### PR TITLE
feat(web): collapse long pastes and slash skills into a chip

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -35,6 +35,11 @@ import {
   CHAT_MENTION_SEARCH_DEBOUNCE_MS,
   getMentionViewScope,
 } from "@/components/chat-mention-helpers";
+import { shouldChipPaste } from "@/components/chat-pasted-text";
+import {
+  insertPastedTextChip,
+  PastedText,
+} from "@/components/chat-pasted-text-extension";
 import {
   createPromptSlashSuggestion,
   PromptSlash,
@@ -730,6 +735,7 @@ export const useChatEditor = ({
       PromptSlash.configure({
         suggestion: createPromptSlashSuggestion(() => promptsRef.current),
       }),
+      PastedText,
     ],
     onCreate: ({ editor: nextEditor }) => {
       editorRef.current = nextEditor;
@@ -742,6 +748,41 @@ export const useChatEditor = ({
       attributes: {
         class:
           "field-sizing-content max-h-48 min-h-10 overflow-y-auto text-sm focus-visible:outline-none",
+      },
+      handlePaste: (_view, event) => {
+        // ProseMirror processes paste before any React `onPaste`
+        // handler, so the chip-on-large-paste logic has to live
+        // here — by the time the React handler fires, the text is
+        // already in the editor.
+        const clipboardData = event.clipboardData;
+        if (clipboardData === null) {
+          return false;
+        }
+
+        const hasFiles = Array.from(clipboardData.items).some(
+          (item) => item.kind === "file",
+        );
+        if (hasFiles) {
+          return false;
+        }
+
+        const pastedText = clipboardData.getData("text/plain");
+        if (!pastedText || !shouldChipPaste(pastedText)) {
+          return false;
+        }
+
+        const targetEditor = editorRef.current;
+        if (targetEditor === null) {
+          return false;
+        }
+
+        event.preventDefault();
+        insertPastedTextChip(targetEditor, {
+          label: "",
+          source: "paste",
+          text: pastedText,
+        });
+        return true;
       },
       handleKeyDown: (view, event) => {
         if (handleMessageHistoryKeyDown(view.state, event)) {
@@ -959,6 +1000,9 @@ export const useChatEditor = ({
       }
 
       if (files.length === 0) {
+        // Plain-text paste collapsing happens earlier inside
+        // ProseMirror via `editorProps.handlePaste`; nothing to do
+        // at the React layer here.
         return;
       }
 

--- a/apps/web/src/components/chat-pasted-text-extension.ts
+++ b/apps/web/src/components/chat-pasted-text-extension.ts
@@ -29,11 +29,10 @@ type InsertPastedTextChipOptions = {
  * lands on a normal text run after the atom node — matching how
  * users expect to keep typing after a paste or skill insert.
  *
- * After the insert we explicitly collapse the browser selection to
- * the end (mirroring `@tiptap/extension-mention`'s default suggestion
- * command). Without this, ProseMirror leaves a NodeSelection on the
- * inserted inline atom, and the next keystroke would replace the
- * chip with the typed character.
+ * After insertion we explicitly drop a `TextSelection` at the end of
+ * the inserted content. Without it ProseMirror keeps a NodeSelection
+ * on the inline atom, and the next keystroke would replace the chip
+ * with the typed character.
  */
 export const insertPastedTextChip = (
   editor: Editor,
@@ -44,19 +43,63 @@ export const insertPastedTextChip = (
     { type: PASTED_TEXT_NODE_NAME, attrs },
     { type: "text", text: " " },
   ];
+  const chain = editor.chain().focus();
   const ran = replaceRange
-    ? editor.chain().focus().insertContentAt(replaceRange, content).run()
-    : editor.chain().focus().insertContent(content).run();
-  editor.view.dom.ownerDocument.defaultView?.getSelection()?.collapseToEnd();
+    ? chain.insertContentAt(replaceRange, content).run()
+    : chain.insertContent(content).run();
+  editor.commands.setTextSelection(editor.state.selection.to);
   return ran;
+};
+
+type RenderChild = string | readonly ["br"];
+
+/**
+ * Build the inline-content children for the `<pasted-text>` element
+ * out of the stored text, splitting on `\n` and inserting `<br>`s
+ * between lines. The API sanitizer keeps `<br>` (the `<pasted-text>`
+ * wrapper itself is unwrapped), and `html-to-markdown.ts` converts
+ * `<br>` to `"  \n"` — preserving newlines that would otherwise be
+ * collapsed by inline whitespace normalization.
+ */
+export const buildPastedTextRenderChildren = (text: string): RenderChild[] => {
+  const lines = text.split("\n");
+  const children: RenderChild[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (index > 0) {
+      children.push(["br"] as const);
+    }
+    if (line.length > 0) {
+      children.push(line);
+    }
+  }
+  return children;
+};
+
+/**
+ * Read the underlying text out of a `<pasted-text>` element. Walks
+ * direct children so that `<br>` separators round-trip back to `\n`
+ * instead of vanishing the way `textContent` would.
+ */
+const parsePastedTextContent = (el: HTMLElement): string => {
+  let result = "";
+  for (const child of Array.from(el.childNodes)) {
+    if (child instanceof HTMLBRElement) {
+      result += "\n";
+      continue;
+    }
+    result += child.textContent ?? "";
+  }
+  return result;
 };
 
 /**
  * Atom inline node that renders a "[Pasted N characters]" chip in the
- * composer. The full text lives on the node attrs and is emitted as
- * a child text node in `renderHTML`, so the API-side sanitizer
- * (`<pasted-text>` is not in the allow-list) unwraps the tag and the
- * model receives the raw text. Visual collapse is composer-only.
+ * composer. The full text lives on the node attrs and is emitted in
+ * `renderHTML` with `<br>` between lines, so the API-side sanitizer
+ * (`<pasted-text>` is not in the allow-list) unwraps the tag while
+ * the `<br>`s — which the allow-list keeps — preserve newlines
+ * through `htmlToMarkdown`'s inline-whitespace collapse. Visual
+ * collapse is composer-only.
  */
 export const PastedText = Node.create({
   name: PASTED_TEXT_NODE_NAME,
@@ -70,7 +113,7 @@ export const PastedText = Node.create({
     return {
       text: {
         default: "",
-        parseHTML: (el: HTMLElement) => el.textContent ?? "",
+        parseHTML: parsePastedTextContent,
         renderHTML: () => ({}),
       },
       label: {
@@ -103,7 +146,11 @@ export const PastedText = Node.create({
   renderHTML({ HTMLAttributes, node }) {
     const text =
       typeof node.attrs["text"] === "string" ? node.attrs["text"] : "";
-    return ["pasted-text", mergeAttributes(HTMLAttributes), text];
+    return [
+      "pasted-text",
+      mergeAttributes(HTMLAttributes),
+      ...buildPastedTextRenderChildren(text),
+    ];
   },
 
   renderText({ node }) {

--- a/apps/web/src/components/chat-pasted-text-extension.ts
+++ b/apps/web/src/components/chat-pasted-text-extension.ts
@@ -1,0 +1,116 @@
+import { mergeAttributes, Node } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { ChatPastedTextNode } from "@/components/chat-pasted-text-node";
+
+export const PASTED_TEXT_NODE_NAME = "pastedText";
+
+export const PASTED_TEXT_SOURCES = ["paste", "prompt"] as const;
+export type PastedTextSource = (typeof PASTED_TEXT_SOURCES)[number];
+
+export type PastedTextAttrs = {
+  text: string;
+  label: string;
+  source: PastedTextSource;
+};
+
+const isPastedTextSource = (value: unknown): value is PastedTextSource =>
+  typeof value === "string" &&
+  (PASTED_TEXT_SOURCES as readonly string[]).includes(value);
+
+type InsertPastedTextChipOptions = {
+  /** When set, replace this range (e.g. the `/skill` trigger). */
+  replaceRange?: { from: number; to: number };
+};
+
+/**
+ * Insert a pasted-text chip and trail it with a space, so the cursor
+ * lands on a normal text run after the atom node — matching how
+ * users expect to keep typing after a paste or skill insert.
+ *
+ * After the insert we explicitly collapse the browser selection to
+ * the end (mirroring `@tiptap/extension-mention`'s default suggestion
+ * command). Without this, ProseMirror leaves a NodeSelection on the
+ * inserted inline atom, and the next keystroke would replace the
+ * chip with the typed character.
+ */
+export const insertPastedTextChip = (
+  editor: Editor,
+  attrs: PastedTextAttrs,
+  { replaceRange }: InsertPastedTextChipOptions = {},
+): boolean => {
+  const content = [
+    { type: PASTED_TEXT_NODE_NAME, attrs },
+    { type: "text", text: " " },
+  ];
+  const ran = replaceRange
+    ? editor.chain().focus().insertContentAt(replaceRange, content).run()
+    : editor.chain().focus().insertContent(content).run();
+  editor.view.dom.ownerDocument.defaultView?.getSelection()?.collapseToEnd();
+  return ran;
+};
+
+/**
+ * Atom inline node that renders a "[Pasted N characters]" chip in the
+ * composer. The full text lives on the node attrs and is emitted as
+ * a child text node in `renderHTML`, so the API-side sanitizer
+ * (`<pasted-text>` is not in the allow-list) unwraps the tag and the
+ * model receives the raw text. Visual collapse is composer-only.
+ */
+export const PastedText = Node.create({
+  name: PASTED_TEXT_NODE_NAME,
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+
+  addAttributes() {
+    return {
+      text: {
+        default: "",
+        parseHTML: (el: HTMLElement) => el.textContent ?? "",
+        renderHTML: () => ({}),
+      },
+      label: {
+        default: "",
+        parseHTML: (el: HTMLElement) => el.dataset["label"] ?? "",
+        renderHTML: (attrs: Record<string, unknown>) =>
+          typeof attrs["label"] === "string" && attrs["label"].length > 0
+            ? { "data-label": attrs["label"] }
+            : {},
+      },
+      source: {
+        default: "paste" satisfies PastedTextSource,
+        parseHTML: (el: HTMLElement) => {
+          const raw = el.dataset["source"];
+          return isPastedTextSource(raw) ? raw : "paste";
+        },
+        renderHTML: (attrs: Record<string, unknown>) => ({
+          "data-source": isPastedTextSource(attrs["source"])
+            ? attrs["source"]
+            : "paste",
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "pasted-text" }];
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    const text =
+      typeof node.attrs["text"] === "string" ? node.attrs["text"] : "";
+    return ["pasted-text", mergeAttributes(HTMLAttributes), text];
+  },
+
+  renderText({ node }) {
+    return typeof node.attrs["text"] === "string" ? node.attrs["text"] : "";
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ChatPastedTextNode);
+  },
+});

--- a/apps/web/src/components/chat-pasted-text-node.tsx
+++ b/apps/web/src/components/chat-pasted-text-node.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import { NodeViewWrapper } from "@tiptap/react";
 import type { NodeViewProps } from "@tiptap/react";
 import { ClipboardPasteIcon, SparklesIcon, XIcon } from "lucide-react";
@@ -23,6 +25,20 @@ export const ChatPastedTextNode = (props: NodeViewProps) => {
     text: string;
     label: string;
     source: PastedTextSource;
+  };
+
+  // Local-state-only edits keep the textarea responsive on large
+  // pastes; we commit back to the node attrs on blur (which fires
+  // when the popover closes), so each keystroke doesn't dispatch a
+  // ProseMirror transaction + draft re-sync.
+  const [draftText, setDraftText] = useState(attrs.text);
+  useEffect(() => {
+    setDraftText(attrs.text);
+  }, [attrs.text]);
+  const commitDraft = () => {
+    if (draftText !== attrs.text) {
+      props.updateAttributes({ text: draftText });
+    }
   };
 
   const fallbackLabel =
@@ -74,11 +90,12 @@ export const ChatPastedTextNode = (props: NodeViewProps) => {
             <textarea
               aria-label={t("common.edit")}
               className="bg-muted/40 focus-visible:ring-ring max-h-60 min-h-32 resize-none overflow-auto rounded-md border p-2 font-mono text-[11px] whitespace-pre-wrap focus-visible:ring-2 focus-visible:outline-none"
+              onBlur={commitDraft}
               onChange={(event) => {
-                props.updateAttributes({ text: event.target.value });
+                setDraftText(event.target.value);
               }}
               spellCheck={false}
-              value={attrs.text}
+              value={draftText}
             />
           </div>
         </PopoverPopup>

--- a/apps/web/src/components/chat-pasted-text-node.tsx
+++ b/apps/web/src/components/chat-pasted-text-node.tsx
@@ -1,0 +1,88 @@
+import { NodeViewWrapper } from "@tiptap/react";
+import type { NodeViewProps } from "@tiptap/react";
+import { ClipboardPasteIcon, SparklesIcon, XIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Popover,
+  PopoverPopup,
+  PopoverTrigger,
+} from "@stll/ui/components/popover";
+import { cn } from "@stll/ui/lib/utils";
+
+import type { PastedTextSource } from "@/components/chat-pasted-text-extension";
+
+const CHIP_MAX_LABEL_WIDTH_CLASS = "max-w-48";
+
+export const ChatPastedTextNode = (props: NodeViewProps) => {
+  const t = useTranslations();
+  // SAFETY: attrs from our own pastedText node schema
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  const attrs = props.node.attrs as {
+    text: string;
+    label: string;
+    source: PastedTextSource;
+  };
+
+  const fallbackLabel =
+    attrs.source === "prompt"
+      ? t("chat.pastedText.fromPromptFallback")
+      : t("chat.pastedText.fromClipboard", {
+          count: attrs.text.length,
+        });
+  const chipLabel = attrs.label.length > 0 ? attrs.label : fallbackLabel;
+
+  const Icon = attrs.source === "prompt" ? SparklesIcon : ClipboardPasteIcon;
+
+  return (
+    <NodeViewWrapper className="inline" data-source={attrs.source}>
+      <Popover>
+        <PopoverTrigger
+          aria-label={t("chat.pastedText.expand")}
+          className={cn(
+            "inline-flex max-w-full items-center gap-1 align-middle",
+            "bg-muted/60 hover:bg-muted rounded-md border px-1.5 py-0.5",
+            "text-foreground text-xs font-medium",
+            "focus-visible:ring-ring transition-colors focus-visible:ring-2 focus-visible:outline-none",
+            "cursor-pointer select-none",
+          )}
+          contentEditable={false}
+          type="button"
+        >
+          <Icon className="text-muted-foreground size-3 shrink-0" />
+          <span className={cn("truncate", CHIP_MAX_LABEL_WIDTH_CLASS)}>
+            {chipLabel}
+          </span>
+        </PopoverTrigger>
+        <PopoverPopup className="w-(--available-width) max-w-md" side="top">
+          <div className="flex max-h-72 flex-col gap-2 text-xs">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-muted-foreground truncate">
+                {chipLabel}
+              </span>
+              <Button
+                aria-label={t("chat.pastedText.remove")}
+                className="size-5 p-0"
+                onClick={() => props.deleteNode()}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <XIcon className="size-3" />
+              </Button>
+            </div>
+            <textarea
+              aria-label={t("common.edit")}
+              className="bg-muted/40 focus-visible:ring-ring max-h-60 min-h-32 resize-none overflow-auto rounded-md border p-2 font-mono text-[11px] whitespace-pre-wrap focus-visible:ring-2 focus-visible:outline-none"
+              onChange={(event) => {
+                props.updateAttributes({ text: event.target.value });
+              }}
+              spellCheck={false}
+              value={attrs.text}
+            />
+          </div>
+        </PopoverPopup>
+      </Popover>
+    </NodeViewWrapper>
+  );
+};

--- a/apps/web/src/components/chat-pasted-text.test.ts
+++ b/apps/web/src/components/chat-pasted-text.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  PASTED_TEXT_CHIP_MIN_CHARS,
+  PASTED_TEXT_CHIP_MIN_CHARS_WITH_LINE_BREAKS,
+  PASTED_TEXT_CHIP_MIN_LINE_BREAKS,
+  shouldChipPaste,
+} from "@/components/chat-pasted-text";
+
+describe("shouldChipPaste", () => {
+  test("leaves a single sentence as raw text", () => {
+    expect(shouldChipPaste("Quick note for the team.")).toBe(false);
+  });
+
+  test("collapses long single-line pastes", () => {
+    expect(shouldChipPaste("a".repeat(PASTED_TEXT_CHIP_MIN_CHARS))).toBe(true);
+  });
+
+  test("collapses substantial multi-line pastes below the char threshold", () => {
+    const linePadding = "x".repeat(
+      Math.ceil(
+        PASTED_TEXT_CHIP_MIN_CHARS_WITH_LINE_BREAKS /
+          (PASTED_TEXT_CHIP_MIN_LINE_BREAKS + 1),
+      ),
+    );
+    const text = Array.from(
+      { length: PASTED_TEXT_CHIP_MIN_LINE_BREAKS + 1 },
+      () => linePadding,
+    ).join("\n");
+    expect(text.length).toBeLessThan(PASTED_TEXT_CHIP_MIN_CHARS);
+    expect(shouldChipPaste(text)).toBe(true);
+  });
+
+  test("leaves short multi-line pastes alone", () => {
+    expect(shouldChipPaste("foo\nbar\nbaz")).toBe(false);
+  });
+
+  test("leaves a multi-line paste alone when total length is small even with many newlines", () => {
+    expect(shouldChipPaste("a\nb\nc\nd\ne\nf\ng")).toBe(false);
+  });
+});

--- a/apps/web/src/components/chat-pasted-text.test.ts
+++ b/apps/web/src/components/chat-pasted-text.test.ts
@@ -6,6 +6,7 @@ import {
   PASTED_TEXT_CHIP_MIN_LINE_BREAKS,
   shouldChipPaste,
 } from "@/components/chat-pasted-text";
+import { buildPastedTextRenderChildren } from "@/components/chat-pasted-text-extension";
 
 describe("shouldChipPaste", () => {
   test("leaves a single sentence as raw text", () => {
@@ -37,5 +38,34 @@ describe("shouldChipPaste", () => {
 
   test("leaves a multi-line paste alone when total length is small even with many newlines", () => {
     expect(shouldChipPaste("a\nb\nc\nd\ne\nf\ng")).toBe(false);
+  });
+});
+
+describe("buildPastedTextRenderChildren", () => {
+  test("returns the text as a single child for single-line content", () => {
+    expect(buildPastedTextRenderChildren("hello")).toEqual(["hello"]);
+  });
+
+  test("inserts <br>s between lines so newlines survive html-to-markdown", () => {
+    expect(buildPastedTextRenderChildren("line1\nline2\nline3")).toEqual([
+      "line1",
+      ["br"],
+      "line2",
+      ["br"],
+      "line3",
+    ]);
+  });
+
+  test("represents blank lines as bare <br>s without an empty text node", () => {
+    expect(buildPastedTextRenderChildren("a\n\nb")).toEqual([
+      "a",
+      ["br"],
+      ["br"],
+      "b",
+    ]);
+  });
+
+  test("emits an empty children array for empty text", () => {
+    expect(buildPastedTextRenderChildren("")).toEqual([]);
   });
 });

--- a/apps/web/src/components/chat-pasted-text.ts
+++ b/apps/web/src/components/chat-pasted-text.ts
@@ -1,0 +1,55 @@
+/**
+ * Threshold helpers for the "Pasted N characters" chip.
+ *
+ * Why a chip and not raw text: long pastes drown the composer
+ * (a 5,000-line log fills the visible area and obscures any
+ * surrounding instructions the user is writing). AI CLIs like
+ * Claude Code and Cursor collapse such pastes into a tappable
+ * placeholder, so the user keeps a clean prompt while the model
+ * still gets the full content on submit.
+ *
+ * The full text is preserved on the node attrs and serialized
+ * back into HTML on `editor.getHTML()`, so the model is unaware
+ * of the visual collapsing.
+ */
+
+/**
+ * Plain pastes of this many characters or more collapse to a chip.
+ * Picked to spare casual pastes (a sentence, a URL, a one-liner of
+ * code) while reliably catching long log dumps and copy/pasted
+ * documents. Tuned conservatively; revisit if users complain
+ * either way.
+ */
+export const PASTED_TEXT_CHIP_MIN_CHARS = 500;
+
+/**
+ * Pastes with at least this many newlines also collapse, even when
+ * shorter than `PASTED_TEXT_CHIP_MIN_CHARS`, as long as they exceed
+ * `PASTED_TEXT_CHIP_MIN_CHARS_WITH_LINE_BREAKS`. A short multi-line
+ * snippet (e.g. a stack trace, a chunk of YAML) hurts composer
+ * legibility just as much as a long single-line dump.
+ */
+export const PASTED_TEXT_CHIP_MIN_LINE_BREAKS = 5;
+export const PASTED_TEXT_CHIP_MIN_CHARS_WITH_LINE_BREAKS = 200;
+
+export const shouldChipPaste = (text: string): boolean => {
+  if (text.length >= PASTED_TEXT_CHIP_MIN_CHARS) {
+    return true;
+  }
+
+  const lineBreaks = countLineBreaks(text);
+  return (
+    lineBreaks >= PASTED_TEXT_CHIP_MIN_LINE_BREAKS &&
+    text.length >= PASTED_TEXT_CHIP_MIN_CHARS_WITH_LINE_BREAKS
+  );
+};
+
+const countLineBreaks = (text: string): number => {
+  let count = 0;
+  for (const ch of text) {
+    if (ch === "\n") {
+      count += 1;
+    }
+  }
+  return count;
+};

--- a/apps/web/src/components/chat/prompt-slash-extension.ts
+++ b/apps/web/src/components/chat/prompt-slash-extension.ts
@@ -1,10 +1,28 @@
 import { Extension } from "@tiptap/core";
+import type { Editor } from "@tiptap/core";
 import { ReactRenderer } from "@tiptap/react";
 import { Suggestion } from "@tiptap/suggestion";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 
+import { insertPastedTextChip } from "@/components/chat-pasted-text-extension";
 import { PromptSlashList } from "@/components/chat/prompt-slash-list";
 import type { ChatPrompt } from "@/lib/prompts/types";
+
+const insertPromptAsChip = (
+  editor: Editor,
+  range: { from: number; to: number },
+  prompt: ChatPrompt,
+) => {
+  insertPastedTextChip(
+    editor,
+    {
+      label: prompt.name,
+      source: "prompt",
+      text: prompt.body,
+    },
+    { replaceRange: range },
+  );
+};
 
 const PLUGIN_NAME = "promptSlash";
 
@@ -14,11 +32,13 @@ type PromptSlashOptions = {
 
 /**
  * `/`-triggered TipTap extension that lets the user pick a saved
- * prompt and drop its body into the composer. Triggers when `/`
- * is typed at the start of a paragraph or after whitespace, so a
- * `/` inside a URL (e.g. `https://...`) is just a slash. Selection
- * inserts the prompt's `body` as plain text and removes the trigger
- * range.
+ * prompt and drop it into the composer as a collapsible chip.
+ * Triggers when `/` is typed at the start of a paragraph or after
+ * whitespace, so a `/` inside a URL (e.g. `https://...`) is just a
+ * slash. Selection inserts a `pastedText` chip carrying the prompt
+ * name as the label and the body as the underlying text — same
+ * visual treatment as a long paste, so a multi-paragraph skill
+ * doesn't dump a wall of text into the input.
  */
 export const PromptSlash = Extension.create<PromptSlashOptions>({
   name: PLUGIN_NAME,
@@ -30,12 +50,7 @@ export const PromptSlash = Extension.create<PromptSlashOptions>({
         allowSpaces: false,
         items: () => [],
         command: ({ editor, range, props }) => {
-          editor
-            .chain()
-            .focus()
-            .deleteRange(range)
-            .insertContent(props.body)
-            .run();
+          insertPromptAsChip(editor, range, props);
         },
       },
     };
@@ -77,7 +92,7 @@ export const createPromptSlashSuggestion = (
   items: ({ query }) => filterPrompts(getPrompts(), query),
 
   command: ({ editor, range, props }) => {
-    editor.chain().focus().deleteRange(range).insertContent(props.body).run();
+    insertPromptAsChip(editor, range, props);
   },
 
   render: () => {

--- a/apps/web/src/components/chat/prompt-slash-list.tsx
+++ b/apps/web/src/components/chat/prompt-slash-list.tsx
@@ -101,7 +101,9 @@ export const PromptSlashList = forwardRef<
         setSelectedIndex((current) => (current + 1) % items.length);
         return true;
       }
-      if (event.key === "Enter") {
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        event.stopPropagation();
         select(safeIndex);
         return true;
       }

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -377,6 +377,12 @@
     "moveToSide": "Přesunout do bočního panelu",
     "newChat": "Nový chat",
     "noThreads": "Zatím žádné konverzace",
+    "pastedText": {
+      "expand": "Zobrazit celý text",
+      "fromClipboard": "Vloženo {count, plural, one {# znak} few {# znaky} other {# znaků}}",
+      "fromPromptFallback": "Dovednost",
+      "remove": "Odstranit"
+    },
     "placeholder": "Zde napište svůj dotaz, / pro dovednosti, @ pro přidání kontextu",
     "prompts": {
       "noResults": "Žádné odpovídající dovednosti",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -377,6 +377,12 @@
     "moveToSide": "In Seitenleiste verschieben",
     "newChat": "Neuer Chat",
     "noThreads": "Noch keine Konversationen",
+    "pastedText": {
+      "expand": "Vollständigen Text anzeigen",
+      "fromClipboard": "{count, plural, one {# Zeichen eingefügt} other {# Zeichen eingefügt}}",
+      "fromPromptFallback": "Skill",
+      "remove": "Entfernen"
+    },
     "placeholder": "Geben Sie hier Ihre Frage ein, / für Skills, @ für Kontext",
     "prompts": {
       "noResults": "Keine passenden Skills",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -377,6 +377,12 @@
     "moveToSide": "Move to side panel",
     "newChat": "New chat",
     "noThreads": "No conversations yet",
+    "pastedText": {
+      "expand": "Show full text",
+      "fromClipboard": "Pasted {count, plural, one {# character} other {# characters}}",
+      "fromPromptFallback": "Skill",
+      "remove": "Remove"
+    },
     "placeholder": "Type your question here, / for skills, @ to add context",
     "prompts": {
       "noResults": "No matching skills",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -377,6 +377,12 @@
     "moveToSide": "Mover al panel lateral",
     "newChat": "Nueva conversación",
     "noThreads": "Aún no hay conversaciones",
+    "pastedText": {
+      "expand": "Mostrar texto completo",
+      "fromClipboard": "Pegado: {count, plural, one {# carácter} other {# caracteres}}",
+      "fromPromptFallback": "Habilidad",
+      "remove": "Eliminar"
+    },
     "placeholder": "Escriba su pregunta aquí, / para skills, @ para añadir contexto",
     "prompts": {
       "noResults": "Sin habilidades coincidentes",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -377,6 +377,12 @@
     "moveToSide": "Vii külgpaneeli",
     "newChat": "Uus vestlus",
     "noThreads": "Vestlusi pole veel",
+    "pastedText": {
+      "expand": "Näita kogu teksti",
+      "fromClipboard": "Kleebitud {count, plural, one {# märk} other {# märki}}",
+      "fromPromptFallback": "Oskus",
+      "remove": "Eemalda"
+    },
     "placeholder": "Kirjutage oma küsimus siia, / oskuste jaoks, @ konteksti lisamiseks",
     "prompts": {
       "noResults": "Sobivaid oskusi pole",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -377,6 +377,12 @@
     "moveToSide": "Déplacer vers le panneau latéral",
     "newChat": "Nouvelle conversation",
     "noThreads": "Aucune conversation",
+    "pastedText": {
+      "expand": "Afficher le texte complet",
+      "fromClipboard": "Collé : {count, plural, one {# caractère} other {# caractères}}",
+      "fromPromptFallback": "Compétence",
+      "remove": "Supprimer"
+    },
     "placeholder": "Saisissez votre question ici, / pour les skills, @ pour ajouter du contexte",
     "prompts": {
       "noResults": "Aucun skill correspondant",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -377,6 +377,12 @@
     "moveToSide": "Áthelyezés az oldalsó panelbe",
     "newChat": "Új csevegés",
     "noThreads": "Még nincsenek beszélgetések",
+    "pastedText": {
+      "expand": "Teljes szöveg megjelenítése",
+      "fromClipboard": "Beillesztve: {count, plural, one {# karakter} other {# karakter}}",
+      "fromPromptFallback": "Készség",
+      "remove": "Eltávolítás"
+    },
     "placeholder": "Írja ide a kérdését, / a skillekhez, @ kontextus hozzáadásához",
     "prompts": {
       "noResults": "Nincs egyező skill",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -377,6 +377,12 @@
     "moveToSide": "Perkelti į šoninį skydelį",
     "newChat": "Naujas pokalbis",
     "noThreads": "Pokalbių dar nėra",
+    "pastedText": {
+      "expand": "Rodyti visą tekstą",
+      "fromClipboard": "Įklijuota {count, plural, one {# simbolis} few {# simboliai} other {# simbolių}}",
+      "fromPromptFallback": "Įgūdis",
+      "remove": "Pašalinti"
+    },
     "placeholder": "Čia įveskite klausimą, / įgūdžiams, @ kontekstui pridėti",
     "prompts": {
       "noResults": "Nėra atitinkančių įgūdžių",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -377,6 +377,12 @@
     "moveToSide": "Pārvietot uz sānu paneli",
     "newChat": "Jauna saruna",
     "noThreads": "Sarunu vēl nav",
+    "pastedText": {
+      "expand": "Rādīt pilnu tekstu",
+      "fromClipboard": "Ielīmēti {count, plural, one {# rakstzīme} other {# rakstzīmes}}",
+      "fromPromptFallback": "Prasme",
+      "remove": "Noņemt"
+    },
     "placeholder": "Ierakstiet jautājumu šeit, / prasmēm, @ konteksta pievienošanai",
     "prompts": {
       "noResults": "Nav atbilstošu prasmju",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -380,6 +380,12 @@ type Messages = {
     "moveToSide": "Move to side panel";
     "newChat": "New chat";
     "noThreads": "No conversations yet";
+    "pastedText": {
+      "expand": "Show full text";
+      "fromClipboard": "Pasted {count, plural, one {# character} other {# characters}}";
+      "fromPromptFallback": "Skill";
+      "remove": "Remove";
+    };
     "placeholder": "Type your question here, / for skills, @ to add context";
     "prompts": {
       "noResults": "No matching skills";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -377,6 +377,12 @@
     "moveToSide": "Przenieś do panelu bocznego",
     "newChat": "Nowy czat",
     "noThreads": "Brak rozmów",
+    "pastedText": {
+      "expand": "Pokaż pełny tekst",
+      "fromClipboard": "Wklejono {count, plural, one {# znak} few {# znaki} other {# znaków}}",
+      "fromPromptFallback": "Umiejętność",
+      "remove": "Usuń"
+    },
     "placeholder": "Wpisz pytanie tutaj, / dla umiejętności, @ aby dodać kontekst",
     "prompts": {
       "noResults": "Brak pasujących umiejętności",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -377,6 +377,12 @@
     "moveToSide": "Mover para o painel lateral",
     "newChat": "Novo bate-papo",
     "noThreads": "Ainda não há conversas",
+    "pastedText": {
+      "expand": "Mostrar texto completo",
+      "fromClipboard": "{count, plural, one {# caractere colado} other {# caracteres colados}}",
+      "fromPromptFallback": "Habilidade",
+      "remove": "Remover"
+    },
     "placeholder": "Digite sua pergunta aqui, / para habilidades, @ para adicionar contexto",
     "prompts": {
       "noResults": "Sem habilidades correspondentes",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -377,6 +377,12 @@
     "moveToSide": "Presunúť do bočného panela",
     "newChat": "Nový chat",
     "noThreads": "Zatiaľ žiadne konverzácie",
+    "pastedText": {
+      "expand": "Zobraziť celý text",
+      "fromClipboard": "Vložené {count, plural, one {# znak} few {# znaky} other {# znakov}}",
+      "fromPromptFallback": "Zručnosť",
+      "remove": "Odstrániť"
+    },
     "placeholder": "Sem napíšte svoju otázku, / pre zručnosti, @ na pridanie kontextu",
     "prompts": {
       "noResults": "Žiadne zhodné zručnosti",


### PR DESCRIPTION
Long plain-text pastes (>= 500 chars, or 5+ newlines with >= 200 chars) and `/skill` insertions now collapse into an inline chip in the chat composer instead of dumping the content inline. Clicking the chip opens a popover with the full text in an editable textarea; on submit the chip serializes back to its raw text via TipTap's `renderHTML` and the API's existing `sanitizeHtml` allow-list unwraps the unknown `<pasted-text>` tag, so the model receives the same content it would have without the chip. Tab now also confirms the highlighted skill in the slash menu (alongside Enter).

Translations added for all 11 non-English locales.

## Test plan

- [ ] Paste 500+ chars into the chat composer; chip appears, placeholder hides, no overlap.
- [ ] Click the chip; popover opens with the full text in a textarea.
- [ ] Edit the textarea; label updates ("Pasted N characters") with the new length.
- [ ] Click X; chip removed.
- [ ] `/` opens slash menu, Tab or Enter inserts the skill chip; cursor lands after it (next keystroke types alongside, doesn't replace).
- [ ] Submit a message containing a chip; model response references the full text.
- [ ] File pastes (e.g. screenshots) still go through the existing attachment flow.