### PR TITLE
feat: add Folio collaboration editing

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -62,9 +62,15 @@ jobs:
           # exceptions package-scoped; do not add namespace/group exceptions.
           allow-dependencies-licenses: >-
             pkg:npm/@ai-sdk/provider-utils,
+            pkg:npm/@hocuspocus/provider,
+            pkg:npm/@hocuspocus/server,
             pkg:npm/@stll/anonymize-chat,
             pkg:npm/@stll/anonymize-wasm,
             pkg:npm/@stll/docx-core,
+            pkg:npm/@t3-oss/env-core,
+            pkg:npm/crossws,
             pkg:npm/jszip,
-            pkg:npm/valibot
+            pkg:npm/valibot,
+            pkg:npm/y-prosemirror,
+            pkg:npm/yjs
           comment-summary-in-pr: always

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -25,6 +25,13 @@ BETTER_AUTH_SECRET="your-secret-at-least-32-chars-long"
 # Required. Issuer URL Better Auth uses to mint and verify session tokens.
 BETTER_AUTH_URL="http://localhost:3001"
 
+# --- Collaboration ---------------------------------------------------------
+# Required by apps/collab, not by the API process. Base HTTP URL of this API
+# so Hocuspocus can validate short-lived room tokens and persist Yjs snapshots.
+# STELLA_API_URL="http://localhost:3001"
+# Optional for apps/collab, default "3002".
+# STELLA_COLLAB_PORT="3002"
+
 # --- Email -----------------------------------------------------------------
 # Required. Selects the transport for transactional email (OTPs, invitations,
 # new-device alerts, in-app feedback). Allowed values: "ses" | "smtp".

--- a/apps/api/drizzle/20260510120000_folio-collab-sessions/migration.sql
+++ b/apps/api/drizzle/20260510120000_folio-collab-sessions/migration.sql
@@ -1,0 +1,110 @@
+CREATE TABLE "folio_collab_sessions" (
+	"id" uuid PRIMARY KEY,
+	"workspace_id" uuid NOT NULL,
+	"entity_id" uuid NOT NULL,
+	"property_id" uuid NOT NULL,
+	"base_version_id" uuid NOT NULL,
+	"finalized_version_id" uuid,
+	"created_by" text NOT NULL,
+	"status" text DEFAULT 'open' NOT NULL,
+	"file_name" varchar(256) NOT NULL,
+	"yjs_snapshot_file_id" uuid NOT NULL,
+	"yjs_snapshot_size_bytes" integer,
+	"yjs_snapshot_updated_at" timestamp,
+	"docx_checkpoint_file_id" uuid NOT NULL,
+	"docx_checkpoint_sha256_hex" varchar(64),
+	"docx_checkpoint_size_bytes" integer,
+	"docx_checkpoint_scan_warnings" jsonb,
+	"docx_checkpoint_updated_at" timestamp,
+	"seed_claimed_by" text,
+	"seed_claimed_at" timestamp,
+	"seeded_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"closed_at" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE TABLE "folio_collab_session_tokens" (
+	"id" uuid PRIMARY KEY,
+	"session_id" uuid NOT NULL,
+	"workspace_id" uuid NOT NULL,
+	"user_id" text NOT NULL,
+	"token_hash" varchar(64) NOT NULL,
+	"permissions" jsonb NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "folio_collab_session_tokens" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_base_version_id_entity_versions_id_fkey" FOREIGN KEY ("base_version_id") REFERENCES "entity_versions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_finalized_version_id_entity_versions_id_fkey" FOREIGN KEY ("finalized_version_id") REFERENCES "entity_versions"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_created_by_user_id_fkey" FOREIGN KEY ("created_by") REFERENCES "user"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_seed_claimed_by_user_id_fkey" FOREIGN KEY ("seed_claimed_by") REFERENCES "user"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_entity_workspace_fkey" FOREIGN KEY ("entity_id","workspace_id") REFERENCES "entities"("id","workspace_id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_sessions" ADD CONSTRAINT "folio_collab_sessions_property_workspace_fkey" FOREIGN KEY ("property_id","workspace_id") REFERENCES "properties"("id","workspace_id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_session_tokens" ADD CONSTRAINT "folio_collab_session_tokens_session_id_fkey" FOREIGN KEY ("session_id") REFERENCES "folio_collab_sessions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_session_tokens" ADD CONSTRAINT "folio_collab_session_tokens_workspace_id_workspaces_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+ALTER TABLE "folio_collab_session_tokens" ADD CONSTRAINT "folio_collab_session_tokens_user_id_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+CREATE INDEX "folio_collab_sessions_workspace_id_idx" ON "folio_collab_sessions" ("workspace_id");
+--> statement-breakpoint
+CREATE INDEX "folio_collab_sessions_entity_id_idx" ON "folio_collab_sessions" ("entity_id");
+--> statement-breakpoint
+CREATE INDEX "folio_collab_sessions_property_id_idx" ON "folio_collab_sessions" ("property_id");
+--> statement-breakpoint
+CREATE INDEX "folio_collab_sessions_base_version_id_idx" ON "folio_collab_sessions" ("base_version_id");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "folio_collab_sessions_open_uidx" ON "folio_collab_sessions" ("workspace_id","entity_id","property_id") WHERE "folio_collab_sessions"."status" = 'open';
+--> statement-breakpoint
+CREATE INDEX "folio_collab_session_tokens_workspace_id_idx" ON "folio_collab_session_tokens" ("workspace_id");
+--> statement-breakpoint
+CREATE INDEX "folio_collab_session_tokens_session_id_idx" ON "folio_collab_session_tokens" ("session_id");
+--> statement-breakpoint
+CREATE INDEX "folio_collab_session_tokens_expires_at_idx" ON "folio_collab_session_tokens" ("expires_at");
+--> statement-breakpoint
+CREATE UNIQUE INDEX "folio_collab_session_tokens_token_hash_uidx" ON "folio_collab_session_tokens" ("token_hash");
+--> statement-breakpoint
+CREATE POLICY "workspace_select" ON "folio_collab_sessions" AS PERMISSIVE FOR SELECT TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_insert" ON "folio_collab_sessions" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_update" ON "folio_collab_sessions" AS PERMISSIVE FOR UPDATE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_delete" ON "folio_collab_sessions" AS PERMISSIVE FOR DELETE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_select" ON "folio_collab_session_tokens" AS PERMISSIVE FOR SELECT TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_insert" ON "folio_collab_session_tokens" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_update" ON "folio_collab_session_tokens" AS PERMISSIVE FOR UPDATE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));
+--> statement-breakpoint
+CREATE POLICY "workspace_delete" ON "folio_collab_session_tokens" AS PERMISSIVE FOR DELETE TO "stella" USING (workspace_id = ANY((SELECT current_setting(
+  'app.workspace_ids', true
+))::uuid[]));

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1030,6 +1030,16 @@ export const DESKTOP_EDIT_SESSION_STATUSES = [
   "cancelled",
 ] as const;
 
+export const FOLIO_COLLAB_SESSION_STATUSES = [
+  "open",
+  "finalized",
+  "cancelled",
+] as const;
+
+export type FolioCollabTokenPermissions = {
+  canEdit: boolean;
+};
+
 export const desktopEditSessions = p.pgTable(
   "desktop_edit_sessions",
   {
@@ -1132,8 +1142,9 @@ export const desktopEditHandoffs = p.pgTable(
     forceTakeover: p.boolean("force_takeover").notNull().default(false),
     expiresAt: p.timestamp("expires_at").notNull(),
     consumedAt: p.timestamp("consumed_at"),
-    desktopSessionId: safeUuid<"desktopEditSession">("desktop_session_id")
-      .references(() => desktopEditSessions.id, { onDelete: "set null" }),
+    desktopSessionId: safeUuid<"desktopEditSession">(
+      "desktop_session_id",
+    ).references(() => desktopEditSessions.id, { onDelete: "set null" }),
     openedAt: p.timestamp("opened_at"),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
@@ -1163,6 +1174,118 @@ export const desktopEditHandoffs = p.pgTable(
         foreignColumns: [properties.id, properties.workspaceId],
       })
       .onDelete("cascade"),
+    ...wsPolicies(),
+  ],
+);
+
+export const folioCollabSessions = p.pgTable(
+  "folio_collab_sessions",
+  {
+    id: pUuid<"folioCollabSession">().primaryKey(),
+    workspaceId: safeWorkspaceId("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    entityId: safeUuid<"entity">("entity_id").notNull(),
+    propertyId: safeUuid<"property">("property_id").notNull(),
+    baseVersionId: safeUuid<"entityVersion">("base_version_id")
+      .notNull()
+      .references(() => entityVersions.id, { onDelete: "cascade" }),
+    finalizedVersionId: safeUuid<"entityVersion">(
+      "finalized_version_id",
+    ).references(() => entityVersions.id, { onDelete: "set null" }),
+    createdBy: p
+      .text("created_by")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    status: p
+      .text("status", { enum: FOLIO_COLLAB_SESSION_STATUSES })
+      .notNull()
+      .default("open"),
+    fileName: p.varchar("file_name", { length: 256 }).notNull(),
+    yjsSnapshotFileId: safeUuid<"userFile">("yjs_snapshot_file_id").notNull(),
+    yjsSnapshotSizeBytes: p.integer("yjs_snapshot_size_bytes"),
+    yjsSnapshotUpdatedAt: p.timestamp("yjs_snapshot_updated_at"),
+    docxCheckpointFileId: safeUuid<"userFile">(
+      "docx_checkpoint_file_id",
+    ).notNull(),
+    docxCheckpointSha256Hex: p.varchar("docx_checkpoint_sha256_hex", {
+      length: 64,
+    }),
+    docxCheckpointSizeBytes: p.integer("docx_checkpoint_size_bytes"),
+    docxCheckpointScanWarnings: jsonb(
+      "docx_checkpoint_scan_warnings",
+    ).$type<string[] | null>(),
+    docxCheckpointUpdatedAt: p.timestamp("docx_checkpoint_updated_at"),
+    seedClaimedBy: p.text("seed_claimed_by").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    seedClaimedAt: p.timestamp("seed_claimed_at"),
+    seededAt: p.timestamp("seeded_at"),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+    closedAt: p.timestamp("closed_at"),
+  },
+  (table) => [
+    p.index("folio_collab_sessions_workspace_id_idx").on(table.workspaceId),
+    p.index("folio_collab_sessions_entity_id_idx").on(table.entityId),
+    p.index("folio_collab_sessions_property_id_idx").on(table.propertyId),
+    p
+      .index("folio_collab_sessions_base_version_id_idx")
+      .on(table.baseVersionId),
+    p
+      .uniqueIndex("folio_collab_sessions_open_uidx")
+      .on(table.workspaceId, table.entityId, table.propertyId)
+      .where(sql`${table.status} = 'open'`),
+    p
+      .foreignKey({
+        columns: [table.entityId, table.workspaceId],
+        foreignColumns: [entities.id, entities.workspaceId],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.propertyId, table.workspaceId],
+        foreignColumns: [properties.id, properties.workspaceId],
+      })
+      .onDelete("cascade"),
+    ...wsPolicies(),
+  ],
+);
+
+export const folioCollabSessionTokens = p.pgTable(
+  "folio_collab_session_tokens",
+  {
+    id: pUuid<"folioCollabSessionToken">().primaryKey(),
+    sessionId: safeUuid<"folioCollabSession">("session_id")
+      .notNull()
+      .references(() => folioCollabSessions.id, { onDelete: "cascade" }),
+    workspaceId: safeWorkspaceId("workspace_id")
+      .notNull()
+      .references(() => workspaces.id, { onDelete: "cascade" }),
+    userId: p
+      .text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    tokenHash: p.varchar("token_hash", { length: 64 }).notNull(),
+    permissions: jsonb("permissions")
+      .$type<FolioCollabTokenPermissions>()
+      .notNull(),
+    expiresAt: p.timestamp("expires_at").notNull(),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    p.index("folio_collab_session_tokens_workspace_id_idx").on(
+      table.workspaceId,
+    ),
+    p.index("folio_collab_session_tokens_session_id_idx").on(table.sessionId),
+    p.index("folio_collab_session_tokens_expires_at_idx").on(table.expiresAt),
+    p
+      .uniqueIndex("folio_collab_session_tokens_token_hash_uidx")
+      .on(table.tokenHash),
     ...wsPolicies(),
   ],
 );
@@ -3029,6 +3152,8 @@ export const relations = defineRelations(
     entityVersionAiSummaries,
     desktopEditSessions,
     desktopEditHandoffs,
+    folioCollabSessions,
+    folioCollabSessionTokens,
     fields,
     justifications,
     templates,
@@ -3190,6 +3315,10 @@ export const relations = defineRelations(
         from: r.workspaces.id,
         to: r.workspaceViews.workspaceId,
       }),
+      folioCollabSessions: r.many.folioCollabSessions({
+        from: r.workspaces.id,
+        to: r.folioCollabSessions.workspaceId,
+      }),
     },
     workspaceMembers: {
       workspace: r.one.workspaces({
@@ -3257,6 +3386,10 @@ export const relations = defineRelations(
       desktopEditSessions: r.many.desktopEditSessions({
         from: r.entities.id,
         to: r.desktopEditSessions.entityId,
+      }),
+      folioCollabSessions: r.many.folioCollabSessions({
+        from: r.entities.id,
+        to: r.folioCollabSessions.entityId,
       }),
       currentVersion: r.one.entityVersions({
         from: r.entities.currentVersionId,
@@ -3390,6 +3523,52 @@ export const relations = defineRelations(
       }),
       createdByUser: r.one.user({
         from: r.desktopEditHandoffs.createdBy,
+        to: r.user.id,
+      }),
+    },
+    folioCollabSessions: {
+      workspace: r.one.workspaces({
+        from: r.folioCollabSessions.workspaceId,
+        to: r.workspaces.id,
+      }),
+      entity: r.one.entities({
+        from: r.folioCollabSessions.entityId,
+        to: r.entities.id,
+      }),
+      property: r.one.properties({
+        from: r.folioCollabSessions.propertyId,
+        to: r.properties.id,
+      }),
+      baseVersion: r.one.entityVersions({
+        from: r.folioCollabSessions.baseVersionId,
+        to: r.entityVersions.id,
+        alias: "folioCollabSessionBaseVersion",
+      }),
+      finalizedVersion: r.one.entityVersions({
+        from: r.folioCollabSessions.finalizedVersionId,
+        to: r.entityVersions.id,
+        alias: "folioCollabSessionFinalizedVersion",
+      }),
+      createdByUser: r.one.user({
+        from: r.folioCollabSessions.createdBy,
+        to: r.user.id,
+      }),
+      tokens: r.many.folioCollabSessionTokens({
+        from: r.folioCollabSessions.id,
+        to: r.folioCollabSessionTokens.sessionId,
+      }),
+    },
+    folioCollabSessionTokens: {
+      session: r.one.folioCollabSessions({
+        from: r.folioCollabSessionTokens.sessionId,
+        to: r.folioCollabSessions.id,
+      }),
+      workspace: r.one.workspaces({
+        from: r.folioCollabSessionTokens.workspaceId,
+        to: r.workspaces.id,
+      }),
+      user: r.one.user({
+        from: r.folioCollabSessionTokens.userId,
         to: r.user.id,
       }),
     },

--- a/apps/api/src/handlers/entities/copy-to-workspace.test.ts
+++ b/apps/api/src/handlers/entities/copy-to-workspace.test.ts
@@ -29,7 +29,19 @@ void mock.module("@/api/lib/search/process-extraction", () => ({
 
 const syncWorkspaceSearchActivityMock = mock(async () => {});
 void mock.module("@/api/lib/search/index-global", () => ({
+  rebuildSupplementalSearchIndex: mock(async () => undefined),
+  reindexWorkspacesForContact: mock(async () => undefined),
+  searchGlobal: mock(async () => ({
+    facets: { editor: [], mimeType: [], type: [], workspace: [] },
+    hits: [],
+    nextCursor: null,
+    totalCount: 0,
+  })),
+  searchGlobalFacet: mock(async () => []),
   syncWorkspaceSearchActivity: syncWorkspaceSearchActivityMock,
+  upsertContactSearchDocument: mock(async () => undefined),
+  upsertWorkspaceSearchDocument: mock(async () => undefined),
+  upsertWorkspaceSearchDocuments: mock(async () => undefined),
 }));
 
 const { default: copyToWorkspace } = await import("./copy-to-workspace");

--- a/apps/api/src/handlers/entities/desktop-edit-session-utils.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-utils.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
 import { fields } from "@/api/db/schema";
@@ -17,6 +17,21 @@ type DocxFieldContent = Extract<FieldContent, { type: "file" }> & {
 type DocxFieldEntry = {
   content: FieldContent;
   propertyId: SafeId<"property">;
+};
+
+export const lockDocxEditTarget = async ({
+  entityId,
+  propertyId,
+  tx,
+  workspaceId,
+}: {
+  entityId: SafeId<"entity">;
+  propertyId: SafeId<"property">;
+  tx: DatabaseTransaction;
+  workspaceId: SafeId<"workspace">;
+}) => {
+  const lockKey = `docx-edit:${workspaceId}:${entityId}:${propertyId}`;
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${lockKey}))`);
 };
 
 export const asDocxFieldContent = (

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.ts
@@ -4,7 +4,11 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 
 import type { SafeDb, Transaction } from "@/api/db";
-import { desktopEditSessions, entityVersions } from "@/api/db/schema";
+import {
+  desktopEditSessions,
+  entityVersions,
+  folioCollabSessions,
+} from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -286,6 +290,29 @@ export const openDesktopEditSessionHandler = async function* ({
           error: {
             message: "Target property is not an editable DOCX field.",
             statusCode: 400 as const,
+          },
+        } as const;
+      }
+
+      const collabSessions = await tx
+        .select({ id: folioCollabSessions.id })
+        .from(folioCollabSessions)
+        .where(
+          and(
+            eq(folioCollabSessions.entityId, entityId),
+            eq(folioCollabSessions.propertyId, propertyId),
+            eq(folioCollabSessions.workspaceId, workspaceId),
+            eq(folioCollabSessions.status, "open"),
+          ),
+        )
+        .limit(1);
+
+      if (collabSessions.at(0)) {
+        return {
+          error: {
+            message:
+              "This document already has a collaborative edit session open.",
+            statusCode: 409 as const,
           },
         } as const;
       }

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.ts
@@ -24,6 +24,7 @@ import { isPgError, PG_ERROR } from "@/api/lib/pg-error";
 import { broadcast } from "@/api/lib/sse";
 
 import {
+  lockDocxEditTarget,
   presignDocxDownloadFromFileId,
   presignDocxFieldDownload,
   readCurrentDocxTarget,
@@ -222,6 +223,13 @@ export const openDesktopEditSessionHandler = async function* ({
   if (force) {
     yield* Result.await(
       safeDb(async (tx) => {
+        await lockDocxEditTarget({
+          entityId,
+          propertyId,
+          tx,
+          workspaceId,
+        });
+
         const existing = await tx
           .select({ id: desktopEditSessions.id })
           .from(desktopEditSessions)
@@ -254,6 +262,13 @@ export const openDesktopEditSessionHandler = async function* ({
 
   const runOpenSession = async ({ allowInsert }: { allowInsert: boolean }) =>
     await safeDb(async (tx) => {
+      await lockDocxEditTarget({
+        entityId,
+        propertyId,
+        tx,
+        workspaceId,
+      });
+
       const existingSession = await readExistingOpenDesktopEditSession({
         entityId,
         propertyId,

--- a/apps/api/src/handlers/entities/open-folio-collab-session.ts
+++ b/apps/api/src/handlers/entities/open-folio-collab-session.ts
@@ -145,13 +145,21 @@ const openFolioCollabSessionHandler = async function* ({
 
       const existingSession = existingSessions.at(0);
       if (existingSession) {
-        const seedClaimStale =
-          existingSession.seededAt === null &&
-          (existingSession.seedClaimedAt === null ||
+        if (existingSession.seededAt === null) {
+          const seedClaimStale =
+            existingSession.seedClaimedAt === null ||
             existingSession.seedClaimedAt.getTime() <
-              Date.now() - SEED_CLAIM_STALE_MS);
+              Date.now() - SEED_CLAIM_STALE_MS;
 
-        if (seedClaimStale) {
+          if (!seedClaimStale) {
+            return {
+              error: {
+                message: "Collaborative edit session is still preparing.",
+                status: 409,
+              },
+            } as const;
+          }
+
           const baseContent = await readVersionDocxTarget({
             entityVersionId: existingSession.baseVersionId,
             propertyId,

--- a/apps/api/src/handlers/entities/open-folio-collab-session.ts
+++ b/apps/api/src/handlers/entities/open-folio-collab-session.ts
@@ -1,0 +1,290 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+import type { Static } from "elysia";
+
+import type { SafeDb } from "@/api/db";
+import {
+  desktopEditSessions,
+  folioCollabSessions,
+  folioCollabSessionTokens,
+} from "@/api/db/schema";
+import {
+  presignDocxFieldDownload,
+  readCurrentDocxTarget,
+  readVersionDocxTarget,
+} from "@/api/handlers/entities/desktop-edit-session-utils";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  computeFolioCollabTokenExpiresAt,
+  createFolioCollabToken,
+  hashFolioCollabToken,
+} from "@/api/lib/folio-collab-sessions";
+
+const openFolioCollabSessionBodySchema = t.Object({
+  entityId: tSafeId("entity"),
+  propertyId: tSafeId("property"),
+});
+
+type OpenFolioCollabSessionBody = Static<
+  typeof openFolioCollabSessionBodySchema
+>;
+
+type OpenFolioCollabSessionResponse = {
+  baseVersionId: SafeId<"entityVersion">;
+  collabSessionId: SafeId<"folioCollabSession">;
+  fileName: string;
+  roomName: string;
+  seedDownloadUrl: string | null;
+  shouldSeed: boolean;
+  token: string;
+  tokenExpiresAt: string;
+};
+
+type OpenFolioCollabSessionProps = {
+  body: OpenFolioCollabSessionBody;
+  organizationId: SafeId<"organization">;
+  safeDb: SafeDb;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+};
+
+const SEED_CLAIM_STALE_MS = 30_000;
+
+const issueToken = async ({
+  collabSessionId,
+  safeDb,
+  userId,
+  workspaceId,
+}: {
+  collabSessionId: SafeId<"folioCollabSession">;
+  safeDb: OpenFolioCollabSessionProps["safeDb"];
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+}) => {
+  const token = createFolioCollabToken();
+  const tokenExpiresAt = computeFolioCollabTokenExpiresAt();
+  await safeDb(async (tx) => {
+    await tx.insert(folioCollabSessionTokens).values({
+      expiresAt: tokenExpiresAt,
+      id: createSafeId<"folioCollabSessionToken">(),
+      permissions: { canEdit: true },
+      sessionId: collabSessionId,
+      tokenHash: hashFolioCollabToken(token),
+      userId,
+      workspaceId,
+    });
+  });
+
+  return { token, tokenExpiresAt };
+};
+
+const openFolioCollabSessionHandler = async function* ({
+  body: { entityId, propertyId },
+  organizationId,
+  safeDb,
+  userId,
+  workspaceId,
+}: OpenFolioCollabSessionProps) {
+  const openSession = yield* Result.await(
+    safeDb(async (tx) => {
+      const desktopSessions = await tx
+        .select({ id: desktopEditSessions.id })
+        .from(desktopEditSessions)
+        .where(
+          and(
+            eq(desktopEditSessions.entityId, entityId),
+            eq(desktopEditSessions.propertyId, propertyId),
+            eq(desktopEditSessions.status, "open"),
+            eq(desktopEditSessions.workspaceId, workspaceId),
+          ),
+        )
+        .limit(1);
+
+      if (desktopSessions.at(0)) {
+        return {
+          error: {
+            message:
+              "This document already has a single-user edit session open.",
+            status: 409,
+          },
+        } as const;
+      }
+
+      const existingSessions = await tx
+        .select({
+          baseVersionId: folioCollabSessions.baseVersionId,
+          fileName: folioCollabSessions.fileName,
+          id: folioCollabSessions.id,
+          seedClaimedAt: folioCollabSessions.seedClaimedAt,
+          seededAt: folioCollabSessions.seededAt,
+        })
+        .from(folioCollabSessions)
+        .where(
+          and(
+            eq(folioCollabSessions.entityId, entityId),
+            eq(folioCollabSessions.propertyId, propertyId),
+            eq(folioCollabSessions.status, "open"),
+            eq(folioCollabSessions.workspaceId, workspaceId),
+          ),
+        )
+        .limit(1);
+
+      const existingSession = existingSessions.at(0);
+      if (existingSession) {
+        const seedClaimStale =
+          existingSession.seededAt === null &&
+          (existingSession.seedClaimedAt === null ||
+            existingSession.seedClaimedAt.getTime() <
+              Date.now() - SEED_CLAIM_STALE_MS);
+
+        if (seedClaimStale) {
+          const baseContent = await readVersionDocxTarget({
+            entityVersionId: existingSession.baseVersionId,
+            propertyId,
+            tx,
+            workspaceId,
+          });
+
+          if (!baseContent) {
+            return {
+              error: {
+                message:
+                  "Collaborative edit session source file is no longer available.",
+                status: 409,
+              },
+            } as const;
+          }
+
+          await tx
+            .update(folioCollabSessions)
+            .set({
+              seedClaimedAt: new Date(),
+              seedClaimedBy: userId,
+            })
+            .where(eq(folioCollabSessions.id, existingSession.id));
+
+          return {
+            baseVersionId: existingSession.baseVersionId,
+            collabSessionId: existingSession.id,
+            fileName: existingSession.fileName,
+            seedDownloadUrl: presignDocxFieldDownload({
+              fileContent: baseContent,
+              organizationId,
+              workspaceId,
+            }),
+            shouldSeed: true,
+          } as const;
+        }
+
+        return {
+          baseVersionId: existingSession.baseVersionId,
+          collabSessionId: existingSession.id,
+          fileName: existingSession.fileName,
+          seedDownloadUrl: null,
+          shouldSeed: false,
+        } as const;
+      }
+
+      const currentTarget = await readCurrentDocxTarget({
+        entityId,
+        propertyId,
+        tx,
+        workspaceId,
+      });
+
+      if (!currentTarget) {
+        return {
+          error: {
+            message: "Target property is not an editable DOCX field.",
+            status: 400,
+          },
+        } as const;
+      }
+
+      const collabSessionId = createSafeId<"folioCollabSession">();
+      await tx.insert(folioCollabSessions).values({
+        baseVersionId: currentTarget.baseVersionId,
+        createdBy: userId,
+        docxCheckpointFileId: createSafeId<"userFile">(),
+        entityId,
+        fileName: currentTarget.fileContent.fileName,
+        id: collabSessionId,
+        propertyId,
+        seedClaimedAt: new Date(),
+        seedClaimedBy: userId,
+        workspaceId,
+        yjsSnapshotFileId: createSafeId<"userFile">(),
+      });
+
+      return {
+        baseVersionId: currentTarget.baseVersionId,
+        collabSessionId,
+        fileName: currentTarget.fileContent.fileName,
+        seedDownloadUrl: presignDocxFieldDownload({
+          fileContent: currentTarget.fileContent,
+          organizationId,
+          workspaceId,
+        }),
+        shouldSeed: true,
+      } as const;
+    }),
+  );
+
+  if ("error" in openSession) {
+    return Result.err(
+      new HandlerError({
+        message: openSession.error.message,
+        status: openSession.error.status,
+      }),
+    );
+  }
+
+  const { token, tokenExpiresAt } = yield* Result.await(
+    Result.tryPromise(
+      async () =>
+        await issueToken({
+          collabSessionId: openSession.collabSessionId,
+          safeDb,
+          userId,
+          workspaceId,
+        }),
+    ),
+  );
+
+  return Result.ok({
+    baseVersionId: openSession.baseVersionId,
+    collabSessionId: openSession.collabSessionId,
+    fileName: openSession.fileName,
+    roomName: openSession.collabSessionId,
+    seedDownloadUrl: openSession.seedDownloadUrl,
+    shouldSeed: openSession.shouldSeed,
+    token,
+    tokenExpiresAt: tokenExpiresAt.toISOString(),
+  } satisfies OpenFolioCollabSessionResponse);
+};
+
+const config = {
+  body: openFolioCollabSessionBodySchema,
+  permissions: { entity: ["update"] },
+} satisfies HandlerConfig;
+
+const openFolioCollabSession = createSafeHandler(
+  config,
+  async function* ({ body, safeDb, session, user, workspaceId }) {
+    return yield* openFolioCollabSessionHandler({
+      body,
+      organizationId: session.activeOrganizationId,
+      safeDb,
+      userId: user.id,
+      workspaceId,
+    });
+  },
+);
+
+export default openFolioCollabSession;

--- a/apps/api/src/handlers/entities/open-folio-collab-session.ts
+++ b/apps/api/src/handlers/entities/open-folio-collab-session.ts
@@ -10,6 +10,7 @@ import {
   folioCollabSessionTokens,
 } from "@/api/db/schema";
 import {
+  lockDocxEditTarget,
   presignDocxFieldDownload,
   readCurrentDocxTarget,
   readVersionDocxTarget,
@@ -93,6 +94,13 @@ const openFolioCollabSessionHandler = async function* ({
 }: OpenFolioCollabSessionProps) {
   const openSession = yield* Result.await(
     safeDb(async (tx) => {
+      await lockDocxEditTarget({
+        entityId,
+        propertyId,
+        tx,
+        workspaceId,
+      });
+
       const desktopSessions = await tx
         .select({ id: desktopEditSessions.id })
         .from(desktopEditSessions)

--- a/apps/api/src/handlers/entities/open-folio-collab-session.ts
+++ b/apps/api/src/handlers/entities/open-folio-collab-session.ts
@@ -4,11 +4,7 @@ import { t } from "elysia";
 import type { Static } from "elysia";
 
 import type { SafeDb } from "@/api/db";
-import {
-  desktopEditSessions,
-  folioCollabSessions,
-  folioCollabSessionTokens,
-} from "@/api/db/schema";
+import { desktopEditSessions, folioCollabSessions } from "@/api/db/schema";
 import {
   lockDocxEditTarget,
   presignDocxFieldDownload,
@@ -21,11 +17,7 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import {
-  computeFolioCollabTokenExpiresAt,
-  createFolioCollabToken,
-  hashFolioCollabToken,
-} from "@/api/lib/folio-collab-sessions";
+import { issueFolioCollabToken } from "@/api/lib/folio-collab-sessions";
 
 const openFolioCollabSessionBodySchema = t.Object({
   entityId: tSafeId("entity"),
@@ -56,34 +48,6 @@ type OpenFolioCollabSessionProps = {
 };
 
 const SEED_CLAIM_STALE_MS = 30_000;
-
-const issueToken = async ({
-  collabSessionId,
-  safeDb,
-  userId,
-  workspaceId,
-}: {
-  collabSessionId: SafeId<"folioCollabSession">;
-  safeDb: OpenFolioCollabSessionProps["safeDb"];
-  userId: SafeId<"user">;
-  workspaceId: SafeId<"workspace">;
-}) => {
-  const token = createFolioCollabToken();
-  const tokenExpiresAt = computeFolioCollabTokenExpiresAt();
-  await safeDb(async (tx) => {
-    await tx.insert(folioCollabSessionTokens).values({
-      expiresAt: tokenExpiresAt,
-      id: createSafeId<"folioCollabSessionToken">(),
-      permissions: { canEdit: true },
-      sessionId: collabSessionId,
-      tokenHash: hashFolioCollabToken(token),
-      userId,
-      workspaceId,
-    });
-  });
-
-  return { token, tokenExpiresAt };
-};
 
 const openFolioCollabSessionHandler = async function* ({
   body: { entityId, propertyId },
@@ -262,11 +226,12 @@ const openFolioCollabSessionHandler = async function* ({
   }
 
   const { token, tokenExpiresAt } = yield* Result.await(
-    Result.tryPromise(
-      async () =>
-        await issueToken({
-          collabSessionId: openSession.collabSessionId,
-          safeDb,
+    safeDb(
+      async (tx) =>
+        await issueFolioCollabToken({
+          permissions: { canEdit: true },
+          sessionId: openSession.collabSessionId,
+          tx,
           userId,
           workspaceId,
         }),

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -18,6 +18,7 @@ import listFiles from "@/api/handlers/entities/list-files";
 import listFolders from "@/api/handlers/entities/list-folders";
 import moveEntity from "@/api/handlers/entities/move";
 import openDesktopEditSession from "@/api/handlers/entities/open-desktop-edit-session";
+import openFolioCollabSession from "@/api/handlers/entities/open-folio-collab-session";
 import organizeSuggestions from "@/api/handlers/entities/organize-suggestions";
 import readEntities from "@/api/handlers/entities/read";
 import readEntityById from "@/api/handlers/entities/read-by-id";
@@ -89,6 +90,10 @@ export const entitiesRoute = new Elysia({
       permissions: readDesktopEditHandoffStatus.config.permissions,
     },
   )
+  .post("/folio-collab-sessions/open", openFolioCollabSession.handler, {
+    body: openFolioCollabSession.config.body,
+    permissions: openFolioCollabSession.config.permissions,
+  })
   .post("/desktop-edit-sessions/release", releaseDesktopEditLock.handler, {
     body: releaseDesktopEditLock.config.body,
     invalidateQuery: true,

--- a/apps/api/src/handlers/folio-collab/cancel.ts
+++ b/apps/api/src/handlers/folio-collab/cancel.ts
@@ -1,0 +1,156 @@
+import { and, eq } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import { folioCollabSessions } from "@/api/db/schema";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import {
+  authorizeFolioCollabSession,
+  FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
+} from "@/api/lib/folio-collab-sessions";
+import { getS3 } from "@/api/lib/s3";
+import { broadcast } from "@/api/lib/sse";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+export const cancelFolioCollabSessionParamsSchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+});
+
+export const cancelFolioCollabSessionBodySchema = t.Object({
+  token: t.String({ minLength: 64, maxLength: 64 }),
+});
+
+type CancelFolioCollabSessionHandlerProps = {
+  body: Static<typeof cancelFolioCollabSessionBodySchema>;
+  sessionId: SafeId<"folioCollabSession">;
+};
+
+type StoredSessionFile = {
+  fileId: SafeId<"userFile">;
+  mimeType: string;
+};
+
+export const cancelFolioCollabSessionHandler = async ({
+  body: { token },
+  sessionId,
+}: CancelFolioCollabSessionHandlerProps) => {
+  const authorizedSession = await authorizeFolioCollabSession({
+    sessionId,
+    token,
+  });
+
+  if (authorizedSession.status === "missing") {
+    return status(404, { message: "Collaborative edit session not found." });
+  }
+
+  if (authorizedSession.status === "token-expired") {
+    return status(401, { message: "Collaborative edit token expired." });
+  }
+
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, { message: "Collaborative edit permission revoked." });
+  }
+
+  if (!authorizedSession.value.canEdit) {
+    return status(403, { message: "Collaborative edit is read-only." });
+  }
+
+  const storedFiles: StoredSessionFile[] = [];
+  const cancelled = await authorizedSession.value.scopedDb(async (tx) => {
+    const sessions = await tx
+      .select({
+        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+        id: folioCollabSessions.id,
+        status: folioCollabSessions.status,
+        yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
+        yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
+      })
+      .from(folioCollabSessions)
+      .where(
+        and(
+          eq(folioCollabSessions.id, sessionId),
+          eq(
+            folioCollabSessions.workspaceId,
+            authorizedSession.value.workspaceId,
+          ),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const session = sessions.at(0);
+
+    if (!session) {
+      return {
+        error: {
+          message: "Collaborative edit session not found.",
+          statusCode: 404,
+        },
+      } as const;
+    }
+
+    if (session.status !== "open") {
+      return {
+        error: {
+          message: "Collaborative edit session is already closed.",
+          statusCode: 409,
+        },
+      } as const;
+    }
+
+    if (session.yjsSnapshotUpdatedAt !== null) {
+      storedFiles.push({
+        fileId: session.yjsSnapshotFileId,
+        mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
+      });
+    }
+
+    if (session.docxCheckpointUpdatedAt !== null) {
+      storedFiles.push({
+        fileId: session.docxCheckpointFileId,
+        mimeType: DOCX_MIME_TYPE,
+      });
+    }
+
+    const closedAt = new Date();
+    await tx
+      .update(folioCollabSessions)
+      .set({ closedAt, status: "cancelled" })
+      .where(eq(folioCollabSessions.id, session.id));
+
+    return { cancelledAt: closedAt } as const;
+  });
+
+  if ("error" in cancelled) {
+    return status(cancelled.error.statusCode, {
+      message: cancelled.error.message,
+    });
+  }
+
+  await Promise.all(
+    storedFiles.map(async ({ fileId, mimeType }) => {
+      const key = createFileKey({
+        fileId,
+        mimeType,
+        organizationId: authorizedSession.value.organizationId,
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+
+      await getS3()
+        .delete(key)
+        .catch((error: unknown) => {
+          captureError(error, { sessionId, storageKey: key });
+        });
+    }),
+  );
+
+  broadcast(authorizedSession.value.workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", authorizedSession.value.workspaceId],
+  });
+
+  return { cancelledAt: cancelled.cancelledAt.toISOString() };
+};

--- a/apps/api/src/handlers/folio-collab/checkpoint.ts
+++ b/apps/api/src/handlers/folio-collab/checkpoint.ts
@@ -1,0 +1,165 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import { folioCollabSessions } from "@/api/db/schema";
+import { createFileKey } from "@/api/handlers/files/utils";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { scanFile } from "@/api/lib/file-scan/scan";
+import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
+import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
+import { getS3 } from "@/api/lib/s3";
+import { broadcast } from "@/api/lib/sse";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+export const checkpointFolioCollabSessionParamsSchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+});
+
+export const checkpointFolioCollabSessionBodySchema = t.Object({
+  file: t.File({
+    maxSize: FILE_SIZE_LIMITS.document,
+  }),
+  token: t.String({ minLength: 64, maxLength: 64 }),
+});
+
+type CheckpointFolioCollabSessionHandlerProps = {
+  body: Static<typeof checkpointFolioCollabSessionBodySchema>;
+  sessionId: SafeId<"folioCollabSession">;
+};
+
+export const checkpointFolioCollabSessionHandler = async ({
+  body: { file, token },
+  sessionId,
+}: CheckpointFolioCollabSessionHandlerProps) => {
+  if (file.type !== DOCX_MIME_TYPE) {
+    return status(400, {
+      message: "Collaborative checkpoints currently support only DOCX files.",
+    });
+  }
+
+  const authorizedSession = await authorizeFolioCollabSession({
+    sessionId,
+    token,
+  });
+
+  if (authorizedSession.status === "missing") {
+    return status(404, { message: "Collaborative edit session not found." });
+  }
+
+  if (authorizedSession.status === "token-expired") {
+    return status(401, { message: "Collaborative edit token expired." });
+  }
+
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, { message: "Collaborative edit permission revoked." });
+  }
+
+  if (!authorizedSession.value.canEdit) {
+    return status(403, { message: "Collaborative edit is read-only." });
+  }
+
+  const buffer = await file.arrayBuffer();
+  const sha256Hex = new Bun.CryptoHasher("sha256").update(buffer).digest("hex");
+
+  const scanResult = await scanFile({
+    buffer: new Uint8Array(buffer),
+    declaredMimeType: file.type,
+    fileName: authorizedSession.value.fileName,
+  });
+
+  if (Result.isError(scanResult)) {
+    return status(422, { message: "File security scan failed." });
+  }
+
+  if (scanResult.value.verdict === "reject") {
+    const reasons = scanResult.value.findings
+      .filter((finding) => finding.severity === "reject")
+      .map((finding) => finding.message);
+
+    return status(422, { message: `File rejected: ${reasons.join("; ")}` });
+  }
+
+  const scanWarnings =
+    scanResult.value.verdict === "warn"
+      ? scanResult.value.findings
+          .filter((finding) => finding.severity === "warn")
+          .map((finding) => finding.message)
+      : null;
+
+  const result = await authorizedSession.value.scopedDb(async (tx) => {
+    const existingSessions = await tx
+      .select({
+        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+        docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+        id: folioCollabSessions.id,
+      })
+      .from(folioCollabSessions)
+      .where(
+        and(
+          eq(folioCollabSessions.id, sessionId),
+          eq(folioCollabSessions.status, "open"),
+          eq(
+            folioCollabSessions.workspaceId,
+            authorizedSession.value.workspaceId,
+          ),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const existingSession = existingSessions.at(0);
+
+    if (!existingSession) {
+      return status(409, {
+        message: "Collaborative edit session is already closed.",
+      });
+    }
+
+    if (existingSession.docxCheckpointSha256Hex === sha256Hex) {
+      return {
+        checkpointedAt:
+          existingSession.docxCheckpointUpdatedAt?.toISOString() ??
+          new Date().toISOString(),
+        noop: true,
+      };
+    }
+
+    const key = createFileKey({
+      fileId: existingSession.docxCheckpointFileId,
+      mimeType: DOCX_MIME_TYPE,
+      organizationId: authorizedSession.value.organizationId,
+      workspaceId: authorizedSession.value.workspaceId,
+    });
+
+    await getS3().write(key, new Uint8Array(buffer));
+
+    const checkpointedAt = new Date();
+    await tx
+      .update(folioCollabSessions)
+      .set({
+        docxCheckpointSha256Hex: sha256Hex,
+        docxCheckpointScanWarnings: scanWarnings,
+        docxCheckpointSizeBytes: file.size,
+        docxCheckpointUpdatedAt: checkpointedAt,
+        fileName: authorizedSession.value.fileName,
+      })
+      .where(eq(folioCollabSessions.id, existingSession.id));
+
+    return {
+      checkpointedAt: checkpointedAt.toISOString(),
+      noop: false,
+    };
+  });
+
+  if ("noop" in result && !result.noop) {
+    broadcast(authorizedSession.value.workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", authorizedSession.value.workspaceId],
+    });
+  }
+
+  return result;
+};

--- a/apps/api/src/handlers/folio-collab/checkpoint.ts
+++ b/apps/api/src/handlers/folio-collab/checkpoint.ts
@@ -5,6 +5,7 @@ import type { Static } from "elysia";
 
 import { folioCollabSessions } from "@/api/db/schema";
 import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { scanFile } from "@/api/lib/file-scan/scan";
@@ -134,7 +135,20 @@ export const checkpointFolioCollabSessionHandler = async ({
       workspaceId: authorizedSession.value.workspaceId,
     });
 
-    await getS3().write(key, new Uint8Array(buffer));
+    const s3WriteResult = await Result.tryPromise(
+      async () => await getS3().write(key, new Uint8Array(buffer)),
+    );
+
+    if (Result.isError(s3WriteResult)) {
+      captureError(s3WriteResult.error, {
+        sessionId,
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+
+      return status(500, {
+        message: "Failed to persist collaborative checkpoint.",
+      });
+    }
 
     const checkpointedAt = new Date();
     await tx

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -79,6 +79,15 @@ export const finalizeFolioCollabSessionHandler = async ({
         captureError(error, { checkpointKey, sessionId });
       });
   };
+  const deletePendingCheckpointKey = async () => {
+    const checkpointKey = checkpointKeyToDelete;
+    if (checkpointKey === null) {
+      return;
+    }
+
+    checkpointKeyToDelete = null;
+    await deleteCheckpointKey(checkpointKey);
+  };
 
   const deleteUploadedKey = async (uploadedKey: string) => {
     await getS3()
@@ -362,19 +371,13 @@ export const finalizeFolioCollabSessionHandler = async ({
 
     if ("error" in result) {
       await Promise.all(uploadedKeys.map(deleteUploadedKey));
-
-      if (checkpointKeyToDelete !== null) {
-        await deleteCheckpointKey(checkpointKeyToDelete);
-      }
+      await deletePendingCheckpointKey();
 
       return status(result.error.statusCode, { message: result.error.message });
     }
 
     shouldRollbackUploadedKeys = false;
-
-    if (checkpointKeyToDelete !== null) {
-      await deleteCheckpointKey(checkpointKeyToDelete);
-    }
+    await deletePendingCheckpointKey();
 
     broadcast(authorizedSession.value.workspaceId, {
       type: "invalidate-query",

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -1,0 +1,450 @@
+import { panic } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { status, t } from "elysia";
+import type { Static } from "elysia";
+
+import {
+  entities,
+  entityVersions,
+  fields,
+  folioCollabSessions,
+  workspaces,
+} from "@/api/db/schema";
+import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
+import { findDocxFieldForProperty } from "@/api/handlers/entities/desktop-edit-session-utils";
+import { validateDocxBuffer } from "@/api/handlers/entities/validate-docx-buffer";
+import {
+  buildVersionStamp,
+  cloneFieldsForRevision,
+} from "@/api/handlers/entities/version-utils";
+import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
+import { getS3 } from "@/api/lib/s3";
+import { processExtraction } from "@/api/lib/search/process-extraction";
+import { broadcast } from "@/api/lib/sse";
+import { DOCX_MIME_TYPE } from "@/api/mime-types";
+
+export const finalizeFolioCollabSessionParamsSchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+});
+
+export const finalizeFolioCollabSessionBodySchema = t.Object({
+  token: t.String({ minLength: 64, maxLength: 64 }),
+});
+
+type FinalizeFolioCollabSessionHandlerProps = {
+  body: Static<typeof finalizeFolioCollabSessionBodySchema>;
+  sessionId: SafeId<"folioCollabSession">;
+};
+
+export const finalizeFolioCollabSessionHandler = async ({
+  body: { token },
+  sessionId,
+}: FinalizeFolioCollabSessionHandlerProps) => {
+  const authorizedSession = await authorizeFolioCollabSession({
+    sessionId,
+    token,
+  });
+
+  if (authorizedSession.status === "missing") {
+    return status(404, { message: "Collaborative edit session not found." });
+  }
+
+  if (authorizedSession.status === "token-expired") {
+    return status(401, { message: "Collaborative edit token expired." });
+  }
+
+  if (authorizedSession.status === "permission-revoked") {
+    return status(403, { message: "Collaborative edit permission revoked." });
+  }
+
+  if (!authorizedSession.value.canEdit) {
+    return status(403, { message: "Collaborative edit is read-only." });
+  }
+
+  const uploadedKeys: string[] = [];
+  let checkpointKeyToDelete: string | null = null;
+  let shouldRollbackUploadedKeys = true;
+
+  const deleteCheckpointKey = async (checkpointKey: string) => {
+    await getS3()
+      .delete(checkpointKey)
+      .catch((error: unknown) => {
+        captureError(error, { checkpointKey, sessionId });
+      });
+  };
+
+  const deleteUploadedKey = async (uploadedKey: string) => {
+    await getS3()
+      .delete(uploadedKey)
+      .catch((error: unknown) => {
+        captureError(error, { rollbackKey: uploadedKey, sessionId });
+      });
+  };
+
+  try {
+    const result = await authorizedSession.value.scopedDb(async (tx) => {
+      const lockedSessions = await tx
+        .select({
+          baseVersionId: folioCollabSessions.baseVersionId,
+          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+          docxCheckpointScanWarnings:
+            folioCollabSessions.docxCheckpointScanWarnings,
+          docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+          docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
+          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+          entityId: folioCollabSessions.entityId,
+          fileName: folioCollabSessions.fileName,
+          id: folioCollabSessions.id,
+          propertyId: folioCollabSessions.propertyId,
+          status: folioCollabSessions.status,
+        })
+        .from(folioCollabSessions)
+        .where(
+          and(
+            eq(folioCollabSessions.id, sessionId),
+            eq(
+              folioCollabSessions.workspaceId,
+              authorizedSession.value.workspaceId,
+            ),
+          ),
+        )
+        .for("update");
+
+      const editSession = lockedSessions.at(0);
+
+      if (!editSession) {
+        return {
+          error: {
+            message: "Collaborative edit session not found.",
+            statusCode: 404,
+          },
+        } as const;
+      }
+
+      if (editSession.status !== "open") {
+        return {
+          error: {
+            message: "Collaborative edit session is already closed.",
+            statusCode: 409,
+          },
+        } as const;
+      }
+
+      if (
+        editSession.docxCheckpointSha256Hex === null ||
+        editSession.docxCheckpointSizeBytes === null ||
+        editSession.docxCheckpointUpdatedAt === null
+      ) {
+        await tx
+          .update(folioCollabSessions)
+          .set({ closedAt: new Date(), status: "cancelled" })
+          .where(eq(folioCollabSessions.id, editSession.id));
+
+        return { outcome: "no_changes" } as const;
+      }
+
+      const lockedEntities = await tx
+        .select({
+          currentVersionId: entities.currentVersionId,
+          docSequence: entities.docSequence,
+          id: entities.id,
+        })
+        .from(entities)
+        .where(
+          and(
+            eq(entities.id, editSession.entityId),
+            eq(entities.workspaceId, authorizedSession.value.workspaceId),
+          ),
+        )
+        .for("update");
+
+      const entity = lockedEntities.at(0);
+      if (!entity) {
+        return {
+          error: { message: "Entity not found.", statusCode: 404 },
+        } as const;
+      }
+
+      const checkpointKey = createFileKey({
+        fileId: editSession.docxCheckpointFileId,
+        mimeType: DOCX_MIME_TYPE,
+        organizationId: authorizedSession.value.organizationId,
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+
+      if (entity.currentVersionId !== editSession.baseVersionId) {
+        await tx
+          .update(folioCollabSessions)
+          .set({ closedAt: new Date(), status: "cancelled" })
+          .where(eq(folioCollabSessions.id, editSession.id));
+
+        checkpointKeyToDelete = checkpointKey;
+
+        return {
+          error: {
+            message:
+              "This document changed in Stella while collaborative editing was open.",
+            statusCode: 409,
+          },
+        } as const;
+      }
+
+      const baseVersion = await tx.query.entityVersions.findFirst({
+        where: {
+          entityId: { eq: editSession.entityId },
+          id: { eq: editSession.baseVersionId },
+          workspaceId: { eq: authorizedSession.value.workspaceId },
+        },
+        columns: { versionNumber: true },
+        with: {
+          fields: { columns: { content: true, propertyId: true } },
+        },
+      });
+
+      if (!baseVersion) {
+        return {
+          error: {
+            message: "Base entity version not found.",
+            statusCode: 409,
+          },
+        } as const;
+      }
+
+      const baseFileField = findDocxFieldForProperty({
+        fieldEntries: baseVersion.fields,
+        propertyId: editSession.propertyId,
+      });
+
+      if (!baseFileField) {
+        return {
+          error: {
+            message:
+              "Collaborative edit session source file is no longer available.",
+            statusCode: 409,
+          },
+        } as const;
+      }
+
+      if (editSession.docxCheckpointSha256Hex === baseFileField.sha256Hex) {
+        await tx
+          .update(folioCollabSessions)
+          .set({ closedAt: new Date(), status: "cancelled" })
+          .where(eq(folioCollabSessions.id, editSession.id));
+
+        checkpointKeyToDelete = checkpointKey;
+
+        return { outcome: "no_changes" } as const;
+      }
+
+      const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+      const validation = await validateDocxBuffer(checkpointBuffer);
+      if (!validation.valid) {
+        return {
+          error: {
+            message: `Document validation failed: ${validation.error}`,
+            statusCode: 422 as const,
+          },
+        } as const;
+      }
+
+      const nextVersionNumber = baseVersion.versionNumber + 1;
+      const workspace = await tx.query.workspaces.findFirst({
+        where: { id: { eq: authorizedSession.value.workspaceId } },
+        columns: { reference: true },
+      });
+
+      const nextVersionStamp = buildVersionStamp({
+        docSequence: entity.docSequence,
+        versionNumber: nextVersionNumber,
+        workspaceReference:
+          workspace?.reference ??
+          panic("Workspace not found for finalized collaborative edit session"),
+      });
+
+      const storedBytes = new Uint8Array(checkpointBuffer);
+      const nextVersionId = createSafeId<"entityVersion">();
+      const sourceFileId = Bun.randomUUIDv7();
+      const sourceKey = createFileKey({
+        fileId: sourceFileId,
+        mimeType: DOCX_MIME_TYPE,
+        organizationId: authorizedSession.value.organizationId,
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+      uploadedKeys.push(sourceKey);
+
+      await getS3().write(sourceKey, storedBytes);
+
+      await tx.insert(entityVersions).values({
+        entityId: editSession.entityId,
+        id: nextVersionId,
+        stamp: nextVersionStamp.stamp,
+        verificationCode: nextVersionStamp.verificationCode,
+        versionNumber: nextVersionNumber,
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+
+      const clonedFields = cloneFieldsForRevision({
+        currentFields: baseVersion.fields,
+        entityVersionId: nextVersionId,
+        propertyId: editSession.propertyId,
+        replacementContent: {
+          encrypted: false,
+          fileName: editSession.fileName,
+          id: sourceFileId,
+          mimeType: DOCX_MIME_TYPE,
+          pdfFileId: null,
+          pdfDerivative: pdfDerivativeStateForFile({
+            encrypted: false,
+            mimeType: DOCX_MIME_TYPE,
+          }),
+          sha256Hex: editSession.docxCheckpointSha256Hex,
+          sizeBytes: editSession.docxCheckpointSizeBytes,
+          type: "file",
+          version: 1,
+          ...(editSession.docxCheckpointScanWarnings !== null && {
+            scanWarnings: editSession.docxCheckpointScanWarnings,
+          }),
+        },
+        workspaceId: authorizedSession.value.workspaceId,
+      });
+
+      const insertedFields = await tx
+        .insert(fields)
+        .values(clonedFields)
+        .returning({ id: fields.id, propertyId: fields.propertyId });
+
+      const nextField = insertedFields.find(
+        (field) => field.propertyId === editSession.propertyId,
+      );
+
+      await tx
+        .update(entities)
+        .set({
+          currentVersionId: nextVersionId,
+          lastEditedBy: authorizedSession.value.userId,
+          updatedAt: new Date(),
+        })
+        .where(eq(entities.id, editSession.entityId));
+
+      await tx
+        .update(workspaces)
+        .set({ lastActivityAt: new Date() })
+        .where(eq(workspaces.id, authorizedSession.value.workspaceId));
+
+      await tx
+        .update(folioCollabSessions)
+        .set({
+          closedAt: new Date(),
+          finalizedVersionId: nextVersionId,
+          status: "finalized",
+        })
+        .where(eq(folioCollabSessions.id, editSession.id));
+
+      checkpointKeyToDelete = checkpointKey;
+
+      return {
+        entityId: editSession.entityId,
+        fieldId:
+          nextField?.id ??
+          panic("Finalized collaborative edit session field was not inserted"),
+        outcome: "finalized",
+        versionId: nextVersionId,
+        versionNumber: nextVersionNumber,
+      } as const;
+    });
+
+    if ("error" in result) {
+      await Promise.all(uploadedKeys.map(deleteUploadedKey));
+
+      if (checkpointKeyToDelete !== null) {
+        await deleteCheckpointKey(checkpointKeyToDelete);
+      }
+
+      return status(result.error.statusCode, { message: result.error.message });
+    }
+
+    shouldRollbackUploadedKeys = false;
+
+    if (checkpointKeyToDelete !== null) {
+      await deleteCheckpointKey(checkpointKeyToDelete);
+    }
+
+    broadcast(authorizedSession.value.workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", authorizedSession.value.workspaceId],
+    });
+
+    if (result.outcome === "finalized") {
+      await processCollaborativeEditDerivatives({
+        entityId: result.entityId,
+        fieldId: result.fieldId,
+        organizationId: authorizedSession.value.organizationId,
+        userId: authorizedSession.value.userId,
+        versionId: result.versionId,
+        workspaceId: authorizedSession.value.workspaceId,
+        scopedDb: authorizedSession.value.scopedDb,
+      });
+    }
+
+    return result;
+  } catch (error) {
+    if (shouldRollbackUploadedKeys) {
+      await Promise.all(uploadedKeys.map(deleteUploadedKey));
+    }
+
+    throw error;
+  }
+};
+
+type ProcessCollaborativeEditDerivativesProps = {
+  entityId: SafeId<"entity">;
+  fieldId: SafeId<"field">;
+  organizationId: SafeId<"organization">;
+  scopedDb: Parameters<typeof computeVersionDiffStats>[0]["scopedDb"];
+  userId: SafeId<"user">;
+  versionId: SafeId<"entityVersion">;
+  workspaceId: SafeId<"workspace">;
+};
+
+const processCollaborativeEditDerivatives = async ({
+  entityId,
+  fieldId,
+  organizationId,
+  scopedDb,
+  userId,
+  versionId,
+  workspaceId,
+}: ProcessCollaborativeEditDerivativesProps) => {
+  await processExtraction(entityId).catch((error: unknown) => {
+    captureError(error, { entityId });
+  });
+
+  enqueuePdfDerivativeOrMarkFailed({
+    encrypted: false,
+    entityId,
+    fieldId,
+    mimeType: DOCX_MIME_TYPE,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, { entityId, fieldId, mimeType: DOCX_MIME_TYPE });
+  });
+
+  computeVersionDiffStats({
+    entityId,
+    organizationId,
+    scopedDb,
+    versionId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, { versionId });
+  });
+};

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -1,0 +1,158 @@
+import Elysia, { status, t } from "elysia";
+
+import {
+  checkpointFolioCollabSessionBodySchema,
+  checkpointFolioCollabSessionHandler,
+  checkpointFolioCollabSessionParamsSchema,
+} from "@/api/handlers/folio-collab/checkpoint";
+import {
+  finalizeFolioCollabSessionBodySchema,
+  finalizeFolioCollabSessionHandler,
+  finalizeFolioCollabSessionParamsSchema,
+} from "@/api/handlers/folio-collab/finalize";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import {
+  authorizeFolioCollabSession,
+  FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
+  FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
+  loadFolioCollabSnapshot,
+  storeFolioCollabSnapshot,
+} from "@/api/lib/folio-collab-sessions";
+
+const authBodySchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+  token: t.String({ minLength: 64, maxLength: 64 }),
+});
+
+const storeSnapshotBodySchema = t.Object({
+  sessionId: tSafeId("folioCollabSession"),
+  snapshotBase64: t.String({
+    maxLength: FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
+  }),
+  token: t.String({ minLength: 64, maxLength: 64 }),
+});
+
+const authorizeOrRespond = async ({
+  sessionId,
+  token,
+}: {
+  sessionId: SafeId<"folioCollabSession">;
+  token: string;
+}) => {
+  const authorized = await authorizeFolioCollabSession({ sessionId, token });
+
+  if (authorized.status === "missing") {
+    return {
+      ok: false,
+      response: status(404, {
+        message: "Collaborative edit session not found.",
+      }),
+    } as const;
+  }
+  if (authorized.status === "token-expired") {
+    return {
+      ok: false,
+      response: status(401, { message: "Collaborative edit token expired." }),
+    } as const;
+  }
+  if (authorized.status === "permission-revoked") {
+    return {
+      ok: false,
+      response: status(403, {
+        message: "Collaborative edit permission revoked.",
+      }),
+    } as const;
+  }
+
+  return { ok: true, value: authorized.value } as const;
+};
+
+export const folioCollabRoute = new Elysia({
+  prefix: "/folio-collab-sessions",
+})
+  .post(
+    "/authorize",
+    async ({ body }) => {
+      const authorized = await authorizeOrRespond(body);
+      if (!authorized.ok) {
+        return authorized.response;
+      }
+      const { value } = authorized;
+
+      return {
+        canEdit: value.canEdit,
+        roomName: value.sessionId,
+        sessionId: value.sessionId,
+        userId: value.userId,
+        workspaceId: value.workspaceId,
+      };
+    },
+    { body: authBodySchema },
+  )
+  .post(
+    "/snapshot/load",
+    async ({ body }) => {
+      const authorized = await authorizeOrRespond(body);
+      if (!authorized.ok) {
+        return authorized.response;
+      }
+      const { value } = authorized;
+
+      return {
+        snapshotBase64: await loadFolioCollabSnapshot(value),
+      };
+    },
+    { body: authBodySchema },
+  )
+  .post(
+    "/snapshot/store",
+    async ({ body }) => {
+      const authorized = await authorizeOrRespond(body);
+      if (!authorized.ok) {
+        return authorized.response;
+      }
+      const { value } = authorized;
+
+      if (!value.canEdit) {
+        return status(403, { message: "Collaborative edit is read-only." });
+      }
+
+      const buffer = Buffer.from(body.snapshotBase64, "base64");
+      if (buffer.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {
+        return status(413, { message: "Collaborative snapshot too large." });
+      }
+
+      const { storedAt } = await storeFolioCollabSnapshot({
+        snapshotBase64: body.snapshotBase64,
+        value,
+      });
+
+      return { storedAt: storedAt.toISOString() };
+    },
+    { body: storeSnapshotBodySchema },
+  )
+  .post(
+    "/:sessionId/checkpoint",
+    async ({ body, params }) =>
+      await checkpointFolioCollabSessionHandler({
+        body,
+        sessionId: params.sessionId,
+      }),
+    {
+      body: checkpointFolioCollabSessionBodySchema,
+      params: checkpointFolioCollabSessionParamsSchema,
+    },
+  )
+  .post(
+    "/:sessionId/finalize",
+    async ({ body, params }) =>
+      await finalizeFolioCollabSessionHandler({
+        body,
+        sessionId: params.sessionId,
+      }),
+    {
+      body: finalizeFolioCollabSessionBodySchema,
+      params: finalizeFolioCollabSessionParamsSchema,
+    },
+  );

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -21,6 +21,7 @@ import {
   authorizeFolioCollabSession,
   FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
   FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
+  issueFolioCollabToken,
   loadFolioCollabSnapshot,
   storeFolioCollabSnapshot,
 } from "@/api/lib/folio-collab-sessions";
@@ -89,8 +90,36 @@ export const folioCollabRoute = new Elysia({
         canEdit: value.canEdit,
         roomName: value.sessionId,
         sessionId: value.sessionId,
+        tokenExpiresAt: value.tokenExpiresAt.toISOString(),
         userId: value.userId,
         workspaceId: value.workspaceId,
+      };
+    },
+    { body: authBodySchema },
+  )
+  .post(
+    "/refresh-token",
+    async ({ body }) => {
+      const authorized = await authorizeOrRespond(body);
+      if (!authorized.ok) {
+        return authorized.response;
+      }
+      const { value } = authorized;
+
+      const { token, tokenExpiresAt } = await value.scopedDb(
+        async (tx) =>
+          await issueFolioCollabToken({
+            permissions: { canEdit: value.canEdit },
+            sessionId: value.sessionId,
+            tx,
+            userId: value.userId,
+            workspaceId: value.workspaceId,
+          }),
+      );
+
+      return {
+        token,
+        tokenExpiresAt: tokenExpiresAt.toISOString(),
       };
     },
     { body: authBodySchema },

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -1,6 +1,11 @@
 import Elysia, { status, t } from "elysia";
 
 import {
+  cancelFolioCollabSessionBodySchema,
+  cancelFolioCollabSessionHandler,
+  cancelFolioCollabSessionParamsSchema,
+} from "@/api/handlers/folio-collab/cancel";
+import {
   checkpointFolioCollabSessionBodySchema,
   checkpointFolioCollabSessionHandler,
   checkpointFolioCollabSessionParamsSchema,
@@ -131,6 +136,18 @@ export const folioCollabRoute = new Elysia({
       return { storedAt: storedAt.toISOString() };
     },
     { body: storeSnapshotBodySchema },
+  )
+  .post(
+    "/:sessionId/cancel",
+    async ({ body, params }) =>
+      await cancelFolioCollabSessionHandler({
+        body,
+        sessionId: params.sessionId,
+      }),
+    {
+      body: cancelFolioCollabSessionBodySchema,
+      params: cancelFolioCollabSessionParamsSchema,
+    },
   )
   .post(
     "/:sessionId/checkpoint",

--- a/apps/api/src/handlers/search/ai.test.ts
+++ b/apps/api/src/handlers/search/ai.test.ts
@@ -34,8 +34,14 @@ mock.module("@/api/db/root", () => ({
 // require a live database connection and cause flaky failures in CI.
 // eslint-disable-next-line typescript-eslint/no-floating-promises -- Bun mock.module is sync for registration
 mock.module("@/api/lib/search/index-global", () => ({
+  rebuildSupplementalSearchIndex: mock(async () => undefined),
+  reindexWorkspacesForContact: mock(async () => undefined),
   searchGlobal: searchGlobalMock,
-  syncWorkspaceSearchActivity: mock(),
+  searchGlobalFacet: mock(async () => []),
+  syncWorkspaceSearchActivity: mock(async () => undefined),
+  upsertContactSearchDocument: mock(async () => undefined),
+  upsertWorkspaceSearchDocument: mock(async () => undefined),
+  upsertWorkspaceSearchDocuments: mock(async () => undefined),
 }));
 
 beforeEach(() => {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -22,6 +22,7 @@ import { expensesRoute } from "@/api/handlers/expenses/routes";
 import { externalPreviewRoute } from "@/api/handlers/external-preview/routes";
 import { fieldsRoute } from "@/api/handlers/fields/routes";
 import { filesRoute } from "@/api/handlers/files/routes";
+import { folioCollabRoute } from "@/api/handlers/folio-collab/routes";
 import { healthRoute } from "@/api/handlers/health/routes";
 import { invoicesRoute } from "@/api/handlers/invoices/routes";
 import { mcpConnectorsRoute } from "@/api/handlers/mcp-connectors/routes";
@@ -303,6 +304,7 @@ const api = new Elysia()
       .use(workspacesRoute)
       .use(propertiesRoute)
       .use(filesRoute)
+      .use(folioCollabRoute)
       .use(desktopEditSessionsRoute)
       .use(entitiesRoute)
       .use(fieldsRoute)

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -33,6 +33,8 @@ export type SafeIdType =
   | "entityVersion"
   | "expense"
   | "field"
+  | "folioCollabSession"
+  | "folioCollabSessionToken"
   | "folder"
   | "infoSoudTrackedCase"
   | "invoice"

--- a/apps/api/src/lib/folio-collab-sessions.ts
+++ b/apps/api/src/lib/folio-collab-sessions.ts
@@ -1,0 +1,208 @@
+import { and, eq } from "drizzle-orm";
+
+import { roles } from "@stll/permissions";
+
+import type { ScopedDb } from "@/api/db";
+import { member } from "@/api/db/auth-schema";
+import { db } from "@/api/db/root";
+import {
+  folioCollabSessions,
+  folioCollabSessionTokens,
+  workspaceMembers,
+  workspaces,
+} from "@/api/db/schema";
+import { createFileKey } from "@/api/handlers/files/utils";
+import type { SafeId } from "@/api/lib/branded-types";
+import { isMemberRole } from "@/api/lib/member-roles";
+import { createRootScopedDb } from "@/api/lib/root-scoped-db";
+import { getS3 } from "@/api/lib/s3";
+import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
+
+/** Short-lived room tokens limit damage if a browser leaks one. */
+export const FOLIO_COLLAB_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+const FOLIO_COLLAB_TOKEN_PART_LENGTH = 32;
+const YJS_UPDATE_MIME_TYPE = "application/octet-stream";
+export const FOLIO_COLLAB_SNAPSHOT_MAX_BYTES = 50 * 1024 * 1024;
+export const FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH =
+  Math.ceil(FOLIO_COLLAB_SNAPSHOT_MAX_BYTES / 3) * 4;
+
+export const createFolioCollabToken = () =>
+  Bun.randomUUIDv7()
+    .replaceAll("-", "")
+    .slice(0, FOLIO_COLLAB_TOKEN_PART_LENGTH) +
+  Bun.randomUUIDv7()
+    .replaceAll("-", "")
+    .slice(0, FOLIO_COLLAB_TOKEN_PART_LENGTH);
+
+export const hashFolioCollabToken = (token: string) =>
+  new Bun.CryptoHasher("sha256").update(token).digest("hex");
+
+export const computeFolioCollabTokenExpiresAt = () =>
+  new Date(Date.now() + FOLIO_COLLAB_TOKEN_TTL_MS);
+
+export type AuthorizedFolioCollabSession = {
+  canEdit: boolean;
+  fileName: string;
+  organizationId: SafeId<"organization">;
+  scopedDb: ScopedDb;
+  sessionId: SafeId<"folioCollabSession">;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+  yjsSnapshotFileId: SafeId<"userFile">;
+};
+
+export type FolioCollabSessionAuthorizationResult =
+  | { status: "authorized"; value: AuthorizedFolioCollabSession }
+  | { status: "missing" }
+  | { status: "token-expired" }
+  | { status: "permission-revoked" };
+
+export const authorizeFolioCollabSession = async ({
+  sessionId,
+  token,
+}: {
+  sessionId: SafeId<"folioCollabSession">;
+  token: string;
+}): Promise<FolioCollabSessionAuthorizationResult> => {
+  const tokenHash = hashFolioCollabToken(token);
+
+  const rows = await db
+    .select({
+      canEdit: folioCollabSessionTokens.permissions,
+      expiresAt: folioCollabSessionTokens.expiresAt,
+      fileName: folioCollabSessions.fileName,
+      organizationId: workspaces.organizationId,
+      organizationRole: member.role,
+      sessionStatus: folioCollabSessions.status,
+      userId: folioCollabSessionTokens.userId,
+      workspaceId: folioCollabSessions.workspaceId,
+      workspaceMemberId: workspaceMembers.id,
+      yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
+    })
+    .from(folioCollabSessionTokens)
+    .innerJoin(
+      folioCollabSessions,
+      eq(folioCollabSessionTokens.sessionId, folioCollabSessions.id),
+    )
+    .innerJoin(workspaces, eq(folioCollabSessions.workspaceId, workspaces.id))
+    .leftJoin(
+      member,
+      and(
+        eq(member.userId, folioCollabSessionTokens.userId),
+        eq(member.organizationId, workspaces.organizationId),
+      ),
+    )
+    .leftJoin(
+      workspaceMembers,
+      and(
+        eq(workspaceMembers.userId, folioCollabSessionTokens.userId),
+        eq(workspaceMembers.workspaceId, folioCollabSessions.workspaceId),
+      ),
+    )
+    .where(
+      and(
+        eq(folioCollabSessionTokens.sessionId, sessionId),
+        eq(folioCollabSessionTokens.tokenHash, tokenHash),
+      ),
+    )
+    .limit(1);
+
+  const row = rows.at(0);
+  if (!row || row.sessionStatus !== "open") {
+    return { status: "missing" };
+  }
+
+  if (row.expiresAt < new Date()) {
+    return { status: "token-expired" };
+  }
+
+  const role = row.organizationRole;
+  const canUseWorkspace =
+    role !== null &&
+    isMemberRole(role) &&
+    (role === "owner" || role === "admin" || row.workspaceMemberId !== null);
+  const hasEntityUpdate =
+    role !== null &&
+    isMemberRole(role) &&
+    roles[role].authorize({ entity: ["update"] }).success;
+
+  if (!canUseWorkspace || !hasEntityUpdate) {
+    return { status: "permission-revoked" };
+  }
+
+  return {
+    status: "authorized",
+    value: {
+      canEdit: row.canEdit.canEdit,
+      fileName: row.fileName,
+      organizationId: row.organizationId,
+      scopedDb: createRootScopedDb({
+        organizationId: row.organizationId,
+        userId: brandPersistedUserId(row.userId),
+        workspaceIds: [row.workspaceId],
+      }),
+      sessionId,
+      userId: brandPersistedUserId(row.userId),
+      workspaceId: row.workspaceId,
+      yjsSnapshotFileId: row.yjsSnapshotFileId,
+    },
+  };
+};
+
+export const loadFolioCollabSnapshot = async (
+  value: AuthorizedFolioCollabSession,
+) => {
+  const sessions = await db
+    .select({
+      yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
+      yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
+    })
+    .from(folioCollabSessions)
+    .where(eq(folioCollabSessions.id, value.sessionId))
+    .limit(1);
+
+  const session = sessions.at(0);
+  if (!session?.yjsSnapshotUpdatedAt) {
+    return null;
+  }
+
+  const key = createFileKey({
+    fileId: session.yjsSnapshotFileId,
+    mimeType: YJS_UPDATE_MIME_TYPE,
+    organizationId: value.organizationId,
+    workspaceId: value.workspaceId,
+  });
+  const buffer = await getS3().file(key).arrayBuffer();
+
+  return Buffer.from(buffer).toString("base64");
+};
+
+export const storeFolioCollabSnapshot = async ({
+  snapshotBase64,
+  value,
+}: {
+  snapshotBase64: string;
+  value: AuthorizedFolioCollabSession;
+}) => {
+  const buffer = Buffer.from(snapshotBase64, "base64");
+  const key = createFileKey({
+    fileId: value.yjsSnapshotFileId,
+    mimeType: YJS_UPDATE_MIME_TYPE,
+    organizationId: value.organizationId,
+    workspaceId: value.workspaceId,
+  });
+  await getS3().write(key, buffer);
+
+  const storedAt = new Date();
+  await db
+    .update(folioCollabSessions)
+    .set({
+      seededAt: storedAt,
+      yjsSnapshotSizeBytes: buffer.byteLength,
+      yjsSnapshotUpdatedAt: storedAt,
+    })
+    .where(eq(folioCollabSessions.id, value.sessionId));
+
+  return { storedAt, sizeBytes: buffer.byteLength };
+};

--- a/apps/api/src/lib/folio-collab-sessions.ts
+++ b/apps/api/src/lib/folio-collab-sessions.ts
@@ -22,7 +22,7 @@ import { brandPersistedUserId } from "@/api/lib/safe-id-boundaries";
 export const FOLIO_COLLAB_TOKEN_TTL_MS = 60 * 60 * 1000;
 
 const FOLIO_COLLAB_TOKEN_PART_LENGTH = 32;
-const YJS_UPDATE_MIME_TYPE = "application/octet-stream";
+export const FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE = "application/octet-stream";
 export const FOLIO_COLLAB_SNAPSHOT_MAX_BYTES = 50 * 1024 * 1024;
 export const FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH =
   Math.ceil(FOLIO_COLLAB_SNAPSHOT_MAX_BYTES / 3) * 4;
@@ -169,7 +169,7 @@ export const loadFolioCollabSnapshot = async (
 
   const key = createFileKey({
     fileId: session.yjsSnapshotFileId,
-    mimeType: YJS_UPDATE_MIME_TYPE,
+    mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
     organizationId: value.organizationId,
     workspaceId: value.workspaceId,
   });
@@ -188,7 +188,7 @@ export const storeFolioCollabSnapshot = async ({
   const buffer = Buffer.from(snapshotBase64, "base64");
   const key = createFileKey({
     fileId: value.yjsSnapshotFileId,
-    mimeType: YJS_UPDATE_MIME_TYPE,
+    mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
     organizationId: value.organizationId,
     workspaceId: value.workspaceId,
   });

--- a/apps/api/src/lib/folio-collab-sessions.ts
+++ b/apps/api/src/lib/folio-collab-sessions.ts
@@ -2,9 +2,10 @@ import { and, eq } from "drizzle-orm";
 
 import { roles } from "@stll/permissions";
 
-import type { ScopedDb } from "@/api/db";
+import type { ScopedDb, Transaction } from "@/api/db";
 import { member } from "@/api/db/auth-schema";
 import { db } from "@/api/db/root";
+import type { FolioCollabTokenPermissions } from "@/api/db/schema";
 import {
   folioCollabSessions,
   folioCollabSessionTokens,
@@ -12,6 +13,7 @@ import {
   workspaces,
 } from "@/api/db/schema";
 import { createFileKey } from "@/api/handlers/files/utils";
+import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { isMemberRole } from "@/api/lib/member-roles";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -47,9 +49,40 @@ export type AuthorizedFolioCollabSession = {
   organizationId: SafeId<"organization">;
   scopedDb: ScopedDb;
   sessionId: SafeId<"folioCollabSession">;
+  tokenExpiresAt: Date;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace">;
   yjsSnapshotFileId: SafeId<"userFile">;
+};
+
+type IssueFolioCollabTokenOptions = {
+  permissions: FolioCollabTokenPermissions;
+  sessionId: SafeId<"folioCollabSession">;
+  tx: Transaction;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+};
+
+export const issueFolioCollabToken = async ({
+  permissions,
+  sessionId,
+  tx,
+  userId,
+  workspaceId,
+}: IssueFolioCollabTokenOptions) => {
+  const token = createFolioCollabToken();
+  const tokenExpiresAt = computeFolioCollabTokenExpiresAt();
+  await tx.insert(folioCollabSessionTokens).values({
+    expiresAt: tokenExpiresAt,
+    id: createSafeId<"folioCollabSessionToken">(),
+    permissions,
+    sessionId,
+    tokenHash: hashFolioCollabToken(token),
+    userId,
+    workspaceId,
+  });
+
+  return { token, tokenExpiresAt };
 };
 
 export type FolioCollabSessionAuthorizationResult =
@@ -143,6 +176,7 @@ export const authorizeFolioCollabSession = async ({
         workspaceIds: [row.workspaceId],
       }),
       sessionId,
+      tokenExpiresAt: row.expiresAt,
       userId: brandPersistedUserId(row.userId),
       workspaceId: row.workspaceId,
       yjsSnapshotFileId: row.yjsSnapshotFileId,

--- a/apps/collab/package.json
+++ b/apps/collab/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@stll/collab",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "bun build --target=bun --packages=external --outfile dist/index.js src/index.ts",
+    "dev": "bun --watch src/index.ts",
+    "start": "bun src/index.ts",
+    "typecheck": "tsgo --noEmit",
+    "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware apps/collab",
+    "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix apps/collab",
+    "format": "oxfmt .",
+    "test": "bun test --pass-with-no-tests"
+  },
+  "dependencies": {
+    "@hocuspocus/server": "^4.0.0",
+    "@t3-oss/env-core": "catalog:",
+    "crossws": "^0.4.5",
+    "valibot": "catalog:",
+    "yjs": "^13.6.30"
+  },
+  "devDependencies": {
+    "@hocuspocus/provider": "^4.0.0",
+    "@stll/typescript-config": "workspace:*",
+    "@types/bun": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/collab/src/env.ts
+++ b/apps/collab/src/env.ts
@@ -1,0 +1,21 @@
+import { createEnv } from "@t3-oss/env-core";
+import * as v from "valibot";
+
+export const env = createEnv({
+  server: {
+    STELLA_API_URL: v.pipe(v.string(), v.url()),
+    STELLA_COLLAB_PORT: v.optional(
+      v.pipe(
+        v.string(),
+        v.digits(),
+        v.transform(Number),
+        v.integer(),
+        v.minValue(1),
+        v.maxValue(65_535),
+      ),
+      "3002",
+    ),
+  },
+  emptyStringAsUndefined: true,
+  runtimeEnv: process.env,
+});

--- a/apps/collab/src/index.ts
+++ b/apps/collab/src/index.ts
@@ -1,0 +1,15 @@
+import { env } from "./env";
+import { createCollabServer } from "./server";
+
+const collabServer = await createCollabServer({
+  apiUrl: env.STELLA_API_URL,
+  port: env.STELLA_COLLAB_PORT,
+});
+
+process.on("SIGTERM", () => {
+  void collabServer.destroy().finally(() => process.exit(0));
+});
+
+process.on("SIGINT", () => {
+  void collabServer.destroy().finally(() => process.exit(0));
+});

--- a/apps/collab/src/server.test.ts
+++ b/apps/collab/src/server.test.ts
@@ -1,0 +1,303 @@
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { describe, expect, test } from "bun:test";
+import { applyUpdate, Doc } from "yjs";
+
+import { createCollabServer } from "./server";
+
+type FakeStellaApiOptions = {
+  canEdit?: boolean;
+  initialSnapshotBase64?: string | null;
+  roomName?: string;
+  token?: string;
+};
+
+type FakeStellaApi = {
+  authorizeRequests: () => number;
+  destroy: () => Promise<void>;
+  latestSnapshotBase64: () => string | null;
+  storeRequests: () => number;
+  url: string;
+};
+
+type AwarenessUserState = {
+  user: {
+    name: string;
+  };
+};
+
+const waitFor = async (
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 3000,
+) => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+
+    await Bun.sleep(10);
+  }
+
+  throw new Error(message);
+};
+
+const bodyString = async (request: Request) => {
+  const value = await request.json();
+  if (typeof value !== "object" || value === null) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+};
+
+const hasAwarenessUserName = (
+  state: Record<string | number, unknown>,
+  name: string,
+): state is AwarenessUserState =>
+  typeof state["user"] === "object" &&
+  state["user"] !== null &&
+  "name" in state["user"] &&
+  state["user"].name === name;
+
+const getTextContent = (doc: Doc, name: string) => doc.getText(name).toJSON();
+
+const createFakeStellaApi = ({
+  canEdit = true,
+  initialSnapshotBase64 = null,
+  roomName = "folio_collab_session_test",
+  token = "collab_token_test",
+}: FakeStellaApiOptions = {}): FakeStellaApi => {
+  let authorizeRequests = 0;
+  let latestSnapshotBase64 = initialSnapshotBase64;
+  let storeRequests = 0;
+
+  const server = Bun.serve({
+    fetch: async (request) => {
+      const url = new URL(request.url);
+      const body = await bodyString(request);
+
+      if (url.pathname === "/v1/folio-collab-sessions/authorize") {
+        authorizeRequests += 1;
+
+        if (body["sessionId"] !== roomName || body["token"] !== token) {
+          return Response.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        return Response.json({
+          canEdit,
+          roomName,
+          sessionId: roomName,
+          userId: "user_test",
+          workspaceId: "workspace_test",
+        });
+      }
+
+      if (url.pathname === "/v1/folio-collab-sessions/snapshot/load") {
+        if (body["sessionId"] !== roomName || body["token"] !== token) {
+          return Response.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        return Response.json({ snapshotBase64: latestSnapshotBase64 });
+      }
+
+      if (url.pathname === "/v1/folio-collab-sessions/snapshot/store") {
+        if (body["sessionId"] !== roomName || body["token"] !== token) {
+          return Response.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        storeRequests += 1;
+        latestSnapshotBase64 = body["snapshotBase64"] ?? null;
+
+        return Response.json({ storedAt: new Date().toISOString() });
+      }
+
+      return Response.json({ message: "Not found" }, { status: 404 });
+    },
+    port: 0,
+  });
+
+  const port = server.port;
+  if (port === undefined) {
+    throw new Error("Fake Stella API did not expose a listening port.");
+  }
+
+  return {
+    authorizeRequests: () => authorizeRequests,
+    destroy: async () => {
+      await server.stop(true);
+    },
+    latestSnapshotBase64: () => latestSnapshotBase64,
+    storeRequests: () => storeRequests,
+    url: `http://127.0.0.1:${port}`,
+  };
+};
+
+const createProvider = ({
+  name,
+  token,
+  url,
+  ydoc,
+}: {
+  name: string;
+  token: string;
+  url: string;
+  ydoc: Doc;
+}) =>
+  new HocuspocusProvider({
+    document: ydoc,
+    name,
+    token,
+    url,
+  });
+
+describe("collaboration server", () => {
+  test("serves HTTP health and accepts a Bun WebSocket upgrade", async () => {
+    const fakeApi = createFakeStellaApi();
+    const collabServer = await createCollabServer({
+      apiUrl: fakeApi.url,
+      port: 0,
+    });
+
+    try {
+      const response = await fetch(collabServer.httpUrl);
+      expect(await response.text()).toBe("Welcome to Hocuspocus!");
+
+      await new Promise<void>((resolve, reject) => {
+        const websocket = new WebSocket(collabServer.websocketUrl);
+        const timeout = setTimeout(() => {
+          reject(new Error("WebSocket did not open."));
+        }, 1000);
+
+        websocket.addEventListener("open", () => {
+          clearTimeout(timeout);
+          websocket.close();
+          resolve();
+        });
+        websocket.addEventListener("error", () => {
+          clearTimeout(timeout);
+          reject(new Error("WebSocket failed to open."));
+        });
+      });
+    } finally {
+      await collabServer.destroy();
+      await fakeApi.destroy();
+    }
+  });
+
+  test("syncs Yjs document updates and awareness between two clients", async () => {
+    const fakeApi = createFakeStellaApi();
+    const collabServer = await createCollabServer({
+      apiUrl: fakeApi.url,
+      debounceMs: 20,
+      maxDebounceMs: 100,
+      port: 0,
+    });
+
+    const firstDoc = new Doc();
+    const secondDoc = new Doc();
+    const firstProvider = createProvider({
+      name: "folio_collab_session_test",
+      token: "collab_token_test",
+      url: collabServer.websocketUrl,
+      ydoc: firstDoc,
+    });
+    const secondProvider = createProvider({
+      name: "folio_collab_session_test",
+      token: "collab_token_test",
+      url: collabServer.websocketUrl,
+      ydoc: secondDoc,
+    });
+
+    try {
+      await waitFor(
+        () => firstProvider.isAuthenticated && secondProvider.isAuthenticated,
+        "Providers did not authenticate.",
+      );
+
+      firstProvider.awareness?.setLocalStateField("user", {
+        color: "#000000",
+        name: "First user",
+      });
+
+      await waitFor(
+        () =>
+          Array.from(secondProvider.awareness?.getStates().values() ?? []).some(
+            (state) => hasAwarenessUserName(state, "First user"),
+          ),
+        "Awareness state did not reach the second provider.",
+      );
+
+      firstDoc.getText("body").insert(0, "hello collaborative folio");
+
+      await waitFor(
+        () => getTextContent(secondDoc, "body") === "hello collaborative folio",
+        "Document update did not sync to the second provider.",
+      );
+
+      await waitFor(
+        () => fakeApi.storeRequests() > 0,
+        "Server did not persist a Yjs snapshot.",
+      );
+
+      const snapshotBase64 = fakeApi.latestSnapshotBase64();
+      expect(snapshotBase64).not.toBeNull();
+
+      const restoredDoc = new Doc();
+      applyUpdate(restoredDoc, Buffer.from(snapshotBase64 ?? "", "base64"));
+      expect(getTextContent(restoredDoc, "body")).toBe(
+        "hello collaborative folio",
+      );
+      expect(fakeApi.authorizeRequests()).toBeGreaterThanOrEqual(2);
+    } finally {
+      firstProvider.destroy();
+      secondProvider.destroy();
+      firstDoc.destroy();
+      secondDoc.destroy();
+      await collabServer.destroy();
+      await fakeApi.destroy();
+    }
+  });
+
+  test("rejects clients when Stella API authorization fails", async () => {
+    const fakeApi = createFakeStellaApi();
+    const collabServer = await createCollabServer({
+      apiUrl: fakeApi.url,
+      debounceMs: 20,
+      maxDebounceMs: 100,
+      port: 0,
+    });
+    const ydoc = new Doc();
+    let authenticationFailed = false;
+    let provider: HocuspocusProvider | null = null;
+
+    try {
+      provider = new HocuspocusProvider({
+        document: ydoc,
+        name: "folio_collab_session_test",
+        onAuthenticationFailed: () => {
+          authenticationFailed = true;
+        },
+        token: "wrong_token",
+        url: collabServer.websocketUrl,
+      });
+
+      await waitFor(
+        () => authenticationFailed,
+        "Provider was not rejected after failed authorization.",
+      );
+
+      expect(provider.isAuthenticated).toBe(false);
+    } finally {
+      provider?.destroy();
+      ydoc.destroy();
+      await collabServer.destroy();
+      await fakeApi.destroy();
+    }
+  });
+});

--- a/apps/collab/src/server.test.ts
+++ b/apps/collab/src/server.test.ts
@@ -7,14 +7,18 @@ import { createCollabServer } from "./server";
 type FakeStellaApiOptions = {
   canEdit?: boolean;
   initialSnapshotBase64?: string | null;
+  refreshedToken?: string;
   roomName?: string;
   token?: string;
+  tokenExpiresAt?: string;
 };
 
 type FakeStellaApi = {
   authorizeRequests: () => number;
   destroy: () => Promise<void>;
   latestSnapshotBase64: () => string | null;
+  refreshRequests: () => number;
+  storeRequestTokens: () => string[];
   storeRequests: () => number;
   url: string;
 };
@@ -67,15 +71,23 @@ const hasAwarenessUserName = (
 
 const getTextContent = (doc: Doc, name: string) => doc.getText(name).toJSON();
 
+const farFutureTokenExpiresAt = () =>
+  new Date(Date.now() + 60 * 60 * 1000).toISOString();
+
 const createFakeStellaApi = ({
   canEdit = true,
   initialSnapshotBase64 = null,
+  refreshedToken = "collab_token_refreshed",
   roomName = "folio_collab_session_test",
   token = "collab_token_test",
+  tokenExpiresAt = farFutureTokenExpiresAt(),
 }: FakeStellaApiOptions = {}): FakeStellaApi => {
   let authorizeRequests = 0;
   let latestSnapshotBase64 = initialSnapshotBase64;
+  let refreshRequests = 0;
+  const storeRequestTokens: string[] = [];
   let storeRequests = 0;
+  let currentToken = token;
 
   const server = Bun.serve({
     fetch: async (request) => {
@@ -93,13 +105,28 @@ const createFakeStellaApi = ({
           canEdit,
           roomName,
           sessionId: roomName,
+          tokenExpiresAt,
           userId: "user_test",
           workspaceId: "workspace_test",
         });
       }
 
+      if (url.pathname === "/v1/folio-collab-sessions/refresh-token") {
+        refreshRequests += 1;
+
+        if (body["sessionId"] !== roomName || body["token"] !== currentToken) {
+          return Response.json({ message: "Unauthorized" }, { status: 401 });
+        }
+
+        currentToken = refreshedToken;
+        return Response.json({
+          token: refreshedToken,
+          tokenExpiresAt: farFutureTokenExpiresAt(),
+        });
+      }
+
       if (url.pathname === "/v1/folio-collab-sessions/snapshot/load") {
-        if (body["sessionId"] !== roomName || body["token"] !== token) {
+        if (body["sessionId"] !== roomName || body["token"] !== currentToken) {
           return Response.json({ message: "Unauthorized" }, { status: 401 });
         }
 
@@ -107,11 +134,12 @@ const createFakeStellaApi = ({
       }
 
       if (url.pathname === "/v1/folio-collab-sessions/snapshot/store") {
-        if (body["sessionId"] !== roomName || body["token"] !== token) {
+        if (body["sessionId"] !== roomName || body["token"] !== currentToken) {
           return Response.json({ message: "Unauthorized" }, { status: 401 });
         }
 
         storeRequests += 1;
+        storeRequestTokens.push(body["token"] ?? "");
         latestSnapshotBase64 = body["snapshotBase64"] ?? null;
 
         return Response.json({ storedAt: new Date().toISOString() });
@@ -133,6 +161,8 @@ const createFakeStellaApi = ({
       await server.stop(true);
     },
     latestSnapshotBase64: () => latestSnapshotBase64,
+    refreshRequests: () => refreshRequests,
+    storeRequestTokens: () => storeRequestTokens,
     storeRequests: () => storeRequests,
     url: `http://127.0.0.1:${port}`,
   };
@@ -259,6 +289,55 @@ describe("collaboration server", () => {
       secondProvider.destroy();
       firstDoc.destroy();
       secondDoc.destroy();
+      await collabServer.destroy();
+      await fakeApi.destroy();
+    }
+  });
+
+  test("refreshes the Stella API token before storing snapshots", async () => {
+    const initialToken = "collab_token_initial";
+    const refreshedToken = "collab_token_refreshed";
+    const fakeApi = createFakeStellaApi({
+      refreshedToken,
+      token: initialToken,
+      tokenExpiresAt: new Date(Date.now() + 50).toISOString(),
+    });
+    const collabServer = await createCollabServer({
+      apiUrl: fakeApi.url,
+      debounceMs: 20,
+      maxDebounceMs: 100,
+      port: 0,
+    });
+
+    const ydoc = new Doc();
+    const provider = createProvider({
+      name: "folio_collab_session_test",
+      token: initialToken,
+      url: collabServer.websocketUrl,
+      ydoc,
+    });
+
+    try {
+      await waitFor(
+        () => provider.isAuthenticated,
+        "Provider did not authenticate.",
+      );
+      await waitFor(
+        () => fakeApi.refreshRequests() > 0,
+        "Server did not refresh the token before expiry.",
+      );
+
+      ydoc.getText("body").insert(0, "stored with refreshed token");
+
+      await waitFor(
+        () => fakeApi.storeRequests() > 0,
+        "Server did not persist a snapshot after refreshing.",
+      );
+
+      expect(fakeApi.storeRequestTokens()).toEqual([refreshedToken]);
+    } finally {
+      provider.destroy();
+      ydoc.destroy();
       await collabServer.destroy();
       await fakeApi.destroy();
     }

--- a/apps/collab/src/server.ts
+++ b/apps/collab/src/server.ts
@@ -144,19 +144,19 @@ export const createCollabServer = async ({
 
       applyUpdate(document, Buffer.from(result.snapshotBase64, "base64"));
     },
-    async onStoreDocument({ document, lastContext }) {
-      if (!lastContext.canEdit) {
+    async onStoreDocument({ document, lastContext: context }) {
+      if (!context.canEdit) {
         return;
       }
 
       await postJson({
         apiUrl,
         body: {
-          sessionId: lastContext.sessionId,
+          sessionId: context.sessionId,
           snapshotBase64: Buffer.from(encodeStateAsUpdate(document)).toString(
             "base64",
           ),
-          token: lastContext.token,
+          token: context.token,
         },
         path: "/folio-collab-sessions/snapshot/store",
         schema: storeSnapshotResponseSchema,

--- a/apps/collab/src/server.ts
+++ b/apps/collab/src/server.ts
@@ -1,0 +1,263 @@
+import { Hocuspocus } from "@hocuspocus/server";
+import type { WebSocketLike } from "@hocuspocus/server";
+import type { Peer } from "crossws";
+import crossws from "crossws/adapters/bun";
+import * as v from "valibot";
+import { applyUpdate, encodeStateAsUpdate } from "yjs";
+
+type CollabAuthContext = {
+  canEdit: boolean;
+  sessionId: string;
+  token: string;
+  userId: string;
+  workspaceId: string;
+};
+
+type ManagedWebSocketLike = WebSocketLike & {
+  markClosed: () => void;
+};
+
+type CreateCollabServerOptions = {
+  apiUrl: string;
+  debounceMs?: number;
+  hostname?: string;
+  maxDebounceMs?: number;
+  port: number;
+};
+
+const authorizeResponseSchema = v.strictObject({
+  canEdit: v.boolean(),
+  roomName: v.string(),
+  sessionId: v.string(),
+  userId: v.string(),
+  workspaceId: v.string(),
+});
+
+const loadSnapshotResponseSchema = v.strictObject({
+  snapshotBase64: v.nullable(v.string()),
+});
+
+const storeSnapshotResponseSchema = v.strictObject({
+  storedAt: v.string(),
+});
+
+const postJson = async <TSchema extends v.GenericSchema>({
+  apiUrl,
+  body,
+  path,
+  schema,
+}: {
+  apiUrl: string;
+  body: Record<string, unknown>;
+  path: string;
+  schema: TSchema;
+}): Promise<v.InferOutput<TSchema>> => {
+  const response = await fetch(`${apiUrl}/v1${path}`, {
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+    method: "POST",
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Stella API request failed: ${response.status}`);
+  }
+
+  return v.parse(schema, await response.json());
+};
+
+const createManagedWebSocket = (peer: Peer): ManagedWebSocketLike => {
+  let readyState: number = WebSocket.OPEN;
+
+  return {
+    close(code?: number, reason?: string) {
+      if (readyState >= WebSocket.CLOSING) {
+        return;
+      }
+
+      readyState = WebSocket.CLOSING;
+      peer.close(code, reason);
+    },
+    markClosed() {
+      readyState = WebSocket.CLOSED;
+    },
+    get readyState() {
+      return readyState;
+    },
+    send(data) {
+      if (readyState >= WebSocket.CLOSING) {
+        return;
+      }
+
+      peer.send(data);
+    },
+  };
+};
+
+export const createCollabServer = async ({
+  apiUrl,
+  debounceMs = 2000,
+  hostname = "0.0.0.0",
+  maxDebounceMs = 10_000,
+  port,
+}: CreateCollabServerOptions) => {
+  const hocuspocus = new Hocuspocus<CollabAuthContext>({
+    debounce: debounceMs,
+    maxDebounce: maxDebounceMs,
+    async onAuthenticate({ documentName, token }) {
+      const authorized = await postJson({
+        apiUrl,
+        body: {
+          sessionId: documentName,
+          token,
+        },
+        path: "/folio-collab-sessions/authorize",
+        schema: authorizeResponseSchema,
+      });
+
+      if (authorized.roomName !== documentName) {
+        throw new Error("Collaboration token does not match the room.");
+      }
+
+      return {
+        canEdit: authorized.canEdit,
+        sessionId: authorized.sessionId,
+        token,
+        userId: authorized.userId,
+        workspaceId: authorized.workspaceId,
+      };
+    },
+    async onLoadDocument({ context, document }) {
+      const result = await postJson({
+        apiUrl,
+        body: {
+          sessionId: context.sessionId,
+          token: context.token,
+        },
+        path: "/folio-collab-sessions/snapshot/load",
+        schema: loadSnapshotResponseSchema,
+      });
+
+      if (!result.snapshotBase64) {
+        return;
+      }
+
+      applyUpdate(document, Buffer.from(result.snapshotBase64, "base64"));
+    },
+    async onStoreDocument({ document, lastContext }) {
+      if (!lastContext.canEdit) {
+        return;
+      }
+
+      await postJson({
+        apiUrl,
+        body: {
+          sessionId: lastContext.sessionId,
+          snapshotBase64: Buffer.from(encodeStateAsUpdate(document)).toString(
+            "base64",
+          ),
+          token: lastContext.token,
+        },
+        path: "/folio-collab-sessions/snapshot/store",
+        schema: storeSnapshotResponseSchema,
+      });
+    },
+  });
+
+  type HocuspocusClientConnection = ReturnType<
+    typeof hocuspocus.handleConnection
+  >;
+
+  const clientConnections = new WeakMap<
+    Peer,
+    { connection: HocuspocusClientConnection; socket: ManagedWebSocketLike }
+  >();
+
+  const webSocketAdapter = crossws({
+    hooks: {
+      close(peer, event) {
+        const client = clientConnections.get(peer);
+        if (!client) {
+          return;
+        }
+
+        client.socket.markClosed();
+        client.connection.handleClose({
+          code: event.code ?? 1000,
+          reason: event.reason ?? "",
+        });
+        clientConnections.delete(peer);
+      },
+      message(peer, message) {
+        clientConnections
+          .get(peer)
+          ?.connection.handleMessage(message.uint8Array());
+      },
+      open(peer) {
+        const socket = createManagedWebSocket(peer);
+        const connection = hocuspocus.handleConnection(socket, peer.request);
+        clientConnections.set(peer, { connection, socket });
+      },
+    },
+  });
+
+  const server = Bun.serve({
+    fetch(request, bunServer): Promise<Response | undefined> | Response {
+      if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+        return webSocketAdapter.handleUpgrade(request, bunServer);
+      }
+
+      return new Response("Welcome to Hocuspocus!", {
+        headers: { "Content-Type": "text/plain" },
+      });
+    },
+    hostname,
+    port,
+    websocket: webSocketAdapter.websocket,
+  });
+
+  const serverPort = server.port;
+  if (serverPort === undefined) {
+    throw new Error("Collaboration server did not expose a listening port.");
+  }
+
+  await hocuspocus.hooks("onListen", {
+    configuration: hocuspocus.configuration,
+    instance: hocuspocus,
+    port: serverPort,
+  });
+
+  const destroy = async () => {
+    await server.stop(true);
+
+    await new Promise<void>((resolve) => {
+      hocuspocus.configuration.extensions.push({
+        async afterUnloadDocument({ instance }) {
+          if (instance.getDocumentsCount() === 0) {
+            resolve();
+          }
+
+          await Promise.resolve();
+        },
+      });
+
+      if (hocuspocus.getDocumentsCount() === 0) {
+        resolve();
+      }
+
+      hocuspocus.closeConnections();
+      hocuspocus.flushPendingStores();
+    });
+
+    await hocuspocus.hooks("onDestroy", { instance: hocuspocus });
+  };
+
+  return {
+    destroy,
+    hocuspocus,
+    httpUrl: `http://127.0.0.1:${serverPort}`,
+    port: serverPort,
+    server,
+    websocketUrl: `ws://127.0.0.1:${serverPort}`,
+  };
+};

--- a/apps/collab/src/server.ts
+++ b/apps/collab/src/server.ts
@@ -8,9 +8,17 @@ import { applyUpdate, encodeStateAsUpdate } from "yjs";
 type CollabAuthContext = {
   canEdit: boolean;
   sessionId: string;
-  token: string;
+  tokenState: CollabSessionTokenState;
   userId: string;
   workspaceId: string;
+};
+
+type CollabSessionTokenState = {
+  refreshInFlight: Promise<string> | null;
+  refreshTimer: ReturnType<typeof setTimeout> | null;
+  sessionId: string;
+  token: string;
+  tokenExpiresAtMs: number;
 };
 
 type ManagedWebSocketLike = WebSocketLike & {
@@ -29,8 +37,14 @@ const authorizeResponseSchema = v.strictObject({
   canEdit: v.boolean(),
   roomName: v.string(),
   sessionId: v.string(),
+  tokenExpiresAt: v.string(),
   userId: v.string(),
   workspaceId: v.string(),
+});
+
+const refreshTokenResponseSchema = v.strictObject({
+  token: v.string(),
+  tokenExpiresAt: v.string(),
 });
 
 const loadSnapshotResponseSchema = v.strictObject({
@@ -40,6 +54,32 @@ const loadSnapshotResponseSchema = v.strictObject({
 const storeSnapshotResponseSchema = v.strictObject({
   storedAt: v.string(),
 });
+
+const TOKEN_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+const TOKEN_REFRESH_RETRY_MS = 1000;
+
+const parseTokenExpiresAt = (value: string) => {
+  const expiresAtMs = Date.parse(value);
+  if (Number.isNaN(expiresAtMs)) {
+    throw new TypeError("Stella API returned an invalid token expiry.");
+  }
+
+  return expiresAtMs;
+};
+
+const tokenRefreshDelayMs = (tokenExpiresAtMs: number) => {
+  const msUntilExpiry = tokenExpiresAtMs - Date.now();
+  if (msUntilExpiry <= 0) {
+    return 0;
+  }
+
+  const leewayMs = Math.min(
+    TOKEN_REFRESH_LEEWAY_MS,
+    Math.floor(msUntilExpiry / 2),
+  );
+
+  return Math.max(0, msUntilExpiry - leewayMs);
+};
 
 const postJson = async <TSchema extends v.GenericSchema>({
   apiUrl,
@@ -101,8 +141,132 @@ export const createCollabServer = async ({
   maxDebounceMs = 10_000,
   port,
 }: CreateCollabServerOptions) => {
+  const sessionTokens = new Map<string, CollabSessionTokenState>();
+
+  const clearSessionTokenRefresh = (state: CollabSessionTokenState) => {
+    if (!state.refreshTimer) {
+      return;
+    }
+
+    clearTimeout(state.refreshTimer);
+    state.refreshTimer = null;
+  };
+
+  const clearSessionToken = (sessionId: string) => {
+    const state = sessionTokens.get(sessionId);
+    if (!state) {
+      return;
+    }
+
+    clearSessionTokenRefresh(state);
+    sessionTokens.delete(sessionId);
+  };
+
+  const scheduleTokenRefresh = (
+    state: CollabSessionTokenState,
+    delayMs = tokenRefreshDelayMs(state.tokenExpiresAtMs),
+  ) => {
+    clearSessionTokenRefresh(state);
+    state.refreshTimer = setTimeout(() => {
+      state.refreshTimer = null;
+      void refreshSessionToken(state).catch(() => {
+        const retryDelayMs = Math.min(
+          TOKEN_REFRESH_RETRY_MS,
+          Math.max(0, state.tokenExpiresAtMs - Date.now()),
+        );
+
+        if (retryDelayMs > 0 && sessionTokens.get(state.sessionId) === state) {
+          scheduleTokenRefresh(state, retryDelayMs);
+        }
+      });
+    }, delayMs);
+  };
+
+  const upsertSessionToken = ({
+    sessionId,
+    token,
+    tokenExpiresAt,
+  }: {
+    sessionId: string;
+    token: string;
+    tokenExpiresAt: string;
+  }) => {
+    const tokenExpiresAtMs = parseTokenExpiresAt(tokenExpiresAt);
+    const existing = sessionTokens.get(sessionId);
+
+    if (existing && existing.tokenExpiresAtMs >= tokenExpiresAtMs) {
+      return existing;
+    }
+
+    if (existing) {
+      existing.token = token;
+      existing.tokenExpiresAtMs = tokenExpiresAtMs;
+      scheduleTokenRefresh(existing);
+      return existing;
+    }
+
+    const state: CollabSessionTokenState = {
+      refreshInFlight: null,
+      refreshTimer: null,
+      sessionId,
+      token,
+      tokenExpiresAtMs,
+    };
+    sessionTokens.set(sessionId, state);
+    scheduleTokenRefresh(state);
+
+    return state;
+  };
+
+  const refreshSessionToken = async (state: CollabSessionTokenState) => {
+    if (state.refreshInFlight) {
+      return await state.refreshInFlight;
+    }
+
+    const refresh = (async () => {
+      const refreshed = await postJson({
+        apiUrl,
+        body: {
+          sessionId: state.sessionId,
+          token: state.token,
+        },
+        path: "/folio-collab-sessions/refresh-token",
+        schema: refreshTokenResponseSchema,
+      });
+
+      state.token = refreshed.token;
+      state.tokenExpiresAtMs = parseTokenExpiresAt(refreshed.tokenExpiresAt);
+      if (sessionTokens.get(state.sessionId) === state) {
+        scheduleTokenRefresh(state);
+      }
+
+      return state.token;
+    })();
+
+    state.refreshInFlight = refresh;
+    try {
+      return await refresh;
+    } finally {
+      if (state.refreshInFlight === refresh) {
+        state.refreshInFlight = null;
+      }
+    }
+  };
+
+  const getFreshSessionToken = async (state: CollabSessionTokenState) => {
+    if (state.tokenExpiresAtMs - Date.now() > TOKEN_REFRESH_LEEWAY_MS) {
+      return state.token;
+    }
+
+    return await refreshSessionToken(state);
+  };
+
   const hocuspocus = new Hocuspocus<CollabAuthContext>({
     debounce: debounceMs,
+    async afterUnloadDocument({ documentName }) {
+      clearSessionToken(documentName);
+      await Promise.resolve();
+    },
     maxDebounce: maxDebounceMs,
     async onAuthenticate({ documentName, token }) {
       const authorized = await postJson({
@@ -119,20 +283,27 @@ export const createCollabServer = async ({
         throw new Error("Collaboration token does not match the room.");
       }
 
+      const tokenState = upsertSessionToken({
+        sessionId: authorized.sessionId,
+        token,
+        tokenExpiresAt: authorized.tokenExpiresAt,
+      });
+
       return {
         canEdit: authorized.canEdit,
         sessionId: authorized.sessionId,
-        token,
+        tokenState,
         userId: authorized.userId,
         workspaceId: authorized.workspaceId,
       };
     },
     async onLoadDocument({ context, document }) {
+      const token = await getFreshSessionToken(context.tokenState);
       const result = await postJson({
         apiUrl,
         body: {
           sessionId: context.sessionId,
-          token: context.token,
+          token,
         },
         path: "/folio-collab-sessions/snapshot/load",
         schema: loadSnapshotResponseSchema,
@@ -149,6 +320,7 @@ export const createCollabServer = async ({
         return;
       }
 
+      const token = await getFreshSessionToken(context.tokenState);
       await postJson({
         apiUrl,
         body: {
@@ -156,7 +328,7 @@ export const createCollabServer = async ({
           snapshotBase64: Buffer.from(encodeStateAsUpdate(document)).toString(
             "base64",
           ),
-          token: context.token,
+          token,
         },
         path: "/folio-collab-sessions/snapshot/store",
         schema: storeSnapshotResponseSchema,
@@ -228,6 +400,11 @@ export const createCollabServer = async ({
   });
 
   const destroy = async () => {
+    for (const state of sessionTokens.values()) {
+      clearSessionTokenRefresh(state);
+    }
+    sessionTokens.clear();
+
     await server.stop(true);
 
     await new Promise<void>((resolve) => {

--- a/apps/collab/tsconfig.json
+++ b/apps/collab/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@stll/typescript-config/base.json",
+  "compilerOptions": {
+    "target": "ES2024",
+    "lib": ["ESNext"],
+    "module": "ESNext",
+    "types": ["bun"]
+  },
+  "include": ["src"]
+}

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -6,6 +6,9 @@
 # Required. Base URL the SPA targets for Eden treaty calls. The dev-runner
 # overrides this at runtime when --port-offset shifts the worktree's API port.
 VITE_API_URL="http://localhost:3001"
+# Optional. WebSocket URL for the Hocuspocus collaborative editing service.
+# Unset keeps Folio on the existing single-user edit-session path.
+# VITE_COLLAB_URL="ws://localhost:3002"
 
 # --- Analytics (PostHog) ---------------------------------------------------
 # Optional. Key prefix "phc_" without a real id disables capture; safe default
@@ -42,6 +45,7 @@ VITE_POSTHOG_KEY="phc_"
 # VITE_FEATURE_TODOS="false"
 # VITE_FEATURE_MCP="false"
 # VITE_FEATURE_DESKTOP_EDITING="false"
+# VITE_FEATURE_FOLIO_COLLAB="false"
 
 # --- Legal links -----------------------------------------------------------
 # Optional. Absolute URL or root-relative path for the Terms of Service link.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "@base-ui/react": "catalog:",
     "@better-auth/oauth-provider": "catalog:",
     "@elysiajs/eden": "^1.4.9",
+    "@hocuspocus/provider": "^4.0.0",
     "@libpdf/core": "catalog:",
     "@posthog/react": "^1.9.0",
     "@pydantic/genai-prices": "^0.0.56",
@@ -90,6 +91,8 @@
     "uuid": "^14.0.0",
     "valibot": "catalog:",
     "vite": "catalog:",
+    "y-prosemirror": "^1.3.7",
+    "yjs": "^13.6.30",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
       "false",
     ),
     VITE_API_URL: v.pipe(v.string(), v.url()),
+    VITE_COLLAB_URL: v.optional(v.pipe(v.string(), v.url())),
     VITE_DESKTOP_BRIDGE_PORT: v.optional(
       v.pipe(
         v.string(),
@@ -67,6 +68,7 @@ export const env = createEnv({
     VITE_FEATURE_TODOS: featureFlagSchema,
     VITE_FEATURE_MCP: featureFlagSchema,
     VITE_FEATURE_DESKTOP_EDITING: featureFlagSchema,
+    VITE_FEATURE_FOLIO_COLLAB: featureFlagSchema,
     VITE_FEEDBACK_EMAIL_TO: v.optional(v.pipe(v.string(), v.email())),
     VITE_TERMS_URL: v.optional(linkUrlSchema, "/terms"),
     VITE_EMPTY_STATE_MATTERS_VIDEO_URL: v.optional(v.pipe(v.string(), v.url())),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   getDocxEditBlockReason,
+  selectDocxBrowserEditorBuffer,
   selectEditorBuffer,
   selectPreviewFile,
   shouldBlockDocxEdit,
@@ -122,6 +123,37 @@ describe("DOCX browser editor buffer selection", () => {
         lastEditingBuffer: null,
         preservedLoadedBuffer: null,
         previewBuffer,
+      }),
+    ).toBe(previewBuffer);
+  });
+
+  test("uses the collaboration seed buffer before seeding a shared session", () => {
+    const seedBuffer = bufferFrom([7]);
+    const previewBuffer = bufferFrom([4]);
+
+    expect(
+      selectDocxBrowserEditorBuffer({
+        collaborationSeedBuffer: seedBuffer,
+        isCollaborativeEditing: true,
+        lastEditingBuffer: null,
+        preservedLoadedBuffer: null,
+        previewBuffer,
+        state: { status: "idle" },
+      }),
+    ).toBe(seedBuffer);
+  });
+
+  test("falls back to the preview buffer for already-seeded shared sessions", () => {
+    const previewBuffer = bufferFrom([4]);
+
+    expect(
+      selectDocxBrowserEditorBuffer({
+        collaborationSeedBuffer: null,
+        isCollaborativeEditing: true,
+        lastEditingBuffer: null,
+        preservedLoadedBuffer: null,
+        previewBuffer,
+        state: { status: "idle" },
       }),
     ).toBe(previewBuffer);
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic.ts
@@ -1,4 +1,5 @@
 import { selectStableArrayBuffer } from "./array-buffer-utils";
+import type { EditSessionState } from "./use-edit-session";
 
 export type DocxPreviewFile = {
   fileId: string;
@@ -72,6 +73,45 @@ export const selectEditorBuffer = (
   }
 
   return options.preservedLoadedBuffer ?? options.previewBuffer;
+};
+
+type SelectDocxBrowserEditorBufferOptions = {
+  collaborationSeedBuffer: ArrayBuffer | null;
+  isCollaborativeEditing: boolean;
+  lastEditingBuffer: ArrayBuffer | null;
+  preservedLoadedBuffer: ArrayBuffer | null;
+  previewBuffer?: ArrayBuffer | undefined;
+  state: EditSessionState;
+};
+
+export const selectDocxBrowserEditorBuffer = ({
+  collaborationSeedBuffer,
+  isCollaborativeEditing,
+  lastEditingBuffer,
+  preservedLoadedBuffer,
+  previewBuffer,
+  state,
+}: SelectDocxBrowserEditorBufferOptions) => {
+  if (isCollaborativeEditing) {
+    return collaborationSeedBuffer ?? previewBuffer;
+  }
+
+  if (state.status === "editing") {
+    return selectEditorBuffer({
+      status: state.status,
+      editingBuffer: state.buffer,
+      lastEditingBuffer,
+      preservedLoadedBuffer,
+      previewBuffer,
+    });
+  }
+
+  return selectEditorBuffer({
+    status: state.status,
+    lastEditingBuffer,
+    preservedLoadedBuffer,
+    previewBuffer,
+  });
 };
 
 type ShouldFinalizeEditSessionOptions = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1026,7 +1026,23 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       })
     ) {
       if (isCollaborativeEditing) {
-        await finalizeActiveSession();
+        if (collaborationSession === null) {
+          return;
+        }
+
+        const finalized = await collaborationSession.finalize();
+        if (finalized === null) {
+          setAutosaveStatus("pending");
+          stellaToast.add({
+            description: t("folio.saveCheckpointFailedDescription"),
+            title: t("folio.editSaveFailedTitle"),
+            type: "error",
+          });
+          return;
+        }
+        if (finalized.outcome === "finalized") {
+          onSaved?.(finalized.fieldId);
+        }
         onClose();
         return;
       }
@@ -1073,16 +1089,34 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     }
     finalizedBufferRef.current = buffer;
     hasSessionChangesRef.current = false;
-    const finalized = await finalizeActiveSession();
     if (isCollaborativeEditing) {
-      if (finalized?.outcome === "finalized") {
-        onSaved?.(finalized.fieldId);
+      if (collaborationSession === null) {
+        return;
+      }
+
+      const collaborativeFinalized = await collaborationSession.finalize();
+      if (collaborativeFinalized === null) {
+        hasSessionChangesRef.current = true;
+        setAutosaveStatus("pending");
+        stellaToast.add({
+          description: t("folio.saveCheckpointFailedDescription"),
+          title: t("folio.editSaveFailedTitle"),
+          type: "error",
+        });
+        return;
+      }
+      if (collaborativeFinalized.outcome === "finalized") {
+        onSaved?.(collaborativeFinalized.fieldId);
       }
       onClose();
+      return;
     }
+
+    await finalizeActiveSession();
   }, [
     cancelActiveSession,
     clearQueuedChangeCheckpoint,
+    collaborationSession,
     fieldId,
     finalizeActiveSession,
     isCollaborativeEditing,
@@ -1179,7 +1213,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     const actions: DocxBrowserEditorActions = {
       cancel: handleCancel,
       finalize: () => {
-        if (state.status === "editing") {
+        if (isCollaborativeEditing || state.status === "editing") {
           void handleFinalize();
         }
       },
@@ -1214,6 +1248,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     flushPendingChanges,
     handleCancel,
     handleFinalize,
+    isCollaborativeEditing,
     requestEditMode,
     state.status,
   ]);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -552,13 +552,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     useState<AutosaveStatus>("synced");
   const targetZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
   const t = useTranslations();
+  const canAutoRequestCollaboration =
+    isEditing && compatibility?.canSafelyEdit === true;
   const collaborationRuntime = useDocxBrowserCollaboration({
     canUnlock,
     externalCollaboration: collaboration,
     entityId,
     fieldId,
     propertyId,
-    initiallyRequested: isEditing,
+    initiallyRequested: canAutoRequestCollaboration,
     workspaceId,
   });
   const {
@@ -1499,6 +1501,11 @@ const useDocxBrowserCollaboration = ({
     },
     workspaceId,
   });
+  useEffect(() => {
+    if (initiallyRequested) {
+      setRequested(true);
+    }
+  }, [initiallyRequested]);
   const collaborationSession =
     collaborationState.status === "ready" ? collaborationState.session : null;
   const cancelCollaboration = useCallback(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -639,18 +639,31 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     collaborationSession?.saveCheckpoint ?? saveDesktopCheckpoint;
   const finalizeActiveSession =
     collaborationSession?.finalize ?? finalizeDesktopSession;
-  const closeCollaborationSession = useCallback(() => {
-    cancelCollaboration();
-    onClose();
-  }, [cancelCollaboration, onClose]);
   const cancelActiveSession = useCallback(async () => {
     if (collaborationSession !== null) {
-      closeCollaborationSession();
+      const cancelled = await collaborationSession.cancel();
+      if (!cancelled) {
+        stellaToast.add({
+          description: t("folio.saveCheckpointFailedDescription"),
+          title: t("folio.saveCheckpointFailedTitle"),
+          type: "error",
+        });
+        return;
+      }
+
+      cancelCollaboration();
+      onClose();
       return;
     }
 
     await cancelDesktopSession();
-  }, [cancelDesktopSession, closeCollaborationSession, collaborationSession]);
+  }, [
+    cancelCollaboration,
+    cancelDesktopSession,
+    collaborationSession,
+    onClose,
+    t,
+  ]);
 
   useEffect(() => {
     if (optimisticPreviewRef.current?.fieldId === fieldId) {
@@ -1356,6 +1369,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   }
 
   const previewIdentity = previewFile.fileId;
+  const collaborationIdentity = collaborationSession?.sessionId ?? "local";
 
   return (
     <div ref={containerRef} className="flex h-full w-full min-w-0 flex-col">
@@ -1391,7 +1405,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             }
           >
             <DocxEditor
-              key={`docx-${previewIdentity}`}
+              key={`docx-${previewIdentity}-${collaborationIdentity}`}
               ref={editorRef}
               autoOpenReviewSidebar={false}
               className="folio-docx-preview folio-peek h-full"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -16,6 +16,7 @@ import {
 import type { CSSProperties, ReactNode, RefObject } from "react";
 
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
 import {
   CheckCircle2Icon,
   EyeIcon,
@@ -31,6 +32,7 @@ import { FormattingBar, setAnonymizationTermsMeta } from "@stll/folio";
 import type {
   AnonymizationTerm,
   DocxCompatibility,
+  DocxEditorCollaboration,
   DocxEditorRef,
   EditorMode,
 } from "@stll/folio";
@@ -52,6 +54,7 @@ import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-a
 import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
 import { StatusMessage } from "@/components/route-components";
 import Tooltip from "@/components/tooltip";
+import { env } from "@/env";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import {
@@ -59,6 +62,7 @@ import {
   useDocxWheelZoom,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom";
 import { useDocxBlockScroll } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-docx-block-scroll";
+import { useFolioCollaborationSession } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session";
 import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
 import { useIsAnonymizationActive } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-active-store";
 import { useAnonymizationMatchesStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store";
@@ -75,7 +79,10 @@ import {
   shouldFinalizeEditSession,
 } from "./docx-browser-editor.logic";
 import type { OptimisticPreviewFile } from "./docx-browser-editor.logic";
-import type { EditSessionErrorReason } from "./use-edit-session";
+import type {
+  EditSessionErrorReason,
+  EditSessionState,
+} from "./use-edit-session";
 import { useEditSession } from "./use-edit-session";
 
 const DocxEditor = lazy(async () => {
@@ -84,7 +91,18 @@ const DocxEditor = lazy(async () => {
 });
 
 const CHANGE_CHECKPOINT_DELAY = 2000;
+const COLLABORATOR_COLOR_SPACE = 16_777_215;
 const noop = () => undefined;
+
+const colorFromStableId = (value: string) => {
+  let hash = 0;
+  for (const character of value) {
+    hash =
+      (hash * 31 + (character.codePointAt(0) ?? 0)) % COLLABORATOR_COLOR_SPACE;
+  }
+  const color = (hash * 2_654_435_761) % COLLABORATOR_COLOR_SPACE;
+  return `#${color.toString(16).padStart(6, "0")}`;
+};
 
 type AutosaveStatus = "synced" | "pending" | "syncing";
 
@@ -105,6 +123,7 @@ type DocxBrowserEditorBaseProps = {
   onSaved?: ((fieldId: string) => void) | undefined;
   onReadonlyEditAttempt?: (() => void) | undefined;
   onScrollTopChange?: ((scrollTop: number) => void) | undefined;
+  collaboration?: DocxEditorCollaboration | undefined;
   scaleOffset?: number | undefined;
   actionsKey?: string | undefined;
   actionsMapRef?: RefObject<Map<string, DocxBrowserEditorActions>> | undefined;
@@ -162,6 +181,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     actionsRef,
     actionBarControls,
     canUnlock = true,
+    collaboration,
     isEditing = true,
     initialScrollTop,
     onClose,
@@ -532,6 +552,24 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     useState<AutosaveStatus>("synced");
   const targetZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
   const t = useTranslations();
+  const collaborationRuntime = useDocxBrowserCollaboration({
+    canUnlock,
+    externalCollaboration: collaboration,
+    entityId,
+    fieldId,
+    propertyId,
+    initiallyRequested: isEditing,
+    workspaceId,
+  });
+  const {
+    activeCollaboration,
+    cancelCollaboration,
+    collaborationEnabled,
+    collaborationSession,
+    collaborationState,
+    isCollaborativeEditing,
+    requestCollaboration,
+  } = collaborationRuntime;
   const previewPlaceholder =
     optimisticPreviewRef.current?.fieldId === fieldId
       ? optimisticPreviewRef.current.file
@@ -560,9 +598,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     isDirty,
     open,
     markDirty,
-    saveCheckpoint,
-    finalize,
-    cancel,
+    saveCheckpoint: saveDesktopCheckpoint,
+    finalize: finalizeDesktopSession,
+    cancel: cancelDesktopSession,
     resetError,
   } = useEditSession({
     workspaceId,
@@ -597,6 +635,23 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     onCancelled: onClose,
   });
 
+  const saveActiveCheckpoint =
+    collaborationSession?.saveCheckpoint ?? saveDesktopCheckpoint;
+  const finalizeActiveSession =
+    collaborationSession?.finalize ?? finalizeDesktopSession;
+  const closeCollaborationSession = useCallback(() => {
+    cancelCollaboration();
+    onClose();
+  }, [cancelCollaboration, onClose]);
+  const cancelActiveSession = useCallback(async () => {
+    if (collaborationSession !== null) {
+      closeCollaborationSession();
+      return;
+    }
+
+    await cancelDesktopSession();
+  }, [cancelDesktopSession, closeCollaborationSession, collaborationSession]);
+
   useEffect(() => {
     if (optimisticPreviewRef.current?.fieldId === fieldId) {
       return;
@@ -628,6 +683,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   }, [t]);
 
   const requestEditMode = useCallback(async () => {
+    if (isCollaborativeEditing) {
+      return true;
+    }
+
     if (state.status === "editing") {
       return true;
     }
@@ -649,6 +708,11 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       return false;
     }
 
+    if (collaborationEnabled) {
+      requestCollaboration();
+      return false;
+    }
+
     didOpenRef.current = true;
     errorToastShownRef.current = false;
     const opened = await open();
@@ -659,8 +723,11 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     return opened;
   }, [
     compatibility?.canSafelyEdit,
+    collaborationEnabled,
+    isCollaborativeEditing,
     open,
     previewFile,
+    requestCollaboration,
     reportPendingCompatibility,
     reportUnsupportedEditAttempt,
     state.status,
@@ -682,14 +749,20 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       reportUnsupportedEditAttempt();
       return;
     }
+    if (collaborationEnabled) {
+      requestCollaboration();
+      return;
+    }
     didOpenRef.current = true;
     errorToastShownRef.current = false;
     void open();
   }, [
     compatibility,
+    collaborationEnabled,
     isEditing,
     open,
     previewFile,
+    requestCollaboration,
     reportUnsupportedEditAttempt,
     state.status,
   ]);
@@ -725,7 +798,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     resetError();
   }, [onClose, resetError, state, t]);
 
-  const isUnlocked = state.status === "editing";
+  const isUnlocked = isCollaborativeEditing || state.status === "editing";
   const wasUnlockedRef = useRef(false);
 
   useEffect(() => {
@@ -809,13 +882,13 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     void (async () => {
       const buffer = await ref.save({ selective: true });
       if (buffer) {
-        const saved = await saveCheckpoint(buffer);
+        const saved = await saveActiveCheckpoint(buffer);
         setAutosaveStatus(saved ? "synced" : "pending");
         return;
       }
       setAutosaveStatus("pending");
     })();
-  }, [saveCheckpoint]);
+  }, [saveActiveCheckpoint]);
 
   // Awaitable variant of `saveChangeCheckpoint` for callers that
   // need to wait for the round-trip before navigating (e.g. the
@@ -833,9 +906,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       setAutosaveStatus("pending");
       return;
     }
-    const saved = await saveCheckpoint(buffer);
+    const saved = await saveActiveCheckpoint(buffer);
     setAutosaveStatus(saved ? "synced" : "pending");
-  }, [clearQueuedChangeCheckpoint, saveCheckpoint]);
+  }, [clearQueuedChangeCheckpoint, saveActiveCheckpoint]);
 
   // Cmd+S / Ctrl+S checkpoints only while the document is actively editable.
   useEffect(() => {
@@ -859,7 +932,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       void (async () => {
         const buffer = await ref.save({ selective: true });
         if (buffer) {
-          const saved = await saveCheckpoint(buffer);
+          const saved = await saveActiveCheckpoint(buffer);
           setAutosaveStatus(saved ? "synced" : "pending");
           return;
         }
@@ -868,7 +941,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [clearQueuedChangeCheckpoint, isUnlocked, saveCheckpoint]);
+  }, [clearQueuedChangeCheckpoint, isUnlocked, saveActiveCheckpoint]);
 
   useEffect(
     () => () => {
@@ -932,7 +1005,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         hasPendingEditorChanges,
       })
     ) {
-      await cancel();
+      if (isCollaborativeEditing) {
+        await finalizeActiveSession();
+        onClose();
+        return;
+      }
+      await cancelActiveSession();
       return;
     }
 
@@ -947,7 +1025,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     }
 
     setAutosaveStatus("syncing");
-    const saved = await saveCheckpoint(buffer);
+    const saved = await saveActiveCheckpoint(buffer);
     if (!saved) {
       setAutosaveStatus("pending");
       stellaToast.add({
@@ -975,15 +1053,24 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     }
     finalizedBufferRef.current = buffer;
     hasSessionChangesRef.current = false;
-    await finalize();
+    const finalized = await finalizeActiveSession();
+    if (isCollaborativeEditing) {
+      if (finalized?.outcome === "finalized") {
+        onSaved?.(finalized.fieldId);
+      }
+      onClose();
+    }
   }, [
-    cancel,
+    cancelActiveSession,
     clearQueuedChangeCheckpoint,
     fieldId,
-    finalize,
+    finalizeActiveSession,
+    isCollaborativeEditing,
     isDirty,
+    onClose,
+    onSaved,
     previewFile,
-    saveCheckpoint,
+    saveActiveCheckpoint,
     t,
   ]);
 
@@ -991,8 +1078,8 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     clearQueuedChangeCheckpoint();
     preservedLoadedBufferRef.current = null;
     hasSessionChangesRef.current = false;
-    await cancel();
-  }, [cancel, clearQueuedChangeCheckpoint]);
+    await cancelActiveSession();
+  }, [cancelActiveSession, clearQueuedChangeCheckpoint]);
 
   const flashUnlockControl = useCallback(() => {
     setIsPromptingUnlock(true);
@@ -1024,6 +1111,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       reportUnsupportedEditAttempt();
       return;
     }
+    if (collaborationEnabled) {
+      requestCollaboration();
+      return;
+    }
     if (
       previewFile !== null &&
       state.status === "idle" &&
@@ -1036,10 +1127,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   }, [
     canUnlock,
     compatibility?.canSafelyEdit,
+    collaborationEnabled,
     flashUnlockControl,
     onBlockedUnlock,
     open,
     previewFile,
+    requestCollaboration,
     reportPendingCompatibility,
     reportUnsupportedEditAttempt,
     state.status,
@@ -1114,23 +1207,17 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     preservedLoadedBufferRef.current?.fieldId === fieldId
       ? preservedLoadedBufferRef.current.buffer
       : null;
-  const editorBuffer = selectEditorBuffer(
-    state.status === "editing"
-      ? {
-          status: state.status,
-          editingBuffer: state.buffer,
-          lastEditingBuffer: lastEditingBufferRef.current,
-          preservedLoadedBuffer,
-          previewBuffer: previewFile?.buffer,
-        }
-      : {
-          status: state.status,
-          lastEditingBuffer: lastEditingBufferRef.current,
-          preservedLoadedBuffer,
-          previewBuffer: previewFile?.buffer,
-        },
-  );
-  if (state.status === "editing" && editorBuffer !== undefined) {
+  const editorBuffer = selectDocxBrowserEditorBuffer({
+    isCollaborativeEditing,
+    lastEditingBuffer: lastEditingBufferRef.current,
+    preservedLoadedBuffer,
+    previewBuffer: previewFile?.buffer,
+    state,
+  });
+  if (
+    (state.status === "editing" || isCollaborativeEditing) &&
+    editorBuffer !== undefined
+  ) {
     lastEditingBufferRef.current = editorBuffer;
     preservedLoadedBufferRef.current = null;
   }
@@ -1159,7 +1246,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
                         "bg-primary/10 text-primary ring-primary/60 animate-pulse ring-2",
                     )}
                     disabled={
-                      state.status === "opening" || state.status === "saving"
+                      state.status === "opening" ||
+                      state.status === "saving" ||
+                      collaborationState.status === "opening"
                     }
                     onClick={handleToggleLock}
                     size={showLockLabel ? "sm" : "icon-sm"}
@@ -1232,6 +1321,22 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         }
         status="error"
         title={t("folio.editSaveFailedTitle")}
+      />
+    );
+  }
+
+  if (collaborationState.status === "error") {
+    return (
+      <StatusMessage
+        actionButton={
+          <Button onClick={onClose} size="sm" variant="outline">
+            {t("common.close")}
+          </Button>
+        }
+        className="h-full w-full"
+        description={collaborationState.message}
+        status="error"
+        title={t("folio.editOpenFailedTitle")}
       />
     );
   }
@@ -1310,6 +1415,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
               onEditorViewReady={setEditorViewForAnonymization}
               showToolbar={showActionBar ? true : isUnlocked}
               toolbarExtra={toolbarExtra}
+              {...(activeCollaboration !== undefined
+                ? { collaboration: activeCollaboration }
+                : {})}
               {...(isUnlocked ? { onChange: handleChange } : {})}
               onReadonlyEditAttempt={handleLockedEditAttempt}
               {...(initialScrollTop !== undefined ? { initialScrollTop } : {})}
@@ -1334,6 +1442,105 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       </div>
     </div>
   );
+};
+
+type UseDocxBrowserCollaborationOptions = {
+  canUnlock: boolean;
+  entityId: string;
+  externalCollaboration?: DocxEditorCollaboration | undefined;
+  fieldId: string;
+  initiallyRequested: boolean;
+  propertyId: string;
+  workspaceId: string;
+};
+
+const useDocxBrowserCollaboration = ({
+  canUnlock,
+  entityId,
+  externalCollaboration,
+  fieldId,
+  initiallyRequested,
+  propertyId,
+  workspaceId,
+}: UseDocxBrowserCollaborationOptions) => {
+  const [requested, setRequested] = useState(initiallyRequested);
+  const currentUser = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ({
+      email: ctx.user.email,
+      id: ctx.user.id,
+      name: ctx.user.name,
+    }),
+  });
+  const collaborationEnabled =
+    env.VITE_FEATURE_FOLIO_COLLAB && env.VITE_COLLAB_URL !== undefined;
+  const collaborationState = useFolioCollaborationSession({
+    enabled: collaborationEnabled && requested && canUnlock,
+    entityId,
+    fieldId,
+    propertyId,
+    user: {
+      color: colorFromStableId(currentUser.id),
+      name: currentUser.name ?? currentUser.email,
+    },
+    workspaceId,
+  });
+  const collaborationSession =
+    collaborationState.status === "ready" ? collaborationState.session : null;
+  const cancelCollaboration = useCallback(() => {
+    setRequested(false);
+  }, []);
+  const requestCollaboration = useCallback(() => {
+    setRequested(true);
+  }, []);
+
+  return {
+    activeCollaboration:
+      collaborationSession?.collaboration ?? externalCollaboration,
+    cancelCollaboration,
+    collaborationEnabled,
+    collaborationSession,
+    collaborationState,
+    isCollaborativeEditing: collaborationSession !== null,
+    requestCollaboration,
+  };
+};
+
+type SelectDocxBrowserEditorBufferOptions = {
+  isCollaborativeEditing: boolean;
+  lastEditingBuffer: ArrayBuffer | null;
+  preservedLoadedBuffer: ArrayBuffer | null;
+  previewBuffer?: ArrayBuffer | undefined;
+  state: EditSessionState;
+};
+
+const selectDocxBrowserEditorBuffer = ({
+  isCollaborativeEditing,
+  lastEditingBuffer,
+  preservedLoadedBuffer,
+  previewBuffer,
+  state,
+}: SelectDocxBrowserEditorBufferOptions) => {
+  if (isCollaborativeEditing) {
+    return previewBuffer;
+  }
+
+  if (state.status === "editing") {
+    return selectEditorBuffer({
+      status: state.status,
+      editingBuffer: state.buffer,
+      lastEditingBuffer,
+      preservedLoadedBuffer,
+      previewBuffer,
+    });
+  }
+
+  return selectEditorBuffer({
+    status: state.status,
+    lastEditingBuffer,
+    preservedLoadedBuffer,
+    previewBuffer,
+  });
 };
 
 const AutosaveIndicator = ({ status }: { status: AutosaveStatus }) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -74,15 +74,12 @@ import "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-docx.c
 
 import {
   getDocxEditBlockReason,
-  selectEditorBuffer,
+  selectDocxBrowserEditorBuffer,
   selectPreviewFile,
   shouldFinalizeEditSession,
 } from "./docx-browser-editor.logic";
 import type { OptimisticPreviewFile } from "./docx-browser-editor.logic";
-import type {
-  EditSessionErrorReason,
-  EditSessionState,
-} from "./use-edit-session";
+import type { EditSessionErrorReason } from "./use-edit-session";
 import { useEditSession } from "./use-edit-session";
 
 const DocxEditor = lazy(async () => {
@@ -544,16 +541,34 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   );
   const changeCheckpointIdleCallbackRef = useRef<number | null>(null);
   const [editorMode, setEditorMode] = useState<EditorMode>("editing");
-  const [compatibility, setCompatibility] = useState<DocxCompatibility | null>(
-    null,
-  );
+  const editTargetKey = `${workspaceId}:${entityId}:${propertyId}:${fieldId}`;
+  const [compatibilityState, setCompatibilityState] = useState<{
+    targetKey: string;
+    value: DocxCompatibility | null;
+  }>({ targetKey: editTargetKey, value: null });
+  const compatibility =
+    compatibilityState.targetKey === editTargetKey
+      ? compatibilityState.value
+      : null;
   const [isPromptingUnlock, setIsPromptingUnlock] = useState(false);
   const [autosaveStatus, setAutosaveStatus] =
     useState<AutosaveStatus>("synced");
   const targetZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
   const t = useTranslations();
+  const previewPlaceholder =
+    optimisticPreviewRef.current?.fieldId === fieldId
+      ? optimisticPreviewRef.current.file
+      : undefined;
+  const previewFileQuery = useQuery({
+    ...fileOptions({ workspaceId, fieldId, purpose: "native-display" }),
+    ...(previewPlaceholder !== undefined
+      ? { placeholderData: previewPlaceholder }
+      : { placeholderData: keepPreviousData }),
+  });
   const canAutoRequestCollaboration =
-    isEditing && compatibility?.canSafelyEdit === true;
+    isEditing &&
+    !previewFileQuery.isPlaceholderData &&
+    compatibility?.canSafelyEdit === true;
   const collaborationRuntime = useDocxBrowserCollaboration({
     canUnlock,
     externalCollaboration: collaboration,
@@ -572,16 +587,6 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     isCollaborativeEditing,
     requestCollaboration,
   } = collaborationRuntime;
-  const previewPlaceholder =
-    optimisticPreviewRef.current?.fieldId === fieldId
-      ? optimisticPreviewRef.current.file
-      : undefined;
-  const previewFileQuery = useQuery({
-    ...fileOptions({ workspaceId, fieldId, purpose: "native-display" }),
-    ...(previewPlaceholder !== undefined
-      ? { placeholderData: previewPlaceholder }
-      : { placeholderData: keepPreviousData }),
-  });
 
   if (previewFileQuery.error) {
     throw previewFileQuery.error;
@@ -681,8 +686,8 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       clearTimeout(lockedEditPromptTimerRef.current);
       lockedEditPromptTimerRef.current = null;
     }
-    setCompatibility(null);
-  }, [fieldId]);
+    setCompatibilityState({ targetKey: editTargetKey, value: null });
+  }, [editTargetKey, fieldId]);
 
   const reportUnsupportedEditAttempt = useCallback(() => {
     stellaToast.warning(t("folio.unsupportedDocxEditTitle"), {
@@ -1222,7 +1227,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     preservedLoadedBufferRef.current?.fieldId === fieldId
       ? preservedLoadedBufferRef.current.buffer
       : null;
+  const collaborationSeedBuffer =
+    collaborationSession?.seedDocumentBuffer ?? null;
   const editorBuffer = selectDocxBrowserEditorBuffer({
+    collaborationSeedBuffer,
     isCollaborativeEditing,
     lastEditingBuffer: lastEditingBufferRef.current,
     preservedLoadedBuffer,
@@ -1420,7 +1428,14 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
                 }
               }}
               onCompatibilityChange={(nextCompatibility) => {
-                setCompatibility(nextCompatibility);
+                if (previewFileQuery.isPlaceholderData) {
+                  return;
+                }
+
+                setCompatibilityState({
+                  targetKey: editTargetKey,
+                  value: nextCompatibility,
+                });
                 onCompatibilityChange?.(nextCompatibility);
               }}
               onAnonymizationMatchesChange={handleAnonymizationMatchesChange}
@@ -1470,6 +1485,11 @@ type UseDocxBrowserCollaborationOptions = {
   workspaceId: string;
 };
 
+type CollaborationRequestState = {
+  requested: boolean;
+  targetKey: string;
+};
+
 const useDocxBrowserCollaboration = ({
   canUnlock,
   entityId,
@@ -1479,7 +1499,15 @@ const useDocxBrowserCollaboration = ({
   propertyId,
   workspaceId,
 }: UseDocxBrowserCollaborationOptions) => {
-  const [requested, setRequested] = useState(initiallyRequested);
+  const targetKey = `${workspaceId}:${entityId}:${propertyId}:${fieldId}`;
+  const [requestState, setRequestState] = useState<CollaborationRequestState>({
+    requested: initiallyRequested,
+    targetKey,
+  });
+  const requested =
+    requestState.targetKey === targetKey
+      ? requestState.requested
+      : initiallyRequested;
   const currentUser = useRouteContext({
     from: "/_protected",
     select: (ctx) => ({
@@ -1502,18 +1530,16 @@ const useDocxBrowserCollaboration = ({
     workspaceId,
   });
   useEffect(() => {
-    if (initiallyRequested) {
-      setRequested(true);
-    }
-  }, [initiallyRequested]);
+    setRequestState({ requested: initiallyRequested, targetKey });
+  }, [initiallyRequested, targetKey]);
   const collaborationSession =
     collaborationState.status === "ready" ? collaborationState.session : null;
   const cancelCollaboration = useCallback(() => {
-    setRequested(false);
-  }, []);
+    setRequestState({ requested: false, targetKey });
+  }, [targetKey]);
   const requestCollaboration = useCallback(() => {
-    setRequested(true);
-  }, []);
+    setRequestState({ requested: true, targetKey });
+  }, [targetKey]);
 
   return {
     activeCollaboration:
@@ -1525,43 +1551,6 @@ const useDocxBrowserCollaboration = ({
     isCollaborativeEditing: collaborationSession !== null,
     requestCollaboration,
   };
-};
-
-type SelectDocxBrowserEditorBufferOptions = {
-  isCollaborativeEditing: boolean;
-  lastEditingBuffer: ArrayBuffer | null;
-  preservedLoadedBuffer: ArrayBuffer | null;
-  previewBuffer?: ArrayBuffer | undefined;
-  state: EditSessionState;
-};
-
-const selectDocxBrowserEditorBuffer = ({
-  isCollaborativeEditing,
-  lastEditingBuffer,
-  preservedLoadedBuffer,
-  previewBuffer,
-  state,
-}: SelectDocxBrowserEditorBufferOptions) => {
-  if (isCollaborativeEditing) {
-    return previewBuffer;
-  }
-
-  if (state.status === "editing") {
-    return selectEditorBuffer({
-      status: state.status,
-      editingBuffer: state.buffer,
-      lastEditingBuffer,
-      preservedLoadedBuffer,
-      previewBuffer,
-    });
-  }
-
-  return selectEditorBuffer({
-    status: state.status,
-    lastEditingBuffer,
-    preservedLoadedBuffer,
-    previewBuffer,
-  });
 };
 
 const AutosaveIndicator = ({ status }: { status: AutosaveStatus }) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-edit-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-edit-session.ts
@@ -19,7 +19,7 @@ import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queri
 
 import { selectStableArrayBuffer } from "./array-buffer-utils";
 
-type EditSessionState =
+export type EditSessionState =
   | { status: "idle" }
   | { status: "opening" }
   | {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -26,9 +26,11 @@ type FinalizeFolioCollaborationSessionResult =
   | { outcome: "no_changes" };
 
 export type FolioCollaborationSession = {
+  cancel: () => Promise<boolean>;
   collaboration: DocxEditorCollaboration;
   finalize: () => Promise<FinalizeFolioCollaborationSessionResult | null>;
   saveCheckpoint: (docxBuffer: ArrayBuffer) => Promise<boolean>;
+  sessionId: string;
 };
 
 type FolioCollaborationSessionState =
@@ -134,6 +136,39 @@ export const useFolioCollaborationSession = ({
 
       const sessionId = response.data.collabSessionId;
       const token = response.data.token;
+      const invalidateSessionQueries = async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({
+            queryKey: entitiesKeys.all(workspaceId),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: filesKeys.byFieldId({
+              workspaceId,
+              fieldId,
+              purpose: "native-display",
+            }),
+          }),
+          queryClient.invalidateQueries({
+            queryKey: filesKeys.metadataByFieldId({
+              workspaceId,
+              fieldId,
+              purpose: "native-display",
+            }),
+          }),
+        ]);
+      };
+      const cancel = async () => {
+        const cancelled = await api["folio-collab-sessions"]({
+          sessionId,
+        }).cancel.post({ token });
+
+        if (cancelled.error) {
+          return false;
+        }
+
+        await invalidateSessionQueries();
+        return true;
+      };
       const saveCheckpoint = async (docxBuffer: ArrayBuffer) => {
         const checkpoint = await api["folio-collab-sessions"]({
           sessionId,
@@ -161,23 +196,7 @@ export const useFolioCollaborationSession = ({
             : fieldId;
         await Promise.all(
           [
-            queryClient.invalidateQueries({
-              queryKey: entitiesKeys.all(workspaceId),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: filesKeys.byFieldId({
-                workspaceId,
-                fieldId,
-                purpose: "native-display",
-              }),
-            }),
-            queryClient.invalidateQueries({
-              queryKey: filesKeys.metadataByFieldId({
-                workspaceId,
-                fieldId,
-                purpose: "native-display",
-              }),
-            }),
+            invalidateSessionQueries(),
             finalizedFieldId !== fieldId
               ? queryClient.invalidateQueries({
                   queryKey: filesKeys.byFieldId({
@@ -218,9 +237,11 @@ export const useFolioCollaborationSession = ({
         provider,
         collaboration,
         session: {
+          cancel,
           collaboration,
           finalize,
           saveCheckpoint,
+          sessionId,
         },
       });
     })().catch((error: unknown) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -30,6 +30,7 @@ export type FolioCollaborationSession = {
   collaboration: DocxEditorCollaboration;
   finalize: () => Promise<FinalizeFolioCollaborationSessionResult | null>;
   saveCheckpoint: (docxBuffer: ArrayBuffer) => Promise<boolean>;
+  seedDocumentBuffer: ArrayBuffer | null;
   sessionId: string;
 };
 
@@ -58,6 +59,29 @@ type UseFolioCollaborationSessionOptions = {
 };
 
 const FOLIO_COLLAB_TOKEN_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+const SEED_DOCUMENT_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+const fetchSeedDocumentBuffer = async (seedDownloadUrl: string) => {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    SEED_DOCUMENT_DOWNLOAD_TIMEOUT_MS,
+  );
+
+  try {
+    const response = await fetch(seedDownloadUrl, {
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to download collaborative editing seed file.");
+    }
+
+    return await response.arrayBuffer();
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
 
 export const useFolioCollaborationSession = ({
   enabled,
@@ -114,6 +138,22 @@ export const useFolioCollaborationSession = ({
       const sessionId = response.data.collabSessionId;
       let token = response.data.token;
       let tokenExpiresAtMs = Date.parse(response.data.tokenExpiresAt);
+      const seedDocumentBuffer = await (async () => {
+        if (!response.data.shouldSeed) {
+          return null;
+        }
+
+        if (response.data.seedDownloadUrl === null) {
+          throw new Error("Collaborative editing seed file is unavailable.");
+        }
+
+        return await fetchSeedDocumentBuffer(response.data.seedDownloadUrl);
+      })();
+
+      if (isDisposed()) {
+        return;
+      }
+
       const refreshTokenIfNeeded = async () => {
         if (
           Number.isFinite(tokenExpiresAtMs) &&
@@ -283,6 +323,7 @@ export const useFolioCollaborationSession = ({
           collaboration,
           finalize,
           saveCheckpoint,
+          seedDocumentBuffer,
           sessionId,
         },
       });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -186,14 +186,14 @@ export const useFolioCollaborationSession = ({
           return token;
         }
 
-        const refreshed = await api
-          .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-          ["folio-collab-sessions"].open.post({
-            entityId: toSafeId<"entity">(entityId),
-            propertyId: toSafeId<"property">(propertyId),
-          });
+        const refreshed = await api["folio-collab-sessions"][
+          "refresh-token"
+        ].post({
+          sessionId,
+          token,
+        });
 
-        if (refreshed.error || refreshed.data.collabSessionId !== sessionId) {
+        if (refreshed.error) {
           return null;
         }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -1,0 +1,258 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { HocuspocusProvider } from "@hocuspocus/provider";
+import { useQueryClient } from "@tanstack/react-query";
+import { yCursorPlugin, ySyncPlugin, yUndoPlugin } from "y-prosemirror";
+import * as Y from "yjs";
+
+import type { DocxEditorCollaboration } from "@stll/folio";
+
+import { env } from "@/env";
+import { api } from "@/lib/api";
+import { DOCX_MIME } from "@/lib/consts";
+import { userErrorMessage } from "@/lib/errors";
+import { toSafeId } from "@/lib/safe-id";
+import { filesKeys } from "@/routes/_protected.workspaces/$workspaceId/-components/files/queries";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+
+type FinalizeFolioCollaborationSessionResult =
+  | {
+      outcome: "finalized";
+      entityId: string;
+      fieldId: string;
+      versionId: string;
+      versionNumber: number;
+    }
+  | { outcome: "no_changes" };
+
+export type FolioCollaborationSession = {
+  collaboration: DocxEditorCollaboration;
+  finalize: () => Promise<FinalizeFolioCollaborationSessionResult | null>;
+  saveCheckpoint: (docxBuffer: ArrayBuffer) => Promise<boolean>;
+};
+
+type FolioCollaborationSessionState =
+  | { status: "idle"; collaboration: null }
+  | { status: "opening"; collaboration: null }
+  | {
+      status: "ready";
+      collaboration: DocxEditorCollaboration;
+      provider: HocuspocusProvider;
+      session: FolioCollaborationSession;
+      sessionId: string;
+    }
+  | { status: "error"; collaboration: null; message: string };
+
+type UseFolioCollaborationSessionOptions = {
+  enabled: boolean;
+  entityId: string;
+  fieldId: string;
+  propertyId: string;
+  user: {
+    color: string;
+    name: string;
+  };
+  workspaceId: string;
+};
+
+export const useFolioCollaborationSession = ({
+  enabled,
+  entityId,
+  fieldId,
+  propertyId,
+  user,
+  workspaceId,
+}: UseFolioCollaborationSessionOptions): FolioCollaborationSessionState => {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<FolioCollaborationSessionState>({
+    status: "idle",
+    collaboration: null,
+  });
+
+  const collabUrl = env.VITE_COLLAB_URL;
+  const canConnect = enabled && collabUrl !== undefined;
+
+  useEffect(() => {
+    if (!canConnect || collabUrl === undefined) {
+      setState({ status: "idle", collaboration: null });
+      return undefined;
+    }
+
+    let disposed = false;
+    let provider: HocuspocusProvider | null = null;
+    setState({ status: "opening", collaboration: null });
+
+    void (async () => {
+      const response = await api
+        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        ["folio-collab-sessions"].open.post({
+          entityId: toSafeId<"entity">(entityId),
+          propertyId: toSafeId<"property">(propertyId),
+        });
+
+      if (disposed) {
+        return;
+      }
+
+      if (response.error) {
+        setState({
+          status: "error",
+          collaboration: null,
+          message: userErrorMessage(
+            response.error,
+            "Failed to open collaborative editing.",
+          ),
+        });
+        return;
+      }
+
+      const ydoc = new Y.Doc();
+      const yXmlFragment = ydoc.get("prosemirror", Y.XmlFragment);
+
+      provider = new HocuspocusProvider({
+        document: ydoc,
+        name: response.data.roomName,
+        token: response.data.token,
+        url: collabUrl,
+      });
+
+      const awareness = provider.awareness;
+      if (!awareness) {
+        provider.destroy();
+        setState({
+          status: "error",
+          collaboration: null,
+          message: "Collaboration provider did not expose awareness.",
+        });
+        return;
+      }
+
+      awareness.setLocalStateField("user", {
+        color: user.color,
+        name: user.name,
+      });
+
+      const sessionId = response.data.collabSessionId;
+      const token = response.data.token;
+      const saveCheckpoint = async (docxBuffer: ArrayBuffer) => {
+        const checkpoint = await api["folio-collab-sessions"]({
+          sessionId,
+        }).checkpoint.post({
+          file: new File([docxBuffer], response.data.fileName, {
+            type: DOCX_MIME,
+          }),
+          token,
+        });
+
+        return !checkpoint.error;
+      };
+      const finalize = async () => {
+        const finalized = await api["folio-collab-sessions"]({
+          sessionId,
+        }).finalize.post({ token });
+
+        if (finalized.error) {
+          return null;
+        }
+
+        const finalizedFieldId =
+          finalized.data.outcome === "finalized"
+            ? finalized.data.fieldId
+            : fieldId;
+        await Promise.all(
+          [
+            queryClient.invalidateQueries({
+              queryKey: entitiesKeys.all(workspaceId),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: filesKeys.byFieldId({
+                workspaceId,
+                fieldId,
+                purpose: "native-display",
+              }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: filesKeys.metadataByFieldId({
+                workspaceId,
+                fieldId,
+                purpose: "native-display",
+              }),
+            }),
+            finalizedFieldId !== fieldId
+              ? queryClient.invalidateQueries({
+                  queryKey: filesKeys.byFieldId({
+                    workspaceId,
+                    fieldId: finalizedFieldId,
+                    purpose: "native-display",
+                  }),
+                })
+              : null,
+            finalizedFieldId !== fieldId
+              ? queryClient.invalidateQueries({
+                  queryKey: filesKeys.metadataByFieldId({
+                    workspaceId,
+                    fieldId: finalizedFieldId,
+                    purpose: "native-display",
+                  }),
+                })
+              : null,
+          ].filter((promise) => promise !== null),
+        );
+
+        return finalized.data;
+      };
+      const collaboration = {
+        awareness,
+        plugins: [
+          ySyncPlugin(yXmlFragment),
+          yCursorPlugin(awareness),
+          yUndoPlugin(),
+        ],
+        shouldSeed: response.data.shouldSeed,
+        yXmlFragment,
+      };
+
+      setState({
+        status: "ready",
+        sessionId,
+        provider,
+        collaboration,
+        session: {
+          collaboration,
+          finalize,
+          saveCheckpoint,
+        },
+      });
+    })().catch((error: unknown) => {
+      if (disposed) {
+        return;
+      }
+
+      setState({
+        status: "error",
+        collaboration: null,
+        message:
+          error instanceof Error
+            ? error.message
+            : "Failed to open collaborative editing.",
+      });
+    });
+
+    return () => {
+      disposed = true;
+      provider?.destroy();
+    };
+  }, [
+    canConnect,
+    collabUrl,
+    entityId,
+    fieldId,
+    propertyId,
+    queryClient,
+    user.color,
+    user.name,
+    workspaceId,
+  ]);
+
+  return useMemo(() => state, [state]);
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -57,6 +57,8 @@ type UseFolioCollaborationSessionOptions = {
   workspaceId: string;
 };
 
+const FOLIO_COLLAB_TOKEN_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
+
 export const useFolioCollaborationSession = ({
   enabled,
   entityId,
@@ -108,13 +110,39 @@ export const useFolioCollaborationSession = ({
         return;
       }
 
+      const sessionId = response.data.collabSessionId;
+      let token = response.data.token;
+      let tokenExpiresAtMs = Date.parse(response.data.tokenExpiresAt);
+      const refreshTokenIfNeeded = async () => {
+        if (
+          Number.isFinite(tokenExpiresAtMs) &&
+          Date.now() < tokenExpiresAtMs - FOLIO_COLLAB_TOKEN_REFRESH_LEEWAY_MS
+        ) {
+          return token;
+        }
+
+        const refreshed = await api
+          .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+          ["folio-collab-sessions"].open.post({
+            entityId: toSafeId<"entity">(entityId),
+            propertyId: toSafeId<"property">(propertyId),
+          });
+
+        if (refreshed.error || refreshed.data.collabSessionId !== sessionId) {
+          return null;
+        }
+
+        token = refreshed.data.token;
+        tokenExpiresAtMs = Date.parse(refreshed.data.tokenExpiresAt);
+        return token;
+      };
       const ydoc = new Y.Doc();
       const yXmlFragment = ydoc.get("prosemirror", Y.XmlFragment);
 
       provider = new HocuspocusProvider({
         document: ydoc,
         name: response.data.roomName,
-        token: response.data.token,
+        token: async () => (await refreshTokenIfNeeded()) ?? "",
         url: collabUrl,
       });
 
@@ -134,8 +162,6 @@ export const useFolioCollaborationSession = ({
         name: user.name,
       });
 
-      const sessionId = response.data.collabSessionId;
-      const token = response.data.token;
       const invalidateSessionQueries = async () => {
         await Promise.all([
           queryClient.invalidateQueries({
@@ -158,9 +184,14 @@ export const useFolioCollaborationSession = ({
         ]);
       };
       const cancel = async () => {
+        const freshToken = await refreshTokenIfNeeded();
+        if (freshToken === null) {
+          return false;
+        }
+
         const cancelled = await api["folio-collab-sessions"]({
           sessionId,
-        }).cancel.post({ token });
+        }).cancel.post({ token: freshToken });
 
         if (cancelled.error) {
           return false;
@@ -170,21 +201,31 @@ export const useFolioCollaborationSession = ({
         return true;
       };
       const saveCheckpoint = async (docxBuffer: ArrayBuffer) => {
+        const freshToken = await refreshTokenIfNeeded();
+        if (freshToken === null) {
+          return false;
+        }
+
         const checkpoint = await api["folio-collab-sessions"]({
           sessionId,
         }).checkpoint.post({
           file: new File([docxBuffer], response.data.fileName, {
             type: DOCX_MIME,
           }),
-          token,
+          token: freshToken,
         });
 
         return !checkpoint.error;
       };
       const finalize = async () => {
+        const freshToken = await refreshTokenIfNeeded();
+        if (freshToken === null) {
+          return null;
+        }
+
         const finalized = await api["folio-collab-sessions"]({
           sessionId,
-        }).finalize.post({ token });
+        }).finalize.post({ token: freshToken });
 
         if (finalized.error) {
           return null;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -109,6 +109,22 @@ export const useFolioCollaborationSession = ({
     let disposed = false;
     const isDisposed = () => disposed;
     let provider: HocuspocusProvider | null = null;
+    let openingSession: { sessionId: string; token: string } | null = null;
+    const cancelOpeningSession = async () => {
+      const session = openingSession;
+      if (session === null) {
+        return;
+      }
+
+      openingSession = null;
+      try {
+        await api["folio-collab-sessions"]({
+          sessionId: session.sessionId,
+        }).cancel.post({ token: session.token });
+      } catch {
+        // Best-effort cleanup for abandoned session opens.
+      }
+    };
     setState({ status: "opening", collaboration: null });
 
     void (async () => {
@@ -137,6 +153,13 @@ export const useFolioCollaborationSession = ({
 
       const sessionId = response.data.collabSessionId;
       let token = response.data.token;
+      openingSession = { sessionId, token };
+
+      if (isDisposed()) {
+        await cancelOpeningSession();
+        return;
+      }
+
       let tokenExpiresAtMs = Date.parse(response.data.tokenExpiresAt);
       const seedDocumentBuffer = await (async () => {
         if (!response.data.shouldSeed) {
@@ -151,6 +174,7 @@ export const useFolioCollaborationSession = ({
       })();
 
       if (isDisposed()) {
+        await cancelOpeningSession();
         return;
       }
 
@@ -189,6 +213,7 @@ export const useFolioCollaborationSession = ({
 
       const awareness = provider.awareness;
       if (!awareness) {
+        await cancelOpeningSession();
         provider.destroy();
         setState({
           status: "error",
@@ -312,6 +337,7 @@ export const useFolioCollaborationSession = ({
         shouldSeed: response.data.shouldSeed,
         yXmlFragment,
       };
+      openingSession = null;
 
       setState({
         status: "ready",
@@ -328,6 +354,7 @@ export const useFolioCollaborationSession = ({
         },
       });
     })().catch((error: unknown) => {
+      void cancelOpeningSession();
       if (isDisposed()) {
         return;
       }
@@ -344,6 +371,7 @@ export const useFolioCollaborationSession = ({
 
     return () => {
       disposed = true;
+      void cancelOpeningSession();
       provider?.destroy();
     };
   }, [

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -77,12 +77,13 @@ export const useFolioCollaborationSession = ({
   const canConnect = enabled && collabUrl !== undefined;
 
   useEffect(() => {
-    if (!canConnect || collabUrl === undefined) {
+    if (!canConnect) {
       setState({ status: "idle", collaboration: null });
       return undefined;
     }
 
     let disposed = false;
+    const isDisposed = () => disposed;
     let provider: HocuspocusProvider | null = null;
     setState({ status: "opening", collaboration: null });
 
@@ -94,7 +95,7 @@ export const useFolioCollaborationSession = ({
           propertyId: toSafeId<"property">(propertyId),
         });
 
-      if (disposed) {
+      if (isDisposed()) {
         return;
       }
 
@@ -286,7 +287,7 @@ export const useFolioCollaborationSession = ({
         },
       });
     })().catch((error: unknown) => {
-      if (disposed) {
+      if (isDisposed()) {
         return;
       }
 

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,23 @@
         "fast-check": "catalog:",
       },
     },
+    "apps/collab": {
+      "name": "@stll/collab",
+      "version": "0.0.0",
+      "dependencies": {
+        "@hocuspocus/server": "^4.0.0",
+        "@t3-oss/env-core": "catalog:",
+        "crossws": "^0.4.5",
+        "valibot": "catalog:",
+        "yjs": "^13.6.30",
+      },
+      "devDependencies": {
+        "@hocuspocus/provider": "^4.0.0",
+        "@stll/typescript-config": "workspace:*",
+        "@types/bun": "catalog:",
+        "typescript": "catalog:",
+      },
+    },
     "apps/desktop": {
       "name": "@stll/desktop",
       "version": "0.0.1",
@@ -192,6 +209,7 @@
         "@base-ui/react": "catalog:",
         "@better-auth/oauth-provider": "catalog:",
         "@elysiajs/eden": "^1.4.9",
+        "@hocuspocus/provider": "^4.0.0",
         "@libpdf/core": "catalog:",
         "@posthog/react": "^1.9.0",
         "@pydantic/genai-prices": "^0.0.56",
@@ -256,6 +274,8 @@
         "uuid": "^14.0.0",
         "valibot": "catalog:",
         "vite": "catalog:",
+        "y-prosemirror": "^1.3.7",
+        "yjs": "^13.6.30",
         "zustand": "^5.0.13",
       },
       "devDependencies": {
@@ -360,6 +380,8 @@
         "prosemirror-transform": "^1.12.0",
         "prosemirror-view": "^1.41.8",
         "utif2": "^4.1.0",
+        "y-prosemirror": "^1.3.7",
+        "yjs": "^13.6.30",
       },
       "devDependencies": {
         "@playwright/test": "^1.59.1",
@@ -878,6 +900,12 @@
 
     "@formatjs/intl-localematcher": ["@formatjs/intl-localematcher@0.8.1", "", { "dependencies": { "@formatjs/fast-memoize": "3.1.0", "tslib": "^2.8.1" } }, "sha512-xwEuwQFdtSq1UKtQnyTZWC+eHdv7Uygoa+H2k/9uzBVQjDyp9r20LNDNKedWXll7FssT3GRHvqsdJGYSUWqYFA=="],
 
+    "@hocuspocus/common": ["@hocuspocus/common@4.0.0", "", { "dependencies": { "lib0": "^0.2.87" } }, "sha512-7BE8TsKBkdiOZO6tfm3ny6bIHPbxkIZb3hsYdVn/X5xbXI8n8w9pnE6pXgEMKQhJm6zsWsa9IDRJIp/c9u+DmA=="],
+
+    "@hocuspocus/provider": ["@hocuspocus/provider@4.0.0", "", { "dependencies": { "@hocuspocus/common": "^4.0.0", "@lifeomic/attempt": "^3.0.2", "lib0": "^0.2.87", "ws": "^8.17.1" }, "peerDependencies": { "y-protocols": "^1.0.6", "yjs": "^13.6.8" } }, "sha512-08gpeNZ6x2pmRD6m4XwRD52yQKnTl32a0HS9VSXZ5A1dIBVqxMz/x8Z06XbkKM2X8sp6vWEUCZCtzAGFSsofgg=="],
+
+    "@hocuspocus/server": ["@hocuspocus/server@4.0.0", "", { "dependencies": { "@hocuspocus/common": "^4.0.0", "async-mutex": "^0.5.0", "crossws": "^0.4.4", "kleur": "^4.1.4", "lib0": "^0.2.47" }, "peerDependencies": { "y-protocols": "^1.0.6", "yjs": "^13.6.8" } }, "sha512-Pgm+kVtTrVvybIJUVot5XumSzD8rPLQglUV0QAAiN6J64dkYc2wWNdGcMwJz3q3yJPV0dO+eRU9JEck+iVdgzQ=="],
+
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@huggingface/tokenizers": ["@huggingface/tokenizers@0.1.3", "", {}, "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA=="],
@@ -969,6 +997,8 @@
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
 
     "@libpdf/core": ["@libpdf/core@0.3.4", "", { "dependencies": { "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "@scure/base": "^2.0.0", "asn1js": "^3.0.7", "lru-cache": "^11.2.6", "pako": "^2.1.0", "pkijs": "^3.3.3" }, "peerDependencies": { "@google-cloud/kms": "^5.0.0", "@google-cloud/secret-manager": "^6.0.0" }, "optionalPeers": ["@google-cloud/kms", "@google-cloud/secret-manager"] }, "sha512-gE8LtgRsUofAMVSY1OVg9jGOfxe7tdUvV2cM4/vp46/TeO1JN4o2rZVIz2bW5rra6JuEzpdgUrdczfwiQft5pQ=="],
+
+    "@lifeomic/attempt": ["@lifeomic/attempt@3.1.0", "", {}, "sha512-QZqem4QuAnAyzfz+Gj5/+SLxqwCAw2qmt7732ZXodr6VDWGeYLG6w1i/vYLa55JQM9wRuBKLmXmiZ2P0LtE5rw=="],
 
     "@litko/yara-x": ["@litko/yara-x@0.5.2", "", { "optionalDependencies": { "@litko/yara-x-darwin-arm64": "0.5.1", "@litko/yara-x-darwin-x64": "0.5.1", "@litko/yara-x-linux-arm64-gnu": "0.5.1", "@litko/yara-x-linux-x64-gnu": "0.5.1", "@litko/yara-x-win32-arm64-msvc": "0.5.1", "@litko/yara-x-win32-x64-msvc": "0.5.1" } }, "sha512-6pzr7ODhzcwL8437qbWpIFeLh3zIOTu8uUen6uoY+i4Vcz3WxF6catbAR2mJMMOXJI+lOLxbn0vzHfS7apwGZw=="],
 
@@ -1584,6 +1614,8 @@
 
     "@stll/case-law": ["@stll/case-law@workspace:packages/case-law"],
 
+    "@stll/collab": ["@stll/collab@workspace:apps/collab"],
+
     "@stll/desktop": ["@stll/desktop@workspace:apps/desktop"],
 
     "@stll/docs": ["@stll/docs@workspace:apps/docs"],
@@ -2028,6 +2060,8 @@
 
     "astro-expressive-code": ["astro-expressive-code@0.42.0", "", { "dependencies": { "rehype-expressive-code": "^0.42.0" }, "peerDependencies": { "astro": "^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta" } }, "sha512-aiTePi2Cn0mJPYWZSzP1GcxCinX9mNtJyCCshVVPSg1yRwM7ADvFJOx0FnS440M9t65hp8JH//dc2qr22Bm4ag=="],
 
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
     "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
@@ -2178,7 +2212,7 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
+    "crossws": ["crossws@0.4.5", "", { "peerDependencies": { "srvx": ">=0.11.5" }, "optionalPeers": ["srvx"] }, "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
@@ -2688,6 +2722,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "isomorphic.js": ["isomorphic.js@0.2.5", "", {}, "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
@@ -2769,6 +2805,8 @@
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lib0": ["lib0@0.2.117", "", { "dependencies": { "isomorphic.js": "^0.2.4" }, "bin": { "0serve": "bin/0serve.js", "0gentesthtml": "bin/gentesthtml.js", "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js" } }, "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw=="],
 
     "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
@@ -3686,6 +3724,10 @@
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
+    "y-prosemirror": ["y-prosemirror@1.3.7", "", { "dependencies": { "lib0": "^0.2.109" }, "peerDependencies": { "prosemirror-model": "^1.7.1", "prosemirror-state": "^1.2.3", "prosemirror-view": "^1.9.10", "y-protocols": "^1.0.1", "yjs": "^13.5.38" } }, "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg=="],
+
+    "y-protocols": ["y-protocols@1.0.7", "", { "dependencies": { "lib0": "^0.2.85" }, "peerDependencies": { "yjs": "^13.0.0" } }, "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -3697,6 +3739,8 @@
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
+
+    "yjs": ["yjs@13.6.30", "", { "dependencies": { "lib0": "^0.2.99" } }, "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ=="],
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
@@ -3939,6 +3983,8 @@
     "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "h3/cookie-es": ["cookie-es@1.2.2", "", {}, "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="],
+
+    "h3/crossws": ["crossws@0.3.5", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA=="],
 
     "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -882,6 +882,7 @@ export default defineConfig({
         "apps/api/src/handlers/auth/ui-routes.ts",
         "apps/api/src/handlers/dev/routes.ts",
         "apps/api/src/handlers/entities/desktop-edit-sessions-route.ts",
+        "apps/api/src/handlers/folio-collab/routes.ts",
         "apps/api/src/handlers/health/routes.ts",
         "apps/api/src/handlers/mcp/routes.ts",
         "apps/api/src/handlers/verify/routes.ts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:ai-tools": "bun --cwd apps/api dev:ai-tools",
     "dev:all": "turbo dev",
     "dev:api": "bun packages/scripts/src/dev-runner.ts dev:api",
+    "dev:collab": "bun --cwd apps/collab dev",
     "dev:desktop": "bun packages/scripts/src/dev-runner.ts dev:desktop",
     "dev:web": "bun packages/scripts/src/dev-runner.ts dev:web",
     "typegen": "turbo run typegen",

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -46,7 +46,9 @@
     "prosemirror-transform": "^1.12.0",
     "prosemirror-view": "^1.41.8",
     "utif2": "^4.1.0",
-    "valibot": "catalog:"
+    "valibot": "catalog:",
+    "y-prosemirror": "^1.3.7",
+    "yjs": "^13.6.30"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -1,6 +1,8 @@
 import type { CSSProperties, ReactNode } from "react";
 
+import type { Plugin } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
+import type { XmlFragment } from "yjs";
 
 import type {
   FolioAIEditApplyMode,
@@ -132,6 +134,8 @@ export type DocxEditorProps = {
    * (decoration meta, apply, scroll-to) from outside the editor.
    */
   onEditorViewReady?: (view: EditorView | null) => void;
+  /** Yjs-backed collaboration owner. Experimental and opt-in. */
+  collaboration?: DocxEditorCollaboration | undefined;
   /**
    * Fires with the current anonymization match list every time
    * the decoration plugin recomputes it (initial mount, term
@@ -160,6 +164,21 @@ export type DocxEditorProps = {
   selectedAnonymizationCanonical?: string | null | undefined;
   /** Monotonic counter from the bridge store; drives the re-scroll. */
   anonymizationSelectionSeq?: number | undefined;
+};
+
+export type DocxEditorCollaboration = {
+  awareness?:
+    | {
+        clientID: number;
+        getStates(): Map<number, unknown>;
+        off(event: "change" | "update", handler: () => void): void;
+        on(event: "change" | "update", handler: () => void): void;
+      }
+    | undefined;
+  onSeeded?: (() => void) | undefined;
+  plugins?: Plugin[] | undefined;
+  shouldSeed?: boolean | undefined;
+  yXmlFragment: XmlFragment;
 };
 
 /**

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -351,6 +351,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       onAnonymizationTermClick,
       selectedAnonymizationCanonical = null,
       anonymizationSelectionSeq,
+      collaboration,
     },
     ref,
   ) {
@@ -650,12 +651,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     );
     const editorPlugins = useMemo(
       () => [
+        ...(collaboration?.plugins ?? []),
         suggestionPlugin,
         aiSuggestionPlugin,
         aiCitationPlugin,
         anonymizationDecorationsPlugin,
       ],
       [
+        collaboration?.plugins,
         suggestionPlugin,
         aiSuggestionPlugin,
         aiCitationPlugin,
@@ -2998,6 +3001,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                           ? { onSelectionTextChange }
                           : {})}
                         externalPlugins={editorPlugins}
+                        {...(collaboration !== undefined
+                          ? { collaboration }
+                          : {})}
                         onHyperlinkClick={handleHyperlinkClick}
                         onContextMenu={handleContextMenu}
                         commentsSidebarOpen={showCommentsSidebar}

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -1,5 +1,6 @@
 export { DocxEditor } from "./components/DocxEditor";
 export type {
+  DocxEditorCollaboration,
   DocxEditorProps,
   DocxEditorRef,
 } from "./components/DocxEditor.props";

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -311,11 +311,13 @@ function createInitialState(
   collaboration?: HiddenProseMirrorCollaboration,
 ): EditorState {
   const activeSchema = manager?.getSchema() ?? schema;
-  const localDoc = document
-    ? styles === undefined || styles === null
-      ? toProseDoc(document)
-      : toProseDoc(document, { styles })
-    : createEmptyDoc();
+  let localDoc = createEmptyDoc();
+  if (document) {
+    localDoc =
+      styles === undefined || styles === null
+        ? toProseDoc(document)
+        : toProseDoc(document, { styles });
+  }
 
   if (collaboration) {
     if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
@@ -591,10 +593,6 @@ const HiddenProseMirrorComponent = forwardRef<
       return;
     }
 
-    if (collaboration) {
-      return;
-    }
-
     // Generate a simple document identity based on its structure
     // This helps detect truly different documents vs the same doc passed back after editing
     const getDocumentId = (doc: Document | null): string => {
@@ -615,6 +613,10 @@ const HiddenProseMirrorComponent = forwardRef<
     const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
     const collaborationSourceChanged =
       currentCollaborationFragment !== lastCollaborationFragmentRef.current;
+
+    if (collaboration && !collaborationSourceChanged) {
+      return;
+    }
 
     // Skip if this is the same document (likely passed back after internal edit)
     // Only reset state if:

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -36,6 +36,14 @@ import {
 import { CellSelection } from "prosemirror-tables";
 import { EditorView } from "prosemirror-view";
 import type { DirectEditorProps } from "prosemirror-view";
+import {
+  initProseMirrorDoc,
+  prosemirrorToYXmlFragment,
+  relativePositionToAbsolutePosition,
+  ySyncPluginKey,
+} from "y-prosemirror";
+import * as Y from "yjs";
+import type { XmlFragment } from "yjs";
 
 import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
 import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
@@ -70,6 +78,11 @@ export type HiddenProseMirrorProps = {
   onSelectionChange?: (state: EditorState) => void;
   /** External ProseMirror plugins */
   externalPlugins?: Plugin[];
+  /** Yjs-backed collaboration document owner. */
+  collaboration?: HiddenProseMirrorCollaboration | undefined;
+  onRemoteSelectionsChange?:
+    | ((selections: HiddenProseMirrorRemoteSelection[]) => void)
+    | undefined;
   /** Extension manager for plugins/schema/commands (optional — falls back to default) */
   extensionManager?: ExtensionManager;
   /** Callback when EditorView is ready */
@@ -80,6 +93,28 @@ export type HiddenProseMirrorProps = {
   onKeyDown?: (view: EditorView, event: KeyboardEvent) => boolean;
   /** Callback when a readonly user action would mutate the document. */
   onReadOnlyEditAttempt?: () => void;
+};
+
+export type HiddenProseMirrorCollaboration = {
+  awareness?: CollaborationAwareness | undefined;
+  onSeeded?: (() => void) | undefined;
+  shouldSeed?: boolean | undefined;
+  yXmlFragment: XmlFragment;
+};
+
+export type HiddenProseMirrorRemoteSelection = {
+  anchor: number;
+  clientId: number;
+  color: string;
+  head: number;
+  name: string;
+};
+
+type CollaborationAwareness = {
+  clientID: number;
+  getStates(): Map<number, unknown>;
+  off(event: "change" | "update", handler: () => void): void;
+  on(event: "change" | "update", handler: () => void): void;
 };
 
 export type HiddenProseMirrorRef = {
@@ -115,6 +150,123 @@ export type HiddenProseMirrorRef = {
   setCellSelection(anchorCellPos: number, headCellPos: number): void;
   /** Scroll the PM view to selection (no-op since hidden) */
   scrollToSelection(): void;
+};
+
+type YSyncState = {
+  binding: {
+    mapping: Parameters<typeof relativePositionToAbsolutePosition>[3];
+  };
+  doc: Y.Doc;
+  type: XmlFragment;
+};
+
+type AwarenessCursor = {
+  anchor: Record<string, unknown>;
+  head: Record<string, unknown>;
+};
+
+type AwarenessUser = {
+  color: string;
+  name: string;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isYSyncState = (value: unknown): value is YSyncState => {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+  const binding = value["binding"];
+  return (
+    value["doc"] instanceof Y.Doc &&
+    value["type"] instanceof Y.XmlFragment &&
+    isObjectRecord(binding) &&
+    binding["mapping"] instanceof Map
+  );
+};
+
+const readAwarenessCursor = (state: unknown): AwarenessCursor | null => {
+  if (!isObjectRecord(state)) {
+    return null;
+  }
+  const cursor = state["cursor"];
+  if (!isObjectRecord(cursor)) {
+    return null;
+  }
+  const anchor = cursor["anchor"];
+  const head = cursor["head"];
+  if (!isObjectRecord(anchor) || !isObjectRecord(head)) {
+    return null;
+  }
+  return { anchor, head };
+};
+
+const readAwarenessUser = (state: unknown, clientId: number): AwarenessUser => {
+  if (!isObjectRecord(state) || !isObjectRecord(state["user"])) {
+    return {
+      color: "var(--doc-image-selection)",
+      name: `User ${clientId}`,
+    };
+  }
+
+  const user = state["user"];
+  return {
+    color:
+      typeof user["color"] === "string"
+        ? user["color"]
+        : "var(--doc-image-selection)",
+    name: typeof user["name"] === "string" ? user["name"] : `User ${clientId}`,
+  };
+};
+
+const collectRemoteSelections = (
+  state: EditorState,
+  awareness: CollaborationAwareness,
+): HiddenProseMirrorRemoteSelection[] => {
+  const syncState: unknown = ySyncPluginKey.getState(state);
+  if (!isYSyncState(syncState)) {
+    return [];
+  }
+
+  const selections: HiddenProseMirrorRemoteSelection[] = [];
+  for (const [clientId, remoteState] of awareness.getStates()) {
+    if (clientId === awareness.clientID) {
+      continue;
+    }
+
+    const cursor = readAwarenessCursor(remoteState);
+    if (cursor === null) {
+      continue;
+    }
+
+    const anchor = relativePositionToAbsolutePosition(
+      syncState.doc,
+      syncState.type,
+      Y.createRelativePositionFromJSON(cursor.anchor),
+      syncState.binding.mapping,
+    );
+    const head = relativePositionToAbsolutePosition(
+      syncState.doc,
+      syncState.type,
+      Y.createRelativePositionFromJSON(cursor.head),
+      syncState.binding.mapping,
+    );
+    if (anchor === null || head === null) {
+      continue;
+    }
+
+    const user = readAwarenessUser(remoteState, clientId);
+    selections.push({
+      anchor,
+      clientId,
+      color: user.color,
+      head,
+      name: user.name,
+    });
+  }
+
+  return selections;
 };
 
 // ============================================================================
@@ -156,14 +308,31 @@ function createInitialState(
   styles: StyleDefinitions | null | undefined,
   manager?: ExtensionManager,
   externalPlugins: Plugin[] = [],
+  collaboration?: HiddenProseMirrorCollaboration,
 ): EditorState {
   const activeSchema = manager?.getSchema() ?? schema;
-  let doc = createEmptyDoc();
-  if (document) {
-    doc =
-      styles === undefined || styles === null
-        ? toProseDoc(document)
-        : toProseDoc(document, { styles });
+  const localDoc = document
+    ? styles === undefined || styles === null
+      ? toProseDoc(document)
+      : toProseDoc(document, { styles })
+    : createEmptyDoc();
+
+  if (collaboration) {
+    if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
+      prosemirrorToYXmlFragment(localDoc, collaboration.yXmlFragment);
+      collaboration.onSeeded?.();
+    }
+
+    const { doc } = initProseMirrorDoc(
+      collaboration.yXmlFragment,
+      activeSchema,
+    );
+
+    return EditorState.create({
+      doc,
+      schema: activeSchema,
+      plugins: [...externalPlugins, ...(manager?.getPlugins() ?? [])],
+    });
   }
 
   // External plugins go first so they can intercept before extension keymaps
@@ -174,7 +343,7 @@ function createInitialState(
   ];
 
   return EditorState.create({
-    doc,
+    doc: localDoc,
     schema: activeSchema,
     plugins,
   });
@@ -215,11 +384,13 @@ const HiddenProseMirrorComponent = forwardRef<
     onTransaction,
     onSelectionChange,
     externalPlugins = [],
+    collaboration,
     extensionManager,
     onEditorViewReady,
     onEditorViewDestroy,
     onKeyDown,
     onReadOnlyEditAttempt,
+    onRemoteSelectionsChange,
   } = props;
 
   // Refs
@@ -231,6 +402,7 @@ const HiddenProseMirrorComponent = forwardRef<
   // Track the document identity to detect truly external changes
   // vs changes that originated from editing (which get passed back through props)
   const lastDocumentIdRef = useRef<string | null>(null);
+  const lastCollaborationFragmentRef = useRef<XmlFragment | null>(null);
   // Track if we've initialized - first render needs to set up state
   const isInitializedRef = useRef(false);
 
@@ -242,6 +414,7 @@ const HiddenProseMirrorComponent = forwardRef<
   const onEditorViewDestroyRef = useRef(onEditorViewDestroy);
   const onKeyDownRef = useRef(onKeyDown);
   const onReadOnlyEditAttemptRef = useRef(onReadOnlyEditAttempt);
+  const onRemoteSelectionsChangeRef = useRef(onRemoteSelectionsChange);
 
   // Keep refs in sync
   readOnlyRef.current = readOnly;
@@ -251,6 +424,7 @@ const HiddenProseMirrorComponent = forwardRef<
   onEditorViewDestroyRef.current = onEditorViewDestroy;
   onKeyDownRef.current = onKeyDown;
   onReadOnlyEditAttemptRef.current = onReadOnlyEditAttempt;
+  onRemoteSelectionsChangeRef.current = onRemoteSelectionsChange;
 
   // Keep document ref in sync
   documentRef.current = document;
@@ -273,6 +447,7 @@ const HiddenProseMirrorComponent = forwardRef<
       styles,
       extensionManager,
       externalPlugins,
+      collaboration,
     );
 
     const editorProps: DirectEditorProps = {
@@ -297,6 +472,12 @@ const HiddenProseMirrorComponent = forwardRef<
         // Notify about selection changes (use ref to avoid dependency issues)
         if (transaction.selectionSet || transaction.docChanged) {
           onSelectionChangeRef.current?.(newState);
+        }
+
+        if (collaboration?.awareness) {
+          onRemoteSelectionsChangeRef.current?.(
+            collectRemoteSelections(newState, collaboration.awareness),
+          );
         }
       },
       // Intercept key events before ProseMirror processes them
@@ -349,9 +530,35 @@ const HiddenProseMirrorComponent = forwardRef<
     document,
     styles,
     externalPlugins,
+    collaboration,
     extensionManager,
     // Callbacks removed from dependencies - accessed via refs
   ]);
+
+  useEffect(() => {
+    const awareness = collaboration?.awareness;
+    if (!awareness || !viewRef.current) {
+      onRemoteSelectionsChangeRef.current?.([]);
+      return undefined;
+    }
+
+    const publishRemoteSelections = () => {
+      if (!viewRef.current) {
+        return;
+      }
+      onRemoteSelectionsChangeRef.current?.(
+        collectRemoteSelections(viewRef.current.state, awareness),
+      );
+    };
+
+    awareness.on("change", publishRemoteSelections);
+    publishRemoteSelections();
+
+    return () => {
+      awareness.off("change", publishRemoteSelections);
+      onRemoteSelectionsChangeRef.current?.([]);
+    };
+  }, [collaboration?.awareness]);
 
   /**
    * Destroy EditorView
@@ -384,6 +591,10 @@ const HiddenProseMirrorComponent = forwardRef<
       return;
     }
 
+    if (collaboration) {
+      return;
+    }
+
     // Generate a simple document identity based on its structure
     // This helps detect truly different documents vs the same doc passed back after editing
     const getDocumentId = (doc: Document | null): string => {
@@ -401,14 +612,19 @@ const HiddenProseMirrorComponent = forwardRef<
     };
 
     const currentDocId = getDocumentId(document);
+    const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
+    const collaborationSourceChanged =
+      currentCollaborationFragment !== lastCollaborationFragmentRef.current;
 
     // Skip if this is the same document (likely passed back after internal edit)
     // Only reset state if:
     // 1. Not yet initialized (first mount)
     // 2. Document identity changed (truly external change like loading a new file)
+    // 3. Collaboration starts/stops or switches sessions
     if (
       isInitializedRef.current &&
-      currentDocId === lastDocumentIdRef.current
+      currentDocId === lastDocumentIdRef.current &&
+      !collaborationSourceChanged
     ) {
       return;
     }
@@ -416,6 +632,7 @@ const HiddenProseMirrorComponent = forwardRef<
     // Update tracking refs
     isInitializedRef.current = true;
     lastDocumentIdRef.current = currentDocId;
+    lastCollaborationFragmentRef.current = currentCollaborationFragment;
 
     // Create new state from document
     const newState = createInitialState(
@@ -423,12 +640,13 @@ const HiddenProseMirrorComponent = forwardRef<
       styles,
       extensionManager,
       externalPlugins,
+      collaboration,
     );
     viewRef.current.updateState(newState);
 
     // Use ref to avoid infinite loop when callback is unstable
     onSelectionChangeRef.current?.(newState);
-  }, [document, styles, extensionManager, externalPlugins]);
+  }, [document, styles, extensionManager, externalPlugins, collaboration]);
   // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
 
   // Update editable state

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -128,7 +128,11 @@ import {
   computeHeaderFooterMarginExtender,
 } from "./headerFooterMargins";
 import { HiddenProseMirror } from "./HiddenProseMirror";
-import type { HiddenProseMirrorRef } from "./HiddenProseMirror";
+import type {
+  HiddenProseMirrorCollaboration,
+  HiddenProseMirrorRemoteSelection,
+  HiddenProseMirrorRef,
+} from "./HiddenProseMirror";
 import { ImageSelectionOverlay } from "./ImageSelectionOverlay";
 import type { ImageSelectionInfo } from "./ImageSelectionOverlay";
 import {
@@ -204,6 +208,8 @@ export type PagedEditorProps = {
   }) => void;
   /** External ProseMirror plugins. */
   externalPlugins?: Plugin[];
+  /** Optional Yjs collaboration owner for the hidden ProseMirror state. */
+  collaboration?: HiddenProseMirrorCollaboration | undefined;
   /** Extension manager for plugins/schema/commands (optional — falls back to default) */
   extensionManager?: ExtensionManager;
   /** Callback when header or footer is double-clicked for editing. */
@@ -377,6 +383,106 @@ const viewportStyles: CSSProperties = {
   paddingTop: VIEWPORT_PADDING_TOP,
   paddingBottom: 24,
   backgroundColor: "transparent",
+};
+
+type RemoteSelectionOverlayProps = {
+  blocks: FlowBlock[];
+  layout: Layout;
+  measures: Measure[];
+  pagesContainer: HTMLDivElement | null;
+  remoteSelection: HiddenProseMirrorRemoteSelection;
+  zoom: number;
+};
+
+const getPageOverlayOffset = (pagesContainer: HTMLDivElement, zoom: number) => {
+  const overlay = pagesContainer.parentElement?.querySelector(
+    '[data-testid="selection-overlay"]',
+  );
+  const firstPage = pagesContainer.querySelector(".layout-page");
+  if (!overlay || !firstPage) {
+    return null;
+  }
+
+  const overlayRect = overlay.getBoundingClientRect();
+  const pageRect = firstPage.getBoundingClientRect();
+  return {
+    x: (pageRect.left - overlayRect.left) / zoom,
+    y: (pageRect.top - overlayRect.top) / zoom,
+  };
+};
+
+const RemoteSelectionOverlay = ({
+  blocks,
+  layout,
+  measures,
+  pagesContainer,
+  remoteSelection,
+  zoom,
+}: RemoteSelectionOverlayProps) => {
+  if (!pagesContainer) {
+    return null;
+  }
+
+  const offset = getPageOverlayOffset(pagesContainer, zoom);
+  if (!offset) {
+    return null;
+  }
+
+  const from = Math.min(remoteSelection.anchor, remoteSelection.head);
+  const to = Math.max(remoteSelection.anchor, remoteSelection.head);
+  const selectionRects = selectionToRects(
+    layout,
+    blocks,
+    measures,
+    from,
+    to,
+  ).map((rect) => ({
+    height: rect.height,
+    pageIndex: rect.pageIndex,
+    width: rect.width,
+    x: rect.x + offset.x,
+    y: rect.y + offset.y,
+  }));
+  const caretBase = getCaretPosition(
+    layout,
+    blocks,
+    measures,
+    remoteSelection.head,
+  );
+  const caretPosition = caretBase
+    ? {
+        ...caretBase,
+        x: caretBase.x + offset.x,
+        y: caretBase.y + offset.y,
+      }
+    : null;
+
+  return (
+    <>
+      <SelectionOverlay
+        blinkInterval={0}
+        caretColor={remoteSelection.color}
+        caretPosition={caretPosition}
+        caretWidth={2}
+        isFocused
+        selectionColor={`color-mix(in srgb, ${remoteSelection.color} 24%, transparent)`}
+        selectionRects={selectionRects}
+      />
+      {caretPosition && (
+        <div
+          className="pointer-events-none absolute z-20 rounded-sm px-1 py-0.5 text-[10px] leading-none shadow-sm"
+          style={{
+            backgroundColor: remoteSelection.color,
+            color: "var(--background)",
+            left: caretPosition.x,
+            top: Math.max(0, caretPosition.y - 18),
+          }}
+        >
+          {remoteSelection.name}
+        </div>
+      )}
+    </>
+  );
 };
 
 const pagesContainerStyles: CSSProperties = {
@@ -1388,6 +1494,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onSelectionChange,
       onSelectionTextChange,
       externalPlugins = EMPTY_PLUGINS,
+      collaboration,
       extensionManager,
       onHeaderFooterDoubleClick,
       hfEditMode,
@@ -1468,6 +1575,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // doesn't depend on a state setter callback that would trigger
     // its own re-run.
     const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
+    const [remoteSelections, setRemoteSelections] = useState<
+      HiddenProseMirrorRemoteSelection[]
+    >([]);
     const suppressSelectionOverlayRef = useRef(false);
     const revealSelectionOverlayTimerRef = useRef<number | null>(null);
 
@@ -4631,10 +4741,12 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           readOnly={readOnly}
           onTransaction={handleTransaction}
           onSelectionChange={handleSelectionChange}
+          onRemoteSelectionsChange={setRemoteSelections}
           onEditorViewReady={handleEditorViewReady}
           onKeyDown={handlePMKeyDown}
           {...(styles !== undefined ? { styles } : {})}
           externalPlugins={externalPlugins}
+          {...(collaboration !== undefined ? { collaboration } : {})}
           {...(extensionManager !== undefined ? { extensionManager } : {})}
           {...(onReadOnlyEditAttempt !== undefined
             ? { onReadOnlyEditAttempt }
@@ -4677,6 +4789,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               isFocused={isFocused}
               pageGap={pageGap}
             />
+            {layout &&
+              remoteSelections.map((remoteSelection) => (
+                <RemoteSelectionOverlay
+                  key={remoteSelection.clientId}
+                  blocks={blocks}
+                  layout={layout}
+                  measures={measures}
+                  pagesContainer={pagesContainerRef.current}
+                  remoteSelection={remoteSelection}
+                  zoom={zoom}
+                />
+              ))}
 
             {/* Image selection overlay */}
             {!readOnly && (

--- a/packages/folio/src/paged-editor/SelectionOverlay.tsx
+++ b/packages/folio/src/paged-editor/SelectionOverlay.tsx
@@ -120,7 +120,9 @@ const Caret: React.FC<{
     }
 
     // Only blink when focused and interval is set
-    if (isFocused && blinkInterval > 0) {
+    if (isFocused && blinkInterval === 0) {
+      setVisible(true);
+    } else if (isFocused && blinkInterval > 0) {
       setVisible(true);
       blinkTimerRef.current = window.setInterval(() => {
         setVisible((v) => !v);
@@ -148,6 +150,9 @@ const Caret: React.FC<{
     // Restart blink timer from this moment
     if (blinkTimerRef.current) {
       window.clearInterval(blinkTimerRef.current);
+    }
+    if (blinkInterval === 0) {
+      return undefined;
     }
     if (blinkInterval > 0) {
       blinkTimerRef.current = window.setInterval(() => {


### PR DESCRIPTION
## Summary
- add token-authorized Folio collaboration sessions and persistence APIs
- add a Bun-native Hocuspocus collaboration service
- wire Yjs collaboration into Folio DOCX editing behind feature flags