### PR TITLE
fix: keep folio highlights readable

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -146,4 +146,23 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.underline).toEqual({ style: "single" });
     expect(run.smallCaps).toBe(true);
   });
+
+  test("omits automatic paragraph default text colors from runs", () => {
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            color: { auto: true },
+            highlight: "darkBlue",
+          },
+        },
+        [schema.text("body text")],
+      ),
+    ]);
+    const run = firstRun(toFlowBlocks(doc, {}));
+
+    expect(run.color).toBeUndefined();
+    expect(run.highlight).toBe("#00008B");
+  });
 });

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -159,8 +159,7 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.smallCaps).toBe(true);
   });
 
-  test("keeps merged paragraph default black identifiable on highlighted runs", () => {
-    const textColor = schema.marks.textColor.create({ rgb: "000000" });
+  test("keeps inherited paragraph default black identifiable on highlighted runs", () => {
     const highlight = schema.marks.highlight.create({ color: "darkBlue" });
     const doc = schema.node("doc", null, [
       schema.node(
@@ -171,13 +170,34 @@ describe("toFlowBlocks run-level OOXML marks", () => {
             highlight: "darkBlue",
           },
         },
-        [schema.text("body text", [textColor, highlight])],
+        [schema.text("body text", [highlight])],
       ),
     ]);
     const run = firstRun(toFlowBlocks(doc, {}));
 
     expect(run.color).toBe("#000000");
     expect(run.textColorSource).toBe("paragraphDefault");
+    expect(run.highlight).toBe("#00008B");
+  });
+
+  test("keeps direct black text colors marked as direct when paragraph default is also black", () => {
+    const textColor = schema.marks.textColor.create({ rgb: "000000" });
+    const highlight = schema.marks.highlight.create({ color: "darkBlue" });
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            color: { rgb: "000000" },
+          },
+        },
+        [schema.text("body text", [textColor, highlight])],
+      ),
+    ]);
+    const run = firstRun(toFlowBlocks(doc, {}));
+
+    expect(run.color).toBe("#000000");
+    expect(run.textColorSource).toBe("direct");
     expect(run.highlight).toBe("#00008B");
   });
 

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -35,6 +35,17 @@ const schema = new Schema({
         kerning: { default: null },
       },
     },
+    textColor: {
+      attrs: {
+        rgb: { default: null },
+        themeColor: { default: null },
+        themeTint: { default: null },
+        themeShade: { default: null },
+      },
+    },
+    highlight: {
+      attrs: { color: {} },
+    },
   },
 });
 
@@ -143,8 +154,50 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.fontSize).toBe(11);
     expect(run.bold).toBe(true);
     expect(run.color).toBe("#C00000");
+    expect(run.textColorSource).toBe("paragraphDefault");
     expect(run.underline).toEqual({ style: "single" });
     expect(run.smallCaps).toBe(true);
+  });
+
+  test("keeps merged paragraph default black identifiable on highlighted runs", () => {
+    const textColor = schema.marks.textColor.create({ rgb: "000000" });
+    const highlight = schema.marks.highlight.create({ color: "darkBlue" });
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            color: { rgb: "000000" },
+            highlight: "darkBlue",
+          },
+        },
+        [schema.text("body text", [textColor, highlight])],
+      ),
+    ]);
+    const run = firstRun(toFlowBlocks(doc, {}));
+
+    expect(run.color).toBe("#000000");
+    expect(run.textColorSource).toBe("paragraphDefault");
+    expect(run.highlight).toBe("#00008B");
+  });
+
+  test("keeps distinguishable direct black text colors marked as direct", () => {
+    const textColor = schema.marks.textColor.create({ rgb: "000000" });
+    const doc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            color: { rgb: "C00000" },
+          },
+        },
+        [schema.text("body text", [textColor])],
+      ),
+    ]);
+    const run = firstRun(toFlowBlocks(doc, {}));
+
+    expect(run.color).toBe("#000000");
+    expect(run.textColorSource).toBe("direct");
   });
 
   test("omits automatic paragraph default text colors from runs", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -42,6 +42,7 @@ import type {
 } from "../prosemirror/schema/marks";
 import type { ParagraphAttrs as PMParagraphAttrs } from "../prosemirror/schema/nodes";
 import type {
+  ColorValue,
   Theme,
   SectionProperties,
   NumberFormat,
@@ -357,7 +358,7 @@ function extractRunFormatting(
       case "textColor": {
         const attrs = mark.attrs as TextColorAttrs;
         if (attrs.themeColor || attrs.rgb) {
-          const colorArg: Parameters<typeof resolveColor>[0] = {};
+          const colorArg: ColorValue = {};
           if (attrs.rgb) {
             colorArg.rgb = attrs.rgb;
           }
@@ -370,7 +371,9 @@ function extractRunFormatting(
           if (attrs.themeShade) {
             colorArg.themeShade = attrs.themeShade;
           }
-          formatting.color = resolveColor(colorArg, theme);
+          if (!isAutomaticTextColorValue(colorArg)) {
+            formatting.color = resolveColor(colorArg, theme);
+          }
         }
         break;
       }
@@ -525,6 +528,11 @@ function extractRunFormatting(
   return formatting;
 }
 
+function isAutomaticTextColorValue(color: ColorValue): boolean {
+  const rgb = color.rgb?.trim().toLowerCase();
+  return color.auto === true || rgb === "auto" || (!rgb && !color.themeColor);
+}
+
 function applyRunFormattingOverrides(
   formatting: RunFormatting,
   mark: Mark,
@@ -606,7 +614,10 @@ function paragraphRunDefaults(
   if (defaultTextFormatting.strike !== undefined) {
     result.strike = defaultTextFormatting.strike;
   }
-  if (defaultTextFormatting.color) {
+  if (
+    defaultTextFormatting.color &&
+    !isAutomaticTextColorValue(defaultTextFormatting.color)
+  ) {
     result.color = resolveColor(defaultTextFormatting.color, theme);
   }
   if (defaultTextFormatting.highlight) {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -83,6 +83,19 @@ const DEFAULT_TABLE_CELL_MARGIN_TWIPS = {
   left: 108,
 } as const;
 type TablePaddingSide = keyof typeof DEFAULT_TABLE_CELL_MARGIN_TWIPS;
+const DEFAULT_BLACK_TEXT_COLOR_VALUES = new Set(["000000", "000"]);
+
+function normalizeResolvedTextColor(color: string): string {
+  return color.trim().toLowerCase().replace(/^#/, "");
+}
+
+function isDefaultBlackResolvedTextColor(color: string): boolean {
+  return DEFAULT_BLACK_TEXT_COLOR_VALUES.has(normalizeResolvedTextColor(color));
+}
+
+function areResolvedTextColorsEqual(left: string, right: string): boolean {
+  return normalizeResolvedTextColor(left) === normalizeResolvedTextColor(right);
+}
 
 /**
  * Constrain image dimensions to fit within the page content area.
@@ -373,6 +386,7 @@ function extractRunFormatting(
           }
           if (!isAutomaticTextColorValue(colorArg)) {
             formatting.color = resolveColor(colorArg, theme);
+            formatting.textColorSource = "direct";
           }
         }
         break;
@@ -533,6 +547,35 @@ function isAutomaticTextColorValue(color: ColorValue): boolean {
   return color.auto === true || rgb === "auto" || (!rgb && !color.themeColor);
 }
 
+function markDefaultBlackTextColorSource(
+  formatting: RunFormatting,
+  paraDefaults: RunFormatting,
+): RunFormatting {
+  if (
+    formatting.color === undefined ||
+    paraDefaults.color === undefined ||
+    !isDefaultBlackResolvedTextColor(formatting.color) ||
+    !areResolvedTextColorsEqual(formatting.color, paraDefaults.color)
+  ) {
+    return formatting;
+  }
+
+  return {
+    ...formatting,
+    textColorSource: "paragraphDefault",
+  };
+}
+
+function mergeRunFormatting(
+  paraDefaults: RunFormatting,
+  formatting: RunFormatting,
+): RunFormatting {
+  return {
+    ...paraDefaults,
+    ...markDefaultBlackTextColorSource(formatting, paraDefaults),
+  };
+}
+
 function applyRunFormattingOverrides(
   formatting: RunFormatting,
   mark: Mark,
@@ -619,6 +662,7 @@ function paragraphRunDefaults(
     !isAutomaticTextColorValue(defaultTextFormatting.color)
   ) {
     result.color = resolveColor(defaultTextFormatting.color, theme);
+    result.textColorSource = "paragraphDefault";
   }
   if (defaultTextFormatting.highlight) {
     const highlight = resolveHighlightToCss(defaultTextFormatting.highlight);
@@ -760,8 +804,7 @@ function paragraphToRuns(
       const run: TextRun = {
         kind: "text",
         text: child.text,
-        ...paraDefaults,
-        ...formatting,
+        ...mergeRunFormatting(paraDefaults, formatting),
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
       };
@@ -779,8 +822,7 @@ function paragraphToRuns(
       const formatting = extractRunFormatting(child.marks, theme);
       const run: TabRun = {
         kind: "tab",
-        ...paraDefaults,
-        ...formatting,
+        ...mergeRunFormatting(paraDefaults, formatting),
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
       };
@@ -820,7 +862,10 @@ function paragraphToRuns(
               : ft === "TIME"
                 ? "TIME"
                 : "OTHER";
-      const fieldFormatting = extractRunFormatting(child.marks, theme);
+      const fieldFormatting = markDefaultBlackTextColorSource(
+        extractRunFormatting(child.marks, theme),
+        paraDefaults,
+      );
       const run: FieldRun = {
         kind: "field",
         fieldType: mappedType,
@@ -854,8 +899,7 @@ function paragraphToRuns(
           const run: TextRun = {
             kind: "text",
             text: sdtChild.text,
-            ...paraDefaults,
-            ...formatting,
+            ...mergeRunFormatting(paraDefaults, formatting),
             pmStart: sdtChildPos,
             pmEnd: sdtChildPos + sdtChild.nodeSize,
           };
@@ -871,8 +915,7 @@ function paragraphToRuns(
           const formatting = extractRunFormatting(sdtChild.marks, theme);
           const run: TabRun = {
             kind: "tab",
-            ...paraDefaults,
-            ...formatting,
+            ...mergeRunFormatting(paraDefaults, formatting),
             pmStart: sdtChildPos,
             pmEnd: sdtChildPos + sdtChild.nodeSize,
           };

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -552,6 +552,7 @@ function markDefaultBlackTextColorSource(
   paraDefaults: RunFormatting,
 ): RunFormatting {
   if (
+    formatting.textColorSource === "direct" ||
     formatting.color === undefined ||
     paraDefaults.color === undefined ||
     !isDefaultBlackResolvedTextColor(formatting.color) ||

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -24,6 +24,7 @@ export type RunFormatting = {
   underline?: boolean | { style?: string; color?: string };
   strike?: boolean;
   color?: string;
+  textColorSource?: "direct" | "paragraphDefault";
   highlight?: string;
   fontFamily?: string;
   fontSize?: number;

--- a/packages/folio/src/core/layout-painter/documentColors.test.ts
+++ b/packages/folio/src/core/layout-painter/documentColors.test.ts
@@ -11,6 +11,10 @@ describe("document automatic text color", () => {
     expect(getAutomaticTextColorForBackground("#111111")).toBe("#FFFFFF");
   });
 
+  test("uses black automatic text on mid-tone document shading", () => {
+    expect(getAutomaticTextColorForBackground("#A9A9A9")).toBe("#000000");
+  });
+
   test("leaves automatic text theme-adaptive when shading is not a concrete color", () => {
     expect(getAutomaticTextColorForBackground("auto")).toBeUndefined();
     expect(getAutomaticTextColorForBackground(undefined)).toBeUndefined();

--- a/packages/folio/src/core/layout-painter/documentColors.ts
+++ b/packages/folio/src/core/layout-painter/documentColors.ts
@@ -1,4 +1,9 @@
 const HEX_COLOR_RE = /^#?[0-9a-f]{6}$/i;
+const BLACK_TEXT_COLOR = "#000000";
+const WHITE_TEXT_COLOR = "#FFFFFF";
+const BLACK_LUMINANCE = 0;
+const WHITE_LUMINANCE = 1;
+const CONTRAST_OFFSET = 0.05;
 
 function normalizeHexColor(color: string): string | null {
   const trimmed = color.trim();
@@ -28,6 +33,12 @@ function relativeLuminance(hexColor: string): number | null {
   return 0.2126 * red + 0.7152 * green + 0.0722 * blue;
 }
 
+function contrastRatio(luminanceA: number, luminanceB: number): number {
+  const lighter = Math.max(luminanceA, luminanceB);
+  const darker = Math.min(luminanceA, luminanceB);
+  return (lighter + CONTRAST_OFFSET) / (darker + CONTRAST_OFFSET);
+}
+
 export function getAutomaticTextColorForBackground(
   backgroundColor: string | undefined,
 ): string | undefined {
@@ -40,5 +51,7 @@ export function getAutomaticTextColorForBackground(
     return undefined;
   }
 
-  return luminance > 0.45 ? "#000000" : "#FFFFFF";
+  const blackContrast = contrastRatio(luminance, BLACK_LUMINANCE);
+  const whiteContrast = contrastRatio(luminance, WHITE_LUMINANCE);
+  return blackContrast >= whiteContrast ? BLACK_TEXT_COLOR : WHITE_TEXT_COLOR;
 }

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -66,6 +66,7 @@ const fakeDocument = {
 
 const TEST_HIGHLIGHT_COLOR = "#FFFF00";
 const TEST_DARK_HIGHLIGHT_COLOR = "#000080";
+const TEST_MID_HIGHLIGHT_COLOR = "#A9A9A9";
 const TEST_EXPLICIT_BLACK_COLOR = " #000000 ";
 const TEST_EXPLICIT_TEXT_COLOR = "#C00000";
 
@@ -227,6 +228,36 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe("#FFFFFF");
+  });
+
+  test("uses the higher-contrast text color on mid-tone DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_MID_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_MID_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#000000");
   });
 
   test("keeps automatic comment text readable when comment styling overrides a DOCX highlight", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -58,6 +58,9 @@ const fakeDocument = {
   },
 } as unknown as Document;
 
+const TEST_HIGHLIGHT_COLOR = "#FFFF00";
+const TEST_EXPLICIT_TEXT_COLOR = "#C00000";
+
 describe("renderLine inline image handling", () => {
   test("pins image dimensions and centers an image-only line", () => {
     const imageRun: ImageRun = {
@@ -156,6 +159,67 @@ describe("renderLine text styling", () => {
     const textEl = lineEl.children[0] as HTMLElement | undefined;
 
     expect(textEl?.style.fontWeight).toBe("800");
+  });
+
+  test("keeps automatic text readable on bright DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#000000");
+  });
+
+  test("preserves explicit text colors on DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          color: TEST_EXPLICIT_TEXT_COLOR,
+          highlight: TEST_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -230,6 +230,38 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.color).toBe("#FFFFFF");
   });
 
+  test("keeps inherited default-black text readable on dark DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          color: TEST_EXPLICIT_BLACK_COLOR,
+          textColorSource: "paragraphDefault",
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#FFFFFF");
+  });
+
   test("keeps automatic hyperlink text readable on dark DOCX highlights", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",
@@ -238,6 +270,41 @@ describe("renderLine text styling", () => {
         {
           kind: "text",
           text: "Highlighted text",
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+          hyperlink: { href: "https://example.com" },
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+    const anchorEl = textEl?.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#FFFFFF");
+    expect(anchorEl?.style.color).toBe("#FFFFFF");
+  });
+
+  test("keeps inherited default-black hyperlink text readable on dark DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          color: TEST_EXPLICIT_BLACK_COLOR,
+          textColorSource: "paragraphDefault",
           highlight: TEST_DARK_HIGHLIGHT_COLOR,
           hyperlink: { href: "https://example.com" },
         },

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -229,6 +229,38 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.color).toBe("#FFFFFF");
   });
 
+  test("keeps automatic comment text readable when comment styling overrides a DOCX highlight", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+          commentIds: [42],
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe("rgba(255, 212, 0, 0.08)");
+    expect(textEl?.style.color).toBeUndefined();
+    expect(textEl?.dataset.commentId).toBe("42");
+  });
+
   test("preserves explicit text colors on DOCX highlights", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -330,6 +330,72 @@ describe("renderLine text styling", () => {
     expect(anchorEl?.style.color).toBe("#FFFFFF");
   });
 
+  test("preserves direct black hyperlink text without DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Linked text",
+          color: TEST_EXPLICIT_BLACK_COLOR,
+          textColorSource: "direct",
+          hyperlink: { href: "https://example.com" },
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 11,
+      width: 77,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+    const anchorEl = textEl?.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.color).toBe("#000000");
+    expect(anchorEl?.style.color).toBe("#000000");
+  });
+
+  test("uses Word blue for inherited default-black hyperlink text without DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Linked text",
+          color: TEST_EXPLICIT_BLACK_COLOR,
+          textColorSource: "paragraphDefault",
+          hyperlink: { href: "https://example.com" },
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 11,
+      width: 77,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+    const anchorEl = textEl?.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.color).toBe("#0563c1");
+    expect(anchorEl?.style.color).toBe("#0563c1");
+  });
+
   test("uses the higher-contrast text color on mid-tone DOCX highlights", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -7,6 +7,7 @@ import type {
   ParagraphFragment,
   ParagraphMeasure,
 } from "../layout-engine/types";
+import { AUTHOR_COLORS, resetAuthorColors } from "../utils/authorColors";
 import { renderLine, renderParagraphFragment } from "./renderParagraph";
 
 class FakeElement {
@@ -15,6 +16,11 @@ class FakeElement {
   innerHTML = "";
   style: Record<string, string> = {};
   children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
   height = 0;
   width = 0;
   src = "";
@@ -59,6 +65,8 @@ const fakeDocument = {
 } as unknown as Document;
 
 const TEST_HIGHLIGHT_COLOR = "#FFFF00";
+const TEST_DARK_HIGHLIGHT_COLOR = "#000080";
+const TEST_EXPLICIT_BLACK_COLOR = " #000000 ";
 const TEST_EXPLICIT_TEXT_COLOR = "#C00000";
 
 describe("renderLine inline image handling", () => {
@@ -220,6 +228,70 @@ describe("renderLine text styling", () => {
 
     expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
     expect(textEl?.style.color).toBe(TEST_EXPLICIT_TEXT_COLOR);
+  });
+
+  test("preserves explicit black text colors on DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          color: TEST_EXPLICIT_BLACK_COLOR,
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#000000");
+  });
+
+  test("preserves tracked-change author colors on DOCX highlights", () => {
+    resetAuthorColors();
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_HIGHLIGHT_COLOR,
+          isInsertion: true,
+          changeAuthor: "Reviewer",
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe(AUTHOR_COLORS[0]);
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -230,6 +230,39 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.color).toBe("#FFFFFF");
   });
 
+  test("keeps automatic hyperlink text readable on dark DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+          hyperlink: { href: "https://example.com" },
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+    const anchorEl = textEl?.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#FFFFFF");
+    expect(anchorEl?.style.color).toBe("#FFFFFF");
+  });
+
   test("uses the higher-contrast text color on mid-tone DOCX highlights", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -199,6 +199,36 @@ describe("renderLine text styling", () => {
     expect(textEl?.style.color).toBe("#000000");
   });
 
+  test("keeps automatic text readable on dark DOCX highlights", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [
+        {
+          kind: "text",
+          text: "Highlighted text",
+          highlight: TEST_DARK_HIGHLIGHT_COLOR,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 16,
+      width: 112,
+      ascent: 10,
+      descent: 2,
+      lineHeight: 12,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const textEl = lineEl.children[0] as HTMLElement | undefined;
+
+    expect(textEl?.style.backgroundColor).toBe(TEST_DARK_HIGHLIGHT_COLOR);
+    expect(textEl?.style.color).toBe("#FFFFFF");
+  });
+
   test("preserves explicit text colors on DOCX highlights", () => {
     const block: ParagraphBlock = {
       kind: "paragraph",

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -396,7 +396,7 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     }
     anchor.textContent = run.text;
     // Style hyperlink — default Word hyperlink color is blue (#0563c1)
-    const hyperlinkColor = run.color || "#0563c1";
+    const hyperlinkColor = run.color?.trim() || span.style.color || "#0563c1";
     anchor.style.color = hyperlinkColor;
     anchor.style.textDecoration = "underline";
     // Override span color to match anchor (prevents color mismatch in selection)

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -232,8 +232,10 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   if (run.highlight) {
     element.style.backgroundColor = run.highlight;
     const hasTrackedChangeColor = run.isInsertion || run.isDeletion;
+    const hasCommentHighlight =
+      run.commentIds !== undefined && run.commentIds.length > 0;
     const automaticTextColor =
-      hasExplicitTextColor || hasTrackedChangeColor
+      hasExplicitTextColor || hasTrackedChangeColor || hasCommentHighlight
         ? undefined
         : getAutomaticTextColorForBackground(run.highlight);
     if (automaticTextColor) {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -147,6 +147,19 @@ function getRenderableTextColor(run: TextRun | TabRun): string | undefined {
   return textColor.trim();
 }
 
+function getHyperlinkTextColor(run: TextRun, inheritedColor: string): string {
+  const textColor = run.color?.trim();
+  if (
+    textColor &&
+    !isAutomaticTextColor(textColor) &&
+    run.textColorSource === "direct"
+  ) {
+    return textColor;
+  }
+
+  return getRenderableTextColor(run) || inheritedColor || "#0563c1";
+}
+
 /**
  * Apply text run styles to an element
  */
@@ -412,8 +425,7 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     }
     anchor.textContent = run.text;
     // Style hyperlink — default Word hyperlink color is blue (#0563c1)
-    const hyperlinkColor =
-      getRenderableTextColor(run) || span.style.color || "#0563c1";
+    const hyperlinkColor = getHyperlinkTextColor(run, span.style.color);
     anchor.style.color = hyperlinkColor;
     anchor.style.textDecoration = "underline";
     // Override span color to match anchor (prevents color mismatch in selection)

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -101,6 +101,17 @@ function isFieldRun(run: Run): run is FieldRun {
   return run.kind === "field";
 }
 
+const DEFAULT_TEXT_COLOR_VALUES = new Set([
+  "000000",
+  "000",
+  "auto",
+  "windowtext",
+]);
+
+function isAutomaticOrDefaultTextColor(color: string): boolean {
+  return DEFAULT_TEXT_COLOR_VALUES.has(color.toLowerCase().replace(/^#/, ""));
+}
+
 /**
  * Apply text run styles to an element
  */
@@ -126,13 +137,10 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   }
 
   // Color — skip black/auto so the CSS variable --doc-canvas-text can adapt to dark mode
-  if (run.color) {
-    const c = run.color.toLowerCase().replace(/^#/, "");
-    const isBlackOrDefault =
-      c === "000000" || c === "000" || c === "auto" || c === "windowtext";
-    if (!isBlackOrDefault) {
-      element.style.color = run.color;
-    }
+  let hasExplicitTextColor = false;
+  if (run.color && !isAutomaticOrDefaultTextColor(run.color)) {
+    element.style.color = run.color;
+    hasExplicitTextColor = true;
   }
 
   // Letter spacing
@@ -203,6 +211,12 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   // Highlight (background color)
   if (run.highlight) {
     element.style.backgroundColor = run.highlight;
+    const automaticTextColor = hasExplicitTextColor
+      ? undefined
+      : getAutomaticTextColorForBackground(run.highlight);
+    if (automaticTextColor) {
+      element.style.color = automaticTextColor;
+    }
   }
 
   // Text decorations

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -101,15 +101,34 @@ function isFieldRun(run: Run): run is FieldRun {
   return run.kind === "field";
 }
 
-const DEFAULT_TEXT_COLOR_VALUES = new Set([
-  "000000",
-  "000",
-  "auto",
-  "windowtext",
-]);
+const AUTOMATIC_TEXT_COLOR_VALUES = new Set(["auto", "windowtext"]);
+const DEFAULT_BLACK_TEXT_COLOR_VALUES = new Set(["000000", "000"]);
 
-function isAutomaticOrDefaultTextColor(color: string): boolean {
-  return DEFAULT_TEXT_COLOR_VALUES.has(color.toLowerCase().replace(/^#/, ""));
+function normalizeTextColorValue(color: string): string {
+  return color.trim().toLowerCase().replace(/^#/, "");
+}
+
+function isAutomaticTextColor(color: string): boolean {
+  return AUTOMATIC_TEXT_COLOR_VALUES.has(normalizeTextColorValue(color));
+}
+
+function isDefaultBlackTextColor(color: string): boolean {
+  return DEFAULT_BLACK_TEXT_COLOR_VALUES.has(normalizeTextColorValue(color));
+}
+
+function shouldRenderTextColor(
+  color: string,
+  highlight: string | undefined,
+): boolean {
+  if (isAutomaticTextColor(color)) {
+    return false;
+  }
+
+  if (highlight) {
+    return true;
+  }
+
+  return !isDefaultBlackTextColor(color);
 }
 
 /**
@@ -138,8 +157,9 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
 
   // Color — skip black/auto so the CSS variable --doc-canvas-text can adapt to dark mode
   let hasExplicitTextColor = false;
-  if (run.color && !isAutomaticOrDefaultTextColor(run.color)) {
-    element.style.color = run.color;
+  const textColor = run.color;
+  if (textColor && shouldRenderTextColor(textColor, run.highlight)) {
+    element.style.color = textColor.trim();
     hasExplicitTextColor = true;
   }
 
@@ -211,9 +231,11 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   // Highlight (background color)
   if (run.highlight) {
     element.style.backgroundColor = run.highlight;
-    const automaticTextColor = hasExplicitTextColor
-      ? undefined
-      : getAutomaticTextColorForBackground(run.highlight);
+    const hasTrackedChangeColor = run.isInsertion || run.isDeletion;
+    const automaticTextColor =
+      hasExplicitTextColor || hasTrackedChangeColor
+        ? undefined
+        : getAutomaticTextColorForBackground(run.highlight);
     if (automaticTextColor) {
       element.style.color = automaticTextColor;
     }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -119,16 +119,32 @@ function isDefaultBlackTextColor(color: string): boolean {
 function shouldRenderTextColor(
   color: string,
   highlight: string | undefined,
+  textColorSource: TextRun["textColorSource"],
 ): boolean {
   if (isAutomaticTextColor(color)) {
     return false;
   }
 
   if (highlight) {
-    return true;
+    return (
+      textColorSource !== "paragraphDefault" || !isDefaultBlackTextColor(color)
+    );
   }
 
   return !isDefaultBlackTextColor(color);
+}
+
+function getRenderableTextColor(run: TextRun | TabRun): string | undefined {
+  const textColor = run.color;
+  if (!textColor) {
+    return undefined;
+  }
+
+  if (!shouldRenderTextColor(textColor, run.highlight, run.textColorSource)) {
+    return undefined;
+  }
+
+  return textColor.trim();
 }
 
 /**
@@ -157,9 +173,9 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
 
   // Color — skip black/auto so the CSS variable --doc-canvas-text can adapt to dark mode
   let hasExplicitTextColor = false;
-  const textColor = run.color;
-  if (textColor && shouldRenderTextColor(textColor, run.highlight)) {
-    element.style.color = textColor.trim();
+  const textColor = getRenderableTextColor(run);
+  if (textColor) {
+    element.style.color = textColor;
     hasExplicitTextColor = true;
   }
 
@@ -396,7 +412,8 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     }
     anchor.textContent = run.text;
     // Style hyperlink — default Word hyperlink color is blue (#0563c1)
-    const hyperlinkColor = run.color?.trim() || span.style.color || "#0563c1";
+    const hyperlinkColor =
+      getRenderableTextColor(run) || span.style.color || "#0563c1";
     anchor.style.color = hyperlinkColor;
     anchor.style.textDecoration = "underline";
     // Override span color to match anchor (prevents color mismatch in selection)
@@ -597,6 +614,9 @@ function renderFieldRun(
     ...(run.underline !== undefined ? { underline: run.underline } : {}),
     ...(run.strike !== undefined ? { strike: run.strike } : {}),
     ...(run.color !== undefined ? { color: run.color } : {}),
+    ...(run.textColorSource !== undefined
+      ? { textColorSource: run.textColorSource }
+      : {}),
     ...(run.highlight !== undefined ? { highlight: run.highlight } : {}),
     ...(run.fontFamily !== undefined ? { fontFamily: run.fontFamily } : {}),
     ...(run.fontSize !== undefined ? { fontSize: run.fontSize } : {}),


### PR DESCRIPTION
## Summary
- Preserve explicit text colors on highlighted DOCX runs
- Apply a contrast text color for automatic/default text when a run has a highlight
- Add regression coverage for bright highlighted runs