### PR TITLE
fix(folio): port upstream DOCX editor fixes

### DIFF
--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import type { FlowBlock, Measure } from "../layout-engine/types";
+import type {
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  TableBlock,
+} from "../layout-engine/types";
+import type { HeaderFooter } from "../types/document";
 import type { HeaderFooterMetrics } from "./headerFooterLayout";
-import { calculateHeaderFooterVisualBounds } from "./headerFooterLayout";
+import {
+  calculateHeaderFooterVisualBounds,
+  convertHeaderFooterToContent,
+  normalizeHeaderFooterMeasureBlocks,
+} from "./headerFooterLayout";
 
 const metrics: HeaderFooterMetrics = {
   section: "header",
@@ -24,6 +34,60 @@ const tableMeasure = (totalHeight: number): Measure => ({
   totalWidth: 120,
   totalHeight,
 });
+
+function paragraph(opts: Partial<ParagraphBlock> = {}): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id: opts.id ?? "p",
+    runs: opts.runs ?? [{ kind: "text", text: "Header" }],
+    ...(opts.attrs ? { attrs: opts.attrs } : {}),
+  };
+}
+
+function emptyParagraph(opts: Partial<ParagraphBlock> = {}): ParagraphBlock {
+  return paragraph({ ...opts, runs: [] });
+}
+
+function table(blocks: FlowBlock[] = []): TableBlock {
+  return {
+    kind: "table",
+    id: "table",
+    rows: [
+      {
+        id: "row",
+        cells: [
+          {
+            id: "cell",
+            blocks,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function measureBlocks(blocks: FlowBlock[]): Measure[] {
+  return blocks.map((block) => {
+    if (block.kind === "table") {
+      return {
+        kind: "table",
+        rows: [],
+        columnWidths: [120],
+        totalWidth: 120,
+        totalHeight: 24,
+      };
+    }
+
+    return {
+      kind: "paragraph",
+      lines: [],
+      totalHeight:
+        block.kind === "paragraph" && block.attrs?.suppressEmptyParagraphHeight
+          ? 0
+          : 12,
+    };
+  });
+}
 
 describe("calculateHeaderFooterVisualBounds", () => {
   test("accounts for page-anchored floating table bounds", () => {
@@ -79,5 +143,72 @@ describe("calculateHeaderFooterVisualBounds", () => {
     );
 
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 70 });
+  });
+});
+
+describe("header/footer layout conversion", () => {
+  test("routes header/footer tables through the body FlowBlock pipeline", () => {
+    const header: HeaderFooter = {
+      type: "header",
+      hdrFtrType: "default",
+      content: [
+        {
+          type: "table",
+          rows: [
+            {
+              type: "tableRow",
+              cells: [
+                {
+                  type: "tableCell",
+                  content: [{ type: "paragraph", content: [] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = convertHeaderFooterToContent(header, 600, metrics, {
+      measureBlocks,
+    });
+
+    expect(result?.blocks[0]?.kind).toBe("table");
+    expect(result?.height).toBe(24);
+  });
+
+  test("normalizes inherited spacing inside table-cell paragraphs", () => {
+    const [normalized] = normalizeHeaderFooterMeasureBlocks([
+      table([
+        paragraph({
+          id: "nested",
+          attrs: {
+            spacing: { before: 10, after: 8 },
+            spacingExplicit: { before: true },
+          },
+        }),
+      ]),
+    ]) as [TableBlock];
+    const nested = normalized.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
+
+    expect(nested.attrs?.spacing?.before).toBe(10);
+    expect(nested.attrs?.spacing?.after).toBeUndefined();
+  });
+
+  test("suppresses only the canonical trailing empty paragraph after a final table", () => {
+    const blocks = normalizeHeaderFooterMeasureBlocks([
+      table(),
+      emptyParagraph({ id: "middle" }),
+      paragraph({ id: "body" }),
+      table(),
+      emptyParagraph({ id: "trailing" }),
+    ]);
+
+    expect(
+      (blocks[1] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight,
+    ).toBeUndefined();
+    expect(
+      (blocks[4] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight,
+    ).toBe(true);
   });
 });

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -24,6 +24,7 @@ import type {
   Measure,
   PageMargins,
   Run,
+  TableBlock,
   TableMeasure,
 } from "../layout-engine/types";
 import type { HeaderFooterContent } from "../layout-painter/renderPage";
@@ -109,6 +110,10 @@ function hasAuthoredVisualContent(block: FlowBlock): boolean {
 export function normalizeHeaderFooterMeasureBlocks(
   blocks: FlowBlock[],
 ): FlowBlock[] {
+  return normalizeFlowBlockArray(blocks);
+}
+
+function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
   // Only the *canonical trailing* OOXML paragraph after the LAST block
   // qualifies for height suppression. Empty paragraphs used as authored
   // spacers in the middle of an HF (e.g. `[table, blank, paragraph,
@@ -130,6 +135,9 @@ export function normalizeHeaderFooterMeasureBlocks(
   }
 
   return blocks.map((block, index) => {
+    if (block.kind === "table") {
+      return normalizeTableBlock(block);
+    }
     if (block.kind !== "paragraph") {
       return block;
     }
@@ -177,6 +185,31 @@ export function normalizeHeaderFooterMeasureBlocks(
       ? { ...block, runs: inlineRuns, attrs }
       : { ...block, runs: inlineRuns };
   });
+}
+
+function normalizeTableBlock(block: TableBlock): TableBlock {
+  let changed = false;
+  const rows = block.rows.map((row) => {
+    let rowChanged = false;
+    const cells = row.cells.map((cell) => {
+      const normalizedBlocks = normalizeFlowBlockArray(cell.blocks);
+      const cellChanged = normalizedBlocks.some(
+        (normalizedBlock, idx) => normalizedBlock !== cell.blocks[idx],
+      );
+      if (!cellChanged) {
+        return cell;
+      }
+      rowChanged = true;
+      return { ...cell, blocks: normalizedBlocks };
+    });
+    if (!rowChanged) {
+      return row;
+    }
+    changed = true;
+    return { ...row, cells };
+  });
+
+  return changed ? { ...block, rows } : block;
 }
 
 // =============================================================================

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -124,6 +124,38 @@ describe("empty paragraph line-height floor", () => {
     expect(measure.totalHeight).toBeCloseTo(11 * PT_TO_PX * 1.15 + 12, 1);
   });
 
+  for (const text of ["", " ", "\u00a0"]) {
+    test(`visually empty single text run ${JSON.stringify(text)} includes authored spacing`, () => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "t3-text-run",
+          pmStart: 0,
+          pmEnd: 0,
+          runs: [{ kind: "text", text }],
+          attrs: {
+            defaultFontSize: 11,
+            defaultFontFamily: "Arial Narrow",
+            spacing: {
+              before: 5,
+              after: 7,
+              line: 1,
+              lineUnit: "multiplier",
+              lineRule: "auto",
+            },
+          },
+        },
+        600,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+      expect(measure.totalHeight).toBeCloseTo(
+        (measure.lines[0]?.lineHeight ?? 0) + 12,
+        1,
+      );
+    });
+  }
+
   test("suppressed empty paragraph keeps a zero-height anchor", () => {
     const measure = measureParagraph(
       {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -297,7 +297,7 @@ function isFieldRun(run: Run): run is FieldRun {
  * Check if text run is empty (only whitespace or no text)
  */
 function isEmptyTextRun(run: TextRun): boolean {
-  return !run.text || run.text.length === 0;
+  return !run.text || run.text.replace(/\u00a0/g, " ").trim().length === 0;
 }
 
 /**
@@ -521,10 +521,18 @@ export function measureParagraph(
       ...emptyMetrics,
     });
 
+    let totalHeight = emptyMetrics.lineHeight;
+    if (spacing?.before) {
+      totalHeight += spacing.before;
+    }
+    if (spacing?.after) {
+      totalHeight += spacing.after;
+    }
+
     return {
       kind: "paragraph",
       lines,
-      totalHeight: emptyMetrics.lineHeight,
+      totalHeight,
     };
   }
 

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -1,7 +1,46 @@
 import { describe, expect, test } from "bun:test";
 
-import type { Document } from "../../types/document";
+import type { Document, TableCell, Theme } from "../../types/document";
 import { toProseDoc } from "./toProseDoc";
+
+const officeTheme: Theme = {
+  colorScheme: {
+    dk1: "000000",
+    lt1: "FFFFFF",
+    dk2: "44546A",
+    lt2: "E7E6E6",
+    accent1: "4472C4",
+    accent2: "ED7D31",
+    accent3: "A5A5A5",
+    accent4: "FFC000",
+    accent5: "5B9BD5",
+    accent6: "70AD47",
+    hlink: "0563C1",
+    folHlink: "954F72",
+  },
+};
+
+function tableCellBorderColor(
+  attrs: Record<string, unknown>,
+  side: "top" | "bottom" | "left" | "right",
+): { rgb?: string; themeColor?: string } | undefined {
+  const borders = attrs["borders"] as
+    | Record<string, { color?: { rgb?: string; themeColor?: string } }>
+    | null
+    | undefined;
+  return borders?.[side]?.color;
+}
+
+function firstTableCellAttrs(doc: Document): Record<string, unknown> {
+  const pmDoc = toProseDoc(doc, {
+    ...(doc.package.styles ? { styles: doc.package.styles } : {}),
+    ...(doc.package.theme !== undefined ? { theme: doc.package.theme } : {}),
+  });
+  const firstTable = pmDoc.firstChild;
+  const firstRow = firstTable?.firstChild;
+  const firstCell = firstRow?.firstChild;
+  return (firstCell?.attrs ?? {}) as Record<string, unknown>;
+}
 
 describe("toProseDoc", () => {
   test("applies oneNDA paragraph mark defaults to unformatted visible text like Word", () => {
@@ -138,6 +177,81 @@ describe("toProseDoc", () => {
     expect(
       text?.marks.find((mark) => mark.type.name === "fontFamily")?.attrs.ascii,
     ).toBe("Open Sans Light");
+  });
+
+  test("resolves themed table-cell border colors against the document theme", () => {
+    const cellFormatting: TableCell["formatting"] = {
+      borders: {
+        top: {
+          style: "single",
+          size: 8,
+          color: { themeColor: "accent2" },
+        },
+      },
+    };
+    const document: Document = {
+      package: {
+        theme: officeTheme,
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  cells: [
+                    {
+                      formatting: cellFormatting,
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const attrs = firstTableCellAttrs(document);
+
+    expect(tableCellBorderColor(attrs, "top")?.rgb).toBe("ED7D31");
+    expect(tableCellBorderColor(attrs, "top")?.themeColor).toBeUndefined();
+  });
+
+  test("keeps unresolved themed table-cell border colors when no document theme exists", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  cells: [
+                    {
+                      formatting: {
+                        borders: {
+                          left: {
+                            style: "single",
+                            size: 8,
+                            color: { themeColor: "accent1", themeTint: "33" },
+                          },
+                        },
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const attrs = firstTableCellAttrs(document);
+
+    expect(tableCellBorderColor(attrs, "left")?.themeColor).toBe("accent1");
   });
 
   test("applies built-in Word Normal defaults when styles.xml is absent", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -41,6 +41,7 @@ import type {
   MathEquation,
   Theme,
 } from "../../types/document";
+import { resolveColor } from "../../utils/colorResolver";
 import { mergeTextFormatting } from "../../utils/textFormattingMerge";
 import { emuToPixels } from "../../utils/units";
 import { buildRunFormattingOverrideAttrs } from "../extensions/marks/RunFormattingOverrideExtension";
@@ -82,6 +83,7 @@ export function toProseDoc(
   const nodes: PMNode[] = [];
 
   const styleResolver = createStyleResolver(options?.styles);
+  const theme = options?.theme ?? document.package.theme ?? null;
 
   for (const block of paragraphs) {
     if (block.type === "paragraph") {
@@ -98,7 +100,7 @@ export function toProseDoc(
         nodes.push(schema.node("pageBreak"));
       }
     } else if (block.type === "table") {
-      const pmTable = convertTable(block, styleResolver);
+      const pmTable = convertTable(block, styleResolver, theme);
       nodes.push(pmTable);
     }
   }
@@ -748,6 +750,7 @@ function calculateRowSpans(
 function convertTable(
   table: Table,
   styleResolver: StyleResolver | null,
+  theme: Theme | null | undefined,
 ): PMNode {
   // Calculate rowSpan values from vMerge
   const rowSpanMap = calculateRowSpans(table);
@@ -921,6 +924,7 @@ function convertTable(
       totalColumns,
       rowSpanMap,
       cellMarginsAttr,
+      theme,
     );
   });
 
@@ -965,6 +969,7 @@ function convertTableRow(
     left?: number;
     right?: number;
   },
+  theme?: Theme | null,
 ): PMNode {
   const attrs: TableRowAttrs = {
     // isHeader controls header row REPETITION on page breaks.
@@ -1173,11 +1178,48 @@ function convertTableRow(
         isLastCol,
         calculatedRowSpan,
         defaultCellMargins,
+        theme,
       ),
     );
   }
 
   return schema.node("tableRow", attrs, cells);
+}
+
+const TABLE_BORDER_SIDES = [
+  "top",
+  "bottom",
+  "left",
+  "right",
+  "insideH",
+  "insideV",
+] as const satisfies readonly (keyof TableBorders)[];
+
+function resolveThemedBorderColors(
+  borders: TableBorders | undefined,
+  theme: Theme | null | undefined,
+): TableBorders | undefined {
+  if (!borders || !theme?.colorScheme) {
+    return borders;
+  }
+
+  let resolved: TableBorders | undefined;
+  for (const side of TABLE_BORDER_SIDES) {
+    const border = borders[side];
+    if (!border?.color?.themeColor || border.color.auto) {
+      continue;
+    }
+
+    resolved ??= { ...borders };
+    resolved[side] = {
+      ...border,
+      color: {
+        rgb: resolveColor(border.color, theme).replace(/^#/, ""),
+      },
+    };
+  }
+
+  return resolved ?? borders;
 }
 
 /**
@@ -1201,6 +1243,7 @@ function convertTableCell(
     left?: number;
     right?: number;
   },
+  theme?: Theme | null,
 ): PMNode {
   const formatting = cell.formatting;
 
@@ -1236,14 +1279,16 @@ function convertTableCell(
   const conditionalBorders = conditionalStyle?.tcPr?.borders;
   const cellBorders = formatting?.borders;
 
-  const borders =
+  const borders = resolveThemedBorderColors(
     baseBorders || conditionalBorders || cellBorders
       ? {
           ...baseBorders,
           ...conditionalBorders,
           ...cellBorders,
         }
-      : undefined;
+      : undefined,
+    theme,
+  );
 
   // Helper to build margins object without undefined values
   const buildMarginsAttr = (src: {
@@ -1319,7 +1364,7 @@ function convertTableCell(
       );
     } else if (content.type === "table") {
       // Nested tables - recursively convert
-      contentNodes.push(convertTable(content, styleResolver));
+      contentNodes.push(convertTable(content, styleResolver, theme));
     }
   }
 
@@ -2200,12 +2245,13 @@ export function headerFooterToProseDoc(
   const styleResolver = options?.styles
     ? createStyleResolver(options.styles)
     : null;
+  const theme = options?.theme ?? null;
 
   for (const block of content) {
     if (block.type === "paragraph") {
       nodes.push(...convertParagraphWithTextBoxes(block, styleResolver));
     } else if (block.type === "table") {
-      nodes.push(convertTable(block, styleResolver));
+      nodes.push(convertTable(block, styleResolver, theme));
     }
   }
 

--- a/packages/folio/src/core/prosemirror/editor.css
+++ b/packages/folio/src/core/prosemirror/editor.css
@@ -717,18 +717,10 @@
   box-sizing: border-box !important;
 }
 
-.hf-editor-pm .ProseMirror td p:has(img),
-.hf-editor-pm .ProseMirror th p:has(img),
-.hf-editor-pm .ProseMirror td p:has(span),
-.hf-editor-pm .ProseMirror th p:has(span) {
+.hf-editor-pm .ProseMirror td p:has(> img.docx-image):not(:has(> span)),
+.hf-editor-pm .ProseMirror th p:has(> img.docx-image):not(:has(> span)) {
   font-size: 0 !important;
   line-height: 0 !important;
-}
-
-.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
-.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
-  position: relative;
-  top: 0.4em;
 }
 
 /* ============================================================================

--- a/packages/folio/src/core/prosemirror/editor.css
+++ b/packages/folio/src/core/prosemirror/editor.css
@@ -443,10 +443,10 @@
   /* Text wrapping handled via inline styles based on noWrap attribute */
 }
 
-/* Table header cells - styling comes from inline styles, not CSS defaults */
+/* Table header cells are structural; DOCX text formatting comes from marks/styles. */
 .prosemirror-editor .ProseMirror th.docx-table-header {
-  font-weight: bold;
-  text-align: left;
+  font-weight: inherit;
+  text-align: inherit;
 }
 
 /* Cell content - paragraphs inside cells */
@@ -657,27 +657,78 @@
 }
 
 /* Header/footer editor ProseMirror styles */
+.hf-editor-pm.prosemirror-editor {
+  width: 100%;
+  max-width: 100%;
+}
 .hf-editor-pm .ProseMirror {
   outline: none;
   min-height: 40px;
-  padding: 4px;
+  padding: 0;
+}
+.hf-editor-pm.prosemirror-editor .ProseMirror {
+  width: 100%;
+  max-width: 100%;
+  min-height: 40px;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
 }
 .hf-editor-pm .ProseMirror:focus {
   outline: none;
 }
 .hf-editor-pm .ProseMirror p {
   display: block;
-  /* !important overrides inline margin-bottom from style-resolved spaceAfter.
-     The layout painter doesn't apply style-resolved spacing to headers/footers,
-     so the editor must match by stripping paragraph margins. */
   margin: 0 !important;
-  padding: 0;
+  padding-top: var(--docx-space-before, 0);
+  padding-right: 0;
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
   min-height: 1em;
   white-space: pre-wrap;
   word-wrap: break-word;
-  /* Override inline line-height from style-resolved lineSpacing to match
-     the layout painter's rendering of header/footer content */
   line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror td p,
+.hf-editor-pm .ProseMirror th p {
+  margin: 0 !important;
+  padding-top: var(--docx-space-before, 0);
+  padding-right: 0;
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  min-height: auto;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror .tableWrapper {
+  overflow: visible;
+}
+
+.hf-editor-pm .ProseMirror table {
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  table-layout: fixed !important;
+  margin: 0;
+}
+
+.hf-editor-pm .ProseMirror td.docx-table-cell,
+.hf-editor-pm .ProseMirror th.docx-table-header {
+  box-sizing: border-box !important;
+}
+
+.hf-editor-pm .ProseMirror td p:has(img),
+.hf-editor-pm .ProseMirror th p:has(img),
+.hf-editor-pm .ProseMirror td p:has(span),
+.hf-editor-pm .ProseMirror th p:has(span) {
+  font-size: 0 !important;
+  line-height: 0 !important;
+}
+
+.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
+.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
+  position: relative;
+  top: 0.4em;
 }
 
 /* ============================================================================

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -64,7 +64,14 @@ function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
   };
 
   const style = paragraphToStyle(formatting);
-  return Object.entries(style)
+  const customStyle: Record<string, string | number> = {};
+  if (style.marginTop) {
+    customStyle["--docx-space-before"] = style.marginTop;
+  }
+  if (style.marginBottom) {
+    customStyle["--docx-space-after"] = style.marginBottom;
+  }
+  return Object.entries({ ...style, ...customStyle })
     .map(([key, value]) => {
       const cssKey = key.replace(/([A-Z])/g, "-$1").toLowerCase();
       return `${cssKey}: ${value}`;

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -18,6 +18,7 @@ import {
 import { Decoration, DecorationSet } from "prosemirror-view";
 
 import type { ColorValue, BorderSpec } from "../../../types/colors";
+import { resolveColor } from "../../../utils/colorResolver";
 import type {
   TableAttrs,
   TableRowAttrs,
@@ -395,7 +396,7 @@ function buildCellBorderStyles(attrs: TableCellAttrs): string[] {
   const borderToCss = (border?: {
     style?: string;
     size?: number;
-    color?: { rgb?: string };
+    color?: ColorValue;
   }): string => {
     if (
       !border ||
@@ -410,7 +411,7 @@ function buildCellBorderStyles(attrs: TableCellAttrs): string[] {
         ? Math.max(1, Math.round((border.size / 8) * 1.333))
         : 1;
     const cssStyle = BORDER_STYLE_CSS[border.style] || "solid";
-    const color = border.color?.rgb ? `#${border.color.rgb}` : "#000000";
+    const color = resolveColor(border.color, undefined);
     return `${widthPx}px ${cssStyle} ${color}`;
   };
 

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+} from "../core/layout-engine/types";
+import {
+  measureTableBlock,
+  measureTableCellBlockVisualHeight,
+} from "./PagedEditor";
+
+const imageOnlyParagraph: ParagraphBlock = {
+  kind: "paragraph",
+  id: "p-image",
+  runs: [
+    {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 186,
+      height: 29,
+    },
+  ],
+  attrs: {
+    spacing: {
+      before: 2,
+      after: 3,
+    },
+  },
+};
+
+const imageParagraphMeasure: ParagraphMeasure = {
+  kind: "paragraph",
+  lines: [
+    {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 0,
+      width: 186,
+      ascent: 30.921_875,
+      descent: 6.078_125,
+      lineHeight: 37,
+    },
+  ],
+  totalHeight: 42,
+};
+
+describe("measureTableCellBlockVisualHeight", () => {
+  test("uses actual image height for image-only table-cell paragraphs", () => {
+    expect(
+      measureTableCellBlockVisualHeight(
+        imageOnlyParagraph,
+        imageParagraphMeasure,
+      ),
+    ).toBe(34);
+  });
+
+  test("ignores visually empty text around image-only table-cell paragraphs", () => {
+    const paragraph: ParagraphBlock = {
+      ...imageOnlyParagraph,
+      runs: [
+        { kind: "text", text: " " },
+        ...imageOnlyParagraph.runs,
+        { kind: "text", text: "\u00a0" },
+      ],
+    };
+
+    expect(
+      measureTableCellBlockVisualHeight(paragraph, imageParagraphMeasure),
+    ).toBe(34);
+  });
+
+  test("keeps measured paragraph height for mixed-content paragraphs", () => {
+    const mixedParagraph: ParagraphBlock = {
+      ...imageOnlyParagraph,
+      runs: [{ kind: "text", text: "Caption" }, ...imageOnlyParagraph.runs],
+    };
+
+    expect(
+      measureTableCellBlockVisualHeight(mixedParagraph, imageParagraphMeasure),
+    ).toBe(42);
+  });
+
+  test("uses totalHeight for non-paragraph block measures", () => {
+    const block: FlowBlock = {
+      kind: "table",
+      id: "nested",
+      rows: [],
+    };
+    const measure: Measure = {
+      kind: "table",
+      rows: [],
+      columnWidths: [],
+      totalWidth: 10,
+      totalHeight: 22,
+    };
+
+    expect(measureTableCellBlockVisualHeight(block, measure)).toBe(22);
+  });
+});
+
+describe("measureTableBlock", () => {
+  test("does not inflate image-only cells by paragraph line-height", () => {
+    const tableMeasure = measureTableBlock(
+      {
+        kind: "table",
+        id: "table",
+        rows: [
+          {
+            id: "row",
+            cells: [
+              {
+                id: "cell",
+                blocks: [imageOnlyParagraph],
+                padding: {
+                  top: 1,
+                  bottom: 1,
+                  left: 0,
+                  right: 0,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      300,
+    );
+
+    expect(tableMeasure.rows[0]?.height).toBeCloseTo(36, 1);
+  });
+});

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -83,6 +83,86 @@ describe("measureTableCellBlockVisualHeight", () => {
     ).toBe(42);
   });
 
+  test("keeps measured paragraph height for floating image-only paragraphs", () => {
+    const floatingImageParagraph: ParagraphBlock = {
+      ...imageOnlyParagraph,
+      runs: [
+        {
+          kind: "image",
+          src: "data:image/png;base64,",
+          width: 186,
+          height: 90,
+          displayMode: "float",
+          wrapType: "square",
+        },
+      ],
+    };
+    const floatingParagraphMeasure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 1,
+          width: 0,
+          ascent: 10,
+          descent: 2,
+          lineHeight: 12,
+        },
+      ],
+      totalHeight: 12,
+    };
+
+    expect(
+      measureTableCellBlockVisualHeight(
+        floatingImageParagraph,
+        floatingParagraphMeasure,
+      ),
+    ).toBe(12);
+  });
+
+  test("keeps measured paragraph height for block image-only paragraphs", () => {
+    const blockImageParagraph: ParagraphBlock = {
+      ...imageOnlyParagraph,
+      runs: [
+        {
+          kind: "image",
+          src: "data:image/png;base64,",
+          width: 186,
+          height: 90,
+          displayMode: "block",
+          wrapType: "topAndBottom",
+          distTop: 8,
+          distBottom: 6,
+        },
+      ],
+    };
+    const blockParagraphMeasure: ParagraphMeasure = {
+      kind: "paragraph",
+      lines: [
+        {
+          fromRun: 0,
+          fromChar: 0,
+          toRun: 0,
+          toChar: 1,
+          width: 186,
+          ascent: 96,
+          descent: 8,
+          lineHeight: 104,
+        },
+      ],
+      totalHeight: 104,
+    };
+
+    expect(
+      measureTableCellBlockVisualHeight(
+        blockImageParagraph,
+        blockParagraphMeasure,
+      ),
+    ).toBe(104);
+  });
+
   test("uses totalHeight for non-paragraph block measures", () => {
     const block: FlowBlock = {
       kind: "table",

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -605,6 +605,28 @@ function resolveTableWidthPx(
   return undefined;
 }
 
+function isInlineFlowImageRun(run: ImageRun): boolean {
+  if (run.displayMode === "float") {
+    return false;
+  }
+
+  if (
+    run.wrapType === "square" ||
+    run.wrapType === "tight" ||
+    run.wrapType === "through" ||
+    run.wrapType === "behind" ||
+    run.wrapType === "inFront"
+  ) {
+    return false;
+  }
+
+  if (run.displayMode === "block" || run.wrapType === "topAndBottom") {
+    return false;
+  }
+
+  return true;
+}
+
 export function measureTableCellBlockVisualHeight(
   block: FlowBlock,
   blockMeasure: Measure,
@@ -625,20 +647,21 @@ export function measureTableCellBlockVisualHeight(
     (run) =>
       run.kind !== "text" || run.text.replace(/\u00a0/g, " ").trim().length > 0,
   );
-  const imageOnlySingleLine =
-    paragraphMeasure.lines.length === 1 &&
-    nonEmptyRuns.length > 0 &&
-    nonEmptyRuns.every((run) => run.kind === "image");
-
-  if (!imageOnlySingleLine) {
+  if (paragraphMeasure.lines.length !== 1 || nonEmptyRuns.length === 0) {
     return paragraphMeasure.totalHeight;
   }
 
-  let maxImageHeight = 0;
+  const inlineImageRuns: ImageRun[] = [];
   for (const run of nonEmptyRuns) {
-    if (run.kind === "image") {
-      maxImageHeight = Math.max(maxImageHeight, run.height);
+    if (run.kind !== "image" || !isInlineFlowImageRun(run)) {
+      return paragraphMeasure.totalHeight;
     }
+    inlineImageRuns.push(run);
+  }
+
+  let maxImageHeight = 0;
+  for (const run of inlineImageRuns) {
+    maxImageHeight = Math.max(maxImageHeight, run.height);
   }
   const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
   const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -78,6 +78,7 @@ import type {
   Measure,
   ParagraphBlock,
   TableBlock,
+  TableCell,
   TableMeasure,
   ImageBlock,
   ImageRun,
@@ -604,7 +605,54 @@ function resolveTableWidthPx(
   return undefined;
 }
 
-function measureTableBlock(
+export function measureTableCellBlockVisualHeight(
+  block: FlowBlock,
+  blockMeasure: Measure,
+): number {
+  if (block.kind !== "paragraph" || blockMeasure.kind !== "paragraph") {
+    if ("totalHeight" in blockMeasure) {
+      return blockMeasure.totalHeight;
+    }
+    if ("height" in blockMeasure) {
+      return blockMeasure.height;
+    }
+    return 0;
+  }
+
+  const paragraphBlock = block;
+  const paragraphMeasure = blockMeasure;
+  const nonEmptyRuns = paragraphBlock.runs.filter(
+    (run) =>
+      run.kind !== "text" || run.text.replace(/\u00a0/g, " ").trim().length > 0,
+  );
+  const imageOnlySingleLine =
+    paragraphMeasure.lines.length === 1 &&
+    nonEmptyRuns.length > 0 &&
+    nonEmptyRuns.every((run) => run.kind === "image");
+
+  if (!imageOnlySingleLine) {
+    return paragraphMeasure.totalHeight;
+  }
+
+  let maxImageHeight = 0;
+  for (const run of nonEmptyRuns) {
+    if (run.kind === "image") {
+      maxImageHeight = Math.max(maxImageHeight, run.height);
+    }
+  }
+  const spacingBefore = paragraphBlock.attrs?.spacing?.before ?? 0;
+  const spacingAfter = paragraphBlock.attrs?.spacing?.after ?? 0;
+
+  return spacingBefore + maxImageHeight + spacingAfter;
+}
+
+function getTableCellVerticalBorderHeight(cell: TableCell | undefined): number {
+  const top = cell?.borders?.top?.width ?? 0;
+  const bottom = cell?.borders?.bottom?.width ?? 0;
+  return top + bottom;
+}
+
+export function measureTableBlock(
   tableBlock: TableBlock,
   contentWidth: number,
 ): TableMeasure {
@@ -730,20 +778,30 @@ function measureTableBlock(
     const row = rows[rowIdx]!; // SAFETY: rowIdx < rows.length
     const sourceRowCells = tableBlock.rows[rowIdx]?.cells;
     let maxHeight = 0;
+    let maxVerticalBorderHeight = 0;
     for (let cellIdx = 0; cellIdx < row.cells.length; cellIdx++) {
       const cell = row.cells[cellIdx]!; // SAFETY: cellIdx < row.cells.length
       const sourceCell = sourceRowCells?.[cellIdx];
       cell.height = 0;
-      for (const measure of cell.blocks) {
-        // Get height from any measure type (paragraph or table)
-        if ("totalHeight" in measure) {
-          cell.height += measure.totalHeight;
+      for (let blockIdx = 0; blockIdx < cell.blocks.length; blockIdx++) {
+        const sourceBlock = sourceCell?.blocks[blockIdx];
+        const blockMeasure = cell.blocks[blockIdx];
+        if (!sourceBlock || !blockMeasure) {
+          continue;
         }
+        cell.height += measureTableCellBlockVisualHeight(
+          sourceBlock,
+          blockMeasure,
+        );
       }
       const padTop = sourceCell?.padding?.top ?? DEFAULT_CELL_PADDING_Y;
       const padBottom = sourceCell?.padding?.bottom ?? DEFAULT_CELL_PADDING_Y;
       cell.height += padTop + padBottom;
       maxHeight = Math.max(maxHeight, cell.height);
+      maxVerticalBorderHeight = Math.max(
+        maxVerticalBorderHeight,
+        getTableCellVerticalBorderHeight(sourceCell),
+      );
     }
 
     // Apply heightRule from the source row
@@ -756,10 +814,13 @@ function measureTableBlock(
     } else if (explicitHeight) {
       // Both 'atLeast' and 'auto' (OOXML default) treat the value as minimum height.
       // ECMA-376 §17.4.81: when hRule is absent or "auto", val is the minimum row height.
-      row.height = Math.max(maxHeight, explicitHeight);
+      row.height = Math.max(
+        maxHeight + maxVerticalBorderHeight,
+        explicitHeight,
+      );
     } else {
       // No explicit height — use content height directly.
-      row.height = maxHeight;
+      row.height = maxHeight + maxVerticalBorderHeight;
     }
   }
 

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -565,7 +565,7 @@
 .hf-editor-pm .ProseMirror {
   outline: none;
   min-height: 40px;
-  padding: 4px;
+  padding: 0;
 }
 
 .hf-editor-pm .ProseMirror:focus {
@@ -574,12 +574,56 @@
 
 .hf-editor-pm .ProseMirror p {
   display: block;
-  margin: 0;
-  padding: 0;
+  margin: 0 !important;
+  padding-top: var(--docx-space-before, 0);
+  padding-right: 0;
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
   min-height: 1em;
   white-space: pre-wrap;
   word-wrap: break-word;
-  line-height: normal;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror td p,
+.hf-editor-pm .ProseMirror th p {
+  margin: 0 !important;
+  padding-top: var(--docx-space-before, 0);
+  padding-right: 0;
+  padding-bottom: var(--docx-space-after, 0);
+  padding-left: 0;
+  min-height: auto;
+  line-height: normal !important;
+}
+
+.hf-editor-pm .ProseMirror .tableWrapper {
+  overflow: visible;
+}
+
+.hf-editor-pm .ProseMirror table {
+  border-collapse: collapse !important;
+  border-spacing: 0 !important;
+  table-layout: fixed !important;
+  margin: 0;
+}
+
+.hf-editor-pm .ProseMirror td.docx-table-cell,
+.hf-editor-pm .ProseMirror th.docx-table-header {
+  box-sizing: border-box !important;
+}
+
+.hf-editor-pm .ProseMirror td p:has(img),
+.hf-editor-pm .ProseMirror th p:has(img),
+.hf-editor-pm .ProseMirror td p:has(span),
+.hf-editor-pm .ProseMirror th p:has(span) {
+  font-size: 0 !important;
+  line-height: 0 !important;
+}
+
+.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
+.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
+  position: relative;
+  top: 0.4em;
 }
 
 .paged-editor--hf-editing .layout-page-content {

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -612,18 +612,10 @@
   box-sizing: border-box !important;
 }
 
-.hf-editor-pm .ProseMirror td p:has(img),
-.hf-editor-pm .ProseMirror th p:has(img),
-.hf-editor-pm .ProseMirror td p:has(span),
-.hf-editor-pm .ProseMirror th p:has(span) {
+.hf-editor-pm .ProseMirror td p:has(> img.docx-image):not(:has(> span)),
+.hf-editor-pm .ProseMirror th p:has(> img.docx-image):not(:has(> span)) {
   font-size: 0 !important;
   line-height: 0 !important;
-}
-
-.hf-editor-pm .ProseMirror td p span:not(:has(> span)),
-.hf-editor-pm .ProseMirror th p span:not(:has(> span)) {
-  position: relative;
-  top: 0.4em;
 }
 
 .paged-editor--hf-editing .layout-page-content {


### PR DESCRIPTION
## Summary
- Resolve themed table-cell border colors against document themes during DOCX-to-ProseMirror conversion.
- Normalize header/footer table content through the shared layout path, including nested table-cell spacing.
- Tighten paragraph and table measurement for whitespace-only text runs and image-only table cells.