### PR TITLE
feat: make Personal matters breadcrumb item clickable

### DIFF
--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/matter-colors";
 import { useUpdateWorkspace } from "@/routes/_protected.workspaces/-mutations";
 import { workspaceOptions } from "@/routes/_protected.workspaces/-queries";
+import { useConfigStore } from "@/stores/config-store";
 
 const breadcrumbInputClassName =
   "border-input bg-background text-foreground inline-flex rounded-md border text-sm shadow-xs/5 transition-colors has-focus-visible:border-ring";
@@ -54,6 +55,7 @@ export const WorkspaceBreadcrumb = ({
   const [iconAnchor, setIconAnchor] = useState<HTMLSpanElement | null>(null);
   const { data: workspace } = useQuery(workspaceOptions(workspaceId));
   const updateWorkspace = useUpdateWorkspace();
+  const updateMattersConfig = useConfigStore((s) => s.updateMatters);
 
   if (!workspace) {
     return (
@@ -163,33 +165,19 @@ export const WorkspaceBreadcrumb = ({
     <LayersIcon className="size-3.5 shrink-0" style={{ color: activeColor }} />
   );
 
-  const clientSegment = workspace.client ? (
+  const { client } = workspace;
+  const clientSegment = client ? (
     <>
       <BreadcrumbItem className="min-w-8 shrink">
         <Link
           className="hover:text-foreground min-w-0 truncate transition-colors"
           onClick={() => {
-            try {
-              const raw = localStorage.getItem("matters_overview_config");
-              const parsed: unknown = raw ? JSON.parse(raw) : null;
-              const config: Record<string, unknown> =
-                typeof parsed === "object" && parsed !== null
-                  ? // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                    (parsed as Record<string, unknown>)
-                  : {};
-              config["clientFilter"] = workspace.client?.id ?? null;
-              localStorage.setItem(
-                "matters_overview_config",
-                JSON.stringify(config),
-              );
-            } catch {
-              // localStorage may throw in private browsing
-            }
+            updateMattersConfig({ clientFilter: client.id });
           }}
-          title={workspace.client.displayName}
+          title={client.displayName}
           to="/workspaces"
         >
-          {workspace.client.displayName}
+          {client.displayName}
         </Link>
       </BreadcrumbItem>
       <BreadcrumbSeparator className="shrink-0" />
@@ -199,6 +187,9 @@ export const WorkspaceBreadcrumb = ({
       <BreadcrumbItem className="min-w-8 shrink">
         <Link
           className="hover:text-foreground text-muted-foreground min-w-0 truncate transition-colors"
+          onClick={() => {
+            updateMattersConfig({ clientFilter: null });
+          }}
           to="/workspaces"
           title={t("workspaces.parties.personalLabel")}
         >

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -197,12 +197,13 @@ export const WorkspaceBreadcrumb = ({
   ) : (
     <>
       <BreadcrumbItem className="min-w-8 shrink">
-        <span
-          className="text-muted-foreground min-w-0 truncate"
+        <Link
+          className="hover:text-foreground text-muted-foreground min-w-0 truncate transition-colors"
+          to="/workspaces"
           title={t("workspaces.parties.personalLabel")}
         >
           {t("workspaces.parties.personalLabel")}
-        </span>
+        </Link>
       </BreadcrumbItem>
       <BreadcrumbSeparator className="shrink-0" />
     </>


### PR DESCRIPTION
## Proposed change

Makes the Personal matters category in the breadcrumb a clickable link to `/workspaces`, consistent with how client names are already handled. Closes #93.

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Changes tested, including in different conditions (dark mode, language, narrow screen, etc).
- [x] DARK MODE SUPPORT | User can use the webapp in dark mode. Make sure your changes are visible in both light and dark mode.
- [x] ISSUE LINKED | Link an issue to this PR (not by mentioning it in the description, but by using the GitHub issue linking feature)
- [x] SCREENSHOT INCLUDED | If relevant, please include a screenshot / video of the functionality added (allows for a quick check of minor ux changes)
<img width="959" height="472" alt="Screenshot 2026-05-11 213201" src="https://github.com/user-attachments/assets/62e80e02-7987-4e67-8765-d20d377aecb5" />
<img width="959" height="470" alt="Screenshot 2026-05-11 213257" src="https://github.com/user-attachments/assets/9f8fb0e9-d93f-4c23-b7ae-58415e727401" />