### PR TITLE
fix(folio): exclude behindDoc images from header visual bounds

### DIFF
--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -144,6 +144,43 @@ describe("calculateHeaderFooterVisualBounds", () => {
 
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 70 });
   });
+
+  test("excludes behindDoc images from visualBottom so they don't extend body margins", () => {
+    // Full-page letterhead: anchored to "margin", posOffset -1460500 EMU
+    // (≈ -153px) places the image just above the body margin and its 1117px
+    // height covers the whole page. Renderer lifts behindDoc images out of
+    // the HF container; if they leak into visualBottom,
+    // `computeHeaderFooterMarginExtender` reserves the full image height as
+    // body push-down and the body cascades off the page.
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "letterhead",
+        runs: [
+          {
+            kind: "image",
+            src: "letterhead.png",
+            width: 790,
+            height: 1117,
+            wrapType: "behind",
+            position: {
+              horizontal: { relativeTo: "margin", posOffset: -702_422 },
+              vertical: { relativeTo: "margin", posOffset: -1_460_500 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterVisualBounds(
+      blocks,
+      [{ kind: "paragraph", lines: [], totalHeight: 0 }],
+      0,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ visualTop: 0, visualBottom: 0 });
+  });
 });
 
 describe("header/footer layout conversion", () => {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -9,6 +9,7 @@ import type {
 import type { HeaderFooter } from "../types/document";
 import type { HeaderFooterMetrics } from "./headerFooterLayout";
 import {
+  calculateHeaderFooterMarginPushBounds,
   calculateHeaderFooterVisualBounds,
   convertHeaderFooterToContent,
   normalizeHeaderFooterMeasureBlocks,
@@ -145,13 +146,12 @@ describe("calculateHeaderFooterVisualBounds", () => {
     expect(bounds).toEqual({ visualTop: 0, visualBottom: 70 });
   });
 
-  test("excludes behindDoc images from visualBottom so they don't extend body margins", () => {
+  test("includes behindDoc images in visualBottom (render+hash signal)", () => {
     // Full-page letterhead: anchored to "margin", posOffset -1460500 EMU
     // (≈ -153px) places the image just above the body margin and its 1117px
-    // height covers the whole page. Renderer lifts behindDoc images out of
-    // the HF container; if they leak into visualBottom,
-    // `computeHeaderFooterMarginExtender` reserves the full image height as
-    // body push-down and the body cascades off the page.
+    // height covers the whole page. `visualBottom` keeps tracking the
+    // image so the renderer's option hash invalidates when the letterhead
+    // changes.
     const blocks: FlowBlock[] = [
       {
         kind: "paragraph",
@@ -179,7 +179,93 @@ describe("calculateHeaderFooterVisualBounds", () => {
       metrics,
     );
 
-    expect(bounds).toEqual({ visualTop: 0, visualBottom: 0 });
+    // marginTop 100 + emuToPixels(-1_460_500) -153 - flowTop 48 = -101;
+    // image bottom = top + 1117 = 1016.
+    expect(bounds).toEqual({ visualTop: -101, visualBottom: 1016 });
+  });
+});
+
+describe("calculateHeaderFooterMarginPushBounds", () => {
+  test("excludes behindDoc image runs so the body margin doesn't reserve a full-page letterhead", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "letterhead",
+        runs: [
+          {
+            kind: "image",
+            src: "letterhead.png",
+            width: 790,
+            height: 1117,
+            wrapType: "behind",
+            position: {
+              horizontal: { relativeTo: "margin", posOffset: -702_422 },
+              vertical: { relativeTo: "margin", posOffset: -1_460_500 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [{ kind: "paragraph", lines: [], totalHeight: 0 }],
+      0,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 0 });
+  });
+
+  test("excludes behindDoc image blocks anchored at block level", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "image",
+        id: "block-letterhead",
+        src: "letterhead.png",
+        width: 790,
+        height: 1117,
+        anchor: { isAnchored: true, behindDoc: true },
+      },
+    ];
+
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [{ kind: "image", width: 790, height: 1117 }],
+      0,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 0 });
+  });
+
+  test("still counts flowing content (paragraph + in-flow image block)", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "title",
+        runs: [{ kind: "text", text: "Header title" }],
+      },
+      {
+        kind: "image",
+        id: "inline-logo",
+        src: "logo.png",
+        width: 120,
+        height: 40,
+      },
+    ];
+
+    const bounds = calculateHeaderFooterMarginPushBounds(
+      blocks,
+      [
+        { kind: "paragraph", lines: [], totalHeight: 12 },
+        { kind: "image", width: 120, height: 40 },
+      ],
+      52,
+      metrics,
+    );
+
+    expect(bounds).toEqual({ top: 0, bottom: 52 });
   });
 });
 

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -365,6 +365,15 @@ export function calculateHeaderFooterVisualBounds(
         if (!run.position && !isFloatingImageRun(run)) {
           continue;
         }
+        // behindDoc images (full-page letterheads, watermarks) paint behind
+        // body content by design and are lifted out of the HF container to
+        // the page root at render time. They must not contribute to the
+        // header's visualBottom — otherwise `computeHeaderFooterMarginExtender`
+        // reserves the entire image as body push-down, and the body (plus
+        // the image's own margin-anchored position) cascades off the page.
+        if (run.wrapType === "behind") {
+          continue;
+        }
         const runTop = resolveHeaderFooterVisualTop(
           run,
           paragraphStartY,

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -327,6 +327,19 @@ function resolveHeaderFooterFloatingTableVisualTop(
   return sourceY;
 }
 
+/**
+ * Image is rendered "behind" body content (full-page letterhead, watermark).
+ * The renderer lifts these out of the HF container to the page root, so they
+ * must not push body margins down — they paint underneath the body by design.
+ */
+function isBehindDocImageRun(run: Run): boolean {
+  return run.kind === "image" && run.wrapType === "behind";
+}
+
+function isBehindDocImageBlock(block: FlowBlock): boolean {
+  return block.kind === "image" && block.anchor?.behindDoc === true;
+}
+
 export function calculateHeaderFooterVisualBounds(
   blocks: FlowBlock[],
   measures: Measure[],
@@ -363,15 +376,6 @@ export function calculateHeaderFooterVisualBounds(
         // and `computeHeaderFooterMarginExtender` wouldn't reserve enough
         // body push-down — the image would overlap body text.
         if (!run.position && !isFloatingImageRun(run)) {
-          continue;
-        }
-        // behindDoc images (full-page letterheads, watermarks) paint behind
-        // body content by design and are lifted out of the HF container to
-        // the page root at render time. They must not contribute to the
-        // header's visualBottom — otherwise `computeHeaderFooterMarginExtender`
-        // reserves the entire image as body push-down, and the body (plus
-        // the image's own margin-anchored position) cascades off the page.
-        if (run.wrapType === "behind") {
           continue;
         }
         const runTop = resolveHeaderFooterVisualTop(
@@ -430,6 +434,105 @@ export function calculateHeaderFooterVisualBounds(
   }
 
   return { visualTop, visualBottom };
+}
+
+/**
+ * Compute the header/footer bounds used by `computeHeaderFooterMarginExtender`
+ * to push body margins clear of HF overflow. Excludes `behindDoc` images
+ * (full-page letterheads, watermarks): the renderer lifts them out of the HF
+ * container onto the page root and paints them behind body content, so they
+ * must not reserve body push-down. Keeping them in `visualBottom` is still
+ * correct for the renderer (and for the page-hash invalidation signal), but
+ * the margin extender needs the flow-only extent.
+ */
+export function calculateHeaderFooterMarginPushBounds(
+  blocks: FlowBlock[],
+  measures: Measure[],
+  flowHeight: number,
+  metrics: HeaderFooterMetrics,
+): { top: number; bottom: number } {
+  let top = 0;
+  let bottom = flowHeight;
+  let cursorY = 0;
+
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i];
+    const measure = measures[i];
+    if (!block || !measure) {
+      continue;
+    }
+
+    if (block.kind === "paragraph" && measure.kind === "paragraph") {
+      const paragraphStartY = cursorY;
+      const paragraphBottomY = paragraphStartY + measure.totalHeight;
+      top = Math.min(top, paragraphStartY);
+      bottom = Math.max(bottom, paragraphBottomY);
+
+      for (const run of block.runs) {
+        if (run.kind !== "image") {
+          continue;
+        }
+        if (!run.position && !isFloatingImageRun(run)) {
+          continue;
+        }
+        if (isBehindDocImageRun(run)) {
+          continue;
+        }
+        const runTop = resolveHeaderFooterVisualTop(
+          run,
+          paragraphStartY,
+          flowHeight,
+          metrics,
+        );
+        top = Math.min(top, runTop);
+        bottom = Math.max(bottom, runTop + run.height);
+      }
+
+      cursorY = paragraphBottomY;
+    } else if (isBehindDocImageBlock(block)) {
+      // ImageBlock with anchor.behindDoc: skip entirely for the same reason
+      // as run-level behindDoc images. Does not advance cursorY because
+      // anchored images don't participate in HF flow either.
+      continue;
+    } else {
+      let blockHeight = 0;
+      let advancesCursor = true;
+      if (block.kind === "table" && measure.kind === "table") {
+        blockHeight = measure.totalHeight;
+        if (block.floating) {
+          advancesCursor = false;
+        }
+      } else if (block.kind === "image" && measure.kind === "image") {
+        blockHeight = measure.height;
+      } else if (block.kind === "textBox" && measure.kind === "textBox") {
+        blockHeight = measure.height;
+      } else {
+        continue;
+      }
+      if (advancesCursor) {
+        const blockBottomY = cursorY + blockHeight;
+        top = Math.min(top, cursorY);
+        bottom = Math.max(bottom, blockBottomY);
+        cursorY = blockBottomY;
+      } else if (
+        block.kind === "table" &&
+        block.floating &&
+        measure.kind === "table"
+      ) {
+        const blockTop = resolveHeaderFooterFloatingTableVisualTop(
+          block.floating,
+          measure,
+          cursorY,
+          flowHeight,
+          metrics,
+        );
+        top = Math.min(top, blockTop);
+        bottom = Math.max(bottom, blockTop + blockHeight);
+      }
+    }
+  }
+
+  return { top, bottom };
 }
 
 // =============================================================================
@@ -516,6 +619,13 @@ export function convertHeaderFooterToContent(
     totalHeight,
     metrics,
   );
+  const { top: marginPushTop, bottom: marginPushBottom } =
+    calculateHeaderFooterMarginPushBounds(
+      blocks,
+      measures,
+      totalHeight,
+      metrics,
+    );
 
   return {
     blocks,
@@ -523,5 +633,7 @@ export function convertHeaderFooterToContent(
     height: totalHeight,
     visualTop,
     visualBottom,
+    marginPushTop,
+    marginPushBottom,
   };
 }

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -144,6 +144,14 @@ export type HeaderFooterContent = {
   visualTop?: number;
   /** Bottom-most visual extent relative to the nominal flow origin. */
   visualBottom?: number;
+  /**
+   * Flow-only bounds used by `computeHeaderFooterMarginExtender` to push
+   * body margins clear of HF overflow. Excludes `behindDoc` images that
+   * the renderer paints behind body content; including them would reserve
+   * a full-page letterhead as body push-down.
+   */
+  marginPushTop?: number;
+  marginPushBottom?: number;
 };
 
 /**

--- a/packages/folio/src/paged-editor/headerFooterMargins.ts
+++ b/packages/folio/src/paged-editor/headerFooterMargins.ts
@@ -23,17 +23,24 @@ type EffectiveHeaderFooterMarginsInput = {
 export type PageMarginsExtender = (margins: PageMargins) => PageMargins;
 
 function headerHeight(content: HeaderFooterContent | undefined): number {
-  return content ? (content.visualBottom ?? content.height) : 0;
+  if (!content) {
+    return 0;
+  }
+  // Prefer the margin-push bounds (excludes behindDoc images that paint
+  // behind body content) so a full-page letterhead doesn't reserve itself
+  // as body push-down. Fall back to visualBottom for callers that predate
+  // the field.
+  return content.marginPushBottom ?? content.visualBottom ?? content.height;
 }
 
 function footerHeight(content: HeaderFooterContent | undefined): number {
   if (!content) {
     return 0;
   }
-  return Math.max(
-    (content.visualBottom ?? content.height) - (content.visualTop ?? 0),
-    content.height,
-  );
+  const bottom =
+    content.marginPushBottom ?? content.visualBottom ?? content.height;
+  const top = content.marginPushTop ?? content.visualTop ?? 0;
+  return Math.max(bottom - top, content.height);
 }
 
 /**


### PR DESCRIPTION
Full-page letterheads anchored to `margin` (e.g. PNG firm letterhead in the header) are lifted out of the HF container to the page root at render time and paint behind the body. Counting them in the header's `visualBottom` made `computeHeaderFooterMarginExtender` reserve the full image height as body push-down, which extended `margins.top` past the page bottom and reflowed the image's own margin-anchored Y into the page bottom — so the letterhead appeared near the page bottom (or as a transparent rectangle filled by the canvas in dark mode) instead of behind the title page.

Skip `wrapType === "behind"` runs in `calculateHeaderFooterVisualBounds` so the header's bounds reflect only flowing content. Position resolution then uses the authored top margin.

Test plan:
- [x] Added unit covering a full-page letterhead anchored to margin
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun test packages/folio/src/core/layout-bridge/`
- [x] Manual: cover-page docx with anchored PNG letterhead renders letterhead at top, body fits, footer unchanged