### PR TITLE
chore(ci): wave 1 supply-chain hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,7 @@ apps/desktop/src-tauri/Cargo.toml       @jan-kubica
 apps/desktop/src-tauri/Cargo.lock       @jan-kubica
 apps/desktop/src-tauri/build.rs         @jan-kubica
 apps/desktop/src-tauri/tauri.conf.json  @jan-kubica
+apps/desktop/src-tauri/capabilities/    @jan-kubica
 
 # Privileged bridge — desktop code with elevated OS access.
 apps/desktop/src-tauri/src/             @jan-kubica

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@ scripts/                                @jan-kubica
 # Desktop signing surface — build runs with signing keys live.
 apps/desktop/package.json               @jan-kubica
 apps/desktop/src-tauri/Cargo.toml       @jan-kubica
+apps/desktop/src-tauri/Cargo.lock       @jan-kubica
 apps/desktop/src-tauri/build.rs         @jan-kubica
 apps/desktop/src-tauri/tauri.conf.json  @jan-kubica
 

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -13,6 +13,11 @@ permissions: {}
 
 jobs:
   audit:
+    # Reusable workflow declares `permissions: contents: read` and runs
+    # actions/checkout. The caller's `permissions: {}` would otherwise
+    # cap the reusable's GITHUB_TOKEN to no scopes (intersection rule).
+    permissions:
+      contents: read
     uses: stella/.github/.github/workflows/audit-branch-protection.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -9,6 +9,8 @@ concurrency:
   group: audit-branch-protection
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   audit:
     uses: stella/.github/.github/workflows/audit-branch-protection.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ concurrency:
     }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   trust-check:
     # Skip draft PRs (CI runs when marked ready for review via

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,16 @@
 name: CLA Assistant
 
+# SECURITY INVARIANT — DO NOT BREAK.
+# This workflow runs under `pull_request_target` and therefore executes in
+# the base-repo trust context with access to secrets (CLA_APP_PRIVATE_KEY,
+# write tokens on issues/PRs). It MUST NOT check out PR head code, MUST
+# NOT run any script, build, or install step from the PR, and MUST NOT
+# pass `github.event.pull_request.head.sha` / `head.ref` into any step
+# that executes code. The only safe operation here is to call the pinned
+# reusable workflow that performs CLA signature verification.
+# Background: pull_request_target + checkout(head) is the same attack
+# shape that led to the tj-actions / Ultralytics / Nx compromises.
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -18,6 +18,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   check:
     if: github.event.pull_request.draft != true || github.event_name != 'pull_request'

--- a/.github/workflows/nightly-typecheck.yml
+++ b/.github/workflows/nightly-typecheck.yml
@@ -6,6 +6,8 @@ on:
     - cron: "17 3 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   full-typecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -27,5 +27,7 @@ jobs:
     if: >-
       github.event.action != 'labeled'
       || github.event.label.name == 'run-pr-lint'
+    # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
+    # Do not switch to `secrets: inherit` — that widens the blast radius
+    # if the reusable ever starts touching named secrets.
     uses: stella/.github/.github/workflows/pr-lint.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
-    secrets: inherit


### PR DESCRIPTION
## Summary

Wave 1 of the CI hardening pass — low-risk, no behavioural changes. Larger items (cache scoping on release, environment gates, OIDC-only npm publish) will follow in separate PRs.

- `permissions: {}` at the root of 4 workflows (`ci.yml`, `db-migrations.yml`, `nightly-typecheck.yml`, `audit-branch-protection.yml`) — every job already declares the perms it actually needs, so this is purely a default-deny safeguard against future drift.
- Drop `secrets: inherit` from `pr-lint.yml`. The reusable workflow at `stella/.github/.github/workflows/pr-lint.yml@9aba86f1` only consumes the auto-provided `GITHUB_TOKEN`, so inheritance was a no-op. Removing it means any future secret usage by the reusable becomes a reviewable diff at the caller.
- Document the `pull_request_target` trust-boundary invariant in `cla.yml` — checking out PR head code from this workflow is the attack shape behind tj-actions / Ultralytics / Nx. Adding a header comment so the rule is visible to future contributors.
- Add `apps/desktop/src-tauri/Cargo.lock` to `CODEOWNERS`. The Rust lockfile feeds the signed desktop build; it should sit behind the same review gate as `Cargo.toml`.

## Test plan

- [x] `actionlint` clean on all six modified workflows
- [ ] CI green on this PR (this PR exercises the new `ci.yml` and `pr-lint.yml` because `pull_request` events use the workflow file from the PR branch)
- [ ] `pr-lint` check passes — confirms the reusable workflow still works without `secrets: inherit`