### PR TITLE
fix(ai-config): unify BYOK key validation, label provider as OpenAI

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -1,4 +1,3 @@
-import { generateText } from "ai";
 import { panic, Result } from "better-result";
 import { t } from "elysia";
 
@@ -9,8 +8,6 @@ import {
   maskApiKey,
 } from "@/api/lib/ai-config-crypto";
 import {
-  getModelForRole,
-  getTemperatureForRole,
   isAllowedBYOKModel,
   MODEL_ROLES,
   supportsRegion,
@@ -23,6 +20,7 @@ import type {
   OrgAIModelSelection,
   OrgAIProviderConfig,
 } from "@/api/lib/ai-models";
+import { probeProvider } from "@/api/lib/ai-provider-probe";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -149,8 +147,7 @@ const updateAIConfig = createSafeRootHandler(
 
     const validationResults = await Promise.all(
       providersToValidate.map(
-        async (providerConfig) =>
-          await validateProviderKey(providerConfig, modelResult.overrideModels),
+        async (providerConfig) => await validateProviderKey(providerConfig),
       ),
     );
 
@@ -441,15 +438,6 @@ const normalizeOverrideModels = (
   };
 };
 
-const getValidationRole = (
-  provider: AIProvider,
-  overrideModels: Record<ModelRole, OrgAIModelSelection>,
-): ModelRole =>
-  MODEL_ROLES.find((role) => overrideModels[role].provider === provider) ??
-  panic(
-    `validateProviderKey called for ${provider} but no role is bound to it`,
-  );
-
 type ShouldValidateProviderConfigOptions = {
   existingConfig: OrgAIConfig | undefined;
   newKeyProviders: ReadonlySet<AIProvider>;
@@ -493,45 +481,35 @@ const shouldValidateProviderConfig = ({
   );
 };
 
-// Provider first-call latency can exceed 10 s and we don't want a
-// healthy key flagged invalid by a slow upstream. Validations run in
-// parallel, so the worst-case settings-save wait is bounded by this
-// single ceiling regardless of how many providers are configured.
-const VALIDATION_TIMEOUT_MS = 20_000;
-
 /**
- * Validate a provider API key by making a minimal API call.
- * Uses a tiny prompt to minimize cost. Always exercises a
- * model the user explicitly chose for this provider —
- * orphan providers are rejected upstream.
+ * Validate a provider API key via the shared lightweight probe
+ * (provider's own auth/list-models endpoint). No token cost and
+ * avoids per-model quirks like reasoning-model token minimums.
  */
 const validateProviderKey = async (
-  providerConfig: OrgAIProviderConfig,
-  overrideModels: Record<ModelRole, OrgAIModelSelection>,
+  providerConfig: OrgAIProviderConfig & { provider: BYOKProvider },
 ): Promise<ValidationResult> => {
-  const role = getValidationRole(providerConfig.provider, overrideModels);
-  const tempConfig: OrgAIConfig = {
-    providers: [providerConfig],
-    overrideModels,
-  };
-
   const result = await Result.tryPromise({
-    try: async () => {
-      const model = getModelForRole(role, tempConfig);
-      return await generateText({
-        model,
-        temperature: getTemperatureForRole(role),
-        prompt: "Say OK",
-        maxOutputTokens: 3,
-        abortSignal: AbortSignal.timeout(VALIDATION_TIMEOUT_MS),
-      });
-    },
+    try: async () =>
+      await probeProvider(
+        providerConfig.provider,
+        providerConfig.apiKey,
+        providerConfig.provider === "azure_foundry"
+          ? providerConfig.baseURL
+          : undefined,
+        providerConfig.provider === "azure_foundry"
+          ? providerConfig.apiVersion
+          : undefined,
+      ),
     catch: (error: unknown) =>
       `API key validation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
   });
 
   if (result.isErr()) {
     return { valid: false, error: result.error };
+  }
+  if (!result.value.valid) {
+    return { valid: false, error: result.value.error ?? "Unknown error" };
   }
   return { valid: true };
 };

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -147,7 +147,8 @@ const updateAIConfig = createSafeRootHandler(
 
     const validationResults = await Promise.all(
       providersToValidate.map(
-        async (providerConfig) => await validateProviderKey(providerConfig),
+        async (providerConfig) =>
+          await validateProviderKey(providerConfig, modelResult.overrideModels),
       ),
     );
 
@@ -485,9 +486,12 @@ const shouldValidateProviderConfig = ({
  * Validate a provider API key via the shared lightweight probe
  * (provider's own auth/list-models endpoint). No token cost and
  * avoids per-model quirks like reasoning-model token minimums.
+ * For Azure Foundry, also verifies each role's deployment name
+ * exists, since those are free-text values typed by the user.
  */
 const validateProviderKey = async (
   providerConfig: OrgAIProviderConfig & { provider: BYOKProvider },
+  overrideModels: Record<ModelRole, OrgAIModelSelection>,
 ): Promise<ValidationResult> => {
   const result = await Result.tryPromise({
     try: async () =>
@@ -499,6 +503,9 @@ const validateProviderKey = async (
           : undefined,
         providerConfig.provider === "azure_foundry"
           ? providerConfig.apiVersion
+          : undefined,
+        providerConfig.provider === "azure_foundry"
+          ? collectAzureDeployments(overrideModels)
           : undefined,
       ),
     catch: (error: unknown) =>
@@ -513,5 +520,18 @@ const validateProviderKey = async (
   }
   return { valid: true };
 };
+
+const collectAzureDeployments = (
+  overrideModels: Record<ModelRole, OrgAIModelSelection>,
+): readonly string[] =>
+  Array.from(
+    new Set(
+      MODEL_ROLES.flatMap((role) =>
+        overrideModels[role].provider === "azure_foundry"
+          ? [overrideModels[role].modelId]
+          : [],
+      ),
+    ),
+  );
 
 export default updateAIConfig;

--- a/apps/api/src/lib/ai-provider-probe.test.ts
+++ b/apps/api/src/lib/ai-provider-probe.test.ts
@@ -46,11 +46,74 @@ describe("probeProvider", () => {
     expect(result).toEqual({ valid: true });
     expect(captured.url?.searchParams.get("api-version")).toBe("v1");
   });
+
+  test("Azure probe accepts when every expected deployment is listed", async () => {
+    mockAzureListModelsResponse([
+      { id: "gpt-5-chat" },
+      { id: "gpt-5-mini" },
+      { id: "gpt-5-reasoning" },
+    ]);
+
+    const result = await probeProvider(
+      "azure_foundry",
+      "azure-key",
+      "https://example.openai.azure.com/openai/v1",
+      undefined,
+      ["gpt-5-chat", "gpt-5-mini"],
+    );
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("Azure probe rejects when an expected deployment is missing", async () => {
+    mockAzureListModelsResponse([{ id: "gpt-5-chat" }]);
+
+    const result = await probeProvider(
+      "azure_foundry",
+      "azure-key",
+      "https://example.openai.azure.com/openai/v1",
+      undefined,
+      ["gpt-5-chat", "typo-deployment"],
+    );
+
+    expect(result).toEqual({
+      valid: false,
+      error: "Azure Foundry deployment not found: typo-deployment",
+    });
+  });
+
+  test("Azure probe treats a malformed list-models body as zero deployments", async () => {
+    mockAzureListModelsResponse("not-an-object");
+
+    const result = await probeProvider(
+      "azure_foundry",
+      "azure-key",
+      "https://example.openai.azure.com/openai/v1",
+      undefined,
+      ["any-deployment"],
+    );
+
+    expect(result).toEqual({
+      valid: false,
+      error: "Azure Foundry deployment not found: any-deployment",
+    });
+  });
 });
 
 type CapturedAzureProbeRequest = {
   apiKey?: string | null;
   url?: URL;
+};
+
+const mockAzureListModelsResponse = (data: unknown): void => {
+  const body = Array.isArray(data)
+    ? JSON.stringify({ object: "list", data })
+    : JSON.stringify(data);
+  const mockFetch: typeof fetch = Object.assign(
+    async () => new Response(body, { status: 200 }),
+    { preconnect: originalFetch.preconnect },
+  );
+  globalThis.fetch = mockFetch;
 };
 
 const captureAzureProbeRequest = (): CapturedAzureProbeRequest => {

--- a/apps/api/src/lib/ai-provider-probe.ts
+++ b/apps/api/src/lib/ai-provider-probe.ts
@@ -104,9 +104,15 @@ export const probeProvider = async (
   apiKey: string,
   endpoint?: string,
   apiVersion?: string,
+  expectedAzureDeployments?: readonly string[],
 ): Promise<ProviderProbeResult> => {
   if (provider === "azure_foundry") {
-    return await probeAzureFoundry(apiKey, endpoint, apiVersion);
+    return await probeAzureFoundry(
+      apiKey,
+      endpoint,
+      apiVersion,
+      expectedAzureDeployments,
+    );
   }
 
   const signal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
@@ -131,6 +137,7 @@ const probeAzureFoundry = async (
   apiKey: string,
   endpoint: string | undefined,
   apiVersion: string | undefined,
+  expectedDeployments: readonly string[] | undefined,
 ): Promise<ProviderProbeResult> => {
   if (!endpoint?.trim()) {
     return {
@@ -152,18 +159,59 @@ const probeAzureFoundry = async (
     signal,
   });
 
-  if (response.ok) {
+  if (!response.ok) {
+    const detail = await extractDetail(response);
+    return {
+      valid: false,
+      error: detail
+        ? `Azure Foundry rejected the key or endpoint (HTTP ${response.status}): ${detail}`
+        : `Azure Foundry rejected the key or endpoint (HTTP ${response.status})`,
+    };
+  }
+
+  if (!expectedDeployments || expectedDeployments.length === 0) {
     return { valid: true };
   }
 
-  const detail = await extractDetail(response);
-  return {
-    valid: false,
-    error: detail
-      ? `Azure Foundry rejected the key or endpoint (HTTP ${response.status}): ${detail}`
-      : `Azure Foundry rejected the key or endpoint (HTTP ${response.status})`,
-  };
+  const deployments = await extractAzureDeployments(response);
+  const missing = expectedDeployments.filter(
+    (deployment) => !deployments.has(deployment),
+  );
+  if (missing.length > 0) {
+    return {
+      valid: false,
+      error: `Azure Foundry deployment not found: ${missing.join(", ")}`,
+    };
+  }
+  return { valid: true };
 };
+
+const extractAzureDeployments = async (
+  response: Response,
+): Promise<ReadonlySet<string>> =>
+  await response
+    .clone()
+    .json()
+    .then((body: unknown) => {
+      if (
+        typeof body !== "object" ||
+        body === null ||
+        !("data" in body) ||
+        !Array.isArray(body.data)
+      ) {
+        return new Set<string>();
+      }
+      const ids = body.data.flatMap((entry: unknown) =>
+        typeof entry === "object" &&
+        entry !== null &&
+        "id" in entry &&
+        typeof entry.id === "string"
+          ? [entry.id]
+          : [],
+      );
+      return new Set<string>(ids);
+    })
+    .catch(() => new Set<string>());
 
 const resolveAzureApiVersion = (apiVersion: string | undefined): string =>
   apiVersion?.trim() ||

--- a/apps/web/src/components/ai-config-providers-editor.tsx
+++ b/apps/web/src/components/ai-config-providers-editor.tsx
@@ -19,6 +19,7 @@ import {
   isProviderValue,
   isRegionValue,
   PROVIDER_KEYS,
+  PROVIDER_LABELS,
   REGION_KEYS,
   REGIONAL_PROVIDERS,
 } from "@/components/ai-config-role-models.logic";
@@ -173,7 +174,7 @@ export const AIConfigProvidersEditor = ({
                   <SelectPopup alignItemWithTrigger={false}>
                     {providerOptions.map((provider) => (
                       <SelectItem key={provider} value={provider}>
-                        {t(`aiConfig.providers.${provider}`)}
+                        {PROVIDER_LABELS[provider]}
                       </SelectItem>
                     ))}
                   </SelectPopup>
@@ -338,7 +339,7 @@ export const AIConfigProvidersEditor = ({
                     <SelectPopup alignItemWithTrigger={false}>
                       {providerOptions.map((provider) => (
                         <SelectItem key={provider} value={provider}>
-                          {t(`aiConfig.providers.${provider}`)}
+                          {PROVIDER_LABELS[provider]}
                         </SelectItem>
                       ))}
                     </SelectPopup>

--- a/apps/web/src/components/ai-config-role-model-picker.tsx
+++ b/apps/web/src/components/ai-config-role-model-picker.tsx
@@ -25,6 +25,7 @@ import {
   getRolePickerRows,
   isProviderValue,
   MODEL_OPTIONS_BY_PROVIDER,
+  PROVIDER_LABELS,
 } from "@/components/ai-config-role-models.logic";
 import type {
   ModelSelection,
@@ -123,7 +124,7 @@ export const AIConfigRoleModelPicker = ({
                 <SelectPopup alignItemWithTrigger={false}>
                   {providers.map((provider) => (
                     <SelectItem key={provider} value={provider}>
-                      {t(`aiConfig.providers.${provider}`)}
+                      {PROVIDER_LABELS[provider]}
                     </SelectItem>
                   ))}
                 </SelectPopup>

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -7,6 +7,15 @@ export const PROVIDER_KEYS = [
   "openrouter",
 ] as const;
 
+export const PROVIDER_LABELS = {
+  google: "Google",
+  anthropic: "Anthropic",
+  mistral: "Mistral",
+  openai: "OpenAI",
+  azure_foundry: "Azure Foundry",
+  openrouter: "OpenRouter",
+} as const satisfies Record<(typeof PROVIDER_KEYS)[number], string>;
+
 export const REGION_KEYS = ["global", "eu", "ch"] as const;
 
 export const ROLE_KEYS = ["chat", "fast", "reasoning", "pdf"] as const;

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Poskytovatel pro {role}",
       "providerKeyInvalid": "{provider} odmítl klíč. Zkontrolujte ho před uložením.",
       "providerKeyInvalidShort": "Neplatný",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Přidejte přihlašovací údaje poskytovatelů, které má Stella používat.",
       "providersPanel": "Poskytovatelé",
       "regions": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Provider für {role}",
       "providerKeyInvalid": "{provider} hat den Schlüssel abgelehnt. Bitte überprüfen Sie ihn.",
       "providerKeyInvalidShort": "Ungültig",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Füge die Provider-Zugangsdaten hinzu, die Stella verwenden soll.",
       "providersPanel": "Provider",
       "regions": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "{role} provider",
       "providerKeyInvalid": "{provider} rejected the key. Double-check it before saving.",
       "providerKeyInvalidShort": "Invalid",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Add the provider credentials you want Stella to use.",
       "providersPanel": "Providers",
       "regions": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Proveedor para {role}",
       "providerKeyInvalid": "{provider} rechazó la clave. Compruébela antes de guardar.",
       "providerKeyInvalidShort": "No válida",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Añade las credenciales de los proveedores que quieres que use Stella.",
       "providersPanel": "Proveedores",
       "regions": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "{role} teenusepakkuja",
       "providerKeyInvalid": "{provider} keeldus võtmest. Kontrollige seda enne salvestamist.",
       "providerKeyInvalidShort": "Vigane",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Lisa nende teenusepakkujate mandaadid, mida Stella peaks kasutama.",
       "providersPanel": "Teenusepakkujad",
       "regions": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Fournisseur pour {role}",
       "providerKeyInvalid": "{provider} a rejeté la clé. Vérifiez-la avant d'enregistrer.",
       "providerKeyInvalidShort": "Invalide",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Ajoutez les identifiants des fournisseurs que Stella doit utiliser.",
       "providersPanel": "Fournisseurs",
       "regions": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "{role} szolgáltatója",
       "providerKeyInvalid": "A {provider} elutasította a kulcsot. Kérjük, ellenőrizze.",
       "providerKeyInvalidShort": "Érvénytelen",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Add meg azoknak a szolgáltatóknak a hitelesítő adatait, amelyeket Stella használjon.",
       "providersPanel": "Szolgáltatók",
       "regions": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "{role} teikėjas",
       "providerKeyInvalid": "{provider} atmetė raktą. Prieš išsaugodami patikrinkite.",
       "providerKeyInvalidShort": "Negaliojantis",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Pridėkite teikėjų prisijungimo duomenis, kuriuos Stella turėtų naudoti.",
       "providersPanel": "Teikėjai",
       "regions": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "{role} pakalpojumu sniedzējs",
       "providerKeyInvalid": "{provider} atteica atslēgu. Pārbaudiet to pirms saglabāšanas.",
       "providerKeyInvalidShort": "Nederīgs",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Pievienojiet to pakalpojumu sniedzēju akreditācijas datus, kurus Stella izmantos.",
       "providersPanel": "Pakalpojumu sniedzēji",
       "regions": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1374,14 +1374,6 @@ type Messages = {
       "providerForRole": "{role} provider";
       "providerKeyInvalid": "{provider} rejected the key. Double-check it before saving.";
       "providerKeyInvalidShort": "Invalid";
-      "providers": {
-        "anthropic": "Anthropic";
-        "azure_foundry": "Azure Foundry";
-        "google": "Google";
-        "mistral": "Mistral";
-        "openai": "ChatGPT";
-        "openrouter": "OpenRouter";
-      };
       "providersDescription": "Add the provider credentials you want Stella to use.";
       "providersPanel": "Providers";
       "regions": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Dostawca dla {role}",
       "providerKeyInvalid": "{provider} odrzucił klucz. Sprawdź go przed zapisaniem.",
       "providerKeyInvalidShort": "Nieprawidłowy",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Dodaj dane uwierzytelniające dostawców, których Stella ma używać.",
       "providersPanel": "Dostawcy",
       "regions": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Provedor {role}",
       "providerKeyInvalid": "{provider} rejeitou a chave. Verifique novamente antes de salvar.",
       "providerKeyInvalidShort": "Inválido",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Adicione as credenciais do provedor que você deseja que stella use.",
       "providersPanel": "Provedores",
       "regions": {

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1371,14 +1371,6 @@
       "providerForRole": "Poskytovateľ pre {role}",
       "providerKeyInvalid": "{provider} odmietol kľúč. Skontrolujte ho pred uložením.",
       "providerKeyInvalidShort": "Neplatný",
-      "providers": {
-        "anthropic": "Anthropic",
-        "azure_foundry": "Azure Foundry",
-        "google": "Google",
-        "mistral": "Mistral",
-        "openai": "ChatGPT",
-        "openrouter": "OpenRouter"
-      },
       "providersDescription": "Pridajte prihlasovacie údaje poskytovateľov, ktoré má Stella používať.",
       "providersPanel": "Poskytovatelia",
       "regions": {

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -21,6 +21,7 @@ import {
   roleModelsFromOverrideModels,
   serializeOverrideModels,
   isProviderValue,
+  PROVIDER_LABELS,
 } from "@/components/ai-config-role-models.logic";
 import type {
   ModelSelection,
@@ -243,7 +244,7 @@ export const AIConfigCard = () => {
               >
                 <span className="font-medium">
                   {isProviderValue(providerConfig.provider)
-                    ? t(`aiConfig.providers.${providerConfig.provider}`)
+                    ? PROVIDER_LABELS[providerConfig.provider]
                     : providerConfig.provider}
                 </span>{" "}
                 <span className="text-muted-foreground font-mono">

--- a/apps/web/src/routes/onboarding/-components/prices-panel.tsx
+++ b/apps/web/src/routes/onboarding/-components/prices-panel.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "use-intl";
 import {
   encodeModelSelection,
   MODEL_OPTIONS_BY_PROVIDER,
+  PROVIDER_LABELS,
   ROLE_KEYS,
 } from "@/components/ai-config-role-models.logic";
 import type {
@@ -258,7 +259,7 @@ export const PricesPanel = ({ providers, roleModels }: PricesPanelProps) => {
               <div className="bg-muted/30 flex items-center gap-2 px-5 py-2">
                 <ProviderIcon className="text-foreground size-4 shrink-0" />
                 <span className="text-foreground text-sm font-medium">
-                  {tOrganization(`aiConfig.providers.${provider}`)}
+                  {PROVIDER_LABELS[provider]}
                 </span>
               </div>
               {rows.length === 0 && (

--- a/apps/web/src/routes/onboarding/-components/sidebar-preview.tsx
+++ b/apps/web/src/routes/onboarding/-components/sidebar-preview.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react";
 import { useTranslations } from "use-intl";
 
+import { PROVIDER_LABELS } from "@/components/ai-config-role-models.logic";
 import type {
   ProviderPreview,
   ProviderValidationStatus,
@@ -185,7 +186,7 @@ export const SidebarPreview = ({
               >
                 <ProviderIcon className="text-foreground size-3.5 shrink-0" />
                 <span className="text-foreground text-xs font-medium">
-                  {tOrganization(`aiConfig.providers.${provider}`)}
+                  {PROVIDER_LABELS[provider]}
                 </span>
                 <span className="ms-auto flex items-center gap-1.5">
                   <span

--- a/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
+++ b/apps/web/src/routes/onboarding/-components/steps/ai-step.tsx
@@ -11,6 +11,7 @@ import { AIConfigRoleModelPicker } from "@/components/ai-config-role-model-picke
 import {
   ensureRoleModelsForProviders,
   getProviderValues,
+  PROVIDER_LABELS,
   serializeOverrideModels,
 } from "@/components/ai-config-role-models.logic";
 import type {
@@ -200,7 +201,7 @@ export const AIStep = ({
         }));
         stellaToast.add({
           title: tOrganization("aiConfig.providerKeyInvalid", {
-            provider: tOrganization(`aiConfig.providers.${draft.provider}`),
+            provider: PROVIDER_LABELS[draft.provider],
           }),
           type: "warning",
         });
@@ -217,7 +218,7 @@ export const AIStep = ({
           toastedRef.current.add(toastKey);
           stellaToast.add({
             title: tOrganization("aiConfig.providerKeyInvalid", {
-              provider: tOrganization(`aiConfig.providers.${draft.provider}`),
+              provider: PROVIDER_LABELS[draft.provider],
             }),
             description: response.data.error,
             type: "warning",


### PR DESCRIPTION
Settings was calling `generateText` with `maxOutputTokens: 3` to validate BYOK keys, which OpenAI reasoning models reject (min 16). Onboarding already had a working lightweight probe (`probeProvider`); the settings handler now reuses it — list-models auth check, no token cost, no per-model quirks.

Also fixes the provider label: "OpenAI" (the API provider), not "ChatGPT" (the consumer product). Brand names aren't translatable, so the `aiConfig.providers.*` i18n keys are replaced with a `PROVIDER_LABELS` const and stripped from all 12 languages.

Test plan:
- [ ] Save a valid OpenAI key on Settings → AI Config with a reasoning model selected (e.g. gpt-5) → saves cleanly
- [ ] Save an invalid key → error toast quotes the provider's HTTP rejection
- [ ] Onboarding flow still validates and labels providers identically
- [ ] Provider dropdown shows "OpenAI" everywhere