### PR TITLE
feat(api): accept DB connection components alongside DATABASE_URL

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -1,8 +1,10 @@
 import { defineConfig } from "drizzle-kit";
 
-// Fallback keeps knip and CI happy when DATABASE_URL is unset.
+import { resolveDatabaseUrl } from "./src/db-url";
+
+// Fallback keeps knip and CI happy when no DB env is set.
 // drizzle-kit push/generate will fail fast on connection, not silently.
-const url = process.env.DATABASE_URL ?? "postgresql://invalid";
+const url = resolveDatabaseUrl() ?? "postgresql://invalid";
 
 export default defineConfig({
   out: "./drizzle",

--- a/apps/api/src/db-url.test.ts
+++ b/apps/api/src/db-url.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveDatabaseUrl } from "@/api/db-url";
+
+const components = {
+  DB_HOST: "db.example",
+  DB_PORT: "5432",
+  DB_USER: "appuser",
+  DB_PASSWORD: "pw",
+  DB_NAME: "appdb",
+};
+
+describe("resolveDatabaseUrl", () => {
+  test("returns DATABASE_URL when present", () => {
+    expect(
+      resolveDatabaseUrl({ DATABASE_URL: "postgres://x/y", ...components }),
+    ).toBe("postgres://x/y");
+  });
+
+  test("returns undefined when nothing is set", () => {
+    expect(resolveDatabaseUrl({})).toBeUndefined();
+  });
+
+  test("assembles URL from components with sslmode=require by default", () => {
+    expect(resolveDatabaseUrl(components)).toBe(
+      "postgres://appuser:pw@db.example:5432/appdb?sslmode=require",
+    );
+  });
+
+  test("respects DB_SSLMODE override", () => {
+    expect(
+      resolveDatabaseUrl({ ...components, DB_SSLMODE: "verify-full" }),
+    ).toBe("postgres://appuser:pw@db.example:5432/appdb?sslmode=verify-full");
+  });
+
+  test("percent-encodes credentials with reserved characters", () => {
+    expect(
+      resolveDatabaseUrl({
+        ...components,
+        DB_USER: "user@host",
+        DB_PASSWORD: "p@ss:w/rd?#",
+      }),
+    ).toBe(
+      "postgres://user%40host:p%40ss%3Aw%2Frd%3F%23@db.example:5432/appdb?sslmode=require",
+    );
+  });
+
+  test("percent-encodes the database name (path segment)", () => {
+    expect(
+      resolveDatabaseUrl({
+        ...components,
+        DB_NAME: "appdb?sslmode=disable",
+      }),
+    ).toBe(
+      "postgres://appuser:pw@db.example:5432/appdb%3Fsslmode%3Ddisable?sslmode=require",
+    );
+  });
+
+  test("preserves bracketed IPv6 host literals", () => {
+    expect(resolveDatabaseUrl({ ...components, DB_HOST: "[::1]" })).toBe(
+      "postgres://appuser:pw@[::1]:5432/appdb?sslmode=require",
+    );
+  });
+
+  test("allows empty DB_PASSWORD", () => {
+    expect(resolveDatabaseUrl({ ...components, DB_PASSWORD: "" })).toBe(
+      "postgres://appuser:@db.example:5432/appdb?sslmode=require",
+    );
+  });
+
+  test("flags DB_PASSWORD as missing when unset, not when empty", () => {
+    expect(() =>
+      resolveDatabaseUrl({
+        DB_HOST: "db.example",
+        DB_PORT: "5432",
+        DB_USER: "appuser",
+        DB_NAME: "appdb",
+      }),
+    ).toThrow(/DB_PASSWORD/);
+  });
+
+  test("throws when components are partially set", () => {
+    expect(() =>
+      resolveDatabaseUrl({ DB_HOST: "db.example", DB_USER: "appuser" }),
+    ).toThrow(/incomplete.*DB_PORT.*DB_PASSWORD.*DB_NAME/);
+  });
+
+  test.each([["disable"], ["allow"], ["prefer"], ["bogus"]])(
+    "throws on DB_SSLMODE=%s",
+    (sslmode) => {
+      expect(() =>
+        resolveDatabaseUrl({ ...components, DB_SSLMODE: sslmode }),
+      ).toThrow(/DB_SSLMODE must be one of/);
+    },
+  );
+
+  test.each([["require"], ["verify-ca"], ["verify-full"]])(
+    "accepts DB_SSLMODE=%s",
+    (sslmode) => {
+      expect(resolveDatabaseUrl({ ...components, DB_SSLMODE: sslmode })).toBe(
+        `postgres://appuser:pw@db.example:5432/appdb?sslmode=${sslmode}`,
+      );
+    },
+  );
+
+  test.each([
+    ["db.example/x"],
+    ["db.example?sslmode=disable"],
+    ["db.example#frag"],
+    ["a@b"],
+    ["db .example"],
+  ])("throws on DB_HOST containing URL delimiter: %s", (host) => {
+    expect(() => resolveDatabaseUrl({ ...components, DB_HOST: host })).toThrow(
+      /DB_HOST must not contain URL delimiters/,
+    );
+  });
+
+  test.each([["abc"], ["5432a"], ["1 2"], ["-5432"]])(
+    "throws on non-numeric DB_PORT=%s",
+    (port) => {
+      expect(() =>
+        resolveDatabaseUrl({ ...components, DB_PORT: port }),
+      ).toThrow(/DB_PORT must be numeric/);
+    },
+  );
+});

--- a/apps/api/src/db-url.ts
+++ b/apps/api/src/db-url.ts
@@ -1,0 +1,78 @@
+/**
+ * Resolve the Postgres connection URL.
+ *
+ * Accepts either DATABASE_URL or a set of components
+ * (DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, and an optional
+ * DB_SSLMODE) that this helper assembles into a URL. Components are
+ * useful when the password is sourced from a different place than
+ * the rest of the connection metadata.
+ */
+
+const COMPONENT_KEYS = [
+  "DB_HOST",
+  "DB_PORT",
+  "DB_USER",
+  "DB_PASSWORD",
+  "DB_NAME",
+] as const;
+
+// Only TLS-enforcing modes are allowed via DB_SSLMODE. `disable`,
+// `allow`, and `prefer` would silently downgrade transport security
+// and have no legitimate reason to appear in a managed deploy.
+const ALLOWED_SSLMODES = ["require", "verify-ca", "verify-full"] as const;
+
+export const resolveDatabaseUrl = (
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined => {
+  if (env["DATABASE_URL"]) {
+    return env["DATABASE_URL"];
+  }
+
+  const { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, DB_SSLMODE } = env;
+
+  // Password is allowed to be the empty string (valid in some local
+  // dev setups), so check it with `undefined` rather than truthiness.
+  if (
+    !DB_HOST &&
+    !DB_PORT &&
+    !DB_USER &&
+    DB_PASSWORD === undefined &&
+    !DB_NAME
+  ) {
+    return undefined;
+  }
+  if (
+    !DB_HOST ||
+    !DB_PORT ||
+    !DB_USER ||
+    DB_PASSWORD === undefined ||
+    !DB_NAME
+  ) {
+    const missing = COMPONENT_KEYS.filter((k) =>
+      k === "DB_PASSWORD" ? env[k] === undefined : !env[k],
+    );
+    throw new Error(
+      `DATABASE_URL not set and DB component env vars incomplete; missing: ${missing.join(", ")}`,
+    );
+  }
+
+  const sslmode = DB_SSLMODE ?? "require";
+  if (!(ALLOWED_SSLMODES as readonly string[]).includes(sslmode)) {
+    throw new Error(`DB_SSLMODE must be one of ${ALLOWED_SSLMODES.join(", ")}`);
+  }
+  // DB_HOST is left unencoded so IPv6 literals like `[::1]` survive,
+  // but URL delimiters in it would otherwise be spliced into the
+  // path/query and could smuggle `sslmode=disable` or point at a
+  // different database. Same idea for DB_PORT, which must be numeric.
+  if (/[/?#@\s]/.test(DB_HOST)) {
+    throw new Error(
+      "DB_HOST must not contain URL delimiters (/, ?, #, @, whitespace)",
+    );
+  }
+  if (!/^\d+$/.test(DB_PORT)) {
+    throw new Error("DB_PORT must be numeric");
+  }
+  const auth = `${encodeURIComponent(DB_USER)}:${encodeURIComponent(DB_PASSWORD)}`;
+  const name = encodeURIComponent(DB_NAME);
+  return `postgres://${auth}@${DB_HOST}:${DB_PORT}/${name}?sslmode=${sslmode}`;
+};

--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -10,6 +10,8 @@
 import { createEnv } from "@t3-oss/env-core";
 import * as v from "valibot";
 
+import { resolveDatabaseUrl } from "@/api/db-url";
+
 export const envBase = createEnv({
   server: {
     DATABASE_URL: v.pipe(v.string(), v.url()),
@@ -35,5 +37,5 @@ export const envBase = createEnv({
     isDev: v.optional(v.boolean(), process.env.NODE_ENV !== "production"),
   },
   emptyStringAsUndefined: true,
-  runtimeEnv: process.env,
+  runtimeEnv: { ...process.env, DATABASE_URL: resolveDatabaseUrl() },
 });


### PR DESCRIPTION
Add `resolveDatabaseUrl()` so the API and migrations accept either a full `DATABASE_URL` or a set of components (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, optional `DB_SSLMODE`). Lets the password come from a different source than the rest of the connection metadata.

- `DATABASE_URL` flow is unchanged.
- Components: user/password/host/port/name are percent-encoded; `DB_SSLMODE` is restricted to TLS-enforcing modes (`require`, `verify-ca`, `verify-full`) and defaults to `require`.

## Test plan
- [x] `bun --filter @stll/api test src/db-url.test.ts`
- [x] `bun --filter @stll/api typecheck` and lint
- [x] Local API boot with existing `DATABASE_URL` unchanged