### PR TITLE
fix(api): restore 20s timeout budget for settings BYOK probe

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -482,6 +482,12 @@ const shouldValidateProviderConfig = ({
   );
 };
 
+// Settings save tolerates a slower upstream than onboarding's probe:
+// a one-shot save shouldn't fail a healthy key because the provider
+// took 6 s instead of 4 s to answer list-models. Onboarding uses the
+// shorter default and soft-passes 502s at the frontend.
+const SETTINGS_PROBE_TIMEOUT_MS = 20_000;
+
 /**
  * Validate a provider API key via the shared lightweight probe
  * (provider's own auth/list-models endpoint). No token cost and
@@ -507,6 +513,7 @@ const validateProviderKey = async (
         providerConfig.provider === "azure_foundry"
           ? collectAzureDeployments(overrideModels)
           : undefined,
+        SETTINGS_PROBE_TIMEOUT_MS,
       ),
     catch: (error: unknown) =>
       `API key validation failed: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/apps/api/src/lib/ai-provider-probe.ts
+++ b/apps/api/src/lib/ai-provider-probe.ts
@@ -11,7 +11,7 @@ import {
   normalizeAzureFoundryBaseURL,
 } from "@/api/lib/azure-foundry";
 
-const VALIDATION_TIMEOUT_MS = 5000;
+const DEFAULT_VALIDATION_TIMEOUT_MS = 5000;
 
 export const PROVIDER_PROBE_VALUES = [
   "google",
@@ -105,6 +105,7 @@ export const probeProvider = async (
   endpoint?: string,
   apiVersion?: string,
   expectedAzureDeployments?: readonly string[],
+  timeoutMs: number = DEFAULT_VALIDATION_TIMEOUT_MS,
 ): Promise<ProviderProbeResult> => {
   if (provider === "azure_foundry") {
     return await probeAzureFoundry(
@@ -112,10 +113,11 @@ export const probeProvider = async (
       endpoint,
       apiVersion,
       expectedAzureDeployments,
+      timeoutMs,
     );
   }
 
-  const signal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
+  const signal = AbortSignal.timeout(timeoutMs);
   const target = PROBE_TARGETS[provider](apiKey);
   const response = await fetch(target.url, { ...target.init, signal });
 
@@ -138,6 +140,7 @@ const probeAzureFoundry = async (
   endpoint: string | undefined,
   apiVersion: string | undefined,
   expectedDeployments: readonly string[] | undefined,
+  timeoutMs: number,
 ): Promise<ProviderProbeResult> => {
   if (!endpoint?.trim()) {
     return {
@@ -151,7 +154,7 @@ const probeAzureFoundry = async (
     return { valid: false, error: normalized.error };
   }
 
-  const signal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
+  const signal = AbortSignal.timeout(timeoutMs);
   const url = new URL(`${normalized.baseURL}/v1/models`);
   url.searchParams.set("api-version", resolveAzureApiVersion(apiVersion));
   const response = await fetch(url, {


### PR DESCRIPTION
Follow-up to #316. The shared probe defaults to 5s — fine for onboarding (frontend soft-passes 502s) but too tight for settings save where AbortError becomes a 400 and blocks the user from saving an otherwise valid config.

Parameterises `probeProvider`'s timeout (default 5s, settings passes 20s), matching the previous `generateText` budget without bringing `generateText` back. Addresses a Codex P2 review comment that landed after #316 merged.

Test plan:
- [ ] Settings save with a real BYOK key still works
- [ ] Probe unit tests pass