### PR TITLE
fix: allow unused AI provider keys

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -412,22 +412,6 @@ const normalizeOverrideModels = (
     return pdf;
   }
 
-  const referencedProviders = new Set<AIProvider>([
-    chat.selection.provider,
-    fast.selection.provider,
-    reasoning.selection.provider,
-    pdf.selection.provider,
-  ]);
-
-  for (const provider of configuredProviders) {
-    if (!referencedProviders.has(provider)) {
-      return {
-        valid: false,
-        error: `Provider ${provider} is configured but not used by any role`,
-      };
-    }
-  }
-
   return {
     valid: true,
     overrideModels: {

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -534,8 +534,8 @@ export type OrgAIConfig = {
   providers: OrgAIProviderConfig[];
   /**
    * Per-role model selection. Every role must resolve to a
-   * configured provider; the update endpoint enforces this
-   * and rejects orphan providers (configured but unused).
+   * configured provider. Additional configured providers may
+   * be stored for later assignment.
    */
   overrideModels: Record<ModelRole, OrgAIModelSelection>;
 };

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -230,13 +230,18 @@ describe("BYOK provider and model configuration", () => {
     ).toBeNull();
   });
 
-  test("blocks serialization when a configured provider is unused", () => {
+  test("allows configured providers that are not assigned to a role", () => {
     expect(
       serializeOverrideModels({
         providers: ["openai", "anthropic"],
         roleModels: createDefaultRoleModels(["openai"]),
       }),
-    ).toBeNull();
+    ).toEqual({
+      chat: { provider: "openai", modelId: "gpt-5.4-mini" },
+      fast: { provider: "openai", modelId: "gpt-5.4-nano" },
+      reasoning: { provider: "openai", modelId: "gpt-5.4" },
+      pdf: { provider: "openai", modelId: "gpt-5.4" },
+    });
   });
 
   test("keeps selected models only while their provider remains configured", () => {

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -370,16 +370,6 @@ export const serializeOverrideModels = ({
     return null;
   }
 
-  // Reject orphan providers — every configured provider
-  // must drive at least one role. Mirrors the API check;
-  // gating it here keeps the save button honest.
-  const referencedProviders = new Set(
-    selections.map((selection) => selection.provider),
-  );
-  if (providers.some((provider) => !referencedProviders.has(provider))) {
-    return null;
-  }
-
   return {
     chat: normalizeModelSelection(chat),
     fast: normalizeModelSelection(fast),


### PR DESCRIPTION
Allows BYOK configurations to store provider credentials even when a provider is not currently assigned to a model role. Keeps role model validation intact while removing the unused-provider rejection from the web serializer and API save path.