### PR TITLE
chore(ci): bump stella/.github reusable SHA pins

### DIFF
--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -18,7 +18,7 @@ jobs:
     # cap the reusable's GITHUB_TOKEN to no scopes (intersection rule).
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@a80fc97388b8f833fb08104e6031e2258dee549a
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
     secrets:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         )
       )
-    uses: stella/.github/.github/workflows/cla.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
+    uses: stella/.github/.github/workflows/cla.yml@a80fc97388b8f833fb08104e6031e2258dee549a
     with:
       allowlist: dependabot[bot],renovate[bot],github-actions[bot]
     secrets:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -30,4 +30,4 @@ jobs:
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.
-    uses: stella/.github/.github/workflows/pr-lint.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
+    uses: stella/.github/.github/workflows/pr-lint.yml@a80fc97388b8f833fb08104e6031e2258dee549a

--- a/.github/workflows/provenance-nightly.yml
+++ b/.github/workflows/provenance-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: stella/.github/.github/workflows/provenance-update.yml@9aba86f19b0d72fb02344c49342d7f0b0c9700b0
+    uses: stella/.github/.github/workflows/provenance-update.yml@a80fc97388b8f833fb08104e6031e2258dee549a
     secrets:
       app_id: ${{ secrets.PROVENANCE_APP_ID }}
       app_private_key: ${{ secrets.PROVENANCE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Picks up two fixes that just landed on stella/.github main as part of the wave-1 hardening pass:

- gh CLI 2.59 incompatibility (`--slurp` + `--jq` mutually exclusive) in `audit-branch-protection.yml`
- pipefail discipline so a failing `gh api` upstream of the `jq 'add // []'` pipe surfaces instead of producing a false "no drift" exit 0

Updates the SHA pin from \`9aba86f1\` → \`a80fc973\` in the four caller workflows: `audit-branch-protection.yml`, `cla.yml`, `pr-lint.yml`, `provenance-nightly.yml`.

## Test plan

- [x] actionlint clean on all four files
- [ ] cla / pr-lint exercise on this PR
- [ ] manual workflow_dispatch of audit-branch-protection on this branch to verify the slurp+pipefail fix