### PR TITLE
chore(ci): blank NPM_TOKEN on web-build and release-desktop install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,11 @@ jobs:
         if: steps.changed.outputs.run == 'true'
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # .npmrc references NPM_TOKEN, but PR installs must not expose
+          # the secret to install-time lifecycle scripts. The token is
+          # only required when publishing — never to read from the public
+          # npm registry. Match the ci-checks / landing-build pattern.
+          NPM_TOKEN: ""
 
       - name: Prepare environment
         if: steps.changed.outputs.run == 'true'

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -276,7 +276,13 @@ jobs:
       - name: Install dependencies
         run: bun ci
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Signing-key secrets are loaded into later steps in this job.
+          # Keep NPM_TOKEN out of the install-time environment so a
+          # compromised transitive dep's lifecycle script cannot
+          # exfiltrate it alongside the signing material.
+          # Public npm reads work without auth; the token is only used
+          # when publishing.
+          NPM_TOKEN: ""
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # stable


### PR DESCRIPTION
## Summary

Wave 2.1 of the CI hardening pass — remove the npm publish token from install-time env where it isn't needed.

The other two PR-install jobs (\`ci-checks\`, \`landing-build\`) already run with \`NPM_TOKEN: \"\"\` — \`bun ci\` reads public packages from the registry without auth, and workspace-internal deps don't go through the registry at all. This brings the remaining two installs onto the same pattern:

- **ci.yml \`web-build\`** — was injecting the real token on every fork PR that passed the run-ci label gate.
- **release-desktop.yml \`build\`** — signing-key secrets (Tauri/Azure Trusted Signing/Apple p12/AC API key) load into later steps in the same job. A compromised transitive dep's postinstall could exfiltrate the npm token alongside them.

The token is only required when publishing.

## Test plan

- [x] actionlint clean
- [ ] CI green on this PR (the \`web-build\` change is exercised by the PR itself; release-desktop is tag-triggered and not part of PR CI)