### PR TITLE
chore(ci): tag-protection ruleset for v* + weekly drift audit

### DIFF
--- a/.github/branch-protection/tags-v.json
+++ b/.github/branch-protection/tags-v.json
@@ -20,7 +20,7 @@
       "type": "deletion"
     },
     {
-      "type": "non_fast_forward"
+      "type": "update"
     }
   ]
 }

--- a/.github/branch-protection/tags-v.json
+++ b/.github/branch-protection/tags-v.json
@@ -1,0 +1,26 @@
+{
+  "name": "v-tag-protection",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -11,16 +11,30 @@ concurrency:
 
 permissions: {}
 
+# Reusable workflow declares `permissions: contents: read` and runs
+# actions/checkout. The callers' `permissions: {}` would otherwise
+# cap the reusable's GITHUB_TOKEN to no scopes (intersection rule).
+# Each job audits exactly one expected ruleset; the reusable matches
+# by `.name` and ignores other live rulesets, so running the reusable
+# multiple times in parallel is safe.
+
 jobs:
-  audit:
-    # Reusable workflow declares `permissions: contents: read` and runs
-    # actions/checkout. The caller's `permissions: {}` would otherwise
-    # cap the reusable's GITHUB_TOKEN to no scopes (intersection rule).
+  audit-branch:
     permissions:
       contents: read
     uses: stella/.github/.github/workflows/audit-branch-protection.yml@a80fc97388b8f833fb08104e6031e2258dee549a
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
+    secrets:
+      BRANCH_PROTECTION_APP_ID: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
+      BRANCH_PROTECTION_APP_KEY: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}
+
+  audit-tag:
+    permissions:
+      contents: read
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    with:
+      expected-config-path: .github/branch-protection/tags-v.json
     secrets:
       BRANCH_PROTECTION_APP_ID: ${{ secrets.BRANCH_PROTECTION_APP_ID }}
       BRANCH_PROTECTION_APP_KEY: ${{ secrets.BRANCH_PROTECTION_APP_KEY }}


### PR DESCRIPTION
## Summary

Item #5 of the supply-chain hardening pass — codify a tag protection ruleset for \`refs/tags/v*\` and extend the weekly audit to cover it.

### Spec

\`.github/branch-protection/tags-v.json\` declares:
- \`target: tag\` matching \`refs/tags/v*\`
- Rules: \`deletion\` + \`non_fast_forward\` (no force-overwriting an existing release tag, no deletion)
- Bypass: admin role (\`actor_id: 5, actor_type: RepositoryRole, bypass_mode: always\`) — mirrors the existing main-branch ruleset and keeps the existing release-bot flow working (the tag-on-version-bump.yml workflow mints an App token; the App is granted admin via the same path)

Tag creation is **not** restricted — only tag rewriting / deletion. This is the lowest-friction increment that closes the "force-push a v-tag, trigger a release of attacker code" surface without disrupting the current release flow.

### Audit wiring

The existing \`audit-branch-protection.yml\` caller now runs the reusable as two parallel jobs: \`audit-branch\` and \`audit-tag\`. The reusable workflow matches expected against live by \`.name\`, so each job audits exactly one ruleset without interference. Weekly cron + on-demand dispatch cover both rulesets from this PR forward.

### Live state

The ruleset itself isn't created by this PR — only the spec is committed. After merge, the live state needs to be created via:

\`\`\`bash
gh api -X POST repos/stella/stella/rulesets --input .github/branch-protection/tags-v.json
\`\`\`

Once created, the audit job will keep the JSON in sync with live state going forward.

## Test plan

- [x] actionlint clean on the modified audit workflow
- [x] JSON schema validates
- [ ] CI green on this PR
- [ ] post-merge: \`gh api -X POST\` to create live ruleset; manual \`workflow_dispatch\` of audit-branch-protection to confirm both jobs pass against live state