### PR TITLE
chore(ci): bump stella/.github reusable SHA pins to 44c8092f

### DIFF
--- a/.github/workflows/audit-branch-protection.yml
+++ b/.github/workflows/audit-branch-protection.yml
@@ -22,7 +22,7 @@ jobs:
   audit-branch:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
       expected-config-path: .github/branch-protection/ruleset-main.json
     secrets:
@@ -32,7 +32,7 @@ jobs:
   audit-tag:
     permissions:
       contents: read
-    uses: stella/.github/.github/workflows/audit-branch-protection.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    uses: stella/.github/.github/workflows/audit-branch-protection.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
       expected-config-path: .github/branch-protection/tags-v.json
     secrets:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -38,7 +38,7 @@ jobs:
           || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
         )
       )
-    uses: stella/.github/.github/workflows/cla.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    uses: stella/.github/.github/workflows/cla.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     with:
       allowlist: dependabot[bot],renovate[bot],github-actions[bot]
     secrets:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -30,4 +30,4 @@ jobs:
     # Reusable workflow only consumes the auto-provided GITHUB_TOKEN.
     # Do not switch to `secrets: inherit` — that widens the blast radius
     # if the reusable ever starts touching named secrets.
-    uses: stella/.github/.github/workflows/pr-lint.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    uses: stella/.github/.github/workflows/pr-lint.yml@44c8092f11c2f454916c320aa7d2144c173329d8

--- a/.github/workflows/provenance-nightly.yml
+++ b/.github/workflows/provenance-nightly.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: stella/.github/.github/workflows/provenance-update.yml@a80fc97388b8f833fb08104e6031e2258dee549a
+    uses: stella/.github/.github/workflows/provenance-update.yml@44c8092f11c2f454916c320aa7d2144c173329d8
     secrets:
       app_id: ${{ secrets.PROVENANCE_APP_ID }}
       app_private_key: ${{ secrets.PROVENANCE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Picks up the audit-workflow fixes that just landed on stella/.github main (PRs #20 + #23 + #24):

- drift detection now fetches the per-ruleset detail endpoint, so the diff compares against real \`conditions\` / \`bypass_actors\` / \`rules\` instead of the list endpoint's nulls
- evidence artifact name is suffixed with a slugged ruleset name, so the new \`audit-branch\` + \`audit-tag\` fan-out doesn't 409 on upload

Files updated: \`audit-branch-protection.yml\`, \`cla.yml\`, \`pr-lint.yml\`, \`provenance-nightly.yml\`.

## Test plan
- [x] actionlint clean
- [ ] CI green
- [ ] post-merge: workflow_dispatch the audit; both \`audit-branch\` and \`audit-tag\` jobs should report "No drift detected" and upload separate artifacts