### PR TITLE
chore(landing): SEO baseline, JSON-LD graph, robots meta, IndexNow ping

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -95,3 +95,34 @@ jobs:
             --repo "$PRIVATE_WORKFLOWS_REPO" \
             --compact \
             --exit-status
+
+      - name: Ping IndexNow with sitemap URLs
+        # The key file is hosted at apps/landing/public/<key>.txt so
+        # search engines can verify ownership. The key is intentionally
+        # public (it's served at https://stll.app/<key>.txt), so the
+        # gitleaks generic-api-key match below is a false positive.
+        env:
+          INDEXNOW_KEY: 4a9799deb8f64ac9be5f9b9e140407ca # gitleaks:allow
+          HOST: stll.app
+        run: |
+          mapfile -t urls < <(
+            curl -fsSL "https://${HOST}/sitemap-0.xml" \
+              | grep -oE '<loc>[^<]+</loc>' \
+              | sed -E 's#</?loc>##g'
+          )
+          if [[ ${#urls[@]} -eq 0 ]]; then
+            echo "No URLs found in sitemap; skipping IndexNow ping." >&2
+            exit 0
+          fi
+          payload="$(
+            jq -n \
+              --arg host "$HOST" \
+              --arg key "$INDEXNOW_KEY" \
+              --arg keyLocation "https://${HOST}/${INDEXNOW_KEY}.txt" \
+              --argjson urlList "$(printf '%s\n' "${urls[@]}" | jq -R . | jq -s .)" \
+              '{host: $host, key: $key, keyLocation: $keyLocation, urlList: $urlList}'
+          )"
+          curl -fsSL -X POST \
+            -H "Content-Type: application/json; charset=utf-8" \
+            -d "$payload" \
+            https://api.indexnow.org/indexnow

--- a/apps/landing/public/4a9799deb8f64ac9be5f9b9e140407ca.txt
+++ b/apps/landing/public/4a9799deb8f64ac9be5f9b9e140407ca.txt
@@ -1,0 +1,1 @@
+4a9799deb8f64ac9be5f9b9e140407ca

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -83,12 +83,12 @@ const socialImageUrl = new URL(socialImage, Astro.site);
       "@graph": [
         {
           "@type": "Organization",
-          "@id": "https://stll.app/#organization",
+          "@id": new URL("#organization", Astro.site).href,
           "name": "stella labs, s.r.o.",
-          "url": "https://stll.app",
+          "url": new URL("/", Astro.site).href,
           "logo": {
             "@type": "ImageObject",
-            "url": "https://stll.app/images/stella-logo.svg",
+            "url": new URL("/images/stella-logo.svg", Astro.site).href,
           },
           "sameAs": [
             "https://github.com/stella/stella",
@@ -98,18 +98,18 @@ const socialImageUrl = new URL(socialImage, Astro.site);
         },
         {
           "@type": "SoftwareApplication",
-          "@id": "https://stll.app/#software",
+          "@id": new URL("#software", Astro.site).href,
           "name": "stella",
           "applicationCategory": "BusinessApplication",
           "operatingSystem": "Web",
           "description": description,
-          "url": "https://stll.app",
+          "url": new URL("/", Astro.site).href,
           "offers": {
             "@type": "Offer",
             "price": "0",
             "priceCurrency": "USD",
           },
-          "publisher": { "@id": "https://stll.app/#organization" },
+          "publisher": { "@id": new URL("#organization", Astro.site).href },
         },
       ],
     })} />

--- a/apps/landing/src/layouts/Base.astro
+++ b/apps/landing/src/layouts/Base.astro
@@ -27,6 +27,7 @@ const socialImageUrl = new URL(socialImage, Astro.site);
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
+    <meta name="robots" content="index, follow, max-image-preview:large" />
     <title>{title}</title>
 
     <!-- Canonical -->
@@ -79,22 +80,38 @@ const socialImageUrl = new URL(socialImage, Astro.site);
     <!-- Structured data -->
     <script is:inline type="application/ld+json" set:html={JSON.stringify({
       "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "stella",
-      "applicationCategory": "BusinessApplication",
-      "operatingSystem": "Web",
-      "description": description,
-      "url": "https://stll.app",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "USD",
-      },
-      "author": {
-        "@type": "Organization",
-        "name": "stella labs, s.r.o.",
-        "url": "https://stll.app/imprint",
-      },
+      "@graph": [
+        {
+          "@type": "Organization",
+          "@id": "https://stll.app/#organization",
+          "name": "stella labs, s.r.o.",
+          "url": "https://stll.app",
+          "logo": {
+            "@type": "ImageObject",
+            "url": "https://stll.app/images/stella-logo.svg",
+          },
+          "sameAs": [
+            "https://github.com/stella/stella",
+            "https://x.com/stll_app",
+            "https://www.linkedin.com/company/stella-app",
+          ],
+        },
+        {
+          "@type": "SoftwareApplication",
+          "@id": "https://stll.app/#software",
+          "name": "stella",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web",
+          "description": description,
+          "url": "https://stll.app",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD",
+          },
+          "publisher": { "@id": "https://stll.app/#organization" },
+        },
+      ],
     })} />
 
     <style is:global>


### PR DESCRIPTION
## Summary

- JSON-LD restructured as a schema.org `@graph` with a standalone `Organization` (logo + `sameAs` for GitHub, X, LinkedIn) and a `SoftwareApplication` linked via `publisher`. Required for Google knowledge-panel eligibility.
- Explicit `<meta name="robots" content="index, follow, max-image-preview:large">` to opt into large image previews in Google Discover.
- Post-deploy step in `deploy-landing.yml` parses the live `sitemap-0.xml` and POSTs every URL to IndexNow (Bing, Yandex, Seznam, Naver). Key file `apps/landing/public/<key>.txt` proves ownership; key is intentionally public, suppressed from gitleaks via inline `gitleaks:allow`.

## Test plan

- [ ] Built `dist/index.html` contains the new `<meta name="robots">` and the `@graph`-shaped JSON-LD.
- [ ] After merge, the post-deploy IndexNow step succeeds (HTTP 200/202 from `api.indexnow.org`).
- [ ] `https://stll.app/<key>.txt` returns the key contents.
- [ ] Rich Results Test (https://search.google.com/test/rich-results) parses Organization + SoftwareApplication without errors.