### PR TITLE
fix(chrome): right inspector rail Suspense fallback + chrome alignment

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -911,12 +911,12 @@ export function AppSidebar(props: AppSidebarProps) {
       style={{ ...sidebarStyle, ...props.style }}
     >
       {/* Stella logo header */}
-      <SidebarHeader>
+      <SidebarHeader className="h-12 border-b p-0">
         <div
           className={
             isCollapsed
-              ? "flex items-center justify-center"
-              : "flex items-center justify-between ps-2"
+              ? "flex h-full items-center justify-center"
+              : "flex h-full items-center justify-between ps-3 pe-2"
           }
         >
           {!isCollapsed && <StellaWordmark className="h-5 w-auto" />}

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -34,6 +34,7 @@ import {
 } from "@stll/ui/components/menu";
 import { Separator } from "@stll/ui/components/separator";
 import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
 import { AppSidebar } from "@/components/app-sidebar";
@@ -414,7 +415,10 @@ function ProtectedContent({
       <ApiVersionMismatchBanner />
       <SelfhostUpdateBanner />
       <header
-        className="flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"
+        className={cn(
+          "flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4",
+          !matterColor && "bg-sidebar",
+        )}
         style={
           matterColor
             ? {

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -460,7 +460,11 @@ function ProtectedContent({
 const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
 const INSPECTOR_PANE_MIN_WIDTH = 320;
 const INSPECTOR_PANE_MAX_WIDTH = 800;
-const INSPECTOR_RAIL_WIDTH = 40;
+// Matches SIDE_RAIL_WIDTH (`w-12` = 48px) so the wrapper width
+// equals the rail's actual rendered width. Earlier this was 40,
+// leaving the rail 8px wider than its wrapper and pushing the
+// toast / find-replace right-offset CSS vars under the visible rail.
+const INSPECTOR_RAIL_WIDTH = 48;
 
 /**
  * Workspace inspector pane — file viewers + chat tabs. Mounted at

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -51,6 +51,11 @@ import {
   useSidebar,
 } from "@/components/sidebar";
 import { getAnalytics } from "@/lib/analytics/provider";
+import {
+  SIDE_RAIL_ICON_BUTTON_SIZE,
+  SIDE_RAIL_WIDTH,
+  TOOLBAR_ROW_HEIGHT,
+} from "@/lib/consts";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
@@ -72,6 +77,41 @@ const LazyInspectorPanel = lazy(
     await import("@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel").then(
       (m) => ({ default: m.InspectorPanel }),
     ),
+);
+
+// Visual shell for the inspector rail while the panel chunk is
+// loading. Mirrors the real rail's chrome (top toggle, bottom
+// "new chat") so the rail doesn't render as an empty strip during
+// the lazy chunk fetch. Buttons are inert; they activate once the
+// real panel mounts.
+const InspectorRailFallback = () => (
+  <div className="bg-background flex h-full border-s shadow-lg">
+    <div
+      className={`bg-muted/50 flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}`}
+    >
+      <div
+        aria-hidden="true"
+        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-b ${TOOLBAR_ROW_HEIGHT}`}
+      >
+        <span
+          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
+        >
+          <PanelRightIcon className="size-4" />
+        </span>
+      </div>
+      <div className="flex-1" />
+      <div
+        aria-hidden="true"
+        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-t ${TOOLBAR_ROW_HEIGHT}`}
+      >
+        <span
+          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
+        >
+          <MessageSquarePlusIcon className="size-4" />
+        </span>
+      </div>
+    </div>
+  </div>
 );
 
 export const Route = createFileRoute("/_protected")({
@@ -561,7 +601,7 @@ function WorkspaceInspectorSidePanel() {
           />
         )}
         <div className="bg-sidebar flex h-full w-full flex-col">
-          <Suspense>
+          <Suspense fallback={<InspectorRailFallback />}>
             <LazyInspectorPanel workspaceId={activeWorkspaceId ?? undefined} />
           </Suspense>
         </div>


### PR DESCRIPTION
## Summary
- Right inspector panel is lazy-loaded; the surrounding `Suspense` had no fallback, so the entire rail rendered as a blank vertical strip during the chunk fetch. Add an `InspectorRailFallback` matching the real rail's width, borders, and top/bottom icon slots and pass it as the Suspense fallback.
- Align `INSPECTOR_RAIL_WIDTH` (40 → 48) with the rail's actual `SIDE_RAIL_WIDTH = w-12` so the wrapper and the rail agree, and the toast / find-replace right-offset CSS vars stop sitting under the visible rail.
- Force `SidebarHeader` to `h-12` with `border-b` so its line lands at the same y as the topbar's border-b in both expanded and collapsed states.
- Tint the topbar with `bg-sidebar` when no matter-color override is set so the top chrome reads as a continuation of the sidebar columns.

## Test plan
- [ ] Hard refresh a protected route in cold cache and confirm the right rail shows the toggle + new-chat icons immediately, not a blank strip.
- [ ] Toggle the left sidebar between expanded/collapsed and confirm the SidebarHeader border-b stays level with the topbar's border-b.
- [ ] Open a matter with a custom color and confirm the topbar still picks up the matter tint instead of `bg-sidebar`.