### PR TITLE
chore: enable no-unnecessary-condition

### DIFF
--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -885,7 +885,7 @@ const runBenchTask = async ({
     surface,
     taskId: task.id,
     tools: trace.tools,
-    usage: result.totalUsage ?? result.usage ?? null,
+    usage: result.totalUsage,
   };
 };
 

--- a/apps/api/scripts/seed-dev.ts
+++ b/apps/api/scripts/seed-dev.ts
@@ -3877,9 +3877,7 @@ export async function seed(organizationId?: string, userId?: string) {
         bankAccounts: "bankAccounts" in c ? c.bankAccounts : undefined,
         billingAddress: "billingAddress" in c ? c.billingAddress : undefined,
         defaultHourlyRate:
-          "defaultHourlyRate" in c && c.defaultHourlyRate !== undefined
-            ? cents(c.defaultHourlyRate)
-            : undefined,
+          "defaultHourlyRate" in c ? cents(c.defaultHourlyRate) : undefined,
         currency: "currency" in c ? c.currency : undefined,
         paymentTermDays: "paymentTermDays" in c ? c.paymentTermDays : undefined,
         originatingAttorneyId: USER_ID,
@@ -3901,10 +3899,7 @@ export async function seed(organizationId?: string, userId?: string) {
         registrationNumber: c.registrationNumber,
         taxId: c.taxId,
         billingAddress: c.billingAddress,
-        defaultHourlyRate:
-          c.defaultHourlyRate === null || c.defaultHourlyRate === undefined
-            ? c.defaultHourlyRate
-            : cents(c.defaultHourlyRate),
+        defaultHourlyRate: cents(c.defaultHourlyRate),
         currency: c.currency,
         paymentTermDays: c.paymentTermDays,
         emails: c.emails,

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -83,10 +83,7 @@ const envApi = createEnv({
         if (provider === "ses") {
           return !!process.env["SES_REGION"];
         }
-        if (provider === "smtp") {
-          return !!(process.env["SMTP_HOST"] && process.env["SMTP_PORT"]);
-        }
-        return true;
+        return !!(process.env["SMTP_HOST"] && process.env["SMTP_PORT"]);
       }, "Missing required env vars for the selected EMAIL_PROVIDER"),
     ),
     SES_REGION: v.optional(v.string()),

--- a/apps/api/src/handlers/auth/metadata.ts
+++ b/apps/api/src/handlers/auth/metadata.ts
@@ -11,7 +11,7 @@ type AuthWithOAuthServerConfig = ReturnType<typeof getAuth> & {
 const hasOAuthServerConfig = (
   auth: ReturnType<typeof getAuth>,
 ): auth is AuthWithOAuthServerConfig => {
-  if (typeof auth !== "object" || auth === null) {
+  if (typeof auth !== "object") {
     return false;
   }
 
@@ -20,7 +20,7 @@ const hasOAuthServerConfig = (
   }
 
   const { api } = auth;
-  if (typeof api !== "object" || api === null) {
+  if (typeof api !== "object") {
     return false;
   }
 

--- a/apps/api/src/handlers/case-law/citation-score.ts
+++ b/apps/api/src/handlers/case-law/citation-score.ts
@@ -105,7 +105,7 @@ export const recencyFactor = (
   citingDate: Date | string | null,
   now: Date = new Date(),
 ): number => {
-  if (citingDate === undefined || citingDate === null) {
+  if (citingDate === null) {
     return 0.5; // Unknown date → half weight
   }
 
@@ -164,7 +164,7 @@ export const citationScore = (
   const wSum = weightedCitationSum(citations, now, weightMap);
 
   let yearsOld = 1;
-  if (decisionDate !== undefined && decisionDate !== null) {
+  if (decisionDate !== null) {
     const d =
       typeof decisionDate === "string" ? new Date(decisionDate) : decisionDate;
     yearsOld = Math.max(

--- a/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/health-check.ts
@@ -107,7 +107,7 @@ const checkField = (
 
   for (const d of decisions) {
     const val = d[field];
-    if (val !== undefined && val !== null && val !== "") {
+    if (val !== undefined && val !== "") {
       present++;
       if (examples.length < 3) {
         const str =
@@ -167,15 +167,12 @@ export const checkAdapterHealth = async (
       return check && check.missing === 0;
     });
 
-    const status = (() => {
-      if (page.decisions.length === 0) {
-        return "down";
-      }
-      if (requiredOk) {
-        return "healthy";
-      }
-      return "degraded";
-    })();
+    let status: HealthResult["status"] = "degraded";
+    if (page.decisions.length === 0) {
+      status = "down";
+    } else if (requiredOk) {
+      status = "healthy";
+    }
 
     return {
       key: adapter.key,
@@ -236,15 +233,12 @@ export const formatHealthReport = (
   const lines: string[] = ["=== Adapter Health Report ===", ""];
 
   for (const r of results) {
-    const icon = (() => {
-      if (r.status === "healthy") {
-        return "OK";
-      }
-      if (r.status === "degraded") {
-        return "WARN";
-      }
-      return "FAIL";
-    })();
+    let icon = "FAIL";
+    if (r.status === "healthy") {
+      icon = "OK";
+    } else if (r.status === "degraded") {
+      icon = "WARN";
+    }
 
     lines.push(`[${icon}] ${r.key} (${r.name})`);
     lines.push(

--- a/apps/api/src/handlers/case-law/ingestion/adapters/nullish-optional-fields.test.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/nullish-optional-fields.test.ts
@@ -669,6 +669,29 @@ describe("case-law adapter nullish optionals", () => {
     expect(decision?.ecli).toBe("ECLI:SK:TEST");
   });
 
+  test("SK Courts skips items missing required court data", async () => {
+    mockFetchWithBodies([
+      {
+        pattern: "/pilot/api/ress-isu-service/v1/rozhodnutie?",
+        body: JSON.stringify({
+          rozhodnutieList: [
+            {
+              spisovaZnacka: "1Cdo/2/2024",
+              sud: null,
+              datumVydania: "01.02.2024",
+            },
+          ],
+          numFound: 1,
+        }),
+      },
+    ]);
+
+    const result = await skCourtsAdapter.fetchPage(null, {});
+
+    expect(result.isOk()).toBe(true);
+    expect(result.unwrap().decisions).toEqual([]);
+  });
+
   test("PL Courts uses the extended page timeout budget for sequential detail fetches", () => {
     expect(plCourtsAdapter.pageTimeoutMs).toBe(280_000);
   });

--- a/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/pagination.ts
@@ -266,12 +266,10 @@ export const createPagePaginatedFetch = <TResponse>(
             } catch (retryParseError) {
               const retryContentType =
                 retryResponse.headers.get("content-type") ?? "unknown";
-              const detail = (() => {
-                if (retryParseError instanceof SyntaxError) {
-                  return `unparseable (content-type: ${retryContentType})`;
-                }
-                return `validation failed: ${retryParseError instanceof Error ? retryParseError.message : String(retryParseError)}`;
-              })();
+              const detail =
+                retryParseError instanceof SyntaxError
+                  ? `unparseable (content-type: ${retryContentType})`
+                  : `validation failed: ${retryParseError instanceof Error ? retryParseError.message : String(retryParseError)}`;
               throw new AdapterFetchError({
                 message: `${opts.adapterKey}: page ${page} retry ${detail}`,
                 adapterKey: opts.adapterKey,
@@ -341,15 +339,13 @@ export const createPagePaginatedFetch = <TResponse>(
           skipped: itemsSkipped,
           totalMs,
           fetchMs,
-          ...(total !== undefined && total !== null
-            ? { sourceTotal: total }
-            : {}),
+          ...(total !== undefined ? { sourceTotal: total } : {}),
         });
 
         const fetched = pageStartOffset + fetchedItems.length;
         const hasMore =
           fetchedItems.length >= opts.pageSize &&
-          (total === undefined || total === null || fetched < total);
+          (total === undefined || fetched < total);
 
         // On abort, rewind to the start of the in-flight chunk so the
         // next cycle re-processes it.
@@ -358,20 +354,16 @@ export const createPagePaginatedFetch = <TResponse>(
         // re-processing the already consumed page tail.
         // When exhausted with zero results (overshot past end),
         // step back so the cursor recovers into the valid range.
-        const nextCursor = (() => {
-          if (signal?.aborted) {
-            return encodeOffsetCursor(offset + processedThroughIndex);
-          }
-          if (hasMore) {
-            return encodeOffsetCursor(fetched);
-          }
-          if (fetchedItems.length > 0) {
-            return encodeOffsetCursor(offset + items.length);
-          }
-          return encodeOffsetCursor(
-            Math.max(0, pageStartOffset - opts.pageSize),
-          );
-        })();
+        let nextCursor = encodeOffsetCursor(
+          Math.max(0, pageStartOffset - opts.pageSize),
+        );
+        if (signal?.aborted) {
+          nextCursor = encodeOffsetCursor(offset + processedThroughIndex);
+        } else if (hasMore) {
+          nextCursor = encodeOffsetCursor(fetched);
+        } else if (fetchedItems.length > 0) {
+          nextCursor = encodeOffsetCursor(offset + items.length);
+        }
 
         return { decisions, nextCursor };
       },

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -265,7 +265,7 @@ const parseItemWithDetail = async (
       identifikacneCislo: toOptionalValue(item.identifikacneCislo),
       judge: toOptionalValue(item.sudca?.meno),
       judgeRegistreGuid: toOptionalValue(item.sudca?.registreGuid),
-      courtRegistreGuid: toOptionalValue(item.sud?.registreGuid),
+      courtRegistreGuid: toOptionalValue(item.sud.registreGuid),
       decisionNature: item.povaha,
       subArea: detail?.podOblast,
       referencedLegislation: detail?.odkazovanePredpisy,

--- a/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/sk-courts.ts
@@ -238,9 +238,13 @@ const parseItemWithDetail = async (
   // and date immediately; fulltext follows via backfill.
 
   const caseNumber = item.spisovaZnacka;
+  const courtInfo = Reflect.get(item, "sud");
+  if (!caseNumber || !isSkSud(courtInfo) || !courtInfo.nazov) {
+    return null;
+  }
   const decisionDate = parseSkDate(item.datumVydania);
   const decisionType = toOptionalValue(item.formaRozhodnutia);
-  const court = item.sud.nazov;
+  const court = courtInfo.nazov;
   const ecli = toOptionalValue(detail?.ecli);
 
   return {
@@ -265,7 +269,7 @@ const parseItemWithDetail = async (
       identifikacneCislo: toOptionalValue(item.identifikacneCislo),
       judge: toOptionalValue(item.sudca?.meno),
       judgeRegistreGuid: toOptionalValue(item.sudca?.registreGuid),
-      courtRegistreGuid: toOptionalValue(item.sud.registreGuid),
+      courtRegistreGuid: toOptionalValue(courtInfo.registreGuid),
       decisionNature: item.povaha,
       subArea: detail?.podOblast,
       referencedLegislation: detail?.odkazovanePredpisy,

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
@@ -768,13 +768,11 @@ const mergeBlocks = (
     // other section headings — already detected by the
     // classifier via SECTION_HEADING_RE which handles
     // both "Odůvodnění" and "O d ů v o d n ě n í").
-    if (inHolding) {
-      if (block.type === "heading") {
-        break;
-      }
-      if (block.type === "paragraph" && !block.role) {
-        block.role = "holding";
-      }
+    if (block.type === "heading") {
+      break;
+    }
+    if (block.type === "paragraph" && !block.role) {
+      block.role = "holding";
     }
   }
 

--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-regional.ts
@@ -289,7 +289,7 @@ const toInlines = (
       ? { type: "text", text: span.text, anonymized: true }
       : { type: "text", text: span.text };
 
-    if (style?.bold && style?.italic) {
+    if (style?.bold && style.italic) {
       inlines.push({
         type: "bold",
         children: [{ type: "italic", children: [node] }],

--- a/apps/api/src/handlers/case-law/ingestion/parsers/libpdf-utils.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/libpdf-utils.ts
@@ -71,7 +71,7 @@ export const buildBoldRanges = (
       continue;
     }
 
-    const bold = isBoldFont(span.fontName ?? "");
+    const bold = isBoldFont(span.fontName);
 
     // Find this span's text in the remaining line text
     const idx = lineText.indexOf(text.trim(), offset);

--- a/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/sk-courts.ts
@@ -187,7 +187,7 @@ const extractLines = async (pdfBytes: Uint8Array): Promise<PdfLine[]> => {
       }
 
       const primarySpan = line.spans[0];
-      const bold = primarySpan ? isBoldFont(primarySpan.fontName ?? "") : false;
+      const bold = primarySpan ? isBoldFont(primarySpan.fontName) : false;
       const fontSize = primarySpan?.fontSize ?? 10;
 
       lines.push({

--- a/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/validate-ast.ts
@@ -141,7 +141,7 @@ export const validateAst = (
       // Skip <div> wrappers that contain child content
       // elements — those children are matched separately.
       if (
-        el.tagName?.toLowerCase() === "div" &&
+        el.tagName.toLowerCase() === "div" &&
         $el.find("p, li, td, th, div").length > 0
       ) {
         return;
@@ -229,9 +229,7 @@ export const validateAst = (
   const typeCounts: Record<string, number> = {};
   for (const b of blocks) {
     const key =
-      b.type === "paragraph" && "role" in b && b.role
-        ? `paragraph-${b.role}`
-        : b.type;
+      b.type === "paragraph" && "role" in b ? `paragraph-${b.role}` : b.type;
     typeCounts[key] = (typeCounts[key] ?? 0) + 1;
   }
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -187,7 +187,7 @@ const runChatStream = async ({
   );
   writer.merge(finalised);
   await flushed;
-  return emptyCompletion !== null;
+  return true;
 };
 
 type StoredUserFile = {
@@ -357,7 +357,7 @@ export const streamChat = async ({
         onAiError,
       });
 
-      if (primaryEmpty && fallbackEligible && fallbackInfo !== null) {
+      if (primaryEmpty && fallbackEligible) {
         // Same conversation, different model. If the fallback also
         // returns empty we surface the error chunk; one automatic
         // retry on a different model is bounded and recoverable,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -187,7 +187,8 @@ const runChatStream = async ({
   );
   writer.merge(finalised);
   await flushed;
-  return true;
+  // eslint-disable-next-line typescript/no-unnecessary-condition -- onFinish can set this while the provider stream drains.
+  return emptyCompletion !== null;
 };
 
 type StoredUserFile = {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -267,6 +267,46 @@ describe("chat third-party anonymization boundary", () => {
     ]);
   });
 
+  test("handles tool parts with an explicitly undefined approval", async () => {
+    const boundary = createBoundary();
+    const messages: ChatMessage[] = [
+      {
+        id: "msg_1",
+        role: "assistant",
+        parts: [
+          // SAFETY: this fixture models a persisted AI SDK tool UI part with
+          // an optional approval property present but undefined.
+          // eslint-disable-next-line typescript/no-unsafe-type-assertion
+          {
+            type: "dynamic-tool",
+            toolName: "read_secret",
+            toolCallId: "call_1",
+            state: "output-available",
+            input: { query: "Jan Novák" },
+            output: { text: "Secret notes" },
+            approval: undefined,
+          } as unknown as ChatMessage["parts"][number],
+        ],
+      },
+    ];
+
+    const prepared = await prepareMessagesForThirdParty({
+      boundary,
+      messages,
+    });
+
+    expect(Result.isOk(prepared)).toBe(true);
+    if (Result.isError(prepared)) {
+      throw prepared.error;
+    }
+
+    expect(prepared.value.at(0)?.parts.at(0)).toMatchObject({
+      approval: undefined,
+      input: { query: "[PERSON_1]" },
+      output: { text: "[CUSTOM_1] notes" },
+    });
+  });
+
   test("returns anonymized live tool output values", async () => {
     const boundary = createBoundary();
     const tools = {

--- a/apps/api/src/handlers/chat/third-party-boundary.test.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.test.ts
@@ -126,7 +126,7 @@ describe("chat third-party anonymization boundary", () => {
       throw prepared.error;
     }
 
-    expect(prepared.value?.at(0)?.parts.at(0)).toEqual({
+    expect(prepared.value.at(0)?.parts.at(0)).toEqual({
       type: "text",
       text: "Does [PERSON_1] appear in [CUSTOM_1] contract?",
     });
@@ -193,7 +193,7 @@ describe("chat third-party anonymization boundary", () => {
       throw prepared.error;
     }
 
-    const part = prepared.value?.at(0)?.parts.at(0);
+    const part = prepared.value.at(0)?.parts.at(0);
 
     expect(part).toMatchObject({
       type: "file",

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -37,8 +37,9 @@ export type ChatThirdPartyBoundary =
        * Canonicals the user marked as "ignore" in the inspector
        * allowlist (workspace and org scopes). Pre-loaded once on
        * boundary creation so we don't hit the DB per anonymize
-       * call. Doc-scope ignores are skipped here — chat threads
-       * aren't tied to a specific entity in the current shape.
+       * call. Doc-scope ignores are skipped here because chat
+       * threads aren't tied to a specific entity in the current
+       * shape.
        */
       excludedCanonicals: Promise<string[]>;
       organizationId: SafeId<"organization">;
@@ -775,10 +776,7 @@ const anonymizeToolPart = ({
     }
 
     const approval =
-      "approval" in part &&
-      part.approval !== undefined &&
-      "reason" in part.approval &&
-      part.approval.reason
+      "approval" in part && "reason" in part.approval && part.approval.reason
         ? part.approval
         : undefined;
     if (approval?.reason) {
@@ -842,7 +840,7 @@ export const prepareToolsForThirdParty = <TTools extends ToolSet>({
           return rawOutput;
         }
 
-        if (deanonymizeInputBeforeExecute && args.length > 0) {
+        if (deanonymizeInputBeforeExecute) {
           // SAFETY: the AI SDK types tool execute's input arg as `any`
           // because each tool defines its own input schema. We
           // recursively walk strings only and preserve every other

--- a/apps/api/src/handlers/chat/third-party-boundary.ts
+++ b/apps/api/src/handlers/chat/third-party-boundary.ts
@@ -775,13 +775,18 @@ const anonymizeToolPart = ({
       });
     }
 
-    const approval =
-      "approval" in part && "reason" in part.approval && part.approval.reason
-        ? part.approval
-        : undefined;
-    if (approval?.reason) {
+    const approval: unknown = Reflect.get(part, "approval");
+    if (
+      typeof approval === "object" &&
+      approval !== null &&
+      "reason" in approval &&
+      typeof approval.reason === "string" &&
+      approval.reason
+    ) {
       queueTextReplacement(replacements, approval.reason, (value) => {
-        prepared.approval = { ...approval, reason: value };
+        Object.assign(prepared, {
+          approval: { ...approval, reason: value },
+        });
       });
     }
 

--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.ts
@@ -189,7 +189,7 @@ const serializeJsonValue = (
   message: string,
 ): SerializeJsonValueResult =>
   Result.try({
-    try: () => JSON.stringify(value),
+    try: (): string | undefined => JSON.stringify(value),
     catch: (cause) =>
       new SandboxError({
         reason: "non-serialisable-return",

--- a/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
+++ b/apps/api/src/handlers/chat/tools/execute/workspace-function-registry.ts
@@ -245,7 +245,7 @@ export const createReadonlyWorkspaceFunctionRegistry = ({
               panic("Entity has no currentVersion");
             }
 
-            const name = entity.name ?? "Untitled";
+            const name = entity.name;
 
             return {
               entityRef: refRegistry.toEntityRef({
@@ -334,7 +334,7 @@ export const createReadonlyWorkspaceFunctionRegistry = ({
 
           const currentVersion = entity.currentVersion;
 
-          const name = entity.name ?? "Untitled";
+          const name = entity.name;
 
           return {
             createdAt: entity.createdAt.toISOString(),

--- a/apps/api/src/handlers/chat/tools/workspace-tools.ts
+++ b/apps/api/src/handlers/chat/tools/workspace-tools.ts
@@ -48,9 +48,6 @@ const formatFieldValue = (content: FieldContent): string => {
       });
     }
     case "int":
-      if (content.value === null || content.value === undefined) {
-        return "";
-      }
       return content.currency
         ? `${content.value} ${content.currency}`
         : String(content.value);

--- a/apps/api/src/handlers/docx/block-directives.ts
+++ b/apps/api/src/handlers/docx/block-directives.ts
@@ -143,16 +143,9 @@ export const parseBlockTree = (
         if (eachBlock) {
           result.push(eachBlock);
         }
-      } else if (
-        d.kind === "endif" ||
-        d.kind === "endeach" ||
-        d.kind === "elseif" ||
-        d.kind === "else"
-      ) {
+      } else {
         // These are handled by their parent parsers
         break;
-      } else {
-        i++;
       }
     }
 
@@ -225,17 +218,13 @@ export const parseBlockTree = (
         return { kind: "if", branches, directiveParagraphs };
       }
 
-      if (d.kind === "endeach") {
-        errors.push({
-          message: "Unexpected {{/each}} inside {{#if}} block",
-          paragraphIndex: d.paragraphIndex,
-          directive: "{{/each}}",
-        });
-        i++;
-        break;
-      }
-
+      errors.push({
+        message: "Unexpected {{/each}} inside {{#if}} block",
+        paragraphIndex: d.paragraphIndex,
+        directive: "{{/each}}",
+      });
       i++;
+      break;
     }
 
     // Unclosed #if
@@ -295,17 +284,13 @@ export const parseBlockTree = (
         break;
       }
 
-      if (d.kind === "elseif" || d.kind === "else") {
-        errors.push({
-          message: `Unexpected {{#${d.kind}}} inside {{#each}} block`,
-          paragraphIndex: d.paragraphIndex,
-          directive: `{{#${d.kind}}}`,
-        });
-        i++;
-        continue;
-      }
-
+      errors.push({
+        message: `Unexpected {{#${d.kind}}} inside {{#each}} block`,
+        paragraphIndex: d.paragraphIndex,
+        directive: `{{#${d.kind}}}`,
+      });
       i++;
+      continue;
     }
 
     // Unclosed #each
@@ -332,15 +317,12 @@ export const parseBlockTree = (
       d.kind === "elseif" ||
       d.kind === "else"
     ) {
-      const tag = (() => {
-        if (d.kind === "endif") {
-          return "{{/if}}";
-        }
-        if (d.kind === "endeach") {
-          return "{{/each}}";
-        }
-        return `{{#${d.kind}}}`;
-      })();
+      let tag = `{{#${d.kind}}}`;
+      if (d.kind === "endif") {
+        tag = "{{/if}}";
+      } else if (d.kind === "endeach") {
+        tag = "{{/each}}";
+      }
       errors.push({
         message: `Orphaned ${tag} without matching opening directive`,
         paragraphIndex: d.paragraphIndex,
@@ -378,7 +360,7 @@ export const flattenTemplateData = (
       result[fullKey] = String(value);
     } else if (Array.isArray(value)) {
       // Arrays are not flattened — handled by #each
-    } else if (typeof value === "object" && value !== null) {
+    } else if (typeof value === "object") {
       Object.assign(result, flattenTemplateData(value, fullKey));
     }
   }

--- a/apps/api/src/handlers/docx/diff-paragraphs.ts
+++ b/apps/api/src/handlers/docx/diff-paragraphs.ts
@@ -83,18 +83,18 @@ const mergeAdjacentWordChanges = (diffs: readonly Diff[]): Diff[] => {
  */
 const wordDiff = (oldText: string, newText: string): Diff[] => {
   const rawDiffs = diffArrays(tokenize(oldText), tokenize(newText)).map(
-    (change): Diff => ({
-      kind: (() => {
-        if (change.added) {
-          return "insert";
-        }
-        if (change.removed) {
-          return "delete";
-        }
-        return "equal";
-      })(),
-      text: change.value.join(""),
-    }),
+    (change): Diff => {
+      let kind: Diff["kind"] = "equal";
+      if (change.added) {
+        kind = "insert";
+      } else if (change.removed) {
+        kind = "delete";
+      }
+      return {
+        kind,
+        text: change.value.join(""),
+      };
+    },
   );
 
   return mergeAdjacentWordChanges(rawDiffs);
@@ -149,15 +149,13 @@ const diffSingleParagraph = (
     }
 
     // INSERT (standalone, not preceded by DELETE)
-    if (kind === "insert") {
-      edits.push({
-        kind: "insert",
-        paragraphIndex,
-        charOffset,
-        text,
-      });
-      // INSERT doesn't advance offset in the original text
-    }
+    edits.push({
+      kind: "insert",
+      paragraphIndex,
+      charOffset,
+      text,
+    });
+    // INSERT doesn't advance offset in the original text
   }
 
   return edits;

--- a/apps/api/src/handlers/docx/patch-template.ts
+++ b/apps/api/src/handlers/docx/patch-template.ts
@@ -212,7 +212,6 @@ const isPatchableValue = (value: TemplateDataValue | undefined): boolean => {
   }
   if (
     typeof value === "object" &&
-    value !== null &&
     !Array.isArray(value) &&
     "paragraphs" in value
   ) {

--- a/apps/api/src/handlers/entities/create.ts
+++ b/apps/api/src/handlers/entities/create.ts
@@ -91,7 +91,7 @@ const createEntitiesHandler = async function* ({
 }: CreateEntitiesHandlerProps) {
   const parentId = body.parentId ?? null;
   const kind = body.kind;
-  const name = body.name?.trim() ?? "";
+  const name = body.name.trim();
 
   // `entities.name` is the canonical display label and is non-null
   // for every kind. Reject empty names here so the row never

--- a/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/finalize-desktop-edit-session.ts
@@ -103,6 +103,13 @@ export const finalizeDesktopEditSessionHandler = async ({
       });
   };
 
+  const deleteCheckpointKeyIfPresent = async (checkpointKey: string | null) => {
+    if (checkpointKey === null) {
+      return;
+    }
+    await deleteCheckpointKey(checkpointKey);
+  };
+
   const deleteUploadedKey = async (uploadedKey: string) => {
     await getS3()
       .delete(uploadedKey)
@@ -432,9 +439,7 @@ export const finalizeDesktopEditSessionHandler = async ({
     if ("error" in result) {
       await Promise.all(uploadedKeys.map(deleteUploadedKey));
 
-      if (checkpointKeyToDelete !== null) {
-        await deleteCheckpointKey(checkpointKeyToDelete);
-      }
+      await deleteCheckpointKeyIfPresent(checkpointKeyToDelete);
 
       return status(result.error.statusCode, {
         ...("code" in result.error && { code: result.error.code }),
@@ -444,9 +449,7 @@ export const finalizeDesktopEditSessionHandler = async ({
 
     shouldRollbackUploadedKeys = false;
 
-    if (checkpointKeyToDelete !== null) {
-      await deleteCheckpointKey(checkpointKeyToDelete);
-    }
+    await deleteCheckpointKeyIfPresent(checkpointKeyToDelete);
 
     broadcast(authorizedSession.value.workspaceId, {
       type: "invalidate-query",

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -519,7 +519,7 @@ const queryEntitiesGenerator = async function* ({
   for (const s of activeSessions) {
     if (!activeEditMap.has(s.entityId)) {
       activeEditMap.set(s.entityId, {
-        name: s.editorName ?? "",
+        name: s.editorName,
         image: s.editorImage,
         isMe: s.createdBy === currentUserId,
       });

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -115,7 +115,6 @@ const upsertField = createSafeHandler(
 
     const isEmpty =
       body.content.value === null ||
-      body.content.value === undefined ||
       body.content.value === "" ||
       (Array.isArray(body.content.value) && body.content.value.length === 0);
 

--- a/apps/api/src/handlers/health/routes.ts
+++ b/apps/api/src/handlers/health/routes.ts
@@ -23,7 +23,6 @@ const PROBE_CACHE_TTL_MS = 5000;
 const unrefTimer = (timerId: ReturnType<typeof setTimeout>) => {
   if (
     typeof timerId === "object" &&
-    timerId !== null &&
     "unref" in timerId &&
     typeof timerId.unref === "function"
   ) {

--- a/apps/api/src/handlers/views/utils.ts
+++ b/apps/api/src/handlers/views/utils.ts
@@ -32,7 +32,7 @@ export const cleanStalePropertyIds = (
     (f) =>
       f.field === "kind" ||
       f.field === "builtin" ||
-      (f.field === "property" && propertyIds.includes(f.propertyId)),
+      propertyIds.includes(f.propertyId),
   );
   if (cleanedFilters.length !== layout.filters.length) {
     layout.filters = cleanedFilters;

--- a/apps/api/src/handlers/workspaces/read-overview.ts
+++ b/apps/api/src/handlers/workspaces/read-overview.ts
@@ -110,7 +110,7 @@ export const readOverviewHandler = async ({
     // icon and click-to-open works.
     const primaryField =
       cv.fields.find((f) => f.content.type === "file") ?? cv.fields.at(0);
-    let name = e.name ?? "Untitled";
+    let name = e.name;
     let mimeType: string | null = null;
     let fieldId: string | null = null;
     let propertyId: string | null = null;

--- a/apps/api/src/lib/analytics/ai.ts
+++ b/apps/api/src/lib/analytics/ai.ts
@@ -441,7 +441,7 @@ export const sanitizeForAIAnalytics = (value: unknown): unknown => {
   }
 
   const serialized = JSON.stringify(value);
-  return serialized ?? Object.prototype.toString.call(value);
+  return serialized;
 };
 
 const normalizeProvider = (provider: string): string => {

--- a/apps/api/src/lib/analytics/ai.ts
+++ b/apps/api/src/lib/analytics/ai.ts
@@ -440,9 +440,12 @@ export const sanitizeForAIAnalytics = (value: unknown): unknown => {
     );
   }
 
-  const serialized = JSON.stringify(value);
-  return serialized;
+  const serialized = stringifyJSONValue(value);
+  return serialized ?? Object.prototype.toString.call(value);
 };
+
+const stringifyJSONValue = (value: unknown): string | undefined =>
+  JSON.stringify(value);
 
 const normalizeProvider = (provider: string): string => {
   if (provider.startsWith("google")) {

--- a/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
+++ b/apps/api/src/lib/bbox/generate-b-boxes-shared.ts
@@ -207,12 +207,7 @@ export const prepareJustificationData = async (
     const tool = data?.field?.property?.tool;
     const content = data?.content;
 
-    if (
-      !fieldContent ||
-      !content ||
-      tool?.type !== "ai-model" ||
-      !data?.field
-    ) {
+    if (!fieldContent || !content || tool?.type !== "ai-model" || !data.field) {
       return Result.err(
         new JustificationDataError({
           justificationId,

--- a/apps/api/src/lib/invalidate-query-macro.ts
+++ b/apps/api/src/lib/invalidate-query-macro.ts
@@ -31,10 +31,6 @@ export const invalidateQuery = new Elysia({ name: "invalidateQueryMacro" })
     validateAuth: true,
     body: invalidateQueryBodySchema,
     afterHandle: (ctx) => {
-      if (ctx.session === null || ctx.session === undefined) {
-        return;
-      }
-
       const event = createInvalidateQueryEvent(ctx.body.queryKey);
       const workspaceId =
         "workspaceId" in ctx ? String(ctx.workspaceId) : undefined;
@@ -50,10 +46,6 @@ export const invalidateQuery = new Elysia({ name: "invalidateQueryMacro" })
     validateAuth: true,
     body: invalidateQueryBodySchema,
     afterHandle: (ctx) => {
-      if (ctx.session === null || ctx.session === undefined) {
-        return;
-      }
-
       broadcastQueryInvalidationToOrganization(
         ctx.session.activeOrganizationId,
         ctx.body.queryKey,

--- a/apps/api/src/lib/json-schema/json-schema-to-type.ts
+++ b/apps/api/src/lib/json-schema/json-schema-to-type.ts
@@ -127,11 +127,7 @@ const renderTupleType = ({
     renderSchemaDefinition(definition, depth),
   );
 
-  if (
-    typeof additionalItems === "object" &&
-    additionalItems !== null &&
-    !Array.isArray(additionalItems)
-  ) {
+  if (typeof additionalItems === "object" && !Array.isArray(additionalItems)) {
     const restType = renderSchemaDefinition(additionalItems, depth);
     return `[${[...itemTypes, `...${restType}[]`].join(", ")}]`;
   }

--- a/apps/api/src/lib/safe-outbound-fetch.ts
+++ b/apps/api/src/lib/safe-outbound-fetch.ts
@@ -88,7 +88,7 @@ export const fetchWithResolvedAddress = async ({
             headers: headersToObject(requestHeaders),
             hostname: url.hostname,
             lookup: (_hostname, options, callback) => {
-              if (typeof options === "object" && options?.all === true) {
+              if (typeof options === "object" && options.all === true) {
                 callback(null, [address]);
                 return;
               }
@@ -222,7 +222,7 @@ export const fetchStreamWithResolvedAddress = async ({
             headers: headersToObject(requestHeaders),
             hostname: url.hostname,
             lookup: (_hostname, options, callback) => {
-              if (typeof options === "object" && options?.all === true) {
+              if (typeof options === "object" && options.all === true) {
                 callback(null, [address]);
                 return;
               }

--- a/apps/api/src/lib/scheduler/tasks/infosoud.ts
+++ b/apps/api/src/lib/scheduler/tasks/infosoud.ts
@@ -34,10 +34,6 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
     total += trackedCases.length;
 
     for (const trackedCase of trackedCases) {
-      if (signal.aborted) {
-        break;
-      }
-
       try {
         const lookupResult = await client.searchCaseWithHearings({
           courtCode: trackedCase.courtCode,
@@ -48,10 +44,6 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
           lookupResult.case,
           lookupResult.hearings.udalosti,
         );
-
-        if (signal.aborted) {
-          break;
-        }
 
         if (agendaItems.length > LIMITS.infoSoudAgendaImportItemsMax) {
           await markTrackedCaseFailed({
@@ -93,10 +85,6 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
 
         synced += 1;
       } catch (error: unknown) {
-        if (signal.aborted) {
-          break;
-        }
-
         await markTrackedCaseFailed({
           error: errorTag(error),
           trackedCaseId: trackedCase.id,

--- a/apps/api/src/lib/scheduler/tasks/infosoud.ts
+++ b/apps/api/src/lib/scheduler/tasks/infosoud.ts
@@ -34,6 +34,11 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
     total += trackedCases.length;
 
     for (const trackedCase of trackedCases) {
+      // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip between scheduler awaits.
+      if (signal.aborted) {
+        break;
+      }
+
       try {
         const lookupResult = await client.searchCaseWithHearings({
           courtCode: trackedCase.courtCode,
@@ -44,6 +49,11 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
           lookupResult.case,
           lookupResult.hearings.udalosti,
         );
+
+        // eslint-disable-next-line typescript/no-unnecessary-condition -- AbortSignal can flip while the external lookup is in flight.
+        if (signal.aborted) {
+          break;
+        }
 
         if (agendaItems.length > LIMITS.infoSoudAgendaImportItemsMax) {
           await markTrackedCaseFailed({
@@ -85,6 +95,11 @@ export const syncInfoSoudTrackedCases: SchedulerTask = async ({
 
         synced += 1;
       } catch (error: unknown) {
+        // eslint-disable-next-line typescript/no-unnecessary-condition -- Avoid marking an intentionally aborted task as a failed tracked case.
+        if (signal.aborted) {
+          break;
+        }
+
         await markTrackedCaseFailed({
           error: errorTag(error),
           trackedCaseId: trackedCase.id,

--- a/apps/api/src/lib/search/index-entity.ts
+++ b/apps/api/src/lib/search/index-entity.ts
@@ -99,7 +99,7 @@ const buildSearchDocument = async (
     entity.currentVersion ?? panic("Entity has no currentVersion");
 
   const fieldTexts: string[] = [];
-  let title = entity.name ?? "";
+  let title = entity.name;
 
   // Sort by propertyId for deterministic title extraction
   const sortedFields = [...version.fields].toSorted((a, b) =>

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -196,7 +196,7 @@ const initRedis = async () => {
         }
         if (parsed.scope === "workspace") {
           broadcastLocal(brandPersistedWorkspaceId(parsed.id), parsed.event);
-        } else if (parsed.scope === "organization") {
+        } else {
           broadcastLocalToOrganization(
             brandPersistedOrganizationId(parsed.id),
             parsed.event,

--- a/apps/api/src/lib/views.ts
+++ b/apps/api/src/lib/views.ts
@@ -171,7 +171,7 @@ export const getDefaultViews = (
   lang: SupportedLang,
   options: GetDefaultViewsOptions = {},
 ): DefaultView[] => {
-  const names = VIEW_NAMES[lang] ?? VIEW_NAMES.en;
+  const names = VIEW_NAMES[lang];
   return DEFAULT_VIEW_TEMPLATES.map((tmpl) => ({
     name: names[tmpl.nameKey],
     layout: cloneDefaultLayout(tmpl.layout, options),

--- a/apps/api/src/lib/workflow/ai-validators.ts
+++ b/apps/api/src/lib/workflow/ai-validators.ts
@@ -196,15 +196,6 @@ export const validateAIOutput = ({
   aiResult,
   property,
 }: ValidateAIOutputProps): ValidateResult => {
-  // oxlint-disable-next-line typescript/strict-boolean-expressions -- aiResult required param
-  if (!aiResult) {
-    return Result.err(
-      new WorkflowValidationError({
-        message: "AI response is missing",
-      }),
-    );
-  }
-
   const { content } = property;
   const { answer, justification } = aiResult;
 

--- a/apps/api/src/lib/workflow/utils.ts
+++ b/apps/api/src/lib/workflow/utils.ts
@@ -63,14 +63,7 @@ type StringCondition = Extract<PropertyCondition, { type: "string" }>;
 const evaluateStringCondition = (
   condition: StringCondition,
   fieldValue: string,
-) => {
-  switch (condition.operator) {
-    case "eq":
-      return fieldValue === condition.value;
-    default:
-      return false;
-  }
-};
+) => fieldValue === condition.value;
 
 type StringArrayCondition = Extract<
   PropertyCondition,
@@ -80,11 +73,4 @@ type StringArrayCondition = Extract<
 const evaluateStringArrayCondition = (
   condition: StringArrayCondition,
   fieldValue: string[],
-) => {
-  switch (condition.operator) {
-    case "contains-every":
-      return condition.value.every((v) => fieldValue.includes(v));
-    default:
-      return false;
-  }
-};
+) => condition.value.every((v) => fieldValue.includes(v));

--- a/apps/api/src/mcp/stella-tools.ts
+++ b/apps/api/src/mcp/stella-tools.ts
@@ -232,7 +232,7 @@ const handleListMattersTool: McpToolHandler = async ({ args, context }) => {
       name: matter.name,
       reference: matter.reference,
       status: matter.status,
-      lastActivityAt: matter.lastActivityAt?.toISOString() ?? null,
+      lastActivityAt: matter.lastActivityAt.toISOString(),
       createdAt: matter.createdAt.toISOString(),
     })),
     totalCountLimit: LIMITS.workspacesCount,
@@ -272,11 +272,7 @@ const handleGetMatterOverviewTool: McpToolHandler = async ({
     }),
   ]);
 
-  if (
-    typeof workspace !== "object" ||
-    workspace === null ||
-    !("name" in workspace)
-  ) {
+  if (typeof workspace !== "object" || !("name" in workspace)) {
     return errorResult("Matter not found or not accessible");
   }
 
@@ -436,10 +432,7 @@ type SearchCaseLawSuccess = Extract<
 const isSearchCaseLawSuccess = (
   value: Awaited<ReturnType<typeof searchDecisionsHandler>>,
 ): value is SearchCaseLawSuccess =>
-  typeof value === "object" &&
-  value !== null &&
-  "hits" in value &&
-  Array.isArray(value.hits);
+  typeof value === "object" && "hits" in value && Array.isArray(value.hits);
 
 type ReadCaseLawDecisionSuccess = Extract<
   Awaited<ReturnType<typeof readDecisionHandler>>,
@@ -450,7 +443,6 @@ const isReadCaseLawDecisionSuccess = (
   value: Awaited<ReturnType<typeof readDecisionHandler>>,
 ): value is ReadCaseLawDecisionSuccess =>
   typeof value === "object" &&
-  value !== null &&
   "caseNumber" in value &&
   typeof value.caseNumber === "string" &&
   "citationsFrom" in value &&
@@ -532,7 +524,7 @@ const handleReadContentAcrossMattersTool: McpToolHandler = async ({
     charCount: row.charCount,
     entityId,
     kind: row.entity.kind,
-    name: row.entity.name ?? null,
+    name: row.entity.name,
     text: truncated ? plaintext.slice(0, MCP_CONTENT_MAX_CHARS) : plaintext,
     truncated,
     workspaceId: row.entity.workspaceId,

--- a/apps/api/src/scripts/resolve-citations.ts
+++ b/apps/api/src/scripts/resolve-citations.ts
@@ -48,7 +48,7 @@ const formatSqlValue = (value: unknown): string => {
     return "";
   }
 
-  return JSON.stringify(value) ?? "";
+  return JSON.stringify(value);
 };
 
 // ── Citation normalization ──────────────────────────────
@@ -537,15 +537,12 @@ const printReport = async () => {
     const citationText = formatSqlValue(row["citation_text"]);
     const count = formatSqlValue(row["cnt"]);
     const norm = normalizeCitation(citationText);
-    const suffix = (() => {
-      if (norm.caseNumber) {
-        return ` → "${norm.caseNumber}"`;
-      }
-      if (norm.ecli) {
-        return ` → ECLI`;
-      }
-      return " → ???";
-    })();
+    let suffix = " → ???";
+    if (norm.caseNumber) {
+      suffix = ` → "${norm.caseNumber}"`;
+    } else if (norm.ecli) {
+      suffix = " → ECLI";
+    }
     console.log(`  [${count}x] ${citationText}${suffix}`);
   }
 
@@ -663,17 +660,13 @@ const printReport = async () => {
 
 // ── Main ────────────────────────────────────────────────
 
-console.log(
-  (() => {
-    if (DRY_RUN) {
-      return "=== DRY RUN (no DB writes) ===";
-    }
-    if (REPORT_ONLY) {
-      return "=== REPORT ONLY ===";
-    }
-    return "=== RESOLVING CITATIONS ===";
-  })(),
-);
+let runModeLabel = "=== RESOLVING CITATIONS ===";
+if (DRY_RUN) {
+  runModeLabel = "=== DRY RUN (no DB writes) ===";
+} else if (REPORT_ONLY) {
+  runModeLabel = "=== REPORT ONLY ===";
+}
+console.log(runModeLabel);
 
 if (!REPORT_ONLY) {
   if (!DRY_RUN) {

--- a/apps/api/src/tests/security/schema-invariants.test.ts
+++ b/apps/api/src/tests/security/schema-invariants.test.ts
@@ -24,7 +24,6 @@ const extractCheckValues = (
   let inList: string | undefined;
   for (const chunk of chunks) {
     if (
-      chunk !== null &&
       typeof chunk === "object" &&
       "value" in chunk &&
       Array.isArray(chunk.value)

--- a/apps/web/src/components/ai-config-providers-editor.tsx
+++ b/apps/web/src/components/ai-config-providers-editor.tsx
@@ -280,7 +280,7 @@ export const AIConfigProvidersEditor = ({
                   <Button
                     disabled={disabled || rowStatus === "checking"}
                     loading={rowStatus === "checking"}
-                    onClick={() => onSaveRow?.(index)}
+                    onClick={() => onSaveRow(index)}
                     size="sm"
                     type="button"
                     variant={rowStatus === "invalid" ? "outline" : "default"}
@@ -307,11 +307,7 @@ export const AIConfigProvidersEditor = ({
 
           return (
             <div
-              className={
-                compact
-                  ? "grid gap-2 border-t p-2 first:border-t-0"
-                  : "grid gap-3 border-t p-3 first:border-t-0"
-              }
+              className="grid gap-3 border-t p-3 first:border-t-0"
               key={`${providerDraft.provider}-${index}`}
             >
               <div className="grid gap-2 sm:grid-cols-[minmax(8rem,0.85fr)_minmax(0,1fr)] sm:items-start">
@@ -366,7 +362,6 @@ export const AIConfigProvidersEditor = ({
                         size="sm"
                         type="button"
                         variant="outline"
-                        className={compact ? "px-2" : undefined}
                       >
                         {t("aiConfig.replaceKey")}
                       </Button>
@@ -386,7 +381,6 @@ export const AIConfigProvidersEditor = ({
                       size="sm"
                       type="button"
                       variant="ghost"
-                      className={compact ? "px-2" : undefined}
                     >
                       {t("aiConfig.keepSavedKey")}
                     </Button>
@@ -398,21 +392,14 @@ export const AIConfigProvidersEditor = ({
                     size="sm"
                     type="button"
                     variant="ghost"
-                    className={compact ? "px-2" : undefined}
                   >
                     <Trash2Icon className="size-4" />
-                    {compact ? null : t("aiConfig.removeProvider")}
+                    {t("aiConfig.removeProvider")}
                   </Button>
                 </div>
               </div>
 
-              <div
-                className={
-                  compact
-                    ? "grid gap-2 sm:grid-cols-2"
-                    : "grid gap-3 sm:grid-cols-2"
-                }
-              >
+              <div className="grid gap-3 sm:grid-cols-2">
                 {needsEndpoint && (
                   <Field>
                     <FieldLabel>{t("aiConfig.endpoint")}</FieldLabel>
@@ -429,11 +416,11 @@ export const AIConfigProvidersEditor = ({
                       type="url"
                       value={providerDraft.endpoint}
                     />
-                    {!compact && (
+                    {
                       <p className="text-muted-foreground text-xs">
                         {t("aiConfig.endpointDescription")}
                       </p>
-                    )}
+                    }
                   </Field>
                 )}
 
@@ -458,7 +445,7 @@ export const AIConfigProvidersEditor = ({
                       type="password"
                       value={providerDraft.apiKey}
                     />
-                    {hasSavedKey && !compact && (
+                    {hasSavedKey && (
                       <p className="text-muted-foreground text-xs">
                         {t("aiConfig.newApiKeyDescription")}
                       </p>
@@ -492,11 +479,11 @@ export const AIConfigProvidersEditor = ({
                         ))}
                       </SelectPopup>
                     </Select>
-                    {!compact && (
+                    {
                       <p className="text-muted-foreground text-xs">
                         {t("aiConfig.dataRegionDescription")}
                       </p>
-                    )}
+                    }
                   </Field>
                 )}
               </div>

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -212,14 +212,10 @@ const prepareOperations = (
 const inputOperationSeverity = (
   operation: ToolInputOperation,
 ): FolioAIEditSeverity | "unspecified" =>
-  "severity" in operation && operation.severity !== undefined
-    ? operation.severity
-    : "unspecified";
+  "severity" in operation ? operation.severity : "unspecified";
 
 const inputOperationArea = (operation: ToolInputOperation): string =>
-  "area" in operation && operation.area !== undefined
-    ? operation.area
-    : REVIEW_UNSPECIFIED_AREA;
+  "area" in operation ? operation.area : REVIEW_UNSPECIFIED_AREA;
 
 type SnapshotBlock = {
   id: string;
@@ -746,41 +742,28 @@ const FileChatOverlayInner = ({
     openIfAIUnavailable();
   }, [openIfAIUnavailable]);
 
-  const filePlaceholder = (() => {
-    if (activeFile === undefined) {
-      return (() => {
-        if (activeExternal) {
-          return t("chat.externalSourcePlaceholder", {
-            title: activeExternal.title,
-          });
-        }
-        return undefined;
-      })();
+  let filePlaceholder: string | undefined;
+  let filePlaceholderAction: string | undefined;
+  if (activeFile === undefined) {
+    if (activeExternal) {
+      filePlaceholder = t("chat.externalSourcePlaceholder", {
+        title: activeExternal.title,
+      });
+      filePlaceholderAction = t("chat.externalSourcePlaceholderAction");
     }
-    return t(
+  } else {
+    filePlaceholder = t(
       activeFile.editable
         ? "chat.editableFilePlaceholder"
         : "chat.filePlaceholder",
-      {
-        fileName: activeFile.fileName,
-      },
+      { fileName: activeFile.fileName },
     );
-  })();
-  const filePlaceholderAction = (() => {
-    if (activeFile === undefined) {
-      return (() => {
-        if (activeExternal) {
-          return t("chat.externalSourcePlaceholderAction");
-        }
-        return undefined;
-      })();
-    }
-    return t(
+    filePlaceholderAction = t(
       activeFile.editable
         ? "chat.editableFilePlaceholderAction"
         : "chat.filePlaceholderAction",
     );
-  })();
+  }
 
   const editorController = useChatEditor({
     placeholder: filePlaceholder,

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -107,7 +107,7 @@ function htmlToPromptText(html: string): string {
       mention instanceof HTMLElement ? (mention.dataset["label"] ?? "") : "";
     mention.replaceWith(document.createTextNode(`@${label}`));
   }
-  return (container.textContent ?? "").trim();
+  return container.textContent.trim();
 }
 
 function writeStoredApplyMode(mode: AISuggestionApplyMode): void {
@@ -299,15 +299,12 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
     (m) => m.role === "assistant" && m.status === "loading",
   );
 
-  const status: FileAIChatStatus = (() => {
-    if (generating) {
-      return "generating";
-    }
-    if (pendingCount > 0) {
-      return "review-ready";
-    }
-    return "idle";
-  })();
+  let status: FileAIChatStatus = "idle";
+  if (generating) {
+    status = "generating";
+  } else if (pendingCount > 0) {
+    status = "review-ready";
+  }
 
   // ---- decoration push (DOCX only) ----------------------------------------
 
@@ -358,12 +355,12 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
     }
     const doc = editorView.state.doc;
     setMessages((prev) => {
-      let changed = false;
+      const messagesState = { changed: false };
       const next = prev.map<ThreadMessage>((m) => {
         if (m.role !== "assistant" || m.suggestions.length === 0) {
           return m;
         }
-        let suggestionsChanged = false;
+        const suggestionsState = { changed: false };
         const updated = m.suggestions.map((s): AISuggestion => {
           if (s.status !== "pending" && s.status !== "stale") {
             return s;
@@ -374,16 +371,16 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
           if (nextStatus === s.status) {
             return s;
           }
-          suggestionsChanged = true;
+          suggestionsState.changed = true;
           return { ...s, status: nextStatus };
         });
-        if (!suggestionsChanged) {
+        if (!suggestionsState.changed) {
           return m;
         }
-        changed = true;
+        messagesState.changed = true;
         return { ...m, suggestions: updated };
       });
-      return changed ? next : prev;
+      return messagesState.changed ? next : prev;
     });
   }, [editorView, allSuggestions, editorView?.state.doc]);
 
@@ -465,17 +462,13 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
 
       const token = ++generationToken.current;
 
-      const fullPrompt = (() => {
-        if (input.pastedText) {
-          return (() => {
-            if (promptText.length === 0) {
-              return input.pastedText;
-            }
-            return `${promptText}\n\n${input.pastedText}`;
-          })();
-        }
-        return promptText;
-      })();
+      let fullPrompt = promptText;
+      if (input.pastedText) {
+        fullPrompt =
+          promptText.length === 0
+            ? input.pastedText
+            : `${promptText}\n\n${input.pastedText}`;
+      }
 
       const docText = editorView
         ? editorView.state.doc.textBetween(
@@ -609,19 +602,19 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
           if (m.role !== "assistant" || m.suggestions.length === 0) {
             return m;
           }
-          let changed = false;
+          const suggestionState = { changed: false };
           const next = m.suggestions.map((s): AISuggestion => {
             if (result.applied.includes(s.id)) {
-              changed = true;
+              suggestionState.changed = true;
               return { ...s, status: "accepted" };
             }
             if (result.stale.includes(s.id)) {
-              changed = true;
+              suggestionState.changed = true;
               return { ...s, status: "stale" };
             }
             return s;
           });
-          return changed ? { ...m, suggestions: next } : m;
+          return suggestionState.changed ? { ...m, suggestions: next } : m;
         }),
       );
     },
@@ -1309,7 +1302,7 @@ export function PromptBar(props: PromptBarProps) {
               disabled={showStop ? false : submitDisabled || !canSubmit}
               onClick={() => {
                 if (showStop) {
-                  onStop?.();
+                  onStop();
                   return;
                 }
                 void submitDraft();
@@ -1560,25 +1553,22 @@ function ThreadPanel(props: ThreadPanelProps) {
         )}
         style={{ scrollbarGutter: "stable" }}
       >
-        {(() => {
-          if (messages.length === 0 && !isFloating) {
-            return (
-              // Standalone empty state. Floating mode never reaches this
-              // branch because the thread doesn't render until the first
-              // message arrives; standalone always renders, so we need a
-              // gentle landing surface instead of a blank canvas.
-              <div className="text-foreground-strong-muted m-auto flex max-w-[28ch] flex-col items-center gap-1 text-center text-[12px] text-balance">
-                <span className="text-foreground-strong-muted text-[13px] font-medium">
-                  Start a chat
-                </span>
-                <span>
-                  Ask about your matter, draft a snippet, or request a quick
-                  research note.
-                </span>
-              </div>
-            );
-          }
-          return messages.map((m) =>
+        {messages.length === 0 && !isFloating ? (
+          // Standalone empty state. Floating mode never reaches this
+          // branch because the thread doesn't render until the first
+          // message arrives; standalone always renders, so we need a
+          // gentle landing surface instead of a blank canvas.
+          <div className="text-foreground-strong-muted m-auto flex max-w-[28ch] flex-col items-center gap-1 text-center text-[12px] text-balance">
+            <span className="text-foreground-strong-muted text-[13px] font-medium">
+              Start a chat
+            </span>
+            <span>
+              Ask about your matter, draft a snippet, or request a quick
+              research note.
+            </span>
+          </div>
+        ) : (
+          messages.map((m) =>
             m.role === "user" ? (
               <UserBubble key={m.id} message={m} />
             ) : (
@@ -1596,8 +1586,8 @@ function ThreadPanel(props: ThreadPanelProps) {
                 onActivateCitation={onActivateCitation}
               />
             ),
-          );
-        })()}
+          )
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/ai-suggestions/review-panel.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.tsx
@@ -1284,7 +1284,7 @@ const SuggestionRow = ({
           )}
         </div>
       </div>
-      {!isResolved && !isApplying && (
+      {!isApplying && (
         <div className="relative mt-2 flex items-center gap-1.5">
           <Button
             className="h-7 px-2.5 text-xs"

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -65,7 +65,7 @@ export const WorkspaceBreadcrumb = ({
     );
   }
 
-  const displayName = workspace.name ?? workspaceId;
+  const displayName = workspace.name;
 
   const startEditingName = () => {
     escapedNameRef.current = false;
@@ -235,7 +235,7 @@ export const WorkspaceBreadcrumb = ({
         <button
           className="text-foreground-muted hover:text-muted-foreground cursor-text text-sm"
           onClick={() => {
-            setRefValue(workspace.reference ?? "");
+            setRefValue(workspace.reference);
             setRefError("");
             setIsEditingRef(true);
           }}
@@ -348,7 +348,7 @@ export const WorkspaceBreadcrumb = ({
                     onContextMenu={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      setRefValue(workspace.reference ?? "");
+                      setRefValue(workspace.reference);
                       setRefError("");
                       setIsEditingRef(true);
                     }}

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -831,10 +831,6 @@ export const useChatEditor = ({
   );
 
   useEffect(() => {
-    if (editor === null) {
-      return undefined;
-    }
-
     syncEditorPlugins(editor);
 
     return () => {
@@ -848,10 +844,6 @@ export const useChatEditor = ({
   }, [editor, extensionVersion, syncEditorPlugins]);
 
   useEffect(() => {
-    if (editor === null) {
-      return;
-    }
-
     if (areDocsEqual(editor.getJSON(), draftDoc)) {
       setIsEmpty(editor.isEmpty);
       return;
@@ -864,19 +856,11 @@ export const useChatEditor = ({
   }, [draftDoc, editor]);
 
   const focus = useCallback(() => {
-    if (editor === null) {
-      return;
-    }
-
     editor.commands.focus("end");
   }, [editor]);
 
   const insertMention = useCallback(
     (mention: ChatMentionOption) => {
-      if (editor === null) {
-        return;
-      }
-
       markDraftStarted();
       editor
         .chain()
@@ -898,21 +882,19 @@ export const useChatEditor = ({
     [editor, markDraftStarted],
   );
 
-  useEffect(() => {
-    if (editor === null) {
-      return undefined;
-    }
-
-    return registerActiveEditor({
-      focus,
-      insertMention,
-      threadKey,
-    });
-  }, [editor, focus, insertMention, registerActiveEditor, threadKey]);
+  useEffect(
+    () =>
+      registerActiveEditor({
+        focus,
+        insertMention,
+        threadKey,
+      }),
+    [focus, insertMention, registerActiveEditor, threadKey],
+  );
 
   const updateAttachments = useCallback(
     (nextAttachments: ChatDraftAttachment[]) => {
-      const doc = editor?.getJSON() ?? draftDoc;
+      const doc = editor.getJSON();
 
       setDraft(
         threadKey,
@@ -926,7 +908,7 @@ export const useChatEditor = ({
         markDraftStarted();
       }
     },
-    [draftDoc, editor, markDraftStarted, setDraft, threadKey],
+    [editor, markDraftStarted, setDraft, threadKey],
   );
 
   const addFiles = useCallback(
@@ -1030,10 +1012,6 @@ export const useChatEditor = ({
 
   const submit = useCallback(
     async (send: (draft: ChatInputDraft) => Promise<void> | void) => {
-      if (editor === null) {
-        return;
-      }
-
       const html = editor.isEmpty ? "" : editor.getHTML().trim();
       const doc = editor.getJSON();
       const files = attachmentsRef.current;

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -436,7 +436,7 @@ export const ChatMentionList = forwardRef<
 
           {drillDown &&
             !entitiesLoading &&
-            drillDownItems?.map((item, i) => (
+            drillDownItems.map((item, i) => (
               <Button
                 className={cn(
                   "min-w-0 justify-start gap-2 overflow-hidden font-normal",

--- a/apps/web/src/components/chat-mention-node.tsx
+++ b/apps/web/src/components/chat-mention-node.tsx
@@ -84,10 +84,10 @@ export const ChatMentionNode = (props: NodeViewProps) => {
         }
       >
         <CategoryIcon
-          attrId={attrs.id ?? ""}
-          attrKind={attrs.kind ?? "document"}
+          attrId={attrs.id}
+          attrKind={attrs.kind}
           attrMimeType={attrs.mimeType}
-          category={attrs.category ?? "entity"}
+          category={attrs.category}
         />
         <span className={cn("truncate", CHAT_MENTION_LABEL_MAX_WIDTH_CLASS)}>
           {attrs.label}

--- a/apps/web/src/components/chat/chat-ui-tools.ts
+++ b/apps/web/src/components/chat/chat-ui-tools.ts
@@ -243,7 +243,6 @@ export const isApprovalRespondedPart = (
   part.state === "approval-responded" &&
   "approval" in part &&
   typeof part.approval === "object" &&
-  part.approval !== null &&
   "id" in part.approval &&
   typeof part.approval.id === "string" &&
   "approved" in part.approval &&

--- a/apps/web/src/components/chat/entity-link.tsx
+++ b/apps/web/src/components/chat/entity-link.tsx
@@ -1,10 +1,5 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
-import {
-  FileTextIcon,
-  FolderIcon,
-  LandmarkIcon,
-  LayersIcon,
-} from "lucide-react";
+import { FileTextIcon, LandmarkIcon, LayersIcon } from "lucide-react";
 
 import { cn } from "@stll/ui/lib/utils";
 
@@ -13,33 +8,14 @@ import type { MentionCategory } from "@/components/chat/chat-mention-href";
 import { parseStellaMentionHref } from "@/components/chat/chat-mention-href";
 import { openEntityInInspector } from "@/components/chat/entity-open";
 import { navigateToWorkspaceFolder } from "@/components/chat/folder-navigation";
-import type { WorkspaceEntity } from "@/lib/types";
-import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
-import { getFirstFile } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
 const DECISION_HASH_PREFIX = "#stella-decision=";
 
 /** Resolve the icon for an entity by its ID. */
 // TODO: fix me
-export const EntityMentionIcon = ({ entityId: _ }: { entityId: string }) => {
-  // TODO: fix me
-  const entity: WorkspaceEntity | undefined = undefined;
-  const file = entity !== undefined ? getFirstFile(entity) : null;
-  const kind: string = "document";
-
-  if (kind === "folder") {
-    return <FolderIcon className="inline size-3 shrink-0" />;
-  }
-  if (file?.mimeType) {
-    return (
-      <DocumentIcon
-        className="inline size-3 shrink-0"
-        mimeType={file.mimeType}
-      />
-    );
-  }
-  return <FileTextIcon className="inline size-3 shrink-0" />;
-};
+export const EntityMentionIcon = ({ entityId: _ }: { entityId: string }) => (
+  <FileTextIcon className="inline size-3 shrink-0" />
+);
 
 const CATEGORY_ICON: Record<
   Exclude<MentionCategory, "entity">,
@@ -139,14 +115,11 @@ export const EntityLink = ({
       })();
       return;
     }
-    if (category === "workspace") {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      navigate({
-        to: "/workspaces/$workspaceId",
-        params: { workspaceId: id },
-      });
-      return;
-    }
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    navigate({
+      to: "/workspaces/$workspaceId",
+      params: { workspaceId: id },
+    });
   };
 
   const icon =

--- a/apps/web/src/components/chat/entity-open.ts
+++ b/apps/web/src/components/chat/entity-open.ts
@@ -132,7 +132,7 @@ export const openEntityInInspector = async (
       throw toAPIError(response.error);
     }
 
-    const responseLabel = response.data.name ?? label;
+    const responseLabel = response.data.name;
     const openedByKind = openEntityByKind({
       entityId,
       kind: response.data.kind,

--- a/apps/web/src/components/chat/streamdown-mention-link.tsx
+++ b/apps/web/src/components/chat/streamdown-mention-link.tsx
@@ -390,12 +390,7 @@ const CategoryIcon = ({
 }) => {
   const Icon = CATEGORY_ICON[category];
   return (
-    <Icon
-      className="size-3 shrink-0"
-      {...(category === "workspace"
-        ? { style: { color: getMatterColor(id) } }
-        : {})}
-    />
+    <Icon className="size-3 shrink-0" style={{ color: getMatterColor(id) }} />
   );
 };
 

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -147,11 +147,7 @@ const UpdateSummary = ({ input, workspaceId }: UpdateSummaryProps) => {
     const cached = qc.getQueryData<WorkspaceProperty[]>(
       propertiesKeys.all(workspaceId),
     );
-    if (
-      cached !== undefined &&
-      input.propertyId !== undefined &&
-      input.propertyId !== null
-    ) {
+    if (cached !== undefined) {
       property = cached.find((p) => p.id === input.propertyId);
     }
   }
@@ -160,15 +156,12 @@ const UpdateSummary = ({ input, workspaceId }: UpdateSummaryProps) => {
     property?.content.type === "single-select" ||
     property?.content.type === "multi-select";
 
-  const displayNew = (() => {
-    if (newVal === null) {
-      return null;
-    }
-    if (Array.isArray(newVal)) {
-      return newVal.join(", ");
-    }
-    return JSON.stringify(newVal);
-  })();
+  let displayNew: string | null = null;
+  if (Array.isArray(newVal)) {
+    displayNew = newVal.join(", ");
+  } else if (newVal !== null) {
+    displayNew = JSON.stringify(newVal);
+  }
 
   return (
     <div className="border-border/50 flex flex-col gap-1.5 border-t px-3 py-2">

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -172,7 +172,7 @@ export function RequireAIKey({ children }: PropsWithChildren) {
     return null;
   }
 
-  if (!isError && data?.available) {
+  if (!isError && data.available) {
     return <>{children}</>;
   }
 

--- a/apps/web/src/components/search-dialog.tsx
+++ b/apps/web/src/components/search-dialog.tsx
@@ -1055,7 +1055,7 @@ const SummaryBody = ({
   let cursor = 0;
 
   for (const match of text.matchAll(CITATION_RE)) {
-    const start = match.index ?? 0;
+    const start = match.index;
     const numberText = match[1];
     const number = numberText ? Number(numberText) : Number.NaN;
     const citation = citationByNumber.get(number);
@@ -1573,7 +1573,7 @@ const SearchHitIcon = ({ hit }: { hit: GlobalSearchHit }) => {
     );
   }
 
-  const Icon = KIND_ICONS[hit.type] ?? FileTextIcon;
+  const Icon = KIND_ICONS[hit.type];
 
   if (hit.type === "matter") {
     const color = resolveMatterColor(hit.workspaceId, hit.color);

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -552,7 +552,7 @@ function SidebarMenuButton({
     />
   );
 
-  if (tooltip === undefined || tooltip === null) {
+  if (tooltip === undefined) {
     return button;
   }
 

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -8,8 +8,6 @@ import {
 } from "react";
 import type { PropsWithChildren } from "react";
 
-import { panic } from "better-result";
-
 import { PALETTE_STORAGE_KEY, THEME_STORAGE_KEY } from "@/consts";
 
 const THEMES = ["light", "dark", "system"] as const;
@@ -172,9 +170,6 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
 
 export const useTheme = (): ThemeProviderState => {
   const context = useContext(ThemeProviderContext);
-  if (context === undefined || context === null) {
-    panic("useTheme must be used within a ThemeProvider");
-  }
   return context;
 };
 

--- a/apps/web/src/lib/auth-session.ts
+++ b/apps/web/src/lib/auth-session.ts
@@ -19,7 +19,7 @@ export const getFreshLinkedAccount = async () => {
 
   return {
     email: user.email,
-    name: user.name ?? null,
+    name: user.name,
     verifiedAt: new Date().toISOString(),
   };
 };

--- a/apps/web/src/lib/pdf/pdf-page.tsx
+++ b/apps/web/src/lib/pdf/pdf-page.tsx
@@ -61,8 +61,8 @@ export const PDFPage = ({ pageId, renderOverlay, fallback }: PDFPageProps) => {
         {
           "--total-scale-factor": "var(--scale-factor)",
           backgroundColor: "var(--document-preview-page, var(--background))",
-          width: `round(down, var(--total-scale-factor) * ${page?.originalWidth ?? 0}px, var(--scale-round-x))`,
-          height: `round(down, var(--total-scale-factor) * ${page?.originalHeight ?? 0}px, var(--scale-round-y))`,
+          width: `round(down, var(--total-scale-factor) * ${page.originalWidth}px, var(--scale-round-x))`,
+          height: `round(down, var(--total-scale-factor) * ${page.originalHeight}px, var(--scale-round-y))`,
         } as CSSProperties
       }
     >

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -79,7 +79,7 @@ const RootAnalyticsIdentity = () => {
     analytics.identifyUser({
       id: user.id,
       email: user.email,
-      name: user.name ?? undefined,
+      name: user.name,
     });
   }, [analytics, user]);
 

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -442,7 +442,7 @@ const getAutoSendFingerprint = (
 
   const segments = [message.id];
   for (const part of message.parts) {
-    if (typeof part !== "object" || part === null || !("type" in part)) {
+    if (typeof part !== "object" || !("type" in part)) {
       continue;
     }
 
@@ -456,7 +456,6 @@ const getAutoSendFingerprint = (
     const approved =
       "approval" in part &&
       typeof part.approval === "object" &&
-      part.approval !== null &&
       "approved" in part.approval &&
       typeof part.approval.approved === "boolean"
         ? String(part.approval.approved)
@@ -485,12 +484,12 @@ export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
     gcTime: STALE_TIME.FIVETEEN.MINUTES,
     queryKey: chatKeys.thread({
       ...key,
-      allowMissingThread: context?.allowMissingThread,
+      allowMissingThread: context.allowMissingThread,
       contextKind: getChatRuntimeContextKind(context),
     }),
     queryFn: async ({ client: queryClient }): Promise<ChatThreadFetched> => {
       const { messages, contextMatterIds } = await fetchThreadMessages(key, {
-        allowMissingThread: context?.allowMissingThread,
+        allowMissingThread: context.allowMissingThread,
       });
 
       const chat = new Chat<PersistedChatMessage>({

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -178,20 +178,12 @@ export const ClauseDetailView = ({
   }, [clauseId, t]);
 
   useEffect(() => {
-    let cancelled = false;
-
     const doLoad = async () => {
       await load();
     };
 
-    if (!cancelled) {
-      // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      doLoad();
-    }
-
-    return () => {
-      cancelled = true;
-    };
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    doLoad();
   }, [load]);
 
   const handleDelete = useCallback(async () => {

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -153,16 +153,16 @@ export const ClauseEditor = ({
   }, [contentKey]);
 
   const toggleBold = useCallback(() => {
-    editor?.chain().focus().toggleBold().run();
+    editor.chain().focus().toggleBold().run();
   }, [editor]);
 
   const toggleItalic = useCallback(() => {
-    editor?.chain().focus().toggleItalic().run();
+    editor.chain().focus().toggleItalic().run();
   }, [editor]);
 
   const toggleHeading = useCallback(
     (level: 1 | 2 | 3) => {
-      editor?.chain().focus().toggleHeading({ level }).run();
+      editor.chain().focus().toggleHeading({ level }).run();
     },
     [editor],
   );

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -522,7 +522,7 @@ const CategoryFormDialog = ({
 
     setSaving(true);
 
-    if (isEdit && initial?.id) {
+    if (isEdit && initial.id) {
       const response = await api["clause-categories"]({
         categoryId: initial.id,
       }).post({ name: name.trim() });

--- a/apps/web/src/routes/_protected.knowledge/-components/paragraph-rendering.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/paragraph-rendering.tsx
@@ -23,7 +23,7 @@ export const HighlightedText = ({ text }: { text: string }) => {
   let lastIndex = 0;
 
   for (const match of text.matchAll(PLACEHOLDER_RE)) {
-    const start = match.index ?? 0;
+    const start = match.index;
     if (start > lastIndex) {
       parts.push(text.slice(lastIndex, start));
     }

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -125,7 +125,7 @@ export const ShortcutFormDialog = ({
 
     setSaving(true);
 
-    if (isEdit && initial?.id) {
+    if (isEdit && initial.id) {
       const response = await api.shortcuts({ shortcutId: initial.id }).post({
         name: form.name.trim(),
         description: form.description.trim() || null,

--- a/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
@@ -284,7 +284,7 @@ const CategoryFormDialog = ({
 
     setSaving(true);
 
-    if (isEdit && initial?.id) {
+    if (isEdit && initial.id) {
       const response = await api["template-categories"]({
         categoryId: initial.id,
       }).post({ name: name.trim() });

--- a/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-form.tsx
@@ -296,7 +296,7 @@ const FieldRenderer = ({
               value={
                 // SAFETY: inputType discriminates; value is string for textarea
                 // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                (value as string) ?? ""
+                value as string
               }
             />
           }
@@ -323,7 +323,7 @@ const FieldRenderer = ({
               value={
                 // SAFETY: inputType discriminates; value is string for number input
                 // eslint-disable-next-line typescript/no-unsafe-type-assertion
-                (value as string) ?? ""
+                value as string
               }
             />
           }
@@ -349,7 +349,7 @@ const FieldRenderer = ({
             value={
               // SAFETY: inputType discriminates; value is string for text/date
               // eslint-disable-next-line typescript/no-unsafe-type-assertion
-              (value as string) ?? ""
+              value as string
             }
           />
         }

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/types.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/types.ts
@@ -60,7 +60,7 @@ export const getCategoryVar = (category: string): string => {
   }
   const idx = hashString(category) % OPTION_VARS.length;
   // idx is in [0, length); indexing is safe.
-  return OPTION_VARS[idx] ?? OPTION_VARS[0] ?? "";
+  return OPTION_VARS[idx] ?? "";
 };
 
 /** Inline style for using a category color. */

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-search.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-search.ts
@@ -45,7 +45,7 @@ const normalizeSearchText = (text: string): NormalizedText => {
   // letter's startMap/endMap still points at its original char.
   const dropSpaceAt = new Set<number>();
   for (const match of text.matchAll(SPACED_LETTER_RUN_RE)) {
-    const matchStart = match.index ?? 0;
+    const matchStart = match.index;
     const matched = match[0];
     for (let i = 0; i < matched.length; i++) {
       if (matched[i] === " ") {

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-text.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/decision-text.tsx
@@ -255,32 +255,28 @@ const renderInline = ({
     );
   }
 
-  if (node.type === "link") {
-    const safeHref = sanitizeHref(node.href);
-    const children = renderInlineChildren({
-      children: node.children,
-      context,
-      offset,
-    });
+  const safeHref = sanitizeHref(node.href);
+  const children = renderInlineChildren({
+    children: node.children,
+    context,
+    offset,
+  });
 
-    if (!safeHref) {
-      return <Fragment key={key}>{children}</Fragment>;
-    }
-
-    return (
-      <a
-        className="decoration-border underline underline-offset-2 hover:decoration-current"
-        href={safeHref}
-        key={key}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        {children}
-      </a>
-    );
+  if (!safeHref) {
+    return <Fragment key={key}>{children}</Fragment>;
   }
 
-  return null;
+  return (
+    <a
+      className="decoration-border underline underline-offset-2 hover:decoration-current"
+      href={safeHref}
+      key={key}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {children}
+    </a>
+  );
 };
 
 const renderInlineChildren = ({

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
@@ -151,8 +151,8 @@ export const MetadataPanel = ({ decision }: MetadataPanelProps) => {
 
   const hasExtra =
     sourceFields.length > 0 ||
-    (astMeta?.keywords?.length ?? 0) > 0 ||
-    (astMeta?.statutes?.length ?? 0) > 0;
+    (astMeta?.keywords.length ?? 0) > 0 ||
+    (astMeta?.statutes.length ?? 0) > 0;
 
   const sourceHref = decision.sourceUrl
     ? sanitizeHref(humanizeSourceUrl(decision.sourceUrl))

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/metadata-panel.tsx
@@ -149,10 +149,10 @@ export const MetadataPanel = ({ decision }: MetadataPanelProps) => {
     }
   }
 
+  const astKeywords = astMeta?.keywords ?? [];
+  const astStatutes = astMeta?.statutes ?? [];
   const hasExtra =
-    sourceFields.length > 0 ||
-    (astMeta?.keywords.length ?? 0) > 0 ||
-    (astMeta?.statutes.length ?? 0) > 0;
+    sourceFields.length > 0 || astKeywords.length > 0 || astStatutes.length > 0;
 
   const sourceHref = decision.sourceUrl
     ? sanitizeHref(humanizeSourceUrl(decision.sourceUrl))
@@ -207,16 +207,16 @@ export const MetadataPanel = ({ decision }: MetadataPanelProps) => {
 
       {expanded && (
         <dl className="space-y-3 border-t pt-3">
-          {astMeta?.keywords && (
+          {astKeywords.length > 0 && (
             <TagList
               label={t("caseLaw.viewer.keywords")}
-              values={astMeta.keywords}
+              values={astKeywords}
             />
           )}
-          {astMeta?.statutes && (
+          {astStatutes.length > 0 && (
             <TagList
               label={t("caseLaw.viewer.statutes")}
-              values={astMeta.statutes}
+              values={astStatutes}
             />
           )}
           {sourceFields.map((f) => (

--- a/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
@@ -82,7 +82,7 @@ export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
         header: t("common.date"),
         cell: (info) => {
           const value = info.getValue();
-          if (value === null || value === undefined) {
+          if (value === null) {
             return "\u2014";
           }
           const date = value instanceof Date ? value : new Date(value);

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -719,7 +719,7 @@ const TemplateDetail = ({
               </p>
             </div>
             <Button
-              disabled={state !== "ready"}
+              disabled={false}
               onClick={handleTestFill}
               size="sm"
               variant="outline"

--- a/apps/web/src/routes/_protected.todos/index.tsx
+++ b/apps/web/src/routes/_protected.todos/index.tsx
@@ -142,10 +142,7 @@ function MyTodosPage() {
       throw toAPIError(response.error);
     }
 
-    const entityId = response.data?.entityId;
-    if (entityId === undefined) {
-      return;
-    }
+    const entityId = response.data.entityId;
 
     await navigate({
       to: "/workspaces/$workspaceId",
@@ -288,7 +285,7 @@ const TaskRow = ({ task }: { task: ValidTask }) => {
     <Link
       className="group hover:bg-muted/50 flex items-center gap-3 rounded-md px-2 py-1.5 text-sm transition-colors"
       onClick={() => {
-        useInspectorStore.getState().openTask(task.id, task.name ?? "");
+        useInspectorStore.getState().openTask(task.id, task.name);
       }}
       params={{ workspaceId: task.workspaceId }}
       to="/workspaces/$workspaceId"

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -417,7 +417,7 @@ function ProtectedContent({
 const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
 const INSPECTOR_PANE_MIN_WIDTH = 320;
 const INSPECTOR_PANE_MAX_WIDTH = 800;
-const INSPECTOR_RAIL_WIDTH = 40;
+const INSPECTOR_RAIL_WIDTH = 48;
 
 /**
  * Workspace inspector pane — file viewers + chat tabs. Mounted at

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -34,6 +34,7 @@ import {
 } from "@stll/ui/components/menu";
 import { Separator } from "@stll/ui/components/separator";
 import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
+import { cn } from "@stll/ui/lib/utils";
 
 import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
 import { AppSidebar } from "@/components/app-sidebar";
@@ -51,6 +52,11 @@ import {
   useSidebar,
 } from "@/components/sidebar";
 import { getAnalytics } from "@/lib/analytics/provider";
+import {
+  SIDE_RAIL_ICON_BUTTON_SIZE,
+  SIDE_RAIL_WIDTH,
+  TOOLBAR_ROW_HEIGHT,
+} from "@/lib/consts";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
@@ -72,6 +78,41 @@ const LazyInspectorPanel = lazy(
     await import("@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel").then(
       (m) => ({ default: m.InspectorPanel }),
     ),
+);
+
+// Visual shell for the inspector rail while the panel chunk is
+// loading. Mirrors the real rail's chrome (top toggle, bottom
+// "new chat") so the rail doesn't render as an empty strip during
+// the lazy chunk fetch. Buttons are inert; they activate once the
+// real panel mounts.
+const InspectorRailFallback = () => (
+  <div className="bg-background flex h-full border-s shadow-lg">
+    <div
+      className={`bg-muted/50 flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}`}
+    >
+      <div
+        aria-hidden="true"
+        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-b ${TOOLBAR_ROW_HEIGHT}`}
+      >
+        <span
+          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
+        >
+          <PanelRightIcon className="size-4" />
+        </span>
+      </div>
+      <div className="flex-1" />
+      <div
+        aria-hidden="true"
+        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-t ${TOOLBAR_ROW_HEIGHT}`}
+      >
+        <span
+          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
+        >
+          <MessageSquarePlusIcon className="size-4" />
+        </span>
+      </div>
+    </div>
+  </div>
 );
 
 export const Route = createFileRoute("/_protected")({
@@ -266,12 +307,15 @@ function ProtectedContent({
   // content is minimized, and its top button is the restore/hide
   // affordance.
   const canShowInspectorButton = inspectorTabsCount === 0;
-  let inspectorButtonTitle = t("inspector.hidePane");
-  if (inspectorTabsCount === 0) {
-    inspectorButtonTitle = t("inspector.openChat");
-  } else if (inspectorMinimized) {
-    inspectorButtonTitle = t("inspector.showPane");
-  }
+  const inspectorButtonTitle = (() => {
+    if (inspectorTabsCount === 0) {
+      return t("inspector.openChat");
+    }
+    if (inspectorMinimized) {
+      return t("inspector.showPane");
+    }
+    return t("inspector.hidePane");
+  })();
 
   // Right-clicking the chrome's icon row (including the empty
   // space after the last icon) offers a quick "Open new chat"
@@ -371,7 +415,10 @@ function ProtectedContent({
       <ApiVersionMismatchBanner />
       <SelfhostUpdateBanner />
       <header
-        className="flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"
+        className={cn(
+          "flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4",
+          !matterColor && "bg-sidebar",
+        )}
         style={
           matterColor
             ? {
@@ -417,6 +464,10 @@ function ProtectedContent({
 const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
 const INSPECTOR_PANE_MIN_WIDTH = 320;
 const INSPECTOR_PANE_MAX_WIDTH = 800;
+// Matches SIDE_RAIL_WIDTH (`w-12` = 48px) so the wrapper width
+// equals the rail's actual rendered width. Earlier this was 40,
+// leaving the rail 8px wider than its wrapper and pushing the
+// toast / find-replace right-offset CSS vars under the visible rail.
 const INSPECTOR_RAIL_WIDTH = 48;
 
 /**
@@ -458,12 +509,18 @@ function WorkspaceInspectorSidePanel() {
   //      with only blank chats active but PDFs from earlier
   //      matters still open in the rail.
   const activeTab = tabs.find((tab) => tab.id === activeId);
-  let tabOriginWorkspaceId: string | null = null;
-  if (activeTab?.type === "pdf" || activeTab?.type === "matter") {
-    tabOriginWorkspaceId = activeTab.workspaceId;
-  } else if (activeTab?.type === "chat") {
-    tabOriginWorkspaceId = activeTab.contextMatterIds.at(0) ?? null;
-  }
+  const tabOriginWorkspaceId = (() => {
+    if (activeTab?.type === "pdf") {
+      return activeTab.workspaceId;
+    }
+    if (activeTab?.type === "matter") {
+      return activeTab.workspaceId;
+    }
+    if (activeTab?.type === "chat") {
+      return activeTab.contextMatterIds.at(0) ?? null;
+    }
+    return null;
+  })();
   // Last-resort: pick *any* tab's stored workspace so the inspector
   // mounts even when the active tab can't dictate one (a task tab,
   // or a chat that hasn't been pinned to a matter yet) and the
@@ -520,9 +577,19 @@ function WorkspaceInspectorSidePanel() {
 
   useEffect(() => {
     document.documentElement.style.setProperty(TOAST_RIGHT_OFFSET_VAR, widthPx);
+    // Keep Folio's find/replace dialog out from under the right inspector
+    // pane. Folio reads --folio-find-replace-right on the overlay so the
+    // dialog lands over the document, not behind the sidebar.
+    document.documentElement.style.setProperty(
+      "--folio-find-replace-right",
+      widthPx,
+    );
 
     return () => {
       document.documentElement.style.removeProperty(TOAST_RIGHT_OFFSET_VAR);
+      document.documentElement.style.removeProperty(
+        "--folio-find-replace-right",
+      );
     };
   }, [widthPx]);
 
@@ -546,7 +613,7 @@ function WorkspaceInspectorSidePanel() {
           />
         )}
         <div className="bg-sidebar flex h-full w-full flex-col">
-          <Suspense>
+          <Suspense fallback={<InspectorRailFallback />}>
             <LazyInspectorPanel workspaceId={activeWorkspaceId ?? undefined} />
           </Suspense>
         </div>

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -34,7 +34,6 @@ import {
 } from "@stll/ui/components/menu";
 import { Separator } from "@stll/ui/components/separator";
 import { TOAST_RIGHT_OFFSET_VAR } from "@stll/ui/components/toast";
-import { cn } from "@stll/ui/lib/utils";
 
 import { ApiVersionMismatchBanner } from "@/components/api-version-mismatch-banner";
 import { AppSidebar } from "@/components/app-sidebar";
@@ -52,11 +51,6 @@ import {
   useSidebar,
 } from "@/components/sidebar";
 import { getAnalytics } from "@/lib/analytics/provider";
-import {
-  SIDE_RAIL_ICON_BUTTON_SIZE,
-  SIDE_RAIL_WIDTH,
-  TOOLBAR_ROW_HEIGHT,
-} from "@/lib/consts";
 import { HOTKEYS } from "@/lib/hotkeys";
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { usePinnedStore } from "@/lib/pinned-store";
@@ -78,41 +72,6 @@ const LazyInspectorPanel = lazy(
     await import("@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel").then(
       (m) => ({ default: m.InspectorPanel }),
     ),
-);
-
-// Visual shell for the inspector rail while the panel chunk is
-// loading. Mirrors the real rail's chrome (top toggle, bottom
-// "new chat") so the rail doesn't render as an empty strip during
-// the lazy chunk fetch. Buttons are inert; they activate once the
-// real panel mounts.
-const InspectorRailFallback = () => (
-  <div className="bg-background flex h-full border-s shadow-lg">
-    <div
-      className={`bg-muted/50 flex shrink-0 flex-col border-e ${SIDE_RAIL_WIDTH}`}
-    >
-      <div
-        aria-hidden="true"
-        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-b ${TOOLBAR_ROW_HEIGHT}`}
-      >
-        <span
-          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
-        >
-          <PanelRightIcon className="size-4" />
-        </span>
-      </div>
-      <div className="flex-1" />
-      <div
-        aria-hidden="true"
-        className={`text-muted-foreground flex w-full shrink-0 items-center justify-center border-t ${TOOLBAR_ROW_HEIGHT}`}
-      >
-        <span
-          className={`flex items-center justify-center ${SIDE_RAIL_ICON_BUTTON_SIZE}`}
-        >
-          <MessageSquarePlusIcon className="size-4" />
-        </span>
-      </div>
-    </div>
-  </div>
 );
 
 export const Route = createFileRoute("/_protected")({
@@ -307,15 +266,12 @@ function ProtectedContent({
   // content is minimized, and its top button is the restore/hide
   // affordance.
   const canShowInspectorButton = inspectorTabsCount === 0;
-  const inspectorButtonTitle = (() => {
-    if (inspectorTabsCount === 0) {
-      return t("inspector.openChat");
-    }
-    if (inspectorMinimized) {
-      return t("inspector.showPane");
-    }
-    return t("inspector.hidePane");
-  })();
+  let inspectorButtonTitle = t("inspector.hidePane");
+  if (inspectorTabsCount === 0) {
+    inspectorButtonTitle = t("inspector.openChat");
+  } else if (inspectorMinimized) {
+    inspectorButtonTitle = t("inspector.showPane");
+  }
 
   // Right-clicking the chrome's icon row (including the empty
   // space after the last icon) offers a quick "Open new chat"
@@ -397,9 +353,6 @@ function ProtectedContent({
         <div className="contents md:hidden">
           <Separator className="mx-1 h-4" orientation="vertical" />
           <Button
-            aria-pressed={
-              inspectorTabsCount > 0 ? !inspectorMinimized : undefined
-            }
             className="size-7"
             onClick={handleInspectorButtonClick}
             size="icon"
@@ -418,10 +371,7 @@ function ProtectedContent({
       <ApiVersionMismatchBanner />
       <SelfhostUpdateBanner />
       <header
-        className={cn(
-          "flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4",
-          !matterColor && "bg-sidebar",
-        )}
+        className="flex h-12 shrink-0 items-center gap-2 overflow-hidden border-b px-4"
         style={
           matterColor
             ? {
@@ -467,11 +417,7 @@ function ProtectedContent({
 const INSPECTOR_PANE_DEFAULT_WIDTH = 512;
 const INSPECTOR_PANE_MIN_WIDTH = 320;
 const INSPECTOR_PANE_MAX_WIDTH = 800;
-// Matches SIDE_RAIL_WIDTH (`w-12` = 48px) so the wrapper width
-// equals the rail's actual rendered width. Earlier this was 40,
-// leaving the rail 8px wider than its wrapper and pushing the
-// toast / find-replace right-offset CSS vars under the visible rail.
-const INSPECTOR_RAIL_WIDTH = 48;
+const INSPECTOR_RAIL_WIDTH = 40;
 
 /**
  * Workspace inspector pane — file viewers + chat tabs. Mounted at
@@ -512,18 +458,12 @@ function WorkspaceInspectorSidePanel() {
   //      with only blank chats active but PDFs from earlier
   //      matters still open in the rail.
   const activeTab = tabs.find((tab) => tab.id === activeId);
-  const tabOriginWorkspaceId = (() => {
-    if (activeTab?.type === "pdf") {
-      return activeTab.workspaceId;
-    }
-    if (activeTab?.type === "matter") {
-      return activeTab.workspaceId;
-    }
-    if (activeTab?.type === "chat") {
-      return activeTab.contextMatterIds.at(0) ?? null;
-    }
-    return null;
-  })();
+  let tabOriginWorkspaceId: string | null = null;
+  if (activeTab?.type === "pdf" || activeTab?.type === "matter") {
+    tabOriginWorkspaceId = activeTab.workspaceId;
+  } else if (activeTab?.type === "chat") {
+    tabOriginWorkspaceId = activeTab.contextMatterIds.at(0) ?? null;
+  }
   // Last-resort: pick *any* tab's stored workspace so the inspector
   // mounts even when the active tab can't dictate one (a task tab,
   // or a chat that hasn't been pinned to a matter yet) and the
@@ -580,19 +520,9 @@ function WorkspaceInspectorSidePanel() {
 
   useEffect(() => {
     document.documentElement.style.setProperty(TOAST_RIGHT_OFFSET_VAR, widthPx);
-    // Keep Folio's find/replace dialog out from under the right inspector
-    // pane. Folio reads --folio-find-replace-right on the overlay so the
-    // dialog lands over the document, not behind the sidebar.
-    document.documentElement.style.setProperty(
-      "--folio-find-replace-right",
-      widthPx,
-    );
 
     return () => {
       document.documentElement.style.removeProperty(TOAST_RIGHT_OFFSET_VAR);
-      document.documentElement.style.removeProperty(
-        "--folio-find-replace-right",
-      );
     };
   }, [widthPx]);
 
@@ -616,7 +546,7 @@ function WorkspaceInspectorSidePanel() {
           />
         )}
         <div className="bg-sidebar flex h-full w-full flex-col">
-          <Suspense fallback={<InspectorRailFallback />}>
+          <Suspense>
             <LazyInspectorPanel workspaceId={activeWorkspaceId ?? undefined} />
           </Suspense>
         </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -334,8 +334,7 @@ function RouteComponentInner({
     filePropertyId !== undefined &&
     !isComparing &&
     compareState === null;
-  const usesEmbeddedDocxToolbar =
-    shouldRenderDocxBrowserShell && filePropertyId !== undefined;
+  const usesEmbeddedDocxToolbar = shouldRenderDocxBrowserShell;
   const latestFileFieldForProperty =
     filePropertyId !== undefined
       ? entity.fields.findLast(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -62,7 +62,7 @@ export const Route = createFileRoute(
         // eslint-disable-next-line no-console
         console.trace(
           `[stella] beforeLoad rejected viewId="${params.viewId}" — redirecting. URL:`,
-          globalThis.location?.href,
+          globalThis.location.href,
         );
       }
       throw redirect({
@@ -311,8 +311,8 @@ function VisibleFieldEntityViewContent({
 
   useSyncTable({
     workspaceId,
-    filters: activeView.layout.filters ?? [],
-    sorts: activeView.layout.sorts ?? [],
+    filters: activeView.layout.filters,
+    sorts: activeView.layout.sorts,
     page,
     fieldMode: "visible",
     fieldIds,
@@ -347,8 +347,8 @@ function FullEntityViewContent({
 }: EntityViewContentProps) {
   useSyncTable({
     workspaceId,
-    filters: activeView.layout.filters ?? [],
-    sorts: activeView.layout.sorts ?? [],
+    filters: activeView.layout.filters,
+    sorts: activeView.layout.sorts,
     page,
   });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/add-entity-menu.tsx
@@ -103,9 +103,7 @@ export const AddEntityMenu = ({
             title: t("success.folderCreated"),
             type: "success",
           });
-          if (data?.entityId !== undefined) {
-            onFolderCreated?.(data.entityId);
-          }
+          onFolderCreated?.(data.entityId);
         },
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/billing-codes-dialog.tsx
@@ -128,7 +128,7 @@ export const BillingCodesDialog = ({
             />
           )}
 
-          {codes !== undefined && codes.length > 0 ? (
+          {codes.length > 0 ? (
             <div className="flex flex-col gap-1.5">
               {codes.map((code) => (
                 <div

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/expense-list-view.tsx
@@ -52,7 +52,7 @@ export const ExpenseListView = ({
   const deleteExpense = useDeleteExpense();
 
   const totalsByCurrency = useMemo(() => {
-    if (expenses === undefined || expenses.length === 0) {
+    if (expenses.length === 0) {
       return [];
     }
     const map = new Map<string, number>();
@@ -66,7 +66,7 @@ export const ExpenseListView = ({
   }, [expenses]);
 
   const editingExpense = editingId
-    ? expenses?.find((e) => e.id === editingId)
+    ? expenses.find((e) => e.id === editingId)
     : null;
 
   const handleCreate = (values: ExpenseFormValues) => {
@@ -159,7 +159,7 @@ export const ExpenseListView = ({
       </div>
 
       {/* Expenses list */}
-      {expenses !== undefined && expenses.length > 0 ? (
+      {expenses.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           {expenses.map((expense) => (
             <ExpenseRow

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-combobox.tsx
@@ -41,7 +41,7 @@ export const MatterCombobox = ({
         <ComboboxList>
           {matters.map((matter) => (
             <ComboboxItem key={matter.id} value={matter.id}>
-              {matter.name ?? t("workspaces.defaultName")}
+              {matter.name}
             </ComboboxItem>
           ))}
         </ComboboxList>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/matter-name-map.ts
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useTranslations } from "use-intl";
 
 import { entitySummariesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 
@@ -11,7 +10,6 @@ import { entitySummariesOptions } from "@/routes/_protected.workspaces/$workspac
  * matter names without duplicating the extraction logic.
  */
 export const useMatterNameMap = (workspaceId: string) => {
-  const t = useTranslations();
   const { data: summaries } = useSuspenseQuery(
     entitySummariesOptions(workspaceId),
   );
@@ -19,8 +17,8 @@ export const useMatterNameMap = (workspaceId: string) => {
   return useMemo(() => {
     const map = new Map<string, string>();
     for (const summary of summaries) {
-      map.set(summary.id, summary.name ?? t("workspaces.defaultName"));
+      map.set(summary.id, summary.name);
     }
     return map;
-  }, [summaries, t]);
+  }, [summaries]);
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/rate-management-dialog.tsx
@@ -157,7 +157,7 @@ const RateTablesView = ({
         />
       )}
 
-      {tables !== undefined && tables.length > 0 ? (
+      {tables.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           {tables.map((table) => (
             <div
@@ -335,12 +335,12 @@ const RateEntriesView = ({
   );
   const { data: org } = useSuspenseQuery(organizationOptions);
 
-  const table = tables?.find((tbl) => tbl.id === rateTableId);
+  const table = tables.find((tbl) => tbl.id === rateTableId);
 
   const createEntry = useCreateRateEntry();
   const deleteEntry = useDeleteRateEntry();
 
-  const members = org?.members ?? [];
+  const members = org.members;
 
   const handleDelete = (id: string) => {
     deleteEntry.mutate(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-day-view.tsx
@@ -65,15 +65,12 @@ export const TimesheetDayView = ({
   const deleteEntry = useDeleteTimeEntry();
 
   const totalMinutes = useMemo(
-    () => (entries ?? []).reduce((sum, e) => sum + e.durationMinutes, 0),
+    () => entries.reduce((sum, e) => sum + e.durationMinutes, 0),
     [entries],
   );
 
   // Compute total billed amount
   const totalBilledAmount = useMemo(() => {
-    if (entries === undefined) {
-      return 0;
-    }
     let total = 0;
     for (const e of entries) {
       if (e.billable) {
@@ -88,14 +85,14 @@ export const TimesheetDayView = ({
 
   // Find dominant currency for display
   const dominantCurrency = useMemo(() => {
-    if (entries === undefined || entries.length === 0) {
+    if (entries.length === 0) {
       return DEFAULT_CURRENCY;
     }
     return entries.at(0)?.currency ?? DEFAULT_CURRENCY;
   }, [entries]);
 
   const editingEntry = editingId
-    ? entries?.find((e) => e.id === editingId)
+    ? entries.find((e) => e.id === editingId)
     : null;
 
   const handleCreate = (values: TimeEntryFormValues) => {
@@ -197,9 +194,6 @@ export const TimesheetDayView = ({
   }, []);
 
   const handleSelectAll = () => {
-    if (entries === undefined) {
-      return;
-    }
     if (selectedIds.size === entries.length) {
       setSelectedIds(new Set());
     } else {
@@ -215,7 +209,7 @@ export const TimesheetDayView = ({
       {/* Summary bar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          {entries !== undefined && entries.length > 0 && (
+          {entries.length > 0 && (
             <Checkbox
               checked={
                 selectedIds.size === entries.length && entries.length > 0
@@ -251,7 +245,7 @@ export const TimesheetDayView = ({
       />
 
       {/* Entries list */}
-      {entries !== undefined && entries !== null && entries.length > 0 ? (
+      {entries.length > 0 ? (
         <div className="flex flex-col gap-1.5">
           {entries.map((entry) => (
             <TimeEntryRow

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/billing/timesheet-week-view.tsx
@@ -64,9 +64,6 @@ export const TimesheetWeekView = ({
   type DayData = { minutes: number; amount: number };
   const grid = useMemo(() => {
     const map = new Map<string, Map<string, DayData>>();
-    if (entries === undefined) {
-      return map;
-    }
     for (const entry of entries) {
       let dayMap = map.get(entry.matterId);
       if (!dayMap) {
@@ -91,7 +88,7 @@ export const TimesheetWeekView = ({
 
   // Find dominant currency
   const dominantCurrency = useMemo(() => {
-    if (entries === undefined || entries.length === 0) {
+    if (entries.length === 0) {
       return DEFAULT_CURRENCY;
     }
     return entries.at(0)?.currency ?? DEFAULT_CURRENCY;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -71,7 +71,7 @@ export const CellResult = ({
   if (type === "file") {
     return (
       <FileCell
-        encrypted={field.content.encrypted ?? false}
+        encrypted={field.content.encrypted}
         entityId={field.entityId}
         fieldId={field.id}
         fileName={field.content.fileName}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -396,7 +396,7 @@ const PropertyComposerBody = ({
     editingProperty &&
     (editingProperty.content.type === "single-select" ||
       editingProperty.content.type === "multi-select")
-      ? (editingProperty.content.options ?? [])
+      ? editingProperty.content.options
       : [];
   const initialFallback: string | null =
     editingProperty &&
@@ -751,57 +751,48 @@ const PropertyComposerBody = ({
           />
         </div>
 
-        {(() => {
-          if (showAiSections) {
-            return (
-              <ComposerCard
-                autoPromptDisabled={
-                  trimmedName.length === 0 || suggestPrompt.isPending
+        {showAiSections ? (
+          <ComposerCard
+            autoPromptDisabled={
+              trimmedName.length === 0 || suggestPrompt.isPending
+            }
+            autoPromptPending={suggestPrompt.isPending}
+            contentType={contentType}
+            editorReady={setEditor}
+            fileChips={selectedFileIds.map(
+              (id) =>
+                fileProperties.find((p) => p.id === id) ?? {
+                  id,
+                  name: id,
+                },
+            )}
+            onAutoPrompt={handleAutoPrompt}
+            onContentTypeChange={setContentType}
+            onMentionsChange={setTextareaMentions}
+            onRemoveFile={(id) =>
+              setSelectedFileIds((prev) => prev.filter((p) => p !== id))
+            }
+            onSubmit={handleSubmit}
+            promptField={promptField}
+            propertyName={trimmedName}
+            typeChanged={typeChanged}
+            {...(availableFileToAdd.length > 0
+              ? {
+                  addFile: (id: string) =>
+                    setSelectedFileIds((prev) => [...prev, id]),
+                  availableFiles: availableFileToAdd,
                 }
-                autoPromptPending={suggestPrompt.isPending}
-                contentType={contentType}
-                editorReady={setEditor}
-                fileChips={selectedFileIds.map(
-                  (id) =>
-                    fileProperties.find((p) => p.id === id) ?? {
-                      id,
-                      name: id,
-                    },
-                )}
-                onAutoPrompt={handleAutoPrompt}
-                onContentTypeChange={setContentType}
-                onMentionsChange={setTextareaMentions}
-                onRemoveFile={(id) =>
-                  setSelectedFileIds((prev) => prev.filter((p) => p !== id))
-                }
-                onSubmit={handleSubmit}
-                promptField={promptField}
-                propertyName={trimmedName}
-                typeChanged={typeChanged}
-                {...(availableFileToAdd.length > 0
-                  ? {
-                      addFile: (id: string) =>
-                        setSelectedFileIds((prev) => [...prev, id]),
-                      availableFiles: availableFileToAdd,
-                    }
-                  : {})}
-                {...(propertyId !== undefined
-                  ? {
-                      propertyId,
-                    }
-                  : {})}
-                workspaceId={workspaceId}
-              />
-            );
-          }
-          return (
-            <ManualTypeRow
-              contentType={contentType}
-              onContentTypeChange={setContentType}
-              typeChanged={typeChanged}
-            />
-          );
-        })()}
+              : {})}
+            {...(propertyId !== undefined ? { propertyId } : {})}
+            workspaceId={workspaceId}
+          />
+        ) : (
+          <ManualTypeRow
+            contentType={contentType}
+            onContentTypeChange={setContentType}
+            typeChanged={typeChanged}
+          />
+        )}
 
         {needsOptions && (
           <InlineOptionEditor

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1128,25 +1128,27 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     const styleLabelElement = containerRef.current?.querySelector<HTMLElement>(
       '[data-folio-style-picker] [data-slot="select-value"]',
     );
-    const stylePreviewElement =
-      styleLabelElement?.querySelector<HTMLElement>("[style]") ??
-      styleLabelElement;
-    const styleLabel = styleLabelElement?.textContent?.trim();
+    if (!styleLabelElement) {
+      return;
+    }
 
-    if (styleLabel !== undefined && styleLabel.length > 0) {
+    const stylePreviewElement =
+      styleLabelElement.querySelector<HTMLElement>("[style]") ??
+      styleLabelElement;
+    const styleLabel = styleLabelElement.textContent.trim();
+
+    if (styleLabel.length > 0) {
       lastStyleLabelRef.current = styleLabel;
     }
 
-    if (stylePreviewElement !== undefined && stylePreviewElement !== null) {
-      const computedStyle = window.getComputedStyle(stylePreviewElement);
-      lastStyleLabelStyleRef.current = {
-        color: computedStyle.color,
-        fontSize: computedStyle.fontSize,
-        fontStyle: computedStyle.fontStyle,
-        fontWeight: computedStyle.fontWeight,
-        lineHeight: computedStyle.lineHeight,
-      };
-    }
+    const computedStyle = window.getComputedStyle(stylePreviewElement);
+    lastStyleLabelStyleRef.current = {
+      color: computedStyle.color,
+      fontSize: computedStyle.fontSize,
+      fontStyle: computedStyle.fontStyle,
+      fontWeight: computedStyle.fontWeight,
+      lineHeight: computedStyle.lineHeight,
+    };
   });
 
   if (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -1135,7 +1135,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     const stylePreviewElement =
       styleLabelElement.querySelector<HTMLElement>("[style]") ??
       styleLabelElement;
-    const styleLabel = styleLabelElement.textContent.trim();
+    const styleLabelText = Reflect.get(styleLabelElement, "textContent");
+    const styleLabel =
+      typeof styleLabelText === "string" ? styleLabelText.trim() : "";
 
     if (styleLabel.length > 0) {
       lastStyleLabelRef.current = styleLabel;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-edit-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-edit-session.ts
@@ -128,6 +128,7 @@ export const useEditSession = ({
   const checkpointQueueRef = useRef(Promise.resolve());
   const releaseContextRef = useRef({ workspaceId, entityId, propertyId });
   const isMountedRef = useRef(true);
+  const isMounted = () => isMountedRef.current;
 
   useEffect(() => {
     releaseContextRef.current = { workspaceId, entityId, propertyId };
@@ -158,7 +159,7 @@ export const useEditSession = ({
       });
 
     if (response.error) {
-      if (!isMountedRef.current) {
+      if (!isMounted()) {
         return false;
       }
       setState({
@@ -172,7 +173,7 @@ export const useEditSession = ({
 
     const { sessionId, sessionToken, downloadUrl, fileName } = response.data;
     sessionRef.current = { fileName, sessionId, sessionToken };
-    if (!isMountedRef.current) {
+    if (!isMounted()) {
       sessionRef.current = null;
       await releaseEditSession(releaseContext);
       return false;
@@ -182,11 +183,9 @@ export const useEditSession = ({
       signal: AbortSignal.timeout(30_000),
     }).catch(() => null);
     if (!fileResponse?.ok) {
-      if (sessionRef.current !== null) {
-        sessionRef.current = null;
-        await releaseEditSession(releaseContext);
-      }
-      if (!isMountedRef.current) {
+      sessionRef.current = null;
+      await releaseEditSession(releaseContext);
+      if (!isMounted()) {
         return false;
       }
       setState({
@@ -198,11 +197,9 @@ export const useEditSession = ({
     }
 
     const downloadedBuffer = await fileResponse.arrayBuffer();
-    if (!isMountedRef.current) {
-      if (sessionRef.current !== null) {
-        sessionRef.current = null;
-        await releaseEditSession(releaseContext);
-      }
+    if (!isMounted()) {
+      sessionRef.current = null;
+      await releaseEditSession(releaseContext);
       return false;
     }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 
 import { revalidateLogic, useForm } from "@tanstack/react-form";
 import type { AnyFieldApi } from "@tanstack/react-form";
-import { panic } from "better-result";
 import { useTranslations } from "use-intl";
 import * as v from "valibot";
 
@@ -103,15 +102,11 @@ const getDefaultValues = (
     };
   }
 
-  if (fieldContent.type === "int") {
-    return {
-      type: "int",
-      value: fieldContent.value,
-      currency: fieldContent.currency,
-    };
-  }
-
-  return panic("Invalid field content type");
+  return {
+    type: "int",
+    value: fieldContent.value,
+    currency: fieldContent.currency,
+  };
 };
 
 type EditFieldDialogProps = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -278,37 +278,30 @@ const InlineEditor = ({
     );
   }
 
-  if (type === "single-select" || type === "multi-select") {
-    const options =
-      property.content.type === "single-select" ||
-      property.content.type === "multi-select"
-        ? property.content.options
-        : [];
-
-    if (type === "single-select") {
-      return (
-        <FieldValueSelect
-          onChange={(value) =>
-            save({ type: "single-select", version: 1, value })
-          }
-          options={options}
-          type="single-select"
-          value={content?.type === "single-select" ? content.value : null}
-        />
-      );
-    }
-
+  const options =
+    property.content.type === "single-select" ||
+    property.content.type === "multi-select"
+      ? property.content.options
+      : [];
+  if (type === "single-select") {
     return (
       <FieldValueSelect
-        onChange={(value) => save({ type: "multi-select", version: 1, value })}
+        onChange={(value) => save({ type: "single-select", version: 1, value })}
         options={options}
-        type="multi-select"
-        value={content?.type === "multi-select" ? content.value : []}
+        type="single-select"
+        value={content?.type === "single-select" ? content.value : null}
       />
     );
   }
 
-  return <span className="text-muted-foreground text-sm">—</span>;
+  return (
+    <FieldValueSelect
+      onChange={(value) => save({ type: "multi-select", version: 1, value })}
+      options={options}
+      type="multi-select"
+      value={content?.type === "multi-select" ? content.value : []}
+    />
+  );
 };
 
 // -- Text inline editor --

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value-select.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/field-value-select.tsx
@@ -24,11 +24,7 @@ const SelectValueContent = ({
 }: SelectValueContentProps) => {
   const t = useTranslations();
 
-  if (
-    value === undefined ||
-    value === null ||
-    (Array.isArray(value) && value.length === 0)
-  ) {
+  if (value === null || (Array.isArray(value) && value.length === 0)) {
     return type === "multi-select"
       ? t("workspaces.fields.selectValues")
       : t("workspaces.fields.selectAValue");

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1365,9 +1365,12 @@ const FilesystemRow = ({
       )}
       {(() => {
         if (isFolder) {
-          return expanded ? (
-            <FolderOpenIcon className="text-muted-foreground size-4 shrink-0" />
-          ) : (
+          if (expanded) {
+            return (
+              <FolderOpenIcon className="text-muted-foreground size-4 shrink-0" />
+            );
+          }
+          return (
             <FolderIcon className="text-muted-foreground size-4 shrink-0" />
           );
         }
@@ -1381,38 +1384,33 @@ const FilesystemRow = ({
         }
         return <FileIcon className="text-muted-foreground size-4 shrink-0" />;
       })()}
-      {(() => {
-        if (isEditing) {
-          return (
-            <InlineEdit
-              inputClassName="w-48"
-              onCancel={cancelEditing}
-              onChange={setEditValue}
-              onCommit={commitRename}
-              suffix={
-                ext ? (
-                  <span className="text-muted-foreground text-sm">{ext}</span>
-                ) : undefined
-              }
-              value={editValue}
-            />
-          );
-        }
-        return (
-          <span className="flex min-w-0 items-center gap-1.5">
-            <span className="truncate" title={name}>
-              {name}
-            </span>
-            {node.activeEditBy && (
-              <ActiveEditBadge
-                className="shrink-0"
-                image={node.activeEditBy.image}
-                name={node.activeEditBy.name}
-              />
-            )}
+      {isEditing ? (
+        <InlineEdit
+          inputClassName="w-48"
+          onCancel={cancelEditing}
+          onChange={setEditValue}
+          onCommit={commitRename}
+          suffix={
+            ext ? (
+              <span className="text-muted-foreground text-sm">{ext}</span>
+            ) : undefined
+          }
+          value={editValue}
+        />
+      ) : (
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="truncate" title={name}>
+            {name}
           </span>
-        );
-      })()}
+          {node.activeEditBy && (
+            <ActiveEditBadge
+              className="shrink-0"
+              image={node.activeEditBy.image}
+              name={node.activeEditBy.name}
+            />
+          )}
+        </span>
+      )}
     </span>
   );
 
@@ -1483,7 +1481,7 @@ const FilesystemRow = ({
     if (node.kind === "task") {
       return () => useInspectorStore.getState().openTask(node.entityId, name);
     }
-    if (navigable && file !== undefined) {
+    if (navigable) {
       return () =>
         useInspectorStore.getState().openFile({
           id: file.fieldId,
@@ -1508,15 +1506,12 @@ const FilesystemRow = ({
   } else if (!contextOpen) {
     bulkEntitiesRef.current = undefined;
   }
-  const bulkEntities = (() => {
-    if (contextOpen) {
-      return bulkEntitiesRef.current;
-    }
-    if (isBulkSelected) {
-      return getSelectedEntities(selectedIds);
-    }
-    return undefined;
-  })();
+  let bulkEntities: WorkspaceEntity[] | undefined;
+  if (contextOpen) {
+    bulkEntities = bulkEntitiesRef.current;
+  } else if (isBulkSelected) {
+    bulkEntities = getSelectedEntities(selectedIds);
+  }
 
   const rowActionsNode = (
     <span className="flex justify-end">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -66,7 +66,7 @@ import { usePermissions } from "@/hooks/use-permissions";
 import { getAnalytics, useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { getFreshLinkedAccount } from "@/lib/auth-session";
-import { createChatThreadId } from "@/lib/chat-thread-ref";
+import { createChatThreadId, toChatThreadId } from "@/lib/chat-thread-ref";
 import type { Citation } from "@/lib/citations";
 import { iterateJustificationCitations } from "@/lib/citations";
 import {
@@ -2217,7 +2217,7 @@ const DocumentAiSourceBar = ({
       return undefined;
     }
 
-    let cancelled = false;
+    const requestState = { cancelled: false };
     setIsGeneratingBoxes(true);
 
     void (async () => {
@@ -2229,7 +2229,7 @@ const DocumentAiSourceBar = ({
             queryKey: workspaceKeys.justifications(workspaceId),
           });
 
-        if (cancelled) {
+        if (requestState.cancelled) {
           return;
         }
 
@@ -2239,18 +2239,18 @@ const DocumentAiSourceBar = ({
           });
         }
       } catch (error) {
-        if (!cancelled) {
+        if (!requestState.cancelled) {
           analytics.captureError(error);
         }
       } finally {
-        if (!cancelled) {
+        if (!requestState.cancelled) {
           setIsGeneratingBoxes(false);
         }
       }
     })();
 
     return () => {
-      cancelled = true;
+      requestState.cancelled = true;
     };
   }, [
     justificationId,
@@ -2358,7 +2358,7 @@ const DocumentAiSourceBar = ({
       if (Array.isArray(v)) {
         return v.join(", ");
       }
-      return v !== null && v !== undefined ? String(v) : null;
+      return v !== null ? String(v) : null;
     }
     return null;
   })();
@@ -2550,7 +2550,9 @@ const useInspectorFind = ({
     setFindQuery("");
     setMatchCount(0);
     setActiveIndex(0);
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.delete(allHighlightName);
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.delete(activeHighlightName);
   }, [activeHighlightName, allHighlightName]);
 
@@ -2602,7 +2604,9 @@ const useInspectorFind = ({
   }, [enabled, findOpen]);
 
   useLayoutEffect(() => {
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.delete(allHighlightName);
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.delete(activeHighlightName);
 
     const root = contentRef.current;
@@ -2627,15 +2631,19 @@ const useInspectorFind = ({
       return undefined;
     }
 
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.set(allHighlightName, new Highlight(...ranges));
     const activeRange = ranges.at(safeActiveIndex);
     if (activeRange) {
+      // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
       CSS.highlights?.set(activeHighlightName, new Highlight(activeRange));
       scrollRangeIntoView(activeRange);
     }
 
     return () => {
+      // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
       CSS.highlights?.delete(allHighlightName);
+      // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
       CSS.highlights?.delete(activeHighlightName);
     };
   }, [
@@ -2831,6 +2839,7 @@ const useExternalPdfBuffer = ({
 
     setState({ status: "loading" });
     const controller = new AbortController();
+    const isAborted = () => controller.signal.aborted;
 
     void (async () => {
       const response = await fetch(url, {
@@ -2838,15 +2847,15 @@ const useExternalPdfBuffer = ({
         signal: controller.signal,
       });
 
-      if (!response.ok || controller.signal.aborted) {
-        if (!controller.signal.aborted) {
+      if (!response.ok || isAborted()) {
+        if (!isAborted()) {
           setState({ status: "error" });
         }
         return;
       }
 
       const next = await response.arrayBuffer();
-      if (controller.signal.aborted) {
+      if (isAborted()) {
         return;
       }
 
@@ -2857,7 +2866,7 @@ const useExternalPdfBuffer = ({
       // `fileId` so each new buffer parses from scratch.
       setState({ status: "ready", buffer: next, token: crypto.randomUUID() });
     })().catch(() => {
-      if (!controller.signal.aborted) {
+      if (!isAborted()) {
         setState({ status: "error" });
       }
     });
@@ -3064,8 +3073,11 @@ const ExternalReferencePanel = ({
     enabled: shouldLoadExternalPdf,
     url: externalFilePreviewUrl,
   });
+  const persistedExternalTab: { chatThreadId?: string | undefined } = tab;
   const externalChatThreadId =
-    tab.chatThreadId ?? fallbackChatThreadIdRef.current;
+    persistedExternalTab.chatThreadId === undefined
+      ? fallbackChatThreadIdRef.current
+      : toChatThreadId(persistedExternalTab.chatThreadId);
   const hasMetadata =
     provider !== undefined ||
     connectorSlug !== undefined ||
@@ -3354,7 +3366,7 @@ const ExternalReferencePanel = ({
                 </div>
               );
             }
-            if (shouldLoadExternalPdf && externalFilePreviewUrl !== undefined) {
+            if (shouldLoadExternalPdf) {
               return (
                 <ExternalPdfPreview
                   buffer={externalPdfPreview.buffer}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.test.ts
@@ -60,21 +60,17 @@ class FakeBroadcastChannel {
   }
 
   addEventListener(
-    type: "message",
+    _type: "message",
     listener: (event: MessageEvent<unknown>) => void,
   ) {
-    if (type === "message") {
-      this.listeners.add(listener);
-    }
+    this.listeners.add(listener);
   }
 
   removeEventListener(
-    type: "message",
+    _type: "message",
     listener: (event: MessageEvent<unknown>) => void,
   ) {
-    if (type === "message") {
-      this.listeners.delete(listener);
-    }
+    this.listeners.delete(listener);
   }
 
   private dispatchToPeers(message: unknown) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store.ts
@@ -687,9 +687,7 @@ export const useInspectorStore = create<State & Actions>()(
             if (tab.mimeType !== undefined) {
               existing.mimeType = tab.mimeType;
             }
-            if (tab.pdfFileId !== undefined) {
-              existing.pdfFileId = tab.pdfFileId;
-            }
+            existing.pdfFileId = tab.pdfFileId;
             // Bump the render id only when the underlying field
             // changed (version switch); a no-op re-open of the same
             // field shouldn't remount the viewer subtree.
@@ -748,9 +746,7 @@ export const useInspectorStore = create<State & Actions>()(
             if (tab.mimeType !== undefined) {
               existing.mimeType = tab.mimeType;
             }
-            if (tab.pdfFileId !== undefined) {
-              existing.pdfFileId = tab.pdfFileId;
-            }
+            existing.pdfFileId = tab.pdfFileId;
             existing.renderId = uuidv7();
             state.tabs = state.tabs.filter(
               (t, i) =>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -300,7 +300,7 @@ export const KanbanCard = ({
     );
   }
 
-  if (navigable && file !== undefined) {
+  if (navigable) {
     return (
       <div className="group/card" ref={dragRef}>
         <div
@@ -532,15 +532,11 @@ const KanbanCardFieldValue = ({
     ));
   }
 
-  if (content.type === "clip") {
-    return (
-      <span className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none">
-        {content.citation ?? content.url}
-      </span>
-    );
-  }
-
-  return null;
+  return (
+    <span className="text-muted-foreground bg-muted/60 truncate rounded px-1.5 py-0.5 text-xs leading-none">
+      {content.citation ?? content.url}
+    </span>
+  );
 };
 
 const KanbanSelectChip = ({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-column.tsx
@@ -274,7 +274,7 @@ export const KanbanColumn = ({
 
     // Column draggable: entire column is the element,
     // grip icon is the drag handle (Trello-style).
-    if (isDraggable && handle && columnValue !== null) {
+    if (isDraggable && handle) {
       cleanups.push(
         draggable({
           element: el,
@@ -369,9 +369,7 @@ export const KanbanColumn = ({
                 <button className="shrink-0 cursor-pointer" type="button">
                   <span
                     className="block size-2.5 rounded-full"
-                    style={{
-                      backgroundColor: color,
-                    }}
+                    style={{ backgroundColor: color }}
                   />
                 </button>
               </ColorPicker>
@@ -381,9 +379,7 @@ export const KanbanColumn = ({
             return (
               <span
                 className="size-2.5 rounded-full"
-                style={{
-                  backgroundColor: color,
-                }}
+                style={{ backgroundColor: color }}
               />
             );
           }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -71,7 +71,7 @@ export const MatterMetadataPanel = ({
   useEffect(() => {
     escapedNameRef.current = false;
     setNameValue(workspace.name);
-    setReferenceValue(workspace.reference ?? "");
+    setReferenceValue(workspace.reference);
     setReferenceError("");
   }, [workspace.name, workspace.reference]);
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -355,7 +355,7 @@ export const OverviewView = ({ workspaceId }: OverviewViewProps) => {
 
         return {
           userId: member.userId,
-          name: member.user.name ?? member.user.email ?? "—",
+          name: member.user.name,
           image: member.user.image,
           daily,
           dailyEntries,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/page-citation.tsx
@@ -54,7 +54,7 @@ export const PageCitation = ({
   const highlightPadding = originalWidth * HIGHLIGHT_PADDING_RATIO * scale;
 
   const topBoundingBox = boundingBoxes
-    ?.toSorted((a, b) => a.yMin - b.yMin)
+    .toSorted((a, b) => a.yMin - b.yMin)
     .at(0);
   const topBoundingBoxKey = topBoundingBox
     ? getBoundingBoxKey(topBoundingBox)
@@ -83,7 +83,7 @@ export const PageCitation = ({
           </feComponentTransfer>
         </filter>
       </svg>
-      {boundingBoxes?.map((bBox) => {
+      {boundingBoxes.map((bBox) => {
         const { xMin, yMin, xMax, yMax } = bBox;
         const width = (xMax - xMin) * scale;
         const height = (yMax - yMin) * scale;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-conditions.tsx
@@ -111,7 +111,7 @@ export const PropertyConditions = ({
   const t = useTranslations();
   const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
 
-  const data = (dependencies ?? [])
+  const data = dependencies
     .map((dependency) => {
       const property = properties.find(
         (p) => p.id === dependency.dependsOnPropertyId,
@@ -129,7 +129,7 @@ export const PropertyConditions = ({
         condition !== null,
     );
 
-  const conditionCount = (dependencies ?? []).filter(
+  const conditionCount = dependencies.filter(
     (dependency) => dependency.condition !== null,
   ).length;
 
@@ -211,15 +211,12 @@ const getOperatorOptions = (
   value: string | string[],
   operatorLabels: Record<ConditionOperator, string>,
 ) => {
-  const operatorKeys: ConditionOperator[] = (() => {
-    if (typeof value === "string") {
-      return STRING_OPERATORS;
-    }
-    if (Array.isArray(value)) {
-      return STRING_ARRAY_OPERATORS;
-    }
-    return [];
-  })();
+  let operatorKeys: ConditionOperator[] = [];
+  if (typeof value === "string") {
+    operatorKeys = STRING_OPERATORS;
+  } else if (Array.isArray(value)) {
+    operatorKeys = STRING_ARRAY_OPERATORS;
+  }
 
   return operatorKeys.map((operator) => ({
     value: operator,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/input.tsx
@@ -161,7 +161,7 @@ export const PropertyPromptInput = ({
   });
 
   useEffect(() => {
-    if (editor !== null && onEditorReady !== undefined) {
+    if (onEditorReady !== undefined) {
       onEditorReady(editor);
     }
   }, [editor, onEditorReady]);
@@ -172,10 +172,7 @@ export const PropertyPromptInput = ({
     if (
       !autoPopulateOnEmpty ||
       didAutoPopulate.current ||
-      editor === undefined ||
-      editor === null ||
       fileProperty === undefined ||
-      fileProperty === null ||
       field.state.value.length > 0
     ) {
       return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/row-actions.tsx
@@ -47,11 +47,7 @@ import { env } from "@/env";
 import { api } from "@/lib/api";
 import { getFreshLinkedAccount } from "@/lib/auth-session";
 import { DOCX_MIME } from "@/lib/consts";
-import {
-  DesktopBridgeIncompatibleError,
-  openDocxInDesktop,
-} from "@/lib/desktop-bridge";
-import { showDesktopEditOpenResultToast } from "@/lib/desktop-edit-status-toast";
+import { openDocxInDesktop } from "@/lib/desktop-bridge";
 import { ClientOperationError, isUnauthorizedError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import type { WorkspaceCellMetadata, WorkspaceEntity } from "@/lib/types";
@@ -224,10 +220,12 @@ export const RowActions = ({
         ...(isLockedByMe ? { force: true as const } : {}),
       };
 
-      const openResult = await openDocxInDesktop(desktopInput);
-      await showDesktopEditOpenResultToast({
-        result: openResult,
-        t,
+      await openDocxInDesktop(desktopInput);
+
+      stellaToast.add({
+        description: t("workspaces.files.desktopEdit.openedDescription"),
+        title: t("workspaces.files.desktopEdit.openedTitle"),
+        type: "success",
       });
     } catch (error) {
       if (error instanceof Error && isUnauthorizedError(error)) {
@@ -236,17 +234,6 @@ export const RowActions = ({
             "workspaces.files.desktopEdit.authRequiredDescription",
           ),
           title: t("workspaces.files.desktopEdit.authRequiredTitle"),
-          type: "error",
-        });
-        return;
-      }
-
-      if (error instanceof DesktopBridgeIncompatibleError) {
-        stellaToast.add({
-          description: t(
-            "workspaces.files.desktopEdit.updateRequiredDescription",
-          ),
-          title: t("workspaces.files.desktopEdit.updateRequiredTitle"),
           type: "error",
         });
         return;
@@ -267,7 +254,7 @@ export const RowActions = ({
 
     const linkedAccount = await getFreshLinkedAccount();
 
-    const openResult = await openDocxInDesktop({
+    await openDocxInDesktop({
       apiBaseUrl: env.VITE_API_URL,
       entityId: file.entityId,
       force: true,
@@ -276,9 +263,10 @@ export const RowActions = ({
       workspaceId,
     });
 
-    await showDesktopEditOpenResultToast({
-      result: openResult,
-      t,
+    stellaToast.add({
+      description: t("workspaces.files.desktopEdit.openedDescription"),
+      title: t("workspaces.files.desktopEdit.openedTitle"),
+      type: "success",
     });
   };
 
@@ -333,17 +321,6 @@ export const RowActions = ({
               "workspaces.files.desktopEdit.authRequiredDescription",
             ),
             title: t("workspaces.files.desktopEdit.authRequiredTitle"),
-            type: "error",
-          });
-          return;
-        }
-
-        if (forceError instanceof DesktopBridgeIncompatibleError) {
-          stellaToast.add({
-            description: t(
-              "workspaces.files.desktopEdit.updateRequiredDescription",
-            ),
-            title: t("workspaces.files.desktopEdit.updateRequiredTitle"),
             type: "error",
           });
           return;
@@ -692,9 +669,7 @@ const CreateSubfolderMenuItem = ({
             title: t("success.folderCreated"),
             type: "success",
           });
-          if (data?.entityId !== undefined) {
-            onSubfolderCreated(data.entityId, entity.entityId);
-          }
+          onSubfolderCreated(data.entityId, entity.entityId);
         },
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -103,7 +103,7 @@ const PropertyCell = ({
   }
 
   // AI-model property: click opens peek PDF with justification
-  if (property.tool.type === "ai-model" && field !== undefined) {
+  if (field !== undefined) {
     const firstFile = getFirstFile(entity);
     const justFieldId = justification?.fileFieldIds.at(0);
     const fileFieldId = justFieldId ?? firstFile?.fieldId;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -112,7 +112,7 @@ export const TaskDetailPanel = ({
   // Auto-assign current user and focus name for new tasks
   const didAutoAssign = useRef(false);
   useEffect(() => {
-    if (isNewTask && task && !isLoading) {
+    if (isNewTask && task) {
       setEditNameValue("");
       setIsEditingName(true);
       clearNewFlag(taskId);
@@ -120,7 +120,7 @@ export const TaskDetailPanel = ({
       // Auto-assign the signed-in user
       if (!didAutoAssign.current) {
         didAutoAssign.current = true;
-        const alreadyAssigned = task.assignees?.some(
+        const alreadyAssigned = task.assignees.some(
           (a) => a.user.id === userId,
         );
         if (!alreadyAssigned) {
@@ -202,17 +202,10 @@ export const TaskDetailPanel = ({
 
   // Sync task status to the inspector tab icon so the vertical
   // tab bar reflects the current status color.
-  const resolvedStatus = (() => {
-    if (task) {
-      return (() => {
-        if (isTaskStatus(task.status)) {
-          return task.status;
-        }
-        return "open";
-      })();
-    }
-    return null;
-  })();
+  let resolvedStatus: TaskStatus | null = null;
+  if (task) {
+    resolvedStatus = isTaskStatus(task.status) ? task.status : "open";
+  }
   useEffect(() => {
     if (resolvedStatus !== null) {
       useInspectorStore.getState().updateTaskStatus(taskId, resolvedStatus);
@@ -306,7 +299,7 @@ export const TaskDetailPanel = ({
                 }
                 if (e.key === "Escape") {
                   setIsEditingName(false);
-                  setEditNameValue(task?.name ?? "");
+                  setEditNameValue(task.name ?? "");
                 }
               }}
               placeholder={t("untitled")}
@@ -347,7 +340,7 @@ export const TaskDetailPanel = ({
 
           <MetadataRow label={t("assignees")}>
             <AssigneePicker
-              assignees={task.assignees ?? []}
+              assignees={task.assignees}
               taskId={taskId}
               workspaceId={workspaceId}
             />
@@ -357,13 +350,13 @@ export const TaskDetailPanel = ({
         {/* Subtasks */}
         <SubtasksSection
           onToggle={handleSubtaskToggle}
-          subtasks={task.children ?? []}
+          subtasks={task.children}
         />
 
         {/* Links */}
         <LinksSection
-          linkedFrom={task.linksAsSource ?? []}
-          linkedTo={task.linksAsTarget ?? []}
+          linkedFrom={task.linksAsSource}
+          linkedTo={task.linksAsTarget}
         />
       </ScrollArea>
     </div>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -289,7 +289,7 @@ export const AssigneePicker = ({
                   >
                     {user.image ? (
                       <img
-                        alt={user.name ?? ""}
+                        alt={user.name}
                         className="size-5 rounded-full"
                         height={20}
                         src={user.image}
@@ -297,7 +297,7 @@ export const AssigneePicker = ({
                       />
                     ) : (
                       <span className="bg-primary/10 flex size-5 items-center justify-center rounded-full text-xs font-medium">
-                        {user.name?.[0]?.toUpperCase() ?? "?"}
+                        {user.name[0]?.toUpperCase() ?? "?"}
                       </span>
                     )}
                     <span className="truncate">{user.name}</span>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar-filters.tsx
@@ -341,9 +341,7 @@ const BuiltinFilterChip = ({
           value={String(filter.value ?? "")}
         >
           <FilterSelectTrigger>
-            {filter.value !== "" && filter.value !== null
-              ? resolveLabel(String(filter.value))
-              : "…"}
+            {filter.value !== "" ? resolveLabel(String(filter.value)) : "…"}
           </FilterSelectTrigger>
           <SelectPopup alignItemWithTrigger={false}>
             {values.map((val) => (
@@ -435,9 +433,7 @@ const PropertyFilterChip = ({
             value={String(filter.value ?? "")}
           >
             <FilterSelectTrigger>
-              {filter.value !== "" && filter.value !== null
-                ? String(filter.value)
-                : "…"}
+              {filter.value !== "" ? String(filter.value) : "…"}
             </FilterSelectTrigger>
             <SelectPopup alignItemWithTrigger={false}>
               {selectOptions.map((opt) => (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -90,7 +90,7 @@ export const ViewToolbar = ({ view, workspaceId }: ViewToolbarProps) => {
 
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-1 px-2 py-1">
-      {view.layout.type === "filesystem" && folderState?.hasFolders && (
+      {view.layout.type === "filesystem" && folderState.hasFolders && (
         <>
           <Button
             onClick={toggleAllFolders}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -70,12 +70,10 @@ const uploadSingleFile = async (
 
     // Attach the raw Response so the queue can extract
     // the Retry-After header on 429 responses.
-    if (response.response !== undefined) {
-      Object.defineProperty(error, "response", {
-        value: response.response,
-        enumerable: false,
-      });
-    }
+    Object.defineProperty(error, "response", {
+      value: response.response,
+      enumerable: false,
+    });
 
     throw error;
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
@@ -84,7 +84,7 @@ export const activeTimerOptions = (workspaceId: string) =>
         throw toAPIError(response.error);
       }
 
-      return response.data?.at(0) ?? null;
+      return response.data.at(0) ?? null;
     },
     refetchInterval: 60_000,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -77,7 +77,7 @@ export const Route = createFileRoute("/_protected/workspaces/$workspaceId")({
       // eslint-disable-next-line no-console
       console.trace(
         "[stella] notFoundComponent triggered — redirecting to /workspaces. Current URL:",
-        globalThis.location?.href,
+        globalThis.location.href,
       );
     }
     return <Navigate replace to="/workspaces" />;

--- a/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matter-card.tsx
@@ -70,7 +70,7 @@ export const MatterCard = ({
       canCreateMatter={canCreateMatter}
       isPersonal={!workspace.client}
       workspaceId={workspace.id}
-      workspaceName={workspace.name ?? t("workspaces.defaultName")}
+      workspaceName={workspace.name}
     >
       {(rename) => (
         <PreviewCard

--- a/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/matters-table.tsx
@@ -155,9 +155,7 @@ const ClientCell = ({ workspace }: CellProps) => {
 };
 
 const ReferenceCell = ({ workspace }: CellProps) => (
-  <span className="text-muted-foreground font-mono">
-    {workspace.reference ?? "—"}
-  </span>
+  <span className="text-muted-foreground font-mono">{workspace.reference}</span>
 );
 
 const EntityCountCell = ({ workspace }: CellProps) => (

--- a/apps/web/src/routes/_protected.workspaces/-utils.ts
+++ b/apps/web/src/routes/_protected.workspaces/-utils.ts
@@ -77,7 +77,7 @@ export const compareWorkspacesByKey = (
     case "name":
       return a.name.localeCompare(b.name);
     case "reference":
-      return (a.reference ?? "").localeCompare(b.reference ?? "");
+      return a.reference.localeCompare(b.reference);
     case "entityCount":
       return a.entityCount - b.entityCount;
     case "lastActivityAt":

--- a/apps/web/src/routes/_protected.workspaces/index.tsx
+++ b/apps/web/src/routes/_protected.workspaces/index.tsx
@@ -73,7 +73,7 @@ function RouteComponent() {
       sortKey: s.matters.sortKey,
       sortDesc: s.matters.sortDesc,
       groupBy: s.matters.groupBy,
-      collapsedGroups: s.matters.collapsedGroups ?? [],
+      collapsedGroups: s.matters.collapsedGroups,
     })),
   );
 
@@ -120,14 +120,9 @@ function RouteComponent() {
   const groups = groupBy === "client" ? groupByClient(sorted) : null;
 
   const collapsedSet = new Set(collapsedGroups);
-  const displayed = (() => {
-    if (groups) {
-      return groups.flatMap((g) =>
-        collapsedSet.has(g.groupId) ? [] : g.workspaces,
-      );
-    }
-    return sorted;
-  })();
+  const displayed = groups
+    ? groups.flatMap((g) => (collapsedSet.has(g.groupId) ? [] : g.workspaces))
+    : sorted;
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -170,50 +165,48 @@ function RouteComponent() {
         <div className="relative flex-1">
           <div className="absolute inset-0 overflow-y-auto" ref={scrollRef}>
             {(() => {
-              if (sorted.length === 0) {
-                return (() => {
-                  if (workspaces.length === 0 && isFetching) {
-                    return (
-                      <div className="grid auto-rows-min gap-4 border-t p-4 md:grid-cols-3">
-                        <Skeleton className="h-22 w-full rounded-xl" />
-                        <Skeleton className="h-22 w-full rounded-xl" />
-                        <Skeleton className="h-22 w-full rounded-xl" />
-                      </div>
-                    );
-                  }
-                  if (workspaces.length === 0) {
-                    return (
-                      <EmptyScreen
-                        className="min-h-full"
-                        description={t("workspaces.emptyMatters.description")}
-                        primaryAction={{
-                          label: t("workspaces.createNewWorkspace"),
-                          icon: PlusIcon,
-                          onClick: () => openCreateMatter(),
-                        }}
-                        mediaPlacement="bottom"
-                        title={t("workspaces.emptyMatters.title")}
-                        video={{
-                          ...EMPTY_SCREEN_MATTERS_VIDEO,
-                          title: t("workspaces.emptyMatters.videoLabel"),
-                        }}
-                      />
-                    );
-                  }
-                  return (
-                    <div className="text-muted-foreground flex flex-1 items-center justify-center p-8 text-sm">
-                      {t("common.empty")}
-                    </div>
-                  );
-                })();
+              if (sorted.length > 0) {
+                return (
+                  <MattersContentView
+                    canCreateMatter={canOpenCreateMatter}
+                    displayed={displayed}
+                    focusIndex={focusIndex}
+                    groups={groups}
+                  />
+                );
+              }
+              if (workspaces.length === 0 && isFetching) {
+                return (
+                  <div className="grid auto-rows-min gap-4 border-t p-4 md:grid-cols-3">
+                    <Skeleton className="h-22 w-full rounded-xl" />
+                    <Skeleton className="h-22 w-full rounded-xl" />
+                    <Skeleton className="h-22 w-full rounded-xl" />
+                  </div>
+                );
+              }
+              if (workspaces.length === 0) {
+                return (
+                  <EmptyScreen
+                    className="min-h-full"
+                    description={t("workspaces.emptyMatters.description")}
+                    primaryAction={{
+                      label: t("workspaces.createNewWorkspace"),
+                      icon: PlusIcon,
+                      onClick: () => openCreateMatter(),
+                    }}
+                    mediaPlacement="bottom"
+                    title={t("workspaces.emptyMatters.title")}
+                    video={{
+                      ...EMPTY_SCREEN_MATTERS_VIDEO,
+                      title: t("workspaces.emptyMatters.videoLabel"),
+                    }}
+                  />
+                );
               }
               return (
-                <MattersContentView
-                  canCreateMatter={canOpenCreateMatter}
-                  displayed={displayed}
-                  focusIndex={focusIndex}
-                  groups={groups}
-                />
+                <div className="text-muted-foreground flex flex-1 items-center justify-center p-8 text-sm">
+                  {t("common.empty")}
+                </div>
               );
             })()}
           </div>
@@ -308,7 +301,7 @@ const MattersContentView = ({
   const gridRef = useRef<HTMLDivElement>(null);
   const viewMode = useConfigStore((s) => s.matters.viewMode);
   const collapsedGroups = useConfigStore(
-    useShallow((s) => s.matters.collapsedGroups ?? []),
+    useShallow((s) => s.matters.collapsedGroups),
   );
   const toggleGroupCollapsed = useConfigStore((s) => s.toggleGroupCollapsed);
   return (

--- a/apps/web/src/routes/auth/accept-invitation.$invitationId.tsx
+++ b/apps/web/src/routes/auth/accept-invitation.$invitationId.tsx
@@ -36,15 +36,11 @@ export const Route = createFileRoute("/auth/accept-invitation/$invitationId")({
     }
   },
   loader: async ({ params }) => {
-    const { data, error } = await authClient.organization.getInvitation({
+    const { data } = await authClient.organization.getInvitation({
       query: { id: params.invitationId },
     });
 
-    if (
-      (error !== undefined && error !== null) ||
-      data === undefined ||
-      data === null
-    ) {
+    if (data === null) {
       throw notFound();
     }
 

--- a/apps/web/src/routes/auth/organization.tsx
+++ b/apps/web/src/routes/auth/organization.tsx
@@ -278,7 +278,7 @@ const CreateOrganizationForm = ({
         return;
       }
 
-      if (!slugCheckData?.status) {
+      if (!slugCheckData.status) {
         formApi.setErrorMap({
           onSubmit: { fields: { slug: t("errors.slugAlreadyTaken") } },
         });

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -76,7 +76,7 @@ export const OnboardingWizard = () => {
   const invalidateSession = useInvalidateSession();
   const queryClient = useQueryClient();
   const { data: sessionData } = useQuery(sessionOptions);
-  const userEmail = sessionData?.user?.email ?? "";
+  const userEmail = sessionData?.user.email ?? "";
   const [step, setStep] = useState<Step>("organization");
   const [data, setData] = useState<WizardData>(() => ({
     orgName: "",
@@ -236,19 +236,14 @@ export const OnboardingWizard = () => {
               ...(providerDraft.apiKey.trim()
                 ? { apiKey: providerDraft.apiKey.trim() }
                 : {}),
-              ...(() => {
-                if (providerDraft.provider === "azure_foundry") {
-                  return {
+              ...(providerDraft.provider === "azure_foundry"
+                ? {
                     endpoint: providerDraft.endpoint.trim(),
                     ...(providerDraft.apiVersion
-                      ? {
-                          apiVersion: providerDraft.apiVersion,
-                        }
+                      ? { apiVersion: providerDraft.apiVersion }
                       : {}),
-                  };
-                }
-                return {};
-              })(),
+                  }
+                : {}),
               region: providerDraft.region,
             })),
             overrideModels: aiOverrideModels,
@@ -300,7 +295,7 @@ export const OnboardingWizard = () => {
           );
 
           const failedCount = inviteResults.filter(
-            (r) => r.error !== null && r.error !== undefined,
+            (r) => r.error !== null,
           ).length;
 
           if (failedCount > 0) {
@@ -341,39 +336,33 @@ export const OnboardingWizard = () => {
   );
 
   const showPrices = step === "ai" && aiPhase === "models";
-  const preview = (() => {
-    if (step === "jurisdiction") {
-      return (
-        <JurisdictionGlobePreview
-          onChange={(practiceJurisdictions) => {
-            setData((d) => ({
-              ...d,
-              practiceJurisdictions,
-            }));
-            setJurisdictionSuggestionApplied(true);
-          }}
-          selected={data.practiceJurisdictions}
-        />
-      );
-    }
-    if (showPrices) {
-      return (
-        <PricesPanel
-          providers={data.aiProviders.map((p) => p.provider)}
-          roleModels={data.aiRoleModels}
-        />
-      );
-    }
-    return (
-      <SidebarPreview
-        aiProviders={previewAiProviders}
-        chatActive={step === "ai"}
-        emailCount={previewEmailCount}
-        matterName=""
-        organizationName={previewOrgName}
+  let preview = (
+    <SidebarPreview
+      aiProviders={previewAiProviders}
+      chatActive={step === "ai"}
+      emailCount={previewEmailCount}
+      matterName=""
+      organizationName={previewOrgName}
+    />
+  );
+  if (step === "jurisdiction") {
+    preview = (
+      <JurisdictionGlobePreview
+        onChange={(practiceJurisdictions) => {
+          setData((d) => ({ ...d, practiceJurisdictions }));
+          setJurisdictionSuggestionApplied(true);
+        }}
+        selected={data.practiceJurisdictions}
       />
     );
-  })();
+  } else if (showPrices) {
+    preview = (
+      <PricesPanel
+        providers={data.aiProviders.map((p) => p.provider)}
+        roleModels={data.aiRoleModels}
+      />
+    );
+  }
 
   const renderStep = () => {
     if (step === "creating") {

--- a/apps/web/src/stores/config-store.ts
+++ b/apps/web/src/stores/config-store.ts
@@ -54,7 +54,7 @@ export const useConfigStore = create<ConfigState>()(
 
       toggleGroupCollapsed: (groupId) => {
         void set((s) => {
-          const current = s.matters.collapsedGroups ?? [];
+          const current = s.matters.collapsedGroups;
           const next = current.includes(groupId)
             ? current.filter((id) => id !== groupId)
             : [...current, groupId];

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -93,6 +93,10 @@ export default defineConfig({
     "typescript/dot-notation": "error",
     "typescript/prefer-readonly": "off",
     "typescript/no-unnecessary-type-conversion": "error",
+    "typescript/no-unnecessary-condition": [
+      "error",
+      { allowConstantLoopConditions: "only-allowed-literals" },
+    ],
     "typescript/no-unnecessary-type-arguments": "error",
 
     "unicorn/switch-case-braces": "off",

--- a/packages/ares/src/parse.test.ts
+++ b/packages/ares/src/parse.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAddress } from "./parse.js";
+
+describe("parseAddress", () => {
+  test("treats null numeric address fields as missing", () => {
+    const address = parseAddress({
+      cisloDomovni: null,
+      cisloOrientacni: null,
+      psc: null,
+      pscTxt: "110 00",
+    });
+
+    expect(address.houseNumber).toBeNull();
+    expect(address.orientationNumber).toBeNull();
+    expect(address.postalCode).toBe("110 00");
+  });
+});

--- a/packages/ares/src/parse.ts
+++ b/packages/ares/src/parse.ts
@@ -29,21 +29,13 @@ const CURRENCIES: Record<string, string> = {
 
 export const parseAddress = (raw: AresRawAddress): AresAddress => ({
   street: raw.nazevUlice ?? null,
-  houseNumber:
-    raw.cisloDomovni !== null && raw.cisloDomovni !== undefined
-      ? String(raw.cisloDomovni)
-      : null,
+  houseNumber: raw.cisloDomovni !== undefined ? String(raw.cisloDomovni) : null,
   orientationNumber:
-    raw.cisloOrientacni !== null && raw.cisloOrientacni !== undefined
-      ? String(raw.cisloOrientacni)
-      : null,
+    raw.cisloOrientacni !== undefined ? String(raw.cisloOrientacni) : null,
   orientationLetter: raw.cisloOrientacniPismeno ?? null,
   municipalityPart: raw.nazevCastiObce ?? null,
   municipality: raw.nazevMestskehoObvodu || raw.nazevObce || null,
-  postalCode:
-    raw.psc !== null && raw.psc !== undefined
-      ? String(raw.psc)
-      : (raw.pscTxt ?? null),
+  postalCode: raw.psc !== undefined ? String(raw.psc) : (raw.pscTxt ?? null),
   district: raw.nazevOkresu ?? null,
   country: raw.nazevStatu ?? null,
   textAddress: raw.textovaAdresa ?? null,

--- a/packages/ares/src/parse.ts
+++ b/packages/ares/src/parse.ts
@@ -29,13 +29,21 @@ const CURRENCIES: Record<string, string> = {
 
 export const parseAddress = (raw: AresRawAddress): AresAddress => ({
   street: raw.nazevUlice ?? null,
-  houseNumber: raw.cisloDomovni !== undefined ? String(raw.cisloDomovni) : null,
+  houseNumber:
+    raw.cisloDomovni !== null && raw.cisloDomovni !== undefined
+      ? String(raw.cisloDomovni)
+      : null,
   orientationNumber:
-    raw.cisloOrientacni !== undefined ? String(raw.cisloOrientacni) : null,
+    raw.cisloOrientacni !== null && raw.cisloOrientacni !== undefined
+      ? String(raw.cisloOrientacni)
+      : null,
   orientationLetter: raw.cisloOrientacniPismeno ?? null,
   municipalityPart: raw.nazevCastiObce ?? null,
   municipality: raw.nazevMestskehoObvodu || raw.nazevObce || null,
-  postalCode: raw.psc !== undefined ? String(raw.psc) : (raw.pscTxt ?? null),
+  postalCode:
+    raw.psc !== null && raw.psc !== undefined
+      ? String(raw.psc)
+      : (raw.pscTxt ?? null),
   district: raw.nazevOkresu ?? null,
   country: raw.nazevStatu ?? null,
   textAddress: raw.textovaAdresa ?? null,

--- a/packages/ares/src/types.ts
+++ b/packages/ares/src/types.ts
@@ -10,10 +10,10 @@ export type AresRawAddress = {
   nazevMestskehoObvodu?: string;
   nazevCastiObce?: string;
   nazevUlice?: string;
-  cisloDomovni?: number;
-  cisloOrientacni?: number;
+  cisloDomovni?: number | null;
+  cisloOrientacni?: number | null;
   cisloOrientacniPismeno?: string;
-  psc?: number;
+  psc?: number | null;
   pscTxt?: string;
   textovaAdresa?: string;
   nazevOkresu?: string;

--- a/packages/docx-core/src/legal-source/compile.ts
+++ b/packages/docx-core/src/legal-source/compile.ts
@@ -265,7 +265,7 @@ const textRunsWithPlaceholders = (
   const runs: Run[] = [];
   let cursor = 0;
   for (const match of text.matchAll(PLACEHOLDER_PATTERN)) {
-    const start = match.index ?? 0;
+    const start = match.index;
     if (start > cursor) {
       runs.push(textRun(text.slice(cursor, start), options));
     }

--- a/packages/folio/src/components/CommentsSidebar.tsx
+++ b/packages/folio/src/components/CommentsSidebar.tsx
@@ -257,7 +257,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
   const visibleComments = useMemo(
     () =>
       comments.filter((c) => {
-        if (c.parentId !== null && c.parentId !== undefined) {
+        if (c.parentId !== undefined) {
           return false;
         }
         if (c.done && !showResolved) {
@@ -272,7 +272,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
   const repliesByParent = useMemo(() => {
     const map = new Map<number, Comment[]>();
     for (const c of comments) {
-      if (c.parentId !== null && c.parentId !== undefined) {
+      if (c.parentId !== undefined) {
         const arr = map.get(c.parentId);
         if (arr) {
           arr.push(c);
@@ -327,7 +327,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
       }
 
       const layoutY = anchorPositions?.get(cardId);
-      if (layoutY !== null && layoutY !== undefined) {
+      if (layoutY !== undefined) {
         pushPosition(
           cardId,
           layoutY,
@@ -360,11 +360,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
     }
 
     // Include the "add comment" input box in the layout if it has a Y position
-    if (
-      isAddingComment &&
-      addCommentYPosition !== null &&
-      addCommentYPosition !== undefined
-    ) {
+    if (isAddingComment && addCommentYPosition !== null) {
       positions.push({
         id: "new-comment-input",
         targetY: addCommentYPosition,
@@ -555,7 +551,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
   };
 
   useEffect(() => {
-    if (activeCommentId === null || activeCommentId === undefined) {
+    if (activeCommentId === null) {
       return;
     }
     setExpandedCard(`comment-${activeCommentId}`);
@@ -629,33 +625,36 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
     // Cards without position yet: hidden completely (no transition)
     const isNewCard = !isKnown && yPos !== undefined;
     const noPosition = hasPositions && yPos === undefined;
-    return {
-      ...(() => {
-        if (hasPositions) {
-          return (() => {
-            if (yPos !== undefined) {
-              return {
-                position: "absolute",
-                top: yPos,
-                left: 0,
-                right: 0,
-                opacity: 1,
-              };
-            }
-            return {
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              opacity: 0,
-              visibility: "hidden" as const,
-            };
-          })();
-        }
+    const positionStyle = (() => {
+      if (!hasPositions) {
+        return { marginBottom: 6 };
+      }
+      if (yPos !== undefined) {
         return {
-          marginBottom: 6,
+          position: "absolute" as const,
+          top: yPos,
+          left: 0,
+          right: 0,
+          opacity: 1,
         };
-      })(),
+      }
+      return {
+        position: "absolute" as const,
+        top: 0,
+        left: 0,
+        right: 0,
+        opacity: 0,
+        visibility: "hidden" as const,
+      };
+    })();
+    let transition = "none";
+    if (!noPosition && isNewCard) {
+      transition = "opacity 0.2s ease, box-shadow 0.2s ease";
+    } else if (!noPosition && initialPositionsDone) {
+      transition = "opacity 0.2s ease, box-shadow 0.2s ease, top 0.15s ease";
+    }
+    return {
+      ...positionStyle,
       padding: isExpanded ? "8px 10px" : "7px 9px",
       borderRadius: 6,
       backgroundColor: "var(--doc-page)",
@@ -663,18 +662,7 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
       boxShadow: isExpanded
         ? "0 1px 2px rgba(60,64,67,0.22), 0 3px 8px rgba(60,64,67,0.12)"
         : "0 1px 2px rgba(60,64,67,0.16), 0 2px 5px rgba(60,64,67,0.08)",
-      transition: (() => {
-        if (noPosition) {
-          return "none";
-        }
-        if (isNewCard) {
-          return "opacity 0.2s ease, box-shadow 0.2s ease";
-        }
-        if (initialPositionsDone) {
-          return "opacity 0.2s ease, box-shadow 0.2s ease, top 0.15s ease";
-        }
-        return "none";
-      })(),
+      transition,
     };
   };
 
@@ -1069,23 +1057,20 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
             }}
             style={{
               ...(() => {
-                if (hasPositions) {
-                  return (() => {
-                    if (cardPositions.get("new-comment-input") !== undefined) {
-                      return {
-                        position: "absolute",
-                        top: cardPositions.get("new-comment-input"),
-                        left: 0,
-                        right: 0,
-                      };
-                    }
-                    return {
-                      position: "relative",
-                      marginBottom: 8,
-                    };
-                  })();
+                const yPos = cardPositions.get("new-comment-input");
+                if (!hasPositions) {
+                  return { marginBottom: 8 };
+                }
+                if (yPos !== undefined) {
+                  return {
+                    position: "absolute" as const,
+                    top: yPos,
+                    left: 0,
+                    right: 0,
+                  };
                 }
                 return {
+                  position: "relative" as const,
                   marginBottom: 8,
                 };
               })(),

--- a/packages/folio/src/components/CommentsSidebar.tsx
+++ b/packages/folio/src/components/CommentsSidebar.tsx
@@ -64,6 +64,11 @@ function getInitials(name: string): string {
     .slice(0, 2);
 }
 
+function getCommentParentId(comment: Comment): number | null | undefined {
+  const runtimeComment: { parentId?: number | null } = comment;
+  return runtimeComment.parentId;
+}
+
 // Kibana-style avatar colors — deterministic per author name
 const AVATAR_COLORS = [
   "#6DCCB1", // teal
@@ -257,7 +262,8 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
   const visibleComments = useMemo(
     () =>
       comments.filter((c) => {
-        if (c.parentId !== undefined) {
+        const parentId = getCommentParentId(c);
+        if (parentId !== null && parentId !== undefined) {
           return false;
         }
         if (c.done && !showResolved) {
@@ -272,12 +278,13 @@ export const CommentsSidebar: React.FC<CommentsSidebarProps> = ({
   const repliesByParent = useMemo(() => {
     const map = new Map<number, Comment[]>();
     for (const c of comments) {
-      if (c.parentId !== undefined) {
-        const arr = map.get(c.parentId);
+      const parentId = getCommentParentId(c);
+      if (parentId !== null && parentId !== undefined) {
+        const arr = map.get(parentId);
         if (arr) {
           arr.push(c);
         } else {
-          map.set(c.parentId, [c]);
+          map.set(parentId, [c]);
         }
       }
     }

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -615,6 +615,11 @@ function createComment(
   };
 }
 
+function getCommentParentId(comment: Comment): number | null | undefined {
+  const runtimeComment: { parentId?: number | null } = comment;
+  return runtimeComment.parentId;
+}
+
 function applyCommentMarkRange(
   view: EditorView,
   range: CommentMarkRange,
@@ -955,16 +960,19 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     const visibleComments = useMemo(() => {
       const visibleRootIds = new Set<number>();
       for (const comment of comments) {
+        const parentId = getCommentParentId(comment);
         if (
-          comment.parentId === undefined ||
+          parentId === null ||
+          parentId === undefined ||
           !visibleCommentIds.has(comment.id)
         ) {
           continue;
         }
-        visibleRootIds.add(comment.parentId);
+        visibleRootIds.add(parentId);
       }
       return comments.filter((comment) => {
-        if (comment.parentId !== undefined) {
+        const parentId = getCommentParentId(comment);
+        if (parentId !== null && parentId !== undefined) {
           return visibleCommentIds.has(comment.id);
         }
         return (

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -912,7 +912,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       if (!doc) {
         return;
       }
-      const bodyComments = doc.package?.document?.comments;
+      const bodyComments = doc.package.document.comments;
       if (bodyComments && bodyComments.length > 0) {
         setComments(bodyComments);
         setVisibleCommentAuthors(null);
@@ -956,7 +956,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       const visibleRootIds = new Set<number>();
       for (const comment of comments) {
         if (
-          comment.parentId === null ||
           comment.parentId === undefined ||
           !visibleCommentIds.has(comment.id)
         ) {
@@ -965,7 +964,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
         visibleRootIds.add(comment.parentId);
       }
       return comments.filter((comment) => {
-        if (comment.parentId !== null && comment.parentId !== undefined) {
+        if (comment.parentId !== undefined) {
           return visibleCommentIds.has(comment.id);
         }
         return (
@@ -1564,7 +1563,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
 
       const doc = structuredClone(history.state);
       const pmDoc = pagedEditorRef.current?.getDocument();
-      if (pmDoc?.package?.document) {
+      if (pmDoc) {
         doc.package.document.content = pmDoc.package.document.content;
       }
       doc.package.document.comments = commentsRef.current;
@@ -1674,20 +1673,26 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
             }
           ).node;
           if (selectedNode?.type.name === "image") {
+            const attrs = selectedNode.attrs;
+            const readRequiredStringAttr = (key: string, fallback: string) => {
+              const value = attrs[key];
+              return typeof value === "string" ? value : fallback;
+            };
+            const readNullableStringAttr = (key: string) => {
+              const value = attrs[key];
+              return typeof value === "string" ? value : null;
+            };
+            const borderWidth = attrs["borderWidth"];
             pmImageCtx = {
               pos: sel.from,
-              wrapType: (selectedNode.attrs["wrapType"] as string) ?? "inline",
-              displayMode:
-                (selectedNode.attrs["displayMode"] as string) ?? "inline",
-              cssFloat: (selectedNode.attrs["cssFloat"] as string) ?? null,
-              transform: (selectedNode.attrs["transform"] as string) ?? null,
-              alt: (selectedNode.attrs["alt"] as string) ?? null,
-              borderWidth:
-                (selectedNode.attrs["borderWidth"] as number) ?? null,
-              borderColor:
-                (selectedNode.attrs["borderColor"] as string) ?? null,
-              borderStyle:
-                (selectedNode.attrs["borderStyle"] as string) ?? null,
+              wrapType: readRequiredStringAttr("wrapType", "inline"),
+              displayMode: readRequiredStringAttr("displayMode", "inline"),
+              cssFloat: readNullableStringAttr("cssFloat"),
+              transform: readNullableStringAttr("transform"),
+              alt: readNullableStringAttr("alt"),
+              borderWidth: typeof borderWidth === "number" ? borderWidth : null,
+              borderColor: readNullableStringAttr("borderColor"),
+              borderStyle: readNullableStringAttr("borderStyle"),
             };
           }
         }
@@ -1851,7 +1856,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           const parentEl = editorContentRef.current;
           const { from: selFrom } = view.state.selection;
           const top = findSelectionYPosition(container, parentEl, selFrom);
-          if (top !== null && top !== undefined && container && parentEl) {
+          if (top !== null && container && parentEl) {
             const pagesEl = container.querySelector(".paged-editor__pages");
             const pageEl = pagesEl?.querySelector(
               ".layout-page",
@@ -1969,12 +1974,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
 </html>`);
       printDocument.close();
 
-      let isCleanedUp = false;
+      const cleanupState = { isCleanedUp: false };
       const cleanup = () => {
-        if (isCleanedUp) {
+        if (cleanupState.isCleanedUp) {
           return;
         }
-        isCleanedUp = true;
+        cleanupState.isCleanedUp = true;
         iframe.remove();
       };
       printWindow.addEventListener("afterprint", cleanup, { once: true });
@@ -2002,7 +2007,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       void (async () => {
         await waitForFrameLoad();
         await waitForFonts();
-        if (isCleanedUp) {
+        if (cleanupState.isCleanedUp) {
           return;
         }
         printWindow.focus();
@@ -2265,7 +2270,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                 setTablePropsOpen(true);
               } else if (action.type === "tableProperties") {
                 setTableProperties(action.props)(view.state, view.dispatch);
-              } else if (action.type === "applyTableStyle") {
+              } else {
                 // Resolve style data from built-in presets or document styles
                 let preset: TableStylePreset | undefined = getBuiltinTableStyle(
                   action.styleId,
@@ -3621,7 +3626,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                           : bodyHistoryAvailability.canRedo
                       }
                       disabled={readOnly}
-                      theme={history.state?.package.theme || theme || null}
+                      theme={history.state.package.theme || theme || null}
                       showZoomControl={showZoomControl}
                       zoom={state.zoom}
                       onZoomChange={handleZoomChange}
@@ -3633,7 +3638,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                       onTableAction={handleTableAction}
                       priorityExtra={toolbarPriorityExtra}
                       inlineExtra={toolbarInlineExtra}
-                      {...(history.state?.package.styles?.styles
+                      {...(history.state.package.styles?.styles
                         ? {
                             documentStyles: history.state.package.styles.styles,
                           }
@@ -3687,13 +3692,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                       <PagedEditor
                         ref={pagedEditorRef}
                         document={history.state}
-                        theme={history.state?.package.theme || theme || null}
+                        theme={history.state.package.theme || theme || null}
                         sectionProperties={effectiveSectionProperties ?? null}
                         headerContent={headerContent}
                         footerContent={footerContent}
                         firstPageHeaderContent={firstPageHeaderContent}
                         firstPageFooterContent={firstPageFooterContent}
-                        {...(history.state?.package.styles
+                        {...(history.state.package.styles
                           ? { styles: history.state.package.styles }
                           : {})}
                         onHeaderFooterDoubleClick={
@@ -3704,9 +3709,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                         zoom={state.zoom}
                         readOnly={readOnly}
                         onDocumentChange={handleDocumentChange}
-                        {...(extensionManager !== undefined
-                          ? { extensionManager }
-                          : {})}
+                        extensionManager={extensionManager}
                         {...(onReadonlyEditAttempt !== undefined
                           ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
                           : {})}
@@ -3748,8 +3751,8 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                                 anchorPositions={anchorPositions}
                                 pageWidth={(() => {
                                   const sp =
-                                    history.state?.package?.document
-                                      ?.finalSectionProperties;
+                                    history.state.package.document
+                                      .finalSectionProperties;
                                   return sp?.pageWidth
                                     ? Math.round(sp.pageWidth / 15)
                                     : 816;
@@ -3887,7 +3890,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
 
                       {/* Floating "add comment" button — appears on right edge of page at selection */}
                       {floatingCommentBtn !== null &&
-                        floatingCommentBtn !== undefined &&
                         !isAddingComment &&
                         !readOnly && (
                           <Tooltip
@@ -3942,11 +3944,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                                   safeRange.from,
                                 );
                                 setAddCommentYPosition(
-                                  yPos ??
-                                    floatingCommentBtn.top ??
-                                    getFallbackCommentYPosition(
-                                      scrollContainerRef.current,
-                                    ),
+                                  yPos ?? floatingCommentBtn.top,
                                 );
                                 setShowCommentsSidebar(true);
                                 setIsAddingComment(true);
@@ -4046,7 +4044,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                               onClose={() => setHfEditPosition(null)}
                               onSelectionChange={handleSelectionChange}
                               onRemove={handleRemoveHeaderFooter}
-                              {...(history.state?.package.styles
+                              {...(history.state.package.styles
                                 ? { styles: history.state.package.styles }
                                 : {})}
                             />
@@ -4194,7 +4192,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                   isOpen={showPageSetup}
                   onClose={() => setShowPageSetup(false)}
                   onApply={handlePageSetupApply}
-                  {...(history.state?.package.document?.finalSectionProperties
+                  {...(history.state.package.document.finalSectionProperties
                     ? {
                         currentProps:
                           history.state.package.document.finalSectionProperties,
@@ -4207,7 +4205,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                   isOpen={footnotePropsOpen}
                   onClose={() => setFootnotePropsOpen(false)}
                   onApply={handleApplyFootnoteProperties}
-                  {...(history.state?.package.document?.finalSectionProperties
+                  {...(history.state.package.document.finalSectionProperties
                     ?.footnotePr
                     ? {
                         footnotePr:
@@ -4215,7 +4213,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                             .footnotePr,
                       }
                     : {})}
-                  {...(history.state?.package.document?.finalSectionProperties
+                  {...(history.state.package.document.finalSectionProperties
                     ?.endnotePr
                     ? {
                         endnotePr:

--- a/packages/folio/src/components/TextContextMenu.tsx
+++ b/packages/folio/src/components/TextContextMenu.tsx
@@ -942,7 +942,7 @@ export function useTextContextMenu(
           // Trigger paste event with shift key simulation
           // Note: This may not work in all browsers due to security restrictions
           navigator.clipboard
-            .readText?.()
+            .readText()
             .then((text) => {
               document.execCommand("insertText", false, text);
             })

--- a/packages/folio/src/components/Toolbar.tsx
+++ b/packages/folio/src/components/Toolbar.tsx
@@ -86,7 +86,7 @@ export function Toolbar({
       const isSelectActive =
         target.tagName === "SELECT" ||
         target.tagName === "OPTION" ||
-        activeEl?.tagName === "SELECT";
+        activeEl.tagName === "SELECT";
 
       if (isSelectActive) {
         return;

--- a/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
+++ b/packages/folio/src/components/dialogs/FindReplaceDialog.tsx
@@ -255,7 +255,7 @@ export function FindReplaceDialog({
     }
 
     const match = onFindNext();
-    if (match && result) {
+    if (match) {
       const newIndex = (result.currentIndex + 1) % result.totalCount;
       setResult({
         ...result,
@@ -276,7 +276,7 @@ export function FindReplaceDialog({
     }
 
     const match = onFindPrevious();
-    if (match && result) {
+    if (match) {
       const newIndex =
         result.currentIndex === 0
           ? result.totalCount - 1

--- a/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
+++ b/packages/folio/src/components/dialogs/ImagePositionDialog.tsx
@@ -81,7 +81,7 @@ export function ImagePositionDialog({
     if (h?.align) {
       setHMode("align");
       setHAlign(h.align);
-    } else if (h?.posOffset !== null && h?.posOffset !== undefined) {
+    } else if (h?.posOffset !== undefined) {
       setHMode("offset");
       setHOffset(h.posOffset);
     }
@@ -92,7 +92,7 @@ export function ImagePositionDialog({
     if (v?.align) {
       setVMode("align");
       setVAlign(v.align);
-    } else if (v?.posOffset !== null && v?.posOffset !== undefined) {
+    } else if (v?.posOffset !== undefined) {
       setVMode("offset");
       setVOffset(v.posOffset);
     }

--- a/packages/folio/src/components/dialogs/findReplaceUtils.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.ts
@@ -507,7 +507,5 @@ export function scrollToMatch(
       .querySelectorAll(".layout-paragraph")
       .item(match.paragraphIndex);
 
-  if (paragraphElement) {
-    paragraphElement.scrollIntoView({ behavior: "smooth", block: "center" });
-  }
+  paragraphElement.scrollIntoView({ behavior: "smooth", block: "center" });
 }

--- a/packages/folio/src/components/hooks/findReplaceSelection.ts
+++ b/packages/folio/src/components/hooks/findReplaceSelection.ts
@@ -105,8 +105,7 @@ function resolveTextRangeInParagraph({
   endOffset,
 }: ResolveTextRangeInParagraphOptions): FindMatchRange | null {
   let textOffset = 0;
-  let from: number | null = null;
-  let to: number | null = null;
+  const range = { from: null as number | null, to: null as number | null };
 
   paragraph.descendants((node, pos) => {
     const tokenLength = getSearchTextTokenLength(node);
@@ -118,22 +117,26 @@ function resolveTextRangeInParagraph({
     const textEnd = textStart + tokenLength;
     const nodeStart = paragraphPos + 1 + pos;
 
-    if (from === null && startOffset >= textStart && startOffset <= textEnd) {
-      from = nodeStart + Math.min(startOffset - textStart, node.nodeSize);
+    if (
+      range.from === null &&
+      startOffset >= textStart &&
+      startOffset <= textEnd
+    ) {
+      range.from = nodeStart + Math.min(startOffset - textStart, node.nodeSize);
     }
-    if (to === null && endOffset >= textStart && endOffset <= textEnd) {
-      to = nodeStart + Math.min(endOffset - textStart, node.nodeSize);
+    if (range.to === null && endOffset >= textStart && endOffset <= textEnd) {
+      range.to = nodeStart + Math.min(endOffset - textStart, node.nodeSize);
     }
 
     textOffset = textEnd;
-    return to === null;
+    return range.to === null;
   });
 
-  if (from === null || to === null || from >= to) {
+  if (range.from === null || range.to === null || range.from >= range.to) {
     return null;
   }
 
-  return { from, to };
+  return { from: range.from, to: range.to };
 }
 
 function getSearchTextTokenLength(node: ProseMirrorNode): number {

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -131,8 +131,8 @@ export const useHeaderFooterEditor = ({
     }
 
     const pkg = history.state.package;
-    const finalProps = pkg.document?.finalSectionProperties;
-    const sections = pkg.document?.sections;
+    const finalProps = pkg.document.finalSectionProperties;
+    const sections = pkg.document.sections;
     const headers = pkg.headers;
     const footers = pkg.footers;
 
@@ -345,20 +345,13 @@ export const useHeaderFooterEditor = ({
   const handleHeaderFooterDoubleClick = useCallback(
     (position: "header" | "footer", pageNumber?: number) => {
       const isFirstPage = hasTitlePg && (pageNumber ?? 1) === 1;
-      const hf = (() => {
-        if (isFirstPage) {
-          return (() => {
-            if (position === "header") {
-              return firstPageHeaderContent;
-            }
-            return firstPageFooterContent;
-          })();
-        }
-        if (position === "header") {
-          return headerContent;
-        }
-        return footerContent;
-      })();
+      let hf = position === "header" ? headerContent : footerContent;
+      if (isFirstPage) {
+        hf =
+          position === "header"
+            ? firstPageHeaderContent
+            : firstPageFooterContent;
+      }
       setHfEditIsFirstPage(isFirstPage);
       if (hf) {
         setHfEditPosition(position);
@@ -370,7 +363,7 @@ export const useHeaderFooterEditor = ({
         return;
       }
       const pkg = history.state.package;
-      const sectionProps = pkg.document?.finalSectionProperties;
+      const sectionProps = pkg.document.finalSectionProperties;
       if (!sectionProps) {
         return;
       }
@@ -400,15 +393,13 @@ export const useHeaderFooterEditor = ({
         package: {
           ...pkg,
           [mapKey]: newMap,
-          document: pkg.document
-            ? {
-                ...pkg.document,
-                finalSectionProperties: {
-                  ...sectionProps,
-                  [refKey]: [...existingRefs, newRef],
-                },
-              }
-            : pkg.document,
+          document: {
+            ...pkg.document,
+            finalSectionProperties: {
+              ...sectionProps,
+              [refKey]: [...existingRefs, newRef],
+            },
+          },
         },
       };
       pushDocument(newDoc);
@@ -441,20 +432,14 @@ export const useHeaderFooterEditor = ({
       // title-page section has the body H/F; signature sections
       // override default with stripped-down rIds). Codex PR #258
       // review.
-      const activeRId = (() => {
-        if (hfEditIsFirstPage) {
-          return (() => {
-            if (hfEditPosition === "header") {
-              return activeFirstHeaderRId;
-            }
-            return activeFirstFooterRId;
-          })();
-        }
-        if (hfEditPosition === "header") {
-          return activeHeaderRId;
-        }
-        return activeFooterRId;
-      })();
+      let activeRId =
+        hfEditPosition === "header" ? activeHeaderRId : activeFooterRId;
+      if (hfEditIsFirstPage) {
+        activeRId =
+          hfEditPosition === "header"
+            ? activeFirstHeaderRId
+            : activeFirstFooterRId;
+      }
       const refType = hfEditIsFirstPage ? "first" : "default";
       const mapKey = hfEditPosition === "header" ? "headers" : "footers";
       const map = pkg[mapKey];
@@ -523,20 +508,14 @@ export const useHeaderFooterEditor = ({
     // rendered, not whatever lives in `finalSectionProperties` (Codex
     // PR #258 review). Drop the ref from every section that points at
     // this rId so we don't leave a dangling reference behind.
-    const activeRId = (() => {
-      if (hfEditIsFirstPage) {
-        return (() => {
-          if (hfEditPosition === "header") {
-            return activeFirstHeaderRId;
-          }
-          return activeFirstFooterRId;
-        })();
-      }
-      if (hfEditPosition === "header") {
-        return activeHeaderRId;
-      }
-      return activeFooterRId;
-    })();
+    let activeRId =
+      hfEditPosition === "header" ? activeHeaderRId : activeFooterRId;
+    if (hfEditIsFirstPage) {
+      activeRId =
+        hfEditPosition === "header"
+          ? activeFirstHeaderRId
+          : activeFirstFooterRId;
+    }
 
     if (activeRId) {
       const newMap = new Map(pkg[mapKey]);
@@ -554,37 +533,26 @@ export const useHeaderFooterEditor = ({
       };
 
       const oldDoc = pkg.document;
-      const newSections = oldDoc?.sections?.map((s) => ({
+      const newSections = oldDoc.sections?.map((s) => ({
         ...s,
         properties: stripRef(s.properties),
       }));
-      const newFinalProps = oldDoc?.finalSectionProperties
+      const newFinalProps = oldDoc.finalSectionProperties
         ? stripRef(oldDoc.finalSectionProperties)
-        : oldDoc?.finalSectionProperties;
+        : oldDoc.finalSectionProperties;
 
       const newDoc: Document = {
         ...history.state,
         package: {
           ...pkg,
           [mapKey]: newMap,
-          document: (() => {
-            if (oldDoc) {
-              return {
-                ...oldDoc,
-                ...(newSections !== undefined
-                  ? {
-                      sections: newSections,
-                    }
-                  : {}),
-                ...(newFinalProps !== undefined
-                  ? {
-                      finalSectionProperties: newFinalProps,
-                    }
-                  : {}),
-              };
-            }
-            return oldDoc;
-          })(),
+          document: {
+            ...oldDoc,
+            ...(newSections !== undefined ? { sections: newSections } : {}),
+            ...(newFinalProps !== undefined
+              ? { finalSectionProperties: newFinalProps }
+              : {}),
+          },
         },
       };
       pushDocument(newDoc);

--- a/packages/folio/src/components/hooks/useHyperlinkHandlers.ts
+++ b/packages/folio/src/components/hooks/useHyperlinkHandlers.ts
@@ -115,7 +115,7 @@ export const useHyperlinkHandlers = ({
         // Build ranges of consecutive hyperlink-marked nodes
         type Range = { start: number; end: number };
         const ranges: Range[] = [];
-        let currentRange: Range | null = null;
+        const currentRange = { value: null as Range | null };
 
         // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
         parent.forEach((node, offset) => {
@@ -130,18 +130,18 @@ export const useHyperlinkHandlers = ({
             : null;
 
           if (hlMark) {
-            if (currentRange) {
-              currentRange.end = nodeEnd;
+            if (currentRange.value !== null) {
+              currentRange.value.end = nodeEnd;
             } else {
-              currentRange = { start: nodeStart, end: nodeEnd };
+              currentRange.value = { start: nodeStart, end: nodeEnd };
             }
-          } else if (currentRange) {
-            ranges.push(currentRange);
-            currentRange = null;
+          } else if (currentRange.value !== null) {
+            ranges.push(currentRange.value);
+            currentRange.value = null;
           }
         });
-        if (currentRange) {
-          ranges.push(currentRange);
+        if (currentRange.value !== null) {
+          ranges.push(currentRange.value);
         }
 
         // Find the range that contains the cursor
@@ -223,7 +223,7 @@ export const useHyperlinkHandlers = ({
     const parentStart = $from.start();
     type Range = { start: number; end: number };
     const ranges: Range[] = [];
-    let currentRange: Range | null = null;
+    const currentRange = { value: null as Range | null };
 
     // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
     parent.forEach((node, offset) => {
@@ -237,18 +237,18 @@ export const useHyperlinkHandlers = ({
         : null;
 
       if (hlMark) {
-        if (currentRange) {
-          currentRange.end = nodeEnd;
+        if (currentRange.value !== null) {
+          currentRange.value.end = nodeEnd;
         } else {
-          currentRange = { start: nodeStart, end: nodeEnd };
+          currentRange.value = { start: nodeStart, end: nodeEnd };
         }
-      } else if (currentRange) {
-        ranges.push(currentRange);
-        currentRange = null;
+      } else if (currentRange.value !== null) {
+        ranges.push(currentRange.value);
+        currentRange.value = null;
       }
     });
-    if (currentRange) {
-      ranges.push(currentRange);
+    if (currentRange.value !== null) {
+      ranges.push(currentRange.value);
     }
 
     const cursorPos = $from.pos;

--- a/packages/folio/src/components/ui/ListButtons.tsx
+++ b/packages/folio/src/components/ui/ListButtons.tsx
@@ -67,7 +67,7 @@ export function ListButtons({
   const isBullet = listState?.type === "bullet";
   const isNumbered = listState?.type === "numbered";
   const isInList = listState?.isInList || isBullet || isNumbered;
-  const canOutdent = (isInList && (listState?.level ?? 0) > 0) || hasIndent;
+  const canOutdent = (isInList && listState.level > 0) || hasIndent;
 
   return (
     <div

--- a/packages/folio/src/components/ui/StylePicker.tsx
+++ b/packages/folio/src/components/ui/StylePicker.tsx
@@ -172,9 +172,7 @@ export function StylePicker({
           color: s.rPr?.color?.rgb ?? def?.color,
         };
       });
-    return docStyles.toSorted(
-      (a, b) => (a.priority ?? 99) - (b.priority ?? 99),
-    );
+    return docStyles.toSorted((a, b) => a.priority - b.priority);
   }, [styles]);
 
   return (

--- a/packages/folio/src/core/ai-edits/aiEdits.test.ts
+++ b/packages/folio/src/core/ai-edits/aiEdits.test.ts
@@ -141,9 +141,6 @@ const makeTrackedDoc = (
 ): { state: EditorState; doc: ReturnType<typeof schema.node> } => {
   const insertionType = schema.marks["insertion"];
   const deletionType = schema.marks["deletion"];
-  if (!insertionType || !deletionType) {
-    throw new Error("schema missing tracked-change marks");
-  }
   const date = "2026-01-01T00:00:00.000Z";
   const textNodes = runs.flatMap((run) => {
     if (typeof run === "string") {
@@ -207,16 +204,6 @@ describe("Folio AI edit operations", () => {
     const fontSizeType = schema.marks["fontSize"];
     const fontFamilyType = schema.marks["fontFamily"];
     const underlineType = schema.marks["underline"];
-    if (
-      !boldType ||
-      !italicType ||
-      !fontSizeType ||
-      !fontFamilyType ||
-      !underlineType
-    ) {
-      throw new Error("schema missing formatting marks");
-    }
-
     const state = EditorState.create({
       schema,
       doc: schema.node("doc", null, [
@@ -585,19 +572,16 @@ describe("Folio AI edit operations", () => {
     //
     // Build a doc whose textContent is "The buyer shallmust pay."
     // (`shall` is a pending deletion, `must` is a pending insertion).
-    const insertionMark = schema.marks["insertion"]?.create({
+    const insertionMark = schema.marks["insertion"].create({
       revisionId: 1,
       author: "AI",
       date: "2026-01-01T00:00:00.000Z",
     });
-    const deletionMark = schema.marks["deletion"]?.create({
+    const deletionMark = schema.marks["deletion"].create({
       revisionId: 1,
       author: "AI",
       date: "2026-01-01T00:00:00.000Z",
     });
-    if (!insertionMark || !deletionMark) {
-      throw new Error("schema missing tracked-change marks");
-    }
     const trackedDoc = schema.node("doc", null, [
       schema.node("paragraph", {}, [
         schema.text("The buyer "),
@@ -758,7 +742,7 @@ describe("Folio AI edit operations", () => {
     expect(shallNodeMarks).not.toBeNull();
     // Pre-existing "shall" deletion is left intact (one deletion
     // mark, no insertion mark added on top by the new revision).
-    const shallMarks: string[] = shallNodeMarks ?? [];
+    const shallMarks: string[] = shallNodeMarks;
     expect(shallMarks.includes("deletion")).toBe(true);
     expect(shallMarks.includes("insertion")).toBe(false);
   });

--- a/packages/folio/src/core/docx/commentParser.ts
+++ b/packages/folio/src/core/docx/commentParser.ts
@@ -43,9 +43,6 @@ function parseCommentsExtensible(xml: string): Map<string, string> {
   const dateUtcByParaId = new Map<string, string>();
 
   const root = parseXml(xml);
-  if (!root) {
-    return dateUtcByParaId;
-  }
 
   // Find the root element (may be w16cex:commentsExtensible or similar)
   const container = findChild(root, "w16cex", "commentsExtensible") ?? root;
@@ -95,9 +92,6 @@ export function parseComments(
   }
 
   const root = parseXml(commentsXml);
-  if (!root) {
-    return [];
-  }
 
   // Build UTC date lookup from extended comments (if available)
   const dateUtcByParaId = commentsExtensibleXml

--- a/packages/folio/src/core/docx/compatibility.ts
+++ b/packages/folio/src/core/docx/compatibility.ts
@@ -74,9 +74,7 @@ function inspectBlocks(
       continue;
     }
 
-    if (block.type === "blockSdt") {
-      inspectBlocks(block.content, record);
-    }
+    inspectBlocks(block.content, record);
   }
 }
 

--- a/packages/folio/src/core/docx/documentParser.ts
+++ b/packages/folio/src/core/docx/documentParser.ts
@@ -151,7 +151,7 @@ function computeListMarker(
   }
 
   const { numId, level } = listRendering;
-  if (numId === undefined || numId === 0) {
+  if (numId === 0) {
     return;
   }
 
@@ -363,7 +363,7 @@ function extractTableVariables(table: Table): string[] {
               variables.push(v);
             }
           }
-        } else if (cellContent.type === "table") {
+        } else {
           // Nested table
           const nestedVars = extractTableVariables(cellContent);
           for (const v of nestedVars) {
@@ -657,9 +657,6 @@ export function parseDocumentBody(
 
   // Parse XML
   const doc = parseXml(xml);
-  if (!doc) {
-    return result;
-  }
 
   // Find root document element (w:document)
   const documentEl = (doc.elements ?? []).find(
@@ -735,7 +732,7 @@ function getTableParagraphs(table: Table): Paragraph[] {
       for (const content of cell.content) {
         if (content.type === "paragraph") {
           paragraphs.push(content);
-        } else if (content.type === "table") {
+        } else {
           paragraphs.push(...getTableParagraphs(content));
         }
       }
@@ -812,7 +809,7 @@ function getTableText(table: Table): string {
       for (const content of cell.content) {
         if (content.type === "paragraph") {
           cellTexts.push(getParagraphText(content));
-        } else if (content.type === "table") {
+        } else {
           cellTexts.push(getTableText(content));
         }
       }

--- a/packages/folio/src/core/docx/footnoteParser.ts
+++ b/packages/folio/src/core/docx/footnoteParser.ts
@@ -226,9 +226,6 @@ export function parseFootnotes(
   }
 
   const doc = parseXml(footnotesXml);
-  if (!doc) {
-    return createFootnoteMap(byId, footnotes);
-  }
 
   // Find the root footnotes element
   const rootElement = doc.elements?.find(
@@ -349,9 +346,6 @@ export function parseEndnotes(
   }
 
   const doc = parseXml(endnotesXml);
-  if (!doc) {
-    return createEndnoteMap(byId, endnotes);
-  }
 
   // Find the root endnotes element
   const rootElement = doc.elements?.find(

--- a/packages/folio/src/core/docx/headerFooterParser.ts
+++ b/packages/folio/src/core/docx/headerFooterParser.ts
@@ -195,9 +195,6 @@ export function parseHeader(
   }
 
   const doc = parseXml(headerXml);
-  if (!doc) {
-    return result;
-  }
 
   // Find the root header element (w:hdr)
   const rootElement = doc.elements?.find(
@@ -255,9 +252,6 @@ export function parseFooter(
   }
 
   const doc = parseXml(footerXml);
-  if (!doc) {
-    return result;
-  }
 
   // Find the root footer element (w:ftr)
   const rootElement = doc.elements?.find(
@@ -423,7 +417,7 @@ export function getHeaderFooterText(hf: HeaderFooter): string {
         }
       }
       texts.push(paraTexts.join(""));
-    } else if (item.type === "table") {
+    } else {
       // Extract text from table cells
       for (const row of item.rows) {
         for (const cell of row.cells) {
@@ -463,7 +457,7 @@ export function isEmptyHeaderFooter(hf: HeaderFooter): boolean {
     if (item.type === "table") {
       return false;
     }
-    if (item.type === "paragraph" && item.content.length > 0) {
+    if (item.content.length > 0) {
       // Check if paragraph has any actual content
       for (const content of item.content) {
         if (content.type !== "run") {

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -1172,7 +1172,7 @@ function parseParagraphContents(
               }
             } else if (content.charType === "separate") {
               hasFieldSeparate = true;
-            } else if (content.charType === "end") {
+            } else {
               hasFieldEnd = true;
             }
           } else if (content.type === "instrText") {
@@ -1582,9 +1582,6 @@ export function parseParagraph(
     if (style?.pPr?.numPr) {
       effectiveNumPr = style.pPr.numPr;
       // Store it on the paragraph formatting so downstream code sees it
-      if (!paragraph.formatting) {
-        paragraph.formatting = {};
-      }
       paragraph.formatting.numPr = effectiveNumPr;
     }
   }
@@ -1624,9 +1621,7 @@ export function parseParagraph(
         if (level.isLgl) {
           listRendering.isLegal = true;
         }
-        if (level.numFmt) {
-          listRendering.numFmt = level.isLgl ? "decimal" : level.numFmt;
-        }
+        listRendering.numFmt = level.isLgl ? "decimal" : level.numFmt;
         if (level.rPr?.hidden) {
           listRendering.markerHidden = true;
         }

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -568,17 +568,15 @@ function extractDocumentFontNames(
   }
 
   // Extract fonts from document content (inline run formatting)
-  if (documentBody.content) {
-    for (const block of documentBody.content) {
-      if (block.type === "paragraph") {
-        for (const item of block.content) {
-          if (item.type === "run" && item.formatting?.fontFamily) {
-            if (item.formatting.fontFamily.ascii) {
-              docxFonts.add(item.formatting.fontFamily.ascii);
-            }
-            if (item.formatting.fontFamily.hAnsi) {
-              docxFonts.add(item.formatting.fontFamily.hAnsi);
-            }
+  for (const block of documentBody.content) {
+    if (block.type === "paragraph") {
+      for (const item of block.content) {
+        if (item.type === "run" && item.formatting?.fontFamily) {
+          if (item.formatting.fontFamily.ascii) {
+            docxFonts.add(item.formatting.fontFamily.ascii);
+          }
+          if (item.formatting.fontFamily.hAnsi) {
+            docxFonts.add(item.formatting.fontFamily.hAnsi);
           }
         }
       }

--- a/packages/folio/src/core/docx/runConsolidator.ts
+++ b/packages/folio/src/core/docx/runConsolidator.ts
@@ -447,7 +447,7 @@ export function consolidateParagraphContent(
  * @returns New paragraph with consolidated runs
  */
 export function consolidateParagraph(paragraph: Paragraph): Paragraph {
-  if (!paragraph.content || paragraph.content.length === 0) {
+  if (paragraph.content.length === 0) {
     return paragraph;
   }
 
@@ -473,9 +473,7 @@ export function countRuns(paragraph: Paragraph): number {
     }
   }
 
-  if (paragraph.content) {
-    countInContent(paragraph.content);
-  }
+  countInContent(paragraph.content);
 
   return count;
 }

--- a/packages/folio/src/core/docx/selectiveSave.test.ts
+++ b/packages/folio/src/core/docx/selectiveSave.test.ts
@@ -972,9 +972,9 @@ describe("Selective save with headers/footers", () => {
       throw new Error("Expected headers or footers map");
     }
     for (const [, hf] of map.entries()) {
-      if (hf.content && hf.content.length > 0) {
+      if (hf.content.length > 0) {
         const para = hf.content.find((b) => b.type === "paragraph");
-        if (para && para.type === "paragraph") {
+        if (para) {
           para.content.push({
             type: "run",
             formatting: {},
@@ -1251,10 +1251,7 @@ describe("Selective save edge cases", () => {
 
       // Verify an unedited paragraph is unchanged
       const uneditedPara = paragraphs.find(
-        (p) =>
-          p.paraId !== undefined &&
-          p.paraId !== null &&
-          !editIds.includes(p.paraId),
+        (p) => p.paraId !== undefined && !editIds.includes(p.paraId),
       );
       if (uneditedPara?.paraId) {
         const originalXml = await getDocumentXml(buffer);

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -34,8 +34,8 @@ function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
           for (const c of item.content) {
             if (
               c.type === "drawing" &&
-              c.image?.src?.startsWith("data:") &&
-              !c.image?.rId
+              c.image.src?.startsWith("data:") &&
+              !c.image.rId
             ) {
               return true;
             }
@@ -93,10 +93,6 @@ export async function attemptSelectiveSave(
   if (hasUntrackedChanges) {
     return null;
   }
-  if (!originalBuffer) {
-    return null;
-  }
-
   // Check for new images/hyperlinks that need relationship management
   const content = doc.package.document.content;
   if (hasNewImagesOrHyperlinks(content)) {

--- a/packages/folio/src/core/docx/serializer/commentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/commentSerializer.ts
@@ -73,7 +73,7 @@ function serializeComment(comment: Comment): string {
   }
 
   let xml = `<w:comment ${attrs.join(" ")}>`;
-  if (comment.content && comment.content.length > 0) {
+  if (comment.content.length > 0) {
     // First paragraph must contain an annotationRef run for Word to link the comment
     // SAFETY: length > 0 verified by condition above
     xml += serializeParagraphWithAnnotationRef(comment.content[0]!);
@@ -94,7 +94,7 @@ function serializeComment(comment: Comment): string {
  * Serialize comments array to comments.xml content
  */
 export function serializeComments(comments: Comment[]): string {
-  if (!comments || comments.length === 0) {
+  if (comments.length === 0) {
     return "";
   }
 
@@ -102,7 +102,7 @@ export function serializeComments(comments: Comment[]): string {
   const topLevel: Comment[] = [];
   const replies: Comment[] = [];
   for (const c of comments) {
-    (c.parentId === null ? topLevel : replies).push(c);
+    (c.parentId === undefined ? topLevel : replies).push(c);
   }
 
   let xml =

--- a/packages/folio/src/core/docx/serializer/commentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/commentSerializer.ts
@@ -102,7 +102,9 @@ export function serializeComments(comments: Comment[]): string {
   const topLevel: Comment[] = [];
   const replies: Comment[] = [];
   for (const c of comments) {
-    (c.parentId === undefined ? topLevel : replies).push(c);
+    const comment: { parentId?: number | null } = c;
+    const { parentId } = comment;
+    (parentId === null || parentId === undefined ? topLevel : replies).push(c);
   }
 
   let xml =

--- a/packages/folio/src/core/docx/serializer/documentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.ts
@@ -105,24 +105,23 @@ function buildNamespaceDeclarations(): string {
 function serializeBlockContent(block: BlockContent): string {
   if (block.type === "paragraph") {
     return serializeParagraph(block);
-  } else if (block.type === "table") {
-    return serializeTable(block);
-  } else if (block.type === "blockSdt") {
-    // Block-level SDT: wrap content in w:sdt
-    const contentXml = block.content
-      .map((b) => serializeBlockContent(b))
-      .join("");
-    const props = block.properties;
-    const prParts: string[] = [];
-    if (props.alias) {
-      prParts.push(`<w:alias w:val="${props.alias}"/>`);
-    }
-    if (props.tag) {
-      prParts.push(`<w:tag w:val="${props.tag}"/>`);
-    }
-    return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
   }
-  return "";
+  if (block.type === "table") {
+    return serializeTable(block);
+  }
+  // Block-level SDT: wrap content in w:sdt
+  const contentXml = block.content
+    .map((b) => serializeBlockContent(b))
+    .join("");
+  const props = block.properties;
+  const prParts: string[] = [];
+  if (props.alias) {
+    prParts.push(`<w:alias w:val="${props.alias}"/>`);
+  }
+  if (props.tag) {
+    prParts.push(`<w:tag w:val="${props.tag}"/>`);
+  }
+  return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
 }
 
 /**

--- a/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
@@ -44,10 +44,8 @@ function buildNamespaceDeclarations(): string {
 function serializeBlock(block: Paragraph | Table): string {
   if (block.type === "paragraph") {
     return serializeParagraph(block);
-  } else if (block.type === "table") {
-    return serializeTable(block);
   }
-  return "";
+  return serializeTable(block);
 }
 
 /**

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -641,12 +641,11 @@ function serializeHyperlink(hyperlink: Hyperlink): string {
     .map((child) => {
       if (child.type === "run") {
         return serializeRun(child);
-      } else if (child.type === "bookmarkStart") {
-        return serializeBookmarkStart(child);
-      } else if (child.type === "bookmarkEnd") {
-        return serializeBookmarkEnd(child);
       }
-      return "";
+      if (child.type === "bookmarkStart") {
+        return serializeBookmarkStart(child);
+      }
+      return serializeBookmarkEnd(child);
     })
     .join("");
 
@@ -739,7 +738,7 @@ function serializeComplexField(field: ComplexField): string {
   // Extract formatting from the first result run to apply to structural runs
   // (begin/separate/end). OOXML consumers expect consistent formatting across
   // all runs in a complex field.
-  const resultFormatting = field.fieldResult?.[0]?.formatting;
+  const resultFormatting = field.fieldResult[0]?.formatting;
   const rPrXml = resultFormatting
     ? serializeTextFormatting(resultFormatting)
     : "";
@@ -848,10 +847,7 @@ function serializeInlineSdt(sdt: InlineSdt): string {
       if (item.type === "run") {
         return serializeRun(item);
       }
-      if (item.type === "hyperlink") {
-        return serializeHyperlink(item);
-      }
-      return "";
+      return serializeHyperlink(item);
     })
     .join("");
 
@@ -901,10 +897,7 @@ function serializeTrackedChange(
         }
         return serializeRun(item);
       }
-      if (item.type === "hyperlink") {
-        return serializeHyperlink(item);
-      }
-      return "";
+      return serializeHyperlink(item);
     })
     .join("");
 

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -60,7 +60,7 @@ export function resetAutoIdCounter(): void {
 
 /** Get a unique positive integer ID, using the provided value or generating one */
 function getUniqueId(id: string | number | undefined): string {
-  if (id !== undefined && id !== null && id !== "" && id !== 0) {
+  if (id !== undefined && id !== "" && id !== 0) {
     return String(id);
   }
   return String(nextAutoId++);
@@ -655,7 +655,7 @@ function serializeOutline(outline: ShapeOutline | undefined): string {
     return "";
   }
   const attrs: string[] = [];
-  if (outline.width !== null) {
+  if (outline.width !== undefined) {
     attrs.push(`w="${outline.width}"`);
   }
   if (outline.cap) {

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -655,7 +655,7 @@ function serializeOutline(outline: ShapeOutline | undefined): string {
     return "";
   }
   const attrs: string[] = [];
-  if (outline.width !== undefined) {
+  if (typeof outline.width === "number") {
     attrs.push(`w="${outline.width}"`);
   }
   if (outline.cap) {

--- a/packages/folio/src/core/docx/serializer/tableSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/tableSerializer.ts
@@ -859,7 +859,7 @@ function serializeCellContent(content: (Paragraph | Table)[]): string {
   for (const item of content) {
     if (item.type === "paragraph") {
       parts.push(serializeParagraph(item));
-    } else if (item.type === "table") {
+    } else {
       parts.push(serializeTable(item));
     }
   }

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -1216,7 +1216,7 @@ function parseTableCellProperties(
 function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   const style: Style = {
     styleId: getAttribute(styleEl, "w", "styleId") ?? "",
-    type: (getAttribute(styleEl, "w", "type") as StyleType) ?? "paragraph",
+    type: getAttribute(styleEl, "w", "type") as StyleType,
   };
 
   // Default flag
@@ -1456,7 +1456,7 @@ function mergeParagraphFormatting(
     return target;
   }
   if (!target) {
-    return source ? { ...source } : undefined;
+    return { ...source };
   }
 
   const result = { ...target };

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -1214,9 +1214,10 @@ function parseTableCellProperties(
  * Parse a single style element (w:style)
  */
 function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
+  const rawType = getAttribute(styleEl, "w", "type");
   const style: Style = {
     styleId: getAttribute(styleEl, "w", "styleId") ?? "",
-    type: getAttribute(styleEl, "w", "type") as StyleType,
+    type: rawType === null ? "paragraph" : (rawType as StyleType),
   };
 
   // Default flag

--- a/packages/folio/src/core/docx/tableParser.ts
+++ b/packages/folio/src/core/docx/tableParser.ts
@@ -342,12 +342,12 @@ export function parseShading(
     shading.fill = { themeColor: themeFill as ThemeColorSlot };
 
     const themeFillTint = getAttribute(shdElement, "w", "themeFillTint");
-    if (themeFillTint && shading.fill) {
+    if (themeFillTint) {
       shading.fill.themeTint = themeFillTint;
     }
 
     const themeFillShade = getAttribute(shdElement, "w", "themeFillShade");
-    if (themeFillShade && shading.fill) {
+    if (themeFillShade) {
       shading.fill.themeShade = themeFillShade;
     }
   }

--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -93,7 +93,7 @@ function sliceRunsForLine(block: ParagraphBlock, line: MeasuredLine): Run[] {
 
     // Handle text runs - may need to slice
     if (run.kind === "text") {
-      const text = run.text ?? "";
+      const text = run.text;
       const isFirstRun = runIndex === line.fromRun;
       const isLastRun = runIndex === line.toRun;
 
@@ -147,7 +147,7 @@ function computeLinePmRange(
     if (runIndex < line.fromRun) {
       // Before the line - count all characters
       if (run.kind === "text") {
-        charOffset += (run.text ?? "").length;
+        charOffset += run.text.length;
       } else if (run.kind === "tab" || run.kind === "lineBreak") {
         charOffset += 1;
       } else if (run.kind === "image") {
@@ -179,7 +179,7 @@ function computeLinePmRange(
       }
 
       if (run.kind === "text") {
-        const text = run.text ?? "";
+        const text = run.text;
         const start = runIndex === line.fromRun ? line.fromChar : 0;
         const end = runIndex === line.toRun ? line.toChar : text.length;
         lineLength += end - start;
@@ -355,7 +355,7 @@ function findCharacterInLine(
 
     // Handle text runs
     if (run.kind === "text") {
-      const text = run.text ?? "";
+      const text = run.text;
       if (text.length === 0) {
         continue;
       }
@@ -611,7 +611,7 @@ export function positionToX(
           }
           charsProcessed += 1;
         } else if (run.kind === "text") {
-          const text = run.text ?? "";
+          const text = run.text;
           if (offsetInLine <= charsProcessed + text.length) {
             const charInRun = offsetInLine - charsProcessed;
             const style = runToFontStyle(run);

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -126,9 +126,6 @@ function findPositionInSpan(
   }
 
   const ownerDoc = spanEl.ownerDocument;
-  if (!ownerDoc) {
-    return pmStart;
-  }
 
   // Binary search for the character boundary
   let left = 0;
@@ -429,9 +426,6 @@ export function getSelectionRectsFromDom(
 
     const text = textNode as Text;
     const ownerDoc = spanEl.ownerDocument;
-    if (!ownerDoc) {
-      continue;
-    }
 
     // Calculate character range within this span
     const startChar = Math.max(0, from - pmStart);
@@ -552,9 +546,6 @@ export function getCaretPositionFromDom(
       const charIndex = Math.min(pmPos - pmStart, text.length);
 
       const ownerDoc = spanEl.ownerDocument;
-      if (!ownerDoc) {
-        continue;
-      }
 
       const range = ownerDoc.createRange();
       range.setStart(text, charIndex);

--- a/packages/folio/src/core/layout-bridge/findBodyPmSpans.test.ts
+++ b/packages/folio/src/core/layout-bridge/findBodyPmSpans.test.ts
@@ -38,7 +38,7 @@ describe("body-scoped PM DOM lookups", () => {
   test("finds only body run spans", () => {
     const spans = findBodyPmSpans(createContainer());
 
-    expect(spans.map((span) => span.textContent?.trim())).toEqual(["body"]);
+    expect(spans.map((span) => span.textContent.trim())).toEqual(["body"]);
   });
 
   test("finds body anchors without matching overlapping header/footer positions", () => {
@@ -50,7 +50,7 @@ describe("body-scoped PM DOM lookups", () => {
       "7",
       "9",
     ]);
-    expect(findBodyPmAnchor(createContainer(), 2)?.textContent?.trim()).toBe(
+    expect(findBodyPmAnchor(createContainer(), 2).textContent.trim()).toBe(
       "body",
     );
   });

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -19,10 +19,7 @@ import type {
   TextRun,
   FootnoteContent,
 } from "../layout-engine/types";
-import {
-  DEFAULT_TEXTBOX_MARGINS as TEXTBOX_MARGINS,
-  DEFAULT_TEXTBOX_WIDTH as TEXTBOX_WIDTH,
-} from "../layout-engine/types";
+import { DEFAULT_TEXTBOX_MARGINS as TEXTBOX_MARGINS } from "../layout-engine/types";
 import { footnoteToProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type { Footnote, StyleDefinitions, Theme } from "../types/document";
 import { measureParagraph } from "./measuring";
@@ -206,7 +203,7 @@ function measureFootnoteBlock(block: FlowBlock, contentWidth: number): Measure {
 
     case "textBox": {
       const margins = block.margins ?? TEXTBOX_MARGINS;
-      const width = block.width ?? TEXTBOX_WIDTH;
+      const width = block.width;
       const innerWidth = Math.max(1, width - margins.left - margins.right);
       const innerMeasures = block.content.map((paragraph) =>
         measureParagraph(paragraph, innerWidth),
@@ -500,7 +497,7 @@ export function buildFootnoteContentMap(
   const footnoteById = new Map<number, Footnote>();
 
   for (const fn of footnotes) {
-    if (fn.noteType === "normal" || fn.noteType === null) {
+    if (fn.noteType === "normal") {
       footnoteById.set(fn.id, fn);
     }
   }

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -188,9 +188,9 @@ function normalizeFlowBlockArray(blocks: FlowBlock[]): FlowBlock[] {
 }
 
 function normalizeTableBlock(block: TableBlock): TableBlock {
-  let changed = false;
+  const blockState = { changed: false };
   const rows = block.rows.map((row) => {
-    let rowChanged = false;
+    const rowState = { changed: false };
     const cells = row.cells.map((cell) => {
       const normalizedBlocks = normalizeFlowBlockArray(cell.blocks);
       const cellChanged = normalizedBlocks.some(
@@ -199,17 +199,17 @@ function normalizeTableBlock(block: TableBlock): TableBlock {
       if (!cellChanged) {
         return cell;
       }
-      rowChanged = true;
+      rowState.changed = true;
       return { ...cell, blocks: normalizedBlocks };
     });
-    if (!rowChanged) {
+    if (!rowState.changed) {
       return row;
     }
-    changed = true;
+    blockState.changed = true;
     return { ...row, cells };
   });
 
-  return changed ? { ...block, rows } : block;
+  return blockState.changed ? { ...block, rows } : block;
 }
 
 // =============================================================================
@@ -330,7 +330,7 @@ function resolveHeaderFooterFloatingTableVisualTop(
 /**
  * Image is rendered "behind" body content (full-page letterhead, watermark).
  * The renderer lifts these out of the HF container to the page root, so they
- * must not push body margins down — they paint underneath the body by design.
+ * must not push body margins down because they paint underneath the body.
  */
 function isBehindDocImageRun(run: Run): boolean {
   return run.kind === "image" && run.wrapType === "behind";
@@ -564,11 +564,7 @@ export function convertHeaderFooterToContent(
   metrics: HeaderFooterMetrics,
   options: ConvertHeaderFooterOptions,
 ): HeaderFooterContent | undefined {
-  if (
-    !headerFooter ||
-    !headerFooter.content ||
-    headerFooter.content.length === 0
-  ) {
+  if (!headerFooter || headerFooter.content.length === 0) {
     return undefined;
   }
 

--- a/packages/folio/src/core/layout-bridge/hitTest.ts
+++ b/packages/folio/src/core/layout-bridge/hitTest.ts
@@ -118,7 +118,7 @@ export function hitTestPage(layout: Layout, point: Point): PageHit | null {
   for (let pageIndex = 0; pageIndex < layout.pages.length; pageIndex++) {
     // SAFETY: pageIndex is bounded by layout.pages.length
     const page = layout.pages[pageIndex]!;
-    const pageHeight = page.size?.h ?? layout.pageSize.h;
+    const pageHeight = page.size.h;
     const pageTop = cursorY;
     const pageBottom = pageTop + pageHeight;
 
@@ -147,10 +147,7 @@ export function hitTestPage(layout: Layout, point: Point): PageHit | null {
     return {
       pageIndex: nearestPageIndex,
       page,
-      pageY: Math.max(
-        0,
-        Math.min(point.y - pageTop, page.size?.h ?? layout.pageSize.h),
-      ),
+      pageY: Math.max(0, Math.min(point.y - pageTop, page.size.h)),
     };
   }
 
@@ -167,7 +164,7 @@ export function getPageTop(layout: Layout, pageIndex: number): number {
   for (let i = 0; i < pageIndex && i < layout.pages.length; i++) {
     // SAFETY: i is bounded by layout.pages.length
     const page = layout.pages[i]!;
-    const pageHeight = page.size?.h ?? layout.pageSize.h;
+    const pageHeight = page.size.h;
     y += pageHeight + pageGap;
   }
 
@@ -521,7 +518,7 @@ export function hitTestTableCell(
     let cellBlock: ParagraphBlock | undefined;
     let cellBlockMeasure: ParagraphMeasure | undefined;
 
-    if (cell.blocks && cell.blocks.length > 0) {
+    if (cell.blocks.length > 0) {
       // SAFETY: length > 0 guarantees index 0 exists
       const firstBlock = cell.blocks[0]!;
       const firstMeasure = cellMeasure.blocks[0];
@@ -646,7 +643,7 @@ export function getTotalDocumentHeight(layout: Layout): number {
   for (let i = 0; i < layout.pages.length; i++) {
     // SAFETY: i is bounded by layout.pages.length
     const page = layout.pages[i]!;
-    height += page.size?.h ?? layout.pageSize.h;
+    height += page.size.h;
     if (i < layout.pages.length - 1) {
       height += pageGap;
     }
@@ -676,7 +673,7 @@ export function getPageBounds(
   const top = getPageTop(layout, pageIndex);
   // SAFETY: bounds check above ensures pageIndex is valid
   const page = layout.pages[pageIndex]!;
-  const height = page.size?.h ?? layout.pageSize.h;
+  const height = page.size.h;
 
   return {
     top,

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -199,13 +199,10 @@ function calculateTypographyMetrics(
     // At least: use specified height or natural height, whichever is larger
     const defaultHeight = singleLineBase * DEFAULT_LINE_HEIGHT_MULTIPLIER;
     lineHeight = Math.max(spacing.line, defaultHeight);
-  } else if (
-    spacing?.line !== undefined &&
-    spacing?.lineUnit === "multiplier"
-  ) {
+  } else if (spacing?.line !== undefined && spacing.lineUnit === "multiplier") {
     // Multiplier applied to font's single-line height
     lineHeight = singleLineBase * spacing.line;
-  } else if (spacing?.line !== undefined && spacing?.lineUnit === "px") {
+  } else if (spacing?.line !== undefined && spacing.lineUnit === "px") {
     // Pixel value
     lineHeight = spacing.line;
   } else {
@@ -668,7 +665,7 @@ export function measureParagraph(
 
       // Compute tab width: advance to the next tab stop position.
       const tabStops = attrs?.tabs;
-      const currentPos = currentLine.width + (currentLine.leftOffset ?? 0);
+      const currentPos = currentLine.width + currentLine.leftOffset;
       const tabWidth = computeTabWidth(currentPos, tabStops);
 
       if (

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -123,7 +123,7 @@ function computeLinePmRange(
 
     if (runIndex < line.fromRun) {
       if (run.kind === "text") {
-        charOffset += (run.text ?? "").length;
+        charOffset += run.text.length;
       } else {
         charOffset += 1;
       }
@@ -151,7 +151,7 @@ function computeLinePmRange(
     }
 
     if (run.kind === "text") {
-      const text = run.text ?? "";
+      const text = run.text;
       const start = runIndex === line.fromRun ? line.fromChar : 0;
       const end = runIndex === line.toRun ? line.toChar : text.length;
       lineLength += end - start;
@@ -267,7 +267,7 @@ function charOffsetToX(
     }
 
     if (run.kind === "text") {
-      const text = run.text ?? "";
+      const text = run.text;
 
       // Get portion of text for this line
       const isFirstRun = runIndex === line.fromRun;

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -65,7 +65,7 @@ function buildSingleRunDoc(
 
 function firstRun(blocks: unknown[]): TextRun {
   const paragraph = blocks.find(
-    (block) => (block as ParagraphBlock).kind === "paragraph",
+    (block) => (block as { kind?: string }).kind === "paragraph",
   ) as ParagraphBlock;
   return paragraph.runs[0] as TextRun;
 }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-style-cascade.test.ts
@@ -25,7 +25,7 @@ function makeDoc(paragraph: Paragraph, styles?: StyleDefinitions): Document {
 
 function firstParagraph(blocks: unknown[]): ParagraphBlock {
   return blocks.find(
-    (block) => (block as ParagraphBlock).kind === "paragraph",
+    (block) => (block as { kind?: string }).kind === "paragraph",
   ) as ParagraphBlock;
 }
 
@@ -35,7 +35,7 @@ function firstRun(blocks: unknown[]): TextRun {
 
 function firstTableRun(blocks: unknown[]): TextRun {
   const table = blocks.find(
-    (block) => (block as LayoutTableBlock).kind === "table",
+    (block) => (block as { kind?: string }).kind === "table",
   ) as LayoutTableBlock;
   const paragraph = table.rows[0]?.cells[0]?.blocks[0] as ParagraphBlock;
   return paragraph.runs[0] as TextRun;

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -252,7 +252,7 @@ function computeListMarker(
   seenNumIds: Set<string>,
 ): string | null {
   const numId = pmAttrs.numPr?.numId;
-  if (numId === null || numId === undefined || numId === 0) {
+  if (numId === undefined || numId === 0) {
     if (pmAttrs.listMarker?.includes("%") && !pmAttrs.listIsBullet) {
       const counters = getLastListCounters(listCounters);
       if (counters) {
@@ -644,10 +644,7 @@ function paragraphRunDefaults(
     defaultTextFormatting.underline &&
     defaultTextFormatting.underline.style !== "none"
   ) {
-    result.underline = {};
-    if (defaultTextFormatting.underline.style) {
-      result.underline.style = defaultTextFormatting.underline.style;
-    }
+    result.underline = { style: defaultTextFormatting.underline.style };
     if (defaultTextFormatting.underline.color) {
       result.underline.color = resolveColor(
         defaultTextFormatting.underline.color,
@@ -853,21 +850,16 @@ function paragraphToRuns(
       // "Exhibit A" / "Section 1.3" in NVCA-style templates) render with no
       // underline. Reuse the same extractor text runs use.
       const ft = child.attrs["fieldType"] as string;
-      const mappedType: FieldRun["fieldType"] = (() => {
-        if (ft === "PAGE") {
-          return "PAGE";
-        }
-        if (ft === "NUMPAGES") {
-          return "NUMPAGES";
-        }
-        if (ft === "DATE") {
-          return "DATE";
-        }
-        if (ft === "TIME") {
-          return "TIME";
-        }
-        return "OTHER";
-      })();
+      let mappedType: FieldRun["fieldType"] = "OTHER";
+      if (ft === "PAGE") {
+        mappedType = "PAGE";
+      } else if (ft === "NUMPAGES") {
+        mappedType = "NUMPAGES";
+      } else if (ft === "DATE") {
+        mappedType = "DATE";
+      } else if (ft === "TIME") {
+        mappedType = "TIME";
+      }
       const fieldFormatting = markDefaultBlackTextColorSource(
         extractRunFormatting(child.marks, theme),
         paraDefaults,
@@ -1205,7 +1197,7 @@ function convertParagraphAttrs(
   } else if (pmAttrs.listMarker) {
     attrs.listMarker = pmAttrs.listMarker;
   }
-  if (pmAttrs.listIsBullet !== undefined && pmAttrs.listIsBullet !== null) {
+  if (pmAttrs.listIsBullet !== undefined) {
     attrs.listIsBullet = pmAttrs.listIsBullet;
   }
   if (pmAttrs.listMarkerHidden) {
@@ -1339,12 +1331,7 @@ export function convertBorderSpecToLayout(
   },
   theme?: Theme | null,
 ): BorderStyle | undefined {
-  if (
-    !border ||
-    !border.style ||
-    border.style === "none" ||
-    border.style === "nil"
-  ) {
+  if (!border.style || border.style === "none" || border.style === "nil") {
     return undefined;
   }
   const result: BorderStyle = {
@@ -1753,13 +1740,20 @@ function convertTextBoxNode(
   const textBox: TextBoxBlock = {
     kind: "textBox",
     id: nextBlockId(),
-    width: (attrs["width"] as number) ?? DEFAULT_TEXTBOX_WIDTH,
+    width: (attrs["width"] as number | undefined) ?? DEFAULT_TEXTBOX_WIDTH,
     margins: {
-      top: (attrs["marginTop"] as number) ?? DEFAULT_TEXTBOX_MARGINS.top,
+      top:
+        (attrs["marginTop"] as number | undefined) ??
+        DEFAULT_TEXTBOX_MARGINS.top,
       bottom:
-        (attrs["marginBottom"] as number) ?? DEFAULT_TEXTBOX_MARGINS.bottom,
-      left: (attrs["marginLeft"] as number) ?? DEFAULT_TEXTBOX_MARGINS.left,
-      right: (attrs["marginRight"] as number) ?? DEFAULT_TEXTBOX_MARGINS.right,
+        (attrs["marginBottom"] as number | undefined) ??
+        DEFAULT_TEXTBOX_MARGINS.bottom,
+      left:
+        (attrs["marginLeft"] as number | undefined) ??
+        DEFAULT_TEXTBOX_MARGINS.left,
+      right:
+        (attrs["marginRight"] as number | undefined) ??
+        DEFAULT_TEXTBOX_MARGINS.right,
     },
     content: contentBlocks,
     pmStart: startPos,
@@ -1953,7 +1947,7 @@ function mergeRunInParagraphs(blocks: FlowBlock[]): FlowBlock[] {
     // `<w:specVanish/>` paragraphs flows inline through the first
     // body paragraph that lacks it (Codex PR #258 review).
     while (
-      current?.kind === "paragraph" &&
+      current.kind === "paragraph" &&
       (current as ParagraphBlock).attrs?.runInWithNext &&
       i + 1 < blocks.length
     ) {

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -33,17 +33,6 @@ import type {
   SectionBreakBlock,
 } from "./types";
 
-// Default page size (US Letter in pixels at 96 DPI)
-const DEFAULT_PAGE_SIZE = { w: 816, h: 1056 };
-
-// Default margins (1 inch = 96 pixels)
-const DEFAULT_MARGINS: PageMargins = {
-  top: 96,
-  right: 96,
-  bottom: 96,
-  left: 96,
-};
-
 export type SectionLayoutConfig = {
   pageSize: { w: number; h: number };
   margins: PageMargins;
@@ -190,19 +179,19 @@ export function layoutDocument(
   }
 
   // Set up options with defaults
-  const pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
-  const baseMargins = {
-    top: options.margins?.top ?? DEFAULT_MARGINS.top,
-    right: options.margins?.right ?? DEFAULT_MARGINS.right,
-    bottom: options.margins?.bottom ?? DEFAULT_MARGINS.bottom,
-    left: options.margins?.left ?? DEFAULT_MARGINS.left,
-    header:
-      options.margins?.header ?? options.margins?.top ?? DEFAULT_MARGINS.top,
-    footer:
-      options.margins?.footer ??
-      options.margins?.bottom ??
-      DEFAULT_MARGINS.bottom,
+  const pageSize = options.pageSize;
+  const baseMargins: PageMargins = {
+    top: options.margins.top,
+    right: options.margins.right,
+    bottom: options.margins.bottom,
+    left: options.margins.left,
   };
+  if (options.margins.header !== undefined) {
+    baseMargins.header = options.margins.header;
+  }
+  if (options.margins.footer !== undefined) {
+    baseMargins.footer = options.margins.footer;
+  }
 
   // Use document margins directly for WYSIWYG fidelity
   // Word uses fixed margins from the document - body content always starts at marginTop
@@ -431,10 +420,6 @@ function layoutParagraph(
   contentWidth: number,
   footnoteHeightById?: Map<number, number>,
 ): void {
-  if (measure.kind !== "paragraph") {
-    throw new Error(`layoutParagraph: expected paragraph measure`);
-  }
-
   const lines = measure.lines;
   if (lines.length === 0) {
     // Empty paragraph - still takes up space based on spacing
@@ -637,10 +622,6 @@ function layoutTable(
   measure: TableMeasure,
   paginator: ReturnType<typeof createPaginator>,
 ): void {
-  if (measure.kind !== "table") {
-    throw new Error(`layoutTable: expected table measure`);
-  }
-
   const rows = measure.rows;
   if (rows.length === 0) {
     return;
@@ -742,10 +723,6 @@ function layoutFloatingTable(
   paginator: ReturnType<typeof createPaginator>,
   contentWidth: number,
 ): void {
-  if (measure.kind !== "table") {
-    throw new Error(`layoutFloatingTable: expected table measure`);
-  }
-
   const state = paginator.getCurrentState();
   const floating = block.floating;
   const page = state.page;
@@ -777,7 +754,7 @@ function layoutFloatingTable(
       x = baseX;
     } else if (spec === "right" || spec === "outside") {
       x = baseX + contentWidth - tableWidth;
-    } else if (spec === "center") {
+    } else {
       x = baseX + (contentWidth - tableWidth) / 2;
     }
   } else if (block.justification === "center") {
@@ -843,10 +820,6 @@ function layoutImage(
   measure: ImageMeasure,
   paginator: ReturnType<typeof createPaginator>,
 ): void {
-  if (measure.kind !== "image") {
-    throw new Error(`layoutImage: expected image measure`);
-  }
-
   // Handle anchored images differently
   if (block.anchor?.isAnchored) {
     layoutAnchoredImage(block, measure, paginator);
@@ -914,10 +887,6 @@ function layoutTextBox(
   measure: TextBoxMeasure,
   paginator: ReturnType<typeof createPaginator>,
 ): void {
-  if (measure.kind !== "textBox") {
-    throw new Error(`layoutTextBox: expected textBox measure`);
-  }
-
   const state = paginator.ensureFits(measure.height);
 
   const fragment: TextBoxFragment = {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -1628,7 +1628,7 @@ export function renderPage(
       if (
         fragment.kind === "paragraph" &&
         blockData?.block.kind === "paragraph" &&
-        blockData?.measure.kind === "paragraph"
+        blockData.measure.kind === "paragraph"
       ) {
         const paragraphBlock = blockData.block as ParagraphBlock;
         const nextBorders =
@@ -1671,7 +1671,7 @@ export function renderPage(
       } else if (
         fragment.kind === "table" &&
         blockData?.block.kind === "table" &&
-        blockData?.measure.kind === "table"
+        blockData.measure.kind === "table"
       ) {
         fragmentEl = renderTableFragment(
           fragment as TableFragment,
@@ -1684,7 +1684,7 @@ export function renderPage(
       } else if (
         fragment.kind === "image" &&
         blockData?.block.kind === "image" &&
-        blockData?.measure.kind === "image"
+        blockData.measure.kind === "image"
       ) {
         fragmentEl = renderImageFragment(
           fragment as ImageFragment,
@@ -1697,7 +1697,7 @@ export function renderPage(
       } else if (
         fragment.kind === "textBox" &&
         blockData?.block.kind === "textBox" &&
-        blockData?.measure.kind === "textBox"
+        blockData.measure.kind === "textBox"
       ) {
         fragmentEl = renderTextBoxFragment(
           fragment as TextBoxFragment,
@@ -2059,7 +2059,7 @@ export function computePageFingerprint(
     } else if (frag.kind === "table") {
       fp += `,fr:${frag.fromRow},tr:${frag.toRow}`;
     }
-    if (blockLookup && frag.blockId !== undefined) {
+    if (blockLookup) {
       const block = blockLookup.get(String(frag.blockId))?.block;
       const annotationFingerprint = block
         ? computeAnnotationFingerprint(block)

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -237,15 +237,12 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     ).webkitTextFillColor = "transparent";
   }
   if (run.emphasisMark) {
-    const variant = (() => {
-      if (run.emphasisMark === "comma") {
-        return "filled sesame";
-      }
-      if (run.emphasisMark === "circle") {
-        return "filled circle";
-      }
-      return "filled dot";
-    })();
+    let variant = "filled dot";
+    if (run.emphasisMark === "comma") {
+      variant = "filled sesame";
+    } else if (run.emphasisMark === "circle") {
+      variant = "filled circle";
+    }
     const position =
       run.emphasisMark === "underDot" ? "under right" : "over right";
     element.style.textEmphasis = variant;
@@ -326,7 +323,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     if (run.changeDate) {
       element.dataset["changeDate"] = run.changeDate;
     }
-    if (run.changeRevisionId !== null) {
+    if (run.changeRevisionId !== undefined) {
       element.dataset["revisionId"] = String(run.changeRevisionId);
     }
   }
@@ -356,7 +353,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     if (run.changeDate) {
       element.dataset["changeDate"] = run.changeDate;
     }
-    if (run.changeRevisionId !== null) {
+    if (run.changeRevisionId !== undefined) {
       element.dataset["revisionId"] = String(run.changeRevisionId);
     }
   }
@@ -1008,7 +1005,7 @@ export function renderLine(
     // - With hanging indent (firstLineIndentPx < 0): starts at leftIndent + firstLineIndent
     // - With first-line indent (firstLineIndentPx > 0): starts at leftIndent + firstLineIndent
     // - No indent: starts at leftIndent
-    const firstLineIndentPx = options?.firstLineIndentPx ?? 0;
+    const firstLineIndentPx = options.firstLineIndentPx ?? 0;
     currentX = leftIndentPx + firstLineIndentPx;
   } else {
     // Non-first lines start at the left indent position
@@ -1440,9 +1437,9 @@ export function renderParagraphFragment(
     if (isFirstLine) {
       const hasHangingIndent = indent?.hanging && indent.hanging > 0;
       const hasFirstLineIndent = indent?.firstLine && indent.firstLine > 0;
-      if (hasHangingIndent && indent?.hanging) {
+      if (hasHangingIndent && indent.hanging) {
         lineAvailableWidth = availableWidth + indent.hanging;
-      } else if (hasFirstLineIndent && indent?.firstLine) {
+      } else if (hasFirstLineIndent && indent.firstLine) {
         lineAvailableWidth = availableWidth - indent.firstLine;
       }
     }
@@ -1499,17 +1496,17 @@ export function renderParagraphFragment(
       if (indentLeft !== 0 && hasHanging) {
         // Hanging indent: first line starts at (indentLeft - hanging)
         lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        lineEl.style.textIndent = `-${indent?.hanging ?? 0}px`;
+        lineEl.style.textIndent = `-${indent.hanging ?? 0}px`;
       } else if (indentLeft !== 0 && hasFirstLine) {
         // First line indent: first line starts at (indentLeft + firstLine)
         lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        lineEl.style.textIndent = `${indent?.firstLine ?? 0}px`;
+        lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
       } else if (indentLeft > 0) {
         // Just left indent, no special first line treatment
         lineEl.style.paddingLeft = `${indentLeft}px`;
       } else if (hasFirstLine) {
         // No left indent, but has first line indent
-        lineEl.style.textIndent = `${indent?.firstLine ?? 0}px`;
+        lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
       }
       // No hanging without left indent (handled by firstLineOffset in measurement)
     } else if (indentLeft > 0) {
@@ -1517,7 +1514,7 @@ export function renderParagraphFragment(
       lineEl.style.paddingLeft = `${indentLeft}px`;
     } else if (hasHanging) {
       // Hanging indent without left indent: body lines need padding = hanging
-      lineEl.style.paddingLeft = `${indent?.hanging ?? 0}px`;
+      lineEl.style.paddingLeft = `${indent.hanging ?? 0}px`;
     }
 
     if (indentRight > 0) {
@@ -1532,7 +1529,7 @@ export function renderParagraphFragment(
     if (
       isFirstLine &&
       block.attrs?.listMarker &&
-      !block.attrs?.listMarkerHidden
+      !block.attrs.listMarkerHidden
     ) {
       // Override padding for list first lines.
       //
@@ -1554,15 +1551,12 @@ export function renderParagraphFragment(
         indent?.hanging !== undefined && indent.hanging > 0;
       const markerHasFirstLine =
         indent?.firstLine !== undefined && indent.firstLine > 0;
-      const markerPos = (() => {
-        if (markerHasHanging) {
-          return Math.max(0, indentLeft - (indent?.hanging ?? 0));
-        }
-        if (markerHasFirstLine) {
-          return indentLeft + (indent?.firstLine ?? 0);
-        }
-        return indentLeft;
-      })();
+      let markerPos = indentLeft;
+      if (markerHasHanging) {
+        markerPos = Math.max(0, indentLeft - (indent.hanging ?? 0));
+      } else if (markerHasFirstLine) {
+        markerPos = indentLeft + (indent.firstLine ?? 0);
+      }
       lineEl.style.paddingLeft = `${markerPos}px`;
       lineEl.style.textIndent = "0"; // Don't use textIndent for lists
 

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -89,7 +89,7 @@ function extractCellFloatingImages(
       // Use actual measured height for Y tracking
       const blockMeasure = cellMeasure.blocks[blockIndex];
       if (blockMeasure && blockMeasure.kind === "table") {
-        paragraphY += (blockMeasure as TableMeasure).totalHeight ?? 0;
+        paragraphY += (blockMeasure as TableMeasure).totalHeight;
       }
       continue;
     }
@@ -349,7 +349,7 @@ function renderCellContent(
       );
       nestedTableEl.style.position = "relative";
       contentEl.append(nestedTableEl);
-      cumulativeY += (measure as TableMeasure).totalHeight ?? 0;
+      cumulativeY += (measure as TableMeasure).totalHeight;
     }
   }
 
@@ -397,7 +397,7 @@ function renderNestedTable(
   let yPos = 0;
   for (const i_item of measure.rows) {
     rowYPositions.push(yPos);
-    yPos += i_item?.height ?? 0;
+    yPos += i_item.height;
   }
   rowYPositions.push(yPos);
 
@@ -554,16 +554,16 @@ function renderTableCell(
 
   // Store PM positions for selection
   if (cell.blocks.length > 0) {
-    const firstBlock = cell.blocks[0];
+    const firstBlock = cell.blocks.at(0);
     const lastBlock = cell.blocks.at(-1);
-    if (
-      firstBlock &&
-      "pmStart" in firstBlock &&
-      firstBlock.pmStart !== undefined
-    ) {
-      cellEl.dataset["pmStart"] = String(firstBlock.pmStart);
+    const pmStart =
+      firstBlock !== undefined && "pmStart" in firstBlock
+        ? firstBlock.pmStart
+        : undefined;
+    if (pmStart !== undefined) {
+      cellEl.dataset["pmStart"] = String(pmStart);
     }
-    if (lastBlock && "pmEnd" in lastBlock && lastBlock.pmEnd !== undefined) {
+    if (lastBlock && "pmEnd" in lastBlock) {
       cellEl.dataset["pmEnd"] = String(lastBlock.pmEnd);
     }
   }
@@ -793,7 +793,7 @@ export function renderTableFragment(
   let yPos = 0;
   for (const i_item of measure.rows) {
     rowYPositions.push(yPos);
-    yPos += i_item?.height ?? 0;
+    yPos += i_item.height;
   }
   rowYPositions.push(yPos); // Add final position for height calculation
 

--- a/packages/folio/src/core/managers/TableSelectionManager.ts
+++ b/packages/folio/src/core/managers/TableSelectionManager.ts
@@ -79,10 +79,6 @@ export function getTableFromDocument(
   doc: Document,
   tableIndex: number,
 ): Table | null {
-  if (!doc.package?.document?.content) {
-    return null;
-  }
-
   let currentTableIndex = 0;
   for (const block of doc.package.document.content) {
     if (block.type === "table") {
@@ -101,10 +97,6 @@ export function updateTableInDocument(
   tableIndex: number,
   newTable: Table,
 ): Document {
-  if (!doc.package?.document?.content) {
-    return doc;
-  }
-
   let currentTableIndex = 0;
   const newContent = doc.package.document.content.map((block) => {
     if (block.type === "table") {
@@ -134,10 +126,6 @@ export function deleteTableFromDocument(
   doc: Document,
   tableIndex: number,
 ): Document {
-  if (!doc.package?.document?.content) {
-    return doc;
-  }
-
   let currentTableIndex = 0;
   const newContent = doc.package.document.content.filter((block) => {
     if (block.type === "table") {

--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -3,7 +3,12 @@ import { Schema } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 import type { Transaction } from "prosemirror-state";
 
-import { acceptAIEditRevision, rejectAIEditRevision } from "./comments";
+import {
+  acceptAIEditRevision,
+  findNextChange,
+  findPreviousChange,
+  rejectAIEditRevision,
+} from "./comments";
 
 const schema = new Schema({
   nodes: {
@@ -103,5 +108,55 @@ describe("AI revision accept/reject scoping", () => {
     // remaining insertion mark belongs to revision B alone.
     expect(view.state.doc.textContent).toBe(" middle beta");
     expect(insertionRevisionsAt(view.state)).toEqual([2]);
+  });
+});
+
+describe("tracked change navigation", () => {
+  test("findNextChange returns the nearest later change before wrapping", () => {
+    const state = makeStateWithMarks();
+
+    const result = findNextChange(state, 6);
+
+    expect(result).toMatchObject({
+      from: 14,
+      to: 18,
+      type: "insertion",
+    });
+  });
+
+  test("findNextChange wraps only when there is no later change", () => {
+    const state = makeStateWithMarks();
+
+    const result = findNextChange(state, state.doc.content.size);
+
+    expect(result).toMatchObject({
+      from: 1,
+      to: 6,
+      type: "insertion",
+    });
+  });
+
+  test("findPreviousChange returns the nearest earlier change before wrapping", () => {
+    const state = makeStateWithMarks();
+
+    const result = findPreviousChange(state, 12);
+
+    expect(result).toMatchObject({
+      from: 1,
+      to: 6,
+      type: "insertion",
+    });
+  });
+
+  test("findPreviousChange wraps only when there is no earlier change", () => {
+    const state = makeStateWithMarks();
+
+    const result = findPreviousChange(state, 0);
+
+    expect(result).toMatchObject({
+      from: 14,
+      to: 18,
+      type: "insertion",
+    });
   });
 });

--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -35,9 +35,6 @@ const makeStateWithMarks = () => {
   // mark untouched; the previous resolveChange ignored the
   // revision id and processed every insertion mark in the range.
   const insertion = schema.marks["insertion"];
-  if (!insertion) {
-    throw new Error("insertion mark missing");
-  }
   return EditorState.create({
     schema,
     doc: schema.node("doc", null, [

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -345,10 +345,10 @@ export function findNextChange(
     return null;
   }
 
-  let result: ChangeRange | null = null;
+  const result = { value: null as ChangeRange | null };
 
   state.doc.descendants((node, pos) => {
-    if (result) {
+    if (result.value) {
       return false;
     }
     if (!node.isText) {
@@ -360,7 +360,7 @@ export function findNextChange(
 
     for (const mark of node.marks) {
       if (mark.type === insertionType || mark.type === deletionType) {
-        result = {
+        result.value = {
           from: Math.max(pos, startPos),
           to: pos + node.nodeSize,
           type: mark.type === insertionType ? "insertion" : "deletion",
@@ -372,11 +372,11 @@ export function findNextChange(
   });
 
   // Wrap around (only once)
-  if (startPos > 0) {
+  if (result.value === null && startPos > 0) {
     return findNextChange(state, 0);
   }
 
-  return result;
+  return result.value;
 }
 
 /**
@@ -392,7 +392,7 @@ export function findPreviousChange(
     return null;
   }
 
-  let result: ChangeRange | null = null;
+  const result = { value: null as ChangeRange | null };
 
   state.doc.descendants((node, pos) => {
     if (!node.isText) {
@@ -404,7 +404,7 @@ export function findPreviousChange(
 
     for (const mark of node.marks) {
       if (mark.type === insertionType || mark.type === deletionType) {
-        result = {
+        result.value = {
           from: pos,
           to: pos + node.nodeSize,
           type: mark.type === insertionType ? "insertion" : "deletion",
@@ -415,9 +415,9 @@ export function findPreviousChange(
   });
 
   // Wrap around (only once — guard prevents infinite recursion)
-  if (startPos < state.doc.content.size) {
+  if (result.value === null && startPos < state.doc.content.size) {
     return findPreviousChange(state, state.doc.content.size);
   }
 
-  return result;
+  return result.value;
 }

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -187,8 +187,7 @@ export function findAIEditRevisionRange(
     typeof revisionIds === "number" ? [revisionIds] : revisionIds,
   );
 
-  let rangeFrom: number | null = null;
-  let rangeTo: number | null = null;
+  const range = { from: null as number | null, to: null as number | null };
 
   state.doc.descendants((node, pos) => {
     if (!node.isText) {
@@ -202,11 +201,11 @@ export function findAIEditRevisionRange(
       ) {
         const start = pos;
         const end = pos + node.nodeSize;
-        if (rangeFrom === null || start < rangeFrom) {
-          rangeFrom = start;
+        if (range.from === null || start < range.from) {
+          range.from = start;
         }
-        if (rangeTo === null || end > rangeTo) {
-          rangeTo = end;
+        if (range.to === null || end > range.to) {
+          range.to = end;
         }
         break;
       }
@@ -214,10 +213,10 @@ export function findAIEditRevisionRange(
     return undefined;
   });
 
-  if (rangeFrom === null || rangeTo === null) {
+  if (range.from === null || range.to === null) {
     return null;
   }
-  return { from: rangeFrom, to: rangeTo };
+  return { from: range.from, to: range.to };
 }
 
 /**
@@ -294,7 +293,7 @@ export function findChangeAtPosition(
   // Find the text node at this position and its mark
   let markStart = from;
   let markEnd = from;
-  let foundMark: typeof insertionType | null = null;
+  let foundMark: typeof insertionType | undefined;
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, offset) => {
@@ -311,7 +310,7 @@ export function findChangeAtPosition(
     }
   });
 
-  if (!foundMark) {
+  if (foundMark === undefined) {
     return { from, to };
   }
 
@@ -373,7 +372,7 @@ export function findNextChange(
   });
 
   // Wrap around (only once)
-  if (!result && startPos > 0) {
+  if (startPos > 0) {
     return findNextChange(state, 0);
   }
 
@@ -416,7 +415,7 @@ export function findPreviousChange(
   });
 
   // Wrap around (only once — guard prevents infinite recursion)
-  if (!result && startPos < state.doc.content.size) {
+  if (startPos < state.doc.content.size) {
     return findPreviousChange(state, state.doc.content.size);
   }
 

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -285,7 +285,7 @@ function paragraphAttrsToFormatting(
     attrs.borders ||
     attrs.shading ||
     attrs.tabs ||
-    attrs.outlineLevel !== null ||
+    attrs.outlineLevel !== undefined ||
     attrs.contextualSpacing ||
     attrs.spacingExplicit ||
     attrs.bidi;
@@ -340,7 +340,7 @@ function paragraphAttrsToFormatting(
   if (attrs.tabs) {
     f.tabs = attrs.tabs;
   }
-  if (attrs.outlineLevel !== undefined && attrs.outlineLevel !== null) {
+  if (attrs.outlineLevel !== undefined) {
     f.outlineLevel = attrs.outlineLevel;
   }
   if (attrs.contextualSpacing) {
@@ -655,7 +655,7 @@ function getMarksKey(marks: readonly Mark[]): string {
 function createHyperlink(linkMark: Mark): Hyperlink {
   const href = linkMark.attrs["href"] as string;
   // Internal bookmark links use the anchor property in OOXML
-  if (href?.startsWith("#")) {
+  if (href.startsWith("#")) {
     return {
       type: "hyperlink",
       anchor: href.slice(1),
@@ -826,7 +826,7 @@ function createMathFromNode(node: PMNode): MathEquation {
 
   const math: MathEquation = {
     type: "mathEquation",
-    display: (attrs.display as "inline" | "block") || "inline",
+    display: (attrs.display as "inline" | "block" | undefined) ?? "inline",
     ommlXml: attrs.ommlXml,
   };
   if (attrs.plainText) {
@@ -842,7 +842,8 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   const attrs = node.attrs as Record<string, unknown>;
 
   const properties: SdtProperties = {
-    sdtType: (attrs["sdtType"] as SdtProperties["sdtType"]) ?? "richText",
+    sdtType:
+      (attrs["sdtType"] as SdtProperties["sdtType"] | undefined) ?? "richText",
   };
   if (attrs["alias"]) {
     properties.alias = attrs["alias"] as string;
@@ -952,7 +953,7 @@ function createImageRun(node: PMNode): Run {
 
   // Round-trip floating image position (ImagePositionAttrs uses loose strings;
   // cast to the strict OOXML union types for the Document model)
-  if (attrs.position?.horizontal && attrs.position?.vertical) {
+  if (attrs.position?.horizontal && attrs.position.vertical) {
     const pos = attrs.position;
     type HRelativeTo = ImagePosition["horizontal"]["relativeTo"];
     type HAlignment = ImagePosition["horizontal"]["alignment"];
@@ -1428,10 +1429,10 @@ function tableAttrsToFormatting(
     const origWidthVal = orig.width?.value;
     const origWidthType = orig.width?.type;
     if (attrs.width !== origWidthVal || attrs.widthType !== origWidthType) {
-      if (attrs.width !== null || attrs.widthType) {
+      if (attrs.widthType) {
         result.width = {
           value: attrs.width ?? 0,
-          type: (attrs.widthType as "auto" | "dxa" | "pct" | "nil") || "dxa",
+          type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
         };
       } else {
         delete result.width;
@@ -1449,7 +1450,7 @@ function tableAttrsToFormatting(
   // newly created tables that don't have _originalFormatting)
   const hasFormatting =
     attrs.styleId ||
-    attrs.width !== null ||
+    attrs.width !== undefined ||
     attrs.widthType ||
     attrs.justification ||
     attrs.floating ||
@@ -1467,10 +1468,10 @@ function tableAttrsToFormatting(
 
   // Restore width — handle width=0 with type="auto" (common OOXML pattern)
   let width: TableFormatting["width"];
-  if (attrs.width !== null || attrs.widthType) {
+  if (attrs.widthType) {
     width = {
       value: attrs.width ?? 0,
-      type: (attrs.widthType as "auto" | "dxa" | "pct" | "nil") || "dxa",
+      type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
     };
   }
 
@@ -1630,10 +1631,10 @@ function tableCellAttrsToFormatting(
       result.gridSpan = attrs.colspan;
     }
     // Width: use !== null to handle width=0 correctly (ProseMirror can set null)
-    if (attrs.width !== null) {
+    if (attrs.width !== undefined) {
       result.width = {
         value: attrs.width ?? 0,
-        type: (attrs.widthType as "auto" | "dxa" | "pct" | "nil") || "dxa",
+        type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
       };
     }
     if (attrs.verticalAlign !== (orig.verticalAlign ?? undefined)) {
@@ -1674,7 +1675,7 @@ function tableCellAttrsToFormatting(
   const hasFormatting =
     attrs.colspan > 1 ||
     attrs.rowspan > 1 ||
-    attrs.width !== null ||
+    attrs.width !== undefined ||
     attrs.verticalAlign ||
     attrs.backgroundColor ||
     attrs.borders ||
@@ -1689,10 +1690,10 @@ function tableCellAttrsToFormatting(
   if (attrs.colspan > 1) {
     f.gridSpan = attrs.colspan;
   }
-  if (attrs.width !== null) {
+  if (attrs.width !== undefined) {
     f.width = {
       value: attrs.width ?? 0,
-      type: (attrs.widthType as "auto" | "dxa" | "pct" | "nil") || "dxa",
+      type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
     };
   }
   if (attrs.verticalAlign) {
@@ -1756,16 +1757,16 @@ function convertPMTextBox(node: PMNode): Paragraph {
           left?: number;
           right?: number;
         } = {};
-        if (attrs.marginTop !== null && attrs.marginTop !== undefined) {
+        if (attrs.marginTop !== undefined) {
           m.top = pixelsToEmu(attrs.marginTop);
         }
-        if (attrs.marginBottom !== null && attrs.marginBottom !== undefined) {
+        if (attrs.marginBottom !== undefined) {
           m.bottom = pixelsToEmu(attrs.marginBottom);
         }
-        if (attrs.marginLeft !== null && attrs.marginLeft !== undefined) {
+        if (attrs.marginLeft !== undefined) {
           m.left = pixelsToEmu(attrs.marginLeft);
         }
-        if (attrs.marginRight !== null && attrs.marginRight !== undefined) {
+        if (attrs.marginRight !== undefined) {
           m.right = pixelsToEmu(attrs.marginRight);
         }
         return m;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1630,10 +1630,11 @@ function tableCellAttrsToFormatting(
     if (attrs.colspan > 1) {
       result.gridSpan = attrs.colspan;
     }
-    // Width: use !== null to handle width=0 correctly (ProseMirror can set null)
-    if (attrs.width !== undefined) {
+    const cellWidth = Reflect.get(attrs, "width");
+    // Width: keep null absent while preserving explicit width=0 values.
+    if (typeof cellWidth === "number") {
       result.width = {
-        value: attrs.width ?? 0,
+        value: cellWidth,
         type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
       };
     }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1781,16 +1781,16 @@ function convertPMTextBox(node: PMNode): Paragraph {
           left?: number;
           right?: number;
         } = {};
-        if (attrs.marginTop !== undefined) {
+        if (typeof attrs.marginTop === "number") {
           m.top = pixelsToEmu(attrs.marginTop);
         }
-        if (attrs.marginBottom !== undefined) {
+        if (typeof attrs.marginBottom === "number") {
           m.bottom = pixelsToEmu(attrs.marginBottom);
         }
-        if (attrs.marginLeft !== undefined) {
+        if (typeof attrs.marginLeft === "number") {
           m.left = pixelsToEmu(attrs.marginLeft);
         }
-        if (attrs.marginRight !== undefined) {
+        if (typeof attrs.marginRight === "number") {
           m.right = pixelsToEmu(attrs.marginRight);
         }
         return m;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -272,6 +272,7 @@ function paragraphAttrsToFormatting(
 
   // Fallback: reconstruct formatting from individual attrs (e.g. for
   // newly created paragraphs that don't have _originalFormatting)
+  const outlineLevel = Reflect.get(attrs, "outlineLevel");
   const hasFormatting =
     attrs.alignment ||
     attrs.spaceBefore ||
@@ -285,7 +286,7 @@ function paragraphAttrsToFormatting(
     attrs.borders ||
     attrs.shading ||
     attrs.tabs ||
-    attrs.outlineLevel !== undefined ||
+    typeof outlineLevel === "number" ||
     attrs.contextualSpacing ||
     attrs.spacingExplicit ||
     attrs.bidi;
@@ -340,8 +341,8 @@ function paragraphAttrsToFormatting(
   if (attrs.tabs) {
     f.tabs = attrs.tabs;
   }
-  if (attrs.outlineLevel !== undefined) {
-    f.outlineLevel = attrs.outlineLevel;
+  if (typeof outlineLevel === "number") {
+    f.outlineLevel = outlineLevel;
   }
   if (attrs.contextualSpacing) {
     f.contextualSpacing = attrs.contextualSpacing;
@@ -1426,13 +1427,21 @@ function tableAttrsToFormatting(
       }
     }
     // Width: check if changed
+    const tableWidth = Reflect.get(attrs, "width");
+    const tableWidthType = Reflect.get(attrs, "widthType");
     const origWidthVal = orig.width?.value;
     const origWidthType = orig.width?.type;
-    if (attrs.width !== origWidthVal || attrs.widthType !== origWidthType) {
-      if (attrs.widthType) {
+    if (tableWidth !== origWidthVal || tableWidthType !== origWidthType) {
+      if (
+        typeof tableWidth === "number" ||
+        typeof tableWidthType === "string"
+      ) {
         result.width = {
-          value: attrs.width ?? 0,
-          type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
+          value: typeof tableWidth === "number" ? tableWidth : 0,
+          type:
+            typeof tableWidthType === "string"
+              ? (tableWidthType as "auto" | "dxa" | "pct" | "nil")
+              : "dxa",
         };
       } else {
         delete result.width;
@@ -1448,10 +1457,12 @@ function tableAttrsToFormatting(
 
   // Fallback: reconstruct formatting from individual attrs (e.g. for
   // newly created tables that don't have _originalFormatting)
+  const tableWidth = Reflect.get(attrs, "width");
+  const tableWidthType = Reflect.get(attrs, "widthType");
   const hasFormatting =
     attrs.styleId ||
-    attrs.width !== undefined ||
-    attrs.widthType ||
+    typeof tableWidth === "number" ||
+    typeof tableWidthType === "string" ||
     attrs.justification ||
     attrs.floating ||
     attrs.cellMargins ||
@@ -1468,10 +1479,13 @@ function tableAttrsToFormatting(
 
   // Restore width — handle width=0 with type="auto" (common OOXML pattern)
   let width: TableFormatting["width"];
-  if (attrs.widthType) {
+  if (typeof tableWidth === "number" || typeof tableWidthType === "string") {
     width = {
-      value: attrs.width ?? 0,
-      type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
+      value: typeof tableWidth === "number" ? tableWidth : 0,
+      type:
+        typeof tableWidthType === "string"
+          ? (tableWidthType as "auto" | "dxa" | "pct" | "nil")
+          : "dxa",
     };
   }
 
@@ -1633,9 +1647,13 @@ function tableCellAttrsToFormatting(
     const cellWidth = Reflect.get(attrs, "width");
     // Width: keep null absent while preserving explicit width=0 values.
     if (typeof cellWidth === "number") {
+      const cellWidthType = Reflect.get(attrs, "widthType");
       result.width = {
         value: cellWidth,
-        type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
+        type:
+          typeof cellWidthType === "string"
+            ? (cellWidthType as "auto" | "dxa" | "pct" | "nil")
+            : "dxa",
       };
     }
     if (attrs.verticalAlign !== (orig.verticalAlign ?? undefined)) {
@@ -1673,10 +1691,11 @@ function tableCellAttrsToFormatting(
   }
 
   // Fallback: reconstruct formatting from individual attrs
+  const cellWidth = Reflect.get(attrs, "width");
   const hasFormatting =
     attrs.colspan > 1 ||
     attrs.rowspan > 1 ||
-    attrs.width !== undefined ||
+    typeof cellWidth === "number" ||
     attrs.verticalAlign ||
     attrs.backgroundColor ||
     attrs.borders ||
@@ -1691,10 +1710,14 @@ function tableCellAttrsToFormatting(
   if (attrs.colspan > 1) {
     f.gridSpan = attrs.colspan;
   }
-  if (attrs.width !== undefined) {
+  if (typeof cellWidth === "number") {
+    const cellWidthType = Reflect.get(attrs, "widthType");
     f.width = {
-      value: attrs.width ?? 0,
-      type: attrs.widthType as "auto" | "dxa" | "pct" | "nil",
+      value: cellWidth,
+      type:
+        typeof cellWidthType === "string"
+          ? (cellWidthType as "auto" | "dxa" | "pct" | "nil")
+          : "dxa",
     };
   }
   if (attrs.verticalAlign) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -639,7 +639,10 @@ function hasDirectRunFormatting(
     return false;
   }
 
-  return Object.keys(formatting).some((key) => key !== "styleId");
+  const entries: [string, unknown][] = Object.entries(formatting);
+  return entries.some(
+    ([key, value]) => key !== "styleId" && value !== undefined,
+  );
 }
 
 function resolveTextFormatting(
@@ -1608,6 +1611,8 @@ function convertRunContent(
  *    - TopAndBottom: image on its own line, text above/below only
  *    - None/Behind/InFront: positioned image, no text wrap
  */
+type PartialImagePosition = Partial<NonNullable<Image["position"]>>;
+
 function convertImage(image: Image): PMNode {
   // Convert EMU to pixels for proper sizing
   const widthPx = image.size.width ? emuToPixels(image.size.width) : undefined;
@@ -1618,7 +1623,8 @@ function convertImage(image: Image): PMNode {
   // Determine wrap type and float direction
   const wrapType = image.wrap.type;
   const wrapText = image.wrap.wrapText;
-  const hAlign = image.position?.horizontal.alignment;
+  const imagePosition: PartialImagePosition | undefined = image.position;
+  const hAlign = imagePosition?.horizontal?.alignment;
 
   // Determine CSS float based on wrap settings
   // In DOCX: wrapText='left' means "text flows on the left" → image is on right → float: right
@@ -1716,29 +1722,33 @@ function convertImage(image: Image): PMNode {
         vertical?: { relativeTo?: string; posOffset?: number; align?: string };
       }
     | undefined;
-  if (image.position) {
+  if (imagePosition) {
     position = {};
-    const h: { relativeTo?: string; posOffset?: number; align?: string } = {
-      relativeTo: image.position.horizontal.relativeTo,
-    };
-    if (image.position.horizontal.posOffset !== undefined) {
-      h.posOffset = image.position.horizontal.posOffset;
+    if (imagePosition.horizontal) {
+      const h: { relativeTo?: string; posOffset?: number; align?: string } = {
+        relativeTo: imagePosition.horizontal.relativeTo,
+      };
+      if (imagePosition.horizontal.posOffset !== undefined) {
+        h.posOffset = imagePosition.horizontal.posOffset;
+      }
+      if (imagePosition.horizontal.alignment) {
+        h.align = imagePosition.horizontal.alignment;
+      }
+      position.horizontal = h;
     }
-    if (image.position.horizontal.alignment) {
-      h.align = image.position.horizontal.alignment;
-    }
-    position.horizontal = h;
 
-    const v: { relativeTo?: string; posOffset?: number; align?: string } = {
-      relativeTo: image.position.vertical.relativeTo,
-    };
-    if (image.position.vertical.posOffset !== undefined) {
-      v.posOffset = image.position.vertical.posOffset;
+    if (imagePosition.vertical) {
+      const v: { relativeTo?: string; posOffset?: number; align?: string } = {
+        relativeTo: imagePosition.vertical.relativeTo,
+      };
+      if (imagePosition.vertical.posOffset !== undefined) {
+        v.posOffset = imagePosition.vertical.posOffset;
+      }
+      if (imagePosition.vertical.alignment) {
+        v.align = imagePosition.vertical.alignment;
+      }
+      position.vertical = v;
     }
-    if (image.position.vertical.alignment) {
-      v.align = image.position.vertical.alignment;
-    }
-    position.vertical = v;
   }
 
   // Convert outline to border attrs
@@ -2006,6 +2016,7 @@ function textFormattingToMarks(
 function convertShape(shape: Shape): PMNode {
   const widthPx = shape.size.width ? emuToPixels(shape.size.width) : 100;
   const heightPx = shape.size.height ? emuToPixels(shape.size.height) : 80;
+  const shapeAttrs: { shapeType?: Shape["shapeType"] } = shape;
 
   let fillColor: string | undefined;
   let fillType: string = "solid";
@@ -2064,7 +2075,7 @@ function convertShape(shape: Shape): PMNode {
   }
 
   return schema.node("shape", {
-    shapeType: shape.shapeType,
+    shapeType: shapeAttrs.shapeType ?? "rect",
     shapeId: shape.id,
     width: widthPx,
     height: heightPx,

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1612,12 +1612,15 @@ function convertRunContent(
  *    - None/Behind/InFront: positioned image, no text wrap
  */
 type PartialImagePosition = Partial<NonNullable<Image["position"]>>;
+type PartialImageSize = Partial<Image["size"]>;
 
 function convertImage(image: Image): PMNode {
   // Convert EMU to pixels for proper sizing
-  const widthPx = image.size.width ? emuToPixels(image.size.width) : undefined;
-  const heightPx = image.size.height
-    ? emuToPixels(image.size.height)
+  const imageData: { size?: PartialImageSize } = image;
+  const imageSize = imageData.size;
+  const widthPx = imageSize?.width ? emuToPixels(imageSize.width) : undefined;
+  const heightPx = imageSize?.height
+    ? emuToPixels(imageSize.height)
     : undefined;
 
   // Determine wrap type and float direction
@@ -1962,18 +1965,25 @@ function textFormattingToMarks(
   }
 
   // Character spacing (spacing, position, scale, kerning)
+  const spacing =
+    typeof formatting.spacing === "number" ? formatting.spacing : null;
+  const position =
+    typeof formatting.position === "number" ? formatting.position : null;
+  const scale = typeof formatting.scale === "number" ? formatting.scale : null;
+  const kerning =
+    typeof formatting.kerning === "number" ? formatting.kerning : null;
   if (
-    formatting.spacing !== undefined ||
-    formatting.position !== undefined ||
-    formatting.scale !== undefined ||
-    formatting.kerning !== undefined
+    spacing !== null ||
+    position !== null ||
+    scale !== null ||
+    kerning !== null
   ) {
     marks.push(
       schema.mark("characterSpacing", {
-        spacing: formatting.spacing ?? null,
-        position: formatting.position ?? null,
-        scale: formatting.scale ?? null,
-        kerning: formatting.kerning ?? null,
+        spacing,
+        position,
+        scale,
+        kerning,
       }),
     );
   }
@@ -2014,8 +2024,10 @@ function textFormattingToMarks(
  * Convert a Shape to a ProseMirror shape node (inline SVG)
  */
 function convertShape(shape: Shape): PMNode {
-  const widthPx = shape.size.width ? emuToPixels(shape.size.width) : 100;
-  const heightPx = shape.size.height ? emuToPixels(shape.size.height) : 80;
+  const shapeData: { size?: Partial<Shape["size"]> } = shape;
+  const shapeSize = shapeData.size;
+  const widthPx = shapeSize?.width ? emuToPixels(shapeSize.width) : 100;
+  const heightPx = shapeSize?.height ? emuToPixels(shapeSize.height) : 80;
   const shapeAttrs: { shapeType?: Shape["shapeType"] } = shape;
 
   let fillColor: string | undefined;
@@ -2170,9 +2182,11 @@ function convertTextBox(
   textBox: TextBox,
   styleResolver: StyleResolver | null,
 ): PMNode {
-  const widthPx = textBox.size.width ? emuToPixels(textBox.size.width) : 200;
-  const heightPx = textBox.size.height
-    ? emuToPixels(textBox.size.height)
+  const textBoxData: { size?: Partial<TextBox["size"]> } = textBox;
+  const textBoxSize = textBoxData.size;
+  const widthPx = textBoxSize?.width ? emuToPixels(textBoxSize.width) : 200;
+  const heightPx = textBoxSize?.height
+    ? emuToPixels(textBoxSize.height)
     : undefined;
 
   // Convert fill color

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -293,7 +293,7 @@ function convertTrackedChange(
           styleResolver,
         ),
       );
-    } else if (item.type === "hyperlink") {
+    } else {
       nodes.push(
         ...convertHyperlink(item, getInheritedRunFormatting, styleResolver),
       );
@@ -639,9 +639,7 @@ function hasDirectRunFormatting(
     return false;
   }
 
-  return Object.entries(formatting).some(
-    ([key, value]) => key !== "styleId" && value !== undefined,
-  );
+  return Object.keys(formatting).some((key) => key !== "styleId");
 }
 
 function resolveTextFormatting(
@@ -1370,7 +1368,7 @@ function convertTableCell(
           conditionalStyle?.rPr,
         ),
       );
-    } else if (content.type === "table") {
+    } else {
       // Nested tables - recursively convert
       contentNodes.push(convertTable(content, styleResolver, theme));
     }
@@ -1400,18 +1398,16 @@ function convertField(
   let displayText = "";
   let fieldFormatting: TextFormatting | undefined;
   const runs = field.type === "simpleField" ? field.content : field.fieldResult;
-  if (runs) {
-    for (const r of runs) {
-      if (r.type === "run") {
-        for (const c of r.content) {
-          if (c.type === "text") {
-            displayText += c.text;
-          }
+  for (const r of runs) {
+    if (r.type === "run") {
+      for (const c of r.content) {
+        if (c.type === "text") {
+          displayText += c.text;
         }
-        // Use formatting from the first run that has it
-        if (!fieldFormatting && r.formatting) {
-          fieldFormatting = r.formatting;
-        }
+      }
+      // Use formatting from the first run that has it
+      if (!fieldFormatting && r.formatting) {
+        fieldFormatting = r.formatting;
       }
     }
   }
@@ -1469,7 +1465,7 @@ function convertInlineSdt(
         styleResolver,
       );
       inlineNodes.push(...runNodes);
-    } else if (content.type === "hyperlink") {
+    } else {
       const linkNodes = convertHyperlink(
         content,
         getInheritedRunFormatting,
@@ -1559,10 +1555,7 @@ function convertRunContent(
       return [schema.node("tab")];
 
     case "drawing":
-      if (content.image) {
-        return [convertImage(content.image)];
-      }
-      return [];
+      return [convertImage(content.image)];
 
     case "shape": {
       // Shapes with text body are handled as text boxes at block level
@@ -1617,15 +1610,15 @@ function convertRunContent(
  */
 function convertImage(image: Image): PMNode {
   // Convert EMU to pixels for proper sizing
-  const widthPx = image.size?.width ? emuToPixels(image.size.width) : undefined;
-  const heightPx = image.size?.height
+  const widthPx = image.size.width ? emuToPixels(image.size.width) : undefined;
+  const heightPx = image.size.height
     ? emuToPixels(image.size.height)
     : undefined;
 
   // Determine wrap type and float direction
   const wrapType = image.wrap.type;
   const wrapText = image.wrap.wrapText;
-  const hAlign = image.position?.horizontal?.alignment;
+  const hAlign = image.position?.horizontal.alignment;
 
   // Determine CSS float based on wrap settings
   // In DOCX: wrapText='left' means "text flows on the left" → image is on right → float: right
@@ -1678,7 +1671,7 @@ function convertImage(image: Image): PMNode {
     displayMode = "block";
   } else if (wrapType === "behind" || wrapType === "inFront") {
     displayMode = "float";
-  } else if (cssFloat && cssFloat !== "none") {
+  } else if (cssFloat !== "none") {
     displayMode = "float";
   } else {
     displayMode = "block";
@@ -1725,30 +1718,27 @@ function convertImage(image: Image): PMNode {
     | undefined;
   if (image.position) {
     position = {};
-    if (image.position.horizontal) {
-      const h: { relativeTo?: string; posOffset?: number; align?: string } = {
-        relativeTo: image.position.horizontal.relativeTo,
-      };
-      if (image.position.horizontal.posOffset !== undefined) {
-        h.posOffset = image.position.horizontal.posOffset;
-      }
-      if (image.position.horizontal.alignment) {
-        h.align = image.position.horizontal.alignment;
-      }
-      position.horizontal = h;
+    const h: { relativeTo?: string; posOffset?: number; align?: string } = {
+      relativeTo: image.position.horizontal.relativeTo,
+    };
+    if (image.position.horizontal.posOffset !== undefined) {
+      h.posOffset = image.position.horizontal.posOffset;
     }
-    if (image.position.vertical) {
-      const v: { relativeTo?: string; posOffset?: number; align?: string } = {
-        relativeTo: image.position.vertical.relativeTo,
-      };
-      if (image.position.vertical.posOffset !== undefined) {
-        v.posOffset = image.position.vertical.posOffset;
-      }
-      if (image.position.vertical.alignment) {
-        v.align = image.position.vertical.alignment;
-      }
-      position.vertical = v;
+    if (image.position.horizontal.alignment) {
+      h.align = image.position.horizontal.alignment;
     }
+    position.horizontal = h;
+
+    const v: { relativeTo?: string; posOffset?: number; align?: string } = {
+      relativeTo: image.position.vertical.relativeTo,
+    };
+    if (image.position.vertical.posOffset !== undefined) {
+      v.posOffset = image.position.vertical.posOffset;
+    }
+    if (image.position.vertical.alignment) {
+      v.align = image.position.vertical.alignment;
+    }
+    position.vertical = v;
   }
 
   // Convert outline to border attrs
@@ -1963,10 +1953,10 @@ function textFormattingToMarks(
 
   // Character spacing (spacing, position, scale, kerning)
   if (
-    formatting.spacing !== null ||
-    formatting.position !== null ||
-    formatting.scale !== null ||
-    formatting.kerning !== null
+    formatting.spacing !== undefined ||
+    formatting.position !== undefined ||
+    formatting.scale !== undefined ||
+    formatting.kerning !== undefined
   ) {
     marks.push(
       schema.mark("characterSpacing", {
@@ -2014,8 +2004,8 @@ function textFormattingToMarks(
  * Convert a Shape to a ProseMirror shape node (inline SVG)
  */
 function convertShape(shape: Shape): PMNode {
-  const widthPx = shape.size?.width ? emuToPixels(shape.size.width) : 100;
-  const heightPx = shape.size?.height ? emuToPixels(shape.size.height) : 80;
+  const widthPx = shape.size.width ? emuToPixels(shape.size.width) : 100;
+  const heightPx = shape.size.height ? emuToPixels(shape.size.height) : 80;
 
   let fillColor: string | undefined;
   let fillType: string = "solid";
@@ -2074,7 +2064,7 @@ function convertShape(shape: Shape): PMNode {
   }
 
   return schema.node("shape", {
-    shapeType: shape.shapeType || "rect",
+    shapeType: shape.shapeType,
     shapeId: shape.id,
     width: widthPx,
     height: heightPx,
@@ -2169,8 +2159,8 @@ function convertTextBox(
   textBox: TextBox,
   styleResolver: StyleResolver | null,
 ): PMNode {
-  const widthPx = textBox.size?.width ? emuToPixels(textBox.size.width) : 200;
-  const heightPx = textBox.size?.height
+  const widthPx = textBox.size.width ? emuToPixels(textBox.size.width) : 200;
+  const heightPx = textBox.size.height
     ? emuToPixels(textBox.size.height)
     : undefined;
 
@@ -2258,7 +2248,7 @@ export function headerFooterToProseDoc(
   for (const block of content) {
     if (block.type === "paragraph") {
       nodes.push(...convertParagraphWithTextBoxes(block, styleResolver));
-    } else if (block.type === "table") {
+    } else {
       nodes.push(convertTable(block, styleResolver, theme));
     }
   }

--- a/packages/folio/src/core/prosemirror/extensions/core/HistoryExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/HistoryExtension.ts
@@ -14,10 +14,8 @@ export const HistoryExtension = createExtension({
     return {
       plugins: [
         history({
-          ...(options.depth !== undefined ? { depth: options.depth } : {}),
-          ...(options.newGroupDelay !== undefined
-            ? { newGroupDelay: options.newGroupDelay }
-            : {}),
+          depth: options.depth,
+          newGroupDelay: options.newGroupDelay,
         }),
       ],
       commands: {

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+const paragraphDomAttrs = (
+  attrs: Record<string, unknown>,
+): Record<string, string> => {
+  const paragraph = schema.node("paragraph", attrs);
+  const toDOM = paragraph.type.spec.toDOM;
+  if (!toDOM) {
+    throw new Error("Expected paragraph node to provide toDOM");
+  }
+
+  const domSpec = toDOM(paragraph) as [string, Record<string, string>, number];
+
+  return domSpec[1];
+};
+
+describe("ParagraphExtension", () => {
+  test("preserves explicit list paragraph left indent", () => {
+    const attrs = paragraphDomAttrs({
+      indentLeft: 1440,
+      numPr: { ilvl: 0, numId: 1 },
+    });
+
+    expect(attrs["style"]).toContain("margin-left: 96px");
+    expect(attrs["style"]).not.toContain("margin-left: 48px");
+  });
+
+  test("uses the synthetic list indent when left indent is null", () => {
+    const attrs = paragraphDomAttrs({
+      indentLeft: null,
+      numPr: { ilvl: 1, numId: 1 },
+    });
+
+    expect(attrs["style"]).toContain("margin-left: 96px");
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -32,7 +32,7 @@ import type { ExtensionContext, ExtensionRuntime } from "../types";
 
 function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
   let indentLeft = attrs.indentLeft;
-  if (attrs.numPr?.numId && indentLeft === null) {
+  if (attrs.numPr?.numId) {
     const level = attrs.numPr.ilvl ?? 0;
     indentLeft = (level + 1) * 720;
   }
@@ -49,7 +49,7 @@ function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
     ...(attrs.lineSpacingRule !== undefined
       ? { lineSpacingRule: attrs.lineSpacingRule }
       : {}),
-    ...(indentLeft !== undefined && indentLeft !== null ? { indentLeft } : {}),
+    ...(indentLeft !== undefined ? { indentLeft } : {}),
     ...(attrs.indentRight !== undefined
       ? { indentRight: attrs.indentRight }
       : {}),
@@ -860,10 +860,12 @@ export const ParagraphExtension = createNodeExtension({
               if (paragraphNode && paragraphNode.type.name === "paragraph") {
                 // Filter out any existing _Toc bookmarks to avoid duplicates on regeneration
                 const existingBookmarks =
-                  (paragraphNode.attrs["bookmarks"] as {
-                    id: number;
-                    name: string;
-                  }[]) || [];
+                  (paragraphNode.attrs["bookmarks"] as
+                    | {
+                        id: number;
+                        name: string;
+                      }[]
+                    | undefined) ?? [];
                 const filteredBookmarks = existingBookmarks.filter(
                   (b) => !b.name.startsWith("_Toc"),
                 );

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -31,8 +31,13 @@ import type { ExtensionContext, ExtensionRuntime } from "../types";
 // ============================================================================
 
 function paragraphAttrsToDOMStyle(attrs: ParagraphAttrs): string {
-  let indentLeft = attrs.indentLeft;
-  if (attrs.numPr?.numId) {
+  const rawIndentLeft: unknown = Reflect.get(attrs, "indentLeft");
+  let indentLeft =
+    typeof rawIndentLeft === "number" ? rawIndentLeft : undefined;
+  if (
+    attrs.numPr?.numId &&
+    (rawIndentLeft === null || rawIndentLeft === undefined)
+  ) {
     const level = attrs.numPr.ilvl ?? 0;
     indentLeft = (level + 1) * 720;
   }

--- a/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -119,10 +119,10 @@ const splitBlockClearBorders: Command = (state, dispatch, view) => {
   // Intercept splitBlock's transaction so we can modify it before dispatch.
   // This ensures attrs + stored marks are set in a single transaction,
   // avoiding a flash where the empty paragraph has no formatting.
-  let splitTr: Transaction | null = null;
+  const splitResult = { tr: null as Transaction | null };
   const capturingDispatch = dispatch
     ? (tr: Transaction) => {
-        splitTr = tr;
+        splitResult.tr = tr;
       }
     : undefined;
 
@@ -130,10 +130,10 @@ const splitBlockClearBorders: Command = (state, dispatch, view) => {
     return false;
   }
 
-  if (dispatch && splitTr !== null) {
+  if (dispatch && splitResult.tr !== null) {
     // After split, cursor is in the new (second) paragraph.
     // Apply attr inheritance, border clearing, and stored marks to the SAME transaction.
-    const tr = splitTr as Transaction;
+    const tr = splitResult.tr;
     const { $from } = tr.selection;
     const newPara = $from.parent;
 

--- a/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ParagraphChangeTrackerExtension.test.ts
@@ -101,9 +101,6 @@ describe("ParagraphChangeTrackerExtension", () => {
         { text: "BBBB", paraId: "P2" },
       ]);
       const bold = schema.marks.bold;
-      if (!bold) {
-        throw new Error("Expected bold mark in test schema");
-      }
       const boldMark = bold.create();
 
       state = state.apply(state.tr.step(new AddMarkStep(7, 11, boldMark)));

--- a/packages/folio/src/core/prosemirror/extensions/marks/BoldExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/BoldExtension.ts
@@ -17,7 +17,7 @@ export const BoldExtension = createMarkExtension({
         tag: "b",
         getAttrs(dom) {
           // Reject <b> with explicit non-bold font-weight (e.g. Google Docs structural wrapper)
-          const fw = dom.style?.fontWeight;
+          const fw = dom.style.fontWeight;
           if (fw === "normal" || fw === "400") {
             return false;
           }

--- a/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
@@ -319,7 +319,7 @@ export function textFormattingToMarks(
   if (formatting.underline && schema.marks["underline"]) {
     marks.push(
       schema.marks["underline"].create({
-        style: formatting.underline.style || "single",
+        style: formatting.underline.style,
         color: formatting.underline.color,
       }),
     );

--- a/packages/folio/src/core/prosemirror/extensions/nodes/FieldExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/FieldExtension.ts
@@ -37,7 +37,7 @@ export const FieldExtension = createNodeExtension({
           return {
             fieldType: dom.dataset["fieldType"] ?? "UNKNOWN",
             instruction: dom.dataset["instruction"] ?? "",
-            displayText: dom.textContent ?? "",
+            displayText: dom.textContent,
             fieldKind: dom.dataset["fieldKind"] ?? "simple",
             fldLock: dom.dataset["fldLock"] === "true",
             dirty: dom.dataset["dirty"] === "true",

--- a/packages/folio/src/core/prosemirror/extensions/nodes/MathExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/MathExtension.ts
@@ -31,7 +31,7 @@ export const MathExtension = createNodeExtension({
           return {
             display: dom.dataset["display"] ?? "inline",
             ommlXml: dom.dataset["ommlXml"] ?? "",
-            plainText: dom.textContent ?? "",
+            plainText: dom.textContent,
           };
         },
       },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -428,7 +428,7 @@ export const ShapeExtension = createNodeExtension({
       if (attrs.gradientType) {
         domAttrs["data-gradient-type"] = attrs.gradientType;
       }
-      if (attrs.gradientAngle !== null) {
+      if (attrs.gradientAngle !== undefined) {
         domAttrs["data-gradient-angle"] = String(attrs.gradientAngle);
       }
       if (attrs.gradientStops) {
@@ -458,19 +458,19 @@ export const ShapeExtension = createNodeExtension({
       if (attrs.shadowColor) {
         domAttrs["data-shadow-color"] = attrs.shadowColor;
       }
-      if (attrs.shadowBlur !== null) {
+      if (attrs.shadowBlur !== undefined) {
         domAttrs["data-shadow-blur"] = String(attrs.shadowBlur);
       }
-      if (attrs.shadowOffsetX !== null) {
+      if (attrs.shadowOffsetX !== undefined) {
         domAttrs["data-shadow-offset-x"] = String(attrs.shadowOffsetX);
       }
-      if (attrs.shadowOffsetY !== null) {
+      if (attrs.shadowOffsetY !== undefined) {
         domAttrs["data-shadow-offset-y"] = String(attrs.shadowOffsetY);
       }
       if (attrs.glowColor) {
         domAttrs["data-glow-color"] = attrs.glowColor;
       }
-      if (attrs.glowRadius !== null) {
+      if (attrs.glowRadius !== undefined) {
         domAttrs["data-glow-radius"] = String(attrs.glowRadius);
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -428,7 +428,7 @@ export const ShapeExtension = createNodeExtension({
       if (attrs.gradientType) {
         domAttrs["data-gradient-type"] = attrs.gradientType;
       }
-      if (attrs.gradientAngle !== undefined) {
+      if (typeof attrs.gradientAngle === "number") {
         domAttrs["data-gradient-angle"] = String(attrs.gradientAngle);
       }
       if (attrs.gradientStops) {
@@ -458,19 +458,19 @@ export const ShapeExtension = createNodeExtension({
       if (attrs.shadowColor) {
         domAttrs["data-shadow-color"] = attrs.shadowColor;
       }
-      if (attrs.shadowBlur !== undefined) {
+      if (typeof attrs.shadowBlur === "number") {
         domAttrs["data-shadow-blur"] = String(attrs.shadowBlur);
       }
-      if (attrs.shadowOffsetX !== undefined) {
+      if (typeof attrs.shadowOffsetX === "number") {
         domAttrs["data-shadow-offset-x"] = String(attrs.shadowOffsetX);
       }
-      if (attrs.shadowOffsetY !== undefined) {
+      if (typeof attrs.shadowOffsetY === "number") {
         domAttrs["data-shadow-offset-y"] = String(attrs.shadowOffsetY);
       }
       if (attrs.glowColor) {
         domAttrs["data-glow-color"] = attrs.glowColor;
       }
-      if (attrs.glowRadius !== undefined) {
+      if (typeof attrs.glowRadius === "number") {
         domAttrs["data-glow-radius"] = String(attrs.glowRadius);
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import { schema, singletonManager } from "../../schema";
+
+const createTableStateWithNullBorders = () => {
+  const doc = schema.node("doc", null, [
+    schema.node("table", null, [
+      schema.node("tableRow", null, [
+        schema.node("tableCell", { borders: null }, [
+          schema.node("paragraph", null, [schema.text("A")]),
+        ]),
+        schema.node("tableCell", { borders: null }, [
+          schema.node("paragraph", null, [schema.text("B")]),
+        ]),
+      ]),
+    ]),
+  ]);
+
+  const cursorPos = { value: null as number | null };
+  doc.descendants((node, pos) => {
+    if (cursorPos.value !== null || node.text !== "A") {
+      return;
+    }
+    cursorPos.value = pos;
+    return false;
+  });
+
+  if (cursorPos.value === null) {
+    throw new Error("Expected table cell text position");
+  }
+
+  return EditorState.create({
+    doc,
+    schema,
+    selection: TextSelection.create(doc, cursorPos.value),
+  });
+};
+
+const runTableCommand = (
+  state: EditorState,
+  commandName: string,
+  ...values: unknown[]
+) => {
+  const commandFactory = singletonManager.getCommand(commandName);
+  if (!commandFactory) {
+    throw new Error(`Missing command: ${commandName}`);
+  }
+
+  let nextState = state;
+  const handled = commandFactory(...values)(state, (tr: Transaction) => {
+    nextState = state.apply(tr);
+  });
+
+  expect(handled).toBe(true);
+  return nextState;
+};
+
+const firstTableCell = (doc: PMNode) => {
+  const cell = { value: null as PMNode | null };
+  doc.descendants((node) => {
+    if (cell.value !== null || node.type.name !== "tableCell") {
+      return;
+    }
+    cell.value = node;
+    return false;
+  });
+
+  if (cell.value === null) {
+    throw new Error("Expected table cell");
+  }
+
+  return cell.value;
+};
+
+describe("table border commands", () => {
+  test("setTableBorderColor creates borders on a cell with null borders", () => {
+    const state = runTableCommand(
+      createTableStateWithNullBorders(),
+      "setTableBorderColor",
+      "#336699",
+    );
+
+    expect(firstTableCell(state.doc).attrs["borders"]).toMatchObject({
+      bottom: { color: { rgb: "336699" }, size: 4, style: "single" },
+      left: { color: { rgb: "336699" }, size: 4, style: "single" },
+      right: { color: { rgb: "336699" }, size: 4, style: "single" },
+      top: { color: { rgb: "336699" }, size: 4, style: "single" },
+    });
+  });
+
+  test("setTableBorderWidth creates borders on a cell with null borders", () => {
+    const state = runTableCommand(
+      createTableStateWithNullBorders(),
+      "setTableBorderWidth",
+      12,
+    );
+
+    expect(firstTableCell(state.doc).attrs["borders"]).toMatchObject({
+      bottom: { color: { rgb: "000000" }, size: 12, style: "single" },
+      left: { color: { rgb: "000000" }, size: 12, style: "single" },
+      right: { color: { rgb: "000000" }, size: 12, style: "single" },
+      top: { color: { rgb: "000000" }, size: 12, style: "single" },
+    });
+  });
+
+  test("setCellBorder creates a single border on a cell with null borders", () => {
+    const state = runTableCommand(
+      createTableStateWithNullBorders(),
+      "setCellBorder",
+      "left",
+      { color: { rgb: "AA0000" }, size: 8, style: "single" },
+      false,
+    );
+
+    expect(firstTableCell(state.doc).attrs["borders"]).toMatchObject({
+      left: { color: { rgb: "AA0000" }, size: 8, style: "single" },
+    });
+  });
+
+  test("setAllTableBorders creates borders on a cell with null borders", () => {
+    const state = runTableCommand(
+      createTableStateWithNullBorders(),
+      "setAllTableBorders",
+      { color: { rgb: "00AA00" }, size: 6, style: "single" },
+    );
+
+    expect(firstTableCell(state.doc).attrs["borders"]).toMatchObject({
+      bottom: { color: { rgb: "00AA00" }, size: 6, style: "single" },
+      left: { color: { rgb: "00AA00" }, size: 6, style: "single" },
+      right: { color: { rgb: "00AA00" }, size: 6, style: "single" },
+      top: { color: { rgb: "00AA00" }, size: 6, style: "single" },
+    });
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -346,7 +346,7 @@ const tableRowSpec: NodeSpec = {
     const attrs = node.attrs as TableRowAttrs;
     const domAttrs: Record<string, string> = {};
 
-    if (attrs.height !== undefined && attrs.height !== null) {
+    if (attrs.height !== undefined) {
       const heightPx = Math.round((attrs.height / 20) * 1.333);
       domAttrs["style"] = `height: ${heightPx}px`;
     }
@@ -1294,12 +1294,11 @@ export const TablePluginExtension = createExtension({
 
             if (
               context.columnIndex !== undefined &&
-              context.columnIndex !== null &&
               colIdx <= context.columnIndex
             ) {
               const paragraph = nodeTypeParagraph.create();
               const cellAttrs = buildCellAttrsFromTemplate(
-                row.child(row.childCount - 1) ?? null,
+                row.child(row.childCount - 1),
                 { colspan: 1, rowspan: 1 },
               );
               cellAttrs["width"] = newColWidthPercent;
@@ -1333,7 +1332,7 @@ export const TablePluginExtension = createExtension({
           }
 
           // Update table columnWidths so full-width tables resize correctly.
-          const colCount = firstRow?.childCount ?? newColumnCount;
+          const colCount = firstRow.childCount;
           const tableWidthTwips =
             (updatedTable.attrs["width"] as number) || 9360;
           const colWidthTwips = Math.floor(
@@ -1376,7 +1375,7 @@ export const TablePluginExtension = createExtension({
           if (row.type.name === "tableRow") {
             let cellPos = rowPos + 1;
             let colIdx = 0;
-            let inserted = false;
+            let insertedCount = 0;
 
             // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
             row.forEach((cell) => {
@@ -1384,9 +1383,8 @@ export const TablePluginExtension = createExtension({
               colIdx += Number(cell.attrs["colspan"]) || 1;
 
               if (
-                !inserted &&
+                insertedCount === 0 &&
                 context.columnIndex !== undefined &&
-                context.columnIndex !== null &&
                 colIdx > context.columnIndex
               ) {
                 const paragraph = nodeTypeParagraph.create();
@@ -1398,14 +1396,14 @@ export const TablePluginExtension = createExtension({
                 cellAttrs["widthType"] = "pct";
                 const newCell = nodeTypeTableCell.create(cellAttrs, paragraph);
                 tr = tr.insert(cellPos, newCell);
-                inserted = true;
+                insertedCount += 1;
               }
             });
 
-            if (!inserted) {
+            if (insertedCount === 0) {
               const paragraph = nodeTypeParagraph.create();
               const cellAttrs = buildCellAttrsFromTemplate(
-                row.child(row.childCount - 1) ?? null,
+                row.child(row.childCount - 1),
                 { colspan: 1, rowspan: 1 },
               );
               cellAttrs["width"] = newColWidthPercent;
@@ -1439,7 +1437,7 @@ export const TablePluginExtension = createExtension({
           }
 
           // Update table columnWidths so full-width tables resize correctly.
-          const colCount = firstRow?.childCount ?? newColumnCount;
+          const colCount = firstRow.childCount;
           const tableWidthTwips =
             (updatedTable.attrs["width"] as number) || 9360;
           const colWidthTwips = Math.floor(
@@ -1493,7 +1491,6 @@ export const TablePluginExtension = createExtension({
 
               if (
                 context.columnIndex !== undefined &&
-                context.columnIndex !== null &&
                 colIdx <= context.columnIndex &&
                 context.columnIndex < colIdx + cellColspan
               ) {
@@ -1533,7 +1530,7 @@ export const TablePluginExtension = createExtension({
           }
 
           // Update table columnWidths to match new column count.
-          const colCount = firstRow?.childCount ?? newColumnCount;
+          const colCount = firstRow.childCount;
           const tableWidthTwips =
             (updatedTable.attrs["width"] as number) || 9360;
           const colWidthTwips = Math.floor(
@@ -1867,8 +1864,7 @@ export const TablePluginExtension = createExtension({
 
             // Update target cell
             const attrs = getAttrs(pos, info.node);
-            const existingBorders =
-              (attrs["borders"] as Record<string, unknown>) ?? {};
+            const existingBorders = attrs["borders"] as Record<string, unknown>;
             setAttrs(pos, {
               ...attrs,
               borders: { ...existingBorders, ...cellBorders },
@@ -1884,8 +1880,10 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                const adjBorders = adjAttrs["borders"] as Record<
+                  string,
+                  unknown
+                >;
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, bottom: cellBorders["top"] },
@@ -1901,8 +1899,10 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                const adjBorders = adjAttrs["borders"] as Record<
+                  string,
+                  unknown
+                >;
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, top: cellBorders["bottom"] },
@@ -1918,8 +1918,10 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                const adjBorders = adjAttrs["borders"] as Record<
+                  string,
+                  unknown
+                >;
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, right: cellBorders["left"] },
@@ -1937,8 +1939,10 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                const adjBorders = adjAttrs["borders"] as Record<
+                  string,
+                  unknown
+                >;
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, left: cellBorders["right"] },
@@ -2033,8 +2037,7 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as Record<string, unknown>) ?? {};
+            const currentBorders = attrs["borders"] as Record<string, unknown>;
 
             const sides = side === "all" ? allSides : [side];
             // When clearOthers is true, start with all sides cleared (preset behavior)
@@ -2072,8 +2075,10 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                  const adjBorders = adjAttrs["borders"] as Record<
+                    string,
+                    unknown
+                  >;
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: syncValue },
@@ -2675,9 +2680,10 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as Record<string, Record<string, unknown>>) ??
-              {};
+            const currentBorders = attrs["borders"] as Record<
+              string,
+              Record<string, unknown>
+            >;
             const newBorders: Record<string, unknown> = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
@@ -2707,8 +2713,10 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                  const adjBorders = adjAttrs["borders"] as Record<
+                    string,
+                    unknown
+                  >;
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },
@@ -2771,9 +2779,10 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as Record<string, Record<string, unknown>>) ??
-              {};
+            const currentBorders = attrs["borders"] as Record<
+              string,
+              Record<string, unknown>
+            >;
             const newBorders: Record<string, unknown> = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
@@ -2803,8 +2812,10 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as Record<string, unknown>) ?? {};
+                  const adjBorders = adjAttrs["borders"] as Record<
+                    string,
+                    unknown
+                  >;
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -1864,7 +1864,11 @@ export const TablePluginExtension = createExtension({
 
             // Update target cell
             const attrs = getAttrs(pos, info.node);
-            const existingBorders = attrs["borders"] as Record<string, unknown>;
+            const existingBorders =
+              (attrs["borders"] as
+                | Record<string, unknown>
+                | null
+                | undefined) ?? {};
             setAttrs(pos, {
               ...attrs,
               borders: { ...existingBorders, ...cellBorders },
@@ -1880,10 +1884,11 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders = adjAttrs["borders"] as Record<
-                  string,
-                  unknown
-                >;
+                const adjBorders =
+                  (adjAttrs["borders"] as
+                    | Record<string, unknown>
+                    | null
+                    | undefined) ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, bottom: cellBorders["top"] },
@@ -1899,10 +1904,11 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders = adjAttrs["borders"] as Record<
-                  string,
-                  unknown
-                >;
+                const adjBorders =
+                  (adjAttrs["borders"] as
+                    | Record<string, unknown>
+                    | null
+                    | undefined) ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, top: cellBorders["bottom"] },
@@ -1918,10 +1924,11 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders = adjAttrs["borders"] as Record<
-                  string,
-                  unknown
-                >;
+                const adjBorders =
+                  (adjAttrs["borders"] as
+                    | Record<string, unknown>
+                    | null
+                    | undefined) ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, right: cellBorders["left"] },
@@ -1939,10 +1946,11 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders = adjAttrs["borders"] as Record<
-                  string,
-                  unknown
-                >;
+                const adjBorders =
+                  (adjAttrs["borders"] as
+                    | Record<string, unknown>
+                    | null
+                    | undefined) ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
                   borders: { ...adjBorders, left: cellBorders["right"] },
@@ -2037,7 +2045,11 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders = attrs["borders"] as Record<string, unknown>;
+            const currentBorders =
+              (attrs["borders"] as
+                | Record<string, unknown>
+                | null
+                | undefined) ?? {};
 
             const sides = side === "all" ? allSides : [side];
             // When clearOthers is true, start with all sides cleared (preset behavior)
@@ -2075,10 +2087,11 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders = adjAttrs["borders"] as Record<
-                    string,
-                    unknown
-                  >;
+                  const adjBorders =
+                    (adjAttrs["borders"] as
+                      | Record<string, unknown>
+                      | null
+                      | undefined) ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: syncValue },
@@ -2680,10 +2693,11 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders = attrs["borders"] as Record<
-              string,
-              Record<string, unknown>
-            >;
+            const currentBorders =
+              (attrs["borders"] as
+                | Record<string, Record<string, unknown>>
+                | null
+                | undefined) ?? {};
             const newBorders: Record<string, unknown> = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
@@ -2713,10 +2727,11 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders = adjAttrs["borders"] as Record<
-                    string,
-                    unknown
-                  >;
+                  const adjBorders =
+                    (adjAttrs["borders"] as
+                      | Record<string, unknown>
+                      | null
+                      | undefined) ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },
@@ -2779,10 +2794,11 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders = attrs["borders"] as Record<
-              string,
-              Record<string, unknown>
-            >;
+            const currentBorders =
+              (attrs["borders"] as
+                | Record<string, Record<string, unknown>>
+                | null
+                | undefined) ?? {};
             const newBorders: Record<string, unknown> = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
@@ -2812,10 +2828,11 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders = adjAttrs["borders"] as Record<
-                    string,
-                    unknown
-                  >;
+                  const adjBorders =
+                    (adjAttrs["borders"] as
+                      | Record<string, unknown>
+                      | null
+                      | undefined) ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -346,7 +346,7 @@ const tableRowSpec: NodeSpec = {
     const attrs = node.attrs as TableRowAttrs;
     const domAttrs: Record<string, string> = {};
 
-    if (attrs.height !== undefined) {
+    if (typeof attrs.height === "number") {
       const heightPx = Math.round((attrs.height / 20) * 1.333);
       domAttrs["style"] = `height: ${heightPx}px`;
     }

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -140,16 +140,16 @@ export const TextBoxExtension = createNodeExtension({
       if (attrs.outlineStyle) {
         domAttrs["data-outline-style"] = attrs.outlineStyle;
       }
-      if (attrs.marginTop !== undefined) {
+      if (typeof attrs.marginTop === "number") {
         domAttrs["data-margin-top"] = String(attrs.marginTop);
       }
-      if (attrs.marginBottom !== undefined) {
+      if (typeof attrs.marginBottom === "number") {
         domAttrs["data-margin-bottom"] = String(attrs.marginBottom);
       }
-      if (attrs.marginLeft !== undefined) {
+      if (typeof attrs.marginLeft === "number") {
         domAttrs["data-margin-left"] = String(attrs.marginLeft);
       }
-      if (attrs.marginRight !== undefined) {
+      if (typeof attrs.marginRight === "number") {
         domAttrs["data-margin-right"] = String(attrs.marginRight);
       }
       if (attrs.verticalAlign) {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -140,16 +140,16 @@ export const TextBoxExtension = createNodeExtension({
       if (attrs.outlineStyle) {
         domAttrs["data-outline-style"] = attrs.outlineStyle;
       }
-      if (attrs.marginTop !== null) {
+      if (attrs.marginTop !== undefined) {
         domAttrs["data-margin-top"] = String(attrs.marginTop);
       }
-      if (attrs.marginBottom !== null) {
+      if (attrs.marginBottom !== undefined) {
         domAttrs["data-margin-bottom"] = String(attrs.marginBottom);
       }
-      if (attrs.marginLeft !== null) {
+      if (attrs.marginLeft !== undefined) {
         domAttrs["data-margin-left"] = String(attrs.marginLeft);
       }
-      if (attrs.marginRight !== null) {
+      if (attrs.marginRight !== undefined) {
         domAttrs["data-margin-right"] = String(attrs.marginRight);
       }
       if (attrs.verticalAlign) {

--- a/packages/folio/src/core/prosemirror/plugins/selectionTracker.ts
+++ b/packages/folio/src/core/prosemirror/plugins/selectionTracker.ts
@@ -120,17 +120,14 @@ export function extractSelectionContext(state: EditorState): SelectionContext {
   }
 
   // List detection
-  const numPr = paragraph.attrs?.["numPr"];
+  const numPr = paragraph.attrs["numPr"];
   const inList = !!numPr?.numId;
-  const listType = (() => {
-    if (numPr?.numId === 1) {
-      return "bullet";
-    }
-    if (numPr?.numId) {
-      return "numbered";
-    }
-    return undefined;
-  })();
+  let listType: "bullet" | "numbered" | undefined;
+  if (numPr?.numId === 1) {
+    listType = "bullet";
+  } else if (numPr?.numId) {
+    listType = "numbered";
+  }
   const listLevel = numPr?.ilvl;
 
   // Comment and tracked change detection

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.test.ts
@@ -91,15 +91,15 @@ describe("SuggestionMode Plugin", () => {
       expect(getPluginState(state)?.active).toBe(false);
 
       // Activate
-      let dispatched: EditorState | null = null;
+      const dispatched = { state: null as EditorState | null };
       setSuggestionMode(true, state, (tr) => {
-        dispatched = state.apply(tr);
+        dispatched.state = state.apply(tr);
       });
-      expect(dispatched).not.toBeNull();
-      if (!dispatched) {
+      expect(dispatched.state).not.toBeNull();
+      if (dispatched.state === null) {
         throw new Error("Expected dispatched state");
       }
-      expect(getPluginState(dispatched)?.active).toBe(true);
+      expect(getPluginState(dispatched.state)?.active).toBe(true);
     });
   });
 

--- a/packages/folio/src/core/prosemirror/selectionState.ts
+++ b/packages/folio/src/core/prosemirror/selectionState.ts
@@ -70,7 +70,7 @@ export function extractSelectionState(
   const paragraph = $from.parent;
   const isEmptyParagraph =
     paragraph.type.name === "paragraph" && paragraph.textContent.length === 0;
-  const paragraphDefaultFormatting = paragraph.attrs?.[
+  const paragraphDefaultFormatting = paragraph.attrs[
     "defaultTextFormatting"
   ] as TextFormatting | undefined;
 

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -306,7 +306,7 @@ export class StyleResolver {
       return target;
     }
     if (!target) {
-      return source ? { ...source } : undefined;
+      return { ...source };
     }
 
     const result = { ...target };

--- a/packages/folio/src/core/utils/clipboard.ts
+++ b/packages/folio/src/core/utils/clipboard.ts
@@ -72,19 +72,25 @@ export const CLIPBOARD_TYPES = {
 /**
  * Extract image files from clipboard data (if present).
  */
+type ClipboardDataLike = {
+  files?: FileList | readonly File[] | undefined;
+  items?: DataTransferItemList | readonly DataTransferItem[] | undefined;
+};
+
 export function getClipboardImageFiles(
-  clipboardData: DataTransfer | null,
+  clipboardData: ClipboardDataLike | null,
 ): File[] {
   if (!clipboardData) {
     return [];
   }
 
   const collectFromItems = (): File[] => {
-    if (!clipboardData.items || clipboardData.items.length === 0) {
+    const items = clipboardData.items;
+    if (!items || items.length === 0) {
       return [];
     }
     const files: File[] = [];
-    for (const item of Array.from(clipboardData.items)) {
+    for (const item of Array.from(items)) {
       if (item.kind !== "file") {
         continue;
       }
@@ -100,10 +106,11 @@ export function getClipboardImageFiles(
   };
 
   const collectFromFiles = (): File[] => {
-    if (!clipboardData.files || clipboardData.files.length === 0) {
+    const clipboardFiles = clipboardData.files;
+    if (!clipboardFiles || clipboardFiles.length === 0) {
       return [];
     }
-    return Array.from(clipboardData.files).filter((file) =>
+    return Array.from(clipboardFiles).filter((file) =>
       file.type.startsWith("image/"),
     );
   };
@@ -155,7 +162,7 @@ export function getClipboardImageFiles(
 
   const groups = new Map<string, File[]>();
   for (const file of files) {
-    const rawName = file.name?.trim() ?? "";
+    const rawName = file.name.trim();
     const baseName = rawName
       ? rawName.replace(/\.[^/.]+$/, "").toLowerCase()
       : "";
@@ -254,23 +261,18 @@ export async function writeToClipboard(
 ): Promise<boolean> {
   try {
     // Try to use the modern Clipboard API
-    if (navigator.clipboard && navigator.clipboard.write) {
-      const items = [
-        new ClipboardItem({
-          [CLIPBOARD_TYPES.PLAIN]: new Blob([content.plainText], {
-            type: CLIPBOARD_TYPES.PLAIN,
-          }),
-          [CLIPBOARD_TYPES.HTML]: new Blob([content.html], {
-            type: CLIPBOARD_TYPES.HTML,
-          }),
+    const items = [
+      new ClipboardItem({
+        [CLIPBOARD_TYPES.PLAIN]: new Blob([content.plainText], {
+          type: CLIPBOARD_TYPES.PLAIN,
         }),
-      ];
-      await navigator.clipboard.write(items);
-      return true;
-    }
-
-    // Fallback to execCommand
-    return writeToClipboardFallback(content);
+        [CLIPBOARD_TYPES.HTML]: new Blob([content.html], {
+          type: CLIPBOARD_TYPES.HTML,
+        }),
+      }),
+    ];
+    await navigator.clipboard.write(items);
+    return true;
   } catch {
     // Fallback to execCommand
     return writeToClipboardFallback(content);
@@ -320,13 +322,8 @@ export async function readFromClipboard(
 
   try {
     // Try modern Clipboard API
-    if (navigator.clipboard && navigator.clipboard.read) {
-      const items = await navigator.clipboard.read();
-      return await parseClipboardItems(items, cleanWordFormatting);
-    }
-
-    // Fallback to reading from event
-    return null;
+    const items = await navigator.clipboard.read();
+    return await parseClipboardItems(items, cleanWordFormatting);
   } catch (error) {
     onError?.(error as Error);
     return null;
@@ -746,7 +743,7 @@ function getRunText(run: Run): string {
  * Get plain text from a paragraph
  */
 function getParagraphText(paragraph: Paragraph): string {
-  return (paragraph.content || [])
+  return paragraph.content
     .map((content) => {
       if (content.type === "run") {
         return getRunText(content);
@@ -770,7 +767,7 @@ function paragraphsToHtml(paragraphs: Paragraph[]): string {
   return paragraphs
     .map(
       (p) =>
-        `<p>${runsToHtml(p.content?.filter((c): c is Run => c.type === "run") || [])}</p>`,
+        `<p>${runsToHtml(p.content.filter((c): c is Run => c.type === "run"))}</p>`,
     )
     .join("");
 }

--- a/packages/folio/src/core/utils/replaceText.ts
+++ b/packages/folio/src/core/utils/replaceText.ts
@@ -108,17 +108,12 @@ function getParagraphByIndex(
   paragraphIndex: number,
 ): Paragraph | null {
   let currentIndex = 0;
-  let found: Paragraph | null = null;
 
-  const walkBlocks = (blocks: readonly BlockContent[]): void => {
-    if (found) {
-      return;
-    }
+  const walkBlocks = (blocks: readonly BlockContent[]): Paragraph | null => {
     for (const block of blocks) {
       if (block.type === "paragraph") {
         if (currentIndex === paragraphIndex) {
-          found = block;
-          return;
+          return block;
         }
         currentIndex++;
         continue;
@@ -127,23 +122,24 @@ function getParagraphByIndex(
       if (block.type === "table") {
         for (const row of block.rows) {
           for (const cell of row.cells) {
-            walkBlocks(cell.content);
-            if (found) {
-              return;
+            const found = walkBlocks(cell.content);
+            if (found !== null) {
+              return found;
             }
           }
         }
         continue;
       }
 
-      if (block.type === "blockSdt") {
-        walkBlocks(block.content);
+      const found = walkBlocks(block.content);
+      if (found !== null) {
+        return found;
       }
     }
+    return null;
   };
 
-  walkBlocks(body.content);
-  return found;
+  return walkBlocks(body.content);
 }
 
 function getParagraphText(paragraph: Paragraph): string {

--- a/packages/folio/src/core/utils/textFormattingMerge.ts
+++ b/packages/folio/src/core/utils/textFormattingMerge.ts
@@ -23,7 +23,7 @@ export function mergeTextFormatting(
       continue;
     }
 
-    if (key === "fontFamily" && typeof value === "object" && value !== null) {
+    if (key === "fontFamily" && typeof value === "object") {
       result["fontFamily"] = mergeFontFamily(
         target.fontFamily,
         value as NonNullable<TextFormatting["fontFamily"]>,
@@ -31,12 +31,12 @@ export function mergeTextFormatting(
       continue;
     }
 
-    if (key === "color" && typeof value === "object" && value !== null) {
+    if (key === "color" && typeof value === "object") {
       result["color"] = value as ColorValue;
       continue;
     }
 
-    if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    if (typeof value === "object" && !Array.isArray(value)) {
       result[key] = {
         ...(target[key] as Record<string, unknown> | undefined),
         ...(value as Record<string, unknown>),

--- a/packages/folio/src/hooks/useTableSelection.ts
+++ b/packages/folio/src/hooks/useTableSelection.ts
@@ -215,9 +215,7 @@ export function useTableSelection({
         newDoc = updateTableInDocument(doc, state.tableIndex, newTable);
         onChange?.(newDoc);
 
-        if (newDoc) {
-          handleCellClick(state.tableIndex, newRowIndex, newColumnIndex);
-        }
+        handleCellClick(state.tableIndex, newRowIndex, newColumnIndex);
       }
     },
     [doc, state, onChange, clearSelection, handleCellClick],

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -158,19 +158,13 @@ function createInitialState(
   externalPlugins: Plugin[] = [],
 ): EditorState {
   const activeSchema = manager?.getSchema() ?? schema;
-  const doc = (() => {
-    if (document) {
-      return (() => {
-        if (styles === undefined || styles === null) {
-          return toProseDoc(document);
-        }
-        return toProseDoc(document, {
-          styles,
-        });
-      })();
-    }
-    return createEmptyDoc();
-  })();
+  let doc = createEmptyDoc();
+  if (document) {
+    doc =
+      styles === undefined || styles === null
+        ? toProseDoc(document)
+        : toProseDoc(document, { styles });
+  }
 
   // External plugins go first so they can intercept before extension keymaps
   // (e.g. suggestion mode must handle Backspace/Delete before deleteSelection)
@@ -399,7 +393,7 @@ const HiddenProseMirrorComponent = forwardRef<
       // Use the document's package id or a hash of its structure
       // For simplicity, we compare based on whether it's a different document object
       // and whether it has different metadata
-      const meta = doc.package?.properties;
+      const meta = doc.package.properties;
       return `${meta?.created || ""}-${meta?.modified || ""}-${meta?.title || ""}`;
     };
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -87,10 +87,7 @@ import type {
   TextBoxBlock,
   FootnoteContent,
 } from "../core/layout-engine/types";
-import {
-  DEFAULT_TEXTBOX_MARGINS,
-  DEFAULT_TEXTBOX_WIDTH,
-} from "../core/layout-engine/types";
+import { DEFAULT_TEXTBOX_MARGINS } from "../core/layout-engine/types";
 // Layout painter
 import { LayoutPainter } from "../core/layout-painter";
 import type { BlockLookup } from "../core/layout-painter";
@@ -1025,7 +1022,7 @@ function extractFloatingZones(
         floating.tblpXSpec === "outside"
       ) {
         x = contentWidth - tableWidth;
-      } else if (floating.tblpXSpec === "center") {
+      } else {
         x = (contentWidth - tableWidth) / 2;
       }
     } else if (tableBlock.justification === "center") {
@@ -1103,16 +1100,15 @@ function measureBlock(
       const imageBlock = block as ImageBlock;
       return {
         kind: "image",
-        width: imageBlock.width ?? 100,
-        height: imageBlock.height ?? 100,
+        width: imageBlock.width,
+        height: imageBlock.height,
       };
     }
 
     case "textBox": {
       const tb = block as TextBoxBlock;
       const margins = tb.margins ?? DEFAULT_TEXTBOX_MARGINS;
-      const innerWidth =
-        (tb.width ?? DEFAULT_TEXTBOX_WIDTH) - margins.left - margins.right;
+      const innerWidth = tb.width - margins.left - margins.right;
       const innerMeasures = tb.content.map((p) =>
         measureParagraph(p, innerWidth),
       );
@@ -1124,7 +1120,7 @@ function measureBlock(
         tb.height ?? contentHeight + margins.top + margins.bottom;
       return {
         kind: "textBox" as const,
-        width: tb.width ?? DEFAULT_TEXTBOX_WIDTH,
+        width: tb.width,
         height: totalHeight,
         innerMeasures,
       };
@@ -1272,7 +1268,7 @@ function buildFootnoteRenderItems(
   doc: Document | null,
 ): Map<number, FootnoteRenderItem[]> {
   const result = new Map<number, FootnoteRenderItem[]>();
-  if (!doc?.package?.footnotes) {
+  if (!doc || !doc.package.footnotes) {
     return result;
   }
 
@@ -1624,7 +1620,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           // Step 2.5: Collect footnote references from blocks
           const footnoteRefs = collectFootnoteRefs(newBlocks);
           const hasFootnotes =
-            footnoteRefs.length > 0 && document?.package?.footnotes;
+            footnoteRefs.length > 0 && document?.package.footnotes;
 
           // Step 2.75: Prepare header/footer content for rendering (needed before layout
           // to compute effective margins when header content exceeds available space)
@@ -2103,9 +2099,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
 
             // Create a range at the exact character position
             const ownerDoc = spanEl.ownerDocument;
-            if (!ownerDoc) {
-              continue;
-            }
             const range = ownerDoc.createRange();
             range.setStart(textNode, charIndex);
             range.setEnd(textNode, charIndex);
@@ -2167,10 +2160,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           const paragraph = emptyRun.closest(
             ".layout-paragraph",
           ) as HTMLElement;
-          if (!paragraph) {
-            continue;
-          }
-
           const pmStart = Number(paragraph.dataset["pmStart"]);
           const pmEnd = Number(paragraph.dataset["pmEnd"]);
 
@@ -2348,9 +2337,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                   continue;
                 }
                 const ownerDoc = spanEl.ownerDocument;
-                if (!ownerDoc) {
-                  continue;
-                }
 
                 // Calculate the character range within this span
                 const startChar = Math.max(0, from - pmStart);
@@ -2495,9 +2481,6 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             continue;
           }
           const ownerDoc = spanEl.ownerDocument;
-          if (!ownerDoc) {
-            continue;
-          }
           const startChar = Math.max(0, from - pmStart);
           const endChar = Math.min(textNode.length, to - pmStart);
           if (!(startChar < endChar)) {
@@ -3016,7 +2999,8 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         return false;
       }
 
-      if (!navigator.clipboard) {
+      // eslint-disable-next-line typescript/no-unnecessary-condition -- Clipboard API may be unavailable in older browsers or insecure contexts.
+      if (navigator.clipboard === undefined) {
         return false;
       }
 
@@ -3083,11 +3067,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           if (isInHfArea) {
             e.preventDefault();
             // Place cursor at start of body content
-            if (hiddenPMRef.current) {
-              hiddenPMRef.current.setSelection(0);
-              hiddenPMRef.current.focus();
-              setIsFocused(true);
-            }
+            hiddenPMRef.current.setSelection(0);
+            hiddenPMRef.current.focus();
+            setIsFocused(true);
             return;
           }
         }
@@ -3175,19 +3157,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             for (let d = $pos.depth; d >= 0; d--) {
               const node = $pos.node(d);
               if (node.type.name === "table") {
-                let rowNode: typeof node | null = null;
-                let idx = 0;
-                // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-                node.forEach((child) => {
-                  if (idx === rowIndex) {
-                    rowNode = child;
-                  }
-                  idx++;
-                });
-                if (rowNode) {
-                  const height = (rowNode as typeof node).attrs["height"] as
-                    | number
-                    | null;
+                if (rowIndex < node.childCount) {
+                  const rowNode = node.child(rowIndex);
+                  const height = rowNode.attrs["height"] as number | null;
                   if (height) {
                     resizeRowOrigHeightRef.current = height;
                   } else {
@@ -3868,9 +3840,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             if (bookmarkName && hiddenPMRef.current) {
               const view = hiddenPMRef.current.getView();
               if (view) {
-                let targetPos: number | null = null;
+                const targetPos = { value: null as number | null };
                 view.state.doc.descendants((node, pos) => {
-                  if (targetPos !== null) {
+                  if (targetPos.value !== null) {
                     return false;
                   }
                   if (node.type.name === "paragraph") {
@@ -3878,14 +3850,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                       | { id: number; name: string }[]
                       | undefined;
                     if (bookmarks?.some((b) => b.name === bookmarkName)) {
-                      targetPos = pos;
+                      targetPos.value = pos;
                       return false;
                     }
                   }
                   return undefined;
                 });
-                if (targetPos !== null) {
-                  const tp: number = targetPos;
+                if (targetPos.value !== null) {
+                  const tp = targetPos.value;
                   scrollToPositionImpl(tp);
                   hiddenPMRef.current.setSelection(tp + 1);
                 }
@@ -4181,7 +4153,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               // Fallback to last page if below all pages
               contentEl = Array.from(pages)
                 .at(-1)
-                ?.querySelector(".layout-page-content") as HTMLElement;
+                ?.querySelector(".layout-page-content") as HTMLElement | null;
             }
             if (!contentEl) {
               return;
@@ -4261,9 +4233,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           (e.metaKey || e.ctrlKey) &&
           e.key.toLowerCase() === "c"
         ) {
-          if (copySelectionText()) {
-            e.preventDefault();
-          }
+          copySelectionText();
           return;
         }
 
@@ -4629,7 +4599,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
           onEditorViewReady={handleEditorViewReady}
           onKeyDown={handlePMKeyDown}
           {...(styles !== undefined ? { styles } : {})}
-          {...(externalPlugins !== undefined ? { externalPlugins } : {})}
+          externalPlugins={externalPlugins}
           {...(extensionManager !== undefined ? { extensionManager } : {})}
           {...(onReadOnlyEditAttempt !== undefined
             ? { onReadOnlyEditAttempt }

--- a/packages/folio/src/paged-editor/SelectionOverlay.tsx
+++ b/packages/folio/src/paged-editor/SelectionOverlay.tsx
@@ -218,7 +218,7 @@ export const SelectionOverlay: React.FC<SelectionOverlayProps> = ({
         ))}
 
       {/* Render caret for collapsed selection */}
-      {hasCollapsedSelection && caretPosition && (
+      {hasCollapsedSelection && (
         <Caret
           position={caretPosition}
           color={caretColor}

--- a/packages/folio/src/paged-editor/useVisualLineNavigation.ts
+++ b/packages/folio/src/paged-editor/useVisualLineNavigation.ts
@@ -102,9 +102,6 @@ export function useVisualLineNavigation({
           const textNode = spanEl.firstChild as Text;
           const charIndex = Math.min(pmPos - pmStart, textNode.length);
           const ownerDoc = spanEl.ownerDocument;
-          if (!ownerDoc) {
-            continue;
-          }
           const range = ownerDoc.createRange();
           range.setStart(textNode, charIndex);
           range.setEnd(textNode, charIndex);
@@ -119,7 +116,9 @@ export function useVisualLineNavigation({
       // Check empty paragraphs
       const emptyRuns = findBodyEmptyRuns(pagesContainerRef.current);
       for (const emptyRun of emptyRuns) {
-        const paragraph = emptyRun.closest(".layout-paragraph") as HTMLElement;
+        const paragraph = emptyRun.closest(
+          ".layout-paragraph",
+        ) as HTMLElement | null;
         if (!paragraph) {
           continue;
         }
@@ -168,7 +167,9 @@ export function useVisualLineNavigation({
       // and empty paragraphs where no spans have pm data)
       for (const line of Array.from(allLines)) {
         const lineEl = line as HTMLElement;
-        const paragraph = lineEl.closest(".layout-paragraph") as HTMLElement;
+        const paragraph = lineEl.closest(
+          ".layout-paragraph",
+        ) as HTMLElement | null;
         if (!paragraph) {
           continue;
         }
@@ -197,7 +198,7 @@ export function useVisualLineNavigation({
       const emptyRun = lineEl.querySelector(".layout-empty-run");
       if (emptyRun) {
         const paragraph = lineEl.closest(".layout-paragraph") as HTMLElement;
-        if (paragraph?.dataset["pmStart"]) {
+        if (paragraph.dataset["pmStart"]) {
           return Number(paragraph.dataset["pmStart"]) + 1;
         }
         const emptyRunEl = emptyRun as HTMLElement;
@@ -210,7 +211,7 @@ export function useVisualLineNavigation({
       if (spans.length === 0) {
         // Empty line - return paragraph content start
         const paragraph = lineEl.closest(".layout-paragraph") as HTMLElement;
-        if (paragraph?.dataset["pmStart"]) {
+        if (paragraph.dataset["pmStart"]) {
           return Number(paragraph.dataset["pmStart"]) + 1;
         }
         return null;
@@ -239,9 +240,6 @@ export function useVisualLineNavigation({
 
           const text = textNode as Text;
           const ownerDoc = spanEl.ownerDocument;
-          if (!ownerDoc) {
-            return pmStart;
-          }
 
           // Binary search for the character at clientX
           let lo = 0;

--- a/packages/scripts/src/dev-runner.ts
+++ b/packages/scripts/src/dev-runner.ts
@@ -1161,7 +1161,7 @@ const runStep = (step: Step) => {
 
   if (!result.success) {
     throw new Error(
-      `${step.label} failed with exit code ${String(result.exitCode ?? 1)}.`,
+      `${step.label} failed with exit code ${String(result.exitCode)}.`,
     );
   }
 };

--- a/packages/scripts/src/i18n-typegen.ts
+++ b/packages/scripts/src/i18n-typegen.ts
@@ -63,7 +63,7 @@ const toLiteral = (value: JsonValue, depth: number): string => {
     return JSON.stringify(value);
   }
 
-  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+  if (typeof value === "object" && !Array.isArray(value)) {
     const entries = Object.entries(value);
     if (entries.length === 0) {
       return "Record<string, never>";


### PR DESCRIPTION
## Summary
- enable `typescript/no-unnecessary-condition` as an error
- remove stale nullish and truthiness branches surfaced by the rule
- keep the repo passing under the stricter type-aware lint rule