### PR TITLE
fix(web): unblock inspector chat input behind HelpBar overlay

### DIFF
--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -607,8 +607,8 @@ const HelpBar = ({ docsHref, supportEmail }: HelpBarProps) => {
   const tEmptyScreen = useTranslations("common.emptyScreen");
 
   return (
-    <div className="fixed inset-x-6 bottom-6 z-20 hidden [@media(min-height:820px)]:block">
-      <div className="border-border/80 bg-background/85 text-muted-foreground mx-auto flex max-w-xl items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center text-sm shadow-xs backdrop-blur">
+    <div className="pointer-events-none fixed inset-x-6 bottom-6 z-20 hidden [@media(min-height:820px)]:block">
+      <div className="border-border/80 bg-background/85 text-muted-foreground pointer-events-auto mx-auto flex max-w-xl items-center justify-center gap-2 rounded-xl border px-4 py-3 text-center text-sm shadow-xs backdrop-blur">
         <CircleHelpIcon className="text-primary size-4 shrink-0" />
         <span>
           {tEmptyScreen("needHelp")}{" "}


### PR DESCRIPTION
## Summary
- HelpBar's outer wrapper used `fixed inset-x-6 bottom-6 z-20` and captured pointer events across the entire bottom strip, so clicks on the inspector chat composer fell through and the editor never focused.
- Marked the wrapper `pointer-events-none` and re-enabled `pointer-events-auto` on the visible card so its links remain clickable.

## Test plan
- [ ] Open the inspector chat tab on a page that renders the empty-screen HelpBar (e.g. `/contacts`) at viewport height ≥ 820px and confirm the prompt input focuses on click.
- [ ] Confirm the support email and docs links inside the HelpBar card still work.