### PR TITLE
chore(folio): extract dialog tree into DocxEditorDialogs

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -18,8 +18,6 @@ import {
   useMemo,
   forwardRef,
   useImperativeHandle,
-  lazy,
-  Suspense,
 } from "react";
 import type { CSSProperties } from "react";
 
@@ -177,6 +175,7 @@ import { CommentsSidebar } from "./CommentsSidebar";
 import type { TrackedChangeEntry } from "./CommentsSidebar";
 // Dialog hooks and utilities (static imports — lightweight, no UI)
 import type { FindMatch } from "./dialogs/findReplaceUtils";
+import type { ImagePropertiesData } from "./dialogs/ImagePropertiesDialog";
 import { useFindReplace as useFindReplaceState } from "./dialogs/useFindReplace";
 import type {
   DisplayMode,
@@ -185,6 +184,7 @@ import type {
   EditorMode,
   EditorState,
 } from "./DocxEditor.props";
+import { DocxEditorDialogs } from "./DocxEditorDialogs";
 import {
   DefaultLoadingIndicator,
   DefaultPlaceholder,
@@ -256,37 +256,7 @@ const toast = (msg: string) => {
   }, 3000);
 };
 
-// Dialog components (lazy-loaded — only fetched when first opened)
-const FindReplaceDialog = lazy(() =>
-  import("./dialogs/FindReplaceDialog").then((m) => ({
-    default: m.FindReplaceDialog,
-  })),
-);
-const TablePropertiesDialog = lazy(() =>
-  import("./dialogs/TablePropertiesDialog").then((m) => ({
-    default: m.TablePropertiesDialog,
-  })),
-);
-const ImagePositionDialog = lazy(() =>
-  import("./dialogs/ImagePositionDialog").then((m) => ({
-    default: m.ImagePositionDialog,
-  })),
-);
-const ImagePropertiesDialog = lazy(() =>
-  import("./dialogs/ImagePropertiesDialog").then((m) => ({
-    default: m.ImagePropertiesDialog,
-  })),
-);
-const FootnotePropertiesDialog = lazy(() =>
-  import("./dialogs/FootnotePropertiesDialog").then((m) => ({
-    default: m.FootnotePropertiesDialog,
-  })),
-);
-const PageSetupDialog = lazy(() =>
-  import("./dialogs/PageSetupDialog").then((m) => ({
-    default: m.PageSetupDialog,
-  })),
-);
+// Dialog tree (lazy-loaded internally) lives in ./DocxEditorDialogs.
 
 // ============================================================================
 // TYPES — see ./DocxEditor.props for the type definitions. Public types are
@@ -310,6 +280,28 @@ const EMPTY_ANCHOR_POSITIONS = new Map<string, number>();
 function getCommentAuthorKey(author?: string): string {
   const trimmed = author?.trim();
   return trimmed && trimmed.length > 0 ? trimmed : "Unknown";
+}
+
+function buildImagePropertiesData(
+  ctx: EditorState["pmImageContext"],
+): ImagePropertiesData | undefined {
+  if (!ctx) {
+    return undefined;
+  }
+  const data: ImagePropertiesData = {};
+  if (ctx.alt != null) {
+    data.alt = ctx.alt;
+  }
+  if (ctx.borderWidth != null) {
+    data.borderWidth = ctx.borderWidth;
+  }
+  if (ctx.borderColor != null) {
+    data.borderColor = ctx.borderColor;
+  }
+  if (ctx.borderStyle != null) {
+    data.borderStyle = ctx.borderStyle;
+  }
+  return data;
 }
 
 /**
@@ -3351,6 +3343,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       </>
     );
 
+    const imagePropertiesCurrentData = buildImagePropertiesData(
+      state.pmImageContext,
+    );
+
     return (
       <ErrorProvider>
         <ErrorBoundary onError={handleEditorError}>
@@ -3887,113 +3883,60 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
             {/* Toast notifications */}
             {/* Toast notifications provided by host app */}
 
-            {/* Lazy-loaded dialogs — only fetched when first opened */}
-            <Suspense fallback={null}>
-              {findReplace.state.dialog.status === "open" && (
-                <FindReplaceDialog
-                  isOpen={true}
-                  onClose={findReplace.close}
-                  onFind={handleFind}
-                  onFindNext={handleFindNext}
-                  onFindPrevious={handleFindPrevious}
-                  onReplace={handleReplace}
-                  onReplaceAll={handleReplaceAll}
-                  initialSearchText={findReplace.state.searchText}
-                  currentResult={findResultRef.current}
-                />
-              )}
-              {tablePropsOpen && (
-                <TablePropertiesDialog
-                  isOpen={tablePropsOpen}
-                  onClose={() => setTablePropsOpen(false)}
-                  onApply={(props) => {
-                    const view = getActiveEditorView();
-                    if (view) {
-                      setTableProperties(props)(view.state, view.dispatch);
-                    }
-                  }}
-                  {...(state.pmTableContext?.table?.attrs
-                    ? {
-                        currentProps: state.pmTableContext.table
-                          .attrs as Record<string, unknown>,
-                      }
-                    : {})}
-                />
-              )}
-              {imagePositionOpen && (
-                <ImagePositionDialog
-                  isOpen={imagePositionOpen}
-                  onClose={() => setImagePositionOpen(false)}
-                  onApply={handleApplyImagePosition}
-                />
-              )}
-              {imagePropsOpen && (
-                <ImagePropertiesDialog
-                  isOpen={imagePropsOpen}
-                  onClose={() => setImagePropsOpen(false)}
-                  onApply={handleApplyImageProperties}
-                  {...(state.pmImageContext
-                    ? {
-                        currentData: (() => {
-                          const data: Record<string, string | number> = {};
-                          if (state.pmImageContext.alt != null) {
-                            data["alt"] = state.pmImageContext.alt;
-                          }
-                          if (state.pmImageContext.borderWidth != null) {
-                            data["borderWidth"] =
-                              state.pmImageContext.borderWidth;
-                          }
-                          if (state.pmImageContext.borderColor != null) {
-                            data["borderColor"] =
-                              state.pmImageContext.borderColor;
-                          }
-                          if (state.pmImageContext.borderStyle != null) {
-                            data["borderStyle"] =
-                              state.pmImageContext.borderStyle;
-                          }
-                          return data as import("./dialogs/ImagePropertiesDialog").ImagePropertiesData;
-                        })(),
-                      }
-                    : {})}
-                />
-              )}
-              {showPageSetup && (
-                <PageSetupDialog
-                  isOpen={showPageSetup}
-                  onClose={() => setShowPageSetup(false)}
-                  onApply={handlePageSetupApply}
-                  {...(history.state.package.document.finalSectionProperties
-                    ? {
-                        currentProps:
-                          history.state.package.document.finalSectionProperties,
-                      }
-                    : {})}
-                />
-              )}
-              {footnotePropsOpen && (
-                <FootnotePropertiesDialog
-                  isOpen={footnotePropsOpen}
-                  onClose={() => setFootnotePropsOpen(false)}
-                  onApply={handleApplyFootnoteProperties}
-                  {...(history.state.package.document.finalSectionProperties
-                    ?.footnotePr
-                    ? {
-                        footnotePr:
-                          history.state.package.document.finalSectionProperties
-                            .footnotePr,
-                      }
-                    : {})}
-                  {...(history.state.package.document.finalSectionProperties
-                    ?.endnotePr
-                    ? {
-                        endnotePr:
-                          history.state.package.document.finalSectionProperties
-                            .endnotePr,
-                      }
-                    : {})}
-                />
-              )}
-            </Suspense>
+            <DocxEditorDialogs
+              findReplace={{
+                state: findReplace.state,
+                onClose: findReplace.close,
+                onFind: handleFind,
+                onFindNext: handleFindNext,
+                onFindPrevious: handleFindPrevious,
+                onReplace: handleReplace,
+                onReplaceAll: handleReplaceAll,
+                currentResult: findResultRef.current,
+              }}
+              tableProperties={{
+                isOpen: tablePropsOpen,
+                onClose: () => setTablePropsOpen(false),
+                onApply: (props) => {
+                  const view = getActiveEditorView();
+                  if (view) {
+                    setTableProperties(props)(view.state, view.dispatch);
+                  }
+                },
+                currentProps: state.pmTableContext?.table?.attrs as
+                  | Record<string, unknown>
+                  | undefined,
+              }}
+              imagePosition={{
+                isOpen: imagePositionOpen,
+                onClose: () => setImagePositionOpen(false),
+                onApply: handleApplyImagePosition,
+              }}
+              imageProperties={{
+                isOpen: imagePropsOpen,
+                onClose: () => setImagePropsOpen(false),
+                onApply: handleApplyImageProperties,
+                currentData: imagePropertiesCurrentData,
+              }}
+              pageSetup={{
+                isOpen: showPageSetup,
+                onClose: () => setShowPageSetup(false),
+                onApply: handlePageSetupApply,
+                currentProps:
+                  history.state.package.document.finalSectionProperties,
+              }}
+              footnoteProperties={{
+                isOpen: footnotePropsOpen,
+                onClose: () => setFootnotePropsOpen(false),
+                onApply: handleApplyFootnoteProperties,
+                footnotePr:
+                  history.state.package.document.finalSectionProperties
+                    ?.footnotePr,
+                endnotePr:
+                  history.state.package.document.finalSectionProperties
+                    ?.endnotePr,
+              }}
+            />
             {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
             {/* Hidden file input for image insertion */}
             <input

--- a/packages/folio/src/components/DocxEditorDialogs.tsx
+++ b/packages/folio/src/components/DocxEditorDialogs.tsx
@@ -1,0 +1,186 @@
+import { Suspense, lazy } from "react";
+
+import type {
+  EndnoteProperties,
+  FootnoteProperties,
+  SectionProperties,
+} from "../core/types/document";
+import type {
+  FindMatch,
+  FindOptions,
+  FindResult,
+} from "./dialogs/findReplaceUtils";
+import type { ImagePositionData } from "./dialogs/ImagePositionDialog";
+import type { ImagePropertiesData } from "./dialogs/ImagePropertiesDialog";
+import type { TableProperties } from "./dialogs/TablePropertiesDialog";
+import type { UseFindReplaceReturn } from "./dialogs/useFindReplace";
+
+const FindReplaceDialog = lazy(() =>
+  import("./dialogs/FindReplaceDialog").then((m) => ({
+    default: m.FindReplaceDialog,
+  })),
+);
+const TablePropertiesDialog = lazy(() =>
+  import("./dialogs/TablePropertiesDialog").then((m) => ({
+    default: m.TablePropertiesDialog,
+  })),
+);
+const ImagePositionDialog = lazy(() =>
+  import("./dialogs/ImagePositionDialog").then((m) => ({
+    default: m.ImagePositionDialog,
+  })),
+);
+const ImagePropertiesDialog = lazy(() =>
+  import("./dialogs/ImagePropertiesDialog").then((m) => ({
+    default: m.ImagePropertiesDialog,
+  })),
+);
+const FootnotePropertiesDialog = lazy(() =>
+  import("./dialogs/FootnotePropertiesDialog").then((m) => ({
+    default: m.FootnotePropertiesDialog,
+  })),
+);
+const PageSetupDialog = lazy(() =>
+  import("./dialogs/PageSetupDialog").then((m) => ({
+    default: m.PageSetupDialog,
+  })),
+);
+
+export type FindReplaceMount = {
+  state: UseFindReplaceReturn["state"];
+  onClose: () => void;
+  onFind: (searchText: string, options: FindOptions) => FindResult | null;
+  onFindNext: () => FindMatch | null;
+  onFindPrevious: () => FindMatch | null;
+  onReplace: (replaceText: string) => boolean;
+  onReplaceAll: (
+    searchText: string,
+    replaceText: string,
+    options: FindOptions,
+  ) => number;
+  currentResult: FindResult | null;
+};
+
+export type TablePropertiesMount = {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: (props: TableProperties) => void;
+  currentProps: Record<string, unknown> | undefined;
+};
+
+export type ImagePositionMount = {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: (data: ImagePositionData) => void;
+};
+
+export type ImagePropertiesMount = {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: (data: ImagePropertiesData) => void;
+  currentData: ImagePropertiesData | undefined;
+};
+
+export type PageSetupMount = {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: (props: Partial<SectionProperties>) => void;
+  currentProps: SectionProperties | undefined;
+};
+
+export type FootnotePropertiesMount = {
+  isOpen: boolean;
+  onClose: () => void;
+  onApply: (
+    footnotePr: FootnoteProperties,
+    endnotePr: EndnoteProperties,
+  ) => void;
+  footnotePr: FootnoteProperties | undefined;
+  endnotePr: EndnoteProperties | undefined;
+};
+
+export type DocxEditorDialogsProps = {
+  findReplace: FindReplaceMount;
+  tableProperties: TablePropertiesMount;
+  imagePosition: ImagePositionMount;
+  imageProperties: ImagePropertiesMount;
+  pageSetup: PageSetupMount;
+  footnoteProperties: FootnotePropertiesMount;
+};
+
+export function DocxEditorDialogs({
+  findReplace,
+  tableProperties,
+  imagePosition,
+  imageProperties,
+  pageSetup,
+  footnoteProperties,
+}: DocxEditorDialogsProps) {
+  return (
+    <Suspense fallback={null}>
+      {findReplace.state.dialog.status === "open" && (
+        <FindReplaceDialog
+          isOpen={true}
+          onClose={findReplace.onClose}
+          onFind={findReplace.onFind}
+          onFindNext={findReplace.onFindNext}
+          onFindPrevious={findReplace.onFindPrevious}
+          onReplace={findReplace.onReplace}
+          onReplaceAll={findReplace.onReplaceAll}
+          initialSearchText={findReplace.state.searchText}
+          currentResult={findReplace.currentResult}
+        />
+      )}
+      {tableProperties.isOpen && (
+        <TablePropertiesDialog
+          isOpen={tableProperties.isOpen}
+          onClose={tableProperties.onClose}
+          onApply={tableProperties.onApply}
+          {...(tableProperties.currentProps
+            ? { currentProps: tableProperties.currentProps }
+            : {})}
+        />
+      )}
+      {imagePosition.isOpen && (
+        <ImagePositionDialog
+          isOpen={imagePosition.isOpen}
+          onClose={imagePosition.onClose}
+          onApply={imagePosition.onApply}
+        />
+      )}
+      {imageProperties.isOpen && (
+        <ImagePropertiesDialog
+          isOpen={imageProperties.isOpen}
+          onClose={imageProperties.onClose}
+          onApply={imageProperties.onApply}
+          {...(imageProperties.currentData
+            ? { currentData: imageProperties.currentData }
+            : {})}
+        />
+      )}
+      {pageSetup.isOpen && (
+        <PageSetupDialog
+          isOpen={pageSetup.isOpen}
+          onClose={pageSetup.onClose}
+          onApply={pageSetup.onApply}
+          {...(pageSetup.currentProps
+            ? { currentProps: pageSetup.currentProps }
+            : {})}
+        />
+      )}
+      {footnoteProperties.isOpen && (
+        <FootnotePropertiesDialog
+          isOpen={footnoteProperties.isOpen}
+          onClose={footnoteProperties.onClose}
+          onApply={footnoteProperties.onApply}
+          {...(footnoteProperties.footnotePr
+            ? { footnotePr: footnoteProperties.footnotePr }
+            : {})}
+          {...(footnoteProperties.endnotePr
+            ? { endnotePr: footnoteProperties.endnotePr }
+            : {})}
+        />
+      )}
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- Move the six `React.lazy()` dialog imports and the ~110-line dialog render block from `DocxEditor.tsx` into a new `DocxEditorDialogs.tsx`. Editor body shrinks by ~140 lines (still 4,196 — many more PRs to go).
- The new component accepts one `Mount` object per dialog mirroring that dialog's own prop shape. State and apply handlers continue to live in `DocxEditor.tsx` and get passed down; no new state model.
- Promote inline `import("./dialogs/ImagePropertiesDialog").ImagePropertiesData` cast to a real import; pull the IIFE that built `currentData` for the image properties dialog into a `buildImagePropertiesData` helper.

Stacks on the `DocxEditor.tsx` decomposition work; depends on no prior PR.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (635 pass)
- [x] `bun --filter @stll/folio format`