### PR TITLE
chore(folio): extract context-menu state into a hook

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -90,7 +90,6 @@ import {
   createStyleResolver,
   setRtl,
   setLtr,
-  isInTable,
   getTableContext,
   addRowAbove,
   addRowBelow,
@@ -193,6 +192,7 @@ import {
 import { ErrorBoundary, ErrorProvider } from "./ErrorBoundary";
 import { FormattingBar } from "./FormattingBar";
 import { resolveFindMatchRange } from "./hooks/findReplaceSelection";
+import { useContextMenu } from "./hooks/useContextMenu";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 import { useDocumentLoader } from "./hooks/useDocumentLoader";
 import { useFindReplace } from "./hooks/useFindReplace";
@@ -548,23 +548,6 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       to: number;
     } | null>(null);
 
-    // Right-click context menu state
-    const [contextMenu, setContextMenu] = useState<{
-      isOpen: boolean;
-      position: { x: number; y: number };
-      hasSelection: boolean;
-      selectionRange: { from: number; to: number };
-      cursorInTable: boolean;
-      cursorInTrackedChange: boolean;
-    }>({
-      isOpen: false,
-      position: { x: 0, y: 0 },
-      hasSelection: false,
-      selectionRange: { from: 0, to: 0 },
-      cursorInTable: false,
-      cursorInTrackedChange: false,
-    });
-
     // Debounce timer for extractTrackedChanges (avoid full doc walk on every keystroke)
     const extractTrackedChangesTimerRef = useRef<ReturnType<
       typeof setTimeout
@@ -840,6 +823,12 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     const imageInputRef = useRef<HTMLInputElement>(null);
     const editorContentRef = useRef<HTMLDivElement>(null);
     const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+    const {
+      contextMenu,
+      openMenu: openContextMenu,
+      closeMenu: closeContextMenu,
+    } = useContextMenu({ pagedEditorRef });
     const toolbarWrapperRef = useRef<HTMLDivElement>(null);
     const toolbarRoRef = useRef<ResizeObserver | null>(null);
     const [_toolbarHeight, setToolbarHeight] = useState(0);
@@ -1984,46 +1973,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     );
 
     // Context menu handler
-    const handleEditorContextMenu = useCallback((e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      const view = pagedEditorRef.current?.getView();
-      const inTable = view ? isInTable(view.state) : false;
-      const { from, to } = view?.state.selection ?? { from: 0, to: 0 };
-      const hasSel = from !== to;
-      // Check if cursor is on a tracked change mark
-      let inTrackedChange = false;
-      if (view) {
-        const $pos = view.state.doc.resolve(from);
-        const node = $pos.parent;
-        if (node.isTextblock) {
-          // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-          node.forEach((child, offset) => {
-            const childStart = $pos.start() + offset;
-            const childEnd = childStart + child.nodeSize;
-            if (
-              from >= childStart &&
-              from <= childEnd &&
-              child.isText &&
-              child.marks.some(
-                (m) =>
-                  m.type.name === "insertion" || m.type.name === "deletion",
-              )
-            ) {
-              inTrackedChange = true;
-            }
-          });
-        }
-      }
-      setContextMenu({
-        isOpen: true,
-        position: { x: e.clientX, y: e.clientY },
-        hasSelection: hasSel,
-        selectionRange: { from, to },
-        cursorInTable: inTable,
-        cursorInTrackedChange: inTrackedChange,
-      });
-    }, []);
+    const handleEditorContextMenu = useCallback(
+      (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        openContextMenu({ x: e.clientX, y: e.clientY });
+      },
+      [openContextMenu],
+    );
 
     // Handle formatting action from toolbar
     const handleFormat = useCallback(
@@ -2209,57 +2166,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       [getActiveEditorView],
     );
 
-    // Right-click context menu handlers
     const handleContextMenu = useCallback(
       (data: { x: number; y: number; hasSelection: boolean }) => {
-        const view = pagedEditorRef.current?.getView();
-        const inTable = view ? isInTable(view.state) : false;
-        let inChange = false;
-        if (view) {
-          const { from } = view.state.selection;
-          const $pos = view.state.doc.resolve(from);
-          const node = $pos.parent;
-          if (node.isTextblock) {
-            // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-            node.forEach((child, offset) => {
-              const s = $pos.start() + offset;
-              if (
-                from >= s &&
-                from <= s + child.nodeSize &&
-                child.isText &&
-                child.marks.some(
-                  (m) =>
-                    m.type.name === "insertion" || m.type.name === "deletion",
-                )
-              ) {
-                inChange = true;
-              }
-            });
-          }
-        }
-        const sel = view?.state.selection ?? { from: 0, to: 0 };
-        setContextMenu({
-          isOpen: true,
-          position: data,
-          hasSelection: data.hasSelection,
-          selectionRange: { from: sel.from, to: sel.to },
-          cursorInTable: inTable,
-          cursorInTrackedChange: inChange,
-        });
+        openContextMenu({ x: data.x, y: data.y }, data.hasSelection);
       },
-      [],
+      [openContextMenu],
     );
 
-    const handleContextMenuClose = useCallback(() => {
-      setContextMenu({
-        isOpen: false,
-        position: { x: 0, y: 0 },
-        hasSelection: false,
-        selectionRange: { from: 0, to: 0 },
-        cursorInTable: false,
-        cursorInTrackedChange: false,
-      });
-    }, []);
+    const handleContextMenuClose = closeContextMenu;
 
     const contextMenuItems = useMemo((): TextContextMenuItem[] => {
       const isMac =

--- a/packages/folio/src/components/hooks/useContextMenu.ts
+++ b/packages/folio/src/components/hooks/useContextMenu.ts
@@ -1,0 +1,113 @@
+import { useCallback, useState } from "react";
+import type { RefObject } from "react";
+
+import type { EditorView } from "prosemirror-view";
+
+import { isInTable } from "../../core/prosemirror";
+import type { PagedEditorRef } from "../../paged-editor/PagedEditor";
+
+export type ContextMenuAnchor = { x: number; y: number };
+
+export type ContextMenuState = {
+  isOpen: boolean;
+  position: ContextMenuAnchor;
+  hasSelection: boolean;
+  selectionRange: { from: number; to: number };
+  cursorInTable: boolean;
+  cursorInTrackedChange: boolean;
+};
+
+const CLOSED_STATE: ContextMenuState = {
+  isOpen: false,
+  position: { x: 0, y: 0 },
+  hasSelection: false,
+  selectionRange: { from: 0, to: 0 },
+  cursorInTable: false,
+  cursorInTrackedChange: false,
+};
+
+/**
+ * True when the cursor sits on a text node carrying an `insertion` or
+ * `deletion` mark — i.e., inside a tracked-change region. Used to decide
+ * whether to surface accept/reject items in the context menu.
+ */
+function isCursorOnTrackedChange(view: EditorView): boolean {
+  const { from } = view.state.selection;
+  const $pos = view.state.doc.resolve(from);
+  const node = $pos.parent;
+  if (!node.isTextblock) {
+    return false;
+  }
+  let onTrackedChange = false;
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child, offset) => {
+    const start = $pos.start() + offset;
+    const end = start + child.nodeSize;
+    if (
+      from >= start &&
+      from <= end &&
+      child.isText &&
+      child.marks.some(
+        (m) => m.type.name === "insertion" || m.type.name === "deletion",
+      )
+    ) {
+      onTrackedChange = true;
+    }
+  });
+  return onTrackedChange;
+}
+
+export type UseContextMenuArgs = {
+  pagedEditorRef: RefObject<PagedEditorRef | null>;
+};
+
+export type UseContextMenuReturn = {
+  contextMenu: ContextMenuState;
+  /**
+   * Open the menu at `anchor`. Reads the live PM selection from
+   * `pagedEditorRef` to decide whether to enable selection-only,
+   * table-only, and tracked-change-only menu items.
+   *
+   * `hasSelectionOverride` is for the PagedEditor child callback path,
+   * which already knows from a layout-overlay selection whether the user
+   * has highlighted text; when omitted we derive it from the PM selection.
+   */
+  openMenu: (anchor: ContextMenuAnchor, hasSelectionOverride?: boolean) => void;
+  closeMenu: () => void;
+};
+
+export function useContextMenu({
+  pagedEditorRef,
+}: UseContextMenuArgs): UseContextMenuReturn {
+  const [contextMenu, setContextMenu] =
+    useState<ContextMenuState>(CLOSED_STATE);
+
+  const openMenu = useCallback(
+    (anchor: ContextMenuAnchor, hasSelectionOverride?: boolean) => {
+      const view = pagedEditorRef.current?.getView();
+      const selection = view?.state.selection ?? { from: 0, to: 0 };
+      const hasSelection =
+        hasSelectionOverride ?? selection.from !== selection.to;
+      const cursorInTable = view ? isInTable(view.state) : false;
+      const cursorInTrackedChange = view
+        ? isCursorOnTrackedChange(view)
+        : false;
+
+      setContextMenu({
+        isOpen: true,
+        position: anchor,
+        hasSelection,
+        selectionRange: { from: selection.from, to: selection.to },
+        cursorInTable,
+        cursorInTrackedChange,
+      });
+    },
+    [pagedEditorRef],
+  );
+
+  const closeMenu = useCallback(() => {
+    setContextMenu(CLOSED_STATE);
+  }, []);
+
+  return { contextMenu, openMenu, closeMenu };
+}


### PR DESCRIPTION
## Summary
- Move right-click menu state and its two open/close paths out of `DocxEditor.tsx` into `hooks/useContextMenu.ts`. The native `oncontextmenu` handler and the PagedEditor child callback now both call a single `openMenu(anchor, hasSelectionOverride?)`.
- Extract the "is the cursor on a tracked-change mark?" walk into a single `isCursorOnTrackedChange` helper inside the hook (previously duplicated across both handlers).
- The items computation and the action dispatcher stay in `DocxEditor.tsx` — they pull in too much surrounding state (comments, clipboard, format, i18n) to extract usefully in this PR.

No behavior change.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (635 pass)
- [x] `bun --filter @stll/folio format`