### PR TITLE
chore(folio): extract editor-mode/display-mode state into a hook

### DIFF
--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -15,17 +15,10 @@ import type { Document, Theme, TabStop } from "../core/types/document";
 import type { DocxInput } from "../core/utils/docxInput";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
+// `EditorMode` is owned by `./hooks/useEditorMode`. Re-imported here for use
+// in `DocxEditorProps`; the canonical export is from the hook module.
+import type { EditorMode } from "./hooks/useEditorMode";
 import type { SelectionFormatting } from "./Toolbar";
-
-/** Editor mode. Public; mirrors Google Docs editing/suggesting/viewing semantics. */
-export type EditorMode = "editing" | "suggesting" | "viewing";
-
-/** How tracked changes render. Internal — drives the display mode dropdown. */
-export type DisplayMode =
-  | "all-markup"
-  | "simple-markup"
-  | "no-markup"
-  | "original";
 
 /** Image context surfaced to the toolbar when the cursor is on an image node. */
 export type ImageContextInfo = {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -182,10 +182,8 @@ import type { FindMatch } from "./dialogs/findReplaceUtils";
 import type { ImagePropertiesData } from "./dialogs/ImagePropertiesDialog";
 import { useFindReplace as useFindReplaceState } from "./dialogs/useFindReplace";
 import type {
-  DisplayMode,
   DocxEditorProps,
   DocxEditorRef,
-  EditorMode,
   EditorState,
 } from "./DocxEditor.props";
 import { DocxEditorDialogs } from "./DocxEditorDialogs";
@@ -200,6 +198,8 @@ import { resolveFindMatchRange } from "./hooks/findReplaceSelection";
 import { useContextMenu } from "./hooks/useContextMenu";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
 import { useDocumentLoader } from "./hooks/useDocumentLoader";
+import type { DisplayMode } from "./hooks/useEditorMode";
+import { useEditorMode } from "./hooks/useEditorMode";
 import { useFindReplace } from "./hooks/useFindReplace";
 import { useHeaderFooterEditor } from "./hooks/useHeaderFooterEditor";
 import { useHyperlinkHandlers } from "./hooks/useHyperlinkHandlers";
@@ -260,15 +260,11 @@ const toast = (msg: string) => {
 // Dialog tree (lazy-loaded internally) lives in ./DocxEditorDialogs.
 
 // ============================================================================
-// TYPES — see ./DocxEditor.props for the type definitions. Public types are
-// re-exported here so callers can keep importing from this module path.
+// TYPES — `DocxEditorProps` / `DocxEditorRef` live in `./DocxEditor.props`,
+// `EditorMode` / `DisplayMode` in `./hooks/useEditorMode`. The package barrel
+// (`src/index.ts`) imports them from those canonical homes directly; no
+// re-export shim here.
 // ============================================================================
-
-export type {
-  DocxEditorProps,
-  DocxEditorRef,
-  EditorMode,
-} from "./DocxEditor.props";
 
 // ============================================================================
 // MAIN COMPONENT
@@ -395,29 +391,18 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
     const [addCommentYPosition, setAddCommentYPosition] = useState<
       number | null
     >(null);
-    const [editingModeInternal, setEditingModeInternal] = useState<EditorMode>(
-      modeProp ?? "editing",
-    );
-    const editingMode = modeProp ?? editingModeInternal;
-    const setEditingMode = useCallback(
-      (mode: EditorMode) => {
-        if (!modeProp) {
-          setEditingModeInternal(mode);
-        }
-        onModeChange?.(mode);
-      },
-      [modeProp, onModeChange],
-    );
-    // 'viewing' mode acts as read-only
-    const readOnly = readOnlyProp || editingMode === "viewing";
-
-    // Track Changes display mode
-    const [displayMode, setDisplayMode] = useState<DisplayMode>("all-markup");
-    const trackChangesOn = editingMode === "suggesting";
-
-    const toggleTrackChanges = useCallback(() => {
-      setEditingMode(trackChangesOn ? "editing" : "suggesting");
-    }, [setEditingMode, trackChangesOn]);
+    const {
+      editingMode,
+      readOnly,
+      trackChangesOn,
+      toggleTrackChanges,
+      displayMode,
+      setDisplayMode,
+    } = useEditorMode({
+      modeProp,
+      onModeChange,
+      readOnlyProp,
+    });
 
     // Floating "add comment" button position (relative to scroll container, null = hidden)
     const [floatingCommentBtn, setFloatingCommentBtn] = useState<{

--- a/packages/folio/src/components/hooks/useEditorMode.ts
+++ b/packages/folio/src/components/hooks/useEditorMode.ts
@@ -1,0 +1,91 @@
+import { useCallback, useState } from "react";
+
+/** Editor mode. Mirrors Google Docs editing/suggesting/viewing semantics. */
+export type EditorMode = "editing" | "suggesting" | "viewing";
+
+/** How tracked changes render. Drives the display mode dropdown. */
+export const DISPLAY_MODES = [
+  "all-markup",
+  "simple-markup",
+  "no-markup",
+  "original",
+] as const;
+
+export type DisplayMode = (typeof DISPLAY_MODES)[number];
+
+export type UseEditorModeArgs = {
+  /** Controlled mode prop, or undefined when uncontrolled. */
+  modeProp: EditorMode | undefined;
+  /** Notified whenever the mode changes (controlled and uncontrolled paths). */
+  onModeChange: ((mode: EditorMode) => void) | undefined;
+  /** External read-only flag from the host. */
+  readOnlyProp: boolean;
+};
+
+export type UseEditorModeReturn = {
+  /** Effective editing mode (controlled `modeProp` wins over the internal value). */
+  editingMode: EditorMode;
+  /** Change mode. No-op for the internal state when the host controls it via `modeProp`. */
+  setEditingMode: (mode: EditorMode) => void;
+  /** True when the host opts into read-only OR the mode is `"viewing"`. */
+  readOnly: boolean;
+  /** True when the mode is `"suggesting"`. */
+  trackChangesOn: boolean;
+  /** Toggle between `"editing"` and `"suggesting"`. */
+  toggleTrackChanges: () => void;
+  /** Display mode for the tracked-changes overlay (`all-markup` by default). */
+  displayMode: DisplayMode;
+  setDisplayMode: (mode: DisplayMode) => void;
+};
+
+/**
+ * Editor-mode and display-mode state for the DocxEditor.
+ *
+ * `editingMode` mirrors Google Docs:
+ *  - `"editing"`     → direct edits (default)
+ *  - `"suggesting"`  → tracked-change edits
+ *  - `"viewing"`     → behaves as read-only
+ *
+ * `displayMode` is independent: it controls how tracked-changes render
+ * (`all-markup`, `simple-markup`, `no-markup`, `original`). Switching the
+ * editing mode does not switch the display mode.
+ */
+export function useEditorMode({
+  modeProp,
+  onModeChange,
+  readOnlyProp,
+}: UseEditorModeArgs): UseEditorModeReturn {
+  const [editingModeInternal, setEditingModeInternal] = useState<EditorMode>(
+    modeProp ?? "editing",
+  );
+  const editingMode = modeProp ?? editingModeInternal;
+
+  const setEditingMode = useCallback(
+    (mode: EditorMode) => {
+      if (!modeProp) {
+        setEditingModeInternal(mode);
+      }
+      onModeChange?.(mode);
+    },
+    [modeProp, onModeChange],
+  );
+
+  const readOnly = readOnlyProp || editingMode === "viewing";
+  const trackChangesOn = editingMode === "suggesting";
+
+  const toggleTrackChanges = useCallback(() => {
+    setEditingMode(trackChangesOn ? "editing" : "suggesting");
+  }, [setEditingMode, trackChangesOn]);
+
+  const [displayMode, setDisplayMode] = useState<DisplayMode>("all-markup");
+
+  return {
+    editingMode,
+    setEditingMode,
+    readOnly,
+    trackChangesOn,
+    toggleTrackChanges,
+    displayMode,
+    setDisplayMode,
+  };
+}

--- a/packages/folio/src/index.ts
+++ b/packages/folio/src/index.ts
@@ -1,9 +1,9 @@
-export {
-  DocxEditor,
-  type DocxEditorProps,
-  type DocxEditorRef,
-  type EditorMode,
-} from "./components/DocxEditor";
+export { DocxEditor } from "./components/DocxEditor";
+export type {
+  DocxEditorProps,
+  DocxEditorRef,
+} from "./components/DocxEditor.props";
+export type { EditorMode } from "./components/hooks/useEditorMode";
 export {
   FormattingBar,
   type FormattingBarProps,


### PR DESCRIPTION
## Summary
- Move editor-mode (`editing` | `suggesting` | `viewing`) and tracked-changes display-mode (`all-markup` | `simple-markup` | `no-markup` | `original`) state into a new `useEditorMode` hook.
- The hook accepts `modeProp` (controlled), `onModeChange`, and `readOnlyProp`; it returns `editingMode`, `readOnly`, `trackChangesOn`, `toggleTrackChanges`, `displayMode`, and `setDisplayMode`.
- `DisplayMode` now lives with the hook and is re-imported into `DocxEditor.tsx`. `EditorMode` keeps its existing public home.

No behavior change.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (635 pass)
- [x] `bun --filter @stll/folio format`