### PR TITLE
chore(folio): extract image + tracked-change detection into pure helpers

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -210,6 +210,10 @@ import { useZoomAndPageInfo } from "./hooks/useZoomAndPageInfo";
 import { InlineHeaderFooterEditor } from "./InlineHeaderFooterEditor";
 import type { InlineHeaderFooterEditorRef } from "./InlineHeaderFooterEditor";
 import { updateScrollPageTotal } from "./scrollPageInfo";
+import {
+  detectActiveTrackedChange,
+  detectImageContext,
+} from "./selectionDetection";
 import { TextContextMenu } from "./TextContextMenu";
 import type { TextContextAction, TextContextMenuItem } from "./TextContextMenu";
 import { ToolbarButton, ToolbarSeparator } from "./Toolbar";
@@ -1180,73 +1184,13 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           };
         }
 
-        // Check if cursor is on an image (NodeSelection)
-        let pmImageCtx: typeof state.pmImageContext = null;
-        if (view) {
-          const sel = view.state.selection;
-          // NodeSelection has a `node` property
-          const selectedNode = (
-            sel as {
-              node?: { type: { name: string }; attrs: Record<string, unknown> };
-            }
-          ).node;
-          if (selectedNode?.type.name === "image") {
-            const attrs = selectedNode.attrs;
-            const readRequiredStringAttr = (key: string, fallback: string) => {
-              const value = attrs[key];
-              return typeof value === "string" ? value : fallback;
-            };
-            const readNullableStringAttr = (key: string) => {
-              const value = attrs[key];
-              return typeof value === "string" ? value : null;
-            };
-            const borderWidth = attrs["borderWidth"];
-            pmImageCtx = {
-              pos: sel.from,
-              wrapType: readRequiredStringAttr("wrapType", "inline"),
-              displayMode: readRequiredStringAttr("displayMode", "inline"),
-              cssFloat: readNullableStringAttr("cssFloat"),
-              transform: readNullableStringAttr("transform"),
-              alt: readNullableStringAttr("alt"),
-              borderWidth: typeof borderWidth === "number" ? borderWidth : null,
-              borderColor: readNullableStringAttr("borderColor"),
-              borderStyle: readNullableStringAttr("borderStyle"),
-            };
-          }
-        }
-
-        // Detect tracked change at cursor position
-        let trackedChange: EditorState["activeTrackedChange"] = null;
-        if (view) {
-          const { from } = view.state.selection;
-          const $pos = view.state.doc.resolve(from);
-          const node = $pos.parent;
-          if (node.isTextblock) {
-            // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-            node.forEach((child, offset) => {
-              const childStart = $pos.start() + offset;
-              const childEnd = childStart + child.nodeSize;
-              if (from >= childStart && from <= childEnd && child.isText) {
-                for (const mark of child.marks) {
-                  if (
-                    mark.type.name === "insertion" ||
-                    mark.type.name === "deletion"
-                  ) {
-                    // Expand to full change range
-                    const range = findChangeAtPosition(view.state, from, from);
-                    trackedChange = {
-                      type: mark.type.name as "insertion" | "deletion",
-                      author: (mark.attrs["author"] as string) || "Unknown",
-                      date: (mark.attrs["date"] as string) || null,
-                      from: range.from,
-                      to: range.to,
-                    };
-                  }
-                }
-              }
-            });
-          }
-        }
+        // Image context (when the selection is a NodeSelection of an image)
+        // and active tracked-change at the cursor live in pure helpers so the
+        // logic is unit-tested without spinning up a real component.
+        const pmImageCtx = view ? detectImageContext(view.state) : null;
+        const trackedChange = view
+          ? detectActiveTrackedChange(view.state)
+          : null;
 
         if (!selectionState) {
           setFloatingCommentBtn(null);

--- a/packages/folio/src/components/hooks/useContextMenu.ts
+++ b/packages/folio/src/components/hooks/useContextMenu.ts
@@ -1,10 +1,9 @@
 import { useCallback, useState } from "react";
 import type { RefObject } from "react";
 
-import type { EditorView } from "prosemirror-view";
-
 import { isInTable } from "../../core/prosemirror";
 import type { PagedEditorRef } from "../../paged-editor/PagedEditor";
+import { detectActiveTrackedChange } from "../selectionDetection";
 
 export type ContextMenuAnchor = { x: number; y: number };
 
@@ -25,37 +24,6 @@ const CLOSED_STATE: ContextMenuState = {
   cursorInTable: false,
   cursorInTrackedChange: false,
 };
-
-/**
- * True when the cursor sits on a text node carrying an `insertion` or
- * `deletion` mark — i.e., inside a tracked-change region. Used to decide
- * whether to surface accept/reject items in the context menu.
- */
-function isCursorOnTrackedChange(view: EditorView): boolean {
-  const { from } = view.state.selection;
-  const $pos = view.state.doc.resolve(from);
-  const node = $pos.parent;
-  if (!node.isTextblock) {
-    return false;
-  }
-  let onTrackedChange = false;
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  node.forEach((child, offset) => {
-    const start = $pos.start() + offset;
-    const end = start + child.nodeSize;
-    if (
-      from >= start &&
-      from <= end &&
-      child.isText &&
-      child.marks.some(
-        (m) => m.type.name === "insertion" || m.type.name === "deletion",
-      )
-    ) {
-      onTrackedChange = true;
-    }
-  });
-  return onTrackedChange;
-}
 
 export type UseContextMenuArgs = {
   pagedEditorRef: RefObject<PagedEditorRef | null>;
@@ -90,7 +58,7 @@ export function useContextMenu({
         hasSelectionOverride ?? selection.from !== selection.to;
       const cursorInTable = view ? isInTable(view.state) : false;
       const cursorInTrackedChange = view
-        ? isCursorOnTrackedChange(view)
+        ? detectActiveTrackedChange(view.state) !== null
         : false;
 
       setContextMenu({

--- a/packages/folio/src/components/selectionDetection.test.ts
+++ b/packages/folio/src/components/selectionDetection.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import { EditorState, NodeSelection, TextSelection } from "prosemirror-state";
+
+import {
+  detectActiveTrackedChange,
+  detectImageContext,
+} from "./selectionDetection";
+
+// Minimal schema covering the bits the detection helpers care about:
+//  - an `image` node (so NodeSelection wraps it)
+//  - `insertion` / `deletion` marks (tracked-change detection)
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { group: "block", content: "inline*", toDOM: () => ["p", 0] },
+    text: { group: "inline" },
+    image: {
+      inline: true,
+      group: "inline",
+      atom: true,
+      attrs: {
+        wrapType: { default: "inline" },
+        displayMode: { default: "inline" },
+        cssFloat: { default: null },
+        transform: { default: null },
+        alt: { default: null },
+        borderWidth: { default: null },
+        borderColor: { default: null },
+        borderStyle: { default: null },
+      },
+      toDOM: () => ["img"],
+    },
+  },
+  marks: {
+    insertion: {
+      attrs: {
+        revisionId: { default: 0 },
+        author: { default: "" },
+        date: { default: "" },
+      },
+      toDOM: () => ["ins", 0],
+    },
+    deletion: {
+      attrs: {
+        revisionId: { default: 0 },
+        author: { default: "" },
+        date: { default: "" },
+      },
+      toDOM: () => ["del", 0],
+    },
+  },
+});
+
+function paragraphState(text: string): EditorState {
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+  return EditorState.create({ doc });
+}
+
+function withCursorAt(state: EditorState, pos: number): EditorState {
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, pos)),
+  );
+}
+
+describe("detectImageContext", () => {
+  test("returns null when the selection is a plain text cursor", () => {
+    const state = paragraphState("hello world");
+    expect(detectImageContext(withCursorAt(state, 3))).toBeNull();
+  });
+
+  test("returns null when the selected node is not an image", () => {
+    // Paragraph node is not an image — a NodeSelection of it should also miss.
+    const state = paragraphState("hi");
+    // Select the paragraph as a NodeSelection (position 0).
+    const ns = NodeSelection.create(state.doc, 0);
+    const withParaSelected = state.apply(state.tr.setSelection(ns));
+    expect(detectImageContext(withParaSelected)).toBeNull();
+  });
+
+  test("returns the attrs as ImageContextInfo when an image is selected", () => {
+    const imageNode = schema.nodes["image"]!.create({
+      wrapType: "float",
+      displayMode: "block",
+      cssFloat: "right",
+      transform: "rotate(15deg)",
+      alt: "alt text",
+      borderWidth: 2,
+      borderColor: "var(--test-border)",
+      borderStyle: "dashed",
+    });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [imageNode]),
+    ]);
+    const initial = EditorState.create({ doc });
+    // The image is the only inline child at position 1 (inside the paragraph).
+    const state = initial.apply(
+      initial.tr.setSelection(NodeSelection.create(initial.doc, 1)),
+    );
+
+    expect(detectImageContext(state)).toEqual({
+      pos: 1,
+      wrapType: "float",
+      displayMode: "block",
+      cssFloat: "right",
+      transform: "rotate(15deg)",
+      alt: "alt text",
+      borderWidth: 2,
+      borderColor: "var(--test-border)",
+      borderStyle: "dashed",
+    });
+  });
+
+  test("falls back to defaults when image attrs are absent", () => {
+    const imageNode = schema.nodes["image"]!.create();
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [imageNode]),
+    ]);
+    const initial = EditorState.create({ doc });
+    const state = initial.apply(
+      initial.tr.setSelection(NodeSelection.create(initial.doc, 1)),
+    );
+
+    expect(detectImageContext(state)).toEqual({
+      pos: 1,
+      wrapType: "inline",
+      displayMode: "inline",
+      cssFloat: null,
+      transform: null,
+      alt: null,
+      borderWidth: null,
+      borderColor: null,
+      borderStyle: null,
+    });
+  });
+});
+
+describe("detectActiveTrackedChange", () => {
+  function paragraphWithMark(
+    markName: "insertion" | "deletion",
+    attrs: { author?: string; date?: string; revisionId?: number },
+    text = "redlined",
+  ): EditorState {
+    const mark = schema.marks[markName]!.create({
+      author: attrs.author ?? "",
+      date: attrs.date ?? "",
+      revisionId: attrs.revisionId ?? 1,
+    });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text(text, [mark])]),
+    ]);
+    return EditorState.create({ doc });
+  }
+
+  test("returns null when the cursor is on plain text", () => {
+    const state = paragraphState("hello");
+    expect(detectActiveTrackedChange(withCursorAt(state, 3))).toBeNull();
+  });
+
+  test("returns the insertion context when the cursor is on an inserted run", () => {
+    const state = withCursorAt(
+      paragraphWithMark("insertion", {
+        author: "Alice",
+        date: "2026-05-15T17:00:00Z",
+      }),
+      3,
+    );
+    expect(detectActiveTrackedChange(state)).toEqual({
+      type: "insertion",
+      author: "Alice",
+      date: "2026-05-15T17:00:00Z",
+      from: 1,
+      to: 9,
+    });
+  });
+
+  test("returns the deletion context when the cursor is on a deleted run", () => {
+    const state = withCursorAt(
+      paragraphWithMark("deletion", { author: "Bob" }),
+      2,
+    );
+    expect(detectActiveTrackedChange(state)).toEqual({
+      type: "deletion",
+      author: "Bob",
+      date: null,
+      from: 1,
+      to: 9,
+    });
+  });
+
+  test('uses "Unknown" / null when author and date attrs are empty', () => {
+    const state = withCursorAt(paragraphWithMark("insertion", {}), 2);
+    expect(detectActiveTrackedChange(state)).toEqual({
+      type: "insertion",
+      author: "Unknown",
+      date: null,
+      from: 1,
+      to: 9,
+    });
+  });
+});

--- a/packages/folio/src/components/selectionDetection.ts
+++ b/packages/folio/src/components/selectionDetection.ts
@@ -1,3 +1,4 @@
+import { NodeSelection } from "prosemirror-state";
 import type { EditorState } from "prosemirror-state";
 
 import { findChangeAtPosition } from "../core/prosemirror/commands/comments";
@@ -15,14 +16,13 @@ export function detectImageContext(
   state: EditorState,
 ): ImageContextInfo | null {
   const sel = state.selection;
-  const selectedNode = (
-    sel as {
-      node?: { type: { name: string }; attrs: Record<string, unknown> };
-    }
-  ).node;
-  if (selectedNode?.type.name !== "image") {
+  // `instanceof NodeSelection` is the idiomatic ProseMirror narrowing —
+  // it gives us a typed `.node` without an unsafe `as` cast and rejects
+  // custom selection subclasses that happen to expose a `node` field.
+  if (!(sel instanceof NodeSelection) || sel.node.type.name !== "image") {
     return null;
   }
+  const selectedNode = sel.node;
 
   const attrs = selectedNode.attrs;
   const readRequiredStringAttr = (key: string, fallback: string) => {

--- a/packages/folio/src/components/selectionDetection.ts
+++ b/packages/folio/src/components/selectionDetection.ts
@@ -1,0 +1,92 @@
+import type { EditorState } from "prosemirror-state";
+
+import { findChangeAtPosition } from "../core/prosemirror/commands/comments";
+import type {
+  ActiveTrackedChangeInfo,
+  ImageContextInfo,
+} from "./DocxEditor.props";
+
+/**
+ * If the editor's current selection is a `NodeSelection` of an `image`
+ * node, return the toolbar/image-dialog context derived from its attrs;
+ * otherwise return `null`. Pure — no state mutation, no DOM access.
+ */
+export function detectImageContext(
+  state: EditorState,
+): ImageContextInfo | null {
+  const sel = state.selection;
+  const selectedNode = (
+    sel as {
+      node?: { type: { name: string }; attrs: Record<string, unknown> };
+    }
+  ).node;
+  if (selectedNode?.type.name !== "image") {
+    return null;
+  }
+
+  const attrs = selectedNode.attrs;
+  const readRequiredStringAttr = (key: string, fallback: string) => {
+    const value = attrs[key];
+    return typeof value === "string" ? value : fallback;
+  };
+  const readNullableStringAttr = (key: string) => {
+    const value = attrs[key];
+    return typeof value === "string" ? value : null;
+  };
+  const borderWidth = attrs["borderWidth"];
+
+  return {
+    pos: sel.from,
+    wrapType: readRequiredStringAttr("wrapType", "inline"),
+    displayMode: readRequiredStringAttr("displayMode", "inline"),
+    cssFloat: readNullableStringAttr("cssFloat"),
+    transform: readNullableStringAttr("transform"),
+    alt: readNullableStringAttr("alt"),
+    borderWidth: typeof borderWidth === "number" ? borderWidth : null,
+    borderColor: readNullableStringAttr("borderColor"),
+    borderStyle: readNullableStringAttr("borderStyle"),
+  };
+}
+
+/**
+ * If the cursor sits on a text node carrying an `insertion` or `deletion`
+ * mark, return the active tracked-change context for the contextual review
+ * toolbar; otherwise return `null`. Pure — no state mutation, no DOM access.
+ *
+ * The returned `from`/`to` cover the full extent of the change (expanded
+ * via `findChangeAtPosition`), not just the cursor's node.
+ */
+export function detectActiveTrackedChange(
+  state: EditorState,
+): ActiveTrackedChangeInfo | null {
+  const { from } = state.selection;
+  const $pos = state.doc.resolve(from);
+  const node = $pos.parent;
+  if (!node.isTextblock) {
+    return null;
+  }
+
+  let trackedChange: ActiveTrackedChangeInfo | null = null;
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child, offset) => {
+    const childStart = $pos.start() + offset;
+    const childEnd = childStart + child.nodeSize;
+    if (from < childStart || from > childEnd || !child.isText) {
+      return;
+    }
+    for (const mark of child.marks) {
+      if (mark.type.name !== "insertion" && mark.type.name !== "deletion") {
+        continue;
+      }
+      const range = findChangeAtPosition(state, from, from);
+      trackedChange = {
+        type: mark.type.name as "insertion" | "deletion",
+        author: (mark.attrs["author"] as string) || "Unknown",
+        date: (mark.attrs["date"] as string) || null,
+        from: range.from,
+        to: range.to,
+      };
+    }
+  });
+  return trackedChange;
+}


### PR DESCRIPTION
## Summary
- `DocxEditor.tsx`'s `handleSelectionChange` walked the selection twice — once for image-node attrs, once for the active tracked-change at the cursor. The `useContextMenu` hook duplicated the tracked-change walk in a slimmer boolean form.
- Pull both walks into `components/selectionDetection.ts` as pure `(state: EditorState) => Info | null` helpers. Both callers now share the implementation.
- Adds `selectionDetection.test.ts` with 8 regression tests: image detection (cursor / non-image NodeSelection / full attrs / defaults) and tracked-change detection (cursor / insertion / deletion / empty author+date defaults).

`bun --filter @stll/folio test` → 643 pass (was 635). No behavior change.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (8 new tests, all pass)
- [x] `bun --filter @stll/folio format`