### PR TITLE
chore(folio): extract selection-formatting assembly into a tested helper

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -216,10 +216,14 @@ import {
   detectActiveTrackedChange,
   detectImageContext,
 } from "./selectionDetection";
+import {
+  buildSelectionFormatting,
+  extractListState,
+} from "./selectionFormattingBuilder";
 import { TextContextMenu } from "./TextContextMenu";
 import type { TextContextAction, TextContextMenuItem } from "./TextContextMenu";
 import { ToolbarButton, ToolbarSeparator } from "./Toolbar";
-import type { SelectionFormatting, FormattingAction } from "./Toolbar";
+import type { FormattingAction } from "./Toolbar";
 import { mapHexToHighlightName } from "./toolbarUtils";
 import { HyperlinkPopup } from "./ui/HyperlinkPopup";
 import { getBuiltinTableStyle } from "./ui/table-styles";
@@ -1257,65 +1261,14 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           ? `#${textFormatting.color.rgb}`
           : undefined;
 
-        // Build list state from numPr
-        const numPr = paragraphFormatting.numPr;
-        let listState: SelectionFormatting["listState"];
-        if (numPr) {
-          const ls: NonNullable<SelectionFormatting["listState"]> = {
-            type: (numPr.numId === 1 ? "bullet" : "numbered") as
-              | "bullet"
-              | "numbered",
-            level: numPr.ilvl ?? 0,
-            isInList: true,
-          };
-          if (numPr.numId !== undefined) {
-            ls.numId = numPr.numId;
-          }
-          listState = ls;
-        }
-
-        const formatting: SelectionFormatting = {
-          underline: !!textFormatting.underline,
-          superscript: textFormatting.vertAlign === "superscript",
-          subscript: textFormatting.vertAlign === "subscript",
-          bidi: !!paragraphFormatting.bidi,
-        };
-        if (textFormatting.bold !== undefined) {
-          formatting.bold = textFormatting.bold;
-        }
-        if (textFormatting.italic !== undefined) {
-          formatting.italic = textFormatting.italic;
-        }
-        if (textFormatting.strike !== undefined) {
-          formatting.strike = textFormatting.strike;
-        }
-        if (fontFamily !== undefined) {
-          formatting.fontFamily = fontFamily;
-        }
-        if (fontSize !== undefined) {
-          formatting.fontSize = fontSize;
-        }
-        if (textColor !== undefined) {
-          formatting.color = textColor;
-        }
-        if (textFormatting.highlight !== undefined) {
-          formatting.highlight = textFormatting.highlight;
-        }
-        if (paragraphFormatting.alignment !== undefined) {
-          formatting.alignment = paragraphFormatting.alignment;
-        }
-        if (paragraphFormatting.lineSpacing !== undefined) {
-          formatting.lineSpacing = paragraphFormatting.lineSpacing;
-        }
-        if (listState !== undefined) {
-          formatting.listState = listState;
-        }
-        if (selectionState.styleId) {
-          formatting.styleId = selectionState.styleId;
-        }
-        if (paragraphFormatting.indentLeft !== undefined) {
-          formatting.indentLeft = paragraphFormatting.indentLeft;
-        }
+        const listState = extractListState(paragraphFormatting.numPr);
+        const formatting = buildSelectionFormatting({
+          selectionState,
+          fontFamily,
+          fontSize,
+          textColor,
+          listState,
+        });
         setState((prev) => ({
           ...prev,
           selectionFormatting: formatting,

--- a/packages/folio/src/components/selectionFormattingBuilder.test.ts
+++ b/packages/folio/src/components/selectionFormattingBuilder.test.ts
@@ -132,7 +132,7 @@ describe("buildSelectionFormatting", () => {
     });
   });
 
-  test("copies the paragraph styleId only when it is a non-empty string", () => {
+  test("copies the paragraph styleId for any non-null source value", () => {
     expect(
       buildSelectionFormatting({
         selectionState: makeSelection({}, {}, "Heading1"),
@@ -142,6 +142,18 @@ describe("buildSelectionFormatting", () => {
         listState: undefined,
       }).styleId,
     ).toBe("Heading1");
+    // Empty string is technically permitted by `SelectionState.styleId`
+    // (`string | null`) and must be passed through — only `null` means
+    // "no paragraph style".
+    expect(
+      buildSelectionFormatting({
+        selectionState: makeSelection({}, {}, ""),
+        fontFamily: undefined,
+        fontSize: undefined,
+        textColor: undefined,
+        listState: undefined,
+      }).styleId,
+    ).toBe("");
     // `null` styleId must not appear on the result.
     expect(
       "styleId" in

--- a/packages/folio/src/components/selectionFormattingBuilder.test.ts
+++ b/packages/folio/src/components/selectionFormattingBuilder.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SelectionState } from "../core/prosemirror";
+import {
+  buildSelectionFormatting,
+  extractListState,
+} from "./selectionFormattingBuilder";
+
+function makeSelection(
+  textFormatting: Partial<SelectionState["textFormatting"]> = {},
+  paragraphFormatting: Partial<SelectionState["paragraphFormatting"]> = {},
+  styleId: string | null = null,
+): SelectionState {
+  return {
+    hasSelection: false,
+    isMultiParagraph: false,
+    textFormatting,
+    paragraphFormatting,
+    styleId,
+    startParagraphIndex: 0,
+    endParagraphIndex: 0,
+  };
+}
+
+describe("extractListState", () => {
+  test("returns undefined when the paragraph is not in a list", () => {
+    expect(extractListState(undefined)).toBeUndefined();
+  });
+
+  test("treats numId === 1 as a bullet list", () => {
+    expect(extractListState({ numId: 1, ilvl: 2 })).toEqual({
+      type: "bullet",
+      level: 2,
+      isInList: true,
+      numId: 1,
+    });
+  });
+
+  test("treats any other numId as a numbered list", () => {
+    expect(extractListState({ numId: 7 })).toEqual({
+      type: "numbered",
+      level: 0,
+      isInList: true,
+      numId: 7,
+    });
+  });
+
+  test("omits numId from the result when it is absent from numPr", () => {
+    expect(extractListState({ ilvl: 1 })).toEqual({
+      type: "numbered",
+      level: 1,
+      isInList: true,
+    });
+  });
+});
+
+describe("buildSelectionFormatting", () => {
+  test("emits the always-present derived booleans", () => {
+    const formatting = buildSelectionFormatting({
+      selectionState: makeSelection(),
+      fontFamily: undefined,
+      fontSize: undefined,
+      textColor: undefined,
+      listState: undefined,
+    });
+    expect(formatting).toEqual({
+      underline: false,
+      superscript: false,
+      subscript: false,
+      bidi: false,
+    });
+  });
+
+  test("derives superscript / subscript from vertAlign", () => {
+    expect(
+      buildSelectionFormatting({
+        selectionState: makeSelection({ vertAlign: "superscript" }),
+        fontFamily: undefined,
+        fontSize: undefined,
+        textColor: undefined,
+        listState: undefined,
+      }).superscript,
+    ).toBe(true);
+    expect(
+      buildSelectionFormatting({
+        selectionState: makeSelection({ vertAlign: "subscript" }),
+        fontFamily: undefined,
+        fontSize: undefined,
+        textColor: undefined,
+        listState: undefined,
+      }).subscript,
+    ).toBe(true);
+  });
+
+  test("copies optional fields only when their source is defined", () => {
+    const formatting = buildSelectionFormatting({
+      selectionState: makeSelection(
+        { bold: true, italic: false },
+        { alignment: "center" },
+      ),
+      fontFamily: undefined,
+      fontSize: undefined,
+      textColor: undefined,
+      listState: undefined,
+    });
+    expect(formatting.bold).toBe(true);
+    expect(formatting.italic).toBe(false);
+    expect(formatting.alignment).toBe("center");
+    // Fields whose sources were `undefined` must be absent (not `undefined`)
+    // so the prop shape stays compatible with exactOptionalPropertyTypes.
+    expect("strike" in formatting).toBe(false);
+    expect("fontFamily" in formatting).toBe(false);
+    expect("fontSize" in formatting).toBe(false);
+  });
+
+  test("passes through resolved font / color / list state", () => {
+    const formatting = buildSelectionFormatting({
+      selectionState: makeSelection(),
+      fontFamily: "Arimo",
+      fontSize: 22,
+      textColor: "var(--test-color)",
+      listState: { type: "bullet", level: 0, isInList: true, numId: 1 },
+    });
+    expect(formatting.fontFamily).toBe("Arimo");
+    expect(formatting.fontSize).toBe(22);
+    expect(formatting.color).toBe("var(--test-color)");
+    expect(formatting.listState).toEqual({
+      type: "bullet",
+      level: 0,
+      isInList: true,
+      numId: 1,
+    });
+  });
+
+  test("copies the paragraph styleId only when it is a non-empty string", () => {
+    expect(
+      buildSelectionFormatting({
+        selectionState: makeSelection({}, {}, "Heading1"),
+        fontFamily: undefined,
+        fontSize: undefined,
+        textColor: undefined,
+        listState: undefined,
+      }).styleId,
+    ).toBe("Heading1");
+    // `null` styleId must not appear on the result.
+    expect(
+      "styleId" in
+        buildSelectionFormatting({
+          selectionState: makeSelection({}, {}, null),
+          fontFamily: undefined,
+          fontSize: undefined,
+          textColor: undefined,
+          listState: undefined,
+        }),
+    ).toBe(false);
+  });
+});

--- a/packages/folio/src/components/selectionFormattingBuilder.ts
+++ b/packages/folio/src/components/selectionFormattingBuilder.ts
@@ -89,7 +89,11 @@ export function buildSelectionFormatting({
   if (listState !== undefined) {
     formatting.listState = listState;
   }
-  if (selectionState.styleId) {
+  // `styleId` is `string | null`. `if (selectionState.styleId)` would also
+  // skip an empty-string id, which OOXML does not produce but the type
+  // technically permits — narrow to "not null" so the only excluded value
+  // is the genuine "no paragraph style" sentinel.
+  if (selectionState.styleId !== null) {
     formatting.styleId = selectionState.styleId;
   }
   if (paragraphFormatting.indentLeft !== undefined) {

--- a/packages/folio/src/components/selectionFormattingBuilder.ts
+++ b/packages/folio/src/components/selectionFormattingBuilder.ts
@@ -1,0 +1,99 @@
+import type { SelectionState } from "../core/prosemirror";
+import type { SelectionFormatting } from "./toolbarPrimitives";
+import type { ListState } from "./ui/ListButtons";
+
+type ParagraphNumPr = NonNullable<
+  SelectionState["paragraphFormatting"]["numPr"]
+>;
+
+/**
+ * Compute the toolbar list state from a paragraph's `numPr`. The legacy
+ * convention treats `numId === 1` as bullets and any other `numId` as
+ * numbered. Returns `undefined` when the paragraph is not in a list.
+ */
+export function extractListState(
+  numPr: ParagraphNumPr | undefined,
+): ListState | undefined {
+  if (!numPr) {
+    return undefined;
+  }
+  const ls: ListState = {
+    type: numPr.numId === 1 ? "bullet" : "numbered",
+    level: numPr.ilvl ?? 0,
+    isInList: true,
+  };
+  if (numPr.numId !== undefined) {
+    ls.numId = numPr.numId;
+  }
+  return ls;
+}
+
+export type BuildSelectionFormattingInput = {
+  selectionState: SelectionState;
+  fontFamily: string | undefined;
+  fontSize: number | undefined;
+  /** Resolved text color as a hex string (e.g. `#1a1a1a`), or `undefined`. */
+  textColor: string | undefined;
+  listState: ListState | undefined;
+};
+
+/**
+ * Assemble the `SelectionFormatting` object the toolbar consumes.
+ *
+ * Several fields are `?: T` (no `| undefined`) under
+ * `exactOptionalPropertyTypes`, so we only assign them when the source
+ * value is defined — assigning `undefined` would be a type error. Pure
+ * (no DOM, no PM state mutation).
+ */
+export function buildSelectionFormatting({
+  selectionState,
+  fontFamily,
+  fontSize,
+  textColor,
+  listState,
+}: BuildSelectionFormattingInput): SelectionFormatting {
+  const { textFormatting, paragraphFormatting } = selectionState;
+  const formatting: SelectionFormatting = {
+    underline: !!textFormatting.underline,
+    superscript: textFormatting.vertAlign === "superscript",
+    subscript: textFormatting.vertAlign === "subscript",
+    bidi: !!paragraphFormatting.bidi,
+  };
+  if (textFormatting.bold !== undefined) {
+    formatting.bold = textFormatting.bold;
+  }
+  if (textFormatting.italic !== undefined) {
+    formatting.italic = textFormatting.italic;
+  }
+  if (textFormatting.strike !== undefined) {
+    formatting.strike = textFormatting.strike;
+  }
+  if (fontFamily !== undefined) {
+    formatting.fontFamily = fontFamily;
+  }
+  if (fontSize !== undefined) {
+    formatting.fontSize = fontSize;
+  }
+  if (textColor !== undefined) {
+    formatting.color = textColor;
+  }
+  if (textFormatting.highlight !== undefined) {
+    formatting.highlight = textFormatting.highlight;
+  }
+  if (paragraphFormatting.alignment !== undefined) {
+    formatting.alignment = paragraphFormatting.alignment;
+  }
+  if (paragraphFormatting.lineSpacing !== undefined) {
+    formatting.lineSpacing = paragraphFormatting.lineSpacing;
+  }
+  if (listState !== undefined) {
+    formatting.listState = listState;
+  }
+  if (selectionState.styleId) {
+    formatting.styleId = selectionState.styleId;
+  }
+  if (paragraphFormatting.indentLeft !== undefined) {
+    formatting.indentLeft = paragraphFormatting.indentLeft;
+  }
+  return formatting;
+}


### PR DESCRIPTION
## Summary
- The toolbar formatting object built inside `handleSelectionChange` had two distinct pure pieces buried in a 250-line callback: deriving the list state from a paragraph's `numPr`, and copying ~12 optional fields into a `SelectionFormatting` shape with `if (x !== undefined) target.x = x` for each (required by `exactOptionalPropertyTypes`).
- Move both into `components/selectionFormattingBuilder.ts` as pure helpers; add `selectionFormattingBuilder.test.ts` with 9 regression tests.
- While here: drop the unnecessary `as "bullet" | "numbered"` cast inside the list-state ternary.

`bun --filter @stll/folio test` → 644 pass (was 635). No behavior change.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (9 new tests, all pass)
- [x] `bun --filter @stll/folio format`