### PR TITLE
fix(folio): clamp scrollToAIEditOperation range to doc size

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -163,6 +163,7 @@ import { useDocumentHistory } from "../hooks/useHistory";
 import { useTableSelection } from "../hooks/useTableSelection";
 import { PagedEditor } from "../paged-editor/PagedEditor";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
+import { clampRangeToDocSize } from "./aiEditRange";
 import { resolveCommentCreationRange } from "./commentAnchors";
 import {
   EMPTY_ANCHOR_POSITIONS,
@@ -2490,18 +2491,24 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           if (!range) {
             return false;
           }
-          // `TextSelection.between` clamps to the nearest valid
-          // inline position; `create` throws "endpoint not pointing
-          // into a node with inline content" when from/to land on a
-          // block boundary, which is exactly what happens for marks
-          // that wrap an entire paragraph.
-          const $from = view.state.doc.resolve(range.from);
-          const $to = view.state.doc.resolve(range.to);
+          // `TextSelection.between` clamps to the nearest valid inline
+          // position; `create` throws "endpoint not pointing into a node
+          // with inline content" when from/to land on a block boundary,
+          // which is exactly what happens for marks that wrap an entire
+          // paragraph. `clampRangeToDocSize` is a defensive guard against
+          // a revision range whose endpoints fell past the doc end after
+          // concurrent edits.
+          const { from, to } = clampRangeToDocSize(
+            view.state.doc.content.size,
+            range,
+          );
+          const $from = view.state.doc.resolve(from);
+          const $to = view.state.doc.resolve(to);
           view.dispatch(
             view.state.tr.setSelection(TextSelection.between($from, $to)),
           );
           requestAnimationFrame(() => {
-            pagedEditorRef.current?.scrollToPosition(range.from);
+            pagedEditorRef.current?.scrollToPosition(from);
           });
           return true;
         },
@@ -2510,12 +2517,11 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           if (!view) {
             return false;
           }
-          // Prefer the caller's snapshot (the one the AI saw when
-          // it generated the suggestion); only fall back to a
-          // fresh recompute when the caller didn't pass one. A
-          // recomputed snapshot re-numbers blocks after any
-          // structural accept, so `b-0007` would point to a
-          // different paragraph than the panel's pending
+          // Prefer the caller's snapshot (the one the AI saw when it
+          // generated the suggestion); only fall back to a fresh recompute
+          // when the caller didn't pass one. A recomputed snapshot
+          // re-numbers blocks after any structural accept, so `b-0007`
+          // would point to a different paragraph than the panel's pending
           // suggestion is referencing.
           const resolvedSnapshot =
             snapshot ?? createFolioAIEditSnapshot(view.state.doc);
@@ -2523,15 +2529,10 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           if (!anchor) {
             return false;
           }
-          const docSize = view.state.doc.content.size;
-          // Clamp because a block range generated from the snapshot
-          // can include a position one past the doc end (e.g.
-          // trailing paragraph) that PM rejects when used directly
-          // for a TextSelection. Use `between` over `create` so a
-          // block-boundary `from` doesn't trip "endpoint not
-          // pointing into a node with inline content".
-          const from = Math.min(anchor.from, docSize);
-          const to = Math.min(anchor.to, docSize);
+          const { from, to } = clampRangeToDocSize(
+            view.state.doc.content.size,
+            anchor,
+          );
           const $from = view.state.doc.resolve(from);
           const $to = view.state.doc.resolve(to);
           view.dispatch(

--- a/packages/folio/src/components/aiEditRange.test.ts
+++ b/packages/folio/src/components/aiEditRange.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { clampRangeToDocSize } from "./aiEditRange";
+
+describe("clampRangeToDocSize", () => {
+  test("passes a range untouched when both endpoints sit inside the doc", () => {
+    expect(clampRangeToDocSize(100, { from: 12, to: 34 })).toEqual({
+      from: 12,
+      to: 34,
+    });
+  });
+
+  test("clamps `to` when it points one past the doc end", () => {
+    expect(clampRangeToDocSize(100, { from: 50, to: 101 })).toEqual({
+      from: 50,
+      to: 100,
+    });
+  });
+
+  test("clamps both endpoints when both exceed the doc", () => {
+    expect(clampRangeToDocSize(50, { from: 80, to: 120 })).toEqual({
+      from: 50,
+      to: 50,
+    });
+  });
+
+  test("clamps a negative `from` up to zero", () => {
+    expect(clampRangeToDocSize(100, { from: -5, to: 20 })).toEqual({
+      from: 0,
+      to: 20,
+    });
+  });
+
+  test("preserves a cursor range (from === to)", () => {
+    expect(clampRangeToDocSize(100, { from: 42, to: 42 })).toEqual({
+      from: 42,
+      to: 42,
+    });
+  });
+
+  test("yields a doc-end cursor when both endpoints are well past the end", () => {
+    // `TextSelection.between` falls back to a cursor selection when both
+    // endpoints collapse — that is the intended behavior for stale ids.
+    expect(clampRangeToDocSize(20, { from: 1000, to: 1500 })).toEqual({
+      from: 20,
+      to: 20,
+    });
+  });
+});

--- a/packages/folio/src/components/aiEditRange.ts
+++ b/packages/folio/src/components/aiEditRange.ts
@@ -1,0 +1,31 @@
+/**
+ * Helpers shared by the AI-edit imperative API methods.
+ *
+ * Lives outside `DocxEditor.tsx` so the bounds-checking logic that protects
+ * `TextSelection.between` from "endpoint not pointing into a node with
+ * inline content" can be unit-tested without spinning up a real PM view.
+ */
+
+export type DocPositionRange = { from: number; to: number };
+
+/**
+ * Clamp a `{from, to}` pair so both endpoints fit inside a document of
+ * `docSize` (in PM content positions). Block-boundary snapshots and stale
+ * range data sometimes produce a `to` one past the last inline position;
+ * `view.state.doc.resolve(...)` rejects that with
+ * "Position … out of range", and `TextSelection.between` doesn't help — it
+ * needs *valid* resolved positions. Clamping before resolution is the cheap
+ * defensive step.
+ *
+ * Order is preserved: if both endpoints exceed `docSize`, the returned
+ * `from` may equal `to`, yielding a cursor selection at the doc end.
+ */
+export function clampRangeToDocSize(
+  docSize: number,
+  range: DocPositionRange,
+): DocPositionRange {
+  return {
+    from: Math.min(Math.max(range.from, 0), docSize),
+    to: Math.min(Math.max(range.to, 0), docSize),
+  };
+}


### PR DESCRIPTION
## Summary
- The two scroll-into-view methods on the AI-edit imperative API share a clamp-then-resolve-then-dispatch pattern, but only `scrollToBlock` actually clamped the range. `scrollToAIEditOperation` resolved `range.from` / `range.to` directly — fine when the revision id is fresh, but a stale id or a concurrent edit between the find and the dispatch can push a position past doc-end, and `view.state.doc.resolve(...)` throws `"Position … out of range"`. Apply the same clamp.
- Extracts the bounds check into a pure `clampRangeToDocSize(docSize, range)` helper in `components/aiEditRange.ts`.
- Adds `aiEditRange.test.ts` with 6 regression tests: in-range passthrough, `to` overshoot, both endpoints overshooting, negative `from`, cursor-range preservation, past-end collapse to a doc-end cursor.

641 tests pass (was 635). No behavior change in the common path.

## Test plan
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio test` (6 new tests, all pass)
- [x] `bun --filter @stll/folio format`