### PR TITLE
fix(folio): scope findChangeAtPosition expansion to one revision

### DIFF
--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -5,6 +5,7 @@ import type { Transaction } from "prosemirror-state";
 
 import {
   acceptAIEditRevision,
+  findChangeAtPosition,
   findNextChange,
   findPreviousChange,
   rejectAIEditRevision,
@@ -108,6 +109,70 @@ describe("AI revision accept/reject scoping", () => {
     // remaining insertion mark belongs to revision B alone.
     expect(view.state.doc.textContent).toBe(" middle beta");
     expect(insertionRevisionsAt(view.state)).toEqual([2]);
+  });
+});
+
+describe("findChangeAtPosition", () => {
+  test("returns the input range unchanged for a non-cursor selection", () => {
+    const state = makeStateWithMarks();
+    expect(findChangeAtPosition(state, 3, 12)).toEqual({ from: 3, to: 12 });
+  });
+
+  test("returns the cursor as-is when no tracked-change marks exist nearby", () => {
+    // Position 10 sits in the plain " middle " run between the two
+    // insertion spans of `makeStateWithMarks`.
+    const state = makeStateWithMarks();
+    expect(findChangeAtPosition(state, 10, 10)).toEqual({
+      from: 10,
+      to: 10,
+    });
+  });
+
+  test("expands a cursor inside a single tracked-change span to that span's full range", () => {
+    // Cursor inside "alpha" (revision A) — expansion should cover the
+    // whole inserted word. Paragraph offsets: 1..6 = "alpha".
+    const state = makeStateWithMarks();
+    expect(findChangeAtPosition(state, 3, 3)).toEqual({ from: 1, to: 6 });
+  });
+
+  test("expands across multiple adjacent text nodes that share the same mark instance", () => {
+    // Three adjacent text nodes that all share the *same* insertion
+    // mark — this comes up when the inserted span is formatted
+    // unevenly (e.g., a bold word inside a tracked-change). The
+    // expansion must reach both edges, not just one neighbouring
+    // node on either side.
+    const insertion = schema.marks["insertion"]!.create(REV_A_ATTRS);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("one", [insertion]),
+          schema.text("two", [insertion]),
+          schema.text("three", [insertion]),
+        ]),
+      ]),
+    });
+    // "one" 1..4, "two" 4..7, "three" 7..12. Cursor in "two".
+    expect(findChangeAtPosition(state, 5, 5)).toEqual({ from: 1, to: 12 });
+  });
+
+  test("does not bleed into an adjacent insertion that belongs to a different revisionId", () => {
+    // Two insertions back-to-back, no plain text between them. Cursor
+    // is in the FIRST insertion. The expansion must stop at the
+    // boundary — accepting/rejecting one revision must not implicate
+    // the other.
+    const insertion = schema.marks["insertion"];
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("alpha", [insertion.create(REV_A_ATTRS)]),
+          schema.text("beta", [insertion.create(REV_B_ATTRS)]),
+        ]),
+      ]),
+    });
+    // "alpha" occupies positions 1..6, "beta" positions 6..10.
+    expect(findChangeAtPosition(state, 3, 3)).toEqual({ from: 1, to: 6 });
   });
 });
 

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -290,10 +290,13 @@ export function findChangeAtPosition(
     return { from, to };
   }
 
-  // Find the text node at this position and its mark
+  // Find the text node at this position and its mark instance. We capture
+  // the specific instance (not just the type) so the adjacency expansion
+  // below stays inside a single revision — two back-to-back insertions
+  // belonging to different `revisionId`s must not be treated as one range.
   let markStart = from;
   let markEnd = from;
-  let foundMark: typeof insertionType | undefined;
+  let foundMark: import("prosemirror-model").Mark | undefined;
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, offset) => {
@@ -302,7 +305,7 @@ export function findChangeAtPosition(
     if (from >= childStart && from <= childEnd && child.isText) {
       for (const mark of child.marks) {
         if (mark.type === insertionType || mark.type === deletionType) {
-          foundMark = mark.type;
+          foundMark = mark;
           markStart = childStart;
           markEnd = childEnd;
         }
@@ -314,20 +317,47 @@ export function findChangeAtPosition(
     return { from, to };
   }
 
-  // Expand to adjacent nodes with the same mark type
+  // Expand to adjacent nodes carrying the *same* mark instance (matching
+  // attrs, including revisionId). Two passes — one left-to-right and one
+  // right-to-left — so the expansion can cross more than one neighbouring
+  // text node on either side (forEach doesn't revisit earlier siblings,
+  // which a single-pass walk would need to do to extend leftward by more
+  // than one step).
+  const sameMark = foundMark;
+  const children: {
+    childStart: number;
+    childEnd: number;
+    marks: readonly import("prosemirror-model").Mark[];
+  }[] = [];
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, offset) => {
+    if (!child.isText) {
+      return;
+    }
     const childStart = $pos.start() + offset;
-    const childEnd = childStart + child.nodeSize;
-    if (child.isText && child.marks.some((m) => m.type === foundMark)) {
-      if (childEnd === markStart) {
-        markStart = childStart;
+    children.push({
+      childStart,
+      childEnd: childStart + child.nodeSize,
+      marks: child.marks,
+    });
+  });
+  let extended = true;
+  while (extended) {
+    extended = false;
+    for (const child of children) {
+      if (!child.marks.some((m) => m.eq(sameMark))) {
+        continue;
       }
-      if (childStart === markEnd) {
-        markEnd = childEnd;
+      if (child.childEnd === markStart) {
+        markStart = child.childStart;
+        extended = true;
+      }
+      if (child.childStart === markEnd) {
+        markEnd = child.childEnd;
+        extended = true;
       }
     }
-  });
+  }
 
   return { from: markStart, to: markEnd };
 }


### PR DESCRIPTION
## Summary
**Correctness #1.** `findChangeAtPosition` walked the cursor's textblock once and captured the mark *type* on the matched text node, then made a second pass that extended `markStart`/`markEnd` to any adjacent text node carrying *any* insertion-or-deletion mark of the same type. Two back-to-back tracked changes belonging to different `revisionId`s therefore looked like one range — accepting or rejecting one revision could target text owned by an adjacent unrelated revision. Now compares mark instances via `mark.eq(...)`, which folds attrs (`revisionId`, `author`, `date`) into the check.

**Correctness #2 (latent, same area).** `Node.forEach` walks left-to-right and does not revisit earlier siblings, so the single-pass expansion could only extend the left boundary by one node. Three-or-more adjacent text nodes sharing the same mark (common when an insertion contains mixed formatting like bold-inside-tracked-change) would return a truncated range. Replaced with a fixed-point loop over a pre-collected children array.

**Perf.** Pre-collected children array (vs. `Node.forEach` adapter on each pass) reduces per-iteration overhead; the loop terminates on the first non-extending pass, so typical single-span cursors converge in one or two iterations.

## Test plan
- [x] `bun --filter @stll/folio test` — 640 pass (was 635)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`
- New regression tests (5):
  - range-selection passthrough
  - plain-cursor passthrough
  - single-span expansion
  - multi-node same-revision expansion
  - cross-revision boundary (the surfaced bug)