### PR TITLE
fix(folio): expand find{Next,Previous}Change across multi-node spans

### DIFF
--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -212,6 +212,33 @@ describe("tracked change navigation", () => {
     });
   });
 
+  test("findPreviousChange surfaces an overlapping change inside a previously expanded range", () => {
+    // A previously inserted span that a second reviewer later deleted
+    // ("inserted-then-deleted") carries BOTH an insertion mark
+    // (revision A) and a deletion mark (revision B) on the same text
+    // node. The forward walk must process both ranges — skipping
+    // strictly by position would return the outer insertion when the
+    // user expects the nearer overlapping deletion.
+    const insertion = schema.marks["insertion"]!.create(REV_A_ATTRS);
+    const deletion = schema.marks["deletion"]!.create(REV_B_ATTRS);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          // "first " — insertion A only, positions 1..7.
+          schema.text("first ", [insertion]),
+          // "second" — insertion A + deletion B, positions 7..13.
+          schema.text("second", [insertion, deletion]),
+        ]),
+      ]),
+    });
+    expect(findPreviousChange(state, 14)).toMatchObject({
+      from: 7,
+      to: 13,
+      type: "deletion",
+    });
+  });
+
   test("findNextChange returns the full range when startPos sits inside a multi-node change", () => {
     // The toolbar calls `findNextChange(state, selectionEnd)` and then
     // accepts/rejects the returned range. If `startPos` lands inside

--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -17,6 +17,12 @@ const schema = new Schema({
     text: { marks: "_" },
   },
   marks: {
+    // `bold` is here so a single tracked-change span can be split into
+    // two adjacent text nodes that share the *same* insertion mark
+    // instance but differ in inline formatting — ProseMirror does not
+    // merge text nodes whose mark sets differ, so this is the only
+    // way to construct a genuinely multi-node tracked change.
+    bold: { toDOM: () => ["strong", 0] },
     insertion: {
       attrs: { revisionId: {}, author: {}, date: {} },
       excludes: "",
@@ -156,6 +162,52 @@ describe("tracked change navigation", () => {
     expect(result).toMatchObject({
       from: 14,
       to: 18,
+      type: "insertion",
+    });
+  });
+
+  // A tracked-change span split into two text nodes that share the *same*
+  // insertion mark instance but differ in inline formatting — exactly
+  // what happens when a user partially bolds inside an AI suggestion.
+  // The navigation buttons must select the WHOLE inserted span, not
+  // just the first text node — otherwise pressing "next change" leaves
+  // the second half outside the selection and follow-up accept/reject
+  // actions miss it.
+  const makeMultiNodeSameRevisionState = () => {
+    const insertion = schema.marks["insertion"]!.create(REV_A_ATTRS);
+    const bold = schema.marks["bold"]!.create();
+    return EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("plain"),
+          schema.text("bold", [insertion, bold]),
+          schema.text("plain", [insertion]),
+          schema.text(" tail"),
+        ]),
+      ]),
+    });
+  };
+
+  test("findNextChange spans the full multi-node tracked change", () => {
+    // Paragraph offsets: "plain" 1..6, "bold" 6..10 (ins+bold),
+    // "plain" 10..15 (ins), " tail" 15..20. Starting before the
+    // change, "next" must select the whole inserted region 6..15.
+    const state = makeMultiNodeSameRevisionState();
+    expect(findNextChange(state, 0)).toMatchObject({
+      from: 6,
+      to: 15,
+      type: "insertion",
+    });
+  });
+
+  test("findPreviousChange spans the full multi-node tracked change", () => {
+    // Starting from beyond the change, "previous" must also select
+    // the whole inserted region 6..15.
+    const state = makeMultiNodeSameRevisionState();
+    expect(findPreviousChange(state, 20)).toMatchObject({
+      from: 6,
+      to: 15,
       type: "insertion",
     });
   });

--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -211,4 +211,19 @@ describe("tracked change navigation", () => {
       type: "insertion",
     });
   });
+
+  test("findNextChange returns the full range when startPos sits inside a multi-node change", () => {
+    // The toolbar calls `findNextChange(state, selectionEnd)` and then
+    // accepts/rejects the returned range. If `startPos` lands inside
+    // an existing tracked change, returning a range clamped to
+    // `startPos` truncates the earlier portion of the same revision
+    // and leaves orphan marks after accept. Return the full expanded
+    // range — including positions BEFORE `startPos`.
+    const state = makeMultiNodeSameRevisionState();
+    expect(findNextChange(state, 8)).toMatchObject({
+      from: 6,
+      to: 15,
+      type: "insertion",
+    });
+  });
 });

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -446,6 +446,13 @@ export function findPreviousChange(
   }
 
   const result = { value: null as ChangeRange | null };
+  // Remember the specific mark instance that produced the kept result, so
+  // the walk can skip later text nodes covered by the same expansion
+  // without skipping a sibling that carries a *different* tracked-change
+  // mark (e.g., an `insertion + deletion` overlay where the same text
+  // node belongs to two distinct revisions). Skipping by position alone
+  // would miss the nearer overlapping change.
+  let resultMark: import("prosemirror-model").Mark | null = null;
 
   state.doc.descendants((node, pos) => {
     if (!node.isText) {
@@ -454,11 +461,18 @@ export function findPreviousChange(
     if (pos >= startPos) {
       return false;
     }
-    // The forward walk would otherwise re-expand the same span once per
-    // text node inside it. Skip nodes already covered by the most
-    // recent kept result — the previous expansion already included
-    // them, and expansion is idempotent.
-    if (result.value && pos < result.value.to) {
+    if (
+      result.value &&
+      resultMark &&
+      pos < result.value.to &&
+      node.marks.every(
+        (m) =>
+          (m.type !== insertionType && m.type !== deletionType) ||
+          m.eq(resultMark!),
+      )
+    ) {
+      // Already covered by the previous expansion AND no additional
+      // tracked-change mark sits on this node — safe to skip.
       return;
     }
 
@@ -475,6 +489,7 @@ export function findPreviousChange(
           to: expanded.to,
           type: mark.type === insertionType ? "insertion" : "deletion",
         };
+        resultMark = mark;
       }
     }
     return undefined;

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -346,38 +346,27 @@ function expandTrackedChangeRange(
   fromHint: number,
   toHint: number,
 ): { from: number; to: number } {
-  // Walk left from `from` and right from `to`, hopping across adjacent
-  // text nodes whose mark set contains the same insertion/deletion
-  // instance. PM's `nodesBetween` visits siblings in tree order; we use
-  // it in a fixed-point loop so the range stabilises across multi-node
-  // expansions. Box-mutate `range` so the visitor (declared once,
-  // outside the loop) can update it in place.
-  const range = { from: fromHint, to: toHint, extended: true };
-  const visitor = (
-    child: import("prosemirror-model").Node,
-    pos: number,
-  ): void => {
-    if (!child.isText) {
-      return;
-    }
-    const childEnd = pos + child.nodeSize;
-    if (!child.marks.some((m) => m.eq(mark))) {
-      return;
-    }
-    if (childEnd === range.from) {
-      range.from = pos;
-      range.extended = true;
-    }
-    if (pos === range.to) {
-      range.to = childEnd;
-      range.extended = true;
-    }
-  };
-  while (range.extended) {
-    range.extended = false;
-    state.doc.nodesBetween(Math.max(0, range.from - 1), range.to + 1, visitor);
+  // Resolve the boundary positions and hop outward through `nodeBefore`
+  // / `nodeAfter` while the neighbouring text node still carries the
+  // same mark instance. O(K) in the number of text nodes that make up
+  // the span — `nodesBetween`-based fixed-point expansion is O(K²) and
+  // re-walks the same subtree on every iteration.
+  let from = fromHint;
+  let to = toHint;
+  let $from = state.doc.resolve(from);
+  while (
+    $from.nodeBefore?.isText &&
+    $from.nodeBefore.marks.some((m) => m.eq(mark))
+  ) {
+    from -= $from.nodeBefore.nodeSize;
+    $from = state.doc.resolve(from);
   }
-  return { from: range.from, to: range.to };
+  let $to = state.doc.resolve(to);
+  while ($to.nodeAfter?.isText && $to.nodeAfter.marks.some((m) => m.eq(mark))) {
+    to += $to.nodeAfter.nodeSize;
+    $to = state.doc.resolve(to);
+  }
+  return { from, to };
 }
 
 /**
@@ -410,6 +399,12 @@ export function findNextChange(
 
     for (const mark of node.marks) {
       if (mark.type === insertionType || mark.type === deletionType) {
+        // Return the FULL expanded range, even when `startPos` lands
+        // inside the matched span. A toolbar that does
+        // `findNextChange(state, selectionEnd)` and then accepts the
+        // returned range must see the whole revision — clamping `from`
+        // up to `startPos` truncates the earlier portion of the same
+        // change and leaves orphaned marks behind after accept.
         const expanded = expandTrackedChangeRange(
           state,
           mark,
@@ -417,7 +412,7 @@ export function findNextChange(
           pos + node.nodeSize,
         );
         result.value = {
-          from: Math.max(expanded.from, startPos),
+          from: expanded.from,
           to: expanded.to,
           type: mark.type === insertionType ? "insertion" : "deletion",
         };
@@ -458,6 +453,13 @@ export function findPreviousChange(
     }
     if (pos >= startPos) {
       return false;
+    }
+    // The forward walk would otherwise re-expand the same span once per
+    // text node inside it. Skip nodes already covered by the most
+    // recent kept result — the previous expansion already included
+    // them, and expansion is idempotent.
+    if (result.value && pos < result.value.to) {
+      return;
     }
 
     for (const mark of node.marks) {

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -333,7 +333,57 @@ export function findChangeAtPosition(
 }
 
 /**
- * Find the next tracked change after the given position.
+ * Walk outward from `[fromHint, toHint]` and return the full extent of the
+ * tracked-change span carrying `mark` (matched via `Mark.eq`, so attrs like
+ * `revisionId` distinguish adjacent changes). Used to keep the
+ * navigation/scroll helpers honest when a tracked-change span is split
+ * across multiple text nodes due to inline formatting (e.g., a bold word
+ * inside an insertion).
+ */
+function expandTrackedChangeRange(
+  state: EditorState,
+  mark: import("prosemirror-model").Mark,
+  fromHint: number,
+  toHint: number,
+): { from: number; to: number } {
+  // Walk left from `from` and right from `to`, hopping across adjacent
+  // text nodes whose mark set contains the same insertion/deletion
+  // instance. PM's `nodesBetween` visits siblings in tree order; we use
+  // it in a fixed-point loop so the range stabilises across multi-node
+  // expansions. Box-mutate `range` so the visitor (declared once,
+  // outside the loop) can update it in place.
+  const range = { from: fromHint, to: toHint, extended: true };
+  const visitor = (
+    child: import("prosemirror-model").Node,
+    pos: number,
+  ): void => {
+    if (!child.isText) {
+      return;
+    }
+    const childEnd = pos + child.nodeSize;
+    if (!child.marks.some((m) => m.eq(mark))) {
+      return;
+    }
+    if (childEnd === range.from) {
+      range.from = pos;
+      range.extended = true;
+    }
+    if (pos === range.to) {
+      range.to = childEnd;
+      range.extended = true;
+    }
+  };
+  while (range.extended) {
+    range.extended = false;
+    state.doc.nodesBetween(Math.max(0, range.from - 1), range.to + 1, visitor);
+  }
+  return { from: range.from, to: range.to };
+}
+
+/**
+ * Find the next tracked change after the given position. Returns the full
+ * range of the change (including adjacent text nodes that share the same
+ * insertion/deletion mark instance), not just the first text node.
  */
 export function findNextChange(
   state: EditorState,
@@ -360,9 +410,15 @@ export function findNextChange(
 
     for (const mark of node.marks) {
       if (mark.type === insertionType || mark.type === deletionType) {
+        const expanded = expandTrackedChangeRange(
+          state,
+          mark,
+          pos,
+          pos + node.nodeSize,
+        );
         result.value = {
-          from: Math.max(pos, startPos),
-          to: pos + node.nodeSize,
+          from: Math.max(expanded.from, startPos),
+          to: expanded.to,
           type: mark.type === insertionType ? "insertion" : "deletion",
         };
         return false;
@@ -380,7 +436,9 @@ export function findNextChange(
 }
 
 /**
- * Find the previous tracked change before the given position.
+ * Find the previous tracked change before the given position. Returns the
+ * full range of the change (including adjacent text nodes that share the
+ * same insertion/deletion mark instance), not just the last text node.
  */
 export function findPreviousChange(
   state: EditorState,
@@ -404,9 +462,15 @@ export function findPreviousChange(
 
     for (const mark of node.marks) {
       if (mark.type === insertionType || mark.type === deletionType) {
+        const expanded = expandTrackedChangeRange(
+          state,
+          mark,
+          pos,
+          pos + node.nodeSize,
+        );
         result.value = {
-          from: pos,
-          to: pos + node.nodeSize,
+          from: expanded.from,
+          to: expanded.to,
           type: mark.type === insertionType ? "insertion" : "deletion",
         };
       }


### PR DESCRIPTION
## Summary
**Correctness.** `findNextChange` / `findPreviousChange` returned only one text node's range when a tracked change spanned multiple text nodes — which happens whenever inline formatting (e.g., a bold word) splits an insertion across siblings that share the same insertion mark instance but differ in their other marks. The toolbar's prev/next-change buttons build a `TextSelection` from the returned range and call `scrollToPosition`, so pressing "next change" only selected the first half of a partially-bolded suggestion, and a follow-up accept/reject acted on the truncated range.

Add an `expandTrackedChangeRange` helper that walks outward across adjacent text nodes whose mark set still contains the same mark instance (gate via `Mark.eq`, so cross-revision adjacency stays separate). `findNextChange` expands from the entry node forward; `findPreviousChange` re-expands the last-matched node in both directions.

**Perf.** The expansion uses `doc.nodesBetween(from − 1, to + 1, …)` rather than a full descendants walk, with a fixed-point loop that terminates on the first non-extending pass — typically 1–2 iterations.

## Test plan
- [x] `bun --filter @stll/folio test` — 637 pass (was 635)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`
- New regression tests cover both directions on a span split as `plain | bold-insertion | plain-insertion | tail` — both helpers must return the full inserted region (6..15), not just one half.