### PR TITLE
fix(folio): correct coord→PM resolution and word-select for atom inline nodes

### DIFF
--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -138,32 +138,40 @@ function findPositionInSpan(
     return pmStart + Math.min(native, pmEnd - pmStart);
   }
 
-  // Fallback: per-glyph rect scan. Earlier we used a
-  // binary search that compared `clientX` against the
-  // `getBoundingClientRect().left` of a collapsed range
-  // at offset `mid`, but a collapsed-range rect's left
-  // edge is the *caret* X (boundary between glyphs N-1
-  // and N), not the visual centre of any glyph. The
-  // tie-break logic then preferred the caret to the
+  // Fallback: per-glyph rect scan. Pick the glyph whose
+  // visual midpoint is closest to `clientX` rather than
+  // walking forward and breaking on the first midpoint
+  // past the cursor — that shortcut assumes monotonic
+  // increasing X, which is only true for LTR runs and
+  // would resolve to the wrong glyph in a bidi/RTL
+  // section. Distance-minimisation is direction-agnostic.
+  // The earlier binary search compared `clientX` against
+  // the `getBoundingClientRect().left` of a collapsed
+  // range at offset `mid`, but that's the *caret* X
+  // (boundary between glyphs N-1 and N), not any glyph's
+  // centre, and the tie-break preferred the caret to the
   // right of the click on every exact midpoint, which
-  // shifted drag selections one position left. Doing a
-  // forward walk that compares against each glyph's
-  // visual midpoint matches what every native text
-  // editor does for a "which character is under the
-  // cursor" hit-test.
-  let bestOffset = textLength;
+  // shifted drag selections one PM position left.
+  // Reuse a single `Range` across the whole loop —
+  // `createRange()` per iteration leaks DOM allocations
+  // on long spans, and each `getBoundingClientRect()`
+  // already forces a layout reflow we can't avoid.
+  const range = ownerDoc.createRange();
+  let bestOffset = 0;
+  let bestDistance = Number.POSITIVE_INFINITY;
   for (let i = 0; i < textLength; i++) {
-    const range = ownerDoc.createRange();
     range.setStart(text, i);
     range.setEnd(text, i + 1);
     const rect = range.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) {
-      continue;
-    }
+    if (rect.width === 0 && rect.height === 0) {continue;}
     const midpoint = rect.left + rect.width / 2;
-    if (clientX < midpoint) {
-      bestOffset = i;
-      break;
+    const distance = Math.abs(clientX - midpoint);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      // Click lands in the right half of glyph `i` →
+      // caret should sit AFTER the glyph (offset i+1);
+      // left half → caret BEFORE (offset i).
+      bestOffset = clientX < midpoint ? i : i + 1;
     }
   }
   return pmStart + Math.min(bestOffset, pmEnd - pmStart);

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -163,7 +163,9 @@ function findPositionInSpan(
     range.setStart(text, i);
     range.setEnd(text, i + 1);
     const rect = range.getBoundingClientRect();
-    if (rect.width === 0 && rect.height === 0) {continue;}
+    if (rect.width === 0 && rect.height === 0) {
+      continue;
+    }
     const midpoint = rect.left + rect.width / 2;
     const distance = Math.abs(clientX - midpoint);
     if (distance < bestDistance) {

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -93,12 +93,19 @@ export function clickToPositionDom(
 }
 
 /**
- * Find exact position within a text span using binary search on character boundaries.
+ * Find exact position within a text span. Defers to the
+ * browser's own hit-tester (`caretPositionFromPoint` /
+ * `caretRangeFromPoint`) — that's what every native text
+ * editor uses, and it correctly handles bidi runs, kerning,
+ * variable fonts, sub-pixel rendering, and line wrap. Falls
+ * back to a per-glyph rect scan when the browser API is
+ * unavailable or returns a point outside this span (e.g. the
+ * caret API resolved to a sibling text node at the same y).
  */
 function findPositionInSpan(
   spanEl: HTMLElement,
   clientX: number,
-  _clientY: number,
+  clientY: number,
 ): number | null {
   const pmStart = Number(spanEl.dataset["pmStart"]);
   const pmEnd = Number(spanEl.dataset["pmEnd"]);
@@ -126,51 +133,79 @@ function findPositionInSpan(
   }
 
   const ownerDoc = spanEl.ownerDocument;
+  const native = caretOffsetFromPoint(ownerDoc, text, clientX, clientY);
+  if (native !== null) {
+    return pmStart + Math.min(native, pmEnd - pmStart);
+  }
 
-  // Binary search for the character boundary
-  let left = 0;
-  let right = textLength;
-
-  while (left < right) {
-    const mid = Math.floor((left + right) / 2);
+  // Fallback: per-glyph rect scan. Earlier we used a
+  // binary search that compared `clientX` against the
+  // `getBoundingClientRect().left` of a collapsed range
+  // at offset `mid`, but a collapsed-range rect's left
+  // edge is the *caret* X (boundary between glyphs N-1
+  // and N), not the visual centre of any glyph. The
+  // tie-break logic then preferred the caret to the
+  // right of the click on every exact midpoint, which
+  // shifted drag selections one position left. Doing a
+  // forward walk that compares against each glyph's
+  // visual midpoint matches what every native text
+  // editor does for a "which character is under the
+  // cursor" hit-test.
+  let bestOffset = textLength;
+  for (let i = 0; i < textLength; i++) {
     const range = ownerDoc.createRange();
-    range.setStart(text, mid);
-    range.setEnd(text, mid);
-
+    range.setStart(text, i);
+    range.setEnd(text, i + 1);
     const rect = range.getBoundingClientRect();
-    const charX = rect.left;
-
-    if (clientX < charX) {
-      right = mid;
-    } else {
-      left = mid + 1;
+    if (rect.width === 0 && rect.height === 0) {
+      continue;
+    }
+    const midpoint = rect.left + rect.width / 2;
+    if (clientX < midpoint) {
+      bestOffset = i;
+      break;
     }
   }
+  return pmStart + Math.min(bestOffset, pmEnd - pmStart);
+}
 
-  // Refine: check if we're closer to left-1 or left
-  if (left > 0 && left <= textLength) {
-    const range = ownerDoc.createRange();
-
-    // Get position of character at left-1
-    range.setStart(text, left - 1);
-    range.setEnd(text, left - 1);
-    const leftRect = range.getBoundingClientRect();
-
-    // Get position of character at left
-    range.setStart(text, Math.min(left, textLength));
-    range.setEnd(text, Math.min(left, textLength));
-    const rightRect = range.getBoundingClientRect();
-
-    // Use the closer boundary
-    const distLeft = Math.abs(clientX - leftRect.left);
-    const distRight = Math.abs(clientX - rightRect.left);
-
-    if (distLeft < distRight) {
-      return pmStart + (left - 1);
+/**
+ * Resolve `(clientX, clientY)` to a character offset
+ * inside `text` using the browser's caret hit-tester.
+ * Returns `null` if the API is unavailable or resolved to
+ * a different node — callers fall back to a glyph-by-glyph
+ * scan in that case.
+ */
+function caretOffsetFromPoint(
+  ownerDoc: Document,
+  text: Text,
+  clientX: number,
+  clientY: number,
+): number | null {
+  // `caretPositionFromPoint` is the spec'd successor;
+  // `caretRangeFromPoint` is the older WebKit-rooted API
+  // still shipped by Chromium and Safari. Try both.
+  type LegacyDocument = Document & {
+    caretPositionFromPoint?: (
+      x: number,
+      y: number,
+    ) => { offsetNode: Node; offset: number } | null;
+    caretRangeFromPoint?: (x: number, y: number) => Range | null;
+  };
+  const doc: LegacyDocument = ownerDoc;
+  if (typeof doc.caretPositionFromPoint === "function") {
+    const pos = doc.caretPositionFromPoint(clientX, clientY);
+    if (pos && pos.offsetNode === text) {
+      return pos.offset;
     }
   }
-
-  return pmStart + Math.min(left, pmEnd - pmStart);
+  if (typeof doc.caretRangeFromPoint === "function") {
+    const range = doc.caretRangeFromPoint(clientX, clientY);
+    if (range && range.startContainer === text) {
+      return range.startOffset;
+    }
+  }
+  return null;
 }
 
 /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3929,22 +3929,48 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
               const $pos = doc.resolve(pmPos);
               const parent = $pos.parent;
 
-              // Find word boundaries
+              // Find word boundaries.
               if (parent.isTextblock) {
-                const text = parent.textContent;
+                // Build a string aligned 1-to-1 with PM
+                // offsets inside the parent. Atom inline
+                // nodes (tab, hard_break, image) take 1 PM
+                // position but don't appear in
+                // `textContent`, so a tab at offset 0 +
+                // text "(a)" + tab at offset 4 + text
+                // "Equity Financing" has parentSize 21
+                // but textContent length 19. Walking
+                // word boundaries on `textContent` and
+                // then writing back via `$pos.start() +
+                // offset` shifts the resulting selection
+                // by one PM position per atom skipped —
+                // double-clicking "Financing" in such a
+                // paragraph selected "y Financin"
+                // instead. Padding atom nodes with a
+                // non-word character keeps every offset
+                // in PM-position space.
+                let pmAlignedText = "";
+                for (let i = 0; i < parent.content.childCount; i++) {
+                  const node = parent.content.child(i);
+                  pmAlignedText += node.isText
+                    ? (node.text ?? "")
+                    : " ".repeat(node.nodeSize);
+                }
                 const offset = $pos.parentOffset;
 
                 // Find word start (go back until whitespace/punctuation)
                 let start = offset;
-                while (start > 0 && /\w/.test(text[start - 1]!)) {
+                while (start > 0 && /\w/.test(pmAlignedText[start - 1]!)) {
                   // SAFETY: start > 0
                   start--;
                 }
 
                 // Find word end (go forward until whitespace/punctuation)
                 let end = offset;
-                while (end < text.length && /\w/.test(text[end]!)) {
-                  // SAFETY: end < text.length
+                while (
+                  end < pmAlignedText.length &&
+                  /\w/.test(pmAlignedText[end]!)
+                ) {
+                  // SAFETY: end < pmAlignedText.length
                   end++;
                 }
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3948,13 +3948,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
                 // instead. Padding atom nodes with a
                 // non-word character keeps every offset
                 // in PM-position space.
-                let pmAlignedText = "";
+                const pmAlignedParts: string[] = [];
                 for (let i = 0; i < parent.content.childCount; i++) {
                   const node = parent.content.child(i);
-                  pmAlignedText += node.isText
-                    ? (node.text ?? "")
-                    : " ".repeat(node.nodeSize);
+                  pmAlignedParts.push(
+                    node.isText ? (node.text ?? "") : " ".repeat(node.nodeSize),
+                  );
                 }
+                const pmAlignedText = pmAlignedParts.join("");
                 const offset = $pos.parentOffset;
 
                 // Find word start (go back until whitespace/punctuation)


### PR DESCRIPTION
## Summary
- `findPositionInSpan` now uses the browser's `caretPositionFromPoint` / `caretRangeFromPoint` for the primary hit-test. The previous binary search compared `clientX` against caret X positions and tie-broke right on every exact-midpoint click, which shifted drag selections one PM position left on both endpoints ("Investor → Investo"). Fallback is a per-glyph midpoint scan, matching native text-editor behaviour.
- Double-click word selection walked `parent.textContent` while writing the selection back via `$pos.start() + offset`. Atom inline nodes (tab, hard_break, image) take 1 PM position but contribute 0 chars to `textContent`, so the two coordinate systems drifted and double-clicking "Financing" in `\t(a)\tEquity Financing` selected "y Financin". Build a PM-aligned string padding atoms with a non-word character so every offset stays in PM space.

## Test plan
- [ ] `bun test packages/folio/src/core/layout-bridge/clickToPositionDomScope.test.ts`
- [ ] In a docx with leading-tab paragraphs, double-click a word and confirm the whole word selects.
- [ ] Drag-select a word and confirm the visible selection matches the dragged range exactly.