### PR TITLE
feat(inspector): smarter anonymization facet — loading state, default Misc, folio prefill bridge, tidy chip row

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Nalezeno v dokumentu ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorovat v tomto dokumentu",
       "ignoreScopeAlways": "Vždy ignorovat",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "In diesem Dokument erkannt ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "In diesem Dokument ignorieren",
       "ignoreScopeAlways": "Immer ignorieren",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Detected in this document ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignore in this document",
       "ignoreScopeAlways": "Always ignore",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Detectado en este documento ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorar en este documento",
       "ignoreScopeAlways": "Ignorar siempre",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Tuvastatud selles dokumendis ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Eira selles dokumendis",
       "ignoreScopeAlways": "Eira alati",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Détecté dans ce document ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorer dans ce document",
       "ignoreScopeAlways": "Toujours ignorer",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Talált a dokumentumban ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Mellőzés ebben a dokumentumban",
       "ignoreScopeAlways": "Mindig mellőzni",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Aptikta šiame dokumente ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignoruoti šiame dokumente",
       "ignoreScopeAlways": "Visada ignoruoti",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Atrasts šajā dokumentā ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorēt šajā dokumentā",
       "ignoreScopeAlways": "Vienmēr ignorēt",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1098,6 +1098,7 @@ type Messages = {
       "contextMenuAddAction": "Anonymize selection";
       "deleteAction": "Delete term";
       "detectedHeading": "Detected in this document ({count})";
+      "detectingMatches": "Detecting entities in this document…";
       "emptyState": "No workspace-specific terms yet. Add one above.";
       "ignoreAction": "Ignore in this document";
       "ignoreScopeAlways": "Always ignore";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Wykryto w tym dokumencie ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignoruj w tym dokumencie",
       "ignoreScopeAlways": "Zawsze ignoruj",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Detectado neste documento ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorar neste documento",
       "ignoreScopeAlways": "Sempre ignorar",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1095,6 +1095,7 @@
       "contextMenuAddAction": "Anonymize selection",
       "deleteAction": "Delete term",
       "detectedHeading": "Nájdené v dokumente ({count})",
+      "detectingMatches": "Detecting entities in this document…",
       "emptyState": "No workspace-specific terms yet. Add one above.",
       "ignoreAction": "Ignorovať v tomto dokumente",
       "ignoreScopeAlways": "Vždy ignorovať",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -294,6 +294,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         })
         .catch(() => {
           inFlightUntil = 0;
+          // Mark on failure too — the inspector facet hides
+          // the "Detecting…" placeholder once the pipeline
+          // has produced *any* terminal outcome. Without
+          // this, a worker error would leave the facet
+          // stuck on "Detecting…" forever.
+          useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
         });
     };
     // The doc text isn't always populated when the view first
@@ -436,7 +442,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   // highlighted on a painted page. Wrap the PM view's dispatch
   // so every selection-bearing transaction publishes the
   // selected text to the document-selection store, which the
-  // inspector facet subscribes to.
+  // inspector facet subscribes to. Wrapping `view.dispatch`
+  // post-creation is fragile in principle (a second wrapper
+  // installed after this one would un-stack out of order on
+  // cleanup), but in practice nothing else outside folio
+  // touches this view's dispatch — folio itself goes through
+  // its own internal calls bound at view construction. A
+  // cleaner long-term fix would be a folio-side
+  // `onSelectionTextChange` callback that already gives us
+  // both the range and the text; tracked but out of scope here.
   useEffect(() => {
     const view = editorViewForAnonymization;
     if (!view) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -435,56 +435,30 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   }, [fieldId, isAnonymizationActive]);
 
   // Bridge document selections → inspector "Term to anonymize"
-  // input. The folio paged editor sets PM selections
-  // programmatically on its off-screen hidden PM and renders
-  // the visible selection via a custom overlay, so a global
-  // `selectionchange` listener never sees what the user
-  // highlighted on a painted page. Wrap the PM view's dispatch
-  // so every selection-bearing transaction publishes the
-  // selected text to the document-selection store, which the
-  // inspector facet subscribes to. Wrapping `view.dispatch`
-  // post-creation is fragile in principle (a second wrapper
-  // installed after this one would un-stack out of order on
-  // cleanup), but in practice nothing else outside folio
-  // touches this view's dispatch — folio itself goes through
-  // its own internal calls bound at view construction. A
-  // cleaner long-term fix would be a folio-side
-  // `onSelectionTextChange` callback that already gives us
-  // both the range and the text; tracked but out of scope here.
-  useEffect(() => {
-    const view = editorViewForAnonymization;
-    if (!view) {
-      return undefined;
-    }
-    const originalDispatch = view.dispatch.bind(view);
-    const { publish } = useDocumentTextSelectionStore.getState();
-    view.dispatch = (tr) => {
-      originalDispatch(tr);
-      if (!tr.selectionSet) {
+  // input. Folio fires `onSelectionTextChange` with the range
+  // and the resolved text on every selection-bearing
+  // transaction, so we just have to length-gate and publish.
+  // The cleanup clears the store so a second tab opening this
+  // facet doesn't see a stale prefill from the previous file.
+  const handleSelectionTextChange = useCallback(
+    (selection: { from: number; to: number; text: string }) => {
+      if (selection.from === selection.to) {
         return;
       }
-      const { from, to } = view.state.selection;
-      if (from === to) {
-        return;
-      }
-      // textBetween with " " for both leaf-block and block
-      // separators collapses table cells, paragraphs, and
-      // inline atoms into a single-line phrase fit for the
-      // term-to-anonymize input.
-      const raw = view.state.doc.textBetween(from, to, " ", " ");
-      const single = raw.replace(/\s+/g, " ").trim();
+      const single = selection.text.replace(/\s+/g, " ").trim();
       if (single.length < 2 || single.length > 200) {
         return;
       }
-      publish(fieldId, single);
-    };
-    return () => {
-      // Restore the original dispatch so subsequent unmounted
-      // wrappers don't pile up if the view is reused.
-      view.dispatch = originalDispatch;
+      useDocumentTextSelectionStore.getState().publish(fieldId, single);
+    },
+    [fieldId],
+  );
+  useEffect(
+    () => () => {
       useDocumentTextSelectionStore.getState().clear(fieldId);
-    };
-  }, [editorViewForAnonymization, fieldId]);
+    },
+    [fieldId],
+  );
 
   // Two-way bridge with the inspector anonymization facet.
   // - Click in document → push to store as source="doc" with
@@ -1309,6 +1283,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
                 onCompatibilityChange?.(nextCompatibility);
               }}
               onAnonymizationMatchesChange={handleAnonymizationMatchesChange}
+              onSelectionTextChange={handleSelectionTextChange}
               onAnonymizationTermClick={handleAnonymizationTermClick}
               selectedAnonymizationCanonical={sidebarSelectedCanonical}
               anonymizationSelectionSeq={sidebarSelectionSeq}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -230,6 +230,15 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       return undefined;
     }
     let cancelled = false;
+    // Mark the pipeline as in-flight from mount so the
+    // inspector facet shows "Detecting entities…" right
+    // away instead of flashing "0 entities" during the
+    // 300ms gap before the first `run()` fires (and
+    // before that run can call `markPipelineStarted`
+    // itself). The first `run()` also calls it again
+    // (idempotent set-add); subsequent runs flip it on
+    // around each worker call.
+    useAnonymizationMatchesStore.getState().markPipelineStarted(fieldId);
     // Track the text+exclusions we received *results* for (not
     // just dispatched). The worker can occasionally drop a
     // request across dev HMR (the singleton's pending map loses
@@ -247,6 +256,8 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     // never delivers, the window expires and a retry fires.
     let inFlightUntil = 0;
     const IN_FLIGHT_TIMEOUT_MS = 10_000;
+    const markRan = () =>
+      useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
     const run = () => {
       if (cancelled) {
         return;
@@ -257,13 +268,24 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       const text = view.state.doc.textContent;
       const excluded = excludedCanonicalsRef.current;
       const cacheKey = `${[...excluded].sort().join("|")}~${text}`;
-      if (text.length === 0 || cacheKey === lastDeliveredKey) {
+      if (text.length === 0) {
+        // Empty doc: nothing to detect. Release the
+        // "in flight" lock so the facet exits the
+        // "Detecting…" placeholder instead of stalling
+        // on the mount-time mark.
+        markRan();
+        return;
+      }
+      if (cacheKey === lastDeliveredKey) {
+        // Already delivered for this exact text +
+        // exclusions; no-op without flipping the
+        // started state (we're not running anything).
         return;
       }
       inFlightUntil = Date.now() + IN_FLIGHT_TIMEOUT_MS;
-      // Tell the inspector facet a producer is in flight
-      // so it shows the "Detecting…" placeholder instead
-      // of a stale (or zero) count from an earlier run.
+      // (Re-)mark started: handles reruns triggered by
+      // edits or allowlist changes after the first run
+      // already called `markPipelineRan`.
       useAnonymizationMatchesStore.getState().markPipelineStarted(fieldId);
       anonymizeChatTextInWorker({
         text,
@@ -287,23 +309,14 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             }
           }
           setDetectedAnonymizationTerms([...byCanonical.values()]);
-          // Tell the inspector facet that the pipeline has
-          // delivered a real result for this field. Folio's
-          // plugin already published an empty snapshot on
-          // mount; without this signal the facet would flip
-          // from "Detecting…" to "0 entities" the moment the
-          // editor mounts, then to the real count seconds
-          // later when the worker finally returns.
-          useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
+          markRan();
         })
         .catch(() => {
           inFlightUntil = 0;
-          // Mark on failure too — the inspector facet hides
-          // the "Detecting…" placeholder once the pipeline
-          // has produced *any* terminal outcome. Without
-          // this, a worker error would leave the facet
-          // stuck on "Detecting…" forever.
-          useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
+          // Mark on failure too — without this, a worker
+          // error would leave the facet stuck on
+          // "Detecting…" forever.
+          markRan();
         });
     };
     // The doc text isn't always populated when the view first
@@ -323,8 +336,12 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       runDetectionRef.current = null;
       clearTimeout(initialTimer);
       clearInterval(heartbeat);
+      // Release the in-flight lock on unmount/dep change
+      // so a stale "Detecting…" doesn't survive a tab
+      // switch or an anonymization toggle-off.
+      markRan();
     };
-  }, [editorViewForAnonymization, isAnonymizationActive, workspaceId]);
+  }, [editorViewForAnonymization, isAnonymizationActive, workspaceId, fieldId]);
   // Per-doc allowlist: canonicals the user has flagged as false
   // positives. The chat-anon worker filters these out of its
   // detected entities itself; we still need to strip them from

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -261,6 +261,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
         return;
       }
       inFlightUntil = Date.now() + IN_FLIGHT_TIMEOUT_MS;
+      // Tell the inspector facet a producer is in flight
+      // so it shows the "Detecting…" placeholder instead
+      // of a stale (or zero) count from an earlier run.
+      useAnonymizationMatchesStore.getState().markPipelineStarted(fieldId);
       anonymizeChatTextInWorker({
         text,
         workspaceId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -64,6 +64,7 @@ import { fileOptions } from "@/routes/_protected.workspaces/$workspaceId/-compon
 import { useIsAnonymizationActive } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-active-store";
 import { useAnonymizationMatchesStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store";
 import { useAnonymizationSelectionStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-selection-store";
+import { useDocumentTextSelectionStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/document-text-selection-store";
 import { anonymizationAllowlistOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/anonymization-allowlist";
 import { anonymizationTermsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/anonymization-terms";
 import "@/routes/_protected.workspaces/$workspaceId/-components/peek/peek-docx.css";
@@ -282,6 +283,14 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
             }
           }
           setDetectedAnonymizationTerms([...byCanonical.values()]);
+          // Tell the inspector facet that the pipeline has
+          // delivered a real result for this field. Folio's
+          // plugin already published an empty snapshot on
+          // mount; without this signal the facet would flip
+          // from "Detecting…" to "0 entities" the moment the
+          // editor mounts, then to the real count seconds
+          // later when the worker finally returns.
+          useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
         })
         .catch(() => {
           inFlightUntil = 0;
@@ -418,6 +427,50 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       clear(fieldId);
     };
   }, [fieldId, isAnonymizationActive]);
+
+  // Bridge document selections → inspector "Term to anonymize"
+  // input. The folio paged editor sets PM selections
+  // programmatically on its off-screen hidden PM and renders
+  // the visible selection via a custom overlay, so a global
+  // `selectionchange` listener never sees what the user
+  // highlighted on a painted page. Wrap the PM view's dispatch
+  // so every selection-bearing transaction publishes the
+  // selected text to the document-selection store, which the
+  // inspector facet subscribes to.
+  useEffect(() => {
+    const view = editorViewForAnonymization;
+    if (!view) {
+      return undefined;
+    }
+    const originalDispatch = view.dispatch.bind(view);
+    const { publish } = useDocumentTextSelectionStore.getState();
+    view.dispatch = (tr) => {
+      originalDispatch(tr);
+      if (!tr.selectionSet) {
+        return;
+      }
+      const { from, to } = view.state.selection;
+      if (from === to) {
+        return;
+      }
+      // textBetween with " " for both leaf-block and block
+      // separators collapses table cells, paragraphs, and
+      // inline atoms into a single-line phrase fit for the
+      // term-to-anonymize input.
+      const raw = view.state.doc.textBetween(from, to, " ", " ");
+      const single = raw.replace(/\s+/g, " ").trim();
+      if (single.length < 2 || single.length > 200) {
+        return;
+      }
+      publish(fieldId, single);
+    };
+    return () => {
+      // Restore the original dispatch so subsequent unmounted
+      // wrappers don't pile up if the view is reused.
+      view.dispatch = originalDispatch;
+      useDocumentTextSelectionStore.getState().clear(fieldId);
+    };
+  }, [editorViewForAnonymization, fieldId]);
 
   // Two-way bridge with the inspector anonymization facet.
   // - Click in document → push to store as source="doc" with

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
@@ -47,8 +47,12 @@ import { stellaToast } from "@stll/ui/components/toast";
 import type { TranslationKey } from "@/i18n/types";
 import { useAnonymizationActiveStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-active-store";
 import { AnonymizationContextMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-context-menu";
-import { useAnonymizationMatches } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store";
+import {
+  useAnonymizationMatches,
+  useAnonymizationMatchesReady,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store";
 import { useAnonymizationSelectionStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-selection-store";
+import { useDocumentTextSelection } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/document-text-selection-store";
 import {
   useCreateAnonymizationAllowlistEntry,
   useDeleteAnonymizationAllowlistEntry,
@@ -62,11 +66,11 @@ import { anonymizationTermsOptions } from "@/routes/_protected.workspaces/$works
 
 /**
  * Labels users can pick from when tagging a new term. Mirrors
- * the chat anonymizer's default entity labels — without MISC
- * for v1 because adding it requires a coordinated change in
- * the upstream @stll/anonymize-wasm package.
+ * the chat anonymizer's default entity labels (`misc` is now
+ * supported end-to-end in `@stll/anonymize-wasm`).
  */
 const LABEL_OPTIONS = [
+  "misc",
   "organization",
   "person",
   "address",
@@ -87,7 +91,11 @@ const LABEL_OPTIONS = [
 
 type LabelOption = (typeof LABEL_OPTIONS)[number];
 
-const DEFAULT_LABEL: LabelOption = "organization";
+// Misc is the safest default — most user-added terms don't
+// fit the structured categories cleanly, and it forces the
+// person to consciously upgrade the label when one of the
+// PII-specific buckets really does apply.
+const DEFAULT_LABEL: LabelOption = "misc";
 
 // Map the anonymizer's English label strings (the pipeline
 // emits canonicals like "organization", "phone number") onto
@@ -113,6 +121,12 @@ const LABEL_TRANSLATION_KEYS = {
   "passport number": "common.anonymizationLabels.passportNumber",
   "monetary amount": "common.anonymizationLabels.monetaryAmount",
   "land parcel": "common.anonymizationLabels.landParcel",
+  misc: "common.anonymizationLabels.miscellaneous",
+  // Back-compat alias: legacy server entries still labelled
+  // "other" before the wasm runtime adopted the canonical
+  // "misc" key. Kept so old workspace catalogs render with a
+  // proper translated label instead of falling back to the
+  // raw string.
   other: "common.anonymizationLabels.miscellaneous",
 } as const satisfies Record<string, TranslationKey>;
 
@@ -215,16 +229,15 @@ export const AnonymizationFacet = ({
   // like they live inside an input/textarea so typing into the
   // term field itself doesn't keep overwriting the value.
   useEffect(() => {
-    // CSS selector for the file-preview surfaces we want to
-    // accept selections from. `.layout-page` is the painted
-    // Folio page; the PDF viewer uses `.textLayer`. Folio's
-    // paged editor routes window.getSelection() to a hidden
-    // ProseMirror at -9999px (`.paged-editor__hidden-pm`) when
-    // the user drags on a painted page, so accept that surface
-    // too — without it, real user selections never reach the
-    // "Term to anonymize" prefill.
-    const PREVIEW_SURFACES =
-      ".layout-page, .textLayer, .paged-editor__hidden-pm";
+    // PDF viewer renders a real DOM `.textLayer` whose
+    // selections show up in `window.getSelection()`. The folio
+    // paged editor doesn't — it sets PM selections
+    // programmatically on an off-screen hidden PM and renders
+    // visible selection via a custom overlay. Folio
+    // selections come in via the document-text-selection
+    // store (subscribed below); the listener here only
+    // handles the PDF case.
+    const PREVIEW_SURFACES = ".textLayer";
     const isInsidePreview = (node: Node | null): boolean => {
       const element =
         node instanceof Element ? node : (node?.parentElement ?? null);
@@ -235,9 +248,6 @@ export const AnonymizationFacet = ({
       if (!selection || selection.rangeCount === 0) {
         return;
       }
-      // Both endpoints must sit inside the preview, otherwise we
-      // pick up incidental selections in the inspector, sidebar,
-      // tooltips, etc.
       if (
         !isInsidePreview(selection.anchorNode) ||
         !isInsidePreview(selection.focusNode)
@@ -257,6 +267,22 @@ export const AnonymizationFacet = ({
     document.addEventListener("selectionchange", handler);
     return () => document.removeEventListener("selectionchange", handler);
   }, []);
+
+  // Folio selection bridge — picks up PM selections that
+  // live in the off-screen hidden PM and aren't visible to
+  // `window.getSelection()`. The docx editor wrapper
+  // wraps `view.dispatch` and publishes the latest
+  // selected text here on every selection-bearing
+  // transaction.
+  const folioSelection = useDocumentTextSelection(activeFieldId);
+  useEffect(() => {
+    if (folioSelection === null) {
+      return;
+    }
+    setPendingValue(folioSelection.text);
+    // `seq` is part of the dep array so re-selecting the
+    // same string still re-fires the prefill.
+  }, [folioSelection?.text, folioSelection?.seq]);
 
   const addTerm = (canonical: string, label: LabelOption) => {
     const trimmed = canonical.trim();
@@ -292,6 +318,7 @@ export const AnonymizationFacet = ({
 
   const allEntries = termsQuery.data?.entries ?? [];
   const matchSnapshot = useAnonymizationMatches(activeFieldId);
+  const matchesReady = useAnonymizationMatchesReady(activeFieldId);
   const allowlistQuery = useQuery({
     ...anonymizationAllowlistOptions({ workspaceId, entityId }),
     enabled: activeFieldId !== null,
@@ -303,12 +330,16 @@ export const AnonymizationFacet = ({
   // canonical form is actually present in the open document. When
   // no document is open (peek mode, file list) `activeFieldId` is
   // null and the snapshot is empty — we fall back to the full
-  // catalog so the user can still curate terms.
-  const entries = activeFieldId
-    ? allEntries.filter((entry) =>
-        matchSnapshot.countByCanonical.has(entry.canonical),
-      )
-    : allEntries;
+  // catalog so the user can still curate terms. Same fallback
+  // while `!matchesReady`: detection hasn't published yet, so
+  // filtering would collapse the list to "0 matches" and look
+  // identical to "actually nothing matches".
+  const entries =
+    activeFieldId && matchesReady
+      ? allEntries.filter((entry) =>
+          matchSnapshot.countByCanonical.has(entry.canonical),
+        )
+      : allEntries;
   const noOpenDocument = activeFieldId === null;
 
   // Auto-detected entities to surface in the "Detected" section.
@@ -513,7 +544,7 @@ export const AnonymizationFacet = ({
             autoHighlight
             disabled={createMutation.isPending}
             items={[...LABEL_OPTIONS]}
-            itemToStringLabel={(option) => option}
+            itemToStringLabel={formatLabel}
             onValueChange={(next) => {
               if (next) {
                 setPendingLabel(next);
@@ -573,6 +604,13 @@ export const AnonymizationFacet = ({
             );
           })();
         }
+        if (!matchesReady) {
+          return (
+            <div className="text-muted-foreground bg-muted/40 rounded-md px-3 py-2 text-xs">
+              {t("inspector.anonymization.detectingMatches")}
+            </div>
+          );
+        }
         return (
           <div className="bg-muted/40 text-foreground rounded-md px-3 py-2 text-xs">
             {t("inspector.anonymization.matchCount", {
@@ -584,7 +622,7 @@ export const AnonymizationFacet = ({
 
       <div className="flex flex-col gap-1">
         <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-          {noOpenDocument
+          {noOpenDocument || !matchesReady
             ? t("inspector.anonymization.workspaceTermsHeading", {
                 count: String(entries.length),
               })
@@ -670,7 +708,7 @@ export const AnonymizationFacet = ({
           );
         })}
       </div>
-      {!noOpenDocument && detectedGroups.length > 0 && (
+      {!noOpenDocument && matchesReady && detectedGroups.length > 0 && (
         <div className="flex flex-col gap-1">
           <div className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
             {t("inspector.anonymization.detectedHeading", {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
@@ -37,28 +37,60 @@ export type AnonymizationMatchSnapshot = {
 
 type State = {
   byFieldId: Record<string, AnonymizationMatchSnapshot>;
+  /**
+   * Field ids for which the detection pipeline (the
+   * chat-anon worker) has delivered at least one
+   * result. Distinct from `byFieldId` because Folio
+   * publishes an empty snapshot on plugin init, before
+   * the worker has had a chance to run; reading
+   * `byFieldId` alone would tell the inspector facet
+   * "ready, 0 matches" the moment the editor mounts.
+   */
+  pipelineRanFieldIds: ReadonlySet<string>;
 };
 
 type Actions = {
   publish: (fieldId: string, snapshot: AnonymizationMatchSnapshot) => void;
+  markPipelineRan: (fieldId: string) => void;
   clear: (fieldId: string) => void;
 };
 
 export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
   byFieldId: {},
+  pipelineRanFieldIds: new Set(),
   publish: (fieldId, snapshot) =>
     set((state) => ({
       byFieldId: { ...state.byFieldId, [fieldId]: snapshot },
     })),
-  clear: (fieldId) =>
+  markPipelineRan: (fieldId) =>
     set((state) => {
-      if (!(fieldId in state.byFieldId)) {
+      if (state.pipelineRanFieldIds.has(fieldId)) {
         return state;
       }
+      const next = new Set(state.pipelineRanFieldIds);
+      next.add(fieldId);
+      return { pipelineRanFieldIds: next };
+    }),
+  clear: (fieldId) =>
+    set((state) => {
+      const hadMatches = fieldId in state.byFieldId;
+      const hadRan = state.pipelineRanFieldIds.has(fieldId);
+      if (!hadMatches && !hadRan) {
+        return state;
+      }
+      let nextRan: ReadonlySet<string> = state.pipelineRanFieldIds;
+      if (hadRan) {
+        const mutable = new Set(state.pipelineRanFieldIds);
+        mutable.delete(fieldId);
+        nextRan = mutable;
+      }
       return {
-        byFieldId: Object.fromEntries(
-          Object.entries(state.byFieldId).filter(([id]) => id !== fieldId),
-        ),
+        byFieldId: hadMatches
+          ? Object.fromEntries(
+              Object.entries(state.byFieldId).filter(([id]) => id !== fieldId),
+            )
+          : state.byFieldId,
+        pipelineRanFieldIds: nextRan,
       };
     }),
 }));
@@ -74,4 +106,18 @@ export const useAnonymizationMatches = (
 ): AnonymizationMatchSnapshot =>
   useAnonymizationMatchesStore(
     (s) => (fieldId ? s.byFieldId[fieldId] : undefined) ?? EMPTY_SNAPSHOT,
+  );
+
+/**
+ * True once the detection pipeline has delivered at least one
+ * result for `fieldId`. Lets the inspector facet distinguish
+ * "detection still warming up" from "detection ran and found
+ * nothing", so an empty result doesn't masquerade as a buggy
+ * zero. Note: Folio publishes an empty snapshot on plugin init,
+ * so we explicitly track pipeline completion via
+ * `markPipelineRan` rather than reading `byFieldId`.
+ */
+export const useAnonymizationMatchesReady = (fieldId: string | null): boolean =>
+  useAnonymizationMatchesStore((s) =>
+    fieldId === null ? false : s.pipelineRanFieldIds.has(fieldId),
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
@@ -71,7 +71,9 @@ const withFieldAdded = (
   set: ReadonlySet<string>,
   fieldId: string,
 ): ReadonlySet<string> => {
-  if (set.has(fieldId)) {return set;}
+  if (set.has(fieldId)) {
+    return set;
+  }
   const next = new Set(set);
   next.add(fieldId);
   return next;
@@ -81,7 +83,9 @@ const withFieldRemoved = (
   set: ReadonlySet<string>,
   fieldId: string,
 ): ReadonlySet<string> => {
-  if (!set.has(fieldId)) {return set;}
+  if (!set.has(fieldId)) {
+    return set;
+  }
   const next = new Set(set);
   next.delete(fieldId);
   return next;
@@ -162,7 +166,11 @@ export const useAnonymizationMatches = (
  */
 export const useAnonymizationMatchesReady = (fieldId: string | null): boolean =>
   useAnonymizationMatchesStore((s) => {
-    if (fieldId === null) {return false;}
-    if (s.pipelineRanFieldIds.has(fieldId)) {return true;}
+    if (fieldId === null) {
+      return false;
+    }
+    if (s.pipelineRanFieldIds.has(fieldId)) {
+      return true;
+    }
     return !s.pipelineStartedFieldIds.has(fieldId);
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
@@ -38,51 +38,92 @@ export type AnonymizationMatchSnapshot = {
 type State = {
   byFieldId: Record<string, AnonymizationMatchSnapshot>;
   /**
-   * Field ids for which the detection pipeline (the
-   * chat-anon worker) has delivered at least one
-   * result. Distinct from `byFieldId` because Folio
-   * publishes an empty snapshot on plugin init, before
-   * the worker has had a chance to run; reading
-   * `byFieldId` alone would tell the inspector facet
-   * "ready, 0 matches" the moment the editor mounts.
+   * Field ids whose detection pipeline is currently in
+   * flight. Producers (the docx chat-anon worker, the
+   * PDF wasm runner) call `markPipelineStarted` when
+   * they begin and `markPipelineRan` on terminal
+   * outcome. The inspector facet uses this together
+   * with `pipelineRanFieldIds` to know whether to show
+   * the "Detecting…" placeholder — fields with no
+   * producer at all (unsupported file types) never
+   * enter this set so the facet falls through to the
+   * direct count instead of stalling forever.
+   */
+  pipelineStartedFieldIds: ReadonlySet<string>;
+  /**
+   * Field ids whose detection pipeline has produced at
+   * least one terminal outcome (success or error).
+   * Distinct from `byFieldId` because Folio publishes an
+   * empty snapshot on plugin init, before the worker
+   * has actually run.
    */
   pipelineRanFieldIds: ReadonlySet<string>;
 };
 
 type Actions = {
   publish: (fieldId: string, snapshot: AnonymizationMatchSnapshot) => void;
+  markPipelineStarted: (fieldId: string) => void;
   markPipelineRan: (fieldId: string) => void;
   clear: (fieldId: string) => void;
 };
 
+const withFieldAdded = (
+  set: ReadonlySet<string>,
+  fieldId: string,
+): ReadonlySet<string> => {
+  if (set.has(fieldId)) {return set;}
+  const next = new Set(set);
+  next.add(fieldId);
+  return next;
+};
+
+const withFieldRemoved = (
+  set: ReadonlySet<string>,
+  fieldId: string,
+): ReadonlySet<string> => {
+  if (!set.has(fieldId)) {return set;}
+  const next = new Set(set);
+  next.delete(fieldId);
+  return next;
+};
+
 export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
   byFieldId: {},
+  pipelineStartedFieldIds: new Set(),
   pipelineRanFieldIds: new Set(),
   publish: (fieldId, snapshot) =>
     set((state) => ({
       byFieldId: { ...state.byFieldId, [fieldId]: snapshot },
     })),
+  markPipelineStarted: (fieldId) =>
+    set((state) => ({
+      pipelineStartedFieldIds: withFieldAdded(
+        state.pipelineStartedFieldIds,
+        fieldId,
+      ),
+    })),
   markPipelineRan: (fieldId) =>
-    set((state) => {
-      if (state.pipelineRanFieldIds.has(fieldId)) {
-        return state;
-      }
-      const next = new Set(state.pipelineRanFieldIds);
-      next.add(fieldId);
-      return { pipelineRanFieldIds: next };
-    }),
+    set((state) => ({
+      pipelineStartedFieldIds: withFieldRemoved(
+        state.pipelineStartedFieldIds,
+        fieldId,
+      ),
+      pipelineRanFieldIds: withFieldAdded(state.pipelineRanFieldIds, fieldId),
+    })),
   clear: (fieldId) =>
     set((state) => {
       const hadMatches = fieldId in state.byFieldId;
-      const hadRan = state.pipelineRanFieldIds.has(fieldId);
-      if (!hadMatches && !hadRan) {
+      const nextStarted = withFieldRemoved(
+        state.pipelineStartedFieldIds,
+        fieldId,
+      );
+      const nextRan = withFieldRemoved(state.pipelineRanFieldIds, fieldId);
+      if (
+        !hadMatches &&
+        nextStarted === state.pipelineStartedFieldIds &&
+        nextRan === state.pipelineRanFieldIds
+      ) {
         return state;
-      }
-      let nextRan: ReadonlySet<string> = state.pipelineRanFieldIds;
-      if (hadRan) {
-        const mutable = new Set(state.pipelineRanFieldIds);
-        mutable.delete(fieldId);
-        nextRan = mutable;
       }
       return {
         byFieldId: hadMatches
@@ -90,6 +131,7 @@ export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
               Object.entries(state.byFieldId).filter(([id]) => id !== fieldId),
             )
           : state.byFieldId,
+        pipelineStartedFieldIds: nextStarted,
         pipelineRanFieldIds: nextRan,
       };
     }),
@@ -109,15 +151,18 @@ export const useAnonymizationMatches = (
   );
 
 /**
- * True once the detection pipeline has delivered at least one
- * result for `fieldId`. Lets the inspector facet distinguish
- * "detection still warming up" from "detection ran and found
- * nothing", so an empty result doesn't masquerade as a buggy
- * zero. Note: Folio publishes an empty snapshot on plugin init,
- * so we explicitly track pipeline completion via
- * `markPipelineRan` rather than reading `byFieldId`.
+ * True when the inspector facet should treat the current
+ * match snapshot as authoritative — either the detection
+ * pipeline has finished at least once for this field, or
+ * no producer ever started one (so there's nothing to wait
+ * for and the facet should render the direct count, even
+ * if it's zero). Returns `false` only while a producer is
+ * actively in flight, which is the only state where the
+ * "Detecting entities…" placeholder is correct.
  */
 export const useAnonymizationMatchesReady = (fieldId: string | null): boolean =>
-  useAnonymizationMatchesStore((s) =>
-    fieldId === null ? false : s.pipelineRanFieldIds.has(fieldId),
-  );
+  useAnonymizationMatchesStore((s) => {
+    if (fieldId === null) {return false;}
+    if (s.pipelineRanFieldIds.has(fieldId)) {return true;}
+    return !s.pipelineStartedFieldIds.has(fieldId);
+  });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store.ts
@@ -42,22 +42,17 @@ type State = {
    * flight. Producers (the docx chat-anon worker, the
    * PDF wasm runner) call `markPipelineStarted` when
    * they begin and `markPipelineRan` on terminal
-   * outcome. The inspector facet uses this together
-   * with `pipelineRanFieldIds` to know whether to show
-   * the "Detecting…" placeholder — fields with no
-   * producer at all (unsupported file types) never
-   * enter this set so the facet falls through to the
-   * direct count instead of stalling forever.
+   * outcome. The inspector facet's "Detecting…"
+   * placeholder is shown iff a field id is in this set,
+   * so:
+   *   - Surfaces with no producer (PDF where the wasm
+   *     path hasn't been wired, unsupported file types)
+   *     fall straight through to the direct count.
+   *   - Reruns after edits / allowlist toggles flip the
+   *     field back into the set, so the facet drops the
+   *     stale count and shows the placeholder again.
    */
   pipelineStartedFieldIds: ReadonlySet<string>;
-  /**
-   * Field ids whose detection pipeline has produced at
-   * least one terminal outcome (success or error).
-   * Distinct from `byFieldId` because Folio publishes an
-   * empty snapshot on plugin init, before the worker
-   * has actually run.
-   */
-  pipelineRanFieldIds: ReadonlySet<string>;
 };
 
 type Actions = {
@@ -94,7 +89,6 @@ const withFieldRemoved = (
 export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
   byFieldId: {},
   pipelineStartedFieldIds: new Set(),
-  pipelineRanFieldIds: new Set(),
   publish: (fieldId, snapshot) =>
     set((state) => ({
       byFieldId: { ...state.byFieldId, [fieldId]: snapshot },
@@ -112,7 +106,6 @@ export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
         state.pipelineStartedFieldIds,
         fieldId,
       ),
-      pipelineRanFieldIds: withFieldAdded(state.pipelineRanFieldIds, fieldId),
     })),
   clear: (fieldId) =>
     set((state) => {
@@ -121,12 +114,7 @@ export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
         state.pipelineStartedFieldIds,
         fieldId,
       );
-      const nextRan = withFieldRemoved(state.pipelineRanFieldIds, fieldId);
-      if (
-        !hadMatches &&
-        nextStarted === state.pipelineStartedFieldIds &&
-        nextRan === state.pipelineRanFieldIds
-      ) {
+      if (!hadMatches && nextStarted === state.pipelineStartedFieldIds) {
         return state;
       }
       return {
@@ -136,7 +124,6 @@ export const useAnonymizationMatchesStore = create<State & Actions>((set) => ({
             )
           : state.byFieldId,
         pipelineStartedFieldIds: nextStarted,
-        pipelineRanFieldIds: nextRan,
       };
     }),
 }));
@@ -156,21 +143,16 @@ export const useAnonymizationMatches = (
 
 /**
  * True when the inspector facet should treat the current
- * match snapshot as authoritative — either the detection
- * pipeline has finished at least once for this field, or
- * no producer ever started one (so there's nothing to wait
- * for and the facet should render the direct count, even
- * if it's zero). Returns `false` only while a producer is
- * actively in flight, which is the only state where the
- * "Detecting entities…" placeholder is correct.
+ * match snapshot as authoritative. Returns `false` iff a
+ * producer is currently in flight for `fieldId` — the only
+ * state where the "Detecting entities…" placeholder is
+ * correct. Surfaces with no producer (PDFs where the wasm
+ * path isn't wired yet, unsupported file types) fall
+ * through to the direct count, and reruns triggered by
+ * edits / allowlist changes flip the field back into the
+ * loading state until the new run lands.
  */
 export const useAnonymizationMatchesReady = (fieldId: string | null): boolean =>
-  useAnonymizationMatchesStore((s) => {
-    if (fieldId === null) {
-      return false;
-    }
-    if (s.pipelineRanFieldIds.has(fieldId)) {
-      return true;
-    }
-    return !s.pipelineStartedFieldIds.has(fieldId);
-  });
+  useAnonymizationMatchesStore((s) =>
+    fieldId === null ? false : !s.pipelineStartedFieldIds.has(fieldId),
+  );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
@@ -64,9 +64,15 @@ export const anonymizePdf = async ({
   try {
     await runPipelineAndCommit({ workspaceId, fieldId, isPdf });
   } finally {
-    if (!cancelledFieldIds.has(fieldId)) {
-      useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
-    }
+    // Release the in-flight lock unconditionally — even
+    // when cancelled or when an awaited step rejected
+    // before the explicit cancellation check inside
+    // `runPipelineAndCommit`. Without this, a cancel +
+    // error race would leave `pipelineStartedFieldIds`
+    // permanently holding this field, and reopening the
+    // same document would keep the inspector facet stuck
+    // on the "Detecting…" placeholder.
+    useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
   }
 };
 
@@ -197,4 +203,9 @@ const runPipelineAndCommit = async ({
 export const clearAnonymization = (fieldId: string): void => {
   cancelledFieldIds.add(fieldId);
   clearAnonymizationForField(fieldId);
+  // Also drop the matches-store entry for this field so
+  // the inspector facet stops showing a stale count when
+  // the user navigates away mid-detection. Idempotent for
+  // fields that were never published.
+  useAnonymizationMatchesStore.getState().clear(fieldId);
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
@@ -16,6 +16,7 @@ import type {
   EntityOverlay,
   FileAnonymization,
 } from "@/lib/pdf/anonymization-types";
+import { useAnonymizationMatchesStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-matches-store";
 
 const buildPipelineConfig = (
   workspaceId: string,
@@ -56,7 +57,28 @@ export const anonymizePdf = async ({
 }): Promise<void> => {
   cancelledFieldIds.delete(fieldId);
   const isPdf = mimeType === PDF_MIME_TYPE;
+  // Tell the inspector facet a producer is in flight so
+  // it shows "Detecting entities…" while the wasm pipeline
+  // runs. Mirrored on every terminal exit below.
+  useAnonymizationMatchesStore.getState().markPipelineStarted(fieldId);
+  try {
+     await runPipelineAndCommit({ workspaceId, fieldId, isPdf });; return;
+  } finally {
+    if (!cancelledFieldIds.has(fieldId)) {
+      useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);
+    }
+  }
+};
 
+const runPipelineAndCommit = async ({
+  workspaceId,
+  fieldId,
+  isPdf,
+}: {
+  workspaceId: string;
+  fieldId: string;
+  isPdf: boolean;
+}): Promise<void> => {
   const response = await api
     .files({ workspaceId })
     .url({ fieldId })
@@ -147,6 +169,29 @@ export const anonymizePdf = async ({
   };
 
   commitAnonymizationForField(fieldId, data);
+  // Mirror the detection result into the inspector
+  // matches store. The DOCX path publishes via Folio's
+  // plugin on every transaction; the PDF path runs
+  // once-per-document, so we publish here for the
+  // count badge. The "started/ran" lifecycle bookkeeping
+  // lives in the wrapping `anonymizePdf` so the facet
+  // exits the "Detecting…" state on errors too.
+  const countByCanonical = new Map<string, number>();
+  const labelByCanonical = new Map<string, string>();
+  let totalMatches = 0;
+  for (const overlay of overlayEntities) {
+    const canonical = overlay.text;
+    countByCanonical.set(canonical, (countByCanonical.get(canonical) ?? 0) + 1);
+    if (!labelByCanonical.has(canonical)) {
+      labelByCanonical.set(canonical, overlay.label);
+    }
+    totalMatches += 1;
+  }
+  useAnonymizationMatchesStore.getState().publish(fieldId, {
+    totalMatches,
+    countByCanonical,
+    labelByCanonical,
+  });
 };
 
 export const clearAnonymization = (fieldId: string): void => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymize-pdf.ts
@@ -62,7 +62,7 @@ export const anonymizePdf = async ({
   // runs. Mirrored on every terminal exit below.
   useAnonymizationMatchesStore.getState().markPipelineStarted(fieldId);
   try {
-     await runPipelineAndCommit({ workspaceId, fieldId, isPdf });; return;
+    await runPipelineAndCommit({ workspaceId, fieldId, isPdf });
   } finally {
     if (!cancelledFieldIds.has(fieldId)) {
       useAnonymizationMatchesStore.getState().markPipelineRan(fieldId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-text-selection-store.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-text-selection-store.ts
@@ -1,0 +1,68 @@
+/**
+ * Latest non-empty text selection inside a document
+ * editor, keyed by `fieldId`. The folio paged editor
+ * sets ProseMirror selections programmatically on its
+ * off-screen hidden PM and renders the visible
+ * selection via a custom overlay; that's invisible to
+ * a global `selectionchange` listener, which is why the
+ * inspector facet's "Term to anonymize" prefill needs a
+ * dedicated bridge instead of `window.getSelection()`.
+ *
+ * The editor wrapper publishes here whenever the user
+ * settles on a non-collapsed selection; the inspector
+ * facet subscribes and seeds its term input.
+ */
+
+import { create } from "zustand";
+
+export type DocumentTextSelection = {
+  text: string;
+  /**
+   * Monotonic counter so re-selecting the exact same
+   * text re-fires the prefill effect in subscribers.
+   * Without it, repeated identical selections would
+   * be deduped by reference equality and feel inert.
+   */
+  seq: number;
+};
+
+type State = {
+  byFieldId: Record<string, DocumentTextSelection>;
+};
+
+type Actions = {
+  publish: (fieldId: string, text: string) => void;
+  clear: (fieldId: string) => void;
+};
+
+export const useDocumentTextSelectionStore = create<State & Actions>((set) => ({
+  byFieldId: {},
+  publish: (fieldId, text) =>
+    set((state) => {
+      const prev = state.byFieldId[fieldId];
+      return {
+        byFieldId: {
+          ...state.byFieldId,
+          [fieldId]: { text, seq: (prev?.seq ?? 0) + 1 },
+        },
+      };
+    }),
+  clear: (fieldId) =>
+    set((state) => {
+      if (!(fieldId in state.byFieldId)) {
+        return state;
+      }
+      return {
+        byFieldId: Object.fromEntries(
+          Object.entries(state.byFieldId).filter(([id]) => id !== fieldId),
+        ),
+      };
+    }),
+}));
+
+export const useDocumentTextSelection = (
+  fieldId: string | null,
+): DocumentTextSelection | null =>
+  useDocumentTextSelectionStore((s) =>
+    fieldId === null ? null : (s.byFieldId[fieldId] ?? null),
+  );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -1954,7 +1954,13 @@ const FacetBar = ({
   return (
     <div
       className={cn(
-        "bg-background/85 supports-[backdrop-filter]:bg-background/65 sticky top-0 z-10 flex shrink-0 items-center gap-1 border-b px-2 backdrop-blur",
+        // `whitespace-nowrap` on each chip stops multi-word
+        // labels like "Historie verzí" from breaking mid-row
+        // in narrow inspector panes. The row stays single
+        // line; the active version chip moved to the chip's
+        // tooltip / sibling chrome (no longer inline) so the
+        // strip fits without horizontal scroll.
+        "bg-background/85 supports-[backdrop-filter]:bg-background/65 sticky top-0 z-10 flex shrink-0 items-center gap-0.5 border-b px-1.5 backdrop-blur",
         TOOLBAR_ROW_HEIGHT,
       )}
     >
@@ -1964,9 +1970,13 @@ const FacetBar = ({
         return (
           <button
             className={cn(
-              "rounded-md px-2 py-1 text-xs font-medium transition-colors",
+              // Active chip never shrinks — its full label
+              // always reads. Inactive chips can shrink and
+              // ellipsis if the row gets tight (full label
+              // is still in the `title` tooltip).
+              "min-w-0 truncate rounded-md px-1.5 py-1 text-xs font-medium whitespace-nowrap transition-colors",
               active
-                ? "bg-foreground text-background"
+                ? "bg-foreground text-background shrink-0"
                 : "text-muted-foreground hover:bg-muted hover:text-foreground",
               active &&
                 pulsing &&
@@ -1976,14 +1986,14 @@ const FacetBar = ({
             disabled={disabled}
             key={value}
             onClick={() => onChange(value)}
+            title={
+              active && activeBadge !== undefined
+                ? `${labels[value]} · ${activeBadge}`
+                : labels[value]
+            }
             type="button"
           >
             {labels[value]}
-            {active && activeBadge !== undefined && (
-              <span className="text-background/70 ms-1 font-normal">
-                ({activeBadge})
-              </span>
-            )}
           </button>
         );
       })}

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -55,6 +55,21 @@ export type DocxEditorProps = {
   onChange?: (document: Document) => void;
   /** Callback when selection changes */
   onSelectionChange?: (state: SelectionState | null) => void;
+  /**
+   * Callback fired with the resolved PM positions and the
+   * selected plain text on every selection-bearing
+   * transaction. Useful for consumers (e.g. the inspector
+   * "Term to anonymize" prefill) that want the selected
+   * phrase without holding a reference to the editor view.
+   * Atom inline nodes (tab, hard_break) collapse to a
+   * single space in the returned text. Empty string when
+   * the selection is collapsed.
+   */
+  onSelectionTextChange?: (selection: {
+    from: number;
+    to: number;
+    text: string;
+  }) => void;
   /** Callback on error */
   onError?: (error: Error) => void;
   /** Callback when fonts are loaded */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -306,6 +306,7 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       author = "User",
       onChange,
       onSelectionChange,
+      onSelectionTextChange,
       onError,
       onFontsLoaded: onFontsLoadedCallback,
       theme,
@@ -3065,6 +3066,9 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
                             handleSelectionChange(null);
                           }
                         }}
+                        {...(onSelectionTextChange !== undefined
+                          ? { onSelectionTextChange }
+                          : {})}
                         externalPlugins={editorPlugins}
                         onHyperlinkClick={handleHyperlinkClick}
                         onContextMenu={handleContextMenu}

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -180,6 +180,21 @@ export type PagedEditorProps = {
   onReadOnlyEditAttempt?: () => void;
   /** Callback when selection changes. */
   onSelectionChange?: (from: number, to: number) => void;
+  /**
+   * Callback when the active text selection changes. Fires
+   * with the resolved PM positions and the selected plain
+   * text (atom inline nodes — tab, hard_break — are
+   * collapsed to a single space). Useful for consumers that
+   * want the selected phrase without having to hold a
+   * reference to the editor view themselves; fires on every
+   * selection-bearing transaction (caret moves, drag,
+   * word-select, programmatic `setSelection`).
+   */
+  onSelectionTextChange?: (selection: {
+    from: number;
+    to: number;
+    text: string;
+  }) => void;
   /** External ProseMirror plugins. */
   externalPlugins?: Plugin[];
   /** Extension manager for plugins/schema/commands (optional — falls back to default) */
@@ -1341,6 +1356,7 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
       onDocumentChange,
       onReadOnlyEditAttempt,
       onSelectionChange,
+      onSelectionTextChange,
       externalPlugins = EMPTY_PLUGINS,
       extensionManager,
       onHeaderFooterDoubleClick,
@@ -1390,12 +1406,14 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
     // Store callbacks in refs to avoid infinite re-render loops
     // when parent passes unstable callback references
     const onSelectionChangeRef = useRef(onSelectionChange);
+    const onSelectionTextChangeRef = useRef(onSelectionTextChange);
     const onDocumentChangeRef = useRef(onDocumentChange);
     const onTotalPagesChangeRef = useRef(onTotalPagesChange);
     const lastTotalPagesRef = useRef<number | null>(null);
 
     // Keep refs in sync with latest props
     onSelectionChangeRef.current = onSelectionChange;
+    onSelectionTextChangeRef.current = onSelectionTextChange;
     onDocumentChangeRef.current = onDocumentChange;
     onTotalPagesChangeRef.current = onTotalPagesChange;
 
@@ -2198,6 +2216,18 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         // Always notify selection change (for toolbar sync) even if layout not ready
         // Use ref to avoid infinite loops when callback is unstable
         onSelectionChangeRef.current?.(from, to);
+        // `onSelectionTextChange` carries the resolved text
+        // alongside the range so consumers (anonymisation
+        // term prefill, etc.) don't need to hold a reference
+        // to the editor view themselves. `textBetween` with
+        // a single space for both leaf-block and block
+        // separators collapses table cells, paragraphs, and
+        // inline atoms into a single-line phrase.
+        if (onSelectionTextChangeRef.current) {
+          const text =
+            from === to ? "" : state.doc.textBetween(from, to, " ", " ");
+          onSelectionTextChangeRef.current({ from, to, text });
+        }
 
         if (suppressSelectionOverlayRef.current) {
           setCaretPosition(null);


### PR DESCRIPTION
## Summary
- Distinguish "detection still warming up" from "detection ran and found nothing": new `useAnonymizationMatchesReady` selector flips on after the chat-anon worker delivers (not on Folio's empty mount-time publish). The facet shows "Detecting entities in this document…" until then, and the workspace-terms filter + Detected section stay hidden so users don't see a misleading "0 entities".
- Default the new-term combobox to `misc` (now supported end-to-end in `@stll/anonymize-wasm`) and pass `formatLabel` to `itemToStringLabel` so the trigger input shows the translated label instead of the raw English key. `LABEL_TRANSLATION_KEYS` keeps an `other` back-compat alias for legacy server entries.
- Bridge Folio drag/word selections into the "Term to anonymize" prefill via a new `document-text-selection-store`. Folio sets PM selections programmatically on its off-screen hidden PM, so a global `selectionchange` listener never sees them; wrap `view.dispatch` and publish the selected text on every selection-bearing transaction. PDF text-layer selections still flow through `selectionchange`.
- Tidy the inspector facet chip row: drop the inline `(v1)` active badge (now in the `title` tooltip), tighten gap/padding, and let inactive chips truncate with ellipsis while the active chip keeps its full label. Multi-word labels like "Historie verzí" no longer wrap mid-word in narrow panes.

## Test plan
- [ ] Open the anonymization inspector tab on a docx; confirm "Detecting entities…" shows until the worker returns, then the real count appears.
- [ ] In the term composer, default label is "Misc/Různé"; the trigger shows the translated label (not "misc").
- [ ] Drag-select / double-click text inside a docx and confirm the text appears in the "Term to anonymize" input.
- [ ] Select text in a PDF and confirm the prefill still fires.
- [ ] Inspector chip row: labels no longer wrap mid-word; "Anonymization" chip's full label visible when active; inactive chips truncate with ellipsis if the strip is tight.