### PR TITLE
fix(folio): prune orphaned comments at save time

### DIFF
--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -168,11 +168,13 @@ import {
   EMPTY_ANCHOR_POSITIONS,
   PENDING_COMMENT_ID,
   applyCommentMarkRange,
+  collectCommentIdsFromContent,
   createComment,
   findSelectionYPosition,
   getCommentAuthorKey,
   getCommentParentId,
   getFallbackCommentYPosition,
+  pruneOrphanedComments,
   removePendingCommentMarkRange,
 } from "./commentsHelpers";
 import { CommentsSidebar } from "./CommentsSidebar";
@@ -1082,7 +1084,19 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       if (pmDoc) {
         doc.package.document.content = pmDoc.package.document.content;
       }
-      doc.package.document.comments = commentsRef.current;
+      // Drop comment threads whose anchor text has been edited away. The
+      // in-memory `comments` array can outlive its in-body anchors (PM
+      // removes the mark when its text is deleted, but the array entry
+      // stays put), and serializing the unfiltered array writes
+      // unanchored threads into `comments.xml` that no reader can
+      // resolve.
+      const referencedCommentIds = collectCommentIdsFromContent(
+        doc.package.document.content,
+      );
+      doc.package.document.comments = pruneOrphanedComments(
+        commentsRef.current,
+        referencedCommentIds,
+      );
       return doc;
     }, [history.state]);
 

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -168,7 +168,7 @@ import {
   EMPTY_ANCHOR_POSITIONS,
   PENDING_COMMENT_ID,
   applyCommentMarkRange,
-  collectCommentIdsFromContent,
+  collectCommentIdsFromSources,
   createComment,
   findSelectionYPosition,
   getCommentAuthorKey,
@@ -1090,8 +1090,16 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
       // stays put), and serializing the unfiltered array writes
       // unanchored threads into `comments.xml` that no reader can
       // resolve.
-      const referencedCommentIds = collectCommentIdsFromContent(
+      // Collect anchors from every part of the doc that can carry a
+      // comment marker — body, headers, footers, footnotes, endnotes.
+      // A body-only walk would prune legitimate header/footer/note
+      // comments because their anchors live outside `document.content`.
+      const referencedCommentIds = collectCommentIdsFromSources(
         doc.package.document.content,
+        doc.package.headers,
+        doc.package.footers,
+        doc.package.footnotes,
+        doc.package.endnotes,
       );
       doc.package.document.comments = pruneOrphanedComments(
         commentsRef.current,

--- a/packages/folio/src/components/commentsHelpers.test.ts
+++ b/packages/folio/src/components/commentsHelpers.test.ts
@@ -163,18 +163,26 @@ describe("collectCommentIdsFromSources", () => {
 });
 
 describe("pruneOrphanedComments", () => {
-  test("keeps top-level comments that are still anchored", () => {
+  test("keeps top-level comments regardless of anchor status", () => {
     const comments = [makeComment(1), makeComment(2)];
     expect(pruneOrphanedComments(comments, new Set([1, 2]))).toEqual(comments);
   });
 
-  test("drops a top-level comment whose anchor is gone", () => {
+  test("keeps a top-level comment whose anchor was deleted (cannot distinguish from a parser-missed reply)", () => {
+    // We don't drop unanchored top-level comments: the parser does
+    // not yet read `commentsExtended.xml` to restore `parentId` on
+    // Word replies, so an unanchored top-level entry might be an
+    // imported reply masquerading as a root. Erring on the side of
+    // preserving data — losing a Word reply on first save is strictly
+    // worse than re-emitting a comment whose anchor was deleted.
     const kept = makeComment(1);
-    const orphan = makeComment(2);
-    expect(pruneOrphanedComments([kept, orphan], new Set([1]))).toEqual([kept]);
+    const unanchoredTopLevel = makeComment(2);
+    expect(
+      pruneOrphanedComments([kept, unanchoredTopLevel], new Set([1])),
+    ).toEqual([kept, unanchoredTopLevel]);
   });
 
-  test("keeps a reply when its parent is still anchored", () => {
+  test("keeps a reply when its parent is still present", () => {
     const parent = makeComment(1);
     const reply = makeComment(2, 1);
     expect(pruneOrphanedComments([parent, reply], new Set([1]))).toEqual([
@@ -183,28 +191,28 @@ describe("pruneOrphanedComments", () => {
     ]);
   });
 
-  test("drops a reply when the parent has been orphaned", () => {
-    const orphanedParent = makeComment(1);
+  test("keeps replies whose explicit parent exists, even when the parent's anchor was deleted", () => {
+    // Top-level entries are kept whether or not they are anchored, so
+    // replies pointing to them are kept too.
+    const parent = makeComment(1);
     const reply = makeComment(2, 1);
-    expect(pruneOrphanedComments([orphanedParent, reply], new Set())).toEqual(
-      [],
-    );
+    expect(pruneOrphanedComments([parent, reply], new Set())).toEqual([
+      parent,
+      reply,
+    ]);
   });
 
-  test("drops a reply with no matching parent", () => {
+  test("drops a reply whose explicit parent doesn't exist", () => {
+    // A reply with an explicit `parentId` that points at no comment
+    // we know about is a genuine broken-thread orphan — the only
+    // kind we can identify confidently.
     const replyOnly = makeComment(2, 999);
     expect(pruneOrphanedComments([replyOnly], new Set([2]))).toEqual([]);
   });
 
-  test("returns an empty array when no top-level comments are anchored", () => {
-    const a = makeComment(1);
-    const b = makeComment(2, 1);
-    expect(pruneOrphanedComments([a, b], new Set([7]))).toEqual([]);
-  });
-
-  test("keeps a reply-to-a-reply when the root top-level comment is anchored", () => {
+  test("keeps a reply-to-a-reply when the root top-level comment exists", () => {
     // Threads can nest more than one level — a reply to a reply must
-    // ride along when the root is anchored, not get pruned because its
+    // ride along when the root is present, not get pruned because its
     // immediate parent isn't a top-level comment.
     const root = makeComment(1);
     const reply = makeComment(2, 1);
@@ -216,10 +224,27 @@ describe("pruneOrphanedComments", () => {
 
   test("drops the whole branch when an intermediate reply has no surviving root", () => {
     // Reply 4 points to reply 3, which points to a parent 2 that was
-    // never created. The chain doesn't reach an anchored top-level,
-    // so the whole branch goes.
+    // never created. The chain doesn't reach a top-level comment in
+    // the array, so the whole branch goes.
     const reply3 = makeComment(3, 2);
     const reply4 = makeComment(4, 3);
     expect(pruneOrphanedComments([reply3, reply4], new Set([2]))).toEqual([]);
+  });
+
+  test("preserves imported Word replies that arrive with parentId undefined", () => {
+    // The OOXML parser does not yet populate `parentId` from
+    // `commentsExtended.xml`, so Word replies look identical to
+    // top-level comments without anchors. Dropping them on save —
+    // the previous behaviour — silently loses every Word reply on
+    // the first save. Keep them.
+    const anchoredParent = makeComment(1);
+    const unparsedReplyA = makeComment(2);
+    const unparsedReplyB = makeComment(3);
+    expect(
+      pruneOrphanedComments(
+        [anchoredParent, unparsedReplyA, unparsedReplyB],
+        new Set([1]),
+      ),
+    ).toEqual([anchoredParent, unparsedReplyA, unparsedReplyB]);
   });
 });

--- a/packages/folio/src/components/commentsHelpers.test.ts
+++ b/packages/folio/src/components/commentsHelpers.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type { Comment } from "../core/types/content";
 import {
-  collectCommentIdsFromContent,
+  collectCommentIdsFromSources,
   pruneOrphanedComments,
 } from "./commentsHelpers";
 
@@ -28,7 +28,7 @@ function makeComment(id: number, parentId?: number): Comment {
   };
 }
 
-describe("collectCommentIdsFromContent", () => {
+describe("collectCommentIdsFromSources", () => {
   test("returns an empty set for content with no comment markers", () => {
     const content = [
       {
@@ -36,7 +36,7 @@ describe("collectCommentIdsFromContent", () => {
         content: [{ type: "run", content: [{ type: "text", text: "hi" }] }],
       },
     ];
-    expect(collectCommentIdsFromContent(content)).toEqual(new Set());
+    expect(collectCommentIdsFromSources(content)).toEqual(new Set());
   });
 
   test("collects ids from commentRangeStart, commentRangeEnd, and commentReference", () => {
@@ -53,7 +53,7 @@ describe("collectCommentIdsFromContent", () => {
         ],
       },
     ];
-    expect(collectCommentIdsFromContent(content)).toEqual(new Set([1, 2]));
+    expect(collectCommentIdsFromSources(content)).toEqual(new Set([1, 2]));
   });
 
   test("finds comment markers nested inside table cells", () => {
@@ -76,7 +76,7 @@ describe("collectCommentIdsFromContent", () => {
         ],
       },
     ];
-    expect(collectCommentIdsFromContent(content)).toEqual(new Set([42]));
+    expect(collectCommentIdsFromSources(content)).toEqual(new Set([42]));
   });
 
   test("ignores commentRange markers whose id is missing or non-numeric", () => {
@@ -89,7 +89,76 @@ describe("collectCommentIdsFromContent", () => {
         ],
       },
     ];
-    expect(collectCommentIdsFromContent(content)).toEqual(new Set());
+    expect(collectCommentIdsFromSources(content)).toEqual(new Set());
+  });
+
+  test("unions ids from multiple sources (body + headers + footnotes + endnotes)", () => {
+    // Real saves pass several subtrees — comments anchored in headers,
+    // footers, footnotes, or endnotes must all be discovered or they
+    // would be pruned away.
+    const body = [
+      {
+        type: "paragraph",
+        content: [{ type: "commentRangeStart", id: 1 }],
+      },
+    ];
+    const headers = new Map([
+      [
+        "rId1",
+        {
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "commentRangeStart", id: 10 }],
+            },
+          ],
+        },
+      ],
+    ]);
+    const footnotes = [
+      {
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "commentReference", id: 20 }],
+          },
+        ],
+      },
+    ];
+    const endnotes = [
+      {
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "commentRangeEnd", id: 30 }],
+          },
+        ],
+      },
+    ];
+    expect(
+      collectCommentIdsFromSources(body, headers, footnotes, endnotes),
+    ).toEqual(new Set([1, 10, 20, 30]));
+  });
+
+  test("walks Map containers (e.g., headers/footers keyed by relationship id)", () => {
+    const headers = new Map([
+      [
+        "rId7",
+        {
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "commentRangeStart", id: 99 }],
+            },
+          ],
+        },
+      ],
+    ]);
+    expect(collectCommentIdsFromSources(headers)).toEqual(new Set([99]));
+  });
+
+  test("tolerates null and undefined source slots", () => {
+    expect(collectCommentIdsFromSources(undefined, null)).toEqual(new Set());
   });
 });
 
@@ -131,5 +200,26 @@ describe("pruneOrphanedComments", () => {
     const a = makeComment(1);
     const b = makeComment(2, 1);
     expect(pruneOrphanedComments([a, b], new Set([7]))).toEqual([]);
+  });
+
+  test("keeps a reply-to-a-reply when the root top-level comment is anchored", () => {
+    // Threads can nest more than one level — a reply to a reply must
+    // ride along when the root is anchored, not get pruned because its
+    // immediate parent isn't a top-level comment.
+    const root = makeComment(1);
+    const reply = makeComment(2, 1);
+    const replyToReply = makeComment(3, 2);
+    expect(
+      pruneOrphanedComments([root, reply, replyToReply], new Set([1])),
+    ).toEqual([root, reply, replyToReply]);
+  });
+
+  test("drops the whole branch when an intermediate reply has no surviving root", () => {
+    // Reply 4 points to reply 3, which points to a parent 2 that was
+    // never created. The chain doesn't reach an anchored top-level,
+    // so the whole branch goes.
+    const reply3 = makeComment(3, 2);
+    const reply4 = makeComment(4, 3);
+    expect(pruneOrphanedComments([reply3, reply4], new Set([2]))).toEqual([]);
   });
 });

--- a/packages/folio/src/components/commentsHelpers.test.ts
+++ b/packages/folio/src/components/commentsHelpers.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Comment } from "../core/types/content";
+import {
+  collectCommentIdsFromContent,
+  pruneOrphanedComments,
+} from "./commentsHelpers";
+
+function makeComment(id: number, parentId?: number): Comment {
+  return {
+    id,
+    author: "Tester",
+    date: "2026-05-15T00:00:00Z",
+    content: [
+      {
+        type: "paragraph",
+        formatting: {},
+        content: [
+          {
+            type: "run",
+            formatting: {},
+            content: [{ type: "text", text: "x" }],
+          },
+        ],
+      },
+    ],
+    ...(parentId !== undefined ? { parentId } : {}),
+  };
+}
+
+describe("collectCommentIdsFromContent", () => {
+  test("returns an empty set for content with no comment markers", () => {
+    const content = [
+      {
+        type: "paragraph",
+        content: [{ type: "run", content: [{ type: "text", text: "hi" }] }],
+      },
+    ];
+    expect(collectCommentIdsFromContent(content)).toEqual(new Set());
+  });
+
+  test("collects ids from commentRangeStart, commentRangeEnd, and commentReference", () => {
+    const content = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "commentRangeStart", id: 1 },
+          { type: "run", content: [{ type: "text", text: "x" }] },
+          { type: "commentRangeEnd", id: 1 },
+          { type: "commentReference", id: 1 },
+          { type: "commentRangeStart", id: 2 },
+          { type: "commentRangeEnd", id: 2 },
+        ],
+      },
+    ];
+    expect(collectCommentIdsFromContent(content)).toEqual(new Set([1, 2]));
+  });
+
+  test("finds comment markers nested inside table cells", () => {
+    const content = [
+      {
+        type: "table",
+        rows: [
+          {
+            cells: [
+              {
+                blocks: [
+                  {
+                    type: "paragraph",
+                    content: [{ type: "commentRangeStart", id: 42 }],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(collectCommentIdsFromContent(content)).toEqual(new Set([42]));
+  });
+
+  test("ignores commentRange markers whose id is missing or non-numeric", () => {
+    const content = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "commentRangeStart" }, // no id
+          { type: "commentRangeEnd", id: "5" }, // string id
+        ],
+      },
+    ];
+    expect(collectCommentIdsFromContent(content)).toEqual(new Set());
+  });
+});
+
+describe("pruneOrphanedComments", () => {
+  test("keeps top-level comments that are still anchored", () => {
+    const comments = [makeComment(1), makeComment(2)];
+    expect(pruneOrphanedComments(comments, new Set([1, 2]))).toEqual(comments);
+  });
+
+  test("drops a top-level comment whose anchor is gone", () => {
+    const kept = makeComment(1);
+    const orphan = makeComment(2);
+    expect(pruneOrphanedComments([kept, orphan], new Set([1]))).toEqual([kept]);
+  });
+
+  test("keeps a reply when its parent is still anchored", () => {
+    const parent = makeComment(1);
+    const reply = makeComment(2, 1);
+    expect(pruneOrphanedComments([parent, reply], new Set([1]))).toEqual([
+      parent,
+      reply,
+    ]);
+  });
+
+  test("drops a reply when the parent has been orphaned", () => {
+    const orphanedParent = makeComment(1);
+    const reply = makeComment(2, 1);
+    expect(pruneOrphanedComments([orphanedParent, reply], new Set())).toEqual(
+      [],
+    );
+  });
+
+  test("drops a reply with no matching parent", () => {
+    const replyOnly = makeComment(2, 999);
+    expect(pruneOrphanedComments([replyOnly], new Set([2]))).toEqual([]);
+  });
+
+  test("returns an empty array when no top-level comments are anchored", () => {
+    const a = makeComment(1);
+    const b = makeComment(2, 1);
+    expect(pruneOrphanedComments([a, b], new Set([7]))).toEqual([]);
+  });
+});

--- a/packages/folio/src/components/commentsHelpers.ts
+++ b/packages/folio/src/components/commentsHelpers.ts
@@ -138,6 +138,82 @@ export function applyCommentMarkRange(
   return true;
 }
 
+/**
+ * Walk an arbitrary Folio content tree and collect every comment id that
+ * is *referenced* by an inline anchor (`commentRangeStart`,
+ * `commentRangeEnd`, or `commentReference`). Used at save time to detect
+ * which comment threads still have something to anchor to, so that
+ * comments whose underlying text has been edited away can be pruned
+ * before serialization instead of being written out as phantom threads
+ * that no Word reader can scroll to.
+ */
+export function collectCommentIdsFromContent(content: unknown): Set<number> {
+  const ids = new Set<number>();
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    if (!node || typeof node !== "object") {
+      return;
+    }
+    const obj = node as Record<string, unknown>;
+    const type = obj["type"];
+    if (
+      (type === "commentRangeStart" ||
+        type === "commentRangeEnd" ||
+        type === "commentReference") &&
+      typeof obj["id"] === "number"
+    ) {
+      ids.add(obj["id"]);
+    }
+    for (const value of Object.values(obj)) {
+      visit(value);
+    }
+  };
+  visit(content);
+  return ids;
+}
+
+/**
+ * Filter `comments` to those still anchored by the document. A top-level
+ * comment is kept when its id appears in `referencedIds`; a reply is
+ * kept when its parent is itself kept (a reply has no anchor of its own
+ * — losing the parent's anchor logically loses the whole thread).
+ *
+ * Phantom comment threads are a real failure mode: when a user deletes
+ * text covered by a comment mark, PM drops the mark with the text but
+ * the comment entry stays in the in-memory `comments` array and gets
+ * serialized back into `comments.xml` on the next save. The thread is
+ * present in the saved file but with no in-body anchor, which Word
+ * either silently drops or surfaces as an orphan that can't be
+ * resolved.
+ */
+export function pruneOrphanedComments(
+  comments: Comment[],
+  referencedIds: Set<number>,
+): Comment[] {
+  const keptTopIds = new Set<number>();
+  for (const comment of comments) {
+    const parentId = getCommentParentId(comment);
+    if (
+      (parentId === null || parentId === undefined) &&
+      referencedIds.has(comment.id)
+    ) {
+      keptTopIds.add(comment.id);
+    }
+  }
+  return comments.filter((comment) => {
+    const parentId = getCommentParentId(comment);
+    if (parentId === null || parentId === undefined) {
+      return keptTopIds.has(comment.id);
+    }
+    return keptTopIds.has(parentId);
+  });
+}
+
 export function removePendingCommentMarkRange(
   view: EditorView,
   range: CommentMarkRange,

--- a/packages/folio/src/components/commentsHelpers.ts
+++ b/packages/folio/src/components/commentsHelpers.ts
@@ -202,39 +202,46 @@ export function collectCommentIdsFromSources(
 }
 
 /**
- * Filter `comments` to those still anchored. A comment is kept when:
- *  - it is top-level and its id appears in `referencedIds`, or
- *  - it has a parent which (transitively) reaches a kept top-level
- *    comment. A reply-to-a-reply that ultimately roots at an anchored
- *    comment stays; a reply whose parent chain doesn't reach a
- *    referenced top-level is dropped.
+ * Filter `comments` to drop entries whose reply chain has lost its root.
  *
- * Phantom comment threads are a real failure mode: when a user deletes
- * text covered by a comment mark, PM drops the mark with the text but
- * the comment entry stays in the in-memory `comments` array and gets
- * serialized back into `comments.xml` on the next save. The thread is
- * present in the saved file but with no in-body anchor, which Word
- * either silently drops or surfaces as an orphan that can't be
- * resolved.
+ * Kept:
+ *  - every top-level comment (`parentId` is null/undefined), regardless of
+ *    whether its id appears in `referencedIds`,
+ *  - replies whose parent chain transitively reaches a kept top-level
+ *    comment.
+ *
+ * Dropped:
+ *  - replies whose explicit `parentId` does not reach a kept top-level
+ *    comment (a true broken-thread orphan).
+ *
+ * Why we don't prune unanchored top-level comments: the OOXML parser
+ * does not yet read `commentsExtended.xml`, so Word comment replies
+ * arrive with `parentId === undefined` and look indistinguishable from
+ * a true top-level comment whose anchor has been edited away. Until the
+ * parser populates the parent link, dropping unanchored top-level
+ * entries would silently lose every imported Word reply on the first
+ * save — a strictly worse failure mode than re-emitting a comment whose
+ * anchor was actually deleted. The complementary "overwrite stale
+ * `comments.xml`" fix in the save paths already prevents the
+ * phantom-thread regression when the array does end up empty.
  */
 export function pruneOrphanedComments(
   comments: Comment[],
-  referencedIds: Set<number>,
+  _referencedIds: Set<number>,
 ): Comment[] {
+  void _referencedIds;
   const keptIds = new Set<number>();
-  // Step 1: top-level comments whose anchor is still in the doc.
+  // Step 1: keep every top-level comment.
   for (const comment of comments) {
     const parentId = getCommentParentId(comment);
-    if (
-      (parentId === null || parentId === undefined) &&
-      referencedIds.has(comment.id)
-    ) {
+    if (parentId === null || parentId === undefined) {
       keptIds.add(comment.id);
     }
   }
-  // Step 2: iteratively pull in replies whose parent has already been
-  // kept. Repeats until no new comment is added, so a thread of depth
-  // N (replies-to-replies-to-…) is fully promoted in N − 1 passes.
+  // Step 2: iteratively pull in replies whose parent chain reaches a kept
+  // top-level comment. Repeats until no new comment is added, so a
+  // thread of depth N (replies-to-replies-to-…) is fully promoted in
+  // N − 1 passes.
   let addedThisPass = true;
   while (addedThisPass) {
     addedThisPass = false;

--- a/packages/folio/src/components/commentsHelpers.ts
+++ b/packages/folio/src/components/commentsHelpers.ts
@@ -139,24 +139,45 @@ export function applyCommentMarkRange(
 }
 
 /**
- * Walk an arbitrary Folio content tree and collect every comment id that
+ * Walk arbitrary Folio content subtrees and collect every comment id that
  * is *referenced* by an inline anchor (`commentRangeStart`,
  * `commentRangeEnd`, or `commentReference`). Used at save time to detect
  * which comment threads still have something to anchor to, so that
  * comments whose underlying text has been edited away can be pruned
  * before serialization instead of being written out as phantom threads
  * that no Word reader can scroll to.
+ *
+ * Pass every part of the document that can carry anchors — comments can
+ * live in headers, footers, footnotes, and endnotes as well as the
+ * main body, and a save path that only checks the body would prune
+ * legitimate header/footer/note comments.
+ *
+ * Uses `for (const key in obj)` instead of `Object.values(obj)` so the
+ * recursive walk doesn't allocate a values array at every node; also
+ * handles `Map` containers (e.g., `package.headers`) which `Object.values`
+ * would silently skip.
  */
-export function collectCommentIdsFromContent(content: unknown): Set<number> {
+export function collectCommentIdsFromSources(
+  ...sources: readonly unknown[]
+): Set<number> {
   const ids = new Set<number>();
   const visit = (node: unknown): void => {
+    if (node === null || node === undefined) {
+      return;
+    }
     if (Array.isArray(node)) {
       for (const item of node) {
         visit(item);
       }
       return;
     }
-    if (!node || typeof node !== "object") {
+    if (node instanceof Map) {
+      for (const value of node.values()) {
+        visit(value);
+      }
+      return;
+    }
+    if (typeof node !== "object") {
       return;
     }
     const obj = node as Record<string, unknown>;
@@ -169,19 +190,24 @@ export function collectCommentIdsFromContent(content: unknown): Set<number> {
     ) {
       ids.add(obj["id"]);
     }
-    for (const value of Object.values(obj)) {
-      visit(value);
+    // oxlint-disable-next-line guard-for-in -- plain object literals from parser; allocating a values array here is hot-path work we want to avoid
+    for (const key in obj) {
+      visit(obj[key]);
     }
   };
-  visit(content);
+  for (const source of sources) {
+    visit(source);
+  }
   return ids;
 }
 
 /**
- * Filter `comments` to those still anchored by the document. A top-level
- * comment is kept when its id appears in `referencedIds`; a reply is
- * kept when its parent is itself kept (a reply has no anchor of its own
- * — losing the parent's anchor logically loses the whole thread).
+ * Filter `comments` to those still anchored. A comment is kept when:
+ *  - it is top-level and its id appears in `referencedIds`, or
+ *  - it has a parent which (transitively) reaches a kept top-level
+ *    comment. A reply-to-a-reply that ultimately roots at an anchored
+ *    comment stays; a reply whose parent chain doesn't reach a
+ *    referenced top-level is dropped.
  *
  * Phantom comment threads are a real failure mode: when a user deletes
  * text covered by a comment mark, PM drops the mark with the text but
@@ -195,23 +221,39 @@ export function pruneOrphanedComments(
   comments: Comment[],
   referencedIds: Set<number>,
 ): Comment[] {
-  const keptTopIds = new Set<number>();
+  const keptIds = new Set<number>();
+  // Step 1: top-level comments whose anchor is still in the doc.
   for (const comment of comments) {
     const parentId = getCommentParentId(comment);
     if (
       (parentId === null || parentId === undefined) &&
       referencedIds.has(comment.id)
     ) {
-      keptTopIds.add(comment.id);
+      keptIds.add(comment.id);
     }
   }
-  return comments.filter((comment) => {
-    const parentId = getCommentParentId(comment);
-    if (parentId === null || parentId === undefined) {
-      return keptTopIds.has(comment.id);
+  // Step 2: iteratively pull in replies whose parent has already been
+  // kept. Repeats until no new comment is added, so a thread of depth
+  // N (replies-to-replies-to-…) is fully promoted in N − 1 passes.
+  let addedThisPass = true;
+  while (addedThisPass) {
+    addedThisPass = false;
+    for (const comment of comments) {
+      if (keptIds.has(comment.id)) {
+        continue;
+      }
+      const parentId = getCommentParentId(comment);
+      if (
+        parentId !== null &&
+        parentId !== undefined &&
+        keptIds.has(parentId)
+      ) {
+        keptIds.add(comment.id);
+        addedThisPass = true;
+      }
     }
-    return keptTopIds.has(parentId);
-  });
+  }
+  return comments.filter((comment) => keptIds.has(comment.id));
 }
 
 export function removePendingCommentMarkRange(

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -131,8 +131,14 @@ async function serializeCommentsToZip(
   zip: JSZip,
   compressionLevel: number,
 ): Promise<void> {
-  const comments = doc.package.document.comments;
-  if (!comments || comments.length === 0) {
+  const comments = doc.package.document.comments ?? [];
+  // Whether the source DOCX already had a `word/comments.xml`. If it did
+  // and we now have zero comments (e.g., the user deleted the only
+  // anchored thread), we MUST overwrite with an empty <w:comments/>
+  // — otherwise the previous file is copied through the rezip baseline
+  // and the saved DOCX still surfaces the now-phantom threads.
+  const hadCommentsFile = zip.file("word/comments.xml") !== null;
+  if (comments.length === 0 && !hadCommentsFile) {
     return;
   }
 

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -99,8 +99,8 @@ export async function attemptSelectiveSave(
     return null;
   }
 
-  const comments = doc.package.document.comments;
-  const hasComments = comments && comments.length > 0;
+  const comments = doc.package.document.comments ?? [];
+  const hasComments = comments.length > 0;
   const headerFooterUpdates = collectHeaderFooterUpdates(doc);
 
   try {
@@ -128,10 +128,15 @@ export async function attemptSelectiveSave(
       updates.set("word/document.xml", patchedDocXml);
     }
 
-    // Always serialize comments.xml when the document has comments
-    if (hasComments) {
+    // Overwrite `word/comments.xml` whenever the source already had one,
+    // even if the editor now has zero comments — otherwise the stale
+    // entries linger in the saved file (the rezip baseline copies the
+    // previous part as-is) and round-trip back as phantom threads.
+    const hadCommentsFile = zip.file("word/comments.xml") !== null;
+    if (hasComments || hadCommentsFile) {
       updates.set("word/comments.xml", serializeComments(comments));
-
+    }
+    if (hasComments) {
       // Ensure [Content_Types].xml has an Override for comments.xml
       const ctFile = zip.file("[Content_Types].xml");
       if (ctFile) {

--- a/packages/folio/src/core/docx/serializer/commentSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/commentSerializer.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Comment } from "../../types/content";
+import { serializeComments } from "./commentSerializer";
+
+function makeComment(id: number, parentId?: number): Comment {
+  return {
+    id,
+    author: "Tester",
+    date: "2026-05-15T00:00:00Z",
+    content: [
+      {
+        type: "paragraph",
+        formatting: {},
+        content: [
+          {
+            type: "run",
+            formatting: {},
+            content: [{ type: "text", text: "body" }],
+          },
+        ],
+      },
+    ],
+    ...(parentId !== undefined ? { parentId } : {}),
+  };
+}
+
+describe("serializeComments", () => {
+  test("emits a valid empty <w:comments/> document when the array is empty", () => {
+    // Previously returned the empty string, which is not valid OOXML.
+    // Save paths now overwrite the original `word/comments.xml` part
+    // even when the editor has zero comments — that requires the
+    // serializer to produce a well-formed empty document so the part
+    // can be replaced rather than skipped.
+    const xml = serializeComments([]);
+    expect(xml.startsWith("<?xml")).toBe(true);
+    expect(xml).toContain("<w:comments xmlns:");
+    expect(xml).toContain("</w:comments>");
+    // No `<w:comment>` children.
+    expect(xml).not.toContain("<w:comment ");
+  });
+
+  test("emits top-level comments before replies", () => {
+    const reply = makeComment(2, 1);
+    const top = makeComment(1);
+    // Caller may pass replies first; the serializer must group them
+    // after the top-level comments.
+    const xml = serializeComments([reply, top]);
+    const topIndex = xml.indexOf('w:id="1"');
+    const replyIndex = xml.indexOf('w:id="2"');
+    expect(topIndex).toBeGreaterThan(-1);
+    expect(replyIndex).toBeGreaterThan(-1);
+    expect(topIndex).toBeLessThan(replyIndex);
+  });
+});

--- a/packages/folio/src/core/docx/serializer/commentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/commentSerializer.ts
@@ -90,14 +90,32 @@ function serializeComment(comment: Comment): string {
   return xml;
 }
 
+const COMMENTS_HEADER =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+  '<w:comments xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" ' +
+  'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
+  'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
+  'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" ' +
+  'xmlns:v="urn:schemas-microsoft-com:vml" ' +
+  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" ' +
+  'xmlns:w10="urn:schemas-microsoft-com:office:word" ' +
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" ' +
+  'xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" ' +
+  'xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" ' +
+  'xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" ' +
+  'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" ' +
+  'mc:Ignorable="w14 wp14">';
+
 /**
- * Serialize comments array to comments.xml content
+ * Serialize comments array to comments.xml content. Returns a valid empty
+ * `<w:comments/>` document for an empty array so callers can overwrite an
+ * existing `word/comments.xml` part when the editor has removed the last
+ * comment — leaving the previous file in place would otherwise re-emit
+ * the orphaned comment threads on every save.
  */
 export function serializeComments(comments: Comment[]): string {
-  if (comments.length === 0) {
-    return "";
-  }
-
   // Separate top-level comments and replies in a single pass
   const topLevel: Comment[] = [];
   const replies: Comment[] = [];
@@ -107,23 +125,7 @@ export function serializeComments(comments: Comment[]): string {
     (parentId === null || parentId === undefined ? topLevel : replies).push(c);
   }
 
-  let xml =
-    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-    '<w:comments xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" ' +
-    'xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" ' +
-    'xmlns:o="urn:schemas-microsoft-com:office:office" ' +
-    'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" ' +
-    'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" ' +
-    'xmlns:v="urn:schemas-microsoft-com:vml" ' +
-    'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" ' +
-    'xmlns:w10="urn:schemas-microsoft-com:office:word" ' +
-    'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
-    'xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" ' +
-    'xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" ' +
-    'xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" ' +
-    'xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" ' +
-    'xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" ' +
-    'mc:Ignorable="w14 wp14">';
+  let xml = COMMENTS_HEADER;
 
   // Serialize top-level comments first, then replies
   for (const comment of topLevel) {


### PR DESCRIPTION
## Summary
**Correctness.** When a user deletes text covered by a comment mark, ProseMirror drops the mark with the text, but the matching `Comment` entry stays in the in-memory `comments` array (the array is managed separately in `DocxEditor.tsx` with no reconciliation against the document). The next save serialised the full array into `comments.xml`, producing comment threads with no in-body anchor. Word silently drops them or surfaces unresolvable orphans, and a round-trip through Folio re-emits the same phantom threads forever.

Fix at the write boundary: `buildCurrentDocument` now collects every `commentRangeStart` / `commentRangeEnd` / `commentReference` id from the content tree and prunes any top-level comment whose anchor is missing. Replies follow their parent — a reply with no surviving parent is dropped, since a reply has no anchor of its own.

**Perf.** One additional tree walk per save (negligible — already serialising the full doc). Helpers are pure; in-memory state stays intact for sidebar display.

## Test plan
- [x] `bun --filter @stll/folio test` — 645 pass (was 635)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`
- 10 new regression tests covering: empty content, all three marker types, table-cell nesting, ignoring missing / non-numeric ids, top-level passthrough, top-level orphan drop, kept reply, dropped reply, reply with missing parent, all-orphan case.