### PR TITLE
fix(folio): preserve w:pPrChange entries through ProseMirror round-trip

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -202,12 +202,14 @@ function convertPMParagraph(
 
   // Restore `w:pPrChange` entries that PM carried opaquely. The editor
   // doesn't surface them in UI, but they must survive an edit so the
-  // saved DOCX still contains the property-change history Word relies on.
+  // saved DOCX still contains the property-change history Word relies
+  // on. Shallow-clone the array so the rebuilt Folio document doesn't
+  // share a mutable reference with PM's attrs.
   if (
     Array.isArray(attrs._propertyChanges) &&
     attrs._propertyChanges.length > 0
   ) {
-    paragraph.propertyChanges = attrs._propertyChanges;
+    paragraph.propertyChanges = [...attrs._propertyChanges];
   }
 
   return paragraph;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -200,6 +200,16 @@ function convertPMParagraph(
     };
   }
 
+  // Restore `w:pPrChange` entries that PM carried opaquely. The editor
+  // doesn't surface them in UI, but they must survive an edit so the
+  // saved DOCX still contains the property-change history Word relies on.
+  if (
+    Array.isArray(attrs._propertyChanges) &&
+    attrs._propertyChanges.length > 0
+  ) {
+    paragraph.propertyChanges = attrs._propertyChanges;
+  }
+
   return paragraph;
 }
 

--- a/packages/folio/src/core/prosemirror/conversion/propertyChangeRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/propertyChangeRoundtrip.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Paragraph, ParagraphPropertyChange } from "../../types/content";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const samplePropertyChange: ParagraphPropertyChange = {
+  type: "paragraphPropertyChange",
+  info: {
+    id: 7,
+    author: "Reviewer",
+    date: "2026-05-15T12:00:00Z",
+  },
+  previousFormatting: { alignment: "left" },
+  currentFormatting: { alignment: "center" },
+};
+
+function paragraphWithPropertyChange(): Paragraph {
+  return {
+    type: "paragraph",
+    formatting: { alignment: "center" },
+    propertyChanges: [samplePropertyChange],
+    content: [
+      {
+        type: "run",
+        formatting: {},
+        content: [{ type: "text", text: "body" }],
+      },
+    ],
+  };
+}
+
+describe("paragraph propertyChanges PM round-trip", () => {
+  test("toProseDoc copies propertyChanges into the paragraph node attrs", () => {
+    const document = {
+      package: {
+        document: {
+          content: [paragraphWithPropertyChange()],
+          finalSectionProperties: {},
+        },
+      },
+    };
+    const pmDoc = toProseDoc(document as never);
+    // The paragraph PM node now carries the entries on a private attr —
+    // editor code never reads it; it exists purely so fromProseDoc can
+    // restore them after an edit.
+    const paragraphNode = pmDoc.firstChild!;
+    expect(paragraphNode.attrs["_propertyChanges"]).toEqual([
+      samplePropertyChange,
+    ]);
+  });
+
+  test("fromProseDoc restores propertyChanges back onto the Folio Paragraph", () => {
+    // Simulate a no-op edit: convert to PM and immediately back. The
+    // entries must survive even though the editor surfaces nothing in
+    // UI for them — the previous behaviour silently stripped them on
+    // every edit, corrupting the `w:pPrChange` history.
+    const original = paragraphWithPropertyChange();
+    const document = {
+      package: {
+        document: {
+          content: [original],
+          finalSectionProperties: {},
+        },
+      },
+    };
+    const pmDoc = toProseDoc(document as never);
+    const roundtripped = fromProseDoc(pmDoc).package.document.content[0] as
+      | Paragraph
+      | undefined;
+
+    expect(roundtripped?.propertyChanges).toEqual([samplePropertyChange]);
+  });
+
+  test("paragraphs without propertyChanges round-trip without inventing them", () => {
+    const plain: Paragraph = {
+      type: "paragraph",
+      formatting: {},
+      content: [
+        {
+          type: "run",
+          formatting: {},
+          content: [{ type: "text", text: "plain" }],
+        },
+      ],
+    };
+    const document = {
+      package: {
+        document: {
+          content: [plain],
+          finalSectionProperties: {},
+        },
+      },
+    };
+    const pmDoc = toProseDoc(document as never);
+    const roundtripped = fromProseDoc(pmDoc).package.document.content[0] as
+      | Paragraph
+      | undefined;
+    // No phantom propertyChanges should be attached.
+    expect(roundtripped?.propertyChanges).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -378,6 +378,12 @@ function paragraphFormattingToAttrs(
   if (formatting) {
     attrs._originalFormatting = formatting;
   }
+  // Carry `w:pPrChange` (paragraph-property-change tracking) opaquely
+  // through ProseMirror. Without this, every edit strips the entries
+  // off the paragraph because nothing in PM's schema represents them.
+  if (paragraph.propertyChanges && paragraph.propertyChanges.length > 0) {
+    attrs._propertyChanges = paragraph.propertyChanges;
+  }
 
   // Helper: assign a value only when defined
   const set = <K extends keyof ParagraphAttrs>(

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -381,8 +381,11 @@ function paragraphFormattingToAttrs(
   // Carry `w:pPrChange` (paragraph-property-change tracking) opaquely
   // through ProseMirror. Without this, every edit strips the entries
   // off the paragraph because nothing in PM's schema represents them.
+  // Shallow-clone the array so the editor state owns its own
+  // reference — mutating the Folio document later must not poke
+  // through into PM attrs.
   if (paragraph.propertyChanges && paragraph.propertyChanges.length > 0) {
-    attrs._propertyChanges = paragraph.propertyChanges;
+    attrs._propertyChanges = [...paragraph.propertyChanges];
   }
 
   // Helper: assign a value only when defined

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -355,6 +355,7 @@ const paragraphNodeSpec: NodeSpec = {
     bookmarks: { default: null },
     _originalFormatting: { default: null },
     _sectionProperties: { default: null },
+    _propertyChanges: { default: null },
   },
   parseDOM: [
     {

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -10,6 +10,7 @@ import type { FloatingTableProperties, TableLook } from "../../types";
 import type {
   ParagraphAlignment,
   ParagraphFormatting,
+  ParagraphPropertyChange,
   LineSpacingRule,
   BorderSpec,
   ShadingProperties,
@@ -131,6 +132,13 @@ export type ParagraphAttrs = {
   /** Full section properties for paragraphs that end a section.
    *  Used by layout engine for per-section column/page config and round-trip. */
   _sectionProperties?: SectionProperties;
+
+  /** Paragraph-property-change tracking entries (`w:pPrChange`).
+   *  Preserved opaquely through ProseMirror — the editor does not surface
+   *  them in UI today, but stripping them on every edit would corrupt the
+   *  `w:pPrChange` history Word relies on for "show previous formatting"
+   *  and for reverting an accepted property change. */
+  _propertyChanges?: ParagraphPropertyChange[];
 };
 
 /**


### PR DESCRIPTION
## Summary
**Correctness.** The OOXML parser populates `paragraph.propertyChanges` from `w:pPrChange` and the serializer emits them faithfully, but the ProseMirror conversion lost them entirely. `toProseDoc` only stashed `_originalFormatting`; `fromProseDoc` only read `_originalFormatting` back. Any edit therefore round-tripped the paragraph through PM and erased the `w:pPrChange` history, so Word's "show previous formatting" and "reject this property change" stopped working on every saved-after-edit DOCX.

Carry the entries opaquely on a new `_propertyChanges` paragraph attr, mirroring the existing `_originalFormatting` / `_sectionProperties` slots. The editor surfaces nothing in UI; the data just survives the round-trip.

**Perf.** Passthrough only — no extra walks.

**Scope.** Run-level `w:rPrChange` has the same bug but needs a different fix because runs aren't discrete PM nodes (they fragment into text + marks). Tracked as a follow-up.

## Test plan
- [x] `bun --filter @stll/folio test` — 638 pass (was 635)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`
- New regression tests in `propertyChangeRoundtrip.test.ts`:
  - `toProseDoc` stashes entries on the PM node attrs
  - `fromProseDoc` restores them
  - paragraphs without property-changes don't gain phantom ones