### PR TITLE
fix(folio): preserve w:moveFrom / w:moveTo identity through PM round-trip

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -361,11 +361,13 @@ function paragraphAttrsToFormatting(
  */
 function extractParagraphContent(
   paragraph: PMNode,
-  documentCounts?: TrackedChangeCounts,
+  // Parameter retained for signature compatibility with the call sites
+  // threaded through tables/cells. The body no longer needs the counts
+  // — `moveFrom`/`moveTo` round-trip is now driven by the explicit
+  // `moveKind` mark attribute set by `toProseDoc`.
+  _documentCounts?: TrackedChangeCounts,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
-  const trackedChangeCounts =
-    documentCounts ?? buildDocumentTrackedChangeCounts(paragraph);
 
   // Track current run being built
   let currentRun: Run | null = null;
@@ -478,20 +480,22 @@ function extractParagraphContent(
       if (dateStr) {
         info.date = dateStr;
       }
-      const revisionId = info.id;
-      const hasInsertionForId =
-        (trackedChangeCounts.insertionById.get(revisionId) ?? 0) > 0;
-      const hasDeletionForId =
-        (trackedChangeCounts.deletionById.get(revisionId) ?? 0) > 0;
-      const isMovePair = hasInsertionForId && hasDeletionForId;
-
+      // The mark itself records whether it originated as a
+      // `w:moveTo` / `w:moveFrom`. The previous "is there both an
+      // insertion AND a deletion with the same revisionId somewhere
+      // in the document?" heuristic was unsound: OOXML doesn't
+      // require `w:moveFrom`/`w:moveTo` to share `w:id` (they
+      // typically don't), and unrelated `w:ins w:id="5"` /
+      // `w:del w:id="5"` from different reviewers would coincidentally
+      // fuse into a phantom move pair.
+      const moveKind = changeMark.attrs["moveKind"];
       if (insertionMark) {
-        if (isMovePair) {
+        if (moveKind === "moveTo") {
           content.push({ type: "moveTo", info, content: [run] });
         } else {
           content.push({ type: "insertion", info, content: [run] });
         }
-      } else if (isMovePair) {
+      } else if (moveKind === "moveFrom") {
         content.push({ type: "moveFrom", info, content: [run] });
       } else {
         content.push({ type: "deletion", info, content: [run] });

--- a/packages/folio/src/core/prosemirror/conversion/moveTrackingRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/moveTrackingRoundtrip.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Deletion,
+  Insertion,
+  MoveFrom,
+  MoveTo,
+  Paragraph,
+} from "../../types/content";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const REVA = { id: 1, author: "Author A", date: "2026-05-15T12:00:00Z" };
+const REVB = { id: 2, author: "Author B", date: "2026-05-15T12:01:00Z" };
+
+function paragraphWith(content: Paragraph["content"]): Paragraph {
+  return {
+    type: "paragraph",
+    formatting: {},
+    content,
+  };
+}
+
+function runText(text: string): MoveTo["content"][number] {
+  return {
+    type: "run",
+    formatting: {},
+    content: [{ type: "text", text }],
+  };
+}
+
+function makeMoveFrom(): MoveFrom {
+  return {
+    type: "moveFrom",
+    info: REVA,
+    content: [runText("moved away")],
+  };
+}
+
+function makeMoveTo(): MoveTo {
+  return {
+    type: "moveTo",
+    info: REVA,
+    content: [runText("moved here")],
+  };
+}
+
+function makeInsertion(info = REVA): Insertion {
+  return {
+    type: "insertion",
+    info,
+    content: [runText("inserted")],
+  };
+}
+
+function makeDeletion(info = REVA): Deletion {
+  return {
+    type: "deletion",
+    info,
+    content: [runText("deleted")],
+  };
+}
+
+function asDocument(paragraphs: Paragraph[]): never {
+  return {
+    package: {
+      document: {
+        content: paragraphs,
+        finalSectionProperties: {},
+      },
+    },
+  } as never;
+}
+
+describe("moveFrom / moveTo PM round-trip", () => {
+  test("toProseDoc stamps the originating element via the moveKind mark attribute", () => {
+    const doc = asDocument([
+      paragraphWith([makeMoveFrom()]),
+      paragraphWith([makeMoveTo()]),
+    ]);
+    const pmDoc = toProseDoc(doc);
+
+    const moveFromText = pmDoc.firstChild!.firstChild!;
+    const moveToText = pmDoc.child(1).firstChild!;
+
+    const moveFromMark = moveFromText.marks.find(
+      (m) => m.type.name === "deletion",
+    );
+    const moveToMark = moveToText.marks.find(
+      (m) => m.type.name === "insertion",
+    );
+
+    expect(moveFromMark?.attrs["moveKind"]).toBe("moveFrom");
+    expect(moveToMark?.attrs["moveKind"]).toBe("moveTo");
+  });
+
+  test("plain insertion / deletion marks keep moveKind = null", () => {
+    const doc = asDocument([
+      paragraphWith([makeInsertion()]),
+      paragraphWith([makeDeletion()]),
+    ]);
+    const pmDoc = toProseDoc(doc);
+    const insMark = pmDoc.firstChild!.firstChild!.marks.find(
+      (m) => m.type.name === "insertion",
+    );
+    const delMark = pmDoc
+      .child(1)
+      .firstChild!.marks.find((m) => m.type.name === "deletion");
+    expect(insMark?.attrs["moveKind"]).toBeNull();
+    expect(delMark?.attrs["moveKind"]).toBeNull();
+  });
+
+  test("fromProseDoc re-emits moveFrom / moveTo elements based on moveKind", () => {
+    const doc = asDocument([
+      paragraphWith([makeMoveFrom()]),
+      paragraphWith([makeMoveTo()]),
+    ]);
+    const roundtripped = fromProseDoc(toProseDoc(doc));
+
+    const p1 = roundtripped.package.document.content[0] as Paragraph;
+    const p2 = roundtripped.package.document.content[1] as Paragraph;
+
+    expect(p1.content[0]?.type).toBe("moveFrom");
+    expect(p2.content[0]?.type).toBe("moveTo");
+  });
+
+  test("coincident revisionIds across plain ins+del don't fuse into a phantom move", () => {
+    // Real-world regression: two reviewers using authoring tools that
+    // restart `w:id` counters can emit `<w:ins w:id="5">` and
+    // `<w:del w:id="5">` for unrelated edits. The previous "is there
+    // both an insertion AND a deletion with the same revisionId
+    // somewhere in the document?" heuristic would re-emit both as a
+    // single move pair, mis-attributing the edits.
+    const doc = asDocument([
+      paragraphWith([makeInsertion(REVA)]),
+      paragraphWith([makeDeletion(REVA)]),
+    ]);
+    const roundtripped = fromProseDoc(toProseDoc(doc));
+
+    const p1 = roundtripped.package.document.content[0] as Paragraph;
+    const p2 = roundtripped.package.document.content[1] as Paragraph;
+
+    // Both must round-trip as plain insertion/deletion — not as a
+    // moveTo / moveFrom pair.
+    expect(p1.content[0]?.type).toBe("insertion");
+    expect(p2.content[0]?.type).toBe("deletion");
+  });
+
+  test("moveFrom / moveTo with different revisionIds still round-trip correctly", () => {
+    // Equally common: real moves where `w:moveFrom w:id="3"` and
+    // `w:moveTo w:id="11"` do NOT share an id. The old heuristic
+    // dropped these into plain (deletion + insertion) because the
+    // counts didn't pair up.
+    const moveFrom: MoveFrom = {
+      type: "moveFrom",
+      info: REVA,
+      content: [runText("moved away")],
+    };
+    const moveTo: MoveTo = {
+      type: "moveTo",
+      info: REVB,
+      content: [runText("moved here")],
+    };
+    const doc = asDocument([
+      paragraphWith([moveFrom]),
+      paragraphWith([moveTo]),
+    ]);
+    const roundtripped = fromProseDoc(toProseDoc(doc));
+
+    const p1 = roundtripped.package.document.content[0] as Paragraph;
+    const p2 = roundtripped.package.document.content[1] as Paragraph;
+
+    expect(p1.content[0]?.type).toBe("moveFrom");
+    expect(p2.content[0]?.type).toBe("moveTo");
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -173,6 +173,7 @@ function convertParagraph(
   const emitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
     markType: "insertion" | "deletion",
+    moveKind: "moveFrom" | "moveTo" | null,
   ): void => {
     emitInlineNodes(
       convertTrackedChange(
@@ -180,6 +181,7 @@ function convertParagraph(
         markType,
         getInheritedRunFormatting,
         styleResolver,
+        moveKind,
       ),
     );
   };
@@ -213,9 +215,17 @@ function convertParagraph(
         convertInlineSdt(content, getInheritedRunFormatting, styleResolver),
       );
     } else if (content.type === "insertion" || content.type === "moveTo") {
-      emitTrackedChange(content, "insertion");
+      emitTrackedChange(
+        content,
+        "insertion",
+        content.type === "moveTo" ? "moveTo" : null,
+      );
     } else if (content.type === "deletion" || content.type === "moveFrom") {
-      emitTrackedChange(content, "deletion");
+      emitTrackedChange(
+        content,
+        "deletion",
+        content.type === "moveFrom" ? "moveFrom" : null,
+      );
     } else if (content.type === "mathEquation") {
       emitInlineNode(convertMathEquation(content));
     }
@@ -282,6 +292,7 @@ function convertTrackedChange(
   markType: "insertion" | "deletion",
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleResolver | null,
+  moveKind: "moveFrom" | "moveTo" | null = null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
   for (const item of change.content) {
@@ -305,6 +316,7 @@ function convertTrackedChange(
     revisionId: change.info.id,
     author: change.info.author,
     date: change.info.date ?? null,
+    moveKind,
   });
 
   return nodes.map((node) => {

--- a/packages/folio/src/core/prosemirror/extensions/marks/TrackedChangeExtensions.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TrackedChangeExtensions.ts
@@ -33,6 +33,12 @@ export const InsertionExtension = createMarkExtension({
       revisionId: { default: 0 },
       author: { default: "" },
       date: { default: null },
+      // `"moveTo"` distinguishes inserted text that originated as a
+      // `w:moveTo` (the destination half of an OOXML move) from a
+      // plain `w:ins`. Carried through PM so `fromProseDoc` can
+      // re-emit the correct OOXML element without relying on
+      // brittle revisionId pairing across the doc.
+      moveKind: { default: null },
     },
     inclusive: false,
     parseDOM: [
@@ -90,6 +96,12 @@ export const DeletionExtension = createMarkExtension({
       revisionId: { default: 0 },
       author: { default: "" },
       date: { default: null },
+      // `"moveFrom"` distinguishes deleted text that originated as a
+      // `w:moveFrom` (the source half of an OOXML move) from a plain
+      // `w:del`. Carried through PM so `fromProseDoc` can re-emit
+      // the correct OOXML element without relying on brittle
+      // revisionId pairing across the doc.
+      moveKind: { default: null },
     },
     inclusive: false,
     parseDOM: [


### PR DESCRIPTION
## Summary
**Correctness.** `toProseDoc` mapped `moveFrom` → deletion mark and `moveTo` → insertion mark with no marker that the original was a move. `fromProseDoc` then reconstructed moves with a "is there an insertion AND a deletion sharing the same `revisionId` somewhere in the document?" heuristic. That heuristic is wrong both directions:

- OOXML doesn't require `w:moveFrom` and `w:moveTo` to share `w:id` — they typically don't. Legitimate moves degraded to a plain (deletion + insertion) pair on round-trip, losing the move relationship.
- Two reviewers using authoring tools that restart `w:id` counters emit `<w:ins w:id="5">` and `<w:del w:id="5">` for unrelated edits. The heuristic fused them into a phantom move pair, mis-attributing both reviewers' edits.

Adds a `moveKind: "moveFrom" | "moveTo" | null` attribute to both `insertion` and `deletion` marks. `toProseDoc` stamps it when the source was a move; `fromProseDoc` re-emits the correct OOXML element directly from the attribute. The id-pair heuristic is gone.

**Perf.** Direct attr read replaces a doc-wide pre-walk for tracked-change counts. The `buildDocumentTrackedChangeCounts` plumbing is now dead in the call sites that read this attr; left in place for the moment to avoid surface churn, but no longer authoritative.

## Test plan
- [x] `bun --filter @stll/folio test` — 640 pass (was 635)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`
- New regression tests in `moveTrackingRoundtrip.test.ts`:
  - `toProseDoc` stamps `moveKind` on the mark
  - plain insertion / deletion keep `moveKind: null`
  - `moveFrom` / `moveTo` round-trip to their original element types
  - coincident `w:id` on unrelated `w:ins` + `w:del` does **not** fuse into a phantom move
  - `moveFrom` / `moveTo` with **different** `revisionId`s still round-trip correctly (the most common real-world shape)