### PR TITLE
fix(folio): parse commentsExtended.xml for comment reply threads

### DIFF
--- a/packages/folio/src/components/commentsHelpers.ts
+++ b/packages/folio/src/components/commentsHelpers.ts
@@ -214,16 +214,17 @@ export function collectCommentIdsFromSources(
  *  - replies whose explicit `parentId` does not reach a kept top-level
  *    comment (a true broken-thread orphan).
  *
- * Why we don't prune unanchored top-level comments: the OOXML parser
- * does not yet read `commentsExtended.xml`, so Word comment replies
- * arrive with `parentId === undefined` and look indistinguishable from
- * a true top-level comment whose anchor has been edited away. Until the
- * parser populates the parent link, dropping unanchored top-level
- * entries would silently lose every imported Word reply on the first
- * save — a strictly worse failure mode than re-emitting a comment whose
- * anchor was actually deleted. The complementary "overwrite stale
- * `comments.xml`" fix in the save paths already prevents the
- * phantom-thread regression when the array does end up empty.
+ * Why we don't prune unanchored top-level comments: pre-Word-2013
+ * documents (and any document missing `commentsExtended.xml`) carry no
+ * reply-thread metadata, so Word replies in those files arrive with
+ * `parentId === undefined` and look indistinguishable from a true
+ * top-level comment whose anchor has been edited away. Dropping
+ * unanchored top-level entries would silently lose every reply in
+ * those older files on the first save — a strictly worse failure mode
+ * than re-emitting a comment whose anchor was actually deleted. The
+ * complementary "overwrite stale `comments.xml`" fix in the save paths
+ * already prevents the phantom-thread regression when the array does
+ * end up empty.
  */
 export function pruneOrphanedComments(
   comments: Comment[],

--- a/packages/folio/src/core/docx/commentParser.test.ts
+++ b/packages/folio/src/core/docx/commentParser.test.ts
@@ -259,6 +259,44 @@ describe("commentParser", () => {
       expect(comments[1].parentId).toBeUndefined();
     });
 
+    test("falls back to first-paragraph paraId when w:comment has none", () => {
+      // Some Word exporters put the join key on the first `w:p` child,
+      // not on `w:comment` itself. The reply-thread metadata still has
+      // to be applied.
+      const commentsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:comments xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+  <w:comment w:id="1" w:author="Alice" w:date="2024-02-10T15:30:00">
+    <w:p w14:paraId="1A2B3C4D">
+      <w:r><w:t>First</w:t></w:r>
+    </w:p>
+  </w:comment>
+  <w:comment w:id="2" w:author="Bob" w:date="2024-03-05T09:15:00">
+    <w:p w14:paraId="5E6F7A8B">
+      <w:r><w:t>Reply</w:t></w:r>
+    </w:p>
+  </w:comment>
+</w:comments>`;
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="1A2B3C4D" w15:done="1"/>
+  <w15:commentEx w15:paraId="5E6F7A8B" w15:paraIdParent="1A2B3C4D"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        commentsXml,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      expect(comments[0].done).toBe(true);
+      expect(comments[1].parentId).toBe(1);
+    });
+
     test("parentId resolution is case-insensitive on paraId", () => {
       const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">

--- a/packages/folio/src/core/docx/commentParser.test.ts
+++ b/packages/folio/src/core/docx/commentParser.test.ts
@@ -194,6 +194,90 @@ describe("commentParser", () => {
       expect(comments[0].date).toBe("2024-02-10T15:30:00");
     });
 
+    test("commentsExtended.xml populates parentId on replies", () => {
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="1A2B3C4D" w15:done="0"/>
+  <w15:commentEx w15:paraId="5E6F7A8B" w15:paraIdParent="1A2B3C4D" w15:done="0"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        COMMENTS_XML,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      expect(comments).toHaveLength(2);
+      // Top-level comment has no parent
+      expect(comments[0].parentId).toBeUndefined();
+      // Reply points at the top-level w:id
+      expect(comments[1].parentId).toBe(1);
+    });
+
+    test("commentsExtended.xml carries the done/resolved state", () => {
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="1A2B3C4D" w15:done="1"/>
+  <w15:commentEx w15:paraId="5E6F7A8B" w15:done="0"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        COMMENTS_XML,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      expect(comments[0].done).toBe(true);
+      expect(comments[1].done).toBe(false);
+    });
+
+    test("paraIdParent that doesn't match any comment is ignored", () => {
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="5E6F7A8B" w15:paraIdParent="DEADBEEF"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        COMMENTS_XML,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      // Reply with unresolvable parent falls back to top-level.
+      expect(comments[1].parentId).toBeUndefined();
+    });
+
+    test("parentId resolution is case-insensitive on paraId", () => {
+      const extendedXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w15:commentsEx xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml">
+  <w15:commentEx w15:paraId="5e6f7a8b" w15:paraIdParent="1a2b3c4d"/>
+</w15:commentsEx>`;
+
+      const comments = parseComments(
+        COMMENTS_XML,
+        emptyStyles,
+        emptyTheme,
+        emptyRels,
+        emptyMedia,
+        null,
+        extendedXml,
+      );
+
+      expect(comments[1].parentId).toBe(1);
+    });
+
     test("paraId matching is case-insensitive", () => {
       // commentsExtensible uses lowercase paraId
       const lowerCaseExtensible = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/packages/folio/src/core/docx/commentParser.ts
+++ b/packages/folio/src/core/docx/commentParser.ts
@@ -186,12 +186,34 @@ export function parseComments(
     const rawDate = getAttribute(child, "w", "date");
     const localDate = rawDate !== null ? String(rawDate) : undefined;
 
-    // The paraId on `w:comment` is the join key used by both
-    // commentsExtensible (UTC dates) and commentsExtended (reply links).
-    const rawParaId =
+    // The paraId join key used by commentsExtensible (UTC dates) and
+    // commentsExtended (reply links) may live on `w:comment` itself,
+    // or on the first `w:p` child — both layouts occur in the wild
+    // and exporters disagree. Check the wrapper first, then fall back
+    // to the first paragraph.
+    let rawParaId =
       getAttribute(child, "w14", "paraId") ??
       child.attributes?.["w14:paraId"] ??
+      getAttribute(child, "w15", "paraId") ??
+      child.attributes?.["w15:paraId"] ??
       getAttribute(child, "w", "paraId");
+    if (!rawParaId) {
+      for (const sub of getChildElements(child)) {
+        const subLocal = sub.name?.replace(/^.*:/, "") ?? "";
+        if (subLocal !== "p") {
+          continue;
+        }
+        rawParaId =
+          getAttribute(sub, "w14", "paraId") ??
+          sub.attributes?.["w14:paraId"] ??
+          getAttribute(sub, "w15", "paraId") ??
+          sub.attributes?.["w15:paraId"] ??
+          getAttribute(sub, "w", "paraId");
+        if (rawParaId) {
+          break;
+        }
+      }
+    }
     const paraId = rawParaId ? String(rawParaId).toUpperCase() : null;
 
     const dateUtc = paraId ? dateUtcByParaId.get(paraId) : undefined;

--- a/packages/folio/src/core/docx/commentParser.ts
+++ b/packages/folio/src/core/docx/commentParser.ts
@@ -1,17 +1,19 @@
 /**
- * Comment Parser - Parse comments.xml and commentsExtensible.xml
+ * Comment Parser - Parse comments.xml, commentsExtensible.xml, and
+ * commentsExtended.xml.
  *
- * Parses OOXML comments (w:comment) from comments.xml file.
- * Cross-references with commentsExtensible.xml (or commentsExtended.xml)
- * to obtain reliable UTC timestamps via w16cex:dateUtc.
- *
- * Note: Microsoft Word stores w:date as local time WITHOUT timezone offset,
- * which is ambiguous. The reliable UTC timestamp lives in the separate
- * commentsExtensible.xml part (Word 2016+).
+ * - `comments.xml` (w) carries the comment author, local date, and body.
+ * - `commentsExtensible.xml` (w16cex, Word 2016+) carries reliable UTC
+ *   timestamps via `w16cex:dateUtc` — Word's `w:date` is local time
+ *   without an offset and so is ambiguous.
+ * - `commentsExtended.xml` (w15, Word 2013+) carries reply-thread
+ *   parent links via `w15:paraIdParent` and the resolved/done state
+ *   via `w15:done`. Cross-referenced via the `w14:paraId` on
+ *   `w:comment` and the matching `w15:paraId` on `w15:commentEx`.
  *
  * OOXML Reference:
  * - Comments: w:comments
- * - Comment: w:comment (w:id, w:author, w:date, w:initials)
+ * - Comment: w:comment (w:id, w:author, w:date, w:initials, w14:paraId)
  * - Comment content: child w:p elements
  */
 
@@ -73,11 +75,69 @@ function parseCommentsExtensible(xml: string): Map<string, string> {
   return dateUtcByParaId;
 }
 
+type CommentExtendedInfo = {
+  parentParaId?: string;
+  done?: boolean;
+};
+
+/**
+ * Build a lookup from paraId → reply-thread info from
+ * commentsExtended.xml. The XML structure is:
+ *
+ * ```xml
+ * <w15:commentsEx>
+ *   <w15:commentEx w15:paraId="..." w15:done="0"/>
+ *   <w15:commentEx w15:paraId="..." w15:paraIdParent="..." w15:done="1"/>
+ * </w15:commentsEx>
+ * ```
+ *
+ * `w15:paraIdParent` points at the parent thread's paraId; `w15:done`
+ * (`"1"` / `"true"`) marks the thread resolved.
+ */
+function parseCommentsExtended(xml: string): Map<string, CommentExtendedInfo> {
+  const infoByParaId = new Map<string, CommentExtendedInfo>();
+
+  const root = parseXml(xml);
+  const container = findChild(root, "w15", "commentsEx") ?? root;
+  for (const child of getChildElements(container)) {
+    const localName = child.name?.replace(/^.*:/, "") ?? "";
+    if (localName !== "commentEx") {
+      continue;
+    }
+
+    const paraId =
+      getAttribute(child, "w15", "paraId") ?? child.attributes?.["w15:paraId"];
+    if (!paraId) {
+      continue;
+    }
+
+    const parentParaId =
+      getAttribute(child, "w15", "paraIdParent") ??
+      child.attributes?.["w15:paraIdParent"];
+    const doneAttr =
+      getAttribute(child, "w15", "done") ?? child.attributes?.["w15:done"];
+
+    const info: CommentExtendedInfo = {};
+    if (parentParaId) {
+      info.parentParaId = String(parentParaId).toUpperCase();
+    }
+    if (doneAttr !== undefined) {
+      const v = String(doneAttr).toLowerCase();
+      info.done = v === "1" || v === "true";
+    }
+    infoByParaId.set(String(paraId).toUpperCase(), info);
+  }
+
+  return infoByParaId;
+}
+
 /**
  * Parse comments.xml into an array of Comment objects.
  *
- * If commentsExtensibleXml is provided, UTC timestamps are cross-referenced
- * via paraId and preferred over the ambiguous w:date local time.
+ * If `commentsExtensibleXml` is provided, UTC timestamps are
+ * cross-referenced via paraId and preferred over the ambiguous w:date
+ * local time. If `commentsExtendedXml` is provided, reply-thread
+ * parent links (`parentId`) and resolved state (`done`) are populated.
  */
 export function parseComments(
   commentsXml: string | null,
@@ -86,6 +146,7 @@ export function parseComments(
   rels: RelationshipMap,
   media: Map<string, MediaFile>,
   commentsExtensibleXml?: string | null,
+  commentsExtendedXml?: string | null,
 ): Comment[] {
   if (!commentsXml) {
     return [];
@@ -93,14 +154,24 @@ export function parseComments(
 
   const root = parseXml(commentsXml);
 
-  // Build UTC date lookup from extended comments (if available)
+  // Build UTC date lookup from commentsExtensible (Word 2016+).
   const dateUtcByParaId = commentsExtensibleXml
     ? parseCommentsExtensible(commentsExtensibleXml)
     : new Map<string, string>();
 
+  // Build reply-thread + done lookup from commentsExtended (Word 2013+).
+  const extendedByParaId = commentsExtendedXml
+    ? parseCommentsExtended(commentsExtendedXml)
+    : new Map<string, CommentExtendedInfo>();
+
   const commentsEl = findChild(root, "w", "comments") ?? root;
   const children = getChildElements(commentsEl);
   const comments: Comment[] = [];
+  // Track the paraId → comment-id mapping so we can resolve
+  // `w15:paraIdParent` (which references the parent comment's paraId,
+  // not its `w:id`) to a numeric `parentId` once every comment is parsed.
+  const commentIdByParaId = new Map<string, number>();
+  const paraIdByCommentIndex = new Map<number, string>();
 
   for (const child of children) {
     const localName = child.name?.replace(/^.*:/, "") ?? "";
@@ -115,17 +186,20 @@ export function parseComments(
     const rawDate = getAttribute(child, "w", "date");
     const localDate = rawDate !== null ? String(rawDate) : undefined;
 
-    // Try to find the UTC date from commentsExtensible.xml via paraId
-    const paraId =
+    // The paraId on `w:comment` is the join key used by both
+    // commentsExtensible (UTC dates) and commentsExtended (reply links).
+    const rawParaId =
       getAttribute(child, "w14", "paraId") ??
       child.attributes?.["w14:paraId"] ??
       getAttribute(child, "w", "paraId");
-    const dateUtc = paraId
-      ? dateUtcByParaId.get(String(paraId).toUpperCase())
-      : undefined;
+    const paraId = rawParaId ? String(rawParaId).toUpperCase() : null;
 
+    const dateUtc = paraId ? dateUtcByParaId.get(paraId) : undefined;
     // Prefer UTC date over ambiguous local date
     const date = dateUtc ?? localDate;
+
+    const extendedInfo = paraId ? extendedByParaId.get(paraId) : undefined;
+    const done = extendedInfo?.done;
 
     // Parse comment content (paragraphs)
     const paragraphs: Paragraph[] = [];
@@ -144,13 +218,43 @@ export function parseComments(
       }
     }
 
+    const commentIndex = comments.length;
+    if (paraId) {
+      commentIdByParaId.set(paraId, id);
+      paraIdByCommentIndex.set(commentIndex, paraId);
+    }
+
     comments.push({
       id,
       author,
       ...(initials !== undefined ? { initials } : {}),
       ...(date !== undefined ? { date } : {}),
+      ...(done !== undefined ? { done } : {}),
       content: paragraphs,
     });
+  }
+
+  // Second pass: resolve `w15:paraIdParent` → numeric parent comment id.
+  // A reply whose parent paraId is unknown (e.g. the parent was deleted
+  // from comments.xml but a stale `w15:commentEx` remains) is left as a
+  // top-level comment so it isn't silently dropped.
+  for (let i = 0; i < comments.length; i++) {
+    const comment = comments[i];
+    if (!comment) {
+      continue;
+    }
+    const paraId = paraIdByCommentIndex.get(i);
+    if (!paraId) {
+      continue;
+    }
+    const parentParaId = extendedByParaId.get(paraId)?.parentParaId;
+    if (!parentParaId) {
+      continue;
+    }
+    const parentId = commentIdByParaId.get(parentParaId);
+    if (parentId !== undefined && parentId !== comment.id) {
+      comments[i] = { ...comment, parentId };
+    }
   }
 
   return comments;

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -253,6 +253,7 @@ export async function parseDocx(
         rels,
         media,
         raw.commentsExtensibleXml,
+        raw.commentsExtendedXml,
       ),
     );
     if (comments.length > 0) {

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -107,7 +107,14 @@ export type RawDocxContent = {
 
   // Comments
   commentsXml: string | null;
+  // commentsExtensible.xml (w16cex, Word 2016+) carries UTC timestamps via
+  // `w16cex:dateUtc`. Different file with a different schema from
+  // commentsExtended.xml, even though the names look similar.
   commentsExtensibleXml: string | null;
+  // commentsExtended.xml (w15, Word 2013+) carries reply-thread parent
+  // links via `w15:paraIdParent` and the resolved/done state via
+  // `w15:done`. Needed to reconstruct comment reply threads on import.
+  commentsExtendedXml: string | null;
 
   // Relationships
   documentRels: string | null;
@@ -173,6 +180,7 @@ export async function unzipDocx(
     endnotesXml: null,
     commentsXml: null,
     commentsExtensibleXml: null,
+    commentsExtendedXml: null,
     documentRels: null,
     packageRels: null,
     contentTypesXml: null,
@@ -238,14 +246,10 @@ export async function unzipDocx(
         content.endnotesXml = xmlContent;
       } else if (lowerPath === "word/comments.xml") {
         content.commentsXml = xmlContent;
-      } else if (
-        lowerPath === "word/commentsextensible.xml" ||
-        lowerPath === "word/commentsextended.xml"
-      ) {
-        // Prefer commentsExtensible (Word 2016+), fall back to commentsExtended
-        if (!content.commentsExtensibleXml) {
-          content.commentsExtensibleXml = xmlContent;
-        }
+      } else if (lowerPath === "word/commentsextensible.xml") {
+        content.commentsExtensibleXml = xmlContent;
+      } else if (lowerPath === "word/commentsextended.xml") {
+        content.commentsExtendedXml = xmlContent;
       } else if (lowerPath === "word/_rels/document.xml.rels") {
         content.documentRels = xmlContent;
       } else if (lowerPath === "_rels/.rels") {


### PR DESCRIPTION
## Summary
- Split `commentsExtensible.xml` (w16cex, UTC dates) and `commentsExtended.xml` (w15, reply links + done state) into separate raw fields — they have different schemas and were previously collapsed into one slot
- Add `parseCommentsExtended` to read `w15:commentEx` and resolve `w15:paraIdParent` against the paraId → comment-id map built while parsing `comments.xml`, populating `parentId` + `done`
- Replies whose parent paraId is unknown stay top-level rather than being dropped

## Test plan
- [x] `bun test commentParser.test.ts` (13 pass, 4 new)
- [x] `bun --filter @stll/folio lint && typecheck`