### PR TITLE
fix(ci): include docs/changelog/** in landing deploy trigger

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - "apps/landing/**"
       - "packages/**"
+      - "docs/changelog/**"
       - "bun.lock"
       - ".github/workflows/deploy-landing.yml"
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Release commits typically touch only `VERSION` and `docs/changelog/<ver>.md`, neither of which were in `deploy-landing.yml`'s `paths:` filter
- v0.2.0 landed on main but the landing site rebuild was skipped, so `/changelog/v0-2-0` 404s even though the build reads release notes from `docs/changelog/`
- Adds `docs/changelog/**` to the paths filter so future releases auto-ship the new entry

## Test plan
- [ ] After merge, confirm a `Deploy Landing` run fires for the next changelog-touching commit
- [ ] `/changelog/v0-2-0` resolves once the in-flight manual dispatch finishes