### PR TITLE
feat: window matter table entity loading

### DIFF
--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -1,0 +1,72 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import { queryEntities } from "@/api/handlers/entities/query-entities";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { LIMITS } from "@/api/lib/limits";
+import {
+  tViewFilterConditionSchema,
+  tViewSortSchema,
+} from "@/api/lib/views-schema";
+
+const readFilesystemTreeBodySchema = t.Object({
+  filters: t.Optional(t.Array(tViewFilterConditionSchema)),
+  sorts: t.Optional(t.Array(tViewSortSchema)),
+  search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
+  fieldMode: t.Optional(t.UnionEnum(["full", "visible"])),
+  fieldIds: t.Optional(
+    t.Array(tSafeId("property"), {
+      maxItems: LIMITS.propertiesCount,
+    }),
+  ),
+});
+
+const config = {
+  permissions: { workspace: ["read"] },
+  body: readFilesystemTreeBodySchema,
+} satisfies HandlerConfig;
+
+type QueryEntities = typeof queryEntities;
+
+export const createReadFilesystemTreeHandler = (
+  queryEntitiesImpl: QueryEntities = queryEntities,
+) =>
+  createSafeHandler(
+    config,
+    async function* ({
+      safeDb,
+      workspaceId,
+      session,
+      body,
+      user: currentUser,
+    }) {
+      const result = yield* Result.await(
+        queryEntitiesImpl({
+          safeDb,
+          workspaceId,
+          currentUserId: currentUser.id,
+          currentOrganizationId: session.activeOrganizationId,
+          filters: body.filters ?? [],
+          sorts: body.sorts ?? [],
+          ...(body.search !== undefined && { search: body.search }),
+          offset: 0,
+          limit: LIMITS.entitiesCount,
+          fieldMode: body.fieldMode ?? "full",
+          fieldIds: body.fieldIds ?? [],
+          excludedKinds: ["task"],
+          previewableForAi: false,
+          includeTotalCount: false,
+        }),
+      );
+
+      return Result.ok({
+        entities: result.entities,
+      });
+    },
+  );
+
+const readFilesystemTree = createReadFilesystemTreeHandler();
+
+export default readFilesystemTree;

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -18,6 +18,7 @@ import {
 const readEntitiesWindowBodySchema = t.Object({
   filters: t.Optional(t.Array(tViewFilterConditionSchema)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
+  search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
   limit: t.Optional(
     t.Integer({
       minimum: 1,
@@ -36,6 +37,7 @@ const readEntitiesWindowBodySchema = t.Object({
       maxItems: LIMITS.propertiesCount,
     }),
   ),
+  previewableForAi: t.Optional(t.Boolean()),
 });
 
 const config = {
@@ -61,11 +63,13 @@ const readEntitiesWindow = createSafeHandler(
         currentOrganizationId: session.activeOrganizationId,
         filters: body.filters ?? [],
         sorts: body.sorts ?? [],
+        ...(body.search !== undefined && { search: body.search }),
         offset,
         limit: limit + 1,
         fieldMode: body.fieldMode ?? "full",
         fieldIds: body.fieldIds ?? [],
         excludedKinds: body.excludedKinds ?? [],
+        previewableForAi: body.previewableForAi ?? false,
         includeTotalCount: false,
       }),
     );

--- a/apps/api/src/handlers/entities/read.test.ts
+++ b/apps/api/src/handlers/entities/read.test.ts
@@ -2,11 +2,14 @@ import { Result } from "better-result";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { createReadEntitiesHandler } from "@/api/handlers/entities/read";
+import { createReadFilesystemTreeHandler } from "@/api/handlers/entities/read-filesystem-tree";
 import { toSafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
 
 const queryEntitiesMock = mock();
 
 const readEntities = createReadEntitiesHandler(queryEntitiesMock);
+const readFilesystemTree = createReadFilesystemTreeHandler(queryEntitiesMock);
 
 const workspaceId = toSafeId<"workspace">("ws_entity_read");
 const organizationId = toSafeId<"organization">("org_entity_read");
@@ -81,6 +84,30 @@ describe("entity read handler search", () => {
         offset: 0,
         limit: 50,
         fieldMode: "visible",
+      }),
+    );
+  });
+
+  test("loads a bounded complete filesystem tree without widening page reads", async () => {
+    await readFilesystemTree.handler(
+      createContext({
+        filters: [],
+        sorts: [],
+        search: "closing binder",
+        fieldMode: "visible",
+        fieldIds: [],
+      }) as Parameters<typeof readFilesystemTree.handler>[0],
+    );
+
+    expect(queryEntitiesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId,
+        currentOrganizationId: organizationId,
+        search: "closing binder",
+        offset: 0,
+        limit: LIMITS.entitiesCount,
+        excludedKinds: ["task"],
+        includeTotalCount: false,
       }),
     );
   });

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -28,6 +28,11 @@ const readEntitiesBodySchema = t.Object({
       maxItems: LIMITS.propertiesCount,
     }),
   ),
+  excludedKinds: t.Optional(
+    t.Array(t.UnionEnum(["document", "folder", "task", "message", "link"]), {
+      maxItems: 5,
+    }),
+  ),
   previewableForAi: t.Optional(t.Boolean()),
 });
 
@@ -65,7 +70,7 @@ export const createReadEntitiesHandler = (
           limit: pageSize,
           fieldMode: body.fieldMode ?? "full",
           fieldIds: body.fieldIds ?? [],
-          excludedKinds: [],
+          excludedKinds: body.excludedKinds ?? [],
           previewableForAi: body.previewableForAi ?? false,
           includeTotalCount: true,
         }),

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -20,6 +20,7 @@ import openDesktopEditSession from "@/api/handlers/entities/open-desktop-edit-se
 import organizeSuggestions from "@/api/handlers/entities/organize-suggestions";
 import readEntities from "@/api/handlers/entities/read";
 import readEntityById from "@/api/handlers/entities/read-by-id";
+import readFilesystemTree from "@/api/handlers/entities/read-filesystem-tree";
 import readKanbanGroup from "@/api/handlers/entities/read-kanban-group";
 import readEntitySummaries from "@/api/handlers/entities/read-summaries";
 import readVersionById from "@/api/handlers/entities/read-version-by-id";
@@ -106,6 +107,9 @@ export const entitiesRoute = new Elysia({
   })
   .post("/query-window", readEntitiesWindow.handler, {
     body: readEntitiesWindow.config.body,
+  })
+  .post("/filesystem-tree", readFilesystemTree.handler, {
+    body: readFilesystemTree.config.body,
   })
   .post("/kanban-group", readKanbanGroup.handler, {
     body: readKanbanGroup.config.body,

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -2,11 +2,8 @@ export const LIMITS = {
   workspacesCount: 1000,
   propertiesCount: 20,
   entitiesCount: 10_000,
-  // TODO: switch matter views to virtualised rendering and cursor-based
-  // server pagination. Loading the whole workspace in one request
-  // doesn't scale once we lift entitiesCount past ~10k.
-  entitiesPageSizeDefault: 10_000,
-  entitiesPageSizeMax: 10_000,
+  entitiesPageSizeDefault: 100,
+  entitiesPageSizeMax: 500,
   entitiesWindowSizeDefault: 200,
   entitiesWindowSizeMax: 500,
   calendarTasksMax: 200,

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,6 +9,7 @@
       "@stll/docx-core": ["../../packages/docx-core/src/index.ts"],
       "@stll/infosoud": ["../../packages/infosoud/src/index.ts"],
       "@stll/money": ["../../packages/money/src/index.ts"],
+      "@stll/permissions": ["../../packages/permissions/src/index.ts"],
       "@stll/skills": ["../../packages/skills/src/index.ts"],
       "@/api/*": ["./src/*"]
     },

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -175,7 +175,9 @@ export const ConversationDownload = ({
   return (
     <Button
       className={cn(
-        "dark:bg-background dark:hover:bg-muted absolute inset-e-4 top-4 rounded-full",
+        "dark:bg-background dark:hover:bg-muted",
+        "absolute",
+        "inset-e-4 top-4 rounded-full",
         className,
       )}
       onClick={handleDownload}

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -120,7 +120,7 @@ export const SourceChips = ({
   }
 
   return (
-    <div className="flex max-w-full [scrollbar-width:none] flex-nowrap gap-1 overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
+    <div className="flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       {uniqueSources.map((part) => (
         <SourceChip
           key={`${messageId}-source-${part.id ?? part.data.entityId}`}

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -120,7 +120,12 @@ export const SourceChips = ({
   }
 
   return (
-    <div className="flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <div
+      className={cn(
+        "flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1",
+        "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+      )}
+    >
       {uniqueSources.map((part) => (
         <SourceChip
           key={`${messageId}-source-${part.id ?? part.data.entityId}`}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -396,7 +396,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
         className,
       )}
       data-sidebar="content"

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -396,7 +396,10 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto",
+        "group-data-[collapsible=icon]:gap-0",
+        "group-data-[collapsible=icon]:[scrollbar-width:none]",
+        "group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
         className,
       )}
       data-sidebar="content"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -189,6 +189,9 @@ export const Route = createFileRoute(
         page: deps.page,
         fieldMode,
         fieldIds,
+        ...(activeView.layout.type === "filesystem" && {
+          excludedKinds: ["task"],
+        }),
       }),
     );
 
@@ -317,6 +320,7 @@ function VisibleFieldEntityViewContent({
     page,
     fieldMode: "visible",
     fieldIds,
+    excludedKinds: ["task"],
   });
 
   const { data } = useSuspenseQuery(
@@ -327,6 +331,7 @@ function VisibleFieldEntityViewContent({
       page,
       fieldMode: "visible",
       fieldIds,
+      excludedKinds: ["task"],
     }),
   );
   const totalPages = Math.ceil(data.totalCount / data.pageSize);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -26,6 +26,7 @@ import {
   DEFAULT_ENTITY_WINDOW_SIZE,
   entitiesOptions,
   entitiesWindowOptions,
+  filesystemEntitiesOptions,
   useEntitiesOptions,
   visibleEntityFieldIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
@@ -172,6 +173,20 @@ export const Route = createFileRoute(
       return;
     }
 
+    if (activeView.layout.type === "filesystem") {
+      await ensureCriticalQueryData(
+        queryClient,
+        filesystemEntitiesOptions({
+          workspaceId,
+          filters: activeView.layout.filters,
+          sorts: activeView.layout.sorts,
+          fieldMode,
+          fieldIds,
+        }),
+      );
+      return;
+    }
+
     if (activeView.layout.type === "calendar") {
       return;
     }
@@ -189,17 +204,10 @@ export const Route = createFileRoute(
         page: deps.page,
         fieldMode,
         fieldIds,
-        ...(activeView.layout.type === "filesystem" && {
-          excludedKinds: ["task"],
-        }),
       }),
     );
 
     if (entities.entities.length === 0) {
-      return;
-    }
-
-    if (activeView.layout.type === "filesystem") {
       return;
     }
 
@@ -275,7 +283,6 @@ function EntityViewContent({
     return (
       <VisibleFieldEntityViewContent
         activeView={activeView}
-        page={page}
         workspaceId={workspaceId}
       />
     );
@@ -308,46 +315,9 @@ const hasVisibleFieldsLayout = (
 
 function VisibleFieldEntityViewContent({
   activeView,
-  page,
   workspaceId,
-}: EntityViewContentProps & { activeView: VisibleFieldsView }) {
-  const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
-  const fieldIds = visibleEntityFieldIds({
-    hiddenProperties: activeView.layout.hiddenProperties,
-    properties,
-  });
-
-  useSyncTable({
-    workspaceId,
-    filters: activeView.layout.filters,
-    sorts: activeView.layout.sorts,
-    page,
-    fieldMode: "visible",
-    fieldIds,
-    excludedKinds: ["task"],
-  });
-
-  const { data } = useSuspenseQuery(
-    useEntitiesOptions({
-      workspaceId,
-      filters: activeView.layout.filters,
-      sorts: activeView.layout.sorts,
-      page,
-      fieldMode: "visible",
-      fieldIds,
-      excludedKinds: ["task"],
-    }),
-  );
-  const totalPages = Math.ceil(data.totalCount / data.pageSize);
-
-  return (
-    <ViewShell
-      activeView={activeView}
-      page={page}
-      totalPages={totalPages}
-      workspaceId={workspaceId}
-    />
-  );
+}: ViewContentProps & { activeView: VisibleFieldsView }) {
+  return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
 }
 
 function FullEntityViewContent({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -23,6 +23,7 @@ import { ViewToolbar } from "@/routes/_protected.workspaces/$workspaceId/-compon
 import { chunkJustificationEntityIds } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useSyncTable } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-table";
 import {
+  DEFAULT_ENTITY_WINDOW_SIZE,
   entitiesOptions,
   entitiesWindowOptions,
   useEntitiesOptions,
@@ -162,7 +163,7 @@ export const Route = createFileRoute(
           workspaceId,
           filters: activeView.layout.filters,
           sorts: activeView.layout.sorts,
-          limit: 200,
+          limit: DEFAULT_ENTITY_WINDOW_SIZE,
           excludedKinds: ["folder", "task"],
           fieldMode,
           fieldIds,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -289,6 +289,10 @@ function EntityViewContent({
     return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
   }
 
+  if (activeView.layout.type === "kanban") {
+    return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
+  }
+
   return (
     <FullEntityViewContent
       activeView={activeView}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -957,7 +957,7 @@ const TypeChipsRow = ({
     <div className="flex flex-col gap-1.5">
       <div
         className={cn(
-          "flex [scrollbar-width:none] items-center gap-1 overflow-x-auto",
+          "flex items-center gap-1 overflow-x-auto [scrollbar-width:none]",
           showSeparator && "border-t pt-2",
         )}
       >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -957,7 +957,8 @@ const TypeChipsRow = ({
     <div className="flex flex-col gap-1.5">
       <div
         className={cn(
-          "flex items-center gap-1 overflow-x-auto [scrollbar-width:none]",
+          "flex items-center gap-1 overflow-x-auto",
+          "[scrollbar-width:none]",
           showSeparator && "border-t pt-2",
         )}
       >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -338,6 +338,10 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
 
   const { filters, sorts, hiddenProperties } = view.layout;
   const primarySort = sorts.at(0) ?? null;
+  const page = useSearch({
+    from: "/_protected/workspaces/$workspaceId/$viewId",
+    select: (s) => s.page ?? 1,
+  });
   const fieldIds = useMemo(
     () => visibleEntityFieldIds({ hiddenProperties, properties }),
     [hiddenProperties, properties],
@@ -368,7 +372,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       workspaceId,
       filters,
       sorts,
-      page: 1,
+      page,
       fieldMode: "visible",
       fieldIds,
     }),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -375,6 +375,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
       page,
       fieldMode: "visible",
       fieldIds,
+      excludedKinds: ["task"],
     }),
   );
   const data = useMemo(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -79,7 +79,7 @@ import {
 } from "@/routes/_protected.workspaces/$workspaceId/-mutations/entities";
 import { useUpdateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
 import {
-  useEntitiesOptions,
+  useFilesystemEntitiesOptions,
   visibleEntityFieldIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
@@ -338,10 +338,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
 
   const { filters, sorts, hiddenProperties } = view.layout;
   const primarySort = sorts.at(0) ?? null;
-  const page = useSearch({
-    from: "/_protected/workspaces/$workspaceId/$viewId",
-    select: (s) => s.page ?? 1,
-  });
   const fieldIds = useMemo(
     () => visibleEntityFieldIds({ hiddenProperties, properties }),
     [hiddenProperties, properties],
@@ -368,20 +364,15 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   );
 
   const { data: entityData } = useSuspenseQuery(
-    useEntitiesOptions({
+    useFilesystemEntitiesOptions({
       workspaceId,
       filters,
       sorts,
-      page,
       fieldMode: "visible",
       fieldIds,
-      excludedKinds: ["task"],
     }),
   );
-  const data = useMemo(
-    () => entityData.entities.filter((e) => e.kind !== "task"),
-    [entityData.entities],
-  );
+  const data = entityData.entities;
 
   // Build a lookup for drag preview data from selected entities.
   const entityMap = useMemo(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -3648,7 +3648,12 @@ const VerticalTab = ({
               "text-muted-foreground hover:bg-accent hover:text-foreground",
               TOOLBAR_ROW_HEIGHT,
               active &&
-                "bg-background text-foreground before:bg-primary before:absolute before:inset-y-0 before:inset-s-0 before:w-0.5",
+                cn(
+                  "bg-background text-foreground before:bg-primary",
+                  "before:absolute",
+                  "before:inset-y-0",
+                  "before:inset-s-0 before:w-0.5",
+                ),
             )}
             onAuxClick={(e) => {
               if (e.button === 1) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -23,6 +23,7 @@ import { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-com
 import { useSyncJustificationChunks } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useTableState } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state";
 import {
+  DEFAULT_ENTITY_WINDOW_SIZE,
   useEntitiesWindowOptions,
   visibleEntityFieldIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
@@ -68,7 +69,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
         workspaceId,
         filters: view.layout.filters,
         sorts: view.layout.sorts,
-        limit: 200,
+        limit: DEFAULT_ENTITY_WINDOW_SIZE,
         excludedKinds: ["folder", "task"],
         fieldMode: "visible",
         fieldIds,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -191,7 +191,14 @@ export const ViewSwitcher = ({
   };
 
   return (
-    <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <div
+      className={cn(
+        "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto px-2",
+        "[-ms-overflow-style:none]",
+        "[scrollbar-width:none]",
+        "[&::-webkit-scrollbar]:hidden",
+      )}
+    >
       <Tabs value={activeViewId}>
         <TabsList variant="underline">
           {views.map((view) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -405,7 +405,7 @@ const ViewTab = ({
       {isActive && (canUpdateView || canCreateView || canDeleteView) && (
         <ViewTabMenu
           canDelete={canDelete}
-          className="absolute inset-e-0 top-1/2 -translate-y-1/2"
+          className={cn("absolute", "inset-e-0 top-1/2 -translate-y-1/2")}
           onRename={() => {
             setIsRenaming(true);
             setRenameValue(name);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -191,7 +191,7 @@ export const ViewSwitcher = ({
   };
 
   return (
-    <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+    <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       <Tabs value={activeViewId}>
         <TabsList variant="underline">
           {views.map((view) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
@@ -20,12 +20,12 @@ export type EntitiesPageKey = {
   pageSize?: number;
   fieldMode?: EntitiesFieldMode;
   fieldIds?: string[];
+  excludedKinds?: EntityKind[];
   previewableForAi?: boolean;
 };
 
 export type EntitiesWindowKey = Omit<EntitiesPageKey, "page" | "pageSize"> & {
   limit?: number;
-  excludedKinds?: EntityKind[];
 };
 
 export type KanbanGroupKey = Omit<EntitiesWindowKey, "excludedKinds"> & {
@@ -52,6 +52,7 @@ export const entitiesKeys = {
     pageSize,
     fieldMode,
     fieldIds,
+    excludedKinds,
     previewableForAi,
   }: EntitiesPageKey) => {
     const normalizedFieldMode = fieldMode ?? "full";
@@ -68,6 +69,7 @@ export const entitiesKeys = {
           normalizedFieldMode === "visible"
             ? normalizeVisibleFieldIds(fieldIds)
             : [],
+        excludedKinds: excludedKinds?.toSorted() ?? [],
         previewableForAi: previewableForAi ?? false,
       },
     ];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
@@ -33,7 +33,7 @@ export type KanbanGroupKey = Omit<EntitiesWindowKey, "excludedKinds"> & {
   groupValue: string | null;
 };
 
-export const DEFAULT_ENTITY_VIEW_PAGE_SIZE = 10_000;
+export const DEFAULT_ENTITY_VIEW_PAGE_SIZE = 100;
 export const DEFAULT_ENTITY_WINDOW_SIZE = 200;
 
 export const normalizeVisibleFieldIds = (
@@ -76,10 +76,12 @@ export const entitiesKeys = {
     workspaceId,
     filters,
     sorts,
+    search,
     limit,
     fieldMode,
     fieldIds,
     excludedKinds,
+    previewableForAi,
   }: EntitiesWindowKey) => {
     const normalizedFieldMode = fieldMode ?? "full";
     return [
@@ -88,6 +90,7 @@ export const entitiesKeys = {
       {
         filters,
         sorts,
+        ...(search?.trim() && { search: search.trim() }),
         limit: limit ?? DEFAULT_ENTITY_WINDOW_SIZE,
         fieldMode: normalizedFieldMode,
         fieldIds:
@@ -95,6 +98,7 @@ export const entitiesKeys = {
             ? normalizeVisibleFieldIds(fieldIds)
             : [],
         excludedKinds: excludedKinds?.toSorted() ?? [],
+        previewableForAi: previewableForAi ?? false,
       },
     ];
   },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.logic.ts
@@ -28,6 +28,11 @@ export type EntitiesWindowKey = Omit<EntitiesPageKey, "page" | "pageSize"> & {
   limit?: number;
 };
 
+export type FilesystemEntitiesKey = Omit<
+  EntitiesPageKey,
+  "page" | "pageSize" | "excludedKinds" | "previewableForAi"
+>;
+
 export type KanbanGroupKey = Omit<EntitiesWindowKey, "excludedKinds"> & {
   groupByPropertyId: string;
   groupValue: string | null;
@@ -101,6 +106,30 @@ export const entitiesKeys = {
             : [],
         excludedKinds: excludedKinds?.toSorted() ?? [],
         previewableForAi: previewableForAi ?? false,
+      },
+    ];
+  },
+  filesystemTree: ({
+    workspaceId,
+    filters,
+    sorts,
+    search,
+    fieldMode,
+    fieldIds,
+  }: FilesystemEntitiesKey) => {
+    const normalizedFieldMode = fieldMode ?? "full";
+    return [
+      ...entitiesKeys.all(workspaceId),
+      "filesystem-tree",
+      {
+        filters,
+        sorts,
+        ...(search?.trim() && { search: search.trim() }),
+        fieldMode: normalizedFieldMode,
+        fieldIds:
+          normalizedFieldMode === "visible"
+            ? normalizeVisibleFieldIds(fieldIds)
+            : [],
       },
     ];
   },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
@@ -190,6 +190,27 @@ describe("entity query field selection", () => {
     ]);
   });
 
+  test("keeps filesystem tree cache identity independent from page state", () => {
+    expect(
+      entitiesKeys
+        .filesystemTree({
+          workspaceId: "workspace-1",
+          filters: [],
+          sorts: [],
+          search: " closing binder ",
+          fieldMode: "visible",
+          fieldIds: ["status", "due", "status"],
+        })
+        .at(-1),
+    ).toEqual({
+      filters: [],
+      sorts: [],
+      search: "closing binder",
+      fieldMode: "visible",
+      fieldIds: ["due", "status"],
+    });
+  });
+
   test("keeps search and AI-previewable state in the window cache identity", () => {
     const previewKey = entitiesKeys.window({
       workspaceId: "workspace-1",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
@@ -169,8 +169,35 @@ describe("entity query field selection", () => {
         fieldMode: "visible",
         fieldIds: ["due", "status"],
         excludedKinds: ["folder", "task"],
+        previewableForAi: false,
       },
     ]);
+  });
+
+  test("keeps search and AI-previewable state in the window cache identity", () => {
+    const previewKey = entitiesKeys.window({
+      workspaceId: "workspace-1",
+      filters: [],
+      sorts: [],
+      search: " closing binder ",
+      previewableForAi: true,
+    });
+    const regularKey = entitiesKeys.window({
+      workspaceId: "workspace-1",
+      filters: [],
+      sorts: [],
+      search: " closing binder ",
+    });
+
+    expect(previewKey).not.toEqual(regularKey);
+    expect(previewKey.at(-1)).toMatchObject({
+      search: "closing binder",
+      previewableForAi: true,
+    });
+    expect(regularKey.at(-1)).toMatchObject({
+      search: "closing binder",
+      previewableForAi: false,
+    });
   });
 
   test("keeps kanban group value in the cache identity", () => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.test.ts
@@ -127,6 +127,22 @@ describe("entity query field selection", () => {
     });
   });
 
+  test("keeps excluded kinds in the page cache identity", () => {
+    expect(
+      entitiesKeys
+        .page({
+          workspaceId: "workspace-1",
+          filters: [],
+          sorts: [],
+          page: 1,
+          excludedKinds: ["task", "folder"],
+        })
+        .at(-1),
+    ).toMatchObject({
+      excludedKinds: ["folder", "task"],
+    });
+  });
+
   test("keeps extra caller fields out of the page cache identity", () => {
     const cleanKey = entitiesKeys.page({
       workspaceId: "workspace-1",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -111,7 +111,8 @@ export const entitiesOptions = (key: EntitiesOptionsInput) =>
             filters: key.filters,
             sorts: key.sorts,
             page: key.page,
-            ...(key.search !== undefined && { search: key.search }),
+            ...(key.search?.trim() && { search: key.search.trim() }),
+            excludedKinds: key.excludedKinds ?? [],
             fieldMode,
             fieldIds:
               fieldMode === "visible"
@@ -147,7 +148,7 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
           {
             filters: key.filters,
             sorts: key.sorts,
-            ...(key.search !== undefined && { search: key.search }),
+            ...(key.search?.trim() && { search: key.search.trim() }),
             limit: key.limit ?? DEFAULT_ENTITY_WINDOW_SIZE,
             excludedKinds: key.excludedKinds ?? [],
             fieldMode,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -17,6 +17,7 @@ import {
 import type {
   EntitiesPageKey,
   EntitiesWindowKey,
+  FilesystemEntitiesKey,
   KanbanGroupKey,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 
@@ -24,6 +25,7 @@ export { DEFAULT_ENTITY_WINDOW_SIZE, entitiesKeys, visibleEntityFieldIds };
 
 type EntitiesOptionsInput = QueryOptionsInput<EntitiesPageKey>;
 type EntitiesWindowOptionsInput = QueryOptionsInput<EntitiesWindowKey>;
+type FilesystemEntitiesOptionsInput = QueryOptionsInput<FilesystemEntitiesKey>;
 type KanbanGroupOptionsInput = QueryOptionsInput<KanbanGroupKey>;
 
 type RawWorkspaceEntity = Omit<
@@ -177,6 +179,42 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
+export const filesystemEntitiesOptions = (
+  key: FilesystemEntitiesOptionsInput,
+) =>
+  queryOptions({
+    queryKey: entitiesKeys.filesystemTree(key),
+    queryFn: async ({ signal }) => {
+      const fieldMode = key.fieldMode ?? "full";
+      const response = await api
+        .entities({ workspaceId: toSafeId<"workspace">(key.workspaceId) })
+        ["filesystem-tree"].post(
+          {
+            filters: key.filters,
+            sorts: key.sorts,
+            ...(key.search?.trim() && { search: key.search.trim() }),
+            fieldMode,
+            fieldIds:
+              fieldMode === "visible"
+                ? normalizeVisibleFieldIds(key.fieldIds).map((fieldId) =>
+                    toSafeId<"property">(fieldId),
+                  )
+                : [],
+          },
+          { fetch: { signal } },
+        );
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      const entities: WorkspaceEntity[] =
+        response.data.entities.map(toWorkspaceEntity);
+
+      return { entities };
+    },
+  });
+
 export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
   infiniteQueryOptions({
     queryKey: entitiesKeys.kanbanGroup(key),
@@ -225,6 +263,10 @@ export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
 // sorts change.
 export const useEntitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
   entitiesWindowOptions(useDeferredValue(key));
+
+export const useFilesystemEntitiesOptions = (
+  key: FilesystemEntitiesOptionsInput,
+) => filesystemEntitiesOptions(useDeferredValue(key));
 
 export const useKanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
   kanbanGroupOptions(useDeferredValue(key));

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -20,7 +20,7 @@ import type {
   KanbanGroupKey,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities.logic";
 
-export { entitiesKeys, visibleEntityFieldIds };
+export { DEFAULT_ENTITY_WINDOW_SIZE, entitiesKeys, visibleEntityFieldIds };
 
 type EntitiesOptionsInput = QueryOptionsInput<EntitiesPageKey>;
 type EntitiesWindowOptionsInput = QueryOptionsInput<EntitiesWindowKey>;
@@ -120,9 +120,6 @@ export const entitiesOptions = (key: EntitiesOptionsInput) =>
                   )
                 : [],
             previewableForAi: key.previewableForAi ?? false,
-            // TODO: replace this load-everything pageSize with
-            // virtualised rendering + cursor pagination. Tracked
-            // alongside the matching limits.ts TODO.
             pageSize: key.pageSize ?? DEFAULT_ENTITY_VIEW_PAGE_SIZE,
           },
           { fetch: { signal } },
@@ -150,6 +147,7 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
           {
             filters: key.filters,
             sorts: key.sorts,
+            ...(key.search !== undefined && { search: key.search }),
             limit: key.limit ?? DEFAULT_ENTITY_WINDOW_SIZE,
             excludedKinds: key.excludedKinds ?? [],
             fieldMode,
@@ -159,6 +157,7 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
                     toSafeId<"property">(fieldId),
                   )
                 : [],
+            previewableForAi: key.previewableForAi ?? false,
             ...(pageParam !== undefined && { cursor: pageParam }),
           },
           { fetch: { signal } },

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -9,6 +9,8 @@
       "@stll/docx-core": ["../../packages/docx-core/src/index.ts"],
       "@stll/infosoud": ["../../packages/infosoud/src/index.ts"],
       "@stll/money": ["../../packages/money/src/index.ts"],
+      "@stll/permissions": ["../../packages/permissions/src/index.ts"],
+      "@stll/skills": ["../../packages/skills/src/index.ts"],
       "@stll/ui/*": ["../../packages/ui/src/*"]
     }
   },


### PR DESCRIPTION
## Summary

- lower the legacy entity page size defaults now that table views use windowed loading
- thread table window size through the shared query constant and route preload
- include search and AI-previewable state in entity window requests and cache keys
- keep filesystem pagination aligned with the URL page parameter
- apply formatter-only class ordering updates required by the web formatter
