### PR TITLE
feat: paginate chat thread history

### DIFF
--- a/apps/api/drizzle/20260516120000_chat-thread-list-pagination/migration.sql
+++ b/apps/api/drizzle/20260516120000_chat-thread-list-pagination/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "chat_threads_org_user_updated_id_idx" ON "chat_threads" ("organization_id", "user_id", "updated_at", "id");

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -2504,6 +2504,9 @@ export const chatThreads = p.pgTable(
     p
       .index("chat_threads_organization_user_idx")
       .on(table.organizationId, table.userId),
+    p
+      .index("chat_threads_org_user_updated_id_idx")
+      .on(table.organizationId, table.userId, table.updatedAt, table.id),
     p.index("chat_threads_user_updated_idx").on(table.userId, table.updatedAt),
     ...chatThreadPolicies(),
   ],

--- a/apps/api/src/handlers/chat/get-threads.ts
+++ b/apps/api/src/handlers/chat/get-threads.ts
@@ -1,46 +1,106 @@
 import { Result } from "better-result";
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { t } from "elysia";
 
+import { chatThreads, workspaces as workspacesTable } from "@/api/db/schema";
+import {
+  decodeChatThreadListCursor,
+  encodeChatThreadListCursor,
+} from "@/api/handlers/chat/thread-list-pagination";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
 
 const config = {
   permissions: { chat: ["create"] },
+  query: t.Object({
+    cursor: t.Optional(t.String({ maxLength: 512 })),
+    limit: t.Optional(
+      t.Integer({
+        minimum: 1,
+        maximum: LIMITS.chatThreadListPageSizeMax,
+      }),
+    ),
+  }),
 } satisfies HandlerConfig;
 
 const getThreads = createSafeRootHandler(
   config,
-  async function* ({ accessibleWorkspaces, safeDb, user }) {
-    const deletingWorkspaceIds = new Set(
-      accessibleWorkspaces
-        .filter((w) => w.status === "deleting")
-        .map((w) => w.id),
-    );
+  async function* ({ accessibleWorkspaces, query, safeDb, session, user }) {
+    const limit = query.limit ?? LIMITS.chatThreadListPageSizeDefault;
+    const cursor = query.cursor
+      ? decodeChatThreadListCursor(query.cursor)
+      : null;
+    if (query.cursor && !cursor) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Invalid cursor" }),
+      );
+    }
+
+    const visibleWorkspaceIds = accessibleWorkspaces
+      .filter((w) => w.status !== "deleting")
+      .map((w) => w.id);
+    const conditions: SQL[] = [
+      eq(chatThreads.organizationId, session.activeOrganizationId),
+      eq(chatThreads.userId, user.id),
+    ];
+    const visibleWorkspaceCondition =
+      visibleWorkspaceIds.length > 0
+        ? or(
+            isNull(chatThreads.workspaceId),
+            inArray(chatThreads.workspaceId, visibleWorkspaceIds),
+          )
+        : isNull(chatThreads.workspaceId);
+    if (visibleWorkspaceCondition) {
+      conditions.push(visibleWorkspaceCondition);
+    }
+    if (cursor) {
+      const cursorCondition = or(
+        lt(chatThreads.updatedAt, cursor.updatedAt),
+        and(
+          eq(chatThreads.updatedAt, cursor.updatedAt),
+          lt(chatThreads.id, cursor.id),
+        ),
+      );
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
 
     const rows = yield* Result.await(
       safeDb((tx) =>
-        tx.query.chatThreads.findMany({
-          where: {
-            userId: { eq: user.id },
-          },
-          columns: {
-            id: true,
-            title: true,
-            createdAt: true,
-            updatedAt: true,
-            workspaceId: true,
-          },
-          with: {
-            workspace: {
-              columns: {
-                id: true,
-                name: true,
-              },
-            },
-          },
-          orderBy: { updatedAt: "desc" },
-        }),
+        tx
+          .select({
+            createdAt: chatThreads.createdAt,
+            id: chatThreads.id,
+            title: chatThreads.title,
+            updatedAt: chatThreads.updatedAt,
+            workspaceId: chatThreads.workspaceId,
+            workspaceName: workspacesTable.name,
+          })
+          .from(chatThreads)
+          .leftJoin(
+            workspacesTable,
+            eq(workspacesTable.id, chatThreads.workspaceId),
+          )
+          .where(and(...conditions))
+          .orderBy(desc(chatThreads.updatedAt), desc(chatThreads.id))
+          .limit(limit + 1),
       ),
     );
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+    const lastItem = page.at(-1);
+    const nextCursor =
+      hasMore && lastItem
+        ? encodeChatThreadListCursor({
+            id: lastItem.id,
+            updatedAt: lastItem.updatedAt,
+          })
+        : null;
 
     const global: {
       id: string;
@@ -63,16 +123,7 @@ const getThreads = createSafeRootHandler(
       }
     >();
 
-    for (const thread of rows) {
-      // Skip threads from workspaces being deleted so users
-      // don't see entries they can't open or manage.
-      if (
-        thread.workspaceId !== null &&
-        deletingWorkspaceIds.has(thread.workspaceId)
-      ) {
-        continue;
-      }
-
+    for (const thread of page) {
       if (thread.workspaceId === null) {
         global.push({
           id: thread.id,
@@ -83,7 +134,7 @@ const getThreads = createSafeRootHandler(
         continue;
       }
 
-      if (!thread.workspace) {
+      if (thread.workspaceName === null) {
         continue;
       }
 
@@ -102,12 +153,12 @@ const getThreads = createSafeRootHandler(
 
       groupedWorkspaceThreads.set(thread.workspaceId, {
         workspaceId: thread.workspaceId,
-        workspaceName: thread.workspace.name,
+        workspaceName: thread.workspaceName,
         threads: [slice],
       });
     }
 
-    const workspaces = Array.from(groupedWorkspaceThreads.values()).sort(
+    const workspaceGroups = Array.from(groupedWorkspaceThreads.values()).sort(
       (left, right) => {
         const leftUpdatedAt = left.threads.at(0)?.updatedAt.getTime() ?? 0;
         const rightUpdatedAt = right.threads.at(0)?.updatedAt.getTime() ?? 0;
@@ -118,7 +169,8 @@ const getThreads = createSafeRootHandler(
 
     return Result.ok({
       global,
-      workspaces,
+      nextCursor,
+      workspaces: workspaceGroups,
     });
   },
 );

--- a/apps/api/src/handlers/chat/get-threads.ts
+++ b/apps/api/src/handlers/chat/get-threads.ts
@@ -1,6 +1,6 @@
 import { Result } from "better-result";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { chatThreads, workspaces as workspacesTable } from "@/api/db/schema";
@@ -57,16 +57,9 @@ const getThreads = createSafeRootHandler(
       conditions.push(visibleWorkspaceCondition);
     }
     if (cursor) {
-      const cursorCondition = or(
-        lt(chatThreads.updatedAt, cursor.updatedAt),
-        and(
-          eq(chatThreads.updatedAt, cursor.updatedAt),
-          lt(chatThreads.id, cursor.id),
-        ),
+      conditions.push(
+        sql`(${chatThreads.updatedAt}, ${chatThreads.id}) < (${cursor.updatedAt}::timestamp, ${cursor.id}::uuid)`,
       );
-      if (cursorCondition) {
-        conditions.push(cursorCondition);
-      }
     }
 
     const rows = yield* Result.await(
@@ -77,6 +70,10 @@ const getThreads = createSafeRootHandler(
             id: chatThreads.id,
             title: chatThreads.title,
             updatedAt: chatThreads.updatedAt,
+            updatedAtCursor: sql<string>`to_char(
+              ${chatThreads.updatedAt},
+              'YYYY-MM-DD"T"HH24:MI:SS.US'
+            )`,
             workspaceId: chatThreads.workspaceId,
             workspaceName: workspacesTable.name,
           })
@@ -98,7 +95,7 @@ const getThreads = createSafeRootHandler(
       hasMore && lastItem
         ? encodeChatThreadListCursor({
             id: lastItem.id,
-            updatedAt: lastItem.updatedAt,
+            updatedAt: lastItem.updatedAtCursor,
           })
         : null;
 

--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -13,7 +13,9 @@ export const chatRoute = new Elysia({ prefix: "/chat" })
   .post("/", sendMessage.handler, {
     body: sendMessage.config.body,
   })
-  .get("/threads", getThreads.handler)
+  .get("/threads", getThreads.handler, {
+    query: getThreads.config.query,
+  })
   .delete("/threads/:threadId", deleteThread.handler, {
     query: deleteThread.config.query,
     params: deleteThread.config.params,

--- a/apps/api/src/handlers/chat/thread-list-pagination.test.ts
+++ b/apps/api/src/handlers/chat/thread-list-pagination.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decodeChatThreadListCursor,
+  encodeChatThreadListCursor,
+} from "@/api/handlers/chat/thread-list-pagination";
+import { brandPersistedChatThreadId } from "@/api/lib/safe-id-boundaries";
+
+describe("chat thread list pagination cursor", () => {
+  test("roundtrips the updated timestamp and thread id", () => {
+    const cursor = encodeChatThreadListCursor({
+      id: brandPersistedChatThreadId("018f4ad2-3a6d-7000-8b1d-44f76f5df001"),
+      updatedAt: new Date("2026-05-16T08:30:00.000Z"),
+    });
+
+    expect(decodeChatThreadListCursor(cursor)).toEqual({
+      id: brandPersistedChatThreadId("018f4ad2-3a6d-7000-8b1d-44f76f5df001"),
+      updatedAt: new Date("2026-05-16T08:30:00.000Z"),
+    });
+  });
+
+  test("rejects malformed cursors", () => {
+    expect(decodeChatThreadListCursor("not-a-cursor")).toBeNull();
+    expect(
+      decodeChatThreadListCursor("2026-05-16T08:30:00.000Z|not-a-thread-id"),
+    ).toBeNull();
+    expect(
+      decodeChatThreadListCursor(
+        "not-a-date|018f4ad2-3a6d-7000-8b1d-44f76f5df001",
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/handlers/chat/thread-list-pagination.test.ts
+++ b/apps/api/src/handlers/chat/thread-list-pagination.test.ts
@@ -10,23 +10,47 @@ describe("chat thread list pagination cursor", () => {
   test("roundtrips the updated timestamp and thread id", () => {
     const cursor = encodeChatThreadListCursor({
       id: brandPersistedChatThreadId("018f4ad2-3a6d-7000-8b1d-44f76f5df001"),
-      updatedAt: new Date("2026-05-16T08:30:00.000Z"),
+      updatedAt: "2026-05-16T08:30:00.123456",
     });
 
     expect(decodeChatThreadListCursor(cursor)).toEqual({
       id: brandPersistedChatThreadId("018f4ad2-3a6d-7000-8b1d-44f76f5df001"),
-      updatedAt: new Date("2026-05-16T08:30:00.000Z"),
+      updatedAt: "2026-05-16T08:30:00.123456",
     });
+  });
+
+  test("preserves sub-millisecond timestamp precision", () => {
+    const cursor = encodeChatThreadListCursor({
+      id: brandPersistedChatThreadId("018f4ad2-3a6d-7000-8b1d-44f76f5df001"),
+      updatedAt: "2026-05-16T08:30:00.000999",
+    });
+
+    expect(cursor).toBe(
+      "2026-05-16T08:30:00.000999|018f4ad2-3a6d-7000-8b1d-44f76f5df001",
+    );
+    expect(decodeChatThreadListCursor(cursor)?.updatedAt).toBe(
+      "2026-05-16T08:30:00.000999",
+    );
   });
 
   test("rejects malformed cursors", () => {
     expect(decodeChatThreadListCursor("not-a-cursor")).toBeNull();
     expect(
-      decodeChatThreadListCursor("2026-05-16T08:30:00.000Z|not-a-thread-id"),
+      decodeChatThreadListCursor("2026-05-16T08:30:00.000000|not-a-thread-id"),
     ).toBeNull();
     expect(
       decodeChatThreadListCursor(
         "not-a-date|018f4ad2-3a6d-7000-8b1d-44f76f5df001",
+      ),
+    ).toBeNull();
+    expect(
+      decodeChatThreadListCursor(
+        "2026-05-16T08:30:00.000Z|018f4ad2-3a6d-7000-8b1d-44f76f5df001",
+      ),
+    ).toBeNull();
+    expect(
+      decodeChatThreadListCursor(
+        "2026-02-31T08:30:00.000000|018f4ad2-3a6d-7000-8b1d-44f76f5df001",
       ),
     ).toBeNull();
   });

--- a/apps/api/src/handlers/chat/thread-list-pagination.ts
+++ b/apps/api/src/handlers/chat/thread-list-pagination.ts
@@ -2,19 +2,20 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { brandPersistedChatThreadId } from "@/api/lib/safe-id-boundaries";
 
 const CURSOR_SEPARATOR = "|";
+const CURSOR_TIMESTAMP_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.(\d{6})$/;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 type ChatThreadListCursor = {
   id: SafeId<"chatThread">;
-  updatedAt: Date;
+  updatedAt: string;
 };
 
 export const encodeChatThreadListCursor = ({
   id,
   updatedAt,
-}: ChatThreadListCursor): string =>
-  `${updatedAt.toISOString()}${CURSOR_SEPARATOR}${id}`;
+}: ChatThreadListCursor): string => `${updatedAt}${CURSOR_SEPARATOR}${id}`;
 
 export const decodeChatThreadListCursor = (
   cursor: string,
@@ -24,11 +25,72 @@ export const decodeChatThreadListCursor = (
     return null;
   }
 
-  const updatedAt = new Date(cursor.slice(0, separatorIndex));
+  const updatedAt = cursor.slice(0, separatorIndex);
   const id = cursor.slice(separatorIndex + 1);
-  if (Number.isNaN(updatedAt.getTime()) || !UUID_RE.test(id)) {
+  if (!isValidCursorTimestamp(updatedAt) || !UUID_RE.test(id)) {
     return null;
   }
 
   return { id: brandPersistedChatThreadId(id), updatedAt };
+};
+
+const isValidCursorTimestamp = (timestamp: string): boolean => {
+  const match = CURSOR_TIMESTAMP_RE.exec(timestamp);
+  if (!match) {
+    return false;
+  }
+
+  const [, year, month, day, hour, minute, second, microsecond] = match;
+  const parts = [year, month, day, hour, minute, second, microsecond].map(
+    Number,
+  );
+  const [
+    yearValue,
+    monthValue,
+    dayValue,
+    hourValue,
+    minuteValue,
+    secondValue,
+    microsecondValue,
+  ] = parts;
+  if (
+    yearValue === undefined ||
+    monthValue === undefined ||
+    dayValue === undefined ||
+    hourValue === undefined ||
+    minuteValue === undefined ||
+    secondValue === undefined ||
+    microsecondValue === undefined ||
+    yearValue < 1 ||
+    monthValue < 1 ||
+    monthValue > 12 ||
+    dayValue < 1 ||
+    hourValue > 23 ||
+    minuteValue > 59 ||
+    secondValue > 59 ||
+    microsecondValue > 999_999
+  ) {
+    return false;
+  }
+
+  const date = new Date(
+    Date.UTC(
+      yearValue,
+      monthValue - 1,
+      dayValue,
+      hourValue,
+      minuteValue,
+      secondValue,
+      Math.floor(microsecondValue / 1000),
+    ),
+  );
+
+  return (
+    date.getUTCFullYear() === yearValue &&
+    date.getUTCMonth() === monthValue - 1 &&
+    date.getUTCDate() === dayValue &&
+    date.getUTCHours() === hourValue &&
+    date.getUTCMinutes() === minuteValue &&
+    date.getUTCSeconds() === secondValue
+  );
 };

--- a/apps/api/src/handlers/chat/thread-list-pagination.ts
+++ b/apps/api/src/handlers/chat/thread-list-pagination.ts
@@ -1,0 +1,34 @@
+import type { SafeId } from "@/api/lib/branded-types";
+import { brandPersistedChatThreadId } from "@/api/lib/safe-id-boundaries";
+
+const CURSOR_SEPARATOR = "|";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type ChatThreadListCursor = {
+  id: SafeId<"chatThread">;
+  updatedAt: Date;
+};
+
+export const encodeChatThreadListCursor = ({
+  id,
+  updatedAt,
+}: ChatThreadListCursor): string =>
+  `${updatedAt.toISOString()}${CURSOR_SEPARATOR}${id}`;
+
+export const decodeChatThreadListCursor = (
+  cursor: string,
+): ChatThreadListCursor | null => {
+  const separatorIndex = cursor.indexOf(CURSOR_SEPARATOR);
+  if (separatorIndex === -1) {
+    return null;
+  }
+
+  const updatedAt = new Date(cursor.slice(0, separatorIndex));
+  const id = cursor.slice(separatorIndex + 1);
+  if (Number.isNaN(updatedAt.getTime()) || !UUID_RE.test(id)) {
+    return null;
+  }
+
+  return { id: brandPersistedChatThreadId(id), updatedAt };
+};

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -82,6 +82,10 @@ export const LIMITS = {
   chatContextTextMaxChars: 32_000,
   /** Max number of file attachments per chat message. */
   chatContextFilesPerMessage: 5,
+  /** Default page size for the user's chat thread history. */
+  chatThreadListPageSizeDefault: 50,
+  /** Max page size for the user's chat thread history. */
+  chatThreadListPageSizeMax: 100,
   /** Max characters of TypeScript source the chat run-stella-query tool accepts. */
   chatRunCodeMaxLength: 16_000,
   /** Default page size for readonly chat execute functions. */

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -1,7 +1,11 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { Link, useMatch, useNavigate } from "@tanstack/react-router";
 import { MessageSquareIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -24,7 +28,10 @@ import { toChatThreadId } from "@/lib/chat-thread-ref";
 import { toAPIError } from "@/lib/errors";
 import type { SafeId } from "@/lib/safe-id";
 import { toSafeId } from "@/lib/safe-id";
-import { groupedChatThreadsOptions } from "@/routes/_protected.chat/-queries";
+import {
+  groupedChatThreadsOptions,
+  mergeGroupedChatThreadPages,
+} from "@/routes/_protected.chat/-queries";
 
 type ThreadsSheetProps = {
   icon?: ReactNode;
@@ -68,7 +75,12 @@ export const ThreadsSheet = ({
     return null;
   })();
 
-  const { data } = useQuery(groupedChatThreadsOptions());
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useInfiniteQuery(groupedChatThreadsOptions());
+  const groupedThreads = useMemo(
+    () => mergeGroupedChatThreadPages(data?.pages),
+    [data?.pages],
+  );
 
   return (
     <Sheet onOpenChange={setIsOpen} open={isOpen}>
@@ -102,17 +114,17 @@ export const ThreadsSheet = ({
           <div className="flex flex-col gap-4">
             <ThreadGroup
               activeThreadRef={activeThreadRef}
-              emptyLabel={t("chat.noThreads")}
+              emptyLabel={hasNextPage ? undefined : t("chat.noThreads")}
               heading={t("navigation.chat")}
               onOpenChange={setIsOpen}
               scope="global"
-              threads={(data?.global ?? []).map((thread) => ({
+              threads={groupedThreads.global.map((thread) => ({
                 createdAt: thread.createdAt,
                 id: thread.id,
                 title: thread.title,
               }))}
             />
-            {(data?.workspaces ?? []).map((workspace) => (
+            {groupedThreads.workspaces.map((workspace) => (
               <ThreadGroup
                 activeThreadRef={activeThreadRef}
                 heading={workspace.workspaceName}
@@ -127,6 +139,19 @@ export const ThreadsSheet = ({
                 workspaceId={workspace.workspaceId}
               />
             ))}
+            {hasNextPage ? (
+              <Button
+                className="self-center"
+                disabled={isFetchingNextPage}
+                onClick={() => {
+                  void fetchNextPage();
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                {isFetchingNextPage ? commonT("loading") : commonT("loadMore")}
+              </Button>
+            ) : null}
           </div>
         </SheetPanel>
       </SheetPopup>

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -10,6 +10,7 @@ import {
   chatKeys,
   createSendAutomaticallyPredicate,
   matchesChatThreadAcrossScopes,
+  mergeGroupedChatThreadPages,
 } from "@/routes/_protected.chat/-queries";
 
 const createMessage = (id = "message-A"): PersistedChatMessage => ({
@@ -17,6 +18,7 @@ const createMessage = (id = "message-A"): PersistedChatMessage => ({
   role: "user",
   parts: [{ type: "text", text: "Hello" }],
 });
+const date = (value: string): Date => new Date(value);
 
 describe("chatKeys", () => {
   test("separates plain chat transports from active DOCX edit transports", () => {
@@ -93,6 +95,102 @@ describe("matchesChatThreadAcrossScopes", () => {
         threadId,
       ),
     ).toBe(false);
+  });
+});
+
+describe("mergeGroupedChatThreadPages", () => {
+  test("deduplicates threads while appending workspace groups across pages", () => {
+    const result = mergeGroupedChatThreadPages([
+      {
+        global: [
+          {
+            createdAt: date("2026-05-16T08:00:00.000Z"),
+            id: "global-A",
+            title: "Global A",
+            updatedAt: date("2026-05-16T08:00:00.000Z"),
+          },
+        ],
+        nextCursor: "page-2",
+        workspaces: [
+          {
+            workspaceId: "workspace-A",
+            workspaceName: "Matter A",
+            threads: [
+              {
+                createdAt: date("2026-05-16T07:00:00.000Z"),
+                id: "workspace-thread-A",
+                title: "Workspace A",
+                updatedAt: date("2026-05-16T07:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+      },
+      {
+        global: [
+          {
+            createdAt: date("2026-05-16T08:00:00.000Z"),
+            id: "global-A",
+            title: "Global A duplicate",
+            updatedAt: date("2026-05-16T08:00:00.000Z"),
+          },
+          {
+            createdAt: date("2026-05-16T06:00:00.000Z"),
+            id: "global-B",
+            title: "Global B",
+            updatedAt: date("2026-05-16T06:00:00.000Z"),
+          },
+        ],
+        nextCursor: null,
+        workspaces: [
+          {
+            workspaceId: "workspace-A",
+            workspaceName: "Matter A",
+            threads: [
+              {
+                createdAt: date("2026-05-16T07:00:00.000Z"),
+                id: "workspace-thread-A",
+                title: "Workspace A duplicate",
+                updatedAt: date("2026-05-16T07:00:00.000Z"),
+              },
+              {
+                createdAt: date("2026-05-16T05:00:00.000Z"),
+                id: "workspace-thread-B",
+                title: "Workspace B",
+                updatedAt: date("2026-05-16T05:00:00.000Z"),
+              },
+            ],
+          },
+          {
+            workspaceId: "workspace-B",
+            workspaceName: "Matter B",
+            threads: [
+              {
+                createdAt: date("2026-05-16T04:00:00.000Z"),
+                id: "workspace-thread-C",
+                title: "Workspace C",
+                updatedAt: date("2026-05-16T04:00:00.000Z"),
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    expect(result.global.map((thread) => thread.id)).toEqual([
+      "global-A",
+      "global-B",
+    ]);
+    expect(result.workspaces).toMatchObject([
+      {
+        workspaceId: "workspace-A",
+        threads: [{ id: "workspace-thread-A" }, { id: "workspace-thread-B" }],
+      },
+      {
+        workspaceId: "workspace-B",
+        threads: [{ id: "workspace-thread-C" }],
+      },
+    ]);
   });
 });
 

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -1,5 +1,5 @@
 import { Chat } from "@ai-sdk/react";
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
 import {
   DefaultChatTransport,
@@ -66,9 +66,16 @@ type ActiveExternalContext = {
 
 type ChatThreadKey = ChatThreadRef;
 
-type GroupedChatThreads = Awaited<ReturnType<typeof fetchGroupedChatThreads>>;
+type GroupedChatThreadsPage = Awaited<
+  ReturnType<typeof fetchGroupedChatThreads>
+>;
+export type GroupedChatThreads = Pick<
+  GroupedChatThreadsPage,
+  "global" | "workspaces"
+>;
 
 const APPLY_ACTIVE_DOCX_EDITS_TOOL_NAME = "apply-active-docx-edits";
+const CHAT_THREADS_PAGE_SIZE = 50;
 const CHAT_TRANSPORT_VERSION = 2;
 
 export type ApplyActiveDocxEditsInput =
@@ -196,14 +203,73 @@ const fetchThreadMessages = async (
   return response.data;
 };
 
-const fetchGroupedChatThreads = async () => {
-  const response = await api.chat.threads.get();
+const fetchGroupedChatThreads = async ({
+  cursor,
+  signal,
+}: {
+  cursor?: string | undefined;
+  signal?: AbortSignal | undefined;
+} = {}) => {
+  const response = await api.chat.threads.get({
+    ...(signal !== undefined && { fetch: { signal } }),
+    query: {
+      limit: CHAT_THREADS_PAGE_SIZE,
+      ...(cursor !== undefined && { cursor }),
+    },
+  });
 
   if (response.error) {
     throw toAPIError(response.error);
   }
 
   return response.data;
+};
+
+export const mergeGroupedChatThreadPages = (
+  pages: readonly GroupedChatThreadsPage[] | undefined,
+): GroupedChatThreads => {
+  const global: GroupedChatThreads["global"] = [];
+  const workspacesById = new Map<
+    string,
+    GroupedChatThreads["workspaces"][number]
+  >();
+  const seenThreadIds = new Set<string>();
+
+  for (const page of pages ?? []) {
+    for (const thread of page.global) {
+      if (seenThreadIds.has(thread.id)) {
+        continue;
+      }
+      seenThreadIds.add(thread.id);
+      global.push(thread);
+    }
+
+    for (const workspace of page.workspaces) {
+      const existing = workspacesById.get(workspace.workspaceId);
+      if (!existing) {
+        const threads: typeof workspace.threads = [];
+        for (const thread of workspace.threads) {
+          if (seenThreadIds.has(thread.id)) {
+            continue;
+          }
+          seenThreadIds.add(thread.id);
+          threads.push(thread);
+        }
+        workspacesById.set(workspace.workspaceId, { ...workspace, threads });
+        continue;
+      }
+
+      for (const thread of workspace.threads) {
+        if (seenThreadIds.has(thread.id)) {
+          continue;
+        }
+        seenThreadIds.add(thread.id);
+        existing.threads.push(thread);
+      }
+    }
+  }
+
+  return { global, workspaces: Array.from(workspacesById.values()) };
 };
 
 const getChatApiPath = () => `${env.VITE_API_URL}/v1/chat`;
@@ -531,10 +597,12 @@ export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
   });
 
 export const groupedChatThreadsOptions = () =>
-  queryOptions({
+  infiniteQueryOptions({
     queryKey: chatKeys.groupedThreads(),
-    queryFn: async (): Promise<GroupedChatThreads> =>
-      await fetchGroupedChatThreads(),
+    queryFn: async ({ pageParam, signal }): Promise<GroupedChatThreadsPage> =>
+      await fetchGroupedChatThreads({ cursor: pageParam, signal }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
 export const invalidateGroupedChatThreads = async (queryClient: QueryClient) =>

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -1,7 +1,11 @@
 import { useEffectEvent, useMemo, useRef, useState } from "react";
 import type { ReactElement, ReactNode } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
   HistoryIcon,
@@ -43,6 +47,7 @@ import {
   chatThreadOptions,
   groupedChatThreadsOptions,
   invalidateGroupedChatThreads,
+  mergeGroupedChatThreadPages,
 } from "@/routes/_protected.chat/-queries";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
@@ -69,7 +74,13 @@ function ChatIndex() {
   const pinnedOrder = usePinnedStore((s) => s.pinnedOrder);
   const { data: workspacesData } = useQuery(workspacesNavigationOptions);
   const workspaces = workspacesData?.workspaces;
-  const { data: groupedThreads } = useQuery(groupedChatThreadsOptions());
+  const { data: groupedThreadPages } = useInfiniteQuery(
+    groupedChatThreadsOptions(),
+  );
+  const groupedThreads = useMemo(
+    () => mergeGroupedChatThreadPages(groupedThreadPages?.pages),
+    [groupedThreadPages?.pages],
+  );
   const anonymized = useChatAnonymized(threadRef);
   const setAnonymized = useSetChatAnonymized(threadRef);
   const getSendMode = useEffectEvent(() => getChatSendMode(threadRef));
@@ -124,7 +135,7 @@ function ChatIndex() {
 
   const recentChats = useMemo(() => {
     const threads: RecentChat[] = [];
-    for (const thread of groupedThreads?.global ?? []) {
+    for (const thread of groupedThreads.global) {
       threads.push({
         scope: "global",
         id: thread.id,
@@ -132,7 +143,7 @@ function ChatIndex() {
         updatedAt: thread.updatedAt,
       });
     }
-    for (const workspace of groupedThreads?.workspaces ?? []) {
+    for (const workspace of groupedThreads.workspaces) {
       for (const thread of workspace.threads) {
         threads.push({
           scope: "workspace",


### PR DESCRIPTION
Adds bounded cursor pagination for chat thread history and wires the chat history UI to load additional pages on demand.

Adds a matching database index and cursor validation tests.