### PR TITLE
fix(case-law): narrow ingestion to dedicated stella_ingestion role

### DIFF
--- a/apps/api/drizzle/20260516000000_case_law_ingestion_role/migration.sql
+++ b/apps/api/drizzle/20260516000000_case_law_ingestion_role/migration.sql
@@ -1,0 +1,127 @@
+-- Bootstrap `stella_ingestion`, the NOLOGIN role used by the case-law
+-- ingestion daemon to mutate the global corpus.
+--
+-- The 2026-05-10 RLS bootstrap left case_law_* tables read-only for
+-- the customer-scoped `stella` role so tenant code paths cannot
+-- mutate global reference data. Ingestion is an admin operation and
+-- needs write access — but going through the master connection
+-- would also grant writes on every tenant table (RLS bypassed,
+-- every grant inherited), so we add a third role narrowly scoped
+-- to the case-law corpus.
+
+CREATE ROLE stella_ingestion NOLOGIN;
+
+-- Schema access; mirrors the stella bootstrap.
+GRANT USAGE ON SCHEMA public TO stella_ingestion;
+
+-- SELECT on the nine case_law_* tables. Reads are needed for
+-- upsert logic, source cursors, and dedup checks. Deliberately
+-- nothing else — `permission denied for table foo` is the loud
+-- failure mode we want if a future ingestion change accidentally
+-- touches anything outside the corpus.
+GRANT SELECT ON TABLE
+  "case_law_sources",
+  "case_law_decisions",
+  "case_law_citations",
+  "case_law_polarity_rules",
+  "case_law_court_weights",
+  "case_law_fts_configs",
+  "case_law_search_documents",
+  "case_law_ingestion_events",
+  "case_law_ingestion_failures"
+TO stella_ingestion;
+
+-- INSERT/UPDATE/DELETE on the eight mutable tables. case_law_sources
+-- is config-only (rows seeded by app code on first run, columns
+-- otherwise rotated only by migrations) so it stays read-only.
+GRANT INSERT, UPDATE, DELETE ON TABLE
+  "case_law_decisions",
+  "case_law_citations",
+  "case_law_polarity_rules",
+  "case_law_court_weights",
+  "case_law_fts_configs",
+  "case_law_search_documents",
+  "case_law_ingestion_events",
+  "case_law_ingestion_failures"
+TO stella_ingestion;
+
+-- Sequence usage for serial PKs on the case_law_* tables.
+DO $$
+DECLARE
+  target_sequence regclass;
+BEGIN
+  FOR target_sequence IN
+    SELECT DISTINCT seq.oid::regclass
+    FROM pg_class seq
+    JOIN pg_namespace n ON n.oid = seq.relnamespace
+    JOIN pg_depend dep ON dep.objid = seq.oid
+    JOIN pg_class tbl ON tbl.oid = dep.refobjid
+    JOIN pg_namespace tbl_ns ON tbl_ns.oid = tbl.relnamespace
+    WHERE n.nspname = 'public'
+      AND tbl_ns.nspname = 'public'
+      AND seq.relkind = 'S'
+      AND dep.deptype IN ('a', 'i')
+      AND tbl.relname IN (
+        'case_law_sources',
+        'case_law_decisions',
+        'case_law_citations',
+        'case_law_polarity_rules',
+        'case_law_court_weights',
+        'case_law_fts_configs',
+        'case_law_search_documents',
+        'case_law_ingestion_events',
+        'case_law_ingestion_failures'
+      )
+  LOOP
+    EXECUTE format(
+      'GRANT USAGE, SELECT ON SEQUENCE %s TO stella_ingestion',
+      target_sequence
+    );
+  END LOOP;
+END $$;
+
+-- RLS is enabled on case_law_* with a SELECT-only `case_law_global_access`
+-- policy targeting `stella`. stella_ingestion is a separate role, so it
+-- needs its own policies. PERMISSIVE FOR ALL with USING (true) /
+-- WITH CHECK (true): the corpus has no tenant — there is nothing to
+-- scope against. Restriction comes from the table-level GRANT list
+-- above, not from RLS.
+CREATE POLICY "case_law_ingestion_access" ON "case_law_sources"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_decisions"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_citations"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_polarity_rules"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_court_weights"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_fts_configs"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_search_documents"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_ingestion_events"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+CREATE POLICY "case_law_ingestion_access" ON "case_law_ingestion_failures"
+  AS PERMISSIVE FOR ALL TO "stella_ingestion"
+  USING (true) WITH CHECK (true);
+
+-- Grant the migration connection role membership in stella_ingestion
+-- so it can SET LOCAL ROLE stella_ingestion per transaction.
+-- Mirrors the stella bootstrap at the bottom of
+-- 20260510140000_document_rls_role_bootstrap.
+DO $$
+BEGIN
+  IF CURRENT_USER <> 'stella_ingestion'
+     AND NOT pg_has_role(CURRENT_USER, 'stella_ingestion', 'member') THEN
+    EXECUTE format('GRANT stella_ingestion TO %I', CURRENT_USER);
+  END IF;
+END $$;

--- a/apps/api/drizzle/20260516000000_case_law_ingestion_role/migration.sql
+++ b/apps/api/drizzle/20260516000000_case_law_ingestion_role/migration.sql
@@ -32,8 +32,8 @@ GRANT SELECT ON TABLE
 TO stella_ingestion;
 
 -- INSERT/UPDATE/DELETE on the eight mutable tables. case_law_sources
--- is config-only (rows seeded by app code on first run, columns
--- otherwise rotated only by migrations) so it stays read-only.
+-- is config-only — rows seeded by ensureSource at startup, columns
+-- otherwise rotated only by migrations.
 GRANT INSERT, UPDATE, DELETE ON TABLE
   "case_law_decisions",
   "case_law_citations",
@@ -44,6 +44,16 @@ GRANT INSERT, UPDATE, DELETE ON TABLE
   "case_law_ingestion_events",
   "case_law_ingestion_failures"
 TO stella_ingestion;
+
+-- Narrow exception on case_law_sources: each adapter cycle bumps
+-- sync_cursor + last_sync_at after a successful pass, and Drizzle's
+-- $onUpdate also writes updated_at. Without these three column-level
+-- UPDATEs the cursor never advances and every cycle is recorded as
+-- failed. All other source columns (name, adapter_key, enabled,
+-- config) remain migration-managed.
+GRANT UPDATE (sync_cursor, last_sync_at, updated_at)
+  ON TABLE "case_law_sources"
+  TO stella_ingestion;
 
 -- Sequence usage for serial PKs on the case_law_* tables.
 DO $$

--- a/apps/api/scripts/ingest-case-law.ts
+++ b/apps/api/scripts/ingest-case-law.ts
@@ -17,17 +17,24 @@
  * With an adapter key, runs only that source once and exits.
  */
 
-import { createScopedDb } from "@/api/db";
+import { createIngestionDb } from "@/api/db";
 import { db } from "@/api/db/root";
 import { caseLawIngestionEvents, caseLawSources } from "@/api/db/schema";
 import { ADAPTER_KEYS, MAX_CYCLE_MS } from "@/api/handlers/case-law/consts";
 import { getAdapter } from "@/api/handlers/case-law/ingestion/adapters";
 import { runIngestionPipeline } from "@/api/handlers/case-law/ingestion/pipeline";
 import { backfillSearchIndex } from "@/api/handlers/case-law/search-index";
-import { toSafeId } from "@/api/lib/branded-types";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { isS3Stale, refreshS3 } from "@/api/lib/s3";
+
+// Case-law ingestion writes the global corpus. The customer-scoped
+// `stella` role is read-only on case_law_* (see migration
+// 20260510140000); the daemon switches to `stella_ingestion`, which
+// has narrow writes on the corpus and nothing else. Any future code
+// path that strays outside case_law_* will hit a loud
+// `permission denied`.
+const ingestionDb = createIngestionDb(db);
 
 /**
  * Bun's native Postgres pool emits unhandled errors when the
@@ -228,8 +235,6 @@ const daysAgoCursor = (n: number): string => {
   return date;
 };
 
-const scriptUserId = toSafeId<"user">("script_case_law");
-
 type CycleOutcome = "completed" | "failed" | "timeout";
 
 type CycleResult = {
@@ -257,13 +262,6 @@ const runOneCycle = async (
   const startedAt = new Date();
   const t0 = performance.now();
 
-  const scopedDb = createScopedDb(
-    db,
-    [],
-    toSafeId<"organization">(""),
-    scriptUserId,
-  );
-
   let outcome: CycleOutcome = "completed";
   let errorMessage: string | null = null;
   let result: Awaited<ReturnType<typeof runIngestionPipeline>> | null = null;
@@ -274,7 +272,7 @@ const runOneCycle = async (
 
     result = await runIngestionPipeline({
       source,
-      scopedDb,
+      scopedDb: ingestionDb,
       dbSlot: { acquire: acquireDbSlot, release: releaseDbSlot },
       signal: AbortSignal.timeout(cycleMs),
     });
@@ -299,18 +297,20 @@ const runOneCycle = async (
   const dbStatus = outcome === "failed" ? "failed" : "completed";
 
   try {
-    await db.insert(caseLawIngestionEvents).values({
-      sourceId: source.id,
-      status: dbStatus,
-      inserted: result?.inserted ?? 0,
-      skipped: result?.skipped ?? 0,
-      searchVectorFailures: result?.searchVectorFailures ?? 0,
-      pagesProcessed: result?.pagesProcessed ?? 0,
-      cursorBefore,
-      cursorAfter: result !== null ? result.nextCursor : cursorBefore,
-      durationMs,
-      errorMessage,
-      startedAt,
+    await ingestionDb(async (tx) => {
+      await tx.insert(caseLawIngestionEvents).values({
+        sourceId: source.id,
+        status: dbStatus,
+        inserted: result?.inserted ?? 0,
+        skipped: result?.skipped ?? 0,
+        searchVectorFailures: result?.searchVectorFailures ?? 0,
+        pagesProcessed: result?.pagesProcessed ?? 0,
+        cursorBefore,
+        cursorAfter: result !== null ? result.nextCursor : cursorBefore,
+        durationMs,
+        errorMessage,
+        startedAt,
+      });
     });
   } catch (eventError) {
     console.error(
@@ -474,18 +474,11 @@ const healthLoop = (async () => {
 // semaphore with bounded concurrency and a generous statement
 // timeout so long texts don't block other work.
 const searchIndexLoop = (async () => {
-  const scopedDb = createScopedDb(
-    db,
-    [],
-    toSafeId<"organization">(""),
-    scriptUserId,
-  );
-
   while (true) {
     await Bun.sleep(SEARCH_INDEX_INTERVAL_MS);
     try {
       const indexed = await backfillSearchIndex(
-        scopedDb,
+        ingestionDb,
         SEARCH_INDEX_BATCH_SIZE,
       );
       if (indexed > 0) {

--- a/apps/api/src/db/index.ts
+++ b/apps/api/src/db/index.ts
@@ -9,7 +9,11 @@ import { PG_ERROR } from "@/api/lib/pg-error";
 // Re-export scoped utilities without pulling in the owner-level
 // db initialization. Runtime imports from `@/api/db` stay safe for
 // handlers and tests; `db` now lives in `@/api/db/root`.
-export { createSafeDb, createScopedDb } from "@/api/db/scoped";
+export {
+  createIngestionDb,
+  createSafeDb,
+  createScopedDb,
+} from "@/api/db/scoped";
 export type { Transaction } from "@/api/db/root";
 
 /**

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -210,6 +210,12 @@ export const globalCaseLawPolicies = () => [
     to: stella,
     using: allowAllRows,
   }),
+  p.pgPolicy("case_law_ingestion_access", {
+    for: "all",
+    to: stellaIngestion,
+    using: allowAllRows,
+    withCheck: allowAllRows,
+  }),
 ];
 
 const mcpConnectorVisibleCheck = sql`(

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -3,6 +3,10 @@ import * as p from "drizzle-orm/pg-core";
 
 export const stella = p.pgRole("stella").existing();
 
+// Narrow write role used only by the case-law ingestion daemon.
+// Bootstrapped in 20260516000000_case_law_ingestion_role.
+export const stellaIngestion = p.pgRole("stella_ingestion").existing();
+
 /** Session setting keys set via `set_config` per transaction. */
 export const SETTING_WORKSPACE_IDS = "app.workspace_ids";
 export const SETTING_ORGANIZATION_ID = "app.organization_id";

--- a/apps/api/src/db/scoped.ts
+++ b/apps/api/src/db/scoped.ts
@@ -13,6 +13,7 @@ import {
   SETTING_USER_ID,
   SETTING_WORKSPACE_IDS,
   stella,
+  stellaIngestion,
 } from "@/api/db/rls";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
@@ -89,6 +90,22 @@ export const createScopedDb =
       userId,
       fn,
     );
+
+// SET LOCAL ROLE stella_ingestion per transaction. Used by the
+// case-law ingestion daemon — narrowed to writes on case_law_*
+// (see 20260516000000_case_law_ingestion_role). No app.* settings
+// because the corpus is global; there is no tenant to scope.
+export const createIngestionDb =
+  <TTransaction extends ScopedTransactionBase>(
+    database: AnyDrizzle<TTransaction>,
+  ) =>
+  async <T>(fn: (tx: TTransaction) => Promise<T>): Promise<T> =>
+    await database.transaction(async (tx: TTransaction) => {
+      await tx.execute(
+        sql`SELECT set_config('role', '${sql.raw(stellaIngestion.name)}', true)`,
+      );
+      return await fn(tx);
+    });
 
 export const createSafeDb =
   <TTransaction extends ScopedTransactionBase>(

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -11,6 +11,9 @@ import {
 } from "@/api/tests/security/rls-fixture";
 import {
   fetchScopedTables,
+  fetchStellaIngestionColumnPrivileges,
+  fetchStellaIngestionPolicies,
+  fetchStellaIngestionTablePrivileges,
   fetchStellaTablePrivileges,
   fetchStellaPolicies,
 } from "@/api/tests/security/rls-helpers";
@@ -60,6 +63,9 @@ describe("policy coverage", () => {
     "case_law_search_documents",
     "case_law_sources",
   ];
+  const INGESTION_MUTABLE_CASE_LAW_TABLES = GLOBAL_CASE_LAW_TABLES.filter(
+    (table) => table !== "case_law_sources",
+  );
 
   test("every table with workspace_id has workspace policies", async () => {
     const scoped = await fetchScopedTables(testDb);
@@ -219,5 +225,44 @@ describe("policy coverage", () => {
       expect(globalPolicy?.check_expr).toBeNull();
       expect(privilegesFor(table)).toEqual(["SELECT"]);
     }
+  });
+
+  test("case-law ingestion role has explicit narrow write boundaries", async () => {
+    const policies = await fetchStellaIngestionPolicies(testDb);
+    const tablePrivileges = await fetchStellaIngestionTablePrivileges(testDb);
+    const columnPrivileges = await fetchStellaIngestionColumnPrivileges(testDb);
+    const privilegesFor = (table: string) =>
+      tablePrivileges
+        .filter((p) => p.table_name === table)
+        .map((p) => p.privilege)
+        .sort();
+
+    for (const table of GLOBAL_CASE_LAW_TABLES) {
+      const ingestionPolicy = policies.find(
+        (p) =>
+          p.table_name === table &&
+          p.policy_name === "case_law_ingestion_access",
+      );
+      expect(ingestionPolicy?.command).toBe("*");
+      expect(ingestionPolicy?.using_expr).toBe("true");
+      expect(ingestionPolicy?.check_expr).toBe("true");
+    }
+
+    for (const table of INGESTION_MUTABLE_CASE_LAW_TABLES) {
+      expect(privilegesFor(table)).toEqual([
+        "DELETE",
+        "INSERT",
+        "SELECT",
+        "UPDATE",
+      ]);
+    }
+
+    expect(privilegesFor("case_law_sources")).toEqual(["SELECT"]);
+    expect(
+      columnPrivileges
+        .filter((p) => p.table_name === "case_law_sources")
+        .map((p) => p.column_name)
+        .sort(),
+    ).toEqual(["last_sync_at", "sync_cursor", "updated_at"]);
   });
 });

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import type { AnyPgTable } from "drizzle-orm/pg-core";
 
 import { member, organization, user } from "@/api/db/auth-schema";
-import { stella } from "@/api/db/rls";
+import { stella, stellaIngestion } from "@/api/db/rls";
 import {
   anonymizationBlacklistEntries,
   billingCodes,
@@ -1058,6 +1058,15 @@ type TablePrivilegeRow = {
  */
 export const fetchStellaPolicies = async (
   db: TestDatabase,
+): Promise<PolicyRow[]> => await fetchPoliciesForRole(db, stella.name);
+
+export const fetchStellaIngestionPolicies = async (
+  db: TestDatabase,
+): Promise<PolicyRow[]> => await fetchPoliciesForRole(db, stellaIngestion.name);
+
+const fetchPoliciesForRole = async (
+  db: TestDatabase,
+  roleName: string,
 ): Promise<PolicyRow[]> => {
   const rows = await db.execute<PolicyRow>(sql`
     SELECT c.relname AS table_name,
@@ -1071,7 +1080,7 @@ export const fetchStellaPolicies = async (
     JOIN pg_class c ON c.oid = p.polrelid
     WHERE p.polroles @> ARRAY[
       (SELECT oid FROM pg_roles
-       WHERE rolname = ${stella.name})
+       WHERE rolname = ${roleName})
     ]::oid[]
     ORDER BY c.relname, p.polname
   `);
@@ -1080,6 +1089,17 @@ export const fetchStellaPolicies = async (
 
 export const fetchStellaTablePrivileges = async (
   db: TestDatabase,
+): Promise<TablePrivilegeRow[]> =>
+  await fetchTablePrivilegesForRole(db, stella.name);
+
+export const fetchStellaIngestionTablePrivileges = async (
+  db: TestDatabase,
+): Promise<TablePrivilegeRow[]> =>
+  await fetchTablePrivilegesForRole(db, stellaIngestion.name);
+
+const fetchTablePrivilegesForRole = async (
+  db: TestDatabase,
+  roleName: string,
 ): Promise<TablePrivilegeRow[]> => {
   const rows = await db.execute<TablePrivilegeRow>(sql`
     SELECT c.relname AS table_name,
@@ -1094,8 +1114,39 @@ export const fetchStellaTablePrivileges = async (
     ) AS privilege(value)
     WHERE n.nspname = 'public'
       AND c.relkind IN ('r', 'p')
-      AND has_table_privilege(${stella.name}, c.oid, privilege.value)
+      AND has_table_privilege(${roleName}, c.oid, privilege.value)
     ORDER BY c.relname, privilege.value
+  `);
+  return rows.rows;
+};
+
+type ColumnPrivilegeRow = {
+  column_name: string;
+  privilege: "UPDATE";
+  table_name: string;
+};
+
+export const fetchStellaIngestionColumnPrivileges = async (
+  db: TestDatabase,
+): Promise<ColumnPrivilegeRow[]> => {
+  const rows = await db.execute<ColumnPrivilegeRow>(sql`
+    SELECT c.relname AS table_name,
+           a.attname AS column_name,
+           'UPDATE' AS privilege
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    WHERE n.nspname = 'public'
+      AND c.relkind IN ('r', 'p')
+      AND a.attnum > 0
+      AND NOT a.attisdropped
+      AND has_column_privilege(
+        ${stellaIngestion.name},
+        c.oid,
+        a.attname,
+        'UPDATE'
+      )
+    ORDER BY c.relname, a.attname
   `);
   return rows.rows;
 };

--- a/apps/api/src/tests/security/test-utils.ts
+++ b/apps/api/src/tests/security/test-utils.ts
@@ -34,6 +34,7 @@ const createTestDb = async (): Promise<TestDatabase> => {
   const pushSchemaDb = drizzle({ client });
 
   await testDb.execute(sql.raw("CREATE ROLE stella NOLOGIN"));
+  await testDb.execute(sql.raw("CREATE ROLE stella_ingestion NOLOGIN"));
 
   const { sqlStatements } = await pushSchema(allSchema, pushSchemaDb);
   for (const statement of sqlStatements) {
@@ -59,6 +60,42 @@ const createTestDb = async (): Promise<TestDatabase> => {
         "case_law_ingestion_events",
         "case_law_ingestion_failures"
       FROM stella
+    `),
+  );
+  await testDb.execute(
+    sql.raw(`
+      GRANT SELECT ON TABLE
+        "case_law_sources",
+        "case_law_decisions",
+        "case_law_citations",
+        "case_law_polarity_rules",
+        "case_law_court_weights",
+        "case_law_fts_configs",
+        "case_law_search_documents",
+        "case_law_ingestion_events",
+        "case_law_ingestion_failures"
+      TO stella_ingestion
+    `),
+  );
+  await testDb.execute(
+    sql.raw(`
+      GRANT INSERT, UPDATE, DELETE ON TABLE
+        "case_law_decisions",
+        "case_law_citations",
+        "case_law_polarity_rules",
+        "case_law_court_weights",
+        "case_law_fts_configs",
+        "case_law_search_documents",
+        "case_law_ingestion_events",
+        "case_law_ingestion_failures"
+      TO stella_ingestion
+    `),
+  );
+  await testDb.execute(
+    sql.raw(`
+      GRANT UPDATE (sync_cursor, last_sync_at, updated_at)
+        ON TABLE "case_law_sources"
+        TO stella_ingestion
     `),
   );
 


### PR DESCRIPTION
## Summary
- Case-law ingestion daemon ran through `createScopedDb` → `SET LOCAL ROLE stella`. The 2026-05-10 RLS bootstrap (`apps/api/drizzle/20260510140000_document_rls_role_bootstrap`) left `case_law_*` read-only for `stella` so customer-scoped paths cannot mutate the global corpus. Every adapter write failed with `permission denied for table case_law_decisions`; after `SUSTAINED_FAILURE_THRESHOLD` (5) consecutive failures each adapter halted and the daemon went silent. Observed today on prod: ~9 hours of zero ingestion across all adapters.

## Why a third role, not just granting writes to `stella`
- Granting writes to `stella` re-opens the surface the May 10 migration closed — any tenant code path that issues an UPDATE on `case_law_*` would succeed
- Going through the master connection expands the daemon's write surface to every table in the DB with RLS bypassed
- A narrowly-scoped role (writes only on `case_law_*`) preserves the loud `permission denied` failure mode if a future ingestion change accidentally touches a non-case-law table

## What changed
- **New migration `20260516000000_case_law_ingestion_role`** creates `stella_ingestion` NOLOGIN, grants SELECT on the nine `case_law_*` tables, grants INSERT/UPDATE/DELETE on the eight mutable ones (sources stays config-only), grants sequence usage, adds permissive RLS policies, and grants the migration connection role membership so `SET ROLE` works
- **New `createIngestionDb`** in `apps/api/src/db/scoped.ts` mirrors `createScopedDb` but switches to `stella_ingestion` and skips the `app.*` session settings (corpus has no tenant)
- **Daemon swap**: `ingest-case-law.ts` uses `createIngestionDb` for the per-cycle pipeline, the search-index backfill loop, and the ingestion-events insert. `ensureSource` keeps the master connection because `case_law_sources` writes are bootstrap-only and intentionally outside the daemon role

## Role matrix (after this PR)
| Role | Writes case_law? | Writes tenant tables? | RLS bypass? |
|---|---|---|---|
| `stella` (customer paths) | ❌ | ✅ with RLS scope | ❌ |
| `stella_ingestion` (daemon) | ✅ (8 tables) | ❌ | ❌ |
| master (migrations, source bootstrap) | ✅ | ✅ | ✅ |

## Test plan
- [x] `tsgo --noEmit` clean for `apps/api`
- [ ] db-migrations workflow validates the new migration applies clean against postgres:18 + replays journals
- [ ] After deploy: `case_law.ingestion.decision_failed` with `permission denied` stops appearing; `[<adapter>] Inserted: N` lines resume

## Deploy ordering
Drizzle migrate runs before the new task definition rolls (per `release.yml` + the migrate ECS task), so the role exists by the time the daemon container restarts. No special promotion needed.