### PR TITLE
fix: add self-host API healthcheck

### DIFF
--- a/docker-compose.selfhost.yml
+++ b/docker-compose.selfhost.yml
@@ -12,6 +12,18 @@ services:
     depends_on:
       gotenberg:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "bun",
+          "-e",
+          "const response = await fetch('http://127.0.0.1:3001/health', { signal: AbortSignal.timeout(4000) }); if (!response.ok) process.exit(1);",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
 
   gotenberg:


### PR DESCRIPTION
## Summary

- Add a Docker Compose healthcheck for the self-host API service.
- Probe `/health` with Bun so the healthcheck does not depend on curl being present in the API image.

## Validation

- `GOTENBERG_USERNAME=healthcheck-smoke GOTENBERG_PASSWORD=healthcheck-smoke docker compose -f docker-compose.selfhost.yml config`
- Pre-push hook: format, i18n, lint, typecheck