### PR TITLE
feat: standardize cursor pagination envelope

### DIFF
--- a/.agents/skills/conventions-scale/SKILL.md
+++ b/.agents/skills/conventions-scale/SKILL.md
@@ -24,8 +24,12 @@ without a rewrite.
 ## What This Means in Practice
 
 **Pagination and streaming.** Never return unbounded result sets.
-Every list endpoint must accept `limit`/`cursor` (or
-`limit`/`offset`). For file processing, prefer streaming over
+Every list endpoint should accept `limit`/`cursor` and return the
+standard `Page<T>` envelope from `apps/api/src/lib/pagination.ts`:
+`{ items, nextCursor, limit }`. Cursors are opaque to callers, and
+`limit` is the normalized server-applied limit. Offset pagination,
+`totalCount`, and unbounded lists require explicit justification in
+the endpoint design. For file processing, prefer streaming over
 loading entire files into memory.
 
 **Tenant isolation.** Application-level filtering (via `SafeId`

--- a/.oxlint-plugins/no-offset-pagination.ts
+++ b/.oxlint-plugins/no-offset-pagination.ts
@@ -1,0 +1,97 @@
+// Disallow new request-level offset pagination in API handlers.
+// oxlint-disable typescript/no-unsafe-assignment, typescript/no-unsafe-member-access, typescript/no-unsafe-return, typescript/no-unsafe-argument, typescript/no-unsafe-call, typescript/strict-boolean-expressions
+//
+// Large list endpoints should use cursor pagination and the standard Page<T>
+// envelope. Legacy offset endpoints must be listed explicitly in oxlint.config.ts
+// with a justification.
+
+import { getCalleeName, getPropertyName } from "./utils.ts";
+
+const SCHEMA_CALLEES = new Set([
+  "t.Integer",
+  "t.Number",
+  "t.Optional",
+  "t.Union",
+]);
+
+const filenameForContext = (context) =>
+  context.filename ?? context.getFilename?.() ?? "";
+
+const isAllowedFile = (context, allowedFiles) => {
+  const filename = filenameForContext(context);
+  return allowedFiles.some((allowedFile) => filename.endsWith(allowedFile));
+};
+
+const containsRequestSchemaCall = (node) => {
+  if (!node) {
+    return false;
+  }
+
+  if (node.type === "CallExpression") {
+    const calleeName = getCalleeName(node.callee);
+    if (calleeName !== null && SCHEMA_CALLEES.has(calleeName)) {
+      return true;
+    }
+    return node.arguments.some(containsRequestSchemaCall);
+  }
+
+  if (node.type === "TSAsExpression" || node.type === "TSSatisfiesExpression") {
+    return containsRequestSchemaCall(node.expression);
+  }
+
+  return false;
+};
+
+export default {
+  meta: { name: "no-offset-pagination" },
+  rules: {
+    "no-offset-pagination": {
+      meta: {
+        type: "problem",
+        messages: {
+          noOffsetPagination:
+            "New API list endpoints must use cursor pagination (`cursor` + `limit`) and return Page<T>. Offset pagination requires an explicit exception in oxlint.config.ts.",
+        },
+        schema: [
+          {
+            type: "object",
+            properties: {
+              allowedFiles: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
+      create(context) {
+        const options = context.options?.[0] ?? {};
+        const allowedFiles = Array.isArray(options.allowedFiles)
+          ? options.allowedFiles
+          : [];
+
+        if (isAllowedFile(context, allowedFiles)) {
+          return {};
+        }
+
+        return {
+          Property(node) {
+            if (getPropertyName(node.key) !== "offset") {
+              return;
+            }
+
+            if (!containsRequestSchemaCall(node.value)) {
+              return;
+            }
+
+            context.report({
+              node,
+              messageId: "noOffsetPagination",
+            });
+          },
+        };
+      },
+    },
+  },
+};

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,11 @@ Never paint yourself into a corner. Architecture must support Magic Circle scale
 without a rewrite. Never return unbounded result sets; keep the API stateless; filter
 by tenant ID in the query. Full guidelines in `/conventions-scale`.
 
+List endpoints should use cursor pagination and return the standard
+`Page<T>` envelope from `apps/api/src/lib/pagination.ts`:
+`{ items, nextCursor, limit }`. Offset pagination, `totalCount`, and unbounded
+lists require explicit justification.
+
 ## UX & Brand
 
 Use semantic tokens (`bg-muted`, `text-foreground`, `border`), not raw colour values.

--- a/apps/api/src/handlers/audit-logs/read.ts
+++ b/apps/api/src/handlers/audit-logs/read.ts
@@ -11,6 +11,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedAuditLogId } from "@/api/lib/safe-id-boundaries";
 
 const CURSOR_SEPARATOR = "|";
@@ -140,15 +141,13 @@ const readAuditLogs = createSafeRootHandler(
       ),
     );
 
-    const hasMore = rows.length > limit;
-    const data = hasMore ? rows.slice(0, limit) : rows;
-    const lastItem = data.at(-1);
-    const nextCursor =
-      hasMore && lastItem
-        ? encodeCursor(lastItem.createdAt, lastItem.id)
-        : null;
-
-    return Result.ok({ data, nextCursor });
+    return Result.ok(
+      createCursorPage({
+        rows,
+        limit,
+        cursorForItem: (item) => encodeCursor(item.createdAt, item.id),
+      }),
+    );
   },
 );
 

--- a/apps/api/src/handlers/case-law/decisions/list.ts
+++ b/apps/api/src/handlers/case-law/decisions/list.ts
@@ -7,6 +7,7 @@ import type { ScopedDb } from "@/api/db";
 import { caseLawDecisions } from "@/api/db/schema";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 
 export const listDecisionsQuerySchema = t.Object({
   limit: t.Optional(
@@ -104,12 +105,9 @@ export const listDecisionsHandler = async (
       .limit(limit + 1),
   );
 
-  const hasMore = decisions.length > limit;
-  const items = hasMore ? decisions.slice(0, limit) : decisions;
-  const lastItem = hasMore ? items.at(-1) : null;
-  const nextCursor = lastItem
-    ? `${lastItem.createdAt.toISOString()}_${lastItem.id}`
-    : null;
-
-  return { decisions: items, nextCursor };
+  return createCursorPage({
+    rows: decisions,
+    limit,
+    cursorForItem: (item) => `${item.createdAt.toISOString()}_${item.id}`,
+  });
 };

--- a/apps/api/src/handlers/clauses/read.ts
+++ b/apps/api/src/handlers/clauses/read.ts
@@ -8,6 +8,7 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 
 // ── Cursor helpers ───────────────────────────────────
 
@@ -122,19 +123,17 @@ export const listClausesHandler = async function* ({
     ),
   );
 
-  const hasMore = rows.length > limit;
-  const items = hasMore ? rows.slice(0, limit) : rows;
-  const lastItem = items.at(-1);
   // Cursor pagination is incompatible with rank-based
   // ordering; disable it when searching.
-  const nextCursor =
-    hasMore && lastItem && !isSearching
-      ? encodeCursor(lastItem.createdAt, lastItem.id)
-      : null;
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) => encodeCursor(item.createdAt, item.id),
+  });
 
   return Result.ok({
-    clauses: items,
-    nextCursor,
+    ...page,
+    nextCursor: isSearching ? null : page.nextCursor,
   });
 };
 

--- a/apps/api/src/handlers/contacts/read.ts
+++ b/apps/api/src/handlers/contacts/read.ts
@@ -6,6 +6,7 @@ import { contacts, workspaces } from "@/api/db/schema";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { escapeLike } from "@/api/lib/escape-like";
+import { createCursorPage } from "@/api/lib/pagination";
 import { brandPersistedContactId } from "@/api/lib/safe-id-boundaries";
 
 const DEFAULT_LIMIT = 50;
@@ -77,7 +78,7 @@ const readContacts = createSafeRootHandler(
       }
     }
 
-    const items = yield* Result.await(
+    const rows = yield* Result.await(
       safeDb((tx) =>
         tx
           .select({
@@ -109,15 +110,13 @@ const readContacts = createSafeRootHandler(
       ),
     );
 
-    const hasMore = items.length > limit;
-    const page = hasMore ? items.slice(0, limit) : items;
-    const lastItem = page.at(-1);
-    const nextCursor =
-      hasMore && lastItem
-        ? encodeCursor(lastItem.displayName, lastItem.id)
-        : null;
-
-    return Result.ok({ items: page, nextCursor });
+    return Result.ok(
+      createCursorPage({
+        rows,
+        limit,
+        cursorForItem: (item) => encodeCursor(item.displayName, item.id),
+      }),
+    );
   },
 );
 

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -14,6 +14,7 @@ import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 import {
   tViewFilterConditionSchema,
   tViewSortSchema,
@@ -194,14 +195,13 @@ const readKanbanGroup = createSafeHandler(
       }),
     );
 
-    const hasMore = result.entities.length > limit;
-    const pageEntities = result.entities.slice(0, limit);
-
-    return Result.ok({
-      entities: pageEntities,
-      limit,
-      nextCursor: hasMore ? encodeEntitiesWindowCursor(offset + limit) : null,
-    });
+    return Result.ok(
+      createCursorPage({
+        rows: result.entities,
+        limit,
+        cursorForItem: () => encodeEntitiesWindowCursor(offset + limit),
+      }),
+    );
   },
 );
 

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -119,13 +119,13 @@ describe("entity read handlers", () => {
       }),
     );
 
-    expect("entities" in result).toBe(true);
-    if (!("entities" in result)) {
+    expect("items" in result).toBe(true);
+    if (!("items" in result)) {
       return;
     }
 
-    expect(result.entities).toHaveLength(2);
-    expect(result.entities.at(0)?.fields).toEqual([
+    expect(result.items).toHaveLength(2);
+    expect(result.items.at(0)?.fields).toEqual([
       expect.objectContaining({
         propertyId: "prop_file",
         content: expect.objectContaining({
@@ -178,12 +178,12 @@ describe("entity read handlers", () => {
       }) as Parameters<typeof readKanbanGroup.handler>[0],
     );
 
-    expect("entities" in result).toBe(true);
-    if (!("entities" in result)) {
+    expect("items" in result).toBe(true);
+    if (!("items" in result)) {
       return;
     }
 
-    expect(result.entities).toHaveLength(2);
+    expect(result.items).toHaveLength(2);
     expect(result.limit).toBe(2);
     expect(result.nextCursor).toEqual(expect.any(String));
   });

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -10,6 +10,7 @@ import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 import {
   tViewFilterConditionSchema,
   tViewSortSchema,
@@ -74,14 +75,13 @@ const readEntitiesWindow = createSafeHandler(
       }),
     );
 
-    const hasMore = result.entities.length > limit;
-    const entities = result.entities.slice(0, limit);
-
-    return Result.ok({
-      entities,
-      limit,
-      nextCursor: hasMore ? encodeEntitiesWindowCursor(offset + limit) : null,
-    });
+    return Result.ok(
+      createCursorPage({
+        rows: result.entities,
+        limit,
+        cursorForItem: () => encodeEntitiesWindowCursor(offset + limit),
+      }),
+    );
   },
 );
 

--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCursorPage } from "@/api/lib/pagination";
+
+describe("cursor pagination", () => {
+  test("returns the requested window and a cursor when another row exists", () => {
+    const page = createCursorPage({
+      rows: [{ id: "one" }, { id: "two" }, { id: "three" }],
+      limit: 2,
+      cursorForItem: (item) => item.id,
+    });
+
+    expect(page).toEqual({
+      items: [{ id: "one" }, { id: "two" }],
+      limit: 2,
+      nextCursor: "two",
+    });
+  });
+
+  test("returns a null cursor on the last page", () => {
+    const page = createCursorPage({
+      rows: [{ id: "one" }, { id: "two" }],
+      limit: 2,
+      cursorForItem: (item) => item.id,
+    });
+
+    expect(page).toEqual({
+      items: [{ id: "one" }, { id: "two" }],
+      limit: 2,
+      nextCursor: null,
+    });
+  });
+});

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -1,0 +1,29 @@
+export type Page<T> = {
+  items: T[];
+  nextCursor: string | null;
+  limit: number;
+};
+
+type CursorPageOptions<T> = {
+  rows: readonly T[];
+  limit: number;
+  cursorForItem: (item: T) => string;
+};
+
+export const createCursorPage = <T>({
+  rows,
+  limit,
+  cursorForItem,
+}: CursorPageOptions<T>): Page<T> => {
+  const items = rows.slice(0, limit);
+  const lastItem = items.at(-1);
+
+  return {
+    items,
+    limit,
+    nextCursor:
+      rows.length > limit && lastItem !== undefined
+        ? cursorForItem(lastItem)
+        : null,
+  };
+};

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -7,6 +7,7 @@ export type API = typeof api;
 
 export { toSafeId } from "@/api/lib/branded-types";
 export type { SafeId, SafeIdType } from "@/api/lib/branded-types";
+export type { Page } from "@/api/lib/pagination";
 
 export type PropertyTable = typeof properties.$inferSelect;
 export type PropertyContent = SchemaValidators.PropertyContent;

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -22,15 +22,15 @@ export default defineConfig({
       sidebar: [
         {
           label: "Getting Started",
-          items: [{ autogenerate: { directory: "getting-started" } }],
+          autogenerate: { directory: "getting-started" },
         },
         {
           label: "Guides",
-          items: [{ autogenerate: { directory: "guides" } }],
+          autogenerate: { directory: "guides" },
         },
         {
           label: "Reference",
-          items: [{ autogenerate: { directory: "reference" } }],
+          autogenerate: { directory: "reference" },
         },
       ],
       customCss: ["./src/styles/custom.css"],

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -22,15 +22,15 @@ export default defineConfig({
       sidebar: [
         {
           label: "Getting Started",
-          autogenerate: { directory: "getting-started" },
+          items: [{ autogenerate: { directory: "getting-started" } }],
         },
         {
           label: "Guides",
-          autogenerate: { directory: "guides" },
+          items: [{ autogenerate: { directory: "guides" } }],
         },
         {
           label: "Reference",
-          autogenerate: { directory: "reference" },
+          items: [{ autogenerate: { directory: "reference" } }],
         },
       ],
       customCss: ["./src/styles/custom.css"],

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -120,12 +120,7 @@ export const SourceChips = ({
   }
 
   return (
-    <div
-      className={cn(
-        "flex max-w-full flex-nowrap gap-1 overflow-x-auto pb-1",
-        "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
-      )}
-    >
+    <div className="flex max-w-full [scrollbar-width:none] flex-nowrap gap-1 overflow-x-auto pb-1 [&::-webkit-scrollbar]:hidden">
       {uniqueSources.map((part) => (
         <SourceChip
           key={`${messageId}-source-${part.id ?? part.data.entityId}`}

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -396,10 +396,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto",
-        "group-data-[collapsible=icon]:gap-0",
-        "group-data-[collapsible=icon]:[scrollbar-width:none]",
-        "group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto group-data-[collapsible=icon]:[scrollbar-width:none] group-data-[collapsible=icon]:gap-0 group-data-[collapsible=icon]:[&::-webkit-scrollbar]:hidden",
         className,
       )}
       data-sidebar="content"

--- a/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
@@ -68,8 +68,7 @@ export const LinkClauseDialog = ({
 
   const categories =
     catData && "categories" in catData ? catData.categories : [];
-  const clauses =
-    clauseData && "clauses" in clauseData ? clauseData.clauses : [];
+  const clauses = clauseData && "items" in clauseData ? clauseData.items : [];
 
   const filtered = clauses.filter((c) => {
     if (selectedCategory && c.categoryId !== selectedCategory) {

--- a/apps/web/src/routes/_protected.knowledge/case/-queries/decisions.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-queries/decisions.ts
@@ -132,7 +132,8 @@ export const decisionsInfiniteOptions = (filters: DecisionListFilters = {}) =>
       }
 
       const facets: SearchFacets = null;
-      return { ...response.data, facets };
+      const { items, ...page } = response.data;
+      return { ...page, decisions: items, facets };
     },
     // SAFETY: TanStack Query needs the initial param typed as
     // string | null; `null` alone infers `null`.

--- a/apps/web/src/routes/_protected.knowledge/clauses.tsx
+++ b/apps/web/src/routes/_protected.knowledge/clauses.tsx
@@ -39,7 +39,7 @@ type ClauseListData = Exclude<
   Response
 >;
 
-type ClauseItem = ClauseListData["clauses"][number];
+type ClauseItem = ClauseListData["items"][number];
 
 // ── View discriminated union ─────────────────────────
 
@@ -91,7 +91,7 @@ function RouteComponent() {
       : [];
 
   const initialClauses: ClauseItem[] =
-    clausesData && "clauses" in clausesData ? clausesData.clauses : [];
+    clausesData && "items" in clausesData ? clausesData.items : [];
 
   const initialNextCursor =
     clausesData && "nextCursor" in clausesData ? clausesData.nextCursor : null;
@@ -185,7 +185,7 @@ function RouteComponent() {
         return;
       }
 
-      setExtraClauses((prev) => [...prev, ...data.clauses]);
+      setExtraClauses((prev) => [...prev, ...data.items]);
       setNextCursor(data.nextCursor);
     } finally {
       if (!controller.signal.aborted) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -957,8 +957,7 @@ const TypeChipsRow = ({
     <div className="flex flex-col gap-1.5">
       <div
         className={cn(
-          "flex items-center gap-1 overflow-x-auto",
-          "[scrollbar-width:none]",
+          "flex [scrollbar-width:none] items-center gap-1 overflow-x-auto",
           showSeparator && "border-t pt-2",
         )}
       >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -191,14 +191,7 @@ export const ViewSwitcher = ({
   };
 
   return (
-    <div
-      className={cn(
-        "flex min-w-0 flex-1 items-center gap-1 overflow-x-auto px-2",
-        "[-ms-overflow-style:none]",
-        "[scrollbar-width:none]",
-        "[&::-webkit-scrollbar]:hidden",
-      )}
-    >
+    <div className="flex min-w-0 flex-1 [scrollbar-width:none] items-center gap-1 overflow-x-auto px-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
       <Tabs value={activeViewId}>
         <TabsList variant="underline">
           {views.map((view) => {
@@ -412,7 +405,7 @@ const ViewTab = ({
       {isActive && (canUpdateView || canCreateView || canDeleteView) && (
         <ViewTabMenu
           canDelete={canDelete}
-          className={cn("absolute", "inset-e-0 top-1/2 -translate-y-1/2")}
+          className="absolute inset-e-0 top-1/2 -translate-y-1/2"
           onRename={() => {
             setIsRenaming(true);
             setRenameValue(name);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -170,7 +170,7 @@ export const entitiesWindowOptions = (key: EntitiesWindowOptionsInput) =>
         throw toAPIError(response.error);
       }
 
-      const { entities: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = response.data;
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };
@@ -249,7 +249,7 @@ export const kanbanGroupOptions = (key: KanbanGroupOptionsInput) =>
         throw toAPIError(response.error);
       }
 
-      const { entities: rawEntities, ...rest } = response.data;
+      const { items: rawEntities, ...rest } = response.data;
       const entities: WorkspaceEntity[] = rawEntities.map(toWorkspaceEntity);
 
       return { ...rest, entities };

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -187,6 +187,7 @@ export default defineConfig({
     "./.oxlint-plugins/security-guards.ts",
     "./.oxlint-plugins/no-unbranded-ownership-id-param.ts",
     "./.oxlint-plugins/no-raw-user-id-schema.ts",
+    "./.oxlint-plugins/no-offset-pagination.ts",
     "./.oxlint-plugins/mcp-security.ts",
     "./.oxlint-plugins/stella-toast.ts",
   ],
@@ -725,6 +726,21 @@ export default defineConfig({
       rules: {
         "no-body-ownership-ids/no-body-ownership-ids": "error",
         "no-raw-user-id-schema/no-raw-user-id-schema": "error",
+        "no-offset-pagination/no-offset-pagination": [
+          "error",
+          {
+            // Existing bounded billing/admin lists. Keep explicit while
+            // these endpoints are migrated or deliberately retained.
+            allowedFiles: [
+              "apps/api/src/handlers/invoices/read.ts",
+              "apps/api/src/handlers/time-entries/read.ts",
+              "apps/api/src/handlers/expenses/read.ts",
+              "apps/api/src/handlers/billing-codes/read.ts",
+              "apps/api/src/handlers/rates/read.ts",
+              "apps/api/src/handlers/rates/entries-read.ts",
+            ],
+          },
+        ],
         "no-untyped-updates/no-untyped-updates": "error",
         "security-guards/no-unscoped-user-query": "warn",
         "no-restricted-imports": [

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -738,6 +738,7 @@ export default defineConfig({
               "apps/api/src/handlers/billing-codes/read.ts",
               "apps/api/src/handlers/rates/read.ts",
               "apps/api/src/handlers/rates/entries-read.ts",
+              "apps/api/src/handlers/skills/list.ts",
             ],
           },
         ],


### PR DESCRIPTION
## Summary
- add a shared cursor pagination Page<T> envelope and helper
- migrate existing cursor-backed list endpoints to return items, nextCursor, and limit
- add an oxlint guardrail for new offset pagination with explicit legacy exceptions