### PR TITLE
fix(chat): guard chat editor against use-after-destroy

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -59,6 +59,7 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { useChatComposerWiring } from "@/components/chat-editor-provider";
 import type { ChatEditorController } from "@/components/chat-editor-provider";
 import { PromptEditorContent } from "@/components/prompt-editor";
 
@@ -1153,8 +1154,7 @@ export function PromptBar(props: PromptBarProps) {
   } = props;
 
   const t = useTranslations();
-  const { editor, canSubmit, isEmpty, submit, setSubmitHandler } =
-    editorController;
+  const { canSubmit, editor, isEmpty } = editorController;
 
   const isGenerating = status === "generating";
   const busy = isGenerating || status === "applying";
@@ -1189,36 +1189,23 @@ export function PromptBar(props: PromptBarProps) {
     };
   }, [attentionPulseSeq]);
 
-  // Wrap controller.submit so the host's `onSubmit` is the only
-  // outbound channel; the editor's draft (HTML) becomes the prompt.
-  const submitDraft = useCallback(async () => {
-    if (submitDisabled) {
-      return;
-    }
-    if (canSubmitNow && !canSubmitNow()) {
-      return;
-    }
-    await submit((draft) => {
+  // The bar emits `{ prompt }`; the underlying composer emits the
+  // raw editor draft. Adapting here lets the rest of the wiring
+  // (Enter handler, blur/setEditable, submit gating) stay shared.
+  const handleComposerSubmit = useCallback(
+    (draft: { html: string }) => {
       onSubmit({ prompt: draft.html });
-    });
-  }, [canSubmitNow, onSubmit, submit, submitDisabled]);
+    },
+    [onSubmit],
+  );
 
-  // Register Enter handler — TipTap's keymap delegates Enter to
-  // the `setSubmitHandler` registered here. Without this, Enter
-  // inserts a newline.
-  useEffect(() => {
-    setSubmitHandler(submitDraft);
-    return () => {
-      setSubmitHandler(null);
-    };
-  }, [setSubmitHandler, submitDraft]);
-
-  useEffect(() => {
-    editor?.setEditable(!inputDisabled);
-    if (inputDisabled) {
-      editor?.commands.blur();
-    }
-  }, [editor, inputDisabled]);
+  const { submitDraft } = useChatComposerWiring({
+    controller: editorController,
+    inputDisabled,
+    onSubmit: handleComposerSubmit,
+    onSubmitGuard: canSubmitNow,
+    submitDisabled,
+  });
 
   return (
     <PromptBarShell

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -202,6 +202,9 @@ const areDocsEqual = (left: JSONContent, right: JSONContent) =>
 const getEditorHtml = (editor: Editor) =>
   editor.isEmpty ? "" : editor.getHTML().trim();
 
+const isUsableEditor = (editor: Editor | null | undefined): editor is Editor =>
+  editor !== null && editor !== undefined && !editor.isDestroyed;
+
 const isSelectionAtStart = ({ selection }: EditorState) =>
   selection.empty && selection.from <= 1;
 
@@ -904,10 +907,14 @@ export const useChatEditor = ({
   );
 
   useEffect(() => {
+    if (!isUsableEditor(editor)) {
+      return undefined;
+    }
+
     syncEditorPlugins(editor);
 
     return () => {
-      if (activePluginKeysRef.current.length === 0) {
+      if (editor.isDestroyed || activePluginKeysRef.current.length === 0) {
         return;
       }
 
@@ -917,29 +924,30 @@ export const useChatEditor = ({
   }, [editor, extensionVersion, syncEditorPlugins]);
 
   useEffect(() => {
-    if (editor.isDestroyed) {
-      return;
+    if (!isUsableEditor(editor)) {
+      return undefined;
     }
     if (areDocsEqual(editor.getJSON(), draftDoc)) {
       setIsEmpty(editor.isEmpty);
-      return;
+      return undefined;
     }
 
     isApplyingStoredDraftRef.current = true;
     editor.commands.setContent(draftDoc);
     isApplyingStoredDraftRef.current = false;
     setIsEmpty(editor.isEmpty);
+    return undefined;
   }, [draftDoc, editor]);
 
   const focus = useCallback(() => {
-    if (editor.isDestroyed) {
+    if (!isUsableEditor(editor)) {
       return;
     }
     editor.commands.focus("end");
   }, [editor]);
 
   const blur = useCallback(() => {
-    if (editor.isDestroyed) {
+    if (!isUsableEditor(editor)) {
       return;
     }
     editor.commands.blur();
@@ -947,7 +955,7 @@ export const useChatEditor = ({
 
   const setEditable = useCallback(
     (editable: boolean) => {
-      if (editor.isDestroyed) {
+      if (!isUsableEditor(editor)) {
         return;
       }
       editor.setEditable(editable);
@@ -957,7 +965,7 @@ export const useChatEditor = ({
 
   const setContent = useCallback(
     (content: Parameters<Editor["commands"]["setContent"]>[0]) => {
-      if (editor.isDestroyed) {
+      if (!isUsableEditor(editor)) {
         return;
       }
       editor.commands.setContent(content);
@@ -967,6 +975,10 @@ export const useChatEditor = ({
 
   const insertMention = useCallback(
     (mention: ChatMentionOption) => {
+      if (!isUsableEditor(editor)) {
+        return;
+      }
+
       markDraftStarted();
       editor
         .chain()
@@ -1000,6 +1012,10 @@ export const useChatEditor = ({
 
   const updateAttachments = useCallback(
     (nextAttachments: ChatDraftAttachment[]) => {
+      if (!isUsableEditor(editor)) {
+        return;
+      }
+
       const doc = editor.getJSON();
 
       setDraft(
@@ -1118,7 +1134,7 @@ export const useChatEditor = ({
 
   const submit = useCallback(
     async (send: (draft: ChatInputDraft) => Promise<void> | void) => {
-      if (editor.isDestroyed) {
+      if (!isUsableEditor(editor)) {
         return;
       }
       const html = editor.isEmpty ? "" : editor.getHTML().trim();
@@ -1145,8 +1161,6 @@ export const useChatEditor = ({
           }),
         );
         // The editor may have been destroyed during `await send(...)`;
-        // TS narrowing from the earlier guard does not survive the await.
-        // eslint-disable-next-line typescript-eslint/no-unnecessary-condition
         if (!editor.isDestroyed) {
           isApplyingStoredDraftRef.current = true;
           editor.commands.setContent(doc);

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -131,7 +131,15 @@ type ActiveChatEditorHandle = {
 
 export type ChatEditorController = {
   attachments: ChatDraftAttachment[];
+  blur: () => void;
   canSubmit: boolean;
+  /**
+   * Read-only TipTap handle. TipTap nulls `commandManager` on destroy, so
+   * any `editor.commands.*` access after teardown throws. Always narrow
+   * with `editor.isDestroyed`, or prefer the controller's mutation
+   * helpers (`blur`, `setEditable`, `setContent`, ...) which already
+   * guard against the destroyed state.
+   */
   editor: Editor | null;
   fileInputAccept: string;
   fileInputRef: React.RefObject<HTMLInputElement | null>;
@@ -143,6 +151,10 @@ export type ChatEditorController = {
   isEmpty: boolean;
   openFilePicker: () => void;
   removeFile: (id: string) => void;
+  setContent: (
+    content: Parameters<Editor["commands"]["setContent"]>[0],
+  ) => void;
+  setEditable: (editable: boolean) => void;
   setSubmitHandler: (handler: (() => Promise<void>) | null) => void;
   submit: (
     send: (draft: ChatInputDraft) => Promise<void> | void,
@@ -375,6 +387,67 @@ export const useChatEditorManager = () => {
   }
 
   return context;
+};
+
+type UseChatComposerWiringOptions = {
+  controller: ChatEditorController;
+  inputDisabled: boolean;
+  onSubmit: (draft: ChatInputDraft) => Promise<void> | void;
+  /**
+   * Pre-submit gate. Return `false` to abort the submit (e.g. when a
+   * file-aware caller wants to block until a DOCX snapshot is ready).
+   * Returning `true` or `undefined` lets the submit proceed.
+   */
+  onSubmitGuard?: (() => boolean | undefined) | undefined;
+  submitDisabled: boolean;
+};
+
+/**
+ * Wires the three effects every chat-composer surface needs:
+ *   1. an Enter→submit handler registered with the controller,
+ *   2. `setEditable`/`blur` synced to `inputDisabled`,
+ *   3. a `submitDraft` callback that respects the disabled gate.
+ *
+ * New composer surfaces should consume this hook rather than
+ * re-implementing the effects: the wiring lives next to the editor
+ * itself, so the use-after-destroy hazard is centrally guarded.
+ */
+export const useChatComposerWiring = ({
+  controller,
+  inputDisabled,
+  onSubmit,
+  onSubmitGuard,
+  submitDisabled,
+}: UseChatComposerWiringOptions) => {
+  const { blur, setEditable, setSubmitHandler, submit } = controller;
+
+  const submitDraft = useCallback(async () => {
+    if (submitDisabled) {
+      return;
+    }
+    if (onSubmitGuard && onSubmitGuard() === false) {
+      return;
+    }
+    await submit(async (draft) => {
+      await onSubmit(draft);
+    });
+  }, [onSubmit, onSubmitGuard, submit, submitDisabled]);
+
+  useEffect(() => {
+    setSubmitHandler(submitDraft);
+    return () => {
+      setSubmitHandler(null);
+    };
+  }, [setSubmitHandler, submitDraft]);
+
+  useEffect(() => {
+    setEditable(!inputDisabled);
+    if (inputDisabled) {
+      blur();
+    }
+  }, [blur, inputDisabled, setEditable]);
+
+  return { submitDraft };
 };
 
 export const useChatEditor = ({
@@ -844,6 +917,9 @@ export const useChatEditor = ({
   }, [editor, extensionVersion, syncEditorPlugins]);
 
   useEffect(() => {
+    if (editor.isDestroyed) {
+      return;
+    }
     if (areDocsEqual(editor.getJSON(), draftDoc)) {
       setIsEmpty(editor.isEmpty);
       return;
@@ -856,8 +932,38 @@ export const useChatEditor = ({
   }, [draftDoc, editor]);
 
   const focus = useCallback(() => {
+    if (editor.isDestroyed) {
+      return;
+    }
     editor.commands.focus("end");
   }, [editor]);
+
+  const blur = useCallback(() => {
+    if (editor.isDestroyed) {
+      return;
+    }
+    editor.commands.blur();
+  }, [editor]);
+
+  const setEditable = useCallback(
+    (editable: boolean) => {
+      if (editor.isDestroyed) {
+        return;
+      }
+      editor.setEditable(editable);
+    },
+    [editor],
+  );
+
+  const setContent = useCallback(
+    (content: Parameters<Editor["commands"]["setContent"]>[0]) => {
+      if (editor.isDestroyed) {
+        return;
+      }
+      editor.commands.setContent(content);
+    },
+    [editor],
+  );
 
   const insertMention = useCallback(
     (mention: ChatMentionOption) => {
@@ -1012,6 +1118,9 @@ export const useChatEditor = ({
 
   const submit = useCallback(
     async (send: (draft: ChatInputDraft) => Promise<void> | void) => {
+      if (editor.isDestroyed) {
+        return;
+      }
       const html = editor.isEmpty ? "" : editor.getHTML().trim();
       const doc = editor.getJSON();
       const files = attachmentsRef.current;
@@ -1035,12 +1144,17 @@ export const useChatEditor = ({
             doc,
           }),
         );
-        isApplyingStoredDraftRef.current = true;
-        editor.commands.setContent(doc);
-        isApplyingStoredDraftRef.current = false;
-        setIsEmpty(editor.isEmpty);
-        if (!editor.isEmpty || files.length > 0) {
-          draftStartedThreadKeyRef.current = threadKey;
+        // The editor may have been destroyed during `await send(...)`;
+        // TS narrowing from the earlier guard does not survive the await.
+        // eslint-disable-next-line typescript-eslint/no-unnecessary-condition
+        if (!editor.isDestroyed) {
+          isApplyingStoredDraftRef.current = true;
+          editor.commands.setContent(doc);
+          isApplyingStoredDraftRef.current = false;
+          setIsEmpty(editor.isEmpty);
+          if (!editor.isEmpty || files.length > 0) {
+            draftStartedThreadKeyRef.current = threadKey;
+          }
         }
         throw error;
       }
@@ -1059,6 +1173,7 @@ export const useChatEditor = ({
 
   return {
     attachments,
+    blur,
     canSubmit,
     editor,
     fileInputAccept: CHAT_FILE_INPUT_ACCEPT,
@@ -1071,6 +1186,8 @@ export const useChatEditor = ({
     isEmpty,
     openFilePicker,
     removeFile,
+    setContent,
+    setEditable,
     setSubmitHandler,
     submit,
   };

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useChatComposerWiring } from "@/components/chat-editor-provider";
 import type {
   ChatEditorController,
   ChatInputDraft,
@@ -67,32 +68,20 @@ export const ChatInputSurface = ({
     isEmpty,
     openFilePicker,
     removeFile,
-    setSubmitHandler,
-    submit,
   } = controller;
   const inputDisabled = disabled;
+  // While the assistant is streaming we render Stop in place of Send,
+  // but Enter still calls submit unless we gate it here. Without this
+  // guard, a user pressing Enter during a turn fires an overlapping
+  // `sendMessage` and the two responses interleave.
   const submitDisabled = disabled || isGenerating;
 
-  const submitDraft = useCallback(async () => {
-    // While the assistant is streaming we render Stop in place of
-    // Send, but Enter still calls submit unless we gate it here.
-    // Without this guard, a user pressing Enter during a turn fires
-    // an overlapping `sendMessage` and the two responses interleave.
-    if (submitDisabled) {
-      return;
-    }
-
-    await submit(async (draft) => {
-      await onSubmit(draft);
-    });
-  }, [onSubmit, submit, submitDisabled]);
-
-  useEffect(() => {
-    setSubmitHandler(submitDraft);
-    return () => {
-      setSubmitHandler(null);
-    };
-  }, [setSubmitHandler, submitDraft]);
+  const { submitDraft } = useChatComposerWiring({
+    controller,
+    inputDisabled,
+    onSubmit,
+    submitDisabled,
+  });
 
   useEffect(() => {
     if (!autoFocus) {
@@ -101,13 +90,6 @@ export const ChatInputSurface = ({
 
     focus();
   }, [autoFocus, focus]);
-
-  useEffect(() => {
-    editor?.setEditable(!inputDisabled);
-    if (inputDisabled) {
-      editor?.commands.blur();
-    }
-  }, [editor, inputDisabled]);
 
   const handleFocus = useCallback(() => {
     onFocusChange?.(true);

--- a/apps/web/src/components/prompt-editor.tsx
+++ b/apps/web/src/components/prompt-editor.tsx
@@ -84,7 +84,7 @@ const syncNativeSelection = (editor: Editor, from: number, to: number) => {
 };
 
 export const selectPromptEditorContents = (editor: Editor | null): boolean => {
-  if (editor === null) {
+  if (editor === null || editor.isDestroyed) {
     return false;
   }
 

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -166,12 +166,8 @@ export const ChatThreadPage = ({
   };
 
   const selectPrompt = (prompt: ChatPrompt) => {
-    const editor = controller.editor;
-    if (!editor) {
-      return;
-    }
-    editor.commands.setContent(prompt.body);
-    editor.commands.focus("end");
+    controller.setContent(prompt.body);
+    controller.focus();
   };
   const sendWithoutAnonymization = useEffectEvent(async () => {
     await resendLatestMessage({ sendMode: CHAT_SEND_MODE.rawOverride });

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -165,12 +165,8 @@ function ChatIndex() {
   }, [groupedThreads]);
 
   const selectPrompt = (prompt: ChatPrompt) => {
-    const editor = controller.editor;
-    if (!editor) {
-      return;
-    }
-    editor.commands.setContent(prompt.body);
-    editor.commands.focus("end");
+    controller.setContent(prompt.body);
+    controller.focus();
   };
 
   const moveToSide = () => {

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -9,7 +9,7 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
 import { EditorContent, useEditor } from "@tiptap/react";
-import type { JSONContent } from "@tiptap/react";
+import type { Editor, JSONContent } from "@tiptap/react";
 import {
   BoldIcon,
   Heading1Icon,
@@ -22,6 +22,9 @@ import { Button } from "@stll/ui/components/button";
 
 import "./clause-editor.css";
 import type { ClauseParagraph, ClauseRun } from "./clause-editor-types";
+
+const isUsableEditor = (editor: Editor | null | undefined): editor is Editor =>
+  editor !== null && editor !== undefined && !editor.isDestroyed;
 
 // ── Conversion: ClauseBody → TipTap JSON ────────────
 
@@ -143,28 +146,42 @@ export const ClauseEditor = ({
 
   // Sync content when the dialog resets
   const contentKey = content.map((p) => p.text).join("\n");
+  const editorReady = isUsableEditor(editor);
 
   useEffect(() => {
-    if (editor.isDestroyed) {
-      return;
+    if (!isUsableEditor(editor)) {
+      return undefined;
     }
     const currentText = editor.getText();
     if (currentText !== contentKey) {
       editor.commands.setContent(clauseBodyToTipTap(content));
     }
+    return undefined;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- editor and content are stable refs; only re-sync when contentKey changes
   }, [contentKey]);
 
   const toggleBold = useCallback(() => {
+    if (!isUsableEditor(editor)) {
+      return;
+    }
+
     editor.chain().focus().toggleBold().run();
   }, [editor]);
 
   const toggleItalic = useCallback(() => {
+    if (!isUsableEditor(editor)) {
+      return;
+    }
+
     editor.chain().focus().toggleItalic().run();
   }, [editor]);
 
   const toggleHeading = useCallback(
     (level: 1 | 2 | 3) => {
+      if (!isUsableEditor(editor)) {
+        return;
+      }
+
       editor.chain().focus().toggleHeading({ level }).run();
     },
     [editor],
@@ -185,7 +202,10 @@ export const ClauseEditor = ({
       {/* Toolbar */}
       <div className="flex items-center gap-0.5 border-b px-1 py-0.5">
         <Button
-          className={editor.isActive("bold") ? "bg-muted" : undefined}
+          className={
+            editorReady && editor.isActive("bold") ? "bg-muted" : undefined
+          }
+          disabled={!editorReady}
           onClick={toggleBold}
           size="icon-xs"
           type="button"
@@ -194,7 +214,10 @@ export const ClauseEditor = ({
           <BoldIcon className="size-3.5" />
         </Button>
         <Button
-          className={editor.isActive("italic") ? "bg-muted" : undefined}
+          className={
+            editorReady && editor.isActive("italic") ? "bg-muted" : undefined
+          }
+          disabled={!editorReady}
           onClick={toggleItalic}
           size="icon-xs"
           type="button"
@@ -205,8 +228,11 @@ export const ClauseEditor = ({
         <div className="bg-border mx-1 h-4 w-px" />
         <Button
           className={
-            editor.isActive("heading", { level: 1 }) ? "bg-muted" : undefined
+            editorReady && editor.isActive("heading", { level: 1 })
+              ? "bg-muted"
+              : undefined
           }
+          disabled={!editorReady}
           onClick={() => toggleHeading(1)}
           size="icon-xs"
           type="button"
@@ -216,8 +242,11 @@ export const ClauseEditor = ({
         </Button>
         <Button
           className={
-            editor.isActive("heading", { level: 2 }) ? "bg-muted" : undefined
+            editorReady && editor.isActive("heading", { level: 2 })
+              ? "bg-muted"
+              : undefined
           }
+          disabled={!editorReady}
           onClick={() => toggleHeading(2)}
           size="icon-xs"
           type="button"
@@ -227,8 +256,11 @@ export const ClauseEditor = ({
         </Button>
         <Button
           className={
-            editor.isActive("heading", { level: 3 }) ? "bg-muted" : undefined
+            editorReady && editor.isActive("heading", { level: 3 })
+              ? "bg-muted"
+              : undefined
           }
+          disabled={!editorReady}
           onClick={() => toggleHeading(3)}
           size="icon-xs"
           type="button"

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-editor.tsx
@@ -145,6 +145,9 @@ export const ClauseEditor = ({
   const contentKey = content.map((p) => p.text).join("\n");
 
   useEffect(() => {
+    if (editor.isDestroyed) {
+      return;
+    }
     const currentText = editor.getText();
     if (currentText !== contentKey) {
       editor.commands.setContent(clauseBodyToTipTap(content));

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -230,12 +230,8 @@ export const ChatTabPanel = ({
 
   const savedPrompts = useSavedPrompts();
   const handleSelectPrompt = (prompt: ChatPrompt) => {
-    const editor = editorController.editor;
-    if (!editor) {
-      return;
-    }
-    editor.commands.setContent(prompt.body);
-    editor.commands.focus("end");
+    editorController.setContent(prompt.body);
+    editorController.focus();
   };
 
   // Inline rename — same UX as file tabs.


### PR DESCRIPTION
## Summary
- TipTap nulls `commandManager` on `destroy()`, so any `editor.commands.*` access after teardown throws `Cannot read properties of null (reading 'commands')`. Two effects in `host.tsx` and `chat-input-surface.tsx` triggered this when `inputDisabled` flipped during the unmount-race window. Guard at the `ChatEditorController` boundary: add `blur`, `setEditable`, `setContent` wrappers that check `isDestroyed`, plus internal guards in `focus`, `submit`, and the draft-sync effect.
- Extract `useChatComposerWiring` so `ChatInputSurface` (full chat) and `PromptBar` (overlay, inspector) share submit-handler registration, the editable/blur sync, and the disabled-gated `submitDraft` callback. The duplication is what let the same bug ship in two places.
- Route remaining `.commands.*` callsites (`chat-tab-panel`, `chat-thread-page`, `chat/index`) through the safe wrappers; add `isDestroyed` guards in `clause-editor` and `prompt-editor`.

## Test plan
- [x] `bun --filter @stll/web typecheck`
- [x] `bun --filter @stll/web lint`
- [x] `bun --filter @stll/web test` (352 pass)
- [ ] Open peek with AI overlay, flip `sendDisabledReason` repeatedly, confirm no console errors.
- [ ] Switch chat threads on `/chat` and toggle the inspector chat tab, confirm composer mounts/unmounts cleanly.