### PR TITLE
fix: require desktop edit event token

### DIFF
--- a/apps/api/src/handlers/entities/desktop-edit-session-events.test.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+const authorizeDesktopEditSessionMock = mock();
+const readDesktopEditSessionEventStateMock = mock();
+
+void mock.module("@/api/lib/desktop-edit-sessions", () => ({
+  authorizeDesktopEditSession: authorizeDesktopEditSessionMock,
+  DESKTOP_EDIT_SESSION_TAKEN_OVER_CODE: "desktop_edit_session_taken_over",
+  DESKTOP_EDIT_SESSION_TAKEN_OVER_MESSAGE:
+    "Desktop editing moved to another device. This local copy is preserved.",
+  readDesktopEditSessionEventState: readDesktopEditSessionEventStateMock,
+}));
+
+const { desktopEditSessionEventsHandler } =
+  await import("@/api/handlers/entities/desktop-edit-session-events");
+
+const sessionId = toSafeId<"desktopEditSession">(
+  "019aa0bc-d957-7bb3-9234-9c2440377225",
+);
+
+describe("desktop edit session events", () => {
+  beforeEach(() => {
+    authorizeDesktopEditSessionMock.mockReset();
+    readDesktopEditSessionEventStateMock.mockReset();
+  });
+
+  test("rejects missing tokens before reading session state", async () => {
+    const response = await desktopEditSessionEventsHandler({
+      headers: {},
+      query: {},
+      sessionId,
+    });
+
+    expect(authorizeDesktopEditSessionMock).not.toHaveBeenCalled();
+    expect(readDesktopEditSessionEventStateMock).not.toHaveBeenCalled();
+    expect(response).toHaveProperty("code", 401);
+    expect(response).toHaveProperty(
+      "response.code",
+      "desktop_edit_session_token_missing",
+    );
+  });
+});

--- a/apps/api/src/handlers/entities/desktop-edit-session-events.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.ts
@@ -100,44 +100,42 @@ export const desktopEditSessionEventsHandler = async ({
 }: DesktopEditSessionEventsHandlerProps) => {
   const sessionToken = getSessionToken({ authorization, legacySessionToken });
 
-  if (authorization || legacySessionToken) {
-    if (!sessionToken) {
-      return status(401, {
-        code: "desktop_edit_session_token_missing",
-        message: "Desktop edit session token missing or malformed.",
-      });
-    }
-
-    const authorized = await authorizeDesktopEditSession({
-      sessionId,
-      sessionToken,
+  if (!sessionToken) {
+    return status(401, {
+      code: "desktop_edit_session_token_missing",
+      message: "Desktop edit session token missing or malformed.",
     });
+  }
 
-    if (authorized.status === "missing") {
-      return status(404, {
-        message: "Desktop edit session not found.",
-      });
-    }
-    if (authorized.status === "token-mismatch") {
-      return status(409, {
-        code: DESKTOP_EDIT_SESSION_TAKEN_OVER_CODE,
-        message: DESKTOP_EDIT_SESSION_TAKEN_OVER_MESSAGE,
-      });
-    }
-    if (authorized.status === "token-expired") {
-      return status(401, {
-        code: "desktop_edit_session_token_expired",
-        message:
-          "Desktop edit session token has expired. Reopen the document from stella.",
-      });
-    }
-    if (authorized.status === "permission-revoked") {
-      return status(403, {
-        code: "desktop_edit_session_permission_revoked",
-        message:
-          "Desktop edit permission was revoked. Reopen the document from stella.",
-      });
-    }
+  const authorized = await authorizeDesktopEditSession({
+    sessionId,
+    sessionToken,
+  });
+
+  if (authorized.status === "missing") {
+    return status(404, {
+      message: "Desktop edit session not found.",
+    });
+  }
+  if (authorized.status === "token-mismatch") {
+    return status(409, {
+      code: DESKTOP_EDIT_SESSION_TAKEN_OVER_CODE,
+      message: DESKTOP_EDIT_SESSION_TAKEN_OVER_MESSAGE,
+    });
+  }
+  if (authorized.status === "token-expired") {
+    return status(401, {
+      code: "desktop_edit_session_token_expired",
+      message:
+        "Desktop edit session token has expired. Reopen the document from stella.",
+    });
+  }
+  if (authorized.status === "permission-revoked") {
+    return status(403, {
+      code: "desktop_edit_session_permission_revoked",
+      message:
+        "Desktop edit permission was revoked. Reopen the document from stella.",
+    });
   }
 
   const eventState = await readDesktopEditSessionEventState(sessionId);


### PR DESCRIPTION
## Summary
- Require desktop edit event streams to present a valid session token before session state is read or a stream is opened.
- Add regression coverage for missing-token event stream requests.

## Validation
- bun --filter @stll/api test src/handlers/entities/desktop-edit-session-events.test.ts
- bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --type-aware apps/api/src/handlers/entities/desktop-edit-session-events.ts apps/api/src/handlers/entities/desktop-edit-session-events.test.ts
- bunx oxfmt --check apps/api/src/handlers/entities/desktop-edit-session-events.ts apps/api/src/handlers/entities/desktop-edit-session-events.test.ts
- bun --filter @stll/api typecheck
- pre-push hook: format, i18n, lint, typecheck