### PR TITLE
refactor(ai-suggestions): make AssistantThreadMessage a discriminated union

### DIFF
--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -545,7 +545,10 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
           );
         }
         updateAssistantMessage(assistantId, (m) => ({
-          ...m,
+          id: m.id,
+          role: "assistant",
+          mode: m.mode,
+          createdAt: m.createdAt,
           status: "complete",
           text: response.text ?? "",
           suggestions: anchored,
@@ -556,7 +559,13 @@ export function FileAIChatHost(props: FileAIChatHostProps) {
           return;
         }
         updateAssistantMessage(assistantId, (m) => ({
-          ...m,
+          id: m.id,
+          role: "assistant",
+          mode: m.mode,
+          createdAt: m.createdAt,
+          text: m.text,
+          suggestions: m.suggestions,
+          citations: m.citations,
           status: "error",
           error: error instanceof Error ? error.message : "Generation failed",
         }));
@@ -1659,9 +1668,7 @@ function AssistantBubble(props: AssistantBubbleProps) {
           </span>
         )}
         {message.status === "error" && (
-          <span className="text-destructive text-[12px]">
-            {message.error ?? "Something went wrong."}
-          </span>
+          <span className="text-destructive text-[12px]">{message.error}</span>
         )}
         {message.text && message.text.length > 0 && (
           <MessageResponse className="text-[13px] leading-relaxed [&_p]:my-0">

--- a/apps/web/src/components/ai-suggestions/types.ts
+++ b/apps/web/src/components/ai-suggestions/types.ts
@@ -50,7 +50,7 @@ export type UserThreadMessage = {
   createdAt: number;
 };
 
-export type AssistantThreadMessage = {
+type AssistantThreadMessageCommon = {
   id: ThreadMessageId;
   role: "assistant";
   /** Markdown-flavoured response. May be empty when the message is suggestions-only. */
@@ -61,11 +61,16 @@ export type AssistantThreadMessage = {
   citations: AICitation[];
   /** Mode that produced the response (mirrors the user message). */
   mode: AIChatMode;
-  status: "loading" | "complete" | "error";
-  /** Populated when status === "error". */
-  error?: string;
   createdAt: number;
 };
+
+type AssistantThreadMessageState =
+  | { status: "loading" }
+  | { status: "complete" }
+  | { status: "error"; error: string };
+
+export type AssistantThreadMessage = AssistantThreadMessageCommon &
+  AssistantThreadMessageState;
 
 export type ThreadMessage = UserThreadMessage | AssistantThreadMessage;
 


### PR DESCRIPTION
Split status-specific fields into a tagged union so \`error\` only exists when \`status === "error"\`. Drops the unreachable \`?? "Something went wrong."\` fallback.

## Test plan
- [x] \`bun --filter @stll/web typecheck\`
- [x] \`bun --filter @stll/web lint\`
- [x] \`bun --filter @stll/web test\`