### PR TITLE
refactor(case-viewer): tighten AnalysisResponse discriminated union

### DIFF
--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -24,9 +24,9 @@ type AnalysisState =
   | { status: "error"; message: string };
 
 type AnalysisResponse =
-  | { status: "done"; analysis?: unknown }
-  | { status: "error"; error?: string }
-  | { status: "generating"; analysis?: unknown };
+  | { status: "done"; analysis: DecisionAnalysis }
+  | { status: "generating"; tree: DecisionAnalysis["tree"] }
+  | { status: "error"; error: string };
 
 const POLL_INTERVAL_MS = 2000;
 
@@ -38,22 +38,27 @@ const parseAnalysisResponse = (value: unknown): AnalysisResponse | null => {
     return null;
   }
 
-  if (value["status"] === "done" || value["status"] === "generating") {
+  const status = value["status"];
+
+  if (status === "done") {
+    const analysis = value["analysis"];
+    return isDecisionAnalysis(analysis) ? { status: "done", analysis } : null;
+  }
+
+  if (status === "generating") {
+    const analysis = value["analysis"];
     return {
-      status: value["status"],
-      analysis: value["analysis"],
+      status: "generating",
+      tree: isDecisionAnalysis(analysis) ? analysis.tree : [],
     };
   }
 
-  if (value["status"] === "error") {
-    return typeof value["error"] === "string"
-      ? {
-          status: value["status"],
-          error: value["error"],
-        }
-      : {
-          status: value["status"],
-        };
+  if (status === "error") {
+    const error = value["error"];
+    return {
+      status: "error",
+      error: typeof error === "string" ? error : "Generation failed",
+    };
   }
 
   return null;
@@ -135,10 +140,7 @@ export const useDecisionAnalysis = (
 
     const analysisResponse = parseAnalysisResponse(data);
     if (analysisResponse) {
-      if (
-        analysisResponse.status === "done" &&
-        isDecisionAnalysis(analysisResponse.analysis)
-      ) {
+      if (analysisResponse.status === "done") {
         if (pollRef.current) {
           clearInterval(pollRef.current);
           pollRef.current = null;
@@ -153,26 +155,16 @@ export const useDecisionAnalysis = (
       }
 
       if (analysisResponse.status === "generating") {
-        setState({
-          status: "generating",
-          tree: isDecisionAnalysis(analysisResponse.analysis)
-            ? analysisResponse.analysis.tree
-            : [],
-        });
+        setState({ status: "generating", tree: analysisResponse.tree });
         return false;
       }
 
-      if (analysisResponse.status === "error") {
-        if (pollRef.current) {
-          clearInterval(pollRef.current);
-          pollRef.current = null;
-        }
-        setState({
-          status: "error",
-          message: analysisResponse.error ?? "Generation failed",
-        });
-        return true;
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
       }
+      setState({ status: "error", message: analysisResponse.error });
+      return true;
     }
 
     // Unexpected response shape (auth failure, server error, etc.)

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -82,15 +82,21 @@ export const useDecisionAnalysis = (
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const queryClient = useQueryClient();
 
+  const stopPolling = useCallback(() => {
+    if (!pollRef.current) {
+      return;
+    }
+    clearInterval(pollRef.current);
+    pollRef.current = null;
+  }, []);
+
   // Reset to idle when decisionId changes (route navigation)
   const prevDecisionId = useRef(decisionId);
   useEffect(() => {
     if (prevDecisionId.current !== decisionId) {
       prevDecisionId.current = decisionId;
       abortRef.current?.abort();
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-      }
+      stopPolling();
 
       if (
         isDecisionAnalysis(existingAnalysis) &&
@@ -110,17 +116,15 @@ export const useDecisionAnalysis = (
     ) {
       setState({ status: "done", analysis: existingAnalysis });
     }
-  }, [existingAnalysis, state.status, decisionId]);
+  }, [existingAnalysis, state.status, decisionId, stopPolling]);
 
   // Cleanup on unmount
   useEffect(
     () => () => {
       abortRef.current?.abort();
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-      }
+      stopPolling();
     },
-    [],
+    [stopPolling],
   );
 
   /** Returns true if analysis resolved (done or error), false if still generating. */
@@ -140,45 +144,40 @@ export const useDecisionAnalysis = (
 
     const analysisResponse = parseAnalysisResponse(data);
     if (analysisResponse) {
-      if (analysisResponse.status === "done") {
-        if (pollRef.current) {
-          clearInterval(pollRef.current);
-          pollRef.current = null;
-        }
-        setState({ status: "done", analysis: analysisResponse.analysis });
-        queryClient.setQueryData(
-          ["case-law-decisions", decisionId],
-          (old: Record<string, unknown> | undefined) =>
-            old ? { ...old, analysis: analysisResponse.analysis } : old,
-        );
-        return true;
+      switch (analysisResponse.status) {
+        case "done":
+          stopPolling();
+          setState({ status: "done", analysis: analysisResponse.analysis });
+          queryClient.setQueryData(
+            ["case-law-decisions", decisionId],
+            (old: Record<string, unknown> | undefined) =>
+              old ? { ...old, analysis: analysisResponse.analysis } : old,
+          );
+          return true;
+
+        case "generating":
+          setState({ status: "generating", tree: analysisResponse.tree });
+          return false;
+
+        case "error":
+          stopPolling();
+          setState({ status: "error", message: analysisResponse.error });
+          return true;
       }
 
-      if (analysisResponse.status === "generating") {
-        setState({ status: "generating", tree: analysisResponse.tree });
-        return false;
-      }
-
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-      setState({ status: "error", message: analysisResponse.error });
-      return true;
+      const unhandledResponse: never = analysisResponse;
+      return unhandledResponse;
     }
 
     // Unexpected response shape (auth failure, server error, etc.)
     // Treat as error to stop polling
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
+    stopPolling();
     setState({
       status: "error",
       message: response.ok ? "Unexpected response" : `HTTP ${response.status}`,
     });
     return true;
-  }, [decisionId, queryClient]);
+  }, [decisionId, queryClient, stopPolling]);
 
   const generate = useCallback(async () => {
     if (state.status === "generating") {
@@ -192,9 +191,7 @@ export const useDecisionAnalysis = (
 
       // Only poll if the first fetch didn't already resolve
       if (!resolved) {
-        if (pollRef.current) {
-          clearInterval(pollRef.current);
-        }
+        stopPolling();
         pollRef.current = setInterval(() => {
           void fetchAnalysis().catch(() => {
             // Ignore poll errors; will retry on next interval
@@ -210,7 +207,7 @@ export const useDecisionAnalysis = (
         message: error instanceof Error ? error.message : "Unknown error",
       });
     }
-  }, [state.status, fetchAnalysis]);
+  }, [state.status, fetchAnalysis, stopPolling]);
 
   return { state, generate };
 };


### PR DESCRIPTION
Validate the analysis payload at the boundary so each branch of \`AnalysisResponse\` carries a fully-typed value (\`done.analysis\`, \`generating.tree\`, \`error.error\`). Consumer drops its defensive \`isDecisionAnalysis\` guards and \`?? fallback\` strings.

## Test plan
- [x] \`bun --filter @stll/web typecheck\`
- [x] \`bun --filter @stll/web lint\`
- [x] \`bun --filter @stll/web test\`