### PR TITLE
fix: harden backend endpoint permissions and pagination

### DIFF
--- a/apps/api/src/handlers/audit-logs/routes.ts
+++ b/apps/api/src/handlers/audit-logs/routes.ts
@@ -11,5 +11,6 @@ export const auditLogsRoute = new Elysia({ prefix: "/audit-logs" })
     // Compliance readers need organization-wide visibility;
     // this is intentionally scoped by auditLog.read rather
     // than workspace membership.
+    permissions: readAuditLogs.config.permissions,
     query: readAuditLogs.config.query,
   });

--- a/apps/api/src/handlers/billing-codes/read.ts
+++ b/apps/api/src/handlers/billing-codes/read.ts
@@ -11,6 +11,7 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedBillingCodeId } from "@/api/lib/safe-id-boundaries";
 
@@ -41,7 +42,7 @@ const decodeBillingCodeCursor = (cursor: string): BillingCodeCursor | null => {
   if (
     typeof sortOrder !== "number" ||
     typeof code !== "string" ||
-    typeof id !== "string"
+    !isUuidPaginationCursorPart(id)
   ) {
     return null;
   }

--- a/apps/api/src/handlers/billing-codes/read.ts
+++ b/apps/api/src/handlers/billing-codes/read.ts
@@ -1,14 +1,22 @@
 import { Result } from "better-result";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, gt, or } from "drizzle-orm";
 import { t } from "elysia";
 
 import { billingCodes } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedBillingCodeId } from "@/api/lib/safe-id-boundaries";
 
 const readBillingCodesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 1000 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
   type: t.Optional(t.Union([t.Literal("task"), t.Literal("activity")])),
   active: t.Optional(t.BooleanString()),
 });
@@ -18,11 +26,33 @@ const config = {
   query: readBillingCodesQuerySchema,
 } satisfies HandlerConfig;
 
+type BillingCodeCursor = {
+  sortOrder: number;
+  code: string;
+  id: SafeId<"billingCode">;
+};
+
+const decodeBillingCodeCursor = (cursor: string): BillingCodeCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const sortOrder = parts?.at(0);
+  const code = parts?.at(1);
+  const id = parts?.at(2);
+
+  if (
+    typeof sortOrder !== "number" ||
+    typeof code !== "string" ||
+    typeof id !== "string"
+  ) {
+    return null;
+  }
+
+  return { sortOrder, code, id: brandPersistedBillingCodeId(id) };
+};
+
 const readBillingCodes = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, query }) {
     const limit = query.limit ?? 500;
-    const offset = query.offset ?? 0;
 
     const conditions = [eq(billingCodes.workspaceId, workspaceId)];
 
@@ -31,6 +61,32 @@ const readBillingCodes = createSafeHandler(
     }
     if (query.active !== undefined) {
       conditions.push(eq(billingCodes.active, query.active));
+    }
+    if (query.cursor) {
+      const cursor = decodeBillingCodeCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(billingCodes.sortOrder, cursor.sortOrder),
+        and(
+          eq(billingCodes.sortOrder, cursor.sortOrder),
+          gt(billingCodes.code, cursor.code),
+        ),
+        and(
+          eq(billingCodes.sortOrder, cursor.sortOrder),
+          eq(billingCodes.code, cursor.code),
+          gt(billingCodes.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
     }
 
     const rows = yield* Result.await(
@@ -46,13 +102,23 @@ const readBillingCodes = createSafeHandler(
           })
           .from(billingCodes)
           .where(and(...conditions))
-          .orderBy(asc(billingCodes.sortOrder), asc(billingCodes.code))
-          .limit(limit)
-          .offset(offset),
+          .orderBy(
+            asc(billingCodes.sortOrder),
+            asc(billingCodes.code),
+            asc(billingCodes.id),
+          )
+          .limit(limit + 1),
       ),
     );
 
-    return Result.ok(rows);
+    return Result.ok(
+      createCursorPage({
+        rows,
+        limit,
+        cursorForItem: (item) =>
+          encodePaginationCursor([item.sortOrder, item.code, item.id]),
+      }),
+    );
   },
 );
 

--- a/apps/api/src/handlers/billing-codes/routes.ts
+++ b/apps/api/src/handlers/billing-codes/routes.ts
@@ -17,17 +17,21 @@ export const billingCodesRoute = new Elysia({
     validateWorkspaceAccess: true,
   })
   .get("/", readBillingCodes.handler, {
+    permissions: readBillingCodes.config.permissions,
     query: readBillingCodes.config.query,
   })
   .put("/", createBillingCode.handler, {
     body: createBillingCode.config.body,
     invalidateQuery: true,
+    permissions: createBillingCode.config.permissions,
   })
   .patch("/", updateBillingCode.handler, {
     body: updateBillingCode.config.body,
     invalidateQuery: true,
+    permissions: updateBillingCode.config.permissions,
   })
   .delete("/", deleteBillingCode.handler, {
     body: deleteBillingCode.config.body,
     invalidateQuery: true,
+    permissions: deleteBillingCode.config.permissions,
   });

--- a/apps/api/src/handlers/case-law/routes.ts
+++ b/apps/api/src/handlers/case-law/routes.ts
@@ -184,18 +184,23 @@ const globalCaseLawRoute = new Elysia({
   prefix: "/case",
 })
   .use(authMacro)
+  .use(permissionMacro)
   .guard({ validateAuth: true })
   .get("/decisions", listDecisions.handler, {
+    permissions: listDecisions.config.permissions,
     query: listDecisions.config.query,
   })
   .get("/decisions/:decisionId", readDecision.handler, {
     params: readDecision.config.params,
+    permissions: readDecision.config.permissions,
   })
   .post("/decisions/search", searchDecisions.handler, {
     body: searchDecisions.config.body,
+    permissions: searchDecisions.config.permissions,
   })
   .get("/decisions/:decisionId/analysis", generateDecisionAnalysis.handler, {
     params: generateDecisionAnalysis.config.params,
+    permissions: generateDecisionAnalysis.config.permissions,
   });
 
 /**
@@ -208,12 +213,16 @@ const caseLawMatterLinksRoute = new Elysia({
   .use(workspaceAccessMacro)
   .use(permissionMacro)
   .guard({ validateWorkspaceAccess: true })
-  .get("/", listMatterLinks.handler)
+  .get("/", listMatterLinks.handler, {
+    permissions: listMatterLinks.config.permissions,
+  })
   .post("/", createMatterLink.handler, {
     body: createMatterLink.config.body,
+    permissions: createMatterLink.config.permissions,
   })
   .delete("/:linkId", deleteMatterLink.handler, {
     params: deleteMatterLink.config.params,
+    permissions: deleteMatterLink.config.permissions,
   });
 
 /**
@@ -224,6 +233,7 @@ const caseLawAdminRoute = new Elysia({
   prefix: "/case/admin",
 })
   .use(authMacro)
+  .use(permissionMacro)
   .guard({ validateAuth: true })
   .onBeforeHandle(({ memberRole, set }) => {
     if (!ADMIN_BYPASS_ROLES.includes(memberRole.role)) {
@@ -232,7 +242,9 @@ const caseLawAdminRoute = new Elysia({
     }
     return undefined;
   })
-  .get("/ingestion/status", getCaseLawIngestionStatus.handler);
+  .get("/ingestion/status", getCaseLawIngestionStatus.handler, {
+    permissions: getCaseLawIngestionStatus.config.permissions,
+  });
 
 export const caseLawRoute = new Elysia()
   .use(globalCaseLawRoute)

--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -12,15 +12,19 @@ export const chatRoute = new Elysia({ prefix: "/chat" })
   .guard({ validateAuth: true })
   .post("/", sendMessage.handler, {
     body: sendMessage.config.body,
+    permissions: sendMessage.config.permissions,
   })
   .get("/threads", getThreads.handler, {
+    permissions: getThreads.config.permissions,
     query: getThreads.config.query,
   })
   .delete("/threads/:threadId", deleteThread.handler, {
-    query: deleteThread.config.query,
     params: deleteThread.config.params,
+    permissions: deleteThread.config.permissions,
+    query: deleteThread.config.query,
   })
   .get("/threads/:threadId/messages", getMessages.handler, {
     params: getMessages.config.params,
+    permissions: getMessages.config.permissions,
     query: getMessages.config.query,
   });

--- a/apps/api/src/handlers/clauses/routes.ts
+++ b/apps/api/src/handlers/clauses/routes.ts
@@ -26,16 +26,21 @@ export const clauseCategoriesRoute = new Elysia({
   .use(authMacro)
   .use(permissionMacro)
   .guard({ validateAuth: true })
-  .get("/", listClauseCategories.handler)
+  .get("/", listClauseCategories.handler, {
+    permissions: listClauseCategories.config.permissions,
+  })
   .put("/", createClauseCategory.handler, {
     body: createClauseCategory.config.body,
+    permissions: createClauseCategory.config.permissions,
   })
   .post("/:categoryId", updateClauseCategory.handler, {
-    params: updateClauseCategory.config.params,
     body: updateClauseCategory.config.body,
+    params: updateClauseCategory.config.params,
+    permissions: updateClauseCategory.config.permissions,
   })
   .delete("/:categoryId", deleteClauseCategory.handler, {
     params: deleteClauseCategory.config.params,
+    permissions: deleteClauseCategory.config.permissions,
   });
 
 // ── Clauses ─────────────────────────────────────────
@@ -47,43 +52,55 @@ export const clausesRoute = new Elysia({
   .use(permissionMacro)
   .guard({ validateAuth: true })
   .get("/", listClauses.handler, {
+    permissions: listClauses.config.permissions,
     query: listClauses.config.query,
   })
   .put("/", createClause.handler, {
     body: createClause.config.body,
+    permissions: createClause.config.permissions,
   })
   .get("/export", exportClauses.handler, {
+    permissions: exportClauses.config.permissions,
     query: exportClauses.config.query,
   })
   .put("/import", importClauses.handler, {
     body: importClauses.config.body,
+    permissions: importClauses.config.permissions,
   })
   .get("/:clauseId", getClause.handler, {
     params: getClause.config.params,
+    permissions: getClause.config.permissions,
   })
   .post("/:clauseId", updateClause.handler, {
-    params: updateClause.config.params,
     body: updateClause.config.body,
+    params: updateClause.config.params,
+    permissions: updateClause.config.permissions,
   })
   .delete("/:clauseId", deleteClause.handler, {
     params: deleteClause.config.params,
+    permissions: deleteClause.config.permissions,
   })
   // ── Versions ───────────────────────────────────
   .get("/:clauseId/versions/:versionId", getClauseVersion.handler, {
     params: getClauseVersion.config.params,
+    permissions: getClauseVersion.config.permissions,
   })
   // ── Variants ────────────────────────────────────
   .get("/:clauseId/variants", listVariants.handler, {
     params: listVariants.config.params,
+    permissions: listVariants.config.permissions,
   })
   .put("/:clauseId/variants", createVariant.handler, {
-    params: createVariant.config.params,
     body: createVariant.config.body,
+    params: createVariant.config.params,
+    permissions: createVariant.config.permissions,
   })
   .post("/:clauseId/variants/:variantId", updateVariant.handler, {
-    params: updateVariant.config.params,
     body: updateVariant.config.body,
+    params: updateVariant.config.params,
+    permissions: updateVariant.config.permissions,
   })
   .delete("/:clauseId/variants/:variantId", deleteVariant.handler, {
     params: deleteVariant.config.params,
+    permissions: deleteVariant.config.permissions,
   });

--- a/apps/api/src/handlers/contacts/routes.ts
+++ b/apps/api/src/handlers/contacts/routes.ts
@@ -18,16 +18,20 @@ export const contactsRoute = new Elysia({ prefix: "/contacts" })
     validateAuth: true,
   })
   .get("/", readContacts.handler, {
+    permissions: readContacts.config.permissions,
     query: readContacts.config.query,
   })
   .get("/search", searchContacts.handler, {
+    permissions: searchContacts.config.permissions,
     query: searchContacts.config.query,
   })
   .get("/ares", aresLookup.handler, {
+    permissions: aresLookup.config.permissions,
     query: aresLookup.config.query,
   })
   .put("/", createContact.handler, {
     body: createContact.config.body,
+    permissions: createContact.config.permissions,
   })
   .group(
     "/:contactId",
@@ -36,9 +40,14 @@ export const contactsRoute = new Elysia({ prefix: "/contacts" })
     },
     (app) =>
       app
-        .get("/", readContactById.handler)
+        .get("/", readContactById.handler, {
+          permissions: readContactById.config.permissions,
+        })
         .post("/", updateContactById.handler, {
           body: updateContactById.config.body,
+          permissions: updateContactById.config.permissions,
         })
-        .delete("/", deleteContactById.handler),
+        .delete("/", deleteContactById.handler, {
+          permissions: deleteContactById.config.permissions,
+        }),
   );

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -65,33 +65,40 @@ export const entitiesRoute = new Elysia({
   .put("/", createEntities.handler, {
     body: createEntities.config.body,
     invalidateQuery: true,
+    permissions: createEntities.config.permissions,
   })
   .post("/upload", uploadEntity.handler, {
     body: uploadEntity.config.body,
     invalidateQuery: true,
+    permissions: uploadEntity.config.permissions,
   })
   .post("/desktop-edit-sessions/open", openDesktopEditSession.handler, {
     body: openDesktopEditSession.config.body,
+    permissions: openDesktopEditSession.config.permissions,
   })
   .post("/desktop-edit-handoffs", createDesktopEditHandoff.handler, {
     body: createDesktopEditHandoff.config.body,
+    permissions: createDesktopEditHandoff.config.permissions,
   })
   .get(
     "/desktop-edit-handoffs/:handoffId/status",
     readDesktopEditHandoffStatus.handler,
     {
       params: readDesktopEditHandoffStatus.config.params,
+      permissions: readDesktopEditHandoffStatus.config.permissions,
     },
   )
   .post("/desktop-edit-sessions/release", releaseDesktopEditLock.handler, {
     body: releaseDesktopEditLock.config.body,
     invalidateQuery: true,
+    permissions: releaseDesktopEditLock.config.permissions,
   })
   .post(
     "/desktop-edit-sessions/request-takeover",
     requestDesktopEditTakeover.handler,
     {
       body: requestDesktopEditTakeover.config.body,
+      permissions: requestDesktopEditTakeover.config.permissions,
     },
   )
   .post("/clip", clipEndpoint.handler, {
@@ -101,69 +108,91 @@ export const entitiesRoute = new Elysia({
   .post("/create-from-legal-source", createFromLegalSource.handler, {
     body: createFromLegalSource.config.body,
     invalidateQuery: true,
+    permissions: createFromLegalSource.config.permissions,
   })
   .post("/query", readEntities.handler, {
     body: readEntities.config.body,
+    permissions: readEntities.config.permissions,
   })
   .post("/query-window", readEntitiesWindow.handler, {
     body: readEntitiesWindow.config.body,
+    permissions: readEntitiesWindow.config.permissions,
   })
   .post("/filesystem-tree", readFilesystemTree.handler, {
     body: readFilesystemTree.config.body,
+    permissions: readFilesystemTree.config.permissions,
   })
   .post("/kanban-group", readKanbanGroup.handler, {
     body: readKanbanGroup.config.body,
+    permissions: readKanbanGroup.config.permissions,
   })
   .post("/organize-suggestions", organizeSuggestions.handler, {
     body: organizeSuggestions.config.body,
+    permissions: organizeSuggestions.config.permissions,
   })
-  .get("/folders", listFolders.handler)
-  .get("/files", listFiles.handler)
+  .get("/folders", listFolders.handler, {
+    permissions: listFolders.config.permissions,
+  })
+  .get("/files", listFiles.handler, {
+    permissions: listFiles.config.permissions,
+  })
   .delete("/", deleteEntities.handler, {
     body: deleteEntities.config.body,
     invalidateQuery: true,
+    permissions: deleteEntities.config.permissions,
   })
   .patch("/move", moveEntity.handler, {
     body: moveEntity.config.body,
     invalidateQuery: true,
+    permissions: moveEntity.config.permissions,
   })
   .patch("/rename", renameEntity.handler, {
     body: renameEntity.config.body,
     invalidateQuery: true,
+    permissions: renameEntity.config.permissions,
   })
   .post("/duplicate", duplicateEntity.handler, {
     body: duplicateEntity.config.body,
     invalidateQuery: true,
+    permissions: duplicateEntity.config.permissions,
   })
   .post("/check-stamp", checkStamp.handler, {
     body: checkStamp.config.body,
+    permissions: checkStamp.config.permissions,
   })
   .get("/summaries", readEntitySummaries.handler, {
+    permissions: readEntitySummaries.config.permissions,
     query: readEntitySummaries.config.query,
   })
   .get("/zip/:entityId", downloadZip.handler, {
     params: downloadZip.config.params,
+    permissions: downloadZip.config.permissions,
   })
   .get("/entity/:entityId", readEntityById.handler, {
     params: readEntityById.config.params,
+    permissions: readEntityById.config.permissions,
   })
   .get("/entity/:entityId/versions", readVersions.handler, {
     params: readVersions.config.params,
+    permissions: readVersions.config.permissions,
   })
   .get("/entity/:entityId/versions/:versionId", readVersionById.handler, {
     params: readVersionById.config.params,
+    permissions: readVersionById.config.permissions,
   })
   .post("/entity/:entityId/compare", compareVersions.handler, {
     body: compareVersions.config.body,
     params: compareVersions.config.params,
+    permissions: compareVersions.config.permissions,
   })
   .patch(
     "/entity/:entityId/versions/:versionId/label",
     updateVersionLabel.handler,
     {
       body: updateVersionLabel.config.body,
-      params: updateVersionLabel.config.params,
       invalidateQuery: true,
+      params: updateVersionLabel.config.params,
+      permissions: updateVersionLabel.config.permissions,
     },
   )
   .patch(
@@ -171,20 +200,27 @@ export const entitiesRoute = new Elysia({
     updateVersionDescription.handler,
     {
       body: updateVersionDescription.config.body,
-      params: updateVersionDescription.config.params,
       invalidateQuery: true,
+      params: updateVersionDescription.config.params,
+      permissions: updateVersionDescription.config.permissions,
     },
   )
   .post(
     "/entity/:entityId/versions/:versionId/restore",
     restoreVersion.handler,
-    { invalidateQuery: true, params: restoreVersion.config.params },
+    {
+      invalidateQuery: true,
+      params: restoreVersion.config.params,
+      permissions: restoreVersion.config.permissions,
+    },
   )
   .delete("/entity/:entityId/versions/:versionId", deleteVersion.handler, {
     invalidateQuery: true,
     params: deleteVersion.config.params,
+    permissions: deleteVersion.config.permissions,
   })
   .post("/upload-version", uploadVersion.handler, {
     body: uploadVersion.config.body,
     invalidateQuery: true,
+    permissions: uploadVersion.config.permissions,
   });

--- a/apps/api/src/handlers/expenses/read.ts
+++ b/apps/api/src/handlers/expenses/read.ts
@@ -17,6 +17,8 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
+  isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedExpenseId } from "@/api/lib/safe-id-boundaries";
 
@@ -42,17 +44,14 @@ type ExpenseCursor = {
   id: SafeId<"expense">;
 };
 
-const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
-
 const decodeExpenseCursor = (cursor: string): ExpenseCursor | null => {
   const parts = decodePaginationCursor(cursor);
   const dateIncurred = parts?.at(0);
   const id = parts?.at(1);
 
   if (
-    typeof dateIncurred !== "string" ||
-    !dateCursorPattern.test(dateIncurred) ||
-    typeof id !== "string"
+    !isDateOnlyPaginationCursorPart(dateIncurred) ||
+    !isUuidPaginationCursorPart(id)
   ) {
     return null;
   }

--- a/apps/api/src/handlers/expenses/read.ts
+++ b/apps/api/src/handlers/expenses/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, asc, eq, gt, gte, inArray, lte, or } from "drizzle-orm";
 import { t } from "elysia";
 
 import { member, user } from "@/api/db/auth-schema";
@@ -10,11 +10,19 @@ import {
 import { expenses } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedExpenseId } from "@/api/lib/safe-id-boundaries";
 
 const readExpensesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 200 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
   userId: t.Optional(tUserId),
   matterId: t.Optional(tSafeId("entity")),
   dateFrom: t.Optional(t.String({ format: "date" })),
@@ -29,11 +37,33 @@ const config = {
   query: readExpensesQuerySchema,
 } satisfies HandlerConfig;
 
+type ExpenseCursor = {
+  dateIncurred: string;
+  id: SafeId<"expense">;
+};
+
+const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
+
+const decodeExpenseCursor = (cursor: string): ExpenseCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const dateIncurred = parts?.at(0);
+  const id = parts?.at(1);
+
+  if (
+    typeof dateIncurred !== "string" ||
+    !dateCursorPattern.test(dateIncurred) ||
+    typeof id !== "string"
+  ) {
+    return null;
+  }
+
+  return { dateIncurred, id: brandPersistedExpenseId(id) };
+};
+
 const readExpenses = createSafeHandler(
   config,
   async function* ({ safeDb, session, workspaceId, query }) {
     const limit = query.limit ?? 100;
-    const offset = query.offset ?? 0;
 
     const conditions = [eq(expenses.workspaceId, workspaceId)];
 
@@ -58,6 +88,27 @@ const readExpenses = createSafeHandler(
     if (query.billable !== undefined) {
       conditions.push(eq(expenses.billable, query.billable));
     }
+    if (query.cursor) {
+      const cursor = decodeExpenseCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(expenses.dateIncurred, cursor.dateIncurred),
+        and(
+          eq(expenses.dateIncurred, cursor.dateIncurred),
+          gt(expenses.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
 
     const rows = yield* Result.await(
       safeDb((tx) =>
@@ -80,15 +131,21 @@ const readExpenses = createSafeHandler(
           })
           .from(expenses)
           .where(and(...conditions))
-          .orderBy(expenses.dateIncurred)
-          .limit(limit)
-          .offset(offset),
+          .orderBy(asc(expenses.dateIncurred), asc(expenses.id))
+          .limit(limit + 1),
       ),
     );
 
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.dateIncurred, item.id]),
+    });
+
     // Batch-fetch user names
     const userIds = new Set<string>();
-    for (const row of rows) {
+    for (const row of page.items) {
       if (row.userId) {
         userIds.add(row.userId);
       }
@@ -114,8 +171,9 @@ const readExpenses = createSafeHandler(
 
     const userMap = new Map(usersResult.map((u) => [u.id, u.name]));
 
-    return Result.ok(
-      rows.map((row) => ({
+    return Result.ok({
+      ...page,
+      items: page.items.map((row) => ({
         id: row.id,
         userId: row.userId,
         matterId: row.matterId,
@@ -132,7 +190,7 @@ const readExpenses = createSafeHandler(
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt?.toISOString() ?? null,
       })),
-    );
+    });
   },
 );
 

--- a/apps/api/src/handlers/expenses/routes.ts
+++ b/apps/api/src/handlers/expenses/routes.ts
@@ -17,17 +17,21 @@ export const expensesRoute = new Elysia({
     validateWorkspaceAccess: true,
   })
   .get("/", readExpenses.handler, {
+    permissions: readExpenses.config.permissions,
     query: readExpenses.config.query,
   })
   .put("/", createExpense.handler, {
     body: createExpense.config.body,
     invalidateQuery: true,
+    permissions: createExpense.config.permissions,
   })
   .patch("/", updateExpense.handler, {
     body: updateExpense.config.body,
     invalidateQuery: true,
+    permissions: updateExpense.config.permissions,
   })
   .delete("/", deleteExpense.handler, {
     body: deleteExpense.config.body,
     invalidateQuery: true,
+    permissions: deleteExpense.config.permissions,
   });

--- a/apps/api/src/handlers/external-preview/routes.ts
+++ b/apps/api/src/handlers/external-preview/routes.ts
@@ -10,8 +10,10 @@ export const externalPreviewRoute = new Elysia({ prefix: "/external-preview" })
   .use(permissionMacro)
   .guard({ validateAuth: true })
   .get("/", previewExternalSource.handler, {
+    permissions: previewExternalSource.config.permissions,
     query: previewExternalSource.config.query,
   })
   .get("/file", previewExternalFile.handler, {
+    permissions: previewExternalFile.config.permissions,
     query: previewExternalFile.config.query,
   });

--- a/apps/api/src/handlers/fields/routes.ts
+++ b/apps/api/src/handlers/fields/routes.ts
@@ -2,20 +2,23 @@ import Elysia from "elysia";
 
 import updateCellMetadata from "@/api/handlers/fields/update-cell-metadata";
 import upsertField from "@/api/handlers/fields/upsert-by-id";
-import { workspaceAccessMacro } from "@/api/lib/auth";
+import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
 
 export const fieldsRoute = new Elysia({ prefix: "/fields/:workspaceId" })
   .use(workspaceAccessMacro)
   .use(invalidateQuery)
+  .use(permissionMacro)
   .guard({
     validateWorkspaceAccess: true,
   })
   .post("/", upsertField.handler, {
     body: upsertField.config.body,
     invalidateQuery: true,
+    permissions: upsertField.config.permissions,
   })
   .patch("/metadata", updateCellMetadata.handler, {
     body: updateCellMetadata.config.body,
     invalidateQuery: true,
+    permissions: updateCellMetadata.config.permissions,
   });

--- a/apps/api/src/handlers/files/routes.ts
+++ b/apps/api/src/handlers/files/routes.ts
@@ -8,7 +8,7 @@ import {
 } from "@/api/handlers/files/read-by-id";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { workspaceAccessMacro } from "@/api/lib/auth";
+import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 
 const readFileEndpoint = createSafeHandler(
@@ -91,16 +91,20 @@ export const filesRoute = new Elysia({
   prefix: "/files/:workspaceId",
 })
   .use(workspaceAccessMacro)
+  .use(permissionMacro)
   .guard({
     validateWorkspaceAccess: true,
   })
   .get("/url/:fieldId", readFileEndpoint.handler, {
-    query: readFileEndpoint.config.query,
     params: readFileEndpoint.config.params,
+    permissions: readFileEndpoint.config.permissions,
+    query: readFileEndpoint.config.query,
   })
   .get("/print-pdf/:fieldId", printPdfEndpoint.handler, {
     params: printPdfEndpoint.config.params,
+    permissions: printPdfEndpoint.config.permissions,
   })
   .get("/stamped/:fieldId", stampedDownloadEndpoint.handler, {
     params: stampedDownloadEndpoint.config.params,
+    permissions: stampedDownloadEndpoint.config.permissions,
   });

--- a/apps/api/src/handlers/invoices/read.ts
+++ b/apps/api/src/handlers/invoices/read.ts
@@ -1,14 +1,44 @@
 import { Result } from "better-result";
-import { eq } from "drizzle-orm";
+import { and, asc, eq, gt, or } from "drizzle-orm";
 import { t } from "elysia";
 
 import { invoices } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedInvoiceId } from "@/api/lib/safe-id-boundaries";
 
 const readInvoicesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 100 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
 });
+
+type InvoiceCursor = {
+  createdAt: Date;
+  id: SafeId<"invoice">;
+};
+
+const decodeInvoiceCursor = (cursor: string): InvoiceCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const createdAt = parts?.at(0);
+  const id = parts?.at(1);
+
+  if (typeof createdAt !== "string" || typeof id !== "string") {
+    return null;
+  }
+
+  const createdAtDate = new Date(createdAt);
+  if (Number.isNaN(createdAtDate.getTime())) {
+    return null;
+  }
+
+  return { createdAt: createdAtDate, id: brandPersistedInvoiceId(id) };
+};
 
 const readInvoices = createSafeHandler(
   {
@@ -17,39 +47,62 @@ const readInvoices = createSafeHandler(
   },
   async function* ({ safeDb, workspaceId, query }) {
     const limit = query.limit ?? 50;
-    const offset = query.offset ?? 0;
+    const conditions = [eq(invoices.workspaceId, workspaceId)];
 
-    const [rowsResult, totalResult] = await Promise.all([
-      safeDb((tx) =>
-        tx.query.invoices.findMany({
-          where: { workspaceId: { eq: workspaceId } },
-          columns: {
-            id: true,
-            invoiceNumber: true,
-            reference: true,
-            status: true,
-            invoiceDate: true,
-            dueDate: true,
-            currency: true,
-            totalAmount: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-          orderBy: (inv, { asc }) => asc(inv.createdAt),
-          limit,
-          offset,
-        }),
-      ),
-      safeDb((tx) =>
-        tx.$count(invoices, eq(invoices.workspaceId, workspaceId)),
-      ),
-    ]);
+    if (query.cursor) {
+      const cursor = decodeInvoiceCursor(query.cursor);
 
-    const rows = yield* rowsResult;
-    const total = yield* totalResult;
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(invoices.createdAt, cursor.createdAt),
+        and(
+          eq(invoices.createdAt, cursor.createdAt),
+          gt(invoices.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
+
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select({
+            id: invoices.id,
+            invoiceNumber: invoices.invoiceNumber,
+            reference: invoices.reference,
+            status: invoices.status,
+            invoiceDate: invoices.invoiceDate,
+            dueDate: invoices.dueDate,
+            currency: invoices.currency,
+            totalAmount: invoices.totalAmount,
+            createdAt: invoices.createdAt,
+            updatedAt: invoices.updatedAt,
+          })
+          .from(invoices)
+          .where(and(...conditions))
+          .orderBy(asc(invoices.createdAt), asc(invoices.id))
+          .limit(limit + 1),
+      ),
+    );
+
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.createdAt.toISOString(), item.id]),
+    });
 
     return Result.ok({
-      rows: rows.map((row) => ({
+      ...page,
+      items: page.items.map((row) => ({
         id: row.id,
         invoiceNumber: row.invoiceNumber,
         reference: row.reference,
@@ -61,7 +114,6 @@ const readInvoices = createSafeHandler(
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt.toISOString(),
       })),
-      total,
     });
   },
 );

--- a/apps/api/src/handlers/invoices/read.ts
+++ b/apps/api/src/handlers/invoices/read.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq, gt, or } from "drizzle-orm";
+import { and, asc, eq, gt, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { invoices } from "@/api/db/schema";
@@ -22,6 +22,8 @@ type InvoiceCursor = {
   createdAt: Date;
   id: SafeId<"invoice">;
 };
+
+const invoiceCreatedAtCursor = sql<Date>`date_trunc('milliseconds', ${invoices.createdAt})`;
 
 const decodeInvoiceCursor = (cursor: string): InvoiceCursor | null => {
   const parts = decodePaginationCursor(cursor);
@@ -59,9 +61,9 @@ const readInvoices = createSafeHandler(
       }
 
       const cursorCondition = or(
-        gt(invoices.createdAt, cursor.createdAt),
+        gt(invoiceCreatedAtCursor, cursor.createdAt),
         and(
-          eq(invoices.createdAt, cursor.createdAt),
+          eq(invoiceCreatedAtCursor, cursor.createdAt),
           gt(invoices.id, cursor.id),
         ),
       );
@@ -84,11 +86,12 @@ const readInvoices = createSafeHandler(
             currency: invoices.currency,
             totalAmount: invoices.totalAmount,
             createdAt: invoices.createdAt,
+            createdAtCursor: invoiceCreatedAtCursor.as("created_at_cursor"),
             updatedAt: invoices.updatedAt,
           })
           .from(invoices)
           .where(and(...conditions))
-          .orderBy(asc(invoices.createdAt), asc(invoices.id))
+          .orderBy(asc(invoiceCreatedAtCursor), asc(invoices.id))
           .limit(limit + 1),
       ),
     );
@@ -97,7 +100,7 @@ const readInvoices = createSafeHandler(
       rows,
       limit,
       cursorForItem: (item) =>
-        encodePaginationCursor([item.createdAt.toISOString(), item.id]),
+        encodePaginationCursor([item.createdAtCursor.toISOString(), item.id]),
     });
 
     return Result.ok({

--- a/apps/api/src/handlers/invoices/read.ts
+++ b/apps/api/src/handlers/invoices/read.ts
@@ -10,6 +10,8 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isUuidPaginationCursorPart,
+  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedInvoiceId } from "@/api/lib/safe-id-boundaries";
 
@@ -30,12 +32,9 @@ const decodeInvoiceCursor = (cursor: string): InvoiceCursor | null => {
   const createdAt = parts?.at(0);
   const id = parts?.at(1);
 
-  if (typeof createdAt !== "string" || typeof id !== "string") {
-    return null;
-  }
+  const createdAtDate = parseDateTimePaginationCursorPart(createdAt);
 
-  const createdAtDate = new Date(createdAt);
-  if (Number.isNaN(createdAtDate.getTime())) {
+  if (!createdAtDate || !isUuidPaginationCursorPart(id)) {
     return null;
   }
 

--- a/apps/api/src/handlers/invoices/routes.ts
+++ b/apps/api/src/handlers/invoices/routes.ts
@@ -21,36 +21,44 @@ export const invoicesRoute = new Elysia({
     validateWorkspaceAccess: true,
   })
   .get("/", readInvoices.handler, {
+    permissions: readInvoices.config.permissions,
     query: readInvoices.config.query,
   })
   .get("/:invoiceId", readInvoiceById.handler, {
     params: readInvoiceById.config.params,
+    permissions: readInvoiceById.config.permissions,
   })
   .put("/", createInvoice.handler, {
-    invalidateQuery: true,
     body: createInvoice.config.body,
+    invalidateQuery: true,
+    permissions: createInvoice.config.permissions,
   })
   .patch("/:invoiceId", updateInvoice.handler, {
+    body: updateInvoice.config.body,
     invalidateQuery: true,
     params: updateInvoice.config.params,
-    body: updateInvoice.config.body,
+    permissions: updateInvoice.config.permissions,
   })
   .post("/:invoiceId/transition", transitionInvoice.handler, {
+    body: transitionInvoice.config.body,
     invalidateQuery: true,
     params: transitionInvoice.config.params,
-    body: transitionInvoice.config.body,
+    permissions: transitionInvoice.config.permissions,
   })
   .delete("/:invoiceId", deleteInvoice.handler, {
     invalidateQuery: true,
     params: deleteInvoice.config.params,
+    permissions: deleteInvoice.config.permissions,
   })
   .post("/:invoiceId/entries", addEntries.handler, {
+    body: addEntries.config.body,
     invalidateQuery: true,
     params: addEntries.config.params,
-    body: addEntries.config.body,
+    permissions: addEntries.config.permissions,
   })
   .delete("/:invoiceId/entries", removeEntries.handler, {
+    body: removeEntries.config.body,
     invalidateQuery: true,
     params: removeEntries.config.params,
-    body: removeEntries.config.body,
+    permissions: removeEntries.config.permissions,
   });

--- a/apps/api/src/handlers/mcp-connectors/routes.ts
+++ b/apps/api/src/handlers/mcp-connectors/routes.ts
@@ -20,42 +20,55 @@ const authenticatedMcpConnectorsRoute = new Elysia({ prefix: "/mcp" })
   .use(invalidateQuery)
   .guard({ validateAuth: true })
   .get("/oauth/callback", mcpOAuthCallback.handler, {
+    permissions: mcpOAuthCallback.config.permissions,
     query: mcpOAuthCallback.config.query,
   })
-  .get("/connectors", listMcpConnectors.handler)
+  .get("/connectors", listMcpConnectors.handler, {
+    permissions: listMcpConnectors.config.permissions,
+  })
   .post("/connectors", createMcpConnector.handler, {
     body: createMcpConnector.config.body,
     invalidateQuery: true,
+    permissions: createMcpConnector.config.permissions,
   })
   .post("/connectors/probe", probeMcpConnector.handler, {
     body: probeMcpConnector.config.body,
+    permissions: probeMcpConnector.config.permissions,
   })
   .post("/connectors/:slug/connect", connectMcpConnector.handler, {
-    params: connectMcpConnector.config.params,
     invalidateQuery: true,
+    params: connectMcpConnector.config.params,
+    permissions: connectMcpConnector.config.permissions,
   })
   .delete("/connectors/:slug", deleteMcpConnector.handler, {
-    params: deleteMcpConnector.config.params,
     invalidateQuery: true,
+    params: deleteMcpConnector.config.params,
+    permissions: deleteMcpConnector.config.permissions,
   })
-  .get("/connections", listMcpConnections.handler)
+  .get("/connections", listMcpConnections.handler, {
+    permissions: listMcpConnections.config.permissions,
+  })
   .post("/connections", createMcpConnection.handler, {
     body: createMcpConnection.config.body,
     invalidateQuery: true,
+    permissions: createMcpConnection.config.permissions,
   })
   .patch("/connections/:connectionId", updateMcpConnection.handler, {
-    params: updateMcpConnection.config.params,
     body: updateMcpConnection.config.body,
     invalidateQuery: true,
+    params: updateMcpConnection.config.params,
+    permissions: updateMcpConnection.config.permissions,
   })
   .delete("/connections/:connectionId", deleteMcpConnection.handler, {
-    params: deleteMcpConnection.config.params,
     invalidateQuery: true,
+    params: deleteMcpConnection.config.params,
+    permissions: deleteMcpConnection.config.permissions,
   })
   .patch("/native-tools/:slug", updateNativeTool.handler, {
-    params: updateNativeTool.config.params,
     body: updateNativeTool.config.body,
     invalidateQuery: true,
+    params: updateNativeTool.config.params,
+    permissions: updateNativeTool.config.permissions,
   });
 
 export const mcpConnectorsRoute = new Elysia().use(

--- a/apps/api/src/handlers/organization-settings/routes.ts
+++ b/apps/api/src/handlers/organization-settings/routes.ts
@@ -20,9 +20,12 @@ export const organizationSettingsRoute = new Elysia({
   .guard({
     validateAuth: true,
   })
-  .get("/", readOrganizationSettings.handler)
+  .get("/", readOrganizationSettings.handler, {
+    permissions: readOrganizationSettings.config.permissions,
+  })
   .post("/", updateOrganizationSettings.handler, {
     body: updateOrganizationSettings.config.body,
+    permissions: updateOrganizationSettings.config.permissions,
   })
   .post("/practice-jurisdictions", updatePracticeJurisdictions.handler, {
     body: updatePracticeJurisdictions.config.body,
@@ -30,14 +33,25 @@ export const organizationSettingsRoute = new Elysia({
   })
   .post("/preview", previewOrganizationSettings.handler, {
     body: previewOrganizationSettings.config.body,
+    permissions: previewOrganizationSettings.config.permissions,
   })
-  .get("/ai-availability", readAIAvailability.handler)
-  .get("/ai-config", readAIConfig.handler)
+  .get("/ai-availability", readAIAvailability.handler, {
+    permissions: readAIAvailability.config.permissions,
+  })
+  .get("/ai-config", readAIConfig.handler, {
+    permissions: readAIConfig.config.permissions,
+  })
   .post("/ai-config", updateAIConfig.handler, {
     body: updateAIConfig.config.body,
+    permissions: updateAIConfig.config.permissions,
   })
-  .delete("/ai-config", deleteAIConfig.handler)
-  .get("/anonymization-blacklist", readAnonymizationBlacklist.handler)
+  .delete("/ai-config", deleteAIConfig.handler, {
+    permissions: deleteAIConfig.config.permissions,
+  })
+  .get("/anonymization-blacklist", readAnonymizationBlacklist.handler, {
+    permissions: readAnonymizationBlacklist.config.permissions,
+  })
   .put("/anonymization-blacklist", updateAnonymizationBlacklist.handler, {
     body: updateAnonymizationBlacklist.config.body,
+    permissions: updateAnonymizationBlacklist.config.permissions,
   });

--- a/apps/api/src/handlers/properties/routes.ts
+++ b/apps/api/src/handlers/properties/routes.ts
@@ -21,23 +21,30 @@ export const propertiesRoute = new Elysia({
   .put("/", createProperty.handler, {
     body: createProperty.config.body,
     invalidateQuery: true,
+    permissions: createProperty.config.permissions,
   })
   .post("/preview", previewProperty.handler, {
     body: previewProperty.config.body,
+    permissions: previewProperty.config.permissions,
   })
   .post("/suggest-prompt", suggestPromptProperty.handler, {
     body: suggestPromptProperty.config.body,
+    permissions: suggestPromptProperty.config.permissions,
   })
-  .get("/", readProperties.handler)
+  .get("/", readProperties.handler, {
+    permissions: readProperties.config.permissions,
+  })
   .group("/property/:propertyId", (app) =>
     app
       .post("/", updateProperty.handler, {
         body: updateProperty.config.body,
-        params: updateProperty.config.params,
         invalidateQuery: true,
+        params: updateProperty.config.params,
+        permissions: updateProperty.config.permissions,
       })
       .delete("/", deleteProperty.handler, {
-        params: deleteProperty.config.params,
         invalidateQuery: true,
+        params: deleteProperty.config.params,
+        permissions: deleteProperty.config.permissions,
       }),
   );

--- a/apps/api/src/handlers/rates/entries-read.ts
+++ b/apps/api/src/handlers/rates/entries-read.ts
@@ -1,20 +1,51 @@
 import { Result } from "better-result";
-import { and, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, or } from "drizzle-orm";
 import { t } from "elysia";
 
 import { member, user } from "@/api/db/auth-schema";
 import { rateEntries } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedRateEntryId } from "@/api/lib/safe-id-boundaries";
 
 const readRateEntriesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 500 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
 });
 
 const rateEntryParamsSchema = workspaceParams({
   rateTableId: tSafeId("rateTable"),
 });
+
+type RateEntryCursor = {
+  effectiveFrom: string;
+  id: SafeId<"rateEntry">;
+};
+
+const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
+
+const decodeRateEntryCursor = (cursor: string): RateEntryCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const effectiveFrom = parts?.at(0);
+  const id = parts?.at(1);
+
+  if (
+    typeof effectiveFrom !== "string" ||
+    !dateCursorPattern.test(effectiveFrom) ||
+    typeof id !== "string"
+  ) {
+    return null;
+  }
+
+  return { effectiveFrom, id: brandPersistedRateEntryId(id) };
+};
 
 const readRateEntries = createSafeHandler(
   {
@@ -36,11 +67,37 @@ const readRateEntries = createSafeHandler(
     );
 
     if (!table) {
-      return Result.ok([]);
+      return Result.ok({
+        items: [],
+        limit: query.limit ?? 200,
+        nextCursor: null,
+      });
     }
 
     const limit = query.limit ?? 200;
-    const offset = query.offset ?? 0;
+    const conditions = [eq(rateEntries.rateTableId, params.rateTableId)];
+
+    if (query.cursor) {
+      const cursor = decodeRateEntryCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(rateEntries.effectiveFrom, cursor.effectiveFrom),
+        and(
+          eq(rateEntries.effectiveFrom, cursor.effectiveFrom),
+          gt(rateEntries.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
 
     const rows = yield* Result.await(
       safeDb((tx) =>
@@ -54,15 +111,21 @@ const readRateEntries = createSafeHandler(
             createdAt: rateEntries.createdAt,
           })
           .from(rateEntries)
-          .where(eq(rateEntries.rateTableId, params.rateTableId))
-          .orderBy(rateEntries.effectiveFrom)
-          .limit(limit)
-          .offset(offset),
+          .where(and(...conditions))
+          .orderBy(asc(rateEntries.effectiveFrom), asc(rateEntries.id))
+          .limit(limit + 1),
       ),
     );
 
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.effectiveFrom, item.id]),
+    });
+
     const userIds = new Set<string>();
-    for (const row of rows) {
+    for (const row of page.items) {
       if (row.userId) {
         userIds.add(row.userId);
       }
@@ -96,8 +159,9 @@ const readRateEntries = createSafeHandler(
       usersResult.map((u) => [u.id, { image: u.image, name: u.name }]),
     );
 
-    return Result.ok(
-      rows.map((row) => ({
+    return Result.ok({
+      ...page,
+      items: page.items.map((row) => ({
         id: row.id,
         userId: row.userId,
         hourlyRate: row.hourlyRate,
@@ -107,7 +171,7 @@ const readRateEntries = createSafeHandler(
         userName: row.userId ? (userMap.get(row.userId)?.name ?? null) : null,
         createdAt: row.createdAt.toISOString(),
       })),
-    );
+    });
   },
 );
 

--- a/apps/api/src/handlers/rates/entries-read.ts
+++ b/apps/api/src/handlers/rates/entries-read.ts
@@ -12,6 +12,8 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
+  isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedRateEntryId } from "@/api/lib/safe-id-boundaries";
 
@@ -29,17 +31,14 @@ type RateEntryCursor = {
   id: SafeId<"rateEntry">;
 };
 
-const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
-
 const decodeRateEntryCursor = (cursor: string): RateEntryCursor | null => {
   const parts = decodePaginationCursor(cursor);
   const effectiveFrom = parts?.at(0);
   const id = parts?.at(1);
 
   if (
-    typeof effectiveFrom !== "string" ||
-    !dateCursorPattern.test(effectiveFrom) ||
-    typeof id !== "string"
+    !isDateOnlyPaginationCursorPart(effectiveFrom) ||
+    !isUuidPaginationCursorPart(id)
   ) {
     return null;
   }

--- a/apps/api/src/handlers/rates/read.ts
+++ b/apps/api/src/handlers/rates/read.ts
@@ -23,6 +23,8 @@ type RateTableCursor = {
   id: SafeId<"rateTable">;
 };
 
+const rateTableCreatedAtCursor = sql<Date>`date_trunc('milliseconds', ${rateTables.createdAt})`;
+
 const decodeRateTableCursor = (cursor: string): RateTableCursor | null => {
   const parts = decodePaginationCursor(cursor);
   const createdAt = parts?.at(0);
@@ -59,9 +61,9 @@ const readRateTables = createSafeHandler(
       }
 
       const cursorCondition = or(
-        gt(rateTables.createdAt, cursor.createdAt),
+        gt(rateTableCreatedAtCursor, cursor.createdAt),
         and(
-          eq(rateTables.createdAt, cursor.createdAt),
+          eq(rateTableCreatedAtCursor, cursor.createdAt),
           gt(rateTables.id, cursor.id),
         ),
       );
@@ -80,11 +82,12 @@ const readRateTables = createSafeHandler(
             currency: rateTables.currency,
             isDefault: rateTables.isDefault,
             createdAt: rateTables.createdAt,
+            createdAtCursor: rateTableCreatedAtCursor.as("created_at_cursor"),
             updatedAt: rateTables.updatedAt,
           })
           .from(rateTables)
           .where(and(...conditions))
-          .orderBy(asc(rateTables.createdAt), asc(rateTables.id))
+          .orderBy(asc(rateTableCreatedAtCursor), asc(rateTables.id))
           .limit(limit + 1),
       ),
     );
@@ -93,7 +96,7 @@ const readRateTables = createSafeHandler(
       rows: tables,
       limit,
       cursorForItem: (item) =>
-        encodePaginationCursor([item.createdAt.toISOString(), item.id]),
+        encodePaginationCursor([item.createdAtCursor.toISOString(), item.id]),
     });
 
     // Batch count entries per table

--- a/apps/api/src/handlers/rates/read.ts
+++ b/apps/api/src/handlers/rates/read.ts
@@ -10,6 +10,8 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isUuidPaginationCursorPart,
+  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedRateTableId } from "@/api/lib/safe-id-boundaries";
 
@@ -30,12 +32,9 @@ const decodeRateTableCursor = (cursor: string): RateTableCursor | null => {
   const createdAt = parts?.at(0);
   const id = parts?.at(1);
 
-  if (typeof createdAt !== "string" || typeof id !== "string") {
-    return null;
-  }
+  const createdAtDate = parseDateTimePaginationCursorPart(createdAt);
 
-  const createdAtDate = new Date(createdAt);
-  if (Number.isNaN(createdAtDate.getTime())) {
+  if (!createdAtDate || !isUuidPaginationCursorPart(id)) {
     return null;
   }
 

--- a/apps/api/src/handlers/rates/read.ts
+++ b/apps/api/src/handlers/rates/read.ts
@@ -1,14 +1,44 @@
 import { Result } from "better-result";
-import { eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { rateEntries, rateTables } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedRateTableId } from "@/api/lib/safe-id-boundaries";
 
 const readRateTablesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 200 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
 });
+
+type RateTableCursor = {
+  createdAt: Date;
+  id: SafeId<"rateTable">;
+};
+
+const decodeRateTableCursor = (cursor: string): RateTableCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const createdAt = parts?.at(0);
+  const id = parts?.at(1);
+
+  if (typeof createdAt !== "string" || typeof id !== "string") {
+    return null;
+  }
+
+  const createdAtDate = new Date(createdAt);
+  if (Number.isNaN(createdAtDate.getTime())) {
+    return null;
+  }
+
+  return { createdAt: createdAtDate, id: brandPersistedRateTableId(id) };
+};
 
 const readRateTables = createSafeHandler(
   {
@@ -17,7 +47,29 @@ const readRateTables = createSafeHandler(
   },
   async function* ({ safeDb, workspaceId, query }) {
     const limit = query.limit ?? 50;
-    const offset = query.offset ?? 0;
+    const conditions = [eq(rateTables.workspaceId, workspaceId)];
+
+    if (query.cursor) {
+      const cursor = decodeRateTableCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(rateTables.createdAt, cursor.createdAt),
+        and(
+          eq(rateTables.createdAt, cursor.createdAt),
+          gt(rateTables.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
+    }
 
     const tables = yield* Result.await(
       safeDb((tx) =>
@@ -31,15 +83,21 @@ const readRateTables = createSafeHandler(
             updatedAt: rateTables.updatedAt,
           })
           .from(rateTables)
-          .where(eq(rateTables.workspaceId, workspaceId))
-          .orderBy(rateTables.createdAt)
-          .limit(limit)
-          .offset(offset),
+          .where(and(...conditions))
+          .orderBy(asc(rateTables.createdAt), asc(rateTables.id))
+          .limit(limit + 1),
       ),
     );
 
+    const page = createCursorPage({
+      rows: tables,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.createdAt.toISOString(), item.id]),
+    });
+
     // Batch count entries per table
-    const tableIds = tables.map((table) => table.id);
+    const tableIds = page.items.map((table) => table.id);
     const entryCounts = new Map<string, number>();
 
     if (tableIds.length > 0) {
@@ -61,8 +119,9 @@ const readRateTables = createSafeHandler(
       }
     }
 
-    return Result.ok(
-      tables.map((table) => ({
+    return Result.ok({
+      ...page,
+      items: page.items.map((table) => ({
         id: table.id,
         name: table.name,
         currency: table.currency,
@@ -71,7 +130,7 @@ const readRateTables = createSafeHandler(
         createdAt: table.createdAt.toISOString(),
         updatedAt: table.updatedAt.toISOString(),
       })),
-    );
+    });
   },
 );
 

--- a/apps/api/src/handlers/rates/routes.ts
+++ b/apps/api/src/handlers/rates/routes.ts
@@ -23,41 +23,50 @@ export const ratesRoute = new Elysia({
   })
   // Rate tables
   .get("/", readRateTables.handler, {
+    permissions: readRateTables.config.permissions,
     query: readRateTables.config.query,
   })
   .put("/", createRateTable.handler, {
-    invalidateQuery: true,
     body: createRateTable.config.body,
+    invalidateQuery: true,
+    permissions: createRateTable.config.permissions,
   })
   .patch("/", updateRateTable.handler, {
-    invalidateQuery: true,
     body: updateRateTable.config.body,
+    invalidateQuery: true,
+    permissions: updateRateTable.config.permissions,
   })
   .delete("/", deleteRateTable.handler, {
-    invalidateQuery: true,
     body: deleteRateTable.config.body,
+    invalidateQuery: true,
+    permissions: deleteRateTable.config.permissions,
   })
   // Rate resolution
   .get("/resolve", resolveRate.handler, {
+    permissions: resolveRate.config.permissions,
     query: resolveRate.config.query,
   })
   // Rate entries
   .get("/:rateTableId/entries", readRateEntries.handler, {
     params: readRateEntries.config.params,
+    permissions: readRateEntries.config.permissions,
     query: readRateEntries.config.query,
   })
   .put("/:rateTableId/entries", createRateEntry.handler, {
-    params: createRateEntry.config.params,
-    invalidateQuery: true,
     body: createRateEntry.config.body,
+    invalidateQuery: true,
+    params: createRateEntry.config.params,
+    permissions: createRateEntry.config.permissions,
   })
   .patch("/:rateTableId/entries", updateRateEntry.handler, {
-    params: updateRateEntry.config.params,
-    invalidateQuery: true,
     body: updateRateEntry.config.body,
+    invalidateQuery: true,
+    params: updateRateEntry.config.params,
+    permissions: updateRateEntry.config.permissions,
   })
   .delete("/:rateTableId/entries", deleteRateEntry.handler, {
-    params: deleteRateEntry.config.params,
-    invalidateQuery: true,
     body: deleteRateEntry.config.body,
+    invalidateQuery: true,
+    params: deleteRateEntry.config.params,
+    permissions: deleteRateEntry.config.permissions,
   });

--- a/apps/api/src/handlers/search/routes.ts
+++ b/apps/api/src/handlers/search/routes.ts
@@ -148,16 +148,23 @@ export const searchRoute = new Elysia({ prefix: "/search" })
   .use(authMacro)
   .use(permissionMacro)
   .guard({ validateAuth: true })
-  .post("/", searchEndpoint.handler, { body: searchEndpoint.config.body })
+  .post("/", searchEndpoint.handler, {
+    body: searchEndpoint.config.body,
+    permissions: searchEndpoint.config.permissions,
+  })
   .post("/facets", searchFacetsEndpoint.handler, {
     body: searchFacetsEndpoint.config.body,
+    permissions: searchFacetsEndpoint.config.permissions,
   })
   .post("/refine", refineSearchEndpoint.handler, {
     body: refineSearchEndpoint.config.body,
+    permissions: refineSearchEndpoint.config.permissions,
   })
   .post("/summary", summarizeSearchEndpoint.handler, {
     body: summarizeSearchEndpoint.config.body,
+    permissions: summarizeSearchEndpoint.config.permissions,
   })
   .post("/summary/chat", searchSummaryChatEndpoint.handler, {
     body: searchSummaryChatEndpoint.config.body,
+    permissions: searchSummaryChatEndpoint.config.permissions,
   });

--- a/apps/api/src/handlers/shortcuts/routes.ts
+++ b/apps/api/src/handlers/shortcuts/routes.ts
@@ -13,20 +13,26 @@ export const shortcutsRoute = new Elysia({ prefix: "/shortcuts" })
   .use(permissionMacro)
   .use(invalidateQuery)
   .guard({ validateAuth: true })
-  .get("/", listShortcuts.handler)
+  .get("/", listShortcuts.handler, {
+    permissions: listShortcuts.config.permissions,
+  })
   .put("/", createShortcut.handler, {
     body: createShortcut.config.body,
     invalidateQuery: true,
+    permissions: createShortcut.config.permissions,
   })
   .post("/seed", seedShortcuts.handler, {
     invalidateQuery: true,
+    permissions: seedShortcuts.config.permissions,
   })
   .post("/:shortcutId", updateShortcut.handler, {
-    params: updateShortcut.config.params,
     body: updateShortcut.config.body,
     invalidateQuery: true,
+    params: updateShortcut.config.params,
+    permissions: updateShortcut.config.permissions,
   })
   .delete("/:shortcutId", deleteShortcut.handler, {
-    params: deleteShortcut.config.params,
     invalidateQuery: true,
+    params: deleteShortcut.config.params,
+    permissions: deleteShortcut.config.permissions,
   });

--- a/apps/api/src/handlers/skills/routes.ts
+++ b/apps/api/src/handlers/skills/routes.ts
@@ -13,21 +13,28 @@ export const skillsRoute = new Elysia({ prefix: "/skills" })
   .use(permissionMacro)
   .use(invalidateQuery)
   .guard({ validateAuth: true })
-  .get("/", listSkills.handler, { query: listSkills.config.query })
+  .get("/", listSkills.handler, {
+    permissions: listSkills.config.permissions,
+    query: listSkills.config.query,
+  })
   .post("/upload", uploadSkill.handler, {
     body: uploadSkill.config.body,
     invalidateQuery: true,
+    permissions: uploadSkill.config.permissions,
   })
   .post("/import-url", importSkillFromUrl.handler, {
     body: importSkillFromUrl.config.body,
     invalidateQuery: true,
+    permissions: importSkillFromUrl.config.permissions,
   })
   .patch("/:skillId", updateSkill.handler, {
-    params: updateSkill.config.params,
     body: updateSkill.config.body,
     invalidateQuery: true,
+    params: updateSkill.config.params,
+    permissions: updateSkill.config.permissions,
   })
   .delete("/:skillId", deleteSkill.handler, {
-    params: deleteSkill.config.params,
     invalidateQuery: true,
+    params: deleteSkill.config.params,
+    permissions: deleteSkill.config.permissions,
   });

--- a/apps/api/src/handlers/tasks/routes.ts
+++ b/apps/api/src/handlers/tasks/routes.ts
@@ -22,35 +22,44 @@ export const tasksRoute = new Elysia({
     validateWorkspaceAccess: true,
   })
   .put("/", createTask.handler, {
-    invalidateQuery: true,
     body: createTask.config.body,
+    invalidateQuery: true,
+    permissions: createTask.config.permissions,
   })
   .patch("/", updateTask.handler, {
-    invalidateQuery: true,
     body: updateTask.config.body,
+    invalidateQuery: true,
+    permissions: updateTask.config.permissions,
   })
   .post("/calendar", calendarTasks.handler, {
     body: calendarTasks.config.body,
+    permissions: calendarTasks.config.permissions,
   })
   .get("/:taskId", readTaskById.handler, {
     params: readTaskById.config.params,
+    permissions: readTaskById.config.permissions,
   })
   .post("/assignees", addAssignee.handler, {
-    invalidateQuery: true,
     body: addAssignee.config.body,
+    invalidateQuery: true,
+    permissions: addAssignee.config.permissions,
   })
   .delete("/assignees", removeAssignee.handler, {
-    invalidateQuery: true,
     body: removeAssignee.config.body,
+    invalidateQuery: true,
+    permissions: removeAssignee.config.permissions,
   })
   .post("/links", createEntityLink.handler, {
-    invalidateQuery: true,
     body: createEntityLink.config.body,
+    invalidateQuery: true,
+    permissions: createEntityLink.config.permissions,
   })
   .delete("/links", deleteEntityLink.handler, {
-    invalidateQuery: true,
     body: deleteEntityLink.config.body,
+    invalidateQuery: true,
+    permissions: deleteEntityLink.config.permissions,
   })
   .get("/:taskId/links", listEntityLinks.handler, {
     params: listEntityLinks.config.params,
+    permissions: listEntityLinks.config.permissions,
   });

--- a/apps/api/src/handlers/templates/routes.ts
+++ b/apps/api/src/handlers/templates/routes.ts
@@ -34,61 +34,80 @@ export const templatesRoute = new Elysia({
   // ── Existing transient endpoints ───────────────────
   .post("/discover", discoverTemplate.handler, {
     body: discoverTemplate.config.body,
+    permissions: discoverTemplate.config.permissions,
   })
   .post("/fill", fillTemplate.handler, {
     body: fillTemplate.config.body,
+    permissions: fillTemplate.config.permissions,
     query: fillTemplate.config.query,
   })
   .post("/manifest", manifestTemplate.handler, {
     body: manifestTemplate.config.body,
+    permissions: manifestTemplate.config.permissions,
   })
   // ── CRUD endpoints ─────────────────────────────────
-  .get("/", listTemplates.handler, { query: listTemplates.config.query })
+  .get("/", listTemplates.handler, {
+    permissions: listTemplates.config.permissions,
+    query: listTemplates.config.query,
+  })
   .put("/", createTemplate.handler, {
     body: createTemplate.config.body,
+    permissions: createTemplate.config.permissions,
   })
   .get("/:templateId/preview", previewTemplate.handler, {
     params: previewTemplate.config.params,
+    permissions: previewTemplate.config.permissions,
   })
   .post("/:templateId/fill-preview", fillTemplatePreview.handler, {
-    params: fillTemplatePreview.config.params,
     body: fillTemplatePreview.config.body,
+    params: fillTemplatePreview.config.params,
+    permissions: fillTemplatePreview.config.permissions,
   })
   .post("/:templateId/fill", fillTemplateById.handler, {
-    params: fillTemplateById.config.params,
     body: fillTemplateById.config.body,
+    params: fillTemplateById.config.params,
+    permissions: fillTemplateById.config.permissions,
     query: fillTemplateById.config.query,
   })
   .get("/:templateId", getTemplate.handler, {
     params: getTemplate.config.params,
+    permissions: getTemplate.config.permissions,
   })
   .post("/:templateId", updateTemplate.handler, {
-    params: updateTemplate.config.params,
     body: updateTemplate.config.body,
+    params: updateTemplate.config.params,
+    permissions: updateTemplate.config.permissions,
   })
   .delete("/:templateId", deleteTemplate.handler, {
     params: deleteTemplate.config.params,
+    permissions: deleteTemplate.config.permissions,
   })
   // ── Versions ──────────────────────────────────────
   .get("/:templateId/versions", listTemplateVersions.handler, {
     params: listTemplateVersions.config.params,
+    permissions: listTemplateVersions.config.permissions,
   })
   .get("/:templateId/versions/:versionId", getTemplateVersion.handler, {
     params: getTemplateVersion.config.params,
+    permissions: getTemplateVersion.config.permissions,
   })
   // ── Clause linking ──────────────────────────────────
   .get("/:templateId/clauses", listTemplateClauses.handler, {
     params: listTemplateClauses.config.params,
+    permissions: listTemplateClauses.config.permissions,
   })
   .put("/:templateId/clauses", linkTemplateClause.handler, {
-    params: linkTemplateClause.config.params,
     body: linkTemplateClause.config.body,
+    params: linkTemplateClause.config.params,
+    permissions: linkTemplateClause.config.permissions,
   })
   .delete("/:templateId/clauses/:linkId", unlinkTemplateClause.handler, {
     params: unlinkTemplateClause.config.params,
+    permissions: unlinkTemplateClause.config.permissions,
   })
   .post("/:templateId/clauses/:linkId/sync", syncTemplateClause.handler, {
     params: syncTemplateClause.config.params,
+    permissions: syncTemplateClause.config.permissions,
   });
 
 // ── Template Categories ────────────────────────────
@@ -99,14 +118,19 @@ export const templateCategoriesRoute = new Elysia({
   .use(authMacro)
   .use(permissionMacro)
   .guard({ validateAuth: true })
-  .get("/", listTemplateCategories.handler)
+  .get("/", listTemplateCategories.handler, {
+    permissions: listTemplateCategories.config.permissions,
+  })
   .put("/", createTemplateCategory.handler, {
     body: createTemplateCategory.config.body,
+    permissions: createTemplateCategory.config.permissions,
   })
   .post("/:categoryId", updateTemplateCategory.handler, {
-    params: updateTemplateCategory.config.params,
     body: updateTemplateCategory.config.body,
+    params: updateTemplateCategory.config.params,
+    permissions: updateTemplateCategory.config.permissions,
   })
   .delete("/:categoryId", deleteTemplateCategory.handler, {
     params: deleteTemplateCategory.config.params,
+    permissions: deleteTemplateCategory.config.permissions,
   });

--- a/apps/api/src/handlers/time-entries/read.ts
+++ b/apps/api/src/handlers/time-entries/read.ts
@@ -1,5 +1,15 @@
 import { Result } from "better-result";
-import { and, eq, gte, inArray, isNotNull, lte } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  lte,
+  or,
+} from "drizzle-orm";
 import { t } from "elysia";
 
 import { member, user } from "@/api/db/auth-schema";
@@ -9,11 +19,19 @@ import {
 } from "@/api/db/billing-validators";
 import { timeEntries } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId, tUserId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
+import { brandPersistedTimeEntryId } from "@/api/lib/safe-id-boundaries";
 
 const readTimeEntriesQuerySchema = t.Object({
   limit: t.Optional(t.Integer({ minimum: 1, maximum: 200 })),
-  offset: t.Optional(t.Integer({ minimum: 0 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
   userId: t.Optional(tUserId),
   matterId: t.Optional(tSafeId("entity")),
   dateFrom: t.Optional(t.String({ format: "date" })),
@@ -24,6 +42,29 @@ const readTimeEntriesQuerySchema = t.Object({
   hasActiveTimer: t.Optional(t.BooleanString()),
 });
 
+type TimeEntryCursor = {
+  dateWorked: string;
+  id: SafeId<"timeEntry">;
+};
+
+const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
+
+const decodeTimeEntryCursor = (cursor: string): TimeEntryCursor | null => {
+  const parts = decodePaginationCursor(cursor);
+  const dateWorked = parts?.at(0);
+  const id = parts?.at(1);
+
+  if (
+    typeof dateWorked !== "string" ||
+    !dateCursorPattern.test(dateWorked) ||
+    typeof id !== "string"
+  ) {
+    return null;
+  }
+
+  return { dateWorked, id: brandPersistedTimeEntryId(id) };
+};
+
 const readTimeEntries = createSafeHandler(
   {
     permissions: { workspace: ["read"] },
@@ -31,7 +72,6 @@ const readTimeEntries = createSafeHandler(
   },
   async function* ({ safeDb, session, workspaceId, query }) {
     const limit = query.limit ?? 100;
-    const offset = query.offset ?? 0;
 
     const conditions = [eq(timeEntries.workspaceId, workspaceId)];
 
@@ -58,6 +98,27 @@ const readTimeEntries = createSafeHandler(
     }
     if (query.hasActiveTimer) {
       conditions.push(isNotNull(timeEntries.timerStartedAt));
+    }
+    if (query.cursor) {
+      const cursor = decodeTimeEntryCursor(query.cursor);
+
+      if (!cursor) {
+        return Result.err(
+          new HandlerError({ status: 400, message: "Invalid cursor" }),
+        );
+      }
+
+      const cursorCondition = or(
+        gt(timeEntries.dateWorked, cursor.dateWorked),
+        and(
+          eq(timeEntries.dateWorked, cursor.dateWorked),
+          gt(timeEntries.id, cursor.id),
+        ),
+      );
+
+      if (cursorCondition) {
+        conditions.push(cursorCondition);
+      }
     }
 
     const rows = yield* Result.await(
@@ -88,15 +149,21 @@ const readTimeEntries = createSafeHandler(
           })
           .from(timeEntries)
           .where(and(...conditions))
-          .orderBy(timeEntries.dateWorked)
-          .limit(limit)
-          .offset(offset),
+          .orderBy(asc(timeEntries.dateWorked), asc(timeEntries.id))
+          .limit(limit + 1),
       ),
     );
 
+    const page = createCursorPage({
+      rows,
+      limit,
+      cursorForItem: (item) =>
+        encodePaginationCursor([item.dateWorked, item.id]),
+    });
+
     // Batch-fetch user names
     const userIds = new Set<string>();
-    for (const row of rows) {
+    for (const row of page.items) {
       if (row.userId) {
         userIds.add(row.userId);
       }
@@ -122,8 +189,9 @@ const readTimeEntries = createSafeHandler(
 
     const userMap = new Map(usersResult.map((u) => [u.id, u.name]));
 
-    return Result.ok(
-      rows.map((row) => ({
+    return Result.ok({
+      ...page,
+      items: page.items.map((row) => ({
         id: row.id,
         userId: row.userId,
         matterId: row.matterId,
@@ -147,7 +215,7 @@ const readTimeEntries = createSafeHandler(
         createdAt: row.createdAt.toISOString(),
         updatedAt: row.updatedAt?.toISOString() ?? null,
       })),
-    );
+    });
   },
 );
 

--- a/apps/api/src/handlers/time-entries/read.ts
+++ b/apps/api/src/handlers/time-entries/read.ts
@@ -26,6 +26,8 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
+  isUuidPaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedTimeEntryId } from "@/api/lib/safe-id-boundaries";
 
@@ -47,17 +49,14 @@ type TimeEntryCursor = {
   id: SafeId<"timeEntry">;
 };
 
-const dateCursorPattern = /^\d{4}-\d{2}-\d{2}$/u;
-
 const decodeTimeEntryCursor = (cursor: string): TimeEntryCursor | null => {
   const parts = decodePaginationCursor(cursor);
   const dateWorked = parts?.at(0);
   const id = parts?.at(1);
 
   if (
-    typeof dateWorked !== "string" ||
-    !dateCursorPattern.test(dateWorked) ||
-    typeof id !== "string"
+    !isDateOnlyPaginationCursorPart(dateWorked) ||
+    !isUuidPaginationCursorPart(id)
   ) {
     return null;
   }

--- a/apps/api/src/handlers/time-entries/routes.ts
+++ b/apps/api/src/handlers/time-entries/routes.ts
@@ -104,48 +104,61 @@ export const timeEntriesRoute = new Elysia({
     validateWorkspaceAccess: true,
   })
   .get("/", readTimeEntries.handler, {
+    permissions: readTimeEntries.config.permissions,
     query: readTimeEntries.config.query,
   })
   .get("/:id", readTimeEntryById.handler, {
     params: readTimeEntryById.config.params,
+    permissions: readTimeEntryById.config.permissions,
   })
   .put("/", createTimeEntry.handler, {
-    invalidateQuery: true,
     body: createTimeEntry.config.body,
+    invalidateQuery: true,
+    permissions: createTimeEntry.config.permissions,
   })
   .patch("/", updateTimeEntryById.handler, {
-    invalidateQuery: true,
     body: updateTimeEntryById.config.body,
+    invalidateQuery: true,
+    permissions: updateTimeEntryById.config.permissions,
   })
   .delete("/", deleteTimeEntryById.handler, {
-    invalidateQuery: true,
     body: deleteTimeEntryById.config.body,
+    invalidateQuery: true,
+    permissions: deleteTimeEntryById.config.permissions,
   })
   .post("/timer/start", timerStart.handler, {
-    invalidateQuery: true,
     body: timerStart.config.body,
+    invalidateQuery: true,
+    permissions: timerStart.config.permissions,
   })
   .post("/timer/stop", timerStop.handler, {
     invalidateQuery: true,
+    permissions: timerStop.config.permissions,
   })
   .post("/batch", batchUpdate.handler, {
-    invalidateQuery: true,
     body: batchUpdate.config.body,
+    invalidateQuery: true,
+    permissions: batchUpdate.config.permissions,
   })
   .delete("/batch", batchDelete.handler, {
-    invalidateQuery: true,
     body: batchDelete.config.body,
+    invalidateQuery: true,
+    permissions: batchDelete.config.permissions,
   })
   .post("/split", splitEntry.handler, {
-    invalidateQuery: true,
     body: splitEntry.config.body,
+    invalidateQuery: true,
+    permissions: splitEntry.config.permissions,
   })
   .get("/export/csv", exportCsv.handler, {
+    permissions: exportCsv.config.permissions,
     query: exportCsv.config.query,
   })
   .get("/export/ledes", exportLedes.handler, {
+    permissions: exportLedes.config.permissions,
     query: exportLedes.config.query,
   })
   .get("/export/pdf", exportPdf.handler, {
+    permissions: exportPdf.config.permissions,
     query: exportPdf.config.query,
   });

--- a/apps/api/src/handlers/user-files/routes.ts
+++ b/apps/api/src/handlers/user-files/routes.ts
@@ -9,4 +9,5 @@ export const userFilesRoute = new Elysia({ prefix: "/user-files" })
   .guard({ validateAuth: true })
   .get("/:fileId/content", readUserFileContent.handler, {
     params: readUserFileContent.config.params,
+    permissions: readUserFileContent.config.permissions,
   });

--- a/apps/api/src/handlers/views/routes.ts
+++ b/apps/api/src/handlers/views/routes.ts
@@ -7,37 +7,46 @@ import readViews from "@/api/handlers/views/read";
 import reorderViews from "@/api/handlers/views/reorder";
 import exportTableView from "@/api/handlers/views/table-export";
 import updateView from "@/api/handlers/views/update";
-import { workspaceAccessMacro } from "@/api/lib/auth";
+import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 
 export const viewsRoute = new Elysia({
   prefix: "/views/:workspaceId",
 })
   .use(workspaceAccessMacro)
+  .use(permissionMacro)
   .guard({
     validateWorkspaceAccess: true,
   })
-  .get("/", readViews.handler)
+  .get("/", readViews.handler, {
+    permissions: readViews.config.permissions,
+  })
   .put("/", createView.handler, {
     body: createView.config.body,
+    permissions: createView.config.permissions,
   })
   .post("/reorder", reorderViews.handler, {
     body: reorderViews.config.body,
+    permissions: reorderViews.config.permissions,
   })
   .group("/view/:viewId", (app) =>
     app
       .post("/", updateView.handler, {
-        params: updateView.config.params,
         body: updateView.config.body,
+        params: updateView.config.params,
+        permissions: updateView.config.permissions,
       })
       .post("/convert", convertView.handler, {
-        params: convertView.config.params,
         body: convertView.config.body,
+        params: convertView.config.params,
+        permissions: convertView.config.permissions,
       })
       .get("/export", exportTableView.handler, {
         params: exportTableView.config.params,
+        permissions: exportTableView.config.permissions,
         query: exportTableView.config.query,
       })
       .delete("/", deleteView.handler, {
         params: deleteView.config.params,
+        permissions: deleteView.config.permissions,
       }),
   );

--- a/apps/api/src/handlers/workspaces/routes.ts
+++ b/apps/api/src/handlers/workspaces/routes.ts
@@ -166,13 +166,20 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
   .guard({
     validateAuth: true,
   })
-  .get("/", readWorkspaces.handler)
-  .get("/navigation", readWorkspaceNavigation.handler)
+  .get("/", readWorkspaces.handler, {
+    permissions: readWorkspaces.config.permissions,
+  })
+  .get("/navigation", readWorkspaceNavigation.handler, {
+    permissions: readWorkspaceNavigation.config.permissions,
+  })
   .put("/", createWorkspaces.handler, {
     body: createWorkspaces.config.body,
     invalidateQuery: true,
+    permissions: createWorkspaces.config.permissions,
   })
-  .get("/active", readActiveWorkspace.handler)
+  .get("/active", readActiveWorkspace.handler, {
+    permissions: readActiveWorkspace.config.permissions,
+  })
   .group(
     "/:workspaceId",
     {
@@ -181,80 +188,107 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
     },
     (app) =>
       app
-        .get("/", readWorkspace.handler)
-        .get("/workflow", readWorkflow.handler)
+        .get("/", readWorkspace.handler, {
+          permissions: readWorkspace.config.permissions,
+        })
+        .get("/workflow", readWorkflow.handler, {
+          permissions: readWorkflow.config.permissions,
+        })
         .post("/workflow/start", workflowStart.handler, {
           body: workflowStart.config.body,
           permissions: workflowStart.config.permissions,
         })
         .post("/justifications/query", readJustifications.handler, {
           body: readJustifications.config.body,
+          permissions: readJustifications.config.permissions,
         })
         .post("/bounding-boxes", generateBoundingBoxes.handler, {
           body: generateBoundingBoxes.config.body,
           invalidateQuery: true,
+          permissions: generateBoundingBoxes.config.permissions,
         })
-        .get("/infosoud/courts", infosoudCourts.handler)
+        .get("/infosoud/courts", infosoudCourts.handler, {
+          permissions: infosoudCourts.config.permissions,
+        })
         .post("/infosoud/lookup", infosoudLookup.handler, {
           body: infosoudLookup.config.body,
+          permissions: infosoudLookup.config.permissions,
         })
         .post("/infosoud/import-agenda", infosoudImportAgenda.handler, {
           body: infosoudImportAgenda.config.body,
           invalidateQuery: true,
+          permissions: infosoudImportAgenda.config.permissions,
         })
-        .get("/overview", readOverview.handler)
+        .get("/overview", readOverview.handler, {
+          permissions: readOverview.config.permissions,
+        })
         .post("/", updateWorkspace.handler, {
           body: updateWorkspace.config.body,
           invalidateQuery: true,
+          permissions: updateWorkspace.config.permissions,
         })
         .post("/duplicate", duplicateWorkspace.handler, {
           body: duplicateWorkspace.config.body,
-          permissions: duplicateWorkspace.config.permissions,
           invalidateOrganizationQuery: true,
+          permissions: duplicateWorkspace.config.permissions,
         })
-        .post("/active", updateActiveWorkspace.handler)
+        .post("/active", updateActiveWorkspace.handler, {
+          permissions: updateActiveWorkspace.config.permissions,
+        })
         .delete("/", deleteWorkspace.handler, {
           invalidateQuery: true,
+          permissions: deleteWorkspace.config.permissions,
         })
         .post("/archive", archiveWorkspace.handler, {
-          permissions: archiveWorkspace.config.permissions,
           invalidateQuery: true,
+          permissions: archiveWorkspace.config.permissions,
         })
         // Unarchive is mounted below, outside the active-only group.
-        .get("/contacts", readWorkspaceContacts.handler)
+        .get("/contacts", readWorkspaceContacts.handler, {
+          permissions: readWorkspaceContacts.config.permissions,
+        })
         .put("/contacts", createWorkspaceContact.handler, {
           body: createWorkspaceContact.config.body,
           invalidateQuery: true,
+          permissions: createWorkspaceContact.config.permissions,
         })
         .delete(
           "/contacts/:workspaceContactId",
           deleteWorkspaceContact.handler,
           {
-            params: deleteWorkspaceContact.config.params,
             invalidateQuery: true,
+            params: deleteWorkspaceContact.config.params,
+            permissions: deleteWorkspaceContact.config.permissions,
           },
         )
-        .get("/anonymization-terms", readWorkspaceAnonymizationTerms.handler)
+        .get("/anonymization-terms", readWorkspaceAnonymizationTerms.handler, {
+          permissions: readWorkspaceAnonymizationTerms.config.permissions,
+        })
         .put(
           "/anonymization-terms",
           createWorkspaceAnonymizationTerms.handler,
           {
             body: createWorkspaceAnonymizationTerms.config.body,
             invalidateQuery: true,
+            permissions: createWorkspaceAnonymizationTerms.config.permissions,
           },
         )
         .delete(
           "/anonymization-terms/:entryId",
           deleteWorkspaceAnonymizationTerm.handler,
           {
-            params: deleteWorkspaceAnonymizationTerm.config.params,
             invalidateQuery: true,
+            params: deleteWorkspaceAnonymizationTerm.config.params,
+            permissions: deleteWorkspaceAnonymizationTerm.config.permissions,
           },
         )
         .get(
           "/anonymization-allowlist",
           readWorkspaceAnonymizationAllowlist.handler,
-          { query: readWorkspaceAnonymizationAllowlist.config.query },
+          {
+            permissions: readWorkspaceAnonymizationAllowlist.config.permissions,
+            query: readWorkspaceAnonymizationAllowlist.config.query,
+          },
         )
         .put(
           "/anonymization-allowlist",
@@ -262,28 +296,36 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
           {
             body: createWorkspaceAnonymizationAllowlistEntry.config.body,
             invalidateQuery: true,
+            permissions:
+              createWorkspaceAnonymizationAllowlistEntry.config.permissions,
           },
         )
         .delete(
           "/anonymization-allowlist/:entryId",
           deleteWorkspaceAnonymizationAllowlistEntry.handler,
           {
-            params: deleteWorkspaceAnonymizationAllowlistEntry.config.params,
             invalidateQuery: true,
+            params: deleteWorkspaceAnonymizationAllowlistEntry.config.params,
+            permissions:
+              deleteWorkspaceAnonymizationAllowlistEntry.config.permissions,
           },
         )
-        .get("/members", readWorkspaceMembers.handler)
+        .get("/members", readWorkspaceMembers.handler, {
+          permissions: readWorkspaceMembers.config.permissions,
+        })
         .put("/members", addWorkspaceMember.handler, {
           body: addWorkspaceMember.config.body,
           invalidateQuery: true,
+          permissions: addWorkspaceMember.config.permissions,
         })
         .delete("/members/:userId", removeWorkspaceMember.handler, {
-          params: removeWorkspaceMember.config.params,
           invalidateQuery: true,
+          params: removeWorkspaceMember.config.params,
+          permissions: removeWorkspaceMember.config.permissions,
         }),
   )
   .post("/:workspaceId/unarchive", unarchiveWorkspace.handler, {
-    validateWorkspaceAccessIncludingArchived: true,
-    permissions: unarchiveWorkspace.config.permissions,
     invalidateQuery: true,
+    permissions: unarchiveWorkspace.config.permissions,
+    validateWorkspaceAccessIncludingArchived: true,
   });

--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { createCursorPage } from "@/api/lib/pagination";
+import {
+  createCursorPage,
+  decodePaginationCursor,
+  encodePaginationCursor,
+} from "@/api/lib/pagination";
 
 describe("cursor pagination", () => {
   test("returns the requested window and a cursor when another row exists", () => {
@@ -29,5 +33,26 @@ describe("cursor pagination", () => {
       limit: 2,
       nextCursor: null,
     });
+  });
+
+  test("roundtrips opaque cursor parts", () => {
+    const cursor = encodePaginationCursor([
+      "2026-05-16T10:30:00.000Z",
+      "invoice_123",
+      7,
+    ]);
+
+    expect(decodePaginationCursor(cursor)).toEqual([
+      "2026-05-16T10:30:00.000Z",
+      "invoice_123",
+      7,
+    ]);
+  });
+
+  test("rejects malformed cursors", () => {
+    expect(decodePaginationCursor("not-json")).toBeNull();
+    expect(decodePaginationCursor(encodePaginationCursor(["valid"]))).toEqual([
+      "valid",
+    ]);
   });
 });

--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -4,6 +4,9 @@ import {
   createCursorPage,
   decodePaginationCursor,
   encodePaginationCursor,
+  isDateOnlyPaginationCursorPart,
+  isUuidPaginationCursorPart,
+  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 
 describe("cursor pagination", () => {
@@ -54,5 +57,30 @@ describe("cursor pagination", () => {
     expect(decodePaginationCursor(encodePaginationCursor(["valid"]))).toEqual([
       "valid",
     ]);
+  });
+
+  test("validates date-only cursor parts", () => {
+    expect(isDateOnlyPaginationCursorPart("2026-05-16")).toBe(true);
+    expect(isDateOnlyPaginationCursorPart("2026-02-30")).toBe(false);
+    expect(isDateOnlyPaginationCursorPart("2026-99-99")).toBe(false);
+    expect(isDateOnlyPaginationCursorPart("2026-5-16")).toBe(false);
+  });
+
+  test("validates UUID cursor parts", () => {
+    expect(
+      isUuidPaginationCursorPart("018f3d26-388b-7b90-9e39-86c58be5f97a"),
+    ).toBe(true);
+    expect(isUuidPaginationCursorPart("not-a-uuid")).toBe(false);
+    expect(isUuidPaginationCursorPart("invoice_123")).toBe(false);
+  });
+
+  test("parses canonical ISO datetime cursor parts", () => {
+    expect(
+      parseDateTimePaginationCursorPart("2026-05-16T10:30:00.000Z"),
+    ).toEqual(new Date("2026-05-16T10:30:00.000Z"));
+    expect(parseDateTimePaginationCursorPart("2026-99-99")).toBeNull();
+    expect(
+      parseDateTimePaginationCursorPart("2026-05-16T10:30:00Z"),
+    ).toBeNull();
   });
 });

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -4,6 +4,8 @@ export type Page<T> = {
   limit: number;
 };
 
+type CursorPrimitive = string | number | boolean | null;
+
 type CursorPageOptions<T> = {
   rows: readonly T[];
   limit: number;
@@ -26,4 +28,20 @@ export const createCursorPage = <T>({
         ? cursorForItem(lastItem)
         : null,
   };
+};
+
+export const encodePaginationCursor = (
+  parts: readonly CursorPrimitive[],
+): string => Buffer.from(JSON.stringify(parts)).toString("base64url");
+
+export const decodePaginationCursor = (cursor: string): unknown[] | null => {
+  try {
+    const parsed: unknown = JSON.parse(
+      Buffer.from(cursor, "base64url").toString("utf-8"),
+    );
+
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
 };

--- a/apps/api/src/lib/pagination.ts
+++ b/apps/api/src/lib/pagination.ts
@@ -12,6 +12,10 @@ type CursorPageOptions<T> = {
   cursorForItem: (item: T) => string;
 };
 
+const dateOnlyCursorPartPattern = /^\d{4}-\d{2}-\d{2}$/u;
+const uuidCursorPartPattern =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
+
 export const createCursorPage = <T>({
   rows,
   limit,
@@ -44,4 +48,38 @@ export const decodePaginationCursor = (cursor: string): unknown[] | null => {
   } catch {
     return null;
   }
+};
+
+export const isDateOnlyPaginationCursorPart = (
+  value: unknown,
+): value is string => {
+  if (typeof value !== "string" || !dateOnlyCursorPartPattern.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  );
+};
+
+export const isUuidPaginationCursorPart = (value: unknown): value is string =>
+  typeof value === "string" && uuidCursorPartPattern.test(value);
+
+export const parseDateTimePaginationCursorPart = (
+  value: unknown,
+): Date | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+    return null;
+  }
+
+  return parsed;
 };

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -59,8 +59,30 @@ export const brandPersistedAuditLogId = (
   auditLogId: string,
 ): SafeId<"auditLog"> => toSafeId<"auditLog">(auditLogId);
 
+export const brandPersistedBillingCodeId = (
+  billingCodeId: string,
+): SafeId<"billingCode"> => toSafeId<"billingCode">(billingCodeId);
+
 export const brandPersistedClauseId = (clauseId: string): SafeId<"clause"> =>
   toSafeId<"clause">(clauseId);
+
+export const brandPersistedExpenseId = (expenseId: string): SafeId<"expense"> =>
+  toSafeId<"expense">(expenseId);
+
+export const brandPersistedInvoiceId = (invoiceId: string): SafeId<"invoice"> =>
+  toSafeId<"invoice">(invoiceId);
+
+export const brandPersistedRateEntryId = (
+  rateEntryId: string,
+): SafeId<"rateEntry"> => toSafeId<"rateEntry">(rateEntryId);
+
+export const brandPersistedRateTableId = (
+  rateTableId: string,
+): SafeId<"rateTable"> => toSafeId<"rateTable">(rateTableId);
+
+export const brandPersistedTimeEntryId = (
+  timeEntryId: string,
+): SafeId<"timeEntry"> => toSafeId<"timeEntry">(timeEntryId);
 
 export const brandPersistedUserId = (userId: string): SafeId<"user"> =>
   toSafeId<"user">(userId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/billing-codes.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/billing-codes.ts
@@ -32,6 +32,6 @@ export const billingCodesOptions = (
         throw toAPIError(response.error);
       }
 
-      return response.data;
+      return response.data.items;
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/expenses.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/expenses.ts
@@ -59,6 +59,6 @@ export const expensesOptions = (
         throw toAPIError(response.error);
       }
 
-      return response.data;
+      return response.data.items;
     },
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
@@ -8,7 +8,7 @@ type InvoiceStatus = "draft" | "finalized" | "sent" | "paid" | "void";
 
 type InvoicesFilters = {
   limit?: number;
-  offset?: number;
+  cursor?: string;
 };
 
 export const invoicesKeys = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { infiniteQueryOptions, queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
@@ -10,6 +10,8 @@ type InvoicesFilters = {
   limit?: number;
   cursor?: string;
 };
+
+const getInitialInvoicesPageParam = (): string | undefined => undefined;
 
 export const invoicesKeys = {
   all: (workspaceId: string) => ["invoices", workspaceId],
@@ -41,6 +43,28 @@ export const invoicesOptions = (
 
       return response.data;
     },
+  });
+
+export const invoicesInfiniteOptions = (workspaceId: string, limit: number) =>
+  infiniteQueryOptions({
+    queryKey: [...invoicesKeys.all(workspaceId), "infinite", { limit }],
+    queryFn: async ({ pageParam, signal }) => {
+      const response = await api.invoices({ workspaceId }).get({
+        query: {
+          limit,
+          ...(pageParam === undefined ? {} : { cursor: pageParam }),
+        },
+        fetch: { signal },
+      });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+    initialPageParam: getInitialInvoicesPageParam(),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
   });
 
 export const invoiceByIdOptions = (workspaceId: string, invoiceId: string) =>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/rates.ts
@@ -32,7 +32,7 @@ export const rateTablesOptions = (workspaceId: string) =>
         throw toAPIError(response.error);
       }
 
-      return response.data;
+      return response.data.items;
     },
   });
 
@@ -50,7 +50,7 @@ export const rateEntriesOptions = (workspaceId: string, rateTableId: string) =>
         throw toAPIError(response.error);
       }
 
-      return response.data;
+      return response.data.items;
     },
     enabled: rateTableId.length > 0,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/time-entries.ts
@@ -60,7 +60,7 @@ export const timeEntriesOptions = (
         throw toAPIError(response.error);
       }
 
-      return response.data;
+      return response.data.items;
     },
   });
 
@@ -84,7 +84,7 @@ export const activeTimerOptions = (workspaceId: string) =>
         throw toAPIError(response.error);
       }
 
-      return response.data.at(0) ?? null;
+      return response.data.items.at(0) ?? null;
     },
     refetchInterval: 60_000,
   });

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
@@ -1,6 +1,6 @@
-import { Suspense, useState } from "react";
+import { Suspense } from "react";
 
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import {
   createFileRoute,
   Link,
@@ -16,7 +16,7 @@ import { Button } from "@stll/ui/components/button";
 import { usePermissions } from "@/hooks/use-permissions";
 import { formatCurrencyAmount } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/format-currency";
 import { InvoiceStatusBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/billing/invoice-status-badge";
-import { invoicesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/invoices";
+import { invoicesInfiniteOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/invoices";
 
 export const Route = createFileRoute(
   "/_protected/workspaces/$workspaceId/invoices",
@@ -78,18 +78,17 @@ const PAGE_SIZE = 50;
 const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
   const t = useTranslations();
   const navigate = useNavigate();
-  const [limit, setLimit] = useState(PAGE_SIZE);
-  const { data } = useSuspenseQuery(invoicesOptions(workspaceId, { limit }));
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useSuspenseInfiniteQuery(invoicesInfiniteOptions(workspaceId, PAGE_SIZE));
+  const invoices = data.pages.flatMap((page) => page.items);
 
-  if (data.items.length === 0) {
+  if (invoices.length === 0) {
     return (
       <div className="text-muted-foreground py-16 text-center text-sm">
         {t("billing.invoices.noInvoices")}
       </div>
     );
   }
-
-  const hasMore = data.nextCursor !== null;
 
   return (
     <div className="flex flex-col gap-3">
@@ -114,7 +113,7 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
             </tr>
           </thead>
           <tbody>
-            {data.items.map((invoice) => (
+            {invoices.map((invoice) => (
               <tr
                 className="hover:bg-muted/30 cursor-pointer border-b last:border-0"
                 key={invoice.id}
@@ -152,10 +151,13 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
           </tbody>
         </table>
       </div>
-      {hasMore && (
+      {hasNextPage && (
         <div className="flex justify-center">
           <Button
-            onClick={() => setLimit((l) => l + PAGE_SIZE)}
+            disabled={isFetchingNextPage}
+            onClick={() => {
+              void fetchNextPage();
+            }}
             size="sm"
             variant="ghost"
           >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/invoices.tsx
@@ -81,7 +81,7 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
   const [limit, setLimit] = useState(PAGE_SIZE);
   const { data } = useSuspenseQuery(invoicesOptions(workspaceId, { limit }));
 
-  if (data.rows.length === 0) {
+  if (data.items.length === 0) {
     return (
       <div className="text-muted-foreground py-16 text-center text-sm">
         {t("billing.invoices.noInvoices")}
@@ -89,7 +89,7 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
     );
   }
 
-  const hasMore = data.rows.length < data.total;
+  const hasMore = data.nextCursor !== null;
 
   return (
     <div className="flex flex-col gap-3">
@@ -114,7 +114,7 @@ const InvoicesList = ({ workspaceId }: { workspaceId: string }) => {
             </tr>
           </thead>
           <tbody>
-            {data.rows.map((invoice) => (
+            {data.items.map((invoice) => (
               <tr
                 className="hover:bg-muted/30 cursor-pointer border-b last:border-0"
                 key={invoice.id}


### PR DESCRIPTION
## Summary
- migrate billing/time list endpoints to cursor Page<T> responses and update web query adapters
- thread endpoint permission configs into route-level permission macros across privileged API routes
- align desktop edit session event stream token validation with the status endpoint

## Checks
- bun --filter @stll/api typecheck
- bun --filter @stll/api lint
- bun --filter @stll/web typecheck
- bun --filter @stll/web lint
- bun --cwd apps/api test src/handlers/entities/desktop-edit-session-events.test.ts src/lib/pagination.test.ts
- pre-commit/pre-push hooks