### PR TITLE
refactor(api): make ProviderProbeResult a discriminated union

### DIFF
--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -507,7 +507,7 @@ const validateProviderKey = async (
     return { valid: false, error: result.error };
   }
   if (!result.value.valid) {
-    return { valid: false, error: result.value.error ?? "Unknown error" };
+    return { valid: false, error: result.value.error };
   }
   return { valid: true };
 };

--- a/apps/api/src/handlers/organization-settings/update-ai-config.ts
+++ b/apps/api/src/handlers/organization-settings/update-ai-config.ts
@@ -21,6 +21,7 @@ import type {
   OrgAIProviderConfig,
 } from "@/api/lib/ai-models";
 import { probeProvider } from "@/api/lib/ai-provider-probe";
+import type { ProviderProbeResult } from "@/api/lib/ai-provider-probe";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -222,7 +223,7 @@ const updateAIConfig = createSafeRootHandler(
   },
 );
 
-type ValidationResult = { valid: true } | { valid: false; error: string };
+type ValidationResult = ProviderProbeResult;
 
 type ProviderConfigInput = {
   provider: BYOKProvider;
@@ -506,10 +507,7 @@ const validateProviderKey = async (
   if (result.isErr()) {
     return { valid: false, error: result.error };
   }
-  if (!result.value.valid) {
-    return { valid: false, error: result.value.error };
-  }
-  return { valid: true };
+  return result.value;
 };
 
 const collectAzureDeployments = (

--- a/apps/api/src/lib/ai-provider-probe.ts
+++ b/apps/api/src/lib/ai-provider-probe.ts
@@ -24,7 +24,9 @@ export const PROVIDER_PROBE_VALUES = [
 
 export type ProviderProbeValue = (typeof PROVIDER_PROBE_VALUES)[number];
 
-export type ProviderProbeResult = { valid: boolean; error?: string };
+export type ProviderProbeResult =
+  | { valid: true }
+  | { valid: false; error: string };
 
 type ProbeTarget = {
   url: string;


### PR DESCRIPTION
\`{ valid: boolean; error?: string }\` permitted impossible states (\`{ valid: true; error: "..." }\`) and forced callers to treat \`error\` as possibly-undefined on the failure branch. Switch to the union shape already used locally by \`ValidationResult\`; drop a now-dead \`?? "Unknown error"\` fallback at the only consumer that relied on the optional.

## Test plan
- [x] \`bun --filter @stll/api typecheck\`
- [x] \`bun --filter @stll/api test ai-provider-probe\`