### PR TITLE
refactor(anonymize): drop unused isPending from chat anonymize preview

### DIFF
--- a/apps/web/src/lib/anonymize/use-chat-anonymization-layer.ts
+++ b/apps/web/src/lib/anonymize/use-chat-anonymization-layer.ts
@@ -62,7 +62,7 @@ export const useChatAnonymizationLayer = ({
   // it — typing with anonymized mode off must not pay any
   // per-keystroke React render cost from this layer.
   const text = useChatDraftText(editor, enabled);
-  const { pairs } = useChatAnonymizePreview({
+  const pairs = useChatAnonymizePreview({
     enabled,
     text,
     workspaceId,

--- a/apps/web/src/lib/anonymize/use-chat-anonymize.ts
+++ b/apps/web/src/lib/anonymize/use-chat-anonymize.ts
@@ -62,7 +62,7 @@ export const useChatAnonymizePreview = ({
   enabled: boolean;
   text: string;
   workspaceId: string;
-}): ChatAnonPair[] | null => {
+}): readonly ChatAnonPair[] | null => {
   const [debouncedText] = useDebounce(text, ANON_PREVIEW_DEBOUNCE_MS);
   const shouldRun = enabled && debouncedText.trim().length > 0;
   const result = useQuery({

--- a/apps/web/src/lib/anonymize/use-chat-anonymize.ts
+++ b/apps/web/src/lib/anonymize/use-chat-anonymize.ts
@@ -62,7 +62,7 @@ export const useChatAnonymizePreview = ({
   enabled: boolean;
   text: string;
   workspaceId: string;
-}): { pairs: ChatAnonPair[] | null; isPending: boolean } => {
+}): ChatAnonPair[] | null => {
   const [debouncedText] = useDebounce(text, ANON_PREVIEW_DEBOUNCE_MS);
   const shouldRun = enabled && debouncedText.trim().length > 0;
   const result = useQuery({
@@ -81,10 +81,7 @@ export const useChatAnonymizePreview = ({
   });
 
   if (!shouldRun) {
-    return { pairs: null, isPending: false };
+    return null;
   }
-  return {
-    pairs: result.data?.pairs ?? null,
-    isPending: result.isFetching,
-  };
+  return result.data?.pairs ?? null;
 };


### PR DESCRIPTION
\`useChatAnonymizePreview\` returned \`{ pairs, isPending }\` but the sole consumer (\`useChatAnonymizationLayer\`) only reads \`pairs\`. Collapse the return shape to \`ChatAnonPair[] | null\`.

## Test plan
- [x] \`bun --filter @stll/web typecheck\`