### PR TITLE
refactor: stabilize file chat threads

### DIFF
--- a/apps/api/drizzle/20260516130000_file-chat-threads/migration.sql
+++ b/apps/api/drizzle/20260516130000_file-chat-threads/migration.sql
@@ -1,0 +1,82 @@
+CREATE TABLE "file_chat_threads" (
+  "id" uuid PRIMARY KEY NOT NULL,
+  "organization_id" varchar(128) NOT NULL,
+  "workspace_id" uuid NOT NULL,
+  "user_id" text NOT NULL,
+  "entity_id" uuid NOT NULL,
+  "field_id" uuid NOT NULL,
+  "chat_thread_id" uuid NOT NULL,
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL,
+  CONSTRAINT "file_chat_threads_organization_id_organization_id_fk"
+    FOREIGN KEY ("organization_id") REFERENCES "organization"("id")
+    ON DELETE cascade,
+  CONSTRAINT "file_chat_threads_workspace_id_workspaces_id_fk"
+    FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id")
+    ON DELETE cascade,
+  CONSTRAINT "file_chat_threads_user_id_user_id_fk"
+    FOREIGN KEY ("user_id") REFERENCES "user"("id")
+    ON DELETE cascade,
+  CONSTRAINT "file_chat_threads_chat_thread_id_chat_threads_id_fk"
+    FOREIGN KEY ("chat_thread_id") REFERENCES "chat_threads"("id")
+    ON DELETE cascade,
+  CONSTRAINT "file_chat_threads_entity_id_workspace_id_entities_id_workspace_id_fk"
+    FOREIGN KEY ("entity_id", "workspace_id")
+    REFERENCES "entities"("id", "workspace_id")
+    ON DELETE cascade,
+  CONSTRAINT "file_chat_threads_field_id_workspace_id_fields_id_workspace_id_fk"
+    FOREIGN KEY ("field_id", "workspace_id")
+    REFERENCES "fields"("id", "workspace_id")
+    ON DELETE cascade
+);
+
+ALTER TABLE "file_chat_threads" ENABLE ROW LEVEL SECURITY;
+
+CREATE UNIQUE INDEX "file_chat_threads_scope_uidx"
+  ON "file_chat_threads" (
+    "organization_id",
+    "workspace_id",
+    "user_id",
+    "entity_id",
+    "field_id"
+  );
+
+CREATE UNIQUE INDEX "file_chat_threads_chat_thread_id_uidx"
+  ON "file_chat_threads" ("chat_thread_id");
+
+CREATE INDEX "file_chat_threads_workspace_entity_field_idx"
+  ON "file_chat_threads" ("workspace_id", "entity_id", "field_id");
+
+CREATE POLICY "file_chat_thread_select" ON "file_chat_threads"
+  FOR SELECT TO "stella"
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY "file_chat_thread_insert" ON "file_chat_threads"
+  FOR INSERT TO "stella"
+  WITH CHECK (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY "file_chat_thread_update" ON "file_chat_threads"
+  FOR UPDATE TO "stella"
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+CREATE POLICY "file_chat_thread_delete" ON "file_chat_threads"
+  FOR DELETE TO "stella"
+  USING (
+    user_id = (SELECT current_setting('app.user_id', true))
+    AND organization_id = (SELECT current_setting('app.organization_id', true))
+    AND workspace_id = ANY((SELECT current_setting('app.workspace_ids', true))::uuid[])
+  );
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "file_chat_threads" TO stella;

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -96,6 +96,12 @@ const chatMessageScopeCheck = sql`(
   )
 )`;
 
+const fileChatThreadScopeCheck = sql`(
+  ${userCheck} AND
+  ${organizationCheck} AND
+  ${workspaceCheck}
+)`;
+
 export const wsPolicies = () => [
   p.pgPolicy("workspace_select", {
     for: "select",
@@ -485,5 +491,28 @@ export const chatMessagePolicies = () => [
     for: "delete",
     to: stella,
     using: chatMessageScopeCheck,
+  }),
+];
+
+export const fileChatThreadPolicies = () => [
+  p.pgPolicy("file_chat_thread_select", {
+    for: "select",
+    to: stella,
+    using: fileChatThreadScopeCheck,
+  }),
+  p.pgPolicy("file_chat_thread_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: fileChatThreadScopeCheck,
+  }),
+  p.pgPolicy("file_chat_thread_update", {
+    for: "update",
+    to: stella,
+    using: fileChatThreadScopeCheck,
+  }),
+  p.pgPolicy("file_chat_thread_delete", {
+    for: "delete",
+    to: stella,
+    using: fileChatThreadScopeCheck,
   }),
 ];

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -13,6 +13,7 @@ import {
   agentSkillResourcePolicies,
   chatMessagePolicies,
   chatThreadPolicies,
+  fileChatThreadPolicies,
   globalCaseLawPolicies,
   mcpConnectorPolicies,
   mcpOAuthStatePolicies,
@@ -2546,6 +2547,68 @@ export const chatMessages = p.pgTable(
   ],
 );
 
+export const fileChatThreads = p.pgTable(
+  "file_chat_threads",
+  {
+    id: pUuid<"fileChatThread">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    workspaceId: safeWorkspaceId("workspace_id").notNull(),
+    userId: p
+      .text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    entityId: safeUuid<"entity">("entity_id").notNull(),
+    fieldId: safeUuid<"field">("field_id").notNull(),
+    chatThreadId: safeUuid<"chatThread">("chat_thread_id")
+      .notNull()
+      .references(() => chatThreads.id, { onDelete: "cascade" }),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    p
+      .uniqueIndex("file_chat_threads_scope_uidx")
+      .on(
+        table.organizationId,
+        table.workspaceId,
+        table.userId,
+        table.entityId,
+        table.fieldId,
+      ),
+    p
+      .uniqueIndex("file_chat_threads_chat_thread_id_uidx")
+      .on(table.chatThreadId),
+    p
+      .index("file_chat_threads_workspace_entity_field_idx")
+      .on(table.workspaceId, table.entityId, table.fieldId),
+    p
+      .foreignKey({
+        columns: [table.workspaceId],
+        foreignColumns: [workspaces.id],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.entityId, table.workspaceId],
+        foreignColumns: [entities.id, entities.workspaceId],
+      })
+      .onDelete("cascade"),
+    p
+      .foreignKey({
+        columns: [table.fieldId, table.workspaceId],
+        foreignColumns: [fields.id, fields.workspaceId],
+      })
+      .onDelete("cascade"),
+    ...fileChatThreadPolicies(),
+  ],
+);
+
 // -- MCP Connectors --
 
 export const MCP_CONNECTOR_AUTH_TYPES = ["none", "bearer", "oauth2"] as const;
@@ -3002,6 +3065,7 @@ export const relations = defineRelations(
     caseLawIngestionFailures,
     chatThreads,
     chatMessages,
+    fileChatThreads,
     mcpConnectors,
     mcpOAuthClients,
     mcpUserConnections,
@@ -3621,6 +3685,10 @@ export const relations = defineRelations(
         from: r.chatThreads.id,
         to: r.chatMessages.threadId,
       }),
+      fileChatThread: r.one.fileChatThreads({
+        from: r.chatThreads.id,
+        to: r.fileChatThreads.chatThreadId,
+      }),
       userFiles: r.many.userFiles({
         from: r.chatThreads.id,
         to: r.userFiles.threadId,
@@ -3634,6 +3702,24 @@ export const relations = defineRelations(
       workspace: r.one.workspaces({
         from: r.chatMessages.workspaceId,
         to: r.workspaces.id,
+      }),
+    },
+    fileChatThreads: {
+      thread: r.one.chatThreads({
+        from: r.fileChatThreads.chatThreadId,
+        to: r.chatThreads.id,
+      }),
+      workspace: r.one.workspaces({
+        from: r.fileChatThreads.workspaceId,
+        to: r.workspaces.id,
+      }),
+      entity: r.one.entities({
+        from: r.fileChatThreads.entityId,
+        to: r.entities.id,
+      }),
+      field: r.one.fields({
+        from: r.fileChatThreads.fieldId,
+        to: r.fields.id,
       }),
     },
     mcpConnectors: {

--- a/apps/api/src/handlers/chat/get-threads.ts
+++ b/apps/api/src/handlers/chat/get-threads.ts
@@ -3,7 +3,11 @@ import type { SQL } from "drizzle-orm";
 import { and, desc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import { t } from "elysia";
 
-import { chatThreads, workspaces as workspacesTable } from "@/api/db/schema";
+import {
+  chatMessages,
+  chatThreads,
+  workspaces as workspacesTable,
+} from "@/api/db/schema";
 import {
   decodeChatThreadListCursor,
   encodeChatThreadListCursor,
@@ -45,6 +49,11 @@ const getThreads = createSafeRootHandler(
     const conditions: SQL[] = [
       eq(chatThreads.organizationId, session.activeOrganizationId),
       eq(chatThreads.userId, user.id),
+      sql`exists (
+        select 1
+        from ${chatMessages}
+        where ${chatMessages.threadId} = ${chatThreads.id}
+      )`,
     ];
     const visibleWorkspaceCondition =
       visibleWorkspaceIds.length > 0

--- a/apps/api/src/handlers/chat/resolve-file-thread.ts
+++ b/apps/api/src/handlers/chat/resolve-file-thread.ts
@@ -1,0 +1,201 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import type { Transaction } from "@/api/db";
+import { chatThreads, fileChatThreads } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { createSafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { PG_ERROR } from "@/api/lib/pg-error";
+
+const resolveFileThreadBodySchema = t.Object({
+  entityId: tSafeId("entity"),
+  fieldId: tSafeId("field"),
+});
+
+const config = {
+  permissions: { chat: ["create"] },
+  body: resolveFileThreadBodySchema,
+} satisfies HandlerConfig;
+
+type FileThreadLookupInput = {
+  entityId: SafeId<"entity">;
+  fieldId: SafeId<"field">;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+};
+
+type ResolveFileThreadTxResult =
+  | {
+      ok: true;
+      chatThreadId: SafeId<"chatThread">;
+    }
+  | {
+      ok: false;
+      message: string;
+      status: 404;
+    };
+
+const findFileChatThread = async (
+  tx: Transaction,
+  {
+    entityId,
+    fieldId,
+    organizationId,
+    userId,
+    workspaceId,
+  }: FileThreadLookupInput,
+) =>
+  await tx.query.fileChatThreads.findFirst({
+    where: {
+      entityId: { eq: entityId },
+      fieldId: { eq: fieldId },
+      organizationId: { eq: organizationId },
+      userId: { eq: userId },
+      workspaceId: { eq: workspaceId },
+    },
+    columns: {
+      chatThreadId: true,
+    },
+  });
+
+const createFileChatThread = async (
+  tx: Transaction,
+  {
+    entityId,
+    fieldId,
+    organizationId,
+    userId,
+    workspaceId,
+  }: FileThreadLookupInput,
+): Promise<ResolveFileThreadTxResult> => {
+  const entity = await tx.query.entities.findFirst({
+    where: {
+      id: { eq: entityId },
+      workspaceId: { eq: workspaceId },
+    },
+    columns: {
+      id: true,
+    },
+    with: {
+      currentVersion: {
+        columns: {},
+        with: {
+          fields: {
+            columns: {
+              content: true,
+              id: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const field = entity?.currentVersion?.fields.find(
+    (candidate) => candidate.id === fieldId,
+  );
+  const content = field?.content;
+
+  if (content?.type !== "file") {
+    return {
+      ok: false,
+      status: 404,
+      message: "File not found",
+    };
+  }
+
+  const chatThreadId = createSafeId<"chatThread">();
+
+  await tx.insert(chatThreads).values({
+    id: chatThreadId,
+    organizationId,
+    title: content.fileName,
+    userId,
+    workspaceId,
+    contextMatterIds: [],
+    dataWorkspaceIds: [workspaceId],
+  });
+
+  await tx.insert(fileChatThreads).values({
+    id: createSafeId<"fileChatThread">(),
+    organizationId,
+    workspaceId,
+    userId,
+    entityId,
+    fieldId,
+    chatThreadId,
+  });
+
+  return {
+    ok: true,
+    chatThreadId,
+  };
+};
+
+const resolveFileThread = createSafeHandler(
+  config,
+  async function* ({ body, safeDb, session, user, workspaceId }) {
+    const input: FileThreadLookupInput = {
+      entityId: body.entityId,
+      fieldId: body.fieldId,
+      organizationId: session.activeOrganizationId,
+      userId: user.id,
+      workspaceId,
+    };
+
+    const txResult = await safeDb(async (tx) => {
+      const existing = await findFileChatThread(tx, input);
+
+      if (existing) {
+        return {
+          ok: true as const,
+          chatThreadId: existing.chatThreadId,
+        };
+      }
+
+      return await createFileChatThread(tx, input);
+    });
+
+    if (Result.isError(txResult)) {
+      if (
+        !DatabaseError.is(txResult.error) ||
+        txResult.error.code !== PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return yield* Result.err(txResult.error);
+      }
+
+      const recovered = yield* Result.await(
+        safeDb(async (tx) => await findFileChatThread(tx, input)),
+      );
+
+      if (recovered) {
+        return Result.ok({ threadId: recovered.chatThreadId });
+      }
+
+      return yield* Result.err(
+        new HandlerError({
+          status: 404,
+          message: "File not found",
+        }),
+      );
+    }
+
+    if (!txResult.value.ok) {
+      return yield* Result.err(
+        new HandlerError({
+          status: txResult.value.status,
+          message: txResult.value.message,
+        }),
+      );
+    }
+
+    return Result.ok({ threadId: txResult.value.chatThreadId });
+  },
+);
+
+export default resolveFileThread;

--- a/apps/api/src/handlers/chat/resolve-file-thread.ts
+++ b/apps/api/src/handlers/chat/resolve-file-thread.ts
@@ -1,4 +1,5 @@
 import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import type { Transaction } from "@/api/db";
@@ -20,6 +21,8 @@ const config = {
   permissions: { chat: ["create"] },
   body: resolveFileThreadBodySchema,
 } satisfies HandlerConfig;
+
+const CHAT_THREAD_TITLE_MAX_LENGTH = 255;
 
 type FileThreadLookupInput = {
   entityId: SafeId<"entity">;
@@ -61,6 +64,49 @@ const findFileChatThread = async (
     columns: {
       chatThreadId: true,
     },
+  });
+
+const findFieldKeyedChatThread = async (
+  tx: Transaction,
+  { fieldId, organizationId, userId, workspaceId }: FileThreadLookupInput,
+) =>
+  (
+    await tx
+      .select({ id: chatThreads.id })
+      .from(chatThreads)
+      .where(
+        and(
+          // File chat threads were previously keyed directly by
+          // field UUID. Preserve those rows without constructing
+          // a new branded ID from request input.
+          sql`${chatThreads.id} = ${fieldId}`,
+          eq(chatThreads.organizationId, organizationId),
+          eq(chatThreads.userId, userId),
+          eq(chatThreads.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1)
+  ).at(0);
+
+const insertFileChatThread = async (
+  tx: Transaction,
+  {
+    entityId,
+    fieldId,
+    organizationId,
+    userId,
+    workspaceId,
+  }: FileThreadLookupInput,
+  chatThreadId: SafeId<"chatThread">,
+) =>
+  await tx.insert(fileChatThreads).values({
+    id: createSafeId<"fileChatThread">(),
+    organizationId,
+    workspaceId,
+    userId,
+    entityId,
+    fieldId,
+    chatThreadId,
   });
 
 const createFileChatThread = async (
@@ -109,27 +155,56 @@ const createFileChatThread = async (
     };
   }
 
+  const fieldKeyedThread = await findFieldKeyedChatThread(tx, {
+    entityId,
+    fieldId,
+    organizationId,
+    userId,
+    workspaceId,
+  });
+
+  if (fieldKeyedThread) {
+    await insertFileChatThread(
+      tx,
+      {
+        entityId,
+        fieldId,
+        organizationId,
+        userId,
+        workspaceId,
+      },
+      fieldKeyedThread.id,
+    );
+
+    return {
+      ok: true,
+      chatThreadId: fieldKeyedThread.id,
+    };
+  }
+
   const chatThreadId = createSafeId<"chatThread">();
 
   await tx.insert(chatThreads).values({
     id: chatThreadId,
     organizationId,
-    title: content.fileName,
+    title: content.fileName.slice(0, CHAT_THREAD_TITLE_MAX_LENGTH),
     userId,
     workspaceId,
     contextMatterIds: [],
     dataWorkspaceIds: [workspaceId],
   });
 
-  await tx.insert(fileChatThreads).values({
-    id: createSafeId<"fileChatThread">(),
-    organizationId,
-    workspaceId,
-    userId,
-    entityId,
-    fieldId,
+  await insertFileChatThread(
+    tx,
+    {
+      entityId,
+      fieldId,
+      organizationId,
+      userId,
+      workspaceId,
+    },
     chatThreadId,
-  });
+  );
 
   return {
     ok: true,

--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -3,16 +3,22 @@ import Elysia from "elysia";
 import deleteThread from "@/api/handlers/chat/delete-thread";
 import getMessages from "@/api/handlers/chat/get-messages";
 import getThreads from "@/api/handlers/chat/get-threads";
+import resolveFileThread from "@/api/handlers/chat/resolve-file-thread";
 import sendMessage from "@/api/handlers/chat/send-message";
-import { authMacro, permissionMacro } from "@/api/lib/auth";
+import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
 
 export const chatRoute = new Elysia({ prefix: "/chat" })
-  .use(authMacro)
+  .use(workspaceAccessMacro)
   .use(permissionMacro)
   .guard({ validateAuth: true })
   .post("/", sendMessage.handler, {
     body: sendMessage.config.body,
     permissions: sendMessage.config.permissions,
+  })
+  .post("/workspaces/:workspaceId/file-thread", resolveFileThread.handler, {
+    body: resolveFileThread.config.body,
+    permissions: resolveFileThread.config.permissions,
+    validateWorkspaceAccess: true,
   })
   .get("/threads", getThreads.handler, {
     permissions: getThreads.config.permissions,

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -17,6 +17,7 @@ export type SafeIdType =
   | "caseLawSource"
   | "chatMessage"
   | "chatThread"
+  | "fileChatThread"
   | "clause"
   | "clauseCategory"
   | "clauseVariant"

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -22,6 +22,7 @@ import {
   entityVersions,
   expenses,
   fields,
+  fileChatThreads,
   invoices,
   justifications,
   matterCounters,
@@ -122,6 +123,7 @@ export const createTestIds = () => ({
   chatMessageWorkspaceA1: id<"chatMessage">(),
   chatMessageWorkspaceA2: id<"chatMessage">(),
   chatMessageWorkspaceB1: id<"chatMessage">(),
+  fileChatThreadA1: id<"fileChatThread">(),
   // Additional properties for dependencies
   propertyA1dep: id<"property">(),
   propertyB1dep: id<"property">(),
@@ -875,6 +877,16 @@ export const setupRlsTestData = async (db: TestDatabase, ids: TestIds) => {
       workspaceId: ids.wsA1,
     },
   ]);
+
+  await db.insert(fileChatThreads).values({
+    id: ids.fileChatThreadA1,
+    organizationId: ids.orgA,
+    workspaceId: ids.wsA1,
+    userId: ids.userA1,
+    entityId: ids.entityA1,
+    fieldId: ids.fieldA1,
+    chatThreadId: ids.chatThreadWorkspaceA1,
+  });
 
   const chatContent = (text: string) => ({
     version: 1 as const,

--- a/apps/api/src/tests/security/rls-negative.test.ts
+++ b/apps/api/src/tests/security/rls-negative.test.ts
@@ -19,6 +19,7 @@ import {
   entityVersions,
   expenses,
   fields,
+  fileChatThreads,
   invoices,
   justifications,
   matterCounters,
@@ -188,6 +189,20 @@ describe("chat SELECT — wrong user or workspace", () => {
       (tx) =>
         tx.$count(chatThreads, eq(chatThreads.id, ids.chatThreadWorkspaceB1)),
       ids.userA1,
+    );
+    expect(c).toBe(0);
+  });
+
+  test("different user in the same workspace cannot read file chat mappings", async () => {
+    const c = await scopedQuery(
+      [ids.wsA1],
+      ids.orgA,
+      (tx) =>
+        tx.$count(
+          fileChatThreads,
+          eq(fileChatThreads.id, ids.fileChatThreadA1),
+        ),
+      ids.userA2,
     );
     expect(c).toBe(0);
   });

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -66,7 +66,10 @@ import type {
   ApplyActiveDocxEditsInput,
   ApplyActiveDocxEditsOutput,
 } from "@/routes/_protected.chat/-queries";
-import { chatThreadOptions } from "@/routes/_protected.chat/-queries";
+import {
+  chatThreadOptions,
+  fileChatThreadOptions,
+} from "@/routes/_protected.chat/-queries";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 
 type ActiveFile = {
@@ -77,6 +80,7 @@ type ActiveFile = {
     | undefined;
   entityId: string;
   editable?: boolean | undefined;
+  fileFieldId?: string | undefined;
   fileName: string;
   supportsDocxEdits?: boolean | undefined;
 };
@@ -490,13 +494,8 @@ const ACTIVE_FILE_BLOCKED_APPROVAL_TOOLS = new Set<ApprovalToolName>();
 type FileChatOverlayProps = {
   /** Workspace this viewer belongs to. Scopes the thread + mention sources. */
   workspaceId?: string | undefined;
-  /**
-   * Stable identifier for this file's chat thread. Use the file's
-   * entity id (or any per-file unique string) so drafts + history
-   * persist across mounts and stay isolated from other files'
-   * chats.
-   */
-  chatThreadId: ChatThreadId;
+  /** Explicit thread id for non-file previews and newly-created chat sessions. */
+  chatThreadId?: ChatThreadId | undefined;
   /**
    * Surfaced to the model via the chat transport so prompts can
    * reference "the file you're looking at" and tools can resolve
@@ -518,25 +517,114 @@ type FileChatOverlayProps = {
 
 const protectedRouteApi = getRouteApi("/_protected");
 
-export const FileChatOverlay = (props: FileChatOverlayProps) => (
-  // Suspense boundary keeps the chat-thread fetch local to the
-  // overlay — without it, a cold cache propagates the suspension
-  // up to the file route and shows the route's pending screen.
-  <Suspense
-    fallback={
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 bottom-8 flex justify-center"
-      >
-        <LoaderCircleIcon className="text-muted-foreground size-4 animate-spin" />
-      </div>
-    }
-  >
-    <FileChatOverlayInner {...props} />
-  </Suspense>
-);
+export const FileChatOverlay = ({
+  workspaceId,
+  chatThreadId,
+  activeFile,
+  activeExternal,
+  docxEditable,
+  docxEditorRef,
+  onNewThread,
+  requestDocxEditMode,
+}: FileChatOverlayProps) => {
+  const fallback = (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-x-0 bottom-8 flex justify-center"
+    >
+      <LoaderCircleIcon className="text-muted-foreground size-4 animate-spin" />
+    </div>
+  );
 
-type FileChatOverlayInnerProps = FileChatOverlayProps;
+  if (chatThreadId === undefined) {
+    const fileFieldId = activeFile?.fileFieldId;
+    if (
+      workspaceId === undefined ||
+      activeFile === undefined ||
+      fileFieldId === undefined
+    ) {
+      return null;
+    }
+
+    return (
+      <Suspense fallback={fallback}>
+        <ResolvedFileChatOverlay
+          activeFile={{ ...activeFile, fileFieldId }}
+          docxEditable={docxEditable}
+          docxEditorRef={docxEditorRef}
+          onNewThread={onNewThread}
+          requestDocxEditMode={requestDocxEditMode}
+          workspaceId={workspaceId}
+        />
+      </Suspense>
+    );
+  }
+
+  return (
+    <Suspense fallback={fallback}>
+      <FileChatOverlayInner
+        activeExternal={activeExternal}
+        activeFile={activeFile}
+        chatThreadId={chatThreadId}
+        docxEditable={docxEditable}
+        docxEditorRef={docxEditorRef}
+        onNewThread={onNewThread}
+        requestDocxEditMode={requestDocxEditMode}
+        workspaceId={workspaceId}
+      />
+    </Suspense>
+  );
+};
+
+type ResolvedFileChatOverlayProps = Omit<
+  FileChatOverlayProps,
+  "activeExternal" | "activeFile" | "chatThreadId" | "workspaceId"
+> & {
+  activeFile: ActiveFile & { fileFieldId: string };
+  workspaceId: string;
+};
+
+const ResolvedFileChatOverlay = ({
+  activeFile,
+  docxEditable,
+  docxEditorRef,
+  onNewThread,
+  requestDocxEditMode,
+  workspaceId,
+}: ResolvedFileChatOverlayProps) => {
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: chatThreadId } = useSuspenseQuery(
+    fileChatThreadOptions({
+      activeOrganizationId,
+      key: {
+        entityId: activeFile.entityId,
+        fieldId: activeFile.fileFieldId,
+        workspaceId,
+      },
+    }),
+  );
+
+  return (
+    <FileChatOverlayInner
+      activeFile={activeFile}
+      chatThreadId={chatThreadId}
+      docxEditable={docxEditable}
+      docxEditorRef={docxEditorRef}
+      onNewThread={onNewThread}
+      requestDocxEditMode={requestDocxEditMode}
+      workspaceId={workspaceId}
+    />
+  );
+};
+
+type FileChatOverlayInnerProps = Omit<
+  FileChatOverlayProps,
+  "chatThreadId"
+> & {
+  chatThreadId: ChatThreadId;
+};
 
 const FileChatOverlayInner = ({
   workspaceId,

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -619,10 +619,7 @@ const ResolvedFileChatOverlay = ({
   );
 };
 
-type FileChatOverlayInnerProps = Omit<
-  FileChatOverlayProps,
-  "chatThreadId"
-> & {
+type FileChatOverlayInnerProps = Omit<FileChatOverlayProps, "chatThreadId"> & {
   chatThreadId: ChatThreadId;
 };
 

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
@@ -50,12 +50,10 @@ type FileViewerWithAIProps = {
    */
   workspaceId?: string | undefined;
   /**
-   * Stable identifier for this file's chat thread. Use the file's
-   * entity id (or any per-file unique string) so drafts + history
-   * persist across mounts and stay isolated from other files'
-   * chats.
+   * Explicit thread id for previews that do not resolve through
+   * the workspace file-chat mapping.
    */
-  chatThreadId: ChatThreadId;
+  chatThreadId?: ChatThreadId | undefined;
   /**
    * Optional file context surfaced to the model so prompts can
    * reference "the file you're looking at" — entity id and human
@@ -87,6 +85,14 @@ export function FileViewerWithAI({
   requestDocxEditMode,
   children,
 }: FileViewerWithAIProps) {
+  const overlayKey = [
+    chatThreadId ?? "mapped-file-chat",
+    workspaceId ?? "",
+    activeFile?.entityId ?? "",
+    activeFile?.fileFieldId ?? "",
+    activeExternal?.url ?? "",
+  ].join(":");
+
   return (
     <div
       className={cn("relative h-full w-full", className)}
@@ -99,7 +105,7 @@ export function FileViewerWithAI({
         chatThreadId={chatThreadId}
         docxEditable={docxEditable}
         docxEditorRef={docxEditorRef}
-        key={chatThreadId}
+        key={overlayKey}
         requestDocxEditMode={requestDocxEditMode}
         workspaceId={workspaceId}
       />

--- a/apps/web/src/lib/chat-thread-ref.ts
+++ b/apps/web/src/lib/chat-thread-ref.ts
@@ -27,6 +27,3 @@ export const toChatThreadId = (value: string): ChatThreadId =>
   toSafeId<"chatThread">(value);
 
 export const createChatThreadId = (): ChatThreadId => toChatThreadId(uuidv7());
-
-export const chatThreadIdFromFileFieldId = (fieldId: string): ChatThreadId =>
-  toChatThreadId(fieldId);

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -24,7 +24,7 @@ import { env } from "@/env";
 import { getAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import type { ChatThreadId, ChatThreadRef } from "@/lib/chat-thread-ref";
-import { getChatThreadKey } from "@/lib/chat-thread-ref";
+import { getChatThreadKey, toChatThreadId } from "@/lib/chat-thread-ref";
 import { STALE_TIME } from "@/lib/consts";
 import { useDevStore } from "@/lib/dev-store";
 import { APIError, toAPIError } from "@/lib/errors";
@@ -65,6 +65,12 @@ type ActiveExternalContext = {
 };
 
 type ChatThreadKey = ChatThreadRef;
+
+type FileChatThreadKey = {
+  entityId: string;
+  fieldId: string;
+  workspaceId: string;
+};
 
 type GroupedChatThreadsPage = Awaited<
   ReturnType<typeof fetchGroupedChatThreads>
@@ -137,6 +143,14 @@ const getChatRuntimeContextKind = (
 
 export const chatKeys = {
   all: ["chat"],
+  fileThread: (activeOrganizationId: string, key: FileChatThreadKey) => [
+    ...chatKeys.all,
+    activeOrganizationId,
+    "file-thread",
+    key.workspaceId,
+    key.entityId,
+    key.fieldId,
+  ],
   groupedThreads: (activeOrganizationId: string) => [
     ...chatKeys.all,
     activeOrganizationId,
@@ -230,6 +244,25 @@ const fetchGroupedChatThreads = async ({
   }
 
   return response.data;
+};
+
+const fetchFileChatThread = async ({
+  entityId,
+  fieldId,
+  workspaceId,
+}: FileChatThreadKey): Promise<ChatThreadId> => {
+  const response = await api.chat
+    .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+    ["file-thread"].post({
+      entityId: toSafeId<"entity">(entityId),
+      fieldId: toSafeId<"field">(fieldId),
+    });
+
+  if (response.error) {
+    throw toAPIError(response.error);
+  }
+
+  return toChatThreadId(response.data.threadId);
 };
 
 export const mergeGroupedChatThreadPages = (
@@ -550,6 +583,22 @@ export type ChatThreadFetched = {
    */
   contextMatterIds: string[];
 };
+
+type FileChatThreadOptionsArgs = {
+  activeOrganizationId: string;
+  key: FileChatThreadKey;
+};
+
+export const fileChatThreadOptions = ({
+  activeOrganizationId,
+  key,
+}: FileChatThreadOptionsArgs) =>
+  queryOptions({
+    staleTime: STALE_TIME.FIVETEEN.MINUTES,
+    gcTime: STALE_TIME.FIVETEEN.MINUTES,
+    queryKey: chatKeys.fileThread(activeOrganizationId, key),
+    queryFn: async () => await fetchFileChatThread(key),
+  });
 
 export type ChatThreadOptionsArgs = ChatThreadOptionsInput & {
   activeOrganizationId: string;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -53,7 +53,6 @@ import { QuerySuspenseBoundary } from "@/components/query-suspense-boundary";
 import { StatusMessage } from "@/components/route-components";
 import Tooltip from "@/components/tooltip";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
-import { chatThreadIdFromFileFieldId } from "@/lib/chat-thread-ref";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import {
   useDocxFitZoom,
@@ -1265,9 +1264,9 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
           activeFile={{
             editable: canUnlock,
             entityId,
+            fileFieldId: fieldId,
             fileName: previewFile.fileName,
           }}
-          chatThreadId={chatThreadIdFromFileFieldId(fieldId)}
           docxEditable={isUnlocked}
           docxEditorRef={editorRef}
           requestDocxEditMode={requestEditMode}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/pdf-viewer.tsx
@@ -6,7 +6,6 @@ import { produce } from "immer";
 
 import { FileViewerWithAI } from "@/components/ai-suggestions/file-viewer-with-ai";
 import { StellaMark } from "@/components/stella-mark";
-import { chatThreadIdFromFileFieldId } from "@/lib/chat-thread-ref";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
@@ -77,7 +76,6 @@ const FullscreenPdfViewer = () => {
           ? { entityId, fileFieldId: fieldId, fileName: file.fileName }
           : undefined
       }
-      chatThreadId={chatThreadIdFromFileFieldId(fieldId)}
       workspaceId={workspaceId}
     >
       <CreatingBBoxes />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -32,7 +32,6 @@ import Tooltip from "@/components/tooltip";
 import { PDF_MIME_TYPE } from "@/consts";
 import { env } from "@/env";
 import { useAnalytics } from "@/lib/analytics/provider";
-import { chatThreadIdFromFileFieldId } from "@/lib/chat-thread-ref";
 import { DOCX_MIME } from "@/lib/consts";
 import { APIError } from "@/lib/errors";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
@@ -150,7 +149,6 @@ const PeekPdfViewerContent = ({
   return (
     <FileViewerWithAI
       activeFile={{ entityId, fileFieldId: fieldId, fileName: file.fileName }}
-      chatThreadId={chatThreadIdFromFileFieldId(fieldId)}
       workspaceId={workspaceId}
     >
       <PDFViewport


### PR DESCRIPTION
## Summary
- Resolve file viewer chat threads through the API.
- Persist per-user file chat thread mappings.
- Add scoped regression coverage.