### PR TITLE
chore(web): React 19 syntax cleanup

### DIFF
--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -24,7 +24,7 @@ export const Conversation = ({
   const stickToBottom = useStickToBottom();
 
   return (
-    <StickToBottomContext.Provider value={stickToBottom}>
+    <StickToBottomContext value={stickToBottom}>
       <div
         className={cn("relative flex-1 overflow-y-hidden", className)}
         role="log"
@@ -32,7 +32,7 @@ export const Conversation = ({
       >
         {children}
       </div>
-    </StickToBottomContext.Provider>
+    </StickToBottomContext>
   );
 };
 

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -364,9 +364,9 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   );
 
   return (
-    <ChatEditorManagerContext.Provider value={contextValue}>
+    <ChatEditorManagerContext value={contextValue}>
       {children}
-    </ChatEditorManagerContext.Provider>
+    </ChatEditorManagerContext>
   );
 };
 

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import type { Ref } from 'react';
+import {
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { Ref } from "react";
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import {

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -1,11 +1,5 @@
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import type { Ref } from 'react';
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import {
@@ -124,15 +118,26 @@ type DrillDownState = {
   name: string;
 };
 
-export const ChatMentionList = forwardRef<
-  ReturnType<NonNullable<SuggestionOptions["render"]>>,
-  SuggestionProps<ChatMentionOption> & {
-    loadWorkspaceEntities: (
-      workspace: ChatMentionOption,
-      query: string,
-    ) => Promise<ChatMentionOption[]>;
-  }
->(({ items, command, clientRect, loadWorkspaceEntities, query }, ref) => {
+type ChatMentionListHandle = ReturnType<
+  NonNullable<SuggestionOptions["render"]>
+>;
+
+type ChatMentionListProps = SuggestionProps<ChatMentionOption> & {
+  loadWorkspaceEntities: (
+    workspace: ChatMentionOption,
+    query: string,
+  ) => Promise<ChatMentionOption[]>;
+  ref?: Ref<ChatMentionListHandle>;
+};
+
+export const ChatMentionList = ({
+  items,
+  command,
+  clientRect,
+  loadWorkspaceEntities,
+  query,
+  ref,
+}: ChatMentionListProps) => {
   const t = useTranslations();
   const categoryLabel = useCategoryLabel();
   const [isOpen, setIsOpen] = useState(true);
@@ -461,6 +466,4 @@ export const ChatMentionList = forwardRef<
       </PopoverPopup>
     </Popover>
   );
-});
-
-ChatMentionList.displayName = "ChatMentionList";
+};

--- a/apps/web/src/components/chat/prompt-slash-list.tsx
+++ b/apps/web/src/components/chat/prompt-slash-list.tsx
@@ -1,10 +1,5 @@
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useImperativeHandle, useRef, useState } from 'react';
+import type { Ref } from 'react';
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { useTranslations } from "use-intl";
@@ -50,10 +45,20 @@ const groupByScope = (
   return result;
 };
 
-export const PromptSlashList = forwardRef<
-  ReturnType<NonNullable<SuggestionOptions["render"]>>,
-  SuggestionProps<ChatPrompt>
->(({ items, command, decorationNode }, ref) => {
+type PromptSlashListHandle = ReturnType<
+  NonNullable<SuggestionOptions["render"]>
+>;
+
+type PromptSlashListProps = SuggestionProps<ChatPrompt> & {
+  ref?: Ref<PromptSlashListHandle>;
+};
+
+export const PromptSlashList = ({
+  items,
+  command,
+  decorationNode,
+  ref,
+}: PromptSlashListProps) => {
   const t = useTranslations();
   const scopeLabel = useScopeLabel();
   const [isOpen, setIsOpen] = useState(true);
@@ -188,6 +193,4 @@ export const PromptSlashList = forwardRef<
       </PopoverPopup>
     </Popover>
   );
-});
-
-PromptSlashList.displayName = "PromptSlashList";
+};

--- a/apps/web/src/components/chat/prompt-slash-list.tsx
+++ b/apps/web/src/components/chat/prompt-slash-list.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useImperativeHandle, useRef, useState } from 'react';
-import type { Ref } from 'react';
+import { useEffect, useImperativeHandle, useRef, useState } from "react";
+import type { Ref } from "react";
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { useTranslations } from "use-intl";

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -113,10 +113,10 @@ export function AIAvailabilityProvider({ children }: PropsWithChildren) {
   );
 
   return (
-    <AIAvailabilityContext.Provider value={value}>
+    <AIAvailabilityContext value={value}>
       {children}
       <AIKeyRequiredDialog onOpenChange={setOpen} open={open} />
-    </AIAvailabilityContext.Provider>
+    </AIAvailabilityContext>
   );
 }
 

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -138,7 +138,7 @@ function SidebarProvider({
   );
 
   return (
-    <SidebarContext.Provider value={contextValue}>
+    <SidebarContext value={contextValue}>
       <div
         className={cn(
           "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
@@ -158,7 +158,7 @@ function SidebarProvider({
       >
         {children}
       </div>
-    </SidebarContext.Provider>
+    </SidebarContext>
   );
 }
 

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -161,11 +161,7 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     [theme, setTheme, palette, setPalette, resolvedTheme],
   );
 
-  return (
-    <ThemeProviderContext.Provider value={value}>
-      {children}
-    </ThemeProviderContext.Provider>
-  );
+  return <ThemeProviderContext value={value}>{children}</ThemeProviderContext>;
 };
 
 export const useTheme = (): ThemeProviderState => {

--- a/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
@@ -11,6 +11,7 @@ import { parseDocumentAst } from "@stll/case-law/document-ast";
 
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { useCaseSearchStore } from "@/lib/case-search-store";
+import { pageTitleLiteral } from "@/lib/page-title";
 import { ensureCriticalQueryData } from "@/lib/react-query";
 import type { SafeId } from "@/lib/safe-id";
 import { toSafeId } from "@/lib/safe-id";
@@ -51,6 +52,11 @@ export const Route = createFileRoute("/_protected/knowledge/case/$decisionId")({
       queryClient,
       decisionOptions(extractId(decisionId)),
     ),
+  head: ({ loaderData }) => ({
+    meta: loaderData?.caseNumber
+      ? [{ title: pageTitleLiteral(loaderData.caseNumber) }]
+      : [],
+  }),
   component: DecisionViewer,
 });
 
@@ -65,14 +71,6 @@ function DecisionViewer() {
     () => parseDocumentAst(decision.documentAst),
     [decision.documentAst],
   );
-
-  useEffect(() => {
-    const prev = document.title;
-    document.title = `${decision.caseNumber} | stella`;
-    return () => {
-      document.title = prev;
-    };
-  }, [decision.caseNumber]);
 
   const mainRef = useRef<HTMLDivElement>(null);
   const [panelWidth, setPanelWidth] = useState(220);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -287,13 +287,19 @@ export const printPdfBuffer = (buffer: ArrayBuffer) => {
 export const fetchPrintPdf = async ({
   workspaceId,
   fieldId,
+  signal,
 }: {
   workspaceId: string;
   fieldId: string;
+  signal?: AbortSignal | undefined;
 }) => {
+  const timeoutSignal = AbortSignal.timeout(30_000);
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, timeoutSignal])
+    : timeoutSignal;
   const response = await fetch(
     `${env.VITE_API_URL}/v1/files/${workspaceId}/print-pdf/${fieldId}`,
-    { credentials: "include", signal: AbortSignal.timeout(30_000) },
+    { credentials: "include", signal: combinedSignal },
   );
 
   if (!response.ok) {
@@ -311,14 +317,6 @@ export const PeekPrintButton = () => {
   const analytics = useAnalytics();
   const pdfDocument = usePDFStore((s) => s.document);
   const [isPrinting, setIsPrinting] = useState(false);
-  const isMounted = useRef(true);
-
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
 
   const handlePrint = useCallback(async () => {
     if (!pdfDocument) {
@@ -328,18 +326,11 @@ export const PeekPrintButton = () => {
     setIsPrinting(true);
     try {
       const data = await pdfDocument.document.getData();
-
-      if (!isMounted.current) {
-        return;
-      }
-
       printPdfBuffer(data.slice().buffer);
     } catch (error: unknown) {
       analytics.captureError(error);
     } finally {
-      if (isMounted.current) {
-        setIsPrinting(false);
-      }
+      setIsPrinting(false);
     }
   }, [analytics, pdfDocument]);
 
@@ -374,29 +365,35 @@ export const PreparedPdfPrintButton = ({
   const t = useTranslations();
   const analytics = useAnalytics();
   const [isPrinting, setIsPrinting] = useState(false);
-  const isMounted = useRef(true);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
+  useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+    },
+    [],
+  );
 
   const handlePrint = useCallback(async () => {
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     setIsPrinting(true);
     try {
-      const data = await fetchPrintPdf({ workspaceId, fieldId });
-      if (!isMounted.current) {
-        return;
-      }
+      const data = await fetchPrintPdf({
+        workspaceId,
+        fieldId,
+        signal: controller.signal,
+      });
       printPdfBuffer(data);
     } catch (error: unknown) {
+      if (controller.signal.aborted) {
+        return;
+      }
       analytics.captureError(error);
     } finally {
-      if (isMounted.current) {
-        setIsPrinting(false);
-      }
+      setIsPrinting(false);
     }
   }, [analytics, fieldId, workspaceId]);
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -406,6 +406,9 @@ export const PreparedPdfPrintButton = ({
         fieldId,
         signal: controller.signal,
       });
+      if (controller.signal.aborted) {
+        return;
+      }
       printPdfBuffer(data);
     } catch (error: unknown) {
       if (controller.signal.aborted) {
@@ -413,7 +416,9 @@ export const PreparedPdfPrintButton = ({
       }
       analytics.captureError(error);
     } finally {
-      setIsPrinting(false);
+      if (!controller.signal.aborted) {
+        setIsPrinting(false);
+      }
     }
   }, [analytics, fieldId, workspaceId]);
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -317,20 +317,40 @@ export const PeekPrintButton = () => {
   const analytics = useAnalytics();
   const pdfDocument = usePDFStore((s) => s.document);
   const [isPrinting, setIsPrinting] = useState(false);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(
+    () => () => {
+      abortControllerRef.current?.abort();
+    },
+    [],
+  );
 
   const handlePrint = useCallback(async () => {
     if (!pdfDocument) {
       return;
     }
 
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
     setIsPrinting(true);
     try {
       const data = await pdfDocument.document.getData();
+      if (controller.signal.aborted) {
+        return;
+      }
       printPdfBuffer(data.slice().buffer);
     } catch (error: unknown) {
+      if (controller.signal.aborted) {
+        return;
+      }
       analytics.captureError(error);
     } finally {
-      setIsPrinting(false);
+      if (!controller.signal.aborted) {
+        setIsPrinting(false);
+      }
     }
   }, [analytics, pdfDocument]);
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useImperativeHandle, useState } from "react";
+import { useImperativeHandle, useState } from 'react';
+import type { Ref } from 'react';
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { useTranslations } from "use-intl";
@@ -9,10 +10,18 @@ import { cn } from "@stll/ui/lib/utils";
 
 import type { MentionOption } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/custom-mention";
 
-export const MentionList = forwardRef<
-  ReturnType<NonNullable<SuggestionOptions["render"]>>,
-  SuggestionProps<MentionOption>
->(({ items, command, decorationNode }, ref) => {
+type MentionListHandle = ReturnType<NonNullable<SuggestionOptions["render"]>>;
+
+type MentionListProps = SuggestionProps<MentionOption> & {
+  ref?: Ref<MentionListHandle>;
+};
+
+export const MentionList = ({
+  items,
+  command,
+  decorationNode,
+  ref,
+}: MentionListProps) => {
   const t = useTranslations();
   const [isOpen, setIsOpen] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -84,6 +93,4 @@ export const MentionList = forwardRef<
       </PopoverPopup>
     </Popover>
   );
-});
-
-MentionList.displayName = "MentionList";
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/property-input/mention-list.tsx
@@ -1,5 +1,5 @@
-import { useImperativeHandle, useState } from 'react';
-import type { Ref } from 'react';
+import { useImperativeHandle, useState } from "react";
+import type { Ref } from "react";
 
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import { useTranslations } from "use-intl";


### PR DESCRIPTION
## Summary
- forwardRef → ref-as-prop (3 sites)
- `<Context.Provider>` → `<Context>` (5 sites)
- decision page title via route head
- isMountedRef → AbortController in peek PDF viewer

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] TipTap mention/suggestion lists still respond to keys
- [ ] decision page title updates on navigation
- [ ] PDF print in peek viewer cancels cleanly on unmount