### PR TITLE
chore(web): state modeling cleanup

### DIFF
--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -36,6 +36,15 @@ const breadcrumbInputClassName =
 
 const matterNameInputClassName = `${breadcrumbInputClassName} font-semibold`;
 
+type NameState = { mode: "view" } | { mode: "edit"; draft: string };
+
+type RefState =
+  | { mode: "view" }
+  | { mode: "edit"; draft: string; error?: string };
+
+const NAME_VIEW: NameState = { mode: "view" };
+const REF_VIEW: RefState = { mode: "view" };
+
 export const WorkspaceBreadcrumb = ({
   workspaceId,
 }: ResolveParams<"/workspaces/$workspaceId">) => {
@@ -44,12 +53,9 @@ export const WorkspaceBreadcrumb = ({
     from: "/_protected/workspaces/$workspaceId/",
     shouldThrow: false,
   });
-  const [value, setValue] = useState("");
-  const [isEditing, setIsEditing] = useState(false);
+  const [nameState, setNameState] = useState<NameState>(NAME_VIEW);
   const escapedNameRef = useRef(false);
-  const [refValue, setRefValue] = useState("");
-  const [isEditingRef, setIsEditingRef] = useState(false);
-  const [refError, setRefError] = useState("");
+  const [refState, setRefState] = useState<RefState>(REF_VIEW);
   const [refInputEl, setRefInputEl] = useState<HTMLInputElement | null>(null);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [iconAnchor, setIconAnchor] = useState<HTMLSpanElement | null>(null);
@@ -69,21 +75,20 @@ export const WorkspaceBreadcrumb = ({
 
   const startEditingName = () => {
     escapedNameRef.current = false;
-    setValue(displayName);
-    setIsEditing(true);
+    setNameState({ mode: "edit", draft: displayName });
   };
 
   const handleSaveProjectName = () => {
     if (escapedNameRef.current) {
       escapedNameRef.current = false;
-      setValue(displayName);
-      setIsEditing(false);
+      setNameState(NAME_VIEW);
       return;
     }
 
-    setIsEditing(false);
+    const draft = nameState.mode === "edit" ? nameState.draft : "";
+    setNameState(NAME_VIEW);
 
-    const workspaceName = value.trim();
+    const workspaceName = draft.trim();
 
     if (!workspaceName || workspaceName === workspace.name) {
       return;
@@ -96,15 +101,21 @@ export const WorkspaceBreadcrumb = ({
   };
 
   const handleSaveReference = () => {
-    const trimmed = refValue.trim();
+    if (refState.mode !== "edit") {
+      return;
+    }
+    const trimmed = refState.draft.trim();
 
     if (!trimmed || trimmed === workspace.reference) {
-      setIsEditingRef(false);
-      setRefError("");
+      setRefState(REF_VIEW);
       return;
     }
 
-    setRefError("");
+    setRefState((prev) =>
+      prev.mode === "edit" && prev.error !== undefined
+        ? { mode: "edit", draft: prev.draft }
+        : prev,
+    );
     updateWorkspace.mutate(
       {
         workspaceId,
@@ -112,11 +123,15 @@ export const WorkspaceBreadcrumb = ({
       },
       {
         onSuccess: () => {
-          setIsEditingRef(false);
+          setRefState(REF_VIEW);
         },
         onError: (error) => {
           if (APIError.is(error) && error.status === 409) {
-            setRefError(t("workspaces.referenceTaken"));
+            setRefState((prev) =>
+              prev.mode === "edit"
+                ? { ...prev, error: t("workspaces.referenceTaken") }
+                : prev,
+            );
             refInputEl?.focus();
             return;
           }
@@ -126,7 +141,7 @@ export const WorkspaceBreadcrumb = ({
               ? error.message
               : t("errors.actionFailed");
           stellaToast.add({ title: message, type: "error" });
-          setIsEditingRef(false);
+          setRefState(REF_VIEW);
         },
       },
     );
@@ -201,22 +216,21 @@ export const WorkspaceBreadcrumb = ({
   );
 
   const referenceSegment = (() => {
-    if (isEditingRef) {
+    if (refState.mode === "edit") {
       return (
         <Input
           className={`${breadcrumbInputClassName} w-28 text-sm`}
           onBlur={handleSaveReference}
           onChange={(e) => {
-            setRefValue(e.target.value);
-            setRefError("");
+            const draft = e.target.value;
+            setRefState({ mode: "edit", draft });
           }}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               handleSaveReference();
             }
             if (e.key === "Escape") {
-              setIsEditingRef(false);
-              setRefError("");
+              setRefState(REF_VIEW);
             }
           }}
           placeholder={t("workspaces.referencePlaceholder")}
@@ -226,7 +240,7 @@ export const WorkspaceBreadcrumb = ({
           }}
           size="sm"
           unstyled
-          value={refValue}
+          value={refState.draft}
         />
       );
     }
@@ -235,9 +249,7 @@ export const WorkspaceBreadcrumb = ({
         <button
           className="text-foreground-muted hover:text-muted-foreground cursor-text text-sm"
           onClick={() => {
-            setRefValue(workspace.reference);
-            setRefError("");
-            setIsEditingRef(true);
+            setRefState({ mode: "edit", draft: workspace.reference });
           }}
           type="button"
         >
@@ -251,9 +263,9 @@ export const WorkspaceBreadcrumb = ({
   const referenceHint = (
     <MatterNumberHint
       anchor={refInputEl}
-      error={refError}
-      open={isEditingRef}
-      value={refValue}
+      error={refState.mode === "edit" ? (refState.error ?? "") : ""}
+      open={refState.mode === "edit"}
+      value={refState.mode === "edit" ? refState.draft : ""}
       variant="popover"
     />
   );
@@ -264,7 +276,7 @@ export const WorkspaceBreadcrumb = ({
         {clientSegment}
         <BreadcrumbItem className="shrink-0">
           {(() => {
-            if (isEditing) {
+            if (nameState.mode === "edit") {
               return (
                 <>
                   <span
@@ -287,7 +299,9 @@ export const WorkspaceBreadcrumb = ({
                     className={`${matterNameInputClassName} w-fit`}
                     disabled={updateWorkspace.isPending}
                     onBlur={() => handleSaveProjectName()}
-                    onChange={(e) => setValue(e.target.value)}
+                    onChange={(e) =>
+                      setNameState({ mode: "edit", draft: e.target.value })
+                    }
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.currentTarget.blur();
@@ -300,7 +314,7 @@ export const WorkspaceBreadcrumb = ({
                     autoFocus
                     size="sm"
                     unstyled
-                    value={value}
+                    value={nameState.draft}
                   />
                 </>
               );
@@ -342,15 +356,16 @@ export const WorkspaceBreadcrumb = ({
                   />
                 </span>
                 <span className="truncate">{displayName}</span>
-                {workspace.reference && !isEditingRef ? (
+                {workspace.reference && refState.mode === "view" ? (
                   <span
                     className="text-foreground-muted shrink-0 text-sm"
                     onContextMenu={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      setRefValue(workspace.reference);
-                      setRefError("");
-                      setIsEditingRef(true);
+                      setRefState({
+                        mode: "edit",
+                        draft: workspace.reference,
+                      });
                     }}
                   >
                     {workspace.reference}
@@ -359,7 +374,7 @@ export const WorkspaceBreadcrumb = ({
               </Link>
             );
           })()}
-          {isEditingRef ? referenceSegment : null}
+          {refState.mode === "edit" ? referenceSegment : null}
           {referenceHint}
         </BreadcrumbItem>
         <Popover onOpenChange={setColorPickerOpen} open={colorPickerOpen}>
@@ -382,7 +397,7 @@ export const WorkspaceBreadcrumb = ({
     );
   }
 
-  if (isEditing) {
+  if (nameState.mode === "edit") {
     return (
       <>
         {clientSegment}
@@ -392,7 +407,9 @@ export const WorkspaceBreadcrumb = ({
             className={`${matterNameInputClassName} w-fit`}
             disabled={updateWorkspace.isPending}
             onBlur={() => handleSaveProjectName()}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={(e) =>
+              setNameState({ mode: "edit", draft: e.target.value })
+            }
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.currentTarget.blur();
@@ -405,7 +422,7 @@ export const WorkspaceBreadcrumb = ({
             autoFocus
             size="sm"
             unstyled
-            value={value}
+            value={nameState.draft}
           />
           {referenceSegment}
           {referenceHint}

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -118,11 +118,17 @@ const groupByCategory = (
   return result;
 };
 
-type DrillDownState = {
+type DrillTarget = {
   workspaceId: string;
   viewId: string;
   name: string;
 };
+
+type DrillState =
+  | { kind: "none" }
+  | { kind: "loading"; target: DrillTarget }
+  | { kind: "loaded"; target: DrillTarget; items: ChatMentionOption[] }
+  | { kind: "error"; target: DrillTarget };
 
 type ChatMentionListHandle = ReturnType<
   NonNullable<SuggestionOptions["render"]>
@@ -148,10 +154,7 @@ export const ChatMentionList = ({
   const categoryLabel = useCategoryLabel();
   const [isOpen, setIsOpen] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [drillDown, setDrillDown] = useState<DrillDownState | null>(null);
-  const [drillDownItems, setDrillDownItems] = useState<ChatMentionOption[]>([]);
-  const [entitiesLoading, setEntitiesLoading] = useState(false);
-  const [entitiesError, setEntitiesError] = useState(false);
+  const [drillState, setDrillState] = useState<DrillState>({ kind: "none" });
   const listRef = useRef<HTMLDivElement>(null);
   const lastClientRectRef = useRef<DOMRect | null>(null);
   const latestClientRect = clientRect?.() ?? null;
@@ -173,32 +176,35 @@ export const ChatMentionList = ({
     [clientRect],
   );
 
-  const activeItems = drillDown ? drillDownItems : items;
+  const drillTarget = drillState.kind === "none" ? null : drillState.target;
+  const drillItems = drillState.kind === "loaded" ? drillState.items : [];
+  const activeItems = drillTarget ? drillItems : items;
   const safeIndex = Math.min(
     selectedIndex,
     Math.max(0, activeItems.length - 1),
   );
 
   useEffect(() => {
-    if (drillDown === null) {
-      setDrillDownItems([]);
-      setEntitiesLoading(false);
-      setEntitiesError(false);
+    if (drillTarget === null) {
       return undefined;
     }
 
     let cancelled = false;
-    setEntitiesLoading(true);
-    setEntitiesError(false);
+    setDrillState((prev) => {
+      if (prev.kind === "loading" && prev.target === drillTarget) {
+        return prev;
+      }
+      return { kind: "loading", target: drillTarget };
+    });
 
     void loadWorkspaceEntities(
       {
-        id: drillDown.workspaceId,
-        label: drillDown.name,
+        id: drillTarget.workspaceId,
+        label: drillTarget.name,
         category: "workspace",
         kind: "workspace",
         mimeType: null,
-        sourceViewId: drillDown.viewId,
+        sourceViewId: drillTarget.viewId,
       },
       query,
     )
@@ -207,23 +213,24 @@ export const ChatMentionList = ({
           return;
         }
 
-        setDrillDownItems(nextItems);
-        setEntitiesLoading(false);
+        setDrillState({
+          kind: "loaded",
+          target: drillTarget,
+          items: nextItems,
+        });
       })
       .catch(() => {
         if (cancelled) {
           return;
         }
 
-        setDrillDownItems([]);
-        setEntitiesError(true);
-        setEntitiesLoading(false);
+        setDrillState({ kind: "error", target: drillTarget });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [drillDown, loadWorkspaceEntities, query]);
+  }, [drillTarget, loadWorkspaceEntities, query]);
 
   // Scroll the selected item into view on index change
   useEffect(() => {
@@ -245,23 +252,26 @@ export const ChatMentionList = ({
       return;
     }
 
-    setDrillDown({
-      workspaceId: workspace.id,
-      viewId: workspace.sourceViewId,
-      name: workspace.label,
+    setDrillState({
+      kind: "loading",
+      target: {
+        workspaceId: workspace.id,
+        viewId: workspace.sourceViewId,
+        name: workspace.label,
+      },
     });
     setSelectedIndex(0);
   };
 
   const handleBack = () => {
-    setDrillDown(null);
+    setDrillState({ kind: "none" });
     setSelectedIndex(0);
   };
 
   useImperativeHandle(ref, () => ({
     onKeyDown: ({ event }) => {
       if (event.key === "Escape") {
-        if (drillDown) {
+        if (drillTarget) {
           handleBack();
           return true;
         }
@@ -308,7 +318,7 @@ export const ChatMentionList = ({
       }
 
       // ArrowRight on a workspace item drills down
-      if (event.key === "ArrowRight" && !drillDown) {
+      if (event.key === "ArrowRight" && !drillTarget) {
         const item = activeItems.at(safeIndex);
         if (item?.category === "workspace") {
           handleDrillDown(item);
@@ -317,7 +327,7 @@ export const ChatMentionList = ({
       }
 
       // ArrowLeft exits drill-down
-      if (event.key === "ArrowLeft" && drillDown) {
+      if (event.key === "ArrowLeft" && drillTarget) {
         handleBack();
         return true;
       }
@@ -346,7 +356,7 @@ export const ChatMentionList = ({
           className="flex max-h-64 w-full min-w-0 flex-col gap-0.5 overflow-x-hidden overflow-y-auto"
           ref={listRef}
         >
-          {drillDown && (
+          {drillTarget && (
             <Button
               className="text-muted-foreground justify-start gap-2 font-normal"
               onClick={handleBack}
@@ -355,35 +365,35 @@ export const ChatMentionList = ({
             >
               <ArrowLeftIcon className="size-3.5 shrink-0" />
               <LayersIcon className="size-3.5 shrink-0" />
-              <span className="truncate">{drillDown.name}</span>
+              <span className="truncate">{drillTarget.name}</span>
             </Button>
           )}
 
-          {drillDown && entitiesLoading && (
+          {drillState.kind === "loading" && (
             <div className="flex items-center justify-center p-2">
               <LoaderIcon className="text-muted-foreground size-4 animate-spin" />
             </div>
           )}
 
-          {drillDown && !entitiesLoading && entitiesError && (
+          {drillState.kind === "error" && (
             <div className="text-destructive flex items-center justify-center p-2 text-center text-sm">
               {t("chat.mention.loadError")}
             </div>
           )}
 
-          {!drillDown && activeItems.length === 0 && (
+          {drillState.kind === "none" && activeItems.length === 0 && (
             <div className="text-muted-foreground flex items-center justify-center p-2 text-center text-sm">
               {t("chat.mention.noResults")}
             </div>
           )}
 
-          {drillDown && !entitiesLoading && drillDownItems.length === 0 && (
+          {drillState.kind === "loaded" && drillState.items.length === 0 && (
             <div className="text-muted-foreground flex items-center justify-center p-2 text-center text-sm">
               {t("chat.mention.noResults")}
             </div>
           )}
 
-          {!drillDown &&
+          {drillState.kind === "none" &&
             groups.map((group) => {
               const firstItem = group.items[0];
               const groupStartIndex = firstItem
@@ -445,9 +455,8 @@ export const ChatMentionList = ({
               );
             })}
 
-          {drillDown &&
-            !entitiesLoading &&
-            drillDownItems.map((item, i) => (
+          {drillState.kind === "loaded" &&
+            drillState.items.map((item, i) => (
               <Button
                 className={cn(
                   "min-w-0 justify-start gap-2 overflow-hidden font-normal",

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -672,22 +672,24 @@ const fallbackIconUrl = (rawUrl: string): string | undefined => {
   }
 };
 
+type WizardState =
+  | { step: "idle" }
+  | { step: "url"; url: string; busy: boolean }
+  | {
+      step: "token";
+      createdConnector: CreatedConnector;
+      token: string;
+      busy: boolean;
+    };
+
+const WIZARD_IDLE: WizardState = { step: "idle" };
+
 function AddServerCard({ onChanged }: { onChanged: () => void }) {
   const t = useTranslations();
-  const [step, setStep] = useState<"idle" | "url" | "token">("idle");
-  const [url, setUrl] = useState("");
-  const [token, setToken] = useState("");
-  const [createdConnector, setCreatedConnector] = useState<
-    CreatedConnector | undefined
-  >();
-  const [busy, setBusy] = useState(false);
+  const [wizard, setWizard] = useState<WizardState>(WIZARD_IDLE);
 
   const reset = () => {
-    setStep("idle");
-    setUrl("");
-    setToken("");
-    setCreatedConnector(undefined);
-    setBusy(false);
+    setWizard(WIZARD_IDLE);
   };
 
   const connectConnector = async (connector: CreatedConnector) => {
@@ -705,8 +707,12 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
     }
 
     if (response.data.type === "bearer") {
-      setCreatedConnector(connector);
-      setStep("token");
+      setWizard({
+        step: "token",
+        createdConnector: connector,
+        token: "",
+        busy: false,
+      });
       return;
     }
 
@@ -733,19 +739,24 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
   };
 
   const addServer = async () => {
-    const trimmedUrl = url.trim();
-    if (!trimmedUrl || busy) {
+    if (wizard.step !== "url") {
+      return;
+    }
+    const trimmedUrl = wizard.url.trim();
+    if (!trimmedUrl || wizard.busy) {
       return;
     }
 
-    setBusy(true);
+    setWizard({ ...wizard, busy: true });
     const response = await api.mcp.connectors.post({
       url: trimmedUrl,
       queryKey: ["mcp"],
     });
-    setBusy(false);
 
     if (response.error) {
+      setWizard((prev) =>
+        prev.step === "url" ? { ...prev, busy: false } : prev,
+      );
       showApiError({
         error: response.error,
         fallback: t("knowledge.mcp.errorDescription"),
@@ -754,25 +765,34 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
       return;
     }
 
+    setWizard((prev) =>
+      prev.step === "url" ? { ...prev, busy: false } : prev,
+    );
     onChanged();
     await connectConnector(response.data.connector);
   };
 
   const saveToken = async () => {
-    const trimmedToken = token.trim();
-    if (!createdConnector || !trimmedToken || busy) {
+    if (wizard.step !== "token") {
+      return;
+    }
+    const trimmedToken = wizard.token.trim();
+    if (!trimmedToken || wizard.busy) {
       return;
     }
 
-    setBusy(true);
+    const { createdConnector } = wizard;
+    setWizard({ ...wizard, busy: true });
     const response = await api.mcp.connections.post({
       connectorSlug: createdConnector.slug,
       token: trimmedToken,
       queryKey: ["mcp"],
     });
-    setBusy(false);
 
     if (response.error) {
+      setWizard((prev) =>
+        prev.step === "token" ? { ...prev, busy: false } : prev,
+      );
       showApiError({
         error: response.error,
         fallback: t("knowledge.mcp.errorDescription"),
@@ -789,11 +809,11 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
     reset();
   };
 
-  if (step === "idle") {
+  if (wizard.step === "idle") {
     return (
       <button
         className="bg-card hover:bg-muted/30 focus-visible:ring-ring flex items-center gap-3 rounded-lg border border-dashed p-3 text-start transition-colors focus-visible:ring-2 focus-visible:outline-none"
-        onClick={() => setStep("url")}
+        onClick={() => setWizard({ step: "url", url: "", busy: false })}
         type="button"
       >
         <PlusIcon className="text-muted-foreground size-5 shrink-0" />
@@ -804,7 +824,7 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
     );
   }
 
-  if (step === "url") {
+  if (wizard.step === "url") {
     return (
       <form
         className="bg-card flex items-center gap-2 rounded-lg border p-2 ps-3"
@@ -819,7 +839,11 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           autoComplete="url"
           autoFocus
           className="border-0 shadow-none focus-visible:ring-0"
-          onChange={(event) => setUrl(event.target.value)}
+          onChange={(event) =>
+            setWizard((prev) =>
+              prev.step === "url" ? { ...prev, url: event.target.value } : prev,
+            )
+          }
           onKeyDown={(event) => {
             if (event.key === "Escape") {
               reset();
@@ -827,10 +851,16 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           }}
           placeholder={t("knowledge.mcp.urlPlaceholder")}
           type="url"
-          value={url}
+          value={wizard.url}
         />
-        <Button disabled={busy || !url.trim()} size="sm" type="submit">
-          {busy ? <LoaderIcon className="me-1.5 size-4 animate-spin" /> : null}
+        <Button
+          disabled={wizard.busy || !wizard.url.trim()}
+          size="sm"
+          type="submit"
+        >
+          {wizard.busy ? (
+            <LoaderIcon className="me-1.5 size-4 animate-spin" />
+          ) : null}
           {t("knowledge.mcp.addAndConnect")}
         </Button>
         <Button
@@ -861,7 +891,13 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           autoComplete="off"
           autoFocus
           className="border-0 font-mono shadow-none focus-visible:ring-0"
-          onChange={(event) => setToken(event.target.value)}
+          onChange={(event) =>
+            setWizard((prev) =>
+              prev.step === "token"
+                ? { ...prev, token: event.target.value }
+                : prev,
+            )
+          }
           onKeyDown={(event) => {
             if (event.key === "Escape") {
               reset();
@@ -869,10 +905,16 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           }}
           placeholder={t("knowledge.mcp.tokenPlaceholder")}
           type="password"
-          value={token}
+          value={wizard.token}
         />
-        <Button disabled={busy || !token.trim()} size="sm" type="submit">
-          {busy ? <LoaderIcon className="me-1.5 size-4 animate-spin" /> : null}
+        <Button
+          disabled={wizard.busy || !wizard.token.trim()}
+          size="sm"
+          type="submit"
+        >
+          {wizard.busy ? (
+            <LoaderIcon className="me-1.5 size-4 animate-spin" />
+          ) : null}
           {t("knowledge.mcp.saveToken")}
         </Button>
         <Button

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -335,10 +335,10 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
   }, []);
 
   // Background right-click context menu
-  const [bgContextOpen, setBgContextOpen] = useState(false);
   const [bgContextAnchor, setBgContextAnchor] = useState<{
     getBoundingClientRect: () => DOMRect;
   } | null>(null);
+  const isBgContextOpen = bgContextAnchor !== null;
 
   const { filters, sorts, hiddenProperties } = view.layout;
   const primarySort = sorts.at(0) ?? null;
@@ -587,7 +587,6 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
     setBgContextAnchor({
       getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
     });
-    setBgContextOpen(true);
   }, []);
 
   const handleFolderCreated = useCallback((entityId: string) => {
@@ -907,12 +906,11 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
         anchor={bgContextAnchor}
         onFolderCreated={handleFolderCreated}
         onOpenChange={(o) => {
-          setBgContextOpen(o);
           if (!o) {
             setBgContextAnchor(null);
           }
         }}
-        open={bgContextOpen}
+        open={isBgContextOpen}
         parentId={currentFolderId}
         showTaskOption={false}
         render={
@@ -954,10 +952,10 @@ const ColumnHeaderCell = ({
 }: ColumnHeaderCellProps) => {
   const t = useTranslations();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [contextOpen, setContextOpen] = useState(false);
   const [contextAnchor, setContextAnchor] = useState<{
     getBoundingClientRect: () => DOMRect;
   } | null>(null);
+  const isContextOpen = contextAnchor !== null;
   const isActive = activeSort?.propertyId === propertyId;
   const SortIcon = activeSort?.desc ? ArrowDownIcon : ArrowUpIcon;
 
@@ -998,7 +996,6 @@ const ColumnHeaderCell = ({
       setContextAnchor({
         getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
       });
-      setContextOpen(true);
     },
     [onHide],
   );
@@ -1034,12 +1031,11 @@ const ColumnHeaderCell = ({
       {onHide && (
         <Menu
           onOpenChange={(open) => {
-            setContextOpen(open);
             if (!open) {
               setContextAnchor(null);
             }
           }}
-          open={contextOpen}
+          open={isContextOpen}
         >
           <MenuTrigger
             render={
@@ -1055,7 +1051,7 @@ const ColumnHeaderCell = ({
             <MenuItem
               onClick={() => {
                 onHide();
-                setContextOpen(false);
+                setContextAnchor(null);
               }}
             >
               <EyeOffIcon className="size-4" />
@@ -1114,7 +1110,10 @@ const FilesystemRow = ({
   getSelectedEntities,
 }: FilesystemRowProps) => {
   const t = useTranslations();
-  const [contextOpen, setContextOpen] = useState(false);
+  const [contextAnchor, setContextAnchor] = useState<{
+    getBoundingClientRect: () => DOMRect;
+  } | null>(null);
+  const isContextOpen = contextAnchor !== null;
   const [editValue, setEditValue] = useState("");
   const isFolder = node.kind === "folder";
   const isEditing = editingEntityId === node.entityId;
@@ -1148,10 +1147,6 @@ const FilesystemRow = ({
     onStartEditing(null);
   };
 
-  const [contextAnchor, setContextAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
-
   const handleContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -1164,7 +1159,6 @@ const FilesystemRow = ({
     setContextAnchor({
       getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
     });
-    setContextOpen(true);
   };
 
   // Drag + drop support via pragmatic-drag-and-drop.
@@ -1501,13 +1495,13 @@ const FilesystemRow = ({
   // selectedIds before RowActions re-renders. Using a ref preserves
   // the selection snapshot from when the menu was triggered.
   const bulkEntitiesRef = useRef<WorkspaceEntity[] | undefined>(undefined);
-  if (contextOpen && isBulkSelected) {
+  if (isContextOpen && isBulkSelected) {
     bulkEntitiesRef.current = getSelectedEntities(selectedIds);
-  } else if (!contextOpen) {
+  } else if (!isContextOpen) {
     bulkEntitiesRef.current = undefined;
   }
   let bulkEntities: WorkspaceEntity[] | undefined;
-  if (contextOpen) {
+  if (isContextOpen) {
     bulkEntities = bulkEntitiesRef.current;
   } else if (isBulkSelected) {
     bulkEntities = getSelectedEntities(selectedIds);
@@ -1520,14 +1514,13 @@ const FilesystemRow = ({
         entity={node}
         onOpen={openInInspector}
         onOpenChange={(o) => {
-          setContextOpen(o);
           if (!o) {
             setContextAnchor(null);
           }
         }}
         onRename={startEditing}
         onSubfolderCreated={onSubfolderCreated}
-        open={contextOpen}
+        open={isContextOpen}
         selectedEntities={bulkEntities}
         workspaceId={workspaceId}
       />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1110,10 +1110,18 @@ const FilesystemRow = ({
   getSelectedEntities,
 }: FilesystemRowProps) => {
   const t = useTranslations();
-  const [contextAnchor, setContextAnchor] = useState<{
-    getBoundingClientRect: () => DOMRect;
-  } | null>(null);
-  const isContextOpen = contextAnchor !== null;
+  // RowActions can open via two paths: a trigger-button click (anchors
+  // the menu to the ellipsis button) or a right-click on the row (anchors
+  // to the cursor position). Model both with a discriminated union so the
+  // anchor and open state stay in sync.
+  const [menuState, setMenuState] = useState<
+    | { type: "closed" }
+    | { type: "trigger" }
+    | { type: "context"; anchor: { getBoundingClientRect: () => DOMRect } }
+  >({ type: "closed" });
+  const isContextOpen = menuState.type !== "closed";
+  const contextAnchor =
+    menuState.type === "context" ? menuState.anchor : undefined;
   const [editValue, setEditValue] = useState("");
   const isFolder = node.kind === "folder";
   const isEditing = editingEntityId === node.entityId;
@@ -1156,8 +1164,11 @@ const FilesystemRow = ({
     }
     const x = e.clientX;
     const y = e.clientY;
-    setContextAnchor({
-      getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+    setMenuState({
+      type: "context",
+      anchor: {
+        getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+      },
     });
   };
 
@@ -1515,7 +1526,11 @@ const FilesystemRow = ({
         onOpen={openInInspector}
         onOpenChange={(o) => {
           if (!o) {
-            setContextAnchor(null);
+            setMenuState({ type: "closed" });
+          } else if (menuState.type === "closed") {
+            // Trigger-button click: Base UI positions the menu against
+            // the trigger element, so no virtual anchor is needed.
+            setMenuState({ type: "trigger" });
           }
         }}
         onRename={startEditing}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
@@ -67,22 +67,36 @@ type InspectorFindOptions = {
   highlightKey: string;
 };
 
+type FindState =
+  | { open: false }
+  | {
+      open: true;
+      query: string;
+      matchCount: number;
+      activeIndex: number;
+    };
+
+const FIND_CLOSED: FindState = { open: false };
+const FIND_OPENED: FindState = {
+  open: true,
+  query: "",
+  matchCount: 0,
+  activeIndex: 0,
+};
+
 const useInspectorFind = ({
   contentRef,
   enabled,
   highlightKey,
 }: InspectorFindOptions) => {
-  const [findOpen, setFindOpen] = useState(false);
-  const [findQuery, setFindQuery] = useState("");
-  const [matchCount, setMatchCount] = useState(0);
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [findState, setFindState] = useState<FindState>(FIND_CLOSED);
   const allHighlightName = `stella-inspector-find-${highlightKey}`;
   const activeHighlightName = `stella-inspector-find-active-${highlightKey}`;
 
   const clearFind = useCallback(() => {
-    setFindQuery("");
-    setMatchCount(0);
-    setActiveIndex(0);
+    setFindState((prev) =>
+      prev.open ? { ...prev, query: "", matchCount: 0, activeIndex: 0 } : prev,
+    );
     // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
     CSS.highlights?.delete(allHighlightName);
     // eslint-disable-next-line typescript/no-unnecessary-condition -- CSS.highlights is not available in every supported browser.
@@ -90,27 +104,48 @@ const useInspectorFind = ({
   }, [activeHighlightName, allHighlightName]);
 
   const closeFind = useCallback(() => {
-    setFindOpen(false);
+    setFindState(FIND_CLOSED);
   }, []);
 
   const openFind = useCallback(() => {
     if (!enabled) {
       return;
     }
-    setFindOpen(true);
+    setFindState((prev) => (prev.open ? prev : FIND_OPENED));
   }, [enabled]);
 
+  const setFindQuery = useCallback((query: string) => {
+    setFindState((prev) => (prev.open ? { ...prev, query } : prev));
+  }, []);
+
   const nextMatch = useCallback(() => {
-    setActiveIndex((current) =>
-      matchCount === 0 ? 0 : (current + 1) % matchCount,
-    );
-  }, [matchCount]);
+    setFindState((prev) => {
+      if (!prev.open || prev.matchCount === 0) {
+        return prev;
+      }
+      return {
+        ...prev,
+        activeIndex: (prev.activeIndex + 1) % prev.matchCount,
+      };
+    });
+  }, []);
 
   const previousMatch = useCallback(() => {
-    setActiveIndex((current) =>
-      matchCount === 0 ? 0 : (current - 1 + matchCount) % matchCount,
-    );
-  }, [matchCount]);
+    setFindState((prev) => {
+      if (!prev.open || prev.matchCount === 0) {
+        return prev;
+      }
+      return {
+        ...prev,
+        activeIndex: (prev.activeIndex - 1 + prev.matchCount) % prev.matchCount,
+      };
+    });
+  }, []);
+
+  const findOpen = findState.open;
+  const findQuery = findState.open ? findState.query : "";
+  const matchCount = findState.open ? findState.matchCount : 0;
+  const activeIndex = findState.open ? findState.activeIndex : 0;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -120,13 +155,13 @@ const useInspectorFind = ({
 
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "f") {
         event.preventDefault();
-        setFindOpen(true);
+        setFindState((prev) => (prev.open ? prev : FIND_OPENED));
         return;
       }
 
       if (event.key === "Escape" && findOpen) {
         event.preventDefault();
-        setFindOpen(false);
+        setFindState(FIND_CLOSED);
       }
     };
 
@@ -145,22 +180,35 @@ const useInspectorFind = ({
     const root = contentRef.current;
     const query = findQuery.trim();
     if (!enabled || !root || query.length === 0) {
-      setMatchCount(0);
-      setActiveIndex(0);
+      setFindState((prev) =>
+        prev.open && (prev.matchCount !== 0 || prev.activeIndex !== 0)
+          ? { ...prev, matchCount: 0, activeIndex: 0 }
+          : prev,
+      );
       return undefined;
     }
 
     const ranges = collectTextRanges(root, query);
-    setMatchCount(ranges.length);
+    setFindState((prev) =>
+      prev.open && prev.matchCount !== ranges.length
+        ? { ...prev, matchCount: ranges.length }
+        : prev,
+    );
 
     if (ranges.length === 0) {
-      setActiveIndex(0);
+      setFindState((prev) =>
+        prev.open && prev.activeIndex !== 0
+          ? { ...prev, activeIndex: 0 }
+          : prev,
+      );
       return undefined;
     }
 
     const safeActiveIndex = activeIndex >= ranges.length ? 0 : activeIndex;
     if (safeActiveIndex !== activeIndex) {
-      setActiveIndex(safeActiveIndex);
+      setFindState((prev) =>
+        prev.open ? { ...prev, activeIndex: safeActiveIndex } : prev,
+      );
       return undefined;
     }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -310,10 +310,10 @@ function VersionItem({
   const t = useTranslations();
   const isSelected = version.file?.fieldId === currentFieldId;
   const isCurrent = version.id === currentVersionId;
-  const [contextOpen, setContextOpen] = useState(false);
   const [contextAnchor, setContextAnchor] = useState<{
     getBoundingClientRect: () => DOMRect;
   } | null>(null);
+  const isContextOpen = contextAnchor !== null;
 
   // Build translated label → color map for this render
   const labelColorMap = new Map(
@@ -337,7 +337,6 @@ function VersionItem({
     setContextAnchor({
       getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
     });
-    setContextOpen(true);
   };
 
   return (
@@ -424,9 +423,8 @@ function VersionItem({
       </button>
 
       <Menu
-        open={contextOpen}
+        open={isContextOpen}
         onOpenChange={(o) => {
-          setContextOpen(o);
           if (!o) {
             setContextAnchor(null);
           }
@@ -462,7 +460,7 @@ function VersionItem({
                 if (value) {
                   onSetLabel(version.id, value);
                   e.currentTarget.reset();
-                  setContextOpen(false);
+                  setContextAnchor(null);
                 }
               }}
             >


### PR DESCRIPTION
## Summary
- merge `isOpen` + `anchor` state (tree-view, versions-sidebar; +1 bonus impossible-state in tree-view FilesystemView)
- model chat mention drill state as a discriminated union
- model external-reference find state as a discriminated union
- model MCP wizard step payload as a union
- model workspace breadcrumb edit modes as a union

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] tree-view + versions-sidebar context menus still open/close cleanly
- [ ] chat mention drill-down renders loading/loaded/error states
- [ ] external-reference find toolbar opens and tracks matches
- [ ] MCP connector wizard advances through url → token steps
- [ ] workspace breadcrumb rename (name + ref) still commits/cancels