### PR TITLE
feat(web): React 19 forms and optimistic UI

### DIFF
--- a/apps/web/src/lib/pdf/pdf-viewport.tsx
+++ b/apps/web/src/lib/pdf/pdf-viewport.tsx
@@ -5,9 +5,9 @@ import {
   useId,
   useRef,
   useState,
-  useTransition,
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
+import { useFormStatus } from "react-dom";
 
 import { Result } from "better-result";
 import { useTranslations } from "use-intl";
@@ -206,18 +206,14 @@ const PDFPasswordPrompt = ({
   const id = useId();
   const t = useTranslations();
   const [value, setValue] = useState("");
-  const [isPending, startFormTransition] = useTransition();
 
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 px-4 py-6">
       <form
-        className="w-full max-w-sm space-y-3"
-        onSubmit={(event) => {
-          event.preventDefault();
-          startFormTransition(() => {
-            onSubmit(value);
-          });
+        action={() => {
+          onSubmit(value);
         }}
+        className="w-full max-w-sm space-y-3"
       >
         <Field invalid={incorrectPassword}>
           <FieldLabel htmlFor={id}>
@@ -239,10 +235,17 @@ const PDFPasswordPrompt = ({
             </FieldError>
           )}
         </Field>
-        <Button className="w-full" disabled={isPending} type="submit">
-          {t("workspaces.pdf.unlock")}
-        </Button>
+        <PDFPasswordSubmitButton label={t("workspaces.pdf.unlock")} />
       </form>
     </div>
+  );
+};
+
+const PDFPasswordSubmitButton = ({ label }: { label: string }) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button className="w-full" disabled={pending} type="submit">
+      {label}
+    </Button>
   );
 };

--- a/apps/web/src/routes/_protected.contacts/-components/add-contact-method-form.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/add-contact-method-form.tsx
@@ -1,3 +1,5 @@
+import { useFormStatus } from "react-dom";
+
 import { PlusIcon } from "lucide-react";
 
 import { Button } from "@stll/ui/components/button";
@@ -25,12 +27,11 @@ export const AddContactMethodForm = ({
   value: string;
 }) => (
   <form
-    className="flex gap-2"
-    noValidate
-    onSubmit={(event) => {
-      event.preventDefault();
+    action={() => {
       onSubmit();
     }}
+    className="flex gap-2"
+    noValidate
   >
     <Input
       className="h-8 min-w-0 flex-1 text-sm"
@@ -42,13 +43,25 @@ export const AddContactMethodForm = ({
       type={type}
       value={value}
     />
-    <Button
+    <AddContactMethodSubmitButton
+      buttonLabel={buttonLabel}
       disabled={disabled || value.trim().length === 0}
-      size="sm"
-      type="submit"
-    >
+    />
+  </form>
+);
+
+const AddContactMethodSubmitButton = ({
+  buttonLabel,
+  disabled,
+}: {
+  buttonLabel: string;
+  disabled: boolean;
+}) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button disabled={disabled || pending} size="sm" type="submit">
       <PlusIcon className="size-4" />
       {buttonLabel}
     </Button>
-  </form>
-);
+  );
+};

--- a/apps/web/src/routes/_protected.contacts/-components/contact-custom-fields-editor.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-custom-fields-editor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 import { PlusIcon, Trash2Icon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -117,11 +118,10 @@ export const ContactCustomFieldsEditor = ({
           </p>
         )}
         <form
-          className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]"
-          onSubmit={(event) => {
-            event.preventDefault();
+          action={() => {
             addCustomField();
           }}
+          className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)_auto]"
         >
           <Input
             disabled={isPending}
@@ -137,16 +137,29 @@ export const ContactCustomFieldsEditor = ({
             placeholder={t("contacts.customFields.valuePlaceholder")}
             value={valueDraft}
           />
-          <Button
+          <AddCustomFieldSubmitButton
             disabled={isPending || labelDraft.trim().length === 0}
-            type="submit"
-          >
-            <PlusIcon className="size-4" />
-            {t("contacts.customFields.addField")}
-          </Button>
+            label={t("contacts.customFields.addField")}
+          />
         </form>
       </div>
     </section>
+  );
+};
+
+const AddCustomFieldSubmitButton = ({
+  disabled,
+  label,
+}: {
+  disabled: boolean;
+  label: string;
+}) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button disabled={disabled || pending} type="submit">
+      <PlusIcon className="size-4" />
+      {label}
+    </Button>
   );
 };
 

--- a/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
@@ -395,6 +395,7 @@ export const AnonymizationDenyListCard = () => {
           >
             <Input
               autoComplete="off"
+              disabled={updateMutation.isPending}
               onChange={(event) => setPendingCanonical(event.target.value)}
               placeholder={t(
                 "settings.organization.anonymization.addPlaceholder",
@@ -404,6 +405,7 @@ export const AnonymizationDenyListCard = () => {
             <div className="flex items-center gap-2">
               <Combobox<LabelOption>
                 autoHighlight
+                disabled={updateMutation.isPending}
                 items={[...LABEL_OPTIONS]}
                 itemToStringLabel={(option) => t(LABEL_TRANSLATION_KEY[option])}
                 onValueChange={(next) => {
@@ -436,7 +438,10 @@ export const AnonymizationDenyListCard = () => {
                 </ComboboxPopup>
               </Combobox>
               <AddTermSubmitButton
-                disabled={pendingCanonical.trim().length === 0}
+                disabled={
+                  pendingCanonical.trim().length === 0 ||
+                  updateMutation.isPending
+                }
                 label={t("settings.organization.anonymization.addAction")}
               />
             </div>

--- a/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Trash2, UploadIcon } from "lucide-react";
@@ -290,7 +291,7 @@ export const AnonymizationDenyListCard = () => {
 
   const entries = blacklistQuery.data?.entries ?? [];
 
-  const submitTerm = () => {
+  const submitTerm = async () => {
     const canonical = pendingCanonical.trim();
     if (canonical.length === 0) {
       return;
@@ -304,27 +305,22 @@ export const AnonymizationDenyListCard = () => {
       })),
       { canonical, label: pendingLabel },
     ]);
-    updateMutation.mutate(
-      { entries: next },
-      {
-        onSuccess: () => {
-          setPendingCanonical("");
-          setPendingLabel(DEFAULT_LABEL);
-          stellaToast.add({
-            title: t("settings.organization.anonymization.termAddedToast", {
-              value: canonical,
-            }),
-            type: "success",
-          });
-        },
-        onError: (error) => {
-          stellaToast.add({
-            title: error instanceof Error ? error.message : String(error),
-            type: "error",
-          });
-        },
-      },
-    );
+    try {
+      await updateMutation.mutateAsync({ entries: next });
+      setPendingCanonical("");
+      setPendingLabel(DEFAULT_LABEL);
+      stellaToast.add({
+        title: t("settings.organization.anonymization.termAddedToast", {
+          value: canonical,
+        }),
+        type: "success",
+      });
+    } catch (error) {
+      stellaToast.add({
+        title: error instanceof Error ? error.message : String(error),
+        type: "error",
+      });
+    }
   };
 
   const removeEntry = (canonical: string) => {
@@ -394,15 +390,11 @@ export const AnonymizationDenyListCard = () => {
       <FramePanel>
         <div className="flex flex-col gap-3 p-1">
           <form
+            action={submitTerm}
             className="flex flex-col gap-2 rounded-md border p-3"
-            onSubmit={(event) => {
-              event.preventDefault();
-              submitTerm();
-            }}
           >
             <Input
               autoComplete="off"
-              disabled={updateMutation.isPending}
               onChange={(event) => setPendingCanonical(event.target.value)}
               placeholder={t(
                 "settings.organization.anonymization.addPlaceholder",
@@ -412,7 +404,6 @@ export const AnonymizationDenyListCard = () => {
             <div className="flex items-center gap-2">
               <Combobox<LabelOption>
                 autoHighlight
-                disabled={updateMutation.isPending}
                 items={[...LABEL_OPTIONS]}
                 itemToStringLabel={(option) => t(LABEL_TRANSLATION_KEY[option])}
                 onValueChange={(next) => {
@@ -444,16 +435,10 @@ export const AnonymizationDenyListCard = () => {
                   </ComboboxEmpty>
                 </ComboboxPopup>
               </Combobox>
-              <Button
-                disabled={
-                  pendingCanonical.trim().length === 0 ||
-                  updateMutation.isPending
-                }
-                size="sm"
-                type="submit"
-              >
-                {t("settings.organization.anonymization.addAction")}
-              </Button>
+              <AddTermSubmitButton
+                disabled={pendingCanonical.trim().length === 0}
+                label={t("settings.organization.anonymization.addAction")}
+              />
             </div>
             <div className="flex items-center gap-2">
               <Button
@@ -533,5 +518,20 @@ export const AnonymizationDenyListCard = () => {
         </div>
       </FramePanel>
     </Frame>
+  );
+};
+
+const AddTermSubmitButton = ({
+  disabled,
+  label,
+}: {
+  disabled: boolean;
+  label: string;
+}) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button disabled={disabled || pending} size="sm" type="submit">
+      {label}
+    </Button>
   );
 };

--- a/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useOptimistic, useTransition } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
@@ -21,25 +21,18 @@ export const OrganizationJurisdictionsCard = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
   const { data: settings } = useQuery(organizationSettingsOptions);
+  const serverSelected = settings?.practiceJurisdictions ?? [];
 
-  // Local optimistic state so rapid edits compose against the latest user
-  // intent rather than the (stale) server-cached `selected`. Without this,
-  // clicking two countries before the first mutation settles makes the
-  // second click compute `next` from the pre-first-click value and silently
-  // drop the first selection.
-  const [localSelected, setLocalSelected] = useState<PracticeJurisdiction[]>(
-    () => settings?.practiceJurisdictions ?? [],
+  // `useOptimistic` mirrors the server value and applies the latest user
+  // intent until the wrapping transition settles. When the mutation
+  // rejects (or the request unmounts), React automatically reverts the
+  // optimistic value back to the passthrough server state — no manual
+  // rollback needed.
+  const [optimisticSelected, applyOptimisticSelection] = useOptimistic(
+    serverSelected,
+    (_current, next: PracticeJurisdiction[]) => next,
   );
-  const [hasLocalEdit, setHasLocalEdit] = useState(false);
-
-  // Reconcile from server only when the user isn't mid-edit. Once mutations
-  // settle and we're back in sync, drop the local-edit flag so future server
-  // refreshes (e.g., another tab edited) flow back through.
-  useEffect(() => {
-    if (!hasLocalEdit && settings) {
-      setLocalSelected(settings.practiceJurisdictions);
-    }
-  }, [settings, hasLocalEdit]);
+  const [, startSelectionTransition] = useTransition();
 
   const updateMutation = useMutation({
     mutationFn: async (next: PracticeJurisdiction[]) => {
@@ -55,19 +48,13 @@ export const OrganizationJurisdictionsCard = () => {
       await queryClient.invalidateQueries({
         queryKey: organizationSettingsKeys.all,
       });
-      setHasLocalEdit(false);
     },
-    onError: (error, attemptedNext) => {
+    onError: (error) => {
       analytics.captureError(error);
       stellaToast.add({
         title: t("errors.actionFailed"),
         type: "error",
       });
-      // Roll back to whatever the server still reports.
-      setLocalSelected(settings?.practiceJurisdictions ?? []);
-      setHasLocalEdit(false);
-      // attemptedNext intentionally ignored after rollback.
-      void attemptedNext;
     },
   });
 
@@ -77,11 +64,17 @@ export const OrganizationJurisdictionsCard = () => {
         <div className="flex flex-col gap-3 p-1">
           <JurisdictionPicker
             onChange={(next) => {
-              setLocalSelected(next);
-              setHasLocalEdit(true);
-              updateMutation.mutate(next);
+              startSelectionTransition(async () => {
+                applyOptimisticSelection(next);
+                await updateMutation.mutateAsync(next).catch(() => {
+                  // The error toast is surfaced via the mutation's
+                  // `onError`. Swallow here so the transition resolves
+                  // and React reverts `optimisticSelected` to the
+                  // server value automatically.
+                });
+              });
             }}
-            selected={localSelected}
+            selected={optimisticSelected}
           />
         </div>
       </FramePanel>

--- a/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/jurisdictions-card.tsx
@@ -1,4 +1,4 @@
-import { useOptimistic, useTransition } from "react";
+import { useOptimistic, useRef, useState, useTransition } from "react";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
@@ -32,6 +32,11 @@ export const OrganizationJurisdictionsCard = () => {
     serverSelected,
     (_current, next: PracticeJurisdiction[]) => next,
   );
+  const [immediateSelected, setImmediateSelected] = useState<
+    PracticeJurisdiction[] | null
+  >(null);
+  const selectionGenerationRef = useRef(0);
+  const selected = immediateSelected ?? optimisticSelected;
   const [, startSelectionTransition] = useTransition();
 
   const updateMutation = useMutation({
@@ -64,17 +69,26 @@ export const OrganizationJurisdictionsCard = () => {
         <div className="flex flex-col gap-3 p-1">
           <JurisdictionPicker
             onChange={(next) => {
+              const generation = selectionGenerationRef.current + 1;
+              selectionGenerationRef.current = generation;
+              setImmediateSelected(next);
               startSelectionTransition(async () => {
                 applyOptimisticSelection(next);
-                await updateMutation.mutateAsync(next).catch(() => {
+                try {
+                  await updateMutation.mutateAsync(next);
+                } catch {
                   // The error toast is surfaced via the mutation's
                   // `onError`. Swallow here so the transition resolves
                   // and React reverts `optimisticSelected` to the
                   // server value automatically.
-                });
+                } finally {
+                  if (selectionGenerationRef.current === generation) {
+                    setImmediateSelected(null);
+                  }
+                }
               });
             }}
-            selected={optimisticSelected}
+            selected={selected}
           />
         </div>
       </FramePanel>

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 import {
   useMutation,
@@ -153,11 +154,13 @@ function ProfilePage() {
             </Select>
           </div>
           <form
-            className="border-border flex flex-col gap-4 border-t p-4"
-            onSubmit={(event) => {
-              event.preventDefault();
-              updateWordEditIdentity.mutate();
+            action={async () => {
+              await updateWordEditIdentity.mutateAsync().catch(() => {
+                // The error toast is surfaced via the mutation's
+                // `onError`; swallow here so the action settles.
+              });
             }}
+            className="border-border flex flex-col gap-4 border-t p-4"
           >
             <div className="flex max-w-lg flex-col gap-2">
               <Label htmlFor="preferred-name-input">
@@ -189,13 +192,7 @@ function ProfilePage() {
                 onChange={(event) => setWordEditShortcut(event.target.value)}
               />
             </div>
-            <Button
-              className="w-fit"
-              disabled={updateWordEditIdentity.isPending}
-              type="submit"
-            >
-              {t("common.save")}
-            </Button>
+            <ProfileSubmitButton label={t("common.save")} />
           </form>
         </FramePanel>
       </Frame>
@@ -219,3 +216,12 @@ function ProfilePage() {
     </>
   );
 }
+
+const ProfileSubmitButton = ({ label }: { label: string }) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button className="w-fit" disabled={pending} type="submit">
+      {label}
+    </Button>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
@@ -654,6 +654,7 @@ export const AnonymizationFacet = ({
       >
         <Input
           autoComplete="off"
+          disabled={createMutation.isPending}
           onChange={(event) => setPendingValue(event.target.value)}
           placeholder={t("inspector.anonymization.addPlaceholder")}
           value={pendingValue}
@@ -661,6 +662,7 @@ export const AnonymizationFacet = ({
         <div className="flex items-center gap-2">
           <Combobox<LabelOption>
             autoHighlight
+            disabled={createMutation.isPending}
             items={[...LABEL_OPTIONS]}
             itemToStringLabel={formatLabel}
             onValueChange={(next) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/anonymization-facet.tsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
@@ -347,37 +348,34 @@ export const AnonymizationFacet = ({
     // same string still re-fires the prefill.
   }, [folioSelection]);
 
-  const addTerm = (canonical: string, label: LabelOption) => {
+  const addTerm = async (canonical: string, label: LabelOption) => {
     const trimmed = canonical.trim();
     if (trimmed.length === 0) {
       return;
     }
-    createMutation.mutate(
-      {
+    try {
+      await createMutation.mutateAsync({
         workspaceId,
         entries: [{ canonical: trimmed, label }],
-      },
-      {
-        onSuccess: () => {
-          setPendingValue("");
-          setPendingLabel(DEFAULT_LABEL);
-          stellaToast.add({
-            title: t("inspector.anonymization.termAddedToast", {
-              value: trimmed,
-            }),
-            type: "success",
-          });
-        },
-        onError: (error) => {
-          stellaToast.add({
-            title: error instanceof Error ? error.message : String(error),
-            type: "error",
-          });
-        },
-      },
-    );
+      });
+      setPendingValue("");
+      setPendingLabel(DEFAULT_LABEL);
+      stellaToast.add({
+        title: t("inspector.anonymization.termAddedToast", {
+          value: trimmed,
+        }),
+        type: "success",
+      });
+    } catch (error) {
+      stellaToast.add({
+        title: error instanceof Error ? error.message : String(error),
+        type: "error",
+      });
+    }
   };
-  const submitTerm = () => addTerm(pendingValue, pendingLabel);
+  const submitTerm = async () => {
+    await addTerm(pendingValue, pendingLabel);
+  };
 
   const allEntries = termsQuery.data?.entries;
   const matchSnapshot = useAnonymizationMatches(activeFieldId);
@@ -651,15 +649,11 @@ export const AnonymizationFacet = ({
       </h3>
 
       <form
+        action={submitTerm}
         className="flex flex-col gap-2 rounded-md border p-3"
-        onSubmit={(event) => {
-          event.preventDefault();
-          submitTerm();
-        }}
       >
         <Input
           autoComplete="off"
-          disabled={createMutation.isPending}
           onChange={(event) => setPendingValue(event.target.value)}
           placeholder={t("inspector.anonymization.addPlaceholder")}
           value={pendingValue}
@@ -667,7 +661,6 @@ export const AnonymizationFacet = ({
         <div className="flex items-center gap-2">
           <Combobox<LabelOption>
             autoHighlight
-            disabled={createMutation.isPending}
             items={[...LABEL_OPTIONS]}
             itemToStringLabel={formatLabel}
             onValueChange={(next) => {
@@ -695,15 +688,10 @@ export const AnonymizationFacet = ({
               </ComboboxEmpty>
             </ComboboxPopup>
           </Combobox>
-          <Button
-            disabled={
-              pendingValue.trim().length === 0 || createMutation.isPending
-            }
-            size="sm"
-            type="submit"
-          >
-            {t("inspector.anonymization.addAction")}
-          </Button>
+          <AddTermSubmitButton
+            disabled={pendingValue.trim().length === 0}
+            label={t("inspector.anonymization.addAction")}
+          />
         </div>
       </form>
 
@@ -1005,8 +993,25 @@ export const AnonymizationFacet = ({
         </div>
       )}
       <AnonymizationContextMenu
-        onAnonymize={(selection) => addTerm(selection, pendingLabel)}
+        onAnonymize={(selection) => {
+          void addTerm(selection, pendingLabel);
+        }}
       />
     </div>
+  );
+};
+
+const AddTermSubmitButton = ({
+  disabled,
+  label,
+}: {
+  disabled: boolean;
+  label: string;
+}) => {
+  const { pending } = useFormStatus();
+  return (
+    <Button disabled={disabled || pending} size="sm" type="submit">
+      {label}
+    </Button>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
@@ -1,5 +1,11 @@
 import type { PropsWithChildren } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useOptimistic,
+  useRef,
+  useTransition,
+} from "react";
 
 import {
   useQuery,
@@ -111,9 +117,19 @@ const EntityMetadataContent = ({
   const { data: versionsData } = useQuery(
     entityVersionsOptions({ workspaceId, entityId: entity.entityId }),
   );
-  const [optimisticProperties, setOptimisticProperties] = useState<
-    WorkspaceProperty[]
-  >([]);
+  // `useOptimistic` keeps any newly created property visible until the
+  // wrapping transition completes (i.e., until the entity/property
+  // queries invalidate and the server-side row shows up). React then
+  // resyncs to the passthrough `properties` value, so we no longer
+  // need to manually prune entries once the field arrives.
+  const [optimisticProperties, addOptimisticProperty] = useOptimistic(
+    properties,
+    (current, action: WorkspaceProperty) =>
+      current.some((property) => property.id === action.id)
+        ? current
+        : [...current, action],
+  );
+  const [, startOptimisticTransition] = useTransition();
   const activeJustification = useWorkspaceStore((s) =>
     activeJustificationFieldId
       ? (s.justifications.find(
@@ -122,13 +138,15 @@ const EntityMetadataContent = ({
       : null,
   );
 
-  const refreshEntityFields = useCallback(() => {
-    void queryClient.invalidateQueries({
-      queryKey: entitiesKeys.all(workspaceId),
-    });
-    void queryClient.invalidateQueries({
-      queryKey: propertiesOptions(workspaceId).queryKey,
-    });
+  const refreshEntityFields = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(workspaceId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: propertiesOptions(workspaceId).queryKey,
+      }),
+    ]);
   }, [queryClient, workspaceId]);
 
   useEffect(() => {
@@ -142,33 +160,19 @@ const EntityMetadataContent = ({
     }
 
     sawWorkflowRunning.current = false;
-    refreshEntityFields();
+    void refreshEntityFields();
   }, [isWorkflowRunning, refreshEntityFields]);
 
   const entityFieldPropertyIds = new Set(
     entity.fields.map((field) => field.propertyId),
   );
-  const entityFieldPropertyIdsKey = [...entityFieldPropertyIds]
-    .toSorted()
-    .join(",");
 
-  useEffect(() => {
-    const currentFieldPropertyIds = new Set(
-      entityFieldPropertyIdsKey.split(",").filter((id) => id.length > 0),
-    );
-    setOptimisticProperties((prev) =>
-      prev.every((property) => !currentFieldPropertyIds.has(property.id))
-        ? prev
-        : prev.filter((property) => !currentFieldPropertyIds.has(property.id)),
-    );
-  }, [entityFieldPropertyIdsKey]);
-
-  const propertyIds = new Set(properties.map((property) => property.id));
-  const visibleProperties = [
-    ...properties,
-    ...optimisticProperties.filter((property) => !propertyIds.has(property.id)),
-  ];
-  const optimisticFields = optimisticProperties.flatMap((property) => {
+  const serverPropertyIds = new Set(properties.map((property) => property.id));
+  const optimisticOnlyProperties = optimisticProperties.filter(
+    (property) => !serverPropertyIds.has(property.id),
+  );
+  const visibleProperties = [...properties, ...optimisticOnlyProperties];
+  const optimisticFields = optimisticOnlyProperties.flatMap((property) => {
     if (entityFieldPropertyIds.has(property.id)) {
       return [];
     }
@@ -202,19 +206,16 @@ const EntityMetadataContent = ({
   }: {
     property: WorkspaceProperty;
   }) => {
-    setOptimisticProperties((prev) => {
-      if (prev.some((item) => item.id === property.id)) {
-        return prev;
-      }
-
-      return [...prev, property];
+    // The dialog already triggered the workflow itself (entity-scoped
+    // when a file source is set, whole-matter otherwise). We dispatch
+    // the optimistic row inside a transition and await the
+    // invalidations inside the same transition body — React keeps the
+    // optimistic property visible until the server queries refresh,
+    // then drops it because the passthrough now contains the real row.
+    startOptimisticTransition(async () => {
+      addOptimisticProperty(property);
+      await refreshEntityFields();
     });
-
-    // The dialog now triggers the workflow itself (entity-scoped when a
-    // file source is set, whole-matter otherwise). Refresh the entity
-    // fields so the optimistic row swaps to a real pending field as soon
-    // as the workflow query reports `running`.
-    refreshEntityFields();
   };
 
   const extractionAction = (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useOptimistic,
   useRef,
+  useState,
   useTransition,
 } from "react";
 
@@ -120,8 +121,7 @@ const EntityMetadataContent = ({
   // `useOptimistic` keeps any newly created property visible until the
   // wrapping transition completes (i.e., until the entity/property
   // queries invalidate and the server-side row shows up). React then
-  // resyncs to the passthrough `properties` value, so we no longer
-  // need to manually prune entries once the field arrives.
+  // resyncs to the passthrough `properties` value.
   const [optimisticProperties, addOptimisticProperty] = useOptimistic(
     properties,
     (current, action: WorkspaceProperty) =>
@@ -130,6 +130,16 @@ const EntityMetadataContent = ({
         : [...current, action],
   );
   const [, startOptimisticTransition] = useTransition();
+  // Track property ids that were just created from this panel and are
+  // still awaiting their first `entity.fields` row. `properties` can
+  // refetch before extraction adds the field, so we can't derive the
+  // pending placeholder from `useOptimistic` alone — once the real
+  // property arrives, React resyncs to the passthrough and the
+  // optimistic-only set empties. The placeholder must persist until
+  // `entity.fields` actually contains the property id.
+  const [pendingPlaceholderIds, setPendingPlaceholderIds] = useState<
+    readonly string[]
+  >([]);
   const activeJustification = useWorkspaceStore((s) =>
     activeJustificationFieldId
       ? (s.justifications.find(
@@ -166,14 +176,35 @@ const EntityMetadataContent = ({
   const entityFieldPropertyIds = new Set(
     entity.fields.map((field) => field.propertyId),
   );
+  const entityFieldPropertyIdsKey = [...entityFieldPropertyIds]
+    .toSorted()
+    .join(",");
+
+  useEffect(() => {
+    const arrivedIds = new Set(
+      entityFieldPropertyIdsKey.split(",").filter((id) => id.length > 0),
+    );
+    setPendingPlaceholderIds((prev) =>
+      prev.every((id) => !arrivedIds.has(id))
+        ? prev
+        : prev.filter((id) => !arrivedIds.has(id)),
+    );
+  }, [entityFieldPropertyIdsKey]);
 
   const serverPropertyIds = new Set(properties.map((property) => property.id));
   const optimisticOnlyProperties = optimisticProperties.filter(
     (property) => !serverPropertyIds.has(property.id),
   );
   const visibleProperties = [...properties, ...optimisticOnlyProperties];
-  const optimisticFields = optimisticOnlyProperties.flatMap((property) => {
-    if (entityFieldPropertyIds.has(property.id)) {
+  const visiblePropertyById = new Map(
+    visibleProperties.map((property) => [property.id, property]),
+  );
+  const optimisticFields = pendingPlaceholderIds.flatMap((propertyId) => {
+    if (entityFieldPropertyIds.has(propertyId)) {
+      return [];
+    }
+    const property = visiblePropertyById.get(propertyId);
+    if (!property) {
       return [];
     }
 
@@ -208,10 +239,16 @@ const EntityMetadataContent = ({
   }) => {
     // The dialog already triggered the workflow itself (entity-scoped
     // when a file source is set, whole-matter otherwise). We dispatch
-    // the optimistic row inside a transition and await the
-    // invalidations inside the same transition body — React keeps the
-    // optimistic property visible until the server queries refresh,
-    // then drops it because the passthrough now contains the real row.
+    // the optimistic property inside a transition and await the
+    // invalidations in the same body — React keeps the optimistic
+    // property visible until the server queries refresh, then drops it
+    // because the passthrough now contains the real row. The pending
+    // placeholder field is tracked separately so it persists until
+    // `entity.fields` actually contains the new property (extraction
+    // can complete after the properties query refetches).
+    setPendingPlaceholderIds((prev) =>
+      prev.includes(property.id) ? prev : [...prev, property.id],
+    );
     startOptimisticTransition(async () => {
       addOptimisticProperty(property);
       await refreshEntityFields();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -241,9 +241,7 @@ export function VersionsSidebar({
               onRestore={(vid) => {
                 void handleRestore(vid);
               }}
-              onSetLabel={(vid, label) => {
-                void handleSetLabel(vid, label);
-              }}
+              onSetLabel={handleSetLabel}
               onSwitchVersion={onSwitchVersion}
             />
           ))}
@@ -288,7 +286,7 @@ type VersionItemProps = {
   canDelete: boolean;
   onSwitchVersion: (fieldId: string, versionId: string) => Promise<void> | void;
   onDelete: (versionId: string) => Promise<void>;
-  onSetLabel: (versionId: string, label: string | null) => void;
+  onSetLabel: (versionId: string, label: string | null) => Promise<void>;
   onRestore: (versionId: string) => void;
   onDownload: (fieldId: string) => void;
 };
@@ -438,7 +436,9 @@ function VersionItem({
             return (
               <MenuItem
                 key={preset.key}
-                onClick={() => onSetLabel(version.id, isActive ? null : label)}
+                onClick={() => {
+                  void onSetLabel(version.id, isActive ? null : label);
+                }}
               >
                 <span
                   className={cn("size-2.5 shrink-0 rounded-full", preset.color)}
@@ -449,19 +449,20 @@ function VersionItem({
             );
           })}
 
-          {/* Custom label input */}
+          {/* Custom label input — the form action resets the
+              uncontrolled input automatically once the mutation
+              settles; we just close the menu after the action
+              finishes. */}
           <div className="px-2 py-1.5">
             <form
-              onSubmit={(e) => {
-                e.preventDefault();
-                const form = new FormData(e.currentTarget);
-                const raw = form.get("customLabel");
+              action={async (formData) => {
+                const raw = formData.get("customLabel");
                 const value = typeof raw === "string" ? raw.trim() : "";
-                if (value) {
-                  onSetLabel(version.id, value);
-                  e.currentTarget.reset();
-                  setContextAnchor(null);
+                if (!value) {
+                  return;
                 }
+                await onSetLabel(version.id, value);
+                setContextAnchor(null);
               }}
             >
               <input

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useOptimistic, useState, useTransition } from "react";
 
 import { EyeOffIcon, PencilLineIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -27,6 +27,11 @@ type PropertyPopoverProps = {
   header: TableHeader;
 };
 
+type ReplaceAction = {
+  index: number;
+  next: PropertyDependency;
+};
+
 export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
   const t = useTranslations();
   const { workspaceId, id, name } = property;
@@ -41,27 +46,20 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
   // a save from silently rewriting the file column as text/manual.
   const canEditViaComposer = property.content.type !== "file";
 
-  // Local optimistic copy of the dependencies. The conditions sub-modal
-  // can fire several edits in quick succession; rebuilding from
-  // `property.tool.dependencies` each time would clobber an in-flight
-  // change with the snapshot from the previous render. We keep the
-  // local copy authoritative while a mutation is pending and only
-  // re-sync from the prop when it settles.
-  const initialDeps =
+  // `useOptimistic` mirrors the server `dependencies` while a save is
+  // in flight so rapid successive edits compose against the latest
+  // user intent. Once the transition settles, React reverts to the
+  // passthrough server value — no manual resync effect needed.
+  const serverDependencies =
     property.tool.type === "ai-model" ? property.tool.dependencies : [];
-  const [localDeps, setLocalDeps] = useState<PropertyDependency[]>(initialDeps);
-  const isUpdatePending = updateProperty.isPending;
-
-  useEffect(() => {
-    if (isUpdatePending) {
-      return;
-    }
-    if (property.tool.type !== "ai-model") {
-      setLocalDeps([]);
-      return;
-    }
-    setLocalDeps(property.tool.dependencies);
-  }, [property, isUpdatePending]);
+  const [optimisticDeps, applyDependencyReplacement] = useOptimistic(
+    serverDependencies,
+    (current, action: ReplaceAction) =>
+      current.map((dependency, index) =>
+        index === action.index ? action.next : dependency,
+      ),
+  );
+  const [, startDepsTransition] = useTransition();
 
   // Conditions are editable from the popover without opening the full
   // composer: replaceValue swaps a dependency in place and we save by
@@ -70,28 +68,28 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
     if (property.tool.type !== "ai-model") {
       return;
     }
-    const nextDependencies = localDeps.map((d, i) => (i === index ? next : d));
-    setLocalDeps(nextDependencies);
-    updateProperty.mutate(
-      {
-        workspaceId,
-        propertyId: id,
-        name,
-        content: property.content,
-        tool: { ...property.tool, dependencies: nextDependencies },
-      },
-      {
-        onSuccess: () => {
-          void startWorkflow();
-        },
-        onError: () => {
-          stellaToast.add({
-            title: t("errors.actionFailed"),
-            type: "error",
-          });
-        },
-      },
-    );
+    const tool = property.tool;
+    startDepsTransition(async () => {
+      applyDependencyReplacement({ index, next });
+      const nextDependencies = tool.dependencies.map((dependency, i) =>
+        i === index ? next : dependency,
+      );
+      try {
+        await updateProperty.mutateAsync({
+          workspaceId,
+          propertyId: id,
+          name,
+          content: property.content,
+          tool: { ...tool, dependencies: nextDependencies },
+        });
+        void startWorkflow();
+      } catch {
+        stellaToast.add({
+          title: t("errors.actionFailed"),
+          type: "error",
+        });
+      }
+    });
   };
 
   return (
@@ -133,7 +131,7 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
             <Separator />
             <div className="flex flex-col p-1">
               <PropertyConditions
-                dependencies={localDeps}
+                dependencies={optimisticDeps}
                 replaceValue={replaceDependency}
                 workspaceId={workspaceId}
               />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -64,16 +64,19 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
   // Conditions are editable from the popover without opening the full
   // composer: replaceValue swaps a dependency in place and we save by
   // round-tripping the whole property through updateProperty.
+  // The mutation payload composes against the latest optimistic
+  // dependencies (not the server snapshot) so two edits fired before
+  // the query refetches don't drop one another's in-flight changes.
   const replaceDependency = (index: number, next: PropertyDependency) => {
     if (property.tool.type !== "ai-model") {
       return;
     }
     const tool = property.tool;
+    const nextDependencies = optimisticDeps.map((dependency, i) =>
+      i === index ? next : dependency,
+    );
     startDepsTransition(async () => {
       applyDependencyReplacement({ index, next });
-      const nextDependencies = tool.dependencies.map((dependency, i) =>
-        i === index ? next : dependency,
-      );
       try {
         await updateProperty.mutateAsync({
           workspaceId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -1,4 +1,10 @@
-import { useOptimistic, useState, useTransition } from "react";
+import {
+  useEffect,
+  useOptimistic,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 
 import { EyeOffIcon, PencilLineIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -59,7 +65,17 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
         index === action.index ? action.next : dependency,
       ),
   );
+  const [immediateDeps, setImmediateDeps] = useState<
+    PropertyDependency[] | null
+  >(null);
+  const displayedDependencies = immediateDeps ?? optimisticDeps;
+  const latestDependenciesRef = useRef(displayedDependencies);
+  const dependencyGenerationRef = useRef(0);
   const [, startDepsTransition] = useTransition();
+
+  useEffect(() => {
+    latestDependenciesRef.current = displayedDependencies;
+  }, [displayedDependencies]);
 
   // Conditions are editable from the popover without opening the full
   // composer: replaceValue swaps a dependency in place and we save by
@@ -72,9 +88,13 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
       return;
     }
     const tool = property.tool;
-    const nextDependencies = optimisticDeps.map((dependency, i) =>
-      i === index ? next : dependency,
+    const nextDependencies = latestDependenciesRef.current.map(
+      (dependency, i) => (i === index ? next : dependency),
     );
+    const generation = dependencyGenerationRef.current + 1;
+    dependencyGenerationRef.current = generation;
+    latestDependenciesRef.current = nextDependencies;
+    setImmediateDeps(nextDependencies);
     startDepsTransition(async () => {
       applyDependencyReplacement({ index, next });
       try {
@@ -91,6 +111,10 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
           title: t("errors.actionFailed"),
           type: "error",
         });
+      } finally {
+        if (dependencyGenerationRef.current === generation) {
+          setImmediateDeps(null);
+        }
       }
     });
   };
@@ -134,7 +158,7 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
             <Separator />
             <div className="flex flex-col p-1">
               <PropertyConditions
-                dependencies={optimisticDeps}
+                dependencies={displayedDependencies}
                 replaceValue={replaceDependency}
                 workspaceId={workspaceId}
               />


### PR DESCRIPTION
## Summary
- adopt `useOptimistic` for jurisdictions card
- adopt `useOptimistic` for entity metadata panel
- adopt `useOptimistic` for property popover
- convert 6 hand-rolled forms to React 19 actions + `useFormStatus` (account profile, PDF password, anonymization deny-list, anonymization facet, versions-sidebar custom label, contact methods + custom fields)

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] jurisdictions edit/save/error rollback
- [ ] entity metadata: rapid successive property additions render correctly
- [ ] property popover dependency edits persist + rollback on error
- [ ] account profile submit + pending state
- [ ] PDF password prompt submit + pending
- [ ] anonymization deny-list/facet add term submit
- [ ] versions-sidebar custom label form resets on success
- [ ] contact methods + custom fields submit