### PR TITLE
feat(web): useInlineRename hook + chat contexts

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -48,6 +48,8 @@ import type {
   ReviewSuggestionPreview,
 } from "@/components/ai-suggestions/review-store";
 import { useChatEditor } from "@/components/chat-editor-provider";
+import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
+import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import type {
   ActiveDocxEditApprovalPart,
@@ -867,114 +869,122 @@ const FileChatOverlayInner = ({
   }, [isGenerating, lastMessageId]);
 
   return (
-    <>
-      {panelOpen && hasThreadContent && (
-        <div
-          aria-label={t("chat.aiThread")}
-          className={cn(
-            // Sizing rules: grows with content but caps at ~45dvh
-            // / 380px so the panel doesn't dominate the file
-            // viewer. No min-height — short threads stay short.
-            "absolute start-1/2 bottom-[88px] z-40 flex max-h-[min(45dvh,380px)] min-h-0 w-[min(560px,calc(100%-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border",
-            "bg-popover/90 border-border text-popover-foreground",
-            "[backdrop-filter:blur(18px)_saturate(160%)] [-webkit-backdrop-filter:blur(18px)_saturate(160%)]",
-            "before:bg-foreground/[0.06] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px",
-            "hover:bg-popover focus-within:bg-popover",
-            "transition-[background-color,border-color] duration-200 ease-out",
-            "shadow-[0_1px_2px_rgb(0_0_0/0.06),0_20px_64px_rgb(0_0_0/0.18)]",
-            "animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1",
-          )}
-          role="dialog"
-        >
-          {/* Plain scroll container — bypasses the legacy
-              Conversation's `size-full` chain, which only resolves
-              correctly when the parent has an explicit height
-              (this overlay uses `max-h` only, so flex-1 children
-              don't get a definite size to base `size-full` on). */}
+    <ChatMattersContext
+      value={{
+        createDocumentMatters,
+        isLoadingCreateDocumentMatters,
+      }}
+    >
+      <ChatApprovalContext
+        value={{
+          activeOrganizationId,
+          alwaysApprovedTools,
+          conversationApprovedTools,
+          handleAllowInConversation,
+          handleAlwaysAllow,
+          handleApprove: handleApproveWithDocxUnlock,
+          handleDeny,
+          blockedApprovalTools,
+        }}
+      >
+        {panelOpen && hasThreadContent && (
           <div
-            ref={threadScrollRef}
-            className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3"
-            style={{ scrollbarGutter: "stable" }}
+            aria-label={t("chat.aiThread")}
+            className={cn(
+              // Sizing rules: grows with content but caps at ~45dvh
+              // / 380px so the panel doesn't dominate the file
+              // viewer. No min-height — short threads stay short.
+              "absolute start-1/2 bottom-[88px] z-40 flex max-h-[min(45dvh,380px)] min-h-0 w-[min(560px,calc(100%-2rem))] -translate-x-1/2 flex-col overflow-hidden rounded-2xl border",
+              "bg-popover/90 border-border text-popover-foreground",
+              "[backdrop-filter:blur(18px)_saturate(160%)] [-webkit-backdrop-filter:blur(18px)_saturate(160%)]",
+              "before:bg-foreground/[0.06] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-px",
+              "hover:bg-popover focus-within:bg-popover",
+              "transition-[background-color,border-color] duration-200 ease-out",
+              "shadow-[0_1px_2px_rgb(0_0_0/0.06),0_20px_64px_rgb(0_0_0/0.18)]",
+              "animate-in fade-in-0 zoom-in-95 slide-in-from-bottom-1",
+            )}
+            role="dialog"
           >
-            <ChatThreadMessages
-              activeOrganizationId={activeOrganizationId}
-              alwaysApprovedTools={alwaysApprovedTools}
-              approvalPendingMessageId={approvalPendingMessageId}
-              blockedApprovalTools={blockedApprovalTools}
-              conversationApprovedTools={conversationApprovedTools}
-              error={error}
-              handleAllowInConversation={handleAllowInConversation}
-              handleAlwaysAllow={handleAlwaysAllow}
-              handleApprove={handleApproveWithDocxUnlock}
-              handleDeny={handleDeny}
-              isGenerating={isGenerating}
-              messages={messages}
-              onAskUserSubmit={handleAskUserSubmit}
-              onCreateDocumentResolve={handleCreateDocumentResolve}
-              onOpenCreatedDocument={handleOpenCreatedDocument}
-              createDocumentMatters={createDocumentMatters}
-              isLoadingCreateDocumentMatters={isLoadingCreateDocumentMatters}
-              onResend={resendLatestMessage}
-              showThinkingIndicator
-              showToolCallDetails={showToolCallDetails}
-              streamdownComponents={streamdownComponents}
-              workspaceId={workspaceId}
-            />
+            {/* Plain scroll container — bypasses the legacy
+                Conversation's `size-full` chain, which only resolves
+                correctly when the parent has an explicit height
+                (this overlay uses `max-h` only, so flex-1 children
+                don't get a definite size to base `size-full` on). */}
+            <div
+              ref={threadScrollRef}
+              className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3"
+              style={{ scrollbarGutter: "stable" }}
+            >
+              <ChatThreadMessages
+                approvalPendingMessageId={approvalPendingMessageId}
+                error={error}
+                isGenerating={isGenerating}
+                messages={messages}
+                onAskUserSubmit={handleAskUserSubmit}
+                onCreateDocumentResolve={handleCreateDocumentResolve}
+                onOpenCreatedDocument={handleOpenCreatedDocument}
+                onResend={resendLatestMessage}
+                showThinkingIndicator
+                showToolCallDetails={showToolCallDetails}
+                streamdownComponents={streamdownComponents}
+                workspaceId={workspaceId}
+              />
+            </div>
           </div>
-        </div>
-      )}
+        )}
 
-      <ChatAnonymizationLayer
-        editor={editorController.editor}
-        enabled={false}
-        workspaceId={workspaceId ?? threadRef.threadId}
-      />
-      <PromptBar
-        attentionPulseSeq={attentionPulseSeq}
-        canSubmitNow={canSubmitWithCurrentDocxSnapshot}
-        editorController={editorController}
-        emptyPlaceholder={
-          (activeFile || activeExternal) && filePlaceholderAction ? (
-            <span className="text-foreground-ghost flex min-w-0 items-center gap-1.5 text-[13px] leading-5">
-              <span className="shrink-0">{filePlaceholderAction}</span>
-              <span className="text-foreground-label max-w-64 truncate">
-                {activeFile?.fileName ?? activeExternal?.title}
+        <ChatAnonymizationLayer
+          editor={editorController.editor}
+          enabled={false}
+          workspaceId={workspaceId ?? threadRef.threadId}
+        />
+        <PromptBar
+          attentionPulseSeq={attentionPulseSeq}
+          canSubmitNow={canSubmitWithCurrentDocxSnapshot}
+          editorController={editorController}
+          emptyPlaceholder={
+            (activeFile || activeExternal) && filePlaceholderAction ? (
+              <span className="text-foreground-ghost flex min-w-0 items-center gap-1.5 text-[13px] leading-5">
+                <span className="shrink-0">{filePlaceholderAction}</span>
+                <span className="text-foreground-label max-w-64 truncate">
+                  {activeFile?.fileName ?? activeExternal?.title}
+                </span>
               </span>
-            </span>
-          ) : undefined
-        }
-        layout="floating"
-        newThreadLabel={t("chat.newChat")}
-        onNewThread={() => {
-          setPanelOpen(false);
-          onNewThread();
-        }}
-        onStop={() => {
-          void stop();
-        }}
-        onSubmit={({ prompt }) => {
-          void ensureAIAvailable().then((available) => {
-            if (!available) {
-              return;
-            }
-            // Always pop the thread open on send, even if the user
-            // minimised it earlier — they're sending a new prompt
-            // and want to see the response stream in.
-            setPanelOpen(true);
-            void sendMessage({ text: prompt });
-          });
-        }}
-        onTogglePanel={() => setPanelOpen((v) => !v)}
-        panelOpen={panelOpen}
-        pendingCount={0}
-        sendDisabledReason={
-          activeFile && docxEditorRef && !editorReady
-            ? "editor-loading"
-            : undefined
-        }
-        showThreadToggle={hasThreadContent}
-        status={isGenerating ? "generating" : "idle"}
-      />
-    </>
+            ) : undefined
+          }
+          layout="floating"
+          newThreadLabel={t("chat.newChat")}
+          onNewThread={() => {
+            setPanelOpen(false);
+            onNewThread();
+          }}
+          onStop={() => {
+            void stop();
+          }}
+          onSubmit={({ prompt }) => {
+            void ensureAIAvailable().then((available) => {
+              if (!available) {
+                return;
+              }
+              // Always pop the thread open on send, even if the user
+              // minimised it earlier — they're sending a new prompt
+              // and want to see the response stream in.
+              setPanelOpen(true);
+              void sendMessage({ text: prompt });
+            });
+          }}
+          onTogglePanel={() => setPanelOpen((v) => !v)}
+          panelOpen={panelOpen}
+          pendingCount={0}
+          sendDisabledReason={
+            activeFile && docxEditorRef && !editorReady
+              ? "editor-loading"
+              : undefined
+          }
+          showThreadToggle={hasThreadContent}
+          status={isGenerating ? "generating" : "idle"}
+        />
+      </ChatApprovalContext>
+    </ChatMattersContext>
   );
 };

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -80,6 +80,7 @@ import {
 } from "@/components/sidebar";
 import { StellaWordmark } from "@/components/stella-wordmark";
 import { PALETTES, THEMES, useTheme } from "@/components/theme-provider";
+import { useInlineRename } from "@/hooks/use-inline-rename";
 import { usePermissions } from "@/hooks/use-permissions";
 import { useSignOut } from "@/hooks/use-sign-out";
 import {
@@ -266,17 +267,33 @@ const MatterItem = ({
   const t = useTranslations();
   const lang = useI18nStore((s) => s.lang);
   const { state, setOpen, isMobile } = useSidebar();
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [renameValue, setRenameValue] = useState(ws.name);
   const [menuOpen, setMenuOpen] = useState(false);
   const [addMemberOpen, setAddMemberOpen] = useState(false);
   const [ctxAnchor, setCtxAnchor] = useState<{
     getBoundingClientRect: () => DOMRect;
   } | null>(null);
   const updateWorkspace = useUpdateWorkspace();
-  const escapedRef = useRef(false);
   const dropRef = useRef<HTMLLIElement>(null);
   const [isDropTarget, setIsDropTarget] = useState(false);
+  const rename = useInlineRename({
+    initial: ws.name,
+    onCommit: (value) => {
+      if (updateWorkspace.isPending) {
+        return;
+      }
+      updateWorkspace.mutate(
+        { workspaceId: ws.id, name: value },
+        {
+          onError: () => {
+            stellaToast.add({
+              title: t("errors.actionFailed"),
+              type: "error",
+            });
+          },
+        },
+      );
+    },
+  });
 
   const canDrag = isPinned && !!onReorder;
   const isCollapsed = state === "collapsed" && !isMobile;
@@ -316,59 +333,23 @@ const MatterItem = ({
 
   const relTime = formatRelativeTime(ws.lastActivityAt, lang);
 
-  const cancelRename = () => {
-    setIsRenaming(false);
-    setRenameValue(ws.name);
-  };
-
   const startRename = () => {
-    escapedRef.current = false;
     setMenuOpen(false);
     setCtxAnchor(null);
-    setRenameValue(ws.name);
 
     if (isCollapsed) {
       setOpen(true);
-      window.requestAnimationFrame(() => setIsRenaming(true));
+      // The sidebar needs a frame to expand before the input can
+      // mount visibly; deferring `startEditing` keeps the rename
+      // affordance lined up with the now-revealed row.
+      window.requestAnimationFrame(() => rename.startEditing());
       return;
     }
 
-    setIsRenaming(true);
+    rename.startEditing();
   };
 
-  const handleRename = () => {
-    if (escapedRef.current) {
-      escapedRef.current = false;
-      cancelRename();
-      return;
-    }
-
-    if (updateWorkspace.isPending) {
-      return;
-    }
-
-    const trimmed = renameValue.trim();
-    if (trimmed.length === 0 || trimmed === ws.name) {
-      cancelRename();
-      return;
-    }
-
-    updateWorkspace.mutate(
-      { workspaceId: ws.id, name: trimmed },
-      {
-        onSuccess: () => setIsRenaming(false),
-        onError: () => {
-          stellaToast.add({
-            title: t("errors.actionFailed"),
-            type: "error",
-          });
-          cancelRename();
-        },
-      },
-    );
-  };
-
-  if (isRenaming) {
+  if (rename.state.mode === "edit") {
     return (
       <SidebarMenuItem>
         <div className="flex h-8 w-full items-center gap-2 rounded-md px-2">
@@ -376,18 +357,20 @@ const MatterItem = ({
           <Input
             autoFocus
             className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm shadow-none outline-none focus-visible:ring-0"
-            onBlur={handleRename}
-            onChange={(e) => setRenameValue(e.currentTarget.value)}
+            onBlur={() => {
+              void rename.commit();
+            }}
+            onChange={(e) => rename.setDraft(e.currentTarget.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.currentTarget.blur();
               }
               if (e.key === "Escape") {
-                escapedRef.current = true;
+                rename.cancel();
                 e.currentTarget.blur();
               }
             }}
-            value={renameValue}
+            value={rename.state.draft}
           />
         </div>
       </SidebarMenuItem>

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -277,8 +277,9 @@ const MatterItem = ({
   const [isDropTarget, setIsDropTarget] = useState(false);
   const rename = useInlineRename({
     initial: ws.name,
-    onCommit: (value) => {
+    onCommit: (value, { setError }) => {
       if (updateWorkspace.isPending) {
+        setError(t("errors.actionFailed"));
         return;
       }
       updateWorkspace.mutate(

--- a/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/workspace-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 import { Link, useMatch } from "@tanstack/react-router";
@@ -21,6 +21,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { BreadcrumbLink } from "@/components/breadcrumbs/shared";
 import { MatterNumberHint } from "@/components/matter-number-hint";
+import { useInlineRename } from "@/hooks/use-inline-rename";
 import { APIError } from "@/lib/errors";
 import {
   getMatterPickerColor,
@@ -36,15 +37,6 @@ const breadcrumbInputClassName =
 
 const matterNameInputClassName = `${breadcrumbInputClassName} font-semibold`;
 
-type NameState = { mode: "view" } | { mode: "edit"; draft: string };
-
-type RefState =
-  | { mode: "view" }
-  | { mode: "edit"; draft: string; error?: string };
-
-const NAME_VIEW: NameState = { mode: "view" };
-const REF_VIEW: RefState = { mode: "view" };
-
 export const WorkspaceBreadcrumb = ({
   workspaceId,
 }: ResolveParams<"/workspaces/$workspaceId">) => {
@@ -53,15 +45,43 @@ export const WorkspaceBreadcrumb = ({
     from: "/_protected/workspaces/$workspaceId/",
     shouldThrow: false,
   });
-  const [nameState, setNameState] = useState<NameState>(NAME_VIEW);
-  const escapedNameRef = useRef(false);
-  const [refState, setRefState] = useState<RefState>(REF_VIEW);
   const [refInputEl, setRefInputEl] = useState<HTMLInputElement | null>(null);
   const [colorPickerOpen, setColorPickerOpen] = useState(false);
   const [iconAnchor, setIconAnchor] = useState<HTMLSpanElement | null>(null);
   const { data: workspace } = useQuery(workspaceOptions(workspaceId));
   const updateWorkspace = useUpdateWorkspace();
   const updateMattersConfig = useConfigStore((s) => s.updateMatters);
+
+  const nameRename = useInlineRename({
+    initial: workspace?.name ?? "",
+    onCommit: (value) => {
+      updateWorkspace.mutate({ workspaceId, name: value });
+    },
+  });
+
+  const refRename = useInlineRename({
+    initial: workspace?.reference ?? "",
+    onCommit: (value, { setError }) => {
+      updateWorkspace.mutate(
+        { workspaceId, reference: value },
+        {
+          onError: (error) => {
+            if (APIError.is(error) && error.status === 409) {
+              setError(t("workspaces.referenceTaken"));
+              refInputEl?.focus();
+              return;
+            }
+
+            const message =
+              APIError.is(error) && error.status < 500
+                ? error.message
+                : t("errors.actionFailed");
+            stellaToast.add({ title: message, type: "error" });
+          },
+        },
+      );
+    },
+  });
 
   if (!workspace) {
     return (
@@ -74,78 +94,16 @@ export const WorkspaceBreadcrumb = ({
   const displayName = workspace.name;
 
   const startEditingName = () => {
-    escapedNameRef.current = false;
-    setNameState({ mode: "edit", draft: displayName });
+    nameRename.startEditing(displayName);
   };
 
-  const handleSaveProjectName = () => {
-    if (escapedNameRef.current) {
-      escapedNameRef.current = false;
-      setNameState(NAME_VIEW);
-      return;
-    }
-
-    const draft = nameState.mode === "edit" ? nameState.draft : "";
-    setNameState(NAME_VIEW);
-
-    const workspaceName = draft.trim();
-
-    if (!workspaceName || workspaceName === workspace.name) {
-      return;
-    }
-
-    updateWorkspace.mutate({
-      workspaceId,
-      name: workspaceName,
-    });
-  };
-
-  const handleSaveReference = () => {
-    if (refState.mode !== "edit") {
-      return;
-    }
-    const trimmed = refState.draft.trim();
-
-    if (!trimmed || trimmed === workspace.reference) {
-      setRefState(REF_VIEW);
-      return;
-    }
-
-    setRefState((prev) =>
-      prev.mode === "edit" && prev.error !== undefined
-        ? { mode: "edit", draft: prev.draft }
-        : prev,
-    );
-    updateWorkspace.mutate(
-      {
-        workspaceId,
-        reference: trimmed,
-      },
-      {
-        onSuccess: () => {
-          setRefState(REF_VIEW);
-        },
-        onError: (error) => {
-          if (APIError.is(error) && error.status === 409) {
-            setRefState((prev) =>
-              prev.mode === "edit"
-                ? { ...prev, error: t("workspaces.referenceTaken") }
-                : prev,
-            );
-            refInputEl?.focus();
-            return;
-          }
-
-          const message =
-            APIError.is(error) && error.status < 500
-              ? error.message
-              : t("errors.actionFailed");
-          stellaToast.add({ title: message, type: "error" });
-          setRefState(REF_VIEW);
-        },
-      },
-    );
-  };
+  const isEditing = nameRename.state.mode === "edit";
+  const nameValue =
+    nameRename.state.mode === "edit" ? nameRename.state.draft : "";
+  const isEditingRef = refRename.state.mode === "edit";
+  const refDraft = refRename.state.mode === "edit" ? refRename.state.draft : "";
+  const refError =
+    refRename.state.mode === "edit" ? (refRename.state.error ?? "") : "";
 
   const handleColorChange = (color: string) => {
     updateWorkspace.mutate({
@@ -216,21 +174,20 @@ export const WorkspaceBreadcrumb = ({
   );
 
   const referenceSegment = (() => {
-    if (refState.mode === "edit") {
+    if (isEditingRef) {
       return (
         <Input
           className={`${breadcrumbInputClassName} w-28 text-sm`}
-          onBlur={handleSaveReference}
-          onChange={(e) => {
-            const draft = e.target.value;
-            setRefState({ mode: "edit", draft });
+          onBlur={() => {
+            void refRename.commit();
           }}
+          onChange={(e) => refRename.setDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
-              handleSaveReference();
+              void refRename.commit();
             }
             if (e.key === "Escape") {
-              setRefState(REF_VIEW);
+              refRename.cancel();
             }
           }}
           placeholder={t("workspaces.referencePlaceholder")}
@@ -240,7 +197,7 @@ export const WorkspaceBreadcrumb = ({
           }}
           size="sm"
           unstyled
-          value={refState.draft}
+          value={refDraft}
         />
       );
     }
@@ -248,9 +205,7 @@ export const WorkspaceBreadcrumb = ({
       return (
         <button
           className="text-foreground-muted hover:text-muted-foreground cursor-text text-sm"
-          onClick={() => {
-            setRefState({ mode: "edit", draft: workspace.reference });
-          }}
+          onClick={() => refRename.startEditing(workspace.reference)}
           type="button"
         >
           {workspace.reference}
@@ -263,9 +218,9 @@ export const WorkspaceBreadcrumb = ({
   const referenceHint = (
     <MatterNumberHint
       anchor={refInputEl}
-      error={refState.mode === "edit" ? (refState.error ?? "") : ""}
-      open={refState.mode === "edit"}
-      value={refState.mode === "edit" ? refState.draft : ""}
+      error={refError}
+      open={isEditingRef}
+      value={refDraft}
       variant="popover"
     />
   );
@@ -276,7 +231,7 @@ export const WorkspaceBreadcrumb = ({
         {clientSegment}
         <BreadcrumbItem className="shrink-0">
           {(() => {
-            if (nameState.mode === "edit") {
+            if (isEditing) {
               return (
                 <>
                   <span
@@ -298,23 +253,23 @@ export const WorkspaceBreadcrumb = ({
                   <Input
                     className={`${matterNameInputClassName} w-fit`}
                     disabled={updateWorkspace.isPending}
-                    onBlur={() => handleSaveProjectName()}
-                    onChange={(e) =>
-                      setNameState({ mode: "edit", draft: e.target.value })
-                    }
+                    onBlur={() => {
+                      void nameRename.commit();
+                    }}
+                    onChange={(e) => nameRename.setDraft(e.target.value)}
                     onKeyDown={(e) => {
                       if (e.key === "Enter") {
                         e.currentTarget.blur();
                       }
                       if (e.key === "Escape") {
-                        escapedNameRef.current = true;
+                        nameRename.cancel();
                         e.currentTarget.blur();
                       }
                     }}
                     autoFocus
                     size="sm"
                     unstyled
-                    value={nameState.draft}
+                    value={nameValue}
                   />
                 </>
               );
@@ -356,16 +311,13 @@ export const WorkspaceBreadcrumb = ({
                   />
                 </span>
                 <span className="truncate">{displayName}</span>
-                {workspace.reference && refState.mode === "view" ? (
+                {workspace.reference && !isEditingRef ? (
                   <span
                     className="text-foreground-muted shrink-0 text-sm"
                     onContextMenu={(e) => {
                       e.preventDefault();
                       e.stopPropagation();
-                      setRefState({
-                        mode: "edit",
-                        draft: workspace.reference,
-                      });
+                      refRename.startEditing(workspace.reference);
                     }}
                   >
                     {workspace.reference}
@@ -374,7 +326,7 @@ export const WorkspaceBreadcrumb = ({
               </Link>
             );
           })()}
-          {refState.mode === "edit" ? referenceSegment : null}
+          {isEditingRef ? referenceSegment : null}
           {referenceHint}
         </BreadcrumbItem>
         <Popover onOpenChange={setColorPickerOpen} open={colorPickerOpen}>
@@ -397,7 +349,7 @@ export const WorkspaceBreadcrumb = ({
     );
   }
 
-  if (nameState.mode === "edit") {
+  if (isEditing) {
     return (
       <>
         {clientSegment}
@@ -406,23 +358,23 @@ export const WorkspaceBreadcrumb = ({
           <Input
             className={`${matterNameInputClassName} w-fit`}
             disabled={updateWorkspace.isPending}
-            onBlur={() => handleSaveProjectName()}
-            onChange={(e) =>
-              setNameState({ mode: "edit", draft: e.target.value })
-            }
+            onBlur={() => {
+              void nameRename.commit();
+            }}
+            onChange={(e) => nameRename.setDraft(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.currentTarget.blur();
               }
               if (e.key === "Escape") {
-                escapedNameRef.current = true;
+                nameRename.cancel();
                 e.currentTarget.blur();
               }
             }}
             autoFocus
             size="sm"
             unstyled
-            value={nameState.draft}
+            value={nameValue}
           />
           {referenceSegment}
           {referenceHint}

--- a/apps/web/src/components/chat/chat-approval-context.tsx
+++ b/apps/web/src/components/chat/chat-approval-context.tsx
@@ -1,0 +1,56 @@
+import { createContext, use } from "react";
+
+import type {
+  ApprovalToolName,
+  ToolApprovalGrant,
+} from "@/components/chat/chat-ui-tools";
+
+/**
+ * Tool-approval handlers and grant sets shared by every leaf that
+ * renders a `tool-approval` part (currently `ToolApprovalCard`).
+ *
+ * Each chat surface (page, tab panel, file overlay) wraps its
+ * subtree with a provider so the approval card can resolve the
+ * full state machine without `ChatThreadMessages` and
+ * `AssistantMessageParts` having to thread it through.
+ *
+ * Handler signatures match `useChatSession`'s exports verbatim;
+ * the provider is a thin pass-through.
+ */
+type ChatApprovalContextValue = {
+  activeOrganizationId: string;
+  handleAllowInConversation: (
+    id: string,
+    toolName: ApprovalToolName,
+  ) => void | PromiseLike<void>;
+  handleAlwaysAllow: (
+    id: string,
+    toolName: ApprovalToolName,
+  ) => void | PromiseLike<void>;
+  handleApprove: (
+    id: string,
+    toolName: ApprovalToolName,
+  ) => void | PromiseLike<void>;
+  handleDeny: (id: string) => void | PromiseLike<void>;
+  alwaysApprovedTools: ReadonlySet<ToolApprovalGrant>;
+  conversationApprovedTools: ReadonlySet<ToolApprovalGrant>;
+  /**
+   * Optional set of tool names that should be auto-denied (e.g.
+   * tools blocked while a specific file overlay is active). Leaves
+   * read this directly so the policy stays close to the gate.
+   */
+  blockedApprovalTools?: ReadonlySet<ApprovalToolName> | undefined;
+};
+
+export const ChatApprovalContext =
+  createContext<ChatApprovalContextValue | null>(null);
+
+export const useChatApproval = (): ChatApprovalContextValue => {
+  const value = use(ChatApprovalContext);
+  if (value === null) {
+    throw new Error(
+      "useChatApproval must be used inside a <ChatApprovalContext> provider",
+    );
+  }
+  return value;
+};

--- a/apps/web/src/components/chat/chat-matters-context.tsx
+++ b/apps/web/src/components/chat/chat-matters-context.tsx
@@ -1,0 +1,37 @@
+import { createContext, use } from "react";
+
+import type { NeedsMatterMatter } from "@/components/chat/needs-matter-card";
+
+/**
+ * Read-only matter list shared by every leaf that resolves a
+ * `tool-create-document` part (currently `NeedsMatterCard`).
+ *
+ * The list is workspace-scoped and lives on whichever component
+ * owns the chat surface — `ChatThreadPage`, `ChatTabPanel`,
+ * `FileChatOverlay` — so the picker can stay in the leaf without
+ * those owners having to drill `createDocumentMatters` and
+ * `isLoadingCreateDocumentMatters` through three intermediate
+ * relays.
+ *
+ * `value` is `null` when no provider is mounted, which lets
+ * `useChatMatters()` throw a descriptive error rather than handing
+ * back undefined fields.
+ */
+type ChatMattersContextValue = {
+  createDocumentMatters: readonly NeedsMatterMatter[];
+  isLoadingCreateDocumentMatters: boolean;
+};
+
+export const ChatMattersContext = createContext<ChatMattersContextValue | null>(
+  null,
+);
+
+export const useChatMatters = (): ChatMattersContextValue => {
+  const value = use(ChatMattersContext);
+  if (value === null) {
+    throw new Error(
+      "useChatMatters must be used inside a <ChatMattersContext> provider",
+    );
+  }
+  return value;
+};

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, expect, test } from "bun:test";
 import { IntlProvider } from "use-intl";
 
+import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
+import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import messages from "@/i18n/langs/en.json";
 import type Messages from "@/i18n/langs/messages.gen";
@@ -26,7 +28,26 @@ const renderWithProviders = (children: ReactNode) =>
         messages={messages as Messages}
         timeZone="UTC"
       >
-        {children}
+        <ChatMattersContext
+          value={{
+            createDocumentMatters: [],
+            isLoadingCreateDocumentMatters: false,
+          }}
+        >
+          <ChatApprovalContext
+            value={{
+              activeOrganizationId: "test-active-organization",
+              alwaysApprovedTools: new Set(),
+              conversationApprovedTools: new Set(),
+              handleAllowInConversation: () => {},
+              handleAlwaysAllow: () => {},
+              handleApprove: () => {},
+              handleDeny: () => {},
+            }}
+          >
+            {children}
+          </ChatApprovalContext>
+        </ChatMattersContext>
       </IntlProvider>
     </QueryClientProvider>,
   );
@@ -43,20 +64,11 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         messages={chatMessages}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         showToolCalls={false}
         streamdownComponents={{
           a: ({ children, ...props }) => <a {...props}>{children}</a>,
@@ -85,20 +97,11 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         messages={chatMessages}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         onResend={() => {}}
         showToolCalls={false}
         streamdownComponents={{
@@ -129,20 +132,11 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         messages={chatMessages}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         onResend={() => {}}
         showToolCalls={false}
         streamdownComponents={{
@@ -168,21 +162,12 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         isGenerating
         messages={chatMessages}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         onResend={() => {}}
         showToolCalls={false}
         streamdownComponents={{
@@ -199,21 +184,12 @@ describe("chat thread messages", () => {
   test("shows a resendable chat message when the chat runtime errors", () => {
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
         error={new Error("provider details must stay hidden")}
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         messages={[]}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         onResend={() => {}}
         showToolCallDetails={false}
         streamdownComponents={{
@@ -230,10 +206,7 @@ describe("chat thread messages", () => {
   test("offers a raw-send override when anonymization blocks an attachment", () => {
     const html = renderWithProviders(
       <ChatThreadMessages
-        activeOrganizationId="org_test"
-        alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
         error={
           new Error(
             JSON.stringify({
@@ -243,16 +216,10 @@ describe("chat thread messages", () => {
             }),
           )
         }
-        handleAllowInConversation={() => {}}
-        handleAlwaysAllow={() => {}}
-        handleApprove={() => {}}
-        handleDeny={() => {}}
         messages={[]}
         onAskUserSubmit={() => {}}
         onCreateDocumentResolve={() => {}}
         onOpenCreatedDocument={() => {}}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
         onResend={() => {}}
         onSendWithoutAnonymization={() => {}}
         showToolCallDetails={false}

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -20,17 +20,14 @@ import {
 import { AnonymizedSpan } from "@/components/chat/anonymized-span";
 import { AskUserCard } from "@/components/chat/ask-user-card";
 import type {
-  ApprovalToolName,
   AskUserOutput,
   ChatAnonRestoration,
   ChatPart,
   ChatUITools,
   PersistedChatMessage,
-  ToolApprovalGrant,
 } from "@/components/chat/chat-ui-tools";
 import { isApprovalPart } from "@/components/chat/chat-ui-tools";
 import { NeedsMatterCard } from "@/components/chat/needs-matter-card";
-import type { NeedsMatterMatter } from "@/components/chat/needs-matter-card";
 import { rehypeAnonSpans } from "@/components/chat/rehype-anon-spans";
 import { SourceChips } from "@/components/chat/source-chips";
 import { StreamdownMentionLink } from "@/components/chat/streamdown-mention-link";
@@ -433,24 +430,7 @@ const getRetryableAssistantMessageId = (
 };
 
 type ChatThreadMessagesProps = {
-  activeOrganizationId: string;
-  alwaysApprovedTools: ReadonlySet<ToolApprovalGrant>;
   approvalPendingMessageId: string | null;
-  blockedApprovalTools?: ReadonlySet<ApprovalToolName> | undefined;
-  conversationApprovedTools: ReadonlySet<ToolApprovalGrant>;
-  handleAllowInConversation: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  handleAlwaysAllow: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  handleApprove: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  handleDeny: (id: string) => void | PromiseLike<void>;
   error?: Error | undefined;
   isGenerating?: boolean | undefined;
   messages: PersistedChatMessage[];
@@ -473,8 +453,6 @@ type ChatThreadMessagesProps = {
       { success: true }
     >,
   ) => Promise<void> | void;
-  createDocumentMatters: readonly NeedsMatterMatter[];
-  isLoadingCreateDocumentMatters: boolean;
   showThinkingIndicator?: boolean | undefined;
   showToolCallDetails?: boolean | undefined;
   showToolCalls?: boolean | undefined;
@@ -492,15 +470,7 @@ type ChatResendOptions = {
 };
 
 export const ChatThreadMessages = ({
-  activeOrganizationId,
-  alwaysApprovedTools,
   approvalPendingMessageId,
-  blockedApprovalTools,
-  conversationApprovedTools,
-  handleAllowInConversation,
-  handleAlwaysAllow,
-  handleApprove,
-  handleDeny,
   error,
   isGenerating = false,
   messages,
@@ -509,8 +479,6 @@ export const ChatThreadMessages = ({
   onAskUserSubmit,
   onCreateDocumentResolve,
   onOpenCreatedDocument,
-  createDocumentMatters,
-  isLoadingCreateDocumentMatters,
   showThinkingIndicator = false,
   showToolCallDetails,
   showToolCalls,
@@ -540,18 +508,6 @@ export const ChatThreadMessages = ({
             {message.role === "assistant" ? (
               <>
                 <AssistantMessageParts
-                  activeOrganizationId={activeOrganizationId}
-                  alwaysApprovedTools={alwaysApprovedTools}
-                  blockedApprovalTools={blockedApprovalTools}
-                  conversationApprovedTools={conversationApprovedTools}
-                  createDocumentMatters={createDocumentMatters}
-                  handleAllowInConversation={handleAllowInConversation}
-                  handleAlwaysAllow={handleAlwaysAllow}
-                  handleApprove={handleApprove}
-                  handleDeny={handleDeny}
-                  isLoadingCreateDocumentMatters={
-                    isLoadingCreateDocumentMatters
-                  }
                   message={message}
                   onAskUserSubmit={onAskUserSubmit}
                   onCreateDocumentResolve={onCreateDocumentResolve}
@@ -561,7 +517,6 @@ export const ChatThreadMessages = ({
                   workspaceId={workspaceId}
                 />
                 <SourceChips
-                  activeOrganizationId={activeOrganizationId}
                   messageId={message.id}
                   parts={message.parts}
                   workspaceId={workspaceId}
@@ -621,16 +576,6 @@ export const ChatThreadMessages = ({
 
 type AssistantMessagePartsProps = Pick<
   ChatThreadMessagesProps,
-  | "activeOrganizationId"
-  | "alwaysApprovedTools"
-  | "blockedApprovalTools"
-  | "conversationApprovedTools"
-  | "createDocumentMatters"
-  | "handleAllowInConversation"
-  | "handleAlwaysAllow"
-  | "handleApprove"
-  | "handleDeny"
-  | "isLoadingCreateDocumentMatters"
   | "onAskUserSubmit"
   | "onCreateDocumentResolve"
   | "onOpenCreatedDocument"
@@ -650,16 +595,6 @@ type AssistantMessagePartsProps = Pick<
  * remount on every streaming text delta.
  */
 const AssistantMessageParts = ({
-  activeOrganizationId,
-  alwaysApprovedTools,
-  blockedApprovalTools,
-  conversationApprovedTools,
-  createDocumentMatters,
-  handleAllowInConversation,
-  handleAlwaysAllow,
-  handleApprove,
-  handleDeny,
-  isLoadingCreateDocumentMatters,
   message,
   onAskUserSubmit,
   onCreateDocumentResolve,
@@ -700,9 +635,7 @@ const AssistantMessageParts = ({
         if (part.type === "tool-create-document") {
           return (
             <NeedsMatterCard
-              isLoadingMatters={isLoadingCreateDocumentMatters}
               key={part.toolCallId}
-              matters={createDocumentMatters}
               onOpenCreated={onOpenCreatedDocument}
               onResolve={onCreateDocumentResolve}
               part={part}
@@ -713,15 +646,7 @@ const AssistantMessageParts = ({
         if (isApprovalPart(part)) {
           return (
             <ToolApprovalCard
-              activeOrganizationId={activeOrganizationId}
-              alwaysApprovedTools={alwaysApprovedTools}
-              blockedApprovalTools={blockedApprovalTools}
-              conversationApprovedTools={conversationApprovedTools}
               key={part.toolCallId}
-              onAllowInConversation={handleAllowInConversation}
-              onAlwaysAllow={handleAlwaysAllow}
-              onApprove={handleApprove}
-              onDeny={handleDeny}
               part={part}
               workspaceId={workspaceId}
             />
@@ -731,7 +656,6 @@ const AssistantMessageParts = ({
         if (isToolUIPart(part)) {
           return (
             <ToolCallCard
-              activeOrganizationId={activeOrganizationId}
               key={part.toolCallId}
               part={part}
               showDetails={shouldShowToolCalls}

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ai-elements/message";
 import { AnonymizedSpan } from "@/components/chat/anonymized-span";
 import { AskUserCard } from "@/components/chat/ask-user-card";
+import { useChatApproval } from "@/components/chat/chat-approval-context";
 import type {
   AskUserOutput,
   ChatAnonRestoration,
@@ -485,6 +486,7 @@ export const ChatThreadMessages = ({
   streamdownComponents,
   workspaceId,
 }: ChatThreadMessagesProps) => {
+  const { activeOrganizationId } = useChatApproval();
   const retryableAssistantMessageId = useMemo(
     () => getRetryableAssistantMessageId(messages),
     [messages],
@@ -508,6 +510,7 @@ export const ChatThreadMessages = ({
             {message.role === "assistant" ? (
               <>
                 <AssistantMessageParts
+                  activeOrganizationId={activeOrganizationId}
                   message={message}
                   onAskUserSubmit={onAskUserSubmit}
                   onCreateDocumentResolve={onCreateDocumentResolve}
@@ -517,6 +520,7 @@ export const ChatThreadMessages = ({
                   workspaceId={workspaceId}
                 />
                 <SourceChips
+                  activeOrganizationId={activeOrganizationId}
                   messageId={message.id}
                   parts={message.parts}
                   workspaceId={workspaceId}
@@ -582,6 +586,7 @@ type AssistantMessagePartsProps = Pick<
   | "streamdownComponents"
   | "workspaceId"
 > & {
+  activeOrganizationId: string;
   message: PersistedChatMessage;
   shouldShowToolCalls: boolean;
 };
@@ -595,6 +600,7 @@ type AssistantMessagePartsProps = Pick<
  * remount on every streaming text delta.
  */
 const AssistantMessageParts = ({
+  activeOrganizationId,
   message,
   onAskUserSubmit,
   onCreateDocumentResolve,
@@ -656,6 +662,7 @@ const AssistantMessageParts = ({
         if (isToolUIPart(part)) {
           return (
             <ToolCallCard
+              activeOrganizationId={activeOrganizationId}
               key={part.toolCallId}
               part={part}
               showDetails={shouldShowToolCalls}

--- a/apps/web/src/components/chat/needs-matter-card.tsx
+++ b/apps/web/src/components/chat/needs-matter-card.tsx
@@ -15,6 +15,7 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useChatMatters } from "@/components/chat/chat-matters-context";
 import type { ChatUITools } from "@/components/chat/chat-ui-tools";
 import { resolveMatterColor } from "@/lib/matter-colors";
 
@@ -32,8 +33,6 @@ export type NeedsMatterMatter = {
 
 type NeedsMatterCardProps = {
   part: CreateDocumentPart;
-  matters: readonly NeedsMatterMatter[];
-  isLoadingMatters: boolean;
   onResolve: (
     toolCallId: string,
     matterId: string,
@@ -44,11 +43,13 @@ type NeedsMatterCardProps = {
 
 export const NeedsMatterCard = ({
   part,
-  matters,
-  isLoadingMatters,
   onResolve,
   onOpenCreated,
 }: NeedsMatterCardProps) => {
+  const {
+    createDocumentMatters: matters,
+    isLoadingCreateDocumentMatters: isLoadingMatters,
+  } = useChatMatters();
   const t = useTranslations();
 
   // Streaming-tolerant input read. While the AI is producing the

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -14,6 +14,7 @@ import { Button } from "@stll/ui/components/button";
 import { cn } from "@stll/ui/lib/utils";
 
 import { useReviewStore } from "@/components/ai-suggestions/review-store";
+import { useChatApproval } from "@/components/chat/chat-approval-context";
 import {
   getChatToolTitleKey,
   getApprovalToolName,
@@ -25,7 +26,6 @@ import type {
   ApprovalToolName,
   ApprovalToolPart,
   ChatUITools,
-  ToolApprovalGrant,
 } from "@/components/chat/chat-ui-tools";
 import { sanitizeHref } from "@/lib/sanitize-href";
 import type { WorkspaceProperty } from "@/lib/types";
@@ -282,39 +282,24 @@ const ActiveDocxEditSummary = ({ input }: ActiveDocxEditSummaryProps) => {
 // -- Main card --
 
 type ToolApprovalCardProps = {
-  activeOrganizationId: string;
-  alwaysApprovedTools: ReadonlySet<ToolApprovalGrant>;
   part: ApprovalToolPart;
-  onAllowInConversation: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  onAlwaysAllow: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  onApprove: (
-    id: string,
-    toolName: ApprovalToolName,
-  ) => void | PromiseLike<void>;
-  onDeny: (id: string) => void | PromiseLike<void>;
-  conversationApprovedTools: ReadonlySet<ToolApprovalGrant>;
-  blockedApprovalTools?: ReadonlySet<ApprovalToolName> | undefined;
   workspaceId?: string | undefined;
 };
 
 export const ToolApprovalCard = ({
-  activeOrganizationId,
-  alwaysApprovedTools,
   part,
-  onAllowInConversation,
-  onAlwaysAllow,
-  onApprove,
-  onDeny,
-  conversationApprovedTools,
-  blockedApprovalTools,
   workspaceId,
 }: ToolApprovalCardProps) => {
+  const {
+    activeOrganizationId,
+    alwaysApprovedTools,
+    conversationApprovedTools,
+    blockedApprovalTools,
+    handleAllowInConversation: onAllowInConversation,
+    handleAlwaysAllow: onAlwaysAllow,
+    handleApprove: onApprove,
+    handleDeny: onDeny,
+  } = useChatApproval();
   const t = useTranslations();
   const name = getApprovalToolName(part);
   const autoApproveRef = useRef(false);

--- a/apps/web/src/hooks/use-inline-rename.ts
+++ b/apps/web/src/hooks/use-inline-rename.ts
@@ -1,0 +1,123 @@
+import { useRef, useState } from "react";
+
+/**
+ * Inline rename state machine shared by toolbars, sidebars, kanban
+ * cards, breadcrumbs, and chat tab headers. The hook owns the
+ * view/edit transition, the draft buffer, and an optional inline
+ * error string; callers wire in domain rules via `validate` and
+ * `onCommit` (which receives a `setError` helper for server-side
+ * validation failures such as 409 conflicts).
+ *
+ * Commit semantics:
+ *  - Empty trimmed value: silently cancel (matches every existing
+ *    site, none of which create empty names).
+ *  - Trimmed value equals current `initial`: silently cancel.
+ *  - `validate` returns a string: stay in edit mode, surface the
+ *    string as `state.error`.
+ *  - `onCommit` may return a promise; while it is in flight the
+ *    state machine stays in `view` mode unless `setError` is
+ *    called from inside `onCommit`, in which case the editor
+ *    re-enters edit mode with the rejected draft (server-side
+ *    validation rollback).
+ */
+type InlineRenameState =
+  | { mode: "view" }
+  | { mode: "edit"; draft: string; error?: string };
+
+type CommitHelpers = {
+  /**
+   * Re-enters edit mode with the rejected draft and surfaces an
+   * inline error. Use this from `onCommit` when a server-side
+   * validation failure (e.g., 409 conflict) needs to be displayed
+   * next to the input rather than thrown as a toast.
+   */
+  setError: (message: string) => void;
+};
+
+type UseInlineRenameOptions = {
+  /** Current persisted value; used as the seed for `draft` and to detect no-op commits. */
+  initial: string;
+  /**
+   * Invoked with the trimmed draft once it has passed `validate`
+   * and is not a no-op. May be async; rejections surface to the
+   * caller (typical pattern: rollback inside `onError`).
+   */
+  onCommit: (value: string, helpers: CommitHelpers) => void | Promise<void>;
+  /**
+   * Synchronous client-side validation. Returns an error message
+   * to display inline, or `null` to allow the commit to proceed.
+   */
+  validate?: (value: string) => string | null;
+};
+
+type UseInlineRenameReturn = {
+  state: InlineRenameState;
+  startEditing: (override?: string) => void;
+  setDraft: (draft: string) => void;
+  commit: () => Promise<void>;
+  cancel: () => void;
+};
+
+export const useInlineRename = ({
+  initial,
+  onCommit,
+  validate,
+}: UseInlineRenameOptions): UseInlineRenameReturn => {
+  const [state, setState] = useState<InlineRenameState>({ mode: "view" });
+  // `cancelled` lets the caller short-circuit an in-flight blur:
+  // pressing Escape blurs the input synchronously, but the blur's
+  // `commit()` reads `state` from a stale closure. The ref flips
+  // immediately so `commit()` can see the cancel even before
+  // React commits the state transition.
+  const cancelledRef = useRef(false);
+
+  const startEditing = (override?: string) => {
+    cancelledRef.current = false;
+    setState({ mode: "edit", draft: override ?? initial });
+  };
+
+  const setDraft = (draft: string) => {
+    // Typing clears any stale error so the user can retry inline
+    // without first having to dismiss the previous server message.
+    setState((prev) => (prev.mode === "edit" ? { mode: "edit", draft } : prev));
+  };
+
+  const cancel = () => {
+    cancelledRef.current = true;
+    setState({ mode: "view" });
+  };
+
+  const commit = async () => {
+    if (state.mode !== "edit" || cancelledRef.current) {
+      cancelledRef.current = false;
+      return;
+    }
+    const trimmed = state.draft.trim();
+    if (!trimmed || trimmed === initial) {
+      setState({ mode: "view" });
+      return;
+    }
+    const validationError = validate?.(trimmed) ?? null;
+    if (validationError !== null) {
+      setState({ mode: "edit", draft: state.draft, error: validationError });
+      return;
+    }
+    // Optimistically exit edit mode; if `onCommit` invokes
+    // `setError`, we flip back to edit with the rejected draft so
+    // server-side validation feels inline. Hold the captured value
+    // in a single-cell ref so the closure can write through it
+    // without TS narrowing the outer binding to its initial null.
+    const errorBox: { current: string | null } = { current: null };
+    setState({ mode: "view" });
+    await onCommit(trimmed, {
+      setError: (message: string) => {
+        errorBox.current = message;
+      },
+    });
+    if (errorBox.current !== null) {
+      setState({ mode: "edit", draft: trimmed, error: errorBox.current });
+    }
+  };
+
+  return { state, startEditing, setDraft, commit, cancel };
+};

--- a/apps/web/src/hooks/use-inline-rename.ts
+++ b/apps/web/src/hooks/use-inline-rename.ts
@@ -9,16 +9,21 @@ import { useRef, useState } from "react";
  * validation failures such as 409 conflicts).
  *
  * Commit semantics:
- *  - Empty trimmed value: silently cancel (matches every existing
- *    site, none of which create empty names).
  *  - Trimmed value equals current `initial`: silently cancel.
- *  - `validate` returns a string: stay in edit mode, surface the
- *    string as `state.error`.
- *  - `onCommit` may return a promise; while it is in flight the
- *    state machine stays in `view` mode unless `setError` is
- *    called from inside `onCommit`, in which case the editor
- *    re-enters edit mode with the rejected draft (server-side
- *    validation rollback).
+ *  - `validate` runs next and may return a string for any value
+ *    (including the empty string) to keep the editor open with
+ *    `state.error` set; returning `null` lets the commit proceed.
+ *  - Without `validate`, an empty trimmed value silently cancels
+ *    (default for callers that never create empty names). Callers
+ *    that need to react to empty input (e.g., emit a toast) should
+ *    define `validate` and let it return `null` so the empty
+ *    string is forwarded to `onCommit`.
+ *  - `onCommit` is invoked with the trimmed draft. The hook
+ *    optimistically transitions to `view` before calling it; if
+ *    `setError` runs (either synchronously, awaited, or later
+ *    from a fire-and-forget `mutate({ onError })` callback) the
+ *    editor re-enters edit mode with the rejected draft so
+ *    server-side validation feels inline.
  */
 type InlineRenameState =
   | { mode: "view" }
@@ -70,9 +75,16 @@ export const useInlineRename = ({
   // immediately so `commit()` can see the cancel even before
   // React commits the state transition.
   const cancelledRef = useRef(false);
+  // `generationRef` invalidates `setError` callbacks from a
+  // previous commit cycle. Without it, a stale fire-and-forget
+  // `onError` could clobber a fresh edit the user has already
+  // started or cancelled. Bumped on every commit, cancel, and
+  // explicit `startEditing`.
+  const generationRef = useRef(0);
 
   const startEditing = (override?: string) => {
     cancelledRef.current = false;
+    generationRef.current += 1;
     setState({ mode: "edit", draft: override ?? initial });
   };
 
@@ -84,6 +96,7 @@ export const useInlineRename = ({
 
   const cancel = () => {
     cancelledRef.current = true;
+    generationRef.current += 1;
     setState({ mode: "view" });
   };
 
@@ -93,29 +106,50 @@ export const useInlineRename = ({
       return;
     }
     const trimmed = state.draft.trim();
-    if (!trimmed || trimmed === initial) {
+    if (trimmed === initial) {
       setState({ mode: "view" });
       return;
     }
+    // Run client-side validation before the empty-string
+    // short-circuit so callers that care about required fields
+    // (e.g., `validate: v => v ? null : "name required"`) can opt
+    // into "stay in edit mode with an inline error" semantics.
     const validationError = validate?.(trimmed) ?? null;
     if (validationError !== null) {
       setState({ mode: "edit", draft: state.draft, error: validationError });
       return;
     }
+    if (!trimmed && validate === undefined) {
+      // No validator opted in; preserve the default "empty draft
+      // silently cancels" behaviour matching every existing site.
+      // Callers that supply `validate` (even if it returns `null`)
+      // are saying "I will handle the empty case myself" so we
+      // forward the empty string through to `onCommit`.
+      setState({ mode: "view" });
+      return;
+    }
     // Optimistically exit edit mode; if `onCommit` invokes
-    // `setError`, we flip back to edit with the rejected draft so
-    // server-side validation feels inline. Hold the captured value
-    // in a single-cell ref so the closure can write through it
-    // without TS narrowing the outer binding to its initial null.
-    const errorBox: { current: string | null } = { current: null };
+    // `setError` we flip straight back to edit with the rejected
+    // draft. `setError` updates state directly so it works for
+    // both awaited promises and fire-and-forget patterns such as
+    // TanStack Query's `.mutate({ onError })`, whose callback may
+    // run after `commit()` has already returned.
+    generationRef.current += 1;
+    const generation = generationRef.current;
     setState({ mode: "view" });
-    await onCommit(trimmed, {
+    const result = onCommit(trimmed, {
       setError: (message: string) => {
-        errorBox.current = message;
+        // Ignore stale callbacks from a previous edit cycle the
+        // user has already moved past (cancelled, started over,
+        // or kicked off another commit).
+        if (generationRef.current !== generation) {
+          return;
+        }
+        setState({ mode: "edit", draft: trimmed, error: message });
       },
     });
-    if (errorBox.current !== null) {
-      setState({ mode: "edit", draft: trimmed, error: errorBox.current });
+    if (result instanceof Promise) {
+      await result;
     }
   };
 

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -15,7 +15,9 @@ import {
 } from "@/components/ai-elements/conversation";
 import { useChatEditor } from "@/components/chat-editor-provider";
 import { ChatInputSurface } from "@/components/chat-input-surface";
+import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
+import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import { getUserMessageHtmlHistory } from "@/components/chat/chat-ui-tools";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
@@ -180,112 +182,128 @@ export const ChatThreadPage = ({
   });
 
   return (
-    <div className="flex w-full max-w-5xl flex-1 flex-col overflow-hidden">
-      <div className="flex items-center justify-between gap-2 px-4 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          {threadRef.scope === "workspace" ? (
-            <Link
-              className={buttonVariants({
-                variant: "ghost",
-                size: "sm",
-              })}
-              params={{ workspaceId: threadRef.workspaceId }}
-              to="/chat/workspaces/$workspaceId/new"
-            >
-              <PlusIcon />
-              {t("chat.newChat")}
-            </Link>
-          ) : (
-            <Link
-              className={buttonVariants({
-                variant: "ghost",
-                size: "sm",
-              })}
-              to="/chat/new"
-            >
-              <PlusIcon />
-              {t("chat.newChat")}
-            </Link>
-          )}
-          {contextMatterIds !== null && (
-            <ChatMatterPicker
-              matterIds={contextMatterIds}
-              onChange={setContextMatterIds}
-            />
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          <ChatAnonymizedToggle enabled={anonymized} onChange={setAnonymized} />
-          <Tooltip
-            content={t("chat.moveToSide")}
-            render={
-              <Button onClick={moveToSide} size="icon-sm" variant="ghost">
-                <Maximize2Icon className="size-4" />
-              </Button>
-            }
-          />
-          <ThreadsSheet />
-        </div>
-      </div>
-
-      <Conversation>
-        <ConversationContent className="gap-3">
-          {messages.length === 0 && !isGenerating && !error ? (
-            <div className="m-auto w-full max-w-md px-4">
-              <PromptSuggestions onSelect={selectPrompt} prompts={prompts} />
+    <ChatMattersContext
+      value={{
+        createDocumentMatters,
+        isLoadingCreateDocumentMatters,
+      }}
+    >
+      <ChatApprovalContext
+        value={{
+          activeOrganizationId,
+          alwaysApprovedTools,
+          conversationApprovedTools,
+          handleAllowInConversation,
+          handleAlwaysAllow,
+          handleApprove,
+          handleDeny,
+        }}
+      >
+        <div className="flex w-full max-w-5xl flex-1 flex-col overflow-hidden">
+          <div className="flex items-center justify-between gap-2 px-4 py-2">
+            <div className="flex min-w-0 items-center gap-2">
+              {threadRef.scope === "workspace" ? (
+                <Link
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                  })}
+                  params={{ workspaceId: threadRef.workspaceId }}
+                  to="/chat/workspaces/$workspaceId/new"
+                >
+                  <PlusIcon />
+                  {t("chat.newChat")}
+                </Link>
+              ) : (
+                <Link
+                  className={buttonVariants({
+                    variant: "ghost",
+                    size: "sm",
+                  })}
+                  to="/chat/new"
+                >
+                  <PlusIcon />
+                  {t("chat.newChat")}
+                </Link>
+              )}
+              {contextMatterIds !== null && (
+                <ChatMatterPicker
+                  matterIds={contextMatterIds}
+                  onChange={setContextMatterIds}
+                />
+              )}
             </div>
-          ) : (
-            <ChatThreadMessages
-              activeOrganizationId={activeOrganizationId}
-              alwaysApprovedTools={alwaysApprovedTools}
-              approvalPendingMessageId={approvalPendingMessageId}
-              conversationApprovedTools={conversationApprovedTools}
-              error={error}
-              handleAllowInConversation={handleAllowInConversation}
-              handleAlwaysAllow={handleAlwaysAllow}
-              handleApprove={handleApprove}
-              handleDeny={handleDeny}
-              isGenerating={isGenerating}
-              messages={messages}
-              onAskUserSubmit={handleAskUserSubmit}
-              onCreateDocumentResolve={handleCreateDocumentResolve}
-              onOpenCreatedDocument={handleOpenCreatedDocument}
-              createDocumentMatters={createDocumentMatters}
-              isLoadingCreateDocumentMatters={isLoadingCreateDocumentMatters}
-              onResend={resendLatestMessage}
-              onSendWithoutAnonymization={sendWithoutAnonymization}
-              showThinkingIndicator
-              showToolCallDetails={showToolCallDetails}
-              streamdownComponents={streamdownComponents}
-              workspaceId={workspaceId}
-            />
-          )}
-        </ConversationContent>
-        <ConversationScrollButton />
-      </Conversation>
+            <div className="flex items-center gap-1">
+              <ChatAnonymizedToggle
+                enabled={anonymized}
+                onChange={setAnonymized}
+              />
+              <Tooltip
+                content={t("chat.moveToSide")}
+                render={
+                  <Button onClick={moveToSide} size="icon-sm" variant="ghost">
+                    <Maximize2Icon className="size-4" />
+                  </Button>
+                }
+              />
+              <ThreadsSheet />
+            </div>
+          </div>
 
-      <ChatAnonymizationLayer
-        editor={controller.editor}
-        enabled={anonymized}
-        workspaceId={workspaceId ?? threadRef.threadId}
-      />
-      <div className="p-4">
-        <ChatInputSurface
-          anonymized={anonymized}
-          autoFocus
-          controller={controller}
-          isGenerating={isGenerating}
-          onStop={() => {
-            void stop();
-          }}
-          onSubmit={async (draft) => {
-            if (!(await ensureAIAvailable())) {
-              return;
-            }
-            await sendMessage(await buildChatRequestMessage(draft));
-          }}
-        />
-      </div>
-    </div>
+          <Conversation>
+            <ConversationContent className="gap-3">
+              {messages.length === 0 && !isGenerating && !error ? (
+                <div className="m-auto w-full max-w-md px-4">
+                  <PromptSuggestions
+                    onSelect={selectPrompt}
+                    prompts={prompts}
+                  />
+                </div>
+              ) : (
+                <ChatThreadMessages
+                  approvalPendingMessageId={approvalPendingMessageId}
+                  error={error}
+                  isGenerating={isGenerating}
+                  messages={messages}
+                  onAskUserSubmit={handleAskUserSubmit}
+                  onCreateDocumentResolve={handleCreateDocumentResolve}
+                  onOpenCreatedDocument={handleOpenCreatedDocument}
+                  onResend={resendLatestMessage}
+                  onSendWithoutAnonymization={sendWithoutAnonymization}
+                  showThinkingIndicator
+                  showToolCallDetails={showToolCallDetails}
+                  streamdownComponents={streamdownComponents}
+                  workspaceId={workspaceId}
+                />
+              )}
+            </ConversationContent>
+            <ConversationScrollButton />
+          </Conversation>
+
+          <ChatAnonymizationLayer
+            editor={controller.editor}
+            enabled={anonymized}
+            workspaceId={workspaceId ?? threadRef.threadId}
+          />
+          <div className="p-4">
+            <ChatInputSurface
+              anonymized={anonymized}
+              autoFocus
+              controller={controller}
+              isGenerating={isGenerating}
+              onStop={() => {
+                void stop();
+              }}
+              onSubmit={async (draft) => {
+                if (!(await ensureAIAvailable())) {
+                  return;
+                }
+                await sendMessage(await buildChatRequestMessage(draft));
+              }}
+            />
+          </div>
+        </div>
+      </ChatApprovalContext>
+    </ChatMattersContext>
   );
 };

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 import { useQueryClient } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
@@ -7,6 +5,7 @@ import { useTranslations } from "use-intl";
 import { Input } from "@stll/ui/components/input";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { useInlineRename } from "@/hooks/use-inline-rename";
 import { invalidateContactCaches } from "@/routes/_protected.contacts/-components/contact-caches";
 import type {
   ContactData,
@@ -50,77 +49,65 @@ export const EditableRow = ({
   const activeOrganizationId = protectedRouteApi.useRouteContext({
     select: (ctx) => ctx.user.activeOrganizationId,
   });
-  const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(value ?? "");
 
   const maxLength = FIELD_MAX_LENGTH[field];
 
-  const handleSave = () => {
-    setIsEditing(false);
-    const trimmed = inputValue.trim();
-    const current = value ?? "";
-
-    if (trimmed === current) {
-      return;
-    }
-
-    if (maxLength !== undefined && trimmed.length > maxLength) {
-      stellaToast.add({
-        title: t("errors.actionFailed"),
-        type: "error",
-      });
-      setInputValue(value ?? "");
-      return;
-    }
-
-    let payload: Record<string, unknown>;
-    if (field === "defaultHourlyRate" || field === "paymentTermDays") {
-      const parsed = trimmed ? Number.parseInt(trimmed, 10) : null;
-      if (parsed !== null && (Number.isNaN(parsed) || parsed < 0)) {
-        setInputValue(value ?? "");
-        return;
-      }
-      if (field === "paymentTermDays" && parsed !== null && parsed > 365) {
-        setInputValue(value ?? "");
-        return;
-      }
-      payload = { [field]: parsed };
-    } else if (field === "displayName") {
-      if (!trimmed) {
+  const rename = useInlineRename({
+    initial: value ?? "",
+    onCommit: (trimmed) => {
+      if (maxLength !== undefined && trimmed.length > maxLength) {
         stellaToast.add({
           title: t("errors.actionFailed"),
           type: "error",
         });
-        setInputValue(value ?? "");
         return;
       }
-      payload = { displayName: trimmed };
-    } else {
-      payload = { [field]: trimmed || null };
-    }
 
-    updateContact.mutate(
-      { contactId: contact.id, ...payload },
-      {
-        onSuccess: () => {
-          void invalidateContactCaches(queryClient, {
-            activeOrganizationId,
-            contactId: contact.id,
-            invalidateWorkspaces: field === "displayName",
-          });
-        },
-        onError: () => {
+      let payload: Record<string, unknown>;
+      if (field === "defaultHourlyRate" || field === "paymentTermDays") {
+        const parsed = trimmed ? Number.parseInt(trimmed, 10) : null;
+        if (parsed !== null && (Number.isNaN(parsed) || parsed < 0)) {
+          return;
+        }
+        if (field === "paymentTermDays" && parsed !== null && parsed > 365) {
+          return;
+        }
+        payload = { [field]: parsed };
+      } else if (field === "displayName") {
+        if (!trimmed) {
           stellaToast.add({
             title: t("errors.actionFailed"),
             type: "error",
           });
-          setInputValue(value ?? "");
-        },
-      },
-    );
-  };
+          return;
+        }
+        payload = { displayName: trimmed };
+      } else {
+        payload = { [field]: trimmed || null };
+      }
 
-  if (isEditing) {
+      updateContact.mutate(
+        { contactId: contact.id, ...payload },
+        {
+          onSuccess: () => {
+            void invalidateContactCaches(queryClient, {
+              activeOrganizationId,
+              contactId: contact.id,
+              invalidateWorkspaces: field === "displayName",
+            });
+          },
+          onError: () => {
+            stellaToast.add({
+              title: t("errors.actionFailed"),
+              type: "error",
+            });
+          },
+        },
+      );
+    },
+  });
+
+  if (rename.state.mode === "edit") {
     return (
       <div className="flex items-baseline gap-2">
         {label && (
@@ -130,19 +117,21 @@ export const EditableRow = ({
           autoFocus
           className="h-auto min-w-0 flex-1 border-0 bg-transparent p-0 text-sm shadow-none outline-none focus-visible:ring-0"
           maxLength={maxLength}
-          onBlur={handleSave}
-          onChange={(e) => setInputValue(e.target.value)}
+          onBlur={() => {
+            void rename.commit();
+          }}
+          onChange={(e) => rename.setDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.currentTarget.blur();
             }
             if (e.key === "Escape") {
-              setInputValue(value ?? "");
-              setIsEditing(false);
+              rename.cancel();
+              e.currentTarget.blur();
             }
           }}
           type={type}
-          value={inputValue}
+          value={rename.state.draft}
         />
       </div>
     );
@@ -155,10 +144,7 @@ export const EditableRow = ({
       )}
       <button
         className="hover:text-foreground cursor-text text-start text-sm"
-        onClick={() => {
-          setInputValue(value ?? "");
-          setIsEditing(true);
-        }}
+        onClick={() => rename.startEditing()}
         type="button"
       >
         {value || <span className="text-foreground-subtle">—</span>}

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -54,12 +54,15 @@ export const EditableRow = ({
 
   const rename = useInlineRename({
     initial: value ?? "",
-    // `displayName` is the only required text field on a contact;
-    // surface the empty case to `onCommit` (and therefore the
-    // toast) by declaring a validator that always passes. Other
-    // fields keep the hook's default "empty draft silently
-    // cancels" behaviour.
-    ...(field === "displayName" ? { validate: () => null } : {}),
+    // Every contact field handles the empty case explicitly in
+    // `onCommit`: `displayName` toasts (it's required), the
+    // numeric fields parse to `null`, and the remaining optional
+    // strings send `null` to clear a previously saved value.
+    // Declaring a pass-through validator opts out of the hook's
+    // default "empty draft silently cancels" so users can wipe
+    // optional rows such as prefix, tax ID, currency, default
+    // hourly rate, or payment terms back to empty.
+    validate: () => null,
     onCommit: (trimmed) => {
       if (maxLength !== undefined && trimmed.length > maxLength) {
         stellaToast.add({

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -54,6 +54,12 @@ export const EditableRow = ({
 
   const rename = useInlineRename({
     initial: value ?? "",
+    // `displayName` is the only required text field on a contact;
+    // surface the empty case to `onCommit` (and therefore the
+    // toast) by declaring a validator that always passes. Other
+    // fields keep the hook's default "empty draft silently
+    // cancels" behaviour.
+    ...(field === "displayName" ? { validate: () => null } : {}),
     onCommit: (trimmed) => {
       if (maxLength !== undefined && trimmed.length > maxLength) {
         stellaToast.add({

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -548,7 +548,11 @@ const ChatTabPanelChrome = ({
  */
 const PromptBarPlaceholder = ({ tab }: { tab: ChatTab }) => {
   const t = useTranslations();
-  const chatContextLabel = useChatContextLabel(tab);
+  const activeOrganizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const chatContextLabel = useChatContextLabel(tab, activeOrganizationId);
   return (
     <PromptBarShell aria-hidden="true" layout="standalone">
       <div className="flex min-h-8 min-w-0 flex-1 items-center px-1.5">

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -303,7 +303,7 @@ export const ChatTabPanel = ({
           }
           onSetAnonymized={setAnonymized}
           onSetContext={(next) => setChatContext(tab.id, next)}
-          onStartRename={labelRename.startEditing}
+          onStartRename={() => labelRename.startEditing()}
           rename={{
             active: labelRename.state.mode === "edit",
             value:

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -43,7 +43,9 @@ import {
   PromptBarShell,
 } from "@/components/ai-suggestions/host";
 import { useChatEditor } from "@/components/chat-editor-provider";
+import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
 import { ChatMatterPicker } from "@/components/chat/chat-matter-picker";
+import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import { ChatThreadMessages } from "@/components/chat/chat-thread-messages";
 import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useAIKeyGate } from "@/components/require-ai-key";
@@ -126,7 +128,11 @@ export const ChatTabPanel = ({
   };
   const getSendMode = useEffectEvent(() => sendMode);
   const showToolCallDetails = useDevStore((s) => s.showToolCallDetails);
-  const chatContextLabel = useChatContextLabel(tab);
+  const activeOrganizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const chatContextLabel = useChatContextLabel(tab, activeOrganizationId);
 
   const { openChat, setChatContext, updateLabel } = useInspectorStore(
     useShallow((s) => ({
@@ -137,10 +143,6 @@ export const ChatTabPanel = ({
   );
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const activeOrganizationId = useRouteContext({
-    from: "/_protected",
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
 
   const moveToMain = buildMaximizeTabAction(tab, {
     activeOrganizationId,
@@ -267,116 +269,123 @@ export const ChatTabPanel = ({
   }, [pendingRenameTabId, tab.id, startRenameFromStore, clearRenameRequest]);
 
   return (
-    <ChatTabPanelChrome
-      matterColor={matterColor}
-      onClose={onClose}
-      onLabelContextMenu={onLabelContextMenu}
-      onMoveToMain={moveToMain}
-      anonymized={anonymized}
-      onNewThread={() =>
-        openChat({
-          workspaceId: tabWorkspaceId,
-          contextMatterIds: tab.contextMatterIds,
-          ...(tab.activeDecisionId
-            ? { activeDecisionId: tab.activeDecisionId }
-            : {}),
-        })
-      }
-      onSetAnonymized={setAnonymized}
-      onSetContext={(next) => setChatContext(tab.id, next)}
-      onStartRename={labelRename.startEditing}
-      rename={{
-        active: labelRename.state.mode === "edit",
-        value: labelRename.state.mode === "edit" ? labelRename.state.draft : "",
-        onChange: labelRename.setDraft,
-        onCommit: () => {
-          void labelRename.commit();
-        },
-        onCancel: labelRename.cancel,
+    <ChatMattersContext
+      value={{
+        createDocumentMatters,
+        isLoadingCreateDocumentMatters,
       }}
-      tab={tab}
     >
-      <Conversation className="min-h-0 flex-1">
-        <ConversationContent className="gap-3">
-          {messages.length === 0 && !isGenerating && !error ? (
-            <ChatEmptyState
-              onSelectPrompt={handleSelectPrompt}
-              prompts={savedPrompts}
-            />
-          ) : (
-            <ChatThreadMessages
-              activeOrganizationId={activeOrganizationId}
-              alwaysApprovedTools={alwaysApprovedTools}
-              approvalPendingMessageId={approvalPendingMessageId}
-              conversationApprovedTools={conversationApprovedTools}
-              error={error}
-              handleAllowInConversation={handleAllowInConversation}
-              handleAlwaysAllow={handleAlwaysAllow}
-              handleApprove={handleApprove}
-              handleDeny={handleDeny}
-              isGenerating={isGenerating}
-              messages={messages}
-              onAskUserSubmit={handleAskUserSubmit}
-              onCreateDocumentResolve={handleCreateDocumentResolve}
-              onOpenCreatedDocument={handleOpenCreatedDocument}
-              createDocumentMatters={createDocumentMatters}
-              isLoadingCreateDocumentMatters={isLoadingCreateDocumentMatters}
-              onResend={resendLatestMessage}
-              onSendWithoutAnonymization={sendWithoutAnonymization}
-              showThinkingIndicator
-              showToolCallDetails={showToolCallDetails}
-              streamdownComponents={streamdownComponents}
-              workspaceId={tabWorkspaceId}
-            />
-          )}
-        </ConversationContent>
-        <ConversationScrollButton />
-      </Conversation>
+      <ChatApprovalContext
+        value={{
+          activeOrganizationId,
+          alwaysApprovedTools,
+          conversationApprovedTools,
+          handleAllowInConversation,
+          handleAlwaysAllow,
+          handleApprove,
+          handleDeny,
+        }}
+      >
+        <ChatTabPanelChrome
+          matterColor={matterColor}
+          onClose={onClose}
+          onLabelContextMenu={onLabelContextMenu}
+          onMoveToMain={moveToMain}
+          anonymized={anonymized}
+          onNewThread={() =>
+            openChat({
+              workspaceId: tabWorkspaceId,
+              contextMatterIds: tab.contextMatterIds,
+              ...(tab.activeDecisionId
+                ? { activeDecisionId: tab.activeDecisionId }
+                : {}),
+            })
+          }
+          onSetAnonymized={setAnonymized}
+          onSetContext={(next) => setChatContext(tab.id, next)}
+          onStartRename={labelRename.startEditing}
+          rename={{
+            active: labelRename.state.mode === "edit",
+            value:
+              labelRename.state.mode === "edit" ? labelRename.state.draft : "",
+            onChange: labelRename.setDraft,
+            onCommit: () => {
+              void labelRename.commit();
+            },
+            onCancel: labelRename.cancel,
+          }}
+          tab={tab}
+        >
+          <Conversation className="min-h-0 flex-1">
+            <ConversationContent className="gap-3">
+              {messages.length === 0 && !isGenerating && !error ? (
+                <ChatEmptyState
+                  onSelectPrompt={handleSelectPrompt}
+                  prompts={savedPrompts}
+                />
+              ) : (
+                <ChatThreadMessages
+                  approvalPendingMessageId={approvalPendingMessageId}
+                  error={error}
+                  isGenerating={isGenerating}
+                  messages={messages}
+                  onAskUserSubmit={handleAskUserSubmit}
+                  onCreateDocumentResolve={handleCreateDocumentResolve}
+                  onOpenCreatedDocument={handleOpenCreatedDocument}
+                  onResend={resendLatestMessage}
+                  onSendWithoutAnonymization={sendWithoutAnonymization}
+                  showThinkingIndicator
+                  showToolCallDetails={showToolCallDetails}
+                  streamdownComponents={streamdownComponents}
+                  workspaceId={tabWorkspaceId}
+                />
+              )}
+            </ConversationContent>
+            <ConversationScrollButton />
+          </Conversation>
 
-      <ChatAnonymizationLayer
-        editor={editorController.editor}
-        enabled={anonymized}
-        workspaceId={tabWorkspaceId ?? threadRef.threadId}
-      />
-      <PromptBar
-        editorController={editorController}
-        emptyPlaceholder={
-          <PromptBarPlaceholderContent>
-            {t("chat.contextPlaceholder", { context: chatContextLabel })}
-          </PromptBarPlaceholderContent>
-        }
-        layout="standalone"
-        onStop={() => {
-          void stop();
-        }}
-        onSubmit={({ prompt }) => {
-          void ensureAIAvailable().then((available) => {
-            if (!available) {
-              return;
+          <ChatAnonymizationLayer
+            editor={editorController.editor}
+            enabled={anonymized}
+            workspaceId={tabWorkspaceId ?? threadRef.threadId}
+          />
+          <PromptBar
+            editorController={editorController}
+            emptyPlaceholder={
+              <PromptBarPlaceholderContent>
+                {t("chat.contextPlaceholder", { context: chatContextLabel })}
+              </PromptBarPlaceholderContent>
             }
-            // PromptBar emits the raw editor HTML; the legacy
-            // backend already parses `<entity-mention>` tags out
-            // of the `text` field, so we forward unchanged.
-            void sendMessage({ text: prompt });
-          });
-        }}
-        onTogglePanel={() => {
-          // Standalone has no thread toggle; never called.
-        }}
-        panelOpen={false}
-        pendingCount={0}
-        showThreadToggle={false}
-        status={isGenerating ? "generating" : "idle"}
-      />
-    </ChatTabPanelChrome>
+            layout="standalone"
+            onStop={() => {
+              void stop();
+            }}
+            onSubmit={({ prompt }) => {
+              void ensureAIAvailable().then((available) => {
+                if (!available) {
+                  return;
+                }
+                // PromptBar emits the raw editor HTML; the legacy
+                // backend already parses `<entity-mention>` tags out
+                // of the `text` field, so we forward unchanged.
+                void sendMessage({ text: prompt });
+              });
+            }}
+            onTogglePanel={() => {
+              // Standalone has no thread toggle; never called.
+            }}
+            panelOpen={false}
+            pendingCount={0}
+            showThreadToggle={false}
+            status={isGenerating ? "generating" : "idle"}
+          />
+        </ChatTabPanelChrome>
+      </ChatApprovalContext>
+    </ChatMattersContext>
   );
 };
 
-const useChatContextLabel = (tab: ChatTab) => {
-  const activeOrganizationId = useRouteContext({
-    from: "/_protected",
-    select: (ctx) => ctx.user.activeOrganizationId,
-  });
+const useChatContextLabel = (tab: ChatTab, activeOrganizationId: string) => {
   const { data } = useQuery(workspacesNavigationOptions(activeOrganizationId));
   const fallbackLabel = tab.label.trim().length > 0 ? tab.label : "chat";
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -49,6 +49,7 @@ import { PromptSuggestions } from "@/components/chat/prompt-suggestions";
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { StellaMark } from "@/components/stella-mark";
 import Tooltip from "@/components/tooltip";
+import { useInlineRename } from "@/hooks/use-inline-rename";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
 import type { ChatThreadRef } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
@@ -244,19 +245,12 @@ export const ChatTabPanel = ({
   };
 
   // Inline rename — same UX as file tabs.
-  const [editingLabel, setEditingLabel] = useState(false);
-  const [labelDraft, setLabelDraft] = useState(tab.label);
-  const startRename = () => {
-    setLabelDraft(tab.label);
-    setEditingLabel(true);
-  };
-  const commitRename = () => {
-    const trimmed = labelDraft.trim();
-    setEditingLabel(false);
-    if (trimmed && trimmed !== tab.label) {
-      updateLabel(tab.id, trimmed);
-    }
-  };
+  const labelRename = useInlineRename({
+    initial: tab.label,
+    onCommit: (value) => {
+      updateLabel(tab.id, value);
+    },
+  });
 
   // The shared tab context menu (right-click on rail icon or
   // ribbon label) dispatches `requestRename(tabId)` to the store.
@@ -264,13 +258,13 @@ export const ChatTabPanel = ({
   // rename state locally so they consume the flag here.
   const pendingRenameTabId = useInspectorStore((s) => s.pendingRenameTabId);
   const clearRenameRequest = useInspectorStore((s) => s.clearRenameRequest);
+  const startRenameFromStore = labelRename.startEditing;
   useEffect(() => {
     if (pendingRenameTabId === tab.id) {
-      setLabelDraft(tab.label);
-      setEditingLabel(true);
+      startRenameFromStore();
       clearRenameRequest();
     }
-  }, [pendingRenameTabId, tab.id, tab.label, clearRenameRequest]);
+  }, [pendingRenameTabId, tab.id, startRenameFromStore, clearRenameRequest]);
 
   return (
     <ChatTabPanelChrome
@@ -290,13 +284,15 @@ export const ChatTabPanel = ({
       }
       onSetAnonymized={setAnonymized}
       onSetContext={(next) => setChatContext(tab.id, next)}
-      onStartRename={startRename}
+      onStartRename={labelRename.startEditing}
       rename={{
-        active: editingLabel,
-        value: labelDraft,
-        onChange: setLabelDraft,
-        onCommit: commitRename,
-        onCancel: () => setEditingLabel(false),
+        active: labelRename.state.mode === "edit",
+        value: labelRename.state.mode === "edit" ? labelRename.state.draft : "",
+        onChange: labelRename.setDraft,
+        onCommit: () => {
+          void labelRename.commit();
+        },
+        onCancel: labelRename.cancel,
       }}
       tab={tab}
     >

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/kanban/kanban-card.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { draggable } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { centerUnderPointer } from "@atlaskit/pragmatic-drag-and-drop/element/center-under-pointer";
@@ -13,6 +13,7 @@ import {
 } from "@stll/ui/components/avatar";
 import { cn } from "@stll/ui/lib/utils";
 
+import { useInlineRename } from "@/hooks/use-inline-rename";
 import { isFileDisplayable } from "@/lib/types";
 import type {
   WorkspaceEntity,
@@ -72,15 +73,19 @@ export const KanbanCard = ({
     const tab = s.tabs.find((t) => t.id === s.activeId);
     return tab?.type === "pdf" && tab.entityId === entity.entityId;
   });
-  const [isEditing, setIsEditing] = useState(false);
-  const [editValue, setEditValue] = useState(name);
-
   // For editing, use the text field value (not the file name)
   const textField = Object.values(entity.fields).find(
     (f) => f.content.type === "text",
   );
   const textName =
     textField?.content.type === "text" ? textField.content.value.trim() : "";
+
+  const rename = useInlineRename({
+    initial: name,
+    onCommit: (value) => {
+      onRename?.(entity.entityId, value);
+    },
+  });
 
   const dragRef = useRef<HTMLDivElement>(null);
 
@@ -131,16 +136,7 @@ export const KanbanCard = ({
   }, [entity.entityId, name, entity.kind, file?.mimeType, entity.parentId]);
 
   const startEditing = () => {
-    setEditValue(textName || name);
-    setIsEditing(true);
-  };
-
-  const commitRename = () => {
-    setIsEditing(false);
-    const trimmed = editValue.trim();
-    if (trimmed && trimmed !== name) {
-      onRename?.(entity.entityId, trimmed);
-    }
+    rename.startEditing(textName || name);
   };
 
   const icon = (
@@ -152,20 +148,20 @@ export const KanbanCard = ({
     />
   );
 
-  const nameElement = isEditing ? (
-    <InlineEdit
-      inputClassName="w-full font-medium"
-      onCancel={() => {
-        setIsEditing(false);
-        setEditValue(name);
-      }}
-      onChange={setEditValue}
-      onCommit={commitRename}
-      value={editValue}
-    />
-  ) : (
-    <span className="truncate">{name}</span>
-  );
+  const nameElement =
+    rename.state.mode === "edit" ? (
+      <InlineEdit
+        inputClassName="w-full font-medium"
+        onCancel={rename.cancel}
+        onChange={rename.setDraft}
+        onCommit={() => {
+          void rename.commit();
+        }}
+        value={rename.state.draft}
+      />
+    ) : (
+      <span className="truncate">{name}</span>
+    );
 
   const isTask = entity.kind === "task";
   const visibleCardFields = cardFields ?? [];

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -191,6 +191,8 @@ import {
   MessageContent,
   MessageResponse,
 } from "@/components/ai-elements/message";
+import { ChatApprovalContext } from "@/components/chat/chat-approval-context";
+import { ChatMattersContext } from "@/components/chat/chat-matters-context";
 import {
   ChatErrorMessage,
   ChatThreadMessages,
@@ -1290,43 +1292,53 @@ const SHARED_CHAT_RENDERER_MESSAGES = [
 function SharedChatRendererSample() {
   return (
     <div className="bg-popover/40 flex flex-col gap-4 rounded-2xl border p-4">
-      <ChatThreadMessages
-        activeOrganizationId="playground"
-        alwaysApprovedTools={new Set()}
-        approvalPendingMessageId={null}
-        conversationApprovedTools={new Set()}
-        handleAllowInConversation={() => {
-          /* no-op in playground */
+      <ChatMattersContext
+        value={{
+          createDocumentMatters: [],
+          isLoadingCreateDocumentMatters: false,
         }}
-        handleAlwaysAllow={() => {
-          /* no-op in playground */
-        }}
-        handleApprove={() => {
-          /* no-op in playground */
-        }}
-        handleDeny={() => {
-          /* no-op in playground */
-        }}
-        messages={SHARED_CHAT_RENDERER_MESSAGES}
-        onAskUserSubmit={() => {
-          /* no-op in playground */
-        }}
-        onCreateDocumentResolve={() => {
-          /* no-op in playground */
-        }}
-        onOpenCreatedDocument={() => {
-          /* no-op in playground */
-        }}
-        createDocumentMatters={[]}
-        isLoadingCreateDocumentMatters={false}
-        onResend={() => {
-          /* no-op in playground */
-        }}
-        showToolCalls={false}
-        streamdownComponents={{
-          a: ({ children, ...props }) => <a {...props}>{children}</a>,
-        }}
-      />
+      >
+        <ChatApprovalContext
+          value={{
+            activeOrganizationId: "dev-active-organization",
+            alwaysApprovedTools: new Set(),
+            conversationApprovedTools: new Set(),
+            handleAllowInConversation: () => {
+              /* no-op in playground */
+            },
+            handleAlwaysAllow: () => {
+              /* no-op in playground */
+            },
+            handleApprove: () => {
+              /* no-op in playground */
+            },
+            handleDeny: () => {
+              /* no-op in playground */
+            },
+          }}
+        >
+          <ChatThreadMessages
+            approvalPendingMessageId={null}
+            messages={SHARED_CHAT_RENDERER_MESSAGES}
+            onAskUserSubmit={() => {
+              /* no-op in playground */
+            }}
+            onCreateDocumentResolve={() => {
+              /* no-op in playground */
+            }}
+            onOpenCreatedDocument={() => {
+              /* no-op in playground */
+            }}
+            onResend={() => {
+              /* no-op in playground */
+            }}
+            showToolCalls={false}
+            streamdownComponents={{
+              a: ({ children, ...props }) => <a {...props}>{children}</a>,
+            }}
+          />
+        </ChatApprovalContext>
+      </ChatMattersContext>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- extract `useInlineRename` hook; migrate 5 sites (kanban-card, chat-tab-panel, workspace-breadcrumb name+ref, contacts EditableRow, app-sidebar matter rename). existing-file-organizer-dialog skipped — child component owns its draft state.
- extract `ChatMattersContext` and `ChatApprovalContext`; drop ~20 props from ChatThreadMessages/AssistantMessageParts/NeedsMatterCard/ToolApprovalCard

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] rename a kanban card via double-click and Enter/blur/Escape
- [ ] rename a chat tab and matter in sidebar
- [ ] rename a workspace name + reference (verify 409 inline error path)
- [ ] edit a contact field (validation + toast paths)
- [ ] chat tool approval: approve / always-allow / allow-in-conversation / deny
- [ ] chat needs-matter card: create matter flow