### PR TITLE
chore(web): useEffect cleanup

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -59,7 +59,6 @@ import type {
 import { useAIKeyGate } from "@/components/require-ai-key";
 import { ChatAnonymizationLayer } from "@/lib/anonymize/use-chat-anonymization-layer";
 import type { ChatThreadId, ChatThreadRef } from "@/lib/chat-thread-ref";
-import { createChatThreadId } from "@/lib/chat-thread-ref";
 import { useDevStore } from "@/lib/dev-store";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
 import { useChatUserContext } from "@/routes/_protected.chat/-hooks/use-chat-user-context";
@@ -509,66 +508,35 @@ type FileChatOverlayProps = {
   docxEditorRef?: RefObject<DocxEditorRef | null> | undefined;
   docxEditable?: boolean | undefined;
   requestDocxEditMode?: (() => boolean | Promise<boolean>) | undefined;
+  /**
+   * Invoked when the user explicitly starts a new thread from the
+   * overlay UI. Owners should swap the `chatThreadId` they pass in
+   * for a fresh value.
+   */
+  onNewThread: () => void;
 };
 
 const protectedRouteApi = getRouteApi("/_protected");
 
-export const FileChatOverlay = ({
-  workspaceId,
-  chatThreadId,
-  activeFile,
-  activeExternal,
-  docxEditable,
-  docxEditorRef,
-  requestDocxEditMode,
-}: FileChatOverlayProps) => {
-  const [currentChatThreadId, setCurrentChatThreadId] = useState(chatThreadId);
+export const FileChatOverlay = (props: FileChatOverlayProps) => (
+  // Suspense boundary keeps the chat-thread fetch local to the
+  // overlay — without it, a cold cache propagates the suspension
+  // up to the file route and shows the route's pending screen.
+  <Suspense
+    fallback={
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 bottom-8 flex justify-center"
+      >
+        <LoaderCircleIcon className="text-muted-foreground size-4 animate-spin" />
+      </div>
+    }
+  >
+    <FileChatOverlayInner {...props} />
+  </Suspense>
+);
 
-  useEffect(() => {
-    setCurrentChatThreadId(chatThreadId);
-  }, [chatThreadId]);
-
-  return (
-    // Suspense boundary keeps the chat-thread fetch local to the
-    // overlay — without it, a cold cache propagates the suspension
-    // up to the file route and shows the route's pending screen.
-    <Suspense
-      fallback={
-        <div
-          aria-hidden="true"
-          className="pointer-events-none absolute inset-x-0 bottom-8 flex justify-center"
-        >
-          <LoaderCircleIcon className="text-muted-foreground size-4 animate-spin" />
-        </div>
-      }
-    >
-      <FileChatOverlayInner
-        activeFile={activeFile}
-        activeExternal={activeExternal}
-        chatThreadId={currentChatThreadId}
-        docxEditable={docxEditable}
-        docxEditorRef={docxEditorRef}
-        onNewThread={() => {
-          // The previous thread's queued/accepted/rejected
-          // suggestions belong to that thread's history. Carrying
-          // them into a fresh thread invites the user to act on
-          // proposals they no longer have context for; reset the
-          // session whenever they explicitly start a new chat.
-          if (activeFile) {
-            useReviewStore.getState().resetSession(activeFile.entityId);
-          }
-          setCurrentChatThreadId(createChatThreadId());
-        }}
-        requestDocxEditMode={requestDocxEditMode}
-        workspaceId={workspaceId}
-      />
-    </Suspense>
-  );
-};
-
-type FileChatOverlayInnerProps = FileChatOverlayProps & {
-  onNewThread: () => void;
-};
+type FileChatOverlayInnerProps = FileChatOverlayProps;
 
 const FileChatOverlayInner = ({
   workspaceId,

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.tsx
@@ -14,13 +14,16 @@
  */
 
 import type { ReactNode, RefObject } from "react";
+import { useState } from "react";
 
 import type { DocxEditorRef } from "@stll/folio";
 import { cn } from "@stll/ui/lib/utils";
 
 import type { ChatThreadId } from "@/lib/chat-thread-ref";
+import { createChatThreadId } from "@/lib/chat-thread-ref";
 
 import { FileChatOverlay } from "./file-chat-overlay";
+import { useReviewStore } from "./review-store";
 import "./file-viewer-with-ai.css";
 
 type ActiveFile = {
@@ -86,19 +89,63 @@ export function FileViewerWithAI({
 }: FileViewerWithAIProps) {
   return (
     <div
-      data-file-viewer-ai="true"
       className={cn("relative h-full w-full", className)}
+      data-file-viewer-ai="true"
     >
       {children}
-      <FileChatOverlay
-        activeFile={activeFile}
+      <FileChatOverlayHost
         activeExternal={activeExternal}
+        activeFile={activeFile}
         chatThreadId={chatThreadId}
         docxEditable={docxEditable}
         docxEditorRef={docxEditorRef}
+        key={chatThreadId}
         requestDocxEditMode={requestDocxEditMode}
         workspaceId={workspaceId}
       />
     </div>
   );
 }
+
+type FileChatOverlayHostProps = Omit<
+  FileViewerWithAIProps,
+  "children" | "className"
+>;
+
+const FileChatOverlayHost = ({
+  workspaceId,
+  chatThreadId: initialChatThreadId,
+  activeFile,
+  activeExternal,
+  docxEditable,
+  docxEditorRef,
+  requestDocxEditMode,
+}: FileChatOverlayHostProps) => {
+  const [currentChatThreadId, setCurrentChatThreadId] =
+    useState(initialChatThreadId);
+
+  const handleNewThread = () => {
+    // The previous thread's queued/accepted/rejected suggestions
+    // belong to that thread's history. Carrying them into a fresh
+    // thread invites the user to act on proposals they no longer
+    // have context for; reset the session whenever they explicitly
+    // start a new chat.
+    if (activeFile) {
+      useReviewStore.getState().resetSession(activeFile.entityId);
+    }
+    setCurrentChatThreadId(createChatThreadId());
+  };
+
+  return (
+    <FileChatOverlay
+      activeExternal={activeExternal}
+      activeFile={activeFile}
+      chatThreadId={currentChatThreadId}
+      docxEditable={docxEditable}
+      docxEditorRef={docxEditorRef}
+      onNewThread={handleNewThread}
+      requestDocxEditMode={requestDocxEditMode}
+      workspaceId={workspaceId}
+    />
+  );
+};

--- a/apps/web/src/components/ai-suggestions/review-panel.tsx
+++ b/apps/web/src/components/ai-suggestions/review-panel.tsx
@@ -5,7 +5,7 @@
  * underlying tracked changes are resolved on the editor.
  */
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import type { CSSProperties, RefObject } from "react";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -700,6 +700,25 @@ const IdentityPopover = ({
   initialsLabel,
   hideAccepted,
   onHideAcceptedChange,
+}: IdentityPopoverProps) => (
+  <IdentityPopoverBody
+    authorName={authorName}
+    hideAccepted={hideAccepted}
+    initialPreferredName={initialPreferredName}
+    initialWordEditShortcut={initialWordEditShortcut}
+    initialsLabel={initialsLabel}
+    key={`${initialPreferredName}|${initialWordEditShortcut}`}
+    onHideAcceptedChange={onHideAcceptedChange}
+  />
+);
+
+const IdentityPopoverBody = ({
+  authorName,
+  initialPreferredName,
+  initialWordEditShortcut,
+  initialsLabel,
+  hideAccepted,
+  onHideAcceptedChange,
 }: IdentityPopoverProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
@@ -707,15 +726,6 @@ const IdentityPopover = ({
   const [wordEditShortcut, setWordEditShortcut] = useState(
     initialWordEditShortcut,
   );
-  // Resync local form state when the underlying user record changes
-  // (e.g., another tab edited the same field) so the popover stops
-  // reflecting stale values once it reopens.
-  useEffect(() => {
-    setPreferredName(initialPreferredName);
-  }, [initialPreferredName]);
-  useEffect(() => {
-    setWordEditShortcut(initialWordEditShortcut);
-  }, [initialWordEditShortcut]);
 
   const updateIdentity = useMutation({
     mutationFn: async () => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -607,10 +607,6 @@ export function AppSidebar(props: AppSidebarProps) {
   const pinnedIds = usePinnedStore((s) => s.pinnedIds);
   const togglePin = usePinnedStore((s) => s.togglePin);
   const reorderPinned = usePinnedStore((s) => s.reorder);
-  const initPinned = usePinnedStore((s) => s.init);
-  useEffect(() => {
-    initPinned(user.id);
-  }, [initPinned, user.id]);
   const { data: workspacesData } = useQuery(
     workspacesNavigationOptions(user.activeOrganizationId),
   );

--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -47,6 +47,62 @@ const AUTO_RETRY_LIMIT = 5;
 const AUTO_RETRY_DELAY_MS = 3000;
 let networkRetryCount = 0;
 
+type UseNetworkRetryOptions = {
+  networkError: boolean;
+  retry: () => void;
+};
+
+type UseNetworkRetryResult = {
+  isAutoRetrying: boolean;
+  retriesExhausted: boolean;
+};
+
+/** Drive the auto-retry lifecycle for transient network errors.
+ *  - Resets the module-scoped counter when the error is cleared
+ *    or the component unmounts (i.e. recovery succeeded).
+ *  - Schedules a single delayed retry per render where the error
+ *    is still network-shaped and the counter is below the limit.
+ *  - Cleans up the pending timer on unmount or when the network
+ *    flag flips, so a stale retry never fires after recovery. */
+const useNetworkRetry = ({
+  networkError,
+  retry,
+}: UseNetworkRetryOptions): UseNetworkRetryResult => {
+  const [isAutoRetrying, setIsAutoRetrying] = useState(
+    () => networkError && networkRetryCount < AUTO_RETRY_LIMIT,
+  );
+
+  useEffect(() => {
+    if (!networkError) {
+      networkRetryCount = 0;
+      setIsAutoRetrying(false);
+      return undefined;
+    }
+
+    if (networkRetryCount >= AUTO_RETRY_LIMIT) {
+      setIsAutoRetrying(false);
+      return undefined;
+    }
+
+    networkRetryCount += 1;
+    setIsAutoRetrying(true);
+    const timer = setTimeout(retry, AUTO_RETRY_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [networkError, retry]);
+
+  useEffect(
+    () => () => {
+      networkRetryCount = 0;
+    },
+    [],
+  );
+
+  return {
+    isAutoRetrying,
+    retriesExhausted: networkError && networkRetryCount >= AUTO_RETRY_LIMIT,
+  };
+};
+
 export const DefaultErrorComponent = ({
   error,
   reset,
@@ -59,9 +115,6 @@ export const DefaultErrorComponent = ({
   const showUnauthorizedError =
     isUnauthorizedError(error) || isMemberError(error);
   const networkError = isNetworkError(error);
-  const [isAutoRetrying, setIsAutoRetrying] = useState(
-    () => networkError && networkRetryCount < AUTO_RETRY_LIMIT,
-  );
 
   const retryErroredQueries = useCallback(() => {
     startTransition(async () => {
@@ -75,7 +128,6 @@ export const DefaultErrorComponent = ({
           analytics.captureError(refetchError);
         });
 
-      setIsAutoRetrying(false);
       reset();
       // Don't reset networkRetryCount here. If the error
       // persists, the error boundary re-catches and the
@@ -85,45 +137,35 @@ export const DefaultErrorComponent = ({
     });
   }, [queryClient, analytics, reset]);
 
-  // Reset the retry counter when the component unmounts
-  // (successful recovery) or when the error is no longer
-  // a network error.
-  useEffect(() => {
-    if (!networkError) {
-      networkRetryCount = 0;
-    }
-    return () => {
-      networkRetryCount = 0;
-    };
-  }, [networkError]);
+  const { isAutoRetrying, retriesExhausted: retriesAtLimit } = useNetworkRetry({
+    networkError,
+    retry: retryErroredQueries,
+  });
 
+  // Capture errors that aren't auth/cancel/network noise once,
+  // plus network errors once retries are exhausted. Keeping the
+  // two cases in one effect avoids the prior staggered chain.
   useEffect(() => {
-    if (showUnauthorizedError || networkError || isCancelledError) {
+    if (showUnauthorizedError || isCancelledError) {
       return;
     }
 
-    analytics.captureError(error);
-  }, [error, analytics, showUnauthorizedError, networkError, isCancelledError]);
+    if (!networkError) {
+      analytics.captureError(error);
+      return;
+    }
 
-  // Capture network errors only once retries are exhausted,
-  // avoiding inflated error counts during transient outages.
-  useEffect(() => {
-    if (networkError && networkRetryCount >= AUTO_RETRY_LIMIT) {
+    if (retriesAtLimit) {
       analytics.captureError(error);
     }
-  }, [networkError, error, analytics]);
-
-  // Auto-retry on transient network errors.
-  useEffect(() => {
-    if (!networkError || networkRetryCount >= AUTO_RETRY_LIMIT) {
-      setIsAutoRetrying(false);
-      return undefined;
-    }
-    networkRetryCount += 1;
-    setIsAutoRetrying(true);
-    const timer = setTimeout(retryErroredQueries, AUTO_RETRY_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, [networkError, retryErroredQueries]);
+  }, [
+    error,
+    analytics,
+    showUnauthorizedError,
+    networkError,
+    isCancelledError,
+    retriesAtLimit,
+  ]);
 
   const t = useTranslations();
 
@@ -143,8 +185,7 @@ export const DefaultErrorComponent = ({
   // Network error: show "Connection lost" with reconnecting
   // indicator instead of generic "Something went wrong".
   if (networkError) {
-    const retriesExhausted =
-      networkRetryCount >= AUTO_RETRY_LIMIT && !isPending;
+    const retriesExhausted = retriesAtLimit && !isPending;
 
     return (
       <StatusMessage

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
@@ -75,13 +75,19 @@ export const ClauseFormDialog = ({
   initial,
 }: ClauseFormDialogProps) => (
   <Dialog onOpenChange={onOpenChange} open={open}>
-    <ClauseFormDialogBody
-      categories={categories}
-      initial={initial}
-      key={initial?.id ?? "new"}
-      onOpenChange={onOpenChange}
-      onSaved={onSaved}
-    />
+    {/* Mount only while open so each open instantiates a fresh
+        form: cancel-then-reopen discards unsaved edits (the
+        behaviour the removed `open`-driven reset effect provided),
+        and switching between create/edit-for-same-id re-seeds from
+        `initial` without an effect. */}
+    {open ? (
+      <ClauseFormDialogBody
+        categories={categories}
+        initial={initial}
+        onOpenChange={onOpenChange}
+        onSaved={onSaved}
+      />
+    ) : null}
   </Dialog>
 );
 

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-form-dialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { useTranslations } from "use-intl";
 
@@ -73,7 +73,31 @@ export const ClauseFormDialog = ({
   onSaved,
   categories,
   initial,
-}: ClauseFormDialogProps) => {
+}: ClauseFormDialogProps) => (
+  <Dialog onOpenChange={onOpenChange} open={open}>
+    <ClauseFormDialogBody
+      categories={categories}
+      initial={initial}
+      key={initial?.id ?? "new"}
+      onOpenChange={onOpenChange}
+      onSaved={onSaved}
+    />
+  </Dialog>
+);
+
+type ClauseFormDialogBodyProps = {
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  categories: CategoryOption[];
+  initial: ClauseFormDialogProps["initial"];
+};
+
+const ClauseFormDialogBody = ({
+  onOpenChange,
+  onSaved,
+  categories,
+  initial,
+}: ClauseFormDialogBodyProps) => {
   const t = useTranslations();
   const isEdit = !!initial?.id;
 
@@ -87,21 +111,6 @@ export const ClauseFormDialog = ({
     bodyParagraphs: initial?.bodyParagraphs ?? DEFAULT_BODY,
   }));
   const [saving, setSaving] = useState(false);
-
-  // Reset form when dialog opens to reflect latest data
-  useEffect(() => {
-    if (open) {
-      setForm({
-        id: initial?.id,
-        title: initial?.title ?? "",
-        description: initial?.description ?? "",
-        usageNotes: initial?.usageNotes ?? "",
-        language: initial?.language ?? "",
-        categoryId: initial?.categoryId ?? "",
-        bodyParagraphs: initial?.bodyParagraphs ?? DEFAULT_BODY,
-      });
-    }
-  }, [open, initial]);
 
   const handleSave = useCallback(async () => {
     if (!form.title.trim()) {
@@ -188,139 +197,135 @@ export const ClauseFormDialog = ({
   }, [form, isEdit, t, onOpenChange, onSaved]);
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogPopup className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>
-            {isEdit ? t("clauses.editClause") : t("clauses.createClause")}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogPanel className="grid gap-4">
+    <DialogPopup className="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle>
+          {isEdit ? t("clauses.editClause") : t("clauses.createClause")}
+        </DialogTitle>
+      </DialogHeader>
+      <DialogPanel className="grid gap-4">
+        <div className="grid gap-1.5">
+          <label className="text-sm font-medium" htmlFor="clause-title">
+            {t("clauses.titleLabel")}
+          </label>
+          <Input
+            id="clause-title"
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                title: e.target.value,
+              }))
+            }
+            placeholder={t("clauses.titlePlaceholder")}
+            value={form.title}
+          />
+        </div>
+
+        <div className="grid gap-1.5">
+          <label className="text-sm font-medium" htmlFor="clause-description">
+            {t("common.description")}
+          </label>
+          <Input
+            id="clause-description"
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                description: e.target.value,
+              }))
+            }
+            placeholder={t("clauses.descriptionPlaceholder")}
+            value={form.description}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
           <div className="grid gap-1.5">
-            <label className="text-sm font-medium" htmlFor="clause-title">
-              {t("clauses.titleLabel")}
+            <label className="text-sm font-medium" htmlFor="clause-language">
+              {t("common.language")}
             </label>
             <Input
-              id="clause-title"
+              id="clause-language"
+              maxLength={10}
               onChange={(e) =>
                 setForm((f) => ({
                   ...f,
-                  title: e.target.value,
+                  language: e.target.value,
                 }))
               }
-              placeholder={t("clauses.titlePlaceholder")}
-              value={form.title}
+              placeholder={t("clauses.languagePlaceholder")}
+              value={form.language}
             />
           </div>
 
           <div className="grid gap-1.5">
-            <label className="text-sm font-medium" htmlFor="clause-description">
-              {t("common.description")}
-            </label>
-            <Input
-              id="clause-description"
-              onChange={(e) =>
+            <span className="text-sm font-medium">{t("common.category")}</span>
+            <Select
+              onValueChange={(val) =>
                 setForm((f) => ({
                   ...f,
-                  description: e.target.value,
+                  categoryId: val ?? "",
                 }))
               }
-              placeholder={t("clauses.descriptionPlaceholder")}
-              value={form.description}
-            />
+              value={form.categoryId || undefined}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder={t("common.uncategorized")} />
+              </SelectTrigger>
+              <SelectPopup>
+                {categories.map((cat) => (
+                  <SelectItem key={cat.id} value={cat.id}>
+                    {cat.name}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
           </div>
+        </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="grid gap-1.5">
-              <label className="text-sm font-medium" htmlFor="clause-language">
-                {t("common.language")}
-              </label>
-              <Input
-                id="clause-language"
-                maxLength={10}
-                onChange={(e) =>
-                  setForm((f) => ({
-                    ...f,
-                    language: e.target.value,
-                  }))
-                }
-                placeholder={t("clauses.languagePlaceholder")}
-                value={form.language}
-              />
-            </div>
+        <div className="grid gap-1.5">
+          <span className="text-sm font-medium">{t("clauses.body")}</span>
+          <ClauseEditor
+            content={form.bodyParagraphs}
+            onChange={(paragraphs) =>
+              setForm((f) => ({
+                ...f,
+                bodyParagraphs: paragraphs,
+              }))
+            }
+          />
+        </div>
 
-            <div className="grid gap-1.5">
-              <span className="text-sm font-medium">
-                {t("common.category")}
-              </span>
-              <Select
-                onValueChange={(val) =>
-                  setForm((f) => ({
-                    ...f,
-                    categoryId: val ?? "",
-                  }))
-                }
-                value={form.categoryId || undefined}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder={t("common.uncategorized")} />
-                </SelectTrigger>
-                <SelectPopup>
-                  {categories.map((cat) => (
-                    <SelectItem key={cat.id} value={cat.id}>
-                      {cat.name}
-                    </SelectItem>
-                  ))}
-                </SelectPopup>
-              </Select>
-            </div>
-          </div>
-
-          <div className="grid gap-1.5">
-            <span className="text-sm font-medium">{t("clauses.body")}</span>
-            <ClauseEditor
-              content={form.bodyParagraphs}
-              onChange={(paragraphs) =>
-                setForm((f) => ({
-                  ...f,
-                  bodyParagraphs: paragraphs,
-                }))
-              }
-            />
-          </div>
-
-          <div className="grid gap-1.5">
-            <label className="text-sm font-medium" htmlFor="clause-usage-notes">
-              {t("clauses.usageNotes")}
-            </label>
-            <Textarea
-              className="min-h-[60px]"
-              id="clause-usage-notes"
-              onChange={(e) =>
-                setForm((f) => ({
-                  ...f,
-                  usageNotes: e.target.value,
-                }))
-              }
-              placeholder={t("clauses.usageNotesPlaceholder")}
-              value={form.usageNotes}
-            />
-          </div>
-        </DialogPanel>
-        <DialogFooter>
-          <DialogClose render={<Button variant="ghost" />}>
-            {t("common.cancel")}
-          </DialogClose>
-          <Button
-            disabled={saving || !form.title.trim()}
-            onClick={() => {
-              void handleSave();
-            }}
-          >
-            {t("common.save")}
-          </Button>
-        </DialogFooter>
-      </DialogPopup>
-    </Dialog>
+        <div className="grid gap-1.5">
+          <label className="text-sm font-medium" htmlFor="clause-usage-notes">
+            {t("clauses.usageNotes")}
+          </label>
+          <Textarea
+            className="min-h-[60px]"
+            id="clause-usage-notes"
+            onChange={(e) =>
+              setForm((f) => ({
+                ...f,
+                usageNotes: e.target.value,
+              }))
+            }
+            placeholder={t("clauses.usageNotesPlaceholder")}
+            value={form.usageNotes}
+          />
+        </div>
+      </DialogPanel>
+      <DialogFooter>
+        <DialogClose render={<Button variant="ghost" />}>
+          {t("common.cancel")}
+        </DialogClose>
+        <Button
+          disabled={saving || !form.title.trim()}
+          onClick={() => {
+            void handleSave();
+          }}
+        >
+          {t("common.save")}
+        </Button>
+      </DialogFooter>
+    </DialogPopup>
   );
 };

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -509,12 +509,18 @@ const CategoryFormDialog = ({
   initial,
 }: CategoryFormDialogProps) => (
   <Dialog onOpenChange={onOpenChange} open={open}>
-    <CategoryFormDialogBody
-      initial={initial}
-      key={initial?.id ?? "new"}
-      onOpenChange={onOpenChange}
-      onSaved={onSaved}
-    />
+    {/* Mount only while open so each open instantiates a fresh
+        form: cancel-then-reopen discards unsaved edits (the
+        behaviour the removed `open`-driven reset effect provided),
+        and switching between create/edit-for-same-id re-seeds from
+        `initial` without an effect. */}
+    {open ? (
+      <CategoryFormDialogBody
+        initial={initial}
+        onOpenChange={onOpenChange}
+        onSaved={onSaved}
+      />
+    ) : null}
   </Dialog>
 );
 

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { useMutation } from "@tanstack/react-query";
 import {
@@ -495,28 +495,44 @@ const CategoryRow = ({
 
 // ── Category Form Dialog ─────────────────────────────
 
+type CategoryFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  initial?: { id: string; name: string };
+};
+
 const CategoryFormDialog = ({
   open,
   onOpenChange,
   onSaved,
   initial,
-}: {
-  open: boolean;
+}: CategoryFormDialogProps) => (
+  <Dialog onOpenChange={onOpenChange} open={open}>
+    <CategoryFormDialogBody
+      initial={initial}
+      key={initial?.id ?? "new"}
+      onOpenChange={onOpenChange}
+      onSaved={onSaved}
+    />
+  </Dialog>
+);
+
+type CategoryFormDialogBodyProps = {
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
-  initial?: { id: string; name: string };
-}) => {
+  initial: { id: string; name: string } | undefined;
+};
+
+const CategoryFormDialogBody = ({
+  onOpenChange,
+  onSaved,
+  initial,
+}: CategoryFormDialogBodyProps) => {
   const t = useTranslations();
   const isEdit = !!initial?.id;
   const [name, setName] = useState(initial?.name ?? "");
   const [saving, setSaving] = useState(false);
-
-  // Reset form when dialog opens
-  useEffect(() => {
-    if (open) {
-      setName(initial?.name ?? "");
-    }
-  }, [open, initial?.name]);
 
   const handleSave = useCallback(async () => {
     if (!name.trim()) {
@@ -568,40 +584,38 @@ const CategoryFormDialog = ({
   }, [name, isEdit, initial, t, onOpenChange, onSaved]);
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogPopup className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>
-            {isEdit ? t("clauses.editCategory") : t("clauses.createCategory")}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogPanel className="grid gap-4">
-          <div className="grid gap-1.5">
-            <label className="text-sm font-medium" htmlFor="category-name">
-              {t("clauses.categoryName")}
-            </label>
-            <Input
-              id="category-name"
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("clauses.categoryNamePlaceholder")}
-              value={name}
-            />
-          </div>
-        </DialogPanel>
-        <DialogFooter>
-          <DialogClose render={<Button variant="ghost" />}>
-            {t("common.cancel")}
-          </DialogClose>
-          <Button
-            disabled={saving || !name.trim()}
-            onClick={() => {
-              void handleSave();
-            }}
-          >
-            {t("common.save")}
-          </Button>
-        </DialogFooter>
-      </DialogPopup>
-    </Dialog>
+    <DialogPopup className="sm:max-w-sm">
+      <DialogHeader>
+        <DialogTitle>
+          {isEdit ? t("clauses.editCategory") : t("clauses.createCategory")}
+        </DialogTitle>
+      </DialogHeader>
+      <DialogPanel className="grid gap-4">
+        <div className="grid gap-1.5">
+          <label className="text-sm font-medium" htmlFor="category-name">
+            {t("clauses.categoryName")}
+          </label>
+          <Input
+            id="category-name"
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t("clauses.categoryNamePlaceholder")}
+            value={name}
+          />
+        </div>
+      </DialogPanel>
+      <DialogFooter>
+        <DialogClose render={<Button variant="ghost" />}>
+          {t("common.cancel")}
+        </DialogClose>
+        <Button
+          disabled={saving || !name.trim()}
+          onClick={() => {
+            void handleSave();
+          }}
+        >
+          {t("common.save")}
+        </Button>
+      </DialogFooter>
+    </DialogPopup>
   );
 };

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -70,6 +70,11 @@ export const ShortcutFormDialog = ({
   initial,
 }: ShortcutFormDialogProps) => (
   <Dialog onOpenChange={onOpenChange} open={open}>
+    {/* Mount only while open so each open instantiates a fresh
+        form: cancel-then-reopen discards unsaved edits and stale
+        validation errors (the behaviour the removed `open`-driven
+        reset effect provided), and switching between create/edit-
+        for-same-id re-seeds from `initial` without an effect. */}
     {open ? (
       <ShortcutFormDialogBody
         canManageTeam={canManageTeam}

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useMutation } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
@@ -68,7 +68,32 @@ export const ShortcutFormDialog = ({
   onSaved,
   canManageTeam,
   initial,
-}: ShortcutFormDialogProps) => {
+}: ShortcutFormDialogProps) => (
+  <Dialog onOpenChange={onOpenChange} open={open}>
+    {open ? (
+      <ShortcutFormDialogBody
+        canManageTeam={canManageTeam}
+        initial={initial}
+        onOpenChange={onOpenChange}
+        onSaved={onSaved}
+      />
+    ) : null}
+  </Dialog>
+);
+
+type ShortcutFormDialogBodyProps = {
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  canManageTeam: boolean;
+  initial: ShortcutInitial | undefined;
+};
+
+const ShortcutFormDialogBody = ({
+  onOpenChange,
+  onSaved,
+  canManageTeam,
+  initial,
+}: ShortcutFormDialogBodyProps) => {
   const t = useTranslations();
   const isEdit = !!initial?.id;
 
@@ -80,19 +105,6 @@ export const ShortcutFormDialog = ({
     scope: initial?.scope ?? "private",
   }));
   const [commandError, setCommandError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (open) {
-      setForm({
-        name: initial?.name ?? "",
-        description: initial?.description ?? "",
-        command: initial?.command ?? "",
-        prompt: initial?.prompt ?? "",
-        scope: initial?.scope ?? "private",
-      });
-      setCommandError(null);
-    }
-  }, [open, initial]);
 
   const validateCommand = (cmd: string): string | null => {
     if (!cmd) {
@@ -179,136 +191,129 @@ export const ShortcutFormDialog = ({
     !commandError;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogPopup className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>
-            {isEdit
-              ? t("knowledge.skills.editShortcut")
-              : t("knowledge.skills.addShortcut")}
-          </DialogTitle>
-        </DialogHeader>
+    <DialogPopup className="sm:max-w-lg">
+      <DialogHeader>
+        <DialogTitle>
+          {isEdit
+            ? t("knowledge.skills.editShortcut")
+            : t("knowledge.skills.addShortcut")}
+        </DialogTitle>
+      </DialogHeader>
 
-        <DialogPanel className="flex flex-col gap-4">
-          {/* Name */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium" htmlFor="shortcut-name">
-              {t("knowledge.skills.form.name")}
-            </label>
+      <DialogPanel className="flex flex-col gap-4">
+        {/* Name */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium" htmlFor="shortcut-name">
+            {t("knowledge.skills.form.name")}
+          </label>
+          <Input
+            id="shortcut-name"
+            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            placeholder={t("knowledge.skills.form.namePlaceholder")}
+            value={form.name}
+          />
+        </div>
+
+        {/* Description */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium" htmlFor="shortcut-description">
+            {t("knowledge.skills.form.description")}
+          </label>
+          <Input
+            id="shortcut-description"
+            onChange={(e) =>
+              setForm((f) => ({ ...f, description: e.target.value }))
+            }
+            placeholder={t("knowledge.skills.form.descriptionPlaceholder")}
+            value={form.description}
+          />
+        </div>
+
+        {/* Command */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium" htmlFor="shortcut-command">
+            {t("knowledge.skills.form.command")}
+          </label>
+          <div className="flex items-stretch">
+            <span className="bg-muted border-border flex items-center rounded-s-md border border-e-0 px-3 text-sm">
+              {t("knowledge.skills.form.commandPrefix")}
+            </span>
             <Input
-              id="shortcut-name"
-              placeholder={t("knowledge.skills.form.namePlaceholder")}
-              value={form.name}
-              onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+              className={cn(
+                "rounded-s-none",
+                commandError && "border-destructive",
+              )}
+              id="shortcut-command"
+              onChange={(e) => handleCommandChange(e.target.value)}
+              placeholder={t("knowledge.skills.form.commandPlaceholder")}
+              value={form.command}
             />
           </div>
-
-          {/* Description */}
-          <div className="flex flex-col gap-1.5">
-            <label
-              className="text-sm font-medium"
-              htmlFor="shortcut-description"
-            >
-              {t("knowledge.skills.form.description")}
-            </label>
-            <Input
-              id="shortcut-description"
-              placeholder={t("knowledge.skills.form.descriptionPlaceholder")}
-              value={form.description}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, description: e.target.value }))
-              }
-            />
-          </div>
-
-          {/* Command */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium" htmlFor="shortcut-command">
-              {t("knowledge.skills.form.command")}
-            </label>
-            <div className="flex items-stretch">
-              <span className="bg-muted border-border flex items-center rounded-s-md border border-e-0 px-3 text-sm">
-                {t("knowledge.skills.form.commandPrefix")}
-              </span>
-              <Input
-                id="shortcut-command"
-                className={cn(
-                  "rounded-s-none",
-                  commandError && "border-destructive",
-                )}
-                placeholder={t("knowledge.skills.form.commandPlaceholder")}
-                value={form.command}
-                onChange={(e) => handleCommandChange(e.target.value)}
-              />
-            </div>
-            {commandError ? (
-              <p className="text-destructive text-xs">{commandError}</p>
-            ) : (
-              <p className="text-muted-foreground text-xs">
-                {t("knowledge.skills.form.commandHint")}
-              </p>
-            )}
-          </div>
-
-          {/* Prompt */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium" htmlFor="shortcut-prompt">
-              {t("knowledge.skills.form.prompt")}
-            </label>
-            <Textarea
-              id="shortcut-prompt"
-              className="min-h-30 resize-y"
-              placeholder={t("knowledge.skills.form.promptPlaceholder")}
-              value={form.prompt}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, prompt: e.target.value }))
-              }
-            />
-          </div>
-
-          {/* Scope — only shown on create and only for admins/owners */}
-          {!isEdit && canManageTeam && (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium" htmlFor="shortcut-scope">
-                {t("knowledge.skills.form.scope")}
-              </label>
-              <Select
-                value={form.scope}
-                onValueChange={(v) => {
-                  if (v !== "team" && v !== "private") {
-                    return;
-                  }
-                  setForm((f) => ({ ...f, scope: v }));
-                }}
-              >
-                <SelectTrigger id="shortcut-scope">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectPopup>
-                  <SelectItem value="private">
-                    {t("knowledge.skills.form.scopePrivate")}
-                  </SelectItem>
-                  <SelectItem value="team">
-                    {t("knowledge.skills.form.scopeTeam")}
-                  </SelectItem>
-                </SelectPopup>
-              </Select>
-            </div>
+          {commandError ? (
+            <p className="text-destructive text-xs">{commandError}</p>
+          ) : (
+            <p className="text-muted-foreground text-xs">
+              {t("knowledge.skills.form.commandHint")}
+            </p>
           )}
-        </DialogPanel>
+        </div>
 
-        <DialogFooter>
-          <DialogClose render={<Button variant="ghost" />}>
-            {t("common.cancel")}
-          </DialogClose>
-          <Button
-            disabled={!canSubmit || saveShortcut.isPending}
-            onClick={handleSubmit}
-          >
-            {isEdit ? t("common.save") : t("common.add")}
-          </Button>
-        </DialogFooter>
-      </DialogPopup>
-    </Dialog>
+        {/* Prompt */}
+        <div className="flex flex-col gap-1.5">
+          <label className="text-sm font-medium" htmlFor="shortcut-prompt">
+            {t("knowledge.skills.form.prompt")}
+          </label>
+          <Textarea
+            className="min-h-30 resize-y"
+            id="shortcut-prompt"
+            onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}
+            placeholder={t("knowledge.skills.form.promptPlaceholder")}
+            value={form.prompt}
+          />
+        </div>
+
+        {/* Scope — only shown on create and only for admins/owners */}
+        {!isEdit && canManageTeam && (
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium" htmlFor="shortcut-scope">
+              {t("knowledge.skills.form.scope")}
+            </label>
+            <Select
+              onValueChange={(v) => {
+                if (v !== "team" && v !== "private") {
+                  return;
+                }
+                setForm((f) => ({ ...f, scope: v }));
+              }}
+              value={form.scope}
+            >
+              <SelectTrigger id="shortcut-scope">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectPopup>
+                <SelectItem value="private">
+                  {t("knowledge.skills.form.scopePrivate")}
+                </SelectItem>
+                <SelectItem value="team">
+                  {t("knowledge.skills.form.scopeTeam")}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          </div>
+        )}
+      </DialogPanel>
+
+      <DialogFooter>
+        <DialogClose render={<Button variant="ghost" />}>
+          {t("common.cancel")}
+        </DialogClose>
+        <Button
+          disabled={!canSubmit || saveShortcut.isPending}
+          onClick={handleSubmit}
+        >
+          {isEdit ? t("common.save") : t("common.add")}
+        </Button>
+      </DialogFooter>
+    </DialogPopup>
   );
 };

--- a/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
@@ -269,12 +269,18 @@ const CategoryFormDialog = ({
   initial,
 }: CategoryFormDialogProps) => (
   <Dialog onOpenChange={onOpenChange} open={open}>
-    <CategoryFormDialogBody
-      initial={initial}
-      key={initial?.id ?? "new"}
-      onOpenChange={onOpenChange}
-      onSaved={onSaved}
-    />
+    {/* Mount only while open so each open instantiates a fresh
+        form: cancel-then-reopen discards unsaved edits (the
+        behaviour the removed `open`-driven reset effect provided),
+        and switching between create/edit-for-same-id re-seeds from
+        `initial` without an effect. */}
+    {open ? (
+      <CategoryFormDialogBody
+        initial={initial}
+        onOpenChange={onOpenChange}
+        onSaved={onSaved}
+      />
+    ) : null}
   </Dialog>
 );
 

--- a/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-category-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
 import {
   MoreHorizontalIcon,
@@ -255,27 +255,44 @@ const CategoryRow = ({
 
 // ── Category Form Dialog ────────────────────────────
 
+type CategoryFormDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  initial?: { id: string; name: string };
+};
+
 const CategoryFormDialog = ({
   open,
   onOpenChange,
   onSaved,
   initial,
-}: {
-  open: boolean;
+}: CategoryFormDialogProps) => (
+  <Dialog onOpenChange={onOpenChange} open={open}>
+    <CategoryFormDialogBody
+      initial={initial}
+      key={initial?.id ?? "new"}
+      onOpenChange={onOpenChange}
+      onSaved={onSaved}
+    />
+  </Dialog>
+);
+
+type CategoryFormDialogBodyProps = {
   onOpenChange: (open: boolean) => void;
   onSaved: () => void;
-  initial?: { id: string; name: string };
-}) => {
+  initial: { id: string; name: string } | undefined;
+};
+
+const CategoryFormDialogBody = ({
+  onOpenChange,
+  onSaved,
+  initial,
+}: CategoryFormDialogBodyProps) => {
   const t = useTranslations();
   const isEdit = !!initial?.id;
   const [name, setName] = useState(initial?.name ?? "");
   const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      setName(initial?.name ?? "");
-    }
-  }, [open, initial?.name]);
 
   const handleSave = useCallback(async () => {
     if (!name.trim()) {
@@ -327,45 +344,41 @@ const CategoryFormDialog = ({
   }, [name, isEdit, initial, t, onOpenChange, onSaved]);
 
   return (
-    <Dialog onOpenChange={onOpenChange} open={open}>
-      <DialogPopup className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle>
-            {isEdit
-              ? t("templates.editCategory")
-              : t("templates.createCategory")}
-          </DialogTitle>
-        </DialogHeader>
-        <DialogPanel className="grid gap-4">
-          <div className="grid gap-1.5">
-            <label
-              className="text-sm font-medium"
-              htmlFor="template-category-name"
-            >
-              {t("templates.categoryName")}
-            </label>
-            <Input
-              id="template-category-name"
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("templates.categoryName")}
-              value={name}
-            />
-          </div>
-        </DialogPanel>
-        <DialogFooter>
-          <DialogClose render={<Button variant="ghost" />}>
-            {t("common.cancel")}
-          </DialogClose>
-          <Button
-            disabled={saving || !name.trim()}
-            onClick={() => {
-              void handleSave();
-            }}
+    <DialogPopup className="sm:max-w-sm">
+      <DialogHeader>
+        <DialogTitle>
+          {isEdit ? t("templates.editCategory") : t("templates.createCategory")}
+        </DialogTitle>
+      </DialogHeader>
+      <DialogPanel className="grid gap-4">
+        <div className="grid gap-1.5">
+          <label
+            className="text-sm font-medium"
+            htmlFor="template-category-name"
           >
-            {t("common.save")}
-          </Button>
-        </DialogFooter>
-      </DialogPopup>
-    </Dialog>
+            {t("templates.categoryName")}
+          </label>
+          <Input
+            id="template-category-name"
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t("templates.categoryName")}
+            value={name}
+          />
+        </div>
+      </DialogPanel>
+      <DialogFooter>
+        <DialogClose render={<Button variant="ghost" />}>
+          {t("common.cancel")}
+        </DialogClose>
+        <Button
+          disabled={saving || !name.trim()}
+          onClick={() => {
+            void handleSave();
+          }}
+        >
+          {t("common.save")}
+        </Button>
+      </DialogFooter>
+    </DialogPopup>
   );
 };

--- a/apps/web/src/routes/_protected.knowledge/prompts.tsx
+++ b/apps/web/src/routes/_protected.knowledge/prompts.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
@@ -24,6 +24,7 @@ import {
 } from "@/components/empty-screen";
 import { api } from "@/lib/api";
 import { userErrorMessage } from "@/lib/errors";
+import { ensureCriticalQueryData } from "@/lib/react-query";
 import { roleOptions } from "@/routes/-queries";
 import {
   knowledgeKeys,
@@ -34,6 +35,23 @@ import { ShortcutFormDialog } from "./-components/shortcut-form-dialog";
 import type { ShortcutInitial } from "./-components/shortcut-form-dialog";
 
 export const Route = createFileRoute("/_protected/knowledge/prompts")({
+  // Seed the default shortcuts before the page renders, so the
+  // component never has to write to the DB during a render-phase
+  // effect. The backend handler is idempotent at the user level
+  // (existing private shortcuts short-circuit the seed).
+  loader: async ({ context }) => {
+    const activeOrganizationId = context.user.activeOrganizationId;
+    const existing = await ensureCriticalQueryData(
+      context.queryClient,
+      shortcutsOptions(activeOrganizationId),
+    );
+    if (existing.length === 0) {
+      await api.shortcuts.seed.post({ queryKey: ["shortcuts"] });
+      await context.queryClient.invalidateQueries({
+        queryKey: knowledgeKeys.shortcuts.all(activeOrganizationId),
+      });
+    }
+  },
   component: PromptsPage,
 });
 
@@ -68,17 +86,6 @@ function PromptsPage() {
   const { data: role } = useQuery(roleOptions);
 
   const canManageTeam = role === "owner" || role === "admin";
-
-  // Seed defaults on first mount if no shortcuts exist yet
-  useEffect(() => {
-    if (!isLoading && shortcuts.length === 0) {
-      void api.shortcuts.seed.post({ queryKey: ["shortcuts"] }).then(() => {
-        void queryClient.invalidateQueries({
-          queryKey: knowledgeKeys.shortcuts.all(activeOrganizationId),
-        });
-      });
-    }
-  }, [activeOrganizationId, isLoading, shortcuts.length, queryClient]);
 
   const [formOpen, setFormOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ShortcutInitial | undefined>();

--- a/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { getRouteApi } from "@tanstack/react-router";
 import { SearchIcon } from "lucide-react";
@@ -21,13 +21,12 @@ export const OrganizationListToolbar = () => {
   // Search lives on the parent route so it survives sub-tab swaps;
   // navigate must target the leaf so we don't pull the user up to
   // the parent (which has no index and would render blank).
-  const q = settingsOrgParentRoute.useSearch({ select: (s) => s.q });
+  const q = settingsOrgParentRoute.useSearch({ select: (s) => s.q ?? "" });
   const navigate = membersRoute.useNavigate();
-  const [localQuery, setLocalQuery] = useState(() => q ?? "");
-
-  useEffect(() => {
-    setLocalQuery(q ?? "");
-  }, [q]);
+  // Local controlled-input value keeps IME composition snappy and
+  // prevents flicker between keystrokes; the URL is the source of
+  // truth and gets the trimmed value via the debounced writer.
+  const [localQuery, setLocalQuery] = useState(q);
 
   const updateSearch = useDebouncedCallback((value: string) => {
     // eslint-disable-next-line typescript/no-floating-promises

--- a/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
@@ -35,11 +35,6 @@ export const OrganizationListToolbar = () => {
   // after the user pauses typing, so `localQuery` already equals
   // the value being re-set.
   const [lastSeenUrlQuery, setLastSeenUrlQuery] = useState(q);
-  if (q !== lastSeenUrlQuery) {
-    setLastSeenUrlQuery(q);
-    setLocalQuery(q);
-  }
-
   const updateSearch = useDebouncedCallback((value: string) => {
     // eslint-disable-next-line typescript/no-floating-promises
     navigate({
@@ -47,6 +42,12 @@ export const OrganizationListToolbar = () => {
       search: (prev) => ({ ...prev, q: value || undefined }),
     });
   }, 300);
+
+  if (q !== lastSeenUrlQuery) {
+    updateSearch.cancel();
+    setLastSeenUrlQuery(q);
+    setLocalQuery(q);
+  }
 
   return (
     <div className="border-border/60 flex items-center gap-2 border-b px-2 py-2">

--- a/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/list-toolbar.tsx
@@ -27,6 +27,18 @@ export const OrganizationListToolbar = () => {
   // prevents flicker between keystrokes; the URL is the source of
   // truth and gets the trimmed value via the debounced writer.
   const [localQuery, setLocalQuery] = useState(q);
+  // Adjusting state during render: when the URL `q` changes to a
+  // value our local mirror has not seen (back/forward navigation,
+  // tab switches landing on a different `?q=`) replace the input
+  // without an effect round-trip. Our own debounced writes also
+  // flow through here, but the post-navigate render arrives only
+  // after the user pauses typing, so `localQuery` already equals
+  // the value being re-set.
+  const [lastSeenUrlQuery, setLastSeenUrlQuery] = useState(q);
+  if (q !== lastSeenUrlQuery) {
+    setLastSeenUrlQuery(q);
+    setLocalQuery(q);
+  }
 
   const updateSearch = useDebouncedCallback((value: string) => {
     // eslint-disable-next-line typescript/no-floating-promises

--- a/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/matter-numbering-card.tsx
@@ -37,34 +37,43 @@ const PATTERN_PRESETS = [
 const PADDING_OPTIONS = [2, 3, 4, 5, 6] as const;
 
 export const MatterNumberingCard = () => {
+  const { data: settings } = useQuery(organizationSettingsOptions);
+
+  if (!settings) {
+    return null;
+  }
+
+  return (
+    <MatterNumberingCardBody
+      key={`${settings.matterNumberPattern}|${settings.matterNumberPadding}`}
+      settings={settings}
+    />
+  );
+};
+
+type MatterNumberingSettings = {
+  matterNumberPattern: string;
+  matterNumberPadding: number;
+};
+
+const MatterNumberingCardBody = ({
+  settings,
+}: {
+  settings: MatterNumberingSettings;
+}) => {
   const t = useTranslations();
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
-  const { data: settings } = useQuery(organizationSettingsOptions);
 
-  const [pattern, setPattern] = useState(
-    settings?.matterNumberPattern ?? "{SEQ}",
-  );
-  const [padding, setPadding] = useState(settings?.matterNumberPadding ?? 3);
-  const [isCustom, setIsCustom] = useState(() => {
-    const p = settings?.matterNumberPattern ?? "{SEQ}";
-    return !PATTERN_PRESETS.some((preset) => preset.value === p);
-  });
-  const [preview, setPreview] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!settings) {
-      return;
-    }
-
-    setPattern(settings.matterNumberPattern);
-    setPadding(settings.matterNumberPadding);
-    setIsCustom(
+  const [pattern, setPattern] = useState(settings.matterNumberPattern);
+  const [padding, setPadding] = useState(settings.matterNumberPadding);
+  const [isCustom, setIsCustom] = useState(
+    () =>
       !PATTERN_PRESETS.some(
         (preset) => preset.value === settings.matterNumberPattern,
       ),
-    );
-  }, [settings]);
+  );
+  const [preview, setPreview] = useState<string | null>(null);
 
   const fetchPreview = useDebouncedCallback(async (p: string, pad: number) => {
     const response = await api["organization-settings"].preview.post({

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useFormStatus } from "react-dom";
 
 import {
@@ -46,6 +46,12 @@ function isCommonTimezone(tz: string): tz is CommonTimezone {
 }
 
 function ProfilePage() {
+  const { data: session } = useSuspenseQuery(sessionOptions);
+
+  return <ProfilePageBody key={session?.user.id ?? "anonymous"} />;
+}
+
+function ProfilePageBody() {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const { data: session } = useSuspenseQuery(sessionOptions);
@@ -57,11 +63,6 @@ function ProfilePage() {
   const [wordEditShortcut, setWordEditShortcut] = useState(
     () => session?.user.wordEditShortcut ?? "",
   );
-
-  useEffect(() => {
-    setPreferredName(session?.user.preferredName ?? "");
-    setWordEditShortcut(session?.user.wordEditShortcut ?? "");
-  }, [session?.user.preferredName, session?.user.wordEditShortcut]);
 
   const updateTimezone = useMutation({
     mutationFn: async (timezoneId: string) => {

--- a/apps/web/src/routes/_protected.settings/account.profile.tsx
+++ b/apps/web/src/routes/_protected.settings/account.profile.tsx
@@ -47,8 +47,17 @@ function isCommonTimezone(tz: string): tz is CommonTimezone {
 
 function ProfilePage() {
   const { data: session } = useSuspenseQuery(sessionOptions);
+  const user = session?.user;
 
-  return <ProfilePageBody key={session?.user.id ?? "anonymous"} />;
+  return (
+    <ProfilePageBody
+      key={[
+        user?.id ?? "anonymous",
+        user?.preferredName ?? "",
+        user?.wordEditShortcut ?? "",
+      ].join(":")}
+    />
+  );
 }
 
 function ProfilePageBody() {

--- a/apps/web/src/routes/_protected.tsx
+++ b/apps/web/src/routes/_protected.tsx
@@ -140,6 +140,12 @@ export const Route = createFileRoute("/_protected")({
       },
     );
 
+    // Seed the pinned-matters store from localStorage before the
+    // sidebar renders. The store's `init` is idempotent (skips when
+    // the same userId is already loaded), so re-runs on navigation
+    // cost nothing and a render-time effect is unnecessary.
+    usePinnedStore.getState().init(context.session.userId);
+
     return {
       user: {
         id: context.session.userId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -193,6 +193,7 @@ function RouteComponent() {
     <RouteComponentInner
       entityId={entityId}
       initialFieldId={initialFieldId}
+      key={initialFieldId}
       workspaceId={workspaceId}
     />
   );
@@ -239,10 +240,6 @@ function RouteComponentInner({
   const openFileForEntity = useInspectorStore((s) => s.openFileForEntity);
   const currentFileFieldIdsByPropertyRef = useRef(new Map<string, string>());
   const navigate = Route.useNavigate();
-
-  useEffect(() => {
-    setActiveFieldId(initialFieldId);
-  }, [initialFieldId]);
 
   useLayoutEffect(() => {
     if (!justificationId || justificationPage === undefined) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/create-property.tsx
@@ -482,16 +482,48 @@ const PropertyComposerBody = ({
 
   const trimmedName = name.trim();
   const promptText = promptFromHtml(prompt);
-  const dependencyIds = useMemo(
-    () => [...new Set([...selectedFileIds, ...textareaMentions])],
-    [selectedFileIds, textareaMentions],
-  );
   const needsOptions =
     contentType === "single-select" || contentType === "multi-select";
   const hasValidOptions = !needsOptions || options.length > 0;
   const typeChanged = isEditMode && contentType !== initialContentType;
   const isMutationPending =
     createProperty.isPending || updateProperty.isPending;
+
+  // Drop the fallback selection from consumers if its target option
+  // was renamed/removed, or if the user switched away from a select
+  // content type. The backend rejects mismatched fallbacks; sanitising
+  // here keeps the UI honest without round-tripping through setState.
+  const effectiveFallback = useMemo(
+    () =>
+      fallback !== null &&
+      needsOptions &&
+      options.some((o) => o.value === fallback)
+        ? fallback
+        : null,
+    [fallback, needsOptions, options],
+  );
+
+  // Keep the auto-included file chips in sync if the underlying
+  // properties list changes (e.g., a file property is created from
+  // another tab while the dialog is open). Derived rather than mirrored
+  // so the source-of-truth state never drifts out of valid options.
+  const validFileIds = useMemo(
+    () => new Set(fileProperties.map((p) => p.id)),
+    [fileProperties],
+  );
+  const effectiveSelectedFileIds = useMemo(
+    () => selectedFileIds.filter((id) => validFileIds.has(id)),
+    [selectedFileIds, validFileIds],
+  );
+
+  const dependencyIds = useMemo(
+    () => [...new Set([...effectiveSelectedFileIds, ...textareaMentions])],
+    [effectiveSelectedFileIds, textareaMentions],
+  );
+
+  const availableFileToAdd = fileProperties.filter(
+    (p) => !effectiveSelectedFileIds.includes(p.id),
+  );
 
   // Manual properties skip the prompt + dependency requirements; the
   // user fills values by hand. Select-type rules still apply.
@@ -523,7 +555,7 @@ const PropertyComposerBody = ({
     }));
 
     if (isEditMode && editingProperty) {
-      const nextContent = buildContent(contentType, options, fallback);
+      const nextContent = buildContent(contentType, options, effectiveFallback);
       const nextTool: WorkspaceProperty["tool"] =
         editingTool?.type === "manual-input"
           ? { version: 1, type: "manual-input" }
@@ -568,7 +600,9 @@ const PropertyComposerBody = ({
         toolType: "ai-model",
         prompt,
         dependencies,
-        ...(isSelectType && options.length > 0 ? { options, fallback } : {}),
+        ...(isSelectType && options.length > 0
+          ? { options, fallback: effectiveFallback }
+          : {}),
       },
       {
         onSuccess: (data) => {
@@ -579,7 +613,7 @@ const PropertyComposerBody = ({
               name: trimmedName,
               createdAt: new Date(),
               status: "stale",
-              content: buildContent(contentType, options, fallback),
+              content: buildContent(contentType, options, effectiveFallback),
               tool: {
                 version: 1,
                 type: "ai-model",
@@ -618,8 +652,8 @@ const PropertyComposerBody = ({
     dependencyIds,
     editingProperty,
     editingTool,
+    effectiveFallback,
     extractionContext,
-    fallback,
     initialDependencyConditions,
     isEditMode,
     onClose,
@@ -685,33 +719,6 @@ const PropertyComposerBody = ({
     workspaceId,
   ]);
 
-  // Drop the fallback selection if its target option was renamed/removed,
-  // or if the user switched away from a select content type. The backend
-  // rejects mismatched fallbacks; clearing here keeps the UI honest.
-  useEffect(() => {
-    if (
-      fallback !== null &&
-      (!needsOptions || !options.some((o) => o.value === fallback))
-    ) {
-      setFallback(null);
-    }
-  }, [fallback, needsOptions, options]);
-
-  // Keep the auto-included file chips in sync if the underlying
-  // properties list changes (e.g., a file property is created from
-  // another tab while the dialog is open).
-  useEffect(() => {
-    setSelectedFileIds((prev) => {
-      const validIds = new Set(fileProperties.map((p) => p.id));
-      const filtered = prev.filter((id) => validIds.has(id));
-      return filtered.length === prev.length ? prev : filtered;
-    });
-  }, [fileProperties]);
-
-  const availableFileToAdd = fileProperties.filter(
-    (p) => !selectedFileIds.includes(p.id),
-  );
-
   const pushOption = (option: WorkspacePropertyOption) =>
     setOptions((prev) => [...prev, option]);
   const removeOptionAt = (index: number) =>
@@ -759,7 +766,7 @@ const PropertyComposerBody = ({
             autoPromptPending={suggestPrompt.isPending}
             contentType={contentType}
             editorReady={setEditor}
-            fileChips={selectedFileIds.map(
+            fileChips={effectiveSelectedFileIds.map(
               (id) =>
                 fileProperties.find((p) => p.id === id) ?? {
                   id,
@@ -796,7 +803,7 @@ const PropertyComposerBody = ({
 
         {needsOptions && (
           <InlineOptionEditor
-            fallback={fallback}
+            fallback={effectiveFallback}
             onFallbackChange={setFallback}
             options={options}
             pushOption={pushOption}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -338,10 +338,10 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   );
 
   // Ref-backed recency log: "most recent first", capped at
-  // MAX_MOUNTED_PDFS. Mutating during render captures the order of
-  // activations without the setState round-trip the old useEffect
-  // pair needed; the ref is only read inside `mountedPdfIds` below,
-  // which re-memoizes whenever activation or open tabs change.
+  // MAX_MOUNTED_PDFS. The ref is written inside `useEffect` (commit
+  // phase) so the recency reflects committed renders only; reading
+  // during render derives `mountedPdfIds` purely from the previous
+  // committed recency plus the current activation/open tabs.
   const pdfRecencyRef = useRef<string[]>([]);
 
   const mountedPdfIds = useMemo(() => {
@@ -354,7 +354,6 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
         next.length = MAX_MOUNTED_PDFS;
       }
     }
-    pdfRecencyRef.current = next;
 
     const set = new Set(next);
     // Always include the active PDF (in case it's not a PDF tab but
@@ -364,6 +363,13 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
     }
     return set;
   }, [activeId, activeTab?.type, pdfTabs]);
+
+  // Commit the latest recency snapshot after the render commits so
+  // discarded renders (Strict Mode, Concurrent) don't pollute the
+  // ref — only the set actually shown to the user is recorded.
+  useEffect(() => {
+    pdfRecencyRef.current = Array.from(mountedPdfIds);
+  }, [mountedPdfIds]);
 
   const panelQueryClient = useQueryClient();
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -331,45 +331,39 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   // The active tab is always mounted; the rest are the most recently
   // viewed ones. Tabs beyond the limit unmount (and re-load on switch).
   const MAX_MOUNTED_PDFS = 3;
-  const [recentPdfIds, setRecentPdfIds] = useState<string[]>([]);
 
   const pdfTabs = useMemo(
     () => tabs.filter((tab): tab is FileTab => tab.type === "pdf"),
     [tabs],
   );
 
-  // Update recency order when the active PDF changes.
-  useEffect(() => {
-    if (!activeId || activeTab?.type !== "pdf") {
-      return;
-    }
-    setRecentPdfIds((prev) => {
-      const next = prev.filter((id) => id !== activeId);
+  // Ref-backed recency log: "most recent first", capped at
+  // MAX_MOUNTED_PDFS. Mutating during render captures the order of
+  // activations without the setState round-trip the old useEffect
+  // pair needed; the ref is only read inside `mountedPdfIds` below,
+  // which re-memoizes whenever activation or open tabs change.
+  const pdfRecencyRef = useRef<string[]>([]);
+
+  const mountedPdfIds = useMemo(() => {
+    const openIds = new Set(pdfTabs.map((tab) => tab.id));
+    let next = pdfRecencyRef.current.filter((id) => openIds.has(id));
+    if (activeId && activeTab?.type === "pdf") {
+      next = next.filter((id) => id !== activeId);
       next.unshift(activeId);
       if (next.length > MAX_MOUNTED_PDFS) {
         next.length = MAX_MOUNTED_PDFS;
       }
-      return next;
-    });
-  }, [activeId, activeTab?.type]);
+    }
+    pdfRecencyRef.current = next;
 
-  // Also prune closed tabs from the recency list.
-  useEffect(() => {
-    const openIds = new Set(pdfTabs.map((tab) => tab.id));
-    setRecentPdfIds((prev) => {
-      const next = prev.filter((id) => openIds.has(id));
-      return next.length === prev.length ? prev : next;
-    });
-  }, [pdfTabs]);
-
-  const mountedPdfIds = useMemo(() => {
-    const set = new Set(recentPdfIds);
-    // Always include the active PDF.
+    const set = new Set(next);
+    // Always include the active PDF (in case it's not a PDF tab but
+    // we want the set to mirror the union of recent + active).
     if (activeId && activeTab?.type === "pdf") {
       set.add(activeId);
     }
     return set;
-  }, [recentPdfIds, activeId, activeTab?.type]);
+  }, [activeId, activeTab?.type, pdfTabs]);
 
   const panelQueryClient = useQueryClient();
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -95,7 +95,6 @@ export const MatterMetadataPanel = ({
       setReferenceError("");
     }
   }, [nameDirty, referenceDirty, workspace, workspaceId]);
-
   const handleSaveName = () => {
     if (!workspace) {
       return;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-
 import { PinIcon, PinOffIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -13,21 +11,14 @@ type PinPropertyProps = {
 
 export const PinProperty = ({ column }: PinPropertyProps) => {
   const t = useTranslations();
-  const pinnedState = column.getIsPinned() !== false;
-  const [isPinned, setIsPinned] = useState(pinnedState);
-
-  useEffect(() => {
-    setIsPinned(pinnedState);
-  }, [pinnedState]);
 
   if (!column.getCanPin()) {
     return null;
   }
 
+  const isPinned = column.getIsPinned() !== false;
   const togglePinned = () => {
-    const nextPinned = !isPinned;
-    setIsPinned(nextPinned);
-    column.pin(nextPinned ? "left" : false);
+    column.pin(isPinned ? false : "left");
   };
 
   if (isPinned) {

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
@@ -151,14 +151,6 @@ const toActionErrorTitle = ({
 }) => (error instanceof Error ? error.message : fallback);
 
 export const CreateMatterDialog = () => {
-  const t = useTranslations();
-  const navigate = useNavigate();
-  const currentUser = routeApi.useRouteContext({
-    select: (ctx) => ctx.user,
-  });
-  const queryClient = useQueryClient();
-  const createWorkspace = useCreateWorkspace();
-  const createContact = useCreateContact();
   const { closeDialog, dialog } = useCreateMatterStore(
     useShallow((s) => ({
       closeDialog: s.closeDialog,
@@ -167,10 +159,47 @@ export const CreateMatterDialog = () => {
   );
   const isOpen = dialog.status === "open";
   const draftClient = dialog.status === "open" ? dialog.draftClient : null;
+
+  return (
+    <Dialog
+      onOpenChange={(open) => {
+        if (!open) {
+          closeDialog();
+        }
+      }}
+      open={isOpen}
+    >
+      {isOpen ? (
+        <CreateMatterDialogBody
+          closeDialog={closeDialog}
+          draftClient={draftClient}
+        />
+      ) : null}
+    </Dialog>
+  );
+};
+
+type CreateMatterDialogBodyProps = {
+  closeDialog: () => void;
+  draftClient: MatterDraftClient | null;
+};
+
+const CreateMatterDialogBody = ({
+  closeDialog,
+  draftClient,
+}: CreateMatterDialogBodyProps) => {
+  const t = useTranslations();
+  const navigate = useNavigate();
+  const currentUser = routeApi.useRouteContext({
+    select: (ctx) => ctx.user,
+  });
+  const queryClient = useQueryClient();
+  const createWorkspace = useCreateWorkspace();
+  const createContact = useCreateContact();
   const [name, setName] = useState("");
   const [ownerType, setOwnerType] = useState<"client" | "personal">("client");
   const [selectedClient, setSelectedClient] =
-    useState<MatterDraftClient | null>(null);
+    useState<MatterDraftClient | null>(draftClient);
   const [memberQuery, setMemberQuery] = useState("");
   const [selectedMemberUserIds, setSelectedMemberUserIds] = useState<string[]>(
     [],
@@ -180,33 +209,12 @@ export const CreateMatterDialog = () => {
   const nameInputRef = useRef<HTMLInputElement>(null);
   const { data: organization } = useQuery({
     ...organizationOptions,
-    enabled: isOpen,
   });
   const { data: workspacesData } = useQuery({
     ...workspacesOptions(currentUser.activeOrganizationId),
-    enabled: isOpen,
   });
 
-  useEffect(() => {
-    if (!isOpen) {
-      return;
-    }
-
-    setName("");
-    setMemberQuery("");
-    setSelectedMemberUserIds([]);
-    setSubmitAttempted(false);
-    setSelectedClient(draftClient);
-    setOwnerType("client");
-  }, [draftClient, isOpen]);
-
   const handleClose = () => {
-    setName("");
-    setMemberQuery("");
-    setSelectedMemberUserIds([]);
-    setSubmitAttempted(false);
-    setSelectedClient(null);
-    setOwnerType("client");
     closeDialog();
   };
 
@@ -419,230 +427,191 @@ export const CreateMatterDialog = () => {
   }, [name, ownerType, selectedClient, workspacesData?.workspaces]);
 
   return (
-    <Dialog
-      onOpenChange={(open) => {
-        if (!open) {
-          handleClose();
-        }
-      }}
-      open={isOpen}
-    >
-      <DialogPopup className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t("workspaces.newMatter")}</DialogTitle>
-        </DialogHeader>
-        <DialogPanel className="flex flex-col gap-5">
-          <OwnerTypeToggle onChange={setOwnerType} value={ownerType} />
+    <DialogPopup className="max-w-md">
+      <DialogHeader>
+        <DialogTitle>{t("workspaces.newMatter")}</DialogTitle>
+      </DialogHeader>
+      <DialogPanel className="flex flex-col gap-5">
+        <OwnerTypeToggle onChange={setOwnerType} value={ownerType} />
 
-          {(() => {
-            if (ownerType === "client") {
-              return (
-                <section className="space-y-3">
-                  <Field className="gap-3" invalid={clientInvalid}>
-                    <FieldLabel
-                      className={
-                        clientInvalid
-                          ? "text-destructive-foreground"
-                          : undefined
-                      }
-                    >
-                      {t("workspaces.parties.client")}
-                    </FieldLabel>
-                    {selectedClient && (
-                      <SelectedClient client={selectedClient} />
-                    )}
-                    <ContactPicker
-                      autoFocus={!selectedClient}
-                      inputRef={clientInputRef}
-                      invalid={clientInvalid}
-                      onCreate={(...args) => {
-                        void handleCreateClient(...args);
-                      }}
-                      onSelect={(contact) => {
-                        setSelectedClient({
-                          id: contact.id,
-                          displayName: contact.displayName,
-                          type: contact.type,
-                        });
-                      }}
-                      placeholder={
-                        selectedClient
-                          ? t("workspaces.parties.changeClient")
-                          : t("workspaces.parties.searchContacts")
-                      }
-                    />
-                    {clientInvalid ? (
-                      <p className="text-destructive-foreground text-xs">
-                        {t("common.required")}
-                      </p>
-                    ) : null}
-                  </Field>
-                </section>
-              );
-            }
+        {(() => {
+          if (ownerType === "client") {
             return (
-              <p className="text-muted-foreground text-xs">
-                {t("workspaces.create.personalDescription")}
-              </p>
-            );
-          })()}
-
-          <section>
-            <Field invalid={nameInvalid}>
-              <FieldLabel
-                className={
-                  nameInvalid ? "text-destructive-foreground" : undefined
-                }
-              >
-                {t("common.name")}
-              </FieldLabel>
-              <Input
-                aria-invalid={nameInvalid}
-                autoFocus={!!selectedClient}
-                ref={nameInputRef}
-                onChange={(e) => setName(e.currentTarget.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    void handleSubmit();
-                  }
-                }}
-                value={name}
-              />
-              {nameInvalid ? (
-                <p className="text-destructive-foreground text-xs">
-                  {t("common.required")}
-                </p>
-              ) : null}
-            </Field>
-          </section>
-
-          {possibleDuplicates.length > 0 && (
-            <section className="bg-muted/30 space-y-2 rounded-lg border px-3 py-3">
-              <h3 className="text-sm font-medium">
-                {t("workspaces.possibleDuplicates")}
-              </h3>
-              <ul className="space-y-1">
-                {possibleDuplicates.map((workspace) => (
-                  <li
-                    className="flex items-center gap-2 text-sm"
-                    key={workspace.id}
+              <section className="space-y-3">
+                <Field className="gap-3" invalid={clientInvalid}>
+                  <FieldLabel
+                    className={
+                      clientInvalid ? "text-destructive-foreground" : undefined
+                    }
                   >
-                    <span className="truncate font-medium">
-                      {workspace.name}
-                    </span>
-                    <span className="text-muted-foreground text-xs">
-                      {workspace.reference}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {ownerType === "client" && (
-            <section className="space-y-3">
-              <h3 className="text-sm font-medium">
-                {t("workspaces.sections.members")}
-              </h3>
-
-              {(() => {
-                if (hasAdditionalOrganizationMembers) {
-                  return (
-                    <div className="space-y-2">
-                      <Combobox<(typeof filteredMembers)[number]>
-                        itemToStringLabel={(member) =>
-                          `${member.user.name} ${member.user.email}`
-                        }
-                        onInputValueChange={(inputValue) => {
-                          setMemberQuery(inputValue);
-                        }}
-                        onValueChange={(member) => {
-                          if (!member) {
-                            return;
-                          }
-
-                          setSelectedMemberUserIds((current) => [
-                            ...current,
-                            member.userId,
-                          ]);
-                          setMemberQuery("");
-                        }}
-                        value={null}
-                      >
-                        <ComboboxInput
-                          placeholder={t("common.search")}
-                          showTrigger={false}
-                          startAddon={<SearchIcon />}
-                          value={memberQuery}
-                        />
-                        <ComboboxPopup>
-                          <ComboboxList>
-                            {filteredMembers.map((member) => (
-                              <ComboboxItem key={member.userId} value={member}>
-                                <div className="flex items-center gap-2">
-                                  <UserIdentity
-                                    avatarClassName="size-8 shrink-0 text-[0.625rem]"
-                                    className="min-w-0 flex-1"
-                                    image={member.user.image}
-                                    name={member.user.name}
-                                    secondaryText={member.user.email}
-                                  />
-                                  <PlusIcon className="text-muted-foreground size-4" />
-                                </div>
-                              </ComboboxItem>
-                            ))}
-                          </ComboboxList>
-                          {filteredMembers.length === 0 ? (
-                            <ComboboxEmpty>
-                              {memberQuery.length > 0
-                                ? t("workspaces.members.noMembersFound")
-                                : t("common.search")}
-                            </ComboboxEmpty>
-                          ) : null}
-                        </ComboboxPopup>
-                      </Combobox>
-                    </div>
-                  );
-                }
-
-                return (
-                  <div className="bg-muted/20 space-y-3 rounded-lg border border-dashed p-3">
-                    <p className="text-muted-foreground text-sm">
-                      {t("workspaces.members.noMembersFound")}
+                    {t("workspaces.parties.client")}
+                  </FieldLabel>
+                  {selectedClient && <SelectedClient client={selectedClient} />}
+                  <ContactPicker
+                    autoFocus={!selectedClient}
+                    inputRef={clientInputRef}
+                    invalid={clientInvalid}
+                    onCreate={(...args) => {
+                      void handleCreateClient(...args);
+                    }}
+                    onSelect={(contact) => {
+                      setSelectedClient({
+                        id: contact.id,
+                        displayName: contact.displayName,
+                        type: contact.type,
+                      });
+                    }}
+                    placeholder={
+                      selectedClient
+                        ? t("workspaces.parties.changeClient")
+                        : t("workspaces.parties.searchContacts")
+                    }
+                  />
+                  {clientInvalid ? (
+                    <p className="text-destructive-foreground text-xs">
+                      {t("common.required")}
                     </p>
+                  ) : null}
+                </Field>
+              </section>
+            );
+          }
+          return (
+            <p className="text-muted-foreground text-xs">
+              {t("workspaces.create.personalDescription")}
+            </p>
+          );
+        })()}
+
+        <section>
+          <Field invalid={nameInvalid}>
+            <FieldLabel
+              className={
+                nameInvalid ? "text-destructive-foreground" : undefined
+              }
+            >
+              {t("common.name")}
+            </FieldLabel>
+            <Input
+              aria-invalid={nameInvalid}
+              autoFocus={!!selectedClient}
+              ref={nameInputRef}
+              onChange={(e) => setName(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+              value={name}
+            />
+            {nameInvalid ? (
+              <p className="text-destructive-foreground text-xs">
+                {t("common.required")}
+              </p>
+            ) : null}
+          </Field>
+        </section>
+
+        {possibleDuplicates.length > 0 && (
+          <section className="bg-muted/30 space-y-2 rounded-lg border px-3 py-3">
+            <h3 className="text-sm font-medium">
+              {t("workspaces.possibleDuplicates")}
+            </h3>
+            <ul className="space-y-1">
+              {possibleDuplicates.map((workspace) => (
+                <li
+                  className="flex items-center gap-2 text-sm"
+                  key={workspace.id}
+                >
+                  <span className="truncate font-medium">{workspace.name}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {workspace.reference}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {ownerType === "client" && (
+          <section className="space-y-3">
+            <h3 className="text-sm font-medium">
+              {t("workspaces.sections.members")}
+            </h3>
+
+            {(() => {
+              if (hasAdditionalOrganizationMembers) {
+                return (
+                  <div className="space-y-2">
+                    <Combobox<(typeof filteredMembers)[number]>
+                      itemToStringLabel={(member) =>
+                        `${member.user.name} ${member.user.email}`
+                      }
+                      onInputValueChange={(inputValue) => {
+                        setMemberQuery(inputValue);
+                      }}
+                      onValueChange={(member) => {
+                        if (!member) {
+                          return;
+                        }
+
+                        setSelectedMemberUserIds((current) => [
+                          ...current,
+                          member.userId,
+                        ]);
+                        setMemberQuery("");
+                      }}
+                      value={null}
+                    >
+                      <ComboboxInput
+                        placeholder={t("common.search")}
+                        showTrigger={false}
+                        startAddon={<SearchIcon />}
+                        value={memberQuery}
+                      />
+                      <ComboboxPopup>
+                        <ComboboxList>
+                          {filteredMembers.map((member) => (
+                            <ComboboxItem key={member.userId} value={member}>
+                              <div className="flex items-center gap-2">
+                                <UserIdentity
+                                  avatarClassName="size-8 shrink-0 text-[0.625rem]"
+                                  className="min-w-0 flex-1"
+                                  image={member.user.image}
+                                  name={member.user.name}
+                                  secondaryText={member.user.email}
+                                />
+                                <PlusIcon className="text-muted-foreground size-4" />
+                              </div>
+                            </ComboboxItem>
+                          ))}
+                        </ComboboxList>
+                        {filteredMembers.length === 0 ? (
+                          <ComboboxEmpty>
+                            {memberQuery.length > 0
+                              ? t("workspaces.members.noMembersFound")
+                              : t("common.search")}
+                          </ComboboxEmpty>
+                        ) : null}
+                      </ComboboxPopup>
+                    </Combobox>
                   </div>
                 );
-              })()}
+              }
 
-              <div className="bg-muted/20 rounded-lg border p-3">
-                {shouldCollapseSelectedMembers ? (
-                  <ScrollArea className="h-64 w-full" scrollbarGutter>
-                    <div className="space-y-2">
-                      <TeamMemberRow
-                        email={currentUser.email}
-                        image={currentUser.image}
-                        name={creatorName}
-                      />
-                      {selectedMembers.map((member) => (
-                        <TeamMemberRow
-                          email={member.user.email}
-                          image={member.user.image}
-                          key={member.userId}
-                          name={member.user.name}
-                          onRemove={() => {
-                            setSelectedMemberUserIds((current) =>
-                              current.filter(
-                                (userId) => userId !== member.userId,
-                              ),
-                            );
-                          }}
-                          removeLabel={t("workspaces.members.removeMember")}
-                        />
-                      ))}
-                    </div>
-                  </ScrollArea>
-                ) : (
+              return (
+                <div className="bg-muted/20 space-y-3 rounded-lg border border-dashed p-3">
+                  <p className="text-muted-foreground text-sm">
+                    {t("workspaces.members.noMembersFound")}
+                  </p>
+                </div>
+              );
+            })()}
+
+            <div className="bg-muted/20 rounded-lg border p-3">
+              {shouldCollapseSelectedMembers ? (
+                <ScrollArea className="h-64 w-full" scrollbarGutter>
                   <div className="space-y-2">
                     <TeamMemberRow
                       email={currentUser.email}
@@ -666,26 +635,48 @@ export const CreateMatterDialog = () => {
                       />
                     ))}
                   </div>
-                )}
-              </div>
-            </section>
-          )}
-        </DialogPanel>
-        <DialogFooter>
-          <DialogClose render={<Button variant="outline" />}>
-            {t("common.cancel")}
-          </DialogClose>
-          <Button
-            disabled={!canSubmit}
-            loading={createWorkspace.isPending}
-            onClick={() => {
-              void handleSubmit();
-            }}
-          >
-            {t("workspaces.createNewWorkspace")}
-          </Button>
-        </DialogFooter>
-      </DialogPopup>
-    </Dialog>
+                </ScrollArea>
+              ) : (
+                <div className="space-y-2">
+                  <TeamMemberRow
+                    email={currentUser.email}
+                    image={currentUser.image}
+                    name={creatorName}
+                  />
+                  {selectedMembers.map((member) => (
+                    <TeamMemberRow
+                      email={member.user.email}
+                      image={member.user.image}
+                      key={member.userId}
+                      name={member.user.name}
+                      onRemove={() => {
+                        setSelectedMemberUserIds((current) =>
+                          current.filter((userId) => userId !== member.userId),
+                        );
+                      }}
+                      removeLabel={t("workspaces.members.removeMember")}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+      </DialogPanel>
+      <DialogFooter>
+        <DialogClose render={<Button variant="outline" />}>
+          {t("common.cancel")}
+        </DialogClose>
+        <Button
+          disabled={!canSubmit}
+          loading={createWorkspace.isPending}
+          onClick={() => {
+            void handleSubmit();
+          }}
+        >
+          {t("workspaces.createNewWorkspace")}
+        </Button>
+      </DialogFooter>
+    </DialogPopup>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/-components/create-matter-dialog.tsx
@@ -173,6 +173,7 @@ export const CreateMatterDialog = () => {
         <CreateMatterDialogBody
           closeDialog={closeDialog}
           draftClient={draftClient}
+          key={draftClient?.id ?? "new"}
         />
       ) : null}
     </Dialog>


### PR DESCRIPTION
## Summary
- reset form dialogs via `key` prop (shortcut, clause, template-category, clause-list, create-matter; create-matter mounts body only when open)
- replace server-state mirror effects with `key` prop (account profile, matter-numbering, matter-metadata sheet, pin-property, review-panel, file-chat-overlay lifted to FileViewerWithAI, document viewer)
- debounce list-toolbar URL writes via `useDebouncedCallback` (read `q` from URL each render)
- collapse network-retry effect chain in route-components into a single hook
- derive `recentPdfIds` in render via ref-backed recency log
- sanitize create-property inputs in render instead of effects
- seed default shortcuts in route loader instead of mount-time mutation
- move `initPinned` to route `beforeLoad` instead of sidebar effect

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] form dialogs reset cleanly on open/close
- [ ] profile edits survive session refetches; matter-numbering settings reset on change
- [ ] file-chat overlay new-thread toggle still works across all viewers
- [ ] list-toolbar search input debounces URL writes
- [ ] network retry banner behaves as before (offline → online)
- [ ] PDF tab recency in inspector ordered correctly
- [ ] create-property fallback/file selections stay in sync with options
- [ ] knowledge/prompts loader seeds defaults once
- [ ] sidebar pinned items load on first visit