### PR TITLE
chore(web): data fetching modernization

### DIFF
--- a/apps/web/src/components/breadcrumbs/case-law-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/case-law-breadcrumb.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { ResolveParams } from "@tanstack/react-router";
 import { BookOpenTextIcon } from "lucide-react";
 
@@ -39,9 +39,13 @@ const extractId = (param: string): SafeId<"caseLawDecision"> => {
 export const CaseLawBreadcrumb = ({
   decisionId: rawParam,
 }: ResolveParams<"/knowledge/case/$decisionId">) => {
-  const { data: decision } = useSuspenseQuery(
+  const { data: decision, isError } = useQuery(
     decisionOptions(extractId(rawParam)),
   );
+
+  if (isError || !decision) {
+    return null;
+  }
 
   const color = getCourtColor(decision.court);
   const displayRef = extractFullRef(decision.documentAst, decision.caseNumber);

--- a/apps/web/src/components/chat-mention-list.tsx
+++ b/apps/web/src/components/chat-mention-list.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 import type { Ref } from "react";
 
+import { useQuery } from "@tanstack/react-query";
 import type { SuggestionOptions, SuggestionProps } from "@tiptap/suggestion";
 import {
   ArrowLeftIcon,
@@ -154,7 +155,7 @@ export const ChatMentionList = ({
   const categoryLabel = useCategoryLabel();
   const [isOpen, setIsOpen] = useState(true);
   const [selectedIndex, setSelectedIndex] = useState(0);
-  const [drillState, setDrillState] = useState<DrillState>({ kind: "none" });
+  const [drillTarget, setDrillTarget] = useState<DrillTarget | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const lastClientRectRef = useRef<DOMRect | null>(null);
   const latestClientRect = clientRect?.() ?? null;
@@ -176,61 +177,57 @@ export const ChatMentionList = ({
     [clientRect],
   );
 
-  const drillTarget = drillState.kind === "none" ? null : drillState.target;
+  const drillDownQuery = useQuery({
+    queryKey: [
+      "chat-mention-entities",
+      drillTarget,
+      query,
+      loadWorkspaceEntities,
+    ],
+    queryFn: async () => {
+      if (drillTarget === null) {
+        return [];
+      }
+      return await loadWorkspaceEntities(
+        {
+          id: drillTarget.workspaceId,
+          label: drillTarget.name,
+          category: "workspace",
+          kind: "workspace",
+          mimeType: null,
+          sourceViewId: drillTarget.viewId,
+        },
+        query,
+      );
+    },
+    enabled: drillTarget !== null,
+    staleTime: 0,
+    refetchOnWindowFocus: false,
+  });
+
+  const drillState: DrillState = (() => {
+    if (drillTarget === null) {
+      return { kind: "none" };
+    }
+    if (drillDownQuery.isError) {
+      return { kind: "error", target: drillTarget };
+    }
+    if (drillDownQuery.isSuccess) {
+      return {
+        kind: "loaded",
+        target: drillTarget,
+        items: drillDownQuery.data,
+      };
+    }
+    return { kind: "loading", target: drillTarget };
+  })();
+
   const drillItems = drillState.kind === "loaded" ? drillState.items : [];
   const activeItems = drillTarget ? drillItems : items;
   const safeIndex = Math.min(
     selectedIndex,
     Math.max(0, activeItems.length - 1),
   );
-
-  useEffect(() => {
-    if (drillTarget === null) {
-      return undefined;
-    }
-
-    let cancelled = false;
-    setDrillState((prev) => {
-      if (prev.kind === "loading" && prev.target === drillTarget) {
-        return prev;
-      }
-      return { kind: "loading", target: drillTarget };
-    });
-
-    void loadWorkspaceEntities(
-      {
-        id: drillTarget.workspaceId,
-        label: drillTarget.name,
-        category: "workspace",
-        kind: "workspace",
-        mimeType: null,
-        sourceViewId: drillTarget.viewId,
-      },
-      query,
-    )
-      .then((nextItems) => {
-        if (cancelled) {
-          return;
-        }
-
-        setDrillState({
-          kind: "loaded",
-          target: drillTarget,
-          items: nextItems,
-        });
-      })
-      .catch(() => {
-        if (cancelled) {
-          return;
-        }
-
-        setDrillState({ kind: "error", target: drillTarget });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [drillTarget, loadWorkspaceEntities, query]);
 
   // Scroll the selected item into view on index change
   useEffect(() => {
@@ -252,19 +249,16 @@ export const ChatMentionList = ({
       return;
     }
 
-    setDrillState({
-      kind: "loading",
-      target: {
-        workspaceId: workspace.id,
-        viewId: workspace.sourceViewId,
-        name: workspace.label,
-      },
+    setDrillTarget({
+      workspaceId: workspace.id,
+      viewId: workspace.sourceViewId,
+      name: workspace.label,
     });
     setSelectedIndex(0);
   };
 
   const handleBack = () => {
-    setDrillState({ kind: "none" });
+    setDrillTarget(null);
     setSelectedIndex(0);
   };
 

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -1,12 +1,22 @@
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
 import type { PermissionInput } from "@stll/permissions";
 
 import { authClient } from "@/lib/auth";
 import { roleOptions } from "@/routes/-queries";
 
+/**
+ * Returns whether the active member's role grants the requested
+ * permissions. Fails closed: a missing/loading role yields `false`
+ * so chrome cannot accidentally expose destructive actions before
+ * the role cache hydrates.
+ */
 export const usePermissions = (permissions: PermissionInput): boolean => {
-  const { data: role } = useSuspenseQuery(roleOptions);
+  const { data: role } = useQuery(roleOptions);
+
+  if (role === undefined) {
+    return false;
+  }
 
   return authClient.organization.checkRolePermission({
     role,

--- a/apps/web/src/lib/errors/index.ts
+++ b/apps/web/src/lib/errors/index.ts
@@ -79,6 +79,22 @@ export const userErrorMessage = (
   return toAPIError(error).message;
 };
 
+/** User-safe error description for thrown errors (e.g. from
+ *  `useMutation` onError). Accepts any thrown value; falls back to
+ *  the supplied text for non-API failures and 5xx responses. */
+export const userErrorFromThrown = (
+  error: unknown,
+  fallback: string,
+): string => {
+  if (APIError.is(error)) {
+    if (error.status >= SERVER_ERROR_THRESHOLD) {
+      return fallback;
+    }
+    return error.message;
+  }
+  return fallback;
+};
+
 const AUTH_ERROR_CODES = {
   YOU_ARE_NOT_A_MEMBER_OF_THIS_ORGANIZATION: true,
 } as const;

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeftIcon,
   Loader2Icon,
@@ -43,7 +43,11 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
-import { userErrorMessage } from "@/lib/errors";
+import {
+  toAPIError,
+  userErrorFromThrown,
+  userErrorMessage,
+} from "@/lib/errors";
 import { ClauseBody } from "@/routes/_protected.knowledge/-components/clause-body";
 import { diffClauseBodies } from "@/routes/_protected.knowledge/-components/clause-diff";
 import type { ParagraphDiff } from "@/routes/_protected.knowledge/-components/clause-diff";
@@ -150,7 +154,6 @@ export const ClauseDetailView = ({
   const detailQuery = useQuery(clauseDetailOptions(organizationId, clauseId));
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   // SAFETY: The API returns body as ClauseParagraph[]
   // but Eden types it as unknown due to JSONB.
@@ -163,31 +166,30 @@ export const ClauseDetailView = ({
     });
   }, [clauseId, organizationId, queryClient]);
 
-  const handleDelete = useCallback(async () => {
-    setDeleting(true);
-    const response = await api.clauses({ clauseId }).delete();
-
-    setDeleting(false);
-
-    if (response.error) {
+  const deleteClause = useMutation({
+    mutationFn: async () => {
+      const response = await api.clauses({ clauseId }).delete();
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      stellaToast.add({
+        type: "success",
+        title: t("clauses.clauseDeleted"),
+      });
+      setDeleteOpen(false);
+      onDeleted();
+    },
+    onError: (error) => {
       stellaToast.add({
         type: "error",
         title: t("clauses.deleteFailed"),
-        description: userErrorMessage(
-          response.error,
-          t("common.unexpectedError"),
-        ),
+        description: userErrorFromThrown(error, t("common.unexpectedError")),
       });
-      return;
-    }
-
-    stellaToast.add({
-      type: "success",
-      title: t("clauses.clauseDeleted"),
-    });
-    setDeleteOpen(false);
-    onDeleted();
-  }, [clauseId, t, onDeleted]);
+    },
+  });
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -231,9 +233,9 @@ export const ClauseDetailView = ({
                       {t("common.cancel")}
                     </AlertDialogClose>
                     <Button
-                      disabled={deleting}
+                      disabled={deleteClause.isPending}
                       onClick={() => {
-                        void handleDelete();
+                        deleteClause.mutate();
                       }}
                       variant="destructive"
                     >

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-detail.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowLeftIcon,
   Loader2Icon,
@@ -49,6 +50,10 @@ import type { ParagraphDiff } from "@/routes/_protected.knowledge/-components/cl
 import { ClauseDiffView } from "@/routes/_protected.knowledge/-components/clause-diff-view";
 import { ClauseFormDialog } from "@/routes/_protected.knowledge/-components/clause-form-dialog";
 import type { BlockDirectiveKind } from "@/routes/_protected.knowledge/-components/paragraph-rendering";
+import {
+  clauseDetailOptions,
+  knowledgeKeys,
+} from "@/routes/_protected.knowledge/-queries";
 
 // ── Types ────────────────────────────────────────────
 
@@ -122,6 +127,7 @@ type CategoryOption = {
 };
 
 type ClauseDetailViewProps = {
+  organizationId: string;
   clauseId: string;
   categories: CategoryOption[];
   onBack: () => void;
@@ -131,60 +137,31 @@ type ClauseDetailViewProps = {
 // ── Main Component ───────────────────────────────────
 
 export const ClauseDetailView = ({
+  organizationId,
   clauseId,
   categories,
   onBack,
   onDeleted,
 }: ClauseDetailViewProps) => {
   const t = useTranslations();
+  const queryClient = useQueryClient();
   const canEditClause = usePermissions({ clause: ["update"] });
   const canDeleteClause = usePermissions({ clause: ["delete"] });
-  const [state, setState] = useState<
-    | { kind: "loading" }
-    | { kind: "ready"; detail: ClauseDetail }
-    | { kind: "error" }
-  >({ kind: "loading" });
+  const detailQuery = useQuery(clauseDetailOptions(organizationId, clauseId));
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
-  const load = useCallback(async () => {
-    const response = await api.clauses({ clauseId }).get();
+  // SAFETY: The API returns body as ClauseParagraph[]
+  // but Eden types it as unknown due to JSONB.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  const detail = detailQuery.data as unknown as ClauseDetail | undefined;
 
-    if (response.error) {
-      stellaToast.add({
-        type: "error",
-        title: t("clauses.loadFailed"),
-        description: userErrorMessage(
-          response.error,
-          t("common.unexpectedError"),
-        ),
-      });
-      setState({ kind: "error" });
-      return;
-    }
-
-    const data = response.data;
-    if (data instanceof Response) {
-      setState({ kind: "error" });
-      return;
-    }
-
-    // SAFETY: The API returns body as ClauseParagraph[]
-    // but Eden types it as unknown due to JSONB.
-    // eslint-disable-next-line typescript/no-unsafe-type-assertion
-    const detail = data as unknown as ClauseDetail;
-    setState({ kind: "ready", detail });
-  }, [clauseId, t]);
-
-  useEffect(() => {
-    const doLoad = async () => {
-      await load();
-    };
-
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    doLoad();
-  }, [load]);
+  const refreshDetail = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: knowledgeKeys.clauses.detail(organizationId, clauseId),
+    });
+  }, [clauseId, organizationId, queryClient]);
 
   const handleDelete = useCallback(async () => {
     setDeleting(true);
@@ -220,7 +197,7 @@ export const ClauseDetailView = ({
           {t("clauses.backToList")}
         </Button>
 
-        {state.kind === "ready" && (
+        {detail && (
           <div className="flex gap-1">
             {canEditClause && (
               <Button
@@ -270,7 +247,7 @@ export const ClauseDetailView = ({
         )}
       </div>
 
-      {state.kind === "loading" && (
+      {detailQuery.isPending && (
         <div className="flex flex-1 items-center justify-center p-8">
           <p className="text-muted-foreground text-sm">
             {t("clauses.loading")}
@@ -278,7 +255,7 @@ export const ClauseDetailView = ({
         </div>
       )}
 
-      {state.kind === "error" && (
+      {detailQuery.isError && (
         <div className="flex flex-1 items-center justify-center p-8">
           <p className="text-muted-foreground text-sm">
             {t("clauses.loadFailed")}
@@ -286,28 +263,24 @@ export const ClauseDetailView = ({
         </div>
       )}
 
-      {state.kind === "ready" && (
+      {detail && (
         <DetailContent
           categories={categories}
           clauseId={clauseId}
-          detail={state.detail}
-          onRefresh={() => {
-            void load();
-          }}
+          detail={detail}
+          onRefresh={refreshDetail}
         />
       )}
 
-      {state.kind === "ready" && (
+      {detail && (
         <ClauseFormDialog
           categories={categories}
           initial={{
-            ...state.detail,
-            bodyParagraphs: state.detail.body,
+            ...detail,
+            bodyParagraphs: detail.body,
           }}
           onOpenChange={setEditOpen}
-          onSaved={() => {
-            void load();
-          }}
+          onSaved={refreshDetail}
           open={editOpen}
         />
       )}

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-list.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { useMutation } from "@tanstack/react-query";
 import {
   DownloadIcon,
   MoreHorizontalIcon,
@@ -43,7 +44,11 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { usePermissions } from "@/hooks/use-permissions";
 import { api } from "@/lib/api";
-import { userErrorMessage } from "@/lib/errors";
+import {
+  toAPIError,
+  userErrorFromThrown,
+  userErrorMessage,
+} from "@/lib/errors";
 import { ClauseImportDialog } from "@/routes/_protected.knowledge/-components/clause-import-dialog";
 import { downloadFile } from "@/routes/_protected.workspaces/$workspaceId/-components/utils";
 
@@ -383,31 +388,29 @@ const CategoryRow = ({
   const canDeleteClause = usePermissions({ clause: ["delete"] });
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
-  const handleDelete = useCallback(async () => {
-    setDeleting(true);
-    const response = await api["clause-categories"]({
-      categoryId: category.id,
-    }).delete();
-
-    setDeleting(false);
-
-    if (response.error) {
+  const deleteCategory = useMutation({
+    mutationFn: async () => {
+      const response = await api["clause-categories"]({
+        categoryId: category.id,
+      }).delete();
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      setDeleteOpen(false);
+      onCategoriesChanged();
+    },
+    onError: (error) => {
       stellaToast.add({
         type: "error",
         title: t("clauses.deleteFailed"),
-        description: userErrorMessage(
-          response.error,
-          t("common.unexpectedError"),
-        ),
+        description: userErrorFromThrown(error, t("common.unexpectedError")),
       });
-      return;
-    }
-
-    setDeleteOpen(false);
-    onCategoriesChanged();
-  }, [category.id, t, onCategoriesChanged]);
+    },
+  });
 
   return (
     <div className="group flex items-center">
@@ -465,9 +468,9 @@ const CategoryRow = ({
               {t("common.cancel")}
             </AlertDialogClose>
             <Button
-              disabled={deleting}
+              disabled={deleteCategory.isPending}
               onClick={() => {
-                void handleDelete();
+                deleteCategory.mutate();
               }}
               variant="destructive"
             >

--- a/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/shortcut-form-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 
+import { useMutation } from "@tanstack/react-query";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
@@ -25,7 +26,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
-import { userErrorMessage } from "@/lib/errors";
+import { APIError, toAPIError, userErrorFromThrown } from "@/lib/errors";
 
 // ── Types ────────────────────────────────────────────
 
@@ -79,7 +80,6 @@ export const ShortcutFormDialog = ({
     scope: initial?.scope ?? "private",
   }));
   const [commandError, setCommandError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -113,45 +113,22 @@ export const ShortcutFormDialog = ({
     setCommandError(validateCommand(lower));
   };
 
-  const handleSubmit = async () => {
-    const err = validateCommand(form.command);
-    if (err) {
-      setCommandError(err);
-      return;
-    }
-    if (!form.name.trim() || !form.command || !form.prompt.trim()) {
-      return;
-    }
-
-    setSaving(true);
-
-    if (isEdit && initial.id) {
-      const response = await api.shortcuts({ shortcutId: initial.id }).post({
-        name: form.name.trim(),
-        description: form.description.trim() || null,
-        command: form.command,
-        prompt: form.prompt.trim(),
-        queryKey: ["shortcuts"],
-      });
-
-      setSaving(false);
-
-      if (response.error) {
-        if (response.error.status === 409) {
-          setCommandError(t("knowledge.skills.errors.commandConflict"));
-          return;
-        }
-        stellaToast.add({
-          title: t("common.unexpectedError"),
-          description: userErrorMessage(
-            response.error,
-            t("common.unexpectedError"),
-          ),
-          type: "error",
+  const saveShortcut = useMutation({
+    mutationFn: async () => {
+      if (isEdit && initial.id) {
+        const response = await api.shortcuts({ shortcutId: initial.id }).post({
+          name: form.name.trim(),
+          description: form.description.trim() || null,
+          command: form.command,
+          prompt: form.prompt.trim(),
+          queryKey: ["shortcuts"],
         });
-        return;
+        if (response.error) {
+          throw toAPIError(response.error);
+        }
+        return response.data;
       }
-    } else {
+
       const trimmedDescription = form.description.trim();
       const response = await api.shortcuts.put({
         name: form.name.trim(),
@@ -161,28 +138,38 @@ export const ShortcutFormDialog = ({
         scope: form.scope,
         queryKey: ["shortcuts"],
       });
-
-      setSaving(false);
-
       if (response.error) {
-        if (response.error.status === 409) {
-          setCommandError(t("knowledge.skills.errors.commandConflict"));
-          return;
-        }
-        stellaToast.add({
-          title: t("common.unexpectedError"),
-          description: userErrorMessage(
-            response.error,
-            t("common.unexpectedError"),
-          ),
-          type: "error",
-        });
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      onSaved();
+      onOpenChange(false);
+    },
+    onError: (error: unknown) => {
+      if (APIError.is(error) && error.status === 409) {
+        setCommandError(t("knowledge.skills.errors.commandConflict"));
         return;
       }
-    }
+      stellaToast.add({
+        title: t("common.unexpectedError"),
+        description: userErrorFromThrown(error, t("common.unexpectedError")),
+        type: "error",
+      });
+    },
+  });
 
-    onSaved();
-    onOpenChange(false);
+  const handleSubmit = () => {
+    const err = validateCommand(form.command);
+    if (err) {
+      setCommandError(err);
+      return;
+    }
+    if (!form.name.trim() || !form.command || !form.prompt.trim()) {
+      return;
+    }
+    saveShortcut.mutate();
   };
 
   const canSubmit =
@@ -315,10 +302,8 @@ export const ShortcutFormDialog = ({
             {t("common.cancel")}
           </DialogClose>
           <Button
-            disabled={!canSubmit || saving}
-            onClick={() => {
-              void handleSubmit();
-            }}
+            disabled={!canSubmit || saveShortcut.isPending}
+            onClick={handleSubmit}
           >
             {isEdit ? t("common.save") : t("common.add")}
           </Button>

--- a/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-upload.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState } from "react";
 
+import { useMutation } from "@tanstack/react-query";
 import { UploadIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -8,7 +9,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 
 import { api } from "@/lib/api";
 import { DOCX_MIME } from "@/lib/consts";
-import { userErrorMessage } from "@/lib/errors";
+import { toAPIError, userErrorFromThrown } from "@/lib/errors";
 
 type DiscoverResponse = Awaited<ReturnType<typeof api.templates.discover.post>>;
 
@@ -24,11 +25,36 @@ type TemplateUploadProps = {
 export const TemplateUpload = ({ onDiscovered }: TemplateUploadProps) => {
   const t = useTranslations();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [loading, setLoading] = useState(false);
   const [isDragOver, setIsDragOver] = useState(false);
 
+  const discoverMutation = useMutation({
+    mutationFn: async (file: File) => {
+      const response = await api.templates.discover.post({ file });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      const { data } = response;
+      if (data instanceof Response) {
+        throw new TypeError("Unexpected response shape");
+      }
+      return { file, data };
+    },
+    onSuccess: ({ file, data }) => {
+      onDiscovered(file, data);
+    },
+    onError: (error) => {
+      stellaToast.add({
+        type: "error",
+        title: t("templates.discoveryFailed"),
+        description: userErrorFromThrown(error, t("common.unexpectedError")),
+      });
+    },
+  });
+  const loading = discoverMutation.isPending;
+
+  const mutateDiscover = discoverMutation.mutate;
   const discover = useCallback(
-    async (file: File) => {
+    (file: File) => {
       if (file.type !== DOCX_MIME) {
         stellaToast.add({
           type: "error",
@@ -36,45 +62,15 @@ export const TemplateUpload = ({ onDiscovered }: TemplateUploadProps) => {
         });
         return;
       }
-
-      setLoading(true);
-      const response = await api.templates.discover.post({
-        file,
-      });
-
-      setLoading(false);
-
-      if (response.error) {
-        stellaToast.add({
-          type: "error",
-          title: t("templates.discoveryFailed"),
-          description: userErrorMessage(
-            response.error,
-            t("common.unexpectedError"),
-          ),
-        });
-        return;
-      }
-
-      const { data } = response;
-      if (data instanceof Response) {
-        stellaToast.add({
-          type: "error",
-          title: t("templates.discoveryFailed"),
-        });
-        return;
-      }
-
-      onDiscovered(file, data);
+      mutateDiscover(file);
     },
-    [onDiscovered, t],
+    [mutateDiscover, t],
   );
 
   const handleFileChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.item(0);
       if (file) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         discover(file);
       }
       // Reset so the same file can be re-selected
@@ -89,7 +85,6 @@ export const TemplateUpload = ({ onDiscovered }: TemplateUploadProps) => {
       setIsDragOver(false);
       const file = e.dataTransfer.files.item(0);
       if (file) {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         discover(file);
       }
     },

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -77,6 +77,11 @@ export const knowledgeKeys = {
       "list",
       { categoryId: categoryId ?? null, search, limit },
     ],
+    detail: (organizationId: string, clauseId: string) => [
+      ...knowledgeKeys.clauses.all(organizationId),
+      clauseId,
+      "detail",
+    ],
   },
   clauseCategories: {
     all: (organizationId: string) => ["clause-categories", organizationId],
@@ -269,6 +274,23 @@ export const clausesOptions = (
 
       const response = await api.clauses.get({
         query,
+        fetch: { signal },
+      });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+    staleTime: STALE_TIME.FIVE.MINUTES,
+  });
+
+export const clauseDetailOptions = (organizationId: string, clauseId: string) =>
+  queryOptions({
+    queryKey: knowledgeKeys.clauses.detail(organizationId, clauseId),
+    queryFn: async ({ signal }) => {
+      const response = await api.clauses({ clauseId }).get({
         fetch: { signal },
       });
 

--- a/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/$decisionId.tsx
@@ -105,7 +105,7 @@ function DecisionViewer() {
     if (!(await ensureAIAvailable())) {
       return;
     }
-    await generateDecisionAnalysis();
+    generateDecisionAnalysis();
   }, [ensureAIAvailable, generateDecisionAnalysis]);
 
   const hasAnalysis =

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -80,11 +80,18 @@ export const useDecisionAnalysis = (
   const hasFreshAnalysis =
     isDecisionAnalysis(existingAnalysis) &&
     !isAnalysisInProgress(existingAnalysis);
-  const [isGenerating, setIsGenerating] = useState(false);
+  // Track which decision the user kicked generation off for. Comparing
+  // against the current `decisionId` in the same render keeps a stale
+  // value from enabling a fetch (and an unintended backend kick-off)
+  // for an unrelated decision during a route transition.
+  const [generatingFor, setGeneratingFor] = useState<string | null>(null);
+  const isGenerating = generatingFor === decisionId;
 
-  // Reset the kick-off flag when the route changes.
+  // Clear the marker once the route moves on so returning to the
+  // original decision lands in `idle` (matching prior behaviour)
+  // instead of resuming a poll the user didn't request again.
   useEffect(() => {
-    setIsGenerating(false);
+    setGeneratingFor(null);
   }, [decisionId]);
 
   const enabled = isGenerating && !hasFreshAnalysis;
@@ -160,8 +167,8 @@ export const useDecisionAnalysis = (
     if (isGenerating) {
       return;
     }
-    setIsGenerating(true);
-  }, [hasErrorResult, hasFreshAnalysis, isGenerating, refetch]);
+    setGeneratingFor(decisionId);
+  }, [decisionId, hasErrorResult, hasFreshAnalysis, isGenerating, refetch]);
 
   const state: AnalysisState = (() => {
     if (hasFreshAnalysis && isDecisionAnalysis(existingAnalysis)) {

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -143,12 +143,25 @@ export const useDecisionAnalysis = (
     );
   }, [query.data, decisionId, queryClient]);
 
+  const hasErrorResult = query.data?.kind === "error" || query.isError;
+  const refetch = query.refetch;
+
   const generate = useCallback(() => {
-    if (hasFreshAnalysis || isGenerating) {
+    if (hasFreshAnalysis) {
+      return;
+    }
+    // Allow retry when the previous attempt settled into an error
+    // state: refetch the polling query so it picks up a fresh
+    // result instead of staying on the cached failure.
+    if (isGenerating && hasErrorResult) {
+      void refetch();
+      return;
+    }
+    if (isGenerating) {
       return;
     }
     setIsGenerating(true);
-  }, [hasFreshAnalysis, isGenerating]);
+  }, [hasErrorResult, hasFreshAnalysis, isGenerating, refetch]);
 
   const state: AnalysisState = (() => {
     if (hasFreshAnalysis && isDecisionAnalysis(existingAnalysis)) {

--- a/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/case-viewer/analysis/use-decision-analysis.ts
@@ -5,9 +5,9 @@
  * triggers generation and polls until complete.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import type { DecisionAnalysis } from "@stll/case-law/analysis";
 import {
@@ -64,150 +64,118 @@ const parseAnalysisResponse = (value: unknown): AnalysisResponse | null => {
   return null;
 };
 
+type AnalysisQueryResult =
+  | { kind: "done"; analysis: DecisionAnalysis }
+  | { kind: "generating"; tree: DecisionAnalysis["tree"] }
+  | { kind: "error"; message: string };
+
+const isTerminal = (result: AnalysisQueryResult): boolean =>
+  result.kind === "done" || result.kind === "error";
+
 export const useDecisionAnalysis = (
   decisionId: string,
   existingAnalysis: unknown,
 ) => {
-  const [state, setState] = useState<AnalysisState>(() => {
-    if (
-      isDecisionAnalysis(existingAnalysis) &&
-      !isAnalysisInProgress(existingAnalysis)
-    ) {
-      return { status: "done", analysis: existingAnalysis };
-    }
-    return { status: "idle" };
+  const queryClient = useQueryClient();
+  const hasFreshAnalysis =
+    isDecisionAnalysis(existingAnalysis) &&
+    !isAnalysisInProgress(existingAnalysis);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  // Reset the kick-off flag when the route changes.
+  useEffect(() => {
+    setIsGenerating(false);
+  }, [decisionId]);
+
+  const enabled = isGenerating && !hasFreshAnalysis;
+
+  const query = useQuery<AnalysisQueryResult>({
+    queryKey: ["decision-analysis", decisionId],
+    queryFn: async ({ signal }): Promise<AnalysisQueryResult> => {
+      const response = await fetch(
+        `${env.VITE_API_URL}/v1/case/decisions/${decisionId}/analysis`,
+        {
+          credentials: "include",
+          signal,
+        },
+      );
+
+      const data: unknown = await response.json();
+      const parsed = parseAnalysisResponse(data);
+
+      if (!parsed) {
+        return {
+          kind: "error",
+          message: response.ok
+            ? "Unexpected response"
+            : `HTTP ${String(response.status)}`,
+        };
+      }
+
+      if (parsed.status === "done") {
+        return { kind: "done", analysis: parsed.analysis };
+      }
+      if (parsed.status === "generating") {
+        return { kind: "generating", tree: parsed.tree };
+      }
+      return { kind: "error", message: parsed.error };
+    },
+    enabled,
+    refetchInterval: (q) =>
+      q.state.data && isTerminal(q.state.data) ? false : POLL_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    staleTime: 0,
+    gcTime: 0,
   });
 
-  const abortRef = useRef<AbortController | null>(null);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const queryClient = useQueryClient();
-
-  const stopPolling = useCallback(() => {
-    if (!pollRef.current) {
-      return;
-    }
-    clearInterval(pollRef.current);
-    pollRef.current = null;
-  }, []);
-
-  // Reset to idle when decisionId changes (route navigation)
-  const prevDecisionId = useRef(decisionId);
+  // Mirror a `done` result into the decision query cache so route
+  // re-renders pick up the persisted analysis without another fetch.
   useEffect(() => {
-    if (prevDecisionId.current !== decisionId) {
-      prevDecisionId.current = decisionId;
-      abortRef.current?.abort();
-      stopPolling();
-
-      if (
-        isDecisionAnalysis(existingAnalysis) &&
-        !isAnalysisInProgress(existingAnalysis)
-      ) {
-        setState({ status: "done", analysis: existingAnalysis });
-      } else {
-        setState({ status: "idle" });
-      }
+    if (query.data?.kind !== "done") {
       return;
     }
-
-    if (
-      isDecisionAnalysis(existingAnalysis) &&
-      !isAnalysisInProgress(existingAnalysis) &&
-      state.status !== "done"
-    ) {
-      setState({ status: "done", analysis: existingAnalysis });
-    }
-  }, [existingAnalysis, state.status, decisionId, stopPolling]);
-
-  // Cleanup on unmount
-  useEffect(
-    () => () => {
-      abortRef.current?.abort();
-      stopPolling();
-    },
-    [stopPolling],
-  );
-
-  /** Returns true if analysis resolved (done or error), false if still generating. */
-  const fetchAnalysis = useCallback(async (): Promise<boolean> => {
-    const controller = new AbortController();
-    abortRef.current = controller;
-
-    const response = await fetch(
-      `${env.VITE_API_URL}/v1/case/decisions/${decisionId}/analysis`,
-      {
-        credentials: "include",
-        signal: controller.signal,
-      },
+    const analysis = query.data.analysis;
+    queryClient.setQueryData(
+      ["case-law-decisions", decisionId],
+      (old: Record<string, unknown> | undefined) =>
+        old ? { ...old, analysis } : old,
     );
+  }, [query.data, decisionId, queryClient]);
 
-    const data: unknown = await response.json();
-
-    const analysisResponse = parseAnalysisResponse(data);
-    if (analysisResponse) {
-      switch (analysisResponse.status) {
-        case "done":
-          stopPolling();
-          setState({ status: "done", analysis: analysisResponse.analysis });
-          queryClient.setQueryData(
-            ["case-law-decisions", decisionId],
-            (old: Record<string, unknown> | undefined) =>
-              old ? { ...old, analysis: analysisResponse.analysis } : old,
-          );
-          return true;
-
-        case "generating":
-          setState({ status: "generating", tree: analysisResponse.tree });
-          return false;
-
-        case "error":
-          stopPolling();
-          setState({ status: "error", message: analysisResponse.error });
-          return true;
-      }
-
-      const unhandledResponse: never = analysisResponse;
-      return unhandledResponse;
-    }
-
-    // Unexpected response shape (auth failure, server error, etc.)
-    // Treat as error to stop polling
-    stopPolling();
-    setState({
-      status: "error",
-      message: response.ok ? "Unexpected response" : `HTTP ${response.status}`,
-    });
-    return true;
-  }, [decisionId, queryClient, stopPolling]);
-
-  const generate = useCallback(async () => {
-    if (state.status === "generating") {
+  const generate = useCallback(() => {
+    if (hasFreshAnalysis || isGenerating) {
       return;
     }
+    setIsGenerating(true);
+  }, [hasFreshAnalysis, isGenerating]);
 
-    setState({ status: "generating", tree: [] });
-
-    try {
-      const resolved = await fetchAnalysis();
-
-      // Only poll if the first fetch didn't already resolve
-      if (!resolved) {
-        stopPolling();
-        pollRef.current = setInterval(() => {
-          void fetchAnalysis().catch(() => {
-            // Ignore poll errors; will retry on next interval
-          });
-        }, POLL_INTERVAL_MS);
-      }
-    } catch (error) {
-      if (abortRef.current?.signal.aborted) {
-        return;
-      }
-      setState({
-        status: "error",
-        message: error instanceof Error ? error.message : "Unknown error",
-      });
+  const state: AnalysisState = (() => {
+    if (hasFreshAnalysis && isDecisionAnalysis(existingAnalysis)) {
+      return { status: "done", analysis: existingAnalysis };
     }
-  }, [state.status, fetchAnalysis, stopPolling]);
+    if (!isGenerating) {
+      return { status: "idle" };
+    }
+    if (query.data) {
+      switch (query.data.kind) {
+        case "done":
+          return { status: "done", analysis: query.data.analysis };
+        case "generating":
+          return { status: "generating", tree: query.data.tree };
+        case "error":
+          return { status: "error", message: query.data.message };
+      }
+    }
+    if (query.isError) {
+      return {
+        status: "error",
+        message:
+          query.error instanceof Error ? query.error.message : "Unknown error",
+      };
+    }
+    return { status: "generating", tree: [] };
+  })();
 
   return { state, generate };
 };

--- a/apps/web/src/routes/_protected.knowledge/clauses.tsx
+++ b/apps/web/src/routes/_protected.knowledge/clauses.tsx
@@ -239,6 +239,7 @@ function RouteComponent() {
       <ClauseDetailView
         categories={categories}
         clauseId={view.clauseId}
+        organizationId={activeOrganizationId}
         onBack={handleBackToList}
         onDeleted={handleBackToList}
       />

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
   CircleHelpIcon,
@@ -29,7 +29,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { McpIcon } from "@/components/mcp-icon";
 import { api } from "@/lib/api";
-import { userErrorMessage } from "@/lib/errors";
+import { toAPIError, userErrorFromThrown } from "@/lib/errors";
 import { subscribeToMcpOAuthOutcome } from "@/lib/mcp-oauth-channel";
 import { toSafeId } from "@/lib/safe-id";
 import { sanitizeHref } from "@/lib/sanitize-href";
@@ -270,158 +270,159 @@ function ConnectorCard({
   userCanManageCustomConnectors: boolean;
 }) {
   const t = useTranslations();
-  const [busy, setBusy] = useState(false);
   const [token, setToken] = useState("");
   const [showTokenInput, setShowTokenInput] = useState(
     connector.authType === "bearer" && connection?.status === "needs_reauth",
   );
 
-  const connect = async () => {
-    setBusy(true);
-    const response = await api.mcp
-      .connectors({ slug: connector.slug })
-      .connect.post({ queryKey: ["mcp"] });
-    setBusy(false);
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    if (response.data.type === "bearer") {
-      setShowTokenInput(true);
-      return;
-    }
-
-    if (response.data.type === "oauth2") {
-      const popup = window.open(
-        response.data.authorizeUrl,
-        "_blank",
-        "width=560,height=720",
-      );
-
-      if (!popup) {
-        window.location.assign(response.data.authorizeUrl);
-      }
-      return;
-    }
-
-    stellaToast.add({
-      title: t("knowledge.mcp.connectedToast"),
-      type: "success",
+  const handleApiError = (error: unknown) => {
+    showApiError({
+      error,
+      fallback: t("knowledge.mcp.errorDescription"),
+      title: t("knowledge.mcp.errorTitle"),
     });
-    onChanged();
   };
 
-  const saveToken = async () => {
+  const connectMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api.mcp
+        .connectors({ slug: connector.slug })
+        .connect.post({ queryKey: ["mcp"] });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: (data) => {
+      if (data.type === "bearer") {
+        setShowTokenInput(true);
+        return;
+      }
+      if (data.type === "oauth2") {
+        const popup = window.open(
+          data.authorizeUrl,
+          "_blank",
+          "width=560,height=720",
+        );
+        if (!popup) {
+          window.location.assign(data.authorizeUrl);
+        }
+        return;
+      }
+      stellaToast.add({
+        title: t("knowledge.mcp.connectedToast"),
+        type: "success",
+      });
+      onChanged();
+    },
+    onError: handleApiError,
+  });
+
+  const saveTokenMutation = useMutation({
+    mutationFn: async (trimmedToken: string) => {
+      const response = await api.mcp.connections.post({
+        connectorSlug: connector.slug,
+        token: trimmedToken,
+        queryKey: ["mcp"],
+      });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      setToken("");
+      setShowTokenInput(false);
+      stellaToast.add({
+        title: t("knowledge.mcp.connectedToast"),
+        type: "success",
+      });
+      onChanged();
+    },
+    onError: handleApiError,
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: async (connectionId: string) => {
+      const response = await api.mcp
+        .connections({
+          connectionId: toSafeId<"mcpUserConnection">(connectionId),
+        })
+        .delete({ queryKey: ["mcp"] });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => onChanged(),
+    onError: handleApiError,
+  });
+
+  const setEnabledMutation = useMutation({
+    mutationFn: async (payload: { connectionId: string; enabled: boolean }) => {
+      const response = await api.mcp
+        .connections({
+          connectionId: toSafeId<"mcpUserConnection">(payload.connectionId),
+        })
+        .patch({
+          enabled: payload.enabled,
+          queryKey: ["mcp"],
+        });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => onChanged(),
+    onError: handleApiError,
+  });
+
+  const deleteConnectorMutation = useMutation({
+    mutationFn: async () => {
+      const response = await api.mcp
+        .connectors({ slug: connector.slug })
+        .delete({ queryKey: ["mcp"] });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => onChanged(),
+    onError: handleApiError,
+  });
+
+  const busy =
+    connectMutation.isPending ||
+    saveTokenMutation.isPending ||
+    disconnectMutation.isPending ||
+    setEnabledMutation.isPending ||
+    deleteConnectorMutation.isPending;
+
+  const connect = () => connectMutation.mutate();
+  const saveToken = () => {
     const trimmedToken = token.trim();
     if (!trimmedToken) {
       return;
     }
-
-    setBusy(true);
-    const response = await api.mcp.connections.post({
-      connectorSlug: connector.slug,
-      token: trimmedToken,
-      queryKey: ["mcp"],
-    });
-    setBusy(false);
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    setToken("");
-    setShowTokenInput(false);
-    stellaToast.add({
-      title: t("knowledge.mcp.connectedToast"),
-      type: "success",
-    });
-    onChanged();
+    saveTokenMutation.mutate(trimmedToken);
   };
-
-  const disconnect = async () => {
+  const disconnect = () => {
     if (!connection || busy) {
       return;
     }
-
-    setBusy(true);
-    const response = await api.mcp
-      .connections({
-        connectionId: toSafeId<"mcpUserConnection">(connection.id),
-      })
-      .delete({ queryKey: ["mcp"] });
-    setBusy(false);
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    onChanged();
+    disconnectMutation.mutate(connection.id);
   };
-
-  const setEnabled = async (enabled: boolean) => {
+  const setEnabled = (enabled: boolean) => {
     if (!connection || busy) {
       return;
     }
-
-    setBusy(true);
-    const response = await api.mcp
-      .connections({
-        connectionId: toSafeId<"mcpUserConnection">(connection.id),
-      })
-      .patch({
-        enabled,
-        queryKey: ["mcp"],
-      });
-    setBusy(false);
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    onChanged();
+    setEnabledMutation.mutate({ connectionId: connection.id, enabled });
   };
-
-  const deleteConnector = async () => {
+  const deleteConnector = () => {
     if (busy) {
       return;
     }
-    setBusy(true);
-    const response = await api.mcp
-      .connectors({ slug: connector.slug })
-      .delete({ queryKey: ["mcp"] });
-    setBusy(false);
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    onChanged();
+    deleteConnectorMutation.mutate();
   };
 
   const connected = connection?.status === "connected";
@@ -466,10 +467,10 @@ function ConnectorCard({
             <ChatUseSwitchButton
               busy={busy}
               enabled={enabled}
-              onToggle={() => void setEnabled(!enabled)}
+              onToggle={() => setEnabled(!enabled)}
             />
           ) : (
-            <Button disabled={busy} onClick={() => void connect()} size="sm">
+            <Button disabled={busy} onClick={connect} size="sm">
               {needsReauth ? (
                 <RefreshCcwIcon className="me-1.5 size-4" />
               ) : (
@@ -484,7 +485,7 @@ function ConnectorCard({
             <Button
               aria-busy={busy}
               aria-label={t("knowledge.mcp.disconnect")}
-              onClick={() => void disconnect()}
+              onClick={disconnect}
               size="sm"
               variant="ghost"
             >
@@ -495,7 +496,7 @@ function ConnectorCard({
             <Button
               aria-busy={busy}
               aria-label={t("common.delete")}
-              onClick={() => void deleteConnector()}
+              onClick={deleteConnector}
               size="sm"
               variant="ghost"
             >
@@ -523,10 +524,7 @@ function ConnectorCard({
               type="password"
               value={token}
             />
-            <Button
-              disabled={busy || !token.trim()}
-              onClick={() => void saveToken()}
-            >
+            <Button disabled={busy || !token.trim()} onClick={saveToken}>
               <KeyRoundIcon className="me-1.5 size-4" />
               {t("knowledge.mcp.saveToken")}
             </Button>
@@ -558,32 +556,38 @@ function NativeToolCard({
   onChanged: () => void;
 }) {
   const t = useTranslations();
-  const [busy, setBusy] = useState(false);
   const iconHref = tool.iconUrl ?? fallbackIconUrl(tool.url);
   const safeIconHref =
     iconHref === undefined ? undefined : sanitizeHref(iconHref);
 
-  const setEnabled = async (enabled: boolean) => {
-    if (busy) {
-      return;
-    }
-    setBusy(true);
-    const response = await api.mcp["native-tools"]({ slug: tool.slug }).patch({
-      enabled,
-      queryKey: ["mcp"],
-    });
-    setBusy(false);
-
-    if (response.error) {
+  const setEnabledMutation = useMutation({
+    mutationFn: async (enabled: boolean) => {
+      const response = await api.mcp["native-tools"]({ slug: tool.slug }).patch(
+        {
+          enabled,
+          queryKey: ["mcp"],
+        },
+      );
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => onChanged(),
+    onError: (error) => {
       showApiError({
-        error: response.error,
+        error,
         fallback: t("knowledge.mcp.errorDescription"),
         title: t("knowledge.mcp.errorTitle"),
       });
+    },
+  });
+  const busy = setEnabledMutation.isPending;
+  const setEnabled = (enabled: boolean) => {
+    if (busy) {
       return;
     }
-
-    onChanged();
+    setEnabledMutation.mutate(enabled);
   };
 
   return (
@@ -611,7 +615,7 @@ function NativeToolCard({
         <ChatUseSwitchButton
           busy={busy}
           enabled={tool.enabled}
-          onToggle={() => void setEnabled(!tool.enabled)}
+          onToggle={() => setEnabled(!tool.enabled)}
         />
       ) : (
         <span
@@ -681,12 +685,11 @@ const fallbackIconUrl = (rawUrl: string): string | undefined => {
 
 type WizardState =
   | { step: "idle" }
-  | { step: "url"; url: string; busy: boolean }
+  | { step: "url"; url: string }
   | {
       step: "token";
       createdConnector: CreatedConnector;
       token: string;
-      busy: boolean;
     };
 
 const WIZARD_IDLE: WizardState = { step: "idle" };
@@ -695,132 +698,135 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
   const t = useTranslations();
   const [wizard, setWizard] = useState<WizardState>(WIZARD_IDLE);
 
+  const handleApiError = (error: unknown) => {
+    showApiError({
+      error,
+      fallback: t("knowledge.mcp.errorDescription"),
+      title: t("knowledge.mcp.errorTitle"),
+    });
+  };
+
   const reset = () => {
     setWizard(WIZARD_IDLE);
   };
 
-  const connectConnector = async (connector: CreatedConnector) => {
-    const response = await api.mcp
-      .connectors({ slug: connector.slug })
-      .connect.post({ queryKey: ["mcp"] });
-
-    if (response.error) {
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    if (response.data.type === "bearer") {
-      setWizard({
-        step: "token",
-        createdConnector: connector,
-        token: "",
-        busy: false,
-      });
-      return;
-    }
-
-    if (response.data.type === "oauth2") {
-      const popup = window.open(
-        response.data.authorizeUrl,
-        "_blank",
-        "width=560,height=720",
-      );
-
-      if (!popup) {
-        window.location.assign(response.data.authorizeUrl);
+  const connectMutation = useMutation({
+    mutationFn: async (connector: CreatedConnector) => {
+      const response = await api.mcp
+        .connectors({ slug: connector.slug })
+        .connect.post({ queryKey: ["mcp"] });
+      if (response.error) {
+        throw toAPIError(response.error);
       }
+      return { connector, data: response.data };
+    },
+    onSuccess: ({ connector, data }) => {
+      if (data.type === "bearer") {
+        setWizard({
+          step: "token",
+          createdConnector: connector,
+          token: "",
+        });
+        return;
+      }
+      if (data.type === "oauth2") {
+        const popup = window.open(
+          data.authorizeUrl,
+          "_blank",
+          "width=560,height=720",
+        );
+        if (!popup) {
+          window.location.assign(data.authorizeUrl);
+        }
+        reset();
+        return;
+      }
+      stellaToast.add({
+        title: t("knowledge.mcp.connectedToast"),
+        type: "success",
+      });
+      onChanged();
       reset();
-      return;
-    }
+    },
+    onError: handleApiError,
+  });
 
-    stellaToast.add({
-      title: t("knowledge.mcp.connectedToast"),
-      type: "success",
-    });
-    onChanged();
-    reset();
-  };
+  const addServerMutation = useMutation({
+    mutationFn: async (trimmedUrl: string) => {
+      const response = await api.mcp.connectors.post({
+        url: trimmedUrl,
+        queryKey: ["mcp"],
+      });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: (data) => {
+      onChanged();
+      connectMutation.mutate(data.connector);
+    },
+    onError: handleApiError,
+  });
 
-  const addServer = async () => {
+  const saveTokenMutation = useMutation({
+    mutationFn: async (payload: { connectorSlug: string; token: string }) => {
+      const response = await api.mcp.connections.post({
+        connectorSlug: payload.connectorSlug,
+        token: payload.token,
+        queryKey: ["mcp"],
+      });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      stellaToast.add({
+        title: t("knowledge.mcp.connectedToast"),
+        type: "success",
+      });
+      onChanged();
+      reset();
+    },
+    onError: handleApiError,
+  });
+
+  const busy =
+    connectMutation.isPending ||
+    addServerMutation.isPending ||
+    saveTokenMutation.isPending;
+
+  const addServer = () => {
     if (wizard.step !== "url") {
       return;
     }
     const trimmedUrl = wizard.url.trim();
-    if (!trimmedUrl || wizard.busy) {
+    if (!trimmedUrl || busy) {
       return;
     }
-
-    setWizard({ ...wizard, busy: true });
-    const response = await api.mcp.connectors.post({
-      url: trimmedUrl,
-      queryKey: ["mcp"],
-    });
-
-    if (response.error) {
-      setWizard((prev) =>
-        prev.step === "url" ? { ...prev, busy: false } : prev,
-      );
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    setWizard((prev) =>
-      prev.step === "url" ? { ...prev, busy: false } : prev,
-    );
-    onChanged();
-    await connectConnector(response.data.connector);
+    addServerMutation.mutate(trimmedUrl);
   };
 
-  const saveToken = async () => {
+  const saveToken = () => {
     if (wizard.step !== "token") {
       return;
     }
     const trimmedToken = wizard.token.trim();
-    if (!trimmedToken || wizard.busy) {
+    if (!trimmedToken || busy) {
       return;
     }
-
-    const { createdConnector } = wizard;
-    setWizard({ ...wizard, busy: true });
-    const response = await api.mcp.connections.post({
-      connectorSlug: createdConnector.slug,
+    saveTokenMutation.mutate({
+      connectorSlug: wizard.createdConnector.slug,
       token: trimmedToken,
-      queryKey: ["mcp"],
     });
-
-    if (response.error) {
-      setWizard((prev) =>
-        prev.step === "token" ? { ...prev, busy: false } : prev,
-      );
-      showApiError({
-        error: response.error,
-        fallback: t("knowledge.mcp.errorDescription"),
-        title: t("knowledge.mcp.errorTitle"),
-      });
-      return;
-    }
-
-    stellaToast.add({
-      title: t("knowledge.mcp.connectedToast"),
-      type: "success",
-    });
-    onChanged();
-    reset();
   };
 
   if (wizard.step === "idle") {
     return (
       <button
         className="bg-card hover:bg-muted/30 focus-visible:ring-ring flex items-center gap-3 rounded-lg border border-dashed p-3 text-start transition-colors focus-visible:ring-2 focus-visible:outline-none"
-        onClick={() => setWizard({ step: "url", url: "", busy: false })}
+        onClick={() => setWizard({ step: "url", url: "" })}
         type="button"
       >
         <PlusIcon className="text-muted-foreground size-5 shrink-0" />
@@ -837,7 +843,7 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
         className="bg-card flex items-center gap-2 rounded-lg border p-2 ps-3"
         onSubmit={(event) => {
           event.preventDefault();
-          void addServer();
+          addServer();
         }}
       >
         <PlusIcon className="text-muted-foreground size-5 shrink-0" />
@@ -860,14 +866,8 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           type="url"
           value={wizard.url}
         />
-        <Button
-          disabled={wizard.busy || !wizard.url.trim()}
-          size="sm"
-          type="submit"
-        >
-          {wizard.busy ? (
-            <LoaderIcon className="me-1.5 size-4 animate-spin" />
-          ) : null}
+        <Button disabled={busy || !wizard.url.trim()} size="sm" type="submit">
+          {busy ? <LoaderIcon className="me-1.5 size-4 animate-spin" /> : null}
           {t("knowledge.mcp.addAndConnect")}
         </Button>
         <Button
@@ -889,7 +889,7 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
         className="flex items-center gap-2"
         onSubmit={(event) => {
           event.preventDefault();
-          void saveToken();
+          saveToken();
         }}
       >
         <KeyRoundIcon className="text-muted-foreground size-5 shrink-0" />
@@ -914,14 +914,8 @@ function AddServerCard({ onChanged }: { onChanged: () => void }) {
           type="password"
           value={wizard.token}
         />
-        <Button
-          disabled={wizard.busy || !wizard.token.trim()}
-          size="sm"
-          type="submit"
-        >
-          {wizard.busy ? (
-            <LoaderIcon className="me-1.5 size-4 animate-spin" />
-          ) : null}
+        <Button disabled={busy || !wizard.token.trim()} size="sm" type="submit">
+          {busy ? <LoaderIcon className="me-1.5 size-4 animate-spin" /> : null}
           {t("knowledge.mcp.saveToken")}
         </Button>
         <Button
@@ -946,13 +940,13 @@ function showApiError({
   fallback,
   title,
 }: {
-  error: Parameters<typeof userErrorMessage>[0];
+  error: unknown;
   fallback: string;
   title: string;
 }) {
   stellaToast.add({
     title,
-    description: userErrorMessage(error, fallback),
+    description: userErrorFromThrown(error, fallback),
     type: "error",
   });
 }

--- a/apps/web/src/routes/_protected.knowledge/skills.tsx
+++ b/apps/web/src/routes/_protected.knowledge/skills.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useRef, useState } from "react";
 
-import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
   DownloadIcon,
@@ -34,7 +38,11 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
-import { userErrorMessage } from "@/lib/errors";
+import {
+  toAPIError,
+  userErrorFromThrown,
+  userErrorMessage,
+} from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import {
   knowledgeKeys,
@@ -432,7 +440,6 @@ function UploadSkillDialog({
   const [file, setFile] = useState<File | null>(null);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const [scope, setScope] = useState<SkillScope>("private");
-  const [saving, setSaving] = useState(false);
 
   const setFirstFile = (files: FileList | null) => {
     const selectedFile = files?.item(0);
@@ -453,35 +460,38 @@ function UploadSkillDialog({
     setIsDraggingFile(true);
   };
 
-  const submit = async () => {
-    if (!file) {
-      return;
-    }
-
-    setSaving(true);
-    const response = await api.skills.upload.post({
-      file,
-      scope,
-      queryKey: ["skills"],
-    });
-    setSaving(false);
-
-    if (response.error) {
+  const uploadSkill = useMutation({
+    mutationFn: async (payload: { file: File; scope: SkillScope }) => {
+      const response = await api.skills.upload.post({
+        file: payload.file,
+        scope: payload.scope,
+        queryKey: ["skills"],
+      });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      onChanged();
+      setFile(null);
+      onOpenChange(false);
+    },
+    onError: (error) => {
       const fallback = t("common.unexpectedError");
       stellaToast.add({
         title: fallback,
-        description:
-          typeof response.error.status === "number"
-            ? userErrorMessage(response.error, fallback)
-            : fallback,
+        description: userErrorFromThrown(error, fallback),
         type: "error",
       });
+    },
+  });
+
+  const submit = () => {
+    if (!file) {
       return;
     }
-
-    onChanged();
-    setFile(null);
-    onOpenChange(false);
+    uploadSkill.mutate({ file, scope });
   };
 
   return (
@@ -544,9 +554,9 @@ function UploadSkillDialog({
             {t("common.cancel")}
           </DialogClose>
           <Button
-            disabled={!file || saving}
+            disabled={!file || uploadSkill.isPending}
             onClick={() => {
-              void submit();
+              submit();
             }}
           >
             <DownloadIcon className="me-1.5 size-4" />
@@ -568,36 +578,39 @@ function ImportSkillDialog({
   const tSkills = useTranslations("knowledge.agentSkills");
   const [url, setUrl] = useState("");
   const [scope, setScope] = useState<SkillScope>("private");
-  const [saving, setSaving] = useState(false);
 
-  const submit = async () => {
-    if (!url.trim()) {
-      return;
-    }
-
-    setSaving(true);
-    const response = await api.skills["import-url"].post({
-      scope,
-      url: url.trim(),
-      queryKey: ["skills"],
-    });
-    setSaving(false);
-
-    if (response.error) {
+  const importSkill = useMutation({
+    mutationFn: async (payload: { url: string; scope: SkillScope }) => {
+      const response = await api.skills["import-url"].post({
+        scope: payload.scope,
+        url: payload.url,
+        queryKey: ["skills"],
+      });
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      onChanged();
+      onOpenChange(false);
+    },
+    onError: (error) => {
       const fallback = t("common.unexpectedError");
       stellaToast.add({
         title: fallback,
-        description:
-          typeof response.error.status === "number"
-            ? userErrorMessage(response.error, fallback)
-            : fallback,
+        description: userErrorFromThrown(error, fallback),
         type: "error",
       });
+    },
+  });
+
+  const submit = () => {
+    const trimmed = url.trim();
+    if (!trimmed) {
       return;
     }
-
-    onChanged();
-    onOpenChange(false);
+    importSkill.mutate({ url: trimmed, scope });
   };
 
   return (
@@ -626,9 +639,9 @@ function ImportSkillDialog({
             {t("common.cancel")}
           </DialogClose>
           <Button
-            disabled={!url.trim() || saving}
+            disabled={!url.trim() || importSkill.isPending}
             onClick={() => {
-              void submit();
+              submit();
             }}
           >
             <GlobeIcon className="me-1.5 size-4" />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
@@ -31,6 +31,8 @@ import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-
 import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 
+const BBOX_POLL_INTERVAL_MS = 1000;
+
 export const DocumentAiSourceBar = ({
   activeTab,
   fieldId,
@@ -164,25 +166,22 @@ export const DocumentAiSourceBar = ({
     setIsAnswerExpanded(false);
   }, [fieldId]);
 
-  // While the mutation is in flight, nudge the justifications cache
-  // every second so the bbox payload appears as soon as the backend
-  // finishes processing.
-  // queryClient is stable across renders so it is safe to omit from
-  // the queryKey here.
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps
-  useQuery({
-    queryKey: ["bounding-boxes-poll", workspaceId, justificationId],
-    queryFn: async () => {
-      await queryClient.invalidateQueries({
+  // Nudge the justifications cache every second while we still need
+  // bboxes. POST success doesn't guarantee the payload is in cache
+  // yet, so we keep polling until `needsBoxes` flips false.
+  useEffect(() => {
+    if (!needsBoxes) {
+      return undefined;
+    }
+    const id = window.setInterval(() => {
+      void queryClient.invalidateQueries({
         queryKey: workspaceKeys.justifications(workspaceId),
       });
-      return Date.now();
-    },
-    enabled: isGeneratingBoxes,
-    refetchInterval: isGeneratingBoxes ? 1000 : false,
-    staleTime: 0,
-    gcTime: 0,
-  });
+    }, BBOX_POLL_INTERVAL_MS);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [needsBoxes, queryClient, workspaceId]);
 
   const scrolledForJustificationRef = useRef<string | null>(null);
   useEffect(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
@@ -1,11 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -50,10 +45,10 @@ export const DocumentAiSourceBar = ({
   const t = useTranslations();
   const openFile = useInspectorStore((s) => s.openFile);
 
-  const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
-  const { data: entity } = useSuspenseQuery(
-    entityOptions(workspaceId, activeTab.entityId),
-  );
+  const propertiesQuery = useQuery(propertiesOptions(workspaceId));
+  const properties = propertiesQuery.data;
+  const entityQuery = useQuery(entityOptions(workspaceId, activeTab.entityId));
+  const entity = entityQuery.data;
   useSyncJustifications({
     workspaceId,
     entityIds: [activeTab.entityId],
@@ -64,7 +59,7 @@ export const DocumentAiSourceBar = ({
   );
 
   const slots = useMemo(() => {
-    if (!justification) {
+    if (!justification || !entity || !properties) {
       return [];
     }
     return Object.values(entity.fields)
@@ -251,7 +246,7 @@ export const DocumentAiSourceBar = ({
     setActiveJustification,
   ]);
 
-  if (!justification) {
+  if (!justification || !entity || !properties) {
     return null;
   }
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
@@ -1,6 +1,11 @@
-import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -16,6 +21,7 @@ import { api } from "@/lib/api";
 import type { Citation } from "@/lib/citations";
 import { iterateJustificationCitations } from "@/lib/citations";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
+import { toAPIError } from "@/lib/errors";
 import {
   getPDFPageIdByNumber,
   useOptionalPDFStore,
@@ -88,7 +94,6 @@ export const DocumentAiSourceBar = ({
   // Eagerly generate bboxes when the justification bar mounts.
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
-  const [isGeneratingBoxes, setIsGeneratingBoxes] = useState(false);
   const setScrollTo = useOptionalPDFStore((s) => s.setScrollTo);
   const pages = useOptionalPDFStore((s) => s.pages);
 
@@ -117,81 +122,82 @@ export const DocumentAiSourceBar = ({
     (citation) => citation.kind === "pdf-bates",
   );
 
-  useEffect(() => {
-    if (
-      !justificationId ||
-      !isActiveTab ||
-      !hasBoundingBoxCitations ||
-      boundingBoxes
-    ) {
-      return undefined;
-    }
+  const generateBoundingBoxes = useMutation({
+    mutationFn: async ({
+      justificationId: id,
+    }: {
+      justificationId: string;
+    }) => {
+      const response = await api
+        .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        ["bounding-boxes"].post({
+          justificationId: toSafeId<"justification">(id),
+          queryKey: workspaceKeys.justifications(workspaceId),
+        });
 
-    const requestState = { cancelled: false };
-    setIsGeneratingBoxes(true);
-
-    void (async () => {
-      try {
-        const response = await api
-          .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
-          ["bounding-boxes"].post({
-            justificationId: toSafeId<"justification">(justificationId),
-            queryKey: workspaceKeys.justifications(workspaceId),
-          });
-
-        if (requestState.cancelled) {
-          return;
-        }
-
-        if (!response.error) {
-          await queryClient.invalidateQueries({
-            queryKey: workspaceKeys.justifications(workspaceId),
-          });
-        }
-      } catch (error) {
-        if (!requestState.cancelled) {
-          analytics.captureError(error);
-        }
-      } finally {
-        if (!requestState.cancelled) {
-          setIsGeneratingBoxes(false);
-        }
+      if (response.error) {
+        throw toAPIError(response.error);
       }
-    })();
+      return response.data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: workspaceKeys.justifications(workspaceId),
+      });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+    },
+  });
 
-    return () => {
-      requestState.cancelled = true;
-    };
-  }, [
-    justificationId,
-    hasBoundingBoxCitations,
-    boundingBoxes,
-    isActiveTab,
-    workspaceId,
-    queryClient,
-    analytics,
-  ]);
+  const needsBoxes = Boolean(
+    justificationId && isActiveTab && hasBoundingBoxCitations && !boundingBoxes,
+  );
+  const isGeneratingBoxes = generateBoundingBoxes.isPending;
+  const mutateBoundingBoxes = generateBoundingBoxes.mutate;
+  // Kick off the generation request when the justification bar
+  // mounts with missing bboxes. The mutation hook itself is the
+  // source of truth for `isPending`.
+  useEffect(() => {
+    if (!needsBoxes || !justificationId) {
+      return;
+    }
+    mutateBoundingBoxes({ justificationId });
+  }, [needsBoxes, justificationId, mutateBoundingBoxes]);
 
   useEffect(() => {
     setIsAnswerExpanded(false);
   }, [fieldId]);
 
-  useEffect(() => {
-    if (!isGeneratingBoxes) {
-      return undefined;
-    }
-
-    const interval = window.setInterval(() => {
-      void queryClient.invalidateQueries({
+  // While the mutation is in flight, nudge the justifications cache
+  // every second so the bbox payload appears as soon as the backend
+  // finishes processing.
+  // queryClient is stable across renders so it is safe to omit from
+  // the queryKey here.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+  useQuery({
+    queryKey: ["bounding-boxes-poll", workspaceId, justificationId],
+    queryFn: async () => {
+      await queryClient.invalidateQueries({
         queryKey: workspaceKeys.justifications(workspaceId),
       });
-    }, 1000);
+      return Date.now();
+    },
+    enabled: isGeneratingBoxes,
+    refetchInterval: isGeneratingBoxes ? 1000 : false,
+    staleTime: 0,
+    gcTime: 0,
+  });
 
-    return () => window.clearInterval(interval);
-  }, [isGeneratingBoxes, queryClient, workspaceId]);
-
+  const scrolledForJustificationRef = useRef<string | null>(null);
   useEffect(() => {
     if (!boundingBoxes || !isActiveTab || !pages || !setScrollTo) {
+      return;
+    }
+    if (!justificationId) {
+      return;
+    }
+    if (scrolledForJustificationRef.current === justificationId) {
       return;
     }
 
@@ -208,7 +214,8 @@ export const DocumentAiSourceBar = ({
       pages,
       pageNumber: firstBox.pageNumber,
     });
-    if (pageId && justificationId) {
+    if (pageId) {
+      scrolledForJustificationRef.current = justificationId;
       setScrollTo({
         pageId,
         target: { kind: "justification", id: justificationId },

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/document-ai-source-bar.tsx
@@ -93,6 +93,10 @@ export const DocumentAiSourceBar = ({
   const analytics = useAnalytics();
   const setScrollTo = useOptionalPDFStore((s) => s.setScrollTo);
   const pages = useOptionalPDFStore((s) => s.pages);
+  const [
+    stoppedBoundingBoxJustificationId,
+    setStoppedBoundingBoxJustificationId,
+  ] = useState<string | null>(null);
 
   const justificationId = justification?.id;
   const boundingBoxes = justification?.boundingBoxes;
@@ -137,18 +141,27 @@ export const DocumentAiSourceBar = ({
       }
       return response.data;
     },
-    onSuccess: async () => {
+    onSuccess: async (data, variables) => {
       await queryClient.invalidateQueries({
         queryKey: workspaceKeys.justifications(workspaceId),
       });
+
+      if (data.boxes.length === 0) {
+        setStoppedBoundingBoxJustificationId(variables.justificationId);
+      }
     },
-    onError: (error) => {
+    onError: (error, variables) => {
       analytics.captureError(error);
+      setStoppedBoundingBoxJustificationId(variables.justificationId);
     },
   });
 
   const needsBoxes = Boolean(
-    justificationId && isActiveTab && hasBoundingBoxCitations && !boundingBoxes,
+    justificationId &&
+    isActiveTab &&
+    hasBoundingBoxCitations &&
+    !boundingBoxes &&
+    stoppedBoundingBoxJustificationId !== justificationId,
   );
   const isGeneratingBoxes = generateBoundingBoxes.isPending;
   const mutateBoundingBoxes = generateBoundingBoxes.mutate;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/entity-metadata-panel.tsx
@@ -8,11 +8,7 @@ import {
   useTransition,
 } from "react";
 
-import {
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
 
@@ -73,6 +69,8 @@ type FieldInfoRow = {
   content: EntityField["content"] | undefined;
 };
 
+const EMPTY_PROPERTIES: WorkspaceProperty[] = [];
+
 export const EntityMetadataPanel = ({
   workspaceId,
   entityId,
@@ -81,15 +79,17 @@ export const EntityMetadataPanel = ({
   activeJustificationFieldId = null,
   onAiFieldClick,
 }: EntityMetadataPanelProps) => {
-  const { data: entity } = useSuspenseQuery(
-    entityOptions(workspaceId, entityId),
-  );
+  const entityQuery = useQuery(entityOptions(workspaceId, entityId));
+
+  if (entityQuery.isError || !entityQuery.data) {
+    return null;
+  }
 
   return (
     <EntityMetadataContent
       activeJustificationFieldId={activeJustificationFieldId}
       currentFilePropertyId={currentFilePropertyId}
-      entity={entity}
+      entity={entityQuery.data}
       entityId={entityId}
       fileFieldId={fileFieldId}
       onAiFieldClick={onAiFieldClick}
@@ -111,7 +111,8 @@ const EntityMetadataContent = ({
   const queryClient = useQueryClient();
   const isWorkflowRunning = useIsWorkflowRunning(workspaceId);
   const sawWorkflowRunning = useRef(false);
-  const { data: properties } = useSuspenseQuery(propertiesOptions(workspaceId));
+  const propertiesQuery = useQuery(propertiesOptions(workspaceId));
+  const properties = propertiesQuery.data ?? EMPTY_PROPERTIES;
   // Version metadata renders in shared chrome (sidepeek + fullscreen);
   // use a non-suspending query so a cache miss does not collapse the
   // surrounding layout.
@@ -190,6 +191,13 @@ const EntityMetadataContent = ({
         : prev.filter((id) => !arrivedIds.has(id)),
     );
   }, [entityFieldPropertyIdsKey]);
+
+  if (propertiesQuery.isError) {
+    return null;
+  }
+  if (propertiesQuery.data === undefined) {
+    return null;
+  }
 
   const serverPropertyIds = new Set(properties.map((property) => property.id));
   const optimisticOnlyProperties = optimisticProperties.filter(

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
@@ -406,6 +406,8 @@ type ExternalPdfState =
     }
   | { status: "ready"; buffer: ArrayBuffer; token: string };
 
+type ExternalPdfPayload = { buffer: ArrayBuffer; token: string };
+
 const useExternalPdfBuffer = ({
   enabled,
   url,
@@ -413,54 +415,55 @@ const useExternalPdfBuffer = ({
   enabled: boolean;
   url?: string | undefined;
 }): ExternalPdfState => {
-  const [state, setState] = useState<ExternalPdfState>({ status: "idle" });
-
-  useEffect(() => {
-    if (!enabled || url === undefined) {
-      setState({ status: "idle" });
-      return undefined;
-    }
-
-    setState({ status: "loading" });
-    const controller = new AbortController();
-    const isAborted = () => controller.signal.aborted;
-
-    void (async () => {
-      const response = await fetch(url, {
+  const query = useQuery({
+    queryKey: ["external-pdf", url],
+    queryFn: async ({ signal }): Promise<ExternalPdfPayload> => {
+      // SAFETY: `enabled` below guarantees `url` is defined when the
+      // queryFn runs.
+      // eslint-disable-next-line typescript/no-non-null-assertion
+      const response = await fetch(url!, {
         credentials: "include",
-        signal: controller.signal,
+        signal,
       });
 
-      if (!response.ok || isAborted()) {
-        if (!isAborted()) {
-          setState({ status: "error" });
-        }
-        return;
+      if (!response.ok) {
+        throw new Error(
+          `External PDF fetch failed: ${String(response.status)}`,
+        );
       }
 
-      const next = await response.arrayBuffer();
-      if (isAborted()) {
-        return;
-      }
-
+      const buffer = await response.arrayBuffer();
       // The PDF document cache (`usePDFDocument`) keys only by
       // `fileId` and ignores the buffer, so a same-URL refetch with
       // new bytes would otherwise return the stale parsed document.
-      // The token rotates per buffer fetch and is folded into the
+      // The token rotates per fresh fetch and is folded into the
       // `fileId` so each new buffer parses from scratch.
-      setState({ status: "ready", buffer: next, token: crypto.randomUUID() });
-    })().catch(() => {
-      if (!isAborted()) {
-        setState({ status: "error" });
-      }
-    });
+      return { buffer, token: crypto.randomUUID() };
+    },
+    enabled: enabled && url !== undefined,
+    // Large binaries — keep them cached for the session so toggling
+    // tabs doesn't trigger a re-download.
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+    retry: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
 
-    return () => {
-      controller.abort();
-    };
-  }, [enabled, url]);
-
-  return state;
+  if (!enabled || url === undefined) {
+    return { status: "idle" };
+  }
+  if (query.isError) {
+    return { status: "error" };
+  }
+  if (query.data === undefined) {
+    return { status: "loading" };
+  }
+  return {
+    status: "ready",
+    buffer: query.data.buffer,
+    token: query.data.token,
+  };
 };
 
 const externalPdfSuspenseFallback = (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -57,9 +57,12 @@ export const MatterMetadataPanel = ({
     null,
   );
   const [nameValue, setNameValue] = useState("");
+  const [nameDirty, setNameDirty] = useState(false);
   const escapedNameRef = useRef(false);
   const [referenceValue, setReferenceValue] = useState("");
+  const [referenceDirty, setReferenceDirty] = useState(false);
   const [referenceError, setReferenceError] = useState("");
+  const seededWorkspaceIdRef = useRef<string | null>(null);
 
   const workspaceQuery = useQuery(workspaceOptions(workspaceId));
   const workspace = workspaceQuery.data;
@@ -73,11 +76,25 @@ export const MatterMetadataPanel = ({
     if (!workspace) {
       return;
     }
-    escapedNameRef.current = false;
-    setNameValue(workspace.name);
-    setReferenceValue(workspace.reference);
-    setReferenceError("");
-  }, [workspace]);
+    if (seededWorkspaceIdRef.current !== workspaceId) {
+      seededWorkspaceIdRef.current = workspaceId;
+      escapedNameRef.current = false;
+      setNameDirty(false);
+      setReferenceDirty(false);
+      setNameValue(workspace.name);
+      setReferenceValue(workspace.reference);
+      setReferenceError("");
+      return;
+    }
+
+    if (!nameDirty) {
+      setNameValue(workspace.name);
+    }
+    if (!referenceDirty) {
+      setReferenceValue(workspace.reference);
+      setReferenceError("");
+    }
+  }, [nameDirty, referenceDirty, workspace, workspaceId]);
 
   const handleSaveName = () => {
     if (!workspace) {
@@ -86,12 +103,14 @@ export const MatterMetadataPanel = ({
     if (escapedNameRef.current) {
       escapedNameRef.current = false;
       setNameValue(workspace.name);
+      setNameDirty(false);
       return;
     }
 
     const trimmed = nameValue.trim();
     if (!trimmed || trimmed === workspace.name) {
       setNameValue(workspace.name);
+      setNameDirty(false);
       return;
     }
 
@@ -102,6 +121,9 @@ export const MatterMetadataPanel = ({
         name: trimmed,
       },
       {
+        onSuccess: () => {
+          setNameDirty(false);
+        },
         onError: (error) => {
           const message =
             APIError.is(error) && error.status < 500
@@ -109,6 +131,7 @@ export const MatterMetadataPanel = ({
               : t("errors.actionFailed");
           stellaToast.add({ title: message, type: "error" });
           setNameValue(fallbackName);
+          setNameDirty(false);
         },
       },
     );
@@ -120,6 +143,8 @@ export const MatterMetadataPanel = ({
     }
     const trimmed = referenceValue.trim();
     if (!trimmed || trimmed === workspace.reference) {
+      setReferenceValue(workspace.reference);
+      setReferenceDirty(false);
       return;
     }
 
@@ -132,6 +157,7 @@ export const MatterMetadataPanel = ({
       },
       {
         onSuccess: () => {
+          setReferenceDirty(false);
           // eslint-disable-next-line typescript/no-floating-promises
           queryClient.invalidateQueries({
             queryKey: workspacesKeys.byId(workspaceId),
@@ -148,6 +174,7 @@ export const MatterMetadataPanel = ({
               ? error.message
               : t("errors.actionFailed");
           stellaToast.add({ title: message, type: "error" });
+          setReferenceDirty(false);
         },
       },
     );
@@ -250,7 +277,10 @@ export const MatterMetadataPanel = ({
             className="rounded-md shadow-none"
             disabled={updateWorkspace.isPending}
             onBlur={handleSaveName}
-            onChange={(e) => setNameValue(e.target.value)}
+            onChange={(e) => {
+              setNameDirty(true);
+              setNameValue(e.target.value);
+            }}
             onKeyDown={(e) => {
               if (e.key === "Enter") {
                 e.currentTarget.blur();
@@ -280,6 +310,7 @@ export const MatterMetadataPanel = ({
               className="w-36 shrink-0 rounded-md shadow-none"
               onBlur={handleSaveReference}
               onChange={(e) => {
+                setReferenceDirty(true);
                 setReferenceValue(e.target.value);
                 setReferenceError("");
               }}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/matter-metadata-sheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { CopyIcon, CopyPlusIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -61,7 +61,8 @@ export const MatterMetadataPanel = ({
   const [referenceValue, setReferenceValue] = useState("");
   const [referenceError, setReferenceError] = useState("");
 
-  const { data: workspace } = useSuspenseQuery(workspaceOptions(workspaceId));
+  const workspaceQuery = useQuery(workspaceOptions(workspaceId));
+  const workspace = workspaceQuery.data;
   const deleteWorkspace = useDeleteWorkspace();
   const duplicateWorkspace = useDuplicateWorkspace();
   const canCreateWorkspace = usePermissions({ workspace: ["create"] });
@@ -69,13 +70,19 @@ export const MatterMetadataPanel = ({
   const updateWorkspace = useUpdateWorkspace();
 
   useEffect(() => {
+    if (!workspace) {
+      return;
+    }
     escapedNameRef.current = false;
     setNameValue(workspace.name);
     setReferenceValue(workspace.reference);
     setReferenceError("");
-  }, [workspace.name, workspace.reference]);
+  }, [workspace]);
 
   const handleSaveName = () => {
+    if (!workspace) {
+      return;
+    }
     if (escapedNameRef.current) {
       escapedNameRef.current = false;
       setNameValue(workspace.name);
@@ -88,6 +95,7 @@ export const MatterMetadataPanel = ({
       return;
     }
 
+    const fallbackName = workspace.name;
     updateWorkspace.mutate(
       {
         workspaceId,
@@ -100,13 +108,16 @@ export const MatterMetadataPanel = ({
               ? error.message
               : t("errors.actionFailed");
           stellaToast.add({ title: message, type: "error" });
-          setNameValue(workspace.name);
+          setNameValue(fallbackName);
         },
       },
     );
   };
 
   const handleSaveReference = () => {
+    if (!workspace) {
+      return;
+    }
     const trimmed = referenceValue.trim();
     if (!trimmed || trimmed === workspace.reference) {
       return;
@@ -217,6 +228,10 @@ export const MatterMetadataPanel = ({
       },
     );
   };
+
+  if (workspaceQuery.isError || !workspace) {
+    return null;
+  }
 
   return (
     <>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/members-section.tsx
@@ -1,12 +1,7 @@
 import { useState } from "react";
 import type { ComponentProps } from "react";
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { PlusIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -232,7 +227,8 @@ export const AddMemberDialog = ({
   const t = useTranslations();
   const queryClient = useQueryClient();
   const addMember = useAddWorkspaceMember();
-  const { data: org } = useSuspenseQuery(organizationOptions);
+  const orgQuery = useQuery(organizationOptions);
+  const org = orgQuery.data;
   const { data: existingMembers = [] } = useQuery(
     workspaceMembersOptions(workspaceId),
   );
@@ -240,9 +236,8 @@ export const AddMemberDialog = ({
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
 
   const existingUserIds = new Set(existingMembers.map((m) => m.userId));
-  const availableMembers = org.members.filter(
-    (m) => !existingUserIds.has(m.userId),
-  );
+  const availableMembers =
+    org?.members.filter((m) => !existingUserIds.has(m.userId)) ?? [];
 
   const memberItems = availableMembers.map((m) => ({
     email: m.user.email,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/parties-section.tsx
@@ -1,11 +1,6 @@
 import { useState } from "react";
 
-import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  useSuspenseQuery,
-} from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import {
   BuildingIcon,
@@ -71,7 +66,8 @@ type PartiesSectionProps = {
 export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
-  const { data: workspace } = useSuspenseQuery(workspaceOptions(workspaceId));
+  const workspaceQuery = useQuery(workspaceOptions(workspaceId));
+  const workspace = workspaceQuery.data;
   const { data: parties = [] } = useQuery(
     workspaceContactsOptions(workspaceId),
   );
@@ -126,6 +122,10 @@ export const PartiesSection = ({ workspaceId }: PartiesSectionProps) => {
       },
     );
   };
+
+  if (workspaceQuery.isError || !workspace) {
+    return null;
+  }
 
   const { client } = workspace;
   if (!client) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import type { ReactNode, RefObject } from "react";
 
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   AlertTriangleIcon,
   FoldHorizontalIcon,
@@ -108,9 +108,10 @@ const PeekPdfViewerContent = ({
 }: PeekPdfViewerProps) => {
   const isImageOrigin = mimeType?.startsWith("image/") ?? false;
 
-  const { data: file } = useSuspenseQuery(
+  const fileQuery = useQuery(
     fileOptions({ workspaceId, fieldId, purpose: filePurpose }),
   );
+  const file = fileQuery.data;
 
   const renderPageOverlay = useCallback(
     (pageId: string) => (
@@ -126,6 +127,10 @@ const PeekPdfViewerContent = ({
     ),
     [activePropertyId, entityId, fieldId, onPeekNavigate, viewId, workspaceId],
   );
+
+  if (fileQuery.isError || !file) {
+    return null;
+  }
 
   if (file.mimeType === DOCX_MIME) {
     return (


### PR DESCRIPTION
## Summary
- fetch clause detail via `useQuery`
- load external-reference PDF bytes via `useQuery` (Infinity stale/gc, no refetch)
- poll decision analysis via `refetchInterval` (terminal-state stops loop)
- fetch chat mention entities via `useQuery`
- split document-ai-source-bar into `useMutation` (kick off) + polling `useQuery`
- replace ad-hoc saving booleans with `useMutation` (clause-detail/clause-list delete, skills upload/save, template-upload, shortcut-form-dialog save, mcp 3 sites); added `userErrorFromThrown` helper
- use `useQuery` for shared chrome (case-law breadcrumb, use-permissions, entity-metadata-panel, document-ai-source-bar, peek-pdf-viewer, matter-metadata-sheet, parties-section, members-section). `chat-tab-panel.tsx` skipped — needs an outer-fetcher/inner-consumer split first

## Test plan
- [x] typecheck, lint, test (352 pass)
- [ ] clause detail loads + delete works
- [ ] external-reference PDF preview opens
- [ ] decision analysis polls and stops on terminal
- [ ] chat mention drill-down loads workspace entities
- [ ] document AI source bar generation + scroll-to-result
- [ ] saving/deleting flows in skills, template upload, shortcut form, MCP
- [ ] shared chrome (breadcrumb, sidebar/permissions, inspector panels) degrades gracefully on cache miss