### PR TITLE
fix: restore PDF previews without Uint8Array toHex

### DIFF
--- a/apps/web/src/lib/pdf/pdfjs-loader.ts
+++ b/apps/web/src/lib/pdf/pdfjs-loader.ts
@@ -1,6 +1,9 @@
 import type * as PDFJS from "pdfjs-dist";
+
+import "@/lib/pdf/uint8array-to-hex-polyfill";
+
 // eslint-disable-next-line import/default -- Vite ?url import returns the asset URL as default export
-import pdfjsWorkerUrl from "pdfjs-dist/build/pdf.worker.min.mjs?url";
+import pdfjsWorkerUrl from "./pdfjs-worker?worker&url";
 
 let pdfjsInstance: typeof PDFJS | null = null;
 

--- a/apps/web/src/lib/pdf/pdfjs-worker.ts
+++ b/apps/web/src/lib/pdf/pdfjs-worker.ts
@@ -1,0 +1,2 @@
+import "@/lib/pdf/uint8array-to-hex-polyfill";
+import "pdfjs-dist/build/pdf.worker.mjs";

--- a/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.test.ts
+++ b/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { installUint8ArrayToHexPolyfill } from "@/lib/pdf/uint8array-to-hex-polyfill.logic";
+
+const originalToHex = Object.getOwnPropertyDescriptor(
+  Uint8Array.prototype,
+  "toHex",
+);
+
+const restoreToHex = () => {
+  if (originalToHex) {
+    // eslint-disable-next-line no-extend-native -- restore the browser/Bun prototype after testing the missing-API regression.
+    Object.defineProperty(Uint8Array.prototype, "toHex", originalToHex);
+    return;
+  }
+
+  Reflect.deleteProperty(Uint8Array.prototype, "toHex");
+};
+
+describe("PDF.js Uint8Array hex compatibility", () => {
+  afterEach(() => {
+    restoreToHex();
+  });
+
+  test("fills the missing Uint8Array.prototype.toHex API used by PDF.js v5 fingerprints", () => {
+    Reflect.deleteProperty(Uint8Array.prototype, "toHex");
+
+    installUint8ArrayToHexPolyfill();
+
+    expect(new Uint8Array([0, 15, 16, 202, 254, 208, 13, 255]).toHex()).toBe(
+      "000f10cafed00dff",
+    );
+  });
+
+  test("keeps an existing browser implementation", () => {
+    const nativeToHex = function nativeToHex() {
+      return "native";
+    };
+
+    // eslint-disable-next-line no-extend-native -- simulate a browser-provided implementation so the polyfill does not replace it.
+    Object.defineProperty(Uint8Array.prototype, "toHex", {
+      configurable: true,
+      value: nativeToHex,
+      writable: true,
+    });
+
+    installUint8ArrayToHexPolyfill();
+
+    expect(new Uint8Array([1]).toHex()).toBe("native");
+  });
+});

--- a/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.ts
+++ b/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.ts
@@ -1,0 +1,28 @@
+const HEX_BYTE_WIDTH = 2;
+const HEX_RADIX = 16;
+
+export const installUint8ArrayToHexPolyfill = () => {
+  if (typeof Uint8Array.prototype.toHex === "function") {
+    return;
+  }
+
+  // eslint-disable-next-line no-extend-native -- PDF.js v5 calls the platform Uint8Array#toHex API; older browsers need this compatibility shim.
+  Object.defineProperty(Uint8Array.prototype, "toHex", {
+    configurable: true,
+    value: function toHex(this: Uint8Array): string {
+      if (!(this instanceof Uint8Array)) {
+        throw new TypeError(
+          "Uint8Array.prototype.toHex called on incompatible receiver",
+        );
+      }
+
+      const hexBytes: string[] = [];
+      for (const byte of this) {
+        hexBytes.push(byte.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, "0"));
+      }
+
+      return hexBytes.join("");
+    },
+    writable: true,
+  });
+};

--- a/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.ts
+++ b/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.logic.ts
@@ -1,5 +1,8 @@
 const HEX_BYTE_WIDTH = 2;
 const HEX_RADIX = 16;
+const HEX_TABLE = Array.from({ length: 256 }, (_, byte) =>
+  byte.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, "0"),
+);
 
 export const installUint8ArrayToHexPolyfill = () => {
   if (typeof Uint8Array.prototype.toHex === "function") {
@@ -17,8 +20,18 @@ export const installUint8ArrayToHexPolyfill = () => {
       }
 
       const hexBytes: string[] = [];
-      for (const byte of this) {
-        hexBytes.push(byte.toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, "0"));
+      for (let i = 0; i < this.length; i++) {
+        const byte = this[i];
+        if (byte === undefined) {
+          throw new TypeError("Uint8Array byte index out of bounds");
+        }
+
+        const hex = HEX_TABLE[byte];
+        if (hex === undefined) {
+          throw new TypeError("Uint8Array byte value out of bounds");
+        }
+
+        hexBytes.push(hex);
       }
 
       return hexBytes.join("");

--- a/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.ts
+++ b/apps/web/src/lib/pdf/uint8array-to-hex-polyfill.ts
@@ -1,0 +1,3 @@
+import { installUint8ArrayToHexPolyfill } from "@/lib/pdf/uint8array-to-hex-polyfill.logic";
+
+installUint8ArrayToHexPolyfill();


### PR DESCRIPTION
Adds a small Uint8Array#toHex compatibility shim before PDF.js loads, including the PDF.js worker entry, so PDF previews can load in runtimes where the platform API is missing.\n\nIncludes focused regression coverage for the missing API path.