### PR TITLE
chore(web): scope org-level query keys by organization

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -25,6 +25,7 @@ import {
 import type { RefObject } from "react";
 
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { LoaderCircleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { v7 as uuidv7 } from "uuid";
@@ -508,6 +509,8 @@ type FileChatOverlayProps = {
   requestDocxEditMode?: (() => boolean | Promise<boolean>) | undefined;
 };
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const FileChatOverlay = ({
   workspaceId,
   chatThreadId,
@@ -575,6 +578,9 @@ const FileChatOverlayInner = ({
   onNewThread,
 }: FileChatOverlayInnerProps) => {
   const t = useTranslations();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const userContext = useChatUserContext();
   const getUserContext = useEffectEvent(() => userContext);
   const lastSentDocxEditSnapshotRef = useRef<FolioAIEditSnapshot | null>(null);
@@ -713,6 +719,7 @@ const FileChatOverlayInner = ({
 
   const { data } = useSuspenseQuery(
     chatThreadOptions({
+      activeOrganizationId,
       key: threadRef,
       context: {
         allowMissingThread: true,
@@ -890,6 +897,7 @@ const FileChatOverlayInner = ({
             style={{ scrollbarGutter: "stable" }}
           >
             <ChatThreadMessages
+              activeOrganizationId={activeOrganizationId}
               alwaysApprovedTools={alwaysApprovedTools}
               approvalPendingMessageId={approvalPendingMessageId}
               blockedApprovalTools={blockedApprovalTools}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -627,7 +627,9 @@ export function AppSidebar(props: AppSidebarProps) {
   useEffect(() => {
     initPinned(user.id);
   }, [initPinned, user.id]);
-  const { data: workspacesData } = useQuery(workspacesNavigationOptions);
+  const { data: workspacesData } = useQuery(
+    workspacesNavigationOptions(user.activeOrganizationId),
+  );
   const workspaces = workspacesData?.workspaces;
   const { data: organization } = useQuery(organizationOptions);
 

--- a/apps/web/src/components/breadcrumbs/contact-breadcrumb.tsx
+++ b/apps/web/src/components/breadcrumbs/contact-breadcrumb.tsx
@@ -1,13 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import type { ResolveParams } from "@tanstack/react-router";
 
 import { BreadcrumbLink } from "@/components/breadcrumbs/shared";
 import { contactOptions } from "@/routes/_protected.contacts/-queries";
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const ContactBreadcrumb = ({
   contactId,
 }: ResolveParams<"/contacts/$contactId">) => {
-  const { data: contact } = useQuery(contactOptions(contactId));
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: contact } = useQuery(
+    contactOptions(activeOrganizationId, contactId),
+  );
 
   return (
     <BreadcrumbLink to="/contacts/$contactId">

--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -12,6 +12,7 @@ import type React from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { QueryKey } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import HardBreak from "@tiptap/extension-hard-break";
 import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
@@ -210,6 +211,8 @@ const isSelectionAtStart = ({ selection }: EditorState) =>
 
 const isSelectionAtEnd = ({ doc, selection }: EditorState) =>
   selection.empty && selection.to >= doc.content.size - 1;
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
   const registrationsRef = useRef(new Map<string, RegisteredExtension>());
@@ -470,6 +473,9 @@ export const useChatEditor = ({
   const placeholderRef = useRef(resolvedPlaceholder);
   placeholderRef.current = resolvedPlaceholder;
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const fileInputRef = useRef<HTMLInputElement>(null);
   const submitHandlerRef = useRef<(() => Promise<void>) | null>(null);
   const fileIdCounterRef = useRef(0);
@@ -686,7 +692,9 @@ export const useChatEditor = ({
     }
   });
 
-  const { data: shortcuts = [] } = useQuery(shortcutsOptions());
+  const { data: shortcuts = [] } = useQuery(
+    shortcutsOptions(activeOrganizationId),
+  );
   const allPrompts = useMemo(
     () =>
       shortcuts.map((s) => ({

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 
 import type {
   ChatMentionOption,
@@ -9,6 +10,8 @@ import type {
 import { buildWorkspaceMentionOptions } from "@/components/chat-mention-helpers";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 type MentionProviders = {
   getItems: (categories: MentionCategory[]) => ChatMentionOption[];
@@ -27,7 +30,12 @@ export const ChatMentionProviders = ({
   children: React.ReactNode;
 }) => {
   const queryClient = useQueryClient();
-  const { data: workspacesData } = useQuery(workspacesNavigationOptions);
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: workspacesData } = useQuery(
+    workspacesNavigationOptions(activeOrganizationId),
+  );
   const workspaces = workspacesData?.workspaces;
   // eslint-disable-next-line @tanstack/query/exhaustive-deps -- the query client is an app-scope dependency, not part of this query's cache identity.
   const { data: firstViewIdsByWorkspaceId } = useQuery({

--- a/apps/web/src/components/chat/chat-matter-picker.tsx
+++ b/apps/web/src/components/chat/chat-matter-picker.tsx
@@ -1,6 +1,7 @@
 import { useDeferredValue, useMemo, useRef, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { ChevronDownIcon, LayersIcon, SearchIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -14,6 +15,8 @@ import {
 
 import { resolveMatterColor } from "@/lib/matter-colors";
 import { workspacesNavigationOptions } from "@/routes/_protected.workspaces/-queries";
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 /**
  * Matter context picker rendered in the chat tab header.
@@ -70,7 +73,10 @@ export const ChatMatterPicker = ({
   // Cache hit thanks to chat-mention-providers and the app sidebar
   // — the navigation list is already in flight on any workspace
   // page.
-  const { data } = useQuery(workspacesNavigationOptions);
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data } = useQuery(workspacesNavigationOptions(activeOrganizationId));
   const workspaces = data?.workspaces;
 
   const personalLabel = t("workspaces.parties.personalLabel");

--- a/apps/web/src/components/chat/chat-thread-messages.test.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.test.tsx
@@ -43,6 +43,7 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}
@@ -84,6 +85,7 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}
@@ -127,6 +129,7 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}
@@ -165,6 +168,7 @@ describe("chat thread messages", () => {
 
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}
@@ -195,6 +199,7 @@ describe("chat thread messages", () => {
   test("shows a resendable chat message when the chat runtime errors", () => {
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}
@@ -225,6 +230,7 @@ describe("chat thread messages", () => {
   test("offers a raw-send override when anonymization blocks an attachment", () => {
     const html = renderWithProviders(
       <ChatThreadMessages
+        activeOrganizationId="org_test"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -433,6 +433,7 @@ const getRetryableAssistantMessageId = (
 };
 
 type ChatThreadMessagesProps = {
+  activeOrganizationId: string;
   alwaysApprovedTools: ReadonlySet<ToolApprovalGrant>;
   approvalPendingMessageId: string | null;
   blockedApprovalTools?: ReadonlySet<ApprovalToolName> | undefined;
@@ -491,6 +492,7 @@ type ChatResendOptions = {
 };
 
 export const ChatThreadMessages = ({
+  activeOrganizationId,
   alwaysApprovedTools,
   approvalPendingMessageId,
   blockedApprovalTools,
@@ -538,6 +540,7 @@ export const ChatThreadMessages = ({
             {message.role === "assistant" ? (
               <>
                 <AssistantMessageParts
+                  activeOrganizationId={activeOrganizationId}
                   alwaysApprovedTools={alwaysApprovedTools}
                   blockedApprovalTools={blockedApprovalTools}
                   conversationApprovedTools={conversationApprovedTools}
@@ -558,6 +561,7 @@ export const ChatThreadMessages = ({
                   workspaceId={workspaceId}
                 />
                 <SourceChips
+                  activeOrganizationId={activeOrganizationId}
                   messageId={message.id}
                   parts={message.parts}
                   workspaceId={workspaceId}
@@ -617,6 +621,7 @@ export const ChatThreadMessages = ({
 
 type AssistantMessagePartsProps = Pick<
   ChatThreadMessagesProps,
+  | "activeOrganizationId"
   | "alwaysApprovedTools"
   | "blockedApprovalTools"
   | "conversationApprovedTools"
@@ -645,6 +650,7 @@ type AssistantMessagePartsProps = Pick<
  * remount on every streaming text delta.
  */
 const AssistantMessageParts = ({
+  activeOrganizationId,
   alwaysApprovedTools,
   blockedApprovalTools,
   conversationApprovedTools,
@@ -707,6 +713,7 @@ const AssistantMessageParts = ({
         if (isApprovalPart(part)) {
           return (
             <ToolApprovalCard
+              activeOrganizationId={activeOrganizationId}
               alwaysApprovedTools={alwaysApprovedTools}
               blockedApprovalTools={blockedApprovalTools}
               conversationApprovedTools={conversationApprovedTools}
@@ -724,6 +731,7 @@ const AssistantMessageParts = ({
         if (isToolUIPart(part)) {
           return (
             <ToolCallCard
+              activeOrganizationId={activeOrganizationId}
               key={part.toolCallId}
               part={part}
               showDetails={shouldShowToolCalls}

--- a/apps/web/src/components/chat/source-chips.tsx
+++ b/apps/web/src/components/chat/source-chips.tsx
@@ -37,6 +37,7 @@ type SourceDocumentPart = {
 };
 
 type SourceChipsProps = {
+  activeOrganizationId: string;
   messageId: string;
   parts: ChatMessage["parts"];
   workspaceId?: string | undefined;
@@ -77,6 +78,7 @@ const getMcpToolInfo = (part: ToolPart): McpToolInfo | null => {
 };
 
 export const SourceChips = ({
+  activeOrganizationId,
   messageId,
   parts,
   workspaceId,
@@ -89,7 +91,7 @@ export const SourceChips = ({
     (source) => source.connectorSlug !== undefined,
   );
   const { data: mcpConnectorsData } = useQuery({
-    ...mcpConnectorsOptions(),
+    ...mcpConnectorsOptions(activeOrganizationId),
     enabled: hasMcpExternalSources,
   });
   const uniqueExternalSourcesWithIcons = useMemo(

--- a/apps/web/src/components/chat/tool-approval-card.tsx
+++ b/apps/web/src/components/chat/tool-approval-card.tsx
@@ -282,6 +282,7 @@ const ActiveDocxEditSummary = ({ input }: ActiveDocxEditSummaryProps) => {
 // -- Main card --
 
 type ToolApprovalCardProps = {
+  activeOrganizationId: string;
   alwaysApprovedTools: ReadonlySet<ToolApprovalGrant>;
   part: ApprovalToolPart;
   onAllowInConversation: (
@@ -303,6 +304,7 @@ type ToolApprovalCardProps = {
 };
 
 export const ToolApprovalCard = ({
+  activeOrganizationId,
   alwaysApprovedTools,
   part,
   onAllowInConversation,
@@ -342,7 +344,7 @@ export const ToolApprovalCard = ({
   const label = externalMcpProviderName ?? t(getChatToolTitleKey(name));
   const externalMcpConnectorSlug = getExternalMcpConnectorSlug(name);
   const { data: mcpConnectorsData } = useQuery({
-    ...mcpConnectorsOptions(),
+    ...mcpConnectorsOptions(activeOrganizationId),
     enabled: externalMcpConnectorSlug !== null,
   });
   const mcpIconHref =

--- a/apps/web/src/components/chat/tool-call-card.tsx
+++ b/apps/web/src/components/chat/tool-call-card.tsx
@@ -207,9 +207,11 @@ const resolveIconHref = (item: CatalogItem): string | undefined => {
 };
 
 export const ToolCallCard = ({
+  activeOrganizationId,
   part,
   showDetails,
 }: {
+  activeOrganizationId: string;
   part: ToolPart;
   /** Show expandable raw output (dev mode). */
   showDetails?: boolean;
@@ -220,7 +222,7 @@ export const ToolCallCard = ({
   const hasCatalogEntry =
     mcpToolInfo !== null || NATIVE_TOOL_BRANDS[name] !== undefined;
   const { data: catalogData } = useQuery({
-    ...mcpConnectorsOptions(),
+    ...mcpConnectorsOptions(activeOrganizationId),
     enabled: hasCatalogEntry,
   });
   const catalogEntry = findCatalogEntry({

--- a/apps/web/src/lib/prompts/use-saved-prompts.ts
+++ b/apps/web/src/lib/prompts/use-saved-prompts.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 
 import { shortcutsOptions } from "@/routes/_protected.knowledge/-queries";
 
@@ -8,13 +9,20 @@ import type { ChatPrompt } from "./types";
 
 const MAX_SUGGESTIONS = 4;
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 /**
  * Returns up to 4 of the most recently created shortcuts from the
  * user's saved shortcuts (private + team). Deterministic order avoids
  * the flicker that random sampling causes across stale→fresh refetches.
  */
 export const useSavedPrompts = (): ChatPrompt[] => {
-  const { data: shortcuts = [] } = useQuery(shortcutsOptions());
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: shortcuts = [] } = useQuery(
+    shortcutsOptions(activeOrganizationId),
+  );
 
   return useMemo(
     () =>

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -1,7 +1,7 @@
 import { useEffectEvent, useMemo, useState } from "react";
 
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { getRouteApi, Link, useNavigate } from "@tanstack/react-router";
 import { Maximize2Icon, PlusIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -47,6 +47,8 @@ type ChatThreadPageProps = {
   workspaceId?: string | undefined;
 };
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const ChatThreadPage = ({
   threadRef,
   workspaceId,
@@ -57,6 +59,9 @@ export const ChatThreadPage = ({
   const getUserContext = useEffectEvent(() => userContext);
   const showToolCallDetails = useDevStore((state) => state.showToolCallDetails);
   const prompts = useSavedPrompts();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   // Local copy of the persisted contextMatterIds, seeded from the
   // server and re-seeded whenever the page navigates to a different
@@ -80,6 +85,7 @@ export const ChatThreadPage = ({
 
   const { data } = useSuspenseQuery(
     chatThreadOptions({
+      activeOrganizationId,
       key: threadRef,
       // A thread can be opened (e.g. via "Move to main" from the
       // inspector) before its first message has reached the server,
@@ -230,6 +236,7 @@ export const ChatThreadPage = ({
             </div>
           ) : (
             <ChatThreadMessages
+              activeOrganizationId={activeOrganizationId}
               alwaysApprovedTools={alwaysApprovedTools}
               approvalPendingMessageId={approvalPendingMessageId}
               conversationApprovedTools={conversationApprovedTools}

--- a/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/threads-sheet.tsx
@@ -6,7 +6,12 @@ import {
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import { Link, useMatch, useNavigate } from "@tanstack/react-router";
+import {
+  getRouteApi,
+  Link,
+  useMatch,
+  useNavigate,
+} from "@tanstack/react-router";
 import { MessageSquareIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -39,6 +44,8 @@ type ThreadsSheetProps = {
   triggerVariant?: "section" | "toolbar";
 };
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const ThreadsSheet = ({
   icon,
   label,
@@ -48,6 +55,9 @@ export const ThreadsSheet = ({
   const commonT = useTranslations("common");
   const [isOpen, setIsOpen] = useState(false);
   const triggerLabel = label ?? commonT("history");
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const globalThreadMatch = useMatch({
     from: "/_protected/chat/$threadId",
@@ -76,7 +86,7 @@ export const ThreadsSheet = ({
   })();
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useInfiniteQuery(groupedChatThreadsOptions());
+    useInfiniteQuery(groupedChatThreadsOptions(activeOrganizationId));
   const groupedThreads = useMemo(
     () => mergeGroupedChatThreadPages(data?.pages),
     [data?.pages],
@@ -171,6 +181,9 @@ const DeleteThreadButton = ({
   const t = useTranslations();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const deleteThread = useMutation({
     mutationFn: async ({
@@ -193,7 +206,7 @@ const DeleteThreadButton = ({
     },
     onSettled: async () => {
       await queryClient.invalidateQueries({
-        queryKey: groupedChatThreadsOptions().queryKey,
+        queryKey: groupedChatThreadsOptions(activeOrganizationId).queryKey,
       });
     },
     onError: () => {

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -77,7 +77,7 @@ export const useChatSession = ({
     from: "/_protected",
     select: (ctx) => ctx.user.activeOrganizationId,
   });
-  const { data: mcpCatalog } = useQuery(mcpConnectorsOptions());
+  const { data: mcpCatalog } = useQuery(mcpConnectorsOptions(organizationId));
   const mcpConnectorIdentities =
     mcpCatalog?.connectors ?? EMPTY_MCP_CONNECTOR_IDENTITIES;
   const [conversationApprovedTools, setConversationApprovedTools] = useState(
@@ -187,7 +187,7 @@ export const useChatSession = ({
   );
 
   const { data: workspacesNavigation, isPending: isLoadingMatters } = useQuery(
-    workspacesNavigationOptions,
+    workspacesNavigationOptions(organizationId),
   );
   const createDocumentMatters: readonly NeedsMatterMatter[] = useMemo(
     () =>

--- a/apps/web/src/routes/_protected.chat/-queries.test.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.test.ts
@@ -30,11 +30,13 @@ describe("chatKeys", () => {
       workspaceId: "ws-1",
     } as const;
 
-    expect(chatKeys.thread(base)).toEqual(
-      chatKeys.thread({ ...base, contextKind: "plain" }),
+    expect(chatKeys.thread("org_test", base)).toEqual(
+      chatKeys.thread("org_test", { ...base, contextKind: "plain" }),
     );
-    expect(chatKeys.thread({ ...base, contextKind: "plain" })).not.toEqual(
-      chatKeys.thread({ ...base, contextKind: "active-docx-edit" }),
+    expect(
+      chatKeys.thread("org_test", { ...base, contextKind: "plain" }),
+    ).not.toEqual(
+      chatKeys.thread("org_test", { ...base, contextKind: "active-docx-edit" }),
     );
   });
 });
@@ -44,12 +46,12 @@ describe("matchesChatThreadAcrossScopes", () => {
   const otherThreadId = toChatThreadId("thread-B");
 
   test("matches the global scope's key for the same thread", () => {
-    const key = chatKeys.thread({ scope: "global", threadId });
+    const key = chatKeys.thread("org_test", { scope: "global", threadId });
     expect(matchesChatThreadAcrossScopes(key, threadId)).toBe(true);
   });
 
   test("matches the workspace scope's key for the same thread", () => {
-    const key = chatKeys.thread({
+    const key = chatKeys.thread("org_test", {
       scope: "workspace",
       workspaceId: "ws-1",
       threadId,
@@ -60,13 +62,16 @@ describe("matchesChatThreadAcrossScopes", () => {
   test("rejects keys for other threads", () => {
     expect(
       matchesChatThreadAcrossScopes(
-        chatKeys.thread({ scope: "global", threadId: otherThreadId }),
+        chatKeys.thread("org_test", {
+          scope: "global",
+          threadId: otherThreadId,
+        }),
         threadId,
       ),
     ).toBe(false);
     expect(
       matchesChatThreadAcrossScopes(
-        chatKeys.thread({
+        chatKeys.thread("org_test", {
           scope: "workspace",
           workspaceId: "ws-1",
           threadId: otherThreadId,

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -137,11 +137,17 @@ const getChatRuntimeContextKind = (
 
 export const chatKeys = {
   all: ["chat"],
-  groupedThreads: () => [...chatKeys.all, "threads", "grouped"],
-  thread: (key: ChatThreadQueryKey) =>
+  groupedThreads: (activeOrganizationId: string) => [
+    ...chatKeys.all,
+    activeOrganizationId,
+    "threads",
+    "grouped",
+  ],
+  thread: (activeOrganizationId: string, key: ChatThreadQueryKey) =>
     key.scope === "global"
       ? [
           ...chatKeys.all,
+          activeOrganizationId,
           "thread",
           key.scope,
           key.threadId,
@@ -151,6 +157,7 @@ export const chatKeys = {
         ]
       : [
           ...chatKeys.all,
+          activeOrganizationId,
           "thread",
           key.scope,
           key.workspaceId,
@@ -544,11 +551,19 @@ export type ChatThreadFetched = {
   contextMatterIds: string[];
 };
 
-export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
+export type ChatThreadOptionsArgs = ChatThreadOptionsInput & {
+  activeOrganizationId: string;
+};
+
+export const chatThreadOptions = ({
+  activeOrganizationId,
+  key,
+  context,
+}: ChatThreadOptionsArgs) =>
   queryOptions({
     staleTime: STALE_TIME.FIVETEEN.MINUTES,
     gcTime: STALE_TIME.FIVETEEN.MINUTES,
-    queryKey: chatKeys.thread({
+    queryKey: chatKeys.thread(activeOrganizationId, {
       ...key,
       allowMissingThread: context.allowMissingThread,
       contextKind: getChatRuntimeContextKind(context),
@@ -596,9 +611,9 @@ export const chatThreadOptions = ({ key, context }: ChatThreadOptionsInput) =>
     },
   });
 
-export const groupedChatThreadsOptions = () =>
+export const groupedChatThreadsOptions = (activeOrganizationId: string) =>
   infiniteQueryOptions({
-    queryKey: chatKeys.groupedThreads(),
+    queryKey: chatKeys.groupedThreads(activeOrganizationId),
     queryFn: async ({ pageParam, signal }): Promise<GroupedChatThreadsPage> =>
       await fetchGroupedChatThreads({ cursor: pageParam, signal }),
     initialPageParam: undefined as string | undefined,
@@ -607,7 +622,16 @@ export const groupedChatThreadsOptions = () =>
 
 export const invalidateGroupedChatThreads = async (queryClient: QueryClient) =>
   await queryClient.invalidateQueries({
-    queryKey: chatKeys.groupedThreads(),
+    // Match every cached `["chat", <orgId>, "threads", "grouped"]` entry —
+    // we cannot reconstruct orgId here so we walk by structural shape.
+    predicate: (query) => {
+      const queryKey = query.queryKey;
+      return (
+        queryKey.at(0) === "chat" &&
+        queryKey.at(2) === "threads" &&
+        queryKey.at(3) === "grouped"
+      );
+    },
   });
 
 export const invalidateChatThread = async ({
@@ -622,19 +646,19 @@ export const invalidateChatThread = async ({
       const queryKey = query.queryKey;
       if (
         queryKey.at(0) !== "chat" ||
-        queryKey.at(1) !== "thread" ||
-        queryKey.at(2) !== threadRef.scope
+        queryKey.at(2) !== "thread" ||
+        queryKey.at(3) !== threadRef.scope
       ) {
         return false;
       }
 
       if (threadRef.scope === "global") {
-        return queryKey.at(3) === threadRef.threadId;
+        return queryKey.at(4) === threadRef.threadId;
       }
 
       return (
-        queryKey.at(3) === threadRef.workspaceId &&
-        queryKey.at(4) === threadRef.threadId
+        queryKey.at(4) === threadRef.workspaceId &&
+        queryKey.at(5) === threadRef.threadId
       );
     },
   });
@@ -648,15 +672,18 @@ export const matchesChatThreadAcrossScopes = (
   queryKey: readonly unknown[],
   threadId: ChatThreadId,
 ): boolean => {
-  if (queryKey.at(0) !== "chat" || queryKey.at(1) !== "thread") {
+  if (queryKey.at(0) !== "chat" || queryKey.at(2) !== "thread") {
     return false;
   }
-  const scope = queryKey.at(2);
+  // queryKey.at(1) is the orgId; we accept any value here since
+  // the predicate is used to invalidate the same thread across
+  // surfaces (and orgs) when scope changes.
+  const scope = queryKey.at(3);
   if (scope === "global") {
-    return queryKey.at(3) === threadId;
+    return queryKey.at(4) === threadId;
   }
   if (scope === "workspace") {
-    return queryKey.at(4) === threadId;
+    return queryKey.at(5) === threadId;
   }
   return false;
 };

--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -6,7 +6,12 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useNavigate,
+} from "@tanstack/react-router";
 import {
   HistoryIcon,
   LayersIcon,
@@ -56,6 +61,8 @@ export const Route = createFileRoute("/_protected/chat/")({
   component: ChatIndex,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 function ChatIndex() {
   const t = useTranslations();
   const lang = useI18nStore((s) => s.lang);
@@ -72,10 +79,15 @@ function ChatIndex() {
   const controller = useChatEditor({ threadRef });
   const prompts = useSavedPrompts();
   const pinnedOrder = usePinnedStore((s) => s.pinnedOrder);
-  const { data: workspacesData } = useQuery(workspacesNavigationOptions);
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: workspacesData } = useQuery(
+    workspacesNavigationOptions(activeOrganizationId),
+  );
   const workspaces = workspacesData?.workspaces;
   const { data: groupedThreadPages } = useInfiniteQuery(
-    groupedChatThreadsOptions(),
+    groupedChatThreadsOptions(activeOrganizationId),
   );
   const groupedThreads = useMemo(
     () => mergeGroupedChatThreadPages(groupedThreadPages?.pages),
@@ -228,6 +240,7 @@ function ChatIndex() {
                 const message = await buildChatRequestMessage(draft);
                 const { chat } = await queryClient.ensureQueryData(
                   chatThreadOptions({
+                    activeOrganizationId,
                     key: threadRef,
                     context: {
                       allowMissingThread: true,

--- a/apps/web/src/routes/_protected.contacts/$contactId.tsx
+++ b/apps/web/src/routes/_protected.contacts/$contactId.tsx
@@ -1,7 +1,12 @@
 import { useState } from "react";
 
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useNavigate,
+} from "@tanstack/react-router";
 import { ArrowLeftIcon, BuildingIcon, PlusIcon, UserIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -38,12 +43,19 @@ export const Route = createFileRoute("/_protected/contacts/$contactId")({
   ),
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 function ContactDetailPage() {
   const t = useTranslations();
   const contactId = Route.useParams({ select: (p) => p.contactId });
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { data: contact } = useSuspenseQuery(contactOptions(contactId));
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data: contact } = useSuspenseQuery(
+    contactOptions(activeOrganizationId, contactId),
+  );
   const deleteContact = useDeleteContact();
   const canCreateMatter = usePermissions({ workspace: ["create"] });
   const canDeleteContact = usePermissions({ contact: ["delete"] });

--- a/apps/web/src/routes/_protected.contacts/-components/contact-caches.ts
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-caches.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import type { QueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
@@ -12,21 +13,28 @@ import { useUpdateContact } from "@/routes/_protected.contacts/-mutations";
 import { contactsKeys } from "@/routes/_protected.contacts/-queries";
 import { workspacesKeys } from "@/routes/_protected.workspaces/-queries";
 
-type InvalidateContactCachesOptions = {
+const protectedRouteApi = getRouteApi("/_protected");
+
+type InvalidateContactCachesArgs = {
+  activeOrganizationId: string;
+  contactId: string;
   invalidateWorkspaces?: boolean;
 };
 
 export const invalidateContactCaches = async (
   queryClient: QueryClient,
-  contactId: string,
-  { invalidateWorkspaces = false }: InvalidateContactCachesOptions = {},
+  {
+    activeOrganizationId,
+    contactId,
+    invalidateWorkspaces = false,
+  }: InvalidateContactCachesArgs,
 ) => {
   const promises = [
     queryClient.invalidateQueries({
-      queryKey: contactsKeys.byId(contactId),
+      queryKey: contactsKeys.byId(activeOrganizationId, contactId),
     }),
     queryClient.invalidateQueries({
-      queryKey: contactsKeys.lists(),
+      queryKey: contactsKeys.lists(activeOrganizationId),
     }),
   ];
 
@@ -45,9 +53,15 @@ export const useContactPatch = (contact: ContactData) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const updateContact = useUpdateContact();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const handleSuccess = () => {
-    void invalidateContactCaches(queryClient, contact.id);
+    void invalidateContactCaches(queryClient, {
+      activeOrganizationId,
+      contactId: contact.id,
+    });
   };
 
   const handleError = (onError?: () => void) => {
@@ -71,7 +85,10 @@ export const useContactPatch = (contact: ContactData) => {
   const saveContactPatchAsync = async (patch: ContactPatch) => {
     try {
       await updateContact.mutateAsync({ contactId: contact.id, ...patch });
-      await invalidateContactCaches(queryClient, contact.id);
+      await invalidateContactCaches(queryClient, {
+        activeOrganizationId,
+        contactId: contact.id,
+      });
       return true;
     } catch {
       handleError();

--- a/apps/web/src/routes/_protected.contacts/-components/contact-notes-editor.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-notes-editor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { Textarea } from "@stll/ui/components/textarea";
@@ -10,10 +11,15 @@ import { invalidateContactCaches } from "@/routes/_protected.contacts/-component
 import type { ContactData } from "@/routes/_protected.contacts/-components/types";
 import { useUpdateContact } from "@/routes/_protected.contacts/-mutations";
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const ContactNotesEditor = ({ contact }: { contact: ContactData }) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const updateContact = useUpdateContact();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [draft, setDraft] = useState(contact.notes ?? "");
   const latestServerNotesRef = useRef(contact.notes ?? "");
   const skipNextSaveRef = useRef(false);
@@ -44,7 +50,10 @@ export const ContactNotesEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          void invalidateContactCaches(queryClient, contact.id);
+          void invalidateContactCaches(queryClient, {
+            activeOrganizationId,
+            contactId: contact.id,
+          });
         },
         onError: () => {
           stellaToast.add({

--- a/apps/web/src/routes/_protected.contacts/-components/contact-owners-editor.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/contact-owners-editor.tsx
@@ -1,4 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import {
@@ -18,11 +19,16 @@ import { organizationOptions } from "@/routes/_protected.organization/-queries";
 
 const NO_OWNER_VALUE = "__none";
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
   const updateContact = useUpdateContact();
   const { data: organization } = useQuery(organizationOptions);
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const memberItems = (organization?.members ?? []).map((member) => ({
     email: member.user.email,
@@ -47,7 +53,9 @@ export const ContactOwnersEditor = ({ contact }: { contact: ContactData }) => {
       },
       {
         onSuccess: () => {
-          void invalidateContactCaches(queryClient, contact.id, {
+          void invalidateContactCaches(queryClient, {
+            activeOrganizationId,
+            contactId: contact.id,
             invalidateWorkspaces: field === "responsibleAttorneyId",
           });
         },

--- a/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
+++ b/apps/web/src/routes/_protected.contacts/-components/editable-row.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { Input } from "@stll/ui/components/input";
@@ -12,6 +13,8 @@ import type {
   EditableField,
 } from "@/routes/_protected.contacts/-components/types";
 import { useUpdateContact } from "@/routes/_protected.contacts/-mutations";
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 const FIELD_MAX_LENGTH: Partial<Record<EditableField, number>> = {
   prefix: 32,
@@ -44,6 +47,9 @@ export const EditableRow = ({
   const t = useTranslations();
   const queryClient = useQueryClient();
   const updateContact = useUpdateContact();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(value ?? "");
 
@@ -97,7 +103,9 @@ export const EditableRow = ({
       { contactId: contact.id, ...payload },
       {
         onSuccess: () => {
-          void invalidateContactCaches(queryClient, contact.id, {
+          void invalidateContactCaches(queryClient, {
+            activeOrganizationId,
+            contactId: contact.id,
             invalidateWorkspaces: field === "displayName",
           });
         },

--- a/apps/web/src/routes/_protected.contacts/-queries.ts
+++ b/apps/web/src/routes/_protected.contacts/-queries.ts
@@ -10,28 +10,36 @@ type ContactsListKey = {
 
 export const contactsKeys = {
   all: ["contacts"],
-  lists: () => [...contactsKeys.all, "list"],
-  list: (key?: ContactsListKey) => [
-    ...contactsKeys.lists(),
-    key ? { type: key.type, q: key.q } : undefined,
+  scoped: (activeOrganizationId: string) => [
+    ...contactsKeys.all,
+    activeOrganizationId,
   ],
-  byId: (contactId: string) => [...contactsKeys.all, contactId],
+  lists: (activeOrganizationId: string) => [
+    ...contactsKeys.scoped(activeOrganizationId),
+    "list",
+  ],
+  list: (activeOrganizationId: string, { type, q }: ContactsListKey) => [
+    ...contactsKeys.lists(activeOrganizationId),
+    { type, q },
+  ],
+  byId: (activeOrganizationId: string, contactId: string) => [
+    ...contactsKeys.scoped(activeOrganizationId),
+    contactId,
+  ],
 };
 
-export const contactsOptions = (filters?: {
-  type?: "person" | "organization" | undefined;
-  q?: string | undefined;
-}) =>
+export const contactsOptions = (
+  activeOrganizationId: string,
+  filters: ContactsListKey = {},
+) =>
   queryOptions({
-    queryKey: contactsKeys.list(filters),
+    queryKey: contactsKeys.list(activeOrganizationId, filters),
     queryFn: async ({ signal }) => {
       const response = await api.contacts.get({
         query: {
           limit: 50,
-          ...(filters?.type !== undefined && {
-            type: filters.type,
-          }),
-          ...(filters?.q !== undefined && { q: filters.q }),
+          ...(filters.type !== undefined && { type: filters.type }),
+          ...(filters.q !== undefined && { q: filters.q }),
         },
         fetch: { signal },
       });
@@ -44,9 +52,12 @@ export const contactsOptions = (filters?: {
     },
   });
 
-export const contactOptions = (contactId: string) =>
+export const contactOptions = (
+  activeOrganizationId: string,
+  contactId: string,
+) =>
   queryOptions({
-    queryKey: contactsKeys.byId(contactId),
+    queryKey: contactsKeys.byId(activeOrganizationId, contactId),
     queryFn: async ({ signal }) => {
       const response = await api
         .contacts({ contactId })

--- a/apps/web/src/routes/_protected.contacts/index.tsx
+++ b/apps/web/src/routes/_protected.contacts/index.tsx
@@ -2,7 +2,12 @@ import { useState } from "react";
 
 import { useForm, useStore } from "@tanstack/react-form";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useNavigate,
+} from "@tanstack/react-router";
 import {
   BuildingIcon,
   EllipsisVerticalIcon,
@@ -80,6 +85,8 @@ export const Route = createFileRoute("/_protected/contacts/")({
   component: ContactsPage,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 function ContactsPage() {
   const t = useTranslations();
   const tContacts = useTranslations("contacts");
@@ -94,9 +101,12 @@ function ContactsPage() {
   }, 300);
 
   const typeFilter = filter === "all" ? undefined : filter;
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const { data, isLoading } = useQuery(
-    contactsOptions({
+    contactsOptions(activeOrganizationId, {
       type: typeFilter,
       q: debouncedQuery || undefined,
     }),
@@ -472,12 +482,17 @@ const CreateContactDialog = ({
 }: CreateContactDialogProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [isAresLoading, setIsAresLoading] = useState(false);
   const [aresBillingAddress, setAresBillingAddress] =
     useState<BillingAddress | null>(null);
   const createContact = useCreateContact();
   const schema = createContactSchema(t("common.required"));
-  const { data: mcpCatalog } = useQuery(mcpConnectorsOptions());
+  const { data: mcpCatalog } = useQuery(
+    mcpConnectorsOptions(activeOrganizationId),
+  );
   const isAresEnabled =
     mcpCatalog?.nativeTools.find((tool) => tool.slug === ARES_NATIVE_TOOL_SLUG)
       ?.enabled ?? false;

--- a/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/link-clause-dialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { SearchIcon, TextQuoteIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -39,6 +40,8 @@ type LinkClauseDialogProps = {
 
 // ── Component ────────────────────────────────────────
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const LinkClauseDialog = ({
   open,
   onOpenChange,
@@ -47,6 +50,9 @@ export const LinkClauseDialog = ({
   onLinked,
 }: LinkClauseDialogProps) => {
   const t = useTranslations();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [selectedCategory, setSelectedCategory] = useState("");
   const [search, setSearch] = useState("");
   const [selectedClauseId, setSelectedClauseId] = useState<string | null>(null);
@@ -54,7 +60,7 @@ export const LinkClauseDialog = ({
   const [linking, setLinking] = useState(false);
 
   const { data: catData } = useQuery({
-    ...clauseCategoriesOptions(),
+    ...clauseCategoriesOptions(activeOrganizationId),
     enabled: open,
   });
   const {
@@ -62,7 +68,7 @@ export const LinkClauseDialog = ({
     isLoading: clausesLoading,
     isError: clausesError,
   } = useQuery({
-    ...clausesOptions({ limit: 200 }),
+    ...clausesOptions(activeOrganizationId, { limit: 200 }),
     enabled: open,
   });
 

--- a/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-clauses-tab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import {
   AlertTriangleIcon,
   PlusIcon,
@@ -64,16 +65,21 @@ type TemplateClausesTabProps = {
 
 // ── Component ────────────────────────────────────────
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const TemplateClausesTab = ({
   templateId,
   clauseSlots,
 }: TemplateClausesTabProps) => {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [linkOpen, setLinkOpen] = useState(false);
 
   const { data, isLoading, isError } = useQuery(
-    templateClausesOptions(templateId),
+    templateClausesOptions(activeOrganizationId, templateId),
   );
 
   const links: LinkedClause[] =
@@ -82,12 +88,15 @@ export const TemplateClausesTab = ({
   const invalidateLinks = useCallback(() => {
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.templates.clauses(templateId),
+        queryKey: knowledgeKeys.templates.clauses(
+          activeOrganizationId,
+          templateId,
+        ),
       })
       .catch(() => {
         /* fire-and-forget */
       });
-  }, [queryClient, templateId]);
+  }, [activeOrganizationId, queryClient, templateId]);
 
   if (isLoading) {
     return (

--- a/apps/web/src/routes/_protected.knowledge/-components/template-preview.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-preview.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { AlertTriangleIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -271,11 +272,16 @@ const SectionDivider = ({ label }: { label: string }) => (
 
 // ── Main component ───────────────────────────────────────
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const TemplatePreview = ({ templateId }: { templateId: string }) => {
   const t = useTranslations("templates");
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const { data, isLoading, isError } = useQuery(
-    templatePreviewOptions(templateId),
+    templatePreviewOptions(activeOrganizationId, templateId),
   );
 
   if (isLoading) {

--- a/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/template-versions-tab.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import { DownloadIcon } from "lucide-react";
 import { useFormatter, useTranslations } from "use-intl";
 
@@ -19,17 +20,22 @@ type TemplateVersionsTabProps = {
 
 // ── Component ────────────────────────────────────────
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const TemplateVersionsTab = ({
   templateId,
 }: TemplateVersionsTabProps) => {
   const t = useTranslations();
   const format = useFormatter();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const {
     data: versionsData,
     isLoading,
     isError,
-  } = useQuery(templateVersionsOptions(templateId));
+  } = useQuery(templateVersionsOptions(activeOrganizationId, templateId));
 
   const versions =
     versionsData && "versions" in versionsData ? versionsData.versions : [];

--- a/apps/web/src/routes/_protected.knowledge/-queries.ts
+++ b/apps/web/src/routes/_protected.knowledge/-queries.ts
@@ -22,54 +22,86 @@ type ClausesListKey = {
 
 export const knowledgeKeys = {
   shortcuts: {
-    all: ["shortcuts"] as const,
-    list: () => [...knowledgeKeys.shortcuts.all, "list"] as const,
+    all: (organizationId: string) => ["shortcuts", organizationId],
+    list: (organizationId: string) => [
+      ...knowledgeKeys.shortcuts.all(organizationId),
+      "list",
+    ],
   },
   skills: {
-    all: ["skills"] as const,
-    list: (key: SkillsPageKey) =>
-      [...knowledgeKeys.skills.all, "list", key] as const,
+    all: (organizationId: string) => ["skills", organizationId],
+    list: (organizationId: string, { limit }: SkillsPageKey) => [
+      ...knowledgeKeys.skills.all(organizationId),
+      "list",
+      { limit },
+    ],
   },
   templates: {
-    all: ["templates"] as const,
-    list: (categoryId?: string | null) =>
-      [...knowledgeKeys.templates.all, "list", { categoryId }] as const,
-    detail: (templateId: string) =>
-      [...knowledgeKeys.templates.all, templateId, "detail"] as const,
-    preview: (templateId: string) =>
-      [...knowledgeKeys.templates.all, templateId, "preview"] as const,
-    versions: (templateId: string) =>
-      [...knowledgeKeys.templates.all, templateId, "versions"] as const,
-    clauses: (templateId: string) =>
-      [...knowledgeKeys.templates.all, templateId, "clauses"] as const,
+    all: (organizationId: string) => ["templates", organizationId],
+    list: (organizationId: string, categoryId?: string | null) => [
+      ...knowledgeKeys.templates.all(organizationId),
+      "list",
+      { categoryId: categoryId ?? null },
+    ],
+    detail: (organizationId: string, templateId: string) => [
+      ...knowledgeKeys.templates.all(organizationId),
+      templateId,
+      "detail",
+    ],
+    preview: (organizationId: string, templateId: string) => [
+      ...knowledgeKeys.templates.all(organizationId),
+      templateId,
+      "preview",
+    ],
+    versions: (organizationId: string, templateId: string) => [
+      ...knowledgeKeys.templates.all(organizationId),
+      templateId,
+      "versions",
+    ],
+    clauses: (organizationId: string, templateId: string) => [
+      ...knowledgeKeys.templates.all(organizationId),
+      templateId,
+      "clauses",
+    ],
   },
   templateCategories: {
-    all: ["template-categories"] as const,
+    all: (organizationId: string) => ["template-categories", organizationId],
   },
   clauses: {
-    all: ["clauses"] as const,
-    list: (key: ClausesListKey) =>
-      [
-        ...knowledgeKeys.clauses.all,
-        "list",
-        { categoryId: key.categoryId, search: key.search, limit: key.limit },
-      ] as const,
+    all: (organizationId: string) => ["clauses", organizationId],
+    list: (
+      organizationId: string,
+      { categoryId, search, limit }: ClausesListKey,
+    ) => [
+      ...knowledgeKeys.clauses.all(organizationId),
+      "list",
+      { categoryId: categoryId ?? null, search, limit },
+    ],
   },
   clauseCategories: {
-    all: ["clause-categories"] as const,
+    all: (organizationId: string) => ["clause-categories", organizationId],
   },
   mcp: {
-    all: ["mcp"] as const,
-    connectors: () => [...knowledgeKeys.mcp.all, "connectors"] as const,
-    connections: () => [...knowledgeKeys.mcp.all, "connections"] as const,
+    all: (organizationId: string) => ["mcp", organizationId],
+    connectors: (organizationId: string) => [
+      ...knowledgeKeys.mcp.all(organizationId),
+      "connectors",
+    ],
+    connections: (organizationId: string) => [
+      ...knowledgeKeys.mcp.all(organizationId),
+      "connections",
+    ],
   },
 };
 
 // ── Template queries ────────────────────────────────
 
-export const templatesOptions = (categoryId?: string | null) =>
+export const templatesOptions = (
+  organizationId: string,
+  categoryId?: string | null,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.templates.list(categoryId),
+    queryKey: knowledgeKeys.templates.list(organizationId, categoryId),
     queryFn: async ({ signal }) => {
       const query: {
         categoryId?: SafeId<"templateCategory"> | "uncategorized";
@@ -93,9 +125,12 @@ export const templatesOptions = (categoryId?: string | null) =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const templateDetailOptions = (templateId: string) =>
+export const templateDetailOptions = (
+  organizationId: string,
+  templateId: string,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.templates.detail(templateId),
+    queryKey: knowledgeKeys.templates.detail(organizationId, templateId),
     queryFn: async ({ signal }) => {
       const response = await api
         .templates({ templateId: toSafeId<"template">(templateId) })
@@ -110,9 +145,12 @@ export const templateDetailOptions = (templateId: string) =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const templatePreviewOptions = (templateId: string) =>
+export const templatePreviewOptions = (
+  organizationId: string,
+  templateId: string,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.templates.preview(templateId),
+    queryKey: knowledgeKeys.templates.preview(organizationId, templateId),
     queryFn: async ({ signal }) => {
       const response = await api
         .templates({ templateId: toSafeId<"template">(templateId) })
@@ -127,9 +165,12 @@ export const templatePreviewOptions = (templateId: string) =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const templateVersionsOptions = (templateId: string) =>
+export const templateVersionsOptions = (
+  organizationId: string,
+  templateId: string,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.templates.versions(templateId),
+    queryKey: knowledgeKeys.templates.versions(organizationId, templateId),
     queryFn: async ({ signal }) => {
       const response = await api
         .templates({ templateId: toSafeId<"template">(templateId) })
@@ -144,9 +185,12 @@ export const templateVersionsOptions = (templateId: string) =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const templateClausesOptions = (templateId: string) =>
+export const templateClausesOptions = (
+  organizationId: string,
+  templateId: string,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.templates.clauses(templateId),
+    queryKey: knowledgeKeys.templates.clauses(organizationId, templateId),
     queryFn: async ({ signal }) => {
       const response = await api
         .templates({ templateId: toSafeId<"template">(templateId) })
@@ -163,9 +207,9 @@ export const templateClausesOptions = (templateId: string) =>
 
 // ── Category queries ────────────────────────────────
 
-export const templateCategoriesOptions = () =>
+export const templateCategoriesOptions = (organizationId: string) =>
   queryOptions({
-    queryKey: knowledgeKeys.templateCategories.all,
+    queryKey: knowledgeKeys.templateCategories.all(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api["template-categories"].get({
         fetch: { signal },
@@ -180,9 +224,9 @@ export const templateCategoriesOptions = () =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const clauseCategoriesOptions = () =>
+export const clauseCategoriesOptions = (organizationId: string) =>
   queryOptions({
-    queryKey: knowledgeKeys.clauseCategories.all,
+    queryKey: knowledgeKeys.clauseCategories.all(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api["clause-categories"].get({
         fetch: { signal },
@@ -199,13 +243,12 @@ export const clauseCategoriesOptions = () =>
 
 // ── Clause queries ──────────────────────────────────
 
-export const clausesOptions = (params: {
-  categoryId?: string | null;
-  search?: string;
-  limit?: number;
-}) =>
+export const clausesOptions = (
+  organizationId: string,
+  params: ClausesListKey,
+) =>
   queryOptions({
-    queryKey: knowledgeKeys.clauses.list(params),
+    queryKey: knowledgeKeys.clauses.list(organizationId, params),
     queryFn: async ({ signal }) => {
       const query: {
         categoryId?: SafeId<"clauseCategory">;
@@ -240,9 +283,9 @@ export const clausesOptions = (params: {
 
 // ── Shortcuts queries ────────────────────────────────
 
-export const shortcutsOptions = () =>
+export const shortcutsOptions = (organizationId: string) =>
   queryOptions({
-    queryKey: knowledgeKeys.shortcuts.list(),
+    queryKey: knowledgeKeys.shortcuts.list(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.shortcuts.get({ fetch: { signal } });
       if (response.error) {
@@ -255,9 +298,11 @@ export const shortcutsOptions = () =>
 
 // ── Skills queries ───────────────────────────────────
 
-export const skillsOptions = () =>
+export const skillsOptions = (organizationId: string) =>
   infiniteQueryOptions({
-    queryKey: knowledgeKeys.skills.list({ limit: SKILLS_PAGE_SIZE }),
+    queryKey: knowledgeKeys.skills.list(organizationId, {
+      limit: SKILLS_PAGE_SIZE,
+    }),
     queryFn: async ({ pageParam, signal }) => {
       const response = await api.skills.get({
         query: {
@@ -278,9 +323,9 @@ export const skillsOptions = () =>
 
 // ── MCP queries ─────────────────────────────────────
 
-export const mcpConnectorsOptions = () =>
+export const mcpConnectorsOptions = (organizationId: string) =>
   queryOptions({
-    queryKey: knowledgeKeys.mcp.connectors(),
+    queryKey: knowledgeKeys.mcp.connectors(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.mcp.connectors.get({ fetch: { signal } });
       if (response.error) {
@@ -291,9 +336,9 @@ export const mcpConnectorsOptions = () =>
     staleTime: STALE_TIME.FIVE.MINUTES,
   });
 
-export const mcpConnectionsOptions = () =>
+export const mcpConnectionsOptions = (organizationId: string) =>
   queryOptions({
-    queryKey: knowledgeKeys.mcp.connections(),
+    queryKey: knowledgeKeys.mcp.connections(organizationId),
     queryFn: async ({ signal }) => {
       const response = await api.mcp.connections.get({ fetch: { signal } });
       if (response.error) {

--- a/apps/web/src/routes/_protected.knowledge/clauses.tsx
+++ b/apps/web/src/routes/_protected.knowledge/clauses.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
@@ -51,9 +51,14 @@ export const Route = createFileRoute("/_protected/knowledge/clauses")({
   component: RouteComponent,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 function RouteComponent() {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [view, setView] = useState<View>({ kind: "list" });
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -69,13 +74,15 @@ function RouteComponent() {
   // Abort in-flight load-more requests when filters change.
   const loadMoreAbort = useRef<AbortController | null>(null);
 
-  const { data: categoriesData } = useQuery(clauseCategoriesOptions());
+  const { data: categoriesData } = useQuery(
+    clauseCategoriesOptions(activeOrganizationId),
+  );
   const {
     data: clausesData,
     isLoading,
     isError,
   } = useQuery({
-    ...clausesOptions({
+    ...clausesOptions(activeOrganizationId, {
       categoryId: selectedCategory,
       search: searchQuery,
     }),
@@ -201,19 +208,19 @@ function RouteComponent() {
     setNextCursor(undefined);
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.clauses.all,
+        queryKey: knowledgeKeys.clauses.all(activeOrganizationId),
       })
       .catch(() => {
         /* fire-and-forget */
       });
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.clauseCategories.all,
+        queryKey: knowledgeKeys.clauseCategories.all(activeOrganizationId),
       })
       .catch(() => {
         /* fire-and-forget */
       });
-  }, [queryClient]);
+  }, [queryClient, activeOrganizationId]);
 
   // ── Back to list ───────────────────────────────────
 
@@ -266,7 +273,8 @@ function RouteComponent() {
         onCategoriesChanged={() => {
           queryClient
             .invalidateQueries({
-              queryKey: knowledgeKeys.clauseCategories.all,
+              queryKey:
+                knowledgeKeys.clauseCategories.all(activeOrganizationId),
             })
             .catch(() => {
               /* fire-and-forget */

--- a/apps/web/src/routes/_protected.knowledge/mcp.tsx
+++ b/apps/web/src/routes/_protected.knowledge/mcp.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
   CircleHelpIcon,
   ExternalLinkIcon,
@@ -42,6 +42,8 @@ import {
 export const Route = createFileRoute("/_protected/knowledge/mcp")({
   component: McpPage,
 });
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 type McpConnector = {
   id: string;
@@ -100,11 +102,16 @@ const sortCatalogItems = <
 function McpPage() {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   const { data: connectorsData, isLoading: connectorsLoading } = useQuery(
-    mcpConnectorsOptions(),
+    mcpConnectorsOptions(activeOrganizationId),
   );
-  const { data: connectionsData } = useQuery(mcpConnectionsOptions());
+  const { data: connectionsData } = useQuery(
+    mcpConnectionsOptions(activeOrganizationId),
+  );
 
   const connectors = connectorsData?.connectors ?? [];
   const nativeTools = connectorsData?.nativeTools ?? [];
@@ -121,7 +128,7 @@ function McpPage() {
             type: "success",
           });
           void queryClient.invalidateQueries({
-            queryKey: knowledgeKeys.mcp.all,
+            queryKey: knowledgeKeys.mcp.all(activeOrganizationId),
           });
           return;
         }
@@ -131,7 +138,7 @@ function McpPage() {
           type: "error",
         });
       }),
-    [queryClient, t],
+    [activeOrganizationId, queryClient, t],
   );
 
   return (
@@ -165,7 +172,7 @@ function McpPage() {
             <AddServerCard
               onChanged={() => {
                 void queryClient.invalidateQueries({
-                  queryKey: knowledgeKeys.mcp.all,
+                  queryKey: knowledgeKeys.mcp.all(activeOrganizationId),
                 });
               }}
             />
@@ -176,7 +183,7 @@ function McpPage() {
         nativeTools={sortCatalogItems(nativeTools)}
         onChanged={() => {
           void queryClient.invalidateQueries({
-            queryKey: knowledgeKeys.mcp.all,
+            queryKey: knowledgeKeys.mcp.all(activeOrganizationId),
           });
         }}
         userCanManageCustomConnectors={canManageCustomConnectors}

--- a/apps/web/src/routes/_protected.knowledge/prompts.tsx
+++ b/apps/web/src/routes/_protected.knowledge/prompts.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import { PencilIcon, PlusIcon, TrashIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
@@ -37,6 +37,8 @@ export const Route = createFileRoute("/_protected/knowledge/prompts")({
   component: PromptsPage,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 // ── Types ────────────────────────────────────────────
 
 type ShortcutRow = {
@@ -56,8 +58,13 @@ function PromptsPage() {
   const t = useTranslations();
   const tSkills = useTranslations("knowledge.skills");
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
-  const { data: shortcuts = [], isLoading } = useQuery(shortcutsOptions());
+  const { data: shortcuts = [], isLoading } = useQuery(
+    shortcutsOptions(activeOrganizationId),
+  );
   const { data: role } = useQuery(roleOptions);
 
   const canManageTeam = role === "owner" || role === "admin";
@@ -67,11 +74,11 @@ function PromptsPage() {
     if (!isLoading && shortcuts.length === 0) {
       void api.shortcuts.seed.post({ queryKey: ["shortcuts"] }).then(() => {
         void queryClient.invalidateQueries({
-          queryKey: knowledgeKeys.shortcuts.all,
+          queryKey: knowledgeKeys.shortcuts.all(activeOrganizationId),
         });
       });
     }
-  }, [isLoading, shortcuts.length, queryClient]);
+  }, [activeOrganizationId, isLoading, shortcuts.length, queryClient]);
 
   const [formOpen, setFormOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<ShortcutInitial | undefined>();
@@ -84,7 +91,7 @@ function PromptsPage() {
 
   const invalidate = () => {
     void queryClient.invalidateQueries({
-      queryKey: knowledgeKeys.shortcuts.all,
+      queryKey: knowledgeKeys.shortcuts.all(activeOrganizationId),
     });
   };
 

--- a/apps/web/src/routes/_protected.knowledge/skills.tsx
+++ b/apps/web/src/routes/_protected.knowledge/skills.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
   DownloadIcon,
   FileUpIcon,
@@ -45,6 +45,8 @@ export const Route = createFileRoute("/_protected/knowledge/skills")({
   component: SkillsPage,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 type SkillScope = "team" | "private";
 
 type InstalledSkill = {
@@ -81,8 +83,11 @@ function SkillsPage() {
   const t = useTranslations();
   const tSkills = useTranslations("knowledge.agentSkills");
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery(skillsOptions());
+    useInfiniteQuery(skillsOptions(activeOrganizationId));
 
   const [uploadOpen, setUploadOpen] = useState(false);
   const [importOpen, setImportOpen] = useState(false);
@@ -96,7 +101,9 @@ function SkillsPage() {
   const builtIn = firstPage?.builtIn ?? [];
 
   const invalidate = () => {
-    void queryClient.invalidateQueries({ queryKey: knowledgeKeys.skills.all });
+    void queryClient.invalidateQueries({
+      queryKey: knowledgeKeys.skills.all(activeOrganizationId),
+    });
   };
 
   const teamSkills = installed.filter((skill) => skill.scope === "team");

--- a/apps/web/src/routes/_protected.knowledge/templates.tsx
+++ b/apps/web/src/routes/_protected.knowledge/templates.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, getRouteApi } from "@tanstack/react-router";
 import {
   ArrowLeftIcon,
   CheckCircle2Icon,
@@ -84,9 +84,14 @@ export const Route = createFileRoute("/_protected/knowledge/templates")({
   component: RouteComponent,
 });
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 function RouteComponent() {
   const t = useTranslations();
   const queryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const [view, setView] = useState<View>({ kind: "list" });
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
     null,
@@ -96,8 +101,10 @@ function RouteComponent() {
     data: templatesData,
     isLoading: templatesLoading,
     isError: templatesError,
-  } = useQuery(templatesOptions(selectedCategoryId));
-  const { data: categoriesData } = useQuery(templateCategoriesOptions());
+  } = useQuery(templatesOptions(activeOrganizationId, selectedCategoryId));
+  const { data: categoriesData } = useQuery(
+    templateCategoriesOptions(activeOrganizationId),
+  );
 
   const templates =
     templatesData && "templates" in templatesData
@@ -115,22 +122,22 @@ function RouteComponent() {
   const invalidateTemplates = useCallback(() => {
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.templates.all,
+        queryKey: knowledgeKeys.templates.all(activeOrganizationId),
       })
       .catch(() => {
         /* fire-and-forget */
       });
-  }, [queryClient]);
+  }, [queryClient, activeOrganizationId]);
 
   const invalidateCategories = useCallback(() => {
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.templateCategories.all,
+        queryKey: knowledgeKeys.templateCategories.all(activeOrganizationId),
       })
       .catch(() => {
         /* fire-and-forget */
       });
-  }, [queryClient]);
+  }, [queryClient, activeOrganizationId]);
 
   if (view.kind === "configure") {
     return (
@@ -438,11 +445,15 @@ const TemplateDetail = ({
   const format = useFormatter();
   const queryClient = useQueryClient();
 
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+
   const {
     data: detailData,
     isLoading,
     isError,
-  } = useQuery(templateDetailOptions(template.id));
+  } = useQuery(templateDetailOptions(activeOrganizationId, template.id));
 
   const detail =
     detailData &&
@@ -635,7 +646,10 @@ const TemplateDetail = ({
     // Invalidate the detail query to pick up new manifest
     queryClient
       .invalidateQueries({
-        queryKey: knowledgeKeys.templates.detail(template.id),
+        queryKey: knowledgeKeys.templates.detail(
+          activeOrganizationId,
+          template.id,
+        ),
       })
       .catch(() => {
         /* fire-and-forget */
@@ -647,7 +661,15 @@ const TemplateDetail = ({
       type: "success",
       title: t("templates.fieldsUpdated"),
     });
-  }, [state, detail, fieldEdit, template.id, t, queryClient]);
+  }, [
+    state,
+    detail,
+    fieldEdit,
+    template.id,
+    t,
+    queryClient,
+    activeOrganizationId,
+  ]);
 
   const fields = detail?.manifest?.fields ?? [];
   const fieldCount = detail?.manifest?.fields.length ?? template.fieldCount;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -23,7 +23,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { useNavigate, useRouteContext } from "@tanstack/react-router";
 import { ArrowUpIcon, Maximize2Icon, SquarePenIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/react/shallow";
@@ -136,8 +136,16 @@ export const ChatTabPanel = ({
   );
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const activeOrganizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
-  const moveToMain = buildMaximizeTabAction(tab, { navigate, queryClient });
+  const moveToMain = buildMaximizeTabAction(tab, {
+    activeOrganizationId,
+    navigate,
+    queryClient,
+  });
 
   const threadRef = useMemo<ChatThreadRef>(
     () =>
@@ -163,6 +171,7 @@ export const ChatTabPanel = ({
   // tab; the thread will be created idempotently on the first send.
   const { data } = useSuspenseQuery(
     chatThreadOptions({
+      activeOrganizationId,
       key: threadRef,
       context: {
         allowMissingThread: true,
@@ -300,6 +309,7 @@ export const ChatTabPanel = ({
             />
           ) : (
             <ChatThreadMessages
+              activeOrganizationId={activeOrganizationId}
               alwaysApprovedTools={alwaysApprovedTools}
               approvalPendingMessageId={approvalPendingMessageId}
               conversationApprovedTools={conversationApprovedTools}
@@ -367,7 +377,11 @@ export const ChatTabPanel = ({
 };
 
 const useChatContextLabel = (tab: ChatTab) => {
-  const { data } = useQuery(workspacesNavigationOptions);
+  const activeOrganizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const { data } = useQuery(workspacesNavigationOptions(activeOrganizationId));
   const fallbackLabel = tab.label.trim().length > 0 ? tab.label : "chat";
 
   return useMemo(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/external-reference-panel.tsx
@@ -9,6 +9,7 @@ import {
 import type { RefObject } from "react";
 
 import { useQuery } from "@tanstack/react-query";
+import { getRouteApi } from "@tanstack/react-router";
 import {
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -54,6 +55,8 @@ import { MeasuredPdfProvider } from "@/routes/_protected.workspaces/$workspaceId
 const SERVER_PREVIEW_ERROR_THRESHOLD = 500;
 
 const toastedPreviewFailures = new Set<string>();
+
+const protectedRouteApi = getRouteApi("/_protected");
 
 export type ExternalReferencePanelProps = {
   onClose: () => void;
@@ -568,6 +571,9 @@ export const ExternalReferencePanel = ({
   workspaceId,
 }: ExternalReferencePanelProps) => {
   const t = useTranslations();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const fallbackChatThreadIdRef = useRef(createChatThreadId());
   const safeHref = sanitizeHref(tab.url);
   const [confirmHref, setConfirmHref] = useState<string | undefined>();
@@ -708,7 +714,7 @@ export const ExternalReferencePanel = ({
     highlightKey,
   });
   const { data: mcpConnectorsData } = useQuery({
-    ...mcpConnectorsOptions(),
+    ...mcpConnectorsOptions(activeOrganizationId),
     enabled: connectorSlug !== undefined,
   });
   const iconHref =

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-panel.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useMatch, useNavigate } from "@tanstack/react-router";
+import { getRouteApi, useMatch, useNavigate } from "@tanstack/react-router";
 import { useTranslations } from "use-intl";
 import { useShallow } from "zustand/shallow";
 
@@ -62,9 +62,14 @@ const hasInAppHistoryEntry = (): boolean => {
   return typeof idx === "number" && idx > 0;
 };
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
   const t = useTranslations();
   const canUpdateEntity = usePermissions({ entity: ["update"] });
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const { tabs, activeId } = useInspectorStore(
     useShallow((s) => ({
       tabs: s.tabs,
@@ -380,6 +385,7 @@ export const InspectorPanel = ({ workspaceId }: InspectorPanelProps) => {
     },
     onMaximize: activeTab
       ? buildMaximizeTabAction(activeTab, {
+          activeOrganizationId,
           navigate,
           queryClient: panelQueryClient,
         })

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-rail.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-rail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
+import { getRouteApi, useNavigate } from "@tanstack/react-router";
 import {
   FileTextIcon,
   LayersIcon,
@@ -242,6 +242,8 @@ type VerticalTabProps = {
   onClose: () => void;
 };
 
+const protectedRouteApi = getRouteApi("/_protected");
+
 const VerticalTab = ({
   tab,
   active,
@@ -252,12 +254,15 @@ const VerticalTab = ({
   const tabRef = useRef<HTMLButtonElement>(null);
   const tabNavigate = useNavigate();
   const tabQueryClient = useQueryClient();
+  const activeOrganizationId = protectedRouteApi.useRouteContext({
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
   const externalConnectorSlug =
     tab.type === "external" ? tab.connectorSlug : undefined;
   const storedExternalIconHref =
     tab.type === "external" ? tab.iconHref : undefined;
   const { data: mcpConnectorsData } = useQuery({
-    ...mcpConnectorsOptions(),
+    ...mcpConnectorsOptions(activeOrganizationId),
     enabled:
       externalConnectorSlug !== undefined &&
       storedExternalIconHref === undefined,
@@ -276,6 +281,7 @@ const VerticalTab = ({
     tabId: tab.id,
     onClose,
     onMaximize: buildMaximizeTabAction(tab, {
+      activeOrganizationId,
       navigate: tabNavigate,
       queryClient: tabQueryClient,
     }),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/maximize-tab.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/maximize-tab.ts
@@ -10,6 +10,7 @@ import type { InspectorTab } from "@/routes/_protected.workspaces/$workspaceId/-
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
 
 type MaximizeContext = {
+  activeOrganizationId: string;
   navigate: ReturnType<typeof useNavigate>;
   queryClient: QueryClient;
 };
@@ -29,7 +30,7 @@ type MaximizeContext = {
  */
 export const buildMaximizeTabAction = (
   tab: InspectorTab,
-  { navigate, queryClient }: MaximizeContext,
+  { activeOrganizationId, navigate, queryClient }: MaximizeContext,
 ): (() => void) | undefined => {
   if (tab.type !== "chat") {
     return undefined;
@@ -46,12 +47,12 @@ export const buildMaximizeTabAction = (
     // would respond with an empty `contextMatterIds`.
     const threadKey =
       tabWorkspaceId === undefined
-        ? chatKeys.thread({
+        ? chatKeys.thread(activeOrganizationId, {
             scope: "global",
             threadId: tab.id,
             allowMissingThread: true,
           })
-        : chatKeys.thread({
+        : chatKeys.thread(activeOrganizationId, {
             scope: "workspace",
             threadId: tab.id,
             workspaceId: tabWorkspaceId,

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/invoices.ts
@@ -24,6 +24,11 @@ export const invoicesKeys = {
     ...invoicesKeys.all(workspaceId),
     { limit: key.limit, cursor: key.cursor },
   ],
+  infinite: (workspaceId: string, limit: number) => [
+    ...invoicesKeys.all(workspaceId),
+    "infinite",
+    { limit },
+  ],
   byId: (workspaceId: string, id: string) => [
     ...invoicesKeys.all(workspaceId),
     id,
@@ -38,7 +43,10 @@ export const invoicesOptions = (
     queryKey: invoicesKeys.list(workspaceId, filters),
     queryFn: async ({ signal }) => {
       const response = await api.invoices({ workspaceId }).get({
-        query: filters,
+        query: {
+          ...(filters.limit !== undefined && { limit: filters.limit }),
+          ...(filters.cursor !== undefined && { cursor: filters.cursor }),
+        },
         fetch: { signal },
       });
 
@@ -52,7 +60,7 @@ export const invoicesOptions = (
 
 export const invoicesInfiniteOptions = (workspaceId: string, limit: number) =>
   infiniteQueryOptions({
-    queryKey: [...invoicesKeys.all(workspaceId), "infinite", { limit }],
+    queryKey: invoicesKeys.infinite(workspaceId, limit),
     queryFn: async ({ pageParam, signal }) => {
       const response = await api.invoices({ workspaceId }).get({
         query: {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/tasks.ts
@@ -5,9 +5,11 @@ import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 
 export const taskKeys = {
-  all: (workspaceId: string) => ["tasks", workspaceId] as const,
-  detail: (workspaceId: string, taskId: string) =>
-    ["tasks", workspaceId, taskId] as const,
+  all: (workspaceId: string) => ["tasks", workspaceId],
+  detail: (workspaceId: string, taskId: string) => [
+    ...taskKeys.all(workspaceId),
+    taskId,
+  ],
 };
 
 const getTaskEndpoint = (workspaceId: string, taskId: string) =>

--- a/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.test.ts
@@ -13,7 +13,7 @@ describe("workspace update cache invalidation", () => {
       workspacesKeys.all,
     );
     expect(
-      workspacesKeys.navigation().slice(0, workspacesKeys.all.length),
+      workspacesKeys.navigation("org_test").slice(0, workspacesKeys.all.length),
     ).toEqual(workspacesKeys.all);
   });
 });

--- a/apps/web/src/routes/_protected.workspaces/-mutations.ts
+++ b/apps/web/src/routes/_protected.workspaces/-mutations.ts
@@ -50,10 +50,6 @@ export const useCreateWorkspace = () => {
       queryClient.invalidateQueries({
         queryKey: workspacesKeys.all,
       });
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
-        queryKey: workspacesKeys.navigation(),
-      });
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -140,10 +136,6 @@ export const useUnarchiveWorkspace = () => {
       queryClient.invalidateQueries({
         queryKey: workspacesKeys.all,
       });
-      // eslint-disable-next-line typescript/no-floating-promises
-      queryClient.invalidateQueries({
-        queryKey: workspacesKeys.navigation(),
-      });
     },
     onError: (error) => {
       analytics.captureError(error);
@@ -207,9 +199,6 @@ export const useDuplicateWorkspace = () => {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: workspacesKeys.all });
-      void queryClient.invalidateQueries({
-        queryKey: workspacesKeys.navigation(),
-      });
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/-queries.ts
+++ b/apps/web/src/routes/_protected.workspaces/-queries.ts
@@ -7,9 +7,14 @@ export const workspacesKeys = {
   all: ["workspaces"],
   list: (activeOrganizationId: string) => [
     ...workspacesKeys.all,
+    "list",
     activeOrganizationId,
   ],
-  navigation: () => [...workspacesKeys.all, "navigation"],
+  navigation: (activeOrganizationId: string) => [
+    ...workspacesKeys.all,
+    "navigation",
+    activeOrganizationId,
+  ],
   byId: (workspaceId: string) => [...workspacesKeys.all, workspaceId],
   overview: (workspaceId: string) => [
     ...workspacesKeys.byId(workspaceId),
@@ -39,20 +44,21 @@ export const workspacesOptions = (activeOrganizationId: string) =>
     refetchOnMount: "always",
   });
 
-export const workspacesNavigationOptions = queryOptions({
-  queryKey: workspacesKeys.navigation(),
-  queryFn: async ({ signal }) => {
-    const response = await api.workspaces.navigation.get({
-      fetch: { signal },
-    });
+export const workspacesNavigationOptions = (activeOrganizationId: string) =>
+  queryOptions({
+    queryKey: workspacesKeys.navigation(activeOrganizationId),
+    queryFn: async ({ signal }) => {
+      const response = await api.workspaces.navigation.get({
+        fetch: { signal },
+      });
 
-    if (response.error) {
-      throw toAPIError(response.error);
-    }
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
 
-    return response.data;
-  },
-});
+      return response.data;
+    },
+  });
 
 export const workspaceOptions = (workspaceId: string) =>
   queryOptions({

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -1291,6 +1291,7 @@ function SharedChatRendererSample() {
   return (
     <div className="bg-popover/40 flex flex-col gap-4 rounded-2xl border p-4">
       <ChatThreadMessages
+        activeOrganizationId="playground"
         alwaysApprovedTools={new Set()}
         approvalPendingMessageId={null}
         conversationApprovedTools={new Set()}


### PR DESCRIPTION
## Summary
- Thread `activeOrganizationId` through workspaces navigation, contacts, knowledge (templates/clauses/categories/skills/MCP/shortcuts), and chat key families so React Query cache identity changes when the user switches organisation.
- Tighten workspace-scoped key helpers (expenses, invoices, time-entries) to destructure their filter input and rebuild the key object; compose `taskKeys.detail` by spreading the parent.
- Replace `caseLawDecisionKeys.list`'s `Record<string, unknown>` input with the existing `DecisionListFilters` type.

## Test plan
- [ ] `bun --filter @stll/web typecheck` clean
- [ ] `bun --filter @stll/web lint` clean
- [ ] `bun --filter @stll/web test` green (chat queries + workspace mutations targeted)
- [ ] manual: switch organisations in the sidebar; sidebar / chat threads / knowledge surfaces refetch instead of reusing the previous org's data