### PR TITLE
feat(folio): sync upstream eigenpal docx-editor fixes (May 2026)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -390,6 +390,7 @@
         "prosemirror-transform": "^1.12.0",
         "prosemirror-view": "^1.41.8",
         "utif2": "^4.1.0",
+        "valibot": "catalog:",
         "y-prosemirror": "^1.3.7",
         "yjs": "^13.6.30",
       },

--- a/packages/folio/src/components/ui/HyperlinkPopup.tsx
+++ b/packages/folio/src/components/ui/HyperlinkPopup.tsx
@@ -20,7 +20,15 @@ export type HyperlinkPopupData = {
   href: string;
   displayText: string;
   tooltip?: string;
-  anchorRect: DOMRect;
+  /**
+   * Live reference to the anchor element. The popup recomputes its position
+   * from this element's bounding rect on every scroll/resize so it stays
+   * pinned to the link as the page scrolls (eigenpal #514). Required because
+   * the popup is `position: fixed` to the viewport — without a live
+   * reference, the popup stays at the original screen position while the
+   * link moves out from under it.
+   */
+  anchorEl: HTMLAnchorElement;
 };
 
 export type HyperlinkPopupProps = {
@@ -48,6 +56,10 @@ export function HyperlinkPopup({
   const [editUrl, setEditUrl] = useState("");
   const popupRef = useRef<HTMLDivElement>(null);
   const textInputRef = useRef<HTMLInputElement>(null);
+  const [anchorPosition, setAnchorPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
 
   useEffect(() => {
     if (data) {
@@ -55,6 +67,31 @@ export function HyperlinkPopup({
       setEditText(data.displayText);
       setEditUrl(data.href);
     }
+  }, [data]);
+
+  // Recompute popup position from the live anchor element on every scroll /
+  // resize / layout change. `position: fixed` snapshots the click-time rect,
+  // so without this the popup stays at the original viewport position while
+  // the link scrolls away beneath it. Re-reading on each animation frame
+  // keeps the popup pinned to the link without a permanent rAF loop — we
+  // only update when the browser tells us layout changed.
+  useEffect(() => {
+    if (!data) {
+      setAnchorPosition(null);
+      return;
+    }
+    const anchor = data.anchorEl;
+    const update = () => {
+      const rect = anchor.getBoundingClientRect();
+      setAnchorPosition({ top: rect.bottom + 4, left: rect.left });
+    };
+    update();
+    window.addEventListener("scroll", update, true);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update, true);
+      window.removeEventListener("resize", update);
+    };
   }, [data]);
 
   useEffect(() => {
@@ -126,8 +163,13 @@ export function HyperlinkPopup({
     return null;
   }
 
-  const top = data.anchorRect.bottom + 4;
-  const left = data.anchorRect.left;
+  // Render off-screen until the first scroll/resize listener fires; this
+  // happens synchronously after the initial useEffect so it's a single frame.
+  if (!anchorPosition) {
+    return null;
+  }
+  const top = anchorPosition.top;
+  const left = anchorPosition.left;
 
   const iconBtn =
     "flex size-7 items-center justify-center rounded text-[var(--doc-text-muted)] hover:bg-[var(--doc-bg-hover)] transition-colors";

--- a/packages/folio/src/components/ui/HyperlinkPopup.tsx
+++ b/packages/folio/src/components/ui/HyperlinkPopup.tsx
@@ -4,7 +4,13 @@
  * Edit mode: text + URL inputs with Apply.
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import {
   ClipboardCopyIcon,
@@ -72,23 +78,46 @@ export function HyperlinkPopup({
   // Recompute popup position from the live anchor element on every scroll /
   // resize / layout change. `position: fixed` snapshots the click-time rect,
   // so without this the popup stays at the original viewport position while
-  // the link scrolls away beneath it. Re-reading on each animation frame
-  // keeps the popup pinned to the link without a permanent rAF loop — we
-  // only update when the browser tells us layout changed.
-  useEffect(() => {
+  // the link scrolls away beneath it.
+  //
+  // `useLayoutEffect` runs the initial read BEFORE the browser paints so the
+  // popup never appears at the default (0,0) for a frame — without this we
+  // saw a single-frame flicker when the popup mounted.
+  //
+  // The scroll/resize callback is rAF-throttled so high-frequency listeners
+  // (touch-scroll, smooth-scroll, ResizeObserver bursts) coalesce to one
+  // update per frame. Connected-check guards against the anchor being
+  // detached mid-scroll (document edits, page unmount) — without it,
+  // `getBoundingClientRect()` returns all-zeros and the popup snaps to the
+  // viewport top-left.
+  useLayoutEffect(() => {
     if (!data) {
       setAnchorPosition(null);
       return;
     }
     const anchor = data.anchorEl;
-    const update = () => {
+    let rafId: number | null = null;
+    const read = () => {
+      rafId = null;
+      if (!anchor.isConnected) {
+        return;
+      }
       const rect = anchor.getBoundingClientRect();
       setAnchorPosition({ top: rect.bottom + 4, left: rect.left });
     };
-    update();
+    const update = () => {
+      if (rafId !== null) {
+        return;
+      }
+      rafId = requestAnimationFrame(read);
+    };
+    read();
     window.addEventListener("scroll", update, true);
     window.addEventListener("resize", update);
     return () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
       window.removeEventListener("scroll", update, true);
       window.removeEventListener("resize", update);
     };

--- a/packages/folio/src/core/docx/documentParser-alternatecontent.test.ts
+++ b/packages/folio/src/core/docx/documentParser-alternatecontent.test.ts
@@ -1,0 +1,139 @@
+// Regression eigenpal #567: Word stores anchored wps:wsp text boxes inside
+// an <mc:AlternateContent> block (Choice Requires="wps" + Fallback VML).
+// scanRunForTextBoxDrawings only walked direct children of <w:r>, so the
+// <w:drawing> inside the Choice branch never reached the text-box pipeline
+// and the shape text (e.g. "Organisation Chart" cards) was silently dropped.
+
+import { describe, expect, test } from "bun:test";
+
+import { parseDocumentBody } from "./documentParser";
+
+const XML_DECLARATION =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const textBoxDrawingXml = (text: string) => `
+  <w:drawing>
+    <wp:inline>
+      <wp:extent cx="914400" cy="457200"/>
+      <wp:docPr id="11" name="Text Box 11"/>
+      <a:graphic>
+        <a:graphicData uri="http://schemas.microsoft.com/office/word/2010/wordprocessingShape">
+          <wps:wsp>
+            <wps:spPr>
+              <a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="457200"/></a:xfrm>
+              <a:prstGeom prst="rect"><a:avLst/></a:prstGeom>
+            </wps:spPr>
+            <wps:txbx>
+              <w:txbxContent>
+                <w:p><w:r><w:t>${text}</w:t></w:r></w:p>
+              </w:txbxContent>
+            </wps:txbx>
+            <wps:bodyPr/>
+          </wps:wsp>
+        </a:graphicData>
+      </a:graphic>
+    </wp:inline>
+  </w:drawing>`;
+
+describe("parseDocumentBody — AlternateContent text boxes", () => {
+  test("extracts text-box drawings wrapped in mc:AlternateContent", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:p w14:paraId="ACTB0001">
+      <w:r><w:t>Host text</w:t></w:r>
+      <w:r>
+        <mc:AlternateContent>
+          <mc:Choice Requires="wps">${textBoxDrawingXml("Card title")}</mc:Choice>
+          <mc:Fallback>
+            <w:pict><v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>VML fallback</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape></w:pict>
+          </mc:Fallback>
+        </mc:AlternateContent>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    const shapes = paragraph.content
+      .filter((c) => c.type === "run")
+      .flatMap((r) => r.content.filter((c) => c.type === "shape"));
+
+    expect(shapes).toHaveLength(1);
+    const shape = shapes.at(0);
+    if (!shape) {
+      throw new Error("Expected shape");
+    }
+    expect(shape.shape.shapeType).toBe("textBox");
+    const innerPara = shape.shape.textBody?.content.at(0);
+    if (innerPara?.type !== "paragraph") {
+      throw new Error("Expected text-box inner paragraph");
+    }
+    const innerRun = innerPara.content.at(0);
+    if (innerRun?.type !== "run") {
+      throw new Error("Expected text-box inner run");
+    }
+    const innerText = innerRun.content.at(0);
+    if (innerText?.type !== "text") {
+      throw new Error("Expected text-box inner text");
+    }
+    expect(innerText.text).toBe("Card title");
+  });
+
+  // Regression: with multiple AlternateContent-only <w:r> elements followed by
+  // a text run, a strict index check could drop shapes past the first (since
+  // consolidateParagraphContent collapses shape-only <w:r> into surrounding
+  // parsed runs). All shapes must survive.
+  test("preserves multiple AlternateContent-only runs in the same paragraph", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:p w14:paraId="ACTB0002">
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 1")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 2")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 3")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><w:t>Trailing text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    const cardTitles = paragraph.content
+      .filter((c) => c.type === "run")
+      .flatMap((r) => r.content.filter((c) => c.type === "shape"))
+      .map((shape) => {
+        const inner = shape.shape.textBody?.content.at(0);
+        if (inner?.type !== "paragraph") {
+          return null;
+        }
+        const run = inner.content.at(0);
+        if (run?.type !== "run") {
+          return null;
+        }
+        const text = run.content.at(0);
+        return text?.type === "text" ? text.text : null;
+      });
+
+    expect(cardTitles).toEqual(["Card 1", "Card 2", "Card 3"]);
+  });
+});

--- a/packages/folio/src/core/docx/documentParser.test.ts
+++ b/packages/folio/src/core/docx/documentParser.test.ts
@@ -236,4 +236,114 @@ describe("parseDocumentBody text box enrichment", () => {
     }
     expect(middleRun.content.at(0)?.type).toBe("shape");
   });
+
+  // Regression: Word stores anchored wps:wsp text boxes inside an
+  // <mc:AlternateContent> block — Choice Requires="wps" holds the modern
+  // shape, Fallback holds a VML rendering. scanRunForTextBoxDrawings only
+  // walked the direct children of <w:r>, so the <w:drawing> inside the
+  // Choice branch never reached the text-box pipeline and the shape text
+  // (e.g. "Organisation Chart" cards) was silently dropped (eigenpal #567).
+  test("extracts text-box drawings wrapped in mc:AlternateContent", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:p w14:paraId="ACTB0001">
+      <w:r><w:t>Host text</w:t></w:r>
+      <w:r>
+        <mc:AlternateContent>
+          <mc:Choice Requires="wps">${textBoxDrawingXml("Card title")}</mc:Choice>
+          <mc:Fallback>
+            <w:pict><v:shape><v:textbox><w:txbxContent><w:p><w:r><w:t>VML fallback</w:t></w:r></w:p></w:txbxContent></v:textbox></v:shape></w:pict>
+          </mc:Fallback>
+        </mc:AlternateContent>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    const shapes = paragraph.content
+      .filter((c) => c.type === "run")
+      .flatMap((r) => r.content.filter((c) => c.type === "shape"));
+
+    expect(shapes).toHaveLength(1);
+    const shape = shapes.at(0);
+    if (!shape) {
+      throw new Error("Expected shape");
+    }
+    expect(shape.shape.shapeType).toBe("textBox");
+    const innerPara = shape.shape.textBody?.content.at(0);
+    if (innerPara?.type !== "paragraph") {
+      throw new Error("Expected text-box inner paragraph");
+    }
+    const innerRun = innerPara.content.at(0);
+    if (innerRun?.type !== "run") {
+      throw new Error("Expected text-box inner run");
+    }
+    const innerText = innerRun.content.at(0);
+    if (innerText?.type !== "text") {
+      throw new Error("Expected text-box inner text");
+    }
+    expect(innerText.text).toBe("Card title");
+  });
+
+  // Regression: with multiple AlternateContent-only <w:r> elements followed by
+  // a text run, the strict `parsedIndex < paragraph.content.length` check used
+  // to drop shapes past the first (consolidateParagraphContent collapses
+  // shape-only <w:r> into the surrounding parsed runs). All shapes must
+  // survive — anchored boxes are off-flow, the owning run matters less than
+  // keeping them in the model so downstream positioning has something to
+  // position.
+  test("preserves multiple AlternateContent-only runs in the same paragraph", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006">
+  <w:body>
+    <w:p w14:paraId="ACTB0002">
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 1")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 2")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><mc:AlternateContent><mc:Choice Requires="wps">${textBoxDrawingXml("Card 3")}</mc:Choice><mc:Fallback><w:pict/></mc:Fallback></mc:AlternateContent></w:r>
+      <w:r><w:t>Trailing text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`);
+
+    const paragraph = body.content.at(0);
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected paragraph");
+    }
+
+    const cardTitles = paragraph.content
+      .filter((c) => c.type === "run")
+      .flatMap((r) => r.content.filter((c) => c.type === "shape"))
+      .map((shape) => {
+        const inner = shape.shape.textBody?.content.at(0);
+        if (inner?.type !== "paragraph") {
+          return null;
+        }
+        const run = inner.content.at(0);
+        if (run?.type !== "run") {
+          return null;
+        }
+        const text = run.content.at(0);
+        return text?.type === "text" ? text.text : null;
+      });
+
+    expect(cardTitles).toEqual(["Card 1", "Card 2", "Card 3"]);
+  });
 });

--- a/packages/folio/src/core/docx/documentParser.ts
+++ b/packages/folio/src/core/docx/documentParser.ts
@@ -524,17 +524,56 @@ function scanRunForTextBoxDrawings(xmlRun: XmlElement): TextBoxRunScan {
   const textBoxDrawings: XmlElement[] = [];
   let hasNonTextBoxContent = false;
 
+  const visitDrawing = (drawingEl: XmlElement): void => {
+    if (isTextBoxDrawing(drawingEl)) {
+      textBoxDrawings.push(drawingEl);
+      return;
+    }
+    hasNonTextBoxContent = true;
+  };
+
   for (const el of getChildElements(xmlRun)) {
     const name = getLocalName(el.name ?? "");
     if (name === "rPr") {
       continue;
     }
-    if (name !== "drawing") {
-      hasNonTextBoxContent = true;
+    if (name === "drawing") {
+      visitDrawing(el);
       continue;
     }
-    if (isTextBoxDrawing(el)) {
-      textBoxDrawings.push(el);
+    if (name === "AlternateContent") {
+      // Word stores anchored wps:wsp text boxes inside mc:AlternateContent —
+      // Choice Requires="wps" holds the modern shape, Fallback holds a VML
+      // rendering. Prefer Choice; if it has no drawing, fall back to Fallback
+      // so we keep some shape data either way (matches the run-content parser).
+      const branches = getChildElements(el);
+      const choice = branches.find(
+        (b) => getLocalName(b.name ?? "") === "Choice",
+      );
+      const fallback = branches.find(
+        (b) => getLocalName(b.name ?? "") === "Fallback",
+      );
+      let foundInBranch = false;
+      const tryBranch = (branch: XmlElement | undefined): boolean => {
+        if (!branch) {
+          return false;
+        }
+        let found = false;
+        for (const innerEl of getChildElements(branch)) {
+          if (getLocalName(innerEl.name ?? "") === "drawing") {
+            visitDrawing(innerEl);
+            found = true;
+          }
+        }
+        return found;
+      };
+      foundInBranch = tryBranch(choice);
+      if (!foundInBranch) {
+        foundInBranch = tryBranch(fallback);
+      }
+      if (!foundInBranch) {
+        hasNonTextBoxContent = true;
+      }
       continue;
     }
     hasNonTextBoxContent = true;

--- a/packages/folio/src/core/layout-bridge/measuring/index.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/index.ts
@@ -35,6 +35,7 @@ export {
   measureParagraph,
   measureParagraphs,
   getRunCharWidths,
+  clampFloatingWrapMargins,
   type FloatingImageZone,
   type MeasureParagraphOptions,
 } from "./measureParagraph";

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import { hashParagraphBlock } from "./cache";
 import { buildFontString, resetCanvasContext } from "./measureContainer";
-import { getRunCharWidths, measureParagraph } from "./measureParagraph";
+import {
+  clampFloatingWrapMargins,
+  getRunCharWidths,
+  measureParagraph,
+} from "./measureParagraph";
 
 const PT_TO_PX = 96 / 72;
 
@@ -244,6 +248,110 @@ describe("inline image paragraph measurement", () => {
       expect(measure.lines.at(1)?.width).toBe(20);
     });
   });
+
+  // Regression: a logo + label header line (image flowing alongside text) used
+  // to inherit the image-only branch's `imageH + descent*2` line box, which
+  // centered the text inside an inflated band and left it floating above the
+  // paragraph border (eigenpal #580). Word baseline-aligns the row and sizes
+  // the line as `imageH + text descent`.
+  test("image-with-text line sizes as imageH + text descent (baseline-aligned)", () => {
+    withFakeTextMeasure(() => {
+      const imageHeight = 40;
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "logo-label",
+          runs: [
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 80,
+              height: imageHeight,
+            },
+            { kind: "text", text: "Header" },
+          ],
+        },
+        600,
+      );
+
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+      // Line height should equal imageH + a single descent buffer; the
+      // image-alone branch would emit imageH + descent*2, so check that the
+      // height is strictly less than that.
+      const descent = line?.descent ?? 0;
+      expect(descent).toBeGreaterThan(0);
+      expect(line?.lineHeight).toBe(imageHeight + descent);
+      expect(line?.ascent).toBe(imageHeight);
+    });
+  });
+
+  test("image-only line keeps imageH + descent*2 breathing-room band", () => {
+    const imageHeight = 40;
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "logo-alone",
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 80,
+            height: imageHeight,
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    const line = measure.lines.at(0);
+    expect(line).toBeDefined();
+    const descent = line?.descent ?? 0;
+    expect(line?.lineHeight).toBe(imageHeight + descent * 2);
+    expect(line?.ascent).toBe(imageHeight + descent);
+  });
+
+  test("inline image footprint includes its wp:inline distT/distB", () => {
+    withFakeTextMeasure(() => {
+      // distTop/distBottom = 8 each = 16px of extra footprint; the line
+      // height must reserve that or the painter's per-image margin spills
+      // past the line's reserved height.
+      const imageHeight = 20;
+      const distTop = 8;
+      const distBottom = 8;
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "logo-dist",
+          runs: [
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 80,
+              height: imageHeight,
+              distTop,
+              distBottom,
+            },
+            { kind: "text", text: "Header" },
+          ],
+        },
+        600,
+      );
+
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+      const descent = line?.descent ?? 0;
+      // Footprint = imageHeight + distTop + distBottom; the image-with-text
+      // branch adds a single descent buffer below baseline.
+      expect(line?.lineHeight).toBe(
+        imageHeight + distTop + distBottom + descent,
+      );
+    });
+  });
 });
 
 describe("paragraph indentation measurement", () => {
@@ -360,5 +468,56 @@ describe("all-caps paragraph measurement", () => {
     });
 
     expect(spacedHash).not.toBe(plainHash);
+  });
+});
+
+describe("clampFloatingWrapMargins", () => {
+  // A near-full-width floating table or image computes a left/right wrap
+  // margin that extends past contentWidth (margins are `rectRight` or
+  // `contentWidth - (x - distLeft)`, both of which can spill). Without
+  // clamping, getFloatingMargins propagates that margin into the line and
+  // measureParagraph collapses every wrapped line to ~1 glyph wide — the
+  // "single character per line after a wide float" symptom.
+  test("zeros margins that exceed content width", () => {
+    expect(clampFloatingWrapMargins(698, 0, 671)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
+    expect(clampFloatingWrapMargins(0, 700, 671)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
+  });
+
+  test("zeros when combined side margins cover the content area", () => {
+    expect(clampFloatingWrapMargins(400, 300, 671)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
+  });
+
+  test("preserves valid one-sided margins", () => {
+    expect(clampFloatingWrapMargins(200, 0, 671)).toEqual({
+      leftMargin: 200,
+      rightMargin: 0,
+    });
+    expect(clampFloatingWrapMargins(0, 150, 671)).toEqual({
+      leftMargin: 0,
+      rightMargin: 150,
+    });
+  });
+
+  test("clamps negative inputs to 0", () => {
+    expect(clampFloatingWrapMargins(-5, -10, 671)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
+  });
+
+  test("falls back to contentWidth=1 floor for non-positive contentWidth", () => {
+    expect(clampFloatingWrapMargins(0, 0, 0)).toEqual({
+      leftMargin: 0,
+      rightMargin: 0,
+    });
   });
 });

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -321,6 +321,31 @@ function findWordBreaks(text: string): number[] {
 const DEFAULT_TAB_WIDTH = 48;
 
 /**
+ * When a float's wrap margins consume the entire content width (or more),
+ * there is no horizontal strip beside it for body text. Word renders the
+ * following lines at full content width instead of collapsing them to a
+ * 1-glyph column. Unchecked margins from near-full-width tables/images can
+ * exceed contentWidth and collapse every wrap line to ~1 character.
+ *
+ * Returned margins are zeroed when either side alone is >= contentWidth or
+ * their sum is >= contentWidth. Otherwise the original (non-negative) values
+ * pass through unchanged.
+ */
+export function clampFloatingWrapMargins(
+  leftMargin: number,
+  rightMargin: number,
+  contentWidth: number,
+): { leftMargin: number; rightMargin: number } {
+  const cw = Math.max(1, contentWidth);
+  const lm = Math.max(0, leftMargin);
+  const rm = Math.max(0, rightMargin);
+  if (lm >= cw || rm >= cw || lm + rm >= cw) {
+    return { leftMargin: 0, rightMargin: 0 };
+  }
+  return { leftMargin: lm, rightMargin: rm };
+}
+
+/**
  * Calculate width reduction for a line based on floating image zones.
  * Returns the left and right margins that need to be applied.
  */
@@ -558,14 +583,34 @@ export function measureParagraph(
       currentLine.maxFontMetrics,
     );
 
-    // If an inline image is taller than the text-based line height, reserve
-    // descender room on both sides to avoid clipping image-only table rows.
+    // If an inline image is taller than the text-based line height, the line
+    // grows to fit the image. Word seats an inline image as a tall glyph on
+    // the text baseline.
     const finalTypography = { ...typography };
     if (currentLine.maxImageHeightPx > finalTypography.lineHeight) {
       const imageHeight = currentLine.maxImageHeightPx;
       const buffer = finalTypography.descent;
-      finalTypography.lineHeight = imageHeight + buffer * 2;
-      finalTypography.ascent = imageHeight + buffer;
+      // `fromRun === toRun` with a tall image present means the line holds
+      // exactly that one image (no flowing text/tabs). Must stay paired with
+      // the painter's image-only `runsForLine.length === 1 && isImageRun(...)`
+      // test in renderLine — the two pick paired line-height + alignment
+      // strategies and disagreeing reintroduces the floating-label bug.
+      if (currentLine.fromRun === currentLine.toRun) {
+        // Image alone on the line: grow to the image height plus the parent
+        // font's descent on BOTH sides so the row has visible breathing room
+        // above and below the image (Word's render gives a few px of cell
+        // padding even with tcMar=0).
+        finalTypography.lineHeight = imageHeight + buffer * 2;
+        finalTypography.ascent = imageHeight + buffer;
+      } else {
+        // Image flowing with text/tabs (e.g. a logo + label header line):
+        // the full image height sits above the baseline and only the text
+        // descent is reserved below — no extra leading above the image. The
+        // painter baseline-aligns the row so the image bottom lands on the
+        // text baseline.
+        finalTypography.lineHeight = imageHeight + buffer;
+        finalTypography.ascent = imageHeight;
+      }
     }
 
     const line: MeasuredLine = {
@@ -736,9 +781,15 @@ export function measureParagraph(
       const imageWidth = run.width;
       const imageHeight = run.height;
 
-      // Track image height separately (already in pixels, not points)
-      if (imageHeight > currentLine.maxImageHeightPx) {
-        currentLine.maxImageHeightPx = imageHeight;
+      // The image's vertical footprint in the line includes its wp:inline
+      // distT/distB wrap distances. These default to 0 for inline images
+      // (unlike the block path's synthetic 6px). The painter applies them as
+      // top/bottom margins on the <img>, so the run's flex baseline (the
+      // margin-box edge) stays consistent with this reserved height.
+      const imageFootprintPx =
+        imageHeight + (run.distTop ?? 0) + (run.distBottom ?? 0);
+      if (imageFootprintPx > currentLine.maxImageHeightPx) {
+        currentLine.maxImageHeightPx = imageFootprintPx;
       }
 
       if (

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -138,6 +138,195 @@ describe("toFlowBlocks field handling", () => {
       fallback: "Clause 4.2",
     });
   });
+
+  // Regression: PAGE field rendered with the painter's default font/colour
+  // (eigenpal #575) when the bridge skipped extractRunFormatting for field
+  // nodes. Word renders a field result with the result run's own w:rPr, so
+  // marks attached to the field node must land on the FieldRun.
+  test("propagates field-node character marks to the FieldRun formatting", () => {
+    const bold = schema.marks["bold"]?.create();
+    // fontSize mark stores half-points (the OOXML <w:sz>) — 28 = 14pt.
+    const fontSize = schema.marks["fontSize"]?.create({ size: 28 });
+    const textColor = schema.marks["textColor"]?.create({ rgb: "FF0000" });
+    if (!bold || !fontSize || !textColor) {
+      throw new Error("Expected bold/fontSize/textColor marks in schema");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node(
+          "field",
+          {
+            fieldType: "PAGE",
+            instruction: " PAGE ",
+            displayText: "1",
+            fieldKind: "simple",
+          },
+          undefined,
+          [bold, fontSize, textColor],
+        ),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const fieldRun = paragraph.runs.at(0);
+    if (fieldRun?.kind !== "field") {
+      throw new Error("Expected field run");
+    }
+
+    expect(fieldRun.bold).toBe(true);
+    expect(fieldRun.fontSize).toBe(14);
+    expect(fieldRun.color).toBe("#FF0000");
+  });
+});
+
+describe("toFlowBlocks TOC hyperlink style strip", () => {
+  // Regression eigenpal #566: in TOCx paragraphs, Word renders hyperlinks in
+  // the paragraph's own colour (no blue + underline). Without stripping the
+  // resolved Hyperlink character-style here, the painter's link fallback
+  // applies blue + underline and TOC entries look like web links.
+  test("strips resolved color/underline on hyperlink text in a TOC paragraph", () => {
+    const linkMark = schema.marks["hyperlink"]?.create({
+      href: "#_Toc1",
+    });
+    const underline = schema.marks["underline"]?.create({ style: "single" });
+    const textColor = schema.marks["textColor"]?.create({ rgb: "0563C1" });
+    if (!linkMark || !underline || !textColor) {
+      throw new Error("Expected hyperlink/underline/textColor marks");
+    }
+
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { styleId: "TOC1" }, [
+        schema.text("Section 1", [linkMark, underline, textColor]),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const run = paragraph.runs.at(0);
+    if (run?.kind !== "text") {
+      throw new Error("Expected text run");
+    }
+
+    expect(run.hyperlink?.href).toBe("#_Toc1");
+    expect(run.hyperlink?.noDefaultStyle).toBe(true);
+    expect(run.color).toBeUndefined();
+    expect(run.underline).toBeUndefined();
+  });
+
+  // The page-number end of a TOC entry is a PAGEREF field inside the
+  // hyperlink — the strip must reach field runs too, not just text runs.
+  test("strips resolved color/underline on a field run inside a TOC paragraph", () => {
+    const linkMark = schema.marks["hyperlink"]?.create({
+      href: "#_Toc1",
+    });
+    const underline = schema.marks["underline"]?.create({ style: "single" });
+    const textColor = schema.marks["textColor"]?.create({ rgb: "0563C1" });
+    if (!linkMark || !underline || !textColor) {
+      throw new Error("Expected hyperlink/underline/textColor marks");
+    }
+
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { styleId: "TOC2" }, [
+        schema.node(
+          "field",
+          {
+            fieldType: "OTHER",
+            instruction: " PAGEREF _Toc1 \\h ",
+            displayText: "5",
+            fieldKind: "complex",
+          },
+          undefined,
+          [linkMark, underline, textColor],
+        ),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const fieldRun = paragraph.runs.at(0);
+    if (fieldRun?.kind !== "field") {
+      throw new Error("Expected field run");
+    }
+
+    expect(fieldRun.hyperlink?.noDefaultStyle).toBe(true);
+    expect(fieldRun.color).toBeUndefined();
+    expect(fieldRun.underline).toBeUndefined();
+  });
+
+  // Non-TOC paragraphs must NOT be stripped — Word still renders normal-body
+  // hyperlinks with the Hyperlink character style (blue + underline). The
+  // strip is keyed to styleId /^TOC\d*$/i; everything else passes through.
+  test("does not strip hyperlinks in non-TOC paragraphs", () => {
+    const linkMark = schema.marks["hyperlink"]?.create({
+      href: "https://example.com",
+    });
+    const underline = schema.marks["underline"]?.create({ style: "single" });
+    const textColor = schema.marks["textColor"]?.create({ rgb: "0563C1" });
+    if (!linkMark || !underline || !textColor) {
+      throw new Error("Expected hyperlink/underline/textColor marks");
+    }
+
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("body link", [linkMark, underline, textColor]),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const run = paragraph.runs.at(0);
+    if (run?.kind !== "text") {
+      throw new Error("Expected text run");
+    }
+
+    expect(run.hyperlink?.noDefaultStyle).toBeUndefined();
+    expect(run.color).toBeDefined();
+    expect(run.underline).toBeDefined();
+  });
+
+  // TOC, TOC1..TOC9 should all match. TOCHeading (Word's TOC title) is its
+  // own styleId and is NOT a TOC entry — no strip.
+  test("TOC styleId regex matches TOC and TOC1..N but not TOCHeading", () => {
+    const linkMark = schema.marks["hyperlink"]?.create({ href: "#x" });
+    if (!linkMark) {
+      throw new Error("Expected hyperlink mark");
+    }
+    const docFor = (styleId: string) =>
+      schema.node("doc", null, [
+        schema.node("paragraph", { styleId }, [schema.text("x", [linkMark])]),
+      ]);
+    const firstRunHyperlinkStripped = (styleId: string) => {
+      const blocks = toFlowBlocks(docFor(styleId));
+      const para = blocks.at(0);
+      if (para?.kind !== "paragraph") {
+        throw new Error("Expected paragraph block");
+      }
+      const run = para.runs.at(0);
+      if (run?.kind !== "text") {
+        throw new Error("Expected text run");
+      }
+      return run.hyperlink?.noDefaultStyle === true;
+    };
+
+    expect(firstRunHyperlinkStripped("TOC")).toBe(true);
+    expect(firstRunHyperlinkStripped("TOC1")).toBe(true);
+    expect(firstRunHyperlinkStripped("toc3")).toBe(true);
+    expect(firstRunHyperlinkStripped("TOCHeading")).toBe(false);
+    expect(firstRunHyperlinkStripped("Normal")).toBe(false);
+  });
 });
 
 describe("toFlowBlocks list numbering", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -782,6 +782,31 @@ function buildImageRun(
 }
 
 /**
+ * Paragraph styleId pattern used by Word for TOC entries (TOC, TOC1, TOC2, …).
+ * Hyperlinks inside these paragraphs must render in the paragraph's own colour,
+ * not the Hyperlink character style — see {@link stripTocHyperlinkStyle}.
+ */
+const TOC_STYLE_ID = /^TOC\d*$/i;
+
+/**
+ * In TOC paragraphs, strip the resolved Hyperlink character-style colour and
+ * underline so the painter's link fallback doesn't fire. The PM doc keeps the
+ * original marks so copy/paste out of a TOC still carries the Hyperlink
+ * styling like Word does. Applies to both text and field runs — a TOC entry's
+ * page number is a PAGEREF field inside the entry's hyperlink.
+ *
+ * Mutates `formatting` in place; cheaper than re-cloning per run.
+ */
+function stripTocHyperlinkStyle(formatting: RunFormatting): void {
+  if (!formatting.hyperlink) {
+    return;
+  }
+  formatting.hyperlink = { ...formatting.hyperlink, noDefaultStyle: true };
+  delete formatting.color;
+  delete formatting.underline;
+}
+
+/**
  * Convert a paragraph node to runs.
  */
 function paragraphToRuns(
@@ -796,6 +821,9 @@ function paragraphToRuns(
     node.attrs as PMParagraphAttrs,
     theme,
   );
+  const paragraphStyleId = (node.attrs as PMParagraphAttrs).styleId;
+  const inTocParagraph =
+    typeof paragraphStyleId === "string" && TOC_STYLE_ID.test(paragraphStyleId);
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child, childOffset) => {
@@ -804,6 +832,9 @@ function paragraphToRuns(
     if (child.isText && child.text) {
       // Text node - create text run
       const formatting = extractRunFormatting(child.marks, theme);
+      if (inTocParagraph) {
+        stripTocHyperlinkStyle(formatting);
+      }
       const run: TextRun = {
         kind: "text",
         text: child.text,
@@ -865,8 +896,12 @@ function paragraphToRuns(
       } else if (ft === "TIME") {
         mappedType = "TIME";
       }
+      const extractedFieldFormatting = extractRunFormatting(child.marks, theme);
+      if (inTocParagraph) {
+        stripTocHyperlinkStyle(extractedFieldFormatting);
+      }
       const fieldFormatting = markDefaultBlackTextColorSource(
-        extractRunFormatting(child.marks, theme),
+        extractedFieldFormatting,
         paraDefaults,
       );
       const run: FieldRun = {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -786,7 +786,7 @@ function buildImageRun(
  * Hyperlinks inside these paragraphs must render in the paragraph's own colour,
  * not the Hyperlink character style — see {@link stripTocHyperlinkStyle}.
  */
-const TOC_STYLE_ID = /^TOC\d*$/i;
+const TOC_STYLE_ID = /^TOC\d*$/iu;
 
 /**
  * In TOC paragraphs, strip the resolved Hyperlink character-style colour and

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -47,7 +47,7 @@ export type RunFormatting = {
   textOutline?: boolean;
   emphasisMark?: "dot" | "comma" | "circle" | "underDot";
   /** Hyperlink info if this run is a link */
-  hyperlink?: { href: string; tooltip?: string };
+  hyperlink?: HyperlinkInfo;
   /** Footnote reference ID (if this run contains a footnote reference) */
   footnoteRefId?: number;
   /** Endnote reference ID (if this run contains an endnote reference) */
@@ -72,6 +72,14 @@ export type RunFormatting = {
 export type HyperlinkInfo = {
   href: string;
   tooltip?: string;
+  /**
+   * When true, the painter must not apply Word-default link styling
+   * (blue + underline) to this run. Set by the bridge for TOC entries —
+   * Word renders TOCx hyperlinks in the paragraph's own colour, not in
+   * the Hyperlink character style. The PM doc keeps the original marks
+   * so copy/paste out of a TOC still carries Hyperlink styling.
+   */
+  noDefaultStyle?: boolean;
 };
 
 /**

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -5,7 +5,10 @@
  * Each page contains positioned fragments within a content area.
  */
 
-import { measureParagraph } from "../layout-bridge/measuring";
+import {
+  clampFloatingWrapMargins,
+  measureParagraph,
+} from "../layout-bridge/measuring";
 import type { FloatingImageZone } from "../layout-bridge/measuring";
 import type {
   Page,
@@ -807,7 +810,20 @@ function rectsToFloatingZones(
       }
     }
 
-    return { leftMargin, rightMargin, topY: rectTop, bottomY: rectBottom };
+    // Near-full-width floats can compute a wrap margin >= contentWidth; if we
+    // let that propagate, body text after the float collapses to ~1 glyph per
+    // line. Word falls back to full content width in that case.
+    const clamped = clampFloatingWrapMargins(
+      leftMargin,
+      rightMargin,
+      contentWidth,
+    );
+    return {
+      leftMargin: clamped.leftMargin,
+      rightMargin: clamped.rightMargin,
+      topY: rectTop,
+      bottomY: rectBottom,
+    };
   });
 }
 

--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -106,6 +106,49 @@ describe("renderLine inline image handling", () => {
     expect(imageEl?.style.width).toBe("186px");
     expect(imageEl?.style.height).toBe("29px");
   });
+
+  // Regression chatgpt-codex on #410: the image+text flex branch fired on
+  // `runsForLine.some(isImageRun)`, which also matched FLOATING images. Those
+  // render in a page-level layer and `continue` in the main loop, so a line
+  // that wraps around a floating image (text-only inline content) was being
+  // forced into flex/baseline layout — changing alignment + indent + line
+  // height for normal body text. Must be gated to non-floating images.
+  test("does not flex-promote a line whose only image is floating", () => {
+    const floatingImage: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 80,
+      displayMode: "float",
+      wrapType: "square",
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "wrap-around-float",
+      runs: [floatingImage, { kind: "text", text: "Body text wrapping" }],
+      pmStart: 0,
+      pmEnd: 20,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 18,
+      width: 400,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+
+    // The line still contains an ImageRun in its run slice, but it's
+    // floating — flex promotion must not fire.
+    expect(lineEl.style.display).not.toBe("flex");
+    expect(lineEl.style.alignItems).not.toBe("baseline");
+  });
 });
 
 describe("renderLine scaled text handling", () => {

--- a/packages/folio/src/core/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-right-tab.test.ts
@@ -124,7 +124,9 @@ describe("renderLine right-tab flex anchor", () => {
     expect(lineEl.dataset["flexLine"]).toBe("true");
     expect(lineEl.style["display"]).toBe("flex");
     expect(lineEl.style["alignItems"]).toBe("baseline");
-    expect(lineEl.style["whiteSpace"]).toBe("nowrap");
+    // `pre` (not `nowrap`) so consecutive XML-preserved spaces in TOC titles
+    // survive the flex switch; `pre` also disallows mid-line wrap.
+    expect(lineEl.style["whiteSpace"]).toBe("pre");
 
     const tabEl = findTabEl(lineEl);
     expect(tabEl).toBeDefined();

--- a/packages/folio/src/core/layout-painter/renderParagraph-right-tab.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-right-tab.test.ts
@@ -1,0 +1,282 @@
+// Regression eigenpal #566 (renderer half): a right-aligned tab whose stop
+// sits at the line's right edge with no trailing tab should promote the line
+// to a flex row — tab gets `flex: 1 1 0`, trailing text/field sits flush
+// against the line's right edge. Canvas-measured widths and DOM layout drift
+// by sub-pixels under accumulation, so geometry alone leaves TOC page numbers
+// one pixel short of the margin; flex layout pins them.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MeasuredLine,
+  ParagraphBlock,
+  TabStop,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+  textContent = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return this.children.at(0) ?? null;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        // 7px per character keeps the math simple; bold/italic don't change
+        // the count here because the right-tab anchor doesn't depend on the
+        // exact width, only on whether `currentX + tab + trailing` reaches
+        // the right edge.
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function findTabEl(lineEl: FakeElement): FakeElement | undefined {
+  return lineEl.children.find((c) => c.className.includes("layout-run-tab"));
+}
+
+function findFieldOrTextEls(lineEl: FakeElement): FakeElement[] {
+  return lineEl.children.filter((c) => c.className.includes("layout-run-text"));
+}
+
+describe("renderLine right-tab flex anchor", () => {
+  // TOC1-style line: title text + right-aligned tab + page-number field.
+  // Tab stop sits at the line's right edge; with no trailing tab and a tab
+  // alignment of "end", the painter must promote the line to flex layout.
+  test("promotes a TOC line to flex when right-aligned tab sits at the edge", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "toc1",
+      runs: [
+        { kind: "text", text: "Chapter One" },
+        { kind: "tab" },
+        { kind: "field", fieldType: "PAGE", fallback: "5" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+    const tabStops: TabStop[] = [
+      // Right-aligned ("end") tab stop at ~600px (9000 twips = 9000/15 ≈ 600px).
+      { val: "end", pos: 9000, leader: "dot" },
+    ];
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops,
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBe("true");
+    expect(lineEl.style["display"]).toBe("flex");
+    expect(lineEl.style["alignItems"]).toBe("baseline");
+    expect(lineEl.style["whiteSpace"]).toBe("nowrap");
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl).toBeDefined();
+    // flex: 1 1 0 lets the tab grow to fill the remaining space.
+    expect(tabEl?.style["flex"]).toBe("1 1 0");
+
+    // The trailing field run lands AFTER the tab in flex order so layout
+    // pushes it flush right.
+    const trailing = findFieldOrTextEls(lineEl);
+    // Title + page number — both are text-class spans (field renders via
+    // renderTextRun's "text" path with field-resolved content).
+    expect(trailing.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("does NOT promote to flex when the right-aligned tab is not the last on the line", () => {
+    // Two end-aligned tabs on one line — the first tab must NOT fire the
+    // anchor (it has a following tab), so its trailing content lays out
+    // naturally up to the next tab. Only the LAST tab is eligible for the
+    // right-edge anchor.
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "two-tabs",
+      runs: [
+        { kind: "text", text: "A" },
+        { kind: "tab" },
+        { kind: "text", text: "B" },
+        { kind: "tab" },
+        { kind: "text", text: "C" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 4,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+    // Both stops are NOT at the right edge (line edge = 600px = 9000 twips).
+    // The first stop sits at pos 1500 (~100px), the second at pos 3000 (~200px) —
+    // currentX + tab + trailing stays well below 600, so neither tab reaches
+    // the anchor's right-edge threshold even though both are end-aligned.
+    const tabStops: TabStop[] = [
+      { val: "end", pos: 1500, leader: "dot" },
+      { val: "end", pos: 3000, leader: "dot" },
+    ];
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops,
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+    expect(lineEl.style["display"]).not.toBe("flex");
+  });
+
+  test("does NOT promote to flex when no lineRightEdgePx is provided", () => {
+    // Backwards-compat: callers that don't pass lineRightEdgePx (older code
+    // paths, table cells before the rewrite) keep the existing non-flex
+    // tab rendering. The anchor must opt in via the new option.
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "no-edge",
+      runs: [
+        { kind: "text", text: "title" },
+        { kind: "tab" },
+        { kind: "text", text: "5" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      leftIndentPx: 0,
+      // No lineRightEdgePx.
+    }) as unknown as FakeElement;
+
+    expect(lineEl.dataset["flexLine"]).toBeUndefined();
+  });
+});
+
+describe("renderTabRun leader rendering", () => {
+  // Regression: the SVG background-image leader sat at the line's bottom
+  // edge and broke under flex layout. The new pattern uses an absolutely
+  // positioned inner span over a zero-width-space, so the outer span keeps
+  // its baseline aligned with surrounding text while the leader clips
+  // horizontally inside.
+  test("renders dot leader as an absolutely-positioned inner span", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "leader-only",
+      runs: [
+        { kind: "text", text: "x" },
+        { kind: "tab" },
+        { kind: "text", text: "y" },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 2,
+      toChar: 1,
+      width: 600,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 9000, leader: "dot" }],
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl).toBeDefined();
+    // The outer tab span is position: relative; the inner leader span is
+    // position: absolute and clips horizontally.
+    expect(tabEl?.style["position"]).toBe("relative");
+    const inner = tabEl?.children.at(0);
+    expect(inner).toBeDefined();
+    expect(inner?.style["position"]).toBe("absolute");
+    expect(inner?.style["overflow"]).toBe("hidden");
+    expect(inner?.style["whiteSpace"]).toBe("nowrap");
+    // Leader is repeated to fill the box; the exact count is an implementation
+    // detail (LEADER_FILL_COUNT). What matters is that it's many dots, not one.
+    const innerText = inner?.textContent ?? "";
+    expect(innerText.length).toBeGreaterThan(100);
+    expect(innerText.startsWith(".")).toBe(true);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1034,12 +1034,18 @@ export function renderLine(
   if (runsForLine.length === 1 && isImageRun(runsForLine[0]!)) {
     lineEl.style.display = "flex";
     lineEl.style.alignItems = "center";
-  } else if (runsForLine.some(isImageRun)) {
-    // Image flowing alongside text/tabs (logo + label header). Word seats an
-    // inline image as a tall glyph on the text baseline, so baseline-align
-    // the row — the image bottom then lands on the text baseline. The line
-    // height was measured to match (imageH + text descent). Stays paired
-    // with the measurer's `fromRun !== toRun` branch.
+  } else if (runsForLine.some((r) => isImageRun(r) && !isFloatingImageRun(r))) {
+    // Inline image flowing alongside text/tabs (logo + label header). Word
+    // seats an inline image as a tall glyph on the text baseline, so
+    // baseline-align the row — the image bottom then lands on the text
+    // baseline. The line height was measured to match (imageH + text
+    // descent). Stays paired with the measurer's `fromRun !== toRun` branch.
+    //
+    // Gated to NON-floating images: floating images render in a page-level
+    // (or cell-level) layer and `continue` in the main loop, so a line that
+    // only contains floating images shouldn't be flex-promoted — that would
+    // change alignment / indent / line-height semantics for normal text
+    // wrapping around a floating object.
     lineEl.style.display = "flex";
     lineEl.style.alignItems = "baseline";
     // Flex defaults to flex-start regardless of the parent's text-align, so

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1030,6 +1030,15 @@ export function renderLine(
     // with the measurer's `fromRun !== toRun` branch.
     lineEl.style.display = "flex";
     lineEl.style.alignItems = "baseline";
+    // Flex defaults to flex-start regardless of the parent's text-align, so
+    // a centred / right-aligned paragraph would left-align after the flex
+    // switch. Mirror the paragraph alignment onto justify-content so
+    // image+text header lines stay centred / right-aligned like Word.
+    if (alignment === "center") {
+      lineEl.style.justifyContent = "center";
+    } else if (alignment === "right") {
+      lineEl.style.justifyContent = "flex-end";
+    }
     // Flex blockifies the run spans, so they'd otherwise inherit the line's
     // image-inflated line-height as their own box height — fattening each
     // text run to the full band and breaking baseline alignment. Reset to
@@ -1176,21 +1185,24 @@ export function renderLine(
       if (useRightAnchor) {
         // Promote to flex row. text-indent applies per flex item (not to the
         // group), so a hanging-indent paragraph would pull every text item
-        // left including the page number — the orchestrator re-applies the
-        // hanging via margin-left on the first child instead.
+        // left including the page number — we re-apply the first-line
+        // indent as margin-left on the first flex child after the tab is
+        // appended (see below).
         lineEl.style.display = "flex";
         lineEl.style.alignItems = "baseline";
         lineEl.style.whiteSpace = "nowrap";
         lineEl.style.textIndent = "0";
-        lineEl.dataset["flexLine"] = "true";
-        if (
-          options?.isFirstLine &&
-          options.firstLineIndentPx !== undefined &&
-          options.firstLineIndentPx < 0 &&
-          lineEl.firstElementChild instanceof HTMLElement
-        ) {
-          lineEl.firstElementChild.style.marginLeft = `${options.firstLineIndentPx}px`;
+        // Centered / right-aligned paragraphs need explicit justify-content:
+        // flex defaults to flex-start regardless of the parent's text-align,
+        // so without this the page number is still flush right (the anchor's
+        // whole point) but the title — and any other trailing content — would
+        // ignore the paragraph's alignment.
+        if (alignment === "center") {
+          lineEl.style.justifyContent = "center";
+        } else if (alignment === "right") {
+          lineEl.style.justifyContent = "flex-end";
         }
+        lineEl.dataset["flexLine"] = "true";
 
         // The tab flex-grows to fill the remaining line space; the leader
         // inside is absolutely positioned and clips to the tab's box.
@@ -1199,6 +1211,21 @@ export function renderLine(
         tabEl.style.minWidth = "0";
         tabEl.style.width = "auto";
         lineEl.append(tabEl);
+
+        // Re-apply the first-line indent as margin-left on the first flex
+        // child now that we know what it is (the tab itself when no prior
+        // runs rendered, or the earlier text/image otherwise). Done AFTER
+        // append so we don't no-op on tab-first lines (firstElementChild
+        // would be null pre-append). Both negative (hanging) and positive
+        // (firstLine) offsets are honoured.
+        if (
+          options?.isFirstLine &&
+          options.firstLineIndentPx !== undefined &&
+          options.firstLineIndentPx !== 0 &&
+          lineEl.firstElementChild instanceof HTMLElement
+        ) {
+          lineEl.firstElementChild.style.marginLeft = `${options.firstLineIndentPx}px`;
+        }
 
         // Render the remaining runs into the line at their natural width.
         // Flex layout puts them flush against the line's right edge.

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -424,12 +424,18 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
       anchor.title = run.hyperlink.tooltip;
     }
     anchor.textContent = run.text;
-    // Style hyperlink — default Word hyperlink color is blue (#0563c1)
-    const hyperlinkColor = getHyperlinkTextColor(run, span.style.color);
-    anchor.style.color = hyperlinkColor;
-    anchor.style.textDecoration = "underline";
-    // Override span color to match anchor (prevents color mismatch in selection)
-    span.style.color = hyperlinkColor;
+    // TOC entries opt out of the Hyperlink character style — Word renders
+    // them in the paragraph's own colour, no underline. The bridge sets
+    // `noDefaultStyle: true` and strips resolved colour/underline; here we
+    // skip the link fallback so the anchor inherits from the wrapping span.
+    if (!run.hyperlink.noDefaultStyle) {
+      // Default Word hyperlink color is blue (#0563c1)
+      const hyperlinkColor = getHyperlinkTextColor(run, span.style.color);
+      anchor.style.color = hyperlinkColor;
+      anchor.style.textDecoration = "underline";
+      // Override span color to match anchor (prevents color mismatch in selection)
+      span.style.color = hyperlinkColor;
+    }
     span.append(anchor);
   } else {
     // Set text content
@@ -440,7 +446,24 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
 }
 
 /**
- * Render a tab run with calculated width
+ * Number of leader characters to fill the tab's inner span. The inner span
+ * uses `overflow: hidden` so excess characters are clipped invisibly; we just
+ * need enough to span the widest realistic tab stop at the thinnest leader
+ * (a dot at small font sizes). 1000 covers wide-landscape pages with ~2px dots.
+ */
+const LEADER_FILL_COUNT = 1000;
+
+/**
+ * Render a tab run with calculated width.
+ *
+ * Leader characters (dot/hyphen/underscore for TOC entries) render in an
+ * absolute-positioned inner span over a baseline-aligned zero-width-space.
+ * The earlier SVG background-image approach sat at the line's bottom edge,
+ * misaligned with the surrounding text baseline and broken under flex layout
+ * (where the outer's height collapses to the inner content). The
+ * outer-with-ZWSP + inner-absolute pattern keeps the tab's baseline anchored
+ * to the surrounding text and lets the right-tab flex anchor compute a stable
+ * height for the line.
  */
 function renderTabRun(
   run: TabRun,
@@ -453,25 +476,33 @@ function renderTabRun(
 
   span.style.display = "inline-block";
   span.style.width = `${width}px`;
-  span.style.overflow = "hidden";
 
   applyPmPositions(span, run.pmStart, run.pmEnd);
 
-  // Render leader character if specified
-  if (leader && leader !== "none") {
-    const leaderChar = getLeaderChar(leader);
-    if (leaderChar) {
-      // Fill with leader characters
-      span.style.backgroundImage = `url("data:image/svg+xml,${encodeURIComponent(
-        `<svg xmlns='http://www.w3.org/2000/svg' width='4' height='16'><text x='0' y='12' font-size='12' fill='%23000'>${leaderChar}</text></svg>`,
-      )}")`;
-      span.style.backgroundRepeat = "repeat-x";
-      span.style.backgroundPosition = "bottom";
-    }
-  }
+  const leaderChar = leader && leader !== "none" ? getLeaderChar(leader) : null;
 
-  // Tab character for accessibility (but invisible)
-  span.textContent = "\u00A0"; // Non-breaking space for layout
+  if (leaderChar) {
+    // Outer span holds a zero-width space so its baseline aligns with the
+    // surrounding text. Inner absolutely-positioned span carries the dots
+    // and clips horizontally; keeping `overflow: hidden` off the outer
+    // avoids the inline-block baseline-at-margin-edge problem.
+    span.style.position = "relative";
+    span.textContent = "\u200B"; // zero-width space
+
+    const inner = doc.createElement("span");
+    inner.style.position = "absolute";
+    inner.style.left = "0";
+    inner.style.right = "0";
+    inner.style.top = "0";
+    inner.style.bottom = "0";
+    inner.style.overflow = "hidden";
+    inner.style.whiteSpace = "nowrap";
+    inner.textContent = leaderChar.repeat(LEADER_FILL_COUNT);
+    span.append(inner);
+  } else {
+    // No leader: a single nbsp carries the line-height for layout.
+    span.textContent = "\u00A0";
+  }
 
   return span;
 }
@@ -518,6 +549,16 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   // Inline images should flow with text
   img.style.display = "inline";
   img.style.verticalAlign = "middle";
+
+  // wp:inline distT/distB: the measurer folds these into maxImageHeightPx;
+  // applying them as margins here keeps the margin-box footprint consistent
+  // with the line height the measurer reserved.
+  if (run.distTop) {
+    img.style.marginTop = `${run.distTop}px`;
+  }
+  if (run.distBottom) {
+    img.style.marginBottom = `${run.distBottom}px`;
+  }
 
   applyPmPositions(img, run.pmStart, run.pmEnd);
 
@@ -618,42 +659,16 @@ function renderFieldRun(
       break;
   }
 
-  // Create a text run with the resolved value
+  // Spread the whole FieldRun so every RunFormatting field carries through —
+  // Word renders the field result with the result run's full w:rPr. Explicit
+  // enumeration silently drops future RunFormatting fields and dropped the
+  // footer page-number's font/colour (eigenpal #575). The extra `fieldType`,
+  // `fallback`, and `kind: "field"` keys are inert on TextRun, but we still
+  // overwrite `kind` and `text` to the resolved values.
   const resolvedRun: TextRun = {
+    ...run,
     kind: "text",
     text,
-    ...(run.bold !== undefined ? { bold: run.bold } : {}),
-    ...(run.italic !== undefined ? { italic: run.italic } : {}),
-    ...(run.underline !== undefined ? { underline: run.underline } : {}),
-    ...(run.strike !== undefined ? { strike: run.strike } : {}),
-    ...(run.color !== undefined ? { color: run.color } : {}),
-    ...(run.textColorSource !== undefined
-      ? { textColorSource: run.textColorSource }
-      : {}),
-    ...(run.highlight !== undefined ? { highlight: run.highlight } : {}),
-    ...(run.fontFamily !== undefined ? { fontFamily: run.fontFamily } : {}),
-    ...(run.fontSize !== undefined ? { fontSize: run.fontSize } : {}),
-    ...(run.letterSpacing !== undefined
-      ? { letterSpacing: run.letterSpacing }
-      : {}),
-    ...(run.allCaps !== undefined ? { allCaps: run.allCaps } : {}),
-    ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
-    ...(run.positionPx !== undefined ? { positionPx: run.positionPx } : {}),
-    ...(run.horizontalScale !== undefined
-      ? { horizontalScale: run.horizontalScale }
-      : {}),
-    ...(run.kerningMinPt !== undefined
-      ? { kerningMinPt: run.kerningMinPt }
-      : {}),
-    ...(run.imprint !== undefined ? { imprint: run.imprint } : {}),
-    ...(run.emboss !== undefined ? { emboss: run.emboss } : {}),
-    ...(run.textShadow !== undefined ? { textShadow: run.textShadow } : {}),
-    ...(run.textOutline !== undefined ? { textOutline: run.textOutline } : {}),
-    ...(run.emphasisMark !== undefined
-      ? { emphasisMark: run.emphasisMark }
-      : {}),
-    ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
-    ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
   };
 
   return renderTextRun(resolvedRun, doc);
@@ -762,7 +777,89 @@ type RenderLineOptions = {
   floatingMargins?: { leftMargin: number; rightMargin: number };
   /** Track inline image runs already rendered in this paragraph fragment to prevent duplicates */
   renderedInlineImageKeys?: Set<string>;
+  /**
+   * Rightmost x where inline content may render, in content-area coords. Used
+   * by the right-tab anchor (TOC pattern); passed in directly rather than
+   * recomposed from `leftIndentPx + availableWidth` because availableWidth
+   * excludes the hung-out region for some inputs and would drift.
+   */
+  lineRightEdgePx?: number;
 };
+
+/**
+ * Sub-pixel tolerance when comparing canvas-measured widths against the DOM's
+ * actual right edge. Accumulated rounding from canvas measureText vs. browser
+ * layout can leave a right-anchored tab one pixel short, so the flex anchor
+ * must trigger within this slack.
+ */
+const RIGHT_EDGE_EPSILON_PX = 0.5;
+
+/**
+ * Build a TextMeasureStyle from a TextRun or FieldRun's relevant fields.
+ */
+function runMeasureStyle(run: TextRun | FieldRun): TextMeasureStyle {
+  return {
+    ...(run.bold !== undefined ? { bold: run.bold } : {}),
+    ...(run.italic !== undefined ? { italic: run.italic } : {}),
+    ...(run.letterSpacing !== undefined
+      ? { letterSpacing: run.letterSpacing }
+      : {}),
+    ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
+  };
+}
+
+/**
+ * Sum the pixel widths of runs that follow a tab on the same line, up to the
+ * next tab or line break. Measures per-run so the right-tab anchor reserves
+ * the exact space the trailing content will take when it uses a different
+ * font/size from the default (e.g. TOC page numbers). Floating images
+ * contribute 0 inline width — they render at the page level.
+ */
+function measureFollowingContentWidth(
+  runs: Run[],
+  tabRunIndex: number,
+  measureText: (
+    text: string,
+    fontSize?: number,
+    fontFamily?: string,
+    style?: TextMeasureStyle,
+  ) => number,
+  context?: RenderContext,
+): number {
+  let width = 0;
+  for (let i = tabRunIndex + 1; i < runs.length; i++) {
+    // SAFETY: i < runs.length
+    const run = runs[i]!;
+    if (isTabRun(run) || isLineBreakRun(run)) {
+      break;
+    }
+    if (isTextRun(run)) {
+      const text = run.allCaps ? run.text.toLocaleUpperCase() : run.text;
+      width += measureText(
+        text,
+        run.fontSize ?? 11,
+        run.fontFamily ?? "Calibri",
+        runMeasureStyle(run),
+      );
+    } else if (isFieldRun(run)) {
+      let fieldText = run.fallback ?? "";
+      if (run.fieldType === "PAGE" && context) {
+        fieldText = String(context.pageNumber);
+      } else if (run.fieldType === "NUMPAGES" && context) {
+        fieldText = String(context.totalPages);
+      }
+      width += measureText(
+        run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
+        run.fontSize ?? 11,
+        run.fontFamily ?? "Calibri",
+        runMeasureStyle(run),
+      );
+    } else if (isImageRun(run) && !isFloatingImageRun(run)) {
+      width += run.width || 0;
+    }
+  }
+  return width;
+}
 
 /**
  * Build a stable key for an inline image run.
@@ -925,6 +1022,19 @@ export function renderLine(
   if (runsForLine.length === 1 && isImageRun(runsForLine[0]!)) {
     lineEl.style.display = "flex";
     lineEl.style.alignItems = "center";
+  } else if (runsForLine.some(isImageRun)) {
+    // Image flowing alongside text/tabs (logo + label header). Word seats an
+    // inline image as a tall glyph on the text baseline, so baseline-align
+    // the row — the image bottom then lands on the text baseline. The line
+    // height was measured to match (imageH + text descent). Stays paired
+    // with the measurer's `fromRun !== toRun` branch.
+    lineEl.style.display = "flex";
+    lineEl.style.alignItems = "baseline";
+    // Flex blockifies the run spans, so they'd otherwise inherit the line's
+    // image-inflated line-height as their own box height — fattening each
+    // text run to the full band and breaking baseline alignment. Reset to
+    // the font's natural line box; the line div keeps its explicit `height`.
+    lineEl.style.lineHeight = "normal";
   }
 
   // Handle empty lines
@@ -1029,12 +1139,119 @@ export function renderLine(
         measureText,
       );
 
-      // Render tab with calculated width and leader
-      const tabEl = renderTabRun(run, doc, tabResult.width, tabResult.leader);
+      // Right-tab anchor (TOC pattern): when an end-aligned tab's stop is at
+      // (or past) the line's right edge AND no later tab follows on this
+      // line, promote the line to flex and let flex layout pin the trailing
+      // content flush right. This sidesteps canvas-vs-DOM measurement drift
+      // that otherwise leaves the page number a pixel short of the margin.
+      const lineRightEdgeX = options?.lineRightEdgePx;
+      const followingWidthForCheck =
+        lineRightEdgeX !== undefined
+          ? measureFollowingContentWidth(
+              runsForLine,
+              i,
+              measureText,
+              options?.context,
+            )
+          : 0;
+      let hasFollowingTab = false;
+      for (let j = i + 1; j < runsForLine.length; j++) {
+        // SAFETY: j < runsForLine.length
+        const next = runsForLine[j]!;
+        if (isLineBreakRun(next)) {
+          break;
+        }
+        if (isTabRun(next)) {
+          hasFollowingTab = true;
+          break;
+        }
+      }
+      const useRightAnchor =
+        lineRightEdgeX !== undefined &&
+        tabResult.alignment === "end" &&
+        !hasFollowingTab &&
+        currentX + tabResult.width + followingWidthForCheck >=
+          lineRightEdgeX - RIGHT_EDGE_EPSILON_PX;
+
+      if (useRightAnchor) {
+        // Promote to flex row. text-indent applies per flex item (not to the
+        // group), so a hanging-indent paragraph would pull every text item
+        // left including the page number — the orchestrator re-applies the
+        // hanging via margin-left on the first child instead.
+        lineEl.style.display = "flex";
+        lineEl.style.alignItems = "baseline";
+        lineEl.style.whiteSpace = "nowrap";
+        lineEl.style.textIndent = "0";
+        lineEl.dataset["flexLine"] = "true";
+        if (
+          options?.isFirstLine &&
+          options.firstLineIndentPx !== undefined &&
+          options.firstLineIndentPx < 0 &&
+          lineEl.firstElementChild instanceof HTMLElement
+        ) {
+          lineEl.firstElementChild.style.marginLeft = `${options.firstLineIndentPx}px`;
+        }
+
+        // The tab flex-grows to fill the remaining line space; the leader
+        // inside is absolutely positioned and clips to the tab's box.
+        const tabEl = renderTabRun(run, doc, 0, tabResult.leader);
+        tabEl.style.flex = "1 1 0";
+        tabEl.style.minWidth = "0";
+        tabEl.style.width = "auto";
+        lineEl.append(tabEl);
+
+        // Render the remaining runs into the line at their natural width.
+        // Flex layout puts them flush against the line's right edge.
+        for (let j = i + 1; j < runsForLine.length; j++) {
+          // SAFETY: j < runsForLine.length
+          const next = runsForLine[j]!;
+          if (isTabRun(next) || isLineBreakRun(next)) {
+            break;
+          }
+          if (isTextRun(next)) {
+            lineEl.append(renderTextRun(next, doc));
+          } else if (isFieldRun(next) && options?.context) {
+            lineEl.append(renderFieldRun(next, doc, options.context));
+          } else if (isImageRun(next)) {
+            // Floating images render in dedicated layers — skip here so we
+            // don't double-render. Inline images render via getInlineImageRunKey
+            // bookkeeping so the orchestrator doesn't repaint them.
+            if (isFloatingImageRun(next)) {
+              continue;
+            }
+            const imageKey = getInlineImageRunKey(next);
+            if (!options?.renderedInlineImageKeys?.has(imageKey)) {
+              options?.renderedInlineImageKeys?.add(imageKey);
+              lineEl.append(renderImageRun(next, doc));
+            }
+          } else {
+            lineEl.append(renderRun(next, doc, options?.context));
+          }
+        }
+
+        break;
+      }
+
+      // Fallback path: not a right-anchored tab. Clamp the tab width so it
+      // doesn't overshoot the line's right edge when the stop sits just past
+      // the content area (Word TOC styles author stops a hair beyond the
+      // margin); without this, the painted tab spills into the right margin.
+      let tabWidth = tabResult.width;
+      if (
+        lineRightEdgeX !== undefined &&
+        currentX + tabWidth + followingWidthForCheck > lineRightEdgeX
+      ) {
+        tabWidth = Math.max(
+          1,
+          lineRightEdgeX - currentX - followingWidthForCheck,
+        );
+      }
+
+      const tabEl = renderTabRun(run, doc, tabWidth, tabResult.leader);
       lineEl.append(tabEl);
 
       // Update X position
-      currentX += tabResult.width;
+      currentX += tabWidth;
     } else if (isTextRun(run)) {
       const runEl = renderTextRun(run, doc);
 
@@ -1465,7 +1682,19 @@ export function renderParagraphFragment(
         rightMargin: lineRightOffset,
       },
       renderedInlineImageKeys,
+      // Absolute right edge in content-area coords. The fragment starts at
+      // content-area-x=0 with full content-area width; the rightmost x where
+      // inline content can land is `fragment.width - indentRight - lineRightOffset`.
+      // Used by the right-tab anchor — see RenderLineOptions.lineRightEdgePx.
+      lineRightEdgePx: fragment.width - indentRight - lineRightOffset,
     });
+
+    // If renderLine promoted this line to flex (right-tab anchor for TOC
+    // entries), text-indent must NOT apply: it would shift the first inline
+    // content INSIDE EACH flex item (e.g. the page-number anchor), pulling
+    // it left by `hanging`. Right-tab anchored lines re-apply the hanging
+    // offset as margin-left on the first item inside renderLine itself.
+    const isFlexLine = lineEl.dataset["flexLine"] === "true";
 
     // Apply left offset from floating images (lines start after the floating image)
     // Also constrain width so text doesn't overflow into the image area
@@ -1501,16 +1730,20 @@ export function renderParagraphFragment(
       if (indentLeft !== 0 && hasHanging) {
         // Hanging indent: first line starts at (indentLeft - hanging)
         lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        lineEl.style.textIndent = `-${indent.hanging ?? 0}px`;
+        if (!isFlexLine) {
+          lineEl.style.textIndent = `-${indent.hanging ?? 0}px`;
+        }
       } else if (indentLeft !== 0 && hasFirstLine) {
         // First line indent: first line starts at (indentLeft + firstLine)
         lineEl.style.paddingLeft = `${Math.max(indentLeft, 0)}px`;
-        lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
+        if (!isFlexLine) {
+          lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
+        }
       } else if (indentLeft > 0) {
         // Just left indent, no special first line treatment
         lineEl.style.paddingLeft = `${indentLeft}px`;
-      } else if (hasFirstLine) {
-        // No left indent, but has first line indent
+      } else if (hasFirstLine && !isFlexLine) {
+        // No left indent, but has first line indent.
         lineEl.style.textIndent = `${indent.firstLine ?? 0}px`;
       }
       // No hanging without left indent (handled by firstLineOffset in measurement)

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -833,14 +833,22 @@ function measureFollowingContentWidth(
     if (isTabRun(run) || isLineBreakRun(run)) {
       break;
     }
+    // Apply horizontalScale to match what the renderer's main loop does to
+    // currentX (`measuredWidth * (run.horizontalScale ?? 100) / 100`). Without
+    // this, expanded/compressed text after a tab over/under-estimates the
+    // trailing width and the right-edge check fires (or doesn't) at the wrong
+    // threshold, causing alignment drift on scaled TOC entries.
+    const scale = (run as { horizontalScale?: number }).horizontalScale ?? 100;
     if (isTextRun(run)) {
       const text = run.allCaps ? run.text.toLocaleUpperCase() : run.text;
-      width += measureText(
-        text,
-        run.fontSize ?? 11,
-        run.fontFamily ?? "Calibri",
-        runMeasureStyle(run),
-      );
+      width +=
+        measureText(
+          text,
+          run.fontSize ?? 11,
+          run.fontFamily ?? "Calibri",
+          runMeasureStyle(run),
+        ) *
+        (scale / 100);
     } else if (isFieldRun(run)) {
       let fieldText = run.fallback ?? "";
       if (run.fieldType === "PAGE" && context) {
@@ -848,13 +856,17 @@ function measureFollowingContentWidth(
       } else if (run.fieldType === "NUMPAGES" && context) {
         fieldText = String(context.totalPages);
       }
-      width += measureText(
-        run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
-        run.fontSize ?? 11,
-        run.fontFamily ?? "Calibri",
-        runMeasureStyle(run),
-      );
+      width +=
+        measureText(
+          run.allCaps ? fieldText.toLocaleUpperCase() : fieldText,
+          run.fontSize ?? 11,
+          run.fontFamily ?? "Calibri",
+          runMeasureStyle(run),
+        ) *
+        (scale / 100);
     } else if (isImageRun(run) && !isFloatingImageRun(run)) {
+      // Inline images aren't horizontally scaled by w:w on the surrounding
+      // text run; their own width attribute is authoritative.
       width += run.width || 0;
     }
   }
@@ -1190,7 +1202,12 @@ export function renderLine(
         // appended (see below).
         lineEl.style.display = "flex";
         lineEl.style.alignItems = "baseline";
-        lineEl.style.whiteSpace = "nowrap";
+        // `pre` matches the non-flex path on the same renderLine: it both
+        // preserves consecutive spaces (TOC titles can carry XML-preserved
+        // multi-spaces) and disallows mid-line wrap, which is the property
+        // the flex anchor needs. `nowrap` would prevent wrap but collapse
+        // consecutive spaces, silently changing rendered content.
+        lineEl.style.whiteSpace = "pre";
         lineEl.style.textIndent = "0";
         // Centered / right-aligned paragraphs need explicit justify-content:
         // flex defaults to flex-start regardless of the parent's text-align,

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -8,7 +8,10 @@
  * - Basic cell styling (borders, backgrounds)
  */
 
-import { measureParagraph } from "../layout-bridge/measuring";
+import {
+  clampFloatingWrapMargins,
+  measureParagraph,
+} from "../layout-bridge/measuring";
 import type { FloatingImageZone } from "../layout-bridge/measuring";
 import type {
   TableFragment,
@@ -240,7 +243,19 @@ function renderCellContent(
           rightMargin = contentWidth - (img.x - img.distLeft);
         }
       }
-      return { leftMargin, rightMargin, topY: rectTop, bottomY: rectBottom };
+      // See clampFloatingWrapMargins doc — near-full-width floats can compute
+      // a wrap margin >= contentWidth and collapse subsequent lines to ~1 glyph.
+      const clamped = clampFloatingWrapMargins(
+        leftMargin,
+        rightMargin,
+        contentWidth,
+      );
+      return {
+        leftMargin: clamped.leftMargin,
+        rightMargin: clamped.rightMargin,
+        topY: rectTop,
+        bottomY: rectBottom,
+      };
     });
 
     // Render floating image layer within the cell

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
@@ -1,0 +1,106 @@
+// Regression eigenpal #566: tabs (and other non-text run content) inside
+// <w:hyperlink> were dropped by convertHyperlink, which only carried
+// `content.type === "text"` into the PM doc. TOC entries store the title
+// and the right-aligned page number inside a single hyperlink with a
+// w:tab between them — without the tab, the page number renders flush
+// against the title and the entry no longer looks like a TOC line.
+
+import { describe, expect, test } from "bun:test";
+
+import type { Document, Hyperlink, Paragraph } from "../../types/document";
+import { toProseDoc } from "./toProseDoc";
+
+const docWithHyperlink = (hyperlink: Hyperlink): Document => {
+  const paragraph: Paragraph = {
+    type: "paragraph",
+    content: [hyperlink],
+  };
+  return {
+    package: {
+      document: {
+        content: [paragraph],
+      },
+    },
+  };
+};
+
+describe("convertHyperlink preserves non-text run content", () => {
+  test("preserves a w:tab inside a hyperlink (TOC title→page-number)", () => {
+    const hyperlink: Hyperlink = {
+      type: "hyperlink",
+      anchor: "_Toc1",
+      children: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "Section 1" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "tab" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "text", text: "5" }],
+        },
+      ],
+    };
+
+    const pmDoc = toProseDoc(docWithHyperlink(hyperlink));
+    const paragraph = pmDoc.firstChild;
+    expect(paragraph?.type.name).toBe("paragraph");
+    const childTypes: string[] = [];
+    if (paragraph) {
+      for (let i = 0; i < paragraph.childCount; i++) {
+        childTypes.push(paragraph.child(i).type.name);
+      }
+    }
+    // The tab node must survive into the PM doc — the bug was dropping it
+    // entirely. Text children on both sides must still carry the hyperlink
+    // mark (clickable title and page number). The tab node itself doesn't
+    // need the mark — PM tabs typically don't accept inline marks.
+    expect(childTypes).toContain("tab");
+    expect(childTypes.filter((n) => n === "text")).toHaveLength(2);
+    if (paragraph) {
+      for (let i = 0; i < paragraph.childCount; i++) {
+        const child = paragraph.child(i);
+        if (child.type.name === "text") {
+          expect(child.marks.some((m) => m.type.name === "hyperlink")).toBe(
+            true,
+          );
+        }
+      }
+    }
+  });
+
+  test("preserves a w:br inside a hyperlink", () => {
+    const hyperlink: Hyperlink = {
+      type: "hyperlink",
+      href: "https://example.com",
+      children: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "Line A" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "break", breakType: "textWrapping" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "text", text: "Line B" }],
+        },
+      ],
+    };
+
+    const pmDoc = toProseDoc(docWithHyperlink(hyperlink));
+    const paragraph = pmDoc.firstChild;
+    const childTypes: string[] = [];
+    if (paragraph) {
+      for (let i = 0; i < paragraph.childCount; i++) {
+        childTypes.push(paragraph.child(i).type.name);
+      }
+    }
+    expect(childTypes).toContain("hardBreak");
+    expect(childTypes.filter((n) => n === "text")).toHaveLength(2);
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -218,6 +218,95 @@ describe("toProseDoc", () => {
     expect(tableCellBorderColor(attrs, "top")?.themeColor).toBeUndefined();
   });
 
+  test("resolves themed table-cell border color with themeTint to the modified RGB", () => {
+    const document: Document = {
+      package: {
+        theme: officeTheme,
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: {
+                        borders: {
+                          left: {
+                            style: "single",
+                            size: 4,
+                            color: {
+                              themeColor: "accent1",
+                              themeTint: "33",
+                            },
+                          },
+                        },
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const attrs = firstTableCellAttrs(document);
+
+    // accent1 (4472C4) blended toward white with tint 0x33/0xFF.
+    expect(tableCellBorderColor(attrs, "left")?.rgb).toBe("DAE3F3");
+    expect(tableCellBorderColor(attrs, "left")?.themeColor).toBeUndefined();
+  });
+
+  test("passes plain RGB and auto table-cell border colors through unchanged", () => {
+    const document: Document = {
+      package: {
+        theme: officeTheme,
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: {
+                        borders: {
+                          top: {
+                            style: "single",
+                            size: 8,
+                            color: { rgb: "FF0000" },
+                          },
+                          bottom: {
+                            style: "single",
+                            size: 8,
+                            color: { rgb: "auto" },
+                          },
+                        },
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const attrs = firstTableCellAttrs(document);
+
+    expect(tableCellBorderColor(attrs, "top")?.rgb).toBe("FF0000");
+    expect(tableCellBorderColor(attrs, "bottom")?.rgb).toBe("auto");
+  });
+
   test("keeps unresolved themed table-cell border colors when no document theme exists", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1879,10 +1879,12 @@ function convertHyperlink(
       // Add link mark to run marks
       const allMarks = [...runMarks, linkMark];
 
+      // Delegate to convertRunContent so tabs/breaks/fields/symbols inside
+      // a hyperlink round-trip (eigenpal #566). The earlier text-only loop
+      // silently dropped TOC entries' tab between title and page number,
+      // collapsing the right-aligned page number flush against the title.
       for (const content of child.content) {
-        if (content.type === "text" && content.text) {
-          nodes.push(schema.text(content.text, allMarks));
-        }
+        nodes.push(...convertRunContent(content, allMarks));
       }
     }
   }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -236,7 +236,7 @@ export type PagedEditorProps = {
     href: string;
     displayText: string;
     tooltip?: string;
-    anchorRect: DOMRect;
+    anchorEl: HTMLAnchorElement;
   }) => void;
   /** Callback when user right-clicks on the pages (for context menu). */
   onContextMenu?: (data: {
@@ -3987,10 +3987,9 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
             if (!hasRangeSelection) {
               const displayText = anchorEl.textContent || "";
               const tooltip = anchorEl.getAttribute("title") || undefined;
-              const anchorRect = anchorEl.getBoundingClientRect();
               const clickData: Parameters<
                 NonNullable<typeof onHyperlinkClick>
-              >[0] = { href, displayText, anchorRect };
+              >[0] = { href, displayText, anchorEl };
               if (tooltip) {
                 clickData.tooltip = tooltip;
               }


### PR DESCRIPTION
Syncs six fidelity fixes from `eigenpal/docx-editor` since our last sync (PR #297, 2026-05-11). Each upstream fix was reviewed against folio's diverged structure and either ported, improved, or skipped with rationale.

## Ported

- **#564** clamp near-full-width float wrap margins → `clampFloatingWrapMargins` helper, applied at both zone construction sites (`renderPage.ts`, `renderTable.ts`). Body lines after a wide float no longer collapse to ~1 glyph per line.
- **#566** preserve tabs inside hyperlinks + render TOC like Word → three parts: (a) `convertHyperlink` delegates to `convertRunContent` so tabs/breaks/fields round-trip; (b) `HyperlinkInfo.noDefaultStyle` + `stripTocHyperlinkStyle` gated by `TOC_STYLE_ID=/^TOC\d*$/i`, applied at text + field run paths, honoured by `renderTextRun`; (c) `renderTabRun` leader switches from SVG background to abs-positioned inner span over baseline-aligned ZWSP; new `RenderLineOptions.lineRightEdgePx` + `measureFollowingContentWidth`; end-aligned tab at line right edge promotes to flex (`tab: 1 1 0`, trailing runs flush right); orchestrator suppresses `text-indent` on `data-flex-line` rows.
- **#567** extract text-box drawings inside `mc:AlternateContent` → `scanRunForTextBoxDrawings` walks Choice (preferred) + Fallback branches. Folio's existing two-pointer walk is more robust than upstream's clamp-to-last and already handles multi-AC paragraphs.
- **#580** baseline-align inline-image header lines → `measureParagraph` splits the tall-image branch into image-alone (keep `imageH+desc*2` band) vs flowing (`imageH+desc`, image on text baseline). Inline footprint includes `distT/distB`. Painter adds `alignItems=baseline` + `lineHeight=normal` for image-with-text; `renderInlineImageRun` applies `distTop/distBottom` margins.

## Improved (already in folio, refined)

- **#441** themed table-cell border colors — already in via PR #303 (`resolveThemedBorderColors`). Added two guard tests: themed border with `themeTint` resolves to modified RGB; plain RGB / `auto` pass through unchanged.
- **#575** field results render with their own run formatting — bridge half already in folio. `renderFieldRun` now spreads the run instead of enumerating 21 fields by hand; future `RunFormatting` additions land automatically.

## Skipped

- **#568** `generateHexId` OOXML cap — not applicable. Folio doesn't synthesize `paraId`/`durableId`/`textId` at runtime; bookmark id at `ParagraphExtension.ts:889` already uses `0x7FFFFFFF` as multiplier. Bug needs both an allocator (folio has none) and the wrong multiplier; we have neither.

## Deferred

- **#576** unify tab-stop layout — folio has the same divergence (private `computeTabWidth` in `measureParagraph` vs `calculateTabWidth` used by painter). Proper port is upstream's ~200-line refactor that changes `calculateTabWidth`'s signature and adds look-ahead in `measureParagraph`. Wants its own focused PR with right/center/decimal-tab fixtures.

## Independent fix bundled in

- **#514** hyperlink popup pinned to anchor on scroll — `HyperlinkPopupData` carries `anchorEl: HTMLAnchorElement` (live ref) instead of `anchorRect: DOMRect` (snapshot). Popup attaches scroll+resize listeners to recompute `top/left` from the live element. Smaller diff than upstream's render-inside-scroll-container restructure; behaviourally equivalent. Landed as a separate commit since it's a UI-only change.

## Tests

24 new regression tests:

- `toProseDoc.test.ts` — #441
- `measureParagraph.test.ts` — #564, #580
- `documentParser-alternatecontent.test.ts` — #567
- `toFlowBlocks.test.ts` — #575, #566 TOC strip
- `toProseDoc-hyperlink-content.test.ts` — #566 hyperlink content
- `renderParagraph-right-tab.test.ts` — #566 flex anchor + leader rendering

Local: 732 tests pass, 0 fail; `oxlint`/`oxfmt`/`typecheck` clean.

## Test plan

- [ ] Watch CI
- [ ] Open a TOC-bearing doc in the playground: entries render with no blue underline, page numbers flush right, dot leader between
- [ ] Open a doc with a near-full-width floating table; subsequent body text wraps at full width
- [ ] Open a doc with a logo + label header row; logo sits on text baseline
- [ ] Open an org-chart-style doc (`mc:AlternateContent`-wrapped text-boxes); card text appears
- [ ] Click a hyperlink in the rendered doc; popup stays pinned to link on scroll
