### PR TITLE
chore(api): tighten env validation

### DIFF
--- a/apps/api/src/env-base.ts
+++ b/apps/api/src/env-base.ts
@@ -12,6 +12,14 @@ import * as v from "valibot";
 
 import { resolveDatabaseUrl } from "@/api/db-url";
 
+/**
+ * NODE_ENV values that identify a deployed (non-local) Stella
+ * environment. Used to gate strict env validation and the
+ * `isDev` default below. Kept here so every entrypoint that
+ * imports `envBase` sees the same definition.
+ */
+export const DEPLOYED_NODE_ENVS = new Set(["production", "staging"]);
+
 const databasePoolMaxSchema = v.optional(
   v.pipe(
     v.string(),
@@ -47,7 +55,10 @@ export const envBase = createEnv({
       v.pipe(v.string(), v.parseBoolean()),
       "false",
     ),
-    isDev: v.optional(v.boolean(), process.env.NODE_ENV !== "production"),
+    isDev: v.optional(
+      v.boolean(),
+      !DEPLOYED_NODE_ENVS.has(process.env.NODE_ENV ?? ""),
+    ),
   },
   emptyStringAsUndefined: true,
   runtimeEnv: { ...process.env, DATABASE_URL: resolveDatabaseUrl() },

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -8,6 +8,8 @@ const featureFlagSchema = v.optional(
   "false",
 );
 
+const DEPLOYED_NODE_ENVS = new Set(["production", "staging"]);
+
 /**
  * API-specific environment variables. These are only required
  * when the full API server boots (auth, email, gotenberg, redis,
@@ -109,8 +111,14 @@ const envApi = createEnv({
     GOTENBERG_URL: v.pipe(v.string(), v.url()),
     GOTENBERG_USERNAME: v.string(),
     GOTENBERG_PASSWORD: v.string(),
-    CONTENT_ENCRYPTION_KEY: v.optional(
-      v.pipe(v.string(), v.regex(/^[0-9a-f]{64}$/iu)),
+    CONTENT_ENCRYPTION_KEY: v.pipe(
+      v.optional(v.pipe(v.string(), v.regex(/^[0-9a-f]{64}$/iu))),
+      v.check(
+        (value) =>
+          value !== undefined ||
+          !DEPLOYED_NODE_ENVS.has(process.env.NODE_ENV ?? ""),
+        "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
+      ),
     ),
     EXTENSION_ORIGIN: v.optional(v.string()),
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,14 +1,12 @@
 import { createEnv } from "@t3-oss/env-core";
 import * as v from "valibot";
 
-import { envBase } from "@/api/env-base";
+import { DEPLOYED_NODE_ENVS, envBase } from "@/api/env-base";
 
 const featureFlagSchema = v.optional(
   v.pipe(v.string(), v.parseBoolean()),
   "false",
 );
-
-const DEPLOYED_NODE_ENVS = new Set(["production", "staging"]);
 
 /**
  * API-specific environment variables. These are only required

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -111,13 +111,13 @@ const envApi = createEnv({
     GOTENBERG_URL: v.pipe(v.string(), v.url()),
     GOTENBERG_USERNAME: v.string(),
     GOTENBERG_PASSWORD: v.string(),
-    CONTENT_ENCRYPTION_KEY: v.pipe(
-      v.optional(v.pipe(v.string(), v.regex(/^[0-9a-f]{64}$/iu))),
-      v.check(
-        (value) =>
-          value !== undefined ||
-          !DEPLOYED_NODE_ENVS.has(process.env.NODE_ENV ?? ""),
-        "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
+    CONTENT_ENCRYPTION_KEY: v.optional(
+      v.pipe(
+        v.string(),
+        v.regex(
+          /^[0-9a-f]{64}$/iu,
+          "CONTENT_ENCRYPTION_KEY must be a 64-character hex string",
+        ),
       ),
     ),
     EXTENSION_ORIGIN: v.optional(v.string()),
@@ -162,6 +162,15 @@ if (
 ) {
   throw new Error(
     "MICROSOFT_AUTH_TENANT_ID is required when Microsoft OAuth is configured.",
+  );
+}
+
+if (
+  DEPLOYED_NODE_ENVS.has(process.env.NODE_ENV ?? "") &&
+  !envApi.CONTENT_ENCRYPTION_KEY
+) {
+  throw new Error(
+    "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
   );
 }
 

--- a/apps/api/src/lib/content-encryption.ts
+++ b/apps/api/src/lib/content-encryption.ts
@@ -3,9 +3,11 @@
  * file content. Defense-in-depth: even if the DB is
  * compromised, extracted text stays encrypted.
  *
- * When CONTENT_ENCRYPTION_KEY is absent (dev mode), content
- * is stored as plaintext wrapped in a no-op envelope so the
- * schema stays consistent.
+ * When CONTENT_ENCRYPTION_KEY is absent, content is stored
+ * as plaintext wrapped in a no-op envelope so the schema
+ * stays consistent. The env validator (`apps/api/src/env.ts`)
+ * requires the key when NODE_ENV is 'production' or 'staging',
+ * so this fallback only fires in local dev / tests.
  */
 
 import { hkdf } from "node:crypto";


### PR DESCRIPTION
## Summary
- Require `CONTENT_ENCRYPTION_KEY` when `NODE_ENV` is `production` or `staging`. Local dev + tests unaffected.

## Test plan
- [ ] `bun --filter @stll/api typecheck`
- [ ] `bun --filter @stll/api lint`