### PR TITLE
fix: use session auth for AI provider validation

### DIFF
--- a/apps/api/src/handlers/ai-config/routes.ts
+++ b/apps/api/src/handlers/ai-config/routes.ts
@@ -1,12 +1,11 @@
 import Elysia from "elysia";
 
-import {
-  handleValidateProvider,
-  validateProviderBody,
-} from "@/api/handlers/ai-config/validate-provider";
+import validateProvider from "@/api/handlers/ai-config/validate-provider";
+import { sessionAuthMacro } from "@/api/lib/auth";
 
-export const aiConfigPublicRoute = new Elysia({ prefix: "/ai-config" }).post(
-  "/validate-provider",
-  async ({ body, request }) => await handleValidateProvider({ body, request }),
-  { body: validateProviderBody },
-);
+export const aiConfigPublicRoute = new Elysia({ prefix: "/ai-config" })
+  .use(sessionAuthMacro)
+  .guard({ validateSession: true })
+  .post("/validate-provider", validateProvider.handler, {
+    body: validateProvider.config.body,
+  });

--- a/apps/api/src/handlers/ai-config/validate-provider.ts
+++ b/apps/api/src/handlers/ai-config/validate-provider.ts
@@ -1,11 +1,13 @@
 import { Result } from "better-result";
-import { status, t } from "elysia";
+import { t } from "elysia";
 
 import {
   PROVIDER_PROBE_VALUES,
   probeProvider,
 } from "@/api/lib/ai-provider-probe";
-import { getSessionAndMemberRole } from "@/api/lib/auth";
+import { createSafeSessionHandler } from "@/api/lib/api-handlers";
+import type { SessionHandlerConfig } from "@/api/lib/api-handlers";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { logger } from "@/api/lib/observability/logger";
 
 const MAX_PROBE_ERROR_DETAIL_LEN = 200;
@@ -18,7 +20,14 @@ export const validateProviderBody = t.Object({
   region: t.Optional(t.UnionEnum(["eu", "global", "ch"])),
 });
 
-type ValidateProviderBody = (typeof validateProviderBody)["static"];
+const config = {
+  body: validateProviderBody,
+} satisfies SessionHandlerConfig;
+
+const truncateProbeError = (message: string): string =>
+  message.length > MAX_PROBE_ERROR_DETAIL_LEN
+    ? message.slice(0, MAX_PROBE_ERROR_DETAIL_LEN)
+    : message;
 
 /**
  * Authenticated, org-agnostic AI provider key health-check. The
@@ -29,51 +38,46 @@ type ValidateProviderBody = (typeof validateProviderBody)["static"];
  * addresses, so the user-supplied Azure `endpoint` cannot reach
  * private targets.
  */
-export const handleValidateProvider = async ({
-  body,
-  request,
-}: {
-  body: ValidateProviderBody;
-  request: Request;
-}) => {
-  const { sessionResult } = await getSessionAndMemberRole(request.headers);
-  if (Result.isError(sessionResult)) {
-    return status(500, { message: "Internal server error" });
-  }
-  const session = sessionResult.value?.session;
-  const user = sessionResult.value?.user;
-  if (!session || !user) {
-    return status(401, { message: "Unauthorized" });
-  }
-
-  try {
-    const result = await probeProvider(
-      body.provider,
-      body.apiKey,
-      body.endpoint,
-      body.apiVersion,
+const validateProvider = createSafeSessionHandler(
+  config,
+  async function* ({ body }) {
+    const result = yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await probeProvider(
+            body.provider,
+            body.apiKey,
+            body.endpoint,
+            body.apiVersion,
+          ),
+        catch: (error: unknown) => {
+          const raw = error instanceof Error ? error.message : "Unknown error";
+          logger.warn("ai_config.provider_validation_unreachable", {
+            provider: body.provider,
+          });
+          return new HandlerError({
+            status: 502,
+            message: truncateProbeError(raw),
+            cause: error,
+          });
+        },
+      }),
     );
+
     if (!result.valid) {
       logger.warn("ai_config.provider_validation_rejected", {
         provider: body.provider,
       });
       if (result.error && result.error.length > MAX_PROBE_ERROR_DETAIL_LEN) {
-        return {
+        return Result.ok({
           valid: false as const,
-          error: result.error.slice(0, MAX_PROBE_ERROR_DETAIL_LEN),
-        };
+          error: truncateProbeError(result.error),
+        });
       }
     }
-    return result;
-  } catch (error) {
-    const raw = error instanceof Error ? error.message : "Unknown error";
-    const message =
-      raw.length > MAX_PROBE_ERROR_DETAIL_LEN
-        ? raw.slice(0, MAX_PROBE_ERROR_DETAIL_LEN)
-        : raw;
-    logger.warn("ai_config.provider_validation_unreachable", {
-      provider: body.provider,
-    });
-    return status(502, { message });
-  }
-};
+
+    return Result.ok(result);
+  },
+);
+
+export default validateProvider;

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -33,9 +33,22 @@ export type HandlerConfig = InputSchema & {
   permissions: PermissionInput;
 };
 
+export type SessionHandlerConfig = InputSchema;
+
 type ConfigRouteSchema<TConfig extends HandlerConfig> = UnwrapRoute<
   Omit<TConfig, "permissions">
 >;
+
+type SessionConfigRouteSchema<TConfig extends SessionHandlerConfig> =
+  UnwrapRoute<TConfig>;
+
+type SessionHandlerContext<
+  TConfig extends SessionHandlerConfig = SessionHandlerConfig,
+> = Context<SessionConfigRouteSchema<TConfig>> & {
+  user: {
+    id: SafeId<"user">;
+  };
+};
 
 type BaseHandlerContext<TConfig extends HandlerConfig = HandlerConfig> =
   Context<ConfigRouteSchema<TConfig>> & {
@@ -96,8 +109,8 @@ type SafeHandlerFn<TContext, TResult> = (
 >;
 
 type SafeHandlerDefinition<
-  TConfig extends HandlerConfig = HandlerConfig,
-  TContext = RootHandlerContext<TConfig>,
+  TConfig extends InputSchema = InputSchema,
+  TContext = Context<UnwrapRoute<TConfig>>,
   TResult = unknown,
 > = {
   config: TConfig;
@@ -117,6 +130,102 @@ function toSafeStatusResponse(
   return status(statusCode, body);
 }
 
+type SafeHandlerLogContext = {
+  request: Request;
+  route: string;
+};
+
+const runSafeHandler = async <TContext extends SafeHandlerLogContext, TResult>(
+  ctx: TContext,
+  handler: SafeHandlerFn<TContext, TResult>,
+): Promise<SafeHandlerResult<TResult>> => {
+  try {
+    const result = await Result.gen(() => handler(ctx));
+
+    if (Result.isOk(result)) {
+      return result.value;
+    }
+
+    const error = result.error;
+
+    if (HandlerError.is(error)) {
+      const statusCode = error.status;
+
+      if (statusCode >= 500) {
+        logAndCaptureSafeError({
+          request: ctx.request,
+          route: ctx.route,
+          error,
+          statusCode,
+        });
+      }
+
+      return toSafeStatusResponse(error.status, safeErrorBody(error));
+    }
+
+    if (DatabaseError.is(error)) {
+      logAndCaptureSafeError({
+        request: ctx.request,
+        route: ctx.route,
+        error,
+        statusCode: 500,
+      });
+
+      return toSafeStatusResponse(500, {
+        message: "Internal server error",
+      });
+    }
+
+    if (DatabaseRlsError.is(error)) {
+      logAndCaptureSafeError({
+        request: ctx.request,
+        route: ctx.route,
+        error,
+        statusCode: 400,
+      });
+
+      return toSafeStatusResponse(400, { message: "Access denied" });
+    }
+
+    logAndCaptureSafeError({
+      request: ctx.request,
+      route: ctx.route,
+      error,
+      statusCode: 500,
+    });
+
+    return toSafeStatusResponse(500, { message: "Internal server error" });
+  } catch (error) {
+    // A typed HandlerError thrown synchronously (or escaping the
+    // Result.gen pipeline) must still surface as its own status,
+    // not a generic 500. Without this branch a deeper handler
+    // that throws HandlerError for a recoverable condition (e.g.
+    // an AI request hitting a role the org has not configured a
+    // BYOK key for) gets reported to the user as "Internal
+    // server error" with no actionable detail.
+    if (HandlerError.is(error)) {
+      if (error.status >= 500) {
+        logAndCaptureSafeError({
+          request: ctx.request,
+          route: ctx.route,
+          error,
+          statusCode: error.status,
+        });
+      }
+      return toSafeStatusResponse(error.status, safeErrorBody(error));
+    }
+
+    logAndCaptureSafeError({
+      request: ctx.request,
+      route: ctx.route,
+      error,
+      statusCode: 500,
+    });
+
+    return toSafeStatusResponse(500, { message: "Internal server error" });
+  }
+};
+
 const createSafeScopedHandler = <
   TConfig extends HandlerConfig,
   TContext extends BaseHandlerContext<TConfig>,
@@ -135,91 +244,7 @@ const createSafeScopedHandler = <
       return toSafeStatusResponse(403, { message: "Forbidden" });
     }
 
-    try {
-      const result = await Result.gen(() => handler(ctx));
-
-      if (Result.isOk(result)) {
-        return result.value;
-      }
-
-      const error = result.error;
-
-      if (HandlerError.is(error)) {
-        const statusCode = error.status;
-
-        if (statusCode >= 500) {
-          logAndCaptureSafeError({
-            request: ctx.request,
-            route: ctx.route,
-            error,
-            statusCode,
-          });
-        }
-
-        return toSafeStatusResponse(error.status, safeErrorBody(error));
-      }
-
-      if (DatabaseError.is(error)) {
-        logAndCaptureSafeError({
-          request: ctx.request,
-          route: ctx.route,
-          error,
-          statusCode: 500,
-        });
-
-        return toSafeStatusResponse(500, {
-          message: "Internal server error",
-        });
-      }
-
-      if (DatabaseRlsError.is(error)) {
-        logAndCaptureSafeError({
-          request: ctx.request,
-          route: ctx.route,
-          error,
-          statusCode: 400,
-        });
-
-        return toSafeStatusResponse(400, { message: "Access denied" });
-      }
-
-      logAndCaptureSafeError({
-        request: ctx.request,
-        route: ctx.route,
-        error,
-        statusCode: 500,
-      });
-
-      return toSafeStatusResponse(500, { message: "Internal server error" });
-    } catch (error) {
-      // A typed HandlerError thrown synchronously (or escaping the
-      // Result.gen pipeline) must still surface as its own status,
-      // not a generic 500. Without this branch a deeper handler
-      // that throws HandlerError for a recoverable condition (e.g.
-      // an AI request hitting a role the org has not configured a
-      // BYOK key for) gets reported to the user as "Internal
-      // server error" with no actionable detail.
-      if (HandlerError.is(error)) {
-        if (error.status >= 500) {
-          logAndCaptureSafeError({
-            request: ctx.request,
-            route: ctx.route,
-            error,
-            statusCode: error.status,
-          });
-        }
-        return toSafeStatusResponse(error.status, safeErrorBody(error));
-      }
-
-      logAndCaptureSafeError({
-        request: ctx.request,
-        route: ctx.route,
-        error,
-        statusCode: 500,
-      });
-
-      return toSafeStatusResponse(500, { message: "Internal server error" });
-    }
+    return await runSafeHandler(ctx, handler);
   },
 });
 
@@ -239,6 +264,18 @@ export const createSafeHandler = <TConfig extends HandlerConfig, TResult>(
   handler: SafeHandlerFn<WorkspaceHandlerContext<TConfig>, TResult>,
 ): SafeHandlerDefinition<TConfig, WorkspaceHandlerContext<TConfig>, TResult> =>
   createSafeScopedHandler(config, handler);
+
+export const createSafeSessionHandler = <
+  TConfig extends SessionHandlerConfig,
+  TResult,
+>(
+  config: TConfig,
+  handler: SafeHandlerFn<SessionHandlerContext<TConfig>, TResult>,
+): SafeHandlerDefinition<TConfig, SessionHandlerContext<TConfig>, TResult> => ({
+  config,
+  handler: async (ctx): Promise<SafeHandlerResult<TResult>> =>
+    await runSafeHandler(ctx, handler),
+});
 
 type LogAndCaptureSafeErrorProps = {
   request: Request;

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -592,6 +592,40 @@ export const getSessionAndMemberRole = async (
   };
 };
 
+export const sessionAuthMacro = new Elysia({ name: "sessionAuthMacro" }).macro({
+  validateSession: {
+    async resolve({ status, request }) {
+      const sessionResult = await Result.tryPromise(
+        async () =>
+          await getAuth().api.getSession({
+            headers: request.headers,
+          }),
+      );
+
+      if (Result.isError(sessionResult)) {
+        return status(500);
+      }
+
+      const session = sessionResult.value?.session;
+      const user = sessionResult.value?.user;
+      if (!session || !user) {
+        return status(401);
+      }
+
+      const userId = toSafeId<"user">(user.id);
+      enrichRequestContext(request, {
+        posthogDistinctId: userId,
+      });
+
+      return {
+        user: {
+          id: userId,
+        },
+      };
+    },
+  },
+});
+
 export const ADMIN_BYPASS_ROLES: readonly MemberRole[] = ["owner", "admin"];
 
 export type AccessibleWorkspace = {


### PR DESCRIPTION
## Summary
- add a session-only safe handler path for authenticated endpoints without an active organization
- route AI provider validation through session auth instead of manual session lookup
- preserve provider probe error truncation and onboarding compatibility

## Checks
- bun --filter @stll/api typecheck
- bun --filter @stll/api lint
- pre-push format/i18n/lint/typecheck