### PR TITLE
refactor(api): tighten folio-collab session pipeline

### DIFF
--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -68,66 +68,172 @@ export const finalizeFolioCollabSessionHandler = async ({
     return status(403, { message: "Collaborative edit is read-only." });
   }
 
-  const uploadedKeys: string[] = [];
-  let checkpointKeyToDelete: string | null = null;
+  const { organizationId, scopedDb, userId, workspaceId } =
+    authorizedSession.value;
+
+  const deleteS3Key = async (key: string, context: Record<string, string>) => {
+    await getS3()
+      .delete(key)
+      .catch((error: unknown) => {
+        captureError(error, context);
+      });
+  };
+
+  // Phase A: non-locking read. entity_versions rows are immutable
+  // once written, so reading the base version outside the heavy
+  // write txn is safe; the session row may move under us, but we
+  // re-verify inside the write txn before we commit any rows.
+  const sessionPreview = await scopedDb(async (tx) => {
+    const rows = await tx
+      .select({
+        baseVersionId: folioCollabSessions.baseVersionId,
+        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+        docxCheckpointScanWarnings:
+          folioCollabSessions.docxCheckpointScanWarnings,
+        docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+        docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
+        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+        entityId: folioCollabSessions.entityId,
+        fileName: folioCollabSessions.fileName,
+        propertyId: folioCollabSessions.propertyId,
+        status: folioCollabSessions.status,
+      })
+      .from(folioCollabSessions)
+      .where(
+        and(
+          eq(folioCollabSessions.id, sessionId),
+          eq(folioCollabSessions.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    return rows.at(0);
+  });
+
+  if (!sessionPreview) {
+    return status(404, { message: "Collaborative edit session not found." });
+  }
+
+  if (sessionPreview.status !== "open") {
+    return status(409, {
+      message: "Collaborative edit session is already closed.",
+    });
+  }
+
+  const checkpointSha256Hex = sessionPreview.docxCheckpointSha256Hex;
+  const checkpointSizeBytes = sessionPreview.docxCheckpointSizeBytes;
+  if (
+    checkpointSha256Hex === null ||
+    checkpointSizeBytes === null ||
+    sessionPreview.docxCheckpointUpdatedAt === null
+  ) {
+    await scopedDb(async (tx) => {
+      await tx
+        .update(folioCollabSessions)
+        .set({ closedAt: new Date(), status: "cancelled" })
+        .where(eq(folioCollabSessions.id, sessionId));
+    });
+    return { outcome: "no_changes" } as const;
+  }
+
+  const checkpointKey = createFileKey({
+    fileId: sessionPreview.docxCheckpointFileId,
+    mimeType: DOCX_MIME_TYPE,
+    organizationId,
+    workspaceId,
+  });
+
+  const baseVersion = await scopedDb(
+    async (tx) =>
+      await tx.query.entityVersions.findFirst({
+        where: {
+          entityId: { eq: sessionPreview.entityId },
+          id: { eq: sessionPreview.baseVersionId },
+          workspaceId: { eq: workspaceId },
+        },
+        columns: { versionNumber: true },
+        with: {
+          fields: { columns: { content: true, propertyId: true } },
+        },
+      }),
+  );
+
+  if (!baseVersion) {
+    return status(409, { message: "Base entity version not found." });
+  }
+
+  const baseFileField = findDocxFieldForProperty({
+    fieldEntries: baseVersion.fields,
+    propertyId: sessionPreview.propertyId,
+  });
+
+  if (!baseFileField) {
+    return status(409, {
+      message: "Collaborative edit session source file is no longer available.",
+    });
+  }
+
+  if (checkpointSha256Hex === baseFileField.sha256Hex) {
+    await scopedDb(async (tx) => {
+      await tx
+        .update(folioCollabSessions)
+        .set({ closedAt: new Date(), status: "cancelled" })
+        .where(eq(folioCollabSessions.id, sessionId));
+    });
+    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+    return { outcome: "no_changes" } as const;
+  }
+
+  // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
+  // source bytes are written to S3 before we open the txn; any
+  // commit failure rolls them back via uploadedKeys.
+  const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+  const validation = await validateDocxBuffer(checkpointBuffer);
+  if (!validation.valid) {
+    return status(422, {
+      message: `Document validation failed: ${validation.error}`,
+    });
+  }
+
+  const storedBytes = new Uint8Array(checkpointBuffer);
+  const nextVersionNumber = baseVersion.versionNumber + 1;
+  const nextVersionId = createSafeId<"entityVersion">();
+  const sourceFileId = Bun.randomUUIDv7();
+  const sourceKey = createFileKey({
+    fileId: sourceFileId,
+    mimeType: DOCX_MIME_TYPE,
+    organizationId,
+    workspaceId,
+  });
+  const uploadedKeys: string[] = [sourceKey];
   let shouldRollbackUploadedKeys = true;
-
-  const deleteCheckpointKey = async (checkpointKey: string) => {
-    await getS3()
-      .delete(checkpointKey)
-      .catch((error: unknown) => {
-        captureError(error, { checkpointKey, sessionId });
-      });
-  };
-  const deletePendingCheckpointKey = async () => {
-    const checkpointKey = checkpointKeyToDelete;
-    if (checkpointKey === null) {
-      return;
-    }
-
-    checkpointKeyToDelete = null;
-    await deleteCheckpointKey(checkpointKey);
-  };
-
-  const deleteUploadedKey = async (uploadedKey: string) => {
-    await getS3()
-      .delete(uploadedKey)
-      .catch((error: unknown) => {
-        captureError(error, { rollbackKey: uploadedKey, sessionId });
-      });
+  const rollbackUploadedKeys = async () => {
+    await Promise.all(
+      uploadedKeys.map(
+        async (key) => await deleteS3Key(key, { rollbackKey: key, sessionId }),
+      ),
+    );
   };
 
   try {
-    const result = await authorizedSession.value.scopedDb(async (tx) => {
+    await getS3().write(sourceKey, storedBytes);
+
+    // Phase C: txn — lock + verify state hasn't drifted + write rows.
+    const result = await scopedDb(async (tx) => {
       const lockedSessions = await tx
         .select({
-          baseVersionId: folioCollabSessions.baseVersionId,
-          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-          docxCheckpointScanWarnings:
-            folioCollabSessions.docxCheckpointScanWarnings,
           docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
-          docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
-          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
-          entityId: folioCollabSessions.entityId,
-          fileName: folioCollabSessions.fileName,
-          id: folioCollabSessions.id,
-          propertyId: folioCollabSessions.propertyId,
           status: folioCollabSessions.status,
         })
         .from(folioCollabSessions)
         .where(
           and(
             eq(folioCollabSessions.id, sessionId),
-            eq(
-              folioCollabSessions.workspaceId,
-              authorizedSession.value.workspaceId,
-            ),
+            eq(folioCollabSessions.workspaceId, workspaceId),
           ),
         )
         .for("update");
 
       const editSession = lockedSessions.at(0);
-
       if (!editSession) {
         return {
           error: {
@@ -136,7 +242,6 @@ export const finalizeFolioCollabSessionHandler = async ({
           },
         } as const;
       }
-
       if (editSession.status !== "open") {
         return {
           error: {
@@ -145,31 +250,25 @@ export const finalizeFolioCollabSessionHandler = async ({
           },
         } as const;
       }
-
-      if (
-        editSession.docxCheckpointSha256Hex === null ||
-        editSession.docxCheckpointSizeBytes === null ||
-        editSession.docxCheckpointUpdatedAt === null
-      ) {
-        await tx
-          .update(folioCollabSessions)
-          .set({ closedAt: new Date(), status: "cancelled" })
-          .where(eq(folioCollabSessions.id, editSession.id));
-
-        return { outcome: "no_changes" } as const;
+      if (editSession.docxCheckpointSha256Hex !== checkpointSha256Hex) {
+        return {
+          error: {
+            message: "Collaborative edit checkpoint changed during finalize.",
+            statusCode: 409,
+          },
+        } as const;
       }
 
       const lockedEntities = await tx
         .select({
           currentVersionId: entities.currentVersionId,
           docSequence: entities.docSequence,
-          id: entities.id,
         })
         .from(entities)
         .where(
           and(
-            eq(entities.id, editSession.entityId),
-            eq(entities.workspaceId, authorizedSession.value.workspaceId),
+            eq(entities.id, sessionPreview.entityId),
+            eq(entities.workspaceId, workspaceId),
           ),
         )
         .for("update");
@@ -181,22 +280,14 @@ export const finalizeFolioCollabSessionHandler = async ({
         } as const;
       }
 
-      const checkpointKey = createFileKey({
-        fileId: editSession.docxCheckpointFileId,
-        mimeType: DOCX_MIME_TYPE,
-        organizationId: authorizedSession.value.organizationId,
-        workspaceId: authorizedSession.value.workspaceId,
-      });
-
-      if (entity.currentVersionId !== editSession.baseVersionId) {
+      if (entity.currentVersionId !== sessionPreview.baseVersionId) {
         await tx
           .update(folioCollabSessions)
           .set({ closedAt: new Date(), status: "cancelled" })
-          .where(eq(folioCollabSessions.id, editSession.id));
-
-        checkpointKeyToDelete = checkpointKey;
+          .where(eq(folioCollabSessions.id, sessionId));
 
         return {
+          deleteCheckpoint: true,
           error: {
             message:
               "This document changed in Stella while collaborative editing was open.",
@@ -205,67 +296,8 @@ export const finalizeFolioCollabSessionHandler = async ({
         } as const;
       }
 
-      const baseVersion = await tx.query.entityVersions.findFirst({
-        where: {
-          entityId: { eq: editSession.entityId },
-          id: { eq: editSession.baseVersionId },
-          workspaceId: { eq: authorizedSession.value.workspaceId },
-        },
-        columns: { versionNumber: true },
-        with: {
-          fields: { columns: { content: true, propertyId: true } },
-        },
-      });
-
-      if (!baseVersion) {
-        return {
-          error: {
-            message: "Base entity version not found.",
-            statusCode: 409,
-          },
-        } as const;
-      }
-
-      const baseFileField = findDocxFieldForProperty({
-        fieldEntries: baseVersion.fields,
-        propertyId: editSession.propertyId,
-      });
-
-      if (!baseFileField) {
-        return {
-          error: {
-            message:
-              "Collaborative edit session source file is no longer available.",
-            statusCode: 409,
-          },
-        } as const;
-      }
-
-      if (editSession.docxCheckpointSha256Hex === baseFileField.sha256Hex) {
-        await tx
-          .update(folioCollabSessions)
-          .set({ closedAt: new Date(), status: "cancelled" })
-          .where(eq(folioCollabSessions.id, editSession.id));
-
-        checkpointKeyToDelete = checkpointKey;
-
-        return { outcome: "no_changes" } as const;
-      }
-
-      const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
-      const validation = await validateDocxBuffer(checkpointBuffer);
-      if (!validation.valid) {
-        return {
-          error: {
-            message: `Document validation failed: ${validation.error}`,
-            statusCode: 422 as const,
-          },
-        } as const;
-      }
-
-      const nextVersionNumber = baseVersion.versionNumber + 1;
       const workspace = await tx.query.workspaces.findFirst({
-        where: { id: { eq: authorizedSession.value.workspaceId } },
+        where: { id: { eq: workspaceId } },
         columns: { reference: true },
       });
 
@@ -277,35 +309,22 @@ export const finalizeFolioCollabSessionHandler = async ({
           panic("Workspace not found for finalized collaborative edit session"),
       });
 
-      const storedBytes = new Uint8Array(checkpointBuffer);
-      const nextVersionId = createSafeId<"entityVersion">();
-      const sourceFileId = Bun.randomUUIDv7();
-      const sourceKey = createFileKey({
-        fileId: sourceFileId,
-        mimeType: DOCX_MIME_TYPE,
-        organizationId: authorizedSession.value.organizationId,
-        workspaceId: authorizedSession.value.workspaceId,
-      });
-      uploadedKeys.push(sourceKey);
-
-      await getS3().write(sourceKey, storedBytes);
-
       await tx.insert(entityVersions).values({
-        entityId: editSession.entityId,
+        entityId: sessionPreview.entityId,
         id: nextVersionId,
         stamp: nextVersionStamp.stamp,
         verificationCode: nextVersionStamp.verificationCode,
         versionNumber: nextVersionNumber,
-        workspaceId: authorizedSession.value.workspaceId,
+        workspaceId,
       });
 
       const clonedFields = cloneFieldsForRevision({
         currentFields: baseVersion.fields,
         entityVersionId: nextVersionId,
-        propertyId: editSession.propertyId,
+        propertyId: sessionPreview.propertyId,
         replacementContent: {
           encrypted: false,
-          fileName: editSession.fileName,
+          fileName: sessionPreview.fileName,
           id: sourceFileId,
           mimeType: DOCX_MIME_TYPE,
           pdfFileId: null,
@@ -313,15 +332,15 @@ export const finalizeFolioCollabSessionHandler = async ({
             encrypted: false,
             mimeType: DOCX_MIME_TYPE,
           }),
-          sha256Hex: editSession.docxCheckpointSha256Hex,
-          sizeBytes: editSession.docxCheckpointSizeBytes,
+          sha256Hex: checkpointSha256Hex,
+          sizeBytes: checkpointSizeBytes,
           type: "file",
           version: 1,
-          ...(editSession.docxCheckpointScanWarnings !== null && {
-            scanWarnings: editSession.docxCheckpointScanWarnings,
+          ...(sessionPreview.docxCheckpointScanWarnings !== null && {
+            scanWarnings: sessionPreview.docxCheckpointScanWarnings,
           }),
         },
-        workspaceId: authorizedSession.value.workspaceId,
+        workspaceId,
       });
 
       const insertedFields = await tx
@@ -330,22 +349,22 @@ export const finalizeFolioCollabSessionHandler = async ({
         .returning({ id: fields.id, propertyId: fields.propertyId });
 
       const nextField = insertedFields.find(
-        (field) => field.propertyId === editSession.propertyId,
+        (field) => field.propertyId === sessionPreview.propertyId,
       );
 
       await tx
         .update(entities)
         .set({
           currentVersionId: nextVersionId,
-          lastEditedBy: authorizedSession.value.userId,
+          lastEditedBy: userId,
           updatedAt: new Date(),
         })
-        .where(eq(entities.id, editSession.entityId));
+        .where(eq(entities.id, sessionPreview.entityId));
 
       await tx
         .update(workspaces)
         .set({ lastActivityAt: new Date() })
-        .where(eq(workspaces.id, authorizedSession.value.workspaceId));
+        .where(eq(workspaces.id, workspaceId));
 
       await tx
         .update(folioCollabSessions)
@@ -354,12 +373,10 @@ export const finalizeFolioCollabSessionHandler = async ({
           finalizedVersionId: nextVersionId,
           status: "finalized",
         })
-        .where(eq(folioCollabSessions.id, editSession.id));
-
-      checkpointKeyToDelete = checkpointKey;
+        .where(eq(folioCollabSessions.id, sessionId));
 
       return {
-        entityId: editSession.entityId,
+        entityId: sessionPreview.entityId,
         fieldId:
           nextField?.id ??
           panic("Finalized collaborative edit session field was not inserted"),
@@ -370,38 +387,36 @@ export const finalizeFolioCollabSessionHandler = async ({
     });
 
     if ("error" in result) {
-      await Promise.all(uploadedKeys.map(deleteUploadedKey));
-      await deletePendingCheckpointKey();
-
+      await rollbackUploadedKeys();
+      if ("deleteCheckpoint" in result) {
+        await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+      }
       return status(result.error.statusCode, { message: result.error.message });
     }
 
     shouldRollbackUploadedKeys = false;
-    await deletePendingCheckpointKey();
+    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
 
-    broadcast(authorizedSession.value.workspaceId, {
+    broadcast(workspaceId, {
       type: "invalidate-query",
-      data: ["entities", authorizedSession.value.workspaceId],
+      data: ["entities", workspaceId],
     });
 
-    if (result.outcome === "finalized") {
-      await processCollaborativeEditDerivatives({
-        entityId: result.entityId,
-        fieldId: result.fieldId,
-        organizationId: authorizedSession.value.organizationId,
-        userId: authorizedSession.value.userId,
-        versionId: result.versionId,
-        workspaceId: authorizedSession.value.workspaceId,
-        scopedDb: authorizedSession.value.scopedDb,
-      });
-    }
+    await processCollaborativeEditDerivatives({
+      entityId: result.entityId,
+      fieldId: result.fieldId,
+      organizationId,
+      scopedDb,
+      userId,
+      versionId: result.versionId,
+      workspaceId,
+    });
 
     return result;
   } catch (error) {
     if (shouldRollbackUploadedKeys) {
-      await Promise.all(uploadedKeys.map(deleteUploadedKey));
+      await rollbackUploadedKeys();
     }
-
     throw error;
   }
 };

--- a/apps/api/src/handlers/folio-collab/rate-limit.test.ts
+++ b/apps/api/src/handlers/folio-collab/rate-limit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { isFolioCollabRateLimitedPath } from "@/api/handlers/folio-collab/rate-limit";
+
+describe("folio-collab session rate limiting", () => {
+  test("covers the folio-collab session endpoints", () => {
+    expect(isFolioCollabRateLimitedPath("/v1/folio-collab-sessions")).toBe(
+      true,
+    );
+    expect(isFolioCollabRateLimitedPath("/v1/folio-collab-sessions/")).toBe(
+      true,
+    );
+    expect(
+      isFolioCollabRateLimitedPath("/v1/folio-collab-sessions/ses_1/token"),
+    ).toBe(true);
+  });
+
+  test("does not cover unrelated endpoints", () => {
+    expect(isFolioCollabRateLimitedPath("/v1/entities/ws_1/query")).toBe(false);
+    expect(
+      isFolioCollabRateLimitedPath("/v1/folio-collab-sessions-archive"),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/handlers/folio-collab/rate-limit.ts
+++ b/apps/api/src/handlers/folio-collab/rate-limit.ts
@@ -1,0 +1,8 @@
+// Canonical matcher for the folio collaborative-edit endpoints, kept in
+// sync with the `/folio-collab-sessions` prefix in ./routes.ts. The shared
+// `/v1` rate limiter consults this so folio-collab traffic counts only
+// against its dedicated `folioCollab` budget, never the general bucket.
+const FOLIO_COLLAB_RATE_LIMIT_PATH_RE = /\/folio-collab-sessions(?:\/|$)/u;
+
+export const isFolioCollabRateLimitedPath = (pathname: string) =>
+  FOLIO_COLLAB_RATE_LIMIT_PATH_RE.test(pathname);

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -152,13 +152,13 @@ export const folioCollabRoute = new Elysia({
         return status(403, { message: "Collaborative edit is read-only." });
       }
 
-      const buffer = Buffer.from(body.snapshotBase64, "base64");
-      if (buffer.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {
+      const snapshotBytes = Buffer.from(body.snapshotBase64, "base64");
+      if (snapshotBytes.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {
         return status(413, { message: "Collaborative snapshot too large." });
       }
 
       const { storedAt } = await storeFolioCollabSnapshot({
-        snapshotBase64: body.snapshotBase64,
+        snapshotBytes,
         value,
       });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -305,7 +305,19 @@ const api = new Elysia()
       .use(workspacesRoute)
       .use(propertiesRoute)
       .use(filesRoute)
-      .use(folioCollabRoute)
+      .use(
+        new Elysia()
+          .use(
+            rateLimit({
+              scoping: "scoped",
+              duration: API_RATE_LIMITS.folioCollab.duration,
+              max: API_RATE_LIMITS.folioCollab.max,
+              generator: scopedGenerator("folio-collab"),
+              context: new InMemoryRateLimitContext(),
+            }),
+          )
+          .use(folioCollabRoute),
+      )
       .use(desktopEditSessionsRoute)
       .use(entitiesRoute)
       .use(fieldsRoute)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,10 +18,12 @@ import { contactsRoute } from "@/api/handlers/contacts/routes";
 import { devPublicRoute, devRoute } from "@/api/handlers/dev/routes";
 import { desktopEditSessionsRoute } from "@/api/handlers/entities/desktop-edit-sessions-route";
 import { entitiesRoute } from "@/api/handlers/entities/routes";
+import { isUploadRateLimitedPath } from "@/api/handlers/entities/upload-rate-limit";
 import { expensesRoute } from "@/api/handlers/expenses/routes";
 import { externalPreviewRoute } from "@/api/handlers/external-preview/routes";
 import { fieldsRoute } from "@/api/handlers/fields/routes";
 import { filesRoute } from "@/api/handlers/files/routes";
+import { isFolioCollabRateLimitedPath } from "@/api/handlers/folio-collab/rate-limit";
 import { folioCollabRoute } from "@/api/handlers/folio-collab/routes";
 import { healthRoute } from "@/api/handlers/health/routes";
 import { invoicesRoute } from "@/api/handlers/invoices/routes";
@@ -297,8 +299,19 @@ const api = new Elysia()
           max: API_RATE_LIMITS.api.max,
           generator: scopedGenerator("api"),
           context: new InMemoryRateLimitContext(),
-          skip: (req) =>
-            /\/entities\/[^/]+\/upload$/u.test(new URL(req.url).pathname),
+          skip: (req) => {
+            // Endpoints with a dedicated rate-limit budget are excluded
+            // from the shared `api` bucket so unrelated `/v1` traffic on
+            // the same IP cannot drain their quota (see `upload` and
+            // `folioCollab` in API_RATE_LIMITS). Each path is matched by
+            // its canonical helper so this skip stays in lockstep with
+            // the dedicated limiter that owns it.
+            const { pathname } = new URL(req.url);
+            return (
+              isUploadRateLimitedPath(pathname) ||
+              isFolioCollabRateLimitedPath(pathname)
+            );
+          },
         }),
       )
       .use(workspaceEventsRoute)

--- a/apps/api/src/lib/folio-collab-sessions.ts
+++ b/apps/api/src/lib/folio-collab-sessions.ts
@@ -25,7 +25,14 @@ export const FOLIO_COLLAB_TOKEN_TTL_MS = 60 * 60 * 1000;
 
 const FOLIO_COLLAB_TOKEN_PART_LENGTH = 32;
 export const FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE = "application/octet-stream";
-export const FOLIO_COLLAB_SNAPSHOT_MAX_BYTES = 50 * 1024 * 1024;
+/**
+ * Yjs collaborative-edit snapshots are deltas over the base DOCX,
+ * not the document itself. 10 MB comfortably covers extended
+ * editing sessions (a heavily-edited 100-page document hovers at
+ * a few hundred kB of Yjs state) while keeping per-instance peak
+ * memory bounded under concurrent traffic.
+ */
+export const FOLIO_COLLAB_SNAPSHOT_MAX_BYTES = 10 * 1024 * 1024;
 export const FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH =
   Math.ceil(FOLIO_COLLAB_SNAPSHOT_MAX_BYTES / 3) * 4;
 
@@ -213,30 +220,29 @@ export const loadFolioCollabSnapshot = async (
 };
 
 export const storeFolioCollabSnapshot = async ({
-  snapshotBase64,
+  snapshotBytes,
   value,
 }: {
-  snapshotBase64: string;
+  snapshotBytes: Uint8Array;
   value: AuthorizedFolioCollabSession;
 }) => {
-  const buffer = Buffer.from(snapshotBase64, "base64");
   const key = createFileKey({
     fileId: value.yjsSnapshotFileId,
     mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
     organizationId: value.organizationId,
     workspaceId: value.workspaceId,
   });
-  await getS3().write(key, buffer);
+  await getS3().write(key, snapshotBytes);
 
   const storedAt = new Date();
   await rootDb
     .update(folioCollabSessions)
     .set({
       seededAt: storedAt,
-      yjsSnapshotSizeBytes: buffer.byteLength,
+      yjsSnapshotSizeBytes: snapshotBytes.byteLength,
       yjsSnapshotUpdatedAt: storedAt,
     })
     .where(eq(folioCollabSessions.id, value.sessionId));
 
-  return { storedAt, sizeBytes: buffer.byteLength };
+  return { storedAt, sizeBytes: snapshotBytes.byteLength };
 };

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -169,4 +169,9 @@ export const API_RATE_LIMITS = {
   api: { duration: 60_000, max: 1000 },
   /** File uploads: 500 req/min (separate budget). */
   upload: { duration: 60_000, max: 500 },
+  /** Folio collaborative-edit token endpoints: 30 req/min per IP.
+   *  Each authorize/refresh/snapshot call runs a multi-table join
+   *  against unauthenticated input, so the budget is intentionally
+   *  much tighter than the general API. */
+  folioCollab: { duration: 60_000, max: 30 },
 } as const;


### PR DESCRIPTION
## Summary
- Lower folio-collab snapshot cap to 10 MB and drop the duplicate base64 decode in `storeFolioCollabSnapshot`.
- Wrap `/v1/folio-collab-sessions/*` in a tighter per-IP rate-limit bucket (30 req/min) separate from the general API budget.
- Lift the finalize transaction: session preview, base-version read, S3 checkpoint fetch + DOCX validation, and source-key S3 write all happen before the write txn now. The txn just locks the session + entity, re-verifies state hasn't drifted, and writes rows.

## Follow-ups (next PR on this surface)
- Introduce `createSafeTokenHandler` and migrate `finalize`/`cancel`/`checkpoint` onto it; default-export `{ config, handler }`.
- Move route-side schemas into the handler files; thin `routes.ts` to wiring only.

## Test plan
- [ ] `bun --filter @stll/api typecheck`
- [ ] `bun --filter @stll/api lint`
- [ ] manual: open a collaborative document in Folio, edit it, finalize → confirm a new entity version lands and the checkpoint S3 object is cleaned up.
- [ ] manual: finalize an unchanged session → returns `no_changes` and cancels.
- [ ] manual: under load, peek at the API instance memory profile during a finalize — should no longer hold the row lock during the S3 round-trips.