### PR TITLE
chore(web): modernize theme-provider for react 19

### DIFF
--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,4 +1,11 @@
-import { createContext, use, useEffect, useState } from "react";
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import type { PropsWithChildren } from "react";
 
 import { PALETTE_STORAGE_KEY, THEME_STORAGE_KEY } from "@/consts";
@@ -72,15 +79,15 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     resolveTheme(theme),
   );
 
-  const setTheme = (next: Theme) => {
+  const setTheme = useCallback((next: Theme) => {
     localStorage.setItem(THEME_STORAGE_KEY, next);
     setThemeState(next);
-  };
+  }, []);
 
-  const setPalette = (next: Palette) => {
+  const setPalette = useCallback((next: Palette) => {
     localStorage.setItem(PALETTE_STORAGE_KEY, next);
     setPaletteState(next);
-  };
+  }, []);
 
   useEffect(() => {
     const root = document.documentElement;
@@ -143,13 +150,12 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     return () => window.removeEventListener("storage", onStorage);
   }, []);
 
-  return (
-    <ThemeProviderContext
-      value={{ theme, setTheme, palette, setPalette, resolvedTheme }}
-    >
-      {children}
-    </ThemeProviderContext>
+  const value = useMemo(
+    () => ({ theme, setTheme, palette, setPalette, resolvedTheme }),
+    [theme, setTheme, palette, setPalette, resolvedTheme],
   );
+
+  return <ThemeProviderContext value={value}>{children}</ThemeProviderContext>;
 };
 
 export const useTheme = (): ThemeProviderState => use(ThemeProviderContext);

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  use,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createContext, use, useEffect, useState } from "react";
 import type { PropsWithChildren } from "react";
 
 import { PALETTE_STORAGE_KEY, THEME_STORAGE_KEY } from "@/consts";
@@ -79,15 +72,15 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     resolveTheme(theme),
   );
 
-  const setTheme = useCallback((next: Theme) => {
+  const setTheme = (next: Theme) => {
     localStorage.setItem(THEME_STORAGE_KEY, next);
     setThemeState(next);
-  }, []);
+  };
 
-  const setPalette = useCallback((next: Palette) => {
+  const setPalette = (next: Palette) => {
     localStorage.setItem(PALETTE_STORAGE_KEY, next);
     setPaletteState(next);
-  }, []);
+  };
 
   useEffect(() => {
     const root = document.documentElement;
@@ -150,12 +143,13 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     return () => window.removeEventListener("storage", onStorage);
   }, []);
 
-  const value = useMemo(
-    () => ({ theme, setTheme, palette, setPalette, resolvedTheme }),
-    [theme, setTheme, palette, setPalette, resolvedTheme],
+  return (
+    <ThemeProviderContext
+      value={{ theme, setTheme, palette, setPalette, resolvedTheme }}
+    >
+      {children}
+    </ThemeProviderContext>
   );
-
-  return <ThemeProviderContext value={value}>{children}</ThemeProviderContext>;
 };
 
 export const useTheme = (): ThemeProviderState => use(ThemeProviderContext);

--- a/apps/web/src/components/theme-provider.tsx
+++ b/apps/web/src/components/theme-provider.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { createContext, use, useEffect, useState } from "react";
 import type { PropsWithChildren } from "react";
 
 import { PALETTE_STORAGE_KEY, THEME_STORAGE_KEY } from "@/consts";
@@ -79,15 +72,15 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     resolveTheme(theme),
   );
 
-  const setTheme = useCallback((next: Theme) => {
+  const setTheme = (next: Theme) => {
     localStorage.setItem(THEME_STORAGE_KEY, next);
     setThemeState(next);
-  }, []);
+  };
 
-  const setPalette = useCallback((next: Palette) => {
+  const setPalette = (next: Palette) => {
     localStorage.setItem(PALETTE_STORAGE_KEY, next);
     setPaletteState(next);
-  }, []);
+  };
 
   useEffect(() => {
     const root = document.documentElement;
@@ -150,23 +143,15 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     return () => window.removeEventListener("storage", onStorage);
   }, []);
 
-  const value = useMemo(
-    () => ({
-      theme,
-      setTheme,
-      palette,
-      setPalette,
-      resolvedTheme,
-    }),
-    [theme, setTheme, palette, setPalette, resolvedTheme],
+  return (
+    <ThemeProviderContext
+      value={{ theme, setTheme, palette, setPalette, resolvedTheme }}
+    >
+      {children}
+    </ThemeProviderContext>
   );
-
-  return <ThemeProviderContext value={value}>{children}</ThemeProviderContext>;
 };
 
-export const useTheme = (): ThemeProviderState => {
-  const context = useContext(ThemeProviderContext);
-  return context;
-};
+export const useTheme = (): ThemeProviderState => use(ThemeProviderContext);
 
 export { THEMES, PALETTES };


### PR DESCRIPTION
## Summary
- `useContext` → `use()` in the consumer hook
- Drop `useMemo` around the context value; React Compiler covers it
- Drop `useCallback` around `setTheme`/`setPalette`; same reason

Pure refactor, no behavior change. Net -15 lines.

## Test plan
- [x] `bun run format`
- [x] `bun run lint` (oxlint type-aware)
- [x] `bun --filter @stll/web typecheck` (tsgo)
- [ ] Browser smoke: theme toggle, palette toggle, cross-tab storage sync, system-theme follow