### PR TITLE
chore(api): tidy presign expiry, db policies, and file-scan

### DIFF
--- a/apps/api/drizzle/20260522120000_audit_logs_deny_mutations/migration.sql
+++ b/apps/api/drizzle/20260522120000_audit_logs_deny_mutations/migration.sql
@@ -1,0 +1,16 @@
+-- Audit logs are append-only. The `audit_logs_select` / `audit_logs_insert`
+-- policies are the only access `stella` has; UPDATE and DELETE are denied
+-- today purely by Postgres' default-deny (no matching policy).
+--
+-- These RESTRICTIVE policies make that immutability explicit and durable.
+-- A RESTRICTIVE `USING (false)` is AND-ed into every permissive policy, so
+-- a future migration that adds a permissive UPDATE/DELETE policy cannot
+-- silently unlock mutation of the audit trail.
+
+CREATE POLICY "audit_logs_no_update" ON "audit_logs"
+  AS RESTRICTIVE FOR UPDATE TO "stella"
+  USING (false);
+
+CREATE POLICY "audit_logs_no_delete" ON "audit_logs"
+  AS RESTRICTIVE FOR DELETE TO "stella"
+  USING (false);

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -564,6 +564,25 @@ export const auditLogs = p.pgTable(
       to: stella,
       withCheck: organizationCheck,
     }),
+    // Audit logs are append-only: SELECT + INSERT above are the only
+    // operations `stella` ever needs. UPDATE/DELETE are denied today
+    // purely by Postgres' default-deny (no matching policy). These
+    // RESTRICTIVE `false` policies make that immutability explicit and
+    // durable — a RESTRICTIVE policy is AND-ed with every permissive
+    // one, so a future migration adding a permissive UPDATE/DELETE
+    // policy cannot silently unlock mutation of the audit trail.
+    p.pgPolicy("audit_logs_no_update", {
+      as: "restrictive",
+      for: "update",
+      to: stella,
+      using: sql`false`,
+    }),
+    p.pgPolicy("audit_logs_no_delete", {
+      as: "restrictive",
+      for: "delete",
+      to: stella,
+      using: sql`false`,
+    }),
   ],
 );
 

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -118,7 +118,7 @@ const envApi = createEnv({
         ),
       ),
     ),
-    EXTENSION_ORIGIN: v.optional(v.string()),
+    EXTENSION_ORIGIN: v.optional(v.pipe(v.string(), v.url())),
 
     /**
      * Comma-separated CIDRs of proxies the API may trust to set

--- a/apps/api/src/handlers/templates/versions.ts
+++ b/apps/api/src/handlers/templates/versions.ts
@@ -7,6 +7,10 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { presignDownloadUrl } from "@/api/lib/s3";
 
+/** Presigned download URLs expire after 15 minutes, matching every
+ *  other read path (`templates/get.ts`, `files/read-by-id.ts`). */
+const PRESIGN_EXPIRES_IN = 900;
+
 // ── Helpers ──────────────────────────────────────────
 
 const verifyTemplateOwnership = async (
@@ -114,7 +118,7 @@ export const getTemplateVersionHandler = async ({
   }
 
   const downloadUrl = presignDownloadUrl(version.s3Key, {
-    expiresIn: 3600,
+    expiresIn: PRESIGN_EXPIRES_IN,
     fileName: template.fileName,
   });
 

--- a/apps/api/src/lib/file-scan/magic.test.ts
+++ b/apps/api/src/lib/file-scan/magic.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import { declaredMimeMatchesMagic } from "./magic";
+
+const bytes = (...values: number[]): Uint8Array => new Uint8Array(values);
+
+const PDF_HEADER = bytes(0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37);
+const PNG_HEADER = bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00);
+const JPEG_HEADER = bytes(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10);
+const GIF_HEADER = bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61);
+// `RIFF` + 4-byte size + `WEBP`.
+const WEBP_HEADER = bytes(
+  0x52,
+  0x49,
+  0x46,
+  0x46,
+  0x24,
+  0x00,
+  0x00,
+  0x00,
+  0x57,
+  0x45,
+  0x42,
+  0x50,
+);
+
+describe("declaredMimeMatchesMagic", () => {
+  test("known type matches its own magic bytes", () => {
+    expect(declaredMimeMatchesMagic("application/pdf", PDF_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/png", PNG_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/jpeg", JPEG_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/gif", GIF_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/webp", WEBP_HEADER)).toBe(true);
+  });
+
+  test("known type rejects bytes of a different format", () => {
+    // A PDF declared as a PNG — the spoof this check exists to catch.
+    expect(declaredMimeMatchesMagic("image/png", PDF_HEADER)).toBe(false);
+    expect(declaredMimeMatchesMagic("application/pdf", PNG_HEADER)).toBe(false);
+    expect(declaredMimeMatchesMagic("image/jpeg", GIF_HEADER)).toBe(false);
+  });
+
+  test("WEBP requires the form type at offset 8, not just the RIFF tag", () => {
+    // RIFF container that is not WEBP (e.g. a WAV) must not pass.
+    const riffWav = bytes(
+      0x52,
+      0x49,
+      0x46,
+      0x46,
+      0x24,
+      0x00,
+      0x00,
+      0x00,
+      0x57,
+      0x41,
+      0x56,
+      0x45,
+    );
+    expect(declaredMimeMatchesMagic("image/webp", riffWav)).toBe(false);
+  });
+
+  test("buffer shorter than the signature does not match", () => {
+    expect(declaredMimeMatchesMagic("image/png", bytes(0x89, 0x50))).toBe(
+      false,
+    );
+    expect(declaredMimeMatchesMagic("image/webp", bytes(0x52, 0x49))).toBe(
+      false,
+    );
+  });
+
+  test("unknown / signature-less declared types pass through", () => {
+    // Text formats have no reliable magic; the check must not block them.
+    expect(declaredMimeMatchesMagic("text/plain", bytes(0x68, 0x69))).toBe(
+      true,
+    );
+    expect(declaredMimeMatchesMagic("text/csv", bytes(0x61, 0x2c, 0x62))).toBe(
+      true,
+    );
+    expect(declaredMimeMatchesMagic("image/svg+xml", bytes(0x3c, 0x73))).toBe(
+      true,
+    );
+  });
+});

--- a/apps/api/src/lib/file-scan/magic.test.ts
+++ b/apps/api/src/lib/file-scan/magic.test.ts
@@ -7,7 +7,8 @@ const bytes = (...values: number[]): Uint8Array => new Uint8Array(values);
 const PDF_HEADER = bytes(0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37);
 const PNG_HEADER = bytes(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00);
 const JPEG_HEADER = bytes(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10);
-const GIF_HEADER = bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61);
+const GIF_89A_HEADER = bytes(0x47, 0x49, 0x46, 0x38, 0x39, 0x61);
+const GIF_87A_HEADER = bytes(0x47, 0x49, 0x46, 0x38, 0x37, 0x61);
 // `RIFF` + 4-byte size + `WEBP`.
 const WEBP_HEADER = bytes(
   0x52,
@@ -29,7 +30,8 @@ describe("declaredMimeMatchesMagic", () => {
     expect(declaredMimeMatchesMagic("application/pdf", PDF_HEADER)).toBe(true);
     expect(declaredMimeMatchesMagic("image/png", PNG_HEADER)).toBe(true);
     expect(declaredMimeMatchesMagic("image/jpeg", JPEG_HEADER)).toBe(true);
-    expect(declaredMimeMatchesMagic("image/gif", GIF_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/gif", GIF_89A_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("image/gif", GIF_87A_HEADER)).toBe(true);
     expect(declaredMimeMatchesMagic("image/webp", WEBP_HEADER)).toBe(true);
   });
 
@@ -37,7 +39,12 @@ describe("declaredMimeMatchesMagic", () => {
     // A PDF declared as a PNG — the spoof this check exists to catch.
     expect(declaredMimeMatchesMagic("image/png", PDF_HEADER)).toBe(false);
     expect(declaredMimeMatchesMagic("application/pdf", PNG_HEADER)).toBe(false);
-    expect(declaredMimeMatchesMagic("image/jpeg", GIF_HEADER)).toBe(false);
+    expect(declaredMimeMatchesMagic("image/jpeg", GIF_89A_HEADER)).toBe(false);
+  });
+
+  test("GIF requires a full GIF87a or GIF89a header", () => {
+    const gif8Spoof = bytes(0x47, 0x49, 0x46, 0x38, 0x00, 0x00);
+    expect(declaredMimeMatchesMagic("image/gif", gif8Spoof)).toBe(false);
   });
 
   test("known type lookup is case-insensitive", () => {

--- a/apps/api/src/lib/file-scan/magic.test.ts
+++ b/apps/api/src/lib/file-scan/magic.test.ts
@@ -40,6 +40,11 @@ describe("declaredMimeMatchesMagic", () => {
     expect(declaredMimeMatchesMagic("image/jpeg", GIF_HEADER)).toBe(false);
   });
 
+  test("known type lookup is case-insensitive", () => {
+    expect(declaredMimeMatchesMagic("Image/PNG", PNG_HEADER)).toBe(true);
+    expect(declaredMimeMatchesMagic("Image/PNG", PDF_HEADER)).toBe(false);
+  });
+
   test("WEBP requires the form type at offset 8, not just the RIFF tag", () => {
     // RIFF container that is not WEBP (e.g. a WAV) must not pass.
     const riffWav = bytes(

--- a/apps/api/src/lib/file-scan/magic.test.ts
+++ b/apps/api/src/lib/file-scan/magic.test.ts
@@ -45,6 +45,15 @@ describe("declaredMimeMatchesMagic", () => {
     expect(declaredMimeMatchesMagic("Image/PNG", PDF_HEADER)).toBe(false);
   });
 
+  test("known type lookup strips content type parameters", () => {
+    expect(
+      declaredMimeMatchesMagic("image/png; charset=utf-8", PNG_HEADER),
+    ).toBe(true);
+    expect(
+      declaredMimeMatchesMagic("Image/PNG ; charset=utf-8", PDF_HEADER),
+    ).toBe(false);
+  });
+
   test("WEBP requires the form type at offset 8, not just the RIFF tag", () => {
     // RIFF container that is not WEBP (e.g. a WAV) must not pass.
     const riffWav = bytes(

--- a/apps/api/src/lib/file-scan/magic.ts
+++ b/apps/api/src/lib/file-scan/magic.ts
@@ -33,7 +33,8 @@ const WEBP_FORM_TYPE = [0x57, 0x45, 0x42, 0x50] as const;
 const PDF_SIGNATURE = [0x25, 0x50, 0x44, 0x46, 0x2d] as const;
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
 const JPEG_SIGNATURE = [0xff, 0xd8, 0xff] as const;
-const GIF_SIGNATURE = [0x47, 0x49, 0x46, 0x38] as const;
+const GIF_87A_SIGNATURE = [0x47, 0x49, 0x46, 0x38, 0x37, 0x61] as const;
+const GIF_89A_SIGNATURE = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61] as const;
 
 const MIME_MAGIC_MATCHERS: Record<string, (buffer: Uint8Array) => boolean> = {
   // %PDF-
@@ -43,7 +44,9 @@ const MIME_MAGIC_MATCHERS: Record<string, (buffer: Uint8Array) => boolean> = {
   // JPEG start-of-image marker
   "image/jpeg": (buffer) => startsWith(buffer, JPEG_SIGNATURE),
   // GIF87a / GIF89a
-  "image/gif": (buffer) => startsWith(buffer, GIF_SIGNATURE),
+  "image/gif": (buffer) =>
+    startsWith(buffer, GIF_87A_SIGNATURE) ||
+    startsWith(buffer, GIF_89A_SIGNATURE),
   "image/webp": (buffer) =>
     startsWith(buffer, WEBP_RIFF_TAG) &&
     startsWith(buffer.subarray(8), WEBP_FORM_TYPE),

--- a/apps/api/src/lib/file-scan/magic.ts
+++ b/apps/api/src/lib/file-scan/magic.ts
@@ -49,6 +49,11 @@ const MIME_MAGIC_MATCHERS: Record<string, (buffer: Uint8Array) => boolean> = {
     startsWith(buffer.subarray(8), WEBP_FORM_TYPE),
 };
 
+const normalizeDeclaredMimeType = (declaredMimeType: string): string => {
+  const [mediaType = ""] = declaredMimeType.split(";");
+  return mediaType.trim().toLowerCase();
+};
+
 /**
  * Returns `false` only when `declaredMimeType` has a known magic-byte
  * signature and `buffer` does not match it. Unknown declared types
@@ -58,7 +63,8 @@ export const declaredMimeMatchesMagic = (
   declaredMimeType: string,
   buffer: Uint8Array,
 ): boolean => {
-  const matcher = MIME_MAGIC_MATCHERS[declaredMimeType.toLowerCase()];
+  const matcher =
+    MIME_MAGIC_MATCHERS[normalizeDeclaredMimeType(declaredMimeType)];
   if (!matcher) {
     return true;
   }

--- a/apps/api/src/lib/file-scan/magic.ts
+++ b/apps/api/src/lib/file-scan/magic.ts
@@ -30,18 +30,20 @@ const startsWith = (
 // offset 8 (bytes 4-7 hold the little-endian file size).
 const WEBP_RIFF_TAG = [0x52, 0x49, 0x46, 0x46] as const;
 const WEBP_FORM_TYPE = [0x57, 0x45, 0x42, 0x50] as const;
+const PDF_SIGNATURE = [0x25, 0x50, 0x44, 0x46, 0x2d] as const;
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+const JPEG_SIGNATURE = [0xff, 0xd8, 0xff] as const;
+const GIF_SIGNATURE = [0x47, 0x49, 0x46, 0x38] as const;
 
 const MIME_MAGIC_MATCHERS: Record<string, (buffer: Uint8Array) => boolean> = {
   // %PDF-
-  "application/pdf": (buffer) =>
-    startsWith(buffer, [0x25, 0x50, 0x44, 0x46, 0x2d]),
+  "application/pdf": (buffer) => startsWith(buffer, PDF_SIGNATURE),
   // \x89 P N G \r \n \x1a \n
-  "image/png": (buffer) =>
-    startsWith(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  "image/png": (buffer) => startsWith(buffer, PNG_SIGNATURE),
   // JPEG start-of-image marker
-  "image/jpeg": (buffer) => startsWith(buffer, [0xff, 0xd8, 0xff]),
+  "image/jpeg": (buffer) => startsWith(buffer, JPEG_SIGNATURE),
   // GIF87a / GIF89a
-  "image/gif": (buffer) => startsWith(buffer, [0x47, 0x49, 0x46, 0x38]),
+  "image/gif": (buffer) => startsWith(buffer, GIF_SIGNATURE),
   "image/webp": (buffer) =>
     startsWith(buffer, WEBP_RIFF_TAG) &&
     startsWith(buffer.subarray(8), WEBP_FORM_TYPE),
@@ -56,7 +58,7 @@ export const declaredMimeMatchesMagic = (
   declaredMimeType: string,
   buffer: Uint8Array,
 ): boolean => {
-  const matcher = MIME_MAGIC_MATCHERS[declaredMimeType];
+  const matcher = MIME_MAGIC_MATCHERS[declaredMimeType.toLowerCase()];
   if (!matcher) {
     return true;
   }

--- a/apps/api/src/lib/file-scan/magic.ts
+++ b/apps/api/src/lib/file-scan/magic.ts
@@ -1,0 +1,64 @@
+/**
+ * Magic-byte signatures for binary upload types with a stable,
+ * well-known header. Used to verify a client-declared media type
+ * against the actual file bytes: a declared type that contradicts
+ * the magic bytes is rejected before the file is stored or rendered.
+ *
+ * ZIP-based Office formats (DOCX/XLSX/PPTX) are covered separately by
+ * `hasZipMagic`. Text formats (`text/plain`, `text/csv`,
+ * `text/markdown`) and SVG have no reliable binary signature and are
+ * intentionally absent — an unknown declared type is treated as a
+ * match so this check never blocks a format it cannot reason about.
+ */
+
+const startsWith = (
+  buffer: Uint8Array,
+  signature: readonly number[],
+): boolean => {
+  if (buffer.length < signature.length) {
+    return false;
+  }
+  for (let i = 0; i < signature.length; i++) {
+    if (buffer[i] !== signature[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+// `RIFF....WEBP`: the container tag is at offset 0, the form type at
+// offset 8 (bytes 4-7 hold the little-endian file size).
+const WEBP_RIFF_TAG = [0x52, 0x49, 0x46, 0x46] as const;
+const WEBP_FORM_TYPE = [0x57, 0x45, 0x42, 0x50] as const;
+
+const MIME_MAGIC_MATCHERS: Record<string, (buffer: Uint8Array) => boolean> = {
+  // %PDF-
+  "application/pdf": (buffer) =>
+    startsWith(buffer, [0x25, 0x50, 0x44, 0x46, 0x2d]),
+  // \x89 P N G \r \n \x1a \n
+  "image/png": (buffer) =>
+    startsWith(buffer, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  // JPEG start-of-image marker
+  "image/jpeg": (buffer) => startsWith(buffer, [0xff, 0xd8, 0xff]),
+  // GIF87a / GIF89a
+  "image/gif": (buffer) => startsWith(buffer, [0x47, 0x49, 0x46, 0x38]),
+  "image/webp": (buffer) =>
+    startsWith(buffer, WEBP_RIFF_TAG) &&
+    startsWith(buffer.subarray(8), WEBP_FORM_TYPE),
+};
+
+/**
+ * Returns `false` only when `declaredMimeType` has a known magic-byte
+ * signature and `buffer` does not match it. Unknown declared types
+ * (text, ZIP-based Office formats handled elsewhere) return `true`.
+ */
+export const declaredMimeMatchesMagic = (
+  declaredMimeType: string,
+  buffer: Uint8Array,
+): boolean => {
+  const matcher = MIME_MAGIC_MATCHERS[declaredMimeType];
+  if (!matcher) {
+    return true;
+  }
+  return matcher(buffer);
+};

--- a/apps/api/src/lib/file-scan/scan.test.ts
+++ b/apps/api/src/lib/file-scan/scan.test.ts
@@ -670,6 +670,18 @@ describe("mime spoofing", () => {
     expect(r.verdict).not.toBe("pass");
     expect(r.findings.some((f) => f.rule.includes("ole"))).toBe(true);
   });
+
+  test("clean PDF declared as image/png → reject (magic mismatch)", async () => {
+    const r = Result.unwrap(
+      await scanFile({
+        buffer: await makePdf(),
+        declaredMimeType: "image/png",
+        fileName: "fake.png",
+      }),
+    );
+    expect(r.verdict).toBe("reject");
+    expect(r.findings.some((f) => f.rule === "mime-magic-mismatch")).toBe(true);
+  });
 });
 
 // -- Integration tests --

--- a/apps/api/src/lib/file-scan/scan.ts
+++ b/apps/api/src/lib/file-scan/scan.ts
@@ -1,5 +1,6 @@
 import { Result, TaggedError } from "better-result";
 
+import { declaredMimeMatchesMagic } from "@/api/lib/file-scan/magic";
 import { mapMatchFinding, scanner } from "@/api/lib/file-scan/pipeline";
 import type { ScanContext } from "@/api/lib/file-scan/scanner";
 import type { ScanFinding, ScanResult } from "@/api/lib/file-scan/types";
@@ -52,6 +53,21 @@ export const scanFile = async ({
           verdict: "reject" as const,
           findings,
         };
+      }
+
+      // Non-ZIP binary types: flag when the client-declared media type
+      // contradicts the file's magic bytes. Text types and any type
+      // without a known signature pass through unchecked. The scan
+      // still continues — a spoofed or polyglot file must also be
+      // inspected by the content scanner below.
+      if (!declaredMimeMatchesMagic(declaredMimeType, buffer)) {
+        findings.push({
+          rule: "mime-magic-mismatch",
+          severity: "reject",
+          message:
+            `File declared as ${declaredMimeType} ` +
+            "but its content does not match that type",
+        });
       }
 
       const ctx: ScanContext = {

--- a/apps/api/src/tests/security/rls-coverage.test.ts
+++ b/apps/api/src/tests/security/rls-coverage.test.ts
@@ -170,6 +170,27 @@ describe("policy coverage", () => {
     }
   });
 
+  test("audit_logs is append-only: UPDATE and DELETE are denied for stella", async () => {
+    const policies = await fetchStellaPolicies(testDb);
+    const auditPolicies = policies.filter((p) => p.table_name === "audit_logs");
+
+    // SELECT + INSERT are the only operations the audit trail exposes.
+    expect(auditPolicies.filter((p) => p.command === "r")).toHaveLength(1);
+    expect(auditPolicies.filter((p) => p.command === "a")).toHaveLength(1);
+
+    // UPDATE / DELETE are locked by RESTRICTIVE `false` policies. A
+    // RESTRICTIVE policy is AND-ed with every permissive one, so a
+    // later migration that adds a permissive UPDATE/DELETE policy
+    // cannot silently unlock mutation of the audit trail.
+    for (const command of ["w", "d"] as const) {
+      const denyPolicies = auditPolicies.filter((p) => p.command === command);
+      expect(denyPolicies).toHaveLength(1);
+      const denyPolicy = denyPolicies.at(0);
+      expect(denyPolicy?.permissive).toBe(false);
+      expect(denyPolicy?.using_expr).toBe("false");
+    }
+  });
+
   test("auth and global case-law tables have explicit stella policy boundaries", async () => {
     const policies = await fetchStellaPolicies(testDb);
     const commandsFor = (table: string) =>

--- a/apps/api/src/tests/security/rls-helpers.ts
+++ b/apps/api/src/tests/security/rls-helpers.ts
@@ -1054,6 +1054,8 @@ type PolicyRow = {
   table_name: string;
   policy_name: string;
   command: string;
+  /** `true` for PERMISSIVE, `false` for RESTRICTIVE policies. */
+  permissive: boolean;
   using_expr: string | null;
   check_expr: string | null;
 };
@@ -1084,6 +1086,7 @@ const fetchPoliciesForRole = async (
     SELECT c.relname AS table_name,
            p.polname AS policy_name,
            p.polcmd  AS command,
+           p.polpermissive AS permissive,
            pg_get_expr(p.polqual, p.polrelid)
              AS using_expr,
            pg_get_expr(p.polwithcheck, p.polrelid)


### PR DESCRIPTION
Small consistency cleanup in `apps/api`:

- Presigned template-version downloads use the standard 900s expiry, matching the other read paths.
- `audit_logs` gets explicit restrictive UPDATE/DELETE policies (append-only table); includes the migration.
- `EXTENSION_ORIGIN` is parsed as a URL, consistent with the other origin variables.
- File scan checks the declared MIME type against magic bytes for common binary formats (PDF, PNG, JPEG, GIF, WEBP).

`@stll/api`: lint clean, typecheck clean, 86 tests pass across the affected suites.