### PR TITLE
chore(web): finish useContext → use() migration

### DIFF
--- a/apps/web/src/components/chat-editor-provider.tsx
+++ b/apps/web/src/components/chat-editor-provider.tsx
@@ -1,7 +1,7 @@
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useEffectEvent,
   useMemo,
@@ -374,7 +374,7 @@ export const ChatEditorProvider = ({ children }: React.PropsWithChildren) => {
 };
 
 export const useChatEditorExtensions = () => {
-  const context = useContext(ChatEditorManagerContext);
+  const context = use(ChatEditorManagerContext);
 
   if (context === null) {
     panic("useChatEditorExtensions must be used within ChatEditorProvider");
@@ -386,7 +386,7 @@ export const useChatEditorExtensions = () => {
 };
 
 export const useChatEditorManager = () => {
-  const context = useContext(ChatEditorManagerContext);
+  const context = use(ChatEditorManagerContext);
 
   if (context === null) {
     panic("useChatEditorManager must be used within ChatEditorProvider");

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,4 +1,4 @@
-import { createContext, use } from "react";
+import { createContext, use, useMemo } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
@@ -59,22 +59,25 @@ export const ChatMentionProviders = ({
     enabled: workspaces !== undefined && workspaces.length > 0,
   });
 
-  const value: MentionProviders = {
-    getItems: (categories) => {
-      const items: ChatMentionOption[] = [];
+  const value = useMemo<MentionProviders>(
+    () => ({
+      getItems: (categories) => {
+        const items: ChatMentionOption[] = [];
 
-      if (categories.includes("workspace") && workspaces) {
-        items.push(
-          ...buildWorkspaceMentionOptions({
-            firstViewIdsByWorkspaceId,
-            workspaces,
-          }),
-        );
-      }
+        if (categories.includes("workspace") && workspaces) {
+          items.push(
+            ...buildWorkspaceMentionOptions({
+              firstViewIdsByWorkspaceId,
+              workspaces,
+            }),
+          );
+        }
 
-      return items;
-    },
-  };
+        return items;
+      },
+    }),
+    [firstViewIdsByWorkspaceId, workspaces],
+  );
 
   return (
     <MentionProvidersContext value={value}>{children}</MentionProvidersContext>

--- a/apps/web/src/components/chat-mention-providers.tsx
+++ b/apps/web/src/components/chat-mention-providers.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useMemo } from "react";
+import { createContext, use } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRouteApi } from "@tanstack/react-router";
@@ -21,7 +21,7 @@ const MentionProvidersContext = createContext<MentionProviders>({
   getItems: () => [],
 });
 
-export const useMentionProviders = () => useContext(MentionProvidersContext);
+export const useMentionProviders = () => use(MentionProvidersContext);
 
 /** Provides org-level mention sources to any ChatEditor below. */
 export const ChatMentionProviders = ({
@@ -59,25 +59,22 @@ export const ChatMentionProviders = ({
     enabled: workspaces !== undefined && workspaces.length > 0,
   });
 
-  const value = useMemo<MentionProviders>(
-    () => ({
-      getItems: (categories) => {
-        const items: ChatMentionOption[] = [];
+  const value: MentionProviders = {
+    getItems: (categories) => {
+      const items: ChatMentionOption[] = [];
 
-        if (categories.includes("workspace") && workspaces) {
-          items.push(
-            ...buildWorkspaceMentionOptions({
-              firstViewIdsByWorkspaceId,
-              workspaces,
-            }),
-          );
-        }
+      if (categories.includes("workspace") && workspaces) {
+        items.push(
+          ...buildWorkspaceMentionOptions({
+            firstViewIdsByWorkspaceId,
+            workspaces,
+          }),
+        );
+      }
 
-        return items;
-      },
-    }),
-    [firstViewIdsByWorkspaceId, workspaces],
-  );
+      return items;
+    },
+  };
 
   return (
     <MentionProvidersContext value={value}>{children}</MentionProvidersContext>

--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -1,8 +1,8 @@
 import type { PropsWithChildren } from "react";
 import {
   createContext,
+  use,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -10,6 +10,7 @@ import {
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useRouteContext } from "@tanstack/react-router";
+import { panic } from "better-result";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
@@ -121,10 +122,10 @@ export function AIAvailabilityProvider({ children }: PropsWithChildren) {
 }
 
 export const useAIKeyGate = () => {
-  const context = useContext(AIAvailabilityContext);
+  const context = use(AIAvailabilityContext);
 
   if (!context) {
-    throw new Error("useAIKeyGate must be used within AIAvailabilityProvider");
+    panic("useAIKeyGate must be used within AIAvailabilityProvider");
   }
 
   return context;

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-} from "react";
+import { createContext, use, useCallback, useMemo, useState } from "react";
 
 import { useHotkey } from "@tanstack/react-hotkeys";
 import { panic } from "better-result";
@@ -56,7 +50,7 @@ type SidebarContextProps = {
 const SidebarContext = createContext<SidebarContextProps | null>(null);
 
 function useSidebar() {
-  const context = useContext(SidebarContext);
+  const context = use(SidebarContext);
   if (!context) {
     panic("useSidebar must be used within a SidebarProvider.");
   }

--- a/apps/web/src/hooks/use-stick-to-bottom.ts
+++ b/apps/web/src/hooks/use-stick-to-bottom.ts
@@ -1,5 +1,7 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, use, useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
+
+import { panic } from "better-result";
 
 const NEAR_BOTTOM_THRESHOLD_PX = 50;
 
@@ -15,11 +17,10 @@ export const StickToBottomContext = createContext<StickToBottomContext | null>(
 );
 
 export const useStickToBottomContext = (): StickToBottomContext => {
-  const ctx = useContext(StickToBottomContext);
+  const ctx = use(StickToBottomContext);
   if (!ctx) {
-    throw new Error(
-      "useStickToBottomContext must be used within a " +
-        "StickToBottom provider",
+    panic(
+      "useStickToBottomContext must be used within a StickToBottom provider",
     );
   }
   return ctx;


### PR DESCRIPTION
## Summary
Sweeps the five remaining wrapper hooks still on `useContext`. Pattern matches #416.

- `useContext` → `use()` in `chat-mention-providers`, `sidebar`, `chat-editor-provider` (×2), `require-ai-key`, `use-stick-to-bottom`
- Drop `useMemo` around the context value in `chat-mention-providers` (React Compiler covers)
- Replace `throw new Error(...)` with `panic(...)` in `require-ai-key` and `use-stick-to-bottom` to match the established invariant-guard pattern (`sidebar`, `chat-editor-provider`)

No behavior change. Net -7 lines.

## Test plan
- [x] `bun run format`
- [x] `bun --filter @stll/web lint` (oxlint type-aware)
- [x] `bun --filter @stll/web typecheck` (tsgo)
- [ ] Browser smoke: open sidebar, open chat composer (mentions + slash menu), trigger AI key dialog, scroll a long chat (stick-to-bottom)