### PR TITLE
refactor(api): folio-collab handler factory + endpoint split

### DIFF
--- a/apps/api/src/handlers/folio-collab/authorize.ts
+++ b/apps/api/src/handlers/folio-collab/authorize.ts
@@ -1,0 +1,60 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
+
+const config = {
+  body: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
+
+const authorizeFolioCollabSessionHandler = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
+  async function* ({ body: { sessionId, token } }) {
+    const authorized = await authorizeFolioCollabSession({ sessionId, token });
+
+    if (authorized.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorized.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorized.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
+
+    const { value } = authorized;
+    return Result.ok({
+      canEdit: value.canEdit,
+      roomName: value.sessionId,
+      sessionId: value.sessionId,
+      tokenExpiresAt: value.tokenExpiresAt.toISOString(),
+      userId: value.userId,
+      workspaceId: value.workspaceId,
+    });
+  },
+);
+
+export default authorizeFolioCollabSessionHandler;

--- a/apps/api/src/handlers/folio-collab/cancel.ts
+++ b/apps/api/src/handlers/folio-collab/cancel.ts
@@ -1,12 +1,15 @@
+import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
-import { status, t } from "elysia";
-import type { Static } from "elysia";
+import { t } from "elysia";
 
 import { folioCollabSessions } from "@/api/db/schema";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   authorizeFolioCollabSession,
   FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
@@ -15,142 +18,164 @@ import { getS3 } from "@/api/lib/s3";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-export const cancelFolioCollabSessionParamsSchema = t.Object({
-  sessionId: tSafeId("folioCollabSession"),
-});
-
-export const cancelFolioCollabSessionBodySchema = t.Object({
-  token: t.String({ minLength: 64, maxLength: 64 }),
-});
-
-type CancelFolioCollabSessionHandlerProps = {
-  body: Static<typeof cancelFolioCollabSessionBodySchema>;
-  sessionId: SafeId<"folioCollabSession">;
-};
-
 type StoredSessionFile = {
   fileId: SafeId<"userFile">;
   mimeType: string;
 };
 
-export const cancelFolioCollabSessionHandler = async ({
-  body: { token },
-  sessionId,
-}: CancelFolioCollabSessionHandlerProps) => {
-  const authorizedSession = await authorizeFolioCollabSession({
-    sessionId,
-    token,
-  });
+const config = {
+  params: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+  }),
+  body: t.Object({
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
 
-  if (authorizedSession.status === "missing") {
-    return status(404, { message: "Collaborative edit session not found." });
-  }
-
-  if (authorizedSession.status === "token-expired") {
-    return status(401, { message: "Collaborative edit token expired." });
-  }
-
-  if (authorizedSession.status === "permission-revoked") {
-    return status(403, { message: "Collaborative edit permission revoked." });
-  }
-
-  if (!authorizedSession.value.canEdit) {
-    return status(403, { message: "Collaborative edit is read-only." });
-  }
-
-  const storedFiles: StoredSessionFile[] = [];
-  const cancelled = await authorizedSession.value.scopedDb(async (tx) => {
-    const sessions = await tx
-      .select({
-        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
-        id: folioCollabSessions.id,
-        status: folioCollabSessions.status,
-        yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
-        yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
-      })
-      .from(folioCollabSessions)
-      .where(
-        and(
-          eq(folioCollabSessions.id, sessionId),
-          eq(
-            folioCollabSessions.workspaceId,
-            authorizedSession.value.workspaceId,
-          ),
-        ),
-      )
-      .limit(1)
-      .for("update");
-    const session = sessions.at(0);
-
-    if (!session) {
-      return {
-        error: {
-          message: "Collaborative edit session not found.",
-          statusCode: 404,
-        },
-      } as const;
-    }
-
-    if (session.status !== "open") {
-      return {
-        error: {
-          message: "Collaborative edit session is already closed.",
-          statusCode: 409,
-        },
-      } as const;
-    }
-
-    if (session.yjsSnapshotUpdatedAt !== null) {
-      storedFiles.push({
-        fileId: session.yjsSnapshotFileId,
-        mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
-      });
-    }
-
-    if (session.docxCheckpointUpdatedAt !== null) {
-      storedFiles.push({
-        fileId: session.docxCheckpointFileId,
-        mimeType: DOCX_MIME_TYPE,
-      });
-    }
-
-    const closedAt = new Date();
-    await tx
-      .update(folioCollabSessions)
-      .set({ closedAt, status: "cancelled" })
-      .where(eq(folioCollabSessions.id, session.id));
-
-    return { cancelledAt: closedAt } as const;
-  });
-
-  if ("error" in cancelled) {
-    return status(cancelled.error.statusCode, {
-      message: cancelled.error.message,
+const cancelFolioCollabSession = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
+  async function* ({ body: { token }, params: { sessionId } }) {
+    const authorizedSession = await authorizeFolioCollabSession({
+      sessionId,
+      token,
     });
-  }
 
-  await Promise.all(
-    storedFiles.map(async ({ fileId, mimeType }) => {
-      const key = createFileKey({
-        fileId,
-        mimeType,
-        organizationId: authorizedSession.value.organizationId,
-        workspaceId: authorizedSession.value.workspaceId,
-      });
+    if (authorizedSession.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
 
-      await getS3()
-        .delete(key)
-        .catch((error: unknown) => {
-          captureError(error, { sessionId, storageKey: key });
+    const { canEdit, organizationId, scopedDb, workspaceId } =
+      authorizedSession.value;
+
+    if (!canEdit) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit is read-only.",
+        }),
+      );
+    }
+
+    const storedFiles: StoredSessionFile[] = [];
+    const cancelled = await scopedDb(async (tx) => {
+      const sessions = await tx
+        .select({
+          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+          id: folioCollabSessions.id,
+          status: folioCollabSessions.status,
+          yjsSnapshotFileId: folioCollabSessions.yjsSnapshotFileId,
+          yjsSnapshotUpdatedAt: folioCollabSessions.yjsSnapshotUpdatedAt,
+        })
+        .from(folioCollabSessions)
+        .where(
+          and(
+            eq(folioCollabSessions.id, sessionId),
+            eq(folioCollabSessions.workspaceId, workspaceId),
+          ),
+        )
+        .limit(1)
+        .for("update");
+      const session = sessions.at(0);
+
+      if (!session) {
+        return {
+          error: {
+            message: "Collaborative edit session not found.",
+            statusCode: 404,
+          },
+        } as const;
+      }
+
+      if (session.status !== "open") {
+        return {
+          error: {
+            message: "Collaborative edit session is already closed.",
+            statusCode: 409,
+          },
+        } as const;
+      }
+
+      if (session.yjsSnapshotUpdatedAt !== null) {
+        storedFiles.push({
+          fileId: session.yjsSnapshotFileId,
+          mimeType: FOLIO_COLLAB_YJS_UPDATE_MIME_TYPE,
         });
-    }),
-  );
+      }
 
-  broadcast(authorizedSession.value.workspaceId, {
-    type: "invalidate-query",
-    data: ["entities", authorizedSession.value.workspaceId],
-  });
+      if (session.docxCheckpointUpdatedAt !== null) {
+        storedFiles.push({
+          fileId: session.docxCheckpointFileId,
+          mimeType: DOCX_MIME_TYPE,
+        });
+      }
 
-  return { cancelledAt: cancelled.cancelledAt.toISOString() };
-};
+      const closedAt = new Date();
+      await tx
+        .update(folioCollabSessions)
+        .set({ closedAt, status: "cancelled" })
+        .where(eq(folioCollabSessions.id, session.id));
+
+      return { cancelledAt: closedAt } as const;
+    });
+
+    if ("error" in cancelled) {
+      return Result.err(
+        new HandlerError({
+          status: cancelled.error.statusCode,
+          message: cancelled.error.message,
+        }),
+      );
+    }
+
+    await Promise.all(
+      storedFiles.map(async ({ fileId, mimeType }) => {
+        const key = createFileKey({
+          fileId,
+          mimeType,
+          organizationId,
+          workspaceId,
+        });
+
+        await getS3()
+          .delete(key)
+          .catch((error: unknown) => {
+            captureError(error, { sessionId, storageKey: key });
+          });
+      }),
+    );
+
+    broadcast(workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", workspaceId],
+    });
+
+    return Result.ok({
+      cancelledAt: cancelled.cancelledAt.toISOString(),
+    });
+  },
+);
+
+export default cancelFolioCollabSession;

--- a/apps/api/src/handlers/folio-collab/checkpoint.ts
+++ b/apps/api/src/handlers/folio-collab/checkpoint.ts
@@ -1,13 +1,14 @@
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
-import { status, t } from "elysia";
-import type { Static } from "elysia";
+import { t } from "elysia";
 
 import { folioCollabSessions } from "@/api/db/schema";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
-import type { SafeId } from "@/api/lib/branded-types";
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { scanFile } from "@/api/lib/file-scan/scan";
 import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
 import { FILE_SIZE_LIMITS } from "@/api/lib/limits";
@@ -15,165 +16,213 @@ import { getS3 } from "@/api/lib/s3";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-export const checkpointFolioCollabSessionParamsSchema = t.Object({
-  sessionId: tSafeId("folioCollabSession"),
-});
-
-export const checkpointFolioCollabSessionBodySchema = t.Object({
-  file: t.File({
-    maxSize: FILE_SIZE_LIMITS.document,
+const config = {
+  params: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
   }),
-  token: t.String({ minLength: 64, maxLength: 64 }),
-});
+  body: t.Object({
+    file: t.File({
+      maxSize: FILE_SIZE_LIMITS.document,
+    }),
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
 
-type CheckpointFolioCollabSessionHandlerProps = {
-  body: Static<typeof checkpointFolioCollabSessionBodySchema>;
-  sessionId: SafeId<"folioCollabSession">;
-};
+const checkpointFolioCollabSession = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
+  async function* ({ body: { file, token }, params: { sessionId } }) {
+    if (file.type !== DOCX_MIME_TYPE) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message:
+            "Collaborative checkpoints currently support only DOCX files.",
+        }),
+      );
+    }
 
-export const checkpointFolioCollabSessionHandler = async ({
-  body: { file, token },
-  sessionId,
-}: CheckpointFolioCollabSessionHandlerProps) => {
-  if (file.type !== DOCX_MIME_TYPE) {
-    return status(400, {
-      message: "Collaborative checkpoints currently support only DOCX files.",
+    const authorizedSession = await authorizeFolioCollabSession({
+      sessionId,
+      token,
     });
-  }
 
-  const authorizedSession = await authorizeFolioCollabSession({
-    sessionId,
-    token,
-  });
+    if (authorizedSession.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
 
-  if (authorizedSession.status === "missing") {
-    return status(404, { message: "Collaborative edit session not found." });
-  }
+    const { canEdit, fileName, organizationId, scopedDb, workspaceId } =
+      authorizedSession.value;
 
-  if (authorizedSession.status === "token-expired") {
-    return status(401, { message: "Collaborative edit token expired." });
-  }
+    if (!canEdit) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit is read-only.",
+        }),
+      );
+    }
 
-  if (authorizedSession.status === "permission-revoked") {
-    return status(403, { message: "Collaborative edit permission revoked." });
-  }
+    const buffer = await file.arrayBuffer();
+    const sha256Hex = new Bun.CryptoHasher("sha256")
+      .update(buffer)
+      .digest("hex");
 
-  if (!authorizedSession.value.canEdit) {
-    return status(403, { message: "Collaborative edit is read-only." });
-  }
+    const scanResult = await scanFile({
+      buffer: new Uint8Array(buffer),
+      declaredMimeType: file.type,
+      fileName,
+    });
 
-  const buffer = await file.arrayBuffer();
-  const sha256Hex = new Bun.CryptoHasher("sha256").update(buffer).digest("hex");
+    if (Result.isError(scanResult)) {
+      return Result.err(
+        new HandlerError({
+          status: 422,
+          message: "File security scan failed.",
+        }),
+      );
+    }
 
-  const scanResult = await scanFile({
-    buffer: new Uint8Array(buffer),
-    declaredMimeType: file.type,
-    fileName: authorizedSession.value.fileName,
-  });
+    if (scanResult.value.verdict === "reject") {
+      const reasons = scanResult.value.findings
+        .filter((finding) => finding.severity === "reject")
+        .map((finding) => finding.message);
 
-  if (Result.isError(scanResult)) {
-    return status(422, { message: "File security scan failed." });
-  }
+      return Result.err(
+        new HandlerError({
+          status: 422,
+          message: `File rejected: ${reasons.join("; ")}`,
+        }),
+      );
+    }
 
-  if (scanResult.value.verdict === "reject") {
-    const reasons = scanResult.value.findings
-      .filter((finding) => finding.severity === "reject")
-      .map((finding) => finding.message);
+    const scanWarnings =
+      scanResult.value.verdict === "warn"
+        ? scanResult.value.findings
+            .filter((finding) => finding.severity === "warn")
+            .map((finding) => finding.message)
+        : null;
 
-    return status(422, { message: `File rejected: ${reasons.join("; ")}` });
-  }
-
-  const scanWarnings =
-    scanResult.value.verdict === "warn"
-      ? scanResult.value.findings
-          .filter((finding) => finding.severity === "warn")
-          .map((finding) => finding.message)
-      : null;
-
-  const result = await authorizedSession.value.scopedDb(async (tx) => {
-    const existingSessions = await tx
-      .select({
-        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-        docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
-        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
-        id: folioCollabSessions.id,
-      })
-      .from(folioCollabSessions)
-      .where(
-        and(
-          eq(folioCollabSessions.id, sessionId),
-          eq(folioCollabSessions.status, "open"),
-          eq(
-            folioCollabSessions.workspaceId,
-            authorizedSession.value.workspaceId,
+    const result = await scopedDb(async (tx) => {
+      const existingSessions = await tx
+        .select({
+          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+          docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+          id: folioCollabSessions.id,
+        })
+        .from(folioCollabSessions)
+        .where(
+          and(
+            eq(folioCollabSessions.id, sessionId),
+            eq(folioCollabSessions.status, "open"),
+            eq(folioCollabSessions.workspaceId, workspaceId),
           ),
-        ),
-      )
-      .limit(1)
-      .for("update");
-    const existingSession = existingSessions.at(0);
+        )
+        .limit(1)
+        .for("update");
+      const existingSession = existingSessions.at(0);
 
-    if (!existingSession) {
-      return status(409, {
-        message: "Collaborative edit session is already closed.",
+      if (!existingSession) {
+        return {
+          error: {
+            statusCode: 409 as const,
+            message: "Collaborative edit session is already closed.",
+          },
+        } as const;
+      }
+
+      if (existingSession.docxCheckpointSha256Hex === sha256Hex) {
+        return {
+          checkpointedAt:
+            existingSession.docxCheckpointUpdatedAt?.toISOString() ??
+            new Date().toISOString(),
+          noop: true,
+        } as const;
+      }
+
+      const key = createFileKey({
+        fileId: existingSession.docxCheckpointFileId,
+        mimeType: DOCX_MIME_TYPE,
+        organizationId,
+        workspaceId,
       });
-    }
 
-    if (existingSession.docxCheckpointSha256Hex === sha256Hex) {
+      const s3WriteResult = await Result.tryPromise(
+        async () => await getS3().write(key, new Uint8Array(buffer)),
+      );
+
+      if (Result.isError(s3WriteResult)) {
+        captureError(s3WriteResult.error, {
+          sessionId,
+          workspaceId,
+        });
+
+        return {
+          error: {
+            statusCode: 500 as const,
+            message: "Failed to persist collaborative checkpoint.",
+          },
+        } as const;
+      }
+
+      const checkpointedAt = new Date();
+      await tx
+        .update(folioCollabSessions)
+        .set({
+          docxCheckpointSha256Hex: sha256Hex,
+          docxCheckpointScanWarnings: scanWarnings,
+          docxCheckpointSizeBytes: file.size,
+          docxCheckpointUpdatedAt: checkpointedAt,
+          fileName,
+        })
+        .where(eq(folioCollabSessions.id, existingSession.id));
+
       return {
-        checkpointedAt:
-          existingSession.docxCheckpointUpdatedAt?.toISOString() ??
-          new Date().toISOString(),
-        noop: true,
-      };
-    }
-
-    const key = createFileKey({
-      fileId: existingSession.docxCheckpointFileId,
-      mimeType: DOCX_MIME_TYPE,
-      organizationId: authorizedSession.value.organizationId,
-      workspaceId: authorizedSession.value.workspaceId,
+        checkpointedAt: checkpointedAt.toISOString(),
+        noop: false,
+      } as const;
     });
 
-    const s3WriteResult = await Result.tryPromise(
-      async () => await getS3().write(key, new Uint8Array(buffer)),
-    );
+    if ("error" in result) {
+      return Result.err(
+        new HandlerError({
+          status: result.error.statusCode,
+          message: result.error.message,
+        }),
+      );
+    }
 
-    if (Result.isError(s3WriteResult)) {
-      captureError(s3WriteResult.error, {
-        sessionId,
-        workspaceId: authorizedSession.value.workspaceId,
-      });
-
-      return status(500, {
-        message: "Failed to persist collaborative checkpoint.",
+    if (!result.noop) {
+      broadcast(workspaceId, {
+        type: "invalidate-query",
+        data: ["entities", workspaceId],
       });
     }
 
-    const checkpointedAt = new Date();
-    await tx
-      .update(folioCollabSessions)
-      .set({
-        docxCheckpointSha256Hex: sha256Hex,
-        docxCheckpointScanWarnings: scanWarnings,
-        docxCheckpointSizeBytes: file.size,
-        docxCheckpointUpdatedAt: checkpointedAt,
-        fileName: authorizedSession.value.fileName,
-      })
-      .where(eq(folioCollabSessions.id, existingSession.id));
+    return Result.ok(result);
+  },
+);
 
-    return {
-      checkpointedAt: checkpointedAt.toISOString(),
-      noop: false,
-    };
-  });
-
-  if ("noop" in result && !result.noop) {
-    broadcast(authorizedSession.value.workspaceId, {
-      type: "invalidate-query",
-      data: ["entities", authorizedSession.value.workspaceId],
-    });
-  }
-
-  return result;
-};
+export default checkpointFolioCollabSession;

--- a/apps/api/src/handlers/folio-collab/finalize.ts
+++ b/apps/api/src/handlers/folio-collab/finalize.ts
@@ -1,7 +1,6 @@
-import { panic } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
-import { status, t } from "elysia";
-import type { Static } from "elysia";
+import { t } from "elysia";
 
 import {
   entities,
@@ -20,9 +19,12 @@ import {
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { captureError } from "@/api/lib/analytics";
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
 import { authorizeFolioCollabSession } from "@/api/lib/folio-collab-sessions";
 import { getS3 } from "@/api/lib/s3";
@@ -30,198 +32,102 @@ import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
 import { DOCX_MIME_TYPE } from "@/api/mime-types";
 
-export const finalizeFolioCollabSessionParamsSchema = t.Object({
-  sessionId: tSafeId("folioCollabSession"),
-});
+const config = {
+  params: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+  }),
+  body: t.Object({
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
 
-export const finalizeFolioCollabSessionBodySchema = t.Object({
-  token: t.String({ minLength: 64, maxLength: 64 }),
-});
+type FinalizeResult =
+  | { outcome: "no_changes" }
+  | {
+      outcome: "finalized";
+      entityId: SafeId<"entity">;
+      fieldId: SafeId<"field">;
+      versionId: SafeId<"entityVersion">;
+      versionNumber: number;
+    };
 
-type FinalizeFolioCollabSessionHandlerProps = {
-  body: Static<typeof finalizeFolioCollabSessionBodySchema>;
-  sessionId: SafeId<"folioCollabSession">;
-};
-
-export const finalizeFolioCollabSessionHandler = async ({
-  body: { token },
-  sessionId,
-}: FinalizeFolioCollabSessionHandlerProps) => {
-  const authorizedSession = await authorizeFolioCollabSession({
-    sessionId,
-    token,
-  });
-
-  if (authorizedSession.status === "missing") {
-    return status(404, { message: "Collaborative edit session not found." });
-  }
-
-  if (authorizedSession.status === "token-expired") {
-    return status(401, { message: "Collaborative edit token expired." });
-  }
-
-  if (authorizedSession.status === "permission-revoked") {
-    return status(403, { message: "Collaborative edit permission revoked." });
-  }
-
-  if (!authorizedSession.value.canEdit) {
-    return status(403, { message: "Collaborative edit is read-only." });
-  }
-
-  const { organizationId, scopedDb, userId, workspaceId } =
-    authorizedSession.value;
-
-  const deleteS3Key = async (key: string, context: Record<string, string>) => {
-    await getS3()
-      .delete(key)
-      .catch((error: unknown) => {
-        captureError(error, context);
-      });
-  };
-
-  // Phase A: non-locking read. entity_versions rows are immutable
-  // once written, so reading the base version outside the heavy
-  // write txn is safe; the session row may move under us, but we
-  // re-verify inside the write txn before we commit any rows.
-  const sessionPreview = await scopedDb(async (tx) => {
-    const rows = await tx
-      .select({
-        baseVersionId: folioCollabSessions.baseVersionId,
-        docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
-        docxCheckpointScanWarnings:
-          folioCollabSessions.docxCheckpointScanWarnings,
-        docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
-        docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
-        docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
-        entityId: folioCollabSessions.entityId,
-        fileName: folioCollabSessions.fileName,
-        propertyId: folioCollabSessions.propertyId,
-        status: folioCollabSessions.status,
-      })
-      .from(folioCollabSessions)
-      .where(
-        and(
-          eq(folioCollabSessions.id, sessionId),
-          eq(folioCollabSessions.workspaceId, workspaceId),
-        ),
-      )
-      .limit(1);
-    return rows.at(0);
-  });
-
-  if (!sessionPreview) {
-    return status(404, { message: "Collaborative edit session not found." });
-  }
-
-  if (sessionPreview.status !== "open") {
-    return status(409, {
-      message: "Collaborative edit session is already closed.",
+const finalizeFolioCollabSession = createSafeTokenHandler<
+  typeof config,
+  FinalizeResult
+>(
+  config,
+  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
+  async function* ({ body: { token }, params: { sessionId } }) {
+    const authorizedSession = await authorizeFolioCollabSession({
+      sessionId,
+      token,
     });
-  }
 
-  const checkpointSha256Hex = sessionPreview.docxCheckpointSha256Hex;
-  const checkpointSizeBytes = sessionPreview.docxCheckpointSizeBytes;
-  if (
-    checkpointSha256Hex === null ||
-    checkpointSizeBytes === null ||
-    sessionPreview.docxCheckpointUpdatedAt === null
-  ) {
-    await scopedDb(async (tx) => {
-      await tx
-        .update(folioCollabSessions)
-        .set({ closedAt: new Date(), status: "cancelled" })
-        .where(eq(folioCollabSessions.id, sessionId));
-    });
-    return { outcome: "no_changes" } as const;
-  }
+    if (authorizedSession.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorizedSession.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
 
-  const checkpointKey = createFileKey({
-    fileId: sessionPreview.docxCheckpointFileId,
-    mimeType: DOCX_MIME_TYPE,
-    organizationId,
-    workspaceId,
-  });
+    const { canEdit, organizationId, scopedDb, userId, workspaceId } =
+      authorizedSession.value;
 
-  const baseVersion = await scopedDb(
-    async (tx) =>
-      await tx.query.entityVersions.findFirst({
-        where: {
-          entityId: { eq: sessionPreview.entityId },
-          id: { eq: sessionPreview.baseVersionId },
-          workspaceId: { eq: workspaceId },
-        },
-        columns: { versionNumber: true },
-        with: {
-          fields: { columns: { content: true, propertyId: true } },
-        },
-      }),
-  );
+    if (!canEdit) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit is read-only.",
+        }),
+      );
+    }
 
-  if (!baseVersion) {
-    return status(409, { message: "Base entity version not found." });
-  }
+    const deleteS3Key = async (
+      key: string,
+      context: Record<string, string>,
+    ) => {
+      await getS3()
+        .delete(key)
+        .catch((error: unknown) => {
+          captureError(error, context);
+        });
+    };
 
-  const baseFileField = findDocxFieldForProperty({
-    fieldEntries: baseVersion.fields,
-    propertyId: sessionPreview.propertyId,
-  });
-
-  if (!baseFileField) {
-    return status(409, {
-      message: "Collaborative edit session source file is no longer available.",
-    });
-  }
-
-  if (checkpointSha256Hex === baseFileField.sha256Hex) {
-    await scopedDb(async (tx) => {
-      await tx
-        .update(folioCollabSessions)
-        .set({ closedAt: new Date(), status: "cancelled" })
-        .where(eq(folioCollabSessions.id, sessionId));
-    });
-    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
-    return { outcome: "no_changes" } as const;
-  }
-
-  // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
-  // source bytes are written to S3 before we open the txn; any
-  // commit failure rolls them back via uploadedKeys.
-  const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
-  const validation = await validateDocxBuffer(checkpointBuffer);
-  if (!validation.valid) {
-    return status(422, {
-      message: `Document validation failed: ${validation.error}`,
-    });
-  }
-
-  const storedBytes = new Uint8Array(checkpointBuffer);
-  const nextVersionNumber = baseVersion.versionNumber + 1;
-  const nextVersionId = createSafeId<"entityVersion">();
-  const sourceFileId = Bun.randomUUIDv7();
-  const sourceKey = createFileKey({
-    fileId: sourceFileId,
-    mimeType: DOCX_MIME_TYPE,
-    organizationId,
-    workspaceId,
-  });
-  const uploadedKeys: string[] = [sourceKey];
-  let shouldRollbackUploadedKeys = true;
-  const rollbackUploadedKeys = async () => {
-    await Promise.all(
-      uploadedKeys.map(
-        async (key) => await deleteS3Key(key, { rollbackKey: key, sessionId }),
-      ),
-    );
-  };
-
-  try {
-    await getS3().write(sourceKey, storedBytes);
-
-    // Phase C: txn — lock + verify state hasn't drifted + write rows.
-    const result = await scopedDb(async (tx) => {
-      const lockedSessions = await tx
+    // Phase A: non-locking read. entity_versions rows are immutable
+    // once written, so reading the base version outside the heavy
+    // write txn is safe; the session row may move under us, but we
+    // re-verify inside the write txn before we commit any rows.
+    const sessionPreview = await scopedDb(async (tx) => {
+      const rows = await tx
         .select({
+          baseVersionId: folioCollabSessions.baseVersionId,
+          docxCheckpointFileId: folioCollabSessions.docxCheckpointFileId,
+          docxCheckpointScanWarnings:
+            folioCollabSessions.docxCheckpointScanWarnings,
           docxCheckpointSha256Hex: folioCollabSessions.docxCheckpointSha256Hex,
+          docxCheckpointSizeBytes: folioCollabSessions.docxCheckpointSizeBytes,
+          docxCheckpointUpdatedAt: folioCollabSessions.docxCheckpointUpdatedAt,
+          entityId: folioCollabSessions.entityId,
+          fileName: folioCollabSessions.fileName,
+          propertyId: folioCollabSessions.propertyId,
           status: folioCollabSessions.status,
         })
         .from(folioCollabSessions)
@@ -231,195 +137,358 @@ export const finalizeFolioCollabSessionHandler = async ({
             eq(folioCollabSessions.workspaceId, workspaceId),
           ),
         )
-        .for("update");
+        .limit(1);
+      return rows.at(0);
+    });
 
-      const editSession = lockedSessions.at(0);
-      if (!editSession) {
-        return {
-          error: {
-            message: "Collaborative edit session not found.",
-            statusCode: 404,
-          },
-        } as const;
-      }
-      if (editSession.status !== "open") {
-        return {
-          error: {
-            message: "Collaborative edit session is already closed.",
-            statusCode: 409,
-          },
-        } as const;
-      }
-      if (editSession.docxCheckpointSha256Hex !== checkpointSha256Hex) {
-        return {
-          error: {
-            message: "Collaborative edit checkpoint changed during finalize.",
-            statusCode: 409,
-          },
-        } as const;
-      }
+    if (!sessionPreview) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
 
-      const lockedEntities = await tx
-        .select({
-          currentVersionId: entities.currentVersionId,
-          docSequence: entities.docSequence,
-        })
-        .from(entities)
-        .where(
-          and(
-            eq(entities.id, sessionPreview.entityId),
-            eq(entities.workspaceId, workspaceId),
-          ),
-        )
-        .for("update");
+    if (sessionPreview.status !== "open") {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Collaborative edit session is already closed.",
+        }),
+      );
+    }
 
-      const entity = lockedEntities.at(0);
-      if (!entity) {
-        return {
-          error: { message: "Entity not found.", statusCode: 404 },
-        } as const;
-      }
-
-      if (entity.currentVersionId !== sessionPreview.baseVersionId) {
+    const checkpointSha256Hex = sessionPreview.docxCheckpointSha256Hex;
+    const checkpointSizeBytes = sessionPreview.docxCheckpointSizeBytes;
+    if (
+      checkpointSha256Hex === null ||
+      checkpointSizeBytes === null ||
+      sessionPreview.docxCheckpointUpdatedAt === null
+    ) {
+      await scopedDb(async (tx) => {
         await tx
           .update(folioCollabSessions)
           .set({ closedAt: new Date(), status: "cancelled" })
           .where(eq(folioCollabSessions.id, sessionId));
-
-        return {
-          deleteCheckpoint: true,
-          error: {
-            message:
-              "This document changed in Stella while collaborative editing was open.",
-            statusCode: 409,
-          },
-        } as const;
-      }
-
-      const workspace = await tx.query.workspaces.findFirst({
-        where: { id: { eq: workspaceId } },
-        columns: { reference: true },
       });
-
-      const nextVersionStamp = buildVersionStamp({
-        docSequence: entity.docSequence,
-        versionNumber: nextVersionNumber,
-        workspaceReference:
-          workspace?.reference ??
-          panic("Workspace not found for finalized collaborative edit session"),
-      });
-
-      await tx.insert(entityVersions).values({
-        entityId: sessionPreview.entityId,
-        id: nextVersionId,
-        stamp: nextVersionStamp.stamp,
-        verificationCode: nextVersionStamp.verificationCode,
-        versionNumber: nextVersionNumber,
-        workspaceId,
-      });
-
-      const clonedFields = cloneFieldsForRevision({
-        currentFields: baseVersion.fields,
-        entityVersionId: nextVersionId,
-        propertyId: sessionPreview.propertyId,
-        replacementContent: {
-          encrypted: false,
-          fileName: sessionPreview.fileName,
-          id: sourceFileId,
-          mimeType: DOCX_MIME_TYPE,
-          pdfFileId: null,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted: false,
-            mimeType: DOCX_MIME_TYPE,
-          }),
-          sha256Hex: checkpointSha256Hex,
-          sizeBytes: checkpointSizeBytes,
-          type: "file",
-          version: 1,
-          ...(sessionPreview.docxCheckpointScanWarnings !== null && {
-            scanWarnings: sessionPreview.docxCheckpointScanWarnings,
-          }),
-        },
-        workspaceId,
-      });
-
-      const insertedFields = await tx
-        .insert(fields)
-        .values(clonedFields)
-        .returning({ id: fields.id, propertyId: fields.propertyId });
-
-      const nextField = insertedFields.find(
-        (field) => field.propertyId === sessionPreview.propertyId,
-      );
-
-      await tx
-        .update(entities)
-        .set({
-          currentVersionId: nextVersionId,
-          lastEditedBy: userId,
-          updatedAt: new Date(),
-        })
-        .where(eq(entities.id, sessionPreview.entityId));
-
-      await tx
-        .update(workspaces)
-        .set({ lastActivityAt: new Date() })
-        .where(eq(workspaces.id, workspaceId));
-
-      await tx
-        .update(folioCollabSessions)
-        .set({
-          closedAt: new Date(),
-          finalizedVersionId: nextVersionId,
-          status: "finalized",
-        })
-        .where(eq(folioCollabSessions.id, sessionId));
-
-      return {
-        entityId: sessionPreview.entityId,
-        fieldId:
-          nextField?.id ??
-          panic("Finalized collaborative edit session field was not inserted"),
-        outcome: "finalized",
-        versionId: nextVersionId,
-        versionNumber: nextVersionNumber,
-      } as const;
-    });
-
-    if ("error" in result) {
-      await rollbackUploadedKeys();
-      if ("deleteCheckpoint" in result) {
-        await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
-      }
-      return status(result.error.statusCode, { message: result.error.message });
+      return Result.ok({ outcome: "no_changes" as const });
     }
 
-    shouldRollbackUploadedKeys = false;
-    await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
-
-    broadcast(workspaceId, {
-      type: "invalidate-query",
-      data: ["entities", workspaceId],
-    });
-
-    await processCollaborativeEditDerivatives({
-      entityId: result.entityId,
-      fieldId: result.fieldId,
+    const checkpointKey = createFileKey({
+      fileId: sessionPreview.docxCheckpointFileId,
+      mimeType: DOCX_MIME_TYPE,
       organizationId,
-      scopedDb,
-      userId,
-      versionId: result.versionId,
       workspaceId,
     });
 
-    return result;
-  } catch (error) {
-    if (shouldRollbackUploadedKeys) {
-      await rollbackUploadedKeys();
+    const baseVersion = await scopedDb(
+      async (tx) =>
+        await tx.query.entityVersions.findFirst({
+          where: {
+            entityId: { eq: sessionPreview.entityId },
+            id: { eq: sessionPreview.baseVersionId },
+            workspaceId: { eq: workspaceId },
+          },
+          columns: { versionNumber: true },
+          with: {
+            fields: { columns: { content: true, propertyId: true } },
+          },
+        }),
+    );
+
+    if (!baseVersion) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Base entity version not found.",
+        }),
+      );
     }
-    throw error;
-  }
-};
+
+    const baseFileField = findDocxFieldForProperty({
+      fieldEntries: baseVersion.fields,
+      propertyId: sessionPreview.propertyId,
+    });
+
+    if (!baseFileField) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message:
+            "Collaborative edit session source file is no longer available.",
+        }),
+      );
+    }
+
+    if (checkpointSha256Hex === baseFileField.sha256Hex) {
+      await scopedDb(async (tx) => {
+        await tx
+          .update(folioCollabSessions)
+          .set({ closedAt: new Date(), status: "cancelled" })
+          .where(eq(folioCollabSessions.id, sessionId));
+      });
+      await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+      return Result.ok({ outcome: "no_changes" as const });
+    }
+
+    // Phase B: heavy IO + DOCX validation, all OUTSIDE the txn. The
+    // source bytes are written to S3 before we open the txn; any
+    // commit failure rolls them back via uploadedKeys.
+    const checkpointBuffer = await getS3().file(checkpointKey).arrayBuffer();
+    const validation = await validateDocxBuffer(checkpointBuffer);
+    if (!validation.valid) {
+      return Result.err(
+        new HandlerError({
+          status: 422,
+          message: `Document validation failed: ${validation.error}`,
+        }),
+      );
+    }
+
+    const storedBytes = new Uint8Array(checkpointBuffer);
+    const nextVersionNumber = baseVersion.versionNumber + 1;
+    const nextVersionId = createSafeId<"entityVersion">();
+    const sourceFileId = Bun.randomUUIDv7();
+    const sourceKey = createFileKey({
+      fileId: sourceFileId,
+      mimeType: DOCX_MIME_TYPE,
+      organizationId,
+      workspaceId,
+    });
+    const uploadedKeys: string[] = [sourceKey];
+    let shouldRollbackUploadedKeys = true;
+    const rollbackUploadedKeys = async () => {
+      await Promise.all(
+        uploadedKeys.map(
+          async (key) =>
+            await deleteS3Key(key, { rollbackKey: key, sessionId }),
+        ),
+      );
+    };
+
+    try {
+      await getS3().write(sourceKey, storedBytes);
+
+      // Phase C: txn — lock + verify state hasn't drifted + write rows.
+      const result = await scopedDb(async (tx) => {
+        const lockedSessions = await tx
+          .select({
+            docxCheckpointSha256Hex:
+              folioCollabSessions.docxCheckpointSha256Hex,
+            status: folioCollabSessions.status,
+          })
+          .from(folioCollabSessions)
+          .where(
+            and(
+              eq(folioCollabSessions.id, sessionId),
+              eq(folioCollabSessions.workspaceId, workspaceId),
+            ),
+          )
+          .for("update");
+
+        const editSession = lockedSessions.at(0);
+        if (!editSession) {
+          return {
+            error: {
+              statusCode: 404 as const,
+              message: "Collaborative edit session not found.",
+            },
+          } as const;
+        }
+        if (editSession.status !== "open") {
+          return {
+            error: {
+              statusCode: 409 as const,
+              message: "Collaborative edit session is already closed.",
+            },
+          } as const;
+        }
+        if (editSession.docxCheckpointSha256Hex !== checkpointSha256Hex) {
+          return {
+            error: {
+              statusCode: 409 as const,
+              message: "Collaborative edit checkpoint changed during finalize.",
+            },
+          } as const;
+        }
+
+        const lockedEntities = await tx
+          .select({
+            currentVersionId: entities.currentVersionId,
+            docSequence: entities.docSequence,
+          })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.id, sessionPreview.entityId),
+              eq(entities.workspaceId, workspaceId),
+            ),
+          )
+          .for("update");
+
+        const entity = lockedEntities.at(0);
+        if (!entity) {
+          return {
+            error: {
+              statusCode: 404 as const,
+              message: "Entity not found.",
+            },
+          } as const;
+        }
+
+        if (entity.currentVersionId !== sessionPreview.baseVersionId) {
+          await tx
+            .update(folioCollabSessions)
+            .set({ closedAt: new Date(), status: "cancelled" })
+            .where(eq(folioCollabSessions.id, sessionId));
+
+          return {
+            deleteCheckpoint: true,
+            error: {
+              statusCode: 409 as const,
+              message:
+                "This document changed in Stella while collaborative editing was open.",
+            },
+          } as const;
+        }
+
+        const workspace = await tx.query.workspaces.findFirst({
+          where: { id: { eq: workspaceId } },
+          columns: { reference: true },
+        });
+
+        const nextVersionStamp = buildVersionStamp({
+          docSequence: entity.docSequence,
+          versionNumber: nextVersionNumber,
+          workspaceReference:
+            workspace?.reference ??
+            panic(
+              "Workspace not found for finalized collaborative edit session",
+            ),
+        });
+
+        await tx.insert(entityVersions).values({
+          entityId: sessionPreview.entityId,
+          id: nextVersionId,
+          stamp: nextVersionStamp.stamp,
+          verificationCode: nextVersionStamp.verificationCode,
+          versionNumber: nextVersionNumber,
+          workspaceId,
+        });
+
+        const clonedFields = cloneFieldsForRevision({
+          currentFields: baseVersion.fields,
+          entityVersionId: nextVersionId,
+          propertyId: sessionPreview.propertyId,
+          replacementContent: {
+            encrypted: false,
+            fileName: sessionPreview.fileName,
+            id: sourceFileId,
+            mimeType: DOCX_MIME_TYPE,
+            pdfFileId: null,
+            pdfDerivative: pdfDerivativeStateForFile({
+              encrypted: false,
+              mimeType: DOCX_MIME_TYPE,
+            }),
+            sha256Hex: checkpointSha256Hex,
+            sizeBytes: checkpointSizeBytes,
+            type: "file",
+            version: 1,
+            ...(sessionPreview.docxCheckpointScanWarnings !== null && {
+              scanWarnings: sessionPreview.docxCheckpointScanWarnings,
+            }),
+          },
+          workspaceId,
+        });
+
+        const insertedFields = await tx
+          .insert(fields)
+          .values(clonedFields)
+          .returning({ id: fields.id, propertyId: fields.propertyId });
+
+        const nextField = insertedFields.find(
+          (field) => field.propertyId === sessionPreview.propertyId,
+        );
+
+        await tx
+          .update(entities)
+          .set({
+            currentVersionId: nextVersionId,
+            lastEditedBy: userId,
+            updatedAt: new Date(),
+          })
+          .where(eq(entities.id, sessionPreview.entityId));
+
+        await tx
+          .update(workspaces)
+          .set({ lastActivityAt: new Date() })
+          .where(eq(workspaces.id, workspaceId));
+
+        await tx
+          .update(folioCollabSessions)
+          .set({
+            closedAt: new Date(),
+            finalizedVersionId: nextVersionId,
+            status: "finalized",
+          })
+          .where(eq(folioCollabSessions.id, sessionId));
+
+        return {
+          entityId: sessionPreview.entityId,
+          fieldId:
+            nextField?.id ??
+            panic(
+              "Finalized collaborative edit session field was not inserted",
+            ),
+          outcome: "finalized" as const,
+          versionId: nextVersionId,
+          versionNumber: nextVersionNumber,
+        } as const;
+      });
+
+      if ("error" in result) {
+        await rollbackUploadedKeys();
+        if ("deleteCheckpoint" in result) {
+          await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+        }
+        return Result.err(
+          new HandlerError({
+            status: result.error.statusCode,
+            message: result.error.message,
+          }),
+        );
+      }
+
+      shouldRollbackUploadedKeys = false;
+      await deleteS3Key(checkpointKey, { checkpointKey, sessionId });
+
+      broadcast(workspaceId, {
+        type: "invalidate-query",
+        data: ["entities", workspaceId],
+      });
+
+      await processCollaborativeEditDerivatives({
+        entityId: result.entityId,
+        fieldId: result.fieldId,
+        organizationId,
+        scopedDb,
+        userId,
+        versionId: result.versionId,
+        workspaceId,
+      });
+
+      return Result.ok(result);
+    } catch (error) {
+      if (shouldRollbackUploadedKeys) {
+        await rollbackUploadedKeys();
+      }
+      throw error;
+    }
+  },
+);
+
+export default finalizeFolioCollabSession;
 
 type ProcessCollaborativeEditDerivativesProps = {
   entityId: SafeId<"entity">;

--- a/apps/api/src/handlers/folio-collab/refresh-token.ts
+++ b/apps/api/src/handlers/folio-collab/refresh-token.ts
@@ -1,0 +1,70 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  authorizeFolioCollabSession,
+  issueFolioCollabToken,
+} from "@/api/lib/folio-collab-sessions";
+
+const config = {
+  body: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
+
+const refreshFolioCollabToken = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth + scopedDb returns plain Promises; nothing to Result.await
+  async function* ({ body: { sessionId, token } }) {
+    const authorized = await authorizeFolioCollabSession({ sessionId, token });
+
+    if (authorized.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorized.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorized.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
+
+    const { value } = authorized;
+    const { token: nextToken, tokenExpiresAt } = await value.scopedDb(
+      async (tx) =>
+        await issueFolioCollabToken({
+          permissions: { canEdit: value.canEdit },
+          sessionId: value.sessionId,
+          tx,
+          userId: value.userId,
+          workspaceId: value.workspaceId,
+        }),
+    );
+
+    return Result.ok({
+      token: nextToken,
+      tokenExpiresAt: tokenExpiresAt.toISOString(),
+    });
+  },
+);
+
+export default refreshFolioCollabToken;

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -1,158 +1,35 @@
-import Elysia, { status, t } from "elysia";
+import Elysia from "elysia";
 
+import authorizeFolioCollabSessionHandler from "@/api/handlers/folio-collab/authorize";
 import cancelFolioCollabSession from "@/api/handlers/folio-collab/cancel";
 import checkpointFolioCollabSession from "@/api/handlers/folio-collab/checkpoint";
 import finalizeFolioCollabSession from "@/api/handlers/folio-collab/finalize";
-import type { SafeId } from "@/api/lib/branded-types";
-import { tSafeId } from "@/api/lib/custom-schema";
-import {
-  authorizeFolioCollabSession,
-  FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
-  FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
-  issueFolioCollabToken,
-  loadFolioCollabSnapshot,
-  storeFolioCollabSnapshot,
-} from "@/api/lib/folio-collab-sessions";
-
-const authBodySchema = t.Object({
-  sessionId: tSafeId("folioCollabSession"),
-  token: t.String({ minLength: 64, maxLength: 64 }),
-});
-
-const storeSnapshotBodySchema = t.Object({
-  sessionId: tSafeId("folioCollabSession"),
-  snapshotBase64: t.String({
-    maxLength: FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
-  }),
-  token: t.String({ minLength: 64, maxLength: 64 }),
-});
-
-const authorizeOrRespond = async ({
-  sessionId,
-  token,
-}: {
-  sessionId: SafeId<"folioCollabSession">;
-  token: string;
-}) => {
-  const authorized = await authorizeFolioCollabSession({ sessionId, token });
-
-  if (authorized.status === "missing") {
-    return {
-      ok: false,
-      response: status(404, {
-        message: "Collaborative edit session not found.",
-      }),
-    } as const;
-  }
-  if (authorized.status === "token-expired") {
-    return {
-      ok: false,
-      response: status(401, { message: "Collaborative edit token expired." }),
-    } as const;
-  }
-  if (authorized.status === "permission-revoked") {
-    return {
-      ok: false,
-      response: status(403, {
-        message: "Collaborative edit permission revoked.",
-      }),
-    } as const;
-  }
-
-  return { ok: true, value: authorized.value } as const;
-};
+import refreshFolioCollabToken from "@/api/handlers/folio-collab/refresh-token";
+import loadFolioCollabSnapshotHandler from "@/api/handlers/folio-collab/snapshot-load";
+import storeFolioCollabSnapshotHandler from "@/api/handlers/folio-collab/snapshot-store";
 
 export const folioCollabRoute = new Elysia({
   prefix: "/folio-collab-sessions",
 })
   .post(
     "/authorize",
-    async ({ body }) => {
-      const authorized = await authorizeOrRespond(body);
-      if (!authorized.ok) {
-        return authorized.response;
-      }
-      const { value } = authorized;
-
-      return {
-        canEdit: value.canEdit,
-        roomName: value.sessionId,
-        sessionId: value.sessionId,
-        tokenExpiresAt: value.tokenExpiresAt.toISOString(),
-        userId: value.userId,
-        workspaceId: value.workspaceId,
-      };
-    },
-    { body: authBodySchema },
+    authorizeFolioCollabSessionHandler.handler,
+    authorizeFolioCollabSessionHandler.config,
   )
   .post(
     "/refresh-token",
-    async ({ body }) => {
-      const authorized = await authorizeOrRespond(body);
-      if (!authorized.ok) {
-        return authorized.response;
-      }
-      const { value } = authorized;
-
-      const { token, tokenExpiresAt } = await value.scopedDb(
-        async (tx) =>
-          await issueFolioCollabToken({
-            permissions: { canEdit: value.canEdit },
-            sessionId: value.sessionId,
-            tx,
-            userId: value.userId,
-            workspaceId: value.workspaceId,
-          }),
-      );
-
-      return {
-        token,
-        tokenExpiresAt: tokenExpiresAt.toISOString(),
-      };
-    },
-    { body: authBodySchema },
+    refreshFolioCollabToken.handler,
+    refreshFolioCollabToken.config,
   )
   .post(
     "/snapshot/load",
-    async ({ body }) => {
-      const authorized = await authorizeOrRespond(body);
-      if (!authorized.ok) {
-        return authorized.response;
-      }
-      const { value } = authorized;
-
-      return {
-        snapshotBase64: await loadFolioCollabSnapshot(value),
-      };
-    },
-    { body: authBodySchema },
+    loadFolioCollabSnapshotHandler.handler,
+    loadFolioCollabSnapshotHandler.config,
   )
   .post(
     "/snapshot/store",
-    async ({ body }) => {
-      const authorized = await authorizeOrRespond(body);
-      if (!authorized.ok) {
-        return authorized.response;
-      }
-      const { value } = authorized;
-
-      if (!value.canEdit) {
-        return status(403, { message: "Collaborative edit is read-only." });
-      }
-
-      const snapshotBytes = Buffer.from(body.snapshotBase64, "base64");
-      if (snapshotBytes.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {
-        return status(413, { message: "Collaborative snapshot too large." });
-      }
-
-      const { storedAt } = await storeFolioCollabSnapshot({
-        snapshotBytes,
-        value,
-      });
-
-      return { storedAt: storedAt.toISOString() };
-    },
-    { body: storeSnapshotBodySchema },
+    storeFolioCollabSnapshotHandler.handler,
+    storeFolioCollabSnapshotHandler.config,
   )
   .post(
     "/:sessionId/cancel",

--- a/apps/api/src/handlers/folio-collab/routes.ts
+++ b/apps/api/src/handlers/folio-collab/routes.ts
@@ -1,20 +1,8 @@
 import Elysia, { status, t } from "elysia";
 
-import {
-  cancelFolioCollabSessionBodySchema,
-  cancelFolioCollabSessionHandler,
-  cancelFolioCollabSessionParamsSchema,
-} from "@/api/handlers/folio-collab/cancel";
-import {
-  checkpointFolioCollabSessionBodySchema,
-  checkpointFolioCollabSessionHandler,
-  checkpointFolioCollabSessionParamsSchema,
-} from "@/api/handlers/folio-collab/checkpoint";
-import {
-  finalizeFolioCollabSessionBodySchema,
-  finalizeFolioCollabSessionHandler,
-  finalizeFolioCollabSessionParamsSchema,
-} from "@/api/handlers/folio-collab/finalize";
+import cancelFolioCollabSession from "@/api/handlers/folio-collab/cancel";
+import checkpointFolioCollabSession from "@/api/handlers/folio-collab/checkpoint";
+import finalizeFolioCollabSession from "@/api/handlers/folio-collab/finalize";
 import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import {
@@ -168,37 +156,16 @@ export const folioCollabRoute = new Elysia({
   )
   .post(
     "/:sessionId/cancel",
-    async ({ body, params }) =>
-      await cancelFolioCollabSessionHandler({
-        body,
-        sessionId: params.sessionId,
-      }),
-    {
-      body: cancelFolioCollabSessionBodySchema,
-      params: cancelFolioCollabSessionParamsSchema,
-    },
+    cancelFolioCollabSession.handler,
+    cancelFolioCollabSession.config,
   )
   .post(
     "/:sessionId/checkpoint",
-    async ({ body, params }) =>
-      await checkpointFolioCollabSessionHandler({
-        body,
-        sessionId: params.sessionId,
-      }),
-    {
-      body: checkpointFolioCollabSessionBodySchema,
-      params: checkpointFolioCollabSessionParamsSchema,
-    },
+    checkpointFolioCollabSession.handler,
+    checkpointFolioCollabSession.config,
   )
   .post(
     "/:sessionId/finalize",
-    async ({ body, params }) =>
-      await finalizeFolioCollabSessionHandler({
-        body,
-        sessionId: params.sessionId,
-      }),
-    {
-      body: finalizeFolioCollabSessionBodySchema,
-      params: finalizeFolioCollabSessionParamsSchema,
-    },
+    finalizeFolioCollabSession.handler,
+    finalizeFolioCollabSession.config,
   );

--- a/apps/api/src/handlers/folio-collab/snapshot-load.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-load.ts
@@ -1,0 +1,57 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  authorizeFolioCollabSession,
+  loadFolioCollabSnapshot,
+} from "@/api/lib/folio-collab-sessions";
+
+const config = {
+  body: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
+
+const loadFolioCollabSnapshotHandler = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
+  async function* ({ body: { sessionId, token } }) {
+    const authorized = await authorizeFolioCollabSession({ sessionId, token });
+
+    if (authorized.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorized.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorized.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
+
+    return Result.ok({
+      snapshotBase64: await loadFolioCollabSnapshot(authorized.value),
+    });
+  },
+);
+
+export default loadFolioCollabSnapshotHandler;

--- a/apps/api/src/handlers/folio-collab/snapshot-store.ts
+++ b/apps/api/src/handlers/folio-collab/snapshot-store.ts
@@ -1,0 +1,85 @@
+import { Result } from "better-result";
+import { t } from "elysia";
+
+import type { TokenHandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeTokenHandler } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  authorizeFolioCollabSession,
+  FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
+  FOLIO_COLLAB_SNAPSHOT_MAX_BYTES,
+  storeFolioCollabSnapshot,
+} from "@/api/lib/folio-collab-sessions";
+
+const config = {
+  body: t.Object({
+    sessionId: tSafeId("folioCollabSession"),
+    snapshotBase64: t.String({
+      maxLength: FOLIO_COLLAB_SNAPSHOT_MAX_BASE64_LENGTH,
+    }),
+    token: t.String({ minLength: 64, maxLength: 64 }),
+  }),
+} satisfies TokenHandlerConfig;
+
+const storeFolioCollabSnapshotHandler = createSafeTokenHandler(
+  config,
+  // eslint-disable-next-line require-yield -- token auth returns a plain Promise; nothing to Result.await
+  async function* ({ body: { sessionId, snapshotBase64, token } }) {
+    const authorized = await authorizeFolioCollabSession({ sessionId, token });
+
+    if (authorized.status === "missing") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Collaborative edit session not found.",
+        }),
+      );
+    }
+    if (authorized.status === "token-expired") {
+      return Result.err(
+        new HandlerError({
+          status: 401,
+          message: "Collaborative edit token expired.",
+        }),
+      );
+    }
+    if (authorized.status === "permission-revoked") {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit permission revoked.",
+        }),
+      );
+    }
+
+    const { value } = authorized;
+    if (!value.canEdit) {
+      return Result.err(
+        new HandlerError({
+          status: 403,
+          message: "Collaborative edit is read-only.",
+        }),
+      );
+    }
+
+    const snapshotBytes = Buffer.from(snapshotBase64, "base64");
+    if (snapshotBytes.byteLength > FOLIO_COLLAB_SNAPSHOT_MAX_BYTES) {
+      return Result.err(
+        new HandlerError({
+          status: 413,
+          message: "Collaborative snapshot too large.",
+        }),
+      );
+    }
+
+    const { storedAt } = await storeFolioCollabSnapshot({
+      snapshotBytes,
+      value,
+    });
+
+    return Result.ok({ storedAt: storedAt.toISOString() });
+  },
+);
+
+export default storeFolioCollabSnapshotHandler;

--- a/apps/api/src/lib/api-handlers.ts
+++ b/apps/api/src/lib/api-handlers.ts
@@ -277,6 +277,32 @@ export const createSafeSessionHandler = <
     await runSafeHandler(ctx, handler),
 });
 
+export type TokenHandlerConfig = InputSchema;
+
+type TokenHandlerContext<
+  TConfig extends TokenHandlerConfig = TokenHandlerConfig,
+> = Context<UnwrapRoute<TConfig>>;
+
+/**
+ * Like `createSafeSessionHandler`, but the framework does not
+ * authenticate the caller — the handler authorizes itself from a
+ * body / param token (e.g. folio-collab session tokens). The
+ * factory gives the handler the same structured error capture,
+ * safe-status responses, and request logging as the org-scoped
+ * variants without claiming a `user.id` that isn't present.
+ */
+export const createSafeTokenHandler = <
+  TConfig extends TokenHandlerConfig,
+  TResult,
+>(
+  config: TConfig,
+  handler: SafeHandlerFn<TokenHandlerContext<TConfig>, TResult>,
+): SafeHandlerDefinition<TConfig, TokenHandlerContext<TConfig>, TResult> => ({
+  config,
+  handler: async (ctx): Promise<SafeHandlerResult<TResult>> =>
+    await runSafeHandler(ctx, handler),
+});
+
 type LogAndCaptureSafeErrorProps = {
   request: Request;
   route: string;

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -9,6 +9,7 @@ export type HandlerErrorStatusCode =
   | 403
   | 404
   | 409
+  | 413
   | 422
   | 429
   | 500

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -4,6 +4,7 @@ import type { ChatTransportErrorCode } from "@stll/anonymize-chat";
 
 export type HandlerErrorStatusCode =
   | 400
+  | 401
   | 402
   | 403
   | 404


### PR DESCRIPTION
## Summary
- Add `createSafeTokenHandler` in `lib/api-handlers.ts` — a sibling of `createSafeSessionHandler` that doesn't claim a framework-provided `user.id`. Same structured error capture, safe-status responses, and request logging as the org-scoped factories.
- Migrate `finalize`, `cancel`, `checkpoint` onto it; each now default-exports `{ config, handler }` with the params + body schemas living in `config`.
- Split the four inline routes in `routes.ts` (`authorize`, `refresh-token`, `snapshot/load`, `snapshot/store`) into their own endpoint files using the same shape; `routes.ts` is now pure wiring.
- Add `401` and `413` to `HandlerErrorStatusCode` so token-expired auth errors and snapshot-too-large responses retain their canonical status codes.

## Test plan
- [ ] `bun --filter @stll/api typecheck`
- [ ] `bun --filter @stll/api lint`
- [ ] manual: open + edit a collaborative document in Folio; confirm authorize / snapshot store/load / checkpoint / finalize / cancel still round-trip.
- [ ] manual: expired token returns 401, missing session 404, revoked permission 403, oversized snapshot 413.