### PR TITLE
fix: scale entity hot paths

### DIFF
--- a/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
+++ b/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
@@ -1,4 +1,112 @@
+ALTER TABLE "entities" ADD COLUMN "display_name" varchar(512) DEFAULT 'Untitled' NOT NULL;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "fields_ws_entity_version_property_idx" ON "fields" ("workspace_id","entity_version_id","property_id");--> statement-breakpoint
+CREATE OR REPLACE FUNCTION stella_entity_display_name(
+  entity_name text,
+  entity_kind text,
+  entity_workspace_id uuid,
+  entity_current_version_id uuid
+)
+RETURNS varchar(512)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT LEFT(
+    COALESCE(
+      NULLIF(entity_name, ''),
+      (
+        SELECT NULLIF(f."content"->>'fileName', '')
+        FROM "fields" f
+        WHERE f."workspace_id" = entity_workspace_id
+          AND f."entity_version_id" = entity_current_version_id
+          AND f."content"->>'type' = 'file'
+        ORDER BY f."property_id" ASC
+        LIMIT 1
+      ),
+      (
+        SELECT NULLIF(BTRIM(f."content"->>'value'), '')
+        FROM "fields" f
+        WHERE f."workspace_id" = entity_workspace_id
+          AND f."entity_version_id" = entity_current_version_id
+          AND f."content"->>'type' = 'text'
+        ORDER BY f."property_id" ASC
+        LIMIT 1
+      ),
+      CASE
+        WHEN entity_kind = 'folder' THEN 'Untitled Folder'
+        WHEN entity_kind = 'task' THEN 'Untitled Task'
+        ELSE 'Untitled'
+      END
+    ),
+    512
+  )::varchar(512)
+$$;--> statement-breakpoint
+CREATE OR REPLACE FUNCTION stella_refresh_entity_display_name(entity_id uuid)
+RETURNS void
+LANGUAGE sql
+AS $$
+  UPDATE "entities" e
+  SET "display_name" = stella_entity_display_name(
+    e."name",
+    e."kind",
+    e."workspace_id",
+    e."current_version_id"
+  )
+  WHERE e."id" = entity_id
+$$;--> statement-breakpoint
+UPDATE "entities" e
+SET "display_name" = stella_entity_display_name(
+  e."name",
+  e."kind",
+  e."workspace_id",
+  e."current_version_id"
+);--> statement-breakpoint
+CREATE OR REPLACE FUNCTION stella_refresh_entity_display_name_from_entity()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  PERFORM stella_refresh_entity_display_name(NEW."id");
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE OR REPLACE FUNCTION stella_refresh_entity_display_name_from_field()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    PERFORM stella_refresh_entity_display_name(e."id")
+    FROM "entities" e
+    WHERE e."workspace_id" = NEW."workspace_id"
+      AND e."current_version_id" = NEW."entity_version_id";
+  END IF;
+
+  IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+    PERFORM stella_refresh_entity_display_name(e."id")
+    FROM "entities" e
+    WHERE e."workspace_id" = OLD."workspace_id"
+      AND e."current_version_id" = OLD."entity_version_id";
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;--> statement-breakpoint
+CREATE TRIGGER entities_refresh_display_name_after_write
+AFTER INSERT OR UPDATE OF "name", "kind", "current_version_id", "workspace_id"
+ON "entities"
+FOR EACH ROW
+EXECUTE FUNCTION stella_refresh_entity_display_name_from_entity();--> statement-breakpoint
+CREATE TRIGGER fields_refresh_entity_display_name_after_write
+AFTER INSERT OR UPDATE OF "content", "property_id", "entity_version_id", "workspace_id" OR DELETE
+ON "fields"
+FOR EACH ROW
+EXECUTE FUNCTION stella_refresh_entity_display_name_from_field();--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_created_at_id_idx" ON "entities" ("workspace_id","created_at","id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_updated_at_id_idx" ON "entities" ("workspace_id","updated_at","id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_updated_at_coalesce_id_idx" ON "entities" ("workspace_id",(COALESCE("updated_at", '0001-01-01 00:00:00'::timestamp)),"id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "entities_ws_display_name_id_idx" ON "entities" ("workspace_id","display_name","id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_kind_created_at_id_idx" ON "entities" ("workspace_id","kind","created_at","id");

--- a/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
+++ b/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
@@ -1,3 +1,4 @@
 CREATE INDEX IF NOT EXISTS "entities_ws_created_at_id_idx" ON "entities" ("workspace_id","created_at","id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_updated_at_id_idx" ON "entities" ("workspace_id","updated_at","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "entities_ws_updated_at_coalesce_id_idx" ON "entities" ("workspace_id",(COALESCE("updated_at", '0001-01-01 00:00:00'::timestamp)),"id");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "entities_ws_kind_created_at_id_idx" ON "entities" ("workspace_id","kind","created_at","id");

--- a/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
+++ b/apps/api/drizzle/20260522100000_entity_hot_path_indexes/migration.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS "entities_ws_created_at_id_idx" ON "entities" ("workspace_id","created_at","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "entities_ws_updated_at_id_idx" ON "entities" ("workspace_id","updated_at","id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "entities_ws_kind_created_at_id_idx" ON "entities" ("workspace_id","kind","created_at","id");

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -854,6 +854,13 @@ export const entities = p.pgTable(
       .index("entities_ws_updated_at_id_idx")
       .on(table.workspaceId, table.updatedAt, table.id),
     p
+      .index("entities_ws_updated_at_coalesce_id_idx")
+      .on(
+        table.workspaceId,
+        sql`COALESCE(${table.updatedAt}, '0001-01-01 00:00:00'::timestamp)`,
+        table.id,
+      ),
+    p
       .index("entities_ws_kind_created_at_id_idx")
       .on(table.workspaceId, table.kind, table.createdAt, table.id),
     p

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -787,6 +787,10 @@ export const entities = p.pgTable(
       },
     ),
     name: p.text("name").notNull(),
+    displayName: p
+      .varchar("display_name", { length: 512 })
+      .notNull()
+      .default("Untitled"),
     createdBy: p
       .text("created_by")
       .references(() => user.id, { onDelete: "set null" }),
@@ -860,6 +864,9 @@ export const entities = p.pgTable(
         sql`COALESCE(${table.updatedAt}, '0001-01-01 00:00:00'::timestamp)`,
         table.id,
       ),
+    p
+      .index("entities_ws_display_name_id_idx")
+      .on(table.workspaceId, table.displayName, table.id),
     p
       .index("entities_ws_kind_created_at_id_idx")
       .on(table.workspaceId, table.kind, table.createdAt, table.id),
@@ -1341,6 +1348,9 @@ export const fields = p.pgTable(
     p
       .uniqueIndex("fields_property_id_entity_version_id_key")
       .on(table.propertyId, table.entityVersionId),
+    p
+      .index("fields_ws_entity_version_property_idx")
+      .on(table.workspaceId, table.entityVersionId, table.propertyId),
     p
       .foreignKey({
         columns: [table.propertyId, table.workspaceId],

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -848,6 +848,15 @@ export const entities = p.pgTable(
   (table) => [
     p.index("entities_workspace_id_idx").on(table.workspaceId),
     p
+      .index("entities_ws_created_at_id_idx")
+      .on(table.workspaceId, table.createdAt, table.id),
+    p
+      .index("entities_ws_updated_at_id_idx")
+      .on(table.workspaceId, table.updatedAt, table.id),
+    p
+      .index("entities_ws_kind_created_at_id_idx")
+      .on(table.workspaceId, table.kind, table.createdAt, table.id),
+    p
       .index("entities_parent_id_idx")
       .on(table.parentId)
       .where(isNotNull(table.parentId)),

--- a/apps/api/src/handlers/entities/cursor-validation.ts
+++ b/apps/api/src/handlers/entities/cursor-validation.ts
@@ -1,0 +1,80 @@
+const dateCursorPattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
+const timestampCursorPattern =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})\.\d{6}$/u;
+
+type DateCursorParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
+const isLeapYear = (year: number): boolean =>
+  year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+
+const daysInMonth = (year: number, month: number): number => {
+  if (month === 2) {
+    return isLeapYear(year) ? 29 : 28;
+  }
+
+  if ([1, 3, 5, 7, 8, 10, 12].includes(month)) {
+    return 31;
+  }
+
+  return 30;
+};
+
+const parseDateCursorParts = (
+  match: RegExpExecArray,
+): DateCursorParts | null => {
+  const yearPart = match.at(1);
+  const monthPart = match.at(2);
+  const dayPart = match.at(3);
+  if (!yearPart || !monthPart || !dayPart) {
+    return null;
+  }
+
+  const year = Number(yearPart);
+  const month = Number(monthPart);
+  const day = Number(dayPart);
+  if (year < 1 || month < 1 || month > 12) {
+    return null;
+  }
+
+  if (day < 1 || day > daysInMonth(year, month)) {
+    return null;
+  }
+
+  return { day, month, year };
+};
+
+export const isValidDateCursorValue = (value: string): boolean => {
+  const match = dateCursorPattern.exec(value);
+  return match !== null && parseDateCursorParts(match) !== null;
+};
+
+export const isValidTimestampCursorValue = (value: string): boolean => {
+  const match = timestampCursorPattern.exec(value);
+  if (match === null || parseDateCursorParts(match) === null) {
+    return false;
+  }
+
+  const hourPart = match.at(4);
+  const minutePart = match.at(5);
+  const secondPart = match.at(6);
+  if (!hourPart || !minutePart || !secondPart) {
+    return false;
+  }
+
+  const hour = Number(hourPart);
+  const minute = Number(minutePart);
+  const second = Number(secondPart);
+
+  return (
+    hour >= 0 &&
+    hour <= 23 &&
+    minute >= 0 &&
+    minute <= 59 &&
+    second >= 0 &&
+    second <= 59
+  );
+};

--- a/apps/api/src/handlers/entities/list-cursor.test.ts
+++ b/apps/api/src/handlers/entities/list-cursor.test.ts
@@ -33,6 +33,15 @@ describe("entity list cursor", () => {
     expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
   });
 
+  test("rejects out-of-range timestamps", () => {
+    const cursor = encodeEntityListCursor({
+      createdAt: "2026-13-40T25:61:61.999999",
+      id: "entity_1",
+    });
+
+    expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
+  });
+
   test("file cursor condition includes the field tie-breaker", () => {
     const condition = entityFileListCursorCondition({
       createdAt: "2026-05-22T09:31:31.123456",
@@ -63,5 +72,15 @@ describe("entity list cursor", () => {
       id: toSafeId<"entity">("entity_1"),
     });
     expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
+  });
+
+  test("rejects out-of-range file cursor timestamps", () => {
+    const cursor = encodeEntityFileListCursor({
+      createdAt: "2026-02-29T09:31:31.123456",
+      fieldId: "field_1",
+      id: "entity_1",
+    });
+
+    expect(() => decodeEntityFileListCursor(cursor)).toThrow(HandlerError);
   });
 });

--- a/apps/api/src/handlers/entities/list-cursor.test.ts
+++ b/apps/api/src/handlers/entities/list-cursor.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
 
 import {
+  decodeEntityFileListCursor,
   decodeEntityListCursor,
+  encodeEntityFileListCursor,
   encodeEntityListCursor,
+  entityFileListCursorCondition,
 } from "@/api/handlers/entities/list-cursor";
 import { toSafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -26,6 +30,38 @@ describe("entity list cursor", () => {
       id: "entity_1",
     });
 
+    expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
+  });
+
+  test("file cursor condition includes the field tie-breaker", () => {
+    const condition = entityFileListCursorCondition({
+      createdAt: "2026-05-22T09:31:31.123456",
+      fieldId: toSafeId<"field">("field_1"),
+      id: toSafeId<"entity">("entity_1"),
+    });
+    if (!condition) {
+      throw new Error("expected file cursor condition");
+    }
+
+    const dialect = new PgDialect();
+    const sql = dialect.sqlToQuery(condition).sql;
+
+    expect(sql).toContain('"entities"."id" =');
+    expect(sql).toContain('"fields"."id" >');
+  });
+
+  test("round-trips file cursor tie-breaker", () => {
+    const cursor = encodeEntityFileListCursor({
+      createdAt: "2026-05-22T09:31:31.123456",
+      fieldId: "field_1",
+      id: "entity_1",
+    });
+
+    expect(decodeEntityFileListCursor(cursor)).toEqual({
+      createdAt: "2026-05-22T09:31:31.123456",
+      fieldId: toSafeId<"field">("field_1"),
+      id: toSafeId<"entity">("entity_1"),
+    });
     expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
   });
 });

--- a/apps/api/src/handlers/entities/list-cursor.test.ts
+++ b/apps/api/src/handlers/entities/list-cursor.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  decodeEntityListCursor,
+  encodeEntityListCursor,
+} from "@/api/handlers/entities/list-cursor";
+import { toSafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+describe("entity list cursor", () => {
+  test("round-trips microsecond timestamp precision", () => {
+    const cursor = encodeEntityListCursor({
+      createdAt: "2026-05-22T09:31:31.123456",
+      id: "entity_1",
+    });
+
+    expect(decodeEntityListCursor(cursor)).toEqual({
+      createdAt: "2026-05-22T09:31:31.123456",
+      id: toSafeId<"entity">("entity_1"),
+    });
+  });
+
+  test("rejects millisecond timestamps", () => {
+    const cursor = encodeEntityListCursor({
+      createdAt: "2026-05-22T09:31:31.123",
+      id: "entity_1",
+    });
+
+    expect(() => decodeEntityListCursor(cursor)).toThrow(HandlerError);
+  });
+});

--- a/apps/api/src/handlers/entities/list-cursor.ts
+++ b/apps/api/src/handlers/entities/list-cursor.ts
@@ -1,0 +1,58 @@
+import { and, eq, gt, or } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { entities } from "@/api/db/schema";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  decodePaginationCursor,
+  encodePaginationCursor,
+  parseDateTimePaginationCursorPart,
+} from "@/api/lib/pagination";
+import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
+
+type EntityListCursor = {
+  createdAt: Date;
+  id: SafeId<"entity">;
+};
+
+export const encodeEntityListCursor = ({
+  createdAt,
+  id,
+}: {
+  createdAt: Date;
+  id: SafeId<"entity"> | string;
+}): string => encodePaginationCursor([createdAt.toISOString(), id]);
+
+export const decodeEntityListCursor = (
+  cursor: string | undefined,
+): EntityListCursor | null => {
+  if (cursor === undefined) {
+    return null;
+  }
+
+  const parts = decodePaginationCursor(cursor);
+  const createdAt = parseDateTimePaginationCursorPart(parts?.at(0));
+  const id = parts?.at(1);
+
+  if (createdAt === null || typeof id !== "string") {
+    throw new HandlerError({ status: 400, message: "Invalid cursor" });
+  }
+
+  return { createdAt, id: brandPersistedEntityId(id) };
+};
+
+export const entityListCursorCondition = (
+  cursor: EntityListCursor | null,
+): SQL | undefined => {
+  if (cursor === null) {
+    return undefined;
+  }
+
+  return (
+    or(
+      gt(entities.createdAt, cursor.createdAt),
+      and(eq(entities.createdAt, cursor.createdAt), gt(entities.id, cursor.id)),
+    ) ?? undefined
+  );
+};

--- a/apps/api/src/handlers/entities/list-cursor.ts
+++ b/apps/api/src/handlers/entities/list-cursor.ts
@@ -2,6 +2,7 @@ import { and, gt, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { entities, fields } from "@/api/db/schema";
+import { isValidTimestampCursorValue } from "@/api/handlers/entities/cursor-validation";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
@@ -14,9 +15,6 @@ import {
 } from "@/api/lib/safe-id-boundaries";
 
 export const ENTITY_LIST_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
-
-const entityListTimestampCursorPattern =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/u;
 
 export const entityListTimestampCursorExpr = (expr: SQL): SQL<string> =>
   sql<string>`to_char(${expr}, ${ENTITY_LIST_TIMESTAMP_CURSOR_FORMAT})`;
@@ -65,7 +63,7 @@ export const decodeEntityListCursor = (
 
   if (
     typeof createdAt !== "string" ||
-    !entityListTimestampCursorPattern.test(createdAt) ||
+    !isValidTimestampCursorValue(createdAt) ||
     typeof id !== "string"
   ) {
     throw new HandlerError({ status: 400, message: "Invalid cursor" });
@@ -92,7 +90,7 @@ export const decodeEntityFileListCursor = (
 
   if (
     typeof createdAt !== "string" ||
-    !entityListTimestampCursorPattern.test(createdAt) ||
+    !isValidTimestampCursorValue(createdAt) ||
     typeof id !== "string" ||
     typeof fieldId !== "string"
   ) {

--- a/apps/api/src/handlers/entities/list-cursor.ts
+++ b/apps/api/src/handlers/entities/list-cursor.ts
@@ -1,14 +1,17 @@
 import { and, gt, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
-import { entities } from "@/api/db/schema";
+import { entities, fields } from "@/api/db/schema";
 import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   decodePaginationCursor,
   encodePaginationCursor,
 } from "@/api/lib/pagination";
-import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
+import {
+  brandPersistedEntityId,
+  brandPersistedFieldId,
+} from "@/api/lib/safe-id-boundaries";
 
 export const ENTITY_LIST_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
 
@@ -23,6 +26,10 @@ type EntityListCursor = {
   id: SafeId<"entity">;
 };
 
+type EntityFileListCursor = EntityListCursor & {
+  fieldId: SafeId<"field">;
+};
+
 export const encodeEntityListCursor = ({
   createdAt,
   id,
@@ -30,6 +37,16 @@ export const encodeEntityListCursor = ({
   createdAt: string;
   id: SafeId<"entity"> | string;
 }): string => encodePaginationCursor([createdAt, id]);
+
+export const encodeEntityFileListCursor = ({
+  createdAt,
+  fieldId,
+  id,
+}: {
+  createdAt: string;
+  fieldId: SafeId<"field"> | string;
+  id: SafeId<"entity"> | string;
+}): string => encodePaginationCursor([createdAt, id, fieldId]);
 
 export const decodeEntityListCursor = (
   cursor: string | undefined,
@@ -39,8 +56,12 @@ export const decodeEntityListCursor = (
   }
 
   const parts = decodePaginationCursor(cursor);
-  const createdAt = parts?.at(0);
-  const id = parts?.at(1);
+  if (!parts || parts.length !== 2) {
+    throw new HandlerError({ status: 400, message: "Invalid cursor" });
+  }
+
+  const createdAt = parts.at(0);
+  const id = parts.at(1);
 
   if (
     typeof createdAt !== "string" ||
@@ -51,6 +72,38 @@ export const decodeEntityListCursor = (
   }
 
   return { createdAt, id: brandPersistedEntityId(id) };
+};
+
+export const decodeEntityFileListCursor = (
+  cursor: string | undefined,
+): EntityFileListCursor | null => {
+  if (cursor === undefined) {
+    return null;
+  }
+
+  const parts = decodePaginationCursor(cursor);
+  if (!parts || parts.length !== 3) {
+    throw new HandlerError({ status: 400, message: "Invalid cursor" });
+  }
+
+  const createdAt = parts.at(0);
+  const id = parts.at(1);
+  const fieldId = parts.at(2);
+
+  if (
+    typeof createdAt !== "string" ||
+    !entityListTimestampCursorPattern.test(createdAt) ||
+    typeof id !== "string" ||
+    typeof fieldId !== "string"
+  ) {
+    throw new HandlerError({ status: 400, message: "Invalid cursor" });
+  }
+
+  return {
+    createdAt,
+    fieldId: brandPersistedFieldId(fieldId),
+    id: brandPersistedEntityId(id),
+  };
 };
 
 export const entityListCursorCondition = (
@@ -66,6 +119,29 @@ export const entityListCursorCondition = (
       and(
         sql`${entities.createdAt} = ${cursor.createdAt}::timestamp`,
         gt(entities.id, cursor.id),
+      ),
+    ) ?? undefined
+  );
+};
+
+export const entityFileListCursorCondition = (
+  cursor: EntityFileListCursor | null,
+): SQL | undefined => {
+  if (cursor === null) {
+    return undefined;
+  }
+
+  return (
+    or(
+      sql`${entities.createdAt} > ${cursor.createdAt}::timestamp`,
+      and(
+        sql`${entities.createdAt} = ${cursor.createdAt}::timestamp`,
+        gt(entities.id, cursor.id),
+      ),
+      and(
+        sql`${entities.createdAt} = ${cursor.createdAt}::timestamp`,
+        sql`${entities.id} = ${cursor.id}`,
+        gt(fields.id, cursor.fieldId),
       ),
     ) ?? undefined
   );

--- a/apps/api/src/handlers/entities/list-cursor.ts
+++ b/apps/api/src/handlers/entities/list-cursor.ts
@@ -1,4 +1,4 @@
-import { and, eq, gt, or } from "drizzle-orm";
+import { and, gt, or, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 
 import { entities } from "@/api/db/schema";
@@ -7,12 +7,19 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import {
   decodePaginationCursor,
   encodePaginationCursor,
-  parseDateTimePaginationCursorPart,
 } from "@/api/lib/pagination";
 import { brandPersistedEntityId } from "@/api/lib/safe-id-boundaries";
 
+export const ENTITY_LIST_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
+
+const entityListTimestampCursorPattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/u;
+
+export const entityListTimestampCursorExpr = (expr: SQL): SQL<string> =>
+  sql<string>`to_char(${expr}, ${ENTITY_LIST_TIMESTAMP_CURSOR_FORMAT})`;
+
 type EntityListCursor = {
-  createdAt: Date;
+  createdAt: string;
   id: SafeId<"entity">;
 };
 
@@ -20,9 +27,9 @@ export const encodeEntityListCursor = ({
   createdAt,
   id,
 }: {
-  createdAt: Date;
+  createdAt: string;
   id: SafeId<"entity"> | string;
-}): string => encodePaginationCursor([createdAt.toISOString(), id]);
+}): string => encodePaginationCursor([createdAt, id]);
 
 export const decodeEntityListCursor = (
   cursor: string | undefined,
@@ -32,10 +39,14 @@ export const decodeEntityListCursor = (
   }
 
   const parts = decodePaginationCursor(cursor);
-  const createdAt = parseDateTimePaginationCursorPart(parts?.at(0));
+  const createdAt = parts?.at(0);
   const id = parts?.at(1);
 
-  if (createdAt === null || typeof id !== "string") {
+  if (
+    typeof createdAt !== "string" ||
+    !entityListTimestampCursorPattern.test(createdAt) ||
+    typeof id !== "string"
+  ) {
     throw new HandlerError({ status: 400, message: "Invalid cursor" });
   }
 
@@ -51,8 +62,11 @@ export const entityListCursorCondition = (
 
   return (
     or(
-      gt(entities.createdAt, cursor.createdAt),
-      and(eq(entities.createdAt, cursor.createdAt), gt(entities.id, cursor.id)),
+      sql`${entities.createdAt} > ${cursor.createdAt}::timestamp`,
+      and(
+        sql`${entities.createdAt} = ${cursor.createdAt}::timestamp`,
+        gt(entities.id, cursor.id),
+      ),
     ) ?? undefined
   );
 };

--- a/apps/api/src/handlers/entities/list-files.ts
+++ b/apps/api/src/handlers/entities/list-files.ts
@@ -1,35 +1,47 @@
 import { Result } from "better-result";
 import { and, asc, eq, sql } from "drizzle-orm";
+import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
 import { entities, fields } from "@/api/db/schema";
+import {
+  decodeEntityListCursor,
+  encodeEntityListCursor,
+  entityListCursorCondition,
+} from "@/api/handlers/entities/list-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 
-// Returns every file-bearing entity in the workspace, unpaginated and
-// trimmed to just the columns the organizer needs (entityId,
-// parentId, fileName, mimeType). The workspace cap of
-// LIMITS.entitiesCount = 10 000 keeps the upper bound bounded.
-//
-// The organizer is the only consumer today; the FilesystemView still
-// uses the paginated read endpoint for its UI rows. Adding a
-// dedicated lightweight endpoint avoids loading every entity's full
-// field set when the dialog only needs the file's name + mime type.
+const listFilesQuerySchema = t.Object({
+  limit: t.Optional(
+    t.Integer({ minimum: 1, maximum: LIMITS.entitiesWindowSizeMax }),
+  ),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
+});
+type ListFilesQuery = (typeof listFilesQuerySchema)["static"];
 
 type ListFilesHandlerProps = {
   safeDb: SafeDb;
   workspaceId: SafeId<"workspace">;
+  query: ListFilesQuery;
 };
 
 const listFilesHandler = async function* ({
+  query,
   safeDb,
   workspaceId,
 }: ListFilesHandlerProps) {
+  const limit = query.limit ?? LIMITS.entitiesWindowSizeDefault;
+  const cursor = decodeEntityListCursor(query.cursor);
+  const cursorCondition = entityListCursorCondition(cursor);
   const rows = yield* Result.await(
     safeDb((tx) =>
       tx
         .select({
+          createdAt: entities.createdAt,
           entityId: entities.id,
           name: entities.name,
           parentId: entities.parentId,
@@ -48,9 +60,11 @@ const listFilesHandler = async function* ({
           and(
             eq(entities.workspaceId, workspaceId),
             eq(entities.kind, "document"),
+            ...(cursorCondition ? [cursorCondition] : []),
           ),
         )
-        .orderBy(asc(entities.createdAt)),
+        .orderBy(asc(entities.createdAt), asc(entities.id))
+        .limit(limit + 1),
     ),
   );
 
@@ -62,7 +76,7 @@ const listFilesHandler = async function* ({
     mimeType: string;
   };
 
-  const files: FileRow[] = [];
+  const files: (FileRow & { createdAt: Date })[] = [];
   for (const row of rows) {
     const content = row.fieldContent;
     if (content.type !== "file") {
@@ -72,22 +86,34 @@ const listFilesHandler = async function* ({
       entityId: row.entityId,
       name: row.name,
       parentId: row.parentId,
+      createdAt: row.createdAt,
       fileName: content.fileName,
       mimeType: content.mimeType,
     });
   }
 
-  return Result.ok({ files });
+  const page = createCursorPage({
+    rows: files,
+    limit,
+    cursorForItem: (item) =>
+      encodeEntityListCursor({ createdAt: item.createdAt, id: item.entityId }),
+  });
+
+  return Result.ok({
+    ...page,
+    items: page.items.map(({ createdAt: _createdAt, ...file }) => file),
+  });
 };
 
 const config = {
   permissions: { workspace: ["read"] },
+  query: listFilesQuerySchema,
 } satisfies HandlerConfig;
 
 const listFiles = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId }) {
-    return yield* listFilesHandler({ safeDb, workspaceId });
+  async function* ({ query, safeDb, workspaceId }) {
+    return yield* listFilesHandler({ query, safeDb, workspaceId });
   },
 );
 

--- a/apps/api/src/handlers/entities/list-files.ts
+++ b/apps/api/src/handlers/entities/list-files.ts
@@ -7,6 +7,7 @@ import { entities, fields } from "@/api/db/schema";
 import {
   decodeEntityListCursor,
   encodeEntityListCursor,
+  entityListTimestampCursorExpr,
   entityListCursorCondition,
 } from "@/api/handlers/entities/list-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -41,7 +42,7 @@ const listFilesHandler = async function* ({
     safeDb((tx) =>
       tx
         .select({
-          createdAt: entities.createdAt,
+          createdAt: entityListTimestampCursorExpr(sql`${entities.createdAt}`),
           entityId: entities.id,
           name: entities.name,
           parentId: entities.parentId,
@@ -76,7 +77,7 @@ const listFilesHandler = async function* ({
     mimeType: string;
   };
 
-  const files: (FileRow & { createdAt: Date })[] = [];
+  const files: (FileRow & { createdAt: string })[] = [];
   for (const row of rows) {
     const content = row.fieldContent;
     if (content.type !== "file") {

--- a/apps/api/src/handlers/entities/list-files.ts
+++ b/apps/api/src/handlers/entities/list-files.ts
@@ -5,10 +5,10 @@ import { t } from "elysia";
 import type { SafeDb } from "@/api/db";
 import { entities, fields } from "@/api/db/schema";
 import {
-  decodeEntityListCursor,
-  encodeEntityListCursor,
+  decodeEntityFileListCursor,
+  encodeEntityFileListCursor,
+  entityFileListCursorCondition,
   entityListTimestampCursorExpr,
-  entityListCursorCondition,
 } from "@/api/handlers/entities/list-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -36,14 +36,15 @@ const listFilesHandler = async function* ({
   workspaceId,
 }: ListFilesHandlerProps) {
   const limit = query.limit ?? LIMITS.entitiesWindowSizeDefault;
-  const cursor = decodeEntityListCursor(query.cursor);
-  const cursorCondition = entityListCursorCondition(cursor);
+  const cursor = decodeEntityFileListCursor(query.cursor);
+  const cursorCondition = entityFileListCursorCondition(cursor);
   const rows = yield* Result.await(
     safeDb((tx) =>
       tx
         .select({
           createdAt: entityListTimestampCursorExpr(sql`${entities.createdAt}`),
           entityId: entities.id,
+          fieldId: fields.id,
           name: entities.name,
           parentId: entities.parentId,
           fieldContent: fields.content,
@@ -64,7 +65,7 @@ const listFilesHandler = async function* ({
             ...(cursorCondition ? [cursorCondition] : []),
           ),
         )
-        .orderBy(asc(entities.createdAt), asc(entities.id))
+        .orderBy(asc(entities.createdAt), asc(entities.id), asc(fields.id))
         .limit(limit + 1),
     ),
   );
@@ -77,7 +78,10 @@ const listFilesHandler = async function* ({
     mimeType: string;
   };
 
-  const files: (FileRow & { createdAt: string })[] = [];
+  const files: (FileRow & {
+    createdAt: string;
+    fieldId: SafeId<"field">;
+  })[] = [];
   for (const row of rows) {
     const content = row.fieldContent;
     if (content.type !== "file") {
@@ -88,6 +92,7 @@ const listFilesHandler = async function* ({
       name: row.name,
       parentId: row.parentId,
       createdAt: row.createdAt,
+      fieldId: row.fieldId,
       fileName: content.fileName,
       mimeType: content.mimeType,
     });
@@ -97,12 +102,18 @@ const listFilesHandler = async function* ({
     rows: files,
     limit,
     cursorForItem: (item) =>
-      encodeEntityListCursor({ createdAt: item.createdAt, id: item.entityId }),
+      encodeEntityFileListCursor({
+        createdAt: item.createdAt,
+        fieldId: item.fieldId,
+        id: item.entityId,
+      }),
   });
 
   return Result.ok({
     ...page,
-    items: page.items.map(({ createdAt: _createdAt, ...file }) => file),
+    items: page.items.map(
+      ({ createdAt: _createdAt, fieldId: _fieldId, ...file }) => file,
+    ),
   });
 };
 

--- a/apps/api/src/handlers/entities/list-folders.ts
+++ b/apps/api/src/handlers/entities/list-folders.ts
@@ -1,31 +1,47 @@
 import { Result } from "better-result";
 import { and, asc, eq } from "drizzle-orm";
+import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
 import { entities } from "@/api/db/schema";
+import {
+  decodeEntityListCursor,
+  encodeEntityListCursor,
+  entityListCursorCondition,
+} from "@/api/handlers/entities/list-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 
-// Returns every folder in the workspace, unpaginated. Folders are
-// few (compared to files) and the workspace-wide entity cap of
-// LIMITS.entitiesCount = 10 000 keeps the upper bound bounded.
-// Used by the file organizer to build a complete parent → child
-// hierarchy regardless of which page the filesystem view is on.
+const listFoldersQuerySchema = t.Object({
+  limit: t.Optional(
+    t.Integer({ minimum: 1, maximum: LIMITS.entitiesWindowSizeMax }),
+  ),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
+});
+type ListFoldersQuery = (typeof listFoldersQuerySchema)["static"];
 
 type ListFoldersHandlerProps = {
   safeDb: SafeDb;
   workspaceId: SafeId<"workspace">;
+  query: ListFoldersQuery;
 };
 
 const listFoldersHandler = async function* ({
+  query,
   safeDb,
   workspaceId,
 }: ListFoldersHandlerProps) {
+  const limit = query.limit ?? LIMITS.entitiesWindowSizeDefault;
+  const cursor = decodeEntityListCursor(query.cursor);
+  const cursorCondition = entityListCursorCondition(cursor);
   const rows = yield* Result.await(
     safeDb((tx) =>
       tx
         .select({
+          createdAt: entities.createdAt,
           id: entities.id,
           name: entities.name,
           parentId: entities.parentId,
@@ -35,23 +51,36 @@ const listFoldersHandler = async function* ({
           and(
             eq(entities.workspaceId, workspaceId),
             eq(entities.kind, "folder"),
+            ...(cursorCondition ? [cursorCondition] : []),
           ),
         )
-        .orderBy(asc(entities.createdAt)),
+        .orderBy(asc(entities.createdAt), asc(entities.id))
+        .limit(limit + 1),
     ),
   );
 
-  return Result.ok({ folders: rows });
+  const page = createCursorPage({
+    rows,
+    limit,
+    cursorForItem: (item) =>
+      encodeEntityListCursor({ createdAt: item.createdAt, id: item.id }),
+  });
+
+  return Result.ok({
+    ...page,
+    items: page.items.map(({ createdAt: _createdAt, ...folder }) => folder),
+  });
 };
 
 const config = {
   permissions: { workspace: ["read"] },
+  query: listFoldersQuerySchema,
 } satisfies HandlerConfig;
 
 const listFolders = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId }) {
-    return yield* listFoldersHandler({ safeDb, workspaceId });
+  async function* ({ query, safeDb, workspaceId }) {
+    return yield* listFoldersHandler({ query, safeDb, workspaceId });
   },
 );
 

--- a/apps/api/src/handlers/entities/list-folders.ts
+++ b/apps/api/src/handlers/entities/list-folders.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, asc, eq } from "drizzle-orm";
+import { and, asc, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import type { SafeDb } from "@/api/db";
@@ -7,6 +7,7 @@ import { entities } from "@/api/db/schema";
 import {
   decodeEntityListCursor,
   encodeEntityListCursor,
+  entityListTimestampCursorExpr,
   entityListCursorCondition,
 } from "@/api/handlers/entities/list-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
@@ -41,7 +42,7 @@ const listFoldersHandler = async function* ({
     safeDb((tx) =>
       tx
         .select({
-          createdAt: entities.createdAt,
+          createdAt: entityListTimestampCursorExpr(sql`${entities.createdAt}`),
           id: entities.id,
           name: entities.name,
           parentId: entities.parentId,

--- a/apps/api/src/handlers/entities/list-organizer.test.ts
+++ b/apps/api/src/handlers/entities/list-organizer.test.ts
@@ -1,0 +1,134 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import listFiles from "@/api/handlers/entities/list-files";
+import listFolders from "@/api/handlers/entities/list-folders";
+import { toSafeId } from "@/api/lib/branded-types";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const workspaceId = toSafeId<"workspace">("ws_organizer_lists");
+const organizationId = toSafeId<"organization">("org_organizer_lists");
+const userId = toSafeId<"user">("user_organizer_lists");
+const createdAt = new Date("2026-01-01T00:00:00.000Z");
+const folder1 = toSafeId<"entity">("folder_1");
+const folder2 = toSafeId<"entity">("folder_2");
+const folder3 = toSafeId<"entity">("folder_3");
+const entity1 = toSafeId<"entity">("entity_1");
+const entity2 = toSafeId<"entity">("entity_2");
+
+const createContext = ({
+  query,
+  rows,
+}: {
+  query: { limit?: number; cursor?: string };
+  rows: unknown[];
+}) => ({
+  workspaceId,
+  user: { id: userId },
+  session: { activeOrganizationId: organizationId },
+  memberRole: { role: "owner" },
+  query,
+  safeDb: async <T>() => Result.ok(asTestRaw<T>(rows)),
+  request: new Request("https://example.test/v1/entities/ws/files"),
+  route: "/v1/entities/:workspaceId/files",
+});
+
+const createFoldersContext = (
+  input: Parameters<typeof createContext>[0],
+): Parameters<typeof listFolders.handler>[0] =>
+  asTestRaw<Parameters<typeof listFolders.handler>[0]>(createContext(input));
+
+const createFilesContext = (
+  input: Parameters<typeof createContext>[0],
+): Parameters<typeof listFiles.handler>[0] =>
+  asTestRaw<Parameters<typeof listFiles.handler>[0]>(createContext(input));
+
+describe("organizer entity lists", () => {
+  test("folders return a cursor page without leaking cursor columns", async () => {
+    const result = await listFolders.handler(
+      createFoldersContext({
+        query: { limit: 2 },
+        rows: [
+          { id: folder1, name: "Pleadings", parentId: null, createdAt },
+          { id: folder2, name: "Evidence", parentId: null, createdAt },
+          { id: folder3, name: "Drafts", parentId: null, createdAt },
+        ],
+      }),
+    );
+
+    expect("items" in result).toBe(true);
+    if (!("items" in result)) {
+      return;
+    }
+
+    expect(result.items).toEqual([
+      { id: folder1, name: "Pleadings", parentId: null },
+      { id: folder2, name: "Evidence", parentId: null },
+    ]);
+    expect(result.nextCursor).toEqual(expect.any(String));
+    expect(result.limit).toBe(2);
+  });
+
+  test("files return a cursor page with only organizer fields", async () => {
+    const result = await listFiles.handler(
+      createFilesContext({
+        query: { limit: 1 },
+        rows: [
+          {
+            entityId: entity1,
+            name: "Document",
+            parentId: null,
+            createdAt,
+            fieldContent: {
+              type: "file",
+              version: 1,
+              id: "file_1",
+              fileName: "Document.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 42,
+              encrypted: false,
+              sha256Hex:
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+              pdfFileId: null,
+            },
+          },
+          {
+            entityId: entity2,
+            name: "Notes",
+            parentId: null,
+            createdAt,
+            fieldContent: {
+              type: "file",
+              version: 1,
+              id: "file_2",
+              fileName: "Notes.pdf",
+              mimeType: "application/pdf",
+              sizeBytes: 42,
+              encrypted: false,
+              sha256Hex:
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              pdfFileId: null,
+            },
+          },
+        ],
+      }),
+    );
+
+    expect("items" in result).toBe(true);
+    if (!("items" in result)) {
+      return;
+    }
+
+    expect(result.items).toEqual([
+      {
+        entityId: entity1,
+        name: "Document",
+        parentId: null,
+        fileName: "Document.pdf",
+        mimeType: "application/pdf",
+      },
+    ]);
+    expect(result.nextCursor).toEqual(expect.any(String));
+    expect(result.limit).toBe(1);
+  });
+});

--- a/apps/api/src/handlers/entities/query-entities.test.ts
+++ b/apps/api/src/handlers/entities/query-entities.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+
+import { buildEntitySortExpressions } from "@/api/handlers/entities/query-entities";
+
+describe("queryEntities sort SQL", () => {
+  test("custom property sorts preserve empty-string fallback for missing values", () => {
+    const [sortExpression] = buildEntitySortExpressions({
+      sorts: [{ propertyId: "prop_sparse", desc: false }],
+    });
+    if (!sortExpression) {
+      throw new Error("expected custom property sort expression");
+    }
+
+    const compiled = new PgDialect().sqlToQuery(sortExpression);
+
+    expect(compiled.sql.toLowerCase()).toContain("coalesce(");
+    expect(compiled.sql).toContain("), '') ASC");
+    expect(compiled.sql).not.toContain("\uffff");
+    expect(compiled.params).not.toContain("\uffff");
+  });
+});

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -306,32 +306,7 @@ const dateSortKey = ({
   type: "date",
 });
 
-const displayedNameExpr = (): SQL => sql`COALESCE(
-  NULLIF(${entities.name}, ''),
-  (
-    SELECT NULLIF(${fields.content}->>'fileName', '')
-    FROM ${fields}
-    WHERE ${fields.workspaceId} = ${entities.workspaceId}
-      AND ${fields.entityVersionId} = ${entities.currentVersionId}
-      AND ${fields.content}->>'type' = 'file'
-    ORDER BY ${fields.propertyId} ASC
-    LIMIT 1
-  ),
-  (
-    SELECT NULLIF(BTRIM(${fields.content}->>'value'), '')
-    FROM ${fields}
-    WHERE ${fields.workspaceId} = ${entities.workspaceId}
-      AND ${fields.entityVersionId} = ${entities.currentVersionId}
-      AND ${fields.content}->>'type' = 'text'
-    ORDER BY ${fields.propertyId} ASC
-    LIMIT 1
-  ),
-  CASE
-    WHEN ${entities.kind} = 'folder' THEN 'Untitled Folder'
-    WHEN ${entities.kind} = 'task' THEN 'Untitled Task'
-    ELSE 'Untitled'
-  END
-)`;
+const displayedNameExpr = (): SQL => sql`${entities.displayName}`;
 
 const propertySortValueExpr = (propertyId: string): SQL => sql`(
   SELECT COALESCE(

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -235,6 +235,7 @@ const HIGH_TEXT_SENTINEL = "\uffff";
 const LOW_DATE_SENTINEL = "0001-01-01";
 const HIGH_DATE_SENTINEL = "9999-12-31";
 const LOW_TIMESTAMP_SENTINEL = new Date("0001-01-01T00:00:00.000Z");
+const dateCursorPattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
 const timestampCursorPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/u;
 
 const orderSortKey = ({ direction, expr }: EntitySortKey): SQL =>
@@ -279,6 +280,18 @@ const defaultNullableTextSortKey = ({
   textSortKey({
     direction,
     expr: sql`COALESCE(${expr}, ${HIGH_TEXT_SENTINEL})`,
+  });
+
+const legacyNullableTextSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey =>
+  textSortKey({
+    direction,
+    expr: sql`COALESCE(${expr}, '')`,
   });
 
 const timestampSortKey = ({
@@ -400,7 +413,7 @@ const buildViewSortKeys = (sorts: readonly ViewSort[]): EntitySortKey[] => {
     }
 
     keys.push(
-      defaultNullableTextSortKey({
+      legacyNullableTextSortKey({
         direction: sort.desc ? "desc" : "asc",
         expr: propertySortValueExpr(sort.propertyId),
       }),
@@ -457,14 +470,57 @@ const buildSortKeys = ({
   textSortKey({ direction: "asc", expr: sql`${entities.id}` }),
 ];
 
+export const buildEntitySortExpressions = ({
+  search,
+  sorts,
+}: {
+  search?: string | undefined;
+  sorts: readonly ViewSort[];
+}): SQL[] => buildSortKeys({ search, sorts }).map(orderSortKey);
+
+const isValidDateCursorValue = (value: string): boolean => {
+  const match = dateCursorPattern.exec(value);
+  if (!match) {
+    return false;
+  }
+
+  const [, yearPart, monthPart, dayPart] = match;
+  const year = Number(yearPart);
+  const month = Number(monthPart);
+  const day = Number(dayPart);
+  if (year < 1 || month < 1 || month > 12) {
+    return false;
+  }
+
+  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    isLeapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  return day >= 1 && day <= (daysInMonth.at(month - 1) ?? 0);
+};
+
 const parseCursorValue = (
   key: EntitySortKey,
   value: EntitiesWindowCursorValue,
 ): number | string | null => {
   switch (key.type) {
-    case "date":
     case "string":
       return typeof value === "string" ? value : null;
+    case "date":
+      return typeof value === "string" && isValidDateCursorValue(value)
+        ? value
+        : null;
     case "number":
       return typeof value === "number" && Number.isFinite(value) ? value : null;
     case "timestamp": {

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -105,6 +105,7 @@ type QueryEntitiesProps = {
   sorts: ViewSort[];
   search?: string | undefined;
   cursor?: EntitiesWindowCursorValues | null | undefined;
+  offset?: number | undefined;
   limit: number;
   fieldMode: QueryEntitiesFieldMode;
   fieldIds: SafeId<"property">[];
@@ -575,6 +576,7 @@ const queryEntitiesGenerator = async function* ({
   sorts,
   search,
   cursor,
+  offset = 0,
   limit,
   fieldMode,
   fieldIds,
@@ -625,14 +627,20 @@ const queryEntitiesGenerator = async function* ({
     : Promise.resolve(null);
 
   const [idRowsResult, countRowsResult] = await Promise.all([
-    safeDb((tx) =>
-      tx
+    safeDb((tx) => {
+      const query = tx
         .select({ cursorValues: cursorValuesExpr, id: entities.id })
         .from(entities)
         .where(paginatedWhereClause)
         .orderBy(...sortExpressions)
-        .limit(limit),
-    ),
+        .limit(limit);
+
+      if (offset <= 0) {
+        return query;
+      }
+
+      return query.offset(offset);
+    }),
     countRowsPromise,
   ]);
 

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -18,6 +18,10 @@ import type {
   EntityKind,
   FieldContent,
 } from "@/api/db/schema-validators";
+import {
+  isValidDateCursorValue,
+  isValidTimestampCursorValue,
+} from "@/api/handlers/entities/cursor-validation";
 import type {
   EntitiesWindowCursorValue,
   EntitiesWindowCursorValues,
@@ -235,8 +239,6 @@ const HIGH_TEXT_SENTINEL = "\uffff";
 const LOW_DATE_SENTINEL = "0001-01-01";
 const HIGH_DATE_SENTINEL = "9999-12-31";
 const LOW_TIMESTAMP_SENTINEL = new Date("0001-01-01T00:00:00.000Z");
-const dateCursorPattern = /^(\d{4})-(\d{2})-(\d{2})$/u;
-const timestampCursorPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/u;
 
 const orderSortKey = ({ direction, expr }: EntitySortKey): SQL =>
   direction === "desc" ? sql`${expr} DESC` : sql`${expr} ASC`;
@@ -478,38 +480,6 @@ export const buildEntitySortExpressions = ({
   sorts: readonly ViewSort[];
 }): SQL[] => buildSortKeys({ search, sorts }).map(orderSortKey);
 
-const isValidDateCursorValue = (value: string): boolean => {
-  const match = dateCursorPattern.exec(value);
-  if (!match) {
-    return false;
-  }
-
-  const [, yearPart, monthPart, dayPart] = match;
-  const year = Number(yearPart);
-  const month = Number(monthPart);
-  const day = Number(dayPart);
-  if (year < 1 || month < 1 || month > 12) {
-    return false;
-  }
-
-  const isLeapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const daysInMonth = [
-    31,
-    isLeapYear ? 29 : 28,
-    31,
-    30,
-    31,
-    30,
-    31,
-    31,
-    30,
-    31,
-    30,
-    31,
-  ];
-  return day >= 1 && day <= (daysInMonth.at(month - 1) ?? 0);
-};
-
 const parseCursorValue = (
   key: EntitySortKey,
   value: EntitiesWindowCursorValue,
@@ -527,7 +497,7 @@ const parseCursorValue = (
       if (typeof value !== "string") {
         return null;
       }
-      return timestampCursorPattern.test(value) ? value : null;
+      return isValidTimestampCursorValue(value) ? value : null;
     }
   }
 

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -18,6 +18,10 @@ import type {
   EntityKind,
   FieldContent,
 } from "@/api/db/schema-validators";
+import type {
+  EntitiesWindowCursorValue,
+  EntitiesWindowCursorValues,
+} from "@/api/handlers/entities/window-cursor";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   AGENDA_ITEM_KIND,
@@ -27,10 +31,8 @@ import type {
   AgendaItemKind,
   AgendaItemSource,
 } from "@/api/lib/entity-constants";
-import {
-  buildFilterConditions,
-  buildSortExpressions,
-} from "@/api/lib/entity-filters";
+import { buildFilterConditions } from "@/api/lib/entity-filters";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import type { ViewFilterCondition, ViewSort } from "@/api/lib/views-schema";
 import { PDF_MIME_TYPE } from "@/api/mime-types";
 
@@ -102,7 +104,7 @@ type QueryEntitiesProps = {
   filters: ViewFilterCondition[];
   sorts: ViewSort[];
   search?: string | undefined;
-  offset: number;
+  cursor?: EntitiesWindowCursorValues | null | undefined;
   limit: number;
   fieldMode: QueryEntitiesFieldMode;
   fieldIds: SafeId<"property">[];
@@ -218,6 +220,377 @@ const buildCellMetadataPredicates = ({
   return predicates;
 };
 
+type SortValueType = "date" | "number" | "string" | "timestamp";
+type SortDirection = "asc" | "desc";
+
+type EntitySortKey = {
+  expr: SQL;
+  cursorExpr: SQL;
+  direction: SortDirection;
+  type: SortValueType;
+};
+
+const HIGH_TEXT_SENTINEL = "\uffff";
+const LOW_DATE_SENTINEL = "0001-01-01";
+const HIGH_DATE_SENTINEL = "9999-12-31";
+const LOW_TIMESTAMP_SENTINEL = new Date("0001-01-01T00:00:00.000Z");
+const timestampCursorPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/u;
+
+const orderSortKey = ({ direction, expr }: EntitySortKey): SQL =>
+  direction === "desc" ? sql`${expr} DESC` : sql`${expr} ASC`;
+
+const timestampCursorExpr = (expr: SQL): SQL =>
+  sql`to_char(${expr}, 'YYYY-MM-DD"T"HH24:MI:SS.US')`;
+
+const textSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey => ({
+  expr,
+  cursorExpr: expr,
+  direction,
+  type: "string",
+});
+
+const numberSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey => ({
+  expr,
+  cursorExpr: expr,
+  direction,
+  type: "number",
+});
+
+const defaultNullableTextSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey =>
+  textSortKey({
+    direction,
+    expr: sql`COALESCE(${expr}, ${HIGH_TEXT_SENTINEL})`,
+  });
+
+const timestampSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey => ({
+  expr,
+  cursorExpr: timestampCursorExpr(expr),
+  direction,
+  type: "timestamp",
+});
+
+const dateSortKey = ({
+  direction,
+  expr,
+}: {
+  direction: SortDirection;
+  expr: SQL;
+}): EntitySortKey => ({
+  expr,
+  cursorExpr: expr,
+  direction,
+  type: "date",
+});
+
+const displayedNameExpr = (): SQL => sql`COALESCE(
+  NULLIF(${entities.name}, ''),
+  (
+    SELECT NULLIF(${fields.content}->>'fileName', '')
+    FROM ${fields}
+    WHERE ${fields.workspaceId} = ${entities.workspaceId}
+      AND ${fields.entityVersionId} = ${entities.currentVersionId}
+      AND ${fields.content}->>'type' = 'file'
+    ORDER BY ${fields.propertyId} ASC
+    LIMIT 1
+  ),
+  (
+    SELECT NULLIF(BTRIM(${fields.content}->>'value'), '')
+    FROM ${fields}
+    WHERE ${fields.workspaceId} = ${entities.workspaceId}
+      AND ${fields.entityVersionId} = ${entities.currentVersionId}
+      AND ${fields.content}->>'type' = 'text'
+    ORDER BY ${fields.propertyId} ASC
+    LIMIT 1
+  ),
+  CASE
+    WHEN ${entities.kind} = 'folder' THEN 'Untitled Folder'
+    WHEN ${entities.kind} = 'task' THEN 'Untitled Task'
+    ELSE 'Untitled'
+  END
+)`;
+
+const propertySortValueExpr = (propertyId: string): SQL => sql`(
+  SELECT COALESCE(
+    ${fields.content}->>'value',
+    ${fields.content}->>'fileName',
+    ''
+  )
+  FROM ${fields}
+  WHERE ${fields.workspaceId} = ${entities.workspaceId}
+    AND ${fields.entityVersionId} = ${entities.currentVersionId}
+    AND ${fields.propertyId} = ${propertyId}
+  LIMIT 1
+)`;
+
+const internalSortKey = ({
+  desc,
+  propertyId,
+}: {
+  desc: boolean;
+  propertyId: string;
+}): EntitySortKey | null => {
+  const direction: SortDirection = desc ? "desc" : "asc";
+  switch (propertyId) {
+    case "_name":
+      return textSortKey({ direction, expr: displayedNameExpr() });
+    case "_created-by":
+      return defaultNullableTextSortKey({
+        direction,
+        expr: sql`(
+          SELECT ${user.name} FROM ${user}
+          WHERE ${user.id} = ${entities.createdBy}
+        )`,
+      });
+    case "_created-at":
+      return timestampSortKey({ direction, expr: sql`${entities.createdAt}` });
+    case "_updated-at":
+      return timestampSortKey({
+        direction,
+        expr: sql`COALESCE(${entities.updatedAt}, ${LOW_TIMESTAMP_SENTINEL})`,
+      });
+    case "_status":
+      return textSortKey({
+        direction,
+        expr: desc
+          ? sql`COALESCE(${entities.status}, '')`
+          : sql`COALESCE(${entities.status}, ${HIGH_TEXT_SENTINEL})`,
+      });
+    case "_priority":
+      return textSortKey({
+        direction,
+        expr: desc
+          ? sql`COALESCE(${entities.priority}, '')`
+          : sql`COALESCE(${entities.priority}, ${HIGH_TEXT_SENTINEL})`,
+      });
+    case "_due-date":
+      return dateSortKey({
+        direction,
+        expr: desc
+          ? sql`COALESCE(${entities.dueDate}, ${LOW_DATE_SENTINEL})`
+          : sql`COALESCE(${entities.dueDate}, ${HIGH_DATE_SENTINEL})`,
+      });
+    case "_version":
+      return numberSortKey({
+        direction,
+        expr: sql`(
+          SELECT COUNT(*) FROM ${entityVersions}
+          WHERE ${entityVersions.entityId} = ${entities.id}
+        )`,
+      });
+    case "_kind":
+      return textSortKey({ direction, expr: sql`${entities.kind}` });
+    default:
+      return null;
+  }
+};
+
+const buildViewSortKeys = (sorts: readonly ViewSort[]): EntitySortKey[] => {
+  if (sorts.length === 0) {
+    return [
+      timestampSortKey({ direction: "asc", expr: sql`${entities.createdAt}` }),
+    ];
+  }
+
+  const keys: EntitySortKey[] = [];
+  for (const sort of sorts) {
+    const internal = internalSortKey(sort);
+    if (internal) {
+      keys.push(internal);
+      continue;
+    }
+
+    keys.push(
+      defaultNullableTextSortKey({
+        direction: sort.desc ? "desc" : "asc",
+        expr: propertySortValueExpr(sort.propertyId),
+      }),
+    );
+  }
+  return keys;
+};
+
+const buildSearchSortKeys = (search: string | undefined): EntitySortKey[] => {
+  const trimmed = search?.trim() ?? "";
+  if (!trimmed) {
+    return [];
+  }
+
+  const titleExpr = sql`(
+    SELECT sd.title
+    FROM ${searchDocuments} sd
+    WHERE sd.entity_id = ${entities.id}
+    LIMIT 1
+  )`;
+  const normalizedTitle = sql`lower(${titleExpr})`;
+  const normalizedSearch = trimmed.toLowerCase();
+
+  return [
+    numberSortKey({
+      direction: "asc",
+      expr: sql`CASE
+        WHEN ${normalizedTitle} = ${normalizedSearch} THEN 0
+        WHEN ${normalizedTitle} LIKE ${`${normalizedSearch}%`} THEN 1
+        WHEN ${normalizedTitle} LIKE ${`%${normalizedSearch}%`} THEN 2
+        ELSE 3
+      END`,
+    }),
+    numberSortKey({
+      direction: "asc",
+      expr: sql`strpos(${normalizedTitle}, ${normalizedSearch})`,
+    }),
+    numberSortKey({
+      direction: "asc",
+      expr: sql`length(${titleExpr})`,
+    }),
+  ];
+};
+
+const buildSortKeys = ({
+  search,
+  sorts,
+}: {
+  search?: string | undefined;
+  sorts: readonly ViewSort[];
+}): EntitySortKey[] => [
+  ...buildSearchSortKeys(search),
+  ...buildViewSortKeys(sorts),
+  textSortKey({ direction: "asc", expr: sql`${entities.id}` }),
+];
+
+const parseCursorValue = (
+  key: EntitySortKey,
+  value: EntitiesWindowCursorValue,
+): number | string | null => {
+  switch (key.type) {
+    case "date":
+    case "string":
+      return typeof value === "string" ? value : null;
+    case "number":
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    case "timestamp": {
+      if (typeof value !== "string") {
+        return null;
+      }
+      return timestampCursorPattern.test(value) ? value : null;
+    }
+  }
+
+  return null;
+};
+
+const cursorValueSql = (key: EntitySortKey, value: number | string): SQL => {
+  if (key.type === "timestamp") {
+    return sql`${value}::timestamp`;
+  }
+
+  return sql`${value}`;
+};
+
+const invalidCursor = () =>
+  new HandlerError({ status: 400, message: "Invalid cursor" });
+
+const buildCursorCondition = ({
+  cursor,
+  sortKeys,
+}: {
+  cursor: EntitiesWindowCursorValues | null | undefined;
+  sortKeys: readonly EntitySortKey[];
+}): Result<SQL | null, HandlerError> => {
+  if (!cursor) {
+    return Result.ok(null);
+  }
+
+  if (cursor.length !== sortKeys.length) {
+    return Result.err(invalidCursor());
+  }
+
+  const parsedValues = sortKeys.map((key, index) =>
+    parseCursorValue(key, cursor[index] ?? null),
+  );
+  if (parsedValues.some((value) => value === null)) {
+    return Result.err(invalidCursor());
+  }
+
+  const branches: SQL[] = [];
+  for (let index = 0; index < sortKeys.length; index++) {
+    const key = sortKeys[index];
+    const value = parsedValues[index];
+    if (!key || value === null || value === undefined) {
+      return Result.err(invalidCursor());
+    }
+
+    const prefix: SQL[] = [];
+    for (let prefixIndex = 0; prefixIndex < index; prefixIndex++) {
+      const prefixKey = sortKeys[prefixIndex];
+      const prefixValue = parsedValues[prefixIndex];
+      if (!prefixKey || prefixValue === null || prefixValue === undefined) {
+        return Result.err(invalidCursor());
+      }
+      prefix.push(
+        sql`${prefixKey.expr} = ${cursorValueSql(prefixKey, prefixValue)}`,
+      );
+    }
+
+    const comparison =
+      key.direction === "asc"
+        ? sql`${key.expr} > ${cursorValueSql(key, value)}`
+        : sql`${key.expr} < ${cursorValueSql(key, value)}`;
+    branches.push(and(...prefix, comparison) ?? comparison);
+  }
+
+  return Result.ok(or(...branches) ?? null);
+};
+
+const normalizeCursorValues = (
+  rawValues: unknown,
+): EntitiesWindowCursorValues => {
+  if (Array.isArray(rawValues)) {
+    return rawValues.filter(isGeneratedCursorValue);
+  }
+
+  if (typeof rawValues !== "string") {
+    return [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValues);
+  } catch {
+    return [];
+  }
+
+  return Array.isArray(parsed) ? parsed.filter(isGeneratedCursorValue) : [];
+};
+
+const isGeneratedCursorValue = (
+  value: unknown,
+): value is EntitiesWindowCursorValue =>
+  value === null || typeof value === "string" || typeof value === "number";
+
 const queryEntitiesGenerator = async function* ({
   safeDb,
   workspaceId,
@@ -226,7 +599,7 @@ const queryEntitiesGenerator = async function* ({
   filters,
   sorts,
   search,
-  offset,
+  cursor,
   limit,
   fieldMode,
   fieldIds,
@@ -255,10 +628,20 @@ const queryEntitiesGenerator = async function* ({
     ...previewableConditions,
     ...extraConditions,
   );
-  const sortExpressions = [
-    ...buildSearchSortExpressions(search),
-    ...buildSortExpressions(sorts),
-  ];
+  const sortKeys = buildSortKeys({ search, sorts });
+  const cursorConditionResult = buildCursorCondition({ cursor, sortKeys });
+  if (Result.isError(cursorConditionResult)) {
+    return Result.err(cursorConditionResult.error);
+  }
+  const paginatedWhereClause =
+    cursorConditionResult.value === null
+      ? whereClause
+      : and(whereClause, cursorConditionResult.value);
+  const sortExpressions = sortKeys.map(orderSortKey);
+  const cursorValuesExpr = sql<EntitiesWindowCursorValues>`jsonb_build_array(${sql.join(
+    sortKeys.map((key) => key.cursorExpr),
+    sql`, `,
+  )})`;
 
   const countRowsPromise = includeTotalCount
     ? safeDb((tx) =>
@@ -269,11 +652,10 @@ const queryEntitiesGenerator = async function* ({
   const [idRowsResult, countRowsResult] = await Promise.all([
     safeDb((tx) =>
       tx
-        .select({ id: entities.id })
+        .select({ cursorValues: cursorValuesExpr, id: entities.id })
         .from(entities)
-        .where(whereClause)
+        .where(paginatedWhereClause)
         .orderBy(...sortExpressions)
-        .offset(offset)
         .limit(limit),
     ),
     countRowsPromise,
@@ -288,9 +670,13 @@ const queryEntitiesGenerator = async function* ({
   }
 
   const pageIds = idRows.map((r) => r.id);
+  const cursorValuesByEntityId = new Map<string, EntitiesWindowCursorValues>(
+    idRows.map((row) => [row.id, normalizeCursorValues(row.cursorValues)]),
+  );
 
   if (pageIds.length === 0) {
     return Result.ok({
+      cursorValuesByEntityId,
       entities: [],
       totalCount,
     });
@@ -595,6 +981,7 @@ const queryEntitiesGenerator = async function* ({
   }
 
   return Result.ok({
+    cursorValuesByEntityId,
     entities: result,
     totalCount,
   });
@@ -622,33 +1009,6 @@ const buildSearchConditions = ({
         AND sd.workspace_id = ${workspaceId}
         AND sd.title ILIKE ${`%${trimmed}%`}
     )`,
-  ];
-};
-
-const buildSearchSortExpressions = (search: string | undefined): SQL[] => {
-  const trimmed = search?.trim() ?? "";
-  if (!trimmed) {
-    return [];
-  }
-
-  const titleExpr = sql`(
-    SELECT sd.title
-    FROM ${searchDocuments} sd
-    WHERE sd.entity_id = ${entities.id}
-    LIMIT 1
-  )`;
-  const normalizedTitle = sql`lower(${titleExpr})`;
-  const normalizedSearch = trimmed.toLowerCase();
-
-  return [
-    sql`CASE
-      WHEN ${normalizedTitle} = ${normalizedSearch} THEN 0
-      WHEN ${normalizedTitle} LIKE ${`${normalizedSearch}%`} THEN 1
-      WHEN ${normalizedTitle} LIKE ${`%${normalizedSearch}%`} THEN 2
-      ELSE 3
-    END ASC`,
-    sql`strpos(${normalizedTitle}, ${normalizedSearch}) ASC`,
-    sql`length(${titleExpr}) ASC`,
   ];
 };
 

--- a/apps/api/src/handlers/entities/read-filesystem-tree.ts
+++ b/apps/api/src/handlers/entities/read-filesystem-tree.ts
@@ -51,7 +51,6 @@ export const createReadFilesystemTreeHandler = (
           filters: body.filters ?? [],
           sorts: body.sorts ?? [],
           ...(body.search !== undefined && { search: body.search }),
-          offset: 0,
           limit: LIMITS.entitiesCount,
           fieldMode: body.fieldMode ?? "full",
           fieldIds: body.fieldIds ?? [],

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -53,7 +53,7 @@ const readKanbanGroupBodySchema = t.Object({
       maximum: LIMITS.entitiesWindowSizeMax,
     }),
   ),
-  cursor: t.Optional(t.String({ maxLength: 512 })),
+  cursor: t.Optional(t.String()),
   fieldMode: t.Optional(t.UnionEnum(["full", "visible"])),
   fieldIds: t.Optional(
     t.Array(tSafeId("property"), {

--- a/apps/api/src/handlers/entities/read-kanban-group.ts
+++ b/apps/api/src/handlers/entities/read-kanban-group.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { and, eq, sql } from "drizzle-orm";
 import type { SQL } from "drizzle-orm";
 import { t } from "elysia";
@@ -176,7 +176,6 @@ const readKanbanGroup = createSafeHandler(
       return Result.err(conditionResult.error);
     }
 
-    const offset = cursorResult.value;
     const limit = body.limit ?? LIMITS.entitiesWindowSizeDefault;
     const result = yield* Result.await(
       queryEntities({
@@ -186,7 +185,7 @@ const readKanbanGroup = createSafeHandler(
         currentOrganizationId: session.activeOrganizationId,
         filters: body.filters ?? [],
         sorts: body.sorts ?? [],
-        offset,
+        cursor: cursorResult.value,
         limit: limit + 1,
         fieldMode: body.fieldMode ?? "full",
         fieldIds: body.fieldIds ?? [],
@@ -199,7 +198,11 @@ const readKanbanGroup = createSafeHandler(
       createCursorPage({
         rows: result.entities,
         limit,
-        cursorForItem: () => encodeEntitiesWindowCursor(offset + limit),
+        cursorForItem: (item) =>
+          encodeEntitiesWindowCursor(
+            result.cursorValuesByEntityId.get(item.entityId) ??
+              panic("Missing cursor values for Kanban group item"),
+          ),
       }),
     );
   },

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -223,4 +223,34 @@ describe("entity read handlers", () => {
       response: { message: "Invalid cursor" },
     });
   });
+
+  test("window query rejects malformed timestamp cursor values before querying", async () => {
+    const safeDb: Parameters<
+      typeof readEntitiesWindow.handler
+    >[0]["safeDb"] = async () => {
+      throw new Error("safeDb should not be called");
+    };
+
+    const result = await readEntitiesWindow.handler(
+      createContext({
+        body: {
+          limit: 2,
+          filters: [],
+          sorts: [],
+          cursor: encodeEntitiesWindowCursor([
+            "2026-13-40T25:61:61.999999",
+            "doc_1",
+          ]),
+          fieldMode: "visible",
+          fieldIds: [],
+        },
+        safeDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Invalid cursor" },
+    });
+  });
 });

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -7,6 +7,7 @@ import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 import readEntities from "./read";
 import readKanbanGroup from "./read-kanban-group";
 import readEntitiesWindow from "./read-window";
+import { encodeEntitiesWindowCursor } from "./window-cursor";
 
 const workspaceId = toSafeId<"workspace">("ws_entity_window");
 const organizationId = toSafeId<"organization">("org_entity_window");
@@ -194,5 +195,32 @@ describe("entity read handlers", () => {
     expect(result.items).toHaveLength(2);
     expect(result.limit).toBe(2);
     expect(result.nextCursor).toEqual(expect.any(String));
+  });
+
+  test("window query rejects malformed date cursor values before querying", async () => {
+    const safeDb: Parameters<
+      typeof readEntitiesWindow.handler
+    >[0]["safeDb"] = async () => {
+      throw new Error("safeDb should not be called");
+    };
+
+    const result = await readEntitiesWindow.handler(
+      createContext({
+        body: {
+          limit: 2,
+          filters: [],
+          sorts: [{ propertyId: "_due-date", desc: false }],
+          cursor: encodeEntitiesWindowCursor(["2026-99-99", "doc_1"]),
+          fieldMode: "visible",
+          fieldIds: [],
+        },
+        safeDb,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: 400,
+      response: { message: "Invalid cursor" },
+    });
   });
 });

--- a/apps/api/src/handlers/entities/read-window.test.ts
+++ b/apps/api/src/handlers/entities/read-window.test.ts
@@ -13,7 +13,11 @@ const organizationId = toSafeId<"organization">("org_entity_window");
 const userId = toSafeId<"user">("user_entity_window");
 const createdAt = new Date("2026-01-01T00:00:00.000Z");
 
-const idRows = [{ id: "doc_1" }, { id: "doc_2" }, { id: "doc_3" }];
+const idRows = [
+  { id: "doc_1", cursorValues: ["2026-01-01T00:00:00.000Z", "doc_1"] },
+  { id: "doc_2", cursorValues: ["2026-01-01T00:00:00.000Z", "doc_2"] },
+  { id: "doc_3", cursorValues: ["2026-01-01T00:00:00.000Z", "doc_3"] },
+];
 const entityRows = idRows.map(({ id }, index) => ({
   id,
   kind: "document" as const,
@@ -159,8 +163,9 @@ describe("entity read handlers", () => {
       return;
     }
 
-    expect(result.entities).toHaveLength(3);
+    expect(result.entities).toHaveLength(2);
     expect(result.totalCount).toBe(3);
+    expect(result.nextCursor).toEqual(expect.any(String));
   });
 
   test("kanban group query paginates one group window", async () => {

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -1,4 +1,4 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { t } from "elysia";
 
 import { queryEntities } from "@/api/handlers/entities/query-entities";
@@ -54,7 +54,6 @@ const readEntitiesWindow = createSafeHandler(
       return Result.err(cursorResult.error);
     }
 
-    const offset = cursorResult.value;
     const limit = body.limit ?? LIMITS.entitiesWindowSizeDefault;
     const result = yield* Result.await(
       queryEntities({
@@ -65,7 +64,7 @@ const readEntitiesWindow = createSafeHandler(
         filters: body.filters ?? [],
         sorts: body.sorts ?? [],
         ...(body.search !== undefined && { search: body.search }),
-        offset,
+        cursor: cursorResult.value,
         limit: limit + 1,
         fieldMode: body.fieldMode ?? "full",
         fieldIds: body.fieldIds ?? [],
@@ -79,7 +78,11 @@ const readEntitiesWindow = createSafeHandler(
       createCursorPage({
         rows: result.entities,
         limit,
-        cursorForItem: () => encodeEntitiesWindowCursor(offset + limit),
+        cursorForItem: (item) =>
+          encodeEntitiesWindowCursor(
+            result.cursorValuesByEntityId.get(item.entityId) ??
+              panic("Missing cursor values for entity window item"),
+          ),
       }),
     );
   },

--- a/apps/api/src/handlers/entities/read-window.ts
+++ b/apps/api/src/handlers/entities/read-window.ts
@@ -26,7 +26,7 @@ const readEntitiesWindowBodySchema = t.Object({
       maximum: LIMITS.entitiesWindowSizeMax,
     }),
   ),
-  cursor: t.Optional(t.String({ maxLength: 512 })),
+  cursor: t.Optional(t.String()),
   excludedKinds: t.Optional(
     t.Array(t.UnionEnum(["document", "folder", "task", "message", "link"]), {
       maxItems: 5,

--- a/apps/api/src/handlers/entities/read.test.ts
+++ b/apps/api/src/handlers/entities/read.test.ts
@@ -89,6 +89,27 @@ describe("entity read handler search", () => {
     );
   });
 
+  test("keeps legacy page-only pagination working without a cursor", async () => {
+    await readEntities.handler(
+      createContext({
+        filters: [],
+        sorts: [],
+        page: 3,
+        pageSize: 25,
+        fieldMode: "visible",
+        fieldIds: [],
+      }),
+    );
+
+    expect(queryEntitiesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: null,
+        limit: 26,
+        offset: 50,
+      }),
+    );
+  });
+
   test("loads a bounded complete filesystem tree without widening page reads", async () => {
     await readFilesystemTree.handler(
       createContext({

--- a/apps/api/src/handlers/entities/read.test.ts
+++ b/apps/api/src/handlers/entities/read.test.ts
@@ -35,6 +35,7 @@ describe("entity read handler search", () => {
     queryEntitiesMock.mockReset();
     queryEntitiesMock.mockResolvedValue(
       Result.ok({
+        cursorValuesByEntityId: new Map(),
         entities: [],
         totalCount: 0,
       }),
@@ -46,7 +47,7 @@ describe("entity read handler search", () => {
       createContext({
         filters: [],
         sorts: [],
-        page: 2,
+        page: 1,
         pageSize: 50,
         search: "closing binder",
         fieldMode: "visible",
@@ -59,8 +60,8 @@ describe("entity read handler search", () => {
         workspaceId,
         currentOrganizationId: organizationId,
         search: "closing binder",
-        offset: 50,
-        limit: 50,
+        cursor: null,
+        limit: 51,
       }),
     );
   });
@@ -81,8 +82,8 @@ describe("entity read handler search", () => {
     expect(queryEntitiesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         previewableForAi: true,
-        offset: 0,
-        limit: 50,
+        cursor: null,
+        limit: 51,
         fieldMode: "visible",
       }),
     );
@@ -104,7 +105,6 @@ describe("entity read handler search", () => {
         workspaceId,
         currentOrganizationId: organizationId,
         search: "closing binder",
-        offset: 0,
         limit: LIMITS.entitiesCount,
         excludedKinds: ["task"],
         includeTotalCount: false,

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -9,7 +9,6 @@ import {
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { createCursorPage } from "@/api/lib/pagination";
 import {
@@ -64,14 +63,8 @@ export const createReadEntitiesHandler = (
     }) {
       const page = body.page ?? 1;
       const pageSize = body.pageSize ?? LIMITS.entitiesPageSizeDefault;
-      if (page > 1 && body.cursor === undefined) {
-        return Result.err(
-          new HandlerError({
-            status: 400,
-            message: "Cursor is required after the first entity page",
-          }),
-        );
-      }
+      const legacyPageOffset =
+        page > 1 && body.cursor === undefined ? (page - 1) * pageSize : 0;
 
       const cursorResult = decodeEntitiesWindowCursor(body.cursor);
       if (Result.isError(cursorResult)) {
@@ -88,6 +81,7 @@ export const createReadEntitiesHandler = (
           sorts: body.sorts ?? [],
           ...(body.search !== undefined && { search: body.search }),
           cursor: cursorResult.value,
+          offset: legacyPageOffset,
           limit: pageSize + 1,
           fieldMode: body.fieldMode ?? "full",
           fieldIds: body.fieldIds ?? [],

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -21,7 +21,7 @@ const readEntitiesBodySchema = t.Object({
   filters: t.Optional(t.Array(tViewFilterConditionSchema)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   page: t.Optional(t.Integer({ minimum: 1 })),
-  cursor: t.Optional(t.String({ maxLength: 512 })),
+  cursor: t.Optional(t.String()),
   search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
   pageSize: t.Optional(
     t.Integer({

--- a/apps/api/src/handlers/entities/read.ts
+++ b/apps/api/src/handlers/entities/read.ts
@@ -1,11 +1,17 @@
-import { Result } from "better-result";
+import { panic, Result } from "better-result";
 import { t } from "elysia";
 
 import { queryEntities } from "@/api/handlers/entities/query-entities";
+import {
+  decodeEntitiesWindowCursor,
+  encodeEntitiesWindowCursor,
+} from "@/api/handlers/entities/window-cursor";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
+import { createCursorPage } from "@/api/lib/pagination";
 import {
   tViewFilterConditionSchema,
   tViewSortSchema,
@@ -15,6 +21,7 @@ const readEntitiesBodySchema = t.Object({
   filters: t.Optional(t.Array(tViewFilterConditionSchema)),
   sorts: t.Optional(t.Array(tViewSortSchema)),
   page: t.Optional(t.Integer({ minimum: 1 })),
+  cursor: t.Optional(t.String({ maxLength: 512 })),
   search: t.Optional(t.String({ maxLength: LIMITS.searchQueryMaxLength })),
   pageSize: t.Optional(
     t.Integer({
@@ -57,6 +64,20 @@ export const createReadEntitiesHandler = (
     }) {
       const page = body.page ?? 1;
       const pageSize = body.pageSize ?? LIMITS.entitiesPageSizeDefault;
+      if (page > 1 && body.cursor === undefined) {
+        return Result.err(
+          new HandlerError({
+            status: 400,
+            message: "Cursor is required after the first entity page",
+          }),
+        );
+      }
+
+      const cursorResult = decodeEntitiesWindowCursor(body.cursor);
+      if (Result.isError(cursorResult)) {
+        return Result.err(cursorResult.error);
+      }
+
       const result = yield* Result.await(
         queryEntitiesImpl({
           safeDb,
@@ -66,8 +87,8 @@ export const createReadEntitiesHandler = (
           filters: body.filters ?? [],
           sorts: body.sorts ?? [],
           ...(body.search !== undefined && { search: body.search }),
-          offset: (page - 1) * pageSize,
-          limit: pageSize,
+          cursor: cursorResult.value,
+          limit: pageSize + 1,
           fieldMode: body.fieldMode ?? "full",
           fieldIds: body.fieldIds ?? [],
           excludedKinds: body.excludedKinds ?? [],
@@ -76,8 +97,19 @@ export const createReadEntitiesHandler = (
         }),
       );
 
+      const cursorPage = createCursorPage({
+        rows: result.entities,
+        limit: pageSize,
+        cursorForItem: (item) =>
+          encodeEntitiesWindowCursor(
+            result.cursorValuesByEntityId.get(item.entityId) ??
+              panic("Missing cursor values for entity page item"),
+          ),
+      });
+
       return Result.ok({
-        entities: result.entities,
+        entities: cursorPage.items,
+        nextCursor: cursorPage.nextCursor,
         totalCount: result.totalCount ?? 0,
         page,
         pageSize,

--- a/apps/api/src/handlers/entities/routes.ts
+++ b/apps/api/src/handlers/entities/routes.ts
@@ -137,9 +137,11 @@ export const entitiesRoute = new Elysia({
     permissions: organizeSuggestions.config.permissions,
   })
   .get("/folders", listFolders.handler, {
+    query: listFolders.config.query,
     permissions: listFolders.config.permissions,
   })
   .get("/files", listFiles.handler, {
+    query: listFiles.config.query,
     permissions: listFiles.config.permissions,
   })
   .delete("/", deleteEntities.handler, {

--- a/apps/api/src/handlers/entities/window-cursor.test.ts
+++ b/apps/api/src/handlers/entities/window-cursor.test.ts
@@ -7,13 +7,16 @@ import {
 } from "@/api/handlers/entities/window-cursor";
 
 describe("entities window cursor", () => {
-  test("round-trips the next offset", () => {
-    const cursor = encodeEntitiesWindowCursor(400);
+  test("round-trips sort tuple values", () => {
+    const cursor = encodeEntitiesWindowCursor([
+      "2026-01-01T00:00:00.000Z",
+      "entity_1",
+    ]);
     const decoded = decodeEntitiesWindowCursor(cursor);
 
     expect(Result.isOk(decoded)).toBe(true);
     if (Result.isOk(decoded)) {
-      expect(decoded.value).toBe(400);
+      expect(decoded.value).toEqual(["2026-01-01T00:00:00.000Z", "entity_1"]);
     }
   });
 

--- a/apps/api/src/handlers/entities/window-cursor.test.ts
+++ b/apps/api/src/handlers/entities/window-cursor.test.ts
@@ -20,6 +20,18 @@ describe("entities window cursor", () => {
     }
   });
 
+  test("round-trips long tuple values generated from user data", () => {
+    const longName = "a".repeat(1000);
+    const cursor = encodeEntitiesWindowCursor([longName, "entity_1"]);
+    const decoded = decodeEntitiesWindowCursor(cursor);
+
+    expect(cursor.length).toBeGreaterThan(512);
+    expect(Result.isOk(decoded)).toBe(true);
+    if (Result.isOk(decoded)) {
+      expect(decoded.value).toEqual([longName, "entity_1"]);
+    }
+  });
+
   test("rejects tampered cursor values", () => {
     const decoded = decodeEntitiesWindowCursor("not-json");
 

--- a/apps/api/src/handlers/entities/window-cursor.ts
+++ b/apps/api/src/handlers/entities/window-cursor.ts
@@ -2,29 +2,37 @@ import { Result } from "better-result";
 
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
-const ENTITIES_WINDOW_CURSOR_VERSION = 1;
+const ENTITIES_WINDOW_CURSOR_VERSION = 2;
+
+export type EntitiesWindowCursorValue = string | number | null;
+export type EntitiesWindowCursorValues = readonly EntitiesWindowCursorValue[];
 
 const invalidCursor = () =>
   new HandlerError({ status: 400, message: "Invalid cursor" });
 
-export const encodeEntitiesWindowCursor = (offset: number): string =>
+const isCursorValue = (value: unknown): value is EntitiesWindowCursorValue =>
+  value === null || typeof value === "string" || typeof value === "number";
+
+export const encodeEntitiesWindowCursor = (
+  values: EntitiesWindowCursorValues,
+): string =>
   Buffer.from(
     JSON.stringify({
       v: ENTITIES_WINDOW_CURSOR_VERSION,
-      offset,
+      values,
     }),
-  ).toString("base64");
+  ).toString("base64url");
 
 export const decodeEntitiesWindowCursor = (
   cursor: string | undefined,
-): Result<number, HandlerError> => {
+): Result<EntitiesWindowCursorValues | null, HandlerError> => {
   if (cursor === undefined) {
-    return Result.ok(0);
+    return Result.ok(null);
   }
 
   let parsed: unknown;
   try {
-    parsed = JSON.parse(Buffer.from(cursor, "base64").toString());
+    parsed = JSON.parse(Buffer.from(cursor, "base64url").toString());
   } catch {
     return Result.err(invalidCursor());
   }
@@ -37,14 +45,13 @@ export const decodeEntitiesWindowCursor = (
     return Result.err(invalidCursor());
   }
 
-  if (!("offset" in parsed)) {
+  if (!("values" in parsed) || !Array.isArray(parsed.values)) {
     return Result.err(invalidCursor());
   }
 
-  const { offset } = parsed;
-  if (typeof offset !== "number" || !Number.isInteger(offset) || offset < 0) {
+  if (!parsed.values.every(isCursorValue)) {
     return Result.err(invalidCursor());
   }
 
-  return Result.ok(offset);
+  return Result.ok(parsed.values);
 };

--- a/apps/api/src/handlers/views/table-export.ts
+++ b/apps/api/src/handlers/views/table-export.ts
@@ -516,7 +516,6 @@ const exportTableView = createSafeHandler(
         currentOrganizationId: session.activeOrganizationId,
         filters: layout.filters,
         sorts: layout.sorts,
-        offset: 0,
         limit: LIMITS.exportRowLimit,
         fieldMode: "visible",
         fieldIds,

--- a/apps/api/src/lib/entity-filters.test.ts
+++ b/apps/api/src/lib/entity-filters.test.ts
@@ -392,7 +392,7 @@ describe("applySorts (in-memory)", () => {
 });
 
 describe("buildSortExpressions", () => {
-  test("_name sort uses the displayed entity name fallback chain", () => {
+  test("_name sort uses the materialized display name", () => {
     const [nameSort] = buildSortExpressions([
       { propertyId: "_name", desc: false },
     ]);
@@ -403,11 +403,7 @@ describe("buildSortExpressions", () => {
     const dialect = new PgDialect();
     const sql = dialect.sqlToQuery(nameSort).sql;
 
-    expect(sql).toContain('NULLIF("entities"."name", \'\')');
-    expect(sql).toContain("NULLIF(\"fields\".\"content\"->>'fileName', '')");
-    expect(sql).toContain('"fields"."content"->>\'value\'');
-    expect(sql).toContain('ORDER BY "fields"."property_id" ASC');
-    expect(sql.indexOf("fileName")).toBeLessThan(sql.indexOf("value"));
+    expect(sql).toBe('"entities"."display_name" ASC');
   });
 
   test("metadata table sorts use entity columns, not property field subqueries", () => {

--- a/apps/api/src/lib/entity-filters.ts
+++ b/apps/api/src/lib/entity-filters.ts
@@ -291,33 +291,7 @@ const internalSortExpr = (
   const dir = (col: SQL) => (direction ? sql`${col} DESC` : sql`${col} ASC`);
   switch (propertyId) {
     case "_name": {
-      const displayedNameExpr = sql`COALESCE(
-        NULLIF(${entities.name}, ''),
-        (
-          SELECT NULLIF(${fields.content}->>'fileName', '')
-          FROM ${fields}
-          WHERE ${fields.workspaceId} = ${entities.workspaceId}
-            AND ${fields.entityVersionId} = ${entities.currentVersionId}
-            AND ${fields.content}->>'type' = 'file'
-          ORDER BY ${fields.propertyId} ASC
-          LIMIT 1
-        ),
-        (
-          SELECT NULLIF(BTRIM(${fields.content}->>'value'), '')
-          FROM ${fields}
-          WHERE ${fields.workspaceId} = ${entities.workspaceId}
-            AND ${fields.entityVersionId} = ${entities.currentVersionId}
-            AND ${fields.content}->>'type' = 'text'
-          ORDER BY ${fields.propertyId} ASC
-          LIMIT 1
-        ),
-        CASE
-          WHEN ${entities.kind} = 'folder' THEN 'Untitled Folder'
-          WHEN ${entities.kind} = 'task' THEN 'Untitled Task'
-          ELSE 'Untitled'
-        END
-      )`;
-      return dir(displayedNameExpr);
+      return dir(sql`${entities.displayName}`);
     }
     case "_created-by": {
       const sub = sql`(

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -6,6 +6,7 @@ export const LIMITS = {
   entitiesPageSizeMax: 500,
   entitiesWindowSizeDefault: 200,
   entitiesWindowSizeMax: 500,
+  workflowEntityBatchSize: 500,
   calendarTasksMax: 200,
   entitySummariesPageSize: 200,
   viewsCount: 20,

--- a/apps/api/src/lib/workflow-queue.test.ts
+++ b/apps/api/src/lib/workflow-queue.test.ts
@@ -38,4 +38,22 @@ describe("workflow entity targeting", () => {
       }),
     ).toEqual([documentA, task, documentB, link]);
   });
+
+  test("deduplicates explicit targets before workflow jobs are counted", () => {
+    expect(
+      resolveWorkflowTargetEntityIds({
+        entityRows,
+        inputEntityIds: [
+          documentA,
+          task,
+          documentA,
+          folder,
+          documentB,
+          task,
+          link,
+        ],
+        inputOrder: [task, task, documentB],
+      }),
+    ).toEqual([task, documentB, documentA, link]);
+  });
 });

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1,20 +1,21 @@
-import { matchError, Result } from "better-result";
+import { matchError, panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
 import { sleep } from "bun";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, count, eq, gt, inArray, or, sql } from "drizzle-orm";
 import Redis from "ioredis";
 
 import { isMockAI } from "@/api/consts";
 import type { ScopedDb } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
 import { entities, fields, justifications, properties } from "@/api/db/schema";
-import type { FieldContent } from "@/api/db/schema-validators";
+import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import { env } from "@/api/env";
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
 import { errorTag } from "@/api/lib/errors/utils";
+import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
@@ -174,6 +175,225 @@ type StartWorkflowResult = {
   status: "started" | "already-running" | "skipped" | "failed";
 };
 
+type WorkflowTargetEntityRow = {
+  id: SafeId<"entity">;
+  kind: EntityKind;
+};
+
+type FullWorkflowTargetCursor = {
+  createdAt: string;
+  id: SafeId<"entity">;
+};
+
+type EnqueueEntityJobsArgs = {
+  entityIds: readonly SafeId<"entity">[];
+  executionPlan: ExecutionLevel[];
+  organizationId: SafeId<"organization">;
+  q: Queue;
+  requestId: string;
+  userId: SafeId<"user">;
+  workspaceId: SafeId<"workspace">;
+};
+
+const chunkItems = <T>(items: readonly T[], size: number): T[][] => {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const enqueueEntityJobs = async ({
+  entityIds,
+  executionPlan,
+  organizationId,
+  q,
+  requestId,
+  userId,
+  workspaceId,
+}: EnqueueEntityJobsArgs): Promise<void> => {
+  if (entityIds.length === 0) {
+    return;
+  }
+
+  await q.addBulk(
+    entityIds.map((entityId) => ({
+      name: "process-entity",
+      data: {
+        workspaceId,
+        organizationId,
+        userId,
+        entityId,
+        executionPlan,
+        requestId,
+      } satisfies EntityJobData,
+    })),
+  );
+};
+
+const fetchExplicitWorkflowTargetRows = async ({
+  inputEntityIds,
+  scopedDb,
+  workspaceId,
+}: {
+  inputEntityIds: readonly SafeId<"entity">[];
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<WorkflowTargetEntityRow[]> => {
+  const entityRows: WorkflowTargetEntityRow[] = [];
+  for (const chunk of chunkItems(
+    inputEntityIds,
+    LIMITS.workflowEntityBatchSize,
+  )) {
+    const rows = await scopedDb((tx) =>
+      tx
+        .select({ id: entities.id, kind: entities.kind })
+        .from(entities)
+        .where(
+          and(
+            eq(entities.workspaceId, workspaceId),
+            inArray(entities.id, chunk),
+          ),
+        ),
+    );
+    for (const row of rows) {
+      entityRows.push(row);
+    }
+  }
+
+  return entityRows;
+};
+
+const WORKFLOW_TIMESTAMP_CURSOR_FORMAT = 'YYYY-MM-DD"T"HH24:MI:SS.US';
+
+const readFullWorkflowSnapshotCursor = async ({
+  scopedDb,
+}: {
+  scopedDb: ScopedDb;
+}): Promise<string> => {
+  const rows = await scopedDb((tx) =>
+    tx.execute<{ value: string }>(
+      sql`SELECT to_char(now(), ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT}) AS value`,
+    ),
+  );
+  const row = rows.at(0);
+  if (!row) {
+    return panic("Workflow snapshot cursor query returned no rows");
+  }
+
+  return row.value;
+};
+
+const countFullWorkflowTargets = async ({
+  createdAtCutoff,
+  scopedDb,
+  workspaceId,
+}: {
+  createdAtCutoff: string;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<number> => {
+  const rows = await scopedDb((tx) =>
+    tx
+      .select({ total: count() })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.workspaceId, workspaceId),
+          eq(entities.kind, "document"),
+          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
+        ),
+      ),
+  );
+
+  return rows.at(0)?.total ?? 0;
+};
+
+const fetchFullWorkflowTargetBatch = async ({
+  createdAtCutoff,
+  lastCursor,
+  scopedDb,
+  workspaceId,
+}: {
+  createdAtCutoff: string;
+  lastCursor: FullWorkflowTargetCursor | null;
+  scopedDb: ScopedDb;
+  workspaceId: SafeId<"workspace">;
+}): Promise<FullWorkflowTargetCursor[]> =>
+  await scopedDb((tx) =>
+    tx
+      .select({
+        createdAt: sql<string>`to_char(${entities.createdAt}, ${WORKFLOW_TIMESTAMP_CURSOR_FORMAT})`,
+        id: entities.id,
+      })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.workspaceId, workspaceId),
+          eq(entities.kind, "document"),
+          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
+          ...(lastCursor === null
+            ? []
+            : [
+                or(
+                  sql`${entities.createdAt} > ${lastCursor.createdAt}::timestamp`,
+                  and(
+                    sql`${entities.createdAt} = ${lastCursor.createdAt}::timestamp`,
+                    gt(entities.id, lastCursor.id),
+                  ),
+                ),
+              ]),
+        ),
+      )
+      .orderBy(asc(entities.createdAt), asc(entities.id))
+      .limit(LIMITS.workflowEntityBatchSize),
+  );
+
+const enqueueFullWorkflowTargets = async ({
+  createdAtCutoff,
+  executionPlan,
+  organizationId,
+  q,
+  requestId,
+  scopedDb,
+  userId,
+  workspaceId,
+}: Omit<EnqueueEntityJobsArgs, "entityIds"> & {
+  createdAtCutoff: string;
+  scopedDb: ScopedDb;
+}): Promise<void> => {
+  let lastCursor: FullWorkflowTargetCursor | null = null;
+
+  while (true) {
+    const rows = await fetchFullWorkflowTargetBatch({
+      createdAtCutoff,
+      lastCursor,
+      scopedDb,
+      workspaceId,
+    });
+
+    if (rows.length === 0) {
+      return;
+    }
+
+    await enqueueEntityJobs({
+      entityIds: rows.map((row) => row.id),
+      executionPlan,
+      organizationId,
+      q,
+      requestId,
+      userId,
+      workspaceId,
+    });
+
+    const lastRow = rows.at(-1);
+    if (!lastRow) {
+      return;
+    }
+    lastCursor = lastRow;
+  }
+};
+
 /**
  * Start a workflow: build execution plan, enqueue entity jobs.
  */
@@ -234,22 +454,33 @@ export const startWorkflow = async ({
       return { status: "skipped" };
     }
 
-    // Full workspace sweeps stay document-only, while explicit edit-triggered
-    // runs can target any non-folder entity that has editable fields.
-    const entityRows = await scopedDb((tx) =>
-      tx
-        .select({ id: entities.id, kind: entities.kind })
-        .from(entities)
-        .where(eq(entities.workspaceId, workspaceId)),
-    );
+    const isExplicitRun =
+      inputEntityIds !== undefined && inputEntityIds.length > 0;
+    const fullWorkflowCreatedAtCutoff = isExplicitRun
+      ? null
+      : await readFullWorkflowSnapshotCursor({ scopedDb });
+    const explicitEntityIds = isExplicitRun
+      ? resolveWorkflowTargetEntityIds({
+          entityRows: await fetchExplicitWorkflowTargetRows({
+            inputEntityIds,
+            scopedDb,
+            workspaceId,
+          }),
+          inputEntityIds,
+          inputOrder,
+        })
+      : [];
+    const targetCount = isExplicitRun
+      ? explicitEntityIds.length
+      : await countFullWorkflowTargets({
+          createdAtCutoff:
+            fullWorkflowCreatedAtCutoff ??
+            panic("Full workflow target count requires a snapshot cursor"),
+          scopedDb,
+          workspaceId,
+        });
 
-    const orderedEntityIds = resolveWorkflowTargetEntityIds({
-      entityRows,
-      inputEntityIds,
-      inputOrder,
-    });
-
-    if (orderedEntityIds.length === 0) {
+    if (targetCount === 0) {
       await redis.del(workflowKey(workspaceId, "running"));
       return { status: "skipped" };
     }
@@ -257,10 +488,7 @@ export const startWorkflow = async ({
     const requestId = Bun.randomUUIDv7();
 
     // Store entity count for completion tracking
-    await redis.set(
-      workflowKey(workspaceId, "total"),
-      String(orderedEntityIds.length),
-    );
+    await redis.set(workflowKey(workspaceId, "total"), String(targetCount));
     await redis.set(workflowKey(workspaceId, "completed"), "0");
 
     // Snapshot the property IDs in this workflow's plan so finishWorkflow
@@ -280,21 +508,36 @@ export const startWorkflow = async ({
     // Broadcast running status
     broadcastWorkflowStatus(workspaceId, true);
 
-    // Enqueue one job per entity
     const q = getQueue();
-    await q.addBulk(
-      orderedEntityIds.map((entityId) => ({
-        name: "process-entity",
-        data: {
-          workspaceId,
-          organizationId,
-          userId,
-          entityId,
+    if (isExplicitRun) {
+      for (const chunk of chunkItems(
+        explicitEntityIds,
+        LIMITS.workflowEntityBatchSize,
+      )) {
+        await enqueueEntityJobs({
+          entityIds: chunk,
           executionPlan,
+          organizationId,
+          q,
           requestId,
-        } satisfies EntityJobData,
-      })),
-    );
+          userId,
+          workspaceId,
+        });
+      }
+    } else {
+      await enqueueFullWorkflowTargets({
+        createdAtCutoff:
+          fullWorkflowCreatedAtCutoff ??
+          panic("Full workflow target enqueue requires a snapshot cursor"),
+        executionPlan,
+        organizationId,
+        q,
+        requestId,
+        scopedDb,
+        userId,
+        workspaceId,
+      });
+    }
 
     return { status: "started" };
   } catch (error: unknown) {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1,7 +1,7 @@
 import { matchError, panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
 import { sleep } from "bun";
-import { and, asc, count, eq, gt, inArray, or, sql } from "drizzle-orm";
+import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
 import Redis from "ioredis";
 
 import { isMockAI } from "@/api/consts";
@@ -284,31 +284,6 @@ const readFullWorkflowSnapshotCursor = async ({
   return row.value;
 };
 
-const countFullWorkflowTargets = async ({
-  createdAtCutoff,
-  scopedDb,
-  workspaceId,
-}: {
-  createdAtCutoff: string;
-  scopedDb: ScopedDb;
-  workspaceId: SafeId<"workspace">;
-}): Promise<number> => {
-  const rows = await scopedDb((tx) =>
-    tx
-      .select({ total: count() })
-      .from(entities)
-      .where(
-        and(
-          eq(entities.workspaceId, workspaceId),
-          eq(entities.kind, "document"),
-          sql`${entities.createdAt} <= ${createdAtCutoff}::timestamp`,
-        ),
-      ),
-  );
-
-  return rows.at(0)?.total ?? 0;
-};
-
 const fetchFullWorkflowTargetBatch = async ({
   createdAtCutoff,
   lastCursor,
@@ -349,19 +324,16 @@ const fetchFullWorkflowTargetBatch = async ({
       .limit(LIMITS.workflowEntityBatchSize),
   );
 
-const enqueueFullWorkflowTargets = async ({
+const collectFullWorkflowTargetIds = async ({
   createdAtCutoff,
-  executionPlan,
-  organizationId,
-  q,
-  requestId,
   scopedDb,
-  userId,
   workspaceId,
-}: Omit<EnqueueEntityJobsArgs, "entityIds"> & {
+}: {
   createdAtCutoff: string;
   scopedDb: ScopedDb;
-}): Promise<void> => {
+  workspaceId: SafeId<"workspace">;
+}): Promise<SafeId<"entity">[]> => {
+  const entityIds: SafeId<"entity">[] = [];
   let lastCursor: FullWorkflowTargetCursor | null = null;
 
   while (true) {
@@ -373,22 +345,16 @@ const enqueueFullWorkflowTargets = async ({
     });
 
     if (rows.length === 0) {
-      return;
+      return entityIds;
     }
 
-    await enqueueEntityJobs({
-      entityIds: rows.map((row) => row.id),
-      executionPlan,
-      organizationId,
-      q,
-      requestId,
-      userId,
-      workspaceId,
-    });
+    for (const row of rows) {
+      entityIds.push(row.id);
+    }
 
     const lastRow = rows.at(-1);
     if (!lastRow) {
-      return;
+      return entityIds;
     }
     lastCursor = lastRow;
   }
@@ -470,15 +436,19 @@ export const startWorkflow = async ({
           inputOrder,
         })
       : [];
-    const targetCount = isExplicitRun
-      ? explicitEntityIds.length
-      : await countFullWorkflowTargets({
+    const fullWorkflowEntityIds = isExplicitRun
+      ? []
+      : await collectFullWorkflowTargetIds({
           createdAtCutoff:
             fullWorkflowCreatedAtCutoff ??
-            panic("Full workflow target count requires a snapshot cursor"),
+            panic("Full workflow target collection requires a snapshot cursor"),
           scopedDb,
           workspaceId,
         });
+    const targetEntityIds = isExplicitRun
+      ? explicitEntityIds
+      : fullWorkflowEntityIds;
+    const targetCount = targetEntityIds.length;
 
     if (targetCount === 0) {
       await redis.del(workflowKey(workspaceId, "running"));
@@ -509,31 +479,16 @@ export const startWorkflow = async ({
     broadcastWorkflowStatus(workspaceId, true);
 
     const q = getQueue();
-    if (isExplicitRun) {
-      for (const chunk of chunkItems(
-        explicitEntityIds,
-        LIMITS.workflowEntityBatchSize,
-      )) {
-        await enqueueEntityJobs({
-          entityIds: chunk,
-          executionPlan,
-          organizationId,
-          q,
-          requestId,
-          userId,
-          workspaceId,
-        });
-      }
-    } else {
-      await enqueueFullWorkflowTargets({
-        createdAtCutoff:
-          fullWorkflowCreatedAtCutoff ??
-          panic("Full workflow target enqueue requires a snapshot cursor"),
+    for (const chunk of chunkItems(
+      targetEntityIds,
+      LIMITS.workflowEntityBatchSize,
+    )) {
+      await enqueueEntityJobs({
+        entityIds: chunk,
         executionPlan,
         organizationId,
         q,
         requestId,
-        scopedDb,
         userId,
         workspaceId,
       });

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -46,6 +46,14 @@ const WORKFLOW_KEY_PREFIX = "workflow";
 const workflowKey = (workspaceId: SafeId<"workspace">, field: string) =>
   `${WORKFLOW_KEY_PREFIX}:${workspaceId}:${field}`;
 
+const WORKFLOW_RUN_STATE_FIELDS = [
+  "running",
+  "total",
+  "completed",
+  "plan-properties",
+  "request-id",
+] as const;
+
 const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
 const EXTRACTION_PREVIEW_THROTTLE_MS = 500;
 
@@ -101,6 +109,26 @@ const getQueue = (): Queue => {
   });
   return queue;
 };
+
+const clearWorkflowRunState = async (
+  redis: Redis,
+  workspaceId: SafeId<"workspace">,
+): Promise<void> => {
+  await redis.del(
+    ...WORKFLOW_RUN_STATE_FIELDS.map((field) =>
+      workflowKey(workspaceId, field),
+    ),
+  );
+};
+
+const isCurrentWorkflowRequest = async ({
+  requestId,
+  workspaceId,
+}: {
+  requestId: string;
+  workspaceId: SafeId<"workspace">;
+}): Promise<boolean> =>
+  (await getRedis().get(workflowKey(workspaceId, "request-id"))) === requestId;
 
 // Self-heal levers. Tuned conservatively so the happy path is never
 // disrupted, but a stuck job/worker can't block the workspace.
@@ -188,6 +216,7 @@ type FullWorkflowTargetCursor = {
 type EnqueueEntityJobsArgs = {
   entityIds: readonly SafeId<"entity">[];
   executionPlan: ExecutionLevel[];
+  jobIds: readonly string[];
   organizationId: SafeId<"organization">;
   q: Queue;
   requestId: string;
@@ -203,9 +232,18 @@ const chunkItems = <T>(items: readonly T[], size: number): T[][] => {
   return chunks;
 };
 
+const workflowEntityJobId = ({
+  entityId,
+  requestId,
+}: {
+  entityId: SafeId<"entity">;
+  requestId: string;
+}): string => `workflow-${requestId}-${entityId}`;
+
 const enqueueEntityJobs = async ({
   entityIds,
   executionPlan,
+  jobIds,
   organizationId,
   q,
   requestId,
@@ -215,20 +253,44 @@ const enqueueEntityJobs = async ({
   if (entityIds.length === 0) {
     return;
   }
+  if (entityIds.length !== jobIds.length) {
+    return panic("Workflow job IDs must match entity IDs");
+  }
 
   await q.addBulk(
-    entityIds.map((entityId) => ({
-      name: "process-entity",
-      data: {
-        workspaceId,
-        organizationId,
-        userId,
-        entityId,
-        executionPlan,
-        requestId,
-      } satisfies EntityJobData,
-    })),
+    entityIds.map((entityId, index) => {
+      const jobId = jobIds.at(index) ?? panic("Missing workflow job ID");
+      return {
+        name: "process-entity",
+        data: {
+          workspaceId,
+          organizationId,
+          userId,
+          entityId,
+          executionPlan,
+          requestId,
+        } satisfies EntityJobData,
+        opts: { jobId },
+      };
+    }),
   );
+};
+
+const removeQueuedWorkflowJobs = async (
+  q: Queue,
+  jobIds: readonly string[],
+): Promise<void> => {
+  for (const chunk of chunkItems(jobIds, LIMITS.workflowEntityBatchSize)) {
+    await Promise.all(
+      chunk.map(async (jobId) => {
+        try {
+          await q.remove(jobId);
+        } catch (error: unknown) {
+          captureError(error, { workflowJobId: jobId });
+        }
+      }),
+    );
+  }
 };
 
 const fetchExplicitWorkflowTargetRows = async ({
@@ -416,7 +478,7 @@ export const startWorkflow = async ({
     );
 
     if (!hasWork) {
-      await redis.del(workflowKey(workspaceId, "running"));
+      await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
 
@@ -451,13 +513,19 @@ export const startWorkflow = async ({
     const targetCount = targetEntityIds.length;
 
     if (targetCount === 0) {
-      await redis.del(workflowKey(workspaceId, "running"));
+      await clearWorkflowRunState(redis, workspaceId);
       return { status: "skipped" };
     }
 
     const requestId = Bun.randomUUIDv7();
 
     // Store entity count for completion tracking
+    await redis.set(
+      workflowKey(workspaceId, "request-id"),
+      requestId,
+      "EX",
+      RUNNING_LOCK_TTL_SEC,
+    );
     await redis.set(workflowKey(workspaceId, "total"), String(targetCount));
     await redis.set(workflowKey(workspaceId, "completed"), "0");
 
@@ -479,24 +547,35 @@ export const startWorkflow = async ({
     broadcastWorkflowStatus(workspaceId, true);
 
     const q = getQueue();
-    for (const chunk of chunkItems(
-      targetEntityIds,
-      LIMITS.workflowEntityBatchSize,
-    )) {
-      await enqueueEntityJobs({
-        entityIds: chunk,
-        executionPlan,
-        organizationId,
-        q,
-        requestId,
-        userId,
-        workspaceId,
-      });
+    const queuedJobIds: string[] = [];
+    try {
+      for (const chunk of chunkItems(
+        targetEntityIds,
+        LIMITS.workflowEntityBatchSize,
+      )) {
+        const chunkJobIds = chunk.map((entityId) =>
+          workflowEntityJobId({ entityId, requestId }),
+        );
+        queuedJobIds.push(...chunkJobIds);
+        await enqueueEntityJobs({
+          entityIds: chunk,
+          executionPlan,
+          jobIds: chunkJobIds,
+          organizationId,
+          q,
+          requestId,
+          userId,
+          workspaceId,
+        });
+      }
+    } catch (error: unknown) {
+      await removeQueuedWorkflowJobs(q, queuedJobIds);
+      throw error;
     }
 
     return { status: "started" };
   } catch (error: unknown) {
-    await redis.del(workflowKey(workspaceId, "running"));
+    await clearWorkflowRunState(redis, workspaceId);
     broadcastWorkflowStatus(workspaceId, false);
     captureError(error, { workspaceId });
     return { status: "failed" };
@@ -592,6 +671,14 @@ export const initWorkflowWorker = () => {
       workspaceId: data.workspaceId,
     });
     void (async () => {
+      const isCurrentRequest = await isCurrentWorkflowRequest({
+        requestId: data.requestId,
+        workspaceId: branded.workspaceId,
+      });
+      if (!isCurrentRequest) {
+        return;
+      }
+
       await markPendingPlannedFieldsErrored(data).catch(
         (pendingFieldsError: unknown) => {
           captureError(pendingFieldsError, {
@@ -604,6 +691,7 @@ export const initWorkflowWorker = () => {
         branded.workspaceId,
         branded.organizationId,
         brandPersistedUserId(data.userId),
+        data.requestId,
       );
     })().catch((completionError: unknown) => {
       captureError(completionError, {
@@ -705,6 +793,14 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
   const userId = brandPersistedUserId(rawUserId);
   const brandedEntityId = brandPersistedEntityId(entityId);
 
+  const isCurrentRequest = await isCurrentWorkflowRequest({
+    requestId,
+    workspaceId: branded.workspaceId,
+  });
+  if (!isCurrentRequest) {
+    return;
+  }
+
   const scopedDb = createRootScopedDb({
     organizationId: branded.organizationId,
     userId,
@@ -712,6 +808,14 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
   });
 
   for (let level = 0; level < executionPlan.length; level++) {
+    const isStillCurrentRequest = await isCurrentWorkflowRequest({
+      requestId,
+      workspaceId: branded.workspaceId,
+    });
+    if (!isStillCurrentRequest) {
+      return;
+    }
+
     // Honour the worker-level timeout. Throwing here ensures we don't
     // start a new batch (or call onEntityCompleted) after the abort.
     signal.throwIfAborted();
@@ -748,7 +852,12 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
   // Broadcast entity invalidation so frontend refetches
   broadcastInvalidation(branded.workspaceId, ["entities", branded.workspaceId]);
 
-  await onEntityCompleted(branded.workspaceId, branded.organizationId, userId);
+  await onEntityCompleted(
+    branded.workspaceId,
+    branded.organizationId,
+    userId,
+    requestId,
+  );
 };
 
 type ProcessOneBatchArgs = {
@@ -846,6 +955,14 @@ const processOneBatch = async ({
   signal,
 }: ProcessOneBatchArgs) => {
   signal.throwIfAborted();
+  const isCurrentRequest = await isCurrentWorkflowRequest({
+    requestId,
+    workspaceId,
+  });
+  if (!isCurrentRequest) {
+    return;
+  }
+
   const entityRow = await scopedDb((tx) =>
     tx.query.entities.findFirst({
       columns: { currentVersionId: true },
@@ -968,6 +1085,14 @@ const processOneBatch = async ({
         requestId,
       });
 
+      const isStillCurrentRequest = await isCurrentWorkflowRequest({
+        requestId,
+        workspaceId,
+      });
+      if (!isStillCurrentRequest) {
+        return;
+      }
+
       await setFieldsStatus({
         workspaceId,
         entityVersionId,
@@ -979,6 +1104,13 @@ const processOneBatch = async ({
     }
 
     const processedFields = batchResult.value;
+    const isStillCurrentRequest = await isCurrentWorkflowRequest({
+      requestId,
+      workspaceId,
+    });
+    if (!isStillCurrentRequest) {
+      return;
+    }
 
     // Write AI results to DB
     const allPropertyIds = [
@@ -1048,14 +1180,23 @@ const onEntityCompleted = async (
   workspaceId: SafeId<"workspace">,
   organizationId: SafeId<"organization">,
   userId: SafeId<"user">,
+  requestId: string,
 ) => {
+  const isCurrentRequest = await isCurrentWorkflowRequest({
+    requestId,
+    workspaceId,
+  });
+  if (!isCurrentRequest) {
+    return;
+  }
+
   const redis = getRedis();
   const completed = await redis.incr(workflowKey(workspaceId, "completed"));
   const totalStr = await redis.get(workflowKey(workspaceId, "total"));
   const total = Number(totalStr ?? "0");
 
   if (completed >= total) {
-    await finishWorkflow(workspaceId, organizationId, userId);
+    await finishWorkflow(workspaceId, organizationId, userId, requestId);
     return;
   }
 
@@ -1070,6 +1211,7 @@ const onEntityCompleted = async (
       workflowKey(workspaceId, "plan-properties"),
       RUNNING_LOCK_TTL_SEC,
     ),
+    redis.expire(workflowKey(workspaceId, "request-id"), RUNNING_LOCK_TTL_SEC),
   ]);
 };
 
@@ -1077,7 +1219,16 @@ const finishWorkflow = async (
   workspaceId: SafeId<"workspace">,
   organizationId: SafeId<"organization">,
   userId: SafeId<"user">,
+  requestId: string,
 ) => {
+  const isCurrentRequest = await isCurrentWorkflowRequest({
+    requestId,
+    workspaceId,
+  });
+  if (!isCurrentRequest) {
+    return;
+  }
+
   const redis = getRedis();
   const scopedDb = createRootScopedDb({
     organizationId,
@@ -1129,12 +1280,7 @@ const finishWorkflow = async (
   }
 
   // Clean up Redis state
-  await redis.del(
-    workflowKey(workspaceId, "running"),
-    workflowKey(workspaceId, "total"),
-    workflowKey(workspaceId, "completed"),
-    workflowKey(workspaceId, "plan-properties"),
-  );
+  await clearWorkflowRunState(redis, workspaceId);
 
   // Broadcast completion
   broadcastWorkflowStatus(workspaceId, false);

--- a/apps/api/src/lib/workflow-targets.ts
+++ b/apps/api/src/lib/workflow-targets.ts
@@ -15,6 +15,19 @@ type ResolveWorkflowTargetEntityIdsArgs = {
 const isExplicitWorkflowTarget = ({ kind }: WorkflowTargetEntityRow) =>
   kind !== "folder";
 
+const dedupeEntityIds = (ids: readonly SafeId<"entity">[]) => {
+  const seen = new Set<SafeId<"entity">>();
+  const uniqueIds: SafeId<"entity">[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    uniqueIds.push(id);
+  }
+  return uniqueIds;
+};
+
 export const resolveWorkflowTargetEntityIds = ({
   entityRows,
   inputEntityIds,
@@ -33,11 +46,17 @@ export const resolveWorkflowTargetEntityIds = ({
 
   const targetIds =
     inputEntityIds && inputEntityIds.length > 0
-      ? inputEntityIds.filter((id) => entityIdsByKind.explicitTargets.has(id))
+      ? dedupeEntityIds(
+          inputEntityIds.filter((id) =>
+            entityIdsByKind.explicitTargets.has(id),
+          ),
+        )
       : [...entityIdsByKind.documents];
 
   const targetSet = new Set(targetIds);
-  const prioritized = (inputOrder ?? []).filter((id) => targetSet.has(id));
+  const prioritized = dedupeEntityIds(inputOrder ?? []).filter((id) =>
+    targetSet.has(id),
+  );
   const prioritizedSet = new Set(prioritized);
   const remaining = targetIds.filter((id) => !prioritizedSet.has(id));
   return [...prioritized, ...remaining];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.route.tsx
@@ -17,23 +17,17 @@ import {
 } from "@/lib/react-query";
 import { optionalSearchStringSchema } from "@/lib/schema";
 import type { WorkspaceView } from "@/lib/types";
-import { EntityPagination } from "@/routes/_protected.workspaces/$workspaceId/-components/entity-pagination";
 import { ViewSwitcher } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher";
 import { ViewToolbar } from "@/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar";
-import { chunkJustificationEntityIds } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
-import { useSyncTable } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-table";
 import {
   DEFAULT_ENTITY_WINDOW_SIZE,
-  entitiesOptions,
   entitiesWindowOptions,
   filesystemEntitiesOptions,
-  useEntitiesOptions,
   visibleEntityFieldIds,
 } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { propertiesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
 import { timeEntriesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/time-entries";
 import { viewsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
-import { justificationsOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 import { workspaceMembersOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace-members";
 import {
   getWeekStart,
@@ -53,7 +47,6 @@ export const Route = createFileRoute(
 )({
   component: RouteComponent,
   validateSearch: searchSchema,
-  loaderDeps: ({ search }) => ({ page: search.page ?? 1 }),
   beforeLoad: ({ params }) => {
     // Reject obviously invalid viewIds (e.g. "workspaces" from stale doubled
     // URLs). Allow UUIDs and the special "all" slug used by the PDF viewer.
@@ -74,7 +67,7 @@ export const Route = createFileRoute(
       });
     }
   },
-  loader: async ({ context, deps, params }) => {
+  loader: async ({ context, params }) => {
     const { workspaceId, viewId } = params;
     const { queryClient } = context;
 
@@ -195,42 +188,13 @@ export const Route = createFileRoute(
       return;
     }
 
-    const entities = await ensureCriticalQueryData(
-      queryClient,
-      entitiesOptions({
-        workspaceId,
-        filters: activeView.layout.filters,
-        sorts: activeView.layout.sorts,
-        page: deps.page,
-        fieldMode,
-        fieldIds,
-      }),
-    );
-
-    if (entities.entities.length === 0) {
-      return;
-    }
-
-    for (const entityIds of chunkJustificationEntityIds(
-      entities.entities.map((entity) => entity.entityId),
-    )) {
-      void prefetchNonCriticalQuery(
-        queryClient,
-        justificationsOptions({ workspaceId, entityIds }),
-        (error: unknown) => {
-          getAnalytics().captureError(error);
-        },
-      );
-    }
+    return;
   },
 });
 
 function RouteComponent() {
   const { workspaceId, viewId } = Route.useParams({
     select: (p) => ({ workspaceId: p.workspaceId, viewId: p.viewId }),
-  });
-  const page = Route.useSearch({
-    select: (s) => s.page ?? 1,
   });
   const viewsQueryOptions = viewsOptions(workspaceId);
   const { data: activeView } = useSuspenseQuery({
@@ -249,21 +213,13 @@ function RouteComponent() {
   }
 
   return (
-    <EntityViewContent
-      activeView={activeView}
-      page={page}
-      workspaceId={workspaceId}
-    />
+    <EntityViewContent activeView={activeView} workspaceId={workspaceId} />
   );
 }
 
 type ViewContentProps = {
   activeView: WorkspaceView;
   workspaceId: string;
-};
-
-type EntityViewContentProps = ViewContentProps & {
-  page: number;
 };
 
 type VisibleFieldsView = WorkspaceView & {
@@ -274,11 +230,7 @@ function OverviewViewContent({ activeView, workspaceId }: ViewContentProps) {
   return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
 }
 
-function EntityViewContent({
-  activeView,
-  page,
-  workspaceId,
-}: EntityViewContentProps) {
+function EntityViewContent({ activeView, workspaceId }: ViewContentProps) {
   if (hasVisibleFieldsLayout(activeView)) {
     return (
       <VisibleFieldEntityViewContent
@@ -300,13 +252,7 @@ function EntityViewContent({
     return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
   }
 
-  return (
-    <FullEntityViewContent
-      activeView={activeView}
-      page={page}
-      workspaceId={workspaceId}
-    />
-  );
+  return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
 }
 
 const hasVisibleFieldsLayout = (
@@ -320,65 +266,13 @@ function VisibleFieldEntityViewContent({
   return <ViewShell activeView={activeView} workspaceId={workspaceId} />;
 }
 
-function FullEntityViewContent({
-  activeView,
-  page,
-  workspaceId,
-}: EntityViewContentProps) {
-  useSyncTable({
-    workspaceId,
-    filters: activeView.layout.filters,
-    sorts: activeView.layout.sorts,
-    page,
-  });
-
-  const { data } = useSuspenseQuery(
-    useEntitiesOptions({
-      workspaceId,
-      filters: activeView.layout.filters,
-      sorts: activeView.layout.sorts,
-      page,
-    }),
-  );
-  const totalPages = Math.ceil(data.totalCount / data.pageSize);
-
-  return (
-    <ViewShell
-      activeView={activeView}
-      page={page}
-      totalPages={totalPages}
-      workspaceId={workspaceId}
-    />
-  );
-}
-
-type ViewShellProps = ViewContentProps & {
-  page?: number;
-  totalPages?: number;
-};
-
-function ViewShell({
-  activeView,
-  page,
-  totalPages,
-  workspaceId,
-}: ViewShellProps) {
+function ViewShell({ activeView, workspaceId }: ViewContentProps) {
   const navigate = Route.useNavigate();
   const matches = useMatches();
   const isOnPdfRoute = matches.some((m) => m.fullPath.endsWith("/document"));
 
-  const setPage = (newPage: number) => {
-    // eslint-disable-next-line typescript/no-floating-promises
-    navigate({
-      search: (prev) => ({
-        ...prev,
-        page: newPage === 1 ? undefined : newPage,
-      }),
-    });
-  };
-
-  // File detail view: hide ViewSwitcher + pagination; breadcrumbs
-  // provide navigation back to the matter.
+  // File detail view: hide the view chrome; breadcrumbs provide navigation
+  // back to the matter.
   if (isOnPdfRoute) {
     return <Outlet />;
   }
@@ -410,13 +304,6 @@ function ViewShell({
         <div className="flex-1 overflow-auto">
           <Outlet />
         </div>
-        {page !== undefined && totalPages !== undefined && totalPages > 1 && (
-          <EntityPagination
-            onPageChange={setPage}
-            page={page}
-            totalPages={totalPages}
-          />
-        )}
       </div>
     </>
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-toolbar.tsx
@@ -417,11 +417,10 @@ const FilesystemOrganizerAction = ({
   const [open, setOpen] = useState(false);
   const selectedIds = useWorkspaceStore((state) => state.filesystemSelectedIds);
 
-  // Folders and files are both fetched unpaginated and independent of
-  // the FilesystemView's current page so the organizer always operates
-  // on the whole matter. useQuery (not useSuspenseQuery) keeps a cache
-  // miss from suspending the toolbar chrome — the action button just
-  // stays disabled until the data resolves.
+  // Folders and files are fetched across all paginated organizer pages,
+  // independent of the FilesystemView's current page. useQuery (not
+  // useSuspenseQuery) keeps a cache miss from suspending the toolbar
+  // chrome — the action button just stays disabled until the data resolves.
   const { data: foldersData } = useQuery(workspaceFoldersOptions(workspaceId));
   const allFolders = useMemo(() => foldersData ?? [], [foldersData]);
   const { data: filesData } = useQuery(workspaceFilesOptions(workspaceId));

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/entities.ts
@@ -332,27 +332,51 @@ export type WorkspaceFolder = {
   parentId: string | null;
 };
 
-// Returns every folder in the workspace, unpaginated. Used by features
-// (e.g. the file organizer) that need a complete folder hierarchy
-// regardless of which page the filesystem view is currently showing.
-export const workspaceFoldersOptions = (workspaceId: string) =>
-  queryOptions({
-    queryKey: [...entitiesKeys.all(workspaceId), "folders"],
-    queryFn: async ({ signal }): Promise<WorkspaceFolder[]> => {
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .folders.get({ fetch: { signal } });
+const fetchAllWorkspaceFolders = async ({
+  signal,
+  workspaceId,
+}: {
+  signal: AbortSignal;
+  workspaceId: string;
+}): Promise<WorkspaceFolder[]> => {
+  const folders: WorkspaceFolder[] = [];
+  let cursor: string | undefined;
+  do {
+    const response = await api
+      .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+      .folders.get({
+        fetch: { signal },
+        query: {
+          limit: DEFAULT_ENTITY_WINDOW_SIZE,
+          ...(cursor !== undefined && { cursor }),
+        },
+      });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+    if (response.error) {
+      throw toAPIError(response.error);
+    }
 
-      return response.data.folders.map((folder) => ({
+    folders.push(
+      ...response.data.items.map((folder) => ({
         entityId: folder.id,
         name: folder.name,
         parentId: folder.parentId,
-      }));
-    },
+      })),
+    );
+    cursor = response.data.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+
+  return folders;
+};
+
+// Fetches the complete folder hierarchy in bounded pages. The API
+// response is paginated so large matters never return one giant
+// organizer payload.
+export const workspaceFoldersOptions = (workspaceId: string) =>
+  queryOptions({
+    queryKey: [...entitiesKeys.all(workspaceId), "folders"],
+    queryFn: async ({ signal }) =>
+      await fetchAllWorkspaceFolders({ signal, workspaceId }),
   });
 
 export type WorkspaceFile = {
@@ -363,28 +387,51 @@ export type WorkspaceFile = {
   mimeType: string;
 };
 
-// Returns every file-bearing entity in the workspace, unpaginated, with
-// just the columns the organizer needs. Used by the file organizer so
-// it operates on the whole matter rather than the FilesystemView's
-// current page.
-export const workspaceFilesOptions = (workspaceId: string) =>
-  queryOptions({
-    queryKey: [...entitiesKeys.all(workspaceId), "files"],
-    queryFn: async ({ signal }): Promise<WorkspaceFile[]> => {
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        .files.get({ fetch: { signal } });
+const fetchAllWorkspaceFiles = async ({
+  signal,
+  workspaceId,
+}: {
+  signal: AbortSignal;
+  workspaceId: string;
+}): Promise<WorkspaceFile[]> => {
+  const files: WorkspaceFile[] = [];
+  let cursor: string | undefined;
+  do {
+    const response = await api
+      .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
+      .files.get({
+        fetch: { signal },
+        query: {
+          limit: DEFAULT_ENTITY_WINDOW_SIZE,
+          ...(cursor !== undefined && { cursor }),
+        },
+      });
 
-      if (response.error) {
-        throw toAPIError(response.error);
-      }
+    if (response.error) {
+      throw toAPIError(response.error);
+    }
 
-      return response.data.files.map((file) => ({
+    files.push(
+      ...response.data.items.map((file) => ({
         entityId: file.entityId,
         name: file.name,
         parentId: file.parentId,
         fileName: file.fileName,
         mimeType: file.mimeType,
-      }));
-    },
+      })),
+    );
+    cursor = response.data.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+
+  return files;
+};
+
+// Fetches every file-bearing entity in bounded pages, with just the
+// columns the organizer needs. The organizer still operates across the
+// whole matter, but no single request returns the whole file set.
+export const workspaceFilesOptions = (workspaceId: string) =>
+  queryOptions({
+    queryKey: [...entitiesKeys.all(workspaceId), "files"],
+    queryFn: async ({ signal }) =>
+      await fetchAllWorkspaceFiles({ signal, workspaceId }),
   });


### PR DESCRIPTION
## Summary
- add keyset cursors for entity read windows, preserving sort/null semantics and supporting indexes
- batch workflow target selection and enqueueing to avoid unbounded workspace entity loads
- paginate file/folder organizer endpoints and fetch bounded pages from the web client

## Validation
- bun run lint
- bun run format
- bun run typecheck
- bun run test
