### PR TITLE
docs: link GHCR to GitHub Container Registry docs

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,7 @@ Stella-specific deploy details.
 
 Each release tag (`vX.Y.Z` or `vX.Y.Z-rc.N`) publishes:
 
-- a multi-architecture API image in GHCR,
+- a multi-architecture API image in [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry),
 - immutable image references by tag, git SHA, and digest,
 - a `release-manifest.json` file containing the source commit, image digest,
   and migration file inventory,

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -8,7 +8,7 @@ Stella-specific deploy details.
 
 Each release tag (`vX.Y.Z` or `vX.Y.Z-rc.N`) publishes:
 
-- a multi-architecture API image in [GHCR](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry),
+- a multi-architecture API image in the [GitHub Container Registry (GHCR)](https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry),
 - immutable image references by tag, git SHA, and digest,
 - a `release-manifest.json` file containing the source commit, image digest,
   and migration file inventory,


### PR DESCRIPTION
## Proposed change

In `docs/releases.md`, link the first mention of `GHCR` to GitHub's container-registry documentation so readers unfamiliar with the acronym get a single useful click target (rather than the bare term, which surfaces an unhelpful search result that now redirects to `github.com/features/actions`).

Closes #242

## Checklist

- [x] BUILD ASSURANCE | Code builds correctly and without any errors or warnings.
- [x] TESTING | Markdown renders correctly; link points to https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry.
- [ ] DARK MODE SUPPORT | N/A — docs-only change.
- [x] ISSUE LINKED | Linked via `Closes #242`.
- [ ] SCREENSHOT INCLUDED | N/A — single inline link in a Markdown bullet.