### PR TITLE
perf(folio): cut editor re-renders, modernize for React 19

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -396,12 +396,16 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
+        "@types/react": "catalog:react19",
+        "@types/react-dom": "catalog:react19",
         "fast-check": "catalog:",
+        "react": "catalog:react19",
+        "react-dom": "catalog:react19",
         "typescript": "catalog:",
       },
       "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "use-intl": ">=4.0.0",
       },
     },

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -52,12 +52,16 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "@types/react": "catalog:react19",
+    "@types/react-dom": "catalog:react19",
     "fast-check": "catalog:",
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19",
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "use-intl": ">=4.0.0"
   }
 }

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -16,10 +16,9 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
-  forwardRef,
   useImperativeHandle,
 } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, Ref } from "react";
 
 import {
   CheckIcon,
@@ -393,1011 +392,916 @@ function areActiveTrackedChangesEqual(
 /**
  * DocxEditor - Complete DOCX editor component
  */
-export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
-  function DocxEditor(
-    {
-      documentBuffer,
-      document: initialDocument,
-      onSave,
-      author = "User",
-      onChange,
-      onSelectionChange,
-      onSelectionTextChange,
-      onError,
-      onFontsLoaded: onFontsLoadedCallback,
-      theme,
-      showToolbar = true,
-      showZoomControl = true,
-      showMarginGuides: _showMarginGuides = false,
-      marginGuideColor: _marginGuideColor,
-      initialZoom = 1,
-      readOnly: readOnlyProp = false,
-      autoOpenReviewSidebar = true,
-      toolbarExtra,
-      className = "",
-      style,
-      placeholder,
-      loadingIndicator,
-      preserveDocumentWhileLoading = false,
-      initialScrollTop,
-      onScrollTopChange,
-      showOutline: showOutlineProp = false,
-      onPrint,
-      onCopy: _onCopy,
-      onCut: _onCut,
-      onPaste: _onPaste,
-      mode: modeProp,
-      onModeChange,
-      onReadonlyEditAttempt,
-      onCompatibilityChange,
-      onEditorViewReady,
-      onAnonymizationMatchesChange,
-      onAnonymizationTermClick,
-      selectedAnonymizationCanonical = null,
-      anonymizationSelectionSeq,
-      collaboration,
-    },
-    ref,
-  ) {
-    const t = useTranslations("folio");
+export function DocxEditor({
+  ref,
+  documentBuffer,
+  document: initialDocument,
+  onSave,
+  author = "User",
+  onChange,
+  onSelectionChange,
+  onSelectionTextChange,
+  onError,
+  onFontsLoaded: onFontsLoadedCallback,
+  theme,
+  showToolbar = true,
+  showZoomControl = true,
+  showMarginGuides: _showMarginGuides = false,
+  marginGuideColor: _marginGuideColor,
+  initialZoom = 1,
+  readOnly: readOnlyProp = false,
+  autoOpenReviewSidebar = true,
+  toolbarExtra,
+  className = "",
+  style,
+  placeholder,
+  loadingIndicator,
+  preserveDocumentWhileLoading = false,
+  initialScrollTop,
+  onScrollTopChange,
+  showOutline: showOutlineProp = false,
+  onPrint,
+  onCopy: _onCopy,
+  onCut: _onCut,
+  onPaste: _onPaste,
+  mode: modeProp,
+  onModeChange,
+  onReadonlyEditAttempt,
+  onCompatibilityChange,
+  onEditorViewReady,
+  onAnonymizationMatchesChange,
+  onAnonymizationTermClick,
+  selectedAnonymizationCanonical = null,
+  anonymizationSelectionSeq,
+  collaboration,
+}: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
+  const t = useTranslations("folio");
 
-    // State
-    const [state, setState] = useState<EditorState>({
-      documentLoad: documentBuffer
-        ? { status: "loading" }
-        : { status: "ready" },
-      selectionFormatting: {},
-      paragraphIndentLeft: 0,
-      paragraphIndentRight: 0,
-      paragraphFirstLineIndent: 0,
-      paragraphHangingIndent: false,
-      paragraphTabs: null,
-      pmTableContext: null,
-      pmImageContext: null,
-      activeTrackedChange: null,
-    });
+  // State
+  const [state, setState] = useState<EditorState>({
+    documentLoad: documentBuffer ? { status: "loading" } : { status: "ready" },
+    selectionFormatting: {},
+    paragraphIndentLeft: 0,
+    paragraphIndentRight: 0,
+    paragraphFirstLineIndent: 0,
+    paragraphHangingIndent: false,
+    paragraphTabs: null,
+    pmTableContext: null,
+    pmImageContext: null,
+    activeTrackedChange: null,
+  });
 
-    // Table properties dialog state
-    const [tablePropsOpen, setTablePropsOpen] = useState(false);
-    // Footnote properties dialog state
-    const [footnotePropsOpen, setFootnotePropsOpen] = useState(false);
-    // Document outline sidebar state
-    const [showOutline, setShowOutline] = useState(showOutlineProp);
-    const showOutlineRef = useRef(false);
-    showOutlineRef.current = showOutline;
-    const [_outlineHeadings, setHeadingInfos] = useState<HeadingInfo[]>([]);
+  // Table properties dialog state
+  const [tablePropsOpen, setTablePropsOpen] = useState(false);
+  // Footnote properties dialog state
+  const [footnotePropsOpen, setFootnotePropsOpen] = useState(false);
+  // Document outline sidebar state
+  const [showOutline, setShowOutline] = useState(showOutlineProp);
+  const showOutlineRef = useRef(false);
+  showOutlineRef.current = showOutline;
+  const [_outlineHeadings, setHeadingInfos] = useState<HeadingInfo[]>([]);
 
-    // Comments sidebar state
-    const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
-    const [visibleCommentAuthors, setVisibleCommentAuthors] =
-      useState<Set<string> | null>(null);
-    const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
-    const [comments, setComments] = useState<Comment[]>([]);
-    const commentsDirtyRef = useRef(false);
-    const commentsRef = useRef<Comment[]>([]);
-    commentsRef.current = comments;
-    const [, setTrackedChanges] = useState<TrackedChangeEntry[]>([]);
-    const [anchorPositions, setAnchorPositions] = useState<Map<string, number>>(
-      EMPTY_ANCHOR_POSITIONS,
-    );
+  // Comments sidebar state
+  const [showCommentsSidebar, setShowCommentsSidebar] = useState(false);
+  const [visibleCommentAuthors, setVisibleCommentAuthors] =
+    useState<Set<string> | null>(null);
+  const [activeCommentId, setActiveCommentId] = useState<number | null>(null);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const commentsDirtyRef = useRef(false);
+  const commentsRef = useRef<Comment[]>([]);
+  commentsRef.current = comments;
+  const [, setTrackedChanges] = useState<TrackedChangeEntry[]>([]);
+  const [anchorPositions, setAnchorPositions] = useState<Map<string, number>>(
+    EMPTY_ANCHOR_POSITIONS,
+  );
 
-    const [isAddingComment, setIsAddingComment] = useState(false);
-    const [commentSelectionRange, setCommentSelectionRange] = useState<{
-      from: number;
-      to: number;
-    } | null>(null);
-    const [addCommentYPosition, setAddCommentYPosition] = useState<
-      number | null
-    >(null);
-    const {
-      editingMode,
-      readOnly,
-      trackChangesOn,
-      toggleTrackChanges,
-      displayMode,
-      setDisplayMode,
-    } = useEditorMode({
-      modeProp,
-      onModeChange,
-      readOnlyProp,
-    });
+  const [isAddingComment, setIsAddingComment] = useState(false);
+  const [commentSelectionRange, setCommentSelectionRange] = useState<{
+    from: number;
+    to: number;
+  } | null>(null);
+  const [addCommentYPosition, setAddCommentYPosition] = useState<number | null>(
+    null,
+  );
+  const {
+    editingMode,
+    readOnly,
+    trackChangesOn,
+    toggleTrackChanges,
+    displayMode,
+    setDisplayMode,
+  } = useEditorMode({
+    modeProp,
+    onModeChange,
+    readOnlyProp,
+  });
 
-    // Floating "add comment" button position (relative to scroll container, null = hidden)
-    const [floatingCommentBtn, setFloatingCommentBtn] = useState<{
-      top: number;
-      left: number;
-      from: number;
-      to: number;
-    } | null>(null);
+  // Floating "add comment" button position (relative to scroll container, null = hidden)
+  const [floatingCommentBtn, setFloatingCommentBtn] = useState<{
+    top: number;
+    left: number;
+    from: number;
+    to: number;
+  } | null>(null);
 
-    // Debounce timer for extractTrackedChanges (avoid full doc walk on every keystroke)
-    const extractTrackedChangesTimerRef = useRef<ReturnType<
-      typeof setTimeout
-    > | null>(null);
+  // Debounce timer for extractTrackedChanges (avoid full doc walk on every keystroke)
+  const extractTrackedChangesTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
 
-    // Extract tracked changes from ProseMirror state
-    const extractTrackedChanges = useCallback(() => {
-      const view = pagedEditorRef.current?.getView();
-      if (!view) {
+  // Extract tracked changes from ProseMirror state
+  const extractTrackedChanges = useCallback(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (!view) {
+      return;
+    }
+    const { doc, schema } = view.state;
+    const insertionType = schema.marks["insertion"];
+    const deletionType = schema.marks["deletion"];
+    if (!insertionType && !deletionType) {
+      return;
+    }
+
+    const raw: TrackedChangeEntry[] = [];
+    doc.descendants((node, pos) => {
+      if (!node.isText) {
         return;
       }
-      const { doc, schema } = view.state;
-      const insertionType = schema.marks["insertion"];
-      const deletionType = schema.marks["deletion"];
-      if (!insertionType && !deletionType) {
-        return;
-      }
-
-      const raw: TrackedChangeEntry[] = [];
-      doc.descendants((node, pos) => {
-        if (!node.isText) {
-          return;
-        }
-        for (const mark of node.marks) {
-          if (mark.type === insertionType || mark.type === deletionType) {
-            const entry: TrackedChangeEntry = {
-              type: mark.type === insertionType ? "insertion" : "deletion",
-              text: node.text || "",
-              author: (mark.attrs["author"] as string) || "",
-              from: pos,
-              to: pos + node.nodeSize,
-              revisionId: mark.attrs["revisionId"] as number,
-            };
-            if (mark.attrs["date"]) {
-              entry.date = mark.attrs["date"] as string;
-            }
-            raw.push(entry);
+      for (const mark of node.marks) {
+        if (mark.type === insertionType || mark.type === deletionType) {
+          const entry: TrackedChangeEntry = {
+            type: mark.type === insertionType ? "insertion" : "deletion",
+            text: node.text || "",
+            author: (mark.attrs["author"] as string) || "",
+            from: pos,
+            to: pos + node.nodeSize,
+            revisionId: mark.attrs["revisionId"] as number,
+          };
+          if (mark.attrs["date"]) {
+            entry.date = mark.attrs["date"] as string;
           }
-        }
-      });
-
-      // Merge adjacent entries with the same revisionId and type into one
-      const merged: TrackedChangeEntry[] = [];
-      for (const entry of raw) {
-        const last = merged.at(-1);
-        if (
-          last &&
-          last.revisionId === entry.revisionId &&
-          last.type === entry.type &&
-          last.to === entry.from
-        ) {
-          last.text += entry.text;
-          last.to = entry.to;
-        } else {
-          merged.push({ ...entry });
+          raw.push(entry);
         }
       }
-      setTrackedChanges(merged);
-    }, []);
+    });
 
-    // Clean up debounce timer on unmount
-    useEffect(
-      () => () => {
+    // Merge adjacent entries with the same revisionId and type into one
+    const merged: TrackedChangeEntry[] = [];
+    for (const entry of raw) {
+      const last = merged.at(-1);
+      if (
+        last &&
+        last.revisionId === entry.revisionId &&
+        last.type === entry.type &&
+        last.to === entry.from
+      ) {
+        last.text += entry.text;
+        last.to = entry.to;
+      } else {
+        merged.push({ ...entry });
+      }
+    }
+    setTrackedChanges(merged);
+  }, []);
+
+  // Clean up debounce timer on unmount
+  useEffect(
+    () => () => {
+      if (extractTrackedChangesTimerRef.current) {
+        clearTimeout(extractTrackedChangesTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  // Sync outline visibility when prop changes
+  useEffect(() => {
+    setShowOutline(showOutlineProp);
+    if (showOutlineProp) {
+      const view = pagedEditorRef.current?.getView();
+      if (view) {
+        setHeadingInfos(collectHeadings(view.state.doc));
+      }
+    }
+  }, [showOutlineProp]);
+
+  // History hook for undo/redo - start with null document
+  const history = useDocumentHistory<Document | null>(initialDocument || null, {
+    maxEntries: 100,
+    groupingInterval: 500,
+    enableKeyboardShortcuts: true,
+  });
+
+  // Extract comments from document model on initial load
+  const commentsLoadedRef = useRef(false);
+  useEffect(() => {
+    if (commentsLoadedRef.current) {
+      return;
+    }
+    const doc = history.state;
+    if (!doc) {
+      return;
+    }
+    const bodyComments = doc.package.document.comments;
+    if (bodyComments && bodyComments.length > 0) {
+      setComments(bodyComments);
+      setVisibleCommentAuthors(null);
+      setActiveCommentId(null);
+      if (autoOpenReviewSidebar) {
+        setShowCommentsSidebar(true);
+      }
+      commentsLoadedRef.current = true;
+    }
+  }, [autoOpenReviewSidebar, history.state]);
+
+  const commentAuthors = useMemo(() => {
+    const seen = new Set<string>();
+    const authors: string[] = [];
+    for (const comment of comments) {
+      const commentAuthor = getCommentAuthorKey(comment.author);
+      if (!seen.has(commentAuthor)) {
+        seen.add(commentAuthor);
+        authors.push(commentAuthor);
+      }
+    }
+    return authors;
+  }, [comments]);
+
+  const visibleCommentAuthorSet = useMemo(
+    () => visibleCommentAuthors ?? new Set(commentAuthors),
+    [visibleCommentAuthors, commentAuthors],
+  );
+
+  const visibleCommentIds = useMemo(() => {
+    const ids = new Set<number>([PENDING_COMMENT_ID]);
+    for (const comment of comments) {
+      if (visibleCommentAuthorSet.has(getCommentAuthorKey(comment.author))) {
+        ids.add(comment.id);
+      }
+    }
+    return ids;
+  }, [comments, visibleCommentAuthorSet]);
+
+  const visibleComments = useMemo(() => {
+    const visibleRootIds = new Set<number>();
+    for (const comment of comments) {
+      const parentId = getCommentParentId(comment);
+      if (
+        parentId === null ||
+        parentId === undefined ||
+        !visibleCommentIds.has(comment.id)
+      ) {
+        continue;
+      }
+      visibleRootIds.add(parentId);
+    }
+    return comments.filter((comment) => {
+      const parentId = getCommentParentId(comment);
+      if (parentId !== null && parentId !== undefined) {
+        return visibleCommentIds.has(comment.id);
+      }
+      return (
+        visibleCommentIds.has(comment.id) || visibleRootIds.has(comment.id)
+      );
+    });
+  }, [comments, visibleCommentIds]);
+
+  const activeCommentVisible =
+    activeCommentId !== null && visibleCommentIds.has(activeCommentId);
+
+  useEffect(() => {
+    if (!activeCommentVisible) {
+      setActiveCommentId(null);
+    }
+  }, [activeCommentVisible]);
+
+  // Extension manager — built once, provides schema + plugins + commands
+  const extensionManager = useMemo(() => {
+    const mgr = new ExtensionManager(createStarterKit());
+    mgr.buildSchema();
+    mgr.initializeRuntime();
+    return mgr;
+  }, []);
+
+  // Suggestion mode plugin
+  const suggestionPlugin = useMemo(
+    () => createSuggestionModePlugin(editingMode === "suggesting", author),
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  // AI suggestion decorations — non-mutating overlay for the review
+  // queue. Always present; the plugin renders nothing until
+  // suggestions are pushed in.
+  const aiSuggestionPlugin = useMemo(
+    () => createAISuggestionDecorationsPlugin(),
+    [],
+  );
+  // AI citation decorations — pointers from chat answers / extraction
+  // justifications back to source ranges. Distinct visual from
+  // suggestions; renders nothing until citations are pushed in.
+  const aiCitationPlugin = useMemo(
+    () => createAICitationDecorationsPlugin(),
+    [],
+  );
+  // Workspace anonymization-term highlights. Always installed;
+  // renders nothing until the host pushes a term list via
+  // `setAnonymizationTermsMeta`.
+  // Hold the callback in a ref so the plugin instance is stable
+  // across re-renders even when the parent passes a fresh
+  // closure each time. The ref always points at the latest
+  // function, so the plugin's view spec calls into the most
+  // recent host implementation without forcing PM to swap
+  // plugins (which would reset its state).
+  const onAnonymizationMatchesChangeRef = useRef(onAnonymizationMatchesChange);
+  onAnonymizationMatchesChangeRef.current = onAnonymizationMatchesChange;
+  const anonymizationDecorationsPlugin = useMemo(
+    () =>
+      createAnonymizationDecorationsPlugin({
+        onMatchesChange: (matches) => {
+          onAnonymizationMatchesChangeRef.current?.(matches);
+        },
+      }),
+    [],
+  );
+  const editorPlugins = useMemo(
+    () => [
+      ...(collaboration?.plugins ?? []),
+      suggestionPlugin,
+      aiSuggestionPlugin,
+      aiCitationPlugin,
+      anonymizationDecorationsPlugin,
+    ],
+    [
+      collaboration?.plugins,
+      suggestionPlugin,
+      aiSuggestionPlugin,
+      aiCitationPlugin,
+      anonymizationDecorationsPlugin,
+    ],
+  );
+
+  // Surface the live PM view to the host for AI overlay wiring.
+  // We watch `history.state` because the document re-loads (e.g.,
+  // unlocking from preview into editing) re-mount the PagedEditor
+  // and replace the view instance.
+  const lastReportedViewRef = useRef<EditorView | null>(null);
+  useEffect(() => {
+    if (!onEditorViewReady) {
+      return;
+    }
+    const view = pagedEditorRef.current?.getView() ?? null;
+    if (lastReportedViewRef.current === view) {
+      return;
+    }
+    lastReportedViewRef.current = view;
+    onEditorViewReady(view);
+  }, [onEditorViewReady, history.state]);
+  useEffect(() => {
+    if (!onEditorViewReady) {
+      return;
+    }
+    return () => {
+      if (lastReportedViewRef.current !== null) {
+        lastReportedViewRef.current = null;
+        onEditorViewReady(null);
+      }
+    };
+  }, [onEditorViewReady]);
+
+  // Refs
+  const pagedEditorRef = useRef<PagedEditorRef>(null);
+  const hfEditorRef = useRef<InlineHeaderFooterEditorRef>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Save the last known selection for restoring after toolbar interactions
+  const lastSelectionRef = useRef<{ from: number; to: number } | null>(null);
+  const imageInputRef = useRef<HTMLInputElement>(null);
+  const editorContentRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const {
+    contextMenu,
+    openMenu: openContextMenu,
+    closeMenu: closeContextMenu,
+  } = useContextMenu({ pagedEditorRef });
+  const toolbarWrapperRef = useRef<HTMLDivElement>(null);
+  const toolbarRoRef = useRef<ResizeObserver | null>(null);
+  const [_toolbarHeight, setToolbarHeight] = useState(0);
+  // Keep history.state accessible in stable callbacks without stale closures
+  const historyStateRef = useRef(history.state);
+  historyStateRef.current = history.state;
+  // Track current border color/width for border presets (like Google Docs)
+  const borderSpecRef = useRef({
+    style: "single",
+    size: 4,
+    color: { rgb: "000000" },
+  });
+
+  const syncCommentHighlightStyles = useCallback(() => {
+    const root = editorContentRef.current;
+    if (!root) {
+      return;
+    }
+
+    const nodes = root.querySelectorAll<HTMLElement>(
+      ".layout-run-text[data-comment-id], .docx-comment[data-comment-id]",
+    );
+    for (const node of nodes) {
+      const commentId = Number.parseInt(node.dataset["commentId"] ?? "", 10);
+      const isPending = commentId === PENDING_COMMENT_ID;
+      const isVisible = isPending || visibleCommentIds.has(commentId);
+      if (!isVisible) {
+        node.style.backgroundColor = "transparent";
+        node.style.borderBottom = "2px solid transparent";
+        node.style.boxShadow = "none";
+        delete node.dataset["activeComment"];
+        continue;
+      }
+
+      if (activeCommentId === commentId) {
+        node.style.backgroundColor =
+          "var(--doc-comment-active-bg, rgba(255, 212, 0, 0.22))";
+        node.style.borderBottom =
+          "1px solid var(--doc-comment-active-border, rgba(180, 130, 0, 0.62))";
+        node.style.boxShadow = "none";
+        node.dataset["activeComment"] = "true";
+        continue;
+      }
+
+      node.style.backgroundColor =
+        "var(--doc-comment-bg, rgba(255, 212, 0, 0.08))";
+      node.style.borderBottom =
+        "1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24))";
+      node.style.boxShadow = "none";
+      delete node.dataset["activeComment"];
+    }
+  }, [visibleCommentIds, activeCommentId]);
+
+  useLayoutEffect(() => {
+    syncCommentHighlightStyles();
+  }, [syncCommentHighlightStyles, anchorPositions]);
+
+  useEffect(() => {
+    syncCommentHighlightStyles();
+    const firstFrame = requestAnimationFrame(() => {
+      syncCommentHighlightStyles();
+      requestAnimationFrame(syncCommentHighlightStyles);
+    });
+    const timeout = setTimeout(syncCommentHighlightStyles, 120);
+    return () => {
+      cancelAnimationFrame(firstFrame);
+      clearTimeout(timeout);
+    };
+  }, [comments.length, syncCommentHighlightStyles]);
+  // Cache style resolver to avoid recreating on every selection change
+  const styleResolverCacheRef = useRef<{
+    styles: unknown;
+    resolver: ReturnType<typeof createStyleResolver>;
+  } | null>(null);
+  const getCachedStyleResolver = useCallback(
+    (styles: Parameters<typeof createStyleResolver>[0]) => {
+      const cached = styleResolverCacheRef.current;
+      if (cached && cached.styles === styles) {
+        return cached.resolver;
+      }
+      const resolver = createStyleResolver(styles);
+      styleResolverCacheRef.current = { styles, resolver };
+      return resolver;
+    },
+    [],
+  );
+
+  const {
+    zoom,
+    zoomRef,
+    setZoomWithViewportAnchor,
+    scrollPageInfo,
+    setScrollPageInfo,
+  } = useZoomAndPageInfo({
+    scrollContainerRef,
+    pagedEditorRef,
+    initialZoom,
+  });
+  const [bodyHistoryAvailability, setBodyHistoryAvailability] = useState({
+    canRedo: false,
+    canUndo: false,
+  });
+
+  // Measure toolbar height for positioning the outline panel below it
+  const toolbarRefCallback = useCallback((el: HTMLDivElement | null) => {
+    toolbarWrapperRef.current = el;
+    // Clean up previous observer
+    if (toolbarRoRef.current) {
+      toolbarRoRef.current.disconnect();
+      toolbarRoRef.current = null;
+    }
+    if (!el) {
+      setToolbarHeight(0);
+      return;
+    }
+    setToolbarHeight(el.offsetHeight);
+    const ro = new ResizeObserver(() => {
+      setToolbarHeight(el.offsetHeight);
+    });
+    ro.observe(el);
+    toolbarRoRef.current = ro;
+  }, []);
+
+  // Cleanup ResizeObserver on unmount
+  useEffect(
+    () => () => {
+      toolbarRoRef.current?.disconnect();
+    },
+    [],
+  );
+
+  const pushDocument = useCallback(
+    (document: Document) => {
+      history.push(document);
+      return document;
+    },
+    [history],
+  );
+
+  const refreshBodyHistoryAvailability = useCallback(() => {
+    const canUndo = pagedEditorRef.current?.canUndo() ?? false;
+    const canRedo = pagedEditorRef.current?.canRedo() ?? false;
+    setBodyHistoryAvailability((prev) =>
+      prev.canUndo === canUndo && prev.canRedo === canRedo
+        ? prev
+        : { canUndo, canRedo },
+    );
+  }, []);
+
+  // Header/footer editing state + content resolution + mutation callbacks
+  const {
+    hfEditPosition,
+    setHfEditPosition,
+    hfEditIsFirstPage,
+    headerContent,
+    footerContent,
+    firstPageHeaderContent,
+    firstPageFooterContent,
+    effectiveSectionProperties,
+    handleHeaderFooterDoubleClick,
+    handleHeaderFooterSave,
+    handleBodyClick,
+    handleRemoveHeaderFooter,
+  } = useHeaderFooterEditor({ history, pushDocument, hfEditorRef });
+
+  // Helper to get the active editor's view — returns HF editor view when in HF editing mode
+  const getActiveEditorView = useCallback(() => {
+    if (hfEditPosition && hfEditorRef.current) {
+      return hfEditorRef.current.getView();
+    }
+    return pagedEditorRef.current?.getView();
+  }, [hfEditPosition]);
+
+  // Helper to focus the active editor
+  const focusActiveEditor = useCallback(() => {
+    if (hfEditPosition && hfEditorRef.current) {
+      hfEditorRef.current.focus();
+    } else {
+      pagedEditorRef.current?.focus();
+    }
+  }, [hfEditPosition]);
+
+  // Helper to undo in the active editor
+  const undoActiveEditor = useCallback(() => {
+    if (hfEditPosition && hfEditorRef.current) {
+      hfEditorRef.current.undo();
+    } else {
+      pagedEditorRef.current?.undo();
+      requestAnimationFrame(refreshBodyHistoryAvailability);
+    }
+  }, [hfEditPosition, refreshBodyHistoryAvailability]);
+
+  // Helper to redo in the active editor
+  const redoActiveEditor = useCallback(() => {
+    if (hfEditPosition && hfEditorRef.current) {
+      hfEditorRef.current.redo();
+    } else {
+      pagedEditorRef.current?.redo();
+      requestAnimationFrame(refreshBodyHistoryAvailability);
+    }
+  }, [hfEditPosition, refreshBodyHistoryAvailability]);
+
+  // Find/Replace hook
+  const findReplace = useFindReplaceState();
+
+  // Page setup dialog state
+  const [showPageSetup, setShowPageSetup] = useState(false);
+
+  // Hyperlink handlers (popup state, navigation, etc.)
+  const {
+    hyperlinkPopupData,
+    handleHyperlinkClick,
+    handleHyperlinkPopupNavigate,
+    handleHyperlinkPopupCopy,
+    handleHyperlinkPopupEdit,
+    handleHyperlinkPopupRemove,
+    handleHyperlinkPopupClose,
+  } = useHyperlinkHandlers({
+    getActiveEditorView,
+    focusActiveEditor,
+  });
+
+  const {
+    imagePositionOpen,
+    setImagePositionOpen,
+    imagePropsOpen,
+    setImagePropsOpen,
+    handleImageFileChange,
+    handleImageWrapType,
+    handleImageTransform,
+    handleApplyImagePosition,
+    handleOpenImageProperties,
+    handleApplyImageProperties,
+  } = useImageHandlers({
+    getActiveEditorView,
+    focusActiveEditor,
+    pmImageContext: state.pmImageContext,
+  });
+
+  // Document loading (parse buffer, reset UI, keep original buffer for save)
+  const { loadBuffer, loadParsedDocument, originalBufferRef } =
+    useDocumentLoader({
+      documentBuffer: documentBuffer ?? null,
+      initialDocument: initialDocument ?? null,
+      history,
+      onError,
+      onCompatibilityChange,
+      onReset: useCallback(() => {
+        commentsDirtyRef.current = false;
+        commentsLoadedRef.current = false;
+        trackedChangesLoadedRef.current = false;
+        setComments([]);
+        setTrackedChanges([]);
+        setVisibleCommentAuthors(null);
+        setActiveCommentId(null);
+        setHeadingInfos([]);
+        setShowCommentsSidebar(false);
+        setIsAddingComment(false);
+        setCommentSelectionRange(null);
+        setAddCommentYPosition(null);
+        setFloatingCommentBtn(null);
+        setHfEditPosition(null);
+        setAnchorPositions(EMPTY_ANCHOR_POSITIONS);
+        findReplace.setMatches([], 0);
         if (extractTrackedChangesTimerRef.current) {
           clearTimeout(extractTrackedChangesTimerRef.current);
+          extractTrackedChangesTimerRef.current = null;
         }
-      },
-      [],
-    );
+      }, [findReplace, setHfEditPosition]),
+      setDocumentLoadState: useCallback((documentLoad: DocumentLoadState) => {
+        setState((prev) => ({ ...prev, documentLoad }));
+      }, []),
+    });
 
-    // Sync outline visibility when prop changes
-    useEffect(() => {
-      setShowOutline(showOutlineProp);
-      if (showOutlineProp) {
+  // Extract tracked changes once PM view is ready (after loading completes)
+  const trackedChangesLoadedRef = useRef(false);
+  useEffect(() => {
+    if (state.documentLoad.status === "ready" && history.state) {
+      const timer = setTimeout(() => {
+        extractTrackedChanges();
+        // Auto-open sidebar once on initial load
+        if (!trackedChangesLoadedRef.current) {
+          trackedChangesLoadedRef.current = true;
+          // Check if we just populated tracked changes
+          setTrackedChanges((prev) => {
+            if (autoOpenReviewSidebar && prev.length > 0) {
+              setShowCommentsSidebar(true);
+            }
+            return prev;
+          });
+        }
+      }, 200);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [
+    state.documentLoad.status,
+    history.state,
+    extractTrackedChanges,
+    autoOpenReviewSidebar,
+  ]);
+
+  const initialScrollAppliedRef = useRef(false);
+  useEffect(() => {
+    if (
+      initialScrollTop === undefined ||
+      state.documentLoad.status !== "ready" ||
+      initialScrollAppliedRef.current
+    ) {
+      return undefined;
+    }
+
+    initialScrollAppliedRef.current = true;
+    const frame = requestAnimationFrame(() => {
+      if (scrollContainerRef.current) {
+        scrollContainerRef.current.scrollTop = initialScrollTop;
+      }
+    });
+
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, [initialScrollTop, state.documentLoad.status]);
+
+  // Listen for font loading
+  useEffect(() => {
+    const cleanup = onFontsLoaded(() => {
+      onFontsLoadedCallback?.();
+    });
+    return cleanup;
+  }, [onFontsLoadedCallback]);
+
+  // Sync editing mode to ProseMirror suggestion mode plugin
+  useEffect(() => {
+    const view = pagedEditorRef.current?.getView();
+    if (view) {
+      setSuggestionMode(
+        editingMode === "suggesting",
+        view.state,
+        view.dispatch,
+        author,
+      );
+    }
+  }, [editingMode, author]);
+
+  // Handle document change
+  const handleDocumentChange = useCallback(
+    (newDocument: Document) => {
+      const currentComments = commentsRef.current;
+      const documentWithComments = structuredClone(newDocument);
+      documentWithComments.package.document.comments = currentComments;
+      pushDocument(documentWithComments);
+      onChange?.(documentWithComments);
+      // Update outline headings if sidebar is open
+      if (showOutlineRef.current) {
         const view = pagedEditorRef.current?.getView();
         if (view) {
           setHeadingInfos(collectHeadings(view.state.doc));
         }
       }
-    }, [showOutlineProp]);
-
-    // History hook for undo/redo - start with null document
-    const history = useDocumentHistory<Document | null>(
-      initialDocument || null,
-      {
-        maxEntries: 100,
-        groupingInterval: 500,
-        enableKeyboardShortcuts: true,
-      },
-    );
-
-    // Extract comments from document model on initial load
-    const commentsLoadedRef = useRef(false);
-    useEffect(() => {
-      if (commentsLoadedRef.current) {
-        return;
+      // Re-extract tracked changes after document change (debounced to avoid
+      // full-document walk on every keystroke in suggestion mode)
+      if (extractTrackedChangesTimerRef.current) {
+        clearTimeout(extractTrackedChangesTimerRef.current);
       }
-      const doc = history.state;
-      if (!doc) {
-        return;
-      }
-      const bodyComments = doc.package.document.comments;
-      if (bodyComments && bodyComments.length > 0) {
-        setComments(bodyComments);
-        setVisibleCommentAuthors(null);
-        setActiveCommentId(null);
-        if (autoOpenReviewSidebar) {
-          setShowCommentsSidebar(true);
-        }
-        commentsLoadedRef.current = true;
-      }
-    }, [autoOpenReviewSidebar, history.state]);
-
-    const commentAuthors = useMemo(() => {
-      const seen = new Set<string>();
-      const authors: string[] = [];
-      for (const comment of comments) {
-        const commentAuthor = getCommentAuthorKey(comment.author);
-        if (!seen.has(commentAuthor)) {
-          seen.add(commentAuthor);
-          authors.push(commentAuthor);
-        }
-      }
-      return authors;
-    }, [comments]);
-
-    const visibleCommentAuthorSet = useMemo(
-      () => visibleCommentAuthors ?? new Set(commentAuthors),
-      [visibleCommentAuthors, commentAuthors],
-    );
-
-    const visibleCommentIds = useMemo(() => {
-      const ids = new Set<number>([PENDING_COMMENT_ID]);
-      for (const comment of comments) {
-        if (visibleCommentAuthorSet.has(getCommentAuthorKey(comment.author))) {
-          ids.add(comment.id);
-        }
-      }
-      return ids;
-    }, [comments, visibleCommentAuthorSet]);
-
-    const visibleComments = useMemo(() => {
-      const visibleRootIds = new Set<number>();
-      for (const comment of comments) {
-        const parentId = getCommentParentId(comment);
-        if (
-          parentId === null ||
-          parentId === undefined ||
-          !visibleCommentIds.has(comment.id)
-        ) {
-          continue;
-        }
-        visibleRootIds.add(parentId);
-      }
-      return comments.filter((comment) => {
-        const parentId = getCommentParentId(comment);
-        if (parentId !== null && parentId !== undefined) {
-          return visibleCommentIds.has(comment.id);
-        }
-        return (
-          visibleCommentIds.has(comment.id) || visibleRootIds.has(comment.id)
-        );
-      });
-    }, [comments, visibleCommentIds]);
-
-    const activeCommentVisible =
-      activeCommentId !== null && visibleCommentIds.has(activeCommentId);
-
-    useEffect(() => {
-      if (!activeCommentVisible) {
-        setActiveCommentId(null);
-      }
-    }, [activeCommentVisible]);
-
-    // Extension manager — built once, provides schema + plugins + commands
-    const extensionManager = useMemo(() => {
-      const mgr = new ExtensionManager(createStarterKit());
-      mgr.buildSchema();
-      mgr.initializeRuntime();
-      return mgr;
-    }, []);
-
-    // Suggestion mode plugin
-    const suggestionPlugin = useMemo(
-      () => createSuggestionModePlugin(editingMode === "suggesting", author),
-      [], // eslint-disable-line react-hooks/exhaustive-deps
-    );
-    // AI suggestion decorations — non-mutating overlay for the review
-    // queue. Always present; the plugin renders nothing until
-    // suggestions are pushed in.
-    const aiSuggestionPlugin = useMemo(
-      () => createAISuggestionDecorationsPlugin(),
-      [],
-    );
-    // AI citation decorations — pointers from chat answers / extraction
-    // justifications back to source ranges. Distinct visual from
-    // suggestions; renders nothing until citations are pushed in.
-    const aiCitationPlugin = useMemo(
-      () => createAICitationDecorationsPlugin(),
-      [],
-    );
-    // Workspace anonymization-term highlights. Always installed;
-    // renders nothing until the host pushes a term list via
-    // `setAnonymizationTermsMeta`.
-    // Hold the callback in a ref so the plugin instance is stable
-    // across re-renders even when the parent passes a fresh
-    // closure each time. The ref always points at the latest
-    // function, so the plugin's view spec calls into the most
-    // recent host implementation without forcing PM to swap
-    // plugins (which would reset its state).
-    const onAnonymizationMatchesChangeRef = useRef(
-      onAnonymizationMatchesChange,
-    );
-    onAnonymizationMatchesChangeRef.current = onAnonymizationMatchesChange;
-    const anonymizationDecorationsPlugin = useMemo(
-      () =>
-        createAnonymizationDecorationsPlugin({
-          onMatchesChange: (matches) => {
-            onAnonymizationMatchesChangeRef.current?.(matches);
-          },
-        }),
-      [],
-    );
-    const editorPlugins = useMemo(
-      () => [
-        ...(collaboration?.plugins ?? []),
-        suggestionPlugin,
-        aiSuggestionPlugin,
-        aiCitationPlugin,
-        anonymizationDecorationsPlugin,
-      ],
-      [
-        collaboration?.plugins,
-        suggestionPlugin,
-        aiSuggestionPlugin,
-        aiCitationPlugin,
-        anonymizationDecorationsPlugin,
-      ],
-    );
-
-    // Surface the live PM view to the host for AI overlay wiring.
-    // We watch `history.state` because the document re-loads (e.g.,
-    // unlocking from preview into editing) re-mount the PagedEditor
-    // and replace the view instance.
-    const lastReportedViewRef = useRef<EditorView | null>(null);
-    useEffect(() => {
-      if (!onEditorViewReady) {
-        return;
-      }
-      const view = pagedEditorRef.current?.getView() ?? null;
-      if (lastReportedViewRef.current === view) {
-        return;
-      }
-      lastReportedViewRef.current = view;
-      onEditorViewReady(view);
-    }, [onEditorViewReady, history.state]);
-    useEffect(() => {
-      if (!onEditorViewReady) {
-        return;
-      }
-      return () => {
-        if (lastReportedViewRef.current !== null) {
-          lastReportedViewRef.current = null;
-          onEditorViewReady(null);
-        }
-      };
-    }, [onEditorViewReady]);
-
-    // Refs
-    const pagedEditorRef = useRef<PagedEditorRef>(null);
-    const hfEditorRef = useRef<InlineHeaderFooterEditorRef>(null);
-    const containerRef = useRef<HTMLDivElement>(null);
-    // Save the last known selection for restoring after toolbar interactions
-    const lastSelectionRef = useRef<{ from: number; to: number } | null>(null);
-    const imageInputRef = useRef<HTMLInputElement>(null);
-    const editorContentRef = useRef<HTMLDivElement>(null);
-    const scrollContainerRef = useRef<HTMLDivElement>(null);
-
-    const {
-      contextMenu,
-      openMenu: openContextMenu,
-      closeMenu: closeContextMenu,
-    } = useContextMenu({ pagedEditorRef });
-    const toolbarWrapperRef = useRef<HTMLDivElement>(null);
-    const toolbarRoRef = useRef<ResizeObserver | null>(null);
-    const [_toolbarHeight, setToolbarHeight] = useState(0);
-    // Keep history.state accessible in stable callbacks without stale closures
-    const historyStateRef = useRef(history.state);
-    historyStateRef.current = history.state;
-    // Track current border color/width for border presets (like Google Docs)
-    const borderSpecRef = useRef({
-      style: "single",
-      size: 4,
-      color: { rgb: "000000" },
-    });
-
-    const syncCommentHighlightStyles = useCallback(() => {
-      const root = editorContentRef.current;
-      if (!root) {
-        return;
-      }
-
-      const nodes = root.querySelectorAll<HTMLElement>(
-        ".layout-run-text[data-comment-id], .docx-comment[data-comment-id]",
-      );
-      for (const node of nodes) {
-        const commentId = Number.parseInt(node.dataset["commentId"] ?? "", 10);
-        const isPending = commentId === PENDING_COMMENT_ID;
-        const isVisible = isPending || visibleCommentIds.has(commentId);
-        if (!isVisible) {
-          node.style.backgroundColor = "transparent";
-          node.style.borderBottom = "2px solid transparent";
-          node.style.boxShadow = "none";
-          delete node.dataset["activeComment"];
-          continue;
-        }
-
-        if (activeCommentId === commentId) {
-          node.style.backgroundColor =
-            "var(--doc-comment-active-bg, rgba(255, 212, 0, 0.22))";
-          node.style.borderBottom =
-            "1px solid var(--doc-comment-active-border, rgba(180, 130, 0, 0.62))";
-          node.style.boxShadow = "none";
-          node.dataset["activeComment"] = "true";
-          continue;
-        }
-
-        node.style.backgroundColor =
-          "var(--doc-comment-bg, rgba(255, 212, 0, 0.08))";
-        node.style.borderBottom =
-          "1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24))";
-        node.style.boxShadow = "none";
-        delete node.dataset["activeComment"];
-      }
-    }, [visibleCommentIds, activeCommentId]);
-
-    useLayoutEffect(() => {
-      syncCommentHighlightStyles();
-    }, [syncCommentHighlightStyles, anchorPositions]);
-
-    useEffect(() => {
-      syncCommentHighlightStyles();
-      const firstFrame = requestAnimationFrame(() => {
-        syncCommentHighlightStyles();
-        requestAnimationFrame(syncCommentHighlightStyles);
-      });
-      const timeout = setTimeout(syncCommentHighlightStyles, 120);
-      return () => {
-        cancelAnimationFrame(firstFrame);
-        clearTimeout(timeout);
-      };
-    }, [comments.length, syncCommentHighlightStyles]);
-    // Cache style resolver to avoid recreating on every selection change
-    const styleResolverCacheRef = useRef<{
-      styles: unknown;
-      resolver: ReturnType<typeof createStyleResolver>;
-    } | null>(null);
-    const getCachedStyleResolver = useCallback(
-      (styles: Parameters<typeof createStyleResolver>[0]) => {
-        const cached = styleResolverCacheRef.current;
-        if (cached && cached.styles === styles) {
-          return cached.resolver;
-        }
-        const resolver = createStyleResolver(styles);
-        styleResolverCacheRef.current = { styles, resolver };
-        return resolver;
-      },
-      [],
-    );
-
-    const {
-      zoom,
-      zoomRef,
-      setZoomWithViewportAnchor,
-      scrollPageInfo,
-      setScrollPageInfo,
-    } = useZoomAndPageInfo({
-      scrollContainerRef,
-      pagedEditorRef,
-      initialZoom,
-    });
-    const [bodyHistoryAvailability, setBodyHistoryAvailability] = useState({
-      canRedo: false,
-      canUndo: false,
-    });
-
-    // Measure toolbar height for positioning the outline panel below it
-    const toolbarRefCallback = useCallback((el: HTMLDivElement | null) => {
-      toolbarWrapperRef.current = el;
-      // Clean up previous observer
-      if (toolbarRoRef.current) {
-        toolbarRoRef.current.disconnect();
-        toolbarRoRef.current = null;
-      }
-      if (!el) {
-        setToolbarHeight(0);
-        return;
-      }
-      setToolbarHeight(el.offsetHeight);
-      const ro = new ResizeObserver(() => {
-        setToolbarHeight(el.offsetHeight);
-      });
-      ro.observe(el);
-      toolbarRoRef.current = ro;
-    }, []);
-
-    // Cleanup ResizeObserver on unmount
-    useEffect(
-      () => () => {
-        toolbarRoRef.current?.disconnect();
-      },
-      [],
-    );
-
-    const pushDocument = useCallback(
-      (document: Document) => {
-        history.push(document);
-        return document;
-      },
-      [history],
-    );
-
-    const refreshBodyHistoryAvailability = useCallback(() => {
-      const canUndo = pagedEditorRef.current?.canUndo() ?? false;
-      const canRedo = pagedEditorRef.current?.canRedo() ?? false;
-      setBodyHistoryAvailability((prev) =>
-        prev.canUndo === canUndo && prev.canRedo === canRedo
-          ? prev
-          : { canUndo, canRedo },
-      );
-    }, []);
-
-    // Header/footer editing state + content resolution + mutation callbacks
-    const {
-      hfEditPosition,
-      setHfEditPosition,
-      hfEditIsFirstPage,
-      headerContent,
-      footerContent,
-      firstPageHeaderContent,
-      firstPageFooterContent,
-      effectiveSectionProperties,
-      handleHeaderFooterDoubleClick,
-      handleHeaderFooterSave,
-      handleBodyClick,
-      handleRemoveHeaderFooter,
-    } = useHeaderFooterEditor({ history, pushDocument, hfEditorRef });
-
-    // Helper to get the active editor's view — returns HF editor view when in HF editing mode
-    const getActiveEditorView = useCallback(() => {
-      if (hfEditPosition && hfEditorRef.current) {
-        return hfEditorRef.current.getView();
-      }
-      return pagedEditorRef.current?.getView();
-    }, [hfEditPosition]);
-
-    // Helper to focus the active editor
-    const focusActiveEditor = useCallback(() => {
-      if (hfEditPosition && hfEditorRef.current) {
-        hfEditorRef.current.focus();
-      } else {
-        pagedEditorRef.current?.focus();
-      }
-    }, [hfEditPosition]);
-
-    // Helper to undo in the active editor
-    const undoActiveEditor = useCallback(() => {
-      if (hfEditPosition && hfEditorRef.current) {
-        hfEditorRef.current.undo();
-      } else {
-        pagedEditorRef.current?.undo();
-        requestAnimationFrame(refreshBodyHistoryAvailability);
-      }
-    }, [hfEditPosition, refreshBodyHistoryAvailability]);
-
-    // Helper to redo in the active editor
-    const redoActiveEditor = useCallback(() => {
-      if (hfEditPosition && hfEditorRef.current) {
-        hfEditorRef.current.redo();
-      } else {
-        pagedEditorRef.current?.redo();
-        requestAnimationFrame(refreshBodyHistoryAvailability);
-      }
-    }, [hfEditPosition, refreshBodyHistoryAvailability]);
-
-    // Find/Replace hook
-    const findReplace = useFindReplaceState();
-
-    // Page setup dialog state
-    const [showPageSetup, setShowPageSetup] = useState(false);
-
-    // Hyperlink handlers (popup state, navigation, etc.)
-    const {
-      hyperlinkPopupData,
-      handleHyperlinkClick,
-      handleHyperlinkPopupNavigate,
-      handleHyperlinkPopupCopy,
-      handleHyperlinkPopupEdit,
-      handleHyperlinkPopupRemove,
-      handleHyperlinkPopupClose,
-    } = useHyperlinkHandlers({
-      getActiveEditorView,
-      focusActiveEditor,
-    });
-
-    const {
-      imagePositionOpen,
-      setImagePositionOpen,
-      imagePropsOpen,
-      setImagePropsOpen,
-      handleImageFileChange,
-      handleImageWrapType,
-      handleImageTransform,
-      handleApplyImagePosition,
-      handleOpenImageProperties,
-      handleApplyImageProperties,
-    } = useImageHandlers({
-      getActiveEditorView,
-      focusActiveEditor,
-      pmImageContext: state.pmImageContext,
-    });
-
-    // Document loading (parse buffer, reset UI, keep original buffer for save)
-    const { loadBuffer, loadParsedDocument, originalBufferRef } =
-      useDocumentLoader({
-        documentBuffer: documentBuffer ?? null,
-        initialDocument: initialDocument ?? null,
-        history,
-        onError,
-        onCompatibilityChange,
-        onReset: useCallback(() => {
-          commentsDirtyRef.current = false;
-          commentsLoadedRef.current = false;
-          trackedChangesLoadedRef.current = false;
-          setComments([]);
-          setTrackedChanges([]);
-          setVisibleCommentAuthors(null);
-          setActiveCommentId(null);
-          setHeadingInfos([]);
-          setShowCommentsSidebar(false);
-          setIsAddingComment(false);
-          setCommentSelectionRange(null);
-          setAddCommentYPosition(null);
-          setFloatingCommentBtn(null);
-          setHfEditPosition(null);
-          setAnchorPositions(EMPTY_ANCHOR_POSITIONS);
-          findReplace.setMatches([], 0);
-          if (extractTrackedChangesTimerRef.current) {
-            clearTimeout(extractTrackedChangesTimerRef.current);
-            extractTrackedChangesTimerRef.current = null;
-          }
-        }, [findReplace, setHfEditPosition]),
-        setDocumentLoadState: useCallback((documentLoad: DocumentLoadState) => {
-          setState((prev) => ({ ...prev, documentLoad }));
-        }, []),
-      });
-
-    // Extract tracked changes once PM view is ready (after loading completes)
-    const trackedChangesLoadedRef = useRef(false);
-    useEffect(() => {
-      if (state.documentLoad.status === "ready" && history.state) {
-        const timer = setTimeout(() => {
-          extractTrackedChanges();
-          // Auto-open sidebar once on initial load
-          if (!trackedChangesLoadedRef.current) {
-            trackedChangesLoadedRef.current = true;
-            // Check if we just populated tracked changes
-            setTrackedChanges((prev) => {
-              if (autoOpenReviewSidebar && prev.length > 0) {
-                setShowCommentsSidebar(true);
-              }
-              return prev;
-            });
-          }
-        }, 200);
-        return () => clearTimeout(timer);
-      }
-      return undefined;
-    }, [
-      state.documentLoad.status,
-      history.state,
-      extractTrackedChanges,
-      autoOpenReviewSidebar,
-    ]);
-
-    const initialScrollAppliedRef = useRef(false);
-    useEffect(() => {
-      if (
-        initialScrollTop === undefined ||
-        state.documentLoad.status !== "ready" ||
-        initialScrollAppliedRef.current
-      ) {
-        return undefined;
-      }
-
-      initialScrollAppliedRef.current = true;
-      const frame = requestAnimationFrame(() => {
-        if (scrollContainerRef.current) {
-          scrollContainerRef.current.scrollTop = initialScrollTop;
-        }
-      });
-
-      return () => {
-        cancelAnimationFrame(frame);
-      };
-    }, [initialScrollTop, state.documentLoad.status]);
-
-    // Listen for font loading
-    useEffect(() => {
-      const cleanup = onFontsLoaded(() => {
-        onFontsLoadedCallback?.();
-      });
-      return cleanup;
-    }, [onFontsLoadedCallback]);
-
-    // Sync editing mode to ProseMirror suggestion mode plugin
-    useEffect(() => {
-      const view = pagedEditorRef.current?.getView();
-      if (view) {
-        setSuggestionMode(
-          editingMode === "suggesting",
-          view.state,
-          view.dispatch,
-          author,
-        );
-      }
-    }, [editingMode, author]);
-
-    // Handle document change
-    const handleDocumentChange = useCallback(
-      (newDocument: Document) => {
-        const currentComments = commentsRef.current;
-        const documentWithComments = structuredClone(newDocument);
-        documentWithComments.package.document.comments = currentComments;
-        pushDocument(documentWithComments);
-        onChange?.(documentWithComments);
-        // Update outline headings if sidebar is open
-        if (showOutlineRef.current) {
-          const view = pagedEditorRef.current?.getView();
-          if (view) {
-            setHeadingInfos(collectHeadings(view.state.doc));
-          }
-        }
-        // Re-extract tracked changes after document change (debounced to avoid
-        // full-document walk on every keystroke in suggestion mode)
-        if (extractTrackedChangesTimerRef.current) {
-          clearTimeout(extractTrackedChangesTimerRef.current);
-        }
-        extractTrackedChangesTimerRef.current = setTimeout(
-          extractTrackedChanges,
-          300,
-        );
-        requestAnimationFrame(refreshBodyHistoryAvailability);
-      },
-      [
-        onChange,
-        pushDocument,
+      extractTrackedChangesTimerRef.current = setTimeout(
         extractTrackedChanges,
-        refreshBodyHistoryAvailability,
-      ],
-    );
-
-    const buildCurrentDocument = useCallback(() => {
-      if (!history.state) {
-        return null;
-      }
-
-      const doc = structuredClone(history.state);
-      const pmDoc = pagedEditorRef.current?.getDocument();
-      if (pmDoc) {
-        doc.package.document.content = pmDoc.package.document.content;
-      }
-      // Drop comment threads whose anchor text has been edited away. The
-      // in-memory `comments` array can outlive its in-body anchors (PM
-      // removes the mark when its text is deleted, but the array entry
-      // stays put), and serializing the unfiltered array writes
-      // unanchored threads into `comments.xml` that no reader can
-      // resolve.
-      // Collect anchors from every part of the doc that can carry a
-      // comment marker — body, headers, footers, footnotes, endnotes.
-      // A body-only walk would prune legitimate header/footer/note
-      // comments because their anchors live outside `document.content`.
-      const referencedCommentIds = collectCommentIdsFromSources(
-        doc.package.document.content,
-        doc.package.headers,
-        doc.package.footers,
-        doc.package.footnotes,
-        doc.package.endnotes,
+        300,
       );
-      doc.package.document.comments = pruneOrphanedComments(
-        commentsRef.current,
-        referencedCommentIds,
-      );
-      return doc;
-    }, [history.state]);
+      requestAnimationFrame(refreshBodyHistoryAvailability);
+    },
+    [
+      onChange,
+      pushDocument,
+      extractTrackedChanges,
+      refreshBodyHistoryAvailability,
+    ],
+  );
 
-    const replaceComments = useCallback(
-      (nextComments: Comment[]) => {
-        commentsDirtyRef.current = true;
-        commentsRef.current = nextComments;
-        setComments(nextComments);
+  const buildCurrentDocument = useCallback(() => {
+    if (!history.state) {
+      return null;
+    }
 
-        const currentDocument = buildCurrentDocument();
-        if (!currentDocument) {
-          return;
-        }
-
-        onChange?.(currentDocument);
-      },
-      [buildCurrentDocument, onChange],
+    const doc = structuredClone(history.state);
+    const pmDoc = pagedEditorRef.current?.getDocument();
+    if (pmDoc) {
+      doc.package.document.content = pmDoc.package.document.content;
+    }
+    // Drop comment threads whose anchor text has been edited away. The
+    // in-memory `comments` array can outlive its in-body anchors (PM
+    // removes the mark when its text is deleted, but the array entry
+    // stays put), and serializing the unfiltered array writes
+    // unanchored threads into `comments.xml` that no reader can
+    // resolve.
+    // Collect anchors from every part of the doc that can carry a
+    // comment marker — body, headers, footers, footnotes, endnotes.
+    // A body-only walk would prune legitimate header/footer/note
+    // comments because their anchors live outside `document.content`.
+    const referencedCommentIds = collectCommentIdsFromSources(
+      doc.package.document.content,
+      doc.package.headers,
+      doc.package.footers,
+      doc.package.footnotes,
+      doc.package.endnotes,
     );
-
-    const updateComments = useCallback(
-      (updater: (comments: Comment[]) => Comment[]) => {
-        replaceComments(updater(commentsRef.current));
-      },
-      [replaceComments],
+    doc.package.document.comments = pruneOrphanedComments(
+      commentsRef.current,
+      referencedCommentIds,
     );
+    return doc;
+  }, [history.state]);
 
-    const selectFindMatch = useCallback((match: FindMatch): boolean => {
-      const editor = pagedEditorRef.current;
-      const view = editor?.getView();
-      if (!editor || !view) {
-        return false;
+  const replaceComments = useCallback(
+    (nextComments: Comment[]) => {
+      commentsDirtyRef.current = true;
+      commentsRef.current = nextComments;
+      setComments(nextComments);
+
+      const currentDocument = buildCurrentDocument();
+      if (!currentDocument) {
+        return;
       }
 
-      const range = resolveFindMatchRange(view.state.doc, match);
-      if (!range) {
-        return false;
-      }
+      onChange?.(currentDocument);
+    },
+    [buildCurrentDocument, onChange],
+  );
 
-      editor.setSelection(range.from, range.to);
-      requestAnimationFrame(() => {
-        editor.scrollToPosition(range.from);
-      });
-      return true;
-    }, []);
+  const updateComments = useCallback(
+    (updater: (comments: Comment[]) => Comment[]) => {
+      replaceComments(updater(commentsRef.current));
+    },
+    [replaceComments],
+  );
 
-    // Find/Replace handlers (depends on handleDocumentChange)
-    const {
-      findResultRef,
-      handleFind,
-      handleFindNext,
-      handleFindPrevious,
-      handleReplace,
-      handleReplaceAll,
-    } = useFindReplace({
-      getDocumentState: buildCurrentDocument,
-      containerRef,
-      handleDocumentChange,
-      findReplace,
-      selectMatch: selectFindMatch,
+  const selectFindMatch = useCallback((match: FindMatch): boolean => {
+    const editor = pagedEditorRef.current;
+    const view = editor?.getView();
+    if (!editor || !view) {
+      return false;
+    }
+
+    const range = resolveFindMatchRange(view.state.doc, match);
+    if (!range) {
+      return false;
+    }
+
+    editor.setSelection(range.from, range.to);
+    requestAnimationFrame(() => {
+      editor.scrollToPosition(range.from);
     });
+    return true;
+  }, []);
 
-    // Handle selection changes from ProseMirror
-    const handleSelectionChange = useCallback(
-      (selectionState: SelectionState | null) => {
-        // Save selection for restoring after toolbar interactions
-        const view = getActiveEditorView();
-        if (view) {
-          const { from, to } = view.state.selection;
-          lastSelectionRef.current = { from, to };
+  // Find/Replace handlers (depends on handleDocumentChange)
+  const {
+    findResultRef,
+    handleFind,
+    handleFindNext,
+    handleFindPrevious,
+    handleReplace,
+    handleReplaceAll,
+  } = useFindReplace({
+    getDocumentState: buildCurrentDocument,
+    containerRef,
+    handleDocumentChange,
+    findReplace,
+    selectMatch: selectFindMatch,
+  });
+
+  // Handle selection changes from ProseMirror
+  const handleSelectionChange = useCallback(
+    (selectionState: SelectionState | null) => {
+      // Save selection for restoring after toolbar interactions
+      const view = getActiveEditorView();
+      if (view) {
+        const { from, to } = view.state.selection;
+        lastSelectionRef.current = { from, to };
+      }
+
+      // Also check table context from ProseMirror
+      let pmTableCtx: TableContextInfo | null = null;
+      if (view) {
+        pmTableCtx = getTableContext(view.state);
+        if (!pmTableCtx.isInTable) {
+          pmTableCtx = null;
         }
+      }
 
-        // Also check table context from ProseMirror
-        let pmTableCtx: TableContextInfo | null = null;
-        if (view) {
-          pmTableCtx = getTableContext(view.state);
-          if (!pmTableCtx.isInTable) {
-            pmTableCtx = null;
-          }
+      // Sync borderSpecRef with the current cell's actual border color
+      if (pmTableCtx?.cellBorderColor) {
+        const colorVal = pmTableCtx.cellBorderColor;
+        // Resolve theme/auto colors to hex
+        let rgb = colorVal.rgb;
+        if (!rgb || rgb === "auto") {
+          const resolved = resolveColor(colorVal, theme);
+          rgb = resolved.replace(/^#/u, "");
         }
+        borderSpecRef.current = {
+          ...borderSpecRef.current,
+          color: { rgb },
+        };
+      }
 
-        // Sync borderSpecRef with the current cell's actual border color
-        if (pmTableCtx?.cellBorderColor) {
-          const colorVal = pmTableCtx.cellBorderColor;
-          // Resolve theme/auto colors to hex
-          let rgb = colorVal.rgb;
-          if (!rgb || rgb === "auto") {
-            const resolved = resolveColor(colorVal, theme);
-            rgb = resolved.replace(/^#/u, "");
-          }
-          borderSpecRef.current = {
-            ...borderSpecRef.current,
-            color: { rgb },
-          };
-        }
+      // Image context (when the selection is a NodeSelection of an image)
+      // and active tracked-change at the cursor live in pure helpers so the
+      // logic is unit-tested without spinning up a real component.
+      const pmImageCtx = view ? detectImageContext(view.state) : null;
+      const trackedChange = view ? detectActiveTrackedChange(view.state) : null;
 
-        // Image context (when the selection is a NodeSelection of an image)
-        // and active tracked-change at the cursor live in pure helpers so the
-        // logic is unit-tested without spinning up a real component.
-        const pmImageCtx = view ? detectImageContext(view.state) : null;
-        const trackedChange = view
-          ? detectActiveTrackedChange(view.state)
-          : null;
-
-        if (!selectionState) {
-          setFloatingCommentBtn(null);
-          setState((prev) => {
-            const selectionFormatting = areSelectionFormattingEqual(
-              prev.selectionFormatting,
-              EMPTY_SELECTION_FORMATTING,
-            )
-              ? prev.selectionFormatting
-              : EMPTY_SELECTION_FORMATTING;
-            const pmTableContext = areTableContextsEqual(
-              prev.pmTableContext,
-              pmTableCtx,
-            )
-              ? prev.pmTableContext
-              : pmTableCtx;
-            const pmImageContext = areImageContextsEqual(
-              prev.pmImageContext,
-              pmImageCtx,
-            )
-              ? prev.pmImageContext
-              : pmImageCtx;
-            const activeTrackedChange = areActiveTrackedChangesEqual(
-              prev.activeTrackedChange,
-              trackedChange,
-            )
-              ? prev.activeTrackedChange
-              : trackedChange;
-            if (
-              selectionFormatting === prev.selectionFormatting &&
-              pmTableContext === prev.pmTableContext &&
-              pmImageContext === prev.pmImageContext &&
-              activeTrackedChange === prev.activeTrackedChange
-            ) {
-              return prev;
-            }
-            return {
-              ...prev,
-              selectionFormatting,
-              pmTableContext,
-              pmImageContext,
-              activeTrackedChange,
-            };
-          });
-          return;
-        }
-
-        // Update toolbar formatting from ProseMirror selection
-        const { textFormatting, paragraphFormatting } = selectionState;
-
-        // Extract font family (prefer ascii, fall back to hAnsi)
-        let fontFamily =
-          textFormatting.fontFamily?.ascii || textFormatting.fontFamily?.hAnsi;
-        let fontSize = textFormatting.fontSize;
-
-        // If no explicit font/size marks, resolve from paragraph style or document defaults
-        if (!fontFamily || !fontSize) {
-          const currentDoc = historyStateRef.current;
-          const paraStyleId = selectionState.styleId;
-          if (currentDoc?.package.styles && paraStyleId) {
-            const resolver = getCachedStyleResolver(currentDoc.package.styles);
-            const resolved = resolver.resolveParagraphStyle(paraStyleId);
-            if (!fontFamily && resolved.runFormatting?.fontFamily) {
-              fontFamily =
-                resolved.runFormatting.fontFamily.ascii ||
-                resolved.runFormatting.fontFamily.hAnsi;
-            }
-            if (!fontSize && resolved.runFormatting?.fontSize) {
-              fontSize = resolved.runFormatting.fontSize;
-            }
-          }
-        }
-
-        // Extract text color as hex string
-        const textColor = textFormatting.color?.rgb
-          ? `#${textFormatting.color.rgb}`
-          : undefined;
-
-        const listState = extractListState(paragraphFormatting.numPr);
-        const formatting = buildSelectionFormatting({
-          selectionState,
-          fontFamily,
-          fontSize,
-          textColor,
-          listState,
-        });
+      if (!selectionState) {
+        setFloatingCommentBtn(null);
         setState((prev) => {
           const selectionFormatting = areSelectionFormattingEqual(
             prev.selectionFormatting,
-            formatting,
+            EMPTY_SELECTION_FORMATTING,
           )
             ? prev.selectionFormatting
-            : formatting;
+            : EMPTY_SELECTION_FORMATTING;
           const pmTableContext = areTableContextsEqual(
             prev.pmTableContext,
             pmTableCtx,
@@ -1416,137 +1320,220 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           )
             ? prev.activeTrackedChange
             : trackedChange;
-          const paragraphIndentLeft = paragraphFormatting.indentLeft ?? 0;
-          const paragraphIndentRight = paragraphFormatting.indentRight ?? 0;
-          const paragraphFirstLineIndent =
-            paragraphFormatting.indentFirstLine ?? 0;
-          const paragraphHangingIndent =
-            paragraphFormatting.hangingIndent ?? false;
-          const paragraphTabs = paragraphFormatting.tabs ?? null;
           if (
             selectionFormatting === prev.selectionFormatting &&
             pmTableContext === prev.pmTableContext &&
             pmImageContext === prev.pmImageContext &&
-            activeTrackedChange === prev.activeTrackedChange &&
-            paragraphIndentLeft === prev.paragraphIndentLeft &&
-            paragraphIndentRight === prev.paragraphIndentRight &&
-            paragraphFirstLineIndent === prev.paragraphFirstLineIndent &&
-            paragraphHangingIndent === prev.paragraphHangingIndent &&
-            paragraphTabs === prev.paragraphTabs
+            activeTrackedChange === prev.activeTrackedChange
           ) {
             return prev;
           }
           return {
             ...prev,
             selectionFormatting,
-            paragraphIndentLeft,
-            paragraphIndentRight,
-            paragraphFirstLineIndent,
-            paragraphHangingIndent,
-            paragraphTabs,
             pmTableContext,
             pmImageContext,
             activeTrackedChange,
           };
         });
+        return;
+      }
 
-        // Update floating comment button position
-        if (
-          view &&
-          selectionState.hasSelection &&
-          !isAddingComment &&
-          !readOnly
-        ) {
-          const container = scrollContainerRef.current;
-          const parentEl = editorContentRef.current;
-          const { from: selFrom } = view.state.selection;
-          const top = findSelectionYPosition(container, parentEl, selFrom);
-          if (top !== null && container && parentEl) {
-            const pagesEl = container.querySelector(".paged-editor__pages");
-            const pageEl =
-              pagesEl instanceof Element
-                ? queryHtmlElement(pagesEl, ".layout-page")
-                : null;
-            const parentRect = parentEl.getBoundingClientRect();
-            const rawLeft = pageEl
-              ? pageEl.getBoundingClientRect().right - parentRect.left + 12
-              : parentRect.width / 2 + 408;
-            const left = Math.max(16, Math.min(rawLeft, parentRect.width - 16));
-            const { from, to } = view.state.selection;
-            if (from !== to) {
-              setFloatingCommentBtn({ top, left, from, to });
-            } else {
-              setFloatingCommentBtn(null);
-            }
+      // Update toolbar formatting from ProseMirror selection
+      const { textFormatting, paragraphFormatting } = selectionState;
+
+      // Extract font family (prefer ascii, fall back to hAnsi)
+      let fontFamily =
+        textFormatting.fontFamily?.ascii || textFormatting.fontFamily?.hAnsi;
+      let fontSize = textFormatting.fontSize;
+
+      // If no explicit font/size marks, resolve from paragraph style or document defaults
+      if (!fontFamily || !fontSize) {
+        const currentDoc = historyStateRef.current;
+        const paraStyleId = selectionState.styleId;
+        if (currentDoc?.package.styles && paraStyleId) {
+          const resolver = getCachedStyleResolver(currentDoc.package.styles);
+          const resolved = resolver.resolveParagraphStyle(paraStyleId);
+          if (!fontFamily && resolved.runFormatting?.fontFamily) {
+            fontFamily =
+              resolved.runFormatting.fontFamily.ascii ||
+              resolved.runFormatting.fontFamily.hAnsi;
           }
-        } else {
-          setFloatingCommentBtn(null);
+          if (!fontSize && resolved.runFormatting?.fontSize) {
+            fontSize = resolved.runFormatting.fontSize;
+          }
         }
+      }
 
-        // Notify parent
-        onSelectionChange?.(selectionState);
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [onSelectionChange, isAddingComment, readOnly],
+      // Extract text color as hex string
+      const textColor = textFormatting.color?.rgb
+        ? `#${textFormatting.color.rgb}`
+        : undefined;
+
+      const listState = extractListState(paragraphFormatting.numPr);
+      const formatting = buildSelectionFormatting({
+        selectionState,
+        fontFamily,
+        fontSize,
+        textColor,
+        listState,
+      });
+      setState((prev) => {
+        const selectionFormatting = areSelectionFormattingEqual(
+          prev.selectionFormatting,
+          formatting,
+        )
+          ? prev.selectionFormatting
+          : formatting;
+        const pmTableContext = areTableContextsEqual(
+          prev.pmTableContext,
+          pmTableCtx,
+        )
+          ? prev.pmTableContext
+          : pmTableCtx;
+        const pmImageContext = areImageContextsEqual(
+          prev.pmImageContext,
+          pmImageCtx,
+        )
+          ? prev.pmImageContext
+          : pmImageCtx;
+        const activeTrackedChange = areActiveTrackedChangesEqual(
+          prev.activeTrackedChange,
+          trackedChange,
+        )
+          ? prev.activeTrackedChange
+          : trackedChange;
+        const paragraphIndentLeft = paragraphFormatting.indentLeft ?? 0;
+        const paragraphIndentRight = paragraphFormatting.indentRight ?? 0;
+        const paragraphFirstLineIndent =
+          paragraphFormatting.indentFirstLine ?? 0;
+        const paragraphHangingIndent =
+          paragraphFormatting.hangingIndent ?? false;
+        const paragraphTabs = paragraphFormatting.tabs ?? null;
+        if (
+          selectionFormatting === prev.selectionFormatting &&
+          pmTableContext === prev.pmTableContext &&
+          pmImageContext === prev.pmImageContext &&
+          activeTrackedChange === prev.activeTrackedChange &&
+          paragraphIndentLeft === prev.paragraphIndentLeft &&
+          paragraphIndentRight === prev.paragraphIndentRight &&
+          paragraphFirstLineIndent === prev.paragraphFirstLineIndent &&
+          paragraphHangingIndent === prev.paragraphHangingIndent &&
+          paragraphTabs === prev.paragraphTabs
+        ) {
+          return prev;
+        }
+        return {
+          ...prev,
+          selectionFormatting,
+          paragraphIndentLeft,
+          paragraphIndentRight,
+          paragraphFirstLineIndent,
+          paragraphHangingIndent,
+          paragraphTabs,
+          pmTableContext,
+          pmImageContext,
+          activeTrackedChange,
+        };
+      });
+
+      // Update floating comment button position
+      if (
+        view &&
+        selectionState.hasSelection &&
+        !isAddingComment &&
+        !readOnly
+      ) {
+        const container = scrollContainerRef.current;
+        const parentEl = editorContentRef.current;
+        const { from: selFrom } = view.state.selection;
+        const top = findSelectionYPosition(container, parentEl, selFrom);
+        if (top !== null && container && parentEl) {
+          const pagesEl = container.querySelector(".paged-editor__pages");
+          const pageEl =
+            pagesEl instanceof Element
+              ? queryHtmlElement(pagesEl, ".layout-page")
+              : null;
+          const parentRect = parentEl.getBoundingClientRect();
+          const rawLeft = pageEl
+            ? pageEl.getBoundingClientRect().right - parentRect.left + 12
+            : parentRect.width / 2 + 408;
+          const left = Math.max(16, Math.min(rawLeft, parentRect.width - 16));
+          const { from, to } = view.state.selection;
+          if (from !== to) {
+            setFloatingCommentBtn({ top, left, from, to });
+          } else {
+            setFloatingCommentBtn(null);
+          }
+        }
+      } else {
+        setFloatingCommentBtn(null);
+      }
+
+      // Notify parent
+      onSelectionChange?.(selectionState);
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [onSelectionChange, isAddingComment, readOnly],
+  );
+
+  // Table selection hook
+  const tableSelection = useTableSelection({
+    document: history.state,
+    onChange: handleDocumentChange,
+    onSelectionChange: (_context) => {
+      // Could notify parent of table selection changes
+    },
+  });
+
+  const handleDirectPrint = useCallback(() => {
+    if (onPrint) {
+      onPrint();
+      return;
+    }
+
+    const pages = containerRef.current?.querySelector(".paged-editor__pages");
+    if (!pages) {
+      toast(t("printRedirect"));
+      return;
+    }
+
+    const iframe = document.createElement("iframe");
+    iframe.style.position = "fixed";
+    iframe.style.width = "0";
+    iframe.style.height = "0";
+    iframe.style.border = "0";
+    iframe.style.opacity = "0";
+    iframe.style.pointerEvents = "none";
+    document.body.append(iframe);
+
+    const printDocument = iframe.contentDocument;
+    const printWindow = iframe.contentWindow;
+    if (!printDocument || !printWindow) {
+      iframe.remove();
+      toast(t("printRedirect"));
+      return;
+    }
+
+    const styles = [
+      ...document.querySelectorAll('style, link[rel="stylesheet"]'),
+    ]
+      .map((node) => node.outerHTML)
+      .join("\n");
+    const pagesCloneRaw = pages.cloneNode(true);
+    if (!(pagesCloneRaw instanceof HTMLElement)) {
+      return;
+    }
+    const pagesClone = pagesCloneRaw;
+    const overlays = pagesClone.querySelectorAll(
+      ".selection-overlay, .layout-selection-overlay, .image-selection-overlay",
     );
+    for (const node of overlays) {
+      node.remove();
+    }
 
-    // Table selection hook
-    const tableSelection = useTableSelection({
-      document: history.state,
-      onChange: handleDocumentChange,
-      onSelectionChange: (_context) => {
-        // Could notify parent of table selection changes
-      },
-    });
-
-    const handleDirectPrint = useCallback(() => {
-      if (onPrint) {
-        onPrint();
-        return;
-      }
-
-      const pages = containerRef.current?.querySelector(".paged-editor__pages");
-      if (!pages) {
-        toast(t("printRedirect"));
-        return;
-      }
-
-      const iframe = document.createElement("iframe");
-      iframe.style.position = "fixed";
-      iframe.style.width = "0";
-      iframe.style.height = "0";
-      iframe.style.border = "0";
-      iframe.style.opacity = "0";
-      iframe.style.pointerEvents = "none";
-      document.body.append(iframe);
-
-      const printDocument = iframe.contentDocument;
-      const printWindow = iframe.contentWindow;
-      if (!printDocument || !printWindow) {
-        iframe.remove();
-        toast(t("printRedirect"));
-        return;
-      }
-
-      const styles = [
-        ...document.querySelectorAll('style, link[rel="stylesheet"]'),
-      ]
-        .map((node) => node.outerHTML)
-        .join("\n");
-      const pagesCloneRaw = pages.cloneNode(true);
-      if (!(pagesCloneRaw instanceof HTMLElement)) {
-        return;
-      }
-      const pagesClone = pagesCloneRaw;
-      const overlays = pagesClone.querySelectorAll(
-        ".selection-overlay, .layout-selection-overlay, .image-selection-overlay",
-      );
-      for (const node of overlays) {
-        node.remove();
-      }
-
-      printDocument.open();
-      printDocument.write(`<!doctype html>
+    printDocument.open();
+    printDocument.write(`<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />
@@ -1582,708 +1569,686 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
   </head>
   <body>${pagesClone.outerHTML}</body>
 </html>`);
-      printDocument.close();
+    printDocument.close();
 
-      const cleanupState = { isCleanedUp: false };
-      const cleanup = () => {
-        if (cleanupState.isCleanedUp) {
-          return;
-        }
-        cleanupState.isCleanedUp = true;
-        iframe.remove();
-      };
-      printWindow.addEventListener("afterprint", cleanup, { once: true });
-      setTimeout(cleanup, 5 * 60 * 1000);
-
-      const waitForFrameLoad = async () =>
-        await new Promise<void>((resolve) => {
-          if (printDocument.readyState === "complete") {
-            resolve();
-            return;
-          }
-
-          iframe.addEventListener("load", () => resolve(), { once: true });
-          setTimeout(resolve, 1000);
-        });
-
-      const waitForFonts = async () =>
-        await Promise.race([
-          printDocument.fonts.ready.catch(() => undefined),
-          new Promise((resolve) => {
-            setTimeout(resolve, 1000);
-          }),
-        ]);
-
-      void (async () => {
-        await waitForFrameLoad();
-        await waitForFonts();
-        if (cleanupState.isCleanedUp) {
-          return;
-        }
-        printWindow.focus();
-        printWindow.print();
-      })();
-    }, [onPrint, t]);
-
-    useKeyboardShortcuts({
-      pagedEditorRef,
-      findReplace,
-      tableSelection,
-      onDirectPrint: handleDirectPrint,
-    });
-
-    // Handle footnote/endnote properties update
-    const handleApplyFootnoteProperties = useCallback(
-      (footnotePr: FootnoteProperties, endnotePr: EndnoteProperties) => {
-        if (!history.state?.package) {
-          return;
-        }
-        const newDoc = {
-          ...history.state.package.document,
-          finalSectionProperties: {
-            ...history.state.package.document.finalSectionProperties,
-            footnotePr,
-            endnotePr,
-          },
-        };
-        pushDocument({
-          ...history.state,
-          package: {
-            ...history.state.package,
-            document: newDoc,
-          },
-        });
-      },
-      [history, pushDocument],
-    );
-
-    // Handle table action from Toolbar - use ProseMirror commands
-    const handleTableAction = useCallback(
-      (action: TableAction) => {
-        const view = getActiveEditorView();
-        if (!view) {
-          return;
-        }
-
-        switch (action) {
-          case "addRowAbove":
-            addRowAbove(view.state, view.dispatch);
-            break;
-          case "addRowBelow":
-            addRowBelow(view.state, view.dispatch);
-            break;
-          case "addColumnLeft":
-            addColumnLeft(view.state, view.dispatch);
-            break;
-          case "addColumnRight":
-            addColumnRight(view.state, view.dispatch);
-            break;
-          case "deleteRow":
-            pmDeleteRow(view.state, view.dispatch);
-            break;
-          case "deleteColumn":
-            pmDeleteColumn(view.state, view.dispatch);
-            break;
-          case "deleteTable":
-            pmDeleteTable(view.state, view.dispatch);
-            break;
-          case "selectTable":
-            pmSelectTable(view.state, view.dispatch);
-            break;
-          case "selectRow":
-            pmSelectRow(view.state, view.dispatch);
-            break;
-          case "selectColumn":
-            pmSelectColumn(view.state, view.dispatch);
-            break;
-          case "mergeCells":
-            pmMergeCells(view.state, view.dispatch);
-            break;
-          case "splitCell":
-            pmSplitCell(view.state, view.dispatch);
-            break;
-          // Border actions — use current border spec from toolbar
-          case "borderAll":
-            setAllTableBorders(
-              view.state,
-              view.dispatch,
-              borderSpecRef.current,
-            );
-            break;
-          case "borderOutside":
-            setOutsideTableBorders(
-              view.state,
-              view.dispatch,
-              borderSpecRef.current,
-            );
-            break;
-          case "borderInside":
-            setInsideTableBorders(
-              view.state,
-              view.dispatch,
-              borderSpecRef.current,
-            );
-            break;
-          case "borderNone":
-            removeTableBorders(view.state, view.dispatch);
-            break;
-          // Per-side border actions (use current border spec)
-          case "borderTop":
-            setCellBorder(
-              "top",
-              borderSpecRef.current,
-              true,
-            )(view.state, view.dispatch);
-            break;
-          case "borderBottom":
-            setCellBorder(
-              "bottom",
-              borderSpecRef.current,
-              true,
-            )(view.state, view.dispatch);
-            break;
-          case "borderLeft":
-            setCellBorder(
-              "left",
-              borderSpecRef.current,
-              true,
-            )(view.state, view.dispatch);
-            break;
-          case "borderRight":
-            setCellBorder(
-              "right",
-              borderSpecRef.current,
-              true,
-            )(view.state, view.dispatch);
-            break;
-          default:
-            // Handle complex actions (with parameters)
-            if (typeof action === "object") {
-              if (action.type === "cellFillColor") {
-                setCellFillColor(action.color)(view.state, view.dispatch);
-              } else if (action.type === "borderColor") {
-                const rgb = action.color.replace(/^#/u, "");
-                borderSpecRef.current = {
-                  ...borderSpecRef.current,
-                  color: { rgb },
-                };
-                setTableBorderColor(action.color)(view.state, view.dispatch);
-              } else if (action.type === "borderWidth") {
-                borderSpecRef.current = {
-                  ...borderSpecRef.current,
-                  size: action.size,
-                };
-                setTableBorderWidth(action.size)(view.state, view.dispatch);
-              } else if (action.type === "cellBorder") {
-                setCellBorder(action.side, {
-                  style: action.style,
-                  size: action.size,
-                  color: { rgb: action.color.replace(/^#/u, "") },
-                })(view.state, view.dispatch);
-              } else if (action.type === "cellVerticalAlign") {
-                setCellVerticalAlign(action.align)(view.state, view.dispatch);
-              } else if (action.type === "cellMargins") {
-                setCellMargins(action.margins)(view.state, view.dispatch);
-              } else if (action.type === "cellTextDirection") {
-                setCellTextDirection(action.direction)(
-                  view.state,
-                  view.dispatch,
-                );
-              } else if (action.type === "toggleNoWrap") {
-                toggleNoWrap()(view.state, view.dispatch);
-              } else if (action.type === "rowHeight") {
-                setRowHeight(action.height, action.rule)(
-                  view.state,
-                  view.dispatch,
-                );
-              } else if (action.type === "toggleHeaderRow") {
-                toggleHeaderRow()(view.state, view.dispatch);
-              } else if (action.type === "distributeColumns") {
-                distributeColumns()(view.state, view.dispatch);
-              } else if (action.type === "autoFitContents") {
-                autoFitContents()(view.state, view.dispatch);
-              } else if (action.type === "openTableProperties") {
-                setTablePropsOpen(true);
-              } else if (action.type === "tableProperties") {
-                setTableProperties(action.props)(view.state, view.dispatch);
-              } else {
-                // Resolve style data from built-in presets or document styles
-                let preset: TableStylePreset | undefined = getBuiltinTableStyle(
-                  action.styleId,
-                );
-                const currentDocForTable = historyStateRef.current;
-                if (!preset && currentDocForTable?.package.styles) {
-                  const styleResolver = getCachedStyleResolver(
-                    currentDocForTable.package.styles,
-                  );
-                  const docStyle = styleResolver.getStyle(action.styleId);
-                  if (docStyle) {
-                    // Convert to preset inline (same as documentStyleToPreset)
-                    preset = {
-                      id: docStyle.styleId,
-                      name: docStyle.name ?? docStyle.styleId,
-                    };
-                    if (docStyle.tblPr?.borders) {
-                      const b = docStyle.tblPr.borders;
-                      preset.tableBorders = {};
-                      for (const side of [
-                        "top",
-                        "bottom",
-                        "left",
-                        "right",
-                        "insideH",
-                        "insideV",
-                      ] as const) {
-                        const bs = b[side];
-                        if (bs) {
-                          const borderEntry: {
-                            style: string;
-                            size?: number;
-                            color?: { rgb: string };
-                          } = {
-                            style: bs.style,
-                          };
-                          if (bs.size !== undefined) {
-                            borderEntry.size = bs.size;
-                          }
-                          if (bs.color?.rgb) {
-                            borderEntry.color = { rgb: bs.color.rgb };
-                          }
-                          preset.tableBorders[side] = borderEntry;
-                        }
-                      }
-                    }
-                    if (docStyle.tblStylePr) {
-                      preset.conditionals = {};
-                      for (const cond of docStyle.tblStylePr) {
-                        const entry: Record<string, unknown> = {};
-                        if (cond.tcPr?.shading?.fill?.rgb) {
-                          entry["backgroundColor"] =
-                            `#${cond.tcPr.shading.fill.rgb}`;
-                        }
-                        if (cond.tcPr?.borders) {
-                          const borders: Record<string, unknown> = {};
-                          for (const s of [
-                            "top",
-                            "bottom",
-                            "left",
-                            "right",
-                          ] as const) {
-                            const bs2 = cond.tcPr.borders[s];
-                            if (bs2) {
-                              borders[s] = {
-                                style: bs2.style,
-                                size: bs2.size,
-                                color: bs2.color?.rgb
-                                  ? { rgb: bs2.color.rgb }
-                                  : undefined,
-                              };
-                            }
-                          }
-                          entry["borders"] = borders;
-                        }
-                        if (cond.rPr?.bold) {
-                          entry["bold"] = true;
-                        }
-                        if (cond.rPr?.color?.rgb) {
-                          entry["color"] = `#${cond.rPr.color.rgb}`;
-                        }
-                        // SAFETY: preset.conditionals is Record<string, ...>; entry satisfies its value type
-                        preset.conditionals[cond.type] = entry as NonNullable<
-                          TableStylePreset["conditionals"]
-                        >[string];
-                      }
-                    }
-                    preset.look = {
-                      firstRow: true,
-                      lastRow: false,
-                      noHBand: false,
-                      noVBand: true,
-                    };
-                  }
-                }
-                if (preset) {
-                  const styleArg: Parameters<typeof applyTableStyle>[0] = {
-                    styleId: preset.id,
-                  };
-                  if (preset.tableBorders) {
-                    styleArg.tableBorders = preset.tableBorders;
-                  }
-                  if (preset.conditionals) {
-                    styleArg.conditionals = preset.conditionals;
-                  }
-                  if (preset.look) {
-                    styleArg.look = preset.look;
-                  }
-                  applyTableStyle(styleArg)(view.state, view.dispatch);
-                }
-              }
-            } else {
-              // Fallback to legacy table selection handler for other actions
-              tableSelection.handleAction(action);
-            }
-        }
-
-        focusActiveEditor();
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [tableSelection, getActiveEditorView, focusActiveEditor],
-    );
-
-    // Context menu handler
-    const handleEditorContextMenu = useCallback(
-      (e: React.MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-        openContextMenu({ x: e.clientX, y: e.clientY });
-      },
-      [openContextMenu],
-    );
-
-    // Handle formatting action from toolbar
-    const handleFormat = useCallback(
-      (action: FormattingAction) => {
-        const view = getActiveEditorView();
-        if (!view) {
-          return;
-        }
-
-        // Focus editor first to ensure we can dispatch commands
-        view.focus();
-
-        // Restore selection if it was lost during toolbar interaction
-        // This happens when user clicks on dropdown menus (font picker, style picker, etc.)
-        // Only restore for the body editor — HF editor manages its own selection
-        const isBodyEditor = view === pagedEditorRef.current?.getView();
-        const { from, to } = view.state.selection;
-        const savedSelection = lastSelectionRef.current;
-
-        if (
-          isBodyEditor &&
-          savedSelection &&
-          (from !== savedSelection.from || to !== savedSelection.to)
-        ) {
-          // Selection was lost (focus moved to dropdown portal) - restore it
-          try {
-            const tr = view.state.tr.setSelection(
-              TextSelection.create(
-                view.state.doc,
-                savedSelection.from,
-                savedSelection.to,
-              ),
-            );
-            view.dispatch(tr);
-          } catch {
-            // If restoration fails (e.g., positions are invalid after doc change), continue with current selection
-          }
-        }
-
-        const commandState = view.state;
-
-        // Handle simple toggle actions
-        if (action === "bold") {
-          toggleBold(commandState, view.dispatch);
-          return;
-        }
-        if (action === "italic") {
-          toggleItalic(commandState, view.dispatch);
-          return;
-        }
-        if (action === "underline") {
-          toggleUnderline(commandState, view.dispatch);
-          return;
-        }
-        if (action === "strikethrough") {
-          toggleStrike(commandState, view.dispatch);
-          return;
-        }
-        if (action === "superscript") {
-          toggleSuperscript(commandState, view.dispatch);
-          return;
-        }
-        if (action === "subscript") {
-          toggleSubscript(commandState, view.dispatch);
-          return;
-        }
-        if (action === "bulletList") {
-          toggleBulletList(commandState, view.dispatch);
-          return;
-        }
-        if (action === "numberedList") {
-          toggleNumberedList(commandState, view.dispatch);
-          return;
-        }
-        if (action === "indent") {
-          // Try list indent first, then paragraph indent
-          if (!increaseListLevel(commandState, view.dispatch)) {
-            increaseIndent()(commandState, view.dispatch);
-          }
-          return;
-        }
-        if (action === "outdent") {
-          // Try list outdent first, then paragraph outdent
-          if (!decreaseListLevel(commandState, view.dispatch)) {
-            decreaseIndent()(commandState, view.dispatch);
-          }
-          return;
-        }
-        if (action === "clearFormatting") {
-          clearFormatting(commandState, view.dispatch);
-          return;
-        }
-        if (action === "setRtl") {
-          setRtl(commandState, view.dispatch);
-          return;
-        }
-        if (action === "setLtr") {
-          setLtr(commandState, view.dispatch);
-          return;
-        }
-
-        // Handle object-based actions
-        if (typeof action === "object") {
-          switch (action.type) {
-            case "alignment":
-              setAlignment(action.value)(commandState, view.dispatch);
-              break;
-            case "textColor": {
-              // action.value can be a ColorValue object or a string like "#FF0000"
-              const colorVal = action.value;
-              if (typeof colorVal === "string") {
-                setTextColor({ rgb: colorVal.replace("#", "") })(
-                  commandState,
-                  view.dispatch,
-                );
-              } else if (colorVal.auto) {
-                // "Automatic" — remove text color
-                clearTextColor(commandState, view.dispatch);
-              } else {
-                setTextColor(colorVal)(commandState, view.dispatch);
-              }
-              break;
-            }
-            case "highlightColor": {
-              // Convert hex to OOXML named highlight value (e.g., 'FFFF00' → 'yellow')
-              const highlightName = action.value
-                ? mapHexToHighlightName(action.value)
-                : "";
-              setHighlight(highlightName || action.value)(
-                commandState,
-                view.dispatch,
-              );
-              break;
-            }
-            case "fontSize":
-              // Convert points to half-points (OOXML uses half-points for font sizes)
-              setFontSize(pointsToHalfPoints(action.value))(
-                commandState,
-                view.dispatch,
-              );
-              break;
-            case "fontFamily":
-              setFontFamily(action.value)(commandState, view.dispatch);
-              break;
-            case "lineSpacing":
-              setLineSpacing(action.value)(commandState, view.dispatch);
-              break;
-            case "applyStyle": {
-              // Resolve style to get its formatting properties
-              // Use ref to avoid stale closure (handleFormat has [] deps)
-              const currentDoc = historyStateRef.current;
-              const styleResolver = currentDoc?.package.styles
-                ? getCachedStyleResolver(currentDoc.package.styles)
-                : null;
-
-              if (styleResolver) {
-                const resolved = styleResolver.resolveParagraphStyle(
-                  action.value,
-                );
-                const styleAttrs: Parameters<typeof applyStyle>[1] = {};
-                if (resolved.paragraphFormatting) {
-                  styleAttrs.paragraphFormatting = resolved.paragraphFormatting;
-                }
-                if (resolved.runFormatting) {
-                  styleAttrs.runFormatting = resolved.runFormatting;
-                }
-                applyStyle(action.value, styleAttrs)(
-                  commandState,
-                  view.dispatch,
-                );
-              } else {
-                // No styles available, just set the styleId
-                applyStyle(action.value)(commandState, view.dispatch);
-              }
-              break;
-            }
-            default:
-              break;
-          }
-        }
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [getActiveEditorView],
-    );
-
-    const handleContextMenu = useCallback(
-      (data: { x: number; y: number; hasSelection: boolean }) => {
-        openContextMenu({ x: data.x, y: data.y }, data.hasSelection);
-      },
-      [openContextMenu],
-    );
-
-    const handleContextMenuClose = closeContextMenu;
-
-    const contextMenuItems = useMemo((): TextContextMenuItem[] => {
-      const isMac =
-        typeof navigator !== "undefined" && navigator.platform.includes("Mac");
-      const mod = isMac ? "⌘" : "Ctrl";
-      if (readOnly) {
-        return [
-          { action: "copy", label: t("copy"), shortcut: `${mod}+C` },
-          {
-            action: "selectAll",
-            label: t("selectAll"),
-            shortcut: `${mod}+A`,
-          },
-        ];
+    const cleanupState = { isCleanedUp: false };
+    const cleanup = () => {
+      if (cleanupState.isCleanedUp) {
+        return;
       }
-      const items: TextContextMenuItem[] = [
-        { action: "cut", label: t("cut"), shortcut: `${mod}+X` },
-        { action: "copy", label: t("copy"), shortcut: `${mod}+C` },
-        { action: "paste", label: t("paste"), shortcut: `${mod}+V` },
-        {
-          action: "pasteAsPlainText",
-          label: t("pasteUnformatted"),
-          shortcut: `${mod}+Shift+V`,
-          dividerAfter: true,
+      cleanupState.isCleanedUp = true;
+      iframe.remove();
+    };
+    printWindow.addEventListener("afterprint", cleanup, { once: true });
+    setTimeout(cleanup, 5 * 60 * 1000);
+
+    const waitForFrameLoad = async () =>
+      await new Promise<void>((resolve) => {
+        if (printDocument.readyState === "complete") {
+          resolve();
+          return;
+        }
+
+        iframe.addEventListener("load", () => resolve(), { once: true });
+        setTimeout(resolve, 1000);
+      });
+
+    const waitForFonts = async () =>
+      await Promise.race([
+        printDocument.fonts.ready.catch(() => undefined),
+        new Promise((resolve) => {
+          setTimeout(resolve, 1000);
+        }),
+      ]);
+
+    void (async () => {
+      await waitForFrameLoad();
+      await waitForFonts();
+      if (cleanupState.isCleanedUp) {
+        return;
+      }
+      printWindow.focus();
+      printWindow.print();
+    })();
+  }, [onPrint, t]);
+
+  useKeyboardShortcuts({
+    pagedEditorRef,
+    findReplace,
+    tableSelection,
+    onDirectPrint: handleDirectPrint,
+  });
+
+  // Handle footnote/endnote properties update
+  const handleApplyFootnoteProperties = useCallback(
+    (footnotePr: FootnoteProperties, endnotePr: EndnoteProperties) => {
+      if (!history.state?.package) {
+        return;
+      }
+      const newDoc = {
+        ...history.state.package.document,
+        finalSectionProperties: {
+          ...history.state.package.document.finalSectionProperties,
+          footnotePr,
+          endnotePr,
         },
+      };
+      pushDocument({
+        ...history.state,
+        package: {
+          ...history.state.package,
+          document: newDoc,
+        },
+      });
+    },
+    [history, pushDocument],
+  );
+
+  // Handle table action from Toolbar - use ProseMirror commands
+  const handleTableAction = useCallback(
+    (action: TableAction) => {
+      const view = getActiveEditorView();
+      if (!view) {
+        return;
+      }
+
+      switch (action) {
+        case "addRowAbove":
+          addRowAbove(view.state, view.dispatch);
+          break;
+        case "addRowBelow":
+          addRowBelow(view.state, view.dispatch);
+          break;
+        case "addColumnLeft":
+          addColumnLeft(view.state, view.dispatch);
+          break;
+        case "addColumnRight":
+          addColumnRight(view.state, view.dispatch);
+          break;
+        case "deleteRow":
+          pmDeleteRow(view.state, view.dispatch);
+          break;
+        case "deleteColumn":
+          pmDeleteColumn(view.state, view.dispatch);
+          break;
+        case "deleteTable":
+          pmDeleteTable(view.state, view.dispatch);
+          break;
+        case "selectTable":
+          pmSelectTable(view.state, view.dispatch);
+          break;
+        case "selectRow":
+          pmSelectRow(view.state, view.dispatch);
+          break;
+        case "selectColumn":
+          pmSelectColumn(view.state, view.dispatch);
+          break;
+        case "mergeCells":
+          pmMergeCells(view.state, view.dispatch);
+          break;
+        case "splitCell":
+          pmSplitCell(view.state, view.dispatch);
+          break;
+        // Border actions — use current border spec from toolbar
+        case "borderAll":
+          setAllTableBorders(view.state, view.dispatch, borderSpecRef.current);
+          break;
+        case "borderOutside":
+          setOutsideTableBorders(
+            view.state,
+            view.dispatch,
+            borderSpecRef.current,
+          );
+          break;
+        case "borderInside":
+          setInsideTableBorders(
+            view.state,
+            view.dispatch,
+            borderSpecRef.current,
+          );
+          break;
+        case "borderNone":
+          removeTableBorders(view.state, view.dispatch);
+          break;
+        // Per-side border actions (use current border spec)
+        case "borderTop":
+          setCellBorder(
+            "top",
+            borderSpecRef.current,
+            true,
+          )(view.state, view.dispatch);
+          break;
+        case "borderBottom":
+          setCellBorder(
+            "bottom",
+            borderSpecRef.current,
+            true,
+          )(view.state, view.dispatch);
+          break;
+        case "borderLeft":
+          setCellBorder(
+            "left",
+            borderSpecRef.current,
+            true,
+          )(view.state, view.dispatch);
+          break;
+        case "borderRight":
+          setCellBorder(
+            "right",
+            borderSpecRef.current,
+            true,
+          )(view.state, view.dispatch);
+          break;
+        default:
+          // Handle complex actions (with parameters)
+          if (typeof action === "object") {
+            if (action.type === "cellFillColor") {
+              setCellFillColor(action.color)(view.state, view.dispatch);
+            } else if (action.type === "borderColor") {
+              const rgb = action.color.replace(/^#/u, "");
+              borderSpecRef.current = {
+                ...borderSpecRef.current,
+                color: { rgb },
+              };
+              setTableBorderColor(action.color)(view.state, view.dispatch);
+            } else if (action.type === "borderWidth") {
+              borderSpecRef.current = {
+                ...borderSpecRef.current,
+                size: action.size,
+              };
+              setTableBorderWidth(action.size)(view.state, view.dispatch);
+            } else if (action.type === "cellBorder") {
+              setCellBorder(action.side, {
+                style: action.style,
+                size: action.size,
+                color: { rgb: action.color.replace(/^#/u, "") },
+              })(view.state, view.dispatch);
+            } else if (action.type === "cellVerticalAlign") {
+              setCellVerticalAlign(action.align)(view.state, view.dispatch);
+            } else if (action.type === "cellMargins") {
+              setCellMargins(action.margins)(view.state, view.dispatch);
+            } else if (action.type === "cellTextDirection") {
+              setCellTextDirection(action.direction)(view.state, view.dispatch);
+            } else if (action.type === "toggleNoWrap") {
+              toggleNoWrap()(view.state, view.dispatch);
+            } else if (action.type === "rowHeight") {
+              setRowHeight(action.height, action.rule)(
+                view.state,
+                view.dispatch,
+              );
+            } else if (action.type === "toggleHeaderRow") {
+              toggleHeaderRow()(view.state, view.dispatch);
+            } else if (action.type === "distributeColumns") {
+              distributeColumns()(view.state, view.dispatch);
+            } else if (action.type === "autoFitContents") {
+              autoFitContents()(view.state, view.dispatch);
+            } else if (action.type === "openTableProperties") {
+              setTablePropsOpen(true);
+            } else if (action.type === "tableProperties") {
+              setTableProperties(action.props)(view.state, view.dispatch);
+            } else {
+              // Resolve style data from built-in presets or document styles
+              let preset: TableStylePreset | undefined = getBuiltinTableStyle(
+                action.styleId,
+              );
+              const currentDocForTable = historyStateRef.current;
+              if (!preset && currentDocForTable?.package.styles) {
+                const styleResolver = getCachedStyleResolver(
+                  currentDocForTable.package.styles,
+                );
+                const docStyle = styleResolver.getStyle(action.styleId);
+                if (docStyle) {
+                  // Convert to preset inline (same as documentStyleToPreset)
+                  preset = {
+                    id: docStyle.styleId,
+                    name: docStyle.name ?? docStyle.styleId,
+                  };
+                  if (docStyle.tblPr?.borders) {
+                    const b = docStyle.tblPr.borders;
+                    preset.tableBorders = {};
+                    for (const side of [
+                      "top",
+                      "bottom",
+                      "left",
+                      "right",
+                      "insideH",
+                      "insideV",
+                    ] as const) {
+                      const bs = b[side];
+                      if (bs) {
+                        const borderEntry: {
+                          style: string;
+                          size?: number;
+                          color?: { rgb: string };
+                        } = {
+                          style: bs.style,
+                        };
+                        if (bs.size !== undefined) {
+                          borderEntry.size = bs.size;
+                        }
+                        if (bs.color?.rgb) {
+                          borderEntry.color = { rgb: bs.color.rgb };
+                        }
+                        preset.tableBorders[side] = borderEntry;
+                      }
+                    }
+                  }
+                  if (docStyle.tblStylePr) {
+                    preset.conditionals = {};
+                    for (const cond of docStyle.tblStylePr) {
+                      const entry: Record<string, unknown> = {};
+                      if (cond.tcPr?.shading?.fill?.rgb) {
+                        entry["backgroundColor"] =
+                          `#${cond.tcPr.shading.fill.rgb}`;
+                      }
+                      if (cond.tcPr?.borders) {
+                        const borders: Record<string, unknown> = {};
+                        for (const s of [
+                          "top",
+                          "bottom",
+                          "left",
+                          "right",
+                        ] as const) {
+                          const bs2 = cond.tcPr.borders[s];
+                          if (bs2) {
+                            borders[s] = {
+                              style: bs2.style,
+                              size: bs2.size,
+                              color: bs2.color?.rgb
+                                ? { rgb: bs2.color.rgb }
+                                : undefined,
+                            };
+                          }
+                        }
+                        entry["borders"] = borders;
+                      }
+                      if (cond.rPr?.bold) {
+                        entry["bold"] = true;
+                      }
+                      if (cond.rPr?.color?.rgb) {
+                        entry["color"] = `#${cond.rPr.color.rgb}`;
+                      }
+                      // SAFETY: preset.conditionals is Record<string, ...>; entry satisfies its value type
+                      preset.conditionals[cond.type] = entry as NonNullable<
+                        TableStylePreset["conditionals"]
+                      >[string];
+                    }
+                  }
+                  preset.look = {
+                    firstRow: true,
+                    lastRow: false,
+                    noHBand: false,
+                    noVBand: true,
+                  };
+                }
+              }
+              if (preset) {
+                const styleArg: Parameters<typeof applyTableStyle>[0] = {
+                  styleId: preset.id,
+                };
+                if (preset.tableBorders) {
+                  styleArg.tableBorders = preset.tableBorders;
+                }
+                if (preset.conditionals) {
+                  styleArg.conditionals = preset.conditionals;
+                }
+                if (preset.look) {
+                  styleArg.look = preset.look;
+                }
+                applyTableStyle(styleArg)(view.state, view.dispatch);
+              }
+            }
+          } else {
+            // Fallback to legacy table selection handler for other actions
+            tableSelection.handleAction(action);
+          }
+      }
+
+      focusActiveEditor();
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [tableSelection, getActiveEditorView, focusActiveEditor],
+  );
+
+  // Context menu handler
+  const handleEditorContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      openContextMenu({ x: e.clientX, y: e.clientY });
+    },
+    [openContextMenu],
+  );
+
+  // Handle formatting action from toolbar
+  const handleFormat = useCallback(
+    (action: FormattingAction) => {
+      const view = getActiveEditorView();
+      if (!view) {
+        return;
+      }
+
+      // Focus editor first to ensure we can dispatch commands
+      view.focus();
+
+      // Restore selection if it was lost during toolbar interaction
+      // This happens when user clicks on dropdown menus (font picker, style picker, etc.)
+      // Only restore for the body editor — HF editor manages its own selection
+      const isBodyEditor = view === pagedEditorRef.current?.getView();
+      const { from, to } = view.state.selection;
+      const savedSelection = lastSelectionRef.current;
+
+      if (
+        isBodyEditor &&
+        savedSelection &&
+        (from !== savedSelection.from || to !== savedSelection.to)
+      ) {
+        // Selection was lost (focus moved to dropdown portal) - restore it
+        try {
+          const tr = view.state.tr.setSelection(
+            TextSelection.create(
+              view.state.doc,
+              savedSelection.from,
+              savedSelection.to,
+            ),
+          );
+          view.dispatch(tr);
+        } catch {
+          // If restoration fails (e.g., positions are invalid after doc change), continue with current selection
+        }
+      }
+
+      const commandState = view.state;
+
+      // Handle simple toggle actions
+      if (action === "bold") {
+        toggleBold(commandState, view.dispatch);
+        return;
+      }
+      if (action === "italic") {
+        toggleItalic(commandState, view.dispatch);
+        return;
+      }
+      if (action === "underline") {
+        toggleUnderline(commandState, view.dispatch);
+        return;
+      }
+      if (action === "strikethrough") {
+        toggleStrike(commandState, view.dispatch);
+        return;
+      }
+      if (action === "superscript") {
+        toggleSuperscript(commandState, view.dispatch);
+        return;
+      }
+      if (action === "subscript") {
+        toggleSubscript(commandState, view.dispatch);
+        return;
+      }
+      if (action === "bulletList") {
+        toggleBulletList(commandState, view.dispatch);
+        return;
+      }
+      if (action === "numberedList") {
+        toggleNumberedList(commandState, view.dispatch);
+        return;
+      }
+      if (action === "indent") {
+        // Try list indent first, then paragraph indent
+        if (!increaseListLevel(commandState, view.dispatch)) {
+          increaseIndent()(commandState, view.dispatch);
+        }
+        return;
+      }
+      if (action === "outdent") {
+        // Try list outdent first, then paragraph outdent
+        if (!decreaseListLevel(commandState, view.dispatch)) {
+          decreaseIndent()(commandState, view.dispatch);
+        }
+        return;
+      }
+      if (action === "clearFormatting") {
+        clearFormatting(commandState, view.dispatch);
+        return;
+      }
+      if (action === "setRtl") {
+        setRtl(commandState, view.dispatch);
+        return;
+      }
+      if (action === "setLtr") {
+        setLtr(commandState, view.dispatch);
+        return;
+      }
+
+      // Handle object-based actions
+      if (typeof action === "object") {
+        switch (action.type) {
+          case "alignment":
+            setAlignment(action.value)(commandState, view.dispatch);
+            break;
+          case "textColor": {
+            // action.value can be a ColorValue object or a string like "#FF0000"
+            const colorVal = action.value;
+            if (typeof colorVal === "string") {
+              setTextColor({ rgb: colorVal.replace("#", "") })(
+                commandState,
+                view.dispatch,
+              );
+            } else if (colorVal.auto) {
+              // "Automatic" — remove text color
+              clearTextColor(commandState, view.dispatch);
+            } else {
+              setTextColor(colorVal)(commandState, view.dispatch);
+            }
+            break;
+          }
+          case "highlightColor": {
+            // Convert hex to OOXML named highlight value (e.g., 'FFFF00' → 'yellow')
+            const highlightName = action.value
+              ? mapHexToHighlightName(action.value)
+              : "";
+            setHighlight(highlightName || action.value)(
+              commandState,
+              view.dispatch,
+            );
+            break;
+          }
+          case "fontSize":
+            // Convert points to half-points (OOXML uses half-points for font sizes)
+            setFontSize(pointsToHalfPoints(action.value))(
+              commandState,
+              view.dispatch,
+            );
+            break;
+          case "fontFamily":
+            setFontFamily(action.value)(commandState, view.dispatch);
+            break;
+          case "lineSpacing":
+            setLineSpacing(action.value)(commandState, view.dispatch);
+            break;
+          case "applyStyle": {
+            // Resolve style to get its formatting properties
+            // Use ref to avoid stale closure (handleFormat has [] deps)
+            const currentDoc = historyStateRef.current;
+            const styleResolver = currentDoc?.package.styles
+              ? getCachedStyleResolver(currentDoc.package.styles)
+              : null;
+
+            if (styleResolver) {
+              const resolved = styleResolver.resolveParagraphStyle(
+                action.value,
+              );
+              const styleAttrs: Parameters<typeof applyStyle>[1] = {};
+              if (resolved.paragraphFormatting) {
+                styleAttrs.paragraphFormatting = resolved.paragraphFormatting;
+              }
+              if (resolved.runFormatting) {
+                styleAttrs.runFormatting = resolved.runFormatting;
+              }
+              applyStyle(action.value, styleAttrs)(commandState, view.dispatch);
+            } else {
+              // No styles available, just set the styleId
+              applyStyle(action.value)(commandState, view.dispatch);
+            }
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [getActiveEditorView],
+  );
+
+  const handleContextMenu = useCallback(
+    (data: { x: number; y: number; hasSelection: boolean }) => {
+      openContextMenu({ x: data.x, y: data.y }, data.hasSelection);
+    },
+    [openContextMenu],
+  );
+
+  const handleContextMenuClose = closeContextMenu;
+
+  const contextMenuItems = useMemo((): TextContextMenuItem[] => {
+    const isMac =
+      typeof navigator !== "undefined" && navigator.platform.includes("Mac");
+    const mod = isMac ? "⌘" : "Ctrl";
+    if (readOnly) {
+      return [
+        { action: "copy", label: t("copy"), shortcut: `${mod}+C` },
         {
-          action: "delete",
-          label: t("delete"),
-          shortcut: "Del",
-          dividerAfter: !contextMenu.hasSelection && !contextMenu.cursorInTable,
+          action: "selectAll",
+          label: t("selectAll"),
+          shortcut: `${mod}+A`,
         },
       ];
-      if (contextMenu.hasSelection) {
-        items.push({
-          action: "addComment",
-          label: t("comment"),
-          dividerAfter: !contextMenu.cursorInTable,
-        });
-      }
-      if (contextMenu.cursorInTable) {
-        items.push(
-          { action: "addRowAbove", label: t("insertRowAbove") },
-          { action: "addRowBelow", label: t("insertRowBelow") },
-          { action: "deleteRow", label: t("deleteRow"), dividerAfter: true },
-          { action: "addColumnLeft", label: t("insertColumnLeft") },
-          { action: "addColumnRight", label: t("insertColumnRight") },
-          {
-            action: "deleteColumn",
-            label: t("deleteColumn"),
-            dividerAfter: true,
-          },
-        );
-      }
-      if (contextMenu.cursorInTrackedChange) {
-        items.push(
-          { action: "acceptChange", label: t("acceptChange") },
-          {
-            action: "rejectChange",
-            label: t("rejectChange"),
-            dividerAfter: true,
-          },
-        );
-      }
+    }
+    const items: TextContextMenuItem[] = [
+      { action: "cut", label: t("cut"), shortcut: `${mod}+X` },
+      { action: "copy", label: t("copy"), shortcut: `${mod}+C` },
+      { action: "paste", label: t("paste"), shortcut: `${mod}+V` },
+      {
+        action: "pasteAsPlainText",
+        label: t("pasteUnformatted"),
+        shortcut: `${mod}+Shift+V`,
+        dividerAfter: true,
+      },
+      {
+        action: "delete",
+        label: t("delete"),
+        shortcut: "Del",
+        dividerAfter: !contextMenu.hasSelection && !contextMenu.cursorInTable,
+      },
+    ];
+    if (contextMenu.hasSelection) {
       items.push({
-        action: "selectAll",
-        label: t("selectAll"),
-        shortcut: `${mod}+A`,
+        action: "addComment",
+        label: t("comment"),
+        dividerAfter: !contextMenu.cursorInTable,
       });
-      return items;
-    }, [
-      contextMenu.hasSelection,
-      contextMenu.cursorInTable,
-      contextMenu.cursorInTrackedChange,
-      readOnly,
-      t,
-    ]);
+    }
+    if (contextMenu.cursorInTable) {
+      items.push(
+        { action: "addRowAbove", label: t("insertRowAbove") },
+        { action: "addRowBelow", label: t("insertRowBelow") },
+        { action: "deleteRow", label: t("deleteRow"), dividerAfter: true },
+        { action: "addColumnLeft", label: t("insertColumnLeft") },
+        { action: "addColumnRight", label: t("insertColumnRight") },
+        {
+          action: "deleteColumn",
+          label: t("deleteColumn"),
+          dividerAfter: true,
+        },
+      );
+    }
+    if (contextMenu.cursorInTrackedChange) {
+      items.push(
+        { action: "acceptChange", label: t("acceptChange") },
+        {
+          action: "rejectChange",
+          label: t("rejectChange"),
+          dividerAfter: true,
+        },
+      );
+    }
+    items.push({
+      action: "selectAll",
+      label: t("selectAll"),
+      shortcut: `${mod}+A`,
+    });
+    return items;
+  }, [
+    contextMenu.hasSelection,
+    contextMenu.cursorInTable,
+    contextMenu.cursorInTrackedChange,
+    readOnly,
+    t,
+  ]);
 
-    const handleContextMenuAction = useCallback(
-      async (action: TextContextAction) => {
-        const view = getActiveEditorView();
-        if (!view) {
-          return;
+  const handleContextMenuAction = useCallback(
+    async (action: TextContextAction) => {
+      const view = getActiveEditorView();
+      if (!view) {
+        return;
+      }
+
+      // Focus the hidden PM so clipboard operations target the right element
+      focusActiveEditor();
+
+      if (readOnly && action !== "copy" && action !== "selectAll") {
+        return;
+      }
+
+      switch (action) {
+        case "cut": {
+          if (readOnly) {
+            return;
+          }
+          // Copy selected text to clipboard, then delete selection
+          const { from, to } = view.state.selection;
+          const text = view.state.doc.textBetween(from, to, "\n");
+          void navigator.clipboard.writeText(text);
+          view.dispatch(view.state.tr.deleteSelection());
+          break;
         }
-
-        // Focus the hidden PM so clipboard operations target the right element
-        focusActiveEditor();
-
-        if (readOnly && action !== "copy" && action !== "selectAll") {
-          return;
+        case "copy": {
+          const { from: cf, to: ct } = view.state.selection;
+          const copied = view.state.doc.textBetween(cf, ct, "\n");
+          void navigator.clipboard.writeText(copied);
+          break;
         }
-
-        switch (action) {
-          case "cut": {
-            if (readOnly) {
-              return;
-            }
-            // Copy selected text to clipboard, then delete selection
-            const { from, to } = view.state.selection;
-            const text = view.state.doc.textBetween(from, to, "\n");
-            void navigator.clipboard.writeText(text);
-            view.dispatch(view.state.tr.deleteSelection());
-            break;
+        case "paste": {
+          if (readOnly) {
+            return;
           }
-          case "copy": {
-            const { from: cf, to: ct } = view.state.selection;
-            const copied = view.state.doc.textBetween(cf, ct, "\n");
-            void navigator.clipboard.writeText(copied);
-            break;
-          }
-          case "paste": {
-            if (readOnly) {
-              return;
-            }
-            // Use Clipboard API — document.execCommand('paste') is blocked in modern browsers
-            try {
-              const items = await navigator.clipboard.read();
-              let html = "";
-              let text = "";
-              for (const item of items) {
-                if (item.types.includes("text/html")) {
-                  html = await (await item.getType("text/html")).text();
-                }
-                if (item.types.includes("text/plain")) {
-                  text = await (await item.getType("text/plain")).text();
-                }
+          // Use Clipboard API — document.execCommand('paste') is blocked in modern browsers
+          try {
+            const items = await navigator.clipboard.read();
+            let html = "";
+            let text = "";
+            for (const item of items) {
+              if (item.types.includes("text/html")) {
+                html = await (await item.getType("text/html")).text();
               }
-              const dt = new DataTransfer();
-              if (html) {
-                dt.items.add(html, "text/html");
-              }
-              if (text) {
-                dt.items.add(text, "text/plain");
-              }
-              const pasteEvent = new ClipboardEvent("paste", {
-                clipboardData: dt,
-                bubbles: true,
-                cancelable: true,
-              });
-              view.dom.dispatchEvent(pasteEvent);
-            } catch {
-              try {
-                const text = await navigator.clipboard.readText();
-                if (text) {
-                  view.dispatch(view.state.tr.insertText(text));
-                }
-              } catch {
-                // Clipboard access denied
+              if (item.types.includes("text/plain")) {
+                text = await (await item.getType("text/plain")).text();
               }
             }
-            break;
-          }
-          case "pasteAsPlainText":
+            const dt = new DataTransfer();
+            if (html) {
+              dt.items.add(html, "text/html");
+            }
+            if (text) {
+              dt.items.add(text, "text/plain");
+            }
+            const pasteEvent = new ClipboardEvent("paste", {
+              clipboardData: dt,
+              bubbles: true,
+              cancelable: true,
+            });
+            view.dom.dispatchEvent(pasteEvent);
+          } catch {
             try {
               const text = await navigator.clipboard.readText();
               if (text) {
@@ -2292,1342 +2257,1331 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
             } catch {
               // Clipboard access denied
             }
-            break;
-          case "delete": {
-            const { from, to } = view.state.selection;
-            if (from !== to) {
-              view.dispatch(view.state.tr.deleteRange(from, to));
-            }
-            break;
           }
-          case "selectAll":
-            view.dispatch(
-              view.state.tr.setSelection(
-                TextSelection.create(
-                  view.state.doc,
-                  0,
-                  view.state.doc.content.size,
-                ),
+          break;
+        }
+        case "pasteAsPlainText":
+          try {
+            const text = await navigator.clipboard.readText();
+            if (text) {
+              view.dispatch(view.state.tr.insertText(text));
+            }
+          } catch {
+            // Clipboard access denied
+          }
+          break;
+        case "delete": {
+          const { from, to } = view.state.selection;
+          if (from !== to) {
+            view.dispatch(view.state.tr.deleteRange(from, to));
+          }
+          break;
+        }
+        case "selectAll":
+          view.dispatch(
+            view.state.tr.setSelection(
+              TextSelection.create(
+                view.state.doc,
+                0,
+                view.state.doc.content.size,
               ),
-            );
-            break;
-          // Table operations
-          case "addRowAbove":
-            addRowAbove(view.state, view.dispatch);
-            break;
-          case "addRowBelow":
-            addRowBelow(view.state, view.dispatch);
-            break;
-          case "deleteRow":
-            pmDeleteRow(view.state, view.dispatch);
-            break;
-          case "addColumnLeft":
-            addColumnLeft(view.state, view.dispatch);
-            break;
-          case "addColumnRight":
-            addColumnRight(view.state, view.dispatch);
-            break;
-          case "deleteColumn":
-            pmDeleteColumn(view.state, view.dispatch);
-            break;
-          // Comment — same flow as floating comment button
-          case "addComment": {
-            // Use the stored selection range from when the context menu opened,
-            // because right-click may collapse the PM selection to a cursor
-            const { from, to } =
-              contextMenu.selectionRange.from !== contextMenu.selectionRange.to
-                ? contextMenu.selectionRange
-                : view.state.selection;
-            if (from === to) {
-              break;
-            }
-            // Compute Y position BEFORE dispatching — dispatch triggers re-layout
-            // which rebuilds page DOM and invalidates the old span elements
-            const yPos = findSelectionYPosition(
-              scrollContainerRef.current,
-              editorContentRef.current,
-              from,
-            );
-            const commentY =
-              yPos ?? getFallbackCommentYPosition(scrollContainerRef.current);
-            setCommentSelectionRange({ from, to });
-            const marked = applyCommentMarkRange(
-              view,
-              { from, to },
-              PENDING_COMMENT_ID,
-              {
-                selectEnd: true,
-              },
-            );
-            if (!marked) {
-              break;
-            }
-            setAddCommentYPosition(commentY);
-            setShowCommentsSidebar(true);
-            setIsAddingComment(true);
-            setFloatingCommentBtn(null);
+            ),
+          );
+          break;
+        // Table operations
+        case "addRowAbove":
+          addRowAbove(view.state, view.dispatch);
+          break;
+        case "addRowBelow":
+          addRowBelow(view.state, view.dispatch);
+          break;
+        case "deleteRow":
+          pmDeleteRow(view.state, view.dispatch);
+          break;
+        case "addColumnLeft":
+          addColumnLeft(view.state, view.dispatch);
+          break;
+        case "addColumnRight":
+          addColumnRight(view.state, view.dispatch);
+          break;
+        case "deleteColumn":
+          pmDeleteColumn(view.state, view.dispatch);
+          break;
+        // Comment — same flow as floating comment button
+        case "addComment": {
+          // Use the stored selection range from when the context menu opened,
+          // because right-click may collapse the PM selection to a cursor
+          const { from, to } =
+            contextMenu.selectionRange.from !== contextMenu.selectionRange.to
+              ? contextMenu.selectionRange
+              : view.state.selection;
+          if (from === to) {
             break;
           }
-          case "acceptChange": {
-            const { from, to } = view.state.selection;
-            const range = findChangeAtPosition(view.state, from, to);
-            acceptChange(range.from, range.to)(view.state, view.dispatch);
+          // Compute Y position BEFORE dispatching — dispatch triggers re-layout
+          // which rebuilds page DOM and invalidates the old span elements
+          const yPos = findSelectionYPosition(
+            scrollContainerRef.current,
+            editorContentRef.current,
+            from,
+          );
+          const commentY =
+            yPos ?? getFallbackCommentYPosition(scrollContainerRef.current);
+          setCommentSelectionRange({ from, to });
+          const marked = applyCommentMarkRange(
+            view,
+            { from, to },
+            PENDING_COMMENT_ID,
+            {
+              selectEnd: true,
+            },
+          );
+          if (!marked) {
             break;
           }
-          case "rejectChange": {
-            const { from, to } = view.state.selection;
-            const range = findChangeAtPosition(view.state, from, to);
-            rejectChange(range.from, range.to)(view.state, view.dispatch);
-            break;
-          }
-          case "separator":
-            // Separators are visual dividers in the menu, never
-            // emitted as an actual user action.
-            break;
+          setAddCommentYPosition(commentY);
+          setShowCommentsSidebar(true);
+          setIsAddingComment(true);
+          setFloatingCommentBtn(null);
+          break;
         }
-        // TextContextMenu calls onClose after onAction, so no need to close here
-      },
-      [
-        getActiveEditorView,
-        focusActiveEditor,
-        readOnly,
-        contextMenu.selectionRange.from,
-        contextMenu.selectionRange.to,
-      ],
-    );
+        case "acceptChange": {
+          const { from, to } = view.state.selection;
+          const range = findChangeAtPosition(view.state, from, to);
+          acceptChange(range.from, range.to)(view.state, view.dispatch);
+          break;
+        }
+        case "rejectChange": {
+          const { from, to } = view.state.selection;
+          const range = findChangeAtPosition(view.state, from, to);
+          rejectChange(range.from, range.to)(view.state, view.dispatch);
+          break;
+        }
+        case "separator":
+          // Separators are visual dividers in the menu, never
+          // emitted as an actual user action.
+          break;
+      }
+      // TextContextMenu calls onClose after onAction, so no need to close here
+    },
+    [
+      getActiveEditorView,
+      focusActiveEditor,
+      readOnly,
+      contextMenu.selectionRange.from,
+      contextMenu.selectionRange.to,
+    ],
+  );
 
-    // Page setup apply handler
-    const handlePageSetupApply = useCallback(
-      (props: Partial<SectionProperties>) => {
-        if (!history.state || readOnly) {
-          return;
-        }
-        const newDoc = {
-          ...history.state,
-          package: {
-            ...history.state.package,
-            document: {
-              ...history.state.package.document,
-              finalSectionProperties: {
-                ...history.state.package.document.finalSectionProperties,
-                ...props,
-              },
+  // Page setup apply handler
+  const handlePageSetupApply = useCallback(
+    (props: Partial<SectionProperties>) => {
+      if (!history.state || readOnly) {
+        return;
+      }
+      const newDoc = {
+        ...history.state,
+        package: {
+          ...history.state.package,
+          document: {
+            ...history.state.package.document,
+            finalSectionProperties: {
+              ...history.state.package.document.finalSectionProperties,
+              ...props,
             },
           },
-        };
-        handleDocumentChange(newDoc);
-      },
-      [history.state, readOnly, handleDocumentChange],
-    );
+        },
+      };
+      handleDocumentChange(newDoc);
+    },
+    [history.state, readOnly, handleDocumentChange],
+  );
 
-    // Handle save
-    const handleSave = useCallback(
-      async (options?: {
-        selective?: boolean;
-      }): Promise<ArrayBuffer | null> => {
-        try {
-          // Build current document from PM editor state
-          const doc = buildCurrentDocument();
-          if (!doc) {
-            return null;
-          }
-
-          // Try selective save first (patches only changed paragraphs). If the
-          // edit cannot be patched, fall back to guarded repack: repackDocx now
-          // validates section/header/footer references before returning bytes.
-          const useSelective = options?.selective !== false;
-          const view = pagedEditorRef.current?.getView();
-          let buffer: ArrayBuffer | null = null;
-
-          if (useSelective && view && originalBufferRef.current) {
-            const editorState = view.state;
-            buffer = await attemptSelectiveSave(
-              doc,
-              originalBufferRef.current,
-              {
-                changedParaIds: getChangedParagraphIds(editorState),
-                structuralChange: hasStructuralChanges(editorState),
-                hasUntrackedChanges: hasUntrackedChanges(editorState),
-              },
-            );
-          }
-
-          if (!buffer) {
-            buffer = await repackDocx(doc);
-          }
-
-          // Clear change tracker after successful save
-          if (view) {
-            originalBufferRef.current = buffer;
-            view.dispatch(clearTrackedChanges(view.state));
-          }
-          commentsDirtyRef.current = false;
-
-          onSave?.(buffer);
-          return buffer;
-        } catch (error) {
-          onError?.(
-            error instanceof Error
-              ? error
-              : new Error("Failed to save document"),
-          );
+  // Handle save
+  const handleSave = useCallback(
+    async (options?: { selective?: boolean }): Promise<ArrayBuffer | null> => {
+      try {
+        // Build current document from PM editor state
+        const doc = buildCurrentDocument();
+        if (!doc) {
           return null;
         }
-      },
-      [buildCurrentDocument, onSave, onError, originalBufferRef],
-    );
 
-    // Handle error from editor
-    const handleEditorError = useCallback(
-      (error: Error) => {
-        onError?.(error);
-      },
-      [onError],
-    );
+        // Try selective save first (patches only changed paragraphs). If the
+        // edit cannot be patched, fall back to guarded repack: repackDocx now
+        // validates section/header/footer references before returning bytes.
+        const useSelective = options?.selective !== false;
+        const view = pagedEditorRef.current?.getView();
+        let buffer: ArrayBuffer | null = null;
 
-    // Expose ref methods
-    useImperativeHandle(
-      ref,
-      () => ({
-        getDocument: () => buildCurrentDocument(),
-        hasPendingChanges: () => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return false;
-          }
-          return (
-            commentsDirtyRef.current ||
-            getChangedParagraphIds(view.state).size > 0 ||
-            hasStructuralChanges(view.state) ||
-            hasUntrackedChanges(view.state)
-          );
-        },
-        getEditorRef: () => pagedEditorRef.current,
-        save: handleSave,
-        setZoom: setZoomWithViewportAnchor,
-        getZoom: () => zoomRef.current,
-        focus: () => {
-          pagedEditorRef.current?.focus();
-        },
-        getCurrentPage: () => scrollPageInfo.currentPage,
-        getTotalPages: () => scrollPageInfo.totalPages,
-        scrollToPage: (pageNumber: number) => {
-          pagedEditorRef.current?.scrollToPage(pageNumber);
-        },
-        openPrintPreview: handleDirectPrint,
-        print: handleDirectPrint,
-        loadDocument: loadParsedDocument,
-        loadDocumentBuffer: loadBuffer,
-        createAIEditSnapshot: () => {
-          const view = pagedEditorRef.current?.getView();
-          return view ? createFolioAIEditSnapshot(view.state.doc) : null;
-        },
-        applyAIEditOperations: ({
+        if (useSelective && view && originalBufferRef.current) {
+          const editorState = view.state;
+          buffer = await attemptSelectiveSave(doc, originalBufferRef.current, {
+            changedParaIds: getChangedParagraphIds(editorState),
+            structuralChange: hasStructuralChanges(editorState),
+            hasUntrackedChanges: hasUntrackedChanges(editorState),
+          });
+        }
+
+        if (!buffer) {
+          buffer = await repackDocx(doc);
+        }
+
+        // Clear change tracker after successful save
+        if (view) {
+          originalBufferRef.current = buffer;
+          view.dispatch(clearTrackedChanges(view.state));
+        }
+        commentsDirtyRef.current = false;
+
+        onSave?.(buffer);
+        return buffer;
+      } catch (error) {
+        onError?.(
+          error instanceof Error ? error : new Error("Failed to save document"),
+        );
+        return null;
+      }
+    },
+    [buildCurrentDocument, onSave, onError, originalBufferRef],
+  );
+
+  // Handle error from editor
+  const handleEditorError = useCallback(
+    (error: Error) => {
+      onError?.(error);
+    },
+    [onError],
+  );
+
+  // Expose ref methods
+  useImperativeHandle(
+    ref,
+    () => ({
+      getDocument: () => buildCurrentDocument(),
+      hasPendingChanges: () => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        return (
+          commentsDirtyRef.current ||
+          getChangedParagraphIds(view.state).size > 0 ||
+          hasStructuralChanges(view.state) ||
+          hasUntrackedChanges(view.state)
+        );
+      },
+      getEditorRef: () => pagedEditorRef.current,
+      save: handleSave,
+      setZoom: setZoomWithViewportAnchor,
+      getZoom: () => zoomRef.current,
+      focus: () => {
+        pagedEditorRef.current?.focus();
+      },
+      getCurrentPage: () => scrollPageInfo.currentPage,
+      getTotalPages: () => scrollPageInfo.totalPages,
+      scrollToPage: (pageNumber: number) => {
+        pagedEditorRef.current?.scrollToPage(pageNumber);
+      },
+      openPrintPreview: handleDirectPrint,
+      print: handleDirectPrint,
+      loadDocument: loadParsedDocument,
+      loadDocumentBuffer: loadBuffer,
+      createAIEditSnapshot: () => {
+        const view = pagedEditorRef.current?.getView();
+        return view ? createFolioAIEditSnapshot(view.state.doc) : null;
+      },
+      applyAIEditOperations: ({
+        snapshot,
+        operations,
+        mode = "tracked-changes",
+        author: operationAuthor = author,
+      }) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return {
+            applied: [],
+            skipped: operations.map((operation) => ({
+              id: operation.id,
+              reason: "unsupportedBlock",
+            })),
+          };
+        }
+
+        const createdComments: Comment[] = [];
+        const result = applyFolioAIEditOperations({
+          view,
           snapshot,
           operations,
-          mode = "tracked-changes",
-          author: operationAuthor = author,
-        }) => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return {
-              applied: [],
-              skipped: operations.map((operation) => ({
-                id: operation.id,
-                reason: "unsupportedBlock",
-              })),
-            };
-          }
+          mode,
+          author: operationAuthor,
+          createCommentId: (text) => {
+            const comment = createComment(text, operationAuthor);
+            createdComments.push(comment);
+            return comment.id;
+          },
+        });
 
-          const createdComments: Comment[] = [];
-          const result = applyFolioAIEditOperations({
-            view,
-            snapshot,
-            operations,
-            mode,
-            author: operationAuthor,
-            createCommentId: (text) => {
-              const comment = createComment(text, operationAuthor);
-              createdComments.push(comment);
-              return comment.id;
-            },
-          });
-
-          if (createdComments.length > 0) {
-            updateComments((currentComments) => [
-              ...currentComments,
-              ...createdComments,
-            ]);
-          }
-
-          return result;
-        },
-        acceptAIEditOperation: (revisionId) => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return false;
-          }
-          return acceptAIEditRevision(revisionId)(view.state, view.dispatch);
-        },
-        rejectAIEditOperation: (revisionId) => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return false;
-          }
-          return rejectAIEditRevision(revisionId)(view.state, view.dispatch);
-        },
-        scrollToAIEditOperation: (revisionId) => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return false;
-          }
-          const range = findAIEditRevisionRange(view.state, revisionId);
-          if (!range) {
-            return false;
-          }
-          // `TextSelection.between` clamps to the nearest valid inline
-          // position; `create` throws "endpoint not pointing into a node
-          // with inline content" when from/to land on a block boundary,
-          // which is exactly what happens for marks that wrap an entire
-          // paragraph. `clampRangeToDocSize` is a defensive guard against
-          // a revision range whose endpoints fell past the doc end after
-          // concurrent edits.
-          const { from, to } = clampRangeToDocSize(
-            view.state.doc.content.size,
-            range,
-          );
-          const $from = view.state.doc.resolve(from);
-          const $to = view.state.doc.resolve(to);
-          view.dispatch(
-            view.state.tr.setSelection(TextSelection.between($from, $to)),
-          );
-          requestAnimationFrame(() => {
-            pagedEditorRef.current?.scrollToPosition(from);
-          });
-          return true;
-        },
-        scrollToBlock: (blockId, snapshot) => {
-          const view = pagedEditorRef.current?.getView();
-          if (!view) {
-            return false;
-          }
-          // Prefer the caller's snapshot (the one the AI saw when it
-          // generated the suggestion); only fall back to a fresh recompute
-          // when the caller didn't pass one. A recomputed snapshot
-          // re-numbers blocks after any structural accept, so `b-0007`
-          // would point to a different paragraph than the panel's pending
-          // suggestion is referencing.
-          const resolvedSnapshot =
-            snapshot ?? createFolioAIEditSnapshot(view.state.doc);
-          const anchor = resolvedSnapshot.anchors[blockId];
-          if (!anchor) {
-            return false;
-          }
-          const { from, to } = clampRangeToDocSize(
-            view.state.doc.content.size,
-            anchor,
-          );
-          const $from = view.state.doc.resolve(from);
-          const $to = view.state.doc.resolve(to);
-          view.dispatch(
-            view.state.tr.setSelection(TextSelection.between($from, $to)),
-          );
-          requestAnimationFrame(() => {
-            pagedEditorRef.current?.scrollToPosition(from);
-          });
-          return true;
-        },
-      }),
-      [
-        author,
-        buildCurrentDocument,
-        scrollPageInfo,
-        handleSave,
-        setZoomWithViewportAnchor,
-        zoomRef,
-        handleDirectPrint,
-        loadParsedDocument,
-        loadBuffer,
-        updateComments,
-      ],
-    );
-
-    // Get the DOM element for the header/footer area on the first page
-    const getHfTargetElement = useCallback(
-      (pos: "header" | "footer"): HTMLElement | null => {
-        const pagesContainer = containerRef.current?.querySelector(
-          ".paged-editor__pages",
-        );
-        if (!pagesContainer) {
-          return null;
+        if (createdComments.length > 0) {
+          updateComments((currentComments) => [
+            ...currentComments,
+            ...createdComments,
+          ]);
         }
-        const selector =
-          pos === "header" ? ".layout-page-header" : ".layout-page-footer";
-        return pagesContainer.querySelector(selector);
+
+        return result;
       },
-      [],
-    );
+      acceptAIEditOperation: (revisionId) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        return acceptAIEditRevision(revisionId)(view.state, view.dispatch);
+      },
+      rejectAIEditOperation: (revisionId) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        return rejectAIEditRevision(revisionId)(view.state, view.dispatch);
+      },
+      scrollToAIEditOperation: (revisionId) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        const range = findAIEditRevisionRange(view.state, revisionId);
+        if (!range) {
+          return false;
+        }
+        // `TextSelection.between` clamps to the nearest valid inline
+        // position; `create` throws "endpoint not pointing into a node
+        // with inline content" when from/to land on a block boundary,
+        // which is exactly what happens for marks that wrap an entire
+        // paragraph. `clampRangeToDocSize` is a defensive guard against
+        // a revision range whose endpoints fell past the doc end after
+        // concurrent edits.
+        const { from, to } = clampRangeToDocSize(
+          view.state.doc.content.size,
+          range,
+        );
+        const $from = view.state.doc.resolve(from);
+        const $to = view.state.doc.resolve(to);
+        view.dispatch(
+          view.state.tr.setSelection(TextSelection.between($from, $to)),
+        );
+        requestAnimationFrame(() => {
+          pagedEditorRef.current?.scrollToPosition(from);
+        });
+        return true;
+      },
+      scrollToBlock: (blockId, snapshot) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        // Prefer the caller's snapshot (the one the AI saw when it
+        // generated the suggestion); only fall back to a fresh recompute
+        // when the caller didn't pass one. A recomputed snapshot
+        // re-numbers blocks after any structural accept, so `b-0007`
+        // would point to a different paragraph than the panel's pending
+        // suggestion is referencing.
+        const resolvedSnapshot =
+          snapshot ?? createFolioAIEditSnapshot(view.state.doc);
+        const anchor = resolvedSnapshot.anchors[blockId];
+        if (!anchor) {
+          return false;
+        }
+        const { from, to } = clampRangeToDocSize(
+          view.state.doc.content.size,
+          anchor,
+        );
+        const $from = view.state.doc.resolve(from);
+        const $to = view.state.doc.resolve(to);
+        view.dispatch(
+          view.state.tr.setSelection(TextSelection.between($from, $to)),
+        );
+        requestAnimationFrame(() => {
+          pagedEditorRef.current?.scrollToPosition(from);
+        });
+        return true;
+      },
+    }),
+    [
+      author,
+      buildCurrentDocument,
+      scrollPageInfo,
+      handleSave,
+      setZoomWithViewportAnchor,
+      zoomRef,
+      handleDirectPrint,
+      loadParsedDocument,
+      loadBuffer,
+      updateComments,
+    ],
+  );
 
-    // Container styles - using overflow: auto so sticky toolbar works
-    const containerStyle: CSSProperties = {
-      display: "flex",
-      flexDirection: "column",
-      height: "100%",
-      width: "100%",
-      backgroundColor: "var(--muted)",
-      ...style,
-    };
-
-    const mainContentStyle: CSSProperties = {
-      display: "flex",
-      flex: 1,
-      minHeight: 0, // Allow flex item to shrink below content size
-      minWidth: 0, // Allow flex item to shrink below content width on narrow viewports
-      flexDirection: "row",
-    };
-
-    const editorContainerStyle: CSSProperties = {
-      flex: 1,
-      minHeight: 0,
-      minWidth: 0, // Allow flex item to shrink below content width on narrow viewports
-      overflow: "auto", // Sole scroll container — PagedEditor sizes to content
-      position: "relative",
-    };
-
-    // Render loading state
-    if (
-      state.documentLoad.status === "loading" &&
-      (!preserveDocumentWhileLoading || !history.state)
-    ) {
-      return (
-        <div
-          className={`folio-root folio-editor folio-editor-loading ${className}`}
-          style={containerStyle}
-          data-testid="folio-editor"
-        >
-          {loadingIndicator || <DefaultLoadingIndicator />}
-        </div>
+  // Get the DOM element for the header/footer area on the first page
+  const getHfTargetElement = useCallback(
+    (pos: "header" | "footer"): HTMLElement | null => {
+      const pagesContainer = containerRef.current?.querySelector(
+        ".paged-editor__pages",
       );
-    }
-
-    // Render error state
-    if (state.documentLoad.status === "error") {
-      return (
-        <div
-          className={`folio-root folio-editor folio-editor-error ${className}`}
-          style={containerStyle}
-          data-testid="folio-editor"
-        >
-          <ParseError message={state.documentLoad.message} />
-        </div>
-      );
-    }
-
-    // Render placeholder when no document
-    if (!history.state) {
-      return (
-        <div
-          className={`folio-root folio-editor folio-editor-empty ${className}`}
-          style={containerStyle}
-          data-testid="folio-editor"
-        >
-          {placeholder || <DefaultPlaceholder />}
-        </div>
-      );
-    }
-
-    const DISPLAY_MODE_LABELS = {
-      "all-markup": t("markupView.allMarkup"),
-      "simple-markup": t("markupView.simple"),
-      "no-markup": t("markupView.noMarkup"),
-      original: t("markupView.original"),
-    } as const satisfies Record<DisplayMode, string>;
-
-    const toolbarChildren = toolbarExtra ?? null;
-    const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
-      visibleCommentAuthorSet.has(commentAuthor),
-    ).length;
-    const allCommentAuthorsVisible =
-      commentAuthors.length > 0 &&
-      showCommentsSidebar &&
-      visibleCommentAuthorCount === commentAuthors.length;
-    const commentVisibilityLabel =
-      visibleCommentAuthorCount === commentAuthors.length
-        ? t("comments.showAll")
-        : `${visibleCommentAuthorCount}/${commentAuthors.length}`;
-    const showAllCommentAuthors = () => {
-      setVisibleCommentAuthors(null);
-      setShowCommentsSidebar(true);
-    };
-    const hideAllCommentAuthors = () => {
-      setVisibleCommentAuthors(new Set());
-      setShowCommentsSidebar(false);
-      setActiveCommentId(null);
-    };
-    const setCommentAuthorVisible = (
-      commentAuthor: string,
-      visible: boolean,
-    ) => {
-      const next = new Set(visibleCommentAuthorSet);
-      if (visible) {
-        next.add(commentAuthor);
-      } else {
-        next.delete(commentAuthor);
+      if (!pagesContainer) {
+        return null;
       }
-      setVisibleCommentAuthors(next);
-      setShowCommentsSidebar(next.size > 0);
-      if (next.size === 0) {
-        setActiveCommentId(null);
-      }
-    };
+      const selector =
+        pos === "header" ? ".layout-page-header" : ".layout-page-footer";
+      return pagesContainer.querySelector(selector);
+    },
+    [],
+  );
 
-    const toolbarPriorityExtra = (
-      <div className="flex shrink-0 items-center gap-1">
-        <Button
-          onClick={toggleTrackChanges}
-          onMouseDown={(e) => e.preventDefault()}
-          disabled={readOnly}
-          aria-pressed={trackChangesOn}
-          aria-label={t("toggleTrackChanges")}
-          className={`h-8 min-w-[140px] justify-start gap-1.5 rounded-md px-2 text-xs text-[var(--doc-text-muted)] shadow-none disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.35] ${
-            trackChangesOn
-              ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)] shadow-[0_0_0_1px_var(--doc-primary)]"
-              : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-          }`}
-          size="xs"
-          title={t("toggleTrackChanges")}
-          variant="ghost"
-        >
-          <PenLineIcon className="size-3.5" />
-          <span className="truncate whitespace-nowrap">
-            {trackChangesOn ? t("trackingOn") : t("trackingOff")}
-          </span>
-        </Button>
-        <StSelect
-          value={displayMode}
-          onValueChange={(val) => setDisplayMode(val as DisplayMode)}
-          items={[
-            { value: "all-markup", label: "All Markup" },
-            { value: "simple-markup", label: "Simple" },
-            { value: "no-markup", label: "No Markup" },
-            { value: "original", label: "Original" },
-          ]}
-        >
-          <StSelectTrigger
-            size="sm"
-            className="h-8 min-h-0 w-[132px] min-w-0 shrink-0 border-transparent bg-transparent text-xs text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
-          >
-            <EyeIcon size={14} className="shrink-0" />
-            <StSelectValue />
-          </StSelectTrigger>
-          <StSelectPopup>
-            {(
-              ["all-markup", "simple-markup", "no-markup", "original"] as const
-            ).map((mode) => (
-              <StSelectItem key={mode} value={mode}>
-                {DISPLAY_MODE_LABELS[mode]}
-              </StSelectItem>
-            ))}
-          </StSelectPopup>
-        </StSelect>
+  // Container styles - using overflow: auto so sticky toolbar works
+  const containerStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    width: "100%",
+    backgroundColor: "var(--muted)",
+    ...style,
+  };
+
+  const mainContentStyle: CSSProperties = {
+    display: "flex",
+    flex: 1,
+    minHeight: 0, // Allow flex item to shrink below content size
+    minWidth: 0, // Allow flex item to shrink below content width on narrow viewports
+    flexDirection: "row",
+  };
+
+  const editorContainerStyle: CSSProperties = {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0, // Allow flex item to shrink below content width on narrow viewports
+    overflow: "auto", // Sole scroll container — PagedEditor sizes to content
+    position: "relative",
+  };
+
+  // Render loading state
+  if (
+    state.documentLoad.status === "loading" &&
+    (!preserveDocumentWhileLoading || !history.state)
+  ) {
+    return (
+      <div
+        className={`folio-root folio-editor folio-editor-loading ${className}`}
+        style={containerStyle}
+        data-testid="folio-editor"
+      >
+        {loadingIndicator || <DefaultLoadingIndicator />}
       </div>
     );
+  }
 
-    const toolbarInlineExtra = (
-      <>
-        <Menu>
-          <MenuTrigger
-            type="button"
-            disabled={comments.length === 0}
-            aria-label={t("comments.visibility")}
-            onMouseDown={(e) => e.preventDefault()}
-            className={`flex h-8 min-w-0 items-center gap-1.5 rounded-md border px-2.5 text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:border-transparent disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.16] disabled:hover:bg-transparent disabled:hover:text-[var(--doc-text-subtle)] ${
-              showCommentsSidebar && visibleCommentAuthorCount > 0
-                ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
-                : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
-            }`}
-          >
-            <StickyNoteIcon size={14} className="shrink-0" />
-            <span className="max-w-24 truncate">{commentVisibilityLabel}</span>
-          </MenuTrigger>
-          <MenuPopup align="start" className="min-w-52">
-            <MenuGroup>
-              <MenuGroupLabel>{t("comments.visibility")}</MenuGroupLabel>
-              <MenuCheckboxItem
-                checked={allCommentAuthorsVisible}
-                onCheckedChange={(checked) => {
-                  if (checked) {
-                    showAllCommentAuthors();
-                  } else {
-                    hideAllCommentAuthors();
-                  }
-                }}
-              >
-                {t("comments.showAll")}
-              </MenuCheckboxItem>
-              <MenuItem onClick={hideAllCommentAuthors}>
-                {t("comments.hideAll")}
-              </MenuItem>
-            </MenuGroup>
-            {(() => {
-              if (commentAuthors.length > 0) {
-                return (
-                  <>
-                    <MenuSeparator />
-                    <MenuGroup>
-                      {commentAuthors.map((commentAuthor) => (
-                        <MenuCheckboxItem
-                          checked={
-                            showCommentsSidebar &&
-                            visibleCommentAuthorSet.has(commentAuthor)
-                          }
-                          key={commentAuthor}
-                          onCheckedChange={(checked) =>
-                            setCommentAuthorVisible(commentAuthor, checked)
-                          }
-                        >
-                          {commentAuthor === "Unknown"
-                            ? t("comments.unknownAuthor")
-                            : commentAuthor}
-                        </MenuCheckboxItem>
-                      ))}
-                    </MenuGroup>
-                  </>
-                );
-              }
-              return null;
-            })()}
-          </MenuPopup>
-        </Menu>
-        <ToolbarSeparator />
-        {state.activeTrackedChange && (
-          <span
-            className="flex items-center gap-1 px-2 text-xs text-[var(--doc-text-muted)]"
-            style={{ maxWidth: 260 }}
-          >
-            <span className="truncate">
-              <span className="font-medium text-[var(--doc-text)]">
-                {state.activeTrackedChange.author}
-              </span>
-              {state.activeTrackedChange.date && (
-                <>
-                  {" · "}
-                  {new Date(
-                    state.activeTrackedChange.date,
-                  ).toLocaleDateString()}
-                </>
-              )}
-              {" · "}
-              {state.activeTrackedChange.type === "insertion"
-                ? t("inserted")
-                : t("deleted")}
-            </span>
-          </span>
-        )}
-        <ToolbarButton
-          onClick={() => {
-            const view = pagedEditorRef.current?.getView();
-            if (!view) {
-              return;
-            }
-            const { from, to } = view.state.selection;
-            const range = findChangeAtPosition(view.state, from, to);
-            acceptChange(range.from, range.to)(view.state, view.dispatch);
-          }}
-          disabled={readOnly || !state.activeTrackedChange}
-          title={t("acceptChange")}
-          ariaLabel={t("acceptChange")}
-        >
-          <CheckIcon size={16} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => {
-            const view = pagedEditorRef.current?.getView();
-            if (!view) {
-              return;
-            }
-            const { from, to } = view.state.selection;
-            const range = findChangeAtPosition(view.state, from, to);
-            rejectChange(range.from, range.to)(view.state, view.dispatch);
-          }}
-          disabled={readOnly || !state.activeTrackedChange}
-          title={t("rejectChange")}
-          ariaLabel={t("rejectChange")}
-        >
-          <XIcon size={16} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => {
-            const view = pagedEditorRef.current?.getView();
-            if (!view) {
-              return;
-            }
-            const { from } = view.state.selection;
-            const change = findPreviousChange(view.state, from);
-            if (change) {
-              view.dispatch(
-                view.state.tr.setSelection(
-                  TextSelection.create(view.state.doc, change.from, change.to),
-                ),
-              );
-              view.focus();
-              // Scroll the rendered page to the change position
-              requestAnimationFrame(() => {
-                pagedEditorRef.current?.scrollToPosition(change.from);
-              });
-            }
-          }}
-          disabled={readOnly}
-          title={t("previousChange")}
-          ariaLabel={t("previousChange")}
-        >
-          <ChevronLeftIcon size={16} />
-        </ToolbarButton>
-        <ToolbarButton
-          onClick={() => {
-            const view = pagedEditorRef.current?.getView();
-            if (!view) {
-              return;
-            }
-            const { to } = view.state.selection;
-            const change = findNextChange(view.state, to);
-            if (change) {
-              view.dispatch(
-                view.state.tr.setSelection(
-                  TextSelection.create(view.state.doc, change.from, change.to),
-                ),
-              );
-              view.focus();
-              // Scroll the rendered page to the change position
-              requestAnimationFrame(() => {
-                pagedEditorRef.current?.scrollToPosition(change.from);
-              });
-            }
-          }}
-          disabled={readOnly}
-          title={t("nextChange")}
-          ariaLabel={t("nextChange")}
-        >
-          <ChevronRightIcon size={16} />
-        </ToolbarButton>
-      </>
-    );
-
-    const imagePropertiesCurrentData = buildImagePropertiesData(
-      state.pmImageContext,
-    );
-
+  // Render error state
+  if (state.documentLoad.status === "error") {
     return (
-      <ErrorProvider>
-        <ErrorBoundary onError={handleEditorError}>
-          <div
-            ref={containerRef}
-            className={`folio-root folio-editor${displayMode !== "all-markup" ? ` folio-root--${displayMode}` : ""} ${className}`}
-            style={containerStyle}
-            data-testid="folio-editor"
-          >
-            {/* Main content area */}
-            <div style={mainContentStyle}>
-              {/* Wrapper for toolbar + scroll container + outline overlay */}
+      <div
+        className={`folio-root folio-editor folio-editor-error ${className}`}
+        style={containerStyle}
+        data-testid="folio-editor"
+      >
+        <ParseError message={state.documentLoad.message} />
+      </div>
+    );
+  }
+
+  // Render placeholder when no document
+  if (!history.state) {
+    return (
+      <div
+        className={`folio-root folio-editor folio-editor-empty ${className}`}
+        style={containerStyle}
+        data-testid="folio-editor"
+      >
+        {placeholder || <DefaultPlaceholder />}
+      </div>
+    );
+  }
+
+  const DISPLAY_MODE_LABELS = {
+    "all-markup": t("markupView.allMarkup"),
+    "simple-markup": t("markupView.simple"),
+    "no-markup": t("markupView.noMarkup"),
+    original: t("markupView.original"),
+  } as const satisfies Record<DisplayMode, string>;
+
+  const toolbarChildren = toolbarExtra ?? null;
+  const visibleCommentAuthorCount = commentAuthors.filter((commentAuthor) =>
+    visibleCommentAuthorSet.has(commentAuthor),
+  ).length;
+  const allCommentAuthorsVisible =
+    commentAuthors.length > 0 &&
+    showCommentsSidebar &&
+    visibleCommentAuthorCount === commentAuthors.length;
+  const commentVisibilityLabel =
+    visibleCommentAuthorCount === commentAuthors.length
+      ? t("comments.showAll")
+      : `${visibleCommentAuthorCount}/${commentAuthors.length}`;
+  const showAllCommentAuthors = () => {
+    setVisibleCommentAuthors(null);
+    setShowCommentsSidebar(true);
+  };
+  const hideAllCommentAuthors = () => {
+    setVisibleCommentAuthors(new Set());
+    setShowCommentsSidebar(false);
+    setActiveCommentId(null);
+  };
+  const setCommentAuthorVisible = (commentAuthor: string, visible: boolean) => {
+    const next = new Set(visibleCommentAuthorSet);
+    if (visible) {
+      next.add(commentAuthor);
+    } else {
+      next.delete(commentAuthor);
+    }
+    setVisibleCommentAuthors(next);
+    setShowCommentsSidebar(next.size > 0);
+    if (next.size === 0) {
+      setActiveCommentId(null);
+    }
+  };
+
+  const toolbarPriorityExtra = (
+    <div className="flex shrink-0 items-center gap-1">
+      <Button
+        onClick={toggleTrackChanges}
+        onMouseDown={(e) => e.preventDefault()}
+        disabled={readOnly}
+        aria-pressed={trackChangesOn}
+        aria-label={t("toggleTrackChanges")}
+        className={`h-8 min-w-[140px] justify-start gap-1.5 rounded-md px-2 text-xs text-[var(--doc-text-muted)] shadow-none disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.35] ${
+          trackChangesOn
+            ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)] shadow-[0_0_0_1px_var(--doc-primary)]"
+            : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+        }`}
+        size="xs"
+        title={t("toggleTrackChanges")}
+        variant="ghost"
+      >
+        <PenLineIcon className="size-3.5" />
+        <span className="truncate whitespace-nowrap">
+          {trackChangesOn ? t("trackingOn") : t("trackingOff")}
+        </span>
+      </Button>
+      <StSelect
+        value={displayMode}
+        onValueChange={(val) => setDisplayMode(val as DisplayMode)}
+        items={[
+          { value: "all-markup", label: "All Markup" },
+          { value: "simple-markup", label: "Simple" },
+          { value: "no-markup", label: "No Markup" },
+          { value: "original", label: "Original" },
+        ]}
+      >
+        <StSelectTrigger
+          size="sm"
+          className="h-8 min-h-0 w-[132px] min-w-0 shrink-0 border-transparent bg-transparent text-xs text-[var(--doc-text-muted)] shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
+        >
+          <EyeIcon size={14} className="shrink-0" />
+          <StSelectValue />
+        </StSelectTrigger>
+        <StSelectPopup>
+          {(
+            ["all-markup", "simple-markup", "no-markup", "original"] as const
+          ).map((mode) => (
+            <StSelectItem key={mode} value={mode}>
+              {DISPLAY_MODE_LABELS[mode]}
+            </StSelectItem>
+          ))}
+        </StSelectPopup>
+      </StSelect>
+    </div>
+  );
+
+  const toolbarInlineExtra = (
+    <>
+      <Menu>
+        <MenuTrigger
+          type="button"
+          disabled={comments.length === 0}
+          aria-label={t("comments.visibility")}
+          onMouseDown={(e) => e.preventDefault()}
+          className={`flex h-8 min-w-0 items-center gap-1.5 rounded-md border px-2.5 text-xs transition-colors duration-100 disabled:cursor-not-allowed disabled:border-transparent disabled:text-[var(--doc-text-subtle)] disabled:opacity-[0.16] disabled:hover:bg-transparent disabled:hover:text-[var(--doc-text-subtle)] ${
+            showCommentsSidebar && visibleCommentAuthorCount > 0
+              ? "border-[var(--doc-primary)] bg-[var(--doc-primary-light)] text-[var(--doc-text)]"
+              : "border-transparent text-[var(--doc-text-muted)] hover:border-[var(--doc-border)] hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)]"
+          }`}
+        >
+          <StickyNoteIcon size={14} className="shrink-0" />
+          <span className="max-w-24 truncate">{commentVisibilityLabel}</span>
+        </MenuTrigger>
+        <MenuPopup align="start" className="min-w-52">
+          <MenuGroup>
+            <MenuGroupLabel>{t("comments.visibility")}</MenuGroupLabel>
+            <MenuCheckboxItem
+              checked={allCommentAuthorsVisible}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  showAllCommentAuthors();
+                } else {
+                  hideAllCommentAuthors();
+                }
+              }}
+            >
+              {t("comments.showAll")}
+            </MenuCheckboxItem>
+            <MenuItem onClick={hideAllCommentAuthors}>
+              {t("comments.hideAll")}
+            </MenuItem>
+          </MenuGroup>
+          {(() => {
+            if (commentAuthors.length > 0) {
+              return (
+                <>
+                  <MenuSeparator />
+                  <MenuGroup>
+                    {commentAuthors.map((commentAuthor) => (
+                      <MenuCheckboxItem
+                        checked={
+                          showCommentsSidebar &&
+                          visibleCommentAuthorSet.has(commentAuthor)
+                        }
+                        key={commentAuthor}
+                        onCheckedChange={(checked) =>
+                          setCommentAuthorVisible(commentAuthor, checked)
+                        }
+                      >
+                        {commentAuthor === "Unknown"
+                          ? t("comments.unknownAuthor")
+                          : commentAuthor}
+                      </MenuCheckboxItem>
+                    ))}
+                  </MenuGroup>
+                </>
+              );
+            }
+            return null;
+          })()}
+        </MenuPopup>
+      </Menu>
+      <ToolbarSeparator />
+      {state.activeTrackedChange && (
+        <span
+          className="flex items-center gap-1 px-2 text-xs text-[var(--doc-text-muted)]"
+          style={{ maxWidth: 260 }}
+        >
+          <span className="truncate">
+            <span className="font-medium text-[var(--doc-text)]">
+              {state.activeTrackedChange.author}
+            </span>
+            {state.activeTrackedChange.date && (
+              <>
+                {" · "}
+                {new Date(state.activeTrackedChange.date).toLocaleDateString()}
+              </>
+            )}
+            {" · "}
+            {state.activeTrackedChange.type === "insertion"
+              ? t("inserted")
+              : t("deleted")}
+          </span>
+        </span>
+      )}
+      <ToolbarButton
+        onClick={() => {
+          const view = pagedEditorRef.current?.getView();
+          if (!view) {
+            return;
+          }
+          const { from, to } = view.state.selection;
+          const range = findChangeAtPosition(view.state, from, to);
+          acceptChange(range.from, range.to)(view.state, view.dispatch);
+        }}
+        disabled={readOnly || !state.activeTrackedChange}
+        title={t("acceptChange")}
+        ariaLabel={t("acceptChange")}
+      >
+        <CheckIcon size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          const view = pagedEditorRef.current?.getView();
+          if (!view) {
+            return;
+          }
+          const { from, to } = view.state.selection;
+          const range = findChangeAtPosition(view.state, from, to);
+          rejectChange(range.from, range.to)(view.state, view.dispatch);
+        }}
+        disabled={readOnly || !state.activeTrackedChange}
+        title={t("rejectChange")}
+        ariaLabel={t("rejectChange")}
+      >
+        <XIcon size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          const view = pagedEditorRef.current?.getView();
+          if (!view) {
+            return;
+          }
+          const { from } = view.state.selection;
+          const change = findPreviousChange(view.state, from);
+          if (change) {
+            view.dispatch(
+              view.state.tr.setSelection(
+                TextSelection.create(view.state.doc, change.from, change.to),
+              ),
+            );
+            view.focus();
+            // Scroll the rendered page to the change position
+            requestAnimationFrame(() => {
+              pagedEditorRef.current?.scrollToPosition(change.from);
+            });
+          }
+        }}
+        disabled={readOnly}
+        title={t("previousChange")}
+        ariaLabel={t("previousChange")}
+      >
+        <ChevronLeftIcon size={16} />
+      </ToolbarButton>
+      <ToolbarButton
+        onClick={() => {
+          const view = pagedEditorRef.current?.getView();
+          if (!view) {
+            return;
+          }
+          const { to } = view.state.selection;
+          const change = findNextChange(view.state, to);
+          if (change) {
+            view.dispatch(
+              view.state.tr.setSelection(
+                TextSelection.create(view.state.doc, change.from, change.to),
+              ),
+            );
+            view.focus();
+            // Scroll the rendered page to the change position
+            requestAnimationFrame(() => {
+              pagedEditorRef.current?.scrollToPosition(change.from);
+            });
+          }
+        }}
+        disabled={readOnly}
+        title={t("nextChange")}
+        ariaLabel={t("nextChange")}
+      >
+        <ChevronRightIcon size={16} />
+      </ToolbarButton>
+    </>
+  );
+
+  const imagePropertiesCurrentData = buildImagePropertiesData(
+    state.pmImageContext,
+  );
+
+  return (
+    <ErrorProvider>
+      <ErrorBoundary onError={handleEditorError}>
+        <div
+          ref={containerRef}
+          className={`folio-root folio-editor${displayMode !== "all-markup" ? ` folio-root--${displayMode}` : ""} ${className}`}
+          style={containerStyle}
+          data-testid="folio-editor"
+        >
+          {/* Main content area */}
+          <div style={mainContentStyle}>
+            {/* Wrapper for toolbar + scroll container + outline overlay */}
+            <div
+              style={{
+                position: "relative",
+                flex: 1,
+                minHeight: 0,
+                minWidth: 0,
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              {/* Toolbar - above the scroll container so scrollbar doesn't extend behind it */}
+              {/* Hide toolbar only when readOnly prop is explicitly set (not from viewing mode) */}
+              {showToolbar && !readOnlyProp && (
+                <div
+                  ref={toolbarRefCallback}
+                  className="z-50 flex flex-shrink-0 flex-col gap-0 bg-[var(--doc-page)]"
+                >
+                  <FormattingBar
+                    currentFormatting={state.selectionFormatting}
+                    onFormat={handleFormat}
+                    onUndo={undoActiveEditor}
+                    onRedo={redoActiveEditor}
+                    canUndo={
+                      hfEditPosition
+                        ? history.canUndo
+                        : bodyHistoryAvailability.canUndo
+                    }
+                    canRedo={
+                      hfEditPosition
+                        ? history.canRedo
+                        : bodyHistoryAvailability.canRedo
+                    }
+                    disabled={readOnly}
+                    theme={history.state.package.theme || theme || null}
+                    showZoomControl={showZoomControl}
+                    zoom={zoom}
+                    onZoomChange={setZoomWithViewportAnchor}
+                    editorRef={editorContentRef}
+                    onRefocusEditor={focusActiveEditor}
+                    onImageWrapType={handleImageWrapType}
+                    onImageTransform={handleImageTransform}
+                    onOpenImageProperties={handleOpenImageProperties}
+                    onTableAction={handleTableAction}
+                    priorityExtra={toolbarPriorityExtra}
+                    inlineExtra={toolbarInlineExtra}
+                    {...(history.state.package.styles?.styles
+                      ? {
+                          documentStyles: history.state.package.styles.styles,
+                        }
+                      : {})}
+                    {...(state.pmImageContext
+                      ? { imageContext: state.pmImageContext }
+                      : {})}
+                    {...(state.pmTableContext
+                      ? { tableContext: state.pmTableContext }
+                      : {})}
+                  >
+                    {toolbarChildren}
+                  </FormattingBar>
+                </div>
+              )}
+
+              {/* Editor container - this is the scroll container (toolbar is above, not inside) */}
               <div
-                style={{
-                  position: "relative",
-                  flex: 1,
-                  minHeight: 0,
-                  minWidth: 0,
-                  display: "flex",
-                  flexDirection: "column",
+                ref={scrollContainerRef}
+                style={editorContainerStyle}
+                data-folio-scroll=""
+                onScroll={(event) => {
+                  onScrollTopChange?.(event.currentTarget.scrollTop);
+                  requestAnimationFrame(syncCommentHighlightStyles);
                 }}
               >
-                {/* Toolbar - above the scroll container so scrollbar doesn't extend behind it */}
-                {/* Hide toolbar only when readOnly prop is explicitly set (not from viewing mode) */}
-                {showToolbar && !readOnlyProp && (
-                  <div
-                    ref={toolbarRefCallback}
-                    className="z-50 flex flex-shrink-0 flex-col gap-0 bg-[var(--doc-page)]"
-                  >
-                    <FormattingBar
-                      currentFormatting={state.selectionFormatting}
-                      onFormat={handleFormat}
-                      onUndo={undoActiveEditor}
-                      onRedo={redoActiveEditor}
-                      canUndo={
-                        hfEditPosition
-                          ? history.canUndo
-                          : bodyHistoryAvailability.canUndo
-                      }
-                      canRedo={
-                        hfEditPosition
-                          ? history.canRedo
-                          : bodyHistoryAvailability.canRedo
-                      }
-                      disabled={readOnly}
-                      theme={history.state.package.theme || theme || null}
-                      showZoomControl={showZoomControl}
-                      zoom={zoom}
-                      onZoomChange={setZoomWithViewportAnchor}
-                      editorRef={editorContentRef}
-                      onRefocusEditor={focusActiveEditor}
-                      onImageWrapType={handleImageWrapType}
-                      onImageTransform={handleImageTransform}
-                      onOpenImageProperties={handleOpenImageProperties}
-                      onTableAction={handleTableAction}
-                      priorityExtra={toolbarPriorityExtra}
-                      inlineExtra={toolbarInlineExtra}
-                      {...(history.state.package.styles?.styles
-                        ? {
-                            documentStyles: history.state.package.styles.styles,
-                          }
-                        : {})}
-                      {...(state.pmImageContext
-                        ? { imageContext: state.pmImageContext }
-                        : {})}
-                      {...(state.pmTableContext
-                        ? { tableContext: state.pmTableContext }
-                        : {})}
-                    >
-                      {toolbarChildren}
-                    </FormattingBar>
-                  </div>
-                )}
-
-                {/* Editor container - this is the scroll container (toolbar is above, not inside) */}
+                {/* Editor content wrapper */}
                 <div
-                  ref={scrollContainerRef}
-                  style={editorContainerStyle}
-                  data-folio-scroll=""
-                  onScroll={(event) => {
-                    onScrollTopChange?.(event.currentTarget.scrollTop);
-                    requestAnimationFrame(syncCommentHighlightStyles);
+                  style={{
+                    display: "flex",
+                    flex: 1,
+                    minHeight: 0,
+                    position: "relative",
                   }}
                 >
-                  {/* Editor content wrapper */}
+                  {/* Editor content area */}
+                  {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions */}
                   <div
-                    style={{
-                      display: "flex",
-                      flex: 1,
-                      minHeight: 0,
-                      position: "relative",
+                    ref={editorContentRef}
+                    style={{ position: "relative", flex: 1, minWidth: 0 }}
+                    onMouseDown={(e) => {
+                      // Focus editor when clicking on the background area (not the editor itself)
+                      // Using mouseDown for immediate response before focus can be lost
+                      if (e.target === e.currentTarget) {
+                        e.preventDefault();
+                        pagedEditorRef.current?.focus();
+                      }
                     }}
+                    onContextMenu={handleEditorContextMenu}
                   >
-                    {/* Editor content area */}
-                    {/* oxlint-disable-next-line jsx-a11y/no-static-element-interactions */}
-                    <div
-                      ref={editorContentRef}
-                      style={{ position: "relative", flex: 1, minWidth: 0 }}
-                      onMouseDown={(e) => {
-                        // Focus editor when clicking on the background area (not the editor itself)
-                        // Using mouseDown for immediate response before focus can be lost
-                        if (e.target === e.currentTarget) {
-                          e.preventDefault();
-                          pagedEditorRef.current?.focus();
+                    <PagedEditor
+                      ref={pagedEditorRef}
+                      document={history.state}
+                      theme={history.state.package.theme || theme || null}
+                      sectionProperties={effectiveSectionProperties ?? null}
+                      headerContent={headerContent}
+                      footerContent={footerContent}
+                      firstPageHeaderContent={firstPageHeaderContent}
+                      firstPageFooterContent={firstPageFooterContent}
+                      {...(history.state.package.styles
+                        ? { styles: history.state.package.styles }
+                        : {})}
+                      onHeaderFooterDoubleClick={handleHeaderFooterDoubleClick}
+                      hfEditMode={hfEditPosition}
+                      onBodyClick={handleBodyClick}
+                      zoom={zoom}
+                      readOnly={readOnly}
+                      onDocumentChange={handleDocumentChange}
+                      extensionManager={extensionManager}
+                      {...(onReadonlyEditAttempt !== undefined
+                        ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
+                        : {})}
+                      onSelectionChange={(_from, _to) => {
+                        // Extract full selection state from PM and use the standard handler
+                        const view = pagedEditorRef.current?.getView();
+                        if (view) {
+                          const selectionState = extractSelectionState(
+                            view.state,
+                          );
+                          handleSelectionChange(selectionState);
+                        } else {
+                          handleSelectionChange(null);
                         }
                       }}
-                      onContextMenu={handleEditorContextMenu}
-                    >
-                      <PagedEditor
-                        ref={pagedEditorRef}
-                        document={history.state}
-                        theme={history.state.package.theme || theme || null}
-                        sectionProperties={effectiveSectionProperties ?? null}
-                        headerContent={headerContent}
-                        footerContent={footerContent}
-                        firstPageHeaderContent={firstPageHeaderContent}
-                        firstPageFooterContent={firstPageFooterContent}
-                        {...(history.state.package.styles
-                          ? { styles: history.state.package.styles }
-                          : {})}
-                        onHeaderFooterDoubleClick={
-                          handleHeaderFooterDoubleClick
-                        }
-                        hfEditMode={hfEditPosition}
-                        onBodyClick={handleBodyClick}
-                        zoom={zoom}
-                        readOnly={readOnly}
-                        onDocumentChange={handleDocumentChange}
-                        extensionManager={extensionManager}
-                        {...(onReadonlyEditAttempt !== undefined
-                          ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
-                          : {})}
-                        onSelectionChange={(_from, _to) => {
-                          // Extract full selection state from PM and use the standard handler
-                          const view = pagedEditorRef.current?.getView();
-                          if (view) {
-                            const selectionState = extractSelectionState(
-                              view.state,
-                            );
-                            handleSelectionChange(selectionState);
-                          } else {
-                            handleSelectionChange(null);
-                          }
-                        }}
-                        {...(onSelectionTextChange !== undefined
-                          ? { onSelectionTextChange }
-                          : {})}
-                        externalPlugins={editorPlugins}
-                        {...(collaboration !== undefined
-                          ? { collaboration }
-                          : {})}
-                        onHyperlinkClick={handleHyperlinkClick}
-                        onContextMenu={handleContextMenu}
-                        commentsSidebarOpen={showCommentsSidebar}
-                        anchorPositionMode="comments"
-                        onAnonymizationTermClick={onAnonymizationTermClick}
-                        selectedAnonymizationCanonical={
-                          selectedAnonymizationCanonical
-                        }
-                        anonymizationSelectionSeq={anonymizationSelectionSeq}
-                        onAnchorPositionsChange={setAnchorPositions}
-                        onTotalPagesChange={(totalPages) => {
-                          setScrollPageInfo((previous) =>
-                            updateScrollPageTotal(previous, totalPages),
-                          );
-                        }}
-                        scrollContainerRef={scrollContainerRef}
-                        sidebarOverlay={(() => {
-                          if (showCommentsSidebar) {
-                            return (
-                              <CommentsSidebar
-                                activeCommentId={activeCommentId}
-                                comments={visibleComments}
-                                anchorPositions={anchorPositions}
-                                pageWidth={(() => {
-                                  const sp =
-                                    history.state.package.document
-                                      .finalSectionProperties;
-                                  return sp?.pageWidth
-                                    ? Math.round(sp.pageWidth / 15)
-                                    : 816;
-                                })()}
-                                editorContainerRef={scrollContainerRef}
-                                onCommentClick={(id) => {
-                                  setActiveCommentId(id);
-                                }}
-                                onCommentResolve={(id) => {
-                                  updateComments((prev) =>
-                                    prev.map((c) =>
-                                      c.id === id
-                                        ? {
-                                            ...c,
-                                            done: true,
-                                          }
-                                        : c,
-                                    ),
-                                  );
-                                }}
-                                onCommentDelete={(id) => {
-                                  updateComments((prev) =>
-                                    prev.filter(
-                                      (c) => c.id !== id && c.parentId !== id,
-                                    ),
-                                  );
-                                  if (activeCommentId === id) {
-                                    setActiveCommentId(null);
-                                  }
-                                }}
-                                onCommentReply={(id, text) => {
-                                  updateComments((prev) => [
-                                    ...prev,
-                                    createComment(text, author, id),
-                                  ]);
-                                }}
-                                onAddComment={(addText) => {
-                                  const comment = createComment(
-                                    addText,
-                                    author,
-                                  );
-                                  // Replace pending comment mark with the real comment ID
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (!view || !commentSelectionRange) {
-                                    return false;
-                                  }
-                                  const marked = applyCommentMarkRange(
-                                    view,
-                                    commentSelectionRange,
-                                    comment.id,
-                                    {
-                                      replacePending: true,
-                                    },
-                                  );
-                                  if (!marked) {
-                                    return false;
-                                  }
-                                  const commentAuthor = getCommentAuthorKey(
-                                    comment.author,
-                                  );
-                                  setVisibleCommentAuthors((current) => {
-                                    if (current === null) {
-                                      return null;
-                                    }
-                                    const next = new Set(current);
-                                    next.add(commentAuthor);
-                                    return next;
-                                  });
-                                  setActiveCommentId(comment.id);
-                                  updateComments((prev) => [...prev, comment]);
-                                  pagedEditorRef.current?.relayout();
-                                  requestAnimationFrame(() => {
-                                    syncCommentHighlightStyles();
-                                    requestAnimationFrame(
-                                      syncCommentHighlightStyles,
-                                    );
-                                  });
-                                  setIsAddingComment(false);
-                                  setCommentSelectionRange(null);
-                                  setAddCommentYPosition(null);
-                                  return true;
-                                }}
-                                onTrackedChangeReply={(revisionId, text) => {
-                                  updateComments((prev) => [
-                                    ...prev,
-                                    createComment(text, author, revisionId),
-                                  ]);
-                                }}
-                                onCancelAddComment={() => {
-                                  // Remove pending comment highlight
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view && commentSelectionRange) {
-                                    removePendingCommentMarkRange(
-                                      view,
-                                      commentSelectionRange,
-                                    );
-                                  }
-                                  setIsAddingComment(false);
-                                  setCommentSelectionRange(null);
-                                  setAddCommentYPosition(null);
-                                }}
-                                onAcceptChange={(from, to) => {
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view) {
-                                    acceptChange(from, to)(
-                                      view.state,
-                                      view.dispatch,
-                                    );
-                                    extractTrackedChanges();
-                                  }
-                                }}
-                                onRejectChange={(from, to) => {
-                                  const view =
-                                    pagedEditorRef.current?.getView();
-                                  if (view) {
-                                    rejectChange(from, to)(
-                                      view.state,
-                                      view.dispatch,
-                                    );
-                                    extractTrackedChanges();
-                                  }
-                                }}
-                                isAddingComment={isAddingComment}
-                                addCommentYPosition={addCommentYPosition}
-                                topOffset={0}
-                              />
-                            );
-                          }
-                          return undefined;
-                        })()}
-                      />
-
-                      {/* Floating "add comment" button — appears on right edge of page at selection */}
-                      {floatingCommentBtn !== null &&
-                        !isAddingComment &&
-                        !readOnly && (
-                          <Tooltip
-                            content="Add comment"
-                            side="bottom"
-                            delayMs={300}
-                          >
-                            <button
-                              type="button"
-                              onMouseDown={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
+                      {...(onSelectionTextChange !== undefined
+                        ? { onSelectionTextChange }
+                        : {})}
+                      externalPlugins={editorPlugins}
+                      {...(collaboration !== undefined
+                        ? { collaboration }
+                        : {})}
+                      onHyperlinkClick={handleHyperlinkClick}
+                      onContextMenu={handleContextMenu}
+                      commentsSidebarOpen={showCommentsSidebar}
+                      anchorPositionMode="comments"
+                      onAnonymizationTermClick={onAnonymizationTermClick}
+                      selectedAnonymizationCanonical={
+                        selectedAnonymizationCanonical
+                      }
+                      anonymizationSelectionSeq={anonymizationSelectionSeq}
+                      onAnchorPositionsChange={setAnchorPositions}
+                      onTotalPagesChange={(totalPages) => {
+                        setScrollPageInfo((previous) =>
+                          updateScrollPageTotal(previous, totalPages),
+                        );
+                      }}
+                      scrollContainerRef={scrollContainerRef}
+                      sidebarOverlay={(() => {
+                        if (showCommentsSidebar) {
+                          return (
+                            <CommentsSidebar
+                              activeCommentId={activeCommentId}
+                              comments={visibleComments}
+                              anchorPositions={anchorPositions}
+                              pageWidth={(() => {
+                                const sp =
+                                  history.state.package.document
+                                    .finalSectionProperties;
+                                return sp?.pageWidth
+                                  ? Math.round(sp.pageWidth / 15)
+                                  : 816;
+                              })()}
+                              editorContainerRef={scrollContainerRef}
+                              onCommentClick={(id) => {
+                                setActiveCommentId(id);
+                              }}
+                              onCommentResolve={(id) => {
+                                updateComments((prev) =>
+                                  prev.map((c) =>
+                                    c.id === id
+                                      ? {
+                                          ...c,
+                                          done: true,
+                                        }
+                                      : c,
+                                  ),
+                                );
+                              }}
+                              onCommentDelete={(id) => {
+                                updateComments((prev) =>
+                                  prev.filter(
+                                    (c) => c.id !== id && c.parentId !== id,
+                                  ),
+                                );
+                                if (activeCommentId === id) {
+                                  setActiveCommentId(null);
+                                }
+                              }}
+                              onCommentReply={(id, text) => {
+                                updateComments((prev) => [
+                                  ...prev,
+                                  createComment(text, author, id),
+                                ]);
+                              }}
+                              onAddComment={(addText) => {
+                                const comment = createComment(addText, author);
+                                // Replace pending comment mark with the real comment ID
                                 const view = pagedEditorRef.current?.getView();
-                                if (!view) {
-                                  setFloatingCommentBtn(null);
-                                  return;
+                                if (!view || !commentSelectionRange) {
+                                  return false;
                                 }
-                                const capturedRange = {
-                                  from: floatingCommentBtn.from,
-                                  to: floatingCommentBtn.to,
-                                };
-                                const currentSelection = view.state.selection;
-                                const safeRange = resolveCommentCreationRange({
-                                  docSize: view.state.doc.content.size,
-                                  capturedRange,
-                                  currentRange: {
-                                    from: currentSelection.from,
-                                    to: currentSelection.to,
-                                  },
-                                  savedRange: lastSelectionRef.current,
-                                });
-                                if (!safeRange) {
-                                  setCommentSelectionRange(null);
-                                  setFloatingCommentBtn(null);
-                                  return;
-                                }
-                                setCommentSelectionRange(safeRange);
                                 const marked = applyCommentMarkRange(
                                   view,
-                                  safeRange,
-                                  PENDING_COMMENT_ID,
-                                  { selectEnd: true },
+                                  commentSelectionRange,
+                                  comment.id,
+                                  {
+                                    replacePending: true,
+                                  },
                                 );
                                 if (!marked) {
-                                  setCommentSelectionRange(null);
-                                  setFloatingCommentBtn(null);
-                                  return;
+                                  return false;
                                 }
-                                const yPos = findSelectionYPosition(
-                                  scrollContainerRef.current,
-                                  editorContentRef.current,
-                                  safeRange.from,
+                                const commentAuthor = getCommentAuthorKey(
+                                  comment.author,
                                 );
-                                setAddCommentYPosition(
-                                  yPos ?? floatingCommentBtn.top,
-                                );
-                                setShowCommentsSidebar(true);
-                                setIsAddingComment(true);
-                                setFloatingCommentBtn(null);
+                                setVisibleCommentAuthors((current) => {
+                                  if (current === null) {
+                                    return null;
+                                  }
+                                  const next = new Set(current);
+                                  next.add(commentAuthor);
+                                  return next;
+                                });
+                                setActiveCommentId(comment.id);
+                                updateComments((prev) => [...prev, comment]);
+                                pagedEditorRef.current?.relayout();
+                                requestAnimationFrame(() => {
+                                  syncCommentHighlightStyles();
+                                  requestAnimationFrame(
+                                    syncCommentHighlightStyles,
+                                  );
+                                });
+                                setIsAddingComment(false);
+                                setCommentSelectionRange(null);
+                                setAddCommentYPosition(null);
+                                return true;
                               }}
-                              style={{
-                                position: "absolute",
-                                top: floatingCommentBtn.top,
-                                left: floatingCommentBtn.left,
-                                transform: "translate(-50%, -50%)",
-                                zIndex: 50,
-                                width: 28,
-                                height: 28,
-                                borderRadius: 6,
-                                border: "1px solid var(--doc-border)",
-                                backgroundColor: "var(--doc-page)",
-                                color: "var(--doc-text-muted)",
-                                cursor: "pointer",
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                boxShadow: "0 2px 8px var(--doc-border)",
-                                transition:
-                                  "background-color 0.15s, box-shadow 0.15s",
+                              onTrackedChangeReply={(revisionId, text) => {
+                                updateComments((prev) => [
+                                  ...prev,
+                                  createComment(text, author, revisionId),
+                                ]);
                               }}
-                              onMouseOver={(e) => {
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.backgroundColor =
-                                  "rgba(26, 115, 232, 0.08)";
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.boxShadow =
-                                  "0 1px 4px rgba(26, 115, 232, 0.3)";
-                              }}
-                              onFocus={(e) => {
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.backgroundColor =
-                                  "rgba(26, 115, 232, 0.08)";
-                              }}
-                              onMouseOut={(e) => {
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.backgroundColor =
-                                  "var(--doc-canvas, #fff)";
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.boxShadow =
-                                  "0 1px 3px rgba(60,64,67,0.2)";
-                              }}
-                              onBlur={(e) => {
-                                (
-                                  e.currentTarget as HTMLButtonElement
-                                ).style.backgroundColor =
-                                  "var(--doc-canvas, #fff)";
-                              }}
-                            >
-                              <SquarePenIcon size={16} />
-                            </button>
-                          </Tooltip>
-                        )}
-
-                      {/* Inline Header/Footer Editor — positioned over the target area */}
-                      {hfEditPosition &&
-                        (() => {
-                          const activeHf = (() => {
-                            if (hfEditIsFirstPage) {
-                              return (() => {
-                                if (hfEditPosition === "header") {
-                                  return firstPageHeaderContent;
+                              onCancelAddComment={() => {
+                                // Remove pending comment highlight
+                                const view = pagedEditorRef.current?.getView();
+                                if (view && commentSelectionRange) {
+                                  removePendingCommentMarkRange(
+                                    view,
+                                    commentSelectionRange,
+                                  );
                                 }
-                                return firstPageFooterContent;
-                              })();
-                            }
-                            if (hfEditPosition === "header") {
-                              return headerContent;
-                            }
-                            return footerContent;
-                          })();
-                          if (!activeHf) {
-                            return null;
-                          }
-                          const targetEl = getHfTargetElement(hfEditPosition);
-                          const parentEl = editorContentRef.current;
-                          if (!targetEl || !parentEl) {
-                            return null;
-                          }
-                          return (
-                            <InlineHeaderFooterEditor
-                              ref={hfEditorRef}
-                              headerFooter={activeHf}
-                              position={hfEditPosition}
-                              targetElement={targetEl}
-                              parentElement={parentEl}
-                              onSave={handleHeaderFooterSave}
-                              onClose={() => setHfEditPosition(null)}
-                              onSelectionChange={handleSelectionChange}
-                              onRemove={handleRemoveHeaderFooter}
-                              {...(history.state.package.styles
-                                ? { styles: history.state.package.styles }
-                                : {})}
+                                setIsAddingComment(false);
+                                setCommentSelectionRange(null);
+                                setAddCommentYPosition(null);
+                              }}
+                              onAcceptChange={(from, to) => {
+                                const view = pagedEditorRef.current?.getView();
+                                if (view) {
+                                  acceptChange(from, to)(
+                                    view.state,
+                                    view.dispatch,
+                                  );
+                                  extractTrackedChanges();
+                                }
+                              }}
+                              onRejectChange={(from, to) => {
+                                const view = pagedEditorRef.current?.getView();
+                                if (view) {
+                                  rejectChange(from, to)(
+                                    view.state,
+                                    view.dispatch,
+                                  );
+                                  extractTrackedChanges();
+                                }
+                              }}
+                              isAddingComment={isAddingComment}
+                              addCommentYPosition={addCommentYPosition}
+                              topOffset={0}
                             />
                           );
-                        })()}
-                    </div>
+                        }
+                        return undefined;
+                      })()}
+                    />
+
+                    {/* Floating "add comment" button — appears on right edge of page at selection */}
+                    {floatingCommentBtn !== null &&
+                      !isAddingComment &&
+                      !readOnly && (
+                        <Tooltip
+                          content="Add comment"
+                          side="bottom"
+                          delayMs={300}
+                        >
+                          <button
+                            type="button"
+                            onMouseDown={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              const view = pagedEditorRef.current?.getView();
+                              if (!view) {
+                                setFloatingCommentBtn(null);
+                                return;
+                              }
+                              const capturedRange = {
+                                from: floatingCommentBtn.from,
+                                to: floatingCommentBtn.to,
+                              };
+                              const currentSelection = view.state.selection;
+                              const safeRange = resolveCommentCreationRange({
+                                docSize: view.state.doc.content.size,
+                                capturedRange,
+                                currentRange: {
+                                  from: currentSelection.from,
+                                  to: currentSelection.to,
+                                },
+                                savedRange: lastSelectionRef.current,
+                              });
+                              if (!safeRange) {
+                                setCommentSelectionRange(null);
+                                setFloatingCommentBtn(null);
+                                return;
+                              }
+                              setCommentSelectionRange(safeRange);
+                              const marked = applyCommentMarkRange(
+                                view,
+                                safeRange,
+                                PENDING_COMMENT_ID,
+                                { selectEnd: true },
+                              );
+                              if (!marked) {
+                                setCommentSelectionRange(null);
+                                setFloatingCommentBtn(null);
+                                return;
+                              }
+                              const yPos = findSelectionYPosition(
+                                scrollContainerRef.current,
+                                editorContentRef.current,
+                                safeRange.from,
+                              );
+                              setAddCommentYPosition(
+                                yPos ?? floatingCommentBtn.top,
+                              );
+                              setShowCommentsSidebar(true);
+                              setIsAddingComment(true);
+                              setFloatingCommentBtn(null);
+                            }}
+                            style={{
+                              position: "absolute",
+                              top: floatingCommentBtn.top,
+                              left: floatingCommentBtn.left,
+                              transform: "translate(-50%, -50%)",
+                              zIndex: 50,
+                              width: 28,
+                              height: 28,
+                              borderRadius: 6,
+                              border: "1px solid var(--doc-border)",
+                              backgroundColor: "var(--doc-page)",
+                              color: "var(--doc-text-muted)",
+                              cursor: "pointer",
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              boxShadow: "0 2px 8px var(--doc-border)",
+                              transition:
+                                "background-color 0.15s, box-shadow 0.15s",
+                            }}
+                            onMouseOver={(e) => {
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.backgroundColor =
+                                "rgba(26, 115, 232, 0.08)";
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.boxShadow =
+                                "0 1px 4px rgba(26, 115, 232, 0.3)";
+                            }}
+                            onFocus={(e) => {
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.backgroundColor =
+                                "rgba(26, 115, 232, 0.08)";
+                            }}
+                            onMouseOut={(e) => {
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.backgroundColor =
+                                "var(--doc-canvas, #fff)";
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.boxShadow =
+                                "0 1px 3px rgba(60,64,67,0.2)";
+                            }}
+                            onBlur={(e) => {
+                              (
+                                e.currentTarget as HTMLButtonElement
+                              ).style.backgroundColor =
+                                "var(--doc-canvas, #fff)";
+                            }}
+                          >
+                            <SquarePenIcon size={16} />
+                          </button>
+                        </Tooltip>
+                      )}
+
+                    {/* Inline Header/Footer Editor — positioned over the target area */}
+                    {hfEditPosition &&
+                      (() => {
+                        const activeHf = (() => {
+                          if (hfEditIsFirstPage) {
+                            return (() => {
+                              if (hfEditPosition === "header") {
+                                return firstPageHeaderContent;
+                              }
+                              return firstPageFooterContent;
+                            })();
+                          }
+                          if (hfEditPosition === "header") {
+                            return headerContent;
+                          }
+                          return footerContent;
+                        })();
+                        if (!activeHf) {
+                          return null;
+                        }
+                        const targetEl = getHfTargetElement(hfEditPosition);
+                        const parentEl = editorContentRef.current;
+                        if (!targetEl || !parentEl) {
+                          return null;
+                        }
+                        return (
+                          <InlineHeaderFooterEditor
+                            ref={hfEditorRef}
+                            headerFooter={activeHf}
+                            position={hfEditPosition}
+                            targetElement={targetEl}
+                            parentElement={parentEl}
+                            onSave={handleHeaderFooterSave}
+                            onClose={() => setHfEditPosition(null)}
+                            onSelectionChange={handleSelectionChange}
+                            onRemove={handleRemoveHeaderFooter}
+                            {...(history.state.package.styles
+                              ? { styles: history.state.package.styles }
+                              : {})}
+                          />
+                        );
+                      })()}
                   </div>
-                  {/* end editor flex wrapper */}
                 </div>
-                {/* end scroll container */}
-
-                {/* Page indicator — Google Docs style, next to scrollbar while scrolling */}
-                {scrollPageInfo.totalPages > 1 && (
-                  <div
-                    style={{
-                      position: "absolute",
-                      right: 24,
-                      top: "50%",
-                      transform: "translateY(-50%)",
-                      backgroundColor: "var(--doc-text)",
-                      color: "var(--doc-page)",
-                      padding: "6px 12px",
-                      borderRadius: "4px",
-                      fontSize: "12px",
-                      fontWeight: 500,
-                      whiteSpace: "nowrap",
-                      pointerEvents: "none",
-                      zIndex: 1000,
-                      opacity: scrollPageInfo.visible ? 1 : 0,
-                      transition: "opacity 0.3s ease",
-                      userSelect: "none",
-                    }}
-                    aria-live="polite"
-                    role="status"
-                  >
-                    {scrollPageInfo.currentPage} of {scrollPageInfo.totalPages}
-                  </div>
-                )}
-
-                {/* Document outline sidebar — absolutely positioned, doesn't scroll */}
-                {/* Document outline and comments sidebar provided by host app */}
+                {/* end editor flex wrapper */}
               </div>
-              {/* end wrapper for scroll container + outline */}
+              {/* end scroll container */}
+
+              {/* Page indicator — Google Docs style, next to scrollbar while scrolling */}
+              {scrollPageInfo.totalPages > 1 && (
+                <div
+                  style={{
+                    position: "absolute",
+                    right: 24,
+                    top: "50%",
+                    transform: "translateY(-50%)",
+                    backgroundColor: "var(--doc-text)",
+                    color: "var(--doc-page)",
+                    padding: "6px 12px",
+                    borderRadius: "4px",
+                    fontSize: "12px",
+                    fontWeight: 500,
+                    whiteSpace: "nowrap",
+                    pointerEvents: "none",
+                    zIndex: 1000,
+                    opacity: scrollPageInfo.visible ? 1 : 0,
+                    transition: "opacity 0.3s ease",
+                    userSelect: "none",
+                  }}
+                  aria-live="polite"
+                  role="status"
+                >
+                  {scrollPageInfo.currentPage} of {scrollPageInfo.totalPages}
+                </div>
+              )}
+
+              {/* Document outline sidebar — absolutely positioned, doesn't scroll */}
+              {/* Document outline and comments sidebar provided by host app */}
             </div>
-
-            {/* Hyperlink popup (Google Docs-style) */}
-            <HyperlinkPopup
-              data={hyperlinkPopupData}
-              onNavigate={handleHyperlinkPopupNavigate}
-              onCopy={handleHyperlinkPopupCopy}
-              onEdit={handleHyperlinkPopupEdit}
-              onRemove={handleHyperlinkPopupRemove}
-              onClose={handleHyperlinkPopupClose}
-              readOnly={readOnly}
-            />
-
-            {/* Right-click context menu */}
-            <TextContextMenu
-              isOpen={contextMenu.isOpen}
-              position={contextMenu.position}
-              hasSelection={contextMenu.hasSelection}
-              isEditable={!readOnly}
-              items={contextMenuItems}
-              onAction={(action) => {
-                void handleContextMenuAction(action);
-              }}
-              onClose={handleContextMenuClose}
-            />
-
-            {/* Toast notifications */}
-            {/* Toast notifications provided by host app */}
-
-            <DocxEditorDialogs
-              findReplace={{
-                state: findReplace.state,
-                onClose: findReplace.close,
-                onFind: handleFind,
-                onFindNext: handleFindNext,
-                onFindPrevious: handleFindPrevious,
-                onReplace: handleReplace,
-                onReplaceAll: handleReplaceAll,
-                currentResult: findResultRef.current,
-              }}
-              tableProperties={{
-                isOpen: tablePropsOpen,
-                onClose: () => setTablePropsOpen(false),
-                onApply: (props) => {
-                  const view = getActiveEditorView();
-                  if (view) {
-                    setTableProperties(props)(view.state, view.dispatch);
-                  }
-                },
-                currentProps: state.pmTableContext?.table?.attrs as
-                  | Record<string, unknown>
-                  | undefined,
-              }}
-              imagePosition={{
-                isOpen: imagePositionOpen,
-                onClose: () => setImagePositionOpen(false),
-                onApply: handleApplyImagePosition,
-              }}
-              imageProperties={{
-                isOpen: imagePropsOpen,
-                onClose: () => setImagePropsOpen(false),
-                onApply: handleApplyImageProperties,
-                currentData: imagePropertiesCurrentData,
-              }}
-              pageSetup={{
-                isOpen: showPageSetup,
-                onClose: () => setShowPageSetup(false),
-                onApply: handlePageSetupApply,
-                currentProps:
-                  history.state.package.document.finalSectionProperties,
-              }}
-              footnoteProperties={{
-                isOpen: footnotePropsOpen,
-                onClose: () => setFootnotePropsOpen(false),
-                onApply: handleApplyFootnoteProperties,
-                footnotePr:
-                  history.state.package.document.finalSectionProperties
-                    ?.footnotePr,
-                endnotePr:
-                  history.state.package.document.finalSectionProperties
-                    ?.endnotePr,
-              }}
-            />
-            {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
-            {/* Hidden file input for image insertion */}
-            <input
-              ref={imageInputRef}
-              type="file"
-              accept="image/*"
-              style={{ display: "none" }}
-              onChange={handleImageFileChange}
-            />
+            {/* end wrapper for scroll container + outline */}
           </div>
-        </ErrorBoundary>
-      </ErrorProvider>
-    );
-  },
-);
+
+          {/* Hyperlink popup (Google Docs-style) */}
+          <HyperlinkPopup
+            data={hyperlinkPopupData}
+            onNavigate={handleHyperlinkPopupNavigate}
+            onCopy={handleHyperlinkPopupCopy}
+            onEdit={handleHyperlinkPopupEdit}
+            onRemove={handleHyperlinkPopupRemove}
+            onClose={handleHyperlinkPopupClose}
+            readOnly={readOnly}
+          />
+
+          {/* Right-click context menu */}
+          <TextContextMenu
+            isOpen={contextMenu.isOpen}
+            position={contextMenu.position}
+            hasSelection={contextMenu.hasSelection}
+            isEditable={!readOnly}
+            items={contextMenuItems}
+            onAction={(action) => {
+              void handleContextMenuAction(action);
+            }}
+            onClose={handleContextMenuClose}
+          />
+
+          {/* Toast notifications */}
+          {/* Toast notifications provided by host app */}
+
+          <DocxEditorDialogs
+            findReplace={{
+              state: findReplace.state,
+              onClose: findReplace.close,
+              onFind: handleFind,
+              onFindNext: handleFindNext,
+              onFindPrevious: handleFindPrevious,
+              onReplace: handleReplace,
+              onReplaceAll: handleReplaceAll,
+              currentResult: findResultRef.current,
+            }}
+            tableProperties={{
+              isOpen: tablePropsOpen,
+              onClose: () => setTablePropsOpen(false),
+              onApply: (props) => {
+                const view = getActiveEditorView();
+                if (view) {
+                  setTableProperties(props)(view.state, view.dispatch);
+                }
+              },
+              currentProps: state.pmTableContext?.table?.attrs as
+                | Record<string, unknown>
+                | undefined,
+            }}
+            imagePosition={{
+              isOpen: imagePositionOpen,
+              onClose: () => setImagePositionOpen(false),
+              onApply: handleApplyImagePosition,
+            }}
+            imageProperties={{
+              isOpen: imagePropsOpen,
+              onClose: () => setImagePropsOpen(false),
+              onApply: handleApplyImageProperties,
+              currentData: imagePropertiesCurrentData,
+            }}
+            pageSetup={{
+              isOpen: showPageSetup,
+              onClose: () => setShowPageSetup(false),
+              onApply: handlePageSetupApply,
+              currentProps:
+                history.state.package.document.finalSectionProperties,
+            }}
+            footnoteProperties={{
+              isOpen: footnotePropsOpen,
+              onClose: () => setFootnotePropsOpen(false),
+              onApply: handleApplyFootnoteProperties,
+              footnotePr:
+                history.state.package.document.finalSectionProperties
+                  ?.footnotePr,
+              endnotePr:
+                history.state.package.document.finalSectionProperties
+                  ?.endnotePr,
+            }}
+          />
+          {/* InlineHeaderFooterEditor is rendered inside the editor content area (position:relative div) */}
+          {/* Hidden file input for image insertion */}
+          <input
+            ref={imageInputRef}
+            type="file"
+            accept="image/*"
+            style={{ display: "none" }}
+            onChange={handleImageFileChange}
+          />
+        </div>
+      </ErrorBoundary>
+    </ErrorProvider>
+  );
+}
 
 // ============================================================================
 // EXPORTS

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -225,7 +225,10 @@ import { TextContextMenu } from "./TextContextMenu";
 import type { TextContextAction, TextContextMenuItem } from "./TextContextMenu";
 import { ToolbarButton, ToolbarSeparator } from "./Toolbar";
 import type { FormattingAction } from "./Toolbar";
-import { mapHexToHighlightName } from "./toolbarUtils";
+import {
+  areSelectionFormattingEqual,
+  mapHexToHighlightName,
+} from "./toolbarUtils";
 import { HyperlinkPopup } from "./ui/HyperlinkPopup";
 import { getBuiltinTableStyle } from "./ui/table-styles";
 import type { TableStylePreset } from "./ui/table-styles";
@@ -304,6 +307,87 @@ function buildImagePropertiesData(
     data.borderStyle = ctx.borderStyle;
   }
   return data;
+}
+
+/**
+ * Shared empty formatting object for selections that carry no formatting
+ * (e.g. no active selection). Reusing one reference lets the selection
+ * `setState` bail out instead of allocating a fresh `{}` each time.
+ */
+const EMPTY_SELECTION_FORMATTING: EditorState["selectionFormatting"] = {};
+
+/**
+ * Structural equality for the ProseMirror table context. `getTableContext`
+ * returns a fresh object on every selection change; comparing by value lets
+ * the selection `setState` preserve the previous reference and skip a render.
+ */
+function areTableContextsEqual(
+  a: EditorState["pmTableContext"],
+  b: EditorState["pmTableContext"],
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.isInTable === b.isInTable &&
+    a.table === b.table &&
+    a.tablePos === b.tablePos &&
+    a.rowIndex === b.rowIndex &&
+    a.columnIndex === b.columnIndex &&
+    a.rowCount === b.rowCount &&
+    a.columnCount === b.columnCount &&
+    a.hasMultiCellSelection === b.hasMultiCellSelection &&
+    a.canSplitCell === b.canSplitCell &&
+    a.cellBorderColor === b.cellBorderColor &&
+    a.cellBackgroundColor === b.cellBackgroundColor
+  );
+}
+
+/** Structural equality for the image context surfaced to the toolbar. */
+function areImageContextsEqual(
+  a: EditorState["pmImageContext"],
+  b: EditorState["pmImageContext"],
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.pos === b.pos &&
+    a.wrapType === b.wrapType &&
+    a.displayMode === b.displayMode &&
+    a.cssFloat === b.cssFloat &&
+    a.transform === b.transform &&
+    a.alt === b.alt &&
+    a.borderWidth === b.borderWidth &&
+    a.borderColor === b.borderColor &&
+    a.borderStyle === b.borderStyle
+  );
+}
+
+/** Structural equality for the active tracked-change context. */
+function areActiveTrackedChangesEqual(
+  a: EditorState["activeTrackedChange"],
+  b: EditorState["activeTrackedChange"],
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.type === b.type &&
+    a.author === b.author &&
+    a.date === b.date &&
+    a.from === b.from &&
+    a.to === b.to
+  );
 }
 
 /**
@@ -1224,13 +1308,47 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
 
         if (!selectionState) {
           setFloatingCommentBtn(null);
-          setState((prev) => ({
-            ...prev,
-            selectionFormatting: {},
-            pmTableContext: pmTableCtx,
-            pmImageContext: pmImageCtx,
-            activeTrackedChange: trackedChange,
-          }));
+          setState((prev) => {
+            const selectionFormatting = areSelectionFormattingEqual(
+              prev.selectionFormatting,
+              EMPTY_SELECTION_FORMATTING,
+            )
+              ? prev.selectionFormatting
+              : EMPTY_SELECTION_FORMATTING;
+            const pmTableContext = areTableContextsEqual(
+              prev.pmTableContext,
+              pmTableCtx,
+            )
+              ? prev.pmTableContext
+              : pmTableCtx;
+            const pmImageContext = areImageContextsEqual(
+              prev.pmImageContext,
+              pmImageCtx,
+            )
+              ? prev.pmImageContext
+              : pmImageCtx;
+            const activeTrackedChange = areActiveTrackedChangesEqual(
+              prev.activeTrackedChange,
+              trackedChange,
+            )
+              ? prev.activeTrackedChange
+              : trackedChange;
+            if (
+              selectionFormatting === prev.selectionFormatting &&
+              pmTableContext === prev.pmTableContext &&
+              pmImageContext === prev.pmImageContext &&
+              activeTrackedChange === prev.activeTrackedChange
+            ) {
+              return prev;
+            }
+            return {
+              ...prev,
+              selectionFormatting,
+              pmTableContext,
+              pmImageContext,
+              activeTrackedChange,
+            };
+          });
           return;
         }
 
@@ -1273,18 +1391,64 @@ export const DocxEditor = forwardRef<DocxEditorRef, DocxEditorProps>(
           textColor,
           listState,
         });
-        setState((prev) => ({
-          ...prev,
-          selectionFormatting: formatting,
-          paragraphIndentLeft: paragraphFormatting.indentLeft ?? 0,
-          paragraphIndentRight: paragraphFormatting.indentRight ?? 0,
-          paragraphFirstLineIndent: paragraphFormatting.indentFirstLine ?? 0,
-          paragraphHangingIndent: paragraphFormatting.hangingIndent ?? false,
-          paragraphTabs: paragraphFormatting.tabs ?? null,
-          pmTableContext: pmTableCtx,
-          pmImageContext: pmImageCtx,
-          activeTrackedChange: trackedChange,
-        }));
+        setState((prev) => {
+          const selectionFormatting = areSelectionFormattingEqual(
+            prev.selectionFormatting,
+            formatting,
+          )
+            ? prev.selectionFormatting
+            : formatting;
+          const pmTableContext = areTableContextsEqual(
+            prev.pmTableContext,
+            pmTableCtx,
+          )
+            ? prev.pmTableContext
+            : pmTableCtx;
+          const pmImageContext = areImageContextsEqual(
+            prev.pmImageContext,
+            pmImageCtx,
+          )
+            ? prev.pmImageContext
+            : pmImageCtx;
+          const activeTrackedChange = areActiveTrackedChangesEqual(
+            prev.activeTrackedChange,
+            trackedChange,
+          )
+            ? prev.activeTrackedChange
+            : trackedChange;
+          const paragraphIndentLeft = paragraphFormatting.indentLeft ?? 0;
+          const paragraphIndentRight = paragraphFormatting.indentRight ?? 0;
+          const paragraphFirstLineIndent =
+            paragraphFormatting.indentFirstLine ?? 0;
+          const paragraphHangingIndent =
+            paragraphFormatting.hangingIndent ?? false;
+          const paragraphTabs = paragraphFormatting.tabs ?? null;
+          if (
+            selectionFormatting === prev.selectionFormatting &&
+            pmTableContext === prev.pmTableContext &&
+            pmImageContext === prev.pmImageContext &&
+            activeTrackedChange === prev.activeTrackedChange &&
+            paragraphIndentLeft === prev.paragraphIndentLeft &&
+            paragraphIndentRight === prev.paragraphIndentRight &&
+            paragraphFirstLineIndent === prev.paragraphFirstLineIndent &&
+            paragraphHangingIndent === prev.paragraphHangingIndent &&
+            paragraphTabs === prev.paragraphTabs
+          ) {
+            return prev;
+          }
+          return {
+            ...prev,
+            selectionFormatting,
+            paragraphIndentLeft,
+            paragraphIndentRight,
+            paragraphFirstLineIndent,
+            paragraphHangingIndent,
+            paragraphTabs,
+            pmTableContext,
+            pmImageContext,
+            activeTrackedChange,
+          };
+        });
 
         // Update floating comment button position
         if (

--- a/packages/folio/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/folio/src/components/InlineHeaderFooterEditor.tsx
@@ -14,9 +14,8 @@ import React, {
   useState,
   useImperativeHandle,
   useLayoutEffect,
-  forwardRef,
 } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, Ref } from "react";
 
 import { undo, redo } from "prosemirror-history";
 import { EditorState } from "prosemirror-state";
@@ -99,23 +98,20 @@ const labelStyle: CSSProperties = {
 // COMPONENT
 // ============================================================================
 
-export const InlineHeaderFooterEditor = forwardRef<
-  InlineHeaderFooterEditorRef,
-  InlineHeaderFooterEditorProps
->(function InlineHeaderFooterEditor(
-  {
-    headerFooter,
-    position,
-    styles,
-    targetElement,
-    parentElement,
-    onSave,
-    onClose,
-    onSelectionChange,
-    onRemove,
-  },
+export function InlineHeaderFooterEditor({
   ref,
-) {
+  headerFooter,
+  position,
+  styles,
+  targetElement,
+  parentElement,
+  onSave,
+  onClose,
+  onSelectionChange,
+  onRemove,
+}: InlineHeaderFooterEditorProps & {
+  ref?: Ref<InlineHeaderFooterEditorRef>;
+}) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const [isDirty, setIsDirty] = useState(false);
@@ -362,7 +358,7 @@ export const InlineHeaderFooterEditor = forwardRef<
       )}
     </div>
   );
-});
+}
 
 // ============================================================================
 // OPTIONS MENU SUB-COMPONENT

--- a/packages/folio/src/components/toolbarUtils.test.ts
+++ b/packages/folio/src/components/toolbarUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SelectionFormatting } from "./toolbarPrimitives";
+import { areSelectionFormattingEqual } from "./toolbarUtils";
+
+describe("selection formatting equality", () => {
+  test("treats identical nullable values as equal", () => {
+    expect(areSelectionFormattingEqual(undefined, undefined)).toBe(true);
+    expect(areSelectionFormattingEqual(null, null)).toBe(true);
+  });
+
+  test("treats one missing formatting value as different", () => {
+    expect(areSelectionFormattingEqual(undefined, {})).toBe(false);
+    expect(areSelectionFormattingEqual({}, null)).toBe(false);
+  });
+
+  test("compares formatting fields structurally", () => {
+    const formatting: SelectionFormatting = {
+      bold: true,
+      fontSize: 22,
+      listState: { type: "bullet", level: 1, isInList: true },
+    };
+
+    expect(
+      areSelectionFormattingEqual(formatting, {
+        bold: true,
+        fontSize: 22,
+        listState: { type: "bullet", level: 1, isInList: true },
+      }),
+    ).toBe(true);
+    expect(
+      areSelectionFormattingEqual(formatting, {
+        bold: true,
+        fontSize: 22,
+        listState: { type: "number", level: 1, isInList: true },
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/folio/src/components/toolbarUtils.ts
+++ b/packages/folio/src/components/toolbarUtils.ts
@@ -238,3 +238,57 @@ export function hasActiveFormatting(formatting?: SelectionFormatting): boolean {
     formatting.subscript
   );
 }
+
+// ============================================================================
+// SELECTION FORMATTING EQUALITY
+// ============================================================================
+
+function areListStatesEqual(
+  a: SelectionFormatting["listState"],
+  b: SelectionFormatting["listState"],
+): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+  return (
+    a.type === b.type &&
+    a.level === b.level &&
+    a.isInList === b.isInList &&
+    a.numId === b.numId
+  );
+}
+
+/**
+ * Structural equality for two `SelectionFormatting` objects.
+ *
+ * `buildSelectionFormatting` allocates a fresh object on every selection
+ * change, so callers use this to preserve the previous reference when the
+ * formatting is unchanged — letting `setState` bail out and skip a render of
+ * the toolbar and editor on ordinary typing.
+ */
+export function areSelectionFormattingEqual(
+  a: SelectionFormatting,
+  b: SelectionFormatting,
+): boolean {
+  return (
+    a.bold === b.bold &&
+    a.italic === b.italic &&
+    a.underline === b.underline &&
+    a.strike === b.strike &&
+    a.superscript === b.superscript &&
+    a.subscript === b.subscript &&
+    a.fontFamily === b.fontFamily &&
+    a.fontSize === b.fontSize &&
+    a.color === b.color &&
+    a.highlight === b.highlight &&
+    a.alignment === b.alignment &&
+    a.lineSpacing === b.lineSpacing &&
+    areListStatesEqual(a.listState, b.listState) &&
+    a.styleId === b.styleId &&
+    a.indentLeft === b.indentLeft &&
+    a.bidi === b.bidi
+  );
+}

--- a/packages/folio/src/components/toolbarUtils.ts
+++ b/packages/folio/src/components/toolbarUtils.ts
@@ -270,9 +270,16 @@ function areListStatesEqual(
  * the toolbar and editor on ordinary typing.
  */
 export function areSelectionFormattingEqual(
-  a: SelectionFormatting,
-  b: SelectionFormatting,
+  a: SelectionFormatting | null | undefined,
+  b: SelectionFormatting | null | undefined,
 ): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!a || !b) {
+    return false;
+  }
+
   return (
     a.bold === b.bold &&
     a.italic === b.italic &&

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -15,15 +15,8 @@
  * so that ProseMirror's internal measurements stay valid.
  */
 
-import {
-  useRef,
-  useEffect,
-  useCallback,
-  useImperativeHandle,
-  forwardRef,
-  memo,
-} from "react";
-import type { CSSProperties } from "react";
+import { useRef, useEffect, useCallback, useImperativeHandle } from "react";
+import type { CSSProperties, Ref } from "react";
 
 import { undo, redo } from "prosemirror-history";
 import type { Transaction, Command, Plugin } from "prosemirror-state";
@@ -373,11 +366,11 @@ function stateToDocument(
 /**
  * HiddenProseMirror - Off-screen ProseMirror editor for keyboard input
  */
-const HiddenProseMirrorComponent = forwardRef<
-  HiddenProseMirrorRef,
-  HiddenProseMirrorProps
->(function HiddenProseMirror(props, ref) {
+export function HiddenProseMirror(
+  props: HiddenProseMirrorProps & { ref?: Ref<HiddenProseMirrorRef> },
+) {
   const {
+    ref,
     document,
     styles,
     theme: _theme,
@@ -815,6 +808,4 @@ const HiddenProseMirrorComponent = forwardRef<
       // DO NOT set aria-hidden - this editor provides semantic structure
     />
   );
-});
-
-export const HiddenProseMirror = memo(HiddenProseMirrorComponent);
+}

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -50,6 +50,8 @@ import "prosemirror-view/style/prosemirror.css";
 
 import "../core/prosemirror/editor.css";
 
+const EMPTY_EXTERNAL_PLUGINS: Plugin[] = [];
+
 // ============================================================================
 // TYPES
 // ============================================================================
@@ -378,7 +380,7 @@ export function HiddenProseMirror(
     readOnly = false,
     onTransaction,
     onSelectionChange,
-    externalPlugins = [],
+    externalPlugins = EMPTY_EXTERNAL_PLUGINS,
     collaboration,
     extensionManager,
     onEditorViewReady,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -20,11 +20,9 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  forwardRef,
   useImperativeHandle,
-  memo,
 } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, Ref } from "react";
 
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction, Plugin } from "prosemirror-state";
@@ -1476,1487 +1474,1519 @@ function buildFootnoteRenderItems(
 /**
  * PagedEditor - Main paginated editing component.
  */
-const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
-  function PagedEditor(props, ref) {
-    const {
-      document,
-      styles,
-      theme: _theme,
-      sectionProperties,
-      headerContent,
-      footerContent,
-      firstPageHeaderContent,
-      firstPageFooterContent,
-      readOnly = false,
-      pageGap = DEFAULT_PAGE_GAP,
-      zoom = 1,
-      onDocumentChange,
-      onReadOnlyEditAttempt,
-      onSelectionChange,
-      onSelectionTextChange,
-      externalPlugins = EMPTY_PLUGINS,
-      collaboration,
-      extensionManager,
-      onHeaderFooterDoubleClick,
-      hfEditMode,
-      onBodyClick,
-      className,
-      style,
-      commentsSidebarOpen = false,
-      sidebarOverlay,
-      scrollContainerRef: scrollContainerRefProp,
-      onHyperlinkClick,
-      onContextMenu,
-      onAnchorPositionsChange,
-      onTotalPagesChange,
-      anchorPositionMode = "comments-and-revisions",
-      onAnonymizationTermClick,
-      selectedAnonymizationCanonical = null,
-      anonymizationSelectionSeq,
-    } = props;
+export function PagedEditor(
+  props: PagedEditorProps & { ref?: Ref<PagedEditorRef> },
+) {
+  const {
+    ref,
+    document,
+    styles,
+    theme: _theme,
+    sectionProperties,
+    headerContent,
+    footerContent,
+    firstPageHeaderContent,
+    firstPageFooterContent,
+    readOnly = false,
+    pageGap = DEFAULT_PAGE_GAP,
+    zoom = 1,
+    onDocumentChange,
+    onReadOnlyEditAttempt,
+    onSelectionChange,
+    onSelectionTextChange,
+    externalPlugins = EMPTY_PLUGINS,
+    collaboration,
+    extensionManager,
+    onHeaderFooterDoubleClick,
+    hfEditMode,
+    onBodyClick,
+    className,
+    style,
+    commentsSidebarOpen = false,
+    sidebarOverlay,
+    scrollContainerRef: scrollContainerRefProp,
+    onHyperlinkClick,
+    onContextMenu,
+    onAnchorPositionsChange,
+    onTotalPagesChange,
+    anchorPositionMode = "comments-and-revisions",
+    onAnonymizationTermClick,
+    selectedAnonymizationCanonical = null,
+    anonymizationSelectionSeq,
+  } = props;
 
-    // Resolve the scroll container: prefer parent-provided ref, fallback to own container
-    const getScrollContainer = useCallback((): HTMLDivElement | null => {
-      if (
-        scrollContainerRefProp &&
-        typeof scrollContainerRefProp === "object"
-      ) {
-        return (
-          scrollContainerRefProp as React.RefObject<HTMLDivElement | null>
-        ).current;
-      }
-      return containerRef.current;
-    }, [scrollContainerRefProp]);
+  // Resolve the scroll container: prefer parent-provided ref, fallback to own container
+  const getScrollContainer = useCallback((): HTMLDivElement | null => {
+    if (scrollContainerRefProp && typeof scrollContainerRefProp === "object") {
+      return (scrollContainerRefProp as React.RefObject<HTMLDivElement | null>)
+        .current;
+    }
+    return containerRef.current;
+  }, [scrollContainerRefProp]);
 
-    // Refs
-    const containerRef = useRef<HTMLDivElement>(null);
-    const pagesContainerRef = useRef<HTMLDivElement>(null);
-    const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
-    const painterRef = useRef<LayoutPainter | null>(null);
+  // Refs
+  const containerRef = useRef<HTMLDivElement>(null);
+  const pagesContainerRef = useRef<HTMLDivElement>(null);
+  const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
+  const painterRef = useRef<LayoutPainter | null>(null);
 
-    // Visual line navigation (ArrowUp/ArrowDown with sticky X)
-    const { handlePMKeyDown } = useVisualLineNavigation({ pagesContainerRef });
+  // Visual line navigation (ArrowUp/ArrowDown with sticky X)
+  const { handlePMKeyDown } = useVisualLineNavigation({ pagesContainerRef });
 
-    // Stable ref for drag-extend callback (avoids circular deps with getPositionFromMouse)
-    // oxlint-disable-next-line eslint/no-empty-function
-    const dragExtendRef = useRef<(cx: number, cy: number) => void>(() => {});
+  // Stable ref for drag-extend callback (avoids circular deps with getPositionFromMouse)
+  // oxlint-disable-next-line eslint/no-empty-function
+  const dragExtendRef = useRef<(cx: number, cy: number) => void>(() => {});
 
-    // Store callbacks in refs to avoid infinite re-render loops
-    // when parent passes unstable callback references
-    const onSelectionChangeRef = useRef(onSelectionChange);
-    const onSelectionTextChangeRef = useRef(onSelectionTextChange);
-    const onDocumentChangeRef = useRef(onDocumentChange);
-    const onTotalPagesChangeRef = useRef(onTotalPagesChange);
-    const lastTotalPagesRef = useRef<number | null>(null);
+  // Store callbacks in refs to avoid infinite re-render loops
+  // when parent passes unstable callback references
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  const onSelectionTextChangeRef = useRef(onSelectionTextChange);
+  const onDocumentChangeRef = useRef(onDocumentChange);
+  const onTotalPagesChangeRef = useRef(onTotalPagesChange);
+  const lastTotalPagesRef = useRef<number | null>(null);
 
-    // Keep refs in sync with latest props
-    onSelectionChangeRef.current = onSelectionChange;
-    onSelectionTextChangeRef.current = onSelectionTextChange;
-    onDocumentChangeRef.current = onDocumentChange;
-    onTotalPagesChangeRef.current = onTotalPagesChange;
+  // Keep refs in sync with latest props
+  onSelectionChangeRef.current = onSelectionChange;
+  onSelectionTextChangeRef.current = onSelectionTextChange;
+  onDocumentChangeRef.current = onDocumentChange;
+  onTotalPagesChangeRef.current = onTotalPagesChange;
 
-    // State
-    const [layout, setLayout] = useState<Layout | null>(null);
-    const [blocks, setBlocks] = useState<FlowBlock[]>([]);
-    const [measures, setMeasures] = useState<Measure[]>([]);
-    const layoutArtifactsRef = useRef<{
-      blocks: FlowBlock[];
-      blockWidths: number[];
-      measures: Measure[];
-    } | null>(null);
-    const [isFocused, setIsFocused] = useState(false);
-    const [selectionRects, setSelectionRects] = useState<SelectionRect[]>([]);
-    const [caretPosition, setCaretPosition] = useState<CaretPosition | null>(
-      null,
-    );
-    const [anonymizationRectGroups, setAnonymizationRectGroups] = useState<
-      AnonymizationRectGroup[]
-    >([]);
-    // Plain ref to the latest match list so the recompute effect
-    // doesn't depend on a state setter callback that would trigger
-    // its own re-run.
-    const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
-    const [remoteSelections, setRemoteSelections] = useState<
-      HiddenProseMirrorRemoteSelection[]
-    >([]);
-    const suppressSelectionOverlayRef = useRef(false);
-    const revealSelectionOverlayTimerRef = useRef<number | null>(null);
+  // State
+  const [layout, setLayout] = useState<Layout | null>(null);
+  const [blocks, setBlocks] = useState<FlowBlock[]>([]);
+  const [measures, setMeasures] = useState<Measure[]>([]);
+  const layoutArtifactsRef = useRef<{
+    blocks: FlowBlock[];
+    blockWidths: number[];
+    measures: Measure[];
+  } | null>(null);
+  const [isFocused, setIsFocused] = useState(false);
+  const [selectionRects, setSelectionRects] = useState<SelectionRect[]>([]);
+  const [caretPosition, setCaretPosition] = useState<CaretPosition | null>(
+    null,
+  );
+  const [anonymizationRectGroups, setAnonymizationRectGroups] = useState<
+    AnonymizationRectGroup[]
+  >([]);
+  // Plain ref to the latest match list so the recompute effect
+  // doesn't depend on a state setter callback that would trigger
+  // its own re-run.
+  const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
+  const [remoteSelections, setRemoteSelections] = useState<
+    HiddenProseMirrorRemoteSelection[]
+  >([]);
+  const suppressSelectionOverlayRef = useRef(false);
+  const revealSelectionOverlayTimerRef = useRef<number | null>(null);
 
-    // Image selection state
-    const [selectedImageInfo, setSelectedImageInfo] =
-      useState<ImageSelectionInfo | null>(null);
-    const isImageInteractingRef = useRef(false);
+  // Image selection state
+  const [selectedImageInfo, setSelectedImageInfo] =
+    useState<ImageSelectionInfo | null>(null);
+  const isImageInteractingRef = useRef(false);
 
-    /** Build ImageSelectionInfo from a DOM element with data-pm-start */
-    const buildImageSelectionInfo = useCallback(
-      (el: HTMLElement, pmPos: number): ImageSelectionInfo => {
-        const imgTagCandidate =
-          el.tagName === "IMG" ? el : el.querySelector("img");
-        const imgTag =
-          imgTagCandidate instanceof HTMLElement ? imgTagCandidate : null;
-        const element = imgTag ?? el;
-        const rect = element.getBoundingClientRect();
-        return {
-          element,
-          pmPos,
-          width: Math.round(rect.width / zoom),
-          height: Math.round(rect.height / zoom),
-        };
-      },
-      [zoom],
-    );
+  /** Build ImageSelectionInfo from a DOM element with data-pm-start */
+  const buildImageSelectionInfo = useCallback(
+    (el: HTMLElement, pmPos: number): ImageSelectionInfo => {
+      const imgTagCandidate =
+        el.tagName === "IMG" ? el : el.querySelector("img");
+      const imgTag =
+        imgTagCandidate instanceof HTMLElement ? imgTagCandidate : null;
+      const element = imgTag ?? el;
+      const rect = element.getBoundingClientRect();
+      return {
+        element,
+        pmPos,
+        width: Math.round(rect.width / zoom),
+        height: Math.round(rect.height / zoom),
+      };
+    },
+    [zoom],
+  );
 
-    // Drag selection state
-    const isDraggingRef = useRef(false);
-    const dragAnchorRef = useRef<number | null>(null);
+  // Drag selection state
+  const isDraggingRef = useRef(false);
+  const dragAnchorRef = useRef<number | null>(null);
 
-    // Column resize state
-    const isResizingColumnRef = useRef(false);
-    const resizeStartXRef = useRef(0);
-    const resizeColumnIndexRef = useRef(0);
-    const resizeTablePmStartRef = useRef(0);
-    const resizeOrigWidthsRef = useRef({
-      left: 0,
-      right: 0,
-    });
-    const resizeHandleRef = useRef<HTMLElement | null>(null);
+  // Column resize state
+  const isResizingColumnRef = useRef(false);
+  const resizeStartXRef = useRef(0);
+  const resizeColumnIndexRef = useRef(0);
+  const resizeTablePmStartRef = useRef(0);
+  const resizeOrigWidthsRef = useRef({
+    left: 0,
+    right: 0,
+  });
+  const resizeHandleRef = useRef<HTMLElement | null>(null);
 
-    // Row resize state
-    const isResizingRowRef = useRef(false);
-    const resizeStartYRef = useRef(0);
-    const resizeRowIndexRef = useRef(0);
-    const resizeRowTablePmStartRef = useRef(0);
-    const resizeRowOrigHeightRef = useRef(0); // twips
-    const resizeRowHandleRef = useRef<HTMLElement | null>(null);
-    const resizeRowIsEdgeRef = useRef(false);
+  // Row resize state
+  const isResizingRowRef = useRef(false);
+  const resizeStartYRef = useRef(0);
+  const resizeRowIndexRef = useRef(0);
+  const resizeRowTablePmStartRef = useRef(0);
+  const resizeRowOrigHeightRef = useRef(0); // twips
+  const resizeRowHandleRef = useRef<HTMLElement | null>(null);
+  const resizeRowIsEdgeRef = useRef(false);
 
-    // Right edge resize state (grows last column only)
-    const isResizingRightEdgeRef = useRef(false);
-    const resizeRightEdgeStartXRef = useRef(0);
-    const resizeRightEdgeColIndexRef = useRef(0);
-    const resizeRightEdgePmStartRef = useRef(0);
-    const resizeRightEdgeOrigWidthRef = useRef(0); // twips
-    const resizeRightEdgeHandleRef = useRef<HTMLElement | null>(null);
+  // Right edge resize state (grows last column only)
+  const isResizingRightEdgeRef = useRef(false);
+  const resizeRightEdgeStartXRef = useRef(0);
+  const resizeRightEdgeColIndexRef = useRef(0);
+  const resizeRightEdgePmStartRef = useRef(0);
+  const resizeRightEdgeOrigWidthRef = useRef(0); // twips
+  const resizeRightEdgeHandleRef = useRef<HTMLElement | null>(null);
 
-    // Cell selection drag state
-    const isCellDraggingRef = useRef(false);
-    const cellDragAnchorPosRef = useRef<number | null>(null);
-    const cellDragLastPmPosRef = useRef<number | null>(null);
-    const cellDragOverflowXRef = useRef<number | null>(null);
-    const CELL_SELECT_OVERFLOW_PX = 5; // px of continued drag after text selection maxes out
+  // Cell selection drag state
+  const isCellDraggingRef = useRef(false);
+  const cellDragAnchorPosRef = useRef<number | null>(null);
+  const cellDragLastPmPosRef = useRef<number | null>(null);
+  const cellDragOverflowXRef = useRef<number | null>(null);
+  const CELL_SELECT_OVERFLOW_PX = 5; // px of continued drag after text selection maxes out
 
-    // Table quick action insert button state
-    type TableInsertButtonState = {
-      type: "row" | "column";
-      /** Pixel position relative to viewport container */
-      x: number;
-      y: number;
-      /** PM position inside target cell (to set selection before dispatching) */
-      cellPmPos: number;
-    };
-    const [tableInsertButton, setTableInsertButton] =
-      useState<TableInsertButtonState | null>(null);
-    const tableInsertHideTimerRef = useRef<ReturnType<
-      typeof setTimeout
-    > | null>(null);
+  // Table quick action insert button state
+  type TableInsertButtonState = {
+    type: "row" | "column";
+    /** Pixel position relative to viewport container */
+    x: number;
+    y: number;
+    /** PM position inside target cell (to set selection before dispatching) */
+    cellPmPos: number;
+  };
+  const [tableInsertButton, setTableInsertButton] =
+    useState<TableInsertButtonState | null>(null);
+  const tableInsertHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
-    const clearTableInsertTimer = useCallback(() => {
+  const clearTableInsertTimer = useCallback(() => {
+    if (tableInsertHideTimerRef.current) {
+      clearTimeout(tableInsertHideTimerRef.current);
+      tableInsertHideTimerRef.current = null;
+    }
+  }, []);
+
+  // Cleanup timer on unmount
+  useEffect(
+    () => () => {
       if (tableInsertHideTimerRef.current) {
         clearTimeout(tableInsertHideTimerRef.current);
-        tableInsertHideTimerRef.current = null;
       }
-    }, []);
+    },
+    [],
+  );
 
-    // Cleanup timer on unmount
-    useEffect(
-      () => () => {
-        if (tableInsertHideTimerRef.current) {
-          clearTimeout(tableInsertHideTimerRef.current);
+  // Selection gate - ensures selection renders only when layout is current
+  const syncCoordinator = useMemo(() => new LayoutSelectionGate(), []);
+
+  // Compute page size and margins
+  const pageSize = useMemo(
+    () => getPageSize(sectionProperties),
+    [sectionProperties],
+  );
+  const margins = useMemo(
+    () => getMargins(sectionProperties),
+    [sectionProperties],
+  );
+  const columns = useMemo(
+    () => getColumns(sectionProperties),
+    [sectionProperties],
+  );
+  const contentWidth = pageSize.w - margins.left - margins.right;
+
+  // Initialize painter using useMemo to ensure it's ready before first render callbacks
+  const painter = useMemo(
+    () =>
+      new LayoutPainter({
+        pageGap,
+        showShadow: false,
+      }),
+    [pageGap],
+  );
+
+  // Keep ref in sync with memoized painter
+  painterRef.current = painter;
+
+  // =========================================================================
+  // Layout Pipeline
+  // =========================================================================
+
+  /**
+   * Run the full layout pipeline:
+   * 1. Convert PM doc to blocks
+   * 2. Measure blocks
+   * 3. Layout blocks onto pages
+   * 4. Paint pages to DOM
+   */
+  const runLayoutPipeline = useCallback(
+    (
+      state: EditorState,
+      options: { dirtyRange?: DirtyRange; forceFull?: boolean } = {},
+    ) => {
+      // Capture current state sequence for this layout run
+      const currentEpoch = syncCoordinator.getStateSeq();
+
+      // Signal layout is starting
+      syncCoordinator.onLayoutStart();
+
+      try {
+        // Step 1: Convert PM doc to flow blocks
+        const pageContentHeight = pageSize.h - margins.top - margins.bottom;
+        const flowOpts: ToFlowBlocksOptions = {
+          pageContentHeight,
+        };
+        if (_theme !== undefined) {
+          flowOpts.theme = _theme;
         }
-      },
-      [],
-    );
+        const newBlocks = toFlowBlocks(state.doc, flowOpts);
+        setBlocks(newBlocks);
 
-    // Selection gate - ensures selection renders only when layout is current
-    const syncCoordinator = useMemo(() => new LayoutSelectionGate(), []);
+        // Compute per-block widths accounting for section breaks with different column configs
+        const bodyLayoutConfig: SectionLayoutConfig = {
+          pageSize,
+          margins,
+        };
+        if (columns !== undefined) {
+          bodyLayoutConfig.columns = columns;
+        }
+        const blockWidths = computePerBlockWidths({
+          blocks: newBlocks,
+          bodyConfig: bodyLayoutConfig,
+          finalConfig: bodyLayoutConfig,
+        });
+        const incrementalResult =
+          options.dirtyRange && !options.forceFull && layoutArtifactsRef.current
+            ? tryBuildIncrementalMeasures({
+                previousBlocks: layoutArtifactsRef.current.blocks,
+                previousMeasures: layoutArtifactsRef.current.measures,
+                previousBlockWidths: layoutArtifactsRef.current.blockWidths,
+                nextBlocks: newBlocks,
+                nextBlockWidths: blockWidths,
+                dirtyRange: options.dirtyRange,
+                measureBlock: measureSingleBlockWithoutFloatingZones,
+              })
+            : null;
+        const newMeasures =
+          incrementalResult?.measures ?? measureBlocks(newBlocks, blockWidths);
+        layoutArtifactsRef.current = {
+          blocks: newBlocks,
+          blockWidths,
+          measures: newMeasures,
+        };
+        setMeasures(newMeasures);
 
-    // Compute page size and margins
-    const pageSize = useMemo(
-      () => getPageSize(sectionProperties),
-      [sectionProperties],
-    );
-    const margins = useMemo(
-      () => getMargins(sectionProperties),
-      [sectionProperties],
-    );
-    const columns = useMemo(
-      () => getColumns(sectionProperties),
-      [sectionProperties],
-    );
-    const contentWidth = pageSize.w - margins.left - margins.right;
+        // Step 2.5: Collect footnote references from blocks
+        const footnoteRefs = collectFootnoteRefs(newBlocks);
+        const hasFootnotes =
+          footnoteRefs.length > 0 && document?.package.footnotes;
 
-    // Initialize painter using useMemo to ensure it's ready before first render callbacks
-    const painter = useMemo(
-      () =>
-        new LayoutPainter({
+        // Step 2.75: Prepare header/footer content for rendering (needed before layout
+        // to compute effective margins when header content exceeds available space)
+        const hfMetricsHeader: HeaderFooterMetrics = {
+          section: "header",
+          pageSize,
+          margins,
+        };
+        const hfMetricsFooter: HeaderFooterMetrics = {
+          section: "footer",
+          pageSize,
+          margins,
+        };
+        const hfOptions = {
+          ...(styles ? { styles } : {}),
+          ...(_theme !== undefined ? { theme: _theme } : {}),
+          measureBlocks,
+        };
+        const headerContentForRender = convertHeaderFooterToContent(
+          headerContent,
+          contentWidth,
+          hfMetricsHeader,
+          hfOptions,
+        );
+        const footerContentForRender = convertHeaderFooterToContent(
+          footerContent,
+          contentWidth,
+          hfMetricsFooter,
+          hfOptions,
+        );
+        const hasTitlePg = sectionProperties?.titlePg === true;
+        const firstPageHeaderForRender = hasTitlePg
+          ? convertHeaderFooterToContent(
+              firstPageHeaderContent,
+              contentWidth,
+              hfMetricsHeader,
+              hfOptions,
+            )
+          : undefined;
+        const firstPageFooterForRender = hasTitlePg
+          ? convertHeaderFooterToContent(
+              firstPageFooterContent,
+              contentWidth,
+              hfMetricsFooter,
+              hfOptions,
+            )
+          : undefined;
+
+        // Default extender — applied to pages 2+ of every section. It
+        // ignores firstPage H/F so a `<w:titlePg/>` section's
+        // overflowing first-page header doesn't push body content down
+        // on every subsequent page.
+        const extendForHfOverflow = computeHeaderFooterMarginExtender({
+          headerContent: headerContentForRender,
+          footerContent: footerContentForRender,
+          firstPageHeaderContent: firstPageHeaderForRender,
+          firstPageFooterContent: firstPageFooterForRender,
+        });
+        // First-page extender — used only for page 1 of a titlePg
+        // section so the title page's larger header reservation is
+        // honored without leaking onto pages 2+.
+        const extendForFirstPage = computeFirstPageHeaderFooterMarginExtender({
+          headerContent: headerContentForRender,
+          footerContent: footerContentForRender,
+          firstPageHeaderContent: firstPageHeaderForRender,
+          firstPageFooterContent: firstPageFooterForRender,
+        });
+        const effectiveMargins = extendForHfOverflow(margins);
+        const effectiveFirstPageMargins = hasTitlePg
+          ? extendForFirstPage(margins)
+          : undefined;
+        // Section-break blocks carry their own `sb.margins` from
+        // `<w:sectPr>` and the layout engine prefers those over the
+        // body-level fallback. Apply the extension to each one too,
+        // otherwise a footer that overflows on one section silently
+        // re-overlaps body text on the next. (Eigenpal #400.)
+        for (const block of newBlocks) {
+          if (block.kind !== "sectionBreak") {
+            continue;
+          }
+          const sb = block as SectionBreakBlock;
+          if (sb.margins) {
+            sb.margins = extendForHfOverflow(sb.margins);
+          }
+        }
+
+        // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
+        let newLayout: Layout;
+        let pageFootnoteMap = new Map<number, number[]>();
+        let footnoteContentMap = new Map<number, FootnoteContent>();
+
+        // Common layout options for all passes
+        const bodyBreakType = sectionProperties?.sectionStart as
+          | "continuous"
+          | "nextPage"
+          | "evenPage"
+          | "oddPage"
+          | undefined;
+        const layoutOpts: Parameters<typeof layoutDocument>[2] = {
+          pageSize,
+          margins: effectiveMargins,
           pageGap,
-          showShadow: false,
-        }),
-      [pageGap],
-    );
+        };
+        if (effectiveFirstPageMargins !== undefined) {
+          layoutOpts.firstPageMargins = effectiveFirstPageMargins;
+        }
+        if (columns !== undefined) {
+          layoutOpts.columns = columns;
+        }
+        if (bodyBreakType !== undefined) {
+          layoutOpts.bodyBreakType = bodyBreakType;
+        }
 
-    // Keep ref in sync with memoized painter
-    painterRef.current = painter;
+        if (hasFootnotes) {
+          // Build footnote content and measure heights up front. The
+          // per-fn height table feeds into the layout engine so each
+          // body line carrying an fn ref reserves space for that fn
+          // on its host page in a single pass — no convergence loop.
+          footnoteContentMap = buildFootnoteContentMap(
+            document!.package.footnotes!,
+            footnoteRefs,
+            contentWidth,
+            (() => {
+              const footnoteOptions: Parameters<
+                typeof buildFootnoteContentMap
+              >[3] = { measureBlocks };
+              if (styles) {
+                footnoteOptions.styles = styles;
+              }
+              if (_theme !== undefined) {
+                footnoteOptions.theme = _theme;
+              }
+              return footnoteOptions;
+            })(),
+          );
 
-    // =========================================================================
-    // Layout Pipeline
-    // =========================================================================
-
-    /**
-     * Run the full layout pipeline:
-     * 1. Convert PM doc to blocks
-     * 2. Measure blocks
-     * 3. Layout blocks onto pages
-     * 4. Paint pages to DOM
-     */
-    const runLayoutPipeline = useCallback(
-      (
-        state: EditorState,
-        options: { dirtyRange?: DirtyRange; forceFull?: boolean } = {},
-      ) => {
-        // Capture current state sequence for this layout run
-        const currentEpoch = syncCoordinator.getStateSeq();
-
-        // Signal layout is starting
-        syncCoordinator.onLayoutStart();
-
-        try {
-          // Step 1: Convert PM doc to flow blocks
-          const pageContentHeight = pageSize.h - margins.top - margins.bottom;
-          const flowOpts: ToFlowBlocksOptions = {
-            pageContentHeight,
-          };
-          if (_theme !== undefined) {
-            flowOpts.theme = _theme;
+          const footnoteHeightById = new Map<number, number>();
+          // Per-fn vertical margin applied by the painter
+          // (`renderFootnoteArea` sets `marginBottom: 4px` on each
+          // fn entry). Reserved alongside content height so the page
+          // accounts for inter-fn whitespace.
+          const FOOTNOTE_ENTRY_MARGIN = 4;
+          for (const [id, content] of footnoteContentMap) {
+            footnoteHeightById.set(id, content.height + FOOTNOTE_ENTRY_MARGIN);
           }
-          const newBlocks = toFlowBlocks(state.doc, flowOpts);
-          setBlocks(newBlocks);
+          // Note: the layout engine adds the divider's height once
+          // per fn-bearing page (in paginator.addFootnoteHeight); we
+          // pass per-fn (content + entry margin) here.
 
-          // Compute per-block widths accounting for section breaks with different column configs
-          const bodyLayoutConfig: SectionLayoutConfig = {
-            pageSize,
-            margins,
-          };
-          if (columns !== undefined) {
-            bodyLayoutConfig.columns = columns;
-          }
-          const blockWidths = computePerBlockWidths({
-            blocks: newBlocks,
-            bodyConfig: bodyLayoutConfig,
-            finalConfig: bodyLayoutConfig,
+          newLayout = layoutDocument(newBlocks, newMeasures, {
+            ...layoutOpts,
+            footnoteHeightById,
           });
-          const incrementalResult =
-            options.dirtyRange &&
-            !options.forceFull &&
-            layoutArtifactsRef.current
-              ? tryBuildIncrementalMeasures({
-                  previousBlocks: layoutArtifactsRef.current.blocks,
-                  previousMeasures: layoutArtifactsRef.current.measures,
-                  previousBlockWidths: layoutArtifactsRef.current.blockWidths,
-                  nextBlocks: newBlocks,
-                  nextBlockWidths: blockWidths,
-                  dirtyRange: options.dirtyRange,
-                  measureBlock: measureSingleBlockWithoutFloatingZones,
-                })
-              : null;
-          const newMeasures =
-            incrementalResult?.measures ??
-            measureBlocks(newBlocks, blockWidths);
-          layoutArtifactsRef.current = {
-            blocks: newBlocks,
-            blockWidths,
-            measures: newMeasures,
-          };
-          setMeasures(newMeasures);
 
-          // Step 2.5: Collect footnote references from blocks
-          const footnoteRefs = collectFootnoteRefs(newBlocks);
-          const hasFootnotes =
-            footnoteRefs.length > 0 && document?.package.footnotes;
+          // The layout engine assigned `page.footnoteIds` line-by-
+          // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
+          // ref in a continuation fragment of a split paragraph
+          // lands on the page where the ref-bearing line actually
+          // is. Build pageFootnoteMap from those page records (not
+          // from `mapFootnotesToPages`'s pmRange scan, which can't
+          // disambiguate split-paragraph halves; Codex PR #258).
+          pageFootnoteMap = new Map<number, number[]>();
+          for (const page of newLayout.pages) {
+            if (page.footnoteIds && page.footnoteIds.length > 0) {
+              pageFootnoteMap.set(page.number, page.footnoteIds);
+            }
+          }
+        } else {
+          // No footnotes — single pass
+          newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
+        }
 
-          // Step 2.75: Prepare header/footer content for rendering (needed before layout
-          // to compute effective margins when header content exceeds available space)
-          const hfMetricsHeader: HeaderFooterMetrics = {
-            section: "header",
-            pageSize,
-            margins,
-          };
-          const hfMetricsFooter: HeaderFooterMetrics = {
-            section: "footer",
-            pageSize,
-            margins,
-          };
-          const hfOptions = {
-            ...(styles ? { styles } : {}),
-            ...(_theme !== undefined ? { theme: _theme } : {}),
-            measureBlocks,
-          };
-          const headerContentForRender = convertHeaderFooterToContent(
-            headerContent,
-            contentWidth,
-            hfMetricsHeader,
-            hfOptions,
-          );
-          const footerContentForRender = convertHeaderFooterToContent(
-            footerContent,
-            contentWidth,
-            hfMetricsFooter,
-            hfOptions,
-          );
-          const hasTitlePg = sectionProperties?.titlePg === true;
-          const firstPageHeaderForRender = hasTitlePg
-            ? convertHeaderFooterToContent(
-                firstPageHeaderContent,
-                contentWidth,
-                hfMetricsHeader,
-                hfOptions,
-              )
-            : undefined;
-          const firstPageFooterForRender = hasTitlePg
-            ? convertHeaderFooterToContent(
-                firstPageFooterContent,
-                contentWidth,
-                hfMetricsFooter,
-                hfOptions,
+        setLayout(newLayout);
+        recordLayoutComplete();
+
+        // Step 4: Paint to DOM
+        if (pagesContainerRef.current && painterRef.current) {
+          // Build block lookup
+          const blockLookup: BlockLookup = new Map();
+          for (let i = 0; i < newBlocks.length; i++) {
+            const block = newBlocks[i];
+            const measure = newMeasures[i];
+            if (block && measure) {
+              blockLookup.set(String(block.id), { block, measure });
+            }
+          }
+          painterRef.current.setBlockLookup(blockLookup);
+
+          // Build per-page footnote render items
+          const footnotesByPage = hasFootnotes
+            ? buildFootnoteRenderItems(
+                pageFootnoteMap,
+                footnoteContentMap,
+                document,
               )
             : undefined;
 
-          // Default extender — applied to pages 2+ of every section. It
-          // ignores firstPage H/F so a `<w:titlePg/>` section's
-          // overflowing first-page header doesn't push body content down
-          // on every subsequent page.
-          const extendForHfOverflow = computeHeaderFooterMarginExtender({
+          // Render pages to container
+          renderPages(newLayout.pages, pagesContainerRef.current, {
+            pageGap,
+            showShadow: true,
+            blockLookup,
             headerContent: headerContentForRender,
             footerContent: footerContentForRender,
             firstPageHeaderContent: firstPageHeaderForRender,
             firstPageFooterContent: firstPageFooterForRender,
+            titlePg: hasTitlePg,
+            headerDistance: sectionProperties?.headerDistance
+              ? twipsToPixels(sectionProperties.headerDistance)
+              : undefined,
+            footerDistance: sectionProperties?.footerDistance
+              ? twipsToPixels(sectionProperties.footerDistance)
+              : undefined,
+            pageBorders: sectionProperties?.pageBorders,
+            theme: _theme,
+            footnotesByPage: footnotesByPage?.size
+              ? footnotesByPage
+              : undefined,
+          } as RenderPageOptions & {
+            pageGap?: number;
+            blockLookup?: BlockLookup;
+            footnotesByPage?: Map<number, FootnoteRenderItem[]>;
           });
-          // First-page extender — used only for page 1 of a titlePg
-          // section so the title page's larger header reservation is
-          // honored without leaking onto pages 2+.
-          const extendForFirstPage = computeFirstPageHeaderFooterMarginExtender(
+        }
+
+        // Compute anchor Y positions for comments sidebar (works without DOM queries).
+        // This is expensive on docs with many comments/tracked changes, so typing
+        // layouts skip it and let the idle full-layout reconcile update the sidebar.
+        const shouldComputeAnchorPositions =
+          onAnchorPositionsChange &&
+          (options.forceFull === true || !options.dirtyRange);
+        if (shouldComputeAnchorPositions) {
+          const positions = computeAnchorPositions(
+            hiddenPMRef.current?.getView() ?? null,
+            newLayout,
+            newBlocks,
+            newMeasures,
+            pageGap,
             {
-              headerContent: headerContentForRender,
-              footerContent: footerContentForRender,
-              firstPageHeaderContent: firstPageHeaderForRender,
-              firstPageFooterContent: firstPageFooterForRender,
+              includeRevisions: anchorPositionMode === "comments-and-revisions",
             },
           );
-          const effectiveMargins = extendForHfOverflow(margins);
-          const effectiveFirstPageMargins = hasTitlePg
-            ? extendForFirstPage(margins)
-            : undefined;
-          // Section-break blocks carry their own `sb.margins` from
-          // `<w:sectPr>` and the layout engine prefers those over the
-          // body-level fallback. Apply the extension to each one too,
-          // otherwise a footer that overflows on one section silently
-          // re-overlaps body text on the next. (Eigenpal #400.)
-          for (const block of newBlocks) {
-            if (block.kind !== "sectionBreak") {
-              continue;
-            }
-            const sb = block as SectionBreakBlock;
-            if (sb.margins) {
-              sb.margins = extendForHfOverflow(sb.margins);
-            }
-          }
-
-          // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
-          let newLayout: Layout;
-          let pageFootnoteMap = new Map<number, number[]>();
-          let footnoteContentMap = new Map<number, FootnoteContent>();
-
-          // Common layout options for all passes
-          const bodyBreakType = sectionProperties?.sectionStart as
-            | "continuous"
-            | "nextPage"
-            | "evenPage"
-            | "oddPage"
-            | undefined;
-          const layoutOpts: Parameters<typeof layoutDocument>[2] = {
-            pageSize,
-            margins: effectiveMargins,
-            pageGap,
-          };
-          if (effectiveFirstPageMargins !== undefined) {
-            layoutOpts.firstPageMargins = effectiveFirstPageMargins;
-          }
-          if (columns !== undefined) {
-            layoutOpts.columns = columns;
-          }
-          if (bodyBreakType !== undefined) {
-            layoutOpts.bodyBreakType = bodyBreakType;
-          }
-
-          if (hasFootnotes) {
-            // Build footnote content and measure heights up front. The
-            // per-fn height table feeds into the layout engine so each
-            // body line carrying an fn ref reserves space for that fn
-            // on its host page in a single pass — no convergence loop.
-            footnoteContentMap = buildFootnoteContentMap(
-              document!.package.footnotes!,
-              footnoteRefs,
-              contentWidth,
-              (() => {
-                const footnoteOptions: Parameters<
-                  typeof buildFootnoteContentMap
-                >[3] = { measureBlocks };
-                if (styles) {
-                  footnoteOptions.styles = styles;
-                }
-                if (_theme !== undefined) {
-                  footnoteOptions.theme = _theme;
-                }
-                return footnoteOptions;
-              })(),
-            );
-
-            const footnoteHeightById = new Map<number, number>();
-            // Per-fn vertical margin applied by the painter
-            // (`renderFootnoteArea` sets `marginBottom: 4px` on each
-            // fn entry). Reserved alongside content height so the page
-            // accounts for inter-fn whitespace.
-            const FOOTNOTE_ENTRY_MARGIN = 4;
-            for (const [id, content] of footnoteContentMap) {
-              footnoteHeightById.set(
-                id,
-                content.height + FOOTNOTE_ENTRY_MARGIN,
-              );
-            }
-            // Note: the layout engine adds the divider's height once
-            // per fn-bearing page (in paginator.addFootnoteHeight); we
-            // pass per-fn (content + entry margin) here.
-
-            newLayout = layoutDocument(newBlocks, newMeasures, {
-              ...layoutOpts,
-              footnoteHeightById,
-            });
-
-            // The layout engine assigned `page.footnoteIds` line-by-
-            // line via `paginator.addFootnoteHeight(_, ids)`, so a fn
-            // ref in a continuation fragment of a split paragraph
-            // lands on the page where the ref-bearing line actually
-            // is. Build pageFootnoteMap from those page records (not
-            // from `mapFootnotesToPages`'s pmRange scan, which can't
-            // disambiguate split-paragraph halves; Codex PR #258).
-            pageFootnoteMap = new Map<number, number[]>();
-            for (const page of newLayout.pages) {
-              if (page.footnoteIds && page.footnoteIds.length > 0) {
-                pageFootnoteMap.set(page.number, page.footnoteIds);
-              }
-            }
-          } else {
-            // No footnotes — single pass
-            newLayout = layoutDocument(newBlocks, newMeasures, layoutOpts);
-          }
-
-          setLayout(newLayout);
-          recordLayoutComplete();
-
-          // Step 4: Paint to DOM
-          if (pagesContainerRef.current && painterRef.current) {
-            // Build block lookup
-            const blockLookup: BlockLookup = new Map();
-            for (let i = 0; i < newBlocks.length; i++) {
-              const block = newBlocks[i];
-              const measure = newMeasures[i];
-              if (block && measure) {
-                blockLookup.set(String(block.id), { block, measure });
-              }
-            }
-            painterRef.current.setBlockLookup(blockLookup);
-
-            // Build per-page footnote render items
-            const footnotesByPage = hasFootnotes
-              ? buildFootnoteRenderItems(
-                  pageFootnoteMap,
-                  footnoteContentMap,
-                  document,
-                )
-              : undefined;
-
-            // Render pages to container
-            renderPages(newLayout.pages, pagesContainerRef.current, {
-              pageGap,
-              showShadow: true,
-              blockLookup,
-              headerContent: headerContentForRender,
-              footerContent: footerContentForRender,
-              firstPageHeaderContent: firstPageHeaderForRender,
-              firstPageFooterContent: firstPageFooterForRender,
-              titlePg: hasTitlePg,
-              headerDistance: sectionProperties?.headerDistance
-                ? twipsToPixels(sectionProperties.headerDistance)
-                : undefined,
-              footerDistance: sectionProperties?.footerDistance
-                ? twipsToPixels(sectionProperties.footerDistance)
-                : undefined,
-              pageBorders: sectionProperties?.pageBorders,
-              theme: _theme,
-              footnotesByPage: footnotesByPage?.size
-                ? footnotesByPage
-                : undefined,
-            } as RenderPageOptions & {
-              pageGap?: number;
-              blockLookup?: BlockLookup;
-              footnotesByPage?: Map<number, FootnoteRenderItem[]>;
-            });
-          }
-
-          // Compute anchor Y positions for comments sidebar (works without DOM queries).
-          // This is expensive on docs with many comments/tracked changes, so typing
-          // layouts skip it and let the idle full-layout reconcile update the sidebar.
-          const shouldComputeAnchorPositions =
-            onAnchorPositionsChange &&
-            (options.forceFull === true || !options.dirtyRange);
-          if (shouldComputeAnchorPositions) {
-            const positions = computeAnchorPositions(
-              hiddenPMRef.current?.getView() ?? null,
-              newLayout,
-              newBlocks,
-              newMeasures,
-              pageGap,
-              {
-                includeRevisions:
-                  anchorPositionMode === "comments-and-revisions",
-              },
-            );
-            onAnchorPositionsChange(positions);
-          }
-        } catch {
-          // Keep the previous anchor positions if layout measurement fails.
+          onAnchorPositionsChange(positions);
         }
-
-        // Signal layout is complete for this sequence
-        syncCoordinator.onLayoutComplete(currentEpoch);
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [
-        contentWidth,
-        columns,
-        pageSize,
-        margins,
-        pageGap,
-        zoom,
-        syncCoordinator,
-        headerContent,
-        footerContent,
-        firstPageHeaderContent,
-        firstPageFooterContent,
-        _theme,
-        sectionProperties,
-        onAnchorPositionsChange,
-        anchorPositionMode,
-        document,
-      ],
-    );
-    const runLayoutPipelineRef = useRef(runLayoutPipeline);
-    runLayoutPipelineRef.current = runLayoutPipeline;
-
-    // =========================================================================
-    // Coalesced Layout (rAF throttle)
-    // =========================================================================
-
-    /**
-     * Ref holding a pending requestAnimationFrame ID and the latest state.
-     * Multiple rapid transactions (e.g. typing "hello") within the same frame
-     * are coalesced so only the final state triggers an interactive layout pass.
-     */
-    const pendingLayoutRef = useRef<{
-      dirtyRange: DirtyRange | null;
-      rafId: number;
-      state: EditorState;
-    } | null>(null);
-    const idleLayoutTimerRef = useRef<number | null>(null);
-    const documentChangeNotifyTimerRef = useRef<number | null>(null);
-
-    const flushDocumentChangeNotification = useCallback(() => {
-      if (documentChangeNotifyTimerRef.current !== null) {
-        window.clearTimeout(documentChangeNotifyTimerRef.current);
-        documentChangeNotifyTimerRef.current = null;
+      } catch {
+        // Keep the previous anchor positions if layout measurement fails.
       }
 
-      const newDoc = hiddenPMRef.current?.getDocument();
-      if (newDoc) {
-        onDocumentChangeRef.current?.(newDoc);
+      // Signal layout is complete for this sequence
+      syncCoordinator.onLayoutComplete(currentEpoch);
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      contentWidth,
+      columns,
+      pageSize,
+      margins,
+      pageGap,
+      zoom,
+      syncCoordinator,
+      headerContent,
+      footerContent,
+      firstPageHeaderContent,
+      firstPageFooterContent,
+      _theme,
+      sectionProperties,
+      onAnchorPositionsChange,
+      anchorPositionMode,
+      document,
+    ],
+  );
+  const runLayoutPipelineRef = useRef(runLayoutPipeline);
+  runLayoutPipelineRef.current = runLayoutPipeline;
+
+  // =========================================================================
+  // Coalesced Layout (rAF throttle)
+  // =========================================================================
+
+  /**
+   * Ref holding a pending requestAnimationFrame ID and the latest state.
+   * Multiple rapid transactions (e.g. typing "hello") within the same frame
+   * are coalesced so only the final state triggers an interactive layout pass.
+   */
+  const pendingLayoutRef = useRef<{
+    dirtyRange: DirtyRange | null;
+    rafId: number;
+    state: EditorState;
+  } | null>(null);
+  const idleLayoutTimerRef = useRef<number | null>(null);
+  const documentChangeNotifyTimerRef = useRef<number | null>(null);
+
+  const flushDocumentChangeNotification = useCallback(() => {
+    if (documentChangeNotifyTimerRef.current !== null) {
+      window.clearTimeout(documentChangeNotifyTimerRef.current);
+      documentChangeNotifyTimerRef.current = null;
+    }
+
+    const newDoc = hiddenPMRef.current?.getDocument();
+    if (newDoc) {
+      onDocumentChangeRef.current?.(newDoc);
+    }
+  }, []);
+
+  const scheduleDocumentChangeNotification = useCallback(() => {
+    if (documentChangeNotifyTimerRef.current !== null) {
+      window.clearTimeout(documentChangeNotifyTimerRef.current);
+    }
+
+    documentChangeNotifyTimerRef.current = window.setTimeout(() => {
+      documentChangeNotifyTimerRef.current = null;
+      flushDocumentChangeNotification();
+    }, DOCUMENT_CHANGE_NOTIFY_DELAY);
+  }, [flushDocumentChangeNotification]);
+
+  const scheduleIdleFullLayout = useCallback(
+    (state: EditorState) => {
+      if (idleLayoutTimerRef.current !== null) {
+        window.clearTimeout(idleLayoutTimerRef.current);
       }
-    }, []);
+      idleLayoutTimerRef.current = window.setTimeout(() => {
+        idleLayoutTimerRef.current = null;
+        runLayoutPipeline(state, { forceFull: true });
+      }, 200);
+    },
+    [runLayoutPipeline],
+  );
 
-    const scheduleDocumentChangeNotification = useCallback(() => {
-      if (documentChangeNotifyTimerRef.current !== null) {
-        window.clearTimeout(documentChangeNotifyTimerRef.current);
+  /**
+   * Schedule a layout pipeline run for the next animation frame.
+   * If a run is already scheduled, the pending state is replaced so only
+   * the most recent document state gets laid out. A full source-of-truth
+   * reconcile is scheduled after the interactive pass has been idle.
+   */
+  const scheduleLayout = useCallback(
+    (state: EditorState, dirtyRange: DirtyRange | null) => {
+      if (idleLayoutTimerRef.current !== null) {
+        window.clearTimeout(idleLayoutTimerRef.current);
+        idleLayoutTimerRef.current = null;
       }
 
-      documentChangeNotifyTimerRef.current = window.setTimeout(() => {
-        documentChangeNotifyTimerRef.current = null;
-        flushDocumentChangeNotification();
-      }, DOCUMENT_CHANGE_NOTIFY_DELAY);
-    }, [flushDocumentChangeNotification]);
-
-    const scheduleIdleFullLayout = useCallback(
-      (state: EditorState) => {
-        if (idleLayoutTimerRef.current !== null) {
-          window.clearTimeout(idleLayoutTimerRef.current);
-        }
-        idleLayoutTimerRef.current = window.setTimeout(() => {
-          idleLayoutTimerRef.current = null;
-          runLayoutPipeline(state, { forceFull: true });
-        }, 200);
-      },
-      [runLayoutPipeline],
-    );
-
-    /**
-     * Schedule a layout pipeline run for the next animation frame.
-     * If a run is already scheduled, the pending state is replaced so only
-     * the most recent document state gets laid out. A full source-of-truth
-     * reconcile is scheduled after the interactive pass has been idle.
-     */
-    const scheduleLayout = useCallback(
-      (state: EditorState, dirtyRange: DirtyRange | null) => {
-        if (idleLayoutTimerRef.current !== null) {
-          window.clearTimeout(idleLayoutTimerRef.current);
-          idleLayoutTimerRef.current = null;
-        }
-
-        if (pendingLayoutRef.current) {
-          // Already scheduled — just update the state to the latest
-          pendingLayoutRef.current.state = state;
-          pendingLayoutRef.current.dirtyRange = mergeDirtyRanges(
-            pendingLayoutRef.current.dirtyRange,
-            dirtyRange,
-          );
-          return;
-        }
-        const rafId = requestAnimationFrame(() => {
-          const pending = pendingLayoutRef.current;
-          pendingLayoutRef.current = null;
-          if (pending) {
-            const layoutOptions: {
-              dirtyRange?: DirtyRange;
-              forceFull?: boolean;
-            } = {};
-            if (pending.dirtyRange) {
-              layoutOptions.dirtyRange = pending.dirtyRange;
-            }
-            runLayoutPipeline(pending.state, layoutOptions);
-            scheduleIdleFullLayout(pending.state);
-          }
-        });
-        pendingLayoutRef.current = { dirtyRange, rafId, state };
-      },
-      [runLayoutPipeline, scheduleIdleFullLayout],
-    );
-
-    // Clean up pending rAF on unmount
-    useEffect(
-      () => () => {
-        if (pendingLayoutRef.current) {
-          cancelAnimationFrame(pendingLayoutRef.current.rafId);
-          pendingLayoutRef.current = null;
-        }
-        if (idleLayoutTimerRef.current !== null) {
-          window.clearTimeout(idleLayoutTimerRef.current);
-          idleLayoutTimerRef.current = null;
-        }
-        if (documentChangeNotifyTimerRef.current !== null) {
-          window.clearTimeout(documentChangeNotifyTimerRef.current);
-          documentChangeNotifyTimerRef.current = null;
-        }
-      },
-      [],
-    );
-
-    /**
-     * Get caret position using DOM-based measurement.
-     * This uses the browser's text rendering to get precise pixel positions.
-     */
-    const getCaretFromDom = useCallback(
-      (pmPos: number, currentZoom: number = 1): CaretPosition | null => {
-        if (!pagesContainerRef.current) {
-          return null;
-        }
-
-        const overlay = pagesContainerRef.current.parentElement?.querySelector(
-          '[data-testid="selection-overlay"]',
+      if (pendingLayoutRef.current) {
+        // Already scheduled — just update the state to the latest
+        pendingLayoutRef.current.state = state;
+        pendingLayoutRef.current.dirtyRange = mergeDirtyRanges(
+          pendingLayoutRef.current.dirtyRange,
+          dirtyRange,
         );
-        if (!overlay) {
-          return null;
-        }
-
-        const overlayRect = overlay.getBoundingClientRect();
-
-        // Find spans with PM position data
-        const spans = findBodyPmSpans(pagesContainerRef.current);
-
-        for (const spanEl of spans) {
-          const pmStart = Number(spanEl.dataset["pmStart"]);
-          const pmEnd = Number(spanEl.dataset["pmEnd"]);
-
-          // Special handling for tab spans - use exclusive end to avoid boundary conflicts
-          // Tab at [5,6) means position 6 belongs to the next run, not the tab
-          if (spanEl.classList.contains("layout-run-tab")) {
-            if (pmPos >= pmStart && pmPos < pmEnd) {
-              const spanRect = spanEl.getBoundingClientRect();
-              return {
-                x: (spanRect.left - overlayRect.left) / currentZoom,
-                y: (spanRect.top - overlayRect.top) / currentZoom,
-                height: getLineHeight(spanEl),
-                pageIndex: getPageIndex(spanEl),
-              };
-            }
-            continue; // Skip to next span
+        return;
+      }
+      const rafId = requestAnimationFrame(() => {
+        const pending = pendingLayoutRef.current;
+        pendingLayoutRef.current = null;
+        if (pending) {
+          const layoutOptions: {
+            dirtyRange?: DirtyRange;
+            forceFull?: boolean;
+          } = {};
+          if (pending.dirtyRange) {
+            layoutOptions.dirtyRange = pending.dirtyRange;
           }
+          runLayoutPipeline(pending.state, layoutOptions);
+          scheduleIdleFullLayout(pending.state);
+        }
+      });
+      pendingLayoutRef.current = { dirtyRange, rafId, state };
+    },
+    [runLayoutPipeline, scheduleIdleFullLayout],
+  );
 
-          if (
-            spanEl.classList.contains("layout-empty-run") &&
-            pmPos >= pmStart &&
-            pmPos <= pmEnd
-          ) {
+  // Clean up pending rAF on unmount
+  useEffect(
+    () => () => {
+      if (pendingLayoutRef.current) {
+        cancelAnimationFrame(pendingLayoutRef.current.rafId);
+        pendingLayoutRef.current = null;
+      }
+      if (idleLayoutTimerRef.current !== null) {
+        window.clearTimeout(idleLayoutTimerRef.current);
+        idleLayoutTimerRef.current = null;
+      }
+      if (documentChangeNotifyTimerRef.current !== null) {
+        window.clearTimeout(documentChangeNotifyTimerRef.current);
+        documentChangeNotifyTimerRef.current = null;
+      }
+    },
+    [],
+  );
+
+  /**
+   * Get caret position using DOM-based measurement.
+   * This uses the browser's text rendering to get precise pixel positions.
+   */
+  const getCaretFromDom = useCallback(
+    (pmPos: number, currentZoom: number = 1): CaretPosition | null => {
+      if (!pagesContainerRef.current) {
+        return null;
+      }
+
+      const overlay = pagesContainerRef.current.parentElement?.querySelector(
+        '[data-testid="selection-overlay"]',
+      );
+      if (!overlay) {
+        return null;
+      }
+
+      const overlayRect = overlay.getBoundingClientRect();
+
+      // Find spans with PM position data
+      const spans = findBodyPmSpans(pagesContainerRef.current);
+
+      for (const spanEl of spans) {
+        const pmStart = Number(spanEl.dataset["pmStart"]);
+        const pmEnd = Number(spanEl.dataset["pmEnd"]);
+
+        // Special handling for tab spans - use exclusive end to avoid boundary conflicts
+        // Tab at [5,6) means position 6 belongs to the next run, not the tab
+        if (spanEl.classList.contains("layout-run-tab")) {
+          if (pmPos >= pmStart && pmPos < pmEnd) {
             const spanRect = spanEl.getBoundingClientRect();
             return {
               x: (spanRect.left - overlayRect.left) / currentZoom,
               y: (spanRect.top - overlayRect.top) / currentZoom,
-              height: getLineHeight(spanEl, Math.max(16, spanRect.height)),
-              pageIndex: getPageIndex(spanEl),
-            };
-          }
-
-          // For text runs, use inclusive range
-          if (
-            pmPos >= pmStart &&
-            pmPos <= pmEnd &&
-            spanEl.firstChild?.nodeType === Node.TEXT_NODE
-          ) {
-            const textNode = spanEl.firstChild as Text;
-            const charIndex = Math.min(pmPos - pmStart, textNode.length);
-
-            // Create a range at the exact character position
-            const ownerDoc = spanEl.ownerDocument;
-            const range = ownerDoc.createRange();
-            range.setStart(textNode, charIndex);
-            range.setEnd(textNode, charIndex);
-
-            const rangeRect = range.getBoundingClientRect();
-            const spanRect = spanEl.getBoundingClientRect();
-            const useSpanStart =
-              charIndex === 0 ||
-              (rangeRect.width === 0 && rangeRect.left < spanRect.left);
-            const caretLeft = useSpanStart ? spanRect.left : rangeRect.left;
-            const caretTop =
-              rangeRect.height > 0 && !useSpanStart
-                ? rangeRect.top
-                : spanRect.top;
-
-            return {
-              x: (caretLeft - overlayRect.left) / currentZoom,
-              y: (caretTop - overlayRect.top) / currentZoom,
               height: getLineHeight(spanEl),
               pageIndex: getPageIndex(spanEl),
             };
           }
-
-          if (pmPos >= pmStart && pmPos <= pmEnd) {
-            const spanRect = spanEl.getBoundingClientRect();
-            return {
-              x: (spanRect.left - overlayRect.left) / currentZoom,
-              y: (spanRect.top - overlayRect.top) / currentZoom,
-              height: getLineHeight(spanEl, Math.max(16, spanRect.height)),
-              pageIndex: getPageIndex(spanEl),
-            };
-          }
+          continue; // Skip to next span
         }
 
-        // Fallback: try to find position in empty paragraphs (they have empty runs)
-        const emptyRuns = findBodyEmptyRuns(pagesContainerRef.current);
-        for (const emptyRun of emptyRuns) {
-          const paragraph = closestHtmlElement(emptyRun, ".layout-paragraph");
-          if (!paragraph) {
-            continue;
-          }
-          const pmStart = Number(paragraph.dataset["pmStart"]);
-          const pmEnd = Number(paragraph.dataset["pmEnd"]);
-
-          if (pmPos >= pmStart && pmPos <= pmEnd) {
-            const runRect = emptyRun.getBoundingClientRect();
-            return {
-              x: (runRect.left - overlayRect.left) / currentZoom,
-              y: (runRect.top - overlayRect.top) / currentZoom,
-              height: getLineHeight(emptyRun),
-              pageIndex: getPageIndex(paragraph),
-            };
-          }
+        if (
+          spanEl.classList.contains("layout-empty-run") &&
+          pmPos >= pmStart &&
+          pmPos <= pmEnd
+        ) {
+          const spanRect = spanEl.getBoundingClientRect();
+          return {
+            x: (spanRect.left - overlayRect.left) / currentZoom,
+            y: (spanRect.top - overlayRect.top) / currentZoom,
+            height: getLineHeight(spanEl, Math.max(16, spanRect.height)),
+            pageIndex: getPageIndex(spanEl),
+          };
         }
 
-        return null;
-      },
-      [],
-    );
+        // For text runs, use inclusive range
+        if (
+          pmPos >= pmStart &&
+          pmPos <= pmEnd &&
+          spanEl.firstChild?.nodeType === Node.TEXT_NODE
+        ) {
+          const textNode = spanEl.firstChild as Text;
+          const charIndex = Math.min(pmPos - pmStart, textNode.length);
 
-    /**
-     * Update selection overlay from PM selection.
-     */
-    const updateSelectionOverlay = useCallback(
-      (state: EditorState) => {
-        const { from, to } = state.selection;
+          // Create a range at the exact character position
+          const ownerDoc = spanEl.ownerDocument;
+          const range = ownerDoc.createRange();
+          range.setStart(textNode, charIndex);
+          range.setEnd(textNode, charIndex);
 
-        // Always notify selection change (for toolbar sync) even if layout not ready
-        // Use ref to avoid infinite loops when callback is unstable
-        onSelectionChangeRef.current?.(from, to);
-        // `onSelectionTextChange` carries the resolved text
-        // alongside the range so consumers (anonymisation
-        // term prefill, etc.) don't need to hold a reference
-        // to the editor view themselves. `textBetween` with
-        // a single space for both leaf-block and block
-        // separators collapses table cells, paragraphs, and
-        // inline atoms into a single-line phrase.
-        if (onSelectionTextChangeRef.current) {
-          const text =
-            from === to ? "" : state.doc.textBetween(from, to, " ", " ");
-          onSelectionTextChangeRef.current({ from, to, text });
+          const rangeRect = range.getBoundingClientRect();
+          const spanRect = spanEl.getBoundingClientRect();
+          const useSpanStart =
+            charIndex === 0 ||
+            (rangeRect.width === 0 && rangeRect.left < spanRect.left);
+          const caretLeft = useSpanStart ? spanRect.left : rangeRect.left;
+          const caretTop =
+            rangeRect.height > 0 && !useSpanStart
+              ? rangeRect.top
+              : spanRect.top;
+
+          return {
+            x: (caretLeft - overlayRect.left) / currentZoom,
+            y: (caretTop - overlayRect.top) / currentZoom,
+            height: getLineHeight(spanEl),
+            pageIndex: getPageIndex(spanEl),
+          };
         }
 
-        if (suppressSelectionOverlayRef.current) {
-          setCaretPosition(null);
-          setSelectionRects([]);
-          return;
+        if (pmPos >= pmStart && pmPos <= pmEnd) {
+          const spanRect = spanEl.getBoundingClientRect();
+          return {
+            x: (spanRect.left - overlayRect.left) / currentZoom,
+            y: (spanRect.top - overlayRect.top) / currentZoom,
+            height: getLineHeight(spanEl, Math.max(16, spanRect.height)),
+            pageIndex: getPageIndex(spanEl),
+          };
+        }
+      }
+
+      // Fallback: try to find position in empty paragraphs (they have empty runs)
+      const emptyRuns = findBodyEmptyRuns(pagesContainerRef.current);
+      for (const emptyRun of emptyRuns) {
+        const paragraph = closestHtmlElement(emptyRun, ".layout-paragraph");
+        if (!paragraph) {
+          continue;
+        }
+        const pmStart = Number(paragraph.dataset["pmStart"]);
+        const pmEnd = Number(paragraph.dataset["pmEnd"]);
+
+        if (pmPos >= pmStart && pmPos <= pmEnd) {
+          const runRect = emptyRun.getBoundingClientRect();
+          return {
+            x: (runRect.left - overlayRect.left) / currentZoom,
+            y: (runRect.top - overlayRect.top) / currentZoom,
+            height: getLineHeight(emptyRun),
+            pageIndex: getPageIndex(paragraph),
+          };
+        }
+      }
+
+      return null;
+    },
+    [],
+  );
+
+  /**
+   * Update selection overlay from PM selection.
+   */
+  const updateSelectionOverlay = useCallback(
+    (state: EditorState) => {
+      const { from, to } = state.selection;
+
+      // Always notify selection change (for toolbar sync) even if layout not ready
+      // Use ref to avoid infinite loops when callback is unstable
+      onSelectionChangeRef.current?.(from, to);
+      // `onSelectionTextChange` carries the resolved text
+      // alongside the range so consumers (anonymisation
+      // term prefill, etc.) don't need to hold a reference
+      // to the editor view themselves. `textBetween` with
+      // a single space for both leaf-block and block
+      // separators collapses table cells, paragraphs, and
+      // inline atoms into a single-line phrase.
+      if (onSelectionTextChangeRef.current) {
+        const text =
+          from === to ? "" : state.doc.textBetween(from, to, " ", " ");
+        onSelectionTextChangeRef.current({ from, to, text });
+      }
+
+      if (suppressSelectionOverlayRef.current) {
+        setCaretPosition(null);
+        setSelectionRects([]);
+        return;
+      }
+
+      // Update visual cell selection highlighting on visible layout table cells
+      if (pagesContainerRef.current) {
+        // Clear previous cell highlighting
+        const prevSelected = pagesContainerRef.current.querySelectorAll(
+          ".layout-table-cell-selected",
+        );
+        for (const el of Array.from(prevSelected)) {
+          el.classList.remove("layout-table-cell-selected");
         }
 
-        // Update visual cell selection highlighting on visible layout table cells
-        if (pagesContainerRef.current) {
-          // Clear previous cell highlighting
-          const prevSelected = pagesContainerRef.current.querySelectorAll(
-            ".layout-table-cell-selected",
+        // If CellSelection, highlight the corresponding visible cells
+        // Use duck-typing ($anchorCell) instead of instanceof to avoid bundling issues
+        const sel = state.selection as CellSelection;
+        const isCellSel =
+          "$anchorCell" in sel && typeof sel.forEachCell === "function";
+        if (isCellSel) {
+          // Collect ranges [cellStart, cellEnd) for each selected cell
+          const selectedRanges: [number, number][] = [];
+          sel.forEachCell((node, pos) => {
+            selectedRanges.push([pos, pos + node.nodeSize]);
+          });
+
+          // Find visible layout cells whose pmStart falls inside a selected cell range
+          const allCells = htmlQueryAll(
+            pagesContainerRef.current,
+            ".layout-table-cell",
           );
-          for (const el of Array.from(prevSelected)) {
-            el.classList.remove("layout-table-cell-selected");
-          }
-
-          // If CellSelection, highlight the corresponding visible cells
-          // Use duck-typing ($anchorCell) instead of instanceof to avoid bundling issues
-          const sel = state.selection as CellSelection;
-          const isCellSel =
-            "$anchorCell" in sel && typeof sel.forEachCell === "function";
-          if (isCellSel) {
-            // Collect ranges [cellStart, cellEnd) for each selected cell
-            const selectedRanges: [number, number][] = [];
-            sel.forEachCell((node, pos) => {
-              selectedRanges.push([pos, pos + node.nodeSize]);
-            });
-
-            // Find visible layout cells whose pmStart falls inside a selected cell range
-            const allCells = htmlQueryAll(
-              pagesContainerRef.current,
-              ".layout-table-cell",
-            );
-            for (const cellEl of allCells) {
-              const pmStartAttr = cellEl.dataset["pmStart"];
-              if (pmStartAttr !== undefined) {
-                const pmPos = Number(pmStartAttr);
-                for (const [start, end] of selectedRanges) {
-                  if (pmPos >= start && pmPos < end) {
-                    cellEl.classList.add("layout-table-cell-selected");
-                    break;
-                  }
+          for (const cellEl of allCells) {
+            const pmStartAttr = cellEl.dataset["pmStart"];
+            if (pmStartAttr !== undefined) {
+              const pmPos = Number(pmStartAttr);
+              for (const [start, end] of selectedRanges) {
+                if (pmPos >= start && pmPos < end) {
+                  cellEl.classList.add("layout-table-cell-selected");
+                  break;
                 }
               }
             }
           }
         }
+      }
 
-        if (!layout || blocks.length === 0) {
-          return;
-        }
+      if (!layout || blocks.length === 0) {
+        return;
+      }
 
-        // Collapsed selection - show caret
-        if (from === to) {
-          // Use DOM-based caret positioning for accuracy
-          const domCaret = getCaretFromDom(from, zoom);
-          if (domCaret) {
-            setCaretPosition(domCaret);
-          } else {
-            // Fallback to layout-based calculation if DOM not ready
-            const overlay =
-              pagesContainerRef.current?.parentElement?.querySelector(
-                '[data-testid="selection-overlay"]',
-              );
-            const firstPage =
-              pagesContainerRef.current?.querySelector(".layout-page");
-
-            if (overlay && firstPage) {
-              const overlayRect = overlay.getBoundingClientRect();
-              const pageRect = firstPage.getBoundingClientRect();
-              const caret = getCaretPosition(layout, blocks, measures, from);
-
-              if (caret) {
-                setCaretPosition({
-                  ...caret,
-                  x: caret.x + (pageRect.left - overlayRect.left) / zoom,
-                  y: caret.y + (pageRect.top - overlayRect.top) / zoom,
-                });
-              } else {
-                setCaretPosition(null);
-              }
-            } else {
-              setCaretPosition(null);
-            }
-          }
-          setSelectionRects([]);
+      // Collapsed selection - show caret
+      if (from === to) {
+        // Use DOM-based caret positioning for accuracy
+        const domCaret = getCaretFromDom(from, zoom);
+        if (domCaret) {
+          setCaretPosition(domCaret);
         } else {
-          // Range selection - show highlight rectangles using DOM-based approach
+          // Fallback to layout-based calculation if DOM not ready
           const overlay =
             pagesContainerRef.current?.parentElement?.querySelector(
               '[data-testid="selection-overlay"]',
             );
+          const firstPage =
+            pagesContainerRef.current?.querySelector(".layout-page");
 
-          if (overlay && pagesContainerRef.current) {
+          if (overlay && firstPage) {
             const overlayRect = overlay.getBoundingClientRect();
-            const domRects: SelectionRect[] = [];
+            const pageRect = firstPage.getBoundingClientRect();
+            const caret = getCaretPosition(layout, blocks, measures, from);
 
-            // Find spans that intersect with the selection range
-            const spans = findBodyPmSpans(pagesContainerRef.current);
-
-            for (const spanEl of spans) {
-              const pmStart = Number(spanEl.dataset["pmStart"]);
-              const pmEnd = Number(spanEl.dataset["pmEnd"]);
-
-              // Check if this span overlaps with selection
-              if (pmEnd > from && pmStart < to) {
-                // Special handling for tab spans - highlight the full visual width
-                if (spanEl.classList.contains("layout-run-tab")) {
-                  const spanRect = spanEl.getBoundingClientRect();
-                  domRects.push({
-                    x: (spanRect.left - overlayRect.left) / zoom,
-                    y: (spanRect.top - overlayRect.top) / zoom,
-                    width: spanRect.width / zoom,
-                    height: spanRect.height / zoom,
-                    pageIndex: getPageIndex(spanEl),
-                  });
-                  continue;
-                }
-
-                // Find the text node — may be a direct child or inside an <a> for hyperlinks
-                let textNode: Text | null = null;
-                if (spanEl.firstChild?.nodeType === Node.TEXT_NODE) {
-                  textNode = spanEl.firstChild as Text;
-                } else if (
-                  spanEl.firstChild instanceof HTMLElement &&
-                  spanEl.firstChild.tagName === "A" &&
-                  spanEl.firstChild.firstChild?.nodeType === Node.TEXT_NODE
-                ) {
-                  textNode = spanEl.firstChild.firstChild as Text;
-                }
-                if (!textNode) {
-                  continue;
-                }
-                const ownerDoc = spanEl.ownerDocument;
-
-                // Calculate the character range within this span
-                const startChar = Math.max(0, from - pmStart);
-                const endChar = Math.min(textNode.length, to - pmStart);
-
-                if (startChar < endChar) {
-                  const range = ownerDoc.createRange();
-                  range.setStart(textNode, startChar);
-                  range.setEnd(textNode, endChar);
-
-                  // Get all client rects for this range (handles line wraps)
-                  const clientRects = range.getClientRects();
-                  const pageIndex = getPageIndex(spanEl);
-                  for (const rect of Array.from(clientRects)) {
-                    domRects.push({
-                      x: (rect.left - overlayRect.left) / zoom,
-                      y: (rect.top - overlayRect.top) / zoom,
-                      width: rect.width / zoom,
-                      height: rect.height / zoom,
-                      pageIndex,
-                    });
-                  }
-                }
-              }
-            }
-
-            if (domRects.length > 0) {
-              setSelectionRects(domRects);
+            if (caret) {
+              setCaretPosition({
+                ...caret,
+                x: caret.x + (pageRect.left - overlayRect.left) / zoom,
+                y: caret.y + (pageRect.top - overlayRect.top) / zoom,
+              });
             } else {
-              // Fallback to layout-based calculation
-              const firstPage =
-                pagesContainerRef.current.querySelector(".layout-page");
-              if (firstPage) {
-                const pageRect = firstPage.getBoundingClientRect();
-                const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
-                const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
-
-                const rects = selectionToRects(
-                  layout,
-                  blocks,
-                  measures,
-                  from,
-                  to,
-                );
-                const adjustedRects = rects.map((rect) => ({
-                  height: rect.height,
-                  pageIndex: rect.pageIndex,
-                  width: rect.width,
-                  x: rect.x + pageOffsetX,
-                  y: rect.y + pageOffsetY,
-                }));
-                setSelectionRects(adjustedRects);
-              } else {
-                setSelectionRects([]);
-              }
+              setCaretPosition(null);
             }
           } else {
-            setSelectionRects([]);
-          }
-          setCaretPosition(null);
-        }
-      },
-      [layout, blocks, measures, getCaretFromDom, zoom],
-      // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
-    );
-
-    // Project anonymization match ranges onto container-space
-    // rectangles. Mirrors the SelectionOverlay flow: prefer real
-    // DOM rects from the painted page spans (correct for indents,
-    // tabs, justified text, line wraps) and fall back to the
-    // layout-coord projection only when the DOM spans aren't
-    // mounted yet (initial paint, off-screen pages). The hidden
-    // ProseMirror's spans are not used — they sit at -9999px and
-    // would yield bogus coordinates.
-    const updateAnonymizationOverlay = useCallback(() => {
-      const matches = anonymizationMatchesRef.current;
-      if (matches.length === 0) {
-        setAnonymizationRectGroups([]);
-        return;
-      }
-      const pagesContainer = pagesContainerRef.current;
-      if (!pagesContainer) {
-        setAnonymizationRectGroups([]);
-        return;
-      }
-      const overlay = pagesContainer.parentElement?.querySelector(
-        '[data-testid="selection-overlay"]',
-      );
-      const firstPage = pagesContainer.querySelector(".layout-page");
-      if (!overlay || !firstPage) {
-        setAnonymizationRectGroups([]);
-        return;
-      }
-      const overlayRect = overlay.getBoundingClientRect();
-      const pageRect = firstPage.getBoundingClientRect();
-      const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
-      const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
-      const pmSpans = findBodyPmSpans(pagesContainer);
-
-      const rectsForMatch = (
-        from: number,
-        to: number,
-      ): AnonymizationRectGroup["rects"] => {
-        const domRects: AnonymizationRectGroup["rects"] = [];
-        for (const spanEl of pmSpans) {
-          const pmStart = Number(spanEl.dataset["pmStart"]);
-          const pmEnd = Number(spanEl.dataset["pmEnd"]);
-          if (!(pmEnd > from && pmStart < to)) {
-            continue;
-          }
-          if (spanEl.classList.contains("layout-run-tab")) {
-            const spanRect = spanEl.getBoundingClientRect();
-            domRects.push({
-              x: (spanRect.left - overlayRect.left) / zoom,
-              y: (spanRect.top - overlayRect.top) / zoom,
-              width: spanRect.width / zoom,
-              height: spanRect.height / zoom,
-              pageIndex: getPageIndex(spanEl),
-            });
-            continue;
-          }
-          let textNode: Text | null = null;
-          if (spanEl.firstChild?.nodeType === Node.TEXT_NODE) {
-            textNode = spanEl.firstChild as Text;
-          } else if (
-            spanEl.firstChild instanceof HTMLElement &&
-            spanEl.firstChild.tagName === "A" &&
-            spanEl.firstChild.firstChild?.nodeType === Node.TEXT_NODE
-          ) {
-            textNode = spanEl.firstChild.firstChild as Text;
-          }
-          if (!textNode) {
-            continue;
-          }
-          const ownerDoc = spanEl.ownerDocument;
-          const startChar = Math.max(0, from - pmStart);
-          const endChar = Math.min(textNode.length, to - pmStart);
-          if (!(startChar < endChar)) {
-            continue;
-          }
-          const range = ownerDoc.createRange();
-          range.setStart(textNode, startChar);
-          range.setEnd(textNode, endChar);
-          const pageIndex = getPageIndex(spanEl);
-          for (const rect of Array.from(range.getClientRects())) {
-            domRects.push({
-              x: (rect.left - overlayRect.left) / zoom,
-              y: (rect.top - overlayRect.top) / zoom,
-              width: rect.width / zoom,
-              height: rect.height / zoom,
-              pageIndex,
-            });
+            setCaretPosition(null);
           }
         }
-        if (domRects.length > 0) {
-          return domRects;
-        }
-        if (!layout || blocks.length === 0) {
-          return [];
-        }
-        return selectionToRects(layout, blocks, measures, from, to).map(
-          (rect) => ({
-            height: rect.height,
-            pageIndex: rect.pageIndex,
-            width: rect.width,
-            x: rect.x + pageOffsetX,
-            y: rect.y + pageOffsetY,
-          }),
+        setSelectionRects([]);
+      } else {
+        // Range selection - show highlight rectangles using DOM-based approach
+        const overlay = pagesContainerRef.current?.parentElement?.querySelector(
+          '[data-testid="selection-overlay"]',
         );
-      };
 
-      const groups: AnonymizationRectGroup[] = [];
-      for (const match of matches) {
-        const rects = rectsForMatch(match.from, match.to);
-        if (rects.length > 0) {
-          groups.push({
-            rects,
-            label: match.label,
-            canonical: match.canonical,
+        if (overlay && pagesContainerRef.current) {
+          const overlayRect = overlay.getBoundingClientRect();
+          const domRects: SelectionRect[] = [];
+
+          // Find spans that intersect with the selection range
+          const spans = findBodyPmSpans(pagesContainerRef.current);
+
+          for (const spanEl of spans) {
+            const pmStart = Number(spanEl.dataset["pmStart"]);
+            const pmEnd = Number(spanEl.dataset["pmEnd"]);
+
+            // Check if this span overlaps with selection
+            if (pmEnd > from && pmStart < to) {
+              // Special handling for tab spans - highlight the full visual width
+              if (spanEl.classList.contains("layout-run-tab")) {
+                const spanRect = spanEl.getBoundingClientRect();
+                domRects.push({
+                  x: (spanRect.left - overlayRect.left) / zoom,
+                  y: (spanRect.top - overlayRect.top) / zoom,
+                  width: spanRect.width / zoom,
+                  height: spanRect.height / zoom,
+                  pageIndex: getPageIndex(spanEl),
+                });
+                continue;
+              }
+
+              // Find the text node — may be a direct child or inside an <a> for hyperlinks
+              let textNode: Text | null = null;
+              if (spanEl.firstChild?.nodeType === Node.TEXT_NODE) {
+                textNode = spanEl.firstChild as Text;
+              } else if (
+                spanEl.firstChild instanceof HTMLElement &&
+                spanEl.firstChild.tagName === "A" &&
+                spanEl.firstChild.firstChild?.nodeType === Node.TEXT_NODE
+              ) {
+                textNode = spanEl.firstChild.firstChild as Text;
+              }
+              if (!textNode) {
+                continue;
+              }
+              const ownerDoc = spanEl.ownerDocument;
+
+              // Calculate the character range within this span
+              const startChar = Math.max(0, from - pmStart);
+              const endChar = Math.min(textNode.length, to - pmStart);
+
+              if (startChar < endChar) {
+                const range = ownerDoc.createRange();
+                range.setStart(textNode, startChar);
+                range.setEnd(textNode, endChar);
+
+                // Get all client rects for this range (handles line wraps)
+                const clientRects = range.getClientRects();
+                const pageIndex = getPageIndex(spanEl);
+                for (const rect of Array.from(clientRects)) {
+                  domRects.push({
+                    x: (rect.left - overlayRect.left) / zoom,
+                    y: (rect.top - overlayRect.top) / zoom,
+                    width: rect.width / zoom,
+                    height: rect.height / zoom,
+                    pageIndex,
+                  });
+                }
+              }
+            }
+          }
+
+          if (domRects.length > 0) {
+            setSelectionRects(domRects);
+          } else {
+            // Fallback to layout-based calculation
+            const firstPage =
+              pagesContainerRef.current.querySelector(".layout-page");
+            if (firstPage) {
+              const pageRect = firstPage.getBoundingClientRect();
+              const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
+              const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
+
+              const rects = selectionToRects(
+                layout,
+                blocks,
+                measures,
+                from,
+                to,
+              );
+              const adjustedRects = rects.map((rect) => ({
+                height: rect.height,
+                pageIndex: rect.pageIndex,
+                width: rect.width,
+                x: rect.x + pageOffsetX,
+                y: rect.y + pageOffsetY,
+              }));
+              setSelectionRects(adjustedRects);
+            } else {
+              setSelectionRects([]);
+            }
+          }
+        } else {
+          setSelectionRects([]);
+        }
+        setCaretPosition(null);
+      }
+    },
+    [layout, blocks, measures, getCaretFromDom, zoom],
+    // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
+  );
+
+  // Project anonymization match ranges onto container-space
+  // rectangles. Mirrors the SelectionOverlay flow: prefer real
+  // DOM rects from the painted page spans (correct for indents,
+  // tabs, justified text, line wraps) and fall back to the
+  // layout-coord projection only when the DOM spans aren't
+  // mounted yet (initial paint, off-screen pages). The hidden
+  // ProseMirror's spans are not used — they sit at -9999px and
+  // would yield bogus coordinates.
+  const updateAnonymizationOverlay = useCallback(() => {
+    const matches = anonymizationMatchesRef.current;
+    if (matches.length === 0) {
+      setAnonymizationRectGroups([]);
+      return;
+    }
+    const pagesContainer = pagesContainerRef.current;
+    if (!pagesContainer) {
+      setAnonymizationRectGroups([]);
+      return;
+    }
+    const overlay = pagesContainer.parentElement?.querySelector(
+      '[data-testid="selection-overlay"]',
+    );
+    const firstPage = pagesContainer.querySelector(".layout-page");
+    if (!overlay || !firstPage) {
+      setAnonymizationRectGroups([]);
+      return;
+    }
+    const overlayRect = overlay.getBoundingClientRect();
+    const pageRect = firstPage.getBoundingClientRect();
+    const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
+    const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
+    const pmSpans = findBodyPmSpans(pagesContainer);
+
+    const rectsForMatch = (
+      from: number,
+      to: number,
+    ): AnonymizationRectGroup["rects"] => {
+      const domRects: AnonymizationRectGroup["rects"] = [];
+      for (const spanEl of pmSpans) {
+        const pmStart = Number(spanEl.dataset["pmStart"]);
+        const pmEnd = Number(spanEl.dataset["pmEnd"]);
+        if (!(pmEnd > from && pmStart < to)) {
+          continue;
+        }
+        if (spanEl.classList.contains("layout-run-tab")) {
+          const spanRect = spanEl.getBoundingClientRect();
+          domRects.push({
+            x: (spanRect.left - overlayRect.left) / zoom,
+            y: (spanRect.top - overlayRect.top) / zoom,
+            width: spanRect.width / zoom,
+            height: spanRect.height / zoom,
+            pageIndex: getPageIndex(spanEl),
+          });
+          continue;
+        }
+        let textNode: Text | null = null;
+        if (spanEl.firstChild?.nodeType === Node.TEXT_NODE) {
+          textNode = spanEl.firstChild as Text;
+        } else if (
+          spanEl.firstChild instanceof HTMLElement &&
+          spanEl.firstChild.tagName === "A" &&
+          spanEl.firstChild.firstChild?.nodeType === Node.TEXT_NODE
+        ) {
+          textNode = spanEl.firstChild.firstChild as Text;
+        }
+        if (!textNode) {
+          continue;
+        }
+        const ownerDoc = spanEl.ownerDocument;
+        const startChar = Math.max(0, from - pmStart);
+        const endChar = Math.min(textNode.length, to - pmStart);
+        if (!(startChar < endChar)) {
+          continue;
+        }
+        const range = ownerDoc.createRange();
+        range.setStart(textNode, startChar);
+        range.setEnd(textNode, endChar);
+        const pageIndex = getPageIndex(spanEl);
+        for (const rect of Array.from(range.getClientRects())) {
+          domRects.push({
+            x: (rect.left - overlayRect.left) / zoom,
+            y: (rect.top - overlayRect.top) / zoom,
+            width: rect.width / zoom,
+            height: rect.height / zoom,
+            pageIndex,
           });
         }
       }
-      setAnonymizationRectGroups(groups);
-    }, [layout, blocks, measures, zoom]);
+      if (domRects.length > 0) {
+        return domRects;
+      }
+      if (!layout || blocks.length === 0) {
+        return [];
+      }
+      return selectionToRects(layout, blocks, measures, from, to).map(
+        (rect) => ({
+          height: rect.height,
+          pageIndex: rect.pageIndex,
+          width: rect.width,
+          x: rect.x + pageOffsetX,
+          y: rect.y + pageOffsetY,
+        }),
+      );
+    };
 
-    const hideSelectionOverlayDuringInput = useCallback(
-      (state: EditorState) => {
-        suppressSelectionOverlayRef.current = true;
-        setCaretPosition(null);
+    const groups: AnonymizationRectGroup[] = [];
+    for (const match of matches) {
+      const rects = rectsForMatch(match.from, match.to);
+      if (rects.length > 0) {
+        groups.push({
+          rects,
+          label: match.label,
+          canonical: match.canonical,
+        });
+      }
+    }
+    setAnonymizationRectGroups(groups);
+  }, [layout, blocks, measures, zoom]);
+
+  const hideSelectionOverlayDuringInput = useCallback(
+    (state: EditorState) => {
+      suppressSelectionOverlayRef.current = true;
+      setCaretPosition(null);
+      setSelectionRects([]);
+
+      if (revealSelectionOverlayTimerRef.current !== null) {
+        window.clearTimeout(revealSelectionOverlayTimerRef.current);
+      }
+
+      revealSelectionOverlayTimerRef.current = window.setTimeout(() => {
+        revealSelectionOverlayTimerRef.current = null;
+        suppressSelectionOverlayRef.current = false;
+        updateSelectionOverlay(hiddenPMRef.current?.getState() ?? state);
+      }, SELECTION_REVEAL_AFTER_INPUT_DELAY);
+    },
+    [updateSelectionOverlay],
+  );
+
+  useEffect(
+    () => () => {
+      if (revealSelectionOverlayTimerRef.current !== null) {
+        window.clearTimeout(revealSelectionOverlayTimerRef.current);
+        revealSelectionOverlayTimerRef.current = null;
+      }
+    },
+    [],
+  );
+
+  // =========================================================================
+  // Event Handlers
+  // =========================================================================
+
+  /**
+   * Handle PM transaction - re-layout on content/selection change.
+   */
+  const handleTransaction = useCallback(
+    (transaction: Transaction, newState: EditorState) => {
+      // Keep the anonymization match list mirrored in a ref so the
+      // overlay recompute reads the latest set without depending on
+      // a state setter inside its useCallback closure. We pull off
+      // the plugin's state on every transaction; if the matches
+      // identity changes (term meta or doc edit), schedule a paint.
+      const nextMatches =
+        anonymizationDecorationsKey.getState(newState)?.matches ?? [];
+      const matchesChanged = nextMatches !== anonymizationMatchesRef.current;
+      anonymizationMatchesRef.current = nextMatches;
+      if (matchesChanged) {
+        updateAnonymizationOverlay();
+      }
+
+      if (transaction.docChanged) {
+        // Increment state sequence to signal document changed
+        syncCoordinator.incrementStateSeq();
+
+        hideSelectionOverlayDuringInput(newState);
+
+        // Content changed - schedule layout (coalesced via rAF)
+        scheduleLayout(newState, getTransactionDirtyRange(transaction));
+
+        // Convert back to the Folio document model off the keypress path.
+        scheduleDocumentChangeNotification();
+      }
+
+      // Request selection update (will only execute when layout is current)
+      syncCoordinator.requestRender();
+
+      // Only update selection overlay immediately for non-doc-changing transactions
+      // (e.g. arrow keys, clicks). For doc changes, the overlay will be updated
+      // after layout completes via the useEffect([layout]) hook, avoiding cursor
+      // flicker from stale DOM positions.
+      if (!transaction.docChanged) {
+        updateSelectionOverlay(newState);
+      }
+    },
+    [
+      scheduleLayout,
+      scheduleDocumentChangeNotification,
+      hideSelectionOverlayDuringInput,
+      updateSelectionOverlay,
+      updateAnonymizationOverlay,
+      syncCoordinator,
+    ],
+    // NOTE: onDocumentChange removed from dependencies - accessed via ref to prevent infinite loops
+  );
+
+  /**
+   * Handle selection change from PM.
+   */
+  const handleSelectionChange = useCallback(
+    (state: EditorState) => {
+      // Check if this is an image node selection - suppress text overlay if so
+      const { selection } = state;
+      if (
+        selection instanceof NodeSelection &&
+        selection.node.type.name === "image"
+      ) {
+        // Suppress text selection overlay for image selections
         setSelectionRects([]);
+        setCaretPosition(null);
+      } else if (syncCoordinator.isSafeToRender()) {
+        // Only update overlay when layout is current. When doc changed,
+        // layout is pending and DOM hasn't been updated yet — updating the
+        // overlay now would position the cursor against stale geometry,
+        // causing it to visibly jump. The overlay will be updated after
+        // layout completes via the useEffect([layout]) hook.
+        updateSelectionOverlay(state);
+      }
 
-        if (revealSelectionOverlayTimerRef.current !== null) {
-          window.clearTimeout(revealSelectionOverlayTimerRef.current);
+      // Defer image selection check until after layout update
+      requestAnimationFrame(() => {
+        const view = hiddenPMRef.current?.getView();
+        if (!view) {
+          setSelectedImageInfo(null);
+          return;
         }
-
-        revealSelectionOverlayTimerRef.current = window.setTimeout(() => {
-          revealSelectionOverlayTimerRef.current = null;
-          suppressSelectionOverlayRef.current = false;
-          updateSelectionOverlay(hiddenPMRef.current?.getState() ?? state);
-        }, SELECTION_REVEAL_AFTER_INPUT_DELAY);
-      },
-      [updateSelectionOverlay],
-    );
-
-    useEffect(
-      () => () => {
-        if (revealSelectionOverlayTimerRef.current !== null) {
-          window.clearTimeout(revealSelectionOverlayTimerRef.current);
-          revealSelectionOverlayTimerRef.current = null;
-        }
-      },
-      [],
-    );
-
-    // =========================================================================
-    // Event Handlers
-    // =========================================================================
-
-    /**
-     * Handle PM transaction - re-layout on content/selection change.
-     */
-    const handleTransaction = useCallback(
-      (transaction: Transaction, newState: EditorState) => {
-        // Keep the anonymization match list mirrored in a ref so the
-        // overlay recompute reads the latest set without depending on
-        // a state setter inside its useCallback closure. We pull off
-        // the plugin's state on every transaction; if the matches
-        // identity changes (term meta or doc edit), schedule a paint.
-        const nextMatches =
-          anonymizationDecorationsKey.getState(newState)?.matches ?? [];
-        const matchesChanged = nextMatches !== anonymizationMatchesRef.current;
-        anonymizationMatchesRef.current = nextMatches;
-        if (matchesChanged) {
-          updateAnonymizationOverlay();
-        }
-
-        if (transaction.docChanged) {
-          // Increment state sequence to signal document changed
-          syncCoordinator.incrementStateSeq();
-
-          hideSelectionOverlayDuringInput(newState);
-
-          // Content changed - schedule layout (coalesced via rAF)
-          scheduleLayout(newState, getTransactionDirtyRange(transaction));
-
-          // Convert back to the Folio document model off the keypress path.
-          scheduleDocumentChangeNotification();
-        }
-
-        // Request selection update (will only execute when layout is current)
-        syncCoordinator.requestRender();
-
-        // Only update selection overlay immediately for non-doc-changing transactions
-        // (e.g. arrow keys, clicks). For doc changes, the overlay will be updated
-        // after layout completes via the useEffect([layout]) hook, avoiding cursor
-        // flicker from stale DOM positions.
-        if (!transaction.docChanged) {
-          updateSelectionOverlay(newState);
-        }
-      },
-      [
-        scheduleLayout,
-        scheduleDocumentChangeNotification,
-        hideSelectionOverlayDuringInput,
-        updateSelectionOverlay,
-        updateAnonymizationOverlay,
-        syncCoordinator,
-      ],
-      // NOTE: onDocumentChange removed from dependencies - accessed via ref to prevent infinite loops
-    );
-
-    /**
-     * Handle selection change from PM.
-     */
-    const handleSelectionChange = useCallback(
-      (state: EditorState) => {
-        // Check if this is an image node selection - suppress text overlay if so
-        const { selection } = state;
-        if (
-          selection instanceof NodeSelection &&
-          selection.node.type.name === "image"
-        ) {
-          // Suppress text selection overlay for image selections
-          setSelectionRects([]);
-          setCaretPosition(null);
-        } else if (syncCoordinator.isSafeToRender()) {
-          // Only update overlay when layout is current. When doc changed,
-          // layout is pending and DOM hasn't been updated yet — updating the
-          // overlay now would position the cursor against stale geometry,
-          // causing it to visibly jump. The overlay will be updated after
-          // layout completes via the useEffect([layout]) hook.
-          updateSelectionOverlay(state);
-        }
-
-        // Defer image selection check until after layout update
-        requestAnimationFrame(() => {
-          const view = hiddenPMRef.current?.getView();
-          if (!view) {
-            setSelectedImageInfo(null);
+        const { selection: sel } = view.state;
+        if (sel instanceof NodeSelection && sel.node.type.name === "image") {
+          const pmPos = sel.from;
+          const imgEl = pagesContainerRef.current
+            ? findBodyPmAnchor(pagesContainerRef.current, pmPos)
+            : null;
+          if (imgEl) {
+            setSelectedImageInfo(buildImageSelectionInfo(imgEl, pmPos));
             return;
           }
-          const { selection: sel } = view.state;
-          if (sel instanceof NodeSelection && sel.node.type.name === "image") {
-            const pmPos = sel.from;
-            const imgEl = pagesContainerRef.current
-              ? findBodyPmAnchor(pagesContainerRef.current, pmPos)
-              : null;
-            if (imgEl) {
-              setSelectedImageInfo(buildImageSelectionInfo(imgEl, pmPos));
-              return;
-            }
-          }
-          if (!isImageInteractingRef.current) {
-            setSelectedImageInfo(null);
-          }
-        });
-      },
-      [updateSelectionOverlay, buildImageSelectionInfo, syncCoordinator],
-    );
-
-    /**
-     * Get PM position from mouse coordinates using DOM-based detection.
-     * Falls back to geometry-based calculation if DOM mapping fails.
-     */
-    const getPositionFromMouse = useCallback(
-      (clientX: number, clientY: number): number | null => {
-        if (!pagesContainerRef.current || !layout) {
-          return null;
         }
-
-        // Try DOM-based click mapping first (most accurate)
-        const domPos = clickToPositionDom(
-          pagesContainerRef.current,
-          clientX,
-          clientY,
-          zoom,
-        );
-        if (domPos !== null) {
-          return domPos;
+        if (!isImageInteractingRef.current) {
+          setSelectedImageInfo(null);
         }
+      });
+    },
+    [updateSelectionOverlay, buildImageSelectionInfo, syncCoordinator],
+  );
 
-        // Fallback to geometry-based mapping
-        const pageElements =
-          pagesContainerRef.current.querySelectorAll(".layout-page");
-        let clickedPageIndex = -1;
-        let pageRect: DOMRect | null = null;
+  /**
+   * Get PM position from mouse coordinates using DOM-based detection.
+   * Falls back to geometry-based calculation if DOM mapping fails.
+   */
+  const getPositionFromMouse = useCallback(
+    (clientX: number, clientY: number): number | null => {
+      if (!pagesContainerRef.current || !layout) {
+        return null;
+      }
 
-        for (let i = 0; i < pageElements.length; i++) {
-          const pageEl = pageElements[i]!; // SAFETY: i < pageElements.length
-          const rect = pageEl.getBoundingClientRect();
-          if (
-            clientX >= rect.left &&
-            clientX <= rect.right &&
-            clientY >= rect.top &&
-            clientY <= rect.bottom
-          ) {
-            clickedPageIndex = i;
-            pageRect = rect;
-            break;
-          }
+      // Try DOM-based click mapping first (most accurate)
+      const domPos = clickToPositionDom(
+        pagesContainerRef.current,
+        clientX,
+        clientY,
+        zoom,
+      );
+      if (domPos !== null) {
+        return domPos;
+      }
+
+      // Fallback to geometry-based mapping
+      const pageElements =
+        pagesContainerRef.current.querySelectorAll(".layout-page");
+      let clickedPageIndex = -1;
+      let pageRect: DOMRect | null = null;
+
+      for (let i = 0; i < pageElements.length; i++) {
+        const pageEl = pageElements[i]!; // SAFETY: i < pageElements.length
+        const rect = pageEl.getBoundingClientRect();
+        if (
+          clientX >= rect.left &&
+          clientX <= rect.right &&
+          clientY >= rect.top &&
+          clientY <= rect.bottom
+        ) {
+          clickedPageIndex = i;
+          pageRect = rect;
+          break;
         }
+      }
 
-        if (clickedPageIndex < 0 || !pageRect) {
-          return null;
-        }
+      if (clickedPageIndex < 0 || !pageRect) {
+        return null;
+      }
 
-        const pageX = (clientX - pageRect.left) / zoom;
-        const pageY = (clientY - pageRect.top) / zoom;
+      const pageX = (clientX - pageRect.left) / zoom;
+      const pageY = (clientY - pageRect.top) / zoom;
 
-        const page = layout.pages[clickedPageIndex];
-        if (!page) {
-          return null;
-        }
+      const page = layout.pages[clickedPageIndex];
+      if (!page) {
+        return null;
+      }
 
-        const pageHit = {
-          pageIndex: clickedPageIndex,
-          page,
-          pageY,
-        };
+      const pageHit = {
+        pageIndex: clickedPageIndex,
+        page,
+        pageY,
+      };
 
-        const fragmentHit = hitTestFragment(pageHit, blocks, measures, {
+      const fragmentHit = hitTestFragment(pageHit, blocks, measures, {
+        x: pageX,
+        y: pageY,
+      });
+
+      if (!fragmentHit) {
+        return null;
+      }
+
+      // For table fragments, do cell-level hit testing
+      if (fragmentHit.fragment.kind === "table") {
+        const tableCellHit = hitTestTableCell(pageHit, blocks, measures, {
           x: pageX,
           y: pageY,
         });
-
-        if (!fragmentHit) {
-          return null;
-        }
-
-        // For table fragments, do cell-level hit testing
-        if (fragmentHit.fragment.kind === "table") {
-          const tableCellHit = hitTestTableCell(pageHit, blocks, measures, {
-            x: pageX,
-            y: pageY,
-          });
-          return clickToPosition(fragmentHit, tableCellHit);
-        }
-
-        return clickToPosition(fragmentHit);
-      },
-      [layout, blocks, measures, zoom],
-    );
-
-    /**
-     * Find the table cell position in ProseMirror doc for a given PM position.
-     * Returns the position just inside the cell node, suitable for CellSelection.create().
-     */
-    const findCellPosFromPmPos = useCallback((pmPos: number): number | null => {
-      const view = hiddenPMRef.current?.getView();
-      if (!view) {
-        return null;
+        return clickToPosition(fragmentHit, tableCellHit);
       }
-      try {
-        const $pos = view.state.doc.resolve(pmPos);
-        for (let d = $pos.depth; d > 0; d--) {
-          const node = $pos.node(d);
-          if (
-            node.type.name === "tableCell" ||
-            node.type.name === "tableHeader"
-          ) {
-            // Return position of the cell node itself (before(d)).
-            // CellSelection.create will resolve this and use cellAround() internally.
-            return $pos.before(d);
-          }
+
+      return clickToPosition(fragmentHit);
+    },
+    [layout, blocks, measures, zoom],
+  );
+
+  /**
+   * Find the table cell position in ProseMirror doc for a given PM position.
+   * Returns the position just inside the cell node, suitable for CellSelection.create().
+   */
+  const findCellPosFromPmPos = useCallback((pmPos: number): number | null => {
+    const view = hiddenPMRef.current?.getView();
+    if (!view) {
+      return null;
+    }
+    try {
+      const $pos = view.state.doc.resolve(pmPos);
+      for (let d = $pos.depth; d > 0; d--) {
+        const node = $pos.node(d);
+        if (
+          node.type.name === "tableCell" ||
+          node.type.name === "tableHeader"
+        ) {
+          // Return position of the cell node itself (before(d)).
+          // CellSelection.create will resolve this and use cellAround() internally.
+          return $pos.before(d);
         }
-      } catch {
-        // Position resolution failed
+      }
+    } catch {
+      // Position resolution failed
+    }
+    return null;
+  }, []);
+
+  /**
+   * Find the closest image element from a click target.
+   * Returns the element with data-pm-start if it's an image, or null.
+   */
+  const findImageElement = useCallback(
+    (target: HTMLElement): HTMLElement | null => {
+      const IMAGE_CONTAINER_CLASSES = [
+        "layout-block-image",
+        "layout-image",
+        "layout-page-floating-image",
+      ];
+      const isImageContainer = (el: HTMLElement) =>
+        !!el.dataset["pmStart"] &&
+        IMAGE_CONTAINER_CLASSES.some((c) => el.classList.contains(c));
+
+      // Inline images: <img class="layout-run layout-run-image" data-pm-start="X">
+      if (
+        target.tagName === "IMG" &&
+        target.classList.contains("layout-run-image")
+      ) {
+        return target;
+      }
+      // Click on <img> inside a container div, or directly on the container
+      if (
+        target.tagName === "IMG" &&
+        target.parentElement &&
+        isImageContainer(target.parentElement)
+      ) {
+        return target.parentElement;
+      }
+      if (isImageContainer(target)) {
+        return target;
       }
       return null;
-    }, []);
+    },
+    [],
+  );
 
-    /**
-     * Find the closest image element from a click target.
-     * Returns the element with data-pm-start if it's an image, or null.
-     */
-    const findImageElement = useCallback(
-      (target: HTMLElement): HTMLElement | null => {
-        const IMAGE_CONTAINER_CLASSES = [
-          "layout-block-image",
-          "layout-image",
-          "layout-page-floating-image",
-        ];
-        const isImageContainer = (el: HTMLElement) =>
-          !!el.dataset["pmStart"] &&
-          IMAGE_CONTAINER_CLASSES.some((c) => el.classList.contains(c));
+  /** Scroll visible pages to a ProseMirror position. */
+  const scrollToPositionImpl = useCallback((pmPos: number) => {
+    if (!isValidPmScrollPosition(pmPos)) {
+      return;
+    }
 
-        // Inline images: <img class="layout-run layout-run-image" data-pm-start="X">
-        if (
-          target.tagName === "IMG" &&
-          target.classList.contains("layout-run-image")
-        ) {
-          return target;
-        }
-        // Click on <img> inside a container div, or directly on the container
-        if (
-          target.tagName === "IMG" &&
-          target.parentElement &&
-          isImageContainer(target.parentElement)
-        ) {
-          return target.parentElement;
-        }
-        if (isImageContainer(target)) {
-          return target;
-        }
-        return null;
-      },
-      [],
-    );
+    const pageContainer = pagesContainerRef.current;
+    if (!pageContainer) {
+      return;
+    }
+    // Phase 1: locate the target via per-run DOM if it's already
+    // rendered, otherwise via the page shell (always present
+    // under virtualization). The shell-based path was added to
+    // fix the "many clicks to arrive" bug — a per-run query on a
+    // virtualized doc only sees runs in the currently-rendered
+    // buffer, so each click stepped one buffer-width forward
+    // instead of jumping straight to the target.
+    const exact = findBodyPmAnchor(pageContainer, pmPos);
+    if (exact) {
+      exact.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
 
-    /** Scroll visible pages to a ProseMirror position. */
-    const scrollToPositionImpl = useCallback((pmPos: number) => {
-      if (!isValidPmScrollPosition(pmPos)) {
+    // Walk all currently-rendered runs to see if pmPos falls
+    // inside one of them (block-node positions never match
+    // exactly but usually live inside a known run).
+    let runMatch: HTMLElement | null = null;
+    for (const el of findBodyPmAnchors(pageContainer)) {
+      const start = Number(el.dataset["pmStart"]);
+      if (Number.isNaN(start)) {
+        continue;
+      }
+      const endAttr = el.dataset["pmEnd"];
+      const end = endAttr === undefined ? start : Number(endAttr);
+      if (start <= pmPos && pmPos <= end) {
+        runMatch = el;
+        break;
+      }
+    }
+    if (runMatch) {
+      runMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+      return;
+    }
+
+    // Target lives outside the rendered buffer. Scroll to its
+    // page shell (which exists with correct dimensions even when
+    // empty), then refine to the exact run once the
+    // IntersectionObserver populates the page content.
+    //
+    // TODO: when the AI review session opens, pre-warm the page
+    // shells that contain pending suggestions (one-shot
+    // populate of ~30 pages instead of 200). Lets this scroll
+    // become single-phase again — no rAF refine — and makes
+    // navigation feel instant for long documents.
+    const shellHit = findPageShellForPmPos(pageContainer, pmPos);
+    if (!shellHit) {
+      return;
+    }
+    const { element: shell } = shellHit;
+    shell.scrollIntoView({ behavior: "smooth", block: "center" });
+
+    let attempts = 0;
+    const refine = () => {
+      attempts++;
+      const exactInShell = findBodyPmAnchor(shell, pmPos);
+      if (exactInShell) {
+        exactInShell.scrollIntoView({ behavior: "smooth", block: "center" });
         return;
       }
-
-      const pageContainer = pagesContainerRef.current;
-      if (!pageContainer) {
-        return;
-      }
-      // Phase 1: locate the target via per-run DOM if it's already
-      // rendered, otherwise via the page shell (always present
-      // under virtualization). The shell-based path was added to
-      // fix the "many clicks to arrive" bug — a per-run query on a
-      // virtualized doc only sees runs in the currently-rendered
-      // buffer, so each click stepped one buffer-width forward
-      // instead of jumping straight to the target.
-      const exact = findBodyPmAnchor(pageContainer, pmPos);
-      if (exact) {
-        exact.scrollIntoView({ behavior: "smooth", block: "center" });
-        return;
-      }
-
-      // Walk all currently-rendered runs to see if pmPos falls
-      // inside one of them (block-node positions never match
-      // exactly but usually live inside a known run).
-      let runMatch: HTMLElement | null = null;
-      for (const el of findBodyPmAnchors(pageContainer)) {
+      let bestEl: HTMLElement | null = null;
+      let bestStart = Number.NEGATIVE_INFINITY;
+      for (const el of findBodyPmAnchors(shell)) {
         const start = Number(el.dataset["pmStart"]);
         if (Number.isNaN(start)) {
           continue;
@@ -2964,1913 +2994,1852 @@ const PagedEditorComponent = forwardRef<PagedEditorRef, PagedEditorProps>(
         const endAttr = el.dataset["pmEnd"];
         const end = endAttr === undefined ? start : Number(endAttr);
         if (start <= pmPos && pmPos <= end) {
-          runMatch = el;
+          bestEl = el;
           break;
         }
+        if (start <= pmPos && start > bestStart) {
+          bestStart = start;
+          bestEl = el;
+        }
       }
-      if (runMatch) {
-        runMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (bestEl) {
+        bestEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        return;
+      }
+      // IntersectionObserver populates on the next tick; give it
+      // a few frames before giving up. ~20 frames covers slow
+      // initial paint on long pages without spinning indefinitely
+      // if the page genuinely has no run at this position.
+      if (attempts < 20) {
+        requestAnimationFrame(refine);
+      }
+    };
+    requestAnimationFrame(refine);
+  }, []);
+
+  const scrollToPageImpl = useCallback(
+    (pageNumber: number) => {
+      const target = getPageScrollTarget(layout, pageNumber);
+      if (!target) {
         return;
       }
 
-      // Target lives outside the rendered buffer. Scroll to its
-      // page shell (which exists with correct dimensions even when
-      // empty), then refine to the exact run once the
-      // IntersectionObserver populates the page content.
-      //
-      // TODO: when the AI review session opens, pre-warm the page
-      // shells that contain pending suggestions (one-shot
-      // populate of ~30 pages instead of 200). Lets this scroll
-      // become single-phase again — no rAF refine — and makes
-      // navigation feel instant for long documents.
-      const shellHit = findPageShellForPmPos(pageContainer, pmPos);
-      if (!shellHit) {
-        return;
-      }
-      const { element: shell } = shellHit;
-      shell.scrollIntoView({ behavior: "smooth", block: "center" });
-
-      let attempts = 0;
-      const refine = () => {
-        attempts++;
-        const exactInShell = findBodyPmAnchor(shell, pmPos);
-        if (exactInShell) {
-          exactInShell.scrollIntoView({ behavior: "smooth", block: "center" });
-          return;
-        }
-        let bestEl: HTMLElement | null = null;
-        let bestStart = Number.NEGATIVE_INFINITY;
-        for (const el of findBodyPmAnchors(shell)) {
-          const start = Number(el.dataset["pmStart"]);
-          if (Number.isNaN(start)) {
-            continue;
-          }
-          const endAttr = el.dataset["pmEnd"];
-          const end = endAttr === undefined ? start : Number(endAttr);
-          if (start <= pmPos && pmPos <= end) {
-            bestEl = el;
-            break;
-          }
-          if (start <= pmPos && start > bestStart) {
-            bestStart = start;
-            bestEl = el;
-          }
-        }
-        if (bestEl) {
-          bestEl.scrollIntoView({ behavior: "smooth", block: "center" });
-          return;
-        }
-        // IntersectionObserver populates on the next tick; give it
-        // a few frames before giving up. ~20 frames covers slow
-        // initial paint on long pages without spinning indefinitely
-        // if the page genuinely has no run at this position.
-        if (attempts < 20) {
-          requestAnimationFrame(refine);
-        }
-      };
-      requestAnimationFrame(refine);
-    }, []);
-
-    const scrollToPageImpl = useCallback(
-      (pageNumber: number) => {
-        const target = getPageScrollTarget(layout, pageNumber);
-        if (!target) {
-          return;
-        }
-
-        if (target.type === "position") {
-          scrollToPositionImpl(target.pmPos);
-          return;
-        }
-
-        const pageContainer = pagesContainerRef.current;
-        const shell = pageContainer?.querySelector<HTMLElement>(
-          `[data-page-number="${String(target.pageIndex + 1)}"]`,
-        );
-        shell?.scrollIntoView({ block: "center", inline: "nearest" });
-      },
-      [layout, scrollToPositionImpl],
-    );
-
-    const focusHiddenEditor = useCallback(() => {
-      if (readOnly) {
-        containerRef.current?.focus({ preventScroll: true });
-        setIsFocused(true);
+      if (target.type === "position") {
+        scrollToPositionImpl(target.pmPos);
         return;
       }
 
-      hiddenPMRef.current?.focus();
+      const pageContainer = pagesContainerRef.current;
+      const shell = pageContainer?.querySelector<HTMLElement>(
+        `[data-page-number="${String(target.pageIndex + 1)}"]`,
+      );
+      shell?.scrollIntoView({ block: "center", inline: "nearest" });
+    },
+    [layout, scrollToPositionImpl],
+  );
+
+  const focusHiddenEditor = useCallback(() => {
+    if (readOnly) {
+      containerRef.current?.focus({ preventScroll: true });
       setIsFocused(true);
-    }, [readOnly]);
+      return;
+    }
 
-    const startPointerTextSelection = useCallback(
-      (clientX: number, clientY: number) => {
-        const pmPos = getPositionFromMouse(clientX, clientY);
+    hiddenPMRef.current?.focus();
+    setIsFocused(true);
+  }, [readOnly]);
 
-        if (pmPos !== null) {
-          const cellPos = findCellPosFromPmPos(pmPos);
-          cellDragAnchorPosRef.current = cellPos;
-          isCellDraggingRef.current = false;
-          cellDragLastPmPosRef.current = null;
-          cellDragOverflowXRef.current = null;
+  const startPointerTextSelection = useCallback(
+    (clientX: number, clientY: number) => {
+      const pmPos = getPositionFromMouse(clientX, clientY);
 
+      if (pmPos !== null) {
+        const cellPos = findCellPosFromPmPos(pmPos);
+        cellDragAnchorPosRef.current = cellPos;
+        isCellDraggingRef.current = false;
+        cellDragLastPmPosRef.current = null;
+        cellDragOverflowXRef.current = null;
+
+        isDraggingRef.current = true;
+        dragAnchorRef.current = pmPos;
+        hiddenPMRef.current?.setSelection(pmPos);
+      } else {
+        cellDragAnchorPosRef.current = null;
+        isCellDraggingRef.current = false;
+        const view = hiddenPMRef.current?.getView();
+        if (view) {
+          const endPos = Math.max(0, view.state.doc.content.size - 1);
+          hiddenPMRef.current?.setSelection(endPos);
+          dragAnchorRef.current = endPos;
           isDraggingRef.current = true;
-          dragAnchorRef.current = pmPos;
-          hiddenPMRef.current?.setSelection(pmPos);
-        } else {
-          cellDragAnchorPosRef.current = null;
-          isCellDraggingRef.current = false;
-          const view = hiddenPMRef.current?.getView();
-          if (view) {
-            const endPos = Math.max(0, view.state.doc.content.size - 1);
-            hiddenPMRef.current?.setSelection(endPos);
-            dragAnchorRef.current = endPos;
-            isDraggingRef.current = true;
-          }
         }
-
-        focusHiddenEditor();
-      },
-      [findCellPosFromPmPos, focusHiddenEditor, getPositionFromMouse],
-    );
-
-    const copySelectionText = useCallback(() => {
-      const view = hiddenPMRef.current?.getView();
-      if (!view) {
-        return false;
       }
 
-      const { from, to } = view.state.selection;
-      if (from === to) {
-        return false;
-      }
+      focusHiddenEditor();
+    },
+    [findCellPosFromPmPos, focusHiddenEditor, getPositionFromMouse],
+  );
 
-      const text = view.state.doc.textBetween(from, to, "\n");
-      if (!text) {
-        return false;
-      }
-
-      // eslint-disable-next-line typescript/no-unnecessary-condition -- Clipboard API may be unavailable in older browsers or insecure contexts.
-      if (navigator.clipboard === undefined) {
-        return false;
-      }
-
-      void navigator.clipboard.writeText(text).catch(() => undefined);
+  const copySelectionText = useCallback(() => {
+    const view = hiddenPMRef.current?.getView();
+    if (!view) {
       return false;
-    }, []);
+    }
 
-    /**
-     * Handle mousedown on pages - start selection or drag.
-     */
-    const handlePagesMouseDown = useCallback(
-      (e: React.MouseEvent) => {
-        if (!hiddenPMRef.current) {
-          return;
-        }
+    const { from, to } = view.state.selection;
+    if (from === to) {
+      return false;
+    }
 
-        // Right-click: prevent default to stop Firefox from resetting selection,
-        // but don't process our selection logic
-        if (e.button === 2) {
-          e.preventDefault();
-          return;
-        }
+    const text = view.state.doc.textBetween(from, to, "\n");
+    if (!text) {
+      return false;
+    }
 
-        if (e.button !== 0) {
-          return;
-        } // Only handle left click
+    // eslint-disable-next-line typescript/no-unnecessary-condition -- Clipboard API may be unavailable in older browsers or insecure contexts.
+    if (navigator.clipboard === undefined) {
+      return false;
+    }
 
-        // Hide table insert button on any mousedown
-        setTableInsertButton(null);
-        clearTableInsertTimer();
+    void navigator.clipboard.writeText(text).catch(() => undefined);
+    return false;
+  }, []);
 
-        const target = e.target instanceof HTMLElement ? e.target : null;
-        if (!target) {
-          return;
-        }
-
-        // Prevent default browser navigation for hyperlink clicks,
-        // but let the rest of the handler run for cursor placement and drag selection.
-        // The popup is shown in handlePagesClick (on mouseup) instead.
-        const anchorClosest = target.closest("a[href]");
-        const anchorEl =
-          anchorClosest instanceof HTMLAnchorElement ? anchorClosest : null;
-        if (anchorEl) {
-          e.preventDefault(); // Prevent navigation only
-        }
-
-        // When in HF edit mode, clicks outside header/footer area close the HF editor
-        if (!readOnly && hfEditMode && onBodyClick) {
-          const isInHfArea =
-            target.closest(".layout-page-header") ||
-            target.closest(".layout-page-footer") ||
-            target.closest(".hf-inline-editor");
-          if (!isInHfArea) {
-            e.preventDefault();
-            e.stopPropagation();
-            onBodyClick();
-            return;
-          }
-        }
-
-        // In normal mode, clicks in header/footer area should place cursor at
-        // start of body content, not inside header/footer (matches Word/Google Docs)
-        if (!readOnly && !hfEditMode) {
-          const isInHfArea =
-            target.closest(".layout-page-header") ||
-            target.closest(".layout-page-footer");
-          if (isInHfArea) {
-            e.preventDefault();
-            // Place cursor at start of body content
-            hiddenPMRef.current.setSelection(0);
-            hiddenPMRef.current.focus();
-            setIsFocused(true);
-            return;
-          }
-        }
-
-        // Column resize: intercept clicks on resize handles
-        if (
-          !readOnly &&
-          target.classList.contains("layout-table-resize-handle")
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          isResizingColumnRef.current = true;
-          resizeStartXRef.current = e.clientX;
-          resizeHandleRef.current = target;
-          target.classList.add("dragging");
-
-          const colIndex = Number.parseInt(
-            target.dataset["columnIndex"] ?? "0",
-            10,
-          );
-          resizeColumnIndexRef.current = colIndex;
-          resizeTablePmStartRef.current = Number.parseInt(
-            target.dataset["tablePmStart"] ?? "0",
-            10,
-          );
-
-          // Get current column widths from the ProseMirror doc
-          const view = hiddenPMRef.current.getView();
-          if (view) {
-            const $pos = view.state.doc.resolve(
-              resizeTablePmStartRef.current + 1,
-            );
-            for (let d = $pos.depth; d >= 0; d--) {
-              const node = $pos.node(d);
-              if (node.type.name === "table") {
-                const widths = node.attrs["columnWidths"] as number[] | null;
-                if (
-                  widths &&
-                  widths[colIndex] !== undefined &&
-                  widths[colIndex + 1] !== undefined
-                ) {
-                  resizeOrigWidthsRef.current = {
-                    left: widths[colIndex]!, // SAFETY: guarded by widths[colIndex] !== undefined check above
-                    right: widths[colIndex + 1]!, // SAFETY: guarded by widths[colIndex + 1] !== undefined check above
-                  };
-                }
-                break;
-              }
-            }
-          }
-          return;
-        }
-
-        // Row resize: intercept clicks on row resize handles or bottom edge handle
-        if (
-          !readOnly &&
-          (target.classList.contains("layout-table-row-resize-handle") ||
-            target.classList.contains("layout-table-edge-handle-bottom"))
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          isResizingRowRef.current = true;
-          resizeStartYRef.current = e.clientY;
-          resizeRowHandleRef.current = target;
-          resizeRowIsEdgeRef.current = target.dataset["isEdge"] === "bottom";
-          target.classList.add("dragging");
-
-          const rowIndex = Number.parseInt(
-            target.dataset["rowIndex"] ?? "0",
-            10,
-          );
-          resizeRowIndexRef.current = rowIndex;
-          resizeRowTablePmStartRef.current = Number.parseInt(
-            target.dataset["tablePmStart"] ?? "0",
-            10,
-          );
-
-          // Get current row height from ProseMirror doc
-          const view = hiddenPMRef.current.getView();
-          if (view) {
-            const $pos = view.state.doc.resolve(
-              resizeRowTablePmStartRef.current + 1,
-            );
-            for (let d = $pos.depth; d >= 0; d--) {
-              const node = $pos.node(d);
-              if (node.type.name === "table") {
-                if (rowIndex < node.childCount) {
-                  const rowNode = node.child(rowIndex);
-                  const height = rowNode.attrs["height"] as number | null;
-                  if (height) {
-                    resizeRowOrigHeightRef.current = height;
-                  } else {
-                    // Estimate from rendered height: find the row element
-                    const tableEl = target.closest(".layout-table");
-                    const rowEl = tableEl?.querySelector(
-                      `[data-row-index="${rowIndex}"]`,
-                    );
-                    const renderedHeight =
-                      rowEl instanceof HTMLElement
-                        ? rowEl.getBoundingClientRect().height
-                        : 30;
-                    resizeRowOrigHeightRef.current = Math.round(
-                      renderedHeight * 15,
-                    );
-                  }
-                }
-                break;
-              }
-            }
-          }
-          return;
-        }
-
-        // Right edge resize: intercept clicks on right edge handle
-        if (
-          !readOnly &&
-          target.classList.contains("layout-table-edge-handle-right")
-        ) {
-          e.preventDefault();
-          e.stopPropagation();
-          isResizingRightEdgeRef.current = true;
-          resizeRightEdgeStartXRef.current = e.clientX;
-          resizeRightEdgeHandleRef.current = target;
-          target.classList.add("dragging");
-
-          const colIndex = Number.parseInt(
-            target.dataset["columnIndex"] ?? "0",
-            10,
-          );
-          resizeRightEdgeColIndexRef.current = colIndex;
-          resizeRightEdgePmStartRef.current = Number.parseInt(
-            target.dataset["tablePmStart"] ?? "0",
-            10,
-          );
-
-          // Get current last column width from ProseMirror doc
-          const view = hiddenPMRef.current.getView();
-          if (view) {
-            const $pos = view.state.doc.resolve(
-              resizeRightEdgePmStartRef.current + 1,
-            );
-            for (let d = $pos.depth; d >= 0; d--) {
-              const node = $pos.node(d);
-              if (node.type.name === "table") {
-                const widths = node.attrs["columnWidths"] as number[] | null;
-                if (widths && widths[colIndex] !== undefined) {
-                  resizeRightEdgeOrigWidthRef.current = widths[colIndex];
-                }
-                break;
-              }
-            }
-          }
-          return;
-        }
-
-        // Check if the click target is an image element
-        const imageEl = findImageElement(target);
-        if (!readOnly && imageEl) {
-          e.preventDefault();
-          e.stopPropagation();
-
-          const pmStart = imageEl.dataset["pmStart"];
-          if (pmStart !== undefined) {
-            const pos = Number.parseInt(pmStart, 10);
-            hiddenPMRef.current.setNodeSelection(pos);
-            setSelectedImageInfo(buildImageSelectionInfo(imageEl, pos));
-            setSelectionRects([]);
-            setCaretPosition(null);
-          }
-
-          focusHiddenEditor();
-          return;
-        }
-
-        // Clicking outside an image clears image selection
-        setSelectedImageInfo(null);
-
-        e.preventDefault(); // Prevent native text selection
-
-        startPointerTextSelection(e.clientX, e.clientY);
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [
-        getPositionFromMouse,
-        findCellPosFromPmPos,
-        readOnly,
-        hfEditMode,
-        onBodyClick,
-        zoom,
-        onHyperlinkClick,
-        clearTableInsertTimer,
-        focusHiddenEditor,
-        startPointerTextSelection,
-      ],
-    );
-
-    // Drag auto-scroll: scrolls when dragging near viewport edges
-    const dragAutoScrollCallbackRef = useCallback((cx: number, cy: number) => {
-      dragExtendRef.current(cx, cy);
-    }, []);
-    const {
-      updateMousePosition: updateDragScroll,
-      stopAutoScroll: stopDragAutoScroll,
-    } = useDragAutoScroll({
-      pagesContainerRef,
-      onScrollExtendSelection: dragAutoScrollCallbackRef,
-    });
-
-    // Wire up the drag-extend callback after getPositionFromMouse is available
-    dragExtendRef.current = (cx: number, cy: number) => {
-      if (!isDraggingRef.current || dragAnchorRef.current === null) {
-        return;
-      }
+  /**
+   * Handle mousedown on pages - start selection or drag.
+   */
+  const handlePagesMouseDown = useCallback(
+    (e: React.MouseEvent) => {
       if (!hiddenPMRef.current) {
         return;
       }
-      const pmPos = getPositionFromMouse(cx, cy);
+
+      // Right-click: prevent default to stop Firefox from resetting selection,
+      // but don't process our selection logic
+      if (e.button === 2) {
+        e.preventDefault();
+        return;
+      }
+
+      if (e.button !== 0) {
+        return;
+      } // Only handle left click
+
+      // Hide table insert button on any mousedown
+      setTableInsertButton(null);
+      clearTableInsertTimer();
+
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (!target) {
+        return;
+      }
+
+      // Prevent default browser navigation for hyperlink clicks,
+      // but let the rest of the handler run for cursor placement and drag selection.
+      // The popup is shown in handlePagesClick (on mouseup) instead.
+      const anchorClosest = target.closest("a[href]");
+      const anchorEl =
+        anchorClosest instanceof HTMLAnchorElement ? anchorClosest : null;
+      if (anchorEl) {
+        e.preventDefault(); // Prevent navigation only
+      }
+
+      // When in HF edit mode, clicks outside header/footer area close the HF editor
+      if (!readOnly && hfEditMode && onBodyClick) {
+        const isInHfArea =
+          target.closest(".layout-page-header") ||
+          target.closest(".layout-page-footer") ||
+          target.closest(".hf-inline-editor");
+        if (!isInHfArea) {
+          e.preventDefault();
+          e.stopPropagation();
+          onBodyClick();
+          return;
+        }
+      }
+
+      // In normal mode, clicks in header/footer area should place cursor at
+      // start of body content, not inside header/footer (matches Word/Google Docs)
+      if (!readOnly && !hfEditMode) {
+        const isInHfArea =
+          target.closest(".layout-page-header") ||
+          target.closest(".layout-page-footer");
+        if (isInHfArea) {
+          e.preventDefault();
+          // Place cursor at start of body content
+          hiddenPMRef.current.setSelection(0);
+          hiddenPMRef.current.focus();
+          setIsFocused(true);
+          return;
+        }
+      }
+
+      // Column resize: intercept clicks on resize handles
+      if (
+        !readOnly &&
+        target.classList.contains("layout-table-resize-handle")
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        isResizingColumnRef.current = true;
+        resizeStartXRef.current = e.clientX;
+        resizeHandleRef.current = target;
+        target.classList.add("dragging");
+
+        const colIndex = Number.parseInt(
+          target.dataset["columnIndex"] ?? "0",
+          10,
+        );
+        resizeColumnIndexRef.current = colIndex;
+        resizeTablePmStartRef.current = Number.parseInt(
+          target.dataset["tablePmStart"] ?? "0",
+          10,
+        );
+
+        // Get current column widths from the ProseMirror doc
+        const view = hiddenPMRef.current.getView();
+        if (view) {
+          const $pos = view.state.doc.resolve(
+            resizeTablePmStartRef.current + 1,
+          );
+          for (let d = $pos.depth; d >= 0; d--) {
+            const node = $pos.node(d);
+            if (node.type.name === "table") {
+              const widths = node.attrs["columnWidths"] as number[] | null;
+              if (
+                widths &&
+                widths[colIndex] !== undefined &&
+                widths[colIndex + 1] !== undefined
+              ) {
+                resizeOrigWidthsRef.current = {
+                  left: widths[colIndex]!, // SAFETY: guarded by widths[colIndex] !== undefined check above
+                  right: widths[colIndex + 1]!, // SAFETY: guarded by widths[colIndex + 1] !== undefined check above
+                };
+              }
+              break;
+            }
+          }
+        }
+        return;
+      }
+
+      // Row resize: intercept clicks on row resize handles or bottom edge handle
+      if (
+        !readOnly &&
+        (target.classList.contains("layout-table-row-resize-handle") ||
+          target.classList.contains("layout-table-edge-handle-bottom"))
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        isResizingRowRef.current = true;
+        resizeStartYRef.current = e.clientY;
+        resizeRowHandleRef.current = target;
+        resizeRowIsEdgeRef.current = target.dataset["isEdge"] === "bottom";
+        target.classList.add("dragging");
+
+        const rowIndex = Number.parseInt(target.dataset["rowIndex"] ?? "0", 10);
+        resizeRowIndexRef.current = rowIndex;
+        resizeRowTablePmStartRef.current = Number.parseInt(
+          target.dataset["tablePmStart"] ?? "0",
+          10,
+        );
+
+        // Get current row height from ProseMirror doc
+        const view = hiddenPMRef.current.getView();
+        if (view) {
+          const $pos = view.state.doc.resolve(
+            resizeRowTablePmStartRef.current + 1,
+          );
+          for (let d = $pos.depth; d >= 0; d--) {
+            const node = $pos.node(d);
+            if (node.type.name === "table") {
+              if (rowIndex < node.childCount) {
+                const rowNode = node.child(rowIndex);
+                const height = rowNode.attrs["height"] as number | null;
+                if (height) {
+                  resizeRowOrigHeightRef.current = height;
+                } else {
+                  // Estimate from rendered height: find the row element
+                  const tableEl = target.closest(".layout-table");
+                  const rowEl = tableEl?.querySelector(
+                    `[data-row-index="${rowIndex}"]`,
+                  );
+                  const renderedHeight =
+                    rowEl instanceof HTMLElement
+                      ? rowEl.getBoundingClientRect().height
+                      : 30;
+                  resizeRowOrigHeightRef.current = Math.round(
+                    renderedHeight * 15,
+                  );
+                }
+              }
+              break;
+            }
+          }
+        }
+        return;
+      }
+
+      // Right edge resize: intercept clicks on right edge handle
+      if (
+        !readOnly &&
+        target.classList.contains("layout-table-edge-handle-right")
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        isResizingRightEdgeRef.current = true;
+        resizeRightEdgeStartXRef.current = e.clientX;
+        resizeRightEdgeHandleRef.current = target;
+        target.classList.add("dragging");
+
+        const colIndex = Number.parseInt(
+          target.dataset["columnIndex"] ?? "0",
+          10,
+        );
+        resizeRightEdgeColIndexRef.current = colIndex;
+        resizeRightEdgePmStartRef.current = Number.parseInt(
+          target.dataset["tablePmStart"] ?? "0",
+          10,
+        );
+
+        // Get current last column width from ProseMirror doc
+        const view = hiddenPMRef.current.getView();
+        if (view) {
+          const $pos = view.state.doc.resolve(
+            resizeRightEdgePmStartRef.current + 1,
+          );
+          for (let d = $pos.depth; d >= 0; d--) {
+            const node = $pos.node(d);
+            if (node.type.name === "table") {
+              const widths = node.attrs["columnWidths"] as number[] | null;
+              if (widths && widths[colIndex] !== undefined) {
+                resizeRightEdgeOrigWidthRef.current = widths[colIndex];
+              }
+              break;
+            }
+          }
+        }
+        return;
+      }
+
+      // Check if the click target is an image element
+      const imageEl = findImageElement(target);
+      if (!readOnly && imageEl) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const pmStart = imageEl.dataset["pmStart"];
+        if (pmStart !== undefined) {
+          const pos = Number.parseInt(pmStart, 10);
+          hiddenPMRef.current.setNodeSelection(pos);
+          setSelectedImageInfo(buildImageSelectionInfo(imageEl, pos));
+          setSelectionRects([]);
+          setCaretPosition(null);
+        }
+
+        focusHiddenEditor();
+        return;
+      }
+
+      // Clicking outside an image clears image selection
+      setSelectedImageInfo(null);
+
+      e.preventDefault(); // Prevent native text selection
+
+      startPointerTextSelection(e.clientX, e.clientY);
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      getPositionFromMouse,
+      findCellPosFromPmPos,
+      readOnly,
+      hfEditMode,
+      onBodyClick,
+      zoom,
+      onHyperlinkClick,
+      clearTableInsertTimer,
+      focusHiddenEditor,
+      startPointerTextSelection,
+    ],
+  );
+
+  // Drag auto-scroll: scrolls when dragging near viewport edges
+  const dragAutoScrollCallbackRef = useCallback((cx: number, cy: number) => {
+    dragExtendRef.current(cx, cy);
+  }, []);
+  const {
+    updateMousePosition: updateDragScroll,
+    stopAutoScroll: stopDragAutoScroll,
+  } = useDragAutoScroll({
+    pagesContainerRef,
+    onScrollExtendSelection: dragAutoScrollCallbackRef,
+  });
+
+  // Wire up the drag-extend callback after getPositionFromMouse is available
+  dragExtendRef.current = (cx: number, cy: number) => {
+    if (!isDraggingRef.current || dragAnchorRef.current === null) {
+      return;
+    }
+    if (!hiddenPMRef.current) {
+      return;
+    }
+    const pmPos = getPositionFromMouse(cx, cy);
+    if (pmPos === null) {
+      return;
+    }
+    hiddenPMRef.current.setSelection(dragAnchorRef.current, pmPos);
+  };
+
+  /**
+   * Handle mousemove - extend selection during drag.
+   */
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      // Column resize drag
+      if (isResizingColumnRef.current) {
+        e.preventDefault();
+        const delta = e.clientX - resizeStartXRef.current;
+        // Move the handle visually
+        if (resizeHandleRef.current) {
+          const origLeft = Number.parseFloat(
+            resizeHandleRef.current.style.left,
+          );
+          resizeHandleRef.current.style.left = `${origLeft + delta}px`;
+          resizeStartXRef.current = e.clientX;
+
+          // Update stored widths (convert pixel delta to twips: 1px ≈ 15 twips at 96dpi)
+          const deltaTwips = Math.round(delta * 15);
+          const minWidth = 300; // ~0.2 inches minimum
+          const newLeft = resizeOrigWidthsRef.current.left + deltaTwips;
+          const newRight = resizeOrigWidthsRef.current.right - deltaTwips;
+          if (newLeft >= minWidth && newRight >= minWidth) {
+            resizeOrigWidthsRef.current = { left: newLeft, right: newRight };
+          }
+        }
+        return;
+      }
+
+      // Row resize drag
+      if (isResizingRowRef.current) {
+        e.preventDefault();
+        const delta = e.clientY - resizeStartYRef.current;
+        if (resizeRowHandleRef.current) {
+          const origTop = Number.parseFloat(
+            resizeRowHandleRef.current.style.top,
+          );
+          resizeRowHandleRef.current.style.top = `${origTop + delta}px`;
+          resizeStartYRef.current = e.clientY;
+
+          // Update stored height (convert pixel delta to twips)
+          const deltaTwips = Math.round(delta * 15);
+          const minHeight = 200; // ~0.14 inches minimum
+          const newHeight = resizeRowOrigHeightRef.current + deltaTwips;
+          if (newHeight >= minHeight) {
+            resizeRowOrigHeightRef.current = newHeight;
+          }
+        }
+        return;
+      }
+
+      // Right edge resize drag
+      if (isResizingRightEdgeRef.current) {
+        e.preventDefault();
+        const delta = e.clientX - resizeRightEdgeStartXRef.current;
+        if (resizeRightEdgeHandleRef.current) {
+          const origLeft = Number.parseFloat(
+            resizeRightEdgeHandleRef.current.style.left,
+          );
+          resizeRightEdgeHandleRef.current.style.left = `${origLeft + delta}px`;
+          resizeRightEdgeStartXRef.current = e.clientX;
+
+          // Update stored width (convert pixel delta to twips)
+          const deltaTwips = Math.round(delta * 15);
+          const minWidth = 300; // ~0.2 inches minimum
+          const newWidth = resizeRightEdgeOrigWidthRef.current + deltaTwips;
+          if (newWidth >= minWidth) {
+            resizeRightEdgeOrigWidthRef.current = newWidth;
+          }
+        }
+        return;
+      }
+
+      if (!isDraggingRef.current || dragAnchorRef.current === null) {
+        return;
+      }
+      if (!hiddenPMRef.current || !pagesContainerRef.current) {
+        return;
+      }
+
+      // Auto-scroll when dragging near viewport edges
+      updateDragScroll(e.clientX, e.clientY);
+
+      const pmPos = getPositionFromMouse(e.clientX, e.clientY);
       if (pmPos === null) {
         return;
       }
-      hiddenPMRef.current.setSelection(dragAnchorRef.current, pmPos);
-    };
 
-    /**
-     * Handle mousemove - extend selection during drag.
-     */
-    const handleMouseMove = useCallback(
-      (e: MouseEvent) => {
-        // Column resize drag
-        if (isResizingColumnRef.current) {
-          e.preventDefault();
-          const delta = e.clientX - resizeStartXRef.current;
-          // Move the handle visually
-          if (resizeHandleRef.current) {
-            const origLeft = Number.parseFloat(
-              resizeHandleRef.current.style.left,
-            );
-            resizeHandleRef.current.style.left = `${origLeft + delta}px`;
-            resizeStartXRef.current = e.clientX;
-
-            // Update stored widths (convert pixel delta to twips: 1px ≈ 15 twips at 96dpi)
-            const deltaTwips = Math.round(delta * 15);
-            const minWidth = 300; // ~0.2 inches minimum
-            const newLeft = resizeOrigWidthsRef.current.left + deltaTwips;
-            const newRight = resizeOrigWidthsRef.current.right - deltaTwips;
-            if (newLeft >= minWidth && newRight >= minWidth) {
-              resizeOrigWidthsRef.current = { left: newLeft, right: newRight };
-            }
-          }
-          return;
-        }
-
-        // Row resize drag
-        if (isResizingRowRef.current) {
-          e.preventDefault();
-          const delta = e.clientY - resizeStartYRef.current;
-          if (resizeRowHandleRef.current) {
-            const origTop = Number.parseFloat(
-              resizeRowHandleRef.current.style.top,
-            );
-            resizeRowHandleRef.current.style.top = `${origTop + delta}px`;
-            resizeStartYRef.current = e.clientY;
-
-            // Update stored height (convert pixel delta to twips)
-            const deltaTwips = Math.round(delta * 15);
-            const minHeight = 200; // ~0.14 inches minimum
-            const newHeight = resizeRowOrigHeightRef.current + deltaTwips;
-            if (newHeight >= minHeight) {
-              resizeRowOrigHeightRef.current = newHeight;
-            }
-          }
-          return;
-        }
-
-        // Right edge resize drag
-        if (isResizingRightEdgeRef.current) {
-          e.preventDefault();
-          const delta = e.clientX - resizeRightEdgeStartXRef.current;
-          if (resizeRightEdgeHandleRef.current) {
-            const origLeft = Number.parseFloat(
-              resizeRightEdgeHandleRef.current.style.left,
-            );
-            resizeRightEdgeHandleRef.current.style.left = `${origLeft + delta}px`;
-            resizeRightEdgeStartXRef.current = e.clientX;
-
-            // Update stored width (convert pixel delta to twips)
-            const deltaTwips = Math.round(delta * 15);
-            const minWidth = 300; // ~0.2 inches minimum
-            const newWidth = resizeRightEdgeOrigWidthRef.current + deltaTwips;
-            if (newWidth >= minWidth) {
-              resizeRightEdgeOrigWidthRef.current = newWidth;
-            }
-          }
-          return;
-        }
-
-        if (!isDraggingRef.current || dragAnchorRef.current === null) {
-          return;
-        }
-        if (!hiddenPMRef.current || !pagesContainerRef.current) {
-          return;
-        }
-
-        // Auto-scroll when dragging near viewport edges
-        updateDragScroll(e.clientX, e.clientY);
-
-        const pmPos = getPositionFromMouse(e.clientX, e.clientY);
-        if (pmPos === null) {
-          return;
-        }
-
-        // Dragging in table cells: text selection first, cell selection when crossing boundary
-        if (cellDragAnchorPosRef.current !== null) {
-          // If already in cell-drag mode, continue updating cell selection
-          if (isCellDraggingRef.current) {
-            const currentCellPos = findCellPosFromPmPos(pmPos);
-            if (currentCellPos !== null) {
-              hiddenPMRef.current.setCellSelection(
-                cellDragAnchorPosRef.current,
-                currentCellPos,
-              );
-              return;
-            }
-          }
-
-          // Switch to cell selection when drag crosses into a different cell
+      // Dragging in table cells: text selection first, cell selection when crossing boundary
+      if (cellDragAnchorPosRef.current !== null) {
+        // If already in cell-drag mode, continue updating cell selection
+        if (isCellDraggingRef.current) {
           const currentCellPos = findCellPosFromPmPos(pmPos);
-          if (
-            currentCellPos !== null &&
-            currentCellPos !== cellDragAnchorPosRef.current
-          ) {
-            isCellDraggingRef.current = true;
+          if (currentCellPos !== null) {
             hiddenPMRef.current.setCellSelection(
               cellDragAnchorPosRef.current,
               currentCellPos,
             );
+            return;
+          }
+        }
+
+        // Switch to cell selection when drag crosses into a different cell
+        const currentCellPos = findCellPosFromPmPos(pmPos);
+        if (
+          currentCellPos !== null &&
+          currentCellPos !== cellDragAnchorPosRef.current
+        ) {
+          isCellDraggingRef.current = true;
+          hiddenPMRef.current.setCellSelection(
+            cellDragAnchorPosRef.current,
+            currentCellPos,
+          );
+          cellDragOverflowXRef.current = null;
+          return;
+        }
+
+        // Detect when text selection has maxed out within the cell:
+        // If pmPos stops changing but mouse keeps moving, user has dragged past text content
+        if (
+          cellDragLastPmPosRef.current !== null &&
+          pmPos === cellDragLastPmPosRef.current
+        ) {
+          if (cellDragOverflowXRef.current === null) {
+            cellDragOverflowXRef.current = e.clientX;
+          } else if (
+            Math.abs(e.clientX - cellDragOverflowXRef.current) >=
+            CELL_SELECT_OVERFLOW_PX
+          ) {
+            // Overflow threshold reached — select the entire cell
+            isCellDraggingRef.current = true;
+            hiddenPMRef.current.setCellSelection(
+              cellDragAnchorPosRef.current,
+              cellDragAnchorPosRef.current,
+            );
             cellDragOverflowXRef.current = null;
             return;
           }
-
-          // Detect when text selection has maxed out within the cell:
-          // If pmPos stops changing but mouse keeps moving, user has dragged past text content
-          if (
-            cellDragLastPmPosRef.current !== null &&
-            pmPos === cellDragLastPmPosRef.current
-          ) {
-            if (cellDragOverflowXRef.current === null) {
-              cellDragOverflowXRef.current = e.clientX;
-            } else if (
-              Math.abs(e.clientX - cellDragOverflowXRef.current) >=
-              CELL_SELECT_OVERFLOW_PX
-            ) {
-              // Overflow threshold reached — select the entire cell
-              isCellDraggingRef.current = true;
-              hiddenPMRef.current.setCellSelection(
-                cellDragAnchorPosRef.current,
-                cellDragAnchorPosRef.current,
-              );
-              cellDragOverflowXRef.current = null;
-              return;
-            }
-          } else {
-            // Position is still advancing — reset overflow tracking
-            cellDragOverflowXRef.current = null;
-            cellDragLastPmPosRef.current = pmPos;
-          }
+        } else {
+          // Position is still advancing — reset overflow tracking
+          cellDragOverflowXRef.current = null;
+          cellDragLastPmPosRef.current = pmPos;
         }
-
-        // Regular text selection drag (within cell or outside tables)
-        const anchor = dragAnchorRef.current;
-        hiddenPMRef.current.setSelection(anchor, pmPos);
-      },
-      [getPositionFromMouse, findCellPosFromPmPos, updateDragScroll],
-    );
-
-    /**
-     * Handle mouseup - end drag selection.
-     */
-    const handleMouseUp = useCallback(() => {
-      // Commit column resize
-      if (isResizingColumnRef.current) {
-        isResizingColumnRef.current = false;
-        if (resizeHandleRef.current) {
-          resizeHandleRef.current.classList.remove("dragging");
-          resizeHandleRef.current = null;
-        }
-
-        // Update ProseMirror document with new column widths
-        const view = hiddenPMRef.current?.getView();
-        if (view) {
-          const pmStart = resizeTablePmStartRef.current;
-          const colIdx = resizeColumnIndexRef.current;
-          const { left: newLeft, right: newRight } =
-            resizeOrigWidthsRef.current;
-
-          // Find the table node and update columnWidths + cell widths
-          const $pos = view.state.doc.resolve(pmStart + 1);
-          for (let d = $pos.depth; d >= 0; d--) {
-            const node = $pos.node(d);
-            if (node.type.name === "table") {
-              const tablePos = $pos.before(d);
-              const tr = view.state.tr;
-              const widths = [...(node.attrs["columnWidths"] as number[])];
-              widths[colIdx] = newLeft;
-              widths[colIdx + 1] = newRight;
-
-              // Update table columnWidths attr
-              tr.setNodeMarkup(tablePos, undefined, {
-                ...node.attrs,
-                columnWidths: widths,
-              });
-
-              // Update cell width attrs in each row
-              let rowOffset = tablePos + 1;
-              // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-              node.forEach((row) => {
-                let cellOffset = rowOffset + 1;
-                let cellColIdx = 0;
-                // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-                row.forEach((cell) => {
-                  const colspan = (cell.attrs["colspan"] as number) || 1;
-                  if (cellColIdx === colIdx || cellColIdx === colIdx + 1) {
-                    const newWidth = cellColIdx === colIdx ? newLeft : newRight;
-                    tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
-                      ...cell.attrs,
-                      width: newWidth,
-                      widthType: "dxa",
-                      colwidth: null,
-                    });
-                  }
-                  cellOffset += cell.nodeSize;
-                  cellColIdx += colspan;
-                });
-                rowOffset += row.nodeSize;
-              });
-
-              view.dispatch(tr);
-              break;
-            }
-          }
-        }
-        return;
       }
 
-      // Commit row resize
-      if (isResizingRowRef.current) {
-        isResizingRowRef.current = false;
-        if (resizeRowHandleRef.current) {
-          resizeRowHandleRef.current.classList.remove("dragging");
-          resizeRowHandleRef.current = null;
-        }
+      // Regular text selection drag (within cell or outside tables)
+      const anchor = dragAnchorRef.current;
+      hiddenPMRef.current.setSelection(anchor, pmPos);
+    },
+    [getPositionFromMouse, findCellPosFromPmPos, updateDragScroll],
+  );
 
-        const view = hiddenPMRef.current?.getView();
-        if (view) {
-          const pmStart = resizeRowTablePmStartRef.current;
-          const rowIdx = resizeRowIndexRef.current;
-          const newHeight = resizeRowOrigHeightRef.current;
+  /**
+   * Handle mouseup - end drag selection.
+   */
+  const handleMouseUp = useCallback(() => {
+    // Commit column resize
+    if (isResizingColumnRef.current) {
+      isResizingColumnRef.current = false;
+      if (resizeHandleRef.current) {
+        resizeHandleRef.current.classList.remove("dragging");
+        resizeHandleRef.current = null;
+      }
 
-          const $pos = view.state.doc.resolve(pmStart + 1);
-          for (let d = $pos.depth; d >= 0; d--) {
-            const node = $pos.node(d);
-            if (node.type.name === "table") {
-              const tablePos = $pos.before(d);
-              const tr = view.state.tr;
+      // Update ProseMirror document with new column widths
+      const view = hiddenPMRef.current?.getView();
+      if (view) {
+        const pmStart = resizeTablePmStartRef.current;
+        const colIdx = resizeColumnIndexRef.current;
+        const { left: newLeft, right: newRight } = resizeOrigWidthsRef.current;
 
-              // Walk to the target row
-              let rowOffset = tablePos + 1;
-              let idx = 0;
+        // Find the table node and update columnWidths + cell widths
+        const $pos = view.state.doc.resolve(pmStart + 1);
+        for (let d = $pos.depth; d >= 0; d--) {
+          const node = $pos.node(d);
+          if (node.type.name === "table") {
+            const tablePos = $pos.before(d);
+            const tr = view.state.tr;
+            const widths = [...(node.attrs["columnWidths"] as number[])];
+            widths[colIdx] = newLeft;
+            widths[colIdx + 1] = newRight;
+
+            // Update table columnWidths attr
+            tr.setNodeMarkup(tablePos, undefined, {
+              ...node.attrs,
+              columnWidths: widths,
+            });
+
+            // Update cell width attrs in each row
+            let rowOffset = tablePos + 1;
+            // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
+            node.forEach((row) => {
+              let cellOffset = rowOffset + 1;
+              let cellColIdx = 0;
               // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-              node.forEach((row) => {
-                if (idx === rowIdx) {
-                  tr.setNodeMarkup(tr.mapping.map(rowOffset), undefined, {
-                    ...row.attrs,
-                    height: newHeight,
-                    heightRule: "atLeast",
+              row.forEach((cell) => {
+                const colspan = (cell.attrs["colspan"] as number) || 1;
+                if (cellColIdx === colIdx || cellColIdx === colIdx + 1) {
+                  const newWidth = cellColIdx === colIdx ? newLeft : newRight;
+                  tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
+                    ...cell.attrs,
+                    width: newWidth,
+                    widthType: "dxa",
+                    colwidth: null,
                   });
                 }
-                rowOffset += row.nodeSize;
-                idx++;
+                cellOffset += cell.nodeSize;
+                cellColIdx += colspan;
               });
+              rowOffset += row.nodeSize;
+            });
 
-              view.dispatch(tr);
-              break;
-            }
+            view.dispatch(tr);
+            break;
           }
         }
-        return;
+      }
+      return;
+    }
+
+    // Commit row resize
+    if (isResizingRowRef.current) {
+      isResizingRowRef.current = false;
+      if (resizeRowHandleRef.current) {
+        resizeRowHandleRef.current.classList.remove("dragging");
+        resizeRowHandleRef.current = null;
       }
 
-      // Commit right edge resize
-      if (isResizingRightEdgeRef.current) {
-        isResizingRightEdgeRef.current = false;
-        if (resizeRightEdgeHandleRef.current) {
-          resizeRightEdgeHandleRef.current.classList.remove("dragging");
-          resizeRightEdgeHandleRef.current = null;
+      const view = hiddenPMRef.current?.getView();
+      if (view) {
+        const pmStart = resizeRowTablePmStartRef.current;
+        const rowIdx = resizeRowIndexRef.current;
+        const newHeight = resizeRowOrigHeightRef.current;
+
+        const $pos = view.state.doc.resolve(pmStart + 1);
+        for (let d = $pos.depth; d >= 0; d--) {
+          const node = $pos.node(d);
+          if (node.type.name === "table") {
+            const tablePos = $pos.before(d);
+            const tr = view.state.tr;
+
+            // Walk to the target row
+            let rowOffset = tablePos + 1;
+            let idx = 0;
+            // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
+            node.forEach((row) => {
+              if (idx === rowIdx) {
+                tr.setNodeMarkup(tr.mapping.map(rowOffset), undefined, {
+                  ...row.attrs,
+                  height: newHeight,
+                  heightRule: "atLeast",
+                });
+              }
+              rowOffset += row.nodeSize;
+              idx++;
+            });
+
+            view.dispatch(tr);
+            break;
+          }
         }
+      }
+      return;
+    }
 
-        const view = hiddenPMRef.current?.getView();
-        if (view) {
-          const pmStart = resizeRightEdgePmStartRef.current;
-          const colIdx = resizeRightEdgeColIndexRef.current;
-          const newWidth = resizeRightEdgeOrigWidthRef.current;
+    // Commit right edge resize
+    if (isResizingRightEdgeRef.current) {
+      isResizingRightEdgeRef.current = false;
+      if (resizeRightEdgeHandleRef.current) {
+        resizeRightEdgeHandleRef.current.classList.remove("dragging");
+        resizeRightEdgeHandleRef.current = null;
+      }
 
-          const $pos = view.state.doc.resolve(pmStart + 1);
-          for (let d = $pos.depth; d >= 0; d--) {
-            const node = $pos.node(d);
-            if (node.type.name === "table") {
-              const tablePos = $pos.before(d);
-              const tr = view.state.tr;
+      const view = hiddenPMRef.current?.getView();
+      if (view) {
+        const pmStart = resizeRightEdgePmStartRef.current;
+        const colIdx = resizeRightEdgeColIndexRef.current;
+        const newWidth = resizeRightEdgeOrigWidthRef.current;
 
-              // Update columnWidths — only change last column
-              const widths = [...(node.attrs["columnWidths"] as number[])];
-              widths[colIdx] = newWidth;
+        const $pos = view.state.doc.resolve(pmStart + 1);
+        for (let d = $pos.depth; d >= 0; d--) {
+          const node = $pos.node(d);
+          if (node.type.name === "table") {
+            const tablePos = $pos.before(d);
+            const tr = view.state.tr;
 
-              tr.setNodeMarkup(tablePos, undefined, {
-                ...node.attrs,
-                columnWidths: widths,
-              });
+            // Update columnWidths — only change last column
+            const widths = [...(node.attrs["columnWidths"] as number[])];
+            widths[colIdx] = newWidth;
 
-              // Update cell width attrs in the last column of each row
-              let rowOffset = tablePos + 1;
+            tr.setNodeMarkup(tablePos, undefined, {
+              ...node.attrs,
+              columnWidths: widths,
+            });
+
+            // Update cell width attrs in the last column of each row
+            let rowOffset = tablePos + 1;
+            // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
+            node.forEach((row) => {
+              let cellOffset = rowOffset + 1;
+              let cellColIdx = 0;
               // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-              node.forEach((row) => {
-                let cellOffset = rowOffset + 1;
-                let cellColIdx = 0;
-                // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
-                row.forEach((cell) => {
-                  const colspan = (cell.attrs["colspan"] as number) || 1;
-                  if (cellColIdx === colIdx) {
-                    tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
-                      ...cell.attrs,
-                      width: newWidth,
-                      widthType: "dxa",
-                      colwidth: null,
-                    });
-                  }
-                  cellOffset += cell.nodeSize;
-                  cellColIdx += colspan;
-                });
-                rowOffset += row.nodeSize;
+              row.forEach((cell) => {
+                const colspan = (cell.attrs["colspan"] as number) || 1;
+                if (cellColIdx === colIdx) {
+                  tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
+                    ...cell.attrs,
+                    width: newWidth,
+                    widthType: "dxa",
+                    colwidth: null,
+                  });
+                }
+                cellOffset += cell.nodeSize;
+                cellColIdx += colspan;
               });
+              rowOffset += row.nodeSize;
+            });
 
-              view.dispatch(tr);
-              break;
-            }
+            view.dispatch(tr);
+            break;
           }
         }
-        return;
       }
+      return;
+    }
 
-      isDraggingRef.current = false;
-      isCellDraggingRef.current = false;
-      cellDragLastPmPosRef.current = null;
-      cellDragOverflowXRef.current = null;
-      stopDragAutoScroll();
-      // Keep dragAnchorRef for potential shift-click extension
-    }, [stopDragAutoScroll]);
+    isDraggingRef.current = false;
+    isCellDraggingRef.current = false;
+    cellDragLastPmPosRef.current = null;
+    cellDragOverflowXRef.current = null;
+    stopDragAutoScroll();
+    // Keep dragAnchorRef for potential shift-click extension
+  }, [stopDragAutoScroll]);
 
-    // Add global mouse event listeners for drag selection
-    useEffect(() => {
-      window.addEventListener("mousemove", handleMouseMove);
-      window.addEventListener("mouseup", handleMouseUp);
+  // Add global mouse event listeners for drag selection
+  useEffect(() => {
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", handleMouseUp);
 
-      return () => {
-        window.removeEventListener("mousemove", handleMouseMove);
-        window.removeEventListener("mouseup", handleMouseUp);
-      };
-    }, [handleMouseMove, handleMouseUp]);
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [handleMouseMove, handleMouseUp]);
 
-    /**
-     * Handle mousemove on pages to show table row/column insert buttons.
-     * Detects proximity to table row/column boundaries and shows a floating "+" button.
-     */
-    const handlePagesMouseMove = useCallback(
-      (e: React.MouseEvent) => {
-        // Skip during drags / resizes
-        if (
-          readOnly ||
-          isDraggingRef.current ||
-          isResizingColumnRef.current ||
-          isResizingRowRef.current ||
-          isResizingRightEdgeRef.current ||
-          isCellDraggingRef.current
-        ) {
-          return;
-        }
-
-        const pagesEl = pagesContainerRef.current;
-        if (!pagesEl) {
-          return;
-        }
-
-        const mouseX = e.clientX;
-        const mouseY = e.clientY;
-
-        // Find the table — either directly under the cursor or nearby (for edge hover)
-        const eventTarget = e.target instanceof HTMLElement ? e.target : null;
-        let tableEl = eventTarget
-          ? closestHtmlElement(eventTarget, ".layout-table")
-          : null;
-        if (!tableEl) {
-          // Mouse may be in the margin area near a table — check all tables
-          const tables = htmlQueryAll(pagesEl, ".layout-table");
-          for (const t of tables) {
-            const r = t.getBoundingClientRect();
-            const nearLeft =
-              mouseX >= r.left - TABLE_INSERT_EDGE_PROXIMITY && mouseX < r.left;
-            const nearTop =
-              mouseY >= r.top - TABLE_INSERT_EDGE_PROXIMITY && mouseY < r.top;
-            const withinX =
-              mouseX >= r.left - TABLE_INSERT_EDGE_PROXIMITY &&
-              mouseX <= r.right;
-            const withinY =
-              mouseY >= r.top - TABLE_INSERT_EDGE_PROXIMITY &&
-              mouseY <= r.bottom;
-            if ((nearLeft && withinY) || (nearTop && withinX)) {
-              tableEl = t;
-              break;
-            }
-          }
-        }
-
-        if (!tableEl) {
-          setTableInsertButton(null);
-          return;
-        }
-
-        const tableRect = tableEl.getBoundingClientRect();
-
-        const nearLeftEdge =
-          mouseX < tableRect.left + TABLE_INSERT_EDGE_PROXIMITY &&
-          mouseX >= tableRect.left - TABLE_INSERT_EDGE_PROXIMITY;
-        const nearTopEdge =
-          mouseY < tableRect.top + TABLE_INSERT_EDGE_PROXIMITY &&
-          mouseY >= tableRect.top - TABLE_INSERT_EDGE_PROXIMITY;
-
-        if (!nearLeftEdge && !nearTopEdge) {
-          setTableInsertButton(null);
-          return;
-        }
-
-        const rows = tableEl.querySelectorAll(":scope > .layout-table-row");
-        if (rows.length === 0) {
-          setTableInsertButton(null);
-          return;
-        }
-
-        const viewportEl = pagesEl.parentElement;
-        if (!viewportEl) {
-          return;
-        }
-        const viewportRect = viewportEl.getBoundingClientRect();
-
-        /** Extract PM position from a cell element */
-        const getCellPmPos = (el: HTMLElement | null): number =>
-          el ? Number(el.dataset["pmStart"]) || 0 : 0;
-
-        // Show button centered on the hovered row (left edge hover)
-        if (nearLeftEdge) {
-          for (const row of rows) {
-            const rowRect = row.getBoundingClientRect();
-            if (mouseY >= rowRect.top && mouseY <= rowRect.bottom) {
-              const cell = queryHtmlElement(row, ".layout-table-cell");
-              const pmPos = getCellPmPos(cell);
-              if (!pmPos) {
-                break;
-              }
-              const rowCenterY = rowRect.top + rowRect.height / 2;
-              setTableInsertButton({
-                type: "row",
-                x: tableRect.left - viewportRect.left - 24,
-                y: rowCenterY - viewportRect.top - 10,
-                cellPmPos: pmPos,
-              });
-              clearTableInsertTimer();
-              return;
-            }
-          }
-        }
-
-        // Show button centered on the hovered column (top edge hover)
-        if (nearTopEdge && rows[0]) {
-          const cells = htmlQueryAll(rows[0], ":scope > .layout-table-cell");
-          for (const cellEl of cells) {
-            const cellRect = cellEl.getBoundingClientRect();
-            if (mouseX >= cellRect.left && mouseX <= cellRect.right) {
-              const pmPos = getCellPmPos(cellEl);
-              if (!pmPos) {
-                break;
-              }
-              const cellCenterX = cellRect.left + cellRect.width / 2;
-              setTableInsertButton({
-                type: "column",
-                x: cellCenterX - viewportRect.left - 10,
-                y: tableRect.top - viewportRect.top - 24,
-                cellPmPos: pmPos,
-              });
-              clearTableInsertTimer();
-              return;
-            }
-          }
-        }
-
-        // Not over any row/column — schedule hide with a small delay
-        if (!tableInsertHideTimerRef.current) {
-          tableInsertHideTimerRef.current = setTimeout(() => {
-            setTableInsertButton(null);
-            tableInsertHideTimerRef.current = null;
-          }, TABLE_INSERT_HIDE_DELAY);
-        }
-      },
-      [readOnly, clearTableInsertTimer],
-    );
-
-    /**
-     * Handle table insert button click — set selection to target cell, then insert.
-     */
-    const handleTableInsertClick = useCallback(
-      (e: React.MouseEvent) => {
-        e.preventDefault();
-        e.stopPropagation();
-        if (!tableInsertButton || !hiddenPMRef.current) {
-          return;
-        }
-
-        const view = hiddenPMRef.current.getView();
-        if (!view) {
-          return;
-        }
-
-        const { type, cellPmPos } = tableInsertButton;
-
-        // Set selection inside the target cell
-        const tr = view.state.tr.setSelection(
-          TextSelection.create(view.state.doc, cellPmPos + 1),
-        );
-        view.dispatch(tr);
-
-        // Dispatch the appropriate insert command
-        if (type === "row") {
-          addRowBelow(view.state, view.dispatch);
-        } else {
-          addColumnRight(view.state, view.dispatch);
-        }
-
-        setTableInsertButton(null);
-        hiddenPMRef.current.focus();
-      },
-      [tableInsertButton],
-    );
-
-    /**
-     * Handle click on pages container (for double-click word selection).
-     */
-    const handlePagesClick = useCallback(
-      (e: React.MouseEvent) => {
-        const target = e.target instanceof HTMLElement ? e.target : null;
-        if (!target) {
-          return;
-        }
-        // Handle hyperlink clicks (single-click only, not drag-to-select)
-        const anchorClosest = target.closest("a[href]");
-        const anchorEl =
-          anchorClosest instanceof HTMLAnchorElement ? anchorClosest : null;
-        if (anchorEl) {
-          e.preventDefault();
-          const href = anchorEl.getAttribute("href") || "";
-          if (href.startsWith("#")) {
-            // Internal bookmark — navigate within document
-            const bookmarkName = href.slice(1);
-            if (bookmarkName && hiddenPMRef.current) {
-              const view = hiddenPMRef.current.getView();
-              if (view) {
-                const targetPos = { value: null as number | null };
-                view.state.doc.descendants((node, pos) => {
-                  if (targetPos.value !== null) {
-                    return false;
-                  }
-                  if (node.type.name === "paragraph") {
-                    const bookmarks = node.attrs["bookmarks"] as
-                      | { id: number; name: string }[]
-                      | undefined;
-                    if (bookmarks?.some((b) => b.name === bookmarkName)) {
-                      targetPos.value = pos;
-                      return false;
-                    }
-                  }
-                  return undefined;
-                });
-                if (targetPos.value !== null) {
-                  const tp = targetPos.value;
-                  scrollToPositionImpl(tp);
-                  hiddenPMRef.current.setSelection(tp + 1);
-                }
-              }
-            }
-          } else if (onHyperlinkClick) {
-            // External hyperlink — show popup only if not a drag-to-select
-            const view = hiddenPMRef.current?.getView();
-            const hasRangeSelection =
-              view && view.state.selection.from !== view.state.selection.to;
-            if (!hasRangeSelection) {
-              const displayText = anchorEl.textContent || "";
-              const tooltip = anchorEl.getAttribute("title") || undefined;
-              const clickData: Parameters<
-                NonNullable<typeof onHyperlinkClick>
-              >[0] = { href, displayText, anchorEl };
-              if (tooltip) {
-                clickData.tooltip = tooltip;
-              }
-              onHyperlinkClick(clickData);
-            }
-          }
-          // External links: already handled by mousedown, just prevent default
-          return;
-        }
-
-        // Double-click on header/footer area triggers editing mode
-        if (!readOnly && e.detail === 2 && onHeaderFooterDoubleClick) {
-          const headerEl = target.closest(".layout-page-header");
-          const footerEl = target.closest(".layout-page-footer");
-          if (headerEl || footerEl) {
-            const pageEl = closestHtmlElement(target, "[data-page-number]");
-            const pageNum = pageEl ? Number(pageEl.dataset["pageNumber"]) : 1;
-            if (headerEl) {
-              e.preventDefault();
-              e.stopPropagation();
-              onHeaderFooterDoubleClick("header", pageNum);
-              return;
-            }
-            if (footerEl) {
-              e.preventDefault();
-              e.stopPropagation();
-              onHeaderFooterDoubleClick("footer", pageNum);
-              return;
-            }
-          }
-        }
-
-        // Double-click: select entire cell (CellSelection) if in table, otherwise word selection
-        if (e.detail === 2 && hiddenPMRef.current) {
-          const pmPos = getPositionFromMouse(e.clientX, e.clientY);
-          if (pmPos !== null) {
-            // If inside a table cell, select the entire cell
-            const cellPos = findCellPosFromPmPos(pmPos);
-            if (cellPos !== null) {
-              e.preventDefault();
-              e.stopPropagation();
-              hiddenPMRef.current.setCellSelection(cellPos, cellPos);
-              return;
-            }
-
-            const view = hiddenPMRef.current.getView();
-            if (view) {
-              const { doc } = view.state;
-              const $pos = doc.resolve(pmPos);
-              const parent = $pos.parent;
-
-              // Find word boundaries.
-              if (parent.isTextblock) {
-                // Build a string aligned 1-to-1 with PM
-                // offsets inside the parent. Atom inline
-                // nodes (tab, hard_break, image) take 1 PM
-                // position but don't appear in
-                // `textContent`, so a tab at offset 0 +
-                // text "(a)" + tab at offset 4 + text
-                // "Equity Financing" has parentSize 21
-                // but textContent length 19. Walking
-                // word boundaries on `textContent` and
-                // then writing back via `$pos.start() +
-                // offset` shifts the resulting selection
-                // by one PM position per atom skipped —
-                // double-clicking "Financing" in such a
-                // paragraph selected "y Financin"
-                // instead. Padding atom nodes with a
-                // non-word character keeps every offset
-                // in PM-position space.
-                const pmAlignedParts: string[] = [];
-                for (let i = 0; i < parent.content.childCount; i++) {
-                  const node = parent.content.child(i);
-                  pmAlignedParts.push(
-                    node.isText ? (node.text ?? "") : " ".repeat(node.nodeSize),
-                  );
-                }
-                const pmAlignedText = pmAlignedParts.join("");
-                const offset = $pos.parentOffset;
-
-                // Find word start (go back until whitespace/punctuation)
-                let start = offset;
-                while (start > 0 && /\w/u.test(pmAlignedText[start - 1]!)) {
-                  // SAFETY: start > 0
-                  start--;
-                }
-
-                // Find word end (go forward until whitespace/punctuation)
-                let end = offset;
-                while (
-                  end < pmAlignedText.length &&
-                  /\w/u.test(pmAlignedText[end]!)
-                ) {
-                  // SAFETY: end < pmAlignedText.length
-                  end++;
-                }
-
-                // Convert to absolute positions
-                const absStart = $pos.start() + start;
-                const absEnd = $pos.start() + end;
-
-                if (absStart < absEnd) {
-                  hiddenPMRef.current.setSelection(absStart, absEnd);
-                }
-              }
-            }
-          }
-        }
-        // Triple-click for paragraph selection
-        if (e.detail === 3 && hiddenPMRef.current) {
-          const pmPos = getPositionFromMouse(e.clientX, e.clientY);
-          if (pmPos !== null) {
-            const view = hiddenPMRef.current.getView();
-            if (view) {
-              const { doc } = view.state;
-              const $pos = doc.resolve(pmPos);
-
-              // Find paragraph start and end
-              const paragraphStart = $pos.start($pos.depth);
-              const paragraphEnd = $pos.end($pos.depth);
-
-              hiddenPMRef.current.setSelection(paragraphStart, paragraphEnd);
-            }
-          }
-        }
-      },
-      // oxlint-disable-next-line react-hooks/exhaustive-deps
-      [
-        getPositionFromMouse,
-        onHeaderFooterDoubleClick,
-        onHyperlinkClick,
-        readOnly,
-      ],
-    );
-
-    /**
-     * Handle right-click on pages — set/preserve selection and show context menu.
-     */
-    const handlePagesContextMenu = useCallback(
-      (e: React.MouseEvent) => {
-        if (!onContextMenu) {
-          return;
-        } // No handler, let browser default
-
-        e.preventDefault();
-
-        const view = hiddenPMRef.current?.getView();
-        if (!view) {
-          return;
-        }
-
-        const { from, to } = view.state.selection;
-        const pmPos = getPositionFromMouse(e.clientX, e.clientY);
-
-        // If the right-click is within the existing selection, keep it
-        // Otherwise, move cursor to the right-click position
-        if (pmPos !== null && (from === to || pmPos < from || pmPos > to)) {
-          hiddenPMRef.current?.setSelection(pmPos);
-          hiddenPMRef.current?.focus();
-          setIsFocused(true);
-        }
-
-        // Read updated selection state after potential change
-        const updatedState = hiddenPMRef.current?.getState();
-        const hasSelection = updatedState
-          ? updatedState.selection.from !== updatedState.selection.to
-          : false;
-
-        onContextMenu({ x: e.clientX, y: e.clientY, hasSelection });
-      },
-      [onContextMenu, getPositionFromMouse],
-    );
-
-    /**
-     * Handle focus on container - redirect to hidden PM.
-     */
-    const handleContainerFocus = useCallback(
-      (e: React.FocusEvent) => {
-        // Don't steal focus from sidebar inputs (textareas, inputs, buttons)
-        if (
-          e.target instanceof HTMLElement &&
-          e.target.closest(".docx-comments-sidebar")
-        ) {
-          return;
-        }
-        focusHiddenEditor();
-      },
-      [focusHiddenEditor],
-    );
-
-    /**
-     * Handle blur from container.
-     */
-    const handleContainerBlur = useCallback((e: React.FocusEvent) => {
-      // Check if focus is moving to hidden PM or staying within container
-      const relatedTarget =
-        e.relatedTarget instanceof HTMLElement ? e.relatedTarget : null;
-      if (relatedTarget && containerRef.current?.contains(relatedTarget)) {
-        return; // Focus staying within editor
-      }
-      // Keep selection visible when focus moves to toolbar or dropdown portals
+  /**
+   * Handle mousemove on pages to show table row/column insert buttons.
+   * Detects proximity to table row/column boundaries and shows a floating "+" button.
+   */
+  const handlePagesMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      // Skip during drags / resizes
       if (
-        relatedTarget?.closest(
-          '[role="toolbar"], [data-radix-popper-content-wrapper], [data-radix-select-content], .docx-table-options-dropdown',
-        )
+        readOnly ||
+        isDraggingRef.current ||
+        isResizingColumnRef.current ||
+        isResizingRowRef.current ||
+        isResizingRightEdgeRef.current ||
+        isCellDraggingRef.current
       ) {
         return;
       }
-      setIsFocused(false);
-    }, []);
 
-    /**
-     * Handle image resize from the overlay.
-     */
-    const handleImageResize = useCallback(
-      (pmPos: number, newWidth: number, newHeight: number) => {
-        const view = hiddenPMRef.current?.getView();
-        if (!view) {
+      const pagesEl = pagesContainerRef.current;
+      if (!pagesEl) {
+        return;
+      }
+
+      const mouseX = e.clientX;
+      const mouseY = e.clientY;
+
+      // Find the table — either directly under the cursor or nearby (for edge hover)
+      const eventTarget = e.target instanceof HTMLElement ? e.target : null;
+      let tableEl = eventTarget
+        ? closestHtmlElement(eventTarget, ".layout-table")
+        : null;
+      if (!tableEl) {
+        // Mouse may be in the margin area near a table — check all tables
+        const tables = htmlQueryAll(pagesEl, ".layout-table");
+        for (const t of tables) {
+          const r = t.getBoundingClientRect();
+          const nearLeft =
+            mouseX >= r.left - TABLE_INSERT_EDGE_PROXIMITY && mouseX < r.left;
+          const nearTop =
+            mouseY >= r.top - TABLE_INSERT_EDGE_PROXIMITY && mouseY < r.top;
+          const withinX =
+            mouseX >= r.left - TABLE_INSERT_EDGE_PROXIMITY && mouseX <= r.right;
+          const withinY =
+            mouseY >= r.top - TABLE_INSERT_EDGE_PROXIMITY && mouseY <= r.bottom;
+          if ((nearLeft && withinY) || (nearTop && withinX)) {
+            tableEl = t;
+            break;
+          }
+        }
+      }
+
+      if (!tableEl) {
+        setTableInsertButton(null);
+        return;
+      }
+
+      const tableRect = tableEl.getBoundingClientRect();
+
+      const nearLeftEdge =
+        mouseX < tableRect.left + TABLE_INSERT_EDGE_PROXIMITY &&
+        mouseX >= tableRect.left - TABLE_INSERT_EDGE_PROXIMITY;
+      const nearTopEdge =
+        mouseY < tableRect.top + TABLE_INSERT_EDGE_PROXIMITY &&
+        mouseY >= tableRect.top - TABLE_INSERT_EDGE_PROXIMITY;
+
+      if (!nearLeftEdge && !nearTopEdge) {
+        setTableInsertButton(null);
+        return;
+      }
+
+      const rows = tableEl.querySelectorAll(":scope > .layout-table-row");
+      if (rows.length === 0) {
+        setTableInsertButton(null);
+        return;
+      }
+
+      const viewportEl = pagesEl.parentElement;
+      if (!viewportEl) {
+        return;
+      }
+      const viewportRect = viewportEl.getBoundingClientRect();
+
+      /** Extract PM position from a cell element */
+      const getCellPmPos = (el: HTMLElement | null): number =>
+        el ? Number(el.dataset["pmStart"]) || 0 : 0;
+
+      // Show button centered on the hovered row (left edge hover)
+      if (nearLeftEdge) {
+        for (const row of rows) {
+          const rowRect = row.getBoundingClientRect();
+          if (mouseY >= rowRect.top && mouseY <= rowRect.bottom) {
+            const cell = queryHtmlElement(row, ".layout-table-cell");
+            const pmPos = getCellPmPos(cell);
+            if (!pmPos) {
+              break;
+            }
+            const rowCenterY = rowRect.top + rowRect.height / 2;
+            setTableInsertButton({
+              type: "row",
+              x: tableRect.left - viewportRect.left - 24,
+              y: rowCenterY - viewportRect.top - 10,
+              cellPmPos: pmPos,
+            });
+            clearTableInsertTimer();
+            return;
+          }
+        }
+      }
+
+      // Show button centered on the hovered column (top edge hover)
+      if (nearTopEdge && rows[0]) {
+        const cells = htmlQueryAll(rows[0], ":scope > .layout-table-cell");
+        for (const cellEl of cells) {
+          const cellRect = cellEl.getBoundingClientRect();
+          if (mouseX >= cellRect.left && mouseX <= cellRect.right) {
+            const pmPos = getCellPmPos(cellEl);
+            if (!pmPos) {
+              break;
+            }
+            const cellCenterX = cellRect.left + cellRect.width / 2;
+            setTableInsertButton({
+              type: "column",
+              x: cellCenterX - viewportRect.left - 10,
+              y: tableRect.top - viewportRect.top - 24,
+              cellPmPos: pmPos,
+            });
+            clearTableInsertTimer();
+            return;
+          }
+        }
+      }
+
+      // Not over any row/column — schedule hide with a small delay
+      if (!tableInsertHideTimerRef.current) {
+        tableInsertHideTimerRef.current = setTimeout(() => {
+          setTableInsertButton(null);
+          tableInsertHideTimerRef.current = null;
+        }, TABLE_INSERT_HIDE_DELAY);
+      }
+    },
+    [readOnly, clearTableInsertTimer],
+  );
+
+  /**
+   * Handle table insert button click — set selection to target cell, then insert.
+   */
+  const handleTableInsertClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (!tableInsertButton || !hiddenPMRef.current) {
+        return;
+      }
+
+      const view = hiddenPMRef.current.getView();
+      if (!view) {
+        return;
+      }
+
+      const { type, cellPmPos } = tableInsertButton;
+
+      // Set selection inside the target cell
+      const tr = view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, cellPmPos + 1),
+      );
+      view.dispatch(tr);
+
+      // Dispatch the appropriate insert command
+      if (type === "row") {
+        addRowBelow(view.state, view.dispatch);
+      } else {
+        addColumnRight(view.state, view.dispatch);
+      }
+
+      setTableInsertButton(null);
+      hiddenPMRef.current.focus();
+    },
+    [tableInsertButton],
+  );
+
+  /**
+   * Handle click on pages container (for double-click word selection).
+   */
+  const handlePagesClick = useCallback(
+    (e: React.MouseEvent) => {
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (!target) {
+        return;
+      }
+      // Handle hyperlink clicks (single-click only, not drag-to-select)
+      const anchorClosest = target.closest("a[href]");
+      const anchorEl =
+        anchorClosest instanceof HTMLAnchorElement ? anchorClosest : null;
+      if (anchorEl) {
+        e.preventDefault();
+        const href = anchorEl.getAttribute("href") || "";
+        if (href.startsWith("#")) {
+          // Internal bookmark — navigate within document
+          const bookmarkName = href.slice(1);
+          if (bookmarkName && hiddenPMRef.current) {
+            const view = hiddenPMRef.current.getView();
+            if (view) {
+              const targetPos = { value: null as number | null };
+              view.state.doc.descendants((node, pos) => {
+                if (targetPos.value !== null) {
+                  return false;
+                }
+                if (node.type.name === "paragraph") {
+                  const bookmarks = node.attrs["bookmarks"] as
+                    | { id: number; name: string }[]
+                    | undefined;
+                  if (bookmarks?.some((b) => b.name === bookmarkName)) {
+                    targetPos.value = pos;
+                    return false;
+                  }
+                }
+                return undefined;
+              });
+              if (targetPos.value !== null) {
+                const tp = targetPos.value;
+                scrollToPositionImpl(tp);
+                hiddenPMRef.current.setSelection(tp + 1);
+              }
+            }
+          }
+        } else if (onHyperlinkClick) {
+          // External hyperlink — show popup only if not a drag-to-select
+          const view = hiddenPMRef.current?.getView();
+          const hasRangeSelection =
+            view && view.state.selection.from !== view.state.selection.to;
+          if (!hasRangeSelection) {
+            const displayText = anchorEl.textContent || "";
+            const tooltip = anchorEl.getAttribute("title") || undefined;
+            const clickData: Parameters<
+              NonNullable<typeof onHyperlinkClick>
+            >[0] = { href, displayText, anchorEl };
+            if (tooltip) {
+              clickData.tooltip = tooltip;
+            }
+            onHyperlinkClick(clickData);
+          }
+        }
+        // External links: already handled by mousedown, just prevent default
+        return;
+      }
+
+      // Double-click on header/footer area triggers editing mode
+      if (!readOnly && e.detail === 2 && onHeaderFooterDoubleClick) {
+        const headerEl = target.closest(".layout-page-header");
+        const footerEl = target.closest(".layout-page-footer");
+        if (headerEl || footerEl) {
+          const pageEl = closestHtmlElement(target, "[data-page-number]");
+          const pageNum = pageEl ? Number(pageEl.dataset["pageNumber"]) : 1;
+          if (headerEl) {
+            e.preventDefault();
+            e.stopPropagation();
+            onHeaderFooterDoubleClick("header", pageNum);
+            return;
+          }
+          if (footerEl) {
+            e.preventDefault();
+            e.stopPropagation();
+            onHeaderFooterDoubleClick("footer", pageNum);
+            return;
+          }
+        }
+      }
+
+      // Double-click: select entire cell (CellSelection) if in table, otherwise word selection
+      if (e.detail === 2 && hiddenPMRef.current) {
+        const pmPos = getPositionFromMouse(e.clientX, e.clientY);
+        if (pmPos !== null) {
+          // If inside a table cell, select the entire cell
+          const cellPos = findCellPosFromPmPos(pmPos);
+          if (cellPos !== null) {
+            e.preventDefault();
+            e.stopPropagation();
+            hiddenPMRef.current.setCellSelection(cellPos, cellPos);
+            return;
+          }
+
+          const view = hiddenPMRef.current.getView();
+          if (view) {
+            const { doc } = view.state;
+            const $pos = doc.resolve(pmPos);
+            const parent = $pos.parent;
+
+            // Find word boundaries.
+            if (parent.isTextblock) {
+              // Build a string aligned 1-to-1 with PM
+              // offsets inside the parent. Atom inline
+              // nodes (tab, hard_break, image) take 1 PM
+              // position but don't appear in
+              // `textContent`, so a tab at offset 0 +
+              // text "(a)" + tab at offset 4 + text
+              // "Equity Financing" has parentSize 21
+              // but textContent length 19. Walking
+              // word boundaries on `textContent` and
+              // then writing back via `$pos.start() +
+              // offset` shifts the resulting selection
+              // by one PM position per atom skipped —
+              // double-clicking "Financing" in such a
+              // paragraph selected "y Financin"
+              // instead. Padding atom nodes with a
+              // non-word character keeps every offset
+              // in PM-position space.
+              const pmAlignedParts: string[] = [];
+              for (let i = 0; i < parent.content.childCount; i++) {
+                const node = parent.content.child(i);
+                pmAlignedParts.push(
+                  node.isText ? (node.text ?? "") : " ".repeat(node.nodeSize),
+                );
+              }
+              const pmAlignedText = pmAlignedParts.join("");
+              const offset = $pos.parentOffset;
+
+              // Find word start (go back until whitespace/punctuation)
+              let start = offset;
+              while (start > 0 && /\w/u.test(pmAlignedText[start - 1]!)) {
+                // SAFETY: start > 0
+                start--;
+              }
+
+              // Find word end (go forward until whitespace/punctuation)
+              let end = offset;
+              while (
+                end < pmAlignedText.length &&
+                /\w/u.test(pmAlignedText[end]!)
+              ) {
+                // SAFETY: end < pmAlignedText.length
+                end++;
+              }
+
+              // Convert to absolute positions
+              const absStart = $pos.start() + start;
+              const absEnd = $pos.start() + end;
+
+              if (absStart < absEnd) {
+                hiddenPMRef.current.setSelection(absStart, absEnd);
+              }
+            }
+          }
+        }
+      }
+      // Triple-click for paragraph selection
+      if (e.detail === 3 && hiddenPMRef.current) {
+        const pmPos = getPositionFromMouse(e.clientX, e.clientY);
+        if (pmPos !== null) {
+          const view = hiddenPMRef.current.getView();
+          if (view) {
+            const { doc } = view.state;
+            const $pos = doc.resolve(pmPos);
+
+            // Find paragraph start and end
+            const paragraphStart = $pos.start($pos.depth);
+            const paragraphEnd = $pos.end($pos.depth);
+
+            hiddenPMRef.current.setSelection(paragraphStart, paragraphEnd);
+          }
+        }
+      }
+    },
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+    [
+      getPositionFromMouse,
+      onHeaderFooterDoubleClick,
+      onHyperlinkClick,
+      readOnly,
+    ],
+  );
+
+  /**
+   * Handle right-click on pages — set/preserve selection and show context menu.
+   */
+  const handlePagesContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      if (!onContextMenu) {
+        return;
+      } // No handler, let browser default
+
+      e.preventDefault();
+
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+
+      const { from, to } = view.state.selection;
+      const pmPos = getPositionFromMouse(e.clientX, e.clientY);
+
+      // If the right-click is within the existing selection, keep it
+      // Otherwise, move cursor to the right-click position
+      if (pmPos !== null && (from === to || pmPos < from || pmPos > to)) {
+        hiddenPMRef.current?.setSelection(pmPos);
+        hiddenPMRef.current?.focus();
+        setIsFocused(true);
+      }
+
+      // Read updated selection state after potential change
+      const updatedState = hiddenPMRef.current?.getState();
+      const hasSelection = updatedState
+        ? updatedState.selection.from !== updatedState.selection.to
+        : false;
+
+      onContextMenu({ x: e.clientX, y: e.clientY, hasSelection });
+    },
+    [onContextMenu, getPositionFromMouse],
+  );
+
+  /**
+   * Handle focus on container - redirect to hidden PM.
+   */
+  const handleContainerFocus = useCallback(
+    (e: React.FocusEvent) => {
+      // Don't steal focus from sidebar inputs (textareas, inputs, buttons)
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.closest(".docx-comments-sidebar")
+      ) {
+        return;
+      }
+      focusHiddenEditor();
+    },
+    [focusHiddenEditor],
+  );
+
+  /**
+   * Handle blur from container.
+   */
+  const handleContainerBlur = useCallback((e: React.FocusEvent) => {
+    // Check if focus is moving to hidden PM or staying within container
+    const relatedTarget =
+      e.relatedTarget instanceof HTMLElement ? e.relatedTarget : null;
+    if (relatedTarget && containerRef.current?.contains(relatedTarget)) {
+      return; // Focus staying within editor
+    }
+    // Keep selection visible when focus moves to toolbar or dropdown portals
+    if (
+      relatedTarget?.closest(
+        '[role="toolbar"], [data-radix-popper-content-wrapper], [data-radix-select-content], .docx-table-options-dropdown',
+      )
+    ) {
+      return;
+    }
+    setIsFocused(false);
+  }, []);
+
+  /**
+   * Handle image resize from the overlay.
+   */
+  const handleImageResize = useCallback(
+    (pmPos: number, newWidth: number, newHeight: number) => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+
+      try {
+        const node = view.state.doc.nodeAt(pmPos);
+        if (!node || node.type.name !== "image") {
           return;
         }
 
-        try {
-          const node = view.state.doc.nodeAt(pmPos);
-          if (!node || node.type.name !== "image") {
+        const tr = view.state.tr.setNodeMarkup(pmPos, undefined, {
+          ...node.attrs,
+          width: newWidth,
+          height: newHeight,
+        });
+        view.dispatch(tr);
+
+        // Re-select the image after resize
+        hiddenPMRef.current?.setNodeSelection(pmPos);
+      } catch {
+        // Position may have changed during resize
+      }
+    },
+    [],
+  );
+
+  /**
+   * Handle image resize start - prevent text selection during resize.
+   */
+  const handleImageResizeStart = useCallback(() => {
+    isImageInteractingRef.current = true;
+  }, []);
+
+  /**
+   * Handle image resize end.
+   */
+  const handleImageResizeEnd = useCallback(() => {
+    isImageInteractingRef.current = false;
+  }, []);
+
+  /**
+   * Handle image drag-to-move: move image node from its current position
+   * to the drop position determined by mouse coordinates.
+   */
+  const handleImageDragMove = useCallback(
+    (pmPos: number, clientX: number, clientY: number) => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return;
+      }
+
+      try {
+        const node = view.state.doc.nodeAt(pmPos);
+        if (!node || node.type.name !== "image") {
+          return;
+        }
+
+        const isFloating =
+          node.attrs["displayMode"] === "float" ||
+          (node.attrs["wrapType"] &&
+            ["square", "tight", "through"].includes(
+              node.attrs["wrapType"] as string,
+            ));
+
+        if (isFloating) {
+          // For floating images: update position attributes so the image
+          // moves to the drop point while staying floating.
+          // Find the page under the drop point
+          const pages =
+            pagesContainerRef.current?.querySelectorAll(".layout-page");
+          if (!pages || pages.length === 0) {
             return;
           }
+
+          let contentEl: HTMLElement | null = null;
+          for (const page of pages) {
+            const rect = page.getBoundingClientRect();
+            if (clientY >= rect.top && clientY <= rect.bottom) {
+              contentEl = queryHtmlElement(page, ".layout-page-content");
+              break;
+            }
+          }
+          if (!contentEl) {
+            // Fallback to last page if below all pages
+            const lastPage = Array.from(pages).at(-1);
+            contentEl = lastPage
+              ? queryHtmlElement(lastPage, ".layout-page-content")
+              : null;
+          }
+          if (!contentEl) {
+            return;
+          }
+
+          const contentRect = contentEl.getBoundingClientRect();
+          // Convert drop coordinates to content-area-relative pixels
+          const dropX = (clientX - contentRect.left) / zoom;
+          const dropY = (clientY - contentRect.top) / zoom;
+          // Pixels to EMU: px * 914400 / 96
+          const PIXELS_TO_EMU = 914_400 / 96;
+          const hOffsetEmu = Math.round(dropX * PIXELS_TO_EMU);
+          const vOffsetEmu = Math.round(dropY * PIXELS_TO_EMU);
+
+          const newPosition = {
+            horizontal: { posOffset: hOffsetEmu, relativeTo: "margin" },
+            vertical: { posOffset: vOffsetEmu, relativeTo: "margin" },
+          };
 
           const tr = view.state.tr.setNodeMarkup(pmPos, undefined, {
             ...node.attrs,
-            width: newWidth,
-            height: newHeight,
+            position: newPosition,
           });
           view.dispatch(tr);
-
-          // Re-select the image after resize
           hiddenPMRef.current?.setNodeSelection(pmPos);
-        } catch {
-          // Position may have changed during resize
-        }
-      },
-      [],
-    );
-
-    /**
-     * Handle image resize start - prevent text selection during resize.
-     */
-    const handleImageResizeStart = useCallback(() => {
-      isImageInteractingRef.current = true;
-    }, []);
-
-    /**
-     * Handle image resize end.
-     */
-    const handleImageResizeEnd = useCallback(() => {
-      isImageInteractingRef.current = false;
-    }, []);
-
-    /**
-     * Handle image drag-to-move: move image node from its current position
-     * to the drop position determined by mouse coordinates.
-     */
-    const handleImageDragMove = useCallback(
-      (pmPos: number, clientX: number, clientY: number) => {
-        const view = hiddenPMRef.current?.getView();
-        if (!view) {
-          return;
-        }
-
-        try {
-          const node = view.state.doc.nodeAt(pmPos);
-          if (!node || node.type.name !== "image") {
+        } else {
+          // For inline images: move to the drop text position
+          const dropPos = getPositionFromMouse(clientX, clientY);
+          if (dropPos === null) {
+            return;
+          }
+          if (dropPos === pmPos || dropPos === pmPos + 1) {
             return;
           }
 
-          const isFloating =
-            node.attrs["displayMode"] === "float" ||
-            (node.attrs["wrapType"] &&
-              ["square", "tight", "through"].includes(
-                node.attrs["wrapType"] as string,
-              ));
+          let tr = view.state.tr;
 
-          if (isFloating) {
-            // For floating images: update position attributes so the image
-            // moves to the drop point while staying floating.
-            // Find the page under the drop point
-            const pages =
-              pagesContainerRef.current?.querySelectorAll(".layout-page");
-            if (!pages || pages.length === 0) {
-              return;
-            }
-
-            let contentEl: HTMLElement | null = null;
-            for (const page of pages) {
-              const rect = page.getBoundingClientRect();
-              if (clientY >= rect.top && clientY <= rect.bottom) {
-                contentEl = queryHtmlElement(page, ".layout-page-content");
-                break;
-              }
-            }
-            if (!contentEl) {
-              // Fallback to last page if below all pages
-              const lastPage = Array.from(pages).at(-1);
-              contentEl = lastPage
-                ? queryHtmlElement(lastPage, ".layout-page-content")
-                : null;
-            }
-            if (!contentEl) {
-              return;
-            }
-
-            const contentRect = contentEl.getBoundingClientRect();
-            // Convert drop coordinates to content-area-relative pixels
-            const dropX = (clientX - contentRect.left) / zoom;
-            const dropY = (clientY - contentRect.top) / zoom;
-            // Pixels to EMU: px * 914400 / 96
-            const PIXELS_TO_EMU = 914_400 / 96;
-            const hOffsetEmu = Math.round(dropX * PIXELS_TO_EMU);
-            const vOffsetEmu = Math.round(dropY * PIXELS_TO_EMU);
-
-            const newPosition = {
-              horizontal: { posOffset: hOffsetEmu, relativeTo: "margin" },
-              vertical: { posOffset: vOffsetEmu, relativeTo: "margin" },
-            };
-
-            const tr = view.state.tr.setNodeMarkup(pmPos, undefined, {
-              ...node.attrs,
-              position: newPosition,
-            });
-            view.dispatch(tr);
-            hiddenPMRef.current?.setNodeSelection(pmPos);
+          if (dropPos <= pmPos) {
+            tr = tr.delete(pmPos, pmPos + node.nodeSize);
+            tr = tr.insert(dropPos, node);
+            hiddenPMRef.current?.setNodeSelection(dropPos);
           } else {
-            // For inline images: move to the drop text position
-            const dropPos = getPositionFromMouse(clientX, clientY);
-            if (dropPos === null) {
-              return;
-            }
-            if (dropPos === pmPos || dropPos === pmPos + 1) {
-              return;
-            }
-
-            let tr = view.state.tr;
-
-            if (dropPos <= pmPos) {
-              tr = tr.delete(pmPos, pmPos + node.nodeSize);
-              tr = tr.insert(dropPos, node);
-              hiddenPMRef.current?.setNodeSelection(dropPos);
-            } else {
-              tr = tr.delete(pmPos, pmPos + node.nodeSize);
-              const adjusted = dropPos - node.nodeSize;
-              tr = tr.insert(Math.min(adjusted, tr.doc.content.size), node);
-              hiddenPMRef.current?.setNodeSelection(
-                Math.min(adjusted, tr.doc.content.size - 1),
-              );
-            }
-
-            view.dispatch(tr);
-          }
-        } catch {
-          // Position may be invalid
-        }
-      },
-      [getPositionFromMouse, zoom],
-    );
-
-    const handleImageDragStart = useCallback(() => {
-      isImageInteractingRef.current = true;
-    }, []);
-
-    const handleImageDragEnd = useCallback(() => {
-      isImageInteractingRef.current = false;
-    }, []);
-
-    /**
-     * Handle keyboard events on container.
-     * Most keyboard handling is done by ProseMirror, but we intercept
-     * specific keys for navigation and ensure focus stays on hidden PM.
-     */
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        if (
-          readOnly &&
-          (e.metaKey || e.ctrlKey) &&
-          e.key.toLowerCase() === "c"
-        ) {
-          copySelectionText();
-          return;
-        }
-
-        if (readOnly) {
-          if (isReadOnlyEditKey(e)) {
-            onReadOnlyEditAttempt?.();
-            e.preventDefault();
-          }
-          return;
-        }
-
-        // Ensure hidden PM is focused if user types
-        if (!hiddenPMRef.current?.isFocused()) {
-          focusHiddenEditor();
-        }
-
-        // Prevent space from scrolling the container - let PM handle it as text input.
-        // During IME composition, let the browser handle space natively to avoid
-        // duplicating the final composed character (e.g., Korean Hangul).
-        if (
-          e.key === " " &&
-          !e.ctrlKey &&
-          !e.metaKey &&
-          !e.nativeEvent.isComposing
-        ) {
-          e.preventDefault();
-          const view = hiddenPMRef.current?.getView();
-          if (view) {
-            // Route through handleTextInput so plugins (suggestion mode) can intercept
-            const { from, to } = view.state.selection;
-            // oxlint-disable-next-line typescript/no-explicit-any
-            const handled = (view as any).someProp(
-              "handleTextInput",
-              (
-                f: (
-                  v: EditorView,
-                  fr: number,
-                  t: number,
-                  text: string,
-                ) => boolean,
-              ) => f(view, from, to, " "),
+            tr = tr.delete(pmPos, pmPos + node.nodeSize);
+            const adjusted = dropPos - node.nodeSize;
+            tr = tr.insert(Math.min(adjusted, tr.doc.content.size), node);
+            hiddenPMRef.current?.setNodeSelection(
+              Math.min(adjusted, tr.doc.content.size - 1),
             );
-            if (!handled) {
-              view.dispatch(view.state.tr.insertText(" "));
-            }
           }
-          return;
+
+          view.dispatch(tr);
         }
+      } catch {
+        // Position may be invalid
+      }
+    },
+    [getPositionFromMouse, zoom],
+  );
 
-        // PageUp/PageDown - let container handle scrolling
-        if (
-          ["PageUp", "PageDown"].includes(e.key) &&
-          !e.metaKey &&
-          !e.ctrlKey
-        ) {
-          // Let PM handle the cursor movement first
-          // If PM doesn't handle it (at bounds), the container will scroll
+  const handleImageDragStart = useCallback(() => {
+    isImageInteractingRef.current = true;
+  }, []);
+
+  const handleImageDragEnd = useCallback(() => {
+    isImageInteractingRef.current = false;
+  }, []);
+
+  /**
+   * Handle keyboard events on container.
+   * Most keyboard handling is done by ProseMirror, but we intercept
+   * specific keys for navigation and ensure focus stays on hidden PM.
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (readOnly && (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "c") {
+        copySelectionText();
+        return;
+      }
+
+      if (readOnly) {
+        if (isReadOnlyEditKey(e)) {
+          onReadOnlyEditAttempt?.();
+          e.preventDefault();
         }
+        return;
+      }
 
-        // Cmd/Ctrl+Home - scroll to top and move cursor to start
-        if (e.key === "Home" && (e.metaKey || e.ctrlKey)) {
-          const sc = getScrollContainer();
-          if (sc) {
-            sc.scrollTop = 0;
-          }
-        }
+      // Ensure hidden PM is focused if user types
+      if (!hiddenPMRef.current?.isFocused()) {
+        focusHiddenEditor();
+      }
 
-        // Cmd/Ctrl+End - scroll to bottom and move cursor to end
-        if (e.key === "End" && (e.metaKey || e.ctrlKey)) {
-          const sc = getScrollContainer();
-          if (sc) {
-            sc.scrollTop = sc.scrollHeight;
-          }
-        }
-      },
-      [
-        copySelectionText,
-        focusHiddenEditor,
-        getScrollContainer,
-        onReadOnlyEditAttempt,
-        readOnly,
-      ],
-    );
-
-    /**
-     * Handle mousedown on container (outside pages).
-     */
-    const handleContainerMouseDown = useCallback(
-      (e: React.MouseEvent) => {
-        // Don't steal focus from sidebar inputs
-        if (
-          e.target instanceof HTMLElement &&
-          e.target.closest(".docx-comments-sidebar")
-        ) {
-          return;
-        }
-        // Focus hidden PM if clicking outside pages area
-        if (!hiddenPMRef.current?.isFocused()) {
-          focusHiddenEditor();
-        }
-      },
-      [focusHiddenEditor],
-    );
-
-    // =========================================================================
-    // Initial Layout
-    // =========================================================================
-
-    /**
-     * Run initial layout when document or view changes.
-     */
-    const handleEditorViewReady = useCallback(
-      (view: EditorView) => {
-        runLayoutPipeline(view.state);
-        updateSelectionOverlay(view.state);
-        anonymizationMatchesRef.current =
-          anonymizationDecorationsKey.getState(view.state)?.matches ?? [];
-        updateAnonymizationOverlay();
-
-        // Auto-focus the editor so the user can start typing immediately
-        if (!readOnly) {
-          // Use requestAnimationFrame to ensure DOM is ready
-          requestAnimationFrame(() => {
-            view.focus();
-            setIsFocused(true);
-          });
-        }
-      },
-      [
-        runLayoutPipeline,
-        updateSelectionOverlay,
-        updateAnonymizationOverlay,
-        readOnly,
-      ],
-    );
-
-    // Re-paint anonymization overlay whenever a fresh layout lands;
-    // selectionToRects needs the latest layout/blocks/measures to
-    // place rectangles correctly after a doc edit or zoom change.
-    useEffect(() => {
-      updateAnonymizationOverlay();
-    }, [updateAnonymizationOverlay]);
-
-    // Re-layout when web fonts finish loading to fix measurements that were
-    // computed against fallback fonts during initial render.
-    // Uses FontFaceSet.onloadingdone to detect when new fonts complete loading.
-    useEffect(() => {
-      const handleFontsLoaded = () => {
+      // Prevent space from scrolling the container - let PM handle it as text input.
+      // During IME composition, let the browser handle space natively to avoid
+      // duplicating the final composed character (e.g., Korean Hangul).
+      if (
+        e.key === " " &&
+        !e.ctrlKey &&
+        !e.metaKey &&
+        !e.nativeEvent.isComposing
+      ) {
+        e.preventDefault();
         const view = hiddenPMRef.current?.getView();
         if (view) {
-          // Clear all cached measurements — font metrics have changed
-          resetCanvasContext();
-          clearAllCaches();
-          runLayoutPipeline(view.state);
-          updateSelectionOverlay(view.state);
+          // Route through handleTextInput so plugins (suggestion mode) can intercept
+          const { from, to } = view.state.selection;
+          // oxlint-disable-next-line typescript/no-explicit-any
+          const handled = (view as any).someProp(
+            "handleTextInput",
+            (
+              f: (
+                v: EditorView,
+                fr: number,
+                t: number,
+                text: string,
+              ) => boolean,
+            ) => f(view, from, to, " "),
+          );
+          if (!handled) {
+            view.dispatch(view.state.tr.insertText(" "));
+          }
         }
-      };
-
-      // Listen for font loading completion events
-      window.document.fonts.addEventListener("loadingdone", handleFontsLoaded);
-      return () => {
-        window.document.fonts.removeEventListener(
-          "loadingdone",
-          handleFontsLoaded,
-        );
-      };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    // Re-layout when non-document layout inputs change (e.g., after HF editor save
-    // or parent-driven page setup/theme updates).
-    // runLayoutPipeline includes these values in its deps, but it
-    // only runs when explicitly called — this effect triggers it.
-    const layoutInputEpochRef = useRef(0);
-    useEffect(() => {
-      // Skip the initial render — handleEditorViewReady already does the first layout
-      if (layoutInputEpochRef.current === 0) {
-        layoutInputEpochRef.current = 1;
         return;
       }
+
+      // PageUp/PageDown - let container handle scrolling
+      if (["PageUp", "PageDown"].includes(e.key) && !e.metaKey && !e.ctrlKey) {
+        // Let PM handle the cursor movement first
+        // If PM doesn't handle it (at bounds), the container will scroll
+      }
+
+      // Cmd/Ctrl+Home - scroll to top and move cursor to start
+      if (e.key === "Home" && (e.metaKey || e.ctrlKey)) {
+        const sc = getScrollContainer();
+        if (sc) {
+          sc.scrollTop = 0;
+        }
+      }
+
+      // Cmd/Ctrl+End - scroll to bottom and move cursor to end
+      if (e.key === "End" && (e.metaKey || e.ctrlKey)) {
+        const sc = getScrollContainer();
+        if (sc) {
+          sc.scrollTop = sc.scrollHeight;
+        }
+      }
+    },
+    [
+      copySelectionText,
+      focusHiddenEditor,
+      getScrollContainer,
+      onReadOnlyEditAttempt,
+      readOnly,
+    ],
+  );
+
+  /**
+   * Handle mousedown on container (outside pages).
+   */
+  const handleContainerMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      // Don't steal focus from sidebar inputs
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.closest(".docx-comments-sidebar")
+      ) {
+        return;
+      }
+      // Focus hidden PM if clicking outside pages area
+      if (!hiddenPMRef.current?.isFocused()) {
+        focusHiddenEditor();
+      }
+    },
+    [focusHiddenEditor],
+  );
+
+  // =========================================================================
+  // Initial Layout
+  // =========================================================================
+
+  /**
+   * Run initial layout when document or view changes.
+   */
+  const handleEditorViewReady = useCallback(
+    (view: EditorView) => {
+      runLayoutPipeline(view.state);
+      updateSelectionOverlay(view.state);
+      anonymizationMatchesRef.current =
+        anonymizationDecorationsKey.getState(view.state)?.matches ?? [];
+      updateAnonymizationOverlay();
+
+      // Auto-focus the editor so the user can start typing immediately
+      if (!readOnly) {
+        // Use requestAnimationFrame to ensure DOM is ready
+        requestAnimationFrame(() => {
+          view.focus();
+          setIsFocused(true);
+        });
+      }
+    },
+    [
+      runLayoutPipeline,
+      updateSelectionOverlay,
+      updateAnonymizationOverlay,
+      readOnly,
+    ],
+  );
+
+  // Re-paint anonymization overlay whenever a fresh layout lands;
+  // selectionToRects needs the latest layout/blocks/measures to
+  // place rectangles correctly after a doc edit or zoom change.
+  useEffect(() => {
+    updateAnonymizationOverlay();
+  }, [updateAnonymizationOverlay]);
+
+  // Re-layout when web fonts finish loading to fix measurements that were
+  // computed against fallback fonts during initial render.
+  // Uses FontFaceSet.onloadingdone to detect when new fonts complete loading.
+  useEffect(() => {
+    const handleFontsLoaded = () => {
       const view = hiddenPMRef.current?.getView();
       if (view) {
-        runLayoutPipelineRef.current(view.state);
+        // Clear all cached measurements — font metrics have changed
+        resetCanvasContext();
+        clearAllCaches();
+        runLayoutPipeline(view.state);
+        updateSelectionOverlay(view.state);
       }
-    }, [
-      headerContent,
-      footerContent,
-      firstPageHeaderContent,
-      firstPageFooterContent,
-      contentWidth,
-      columns,
-      pageSize,
-      margins,
-      pageGap,
-      sectionProperties,
-      _theme,
-    ]);
+    };
 
-    // Re-compute selection overlay when the container resizes.
-    // Page elements shift during window resize (centering, scrollbar changes),
-    // causing caret/selection coordinates to become stale.
-    useEffect(() => {
-      const container = containerRef.current;
-      if (!container) {
-        return;
-      }
+    // Listen for font loading completion events
+    window.document.fonts.addEventListener("loadingdone", handleFontsLoaded);
+    return () => {
+      window.document.fonts.removeEventListener(
+        "loadingdone",
+        handleFontsLoaded,
+      );
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-      const observer = new ResizeObserver(() => {
-        const state = hiddenPMRef.current?.getState();
-        if (state) {
-          updateSelectionOverlay(state);
-        }
-      });
+  // Re-layout when non-document layout inputs change (e.g., after HF editor save
+  // or parent-driven page setup/theme updates).
+  // runLayoutPipeline includes these values in its deps, but it
+  // only runs when explicitly called — this effect triggers it.
+  const layoutInputEpochRef = useRef(0);
+  useEffect(() => {
+    // Skip the initial render — handleEditorViewReady already does the first layout
+    if (layoutInputEpochRef.current === 0) {
+      layoutInputEpochRef.current = 1;
+      return;
+    }
+    const view = hiddenPMRef.current?.getView();
+    if (view) {
+      runLayoutPipelineRef.current(view.state);
+    }
+  }, [
+    headerContent,
+    footerContent,
+    firstPageHeaderContent,
+    firstPageFooterContent,
+    contentWidth,
+    columns,
+    pageSize,
+    margins,
+    pageGap,
+    sectionProperties,
+    _theme,
+  ]);
 
-      observer.observe(container);
-      return () => observer.disconnect();
-    }, [updateSelectionOverlay]);
+  // Re-compute selection overlay when the container resizes.
+  // Page elements shift during window resize (centering, scrollbar changes),
+  // causing caret/selection coordinates to become stale.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
 
-    // =========================================================================
-    // Imperative Handle
-    // =========================================================================
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        getDocument() {
-          return hiddenPMRef.current?.getDocument() ?? null;
-        },
-        getState() {
-          return hiddenPMRef.current?.getState() ?? null;
-        },
-        getView() {
-          return hiddenPMRef.current?.getView() ?? null;
-        },
-        focus() {
-          hiddenPMRef.current?.focus();
-          setIsFocused(true);
-        },
-        blur() {
-          hiddenPMRef.current?.blur();
-          setIsFocused(false);
-        },
-        isFocused() {
-          return hiddenPMRef.current?.isFocused() ?? false;
-        },
-        dispatch(tr: Transaction) {
-          hiddenPMRef.current?.dispatch(tr);
-        },
-        undo() {
-          return hiddenPMRef.current?.undo() ?? false;
-        },
-        redo() {
-          return hiddenPMRef.current?.redo() ?? false;
-        },
-        canUndo() {
-          return hiddenPMRef.current?.canUndo() ?? false;
-        },
-        canRedo() {
-          return hiddenPMRef.current?.canRedo() ?? false;
-        },
-        setSelection(anchor: number, head?: number) {
-          hiddenPMRef.current?.setSelection(anchor, head);
-        },
-        getLayout() {
-          return layout;
-        },
-        relayout() {
-          const state = hiddenPMRef.current?.getState();
-          if (state) {
-            runLayoutPipeline(state);
-          }
-        },
-        scrollToPosition: scrollToPositionImpl,
-        scrollToPage: scrollToPageImpl,
-      }),
-      [layout, runLayoutPipeline, scrollToPageImpl, scrollToPositionImpl],
-    );
-
-    useEffect(() => {
-      if (!layout) {
-        return;
-      }
-
-      const totalPages = layout.pages.length;
-      if (lastTotalPagesRef.current === totalPages) {
-        return;
-      }
-
-      lastTotalPagesRef.current = totalPages;
-      onTotalPagesChangeRef.current?.(totalPages);
-    }, [layout]);
-
-    // Update selection overlay when layout changes
-    // This is needed because handleEditorViewReady calls runLayoutPipeline which
-    // sets layout asynchronously, so updateSelectionOverlay would return early
-    // if layout is still null. This effect ensures we update once layout is ready.
-    useEffect(() => {
+    const observer = new ResizeObserver(() => {
       const state = hiddenPMRef.current?.getState();
-      if (layout && state) {
+      if (state) {
         updateSelectionOverlay(state);
       }
-    }, [layout, updateSelectionOverlay]);
+    });
 
-    // =========================================================================
-    // Render
-    // =========================================================================
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [updateSelectionOverlay]);
 
-    // Calculate total height for scroll
-    const totalHeight = useMemo(() => {
-      if (!layout) {
-        return DEFAULT_PAGE_HEIGHT + 48;
-      }
-      const numPages = layout.pages.length;
-      return numPages * pageSize.h + (numPages - 1) * pageGap + 48;
-    }, [layout, pageSize.h, pageGap]);
-    const scaledViewportHeight = Math.max(1, totalHeight * zoom);
-    const scaledViewportWidth = Math.max(
-      1,
-      pageSize.w * zoom +
-        (commentsSidebarOpen ? COMMENTS_SIDEBAR_SCROLL_GUTTER : 0),
-    );
-    const viewportExtentStyle: CSSProperties = {
-      position: "relative",
-      width: `max(100%, ${String(scaledViewportWidth)}px)`,
-      height: scaledViewportHeight,
-      backgroundColor: "transparent",
-    };
-    const scaledViewportStyle: CSSProperties = {
-      ...viewportStyles,
-      position: "absolute",
-      top: 0,
-      left: `max(0px, calc((100% - ${String(scaledViewportWidth)}px) / 2))`,
-      width: pageSize.w,
-      minHeight: totalHeight,
-      transform: (() => {
-        const parts: string[] = [];
-        if (zoom !== 1) {
-          parts.push(`scale(${zoom})`);
+  // =========================================================================
+  // Imperative Handle
+  // =========================================================================
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      getDocument() {
+        return hiddenPMRef.current?.getDocument() ?? null;
+      },
+      getState() {
+        return hiddenPMRef.current?.getState() ?? null;
+      },
+      getView() {
+        return hiddenPMRef.current?.getView() ?? null;
+      },
+      focus() {
+        hiddenPMRef.current?.focus();
+        setIsFocused(true);
+      },
+      blur() {
+        hiddenPMRef.current?.blur();
+        setIsFocused(false);
+      },
+      isFocused() {
+        return hiddenPMRef.current?.isFocused() ?? false;
+      },
+      dispatch(tr: Transaction) {
+        hiddenPMRef.current?.dispatch(tr);
+      },
+      undo() {
+        return hiddenPMRef.current?.undo() ?? false;
+      },
+      redo() {
+        return hiddenPMRef.current?.redo() ?? false;
+      },
+      canUndo() {
+        return hiddenPMRef.current?.canUndo() ?? false;
+      },
+      canRedo() {
+        return hiddenPMRef.current?.canRedo() ?? false;
+      },
+      setSelection(anchor: number, head?: number) {
+        hiddenPMRef.current?.setSelection(anchor, head);
+      },
+      getLayout() {
+        return layout;
+      },
+      relayout() {
+        const state = hiddenPMRef.current?.getState();
+        if (state) {
+          runLayoutPipeline(state);
         }
-        return parts.length > 0 ? parts.join(" ") : undefined;
-      })(),
-      transformOrigin: "top left",
-    };
+      },
+      scrollToPosition: scrollToPositionImpl,
+      scrollToPage: scrollToPageImpl,
+    }),
+    [layout, runLayoutPipeline, scrollToPageImpl, scrollToPositionImpl],
+  );
 
-    return (
+  useEffect(() => {
+    if (!layout) {
+      return;
+    }
+
+    const totalPages = layout.pages.length;
+    if (lastTotalPagesRef.current === totalPages) {
+      return;
+    }
+
+    lastTotalPagesRef.current = totalPages;
+    onTotalPagesChangeRef.current?.(totalPages);
+  }, [layout]);
+
+  // Update selection overlay when layout changes
+  // This is needed because handleEditorViewReady calls runLayoutPipeline which
+  // sets layout asynchronously, so updateSelectionOverlay would return early
+  // if layout is still null. This effect ensures we update once layout is ready.
+  useEffect(() => {
+    const state = hiddenPMRef.current?.getState();
+    if (layout && state) {
+      updateSelectionOverlay(state);
+    }
+  }, [layout, updateSelectionOverlay]);
+
+  // =========================================================================
+  // Render
+  // =========================================================================
+
+  // Calculate total height for scroll
+  const totalHeight = useMemo(() => {
+    if (!layout) {
+      return DEFAULT_PAGE_HEIGHT + 48;
+    }
+    const numPages = layout.pages.length;
+    return numPages * pageSize.h + (numPages - 1) * pageGap + 48;
+  }, [layout, pageSize.h, pageGap]);
+  const scaledViewportHeight = Math.max(1, totalHeight * zoom);
+  const scaledViewportWidth = Math.max(
+    1,
+    pageSize.w * zoom +
+      (commentsSidebarOpen ? COMMENTS_SIDEBAR_SCROLL_GUTTER : 0),
+  );
+  const viewportExtentStyle: CSSProperties = {
+    position: "relative",
+    width: `max(100%, ${String(scaledViewportWidth)}px)`,
+    height: scaledViewportHeight,
+    backgroundColor: "transparent",
+  };
+  const scaledViewportStyle: CSSProperties = {
+    ...viewportStyles,
+    position: "absolute",
+    top: 0,
+    left: `max(0px, calc((100% - ${String(scaledViewportWidth)}px) / 2))`,
+    width: pageSize.w,
+    minHeight: totalHeight,
+    transform: (() => {
+      const parts: string[] = [];
+      if (zoom !== 1) {
+        parts.push(`scale(${zoom})`);
+      }
+      return parts.length > 0 ? parts.join(" ") : undefined;
+    })(),
+    transformOrigin: "top left",
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={`folio-root paged-editor ${className ?? ""}`}
+      style={{ ...containerStyles, ...style }}
+      tabIndex={0}
+      role="textbox"
+      aria-multiline
+      onFocus={handleContainerFocus}
+      onBlur={handleContainerBlur}
+      onKeyDown={handleKeyDown}
+      onMouseDown={handleContainerMouseDown}
+    >
+      {/* Hidden ProseMirror for keyboard input */}
+      <HiddenProseMirror
+        ref={hiddenPMRef}
+        document={document}
+        widthPx={contentWidth}
+        readOnly={readOnly}
+        onTransaction={handleTransaction}
+        onSelectionChange={handleSelectionChange}
+        onRemoteSelectionsChange={setRemoteSelections}
+        onEditorViewReady={handleEditorViewReady}
+        onKeyDown={handlePMKeyDown}
+        {...(styles !== undefined ? { styles } : {})}
+        externalPlugins={externalPlugins}
+        {...(collaboration !== undefined ? { collaboration } : {})}
+        {...(extensionManager !== undefined ? { extensionManager } : {})}
+        {...(onReadOnlyEditAttempt !== undefined
+          ? { onReadOnlyEditAttempt }
+          : {})}
+      />
+
+      {/* Viewport for visible pages */}
       <div
-        ref={containerRef}
-        className={`folio-root paged-editor ${className ?? ""}`}
-        style={{ ...containerStyles, ...style }}
-        tabIndex={0}
-        role="textbox"
-        aria-multiline
-        onFocus={handleContainerFocus}
-        onBlur={handleContainerBlur}
-        onKeyDown={handleKeyDown}
-        onMouseDown={handleContainerMouseDown}
+        className="paged-editor__viewport-extent"
+        style={viewportExtentStyle}
       >
-        {/* Hidden ProseMirror for keyboard input */}
-        <HiddenProseMirror
-          ref={hiddenPMRef}
-          document={document}
-          widthPx={contentWidth}
-          readOnly={readOnly}
-          onTransaction={handleTransaction}
-          onSelectionChange={handleSelectionChange}
-          onRemoteSelectionsChange={setRemoteSelections}
-          onEditorViewReady={handleEditorViewReady}
-          onKeyDown={handlePMKeyDown}
-          {...(styles !== undefined ? { styles } : {})}
-          externalPlugins={externalPlugins}
-          {...(collaboration !== undefined ? { collaboration } : {})}
-          {...(extensionManager !== undefined ? { extensionManager } : {})}
-          {...(onReadOnlyEditAttempt !== undefined
-            ? { onReadOnlyEditAttempt }
-            : {})}
-        />
+        <div className="paged-editor__viewport" style={scaledViewportStyle}>
+          {/* Pages container */}
+          <div
+            ref={pagesContainerRef}
+            className={`paged-editor__pages${readOnly ? " paged-editor--readonly" : ""}${hfEditMode ? ` paged-editor--hf-editing paged-editor--editing-${hfEditMode}` : ""}`}
+            style={pagesContainerStyles}
+            onMouseDown={handlePagesMouseDown}
+            onMouseMove={handlePagesMouseMove}
+            onClick={handlePagesClick}
+            onContextMenu={handlePagesContextMenu}
+            aria-hidden="true" // Visual only, PM provides semantic content
+          />
 
-        {/* Viewport for visible pages */}
-        <div
-          className="paged-editor__viewport-extent"
-          style={viewportExtentStyle}
-        >
-          <div className="paged-editor__viewport" style={scaledViewportStyle}>
-            {/* Pages container */}
-            <div
-              ref={pagesContainerRef}
-              className={`paged-editor__pages${readOnly ? " paged-editor--readonly" : ""}${hfEditMode ? ` paged-editor--hf-editing paged-editor--editing-${hfEditMode}` : ""}`}
-              style={pagesContainerStyles}
-              onMouseDown={handlePagesMouseDown}
-              onMouseMove={handlePagesMouseMove}
-              onClick={handlePagesClick}
-              onContextMenu={handlePagesContextMenu}
-              aria-hidden="true" // Visual only, PM provides semantic content
-            />
-
-            {/* Anonymization highlights — paints on top of the
+          {/* Anonymization highlights — paints on top of the
                 rendered pages so PII spans the wasm pipeline would
                 redact are visible inline. Always mounted, renders
                 nothing when no terms are pushed. */}
-            <AnonymizationRectsOverlay
-              groups={anonymizationRectGroups}
-              onTermClick={onAnonymizationTermClick}
-              selectedCanonical={selectedAnonymizationCanonical}
-              selectionSeq={anonymizationSelectionSeq}
-            />
+          <AnonymizationRectsOverlay
+            groups={anonymizationRectGroups}
+            onTermClick={onAnonymizationTermClick}
+            selectedCanonical={selectedAnonymizationCanonical}
+            selectionSeq={anonymizationSelectionSeq}
+          />
 
-            {/* Selection overlay */}
-            <SelectionOverlay
-              selectionRects={selectionRects}
-              caretPosition={caretPosition}
-              isFocused={isFocused}
-              pageGap={pageGap}
-            />
-            {layout &&
-              remoteSelections.map((remoteSelection) => (
-                <RemoteSelectionOverlay
-                  key={remoteSelection.clientId}
-                  blocks={blocks}
-                  layout={layout}
-                  measures={measures}
-                  pagesContainer={pagesContainerRef.current}
-                  remoteSelection={remoteSelection}
-                  zoom={zoom}
-                />
-              ))}
-
-            {/* Image selection overlay */}
-            {!readOnly && (
-              <ImageSelectionOverlay
-                imageInfo={selectedImageInfo}
+          {/* Selection overlay */}
+          <SelectionOverlay
+            selectionRects={selectionRects}
+            caretPosition={caretPosition}
+            isFocused={isFocused}
+            pageGap={pageGap}
+          />
+          {layout &&
+            remoteSelections.map((remoteSelection) => (
+              <RemoteSelectionOverlay
+                key={remoteSelection.clientId}
+                blocks={blocks}
+                layout={layout}
+                measures={measures}
+                pagesContainer={pagesContainerRef.current}
+                remoteSelection={remoteSelection}
                 zoom={zoom}
-                isFocused={isFocused}
-                onResize={handleImageResize}
-                onResizeStart={handleImageResizeStart}
-                onResizeEnd={handleImageResizeEnd}
-                onDragMove={handleImageDragMove}
-                onDragStart={handleImageDragStart}
-                onDragEnd={handleImageDragEnd}
               />
-            )}
+            ))}
 
-            {/* Table quick action insert button */}
-            {tableInsertButton && (
-              <button
-                type="button"
-                onMouseDown={handleTableInsertClick}
-                onMouseEnter={clearTableInsertTimer}
-                onMouseLeave={() => setTableInsertButton(null)}
-                style={{
-                  position: "absolute",
-                  left: tableInsertButton.x,
-                  top: tableInsertButton.y,
-                  width: 20,
-                  height: 20,
-                  borderRadius: "4px",
-                  border: "1px solid var(--doc-border, #dadce0)",
-                  backgroundColor: "var(--doc-bg, #f8f9fa)",
-                  color: "var(--doc-text-muted, #5f6368)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  cursor: "pointer",
-                  zIndex: 200,
-                  padding: 0,
-                  boxShadow: "none",
-                }}
-                title={
-                  tableInsertButton.type === "row"
-                    ? "Insert row below"
-                    : "Insert column to the right"
-                }
-                aria-label={
-                  tableInsertButton.type === "row"
-                    ? "Insert row below"
-                    : "Insert column to the right"
-                }
-              >
-                <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-                  <path
-                    d="M6 1v10M1 6h10"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </button>
-            )}
-          </div>
+          {/* Image selection overlay */}
+          {!readOnly && (
+            <ImageSelectionOverlay
+              imageInfo={selectedImageInfo}
+              zoom={zoom}
+              isFocused={isFocused}
+              onResize={handleImageResize}
+              onResizeStart={handleImageResizeStart}
+              onResizeEnd={handleImageResizeEnd}
+              onDragMove={handleImageDragMove}
+              onDragStart={handleImageDragStart}
+              onDragEnd={handleImageDragEnd}
+            />
+          )}
+
+          {/* Table quick action insert button */}
+          {tableInsertButton && (
+            <button
+              type="button"
+              onMouseDown={handleTableInsertClick}
+              onMouseEnter={clearTableInsertTimer}
+              onMouseLeave={() => setTableInsertButton(null)}
+              style={{
+                position: "absolute",
+                left: tableInsertButton.x,
+                top: tableInsertButton.y,
+                width: 20,
+                height: 20,
+                borderRadius: "4px",
+                border: "1px solid var(--doc-border, #dadce0)",
+                backgroundColor: "var(--doc-bg, #f8f9fa)",
+                color: "var(--doc-text-muted, #5f6368)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                cursor: "pointer",
+                zIndex: 200,
+                padding: 0,
+                boxShadow: "none",
+              }}
+              title={
+                tableInsertButton.type === "row"
+                  ? "Insert row below"
+                  : "Insert column to the right"
+              }
+              aria-label={
+                tableInsertButton.type === "row"
+                  ? "Insert row below"
+                  : "Insert column to the right"
+              }
+            >
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                <path
+                  d="M6 1v10M1 6h10"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          )}
         </div>
-
-        {/* Sidebar overlay — inside scroll container, scrolls with document */}
-        {sidebarOverlay}
       </div>
-    );
-  },
-);
 
-export const PagedEditor = memo(PagedEditorComponent);
+      {/* Sidebar overlay — inside scroll container, scrolls with document */}
+      {sidebarOverlay}
+    </div>
+  );
+}

--- a/packages/folio/src/paged-editor/SelectionOverlay.tsx
+++ b/packages/folio/src/paged-editor/SelectionOverlay.tsx
@@ -9,7 +9,7 @@
  * renders selection rectangles in container-relative coordinates.
  */
 
-import React, { useEffect, useState, useRef } from "react";
+import React, { useEffect, useState } from "react";
 
 import type {
   SelectionRect,
@@ -69,7 +69,8 @@ const caretStyles = (
   caret: CaretPosition,
   color: string,
   width: number,
-  visible: boolean,
+  isFocused: boolean,
+  blinkInterval: number,
 ): React.CSSProperties => ({
   position: "absolute",
   left: caret.x,
@@ -77,8 +78,13 @@ const caretStyles = (
   width,
   height: caret.height,
   backgroundColor: color,
-  opacity: visible ? 1 : 0,
-  transition: "opacity 0.05s ease-out",
+  // Solid when focused; the animation (when blinking is enabled) takes over
+  // the opacity. `blinkInterval === 0` keeps the caret solid with no blink.
+  opacity: isFocused ? 1 : 0,
+  animation:
+    isFocused && blinkInterval > 0
+      ? `folio-caret-blink ${blinkInterval * 2}ms steps(1, end) infinite`
+      : undefined,
   pointerEvents: "none",
 });
 
@@ -100,7 +106,12 @@ const selectionRectStyles = (
 // =============================================================================
 
 /**
- * Caret component with blinking animation.
+ * Caret component.
+ *
+ * The blink is a pure CSS animation (`folio-caret-blink`), so the cursor
+ * never drives React state updates while it blinks. The parent remounts this
+ * component — keyed on caret position — after typing or navigation, which
+ * restarts the animation from its solid phase so the caret shows immediately.
  */
 const Caret: React.FC<{
   position: CaretPosition;
@@ -108,72 +119,12 @@ const Caret: React.FC<{
   width: number;
   blinkInterval: number;
   isFocused: boolean;
-}> = ({ position, color, width, blinkInterval, isFocused }) => {
-  const [visible, setVisible] = useState(isFocused);
-  const blinkTimerRef = useRef<number | null>(null);
-
-  useEffect(() => {
-    // Clear any existing timer
-    if (blinkTimerRef.current) {
-      window.clearInterval(blinkTimerRef.current);
-      blinkTimerRef.current = null;
-    }
-
-    // Only blink when focused and interval is set
-    if (isFocused && blinkInterval === 0) {
-      setVisible(true);
-    } else if (isFocused && blinkInterval > 0) {
-      setVisible(true);
-      blinkTimerRef.current = window.setInterval(() => {
-        setVisible((v) => !v);
-      }, blinkInterval);
-    } else {
-      // Hide caret when not focused
-      setVisible(false);
-    }
-
-    return () => {
-      if (blinkTimerRef.current) {
-        window.clearInterval(blinkTimerRef.current);
-      }
-    };
-  }, [isFocused, blinkInterval]);
-
-  // Reset blink cycle when position changes (show immediately after typing/navigation)
-  useEffect(() => {
-    if (!isFocused) {
-      return;
-    }
-
-    setVisible(true);
-
-    // Restart blink timer from this moment
-    if (blinkTimerRef.current) {
-      window.clearInterval(blinkTimerRef.current);
-    }
-    if (blinkInterval === 0) {
-      return undefined;
-    }
-    if (blinkInterval > 0) {
-      blinkTimerRef.current = window.setInterval(() => {
-        setVisible((v) => !v);
-      }, blinkInterval);
-    }
-
-    return () => {
-      if (blinkTimerRef.current) {
-        window.clearInterval(blinkTimerRef.current);
-      }
-    };
-  }, [position.x, position.y, isFocused, blinkInterval]);
-
-  return (
-    <div
-      style={caretStyles(position, color, width, visible)}
-      data-testid="caret"
-    />
-  );
-};
+}> = ({ position, color, width, blinkInterval, isFocused }) => (
+  <div
+    style={caretStyles(position, color, width, isFocused, blinkInterval)}
+    data-testid="caret"
+  />
+);
 
 /**
  * Selection rectangle component.
@@ -222,9 +173,11 @@ export const SelectionOverlay: React.FC<SelectionOverlayProps> = ({
           />
         ))}
 
-      {/* Render caret for collapsed selection */}
+      {/* Render caret for collapsed selection. The `key` remounts the caret
+          when it moves, restarting the CSS blink from its visible phase. */}
       {hasCollapsedSelection && (
         <Caret
+          key={`${caretPosition.x}-${caretPosition.y}-${caretPosition.height}`}
           position={caretPosition}
           color={caretColor}
           width={caretWidth}

--- a/packages/folio/src/paged-editor/SelectionOverlay.tsx
+++ b/packages/folio/src/paged-editor/SelectionOverlay.tsx
@@ -16,6 +16,7 @@ import type {
   CaretPosition,
 } from "../core/layout-bridge/selectionRects";
 import type { Layout, FlowBlock, Measure } from "../core/layout-engine/types";
+import "../styles/editor.css";
 
 // =============================================================================
 // TYPES

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -167,6 +167,21 @@
   display: inline-block;
 }
 
+/* Overlay caret blink — driven by a CSS animation so the cursor never
+ * triggers React re-renders while it blinks. The overlay caret restarts the
+ * cycle (visible first) by remounting, keyed on its position, after typing
+ * or navigation. */
+@keyframes folio-caret-blink {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+
 .docx-paragraph-editable {
   cursor: text;
 }


### PR DESCRIPTION
## Summary

Two folio changes.

**Re-render reduction** — selection changes allocated a fresh editor-state object on every keystroke and cursor move, re-rendering `DocxEditor` and the toolbar; the overlay caret re-rendered on a `setInterval` to blink.
- The selection `setState` now compares formatting and table/image/tracked-change context by value, returns the previous state when nothing changed, and otherwise preserves unchanged sub-references.
- The overlay caret blinks via a CSS animation (`folio-caret-blink`) instead of a timer; it is keyed on caret position so the cycle restarts from visible on move.

**React 19** — the monorepo already pins React 19 via the `react19` catalog; folio's `peerDependencies` were the only place still allowing React 18.
- Narrow the `react`/`react-dom` peer ranges to `^19.0.0` and add explicit `catalog:react19` devDependencies.
- Replace `forwardRef` with the React 19 `ref`-as-prop form in `DocxEditor`, `PagedEditor`, `HiddenProseMirror`, `InlineHeaderFooterEditor`.
- Drop the `memo()` wrappers on `PagedEditor` / `HiddenProseMirror` — React Compiler already memoizes element creation, so they were redundant.

## Note for reviewers

`DocxEditor.tsx` and `PagedEditor.tsx` show a very large diff: removing the `forwardRef` wrapper removes a nesting level, so oxfmt re-indents the whole component body. Review with whitespace ignored (`git diff -w`) — the non-whitespace change in those two files is limited to the signature and the closing brace.