### PR TITLE
feat: refresh Gemini model catalog

### DIFF
--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -66,7 +66,10 @@ import {
 import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
-import { requireAIAvailable } from "@/api/lib/ai-models";
+import {
+  requireAIAvailable,
+  validateDevModelOverride,
+} from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -106,6 +109,9 @@ const sendMessage = createSafeRootHandler(
           message: "Dev model overrides are only available locally.",
         }),
       );
+    }
+    if (body.devModelId) {
+      yield* validateDevModelOverride(body.devModelId, orgAIConfig);
     }
 
     const accessibleWorkspaceIds = activeWorkspaceIds;

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -1,3 +1,4 @@
+import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import type { OrgAIConfig } from "@/api/lib/ai-models";
@@ -19,6 +20,7 @@ const {
   isAllowedBYOKModel,
   REGIONAL_PROVIDERS,
   supportsRegion,
+  validateDevModelOverride,
 } = await import("@/api/lib/ai-models");
 
 type AIProvider =
@@ -125,6 +127,65 @@ describe("BYOK model overrides", () => {
       modelId: "google/gemini-3.5-flash",
       provider: "openrouter",
     });
+  });
+
+  test("rejects provider-qualified dev overrides without matching BYOK credentials", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org-google",
+          provider: "google",
+        },
+      ],
+      overrideModels: {
+        chat: { provider: "google", modelId: "gemini-3.5-flash" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
+        pdf: { provider: "google", modelId: "gemini-3.5-flash" },
+      },
+    };
+
+    const result = validateDevModelOverride(
+      "openrouter::google/gemini-3.5-flash",
+      orgConfig,
+    );
+
+    expect(Result.isError(result)).toBe(true);
+    if (Result.isOk(result)) {
+      throw new Error("Expected provider validation to fail");
+    }
+    expect(result.error.status).toBe(400);
+    expect(result.error.message).toContain("openrouter");
+  });
+
+  test("allows provider-qualified dev overrides with matching BYOK credentials", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org-google",
+          provider: "google",
+        },
+        {
+          apiKey: "sk-or-v1-org",
+          provider: "openrouter",
+        },
+      ],
+      overrideModels: {
+        chat: { provider: "google", modelId: "gemini-3.5-flash" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
+        pdf: { provider: "google", modelId: "gemini-3.5-flash" },
+      },
+    };
+
+    expect(
+      Result.isOk(
+        validateDevModelOverride(
+          "openrouter::google/gemini-3.5-flash",
+          orgConfig,
+        ),
+      ),
+    ).toBe(true);
   });
 
   test("uses a per-role provider-qualified model selection", () => {

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -14,6 +14,7 @@ process.env["SMTP_PORT"] ??= "1025";
 
 const {
   getModelForRole,
+  getModelInfoById,
   getModelInfoForRole,
   isAllowedBYOKModel,
   REGIONAL_PROVIDERS,
@@ -87,6 +88,45 @@ describe("isAllowedBYOKModel", () => {
 });
 
 describe("BYOK model overrides", () => {
+  test("reports provider-qualified dev model overrides", () => {
+    expect(
+      getModelInfoById("openrouter::google/gemini-3.5-flash"),
+    ).toMatchObject({
+      keySource: "instance",
+      modelId: "google/gemini-3.5-flash",
+      provider: "openrouter",
+    });
+  });
+
+  test("routes provider-qualified BYOK dev model overrides through the selected provider", () => {
+    const orgConfig: OrgAIConfig = {
+      providers: [
+        {
+          apiKey: "sk-org-google",
+          provider: "google",
+        },
+        {
+          apiKey: "sk-or-v1-org",
+          provider: "openrouter",
+        },
+      ],
+      overrideModels: {
+        chat: { provider: "google", modelId: "gemini-3.5-flash" },
+        fast: { provider: "google", modelId: "gemini-3.1-flash-lite-preview" },
+        reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
+        pdf: { provider: "google", modelId: "gemini-3.5-flash" },
+      },
+    };
+
+    expect(
+      getModelInfoById("openrouter::google/gemini-3.5-flash", orgConfig),
+    ).toMatchObject({
+      keySource: "byok",
+      modelId: "google/gemini-3.5-flash",
+      provider: "openrouter",
+    });
+  });
+
   test("uses a per-role provider-qualified model selection", () => {
     const orgConfig: OrgAIConfig = {
       providers: [

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -60,7 +60,7 @@ describe("REGIONAL_PROVIDERS", () => {
 describe("isAllowedBYOKModel", () => {
   test("accepts curated catalog models", () => {
     expect(isAllowedBYOKModel("anthropic", "claude-opus-4-7")).toBe(true);
-    expect(isAllowedBYOKModel("google", "gemini-3-pro-preview")).toBe(true);
+    expect(isAllowedBYOKModel("google", "gemini-3.5-flash")).toBe(true);
     expect(isAllowedBYOKModel("mistral", "mistral-medium-3-5")).toBe(true);
     expect(isAllowedBYOKModel("mistral", "mistral-large-latest")).toBe(true);
     expect(isAllowedBYOKModel("openai", "gpt-5.4")).toBe(true);
@@ -73,7 +73,7 @@ describe("isAllowedBYOKModel", () => {
   test("rejects models outside the curated catalog", () => {
     expect(isAllowedBYOKModel("openrouter", "x-ai/grok-4")).toBe(false);
     expect(isAllowedBYOKModel("anthropic", "claude-2")).toBe(false);
-    expect(isAllowedBYOKModel("google", "gemini-1.5-pro")).toBe(false);
+    expect(isAllowedBYOKModel("google", "gemini-2.5-pro")).toBe(false);
     expect(isAllowedBYOKModel("mistral", "pixtral-large-latest")).toBe(false);
     expect(isAllowedBYOKModel("mistral", "mistral-tiny")).toBe(false);
     expect(isAllowedBYOKModel("openai", "gpt-4o")).toBe(false);

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -72,15 +72,15 @@ export type AIProvider =
 export const DEFAULT_MODELS = {
   google: {
     fast: "gemini-3.1-flash-lite-preview",
-    chat: "gemini-3.1-flash-lite-preview",
+    chat: "gemini-3.5-flash",
     reasoning: "gemini-3.1-pro-preview",
-    pdf: "gemini-3.1-flash-lite-preview",
+    pdf: "gemini-3.5-flash",
   },
   openrouter: {
     fast: "google/gemini-3.1-flash-lite-preview",
-    chat: "google/gemini-3.1-flash-lite-preview",
+    chat: "google/gemini-3.5-flash",
     reasoning: "google/gemini-3.1-pro-preview",
-    pdf: "google/gemini-3.1-flash-lite-preview",
+    pdf: "google/gemini-3.5-flash",
   },
   openai: {
     fast: "gpt-5.4-nano",
@@ -125,11 +125,9 @@ export const DEFAULT_MODELS = {
  */
 export const BYOK_MODEL_OPTIONS = {
   google: [
-    "gemini-3-pro-preview",
-    "gemini-3-flash-preview",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
+    "gemini-3.1-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-3.1-flash-lite-preview",
   ],
   anthropic: [
     "claude-opus-4-7",
@@ -147,9 +145,9 @@ export const BYOK_MODEL_OPTIONS = {
   openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
   azure_foundry: [],
   openrouter: [
-    "google/gemini-3-flash-preview",
     "google/gemini-3.1-pro-preview",
-    "google/gemini-2.5-flash-lite",
+    "google/gemini-3.5-flash",
+    "google/gemini-3.1-flash-lite-preview",
     "anthropic/claude-opus-4.5",
     "anthropic/claude-sonnet-4.5",
     "openai/gpt-5.4",

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -58,14 +58,22 @@ export const MODEL_ROLES = [
   "pdf",
 ] as const satisfies readonly ModelRole[];
 
-export type AIProvider =
-  | "google"
-  | "openrouter"
-  | "openai"
-  | "azure_foundry"
-  | "anthropic"
-  | "mistral"
-  | "openai_compatible";
+export const AI_PROVIDERS = [
+  "google",
+  "openrouter",
+  "openai",
+  "azure_foundry",
+  "anthropic",
+  "mistral",
+  "openai_compatible",
+] as const;
+
+export type AIProvider = (typeof AI_PROVIDERS)[number];
+
+const AI_PROVIDER_VALUES = new Set<string>(AI_PROVIDERS);
+
+const isAIProvider = (value: string): value is AIProvider =>
+  AI_PROVIDER_VALUES.has(value);
 
 // -- Default model IDs per provider -----------------------------
 
@@ -575,6 +583,22 @@ export type ResolvedModelInfo = {
   region?: DataRegion | undefined;
 };
 
+type ModelOverride = {
+  modelId: string;
+  provider?: AIProvider | undefined;
+};
+
+const decodeModelOverride = (value: string): ModelOverride => {
+  const [providerRaw, ...modelParts] = value.split("::");
+  const modelId = modelParts.join("::");
+
+  if (providerRaw && modelId && isAIProvider(providerRaw)) {
+    return { provider: providerRaw, modelId };
+  }
+
+  return { modelId: value };
+};
+
 // -- BYOK factory cache -----------------------------------------
 
 /**
@@ -754,12 +778,15 @@ export const getModelInfoById = (
   modelId: string,
   orgConfig?: OrgAIConfig | null,
 ): ResolvedModelInfo => {
+  const override = decodeModelOverride(modelId);
   if (orgConfig) {
-    const providerConfig = getPrimaryOrgProvider(orgConfig);
+    const providerConfig = override.provider
+      ? getOrgProviderConfig(orgConfig, override.provider)
+      : getPrimaryOrgProvider(orgConfig);
     return {
       keySource: "byok",
       provider: providerConfig.provider,
-      modelId,
+      modelId: override.modelId,
       region:
         providerConfig.provider === "azure_foundry"
           ? undefined
@@ -767,10 +794,11 @@ export const getModelInfoById = (
     };
   }
 
+  const provider = override.provider ?? getActiveProvider();
   return {
     keySource: "instance",
-    provider: getActiveProvider(),
-    modelId,
+    provider,
+    modelId: override.modelId,
   };
 };
 
@@ -785,10 +813,19 @@ export const getModelById = (
   modelId: string,
   orgConfig?: OrgAIConfig | null,
 ): LanguageModel => {
+  const override = decodeModelOverride(modelId);
   if (orgConfig) {
+    const providerConfig = override.provider
+      ? getOrgProviderConfig(orgConfig, override.provider)
+      : getPrimaryOrgProvider(orgConfig);
     return withLocalAIDevTools(
-      getCachedFactory(getPrimaryOrgProvider(orgConfig))(modelId),
+      getCachedFactory(providerConfig)(override.modelId),
     );
   }
-  return withLocalAIDevTools(getInstanceFactory()(modelId));
+  if (override.provider) {
+    return withLocalAIDevTools(
+      createModelFactory({ provider: override.provider })(override.modelId),
+    );
+  }
+  return withLocalAIDevTools(getInstanceFactory()(override.modelId));
 };

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -272,41 +272,15 @@ const resolveProvider = (): AIProvider => {
   );
 };
 
-/**
- * Whether the instance can serve AI to an org that has not set
- * BYOK. False when REQUIRE_PERSONAL_AI_KEY forces BYOK or when
- * no provider has the credentials it needs to run.
- *
- * AI_PROVIDER alone is not enough: an explicit provider must be
- * paired with the matching key (e.g. AI_PROVIDER=openai requires
- * OPENAI_API_KEY) or the model factory will fail at runtime.
- */
-export const hasInstanceProvider = (): boolean => {
+const hasInstanceProviderCredentials = (provider: AIProvider): boolean => {
   if (env.REQUIRE_PERSONAL_AI_KEY) {
     return false;
   }
-  // Mock provider stands in for any real key.
   if (env.USE_MOCK_AI) {
     return true;
   }
-  // Auto-detect path: any single provider key is enough.
-  const hasAnyKey = !!(
-    env.OPENROUTER_API_KEY ||
-    env.GOOGLE_GENERATIVE_AI_API_KEY ||
-    env.GOOGLE_AI_API_KEY_EU ||
-    env.GOOGLE_AI_API_KEY_CH ||
-    env.OPENAI_API_KEY ||
-    (env.AZURE_API_KEY && (env.AZURE_RESOURCE_NAME || env.AZURE_BASE_URL)) ||
-    env.ANTHROPIC_API_KEY ||
-    env.MISTRAL_API_KEY
-  );
-  if (!env.AI_PROVIDER) {
-    return hasAnyKey;
-  }
-  // Explicit provider: each provider has its own credential
-  // requirement. Mirror resolveProvider's expectations so the
-  // gate matches what the model factory would actually accept.
-  switch (env.AI_PROVIDER) {
+
+  switch (provider) {
     case "openrouter":
       return !!env.OPENROUTER_API_KEY;
     case "google":
@@ -328,9 +302,30 @@ export const hasInstanceProvider = (): boolean => {
       return !!env.MISTRAL_API_KEY;
     case "openai_compatible":
       return !!(env.OPENAI_API_KEY && env.AI_PROVIDER_BASE_URL);
-    default:
-      return false;
+    default: {
+      const _exhaustive: never = provider;
+      return _exhaustive;
+    }
   }
+};
+
+/**
+ * Whether the instance can serve AI to an org that has not set
+ * BYOK. False when REQUIRE_PERSONAL_AI_KEY forces BYOK or when
+ * no provider has the credentials it needs to run.
+ *
+ * AI_PROVIDER alone is not enough: an explicit provider must be
+ * paired with the matching key (e.g. AI_PROVIDER=openai requires
+ * OPENAI_API_KEY) or the model factory will fail at runtime.
+ */
+export const hasInstanceProvider = (): boolean => {
+  if (env.REQUIRE_PERSONAL_AI_KEY) {
+    return false;
+  }
+  if (!env.AI_PROVIDER) {
+    return AI_PROVIDERS.some(hasInstanceProviderCredentials);
+  }
+  return hasInstanceProviderCredentials(env.AI_PROVIDER);
 };
 
 /**
@@ -690,12 +685,54 @@ const withLocalAIDevTools = (model: WrappableLanguageModel): LanguageModel => {
 const getPrimaryOrgProvider = (config: OrgAIConfig): OrgAIProviderConfig =>
   config.providers.at(0) ?? panic("Org AI config has no configured providers");
 
+const findOrgProviderConfig = (
+  config: OrgAIConfig,
+  provider: AIProvider,
+): OrgAIProviderConfig | undefined =>
+  config.providers.find((candidate) => candidate.provider === provider);
+
 const getOrgProviderConfig = (
   config: OrgAIConfig,
   provider: AIProvider,
 ): OrgAIProviderConfig =>
-  config.providers.find((candidate) => candidate.provider === provider) ??
+  findOrgProviderConfig(config, provider) ??
   panic(`Org AI config has no ${provider} provider`);
+
+export const validateDevModelOverride = (
+  modelId: string,
+  orgConfig: OrgAIConfig | null,
+): Result<void, HandlerError<400>> => {
+  const override = decodeModelOverride(modelId);
+  if (!override.provider) {
+    return Result.ok(undefined);
+  }
+
+  if (orgConfig) {
+    if (findOrgProviderConfig(orgConfig, override.provider)) {
+      return Result.ok(undefined);
+    }
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message:
+          `Dev model override provider "${override.provider}" is not ` +
+          "configured for this organization.",
+      }),
+    );
+  }
+
+  if (hasInstanceProviderCredentials(override.provider)) {
+    return Result.ok(undefined);
+  }
+  return Result.err(
+    new HandlerError({
+      status: 400,
+      message:
+        `Dev model override provider "${override.provider}" is not ` +
+        "configured for this deployment.",
+    }),
+  );
+};
 
 /**
  * Get a model instance for a logical role.

--- a/apps/api/src/lib/analytics/ai.test.ts
+++ b/apps/api/src/lib/analytics/ai.test.ts
@@ -66,10 +66,10 @@ const createGoogleOrgAIConfig = (): OrgAIConfig => ({
     },
   ],
   overrideModels: {
-    chat: { provider: "google", modelId: "gemini-2.5-flash" },
-    fast: { provider: "google", modelId: "gemini-2.5-flash" },
-    reasoning: { provider: "google", modelId: "gemini-2.5-pro" },
-    pdf: { provider: "google", modelId: "gemini-2.5-flash" },
+    chat: { provider: "google", modelId: "gemini-3.5-flash" },
+    fast: { provider: "google", modelId: "gemini-3.5-flash" },
+    reasoning: { provider: "google", modelId: "gemini-3.1-pro-preview" },
+    pdf: { provider: "google", modelId: "gemini-3.5-flash" },
   },
 });
 

--- a/apps/web/src/components/ai-config-role-models.logic.test.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.test.ts
@@ -134,8 +134,8 @@ describe("BYOK provider and model configuration", () => {
       ]),
     ).toContainEqual({
       provider: "openrouter",
-      modelId: "google/gemini-3-flash-preview",
-      value: "openrouter::google/gemini-3-flash-preview",
+      modelId: "google/gemini-3.5-flash",
+      value: "openrouter::google/gemini-3.5-flash",
     });
   });
 
@@ -154,8 +154,8 @@ describe("BYOK provider and model configuration", () => {
     });
     expect(modelOptions).toContainEqual({
       provider: "google",
-      modelId: "gemini-3-pro-preview",
-      value: "google::gemini-3-pro-preview",
+      modelId: "gemini-3.5-flash",
+      value: "google::gemini-3.5-flash",
     });
     expect(modelOptions).toContainEqual({
       provider: "mistral",
@@ -179,8 +179,8 @@ describe("BYOK provider and model configuration", () => {
     });
     expect(modelOptions).not.toContainEqual({
       provider: "google",
-      modelId: "gemini-1.5-pro",
-      value: "google::gemini-1.5-pro",
+      modelId: "gemini-2.5-pro",
+      value: "google::gemini-2.5-pro",
     });
     expect(modelOptions).not.toContainEqual({
       provider: "mistral",

--- a/apps/web/src/components/ai-config-role-models.logic.ts
+++ b/apps/web/src/components/ai-config-role-models.logic.ts
@@ -82,10 +82,10 @@ export const CUSTOM_MODEL_ID_PROVIDERS = new Set<ProviderValue>([
 
 export const DEFAULT_MODELS_BY_PROVIDER = {
   google: {
-    chat: "gemini-3-flash-preview",
-    fast: "gemini-2.5-flash-lite",
-    reasoning: "gemini-3-pro-preview",
-    pdf: "gemini-3-flash-preview",
+    chat: "gemini-3.5-flash",
+    fast: "gemini-3.1-flash-lite-preview",
+    reasoning: "gemini-3.1-pro-preview",
+    pdf: "gemini-3.5-flash",
   },
   anthropic: {
     chat: "claude-sonnet-4-6",
@@ -106,20 +106,18 @@ export const DEFAULT_MODELS_BY_PROVIDER = {
     pdf: "gpt-5.4",
   },
   openrouter: {
-    chat: "google/gemini-3-flash-preview",
-    fast: "google/gemini-2.5-flash-lite",
+    chat: "google/gemini-3.5-flash",
+    fast: "google/gemini-3.1-flash-lite-preview",
     reasoning: "google/gemini-3.1-pro-preview",
-    pdf: "google/gemini-3-flash-preview",
+    pdf: "google/gemini-3.5-flash",
   },
 } as const satisfies Partial<Record<ProviderValue, Record<RoleValue, string>>>;
 
 export const MODEL_OPTIONS_BY_PROVIDER = {
   google: [
-    "gemini-3-pro-preview",
-    "gemini-3-flash-preview",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
+    "gemini-3.1-pro-preview",
+    "gemini-3.5-flash",
+    "gemini-3.1-flash-lite-preview",
   ],
   anthropic: [
     "claude-opus-4-7",
@@ -137,9 +135,9 @@ export const MODEL_OPTIONS_BY_PROVIDER = {
   openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
   azure_foundry: [],
   openrouter: [
-    "google/gemini-3-flash-preview",
     "google/gemini-3.1-pro-preview",
-    "google/gemini-2.5-flash-lite",
+    "google/gemini-3.5-flash",
+    "google/gemini-3.1-flash-lite-preview",
     "anthropic/claude-opus-4.5",
     "anthropic/claude-sonnet-4.5",
     "openai/gpt-5.4",

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -26,6 +26,11 @@ import {
 } from "@stll/ui/components/menu";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import {
+  MODEL_OPTIONS_BY_PROVIDER,
+  PROVIDER_KEYS,
+  PROVIDER_LABELS,
+} from "@/components/ai-config-role-models.logic";
 import { env } from "@/env";
 import { api } from "@/lib/api";
 import { useDevStore } from "@/lib/dev-store";
@@ -41,58 +46,24 @@ const aiSdkDevtoolsUrl = (() => {
 })();
 
 /**
- * Models available in the dev model selector.
+ * Options for the dev-only chat-model override.
  *
- * Grouped by role (matching ai-models.ts constants on the
- * backend) and by provider for manual overrides.
+ * Sourced from MODEL_OPTIONS_BY_PROVIDER — the same catalog the org
+ * BYOK picker uses — so this list never drifts from the real model
+ * catalog. The selected id is routed through the active provider by
+ * getModelById on the API, so pick a model whose provider matches
+ * the running backend.
  */
-const CHAT_MODELS = [
-  // Default: uses CHAT_MODEL from ai-models.ts
-  { value: "", label: "Default (Gemini 3 Flash)" },
-
-  // --- Low ($0.50–$3/M output) ---
-  { value: "openai/gpt-5-mini", label: "GPT-5 Mini · Low" },
-  { value: "google/gemini-2.5-flash", label: "Gemini 2.5 Flash · Low" },
-  {
-    value: "google/gemini-3-flash-preview",
-    label: "Gemini 3.0 Flash · Low",
-  },
-  {
-    value: "perplexity/sonar",
-    label: "Sonar (web search) · Low",
-  },
-
-  // --- Mid ($5–$12/M output) ---
-  {
-    value: "anthropic/claude-haiku-4-5",
-    label: "Claude Haiku 4.5 · Mid",
-  },
-  { value: "openai/o3", label: "o3 · Mid" },
-  { value: "openai/gpt-5", label: "GPT-5 · Mid" },
-  {
-    value: "google/gemini-3-pro-preview",
-    label: "Gemini 3.0 Pro · Mid",
-  },
-  {
-    value: "google/gemini-3.1-pro-preview",
-    label: "Gemini 3.1 Pro · Mid",
-  },
-
-  // --- High ($14–$15/M output) ---
-  {
-    value: "openai/gpt-5.3-codex",
-    label: "GPT-5.3 Codex · High",
-  },
-  { value: "openai/gpt-5.4", label: "GPT-5.4 · High" },
-  {
-    value: "perplexity/sonar-pro",
-    label: "Sonar Pro (web search) · High",
-  },
-  {
-    value: "anthropic/claude-sonnet-4-6",
-    label: "Claude Sonnet 4.6 · High",
-  },
-] as const;
+const CHAT_MODELS: { value: string; label: string }[] = [
+  // Empty value falls through to getModelForRole("chat") on the API.
+  { value: "", label: "Default (chat role)" },
+  ...PROVIDER_KEYS.flatMap((provider) =>
+    MODEL_OPTIONS_BY_PROVIDER[provider].map((modelId) => ({
+      value: modelId,
+      label: `${PROVIDER_LABELS[provider]} · ${modelId}`,
+    })),
+  ),
+];
 
 const SEED_STATUS_POLL_INTERVAL_MS = 1000;
 const SEED_STATUS_MAX_POLLS = 180;

--- a/apps/web/src/components/dev-sidebar-group.tsx
+++ b/apps/web/src/components/dev-sidebar-group.tsx
@@ -27,6 +27,7 @@ import {
 import { stellaToast } from "@stll/ui/components/toast";
 
 import {
+  encodeModelSelection,
   MODEL_OPTIONS_BY_PROVIDER,
   PROVIDER_KEYS,
   PROVIDER_LABELS,
@@ -50,16 +51,15 @@ const aiSdkDevtoolsUrl = (() => {
  *
  * Sourced from MODEL_OPTIONS_BY_PROVIDER — the same catalog the org
  * BYOK picker uses — so this list never drifts from the real model
- * catalog. The selected id is routed through the active provider by
- * getModelById on the API, so pick a model whose provider matches
- * the running backend.
+ * catalog. Values carry the provider so the API routes the override
+ * through the matching model factory instead of the active provider.
  */
 const CHAT_MODELS: { value: string; label: string }[] = [
   // Empty value falls through to getModelForRole("chat") on the API.
   { value: "", label: "Default (chat role)" },
   ...PROVIDER_KEYS.flatMap((provider) =>
     MODEL_OPTIONS_BY_PROVIDER[provider].map((modelId) => ({
-      value: modelId,
+      value: encodeModelSelection({ provider, modelId }),
       label: `${PROVIDER_LABELS[provider]} · ${modelId}`,
     })),
   ),

--- a/apps/web/src/routes/onboarding/-components/prices-panel.tsx
+++ b/apps/web/src/routes/onboarding/-components/prices-panel.tsx
@@ -43,7 +43,7 @@ const OPENROUTER_MARKUP = 1.055;
 // SOURCE: github.com/pydantic/genai-prices PR #379 (merged 2026-05-19)
 const PENDING_MODEL_PRICES: Provider = {
   id: "stella-pending-prices",
-  name: "Google",
+  name: PROVIDER_LABELS.google,
   api_pattern: ".*",
   models: [
     {

--- a/apps/web/src/routes/onboarding/-components/prices-panel.tsx
+++ b/apps/web/src/routes/onboarding/-components/prices-panel.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from "react";
 
 import { calcPrice } from "@pydantic/genai-prices";
-import type { ModelPrice, TieredPrices } from "@pydantic/genai-prices";
+import type {
+  ModelPrice,
+  Provider,
+  TieredPrices,
+  Usage,
+} from "@pydantic/genai-prices";
 import { useTranslations } from "use-intl";
 
 import {
@@ -28,6 +33,32 @@ const TYPICAL_OUTPUT_TOKENS = 2000;
 // entry in genai-prices for most models, so we look up the bare
 // model id (`provider/model` → `model`) and apply this multiplier.
 const OPENROUTER_MARKUP = 1.055;
+
+// Prices already merged into @pydantic/genai-prices upstream but not in
+// a published release yet. Each entry mirrors the upstream definition
+// verbatim, so the figure stays stable once the bundled catalog ships
+// it. Consulted only as a fallback by `priceFor`, so each model turns
+// into harmless dead weight — and can be deleted — once a genai-prices
+// release covers it.
+// SOURCE: github.com/pydantic/genai-prices PR #379 (merged 2026-05-19)
+const PENDING_MODEL_PRICES: Provider = {
+  id: "stella-pending-prices",
+  name: "Google",
+  api_pattern: ".*",
+  models: [
+    {
+      id: "gemini-3.5-flash",
+      match: { starts_with: "gemini-3.5-flash" },
+      prices: { input_mtok: 1.5, cache_read_mtok: 0.15, output_mtok: 9 },
+    },
+  ],
+};
+
+// Bundled catalog first; fall back to PENDING_MODEL_PRICES for models
+// genai-prices does not price yet.
+const priceFor = (usage: Usage, modelId: string) =>
+  calcPrice(usage, modelId) ??
+  calcPrice(usage, modelId, { provider: PENDING_MODEL_PRICES });
 
 const formatPerMTok = (
   raw: number | TieredPrices | undefined,
@@ -77,7 +108,7 @@ const lookupPrice = (modelId: string): LookupResult | null => {
     input_tokens: TYPICAL_INPUT_TOKENS,
     output_tokens: TYPICAL_OUTPUT_TOKENS,
   };
-  const direct = calcPrice(usage, modelId);
+  const direct = priceFor(usage, modelId);
   if (direct) {
     return { calc: direct, markup: 1 };
   }
@@ -87,7 +118,7 @@ const lookupPrice = (modelId: string): LookupResult | null => {
   // BYOK markup so the user sees an accurate effective price.
   const slashIndex = modelId.indexOf("/");
   if (slashIndex !== -1) {
-    const fallback = calcPrice(usage, modelId.slice(slashIndex + 1));
+    const fallback = priceFor(usage, modelId.slice(slashIndex + 1));
     if (fallback) {
       return { calc: fallback, markup: OPENROUTER_MARKUP };
     }


### PR DESCRIPTION
## What

Refreshes the Gemini models offered in the AI provider picker.

**Catalog** (`BYOK_MODEL_OPTIONS` / `MODEL_OPTIONS_BY_PROVIDER`, direct Google and the OpenRouter mirror):

| Provider | Before | After |
|---|---|---|
| Google | `gemini-3-pro-preview`, `gemini-3-flash-preview`, `gemini-2.5-pro`, `gemini-2.5-flash`, `gemini-2.5-flash-lite` | `gemini-3.1-pro-preview`, `gemini-3.5-flash`, `gemini-3.1-flash-lite-preview` |

`gemini-3-flash-preview` is the former name of `gemini-3.5-flash`, and `gemini-3.1-pro-preview` supersedes `gemini-3-pro-preview`, so the 3.0 entries were dropped as redundant. Gemini 2.5 dropped entirely.

Instance defaults (`DEFAULT_MODELS`) and the picker defaults (`DEFAULT_MODELS_BY_PROVIDER`) are aligned: chat/pdf use `gemini-3.5-flash`, fast uses `gemini-3.1-flash-lite-preview`, reasoning uses `gemini-3.1-pro-preview`.

**Pricing** — `@pydantic/genai-prices` has no published release with Gemini 3.5 yet (merged upstream in pydantic/genai-prices#379, unreleased). Added a fallback `Provider` in the prices panel mirroring that entry verbatim. It is consulted only when the bundled catalog misses, so it self-clears once a release ships 3.5.

**Dev sidebar** — the dev-only chat-model picker carried its own hardcoded, drifted model list. Rewired it to source from `MODEL_OPTIONS_BY_PROVIDER` so it stays in sync with the catalog.

## Notes

- Gemini 3.5 Pro is not added: it is not GA (absent from `@ai-sdk/google` and Google's pricing page).

## Test plan

- `bun run typecheck` — `@stll/api` and `@stll/web` pass
- Suites: `ai-models`, `ai-config-role-models.logic`, `analytics/ai` — pass