### PR TITLE
fix(filesystem): allow cmd/ctrl-click to multi-select folders

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { getFolderClickIntent } from "./tree-view-selection.logic";
+
+describe("folder row clicks", () => {
+  test("modifier-click toggles selection without navigation", () => {
+    expect(
+      getFolderClickIntent({
+        currentFolderId: "parent",
+        hasModifier: true,
+      }),
+    ).toEqual({ type: "toggle-selection" });
+  });
+
+  test("plain drill-down click clears selection without selecting the parent folder", () => {
+    expect(
+      getFolderClickIntent({
+        currentFolderId: "parent",
+        hasModifier: false,
+      }),
+    ).toEqual({ type: "clear-and-navigate" });
+  });
+
+  test("plain tree click clears selection before toggling folder expansion", () => {
+    expect(
+      getFolderClickIntent({
+        currentFolderId: undefined,
+        hasModifier: false,
+      }),
+    ).toEqual({ type: "clear-and-toggle" });
+  });
+});

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic.ts
@@ -1,0 +1,24 @@
+export type FolderClickIntent =
+  | { type: "clear-and-navigate" }
+  | { type: "clear-and-toggle" }
+  | { type: "toggle-selection" };
+
+type GetFolderClickIntentOptions = {
+  currentFolderId: string | undefined;
+  hasModifier: boolean;
+};
+
+export const getFolderClickIntent = ({
+  currentFolderId,
+  hasModifier,
+}: GetFolderClickIntentOptions): FolderClickIntent => {
+  if (hasModifier) {
+    return { type: "toggle-selection" };
+  }
+
+  if (currentFolderId) {
+    return { type: "clear-and-navigate" };
+  }
+
+  return { type: "clear-and-toggle" };
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1554,8 +1554,9 @@ const FilesystemRow = ({
           <button
             className="text-start"
             onClick={(e) => {
-              if (e.metaKey || e.ctrlKey) {
-                onSelect(node.entityId, true);
+              const isMeta = e.metaKey || e.ctrlKey;
+              onSelect(node.entityId, isMeta);
+              if (isMeta) {
                 return;
               }
               if (currentFolderId) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -62,6 +62,7 @@ import { AddEntityMenu } from "@/routes/_protected.workspaces/$workspaceId/-comp
 import { DocumentIcon } from "@/routes/_protected.workspaces/$workspaceId/-components/document-icon";
 import { ENTITY_DRAG_TYPE } from "@/routes/_protected.workspaces/$workspaceId/-components/drag-constants";
 import { EmptyState } from "@/routes/_protected.workspaces/$workspaceId/-components/empty-state";
+import { getFolderClickIntent } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view-selection.logic";
 import { flattenFilesystemRows } from "@/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-virtualization";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
@@ -880,6 +881,7 @@ export const FilesystemView = ({ workspaceId, view }: FilesystemViewProps) => {
                         name: newName,
                       });
                     }}
+                    onClearSelection={clearSelection}
                     onSelect={handleSelect}
                     onStartEditing={setEditingEntityId}
                     onSubfolderCreated={handleSubfolderCreated}
@@ -1081,6 +1083,7 @@ type FilesystemRowProps = {
   onNavigateToFolder: (folderId: string) => void;
   onStartEditing: (entityId: string | null) => void;
   onRename: (entityId: string, newName: string) => void;
+  onClearSelection: () => void;
   onSelect: (entityId: string, meta: boolean) => void;
   onSubfolderCreated: (entityId: string, parentId: string) => void;
   getSelectedDragItems: (ids: Set<string>) => DragPreviewData[];
@@ -1104,6 +1107,7 @@ const FilesystemRow = ({
   onNavigateToFolder,
   onStartEditing,
   onRename,
+  onClearSelection,
   onSelect,
   onSubfolderCreated,
   getSelectedDragItems,
@@ -1554,12 +1558,18 @@ const FilesystemRow = ({
           <button
             className="text-start"
             onClick={(e) => {
-              const isMeta = e.metaKey || e.ctrlKey;
-              onSelect(node.entityId, isMeta);
-              if (isMeta) {
+              const intent = getFolderClickIntent({
+                currentFolderId,
+                hasModifier: e.metaKey || e.ctrlKey,
+              });
+
+              if (intent.type === "toggle-selection") {
+                onSelect(node.entityId, true);
                 return;
               }
-              if (currentFolderId) {
+
+              onClearSelection();
+              if (intent.type === "clear-and-navigate") {
                 onNavigateToFolder(node.entityId);
               } else {
                 onToggleFolder(node.entityId);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -1553,7 +1553,11 @@ const FilesystemRow = ({
         <div className={gridCls} style={{ gridTemplateColumns: gridTemplate }}>
           <button
             className="text-start"
-            onClick={() => {
+            onClick={(e) => {
+              if (e.metaKey || e.ctrlKey) {
+                onSelect(node.entityId, true);
+                return;
+              }
               if (currentFolderId) {
                 onNavigateToFolder(node.entityId);
               } else {


### PR DESCRIPTION
## Summary

Folders in the Files tree view could not be added to a multi-selection: the folder row's button only navigated or toggled expansion and never called `onSelect`, while the file row's button correctly does `onSelect(node.entityId, e.metaKey || e.ctrlKey)`. As a result, bulk actions like download-as-zip and delete were unreachable for folders.

This change makes the folder button mirror the file row's modifier-key contract: Cmd/Ctrl-click on a folder toggles its selection without navigating. Plain click (navigate/toggle), double-click (navigate into), drag-and-drop, and the right-click context menu are all unchanged.

Closes #20

## Test plan

- [ ] Cmd-click (Mac) / Ctrl-click (Win/Linux) a folder → row becomes highlighted; folder does not expand or navigate
- [ ] Cmd-click a second folder → both selected
- [ ] Cmd-click a file while folders are selected → mixed selection visible
- [ ] Cmd-click an already-selected folder → removed from selection
- [ ] Plain click a folder → still navigates (when inside a folder) or toggles expansion (at the root)
- [ ] Double-click a folder → still navigates into it
- [ ] Right-click a folder → context menu still opens
- [ ] Build a multi-selection then right-click any row → bulk actions operate on the full set (folders included)