### PR TITLE
chore(i18n): simplify MCP connector description

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1281,11 +1281,11 @@
         "title": "Vzorová ustanovení"
       },
       "connectors": {
-        "description": "Připojení Stelly k ověřeným externím nástrojům",
+        "description": "Připojení stelly k externím nástrojům",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Připojení Stelly k ověřeným externím nástrojům",
+        "description": "Připojení stelly k externím nástrojům",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1281,11 +1281,11 @@
         "title": "Klauseln"
       },
       "connectors": {
-        "description": "Stella mit geprüften externen Tool-Servern verbinden",
+        "description": "stella mit externen Tools verbinden",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Stella mit geprüften externen Tool-Servern verbinden",
+        "description": "stella mit externen Tools verbinden",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1281,11 +1281,11 @@
         "title": "Clauses"
       },
       "connectors": {
-        "description": "Connect Stella to vetted external tool servers",
+        "description": "Connect stella to external tools",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Connect Stella to vetted external tool servers",
+        "description": "Connect stella to external tools",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1281,11 +1281,11 @@
         "title": "Cláusulas"
       },
       "connectors": {
-        "description": "Conecte Stella a servidores externos de herramientas verificados",
+        "description": "Conecte stella a herramientas externas",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Conecte Stella a servidores externos de herramientas verificados",
+        "description": "Conecte stella a herramientas externas",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1281,11 +1281,11 @@
         "title": "Klauslid"
       },
       "connectors": {
-        "description": "Ühendage Stella kontrollitud väliste tööriistaserveritega",
+        "description": "Ühendage stella väliste tööriistadega",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Ühendage Stella kontrollitud väliste tööriistaserveritega",
+        "description": "Ühendage stella väliste tööriistadega",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1281,11 +1281,11 @@
         "title": "Clauses"
       },
       "connectors": {
-        "description": "Connecter Stella à des serveurs d’outils externes vérifiés",
+        "description": "Connecter stella à des outils externes",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Connecter Stella à des serveurs d’outils externes vérifiés",
+        "description": "Connecter stella à des outils externes",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1281,11 +1281,11 @@
         "title": "Kikötések"
       },
       "connectors": {
-        "description": "A Stella összekapcsolása ellenőrzött külső eszközszerverekkel",
+        "description": "A stella összekapcsolása külső eszközökkel",
         "title": "MCP"
       },
       "mcp": {
-        "description": "A Stella összekapcsolása ellenőrzött külső eszközszerverekkel",
+        "description": "A stella összekapcsolása külső eszközökkel",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1281,11 +1281,11 @@
         "title": "Sąlygos"
       },
       "connectors": {
-        "description": "Prijunkite Stella prie patikrintų išorinių įrankių serverių",
+        "description": "Prijunkite stella prie išorinių įrankių",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Prijunkite Stella prie patikrintų išorinių įrankių serverių",
+        "description": "Prijunkite stella prie išorinių įrankių",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1281,11 +1281,11 @@
         "title": "Klauzulas"
       },
       "connectors": {
-        "description": "Savienojiet Stella ar pārbaudītiem ārējiem rīku serveriem",
+        "description": "Savienojiet stella ar ārējiem rīkiem",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Savienojiet Stella ar pārbaudītiem ārējiem rīku serveriem",
+        "description": "Savienojiet stella ar ārējiem rīkiem",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1284,11 +1284,11 @@ type Messages = {
         "title": "Clauses";
       };
       "connectors": {
-        "description": "Connect Stella to vetted external tool servers";
+        "description": "Connect stella to external tools";
         "title": "MCP";
       };
       "mcp": {
-        "description": "Connect Stella to vetted external tool servers";
+        "description": "Connect stella to external tools";
         "title": "MCP";
       };
       "prompts": {

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1281,11 +1281,11 @@
         "title": "Klauzule"
       },
       "connectors": {
-        "description": "Połącz Stellę ze zweryfikowanymi zewnętrznymi serwerami narzędzi",
+        "description": "Połącz stellę z zewnętrznymi narzędziami",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Połącz Stellę ze zweryfikowanymi zewnętrznymi serwerami narzędzi",
+        "description": "Połącz stellę z zewnętrznymi narzędziami",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1285,7 +1285,7 @@
         "title": "Conectores"
       },
       "mcp": {
-        "description": "Conecte a Stella a servidores externos de ferramentas verificados",
+        "description": "Conecte a stella a ferramentas externas",
         "title": "MCP"
       },
       "prompts": {

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1281,8 +1281,8 @@
         "title": "Cláusulas"
       },
       "connectors": {
-        "description": "Conecte-se a sistemas externos",
-        "title": "Conectores"
+        "description": "Conecte a stella a ferramentas externas",
+        "title": "MCP"
       },
       "mcp": {
         "description": "Conecte a stella a ferramentas externas",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1281,11 +1281,11 @@
         "title": "Vzorové ustanovenia"
       },
       "connectors": {
-        "description": "Pripojte Stellu k overeným externým nástrojovým serverom",
+        "description": "Pripojte stellu k externým nástrojom",
         "title": "MCP"
       },
       "mcp": {
-        "description": "Pripojte Stellu k overeným externým nástrojovým serverom",
+        "description": "Pripojte stellu k externým nástrojom",
         "title": "MCP"
       },
       "prompts": {


### PR DESCRIPTION
## What

Simplifies the connectors/MCP section description across all 12 languages.

- Lowercase the `stella` brand (always lowercase in user-facing copy).
- Drop "vetted" — the servers host third-party tools and are not vetted by stella.
- Drop "servers" — name what the user connects to (external tools) rather than the transport.

Values only; translation keys are unchanged. Result matches the existing Czech phrasing, e.g. EN becomes "Connect stella to external tools".

## Test plan

- i18n pre-commit hook passes.