### PR TITLE
chore(web): tree-view debounce + disable-comment hygiene

### DIFF
--- a/apps/web/src/components/require-ai-key.tsx
+++ b/apps/web/src/components/require-ai-key.tsx
@@ -255,7 +255,7 @@ export function AIKeyRequiredDialog({
         providers: providerValues,
       }),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-syncs only when the dialog opens or `configured` flips; depending on the full `config` identity would overwrite user edits on every refetch.
   }, [open, config?.configured]);
 
   const updateProviders = (nextProviders: ProviderCredentialDraft[]) => {

--- a/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/ai-config-card.tsx
@@ -86,7 +86,7 @@ export const AIConfigCard = () => {
         providers: providerValues,
       }),
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally depends only on `configured` (see comment above); the full `config` identity would overwrite user edits on every refetch.
   }, [config?.configured]);
 
   const updateProviders = (nextProviders: ProviderCredentialDraft[]) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -851,7 +851,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     // propagates lock-state changes via `updateEditable`. Including
     // it here would tear down + re-create the registration on every
     // toggle, invalidating the token contract documented above.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `isUnlocked` deliberately excluded; see block comment above.
   }, [entityId, requestEditMode]);
 
   useEffect(() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/filesystem/tree-view.tsx
@@ -27,6 +27,7 @@ import {
   FolderIcon,
   FolderOpenIcon,
 } from "lucide-react";
+import { useDebouncedCallback } from "use-debounce";
 import { useLocale, useTranslations } from "use-intl";
 
 import {
@@ -1179,7 +1180,6 @@ const FilesystemRow = ({
 
   const moveEntity = useMoveEntity();
   const [isDropTarget, setIsDropTarget] = useState(false);
-  const autoExpandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Store volatile values in refs so the effect doesn't
   // re-register drag/drop handlers on every render.
@@ -1199,6 +1199,10 @@ const FilesystemRow = ({
   getSelectedDragItemsRef.current = getSelectedDragItems;
   const getSelectedEntitiesRef = useRef(getSelectedEntities);
   getSelectedEntitiesRef.current = getSelectedEntities;
+
+  const scheduleAutoExpand = useDebouncedCallback(() => {
+    onToggleFolderRef.current(node.entityId);
+  }, 600);
 
   useEffect(() => {
     const el = rowRef.current;
@@ -1283,24 +1287,16 @@ const FilesystemRow = ({
               onDragEnter: () => {
                 setIsDropTarget(true);
                 if (!expandedRef.current) {
-                  autoExpandTimer.current = setTimeout(() => {
-                    onToggleFolderRef.current(node.entityId);
-                  }, 600);
+                  scheduleAutoExpand();
                 }
               },
               onDragLeave: () => {
                 setIsDropTarget(false);
-                if (autoExpandTimer.current) {
-                  clearTimeout(autoExpandTimer.current);
-                  autoExpandTimer.current = null;
-                }
+                scheduleAutoExpand.cancel();
               },
               onDrop: ({ source }) => {
                 setIsDropTarget(false);
-                if (autoExpandTimer.current) {
-                  clearTimeout(autoExpandTimer.current);
-                  autoExpandTimer.current = null;
-                }
+                scheduleAutoExpand.cancel();
                 const entityIds = getDragEntityIds(source.data);
                 if (!entityIds) {
                   return;
@@ -1335,10 +1331,7 @@ const FilesystemRow = ({
     );
     return () => {
       cleanup();
-      if (autoExpandTimer.current) {
-        clearTimeout(autoExpandTimer.current);
-        autoExpandTimer.current = null;
-      }
+      scheduleAutoExpand.cancel();
     };
   }, [
     node.entityId,
@@ -1349,6 +1342,7 @@ const FilesystemRow = ({
     isFolder,
     workspaceId,
     t,
+    scheduleAutoExpand,
   ]);
 
   // Shared cells: Name + Type


### PR DESCRIPTION
## Summary

Two small follow-ups from the R19 modernization scan.

**1. tree-view drag-hover auto-expand → `useDebouncedCallback`**

Replaces a manual `useRef<setTimeout>` + three `clearTimeout` sites with a single `useDebouncedCallback`. Matches CLAUDE.md's "use `useDebouncedCallback` instead of hand-rolling debounce" guideline. The library handles unmount cleanup automatically; `.cancel()` replaces the conditional `clearTimeout` blocks on drag-leave, drop, and effect teardown.

`useDebouncedCallback`'s returned function is stable across renders (memoized internally with empty deps), so adding it to the drag effect's deps array does not cause re-registration of drag handlers.

**2. Inline rationale on three `exhaustive-deps` disables**

Three suppressions either had no inline reason or had the explanation in a block comment above. Lint output is more readable when the `-- reason` lives on the directive itself.

- `require-ai-key.tsx:258` — no reason. Effect intentionally re-syncs only on dialog-open / configured-flip; including full `config` identity would overwrite user edits on refetch.
- `ai-config-card.tsx:89` — comment above, none inline. Same rationale.
- `docx-browser-editor.tsx:854` — five-line block comment above explaining the register/unregister lifecycle; added a short inline pointer.

Suspense boundary audit (`useSuspenseQuery` in shared chrome) came back clean — only hit was `file-chat-overlay.tsx`, and both call sites are already wrapped in explicit local `<Suspense>`.

## Test plan

- [x] `bun run format`
- [x] `bun --filter @stll/web lint` (oxlint type-aware, 520 rules)
- [x] `bun --filter @stll/web typecheck` (tsgo, 0 errors)
- [ ] Browser smoke: drag a file over a collapsed folder in the filesystem tree-view; folder should auto-expand after ~600ms hover; cancel by dragging away before the timer fires