### PR TITLE
fix(api): fan out desktop-edit session SSE events across instances

### DIFF
--- a/apps/api/src/handlers/entities/desktop-edit-session-events.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.ts
@@ -8,6 +8,8 @@ import {
   DESKTOP_EDIT_SESSION_TAKEN_OVER_MESSAGE,
   readDesktopEditSessionEventState,
 } from "@/api/lib/desktop-edit-sessions";
+import { broadcastSessionEvent, registerSessionDelivery } from "@/api/lib/sse";
+import type { SSEEvent } from "@/api/lib/sse";
 
 const SESSION_TOKEN_LENGTH = 64;
 const BEARER_PREFIX = "Bearer ";
@@ -44,15 +46,35 @@ const formatSSE = (event: { type: string; data: unknown }): Uint8Array => {
 };
 
 /**
- * Push an event to all SSE connections for a given session.
- * Called from takeover request, release, and expiry handlers.
+ * Internal close signal carried over the SSE channel. Never enqueued
+ * to clients — it tears down the streams instead.
  */
-export const pushSessionEvent = (
+const SESSION_CLOSE_SIGNAL = "__desktop_edit_session_closed__";
+
+/**
+ * Deliver a session event to SSE connections held by THIS instance.
+ * Invoked by the Redis pub/sub fan-out (and by the local fallback when
+ * Redis is unavailable). The close signal tears the streams down
+ * rather than enqueueing a chunk.
+ */
+const deliverSessionEventLocal = (
   sessionId: SafeId<"desktopEditSession">,
-  event: { type: string; data: unknown },
+  event: SSEEvent,
 ): void => {
   const conns = connections.get(sessionId);
   if (!conns) {
+    return;
+  }
+
+  if (event.type === SESSION_CLOSE_SIGNAL) {
+    for (const conn of conns) {
+      try {
+        conn.controller.close();
+      } catch {
+        // Already closed.
+      }
+    }
+    connections.delete(sessionId);
     return;
   }
 
@@ -61,30 +83,34 @@ export const pushSessionEvent = (
     try {
       conn.controller.enqueue(encoded);
     } catch {
-      // Connection closed; will be cleaned up on cancel
+      // Connection closed; will be cleaned up on cancel.
     }
   }
 };
 
+// Cross-instance fan-out: every API instance receives session messages
+// on the shared Redis channel and delivers to its local streams.
+registerSessionDelivery(deliverSessionEventLocal);
+
 /**
- * Close all SSE connections for a session (e.g., on session close).
+ * Push an event to all SSE connections for a session, across every API
+ * instance. Called from takeover request, release, and expiry handlers.
+ */
+export const pushSessionEvent = (
+  sessionId: SafeId<"desktopEditSession">,
+  event: SSEEvent,
+): void => {
+  broadcastSessionEvent(sessionId, event);
+};
+
+/**
+ * Close all SSE connections for a session, across every API instance
+ * (e.g., on session finalize or close).
  */
 export const closeSessionConnections = (
   sessionId: SafeId<"desktopEditSession">,
 ): void => {
-  const conns = connections.get(sessionId);
-  if (!conns) {
-    return;
-  }
-
-  for (const conn of conns) {
-    try {
-      conn.controller.close();
-    } catch {
-      // Already closed
-    }
-  }
-  connections.delete(sessionId);
+  broadcastSessionEvent(sessionId, { type: SESSION_CLOSE_SIGNAL, data: null });
 };
 
 type DesktopEditSessionEventsHandlerProps = {

--- a/apps/api/src/handlers/entities/desktop-edit-session-events.ts
+++ b/apps/api/src/handlers/entities/desktop-edit-session-events.ts
@@ -83,8 +83,12 @@ const deliverSessionEventLocal = (
     try {
       conn.controller.enqueue(encoded);
     } catch {
-      // Connection closed; will be cleaned up on cancel.
+      conns.delete(conn);
     }
+  }
+
+  if (conns.size === 0 && connections.get(sessionId) === conns) {
+    connections.delete(sessionId);
   }
 };
 

--- a/apps/api/src/lib/safe-id-boundaries.ts
+++ b/apps/api/src/lib/safe-id-boundaries.ts
@@ -40,6 +40,11 @@ export const brandPersistedUserFileId = (
   userFileId: string,
 ): SafeId<"userFile"> => toSafeId<"userFile">(userFileId);
 
+export const brandPersistedDesktopEditSessionId = (
+  desktopEditSessionId: string,
+): SafeId<"desktopEditSession"> =>
+  toSafeId<"desktopEditSession">(desktopEditSessionId);
+
 export const brandPersistedChatThreadId = (
   chatThreadId: string,
 ): SafeId<"chatThread"> => toSafeId<"chatThread">(chatThreadId);

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -17,6 +17,8 @@ const KEEP_ALIVE_INTERVAL_MS = 20_000;
 /** Redis pub/sub channel for cross-instance SSE broadcasts. */
 const REDIS_CHANNEL = "sse:broadcast";
 
+const INSTANCE_ID = `api:${process.pid}:${Bun.randomUUIDv7()}`;
+
 export type SSEEvent = {
   type: string;
   data: unknown;
@@ -139,6 +141,7 @@ type RedisPayload = {
   scope: "workspace" | "organization" | "session";
   id: string;
   event: SSEEvent;
+  originInstanceId?: string | undefined;
 };
 
 const parseRedisPayload = (raw: string): RedisPayload | null => {
@@ -175,6 +178,11 @@ const parseRedisPayload = (raw: string): RedisPayload | null => {
     scope,
     id: parsed.id,
     event: { type: event.type, data: "data" in event ? event.data : undefined },
+    originInstanceId:
+      "originInstanceId" in parsed &&
+      typeof parsed.originInstanceId === "string"
+        ? parsed.originInstanceId
+        : undefined,
   };
 };
 
@@ -206,7 +214,7 @@ const initRedis = async () => {
             brandPersistedOrganizationId(parsed.id),
             parsed.event,
           );
-        } else {
+        } else if (parsed.originInstanceId !== INSTANCE_ID) {
           sessionDeliveryHandler?.(
             brandPersistedDesktopEditSessionId(parsed.id),
             parsed.event,
@@ -308,14 +316,20 @@ export const broadcastSessionEvent = (
   sessionId: SafeId<"desktopEditSession">,
   event: SSEEvent,
 ): void => {
-  const payload: RedisPayload = { scope: "session", id: sessionId, event };
+  sessionDeliveryHandler?.(sessionId, event);
+
+  const payload: RedisPayload = {
+    scope: "session",
+    id: sessionId,
+    event,
+    originInstanceId: INSTANCE_ID,
+  };
   publisher
     .publish(REDIS_CHANNEL, JSON.stringify(payload))
     .catch((error: unknown) => {
       logger.warn("sse.redis_publish_failed", {
         "error.type": errorTag(error),
       });
-      sessionDeliveryHandler?.(sessionId, event);
     });
 };
 

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -6,6 +6,7 @@ import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
 import {
+  brandPersistedDesktopEditSessionId,
   brandPersistedOrganizationId,
   brandPersistedWorkspaceId,
 } from "@/api/lib/safe-id-boundaries";
@@ -16,7 +17,7 @@ const KEEP_ALIVE_INTERVAL_MS = 20_000;
 /** Redis pub/sub channel for cross-instance SSE broadcasts. */
 const REDIS_CHANNEL = "sse:broadcast";
 
-type SSEEvent = {
+export type SSEEvent = {
   type: string;
   data: unknown;
 };
@@ -135,7 +136,7 @@ const broadcastLocalToOrganization = (
 // this one) and delivers to local SSE connections.
 
 type RedisPayload = {
-  scope: "workspace" | "organization";
+  scope: "workspace" | "organization" | "session";
   id: string;
   event: SSEEvent;
 };
@@ -154,7 +155,11 @@ const parseRedisPayload = (raw: string): RedisPayload | null => {
     return null;
   }
   const scope = parsed.scope;
-  if (scope !== "workspace" && scope !== "organization") {
+  if (
+    scope !== "workspace" &&
+    scope !== "organization" &&
+    scope !== "session"
+  ) {
     return null;
   }
   const event = parsed.event;
@@ -196,9 +201,14 @@ const initRedis = async () => {
         }
         if (parsed.scope === "workspace") {
           broadcastLocal(brandPersistedWorkspaceId(parsed.id), parsed.event);
-        } else {
+        } else if (parsed.scope === "organization") {
           broadcastLocalToOrganization(
             brandPersistedOrganizationId(parsed.id),
+            parsed.event,
+          );
+        } else {
+          sessionDeliveryHandler?.(
+            brandPersistedDesktopEditSessionId(parsed.id),
             parsed.event,
           );
         }
@@ -262,6 +272,50 @@ export const broadcastToOrganization = (
         "error.type": errorTag(error),
       });
       broadcastLocalToOrganization(organizationId, event);
+    });
+};
+
+// ── Desktop-edit session events ─────────────────────────
+//
+// Session-scoped SSE rides the same Redis channel as workspace
+// broadcasts. The desktop-edit-session-events module owns the
+// per-instance connection registry; it registers a local-delivery
+// handler here so cross-instance session messages reach its streams.
+
+type SessionDeliveryHandler = (
+  sessionId: SafeId<"desktopEditSession">,
+  event: SSEEvent,
+) => void;
+
+let sessionDeliveryHandler: SessionDeliveryHandler | null = null;
+
+/**
+ * Register the local-delivery handler for session-scoped events.
+ * Called once at startup by the desktop-edit-session-events module.
+ */
+export const registerSessionDelivery = (
+  handler: SessionDeliveryHandler,
+): void => {
+  sessionDeliveryHandler = handler;
+};
+
+/**
+ * Broadcast a desktop-edit session event to all API instances via
+ * Redis pub/sub. Falls back to local delivery when Redis is
+ * unavailable so single-instance deployments still get events.
+ */
+export const broadcastSessionEvent = (
+  sessionId: SafeId<"desktopEditSession">,
+  event: SSEEvent,
+): void => {
+  const payload: RedisPayload = { scope: "session", id: sessionId, event };
+  publisher
+    .publish(REDIS_CHANNEL, JSON.stringify(payload))
+    .catch((error: unknown) => {
+      logger.warn("sse.redis_publish_failed", {
+        "error.type": errorTag(error),
+      });
+      sessionDeliveryHandler?.(sessionId, event);
     });
 };
 


### PR DESCRIPTION
## Problem

`pushSessionEvent` and `closeSessionConnections` (desktop-edit session events) delivered only to SSE streams held by the **calling API instance's** in-memory `connections` map. With more than one API replica, a takeover / release / finalize event raised on instance A never reached a session-events stream connected to instance B — so a displaced desktop editor was not notified that its lock had been taken.

Workspace SSE already fans out across instances via Redis pub/sub (`sse.ts`); desktop-edit session events were the outlier.

## Change

Route session events through the same Redis channel workspace SSE uses:

- `sse.ts` gains a `"session"` scope on the shared `sse:broadcast` channel, plus `broadcastSessionEvent()` and a `registerSessionDelivery()` injection seam so the session module plugs in local delivery without a circular import.
- `desktop-edit-session-events.ts` publishes events through Redis; every instance (including the publisher) receives them on the subscriber and delivers to its local streams. Falls back to local delivery when Redis is unavailable, matching the existing workspace `broadcast`.
- `closeSessionConnections` broadcasts an internal close signal so remote instances tear down their streams too.
- Re-branding of the session ID after the Redis round-trip goes through a new `brandPersistedDesktopEditSessionId` helper in `safe-id-boundaries.ts`, consistent with the workspace/org helpers.

## Behaviour note

Local delivery now goes synchronous → asynchronous (a Redis round-trip), identical to how workspace SSE already behaves. All callers are fire-and-forget `void`; push-then-close ordering relies on Redis preserving publish order from a single connection.

## Verification

- `apps/api` lint — 0 warnings, 0 errors
- `apps/api` typecheck — clean
- SSE-related tests — pass

⚠️ **Merge gate:** unit tests cannot exercise cross-instance fan-out. This should be verified against a real multi-replica deployment (2+ API instances + Redis) before merge.