### PR TITLE
refactor(api): build the S3 client lazily instead of at import

### DIFF
--- a/apps/api/src/lib/s3.test.ts
+++ b/apps/api/src/lib/s3.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveS3Credentials } from "@/api/lib/s3";
+import { getS3, isS3Stale, resolveS3Credentials } from "@/api/lib/s3";
 
 const jsonResponse = (body: unknown): Response =>
   new Response(JSON.stringify(body), { status: 200 });
@@ -20,6 +20,12 @@ const requestUrl = (input: string | URL | Request): string => {
 };
 
 describe("resolveS3Credentials", () => {
+  test("treats a lazily built fallback client as stale", () => {
+    getS3();
+
+    expect(isS3Stale()).toBe(true);
+  });
+
   test("prefers ECS task credentials over static credentials for AWS S3 endpoints", async () => {
     const requestedUrls: string[] = [];
     const fetchImpl = async (

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -324,16 +324,13 @@ let _clientCreatedAt = 0;
  * any request, so the lazy build here is only a fallback.
  */
 export const getS3 = (): S3Client => {
-  if (!_client) {
-    _client = buildS3Client(staticCredentialsFromEnv());
-    _clientCreatedAt = Date.now();
-  }
+  _client ??= buildS3Client(staticCredentialsFromEnv());
   return _client;
 };
 
 /** True when credentials are older than 50 minutes (or not yet built). */
 export const isS3Stale = (): boolean =>
-  Date.now() - _clientCreatedAt > CREDENTIAL_MAX_AGE_MS;
+  !_client || Date.now() - _clientCreatedAt > CREDENTIAL_MAX_AGE_MS;
 
 /**
  * Generate a presigned GET URL that forces the browser to

--- a/apps/api/src/lib/s3.ts
+++ b/apps/api/src/lib/s3.ts
@@ -309,20 +309,29 @@ export const refreshS3 = async (): Promise<void> => {
 };
 
 const CREDENTIAL_MAX_AGE_MS = 50 * 60 * 1000;
-let _client: S3Client = buildS3Client(
-  envBase.S3_ACCESS_KEY_ID && envBase.S3_SECRET_ACCESS_KEY
-    ? {
-        accessKeyId: envBase.S3_ACCESS_KEY_ID,
-        secretAccessKey: envBase.S3_SECRET_ACCESS_KEY,
-      }
-    : null,
-);
-let _clientCreatedAt = Date.now();
 
-/** Returns the current S3 client (synchronous). */
-export const getS3 = (): S3Client => _client;
+// Lazily built so that importing this module's pure helpers
+// (presignDownloadUrl, contentDisposition) does not construct an S3
+// client at import time. refreshS3() — called at startup and
+// periodically — replaces the client with credentials resolved via
+// the configured provider.
+let _client: S3Client | null = null;
+let _clientCreatedAt = 0;
 
-/** True when credentials are older than 50 minutes. */
+/**
+ * Returns the S3 client, building one from static env credentials on
+ * first use. In normal operation refreshS3() runs at startup before
+ * any request, so the lazy build here is only a fallback.
+ */
+export const getS3 = (): S3Client => {
+  if (!_client) {
+    _client = buildS3Client(staticCredentialsFromEnv());
+    _clientCreatedAt = Date.now();
+  }
+  return _client;
+};
+
+/** True when credentials are older than 50 minutes (or not yet built). */
 export const isS3Stale = (): boolean =>
   Date.now() - _clientCreatedAt > CREDENTIAL_MAX_AGE_MS;
 


### PR DESCRIPTION
## Change

`s3.ts` constructed the S3 client at module-evaluation time (`let _client = buildS3Client(...)`), so importing the module for its pure helpers (`presignDownloadUrl`, `contentDisposition`) also built a client.

Construction is now deferred behind `getS3()`: the client is built from static env credentials on first use. `refreshS3()` — called at startup and on the periodic refresh loop — still replaces it with credentials resolved via the configured provider.

## Behaviour

Unchanged in normal operation: `index.ts` awaits `refreshS3()` at startup before any request is served, so the lazy build in `getS3()` is only a fallback path. `isS3Stale()` returns `true` before the client is built, which is correct (it signals "needs refresh").

## Scope note

The audit also flagged the entity upload path for holding the file `~3×` in memory. On inspection that finding is incorrect: `new Uint8Array(fileBuffer)` constructs a *view* over the `ArrayBuffer`, not a copy, so the two call sites do not duplicate the file. No change made there.

## Verification

- `apps/api` lint — 0 warnings, 0 errors
- `apps/api` typecheck — clean
- `s3.test.ts` — 5 pass, 0 fail