### PR TITLE
chore: api error-handling + packages/ui React 19 cleanup

### DIFF
--- a/apps/api/src/db-url.ts
+++ b/apps/api/src/db-url.ts
@@ -1,3 +1,5 @@
+import { panic } from "better-result";
+
 /**
  * Resolve the Postgres connection URL.
  *
@@ -51,26 +53,24 @@ export const resolveDatabaseUrl = (
     const missing = COMPONENT_KEYS.filter((k) =>
       k === "DB_PASSWORD" ? env[k] === undefined : !env[k],
     );
-    throw new Error(
+    panic(
       `DATABASE_URL not set and DB component env vars incomplete; missing: ${missing.join(", ")}`,
     );
   }
 
   const sslmode = DB_SSLMODE ?? "require";
   if (!(ALLOWED_SSLMODES as readonly string[]).includes(sslmode)) {
-    throw new Error(`DB_SSLMODE must be one of ${ALLOWED_SSLMODES.join(", ")}`);
+    panic(`DB_SSLMODE must be one of ${ALLOWED_SSLMODES.join(", ")}`);
   }
   // DB_HOST is left unencoded so IPv6 literals like `[::1]` survive,
   // but URL delimiters in it would otherwise be spliced into the
   // path/query and could smuggle `sslmode=disable` or point at a
   // different database. Same idea for DB_PORT, which must be numeric.
   if (/[/?#@\s]/u.test(DB_HOST)) {
-    throw new Error(
-      "DB_HOST must not contain URL delimiters (/, ?, #, @, whitespace)",
-    );
+    panic("DB_HOST must not contain URL delimiters (/, ?, #, @, whitespace)");
   }
   if (!/^\d+$/u.test(DB_PORT)) {
-    throw new Error("DB_PORT must be numeric");
+    panic("DB_PORT must be numeric");
   }
   const auth = `${encodeURIComponent(DB_USER)}:${encodeURIComponent(DB_PASSWORD)}`;
   const name = encodeURIComponent(DB_NAME);

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,4 +1,5 @@
 import { createEnv } from "@t3-oss/env-core";
+import { panic } from "better-result";
 import * as v from "valibot";
 
 import { DEPLOYED_NODE_ENVS, envBase } from "@/api/env-base";
@@ -158,7 +159,7 @@ if (
   (envApi.MICROSOFT_AUTH_CLIENT_ID || envApi.MICROSOFT_AUTH_CLIENT_SECRET) &&
   !envApi.MICROSOFT_AUTH_TENANT_ID
 ) {
-  throw new Error(
+  panic(
     "MICROSOFT_AUTH_TENANT_ID is required when Microsoft OAuth is configured.",
   );
 }
@@ -167,7 +168,7 @@ if (
   DEPLOYED_NODE_ENVS.has(process.env.NODE_ENV ?? "") &&
   !envApi.CONTENT_ENCRYPTION_KEY
 ) {
-  throw new Error(
+  panic(
     "CONTENT_ENCRYPTION_KEY is required when NODE_ENV is 'production' or 'staging'.",
   );
 }

--- a/apps/api/src/handlers/case-law/ingestion/adapters/retry.ts
+++ b/apps/api/src/handlers/case-law/ingestion/adapters/retry.ts
@@ -5,6 +5,8 @@
  * all adapters, replacing ad-hoc linear/fixed delays.
  */
 
+import { panic } from "better-result";
+
 import { ADAPTER_TIMEOUT } from "@/api/handlers/case-law/consts";
 import { logger } from "@/api/lib/observability/logger";
 
@@ -147,5 +149,5 @@ export const fetchWithRetry = async (
   }
 
   // Unreachable: the loop always returns or throws
-  throw new Error("fetchWithRetry: unreachable");
+  return panic("fetchWithRetry: unreachable");
 };

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import { sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
@@ -45,7 +46,7 @@ export const assertMigrationsApplied = async (): Promise<void> => {
 
   const local = listLocalMigrations();
   if (local.length === 0) {
-    throw new Error(
+    panic(
       `[startup] No migration files at ${MIGRATIONS_DIR}; refusing to start. ` +
         "The runtime image must include apps/api/drizzle/.",
     );
@@ -56,7 +57,7 @@ export const assertMigrationsApplied = async (): Promise<void> => {
 
   if (missing.length > 0) {
     const missingNames = missing.map((m) => m.name).join(", ");
-    throw new Error(
+    panic(
       `[startup] Schema drift: ${missing.length} migration(s) in code are not applied to the database. ` +
         `Code has ${local.length}; DB has ${appliedHashes.size}. ` +
         `Missing or modified after apply: ${missingNames}. ` +

--- a/apps/api/src/mcp/auth.ts
+++ b/apps/api/src/mcp/auth.ts
@@ -37,12 +37,14 @@ export const getMcpAccessTokenVerificationOptions = (
 export const extractMcpSession = (payload: JWTPayload): McpSession => {
   const userId = payload.sub;
   if (!userId) {
-    throw new Error("Token missing sub claim");
+    throw new McpAuthenticationError({ message: "Token missing sub claim" });
   }
 
   const rawOrganizationId = payload["org_id"];
   if (typeof rawOrganizationId !== "string" || rawOrganizationId.length === 0) {
-    throw new Error("Token missing org_id claim");
+    throw new McpAuthenticationError({
+      message: "Token missing org_id claim",
+    });
   }
 
   const rawScopes = payload["scope"];

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -26,9 +26,9 @@ function Combobox<Value, Multiple extends boolean | undefined = false>(
     [chipsRef, props.multiple],
   );
   return (
-    <ComboboxContext.Provider value={contextValue}>
+    <ComboboxContext value={contextValue}>
       <ComboboxPrimitive.Root {...props} />
-    </ComboboxContext.Provider>
+    </ComboboxContext>
   );
 }
 
@@ -154,7 +154,7 @@ function ComboboxPopup({
   alignOffset?: ComboboxPrimitive.Positioner.Props["alignOffset"];
   side?: ComboboxPrimitive.Positioner.Props["side"];
 }) {
-  const { chipsRef } = React.useContext(ComboboxContext);
+  const { chipsRef } = React.use(ComboboxContext);
 
   return (
     <ComboboxPrimitive.Portal>
@@ -342,7 +342,7 @@ function ComboboxChips({
 }: ComboboxPrimitive.Chips.Props & {
   startAddon?: React.ReactNode;
 }) {
-  const { chipsRef } = React.useContext(ComboboxContext);
+  const { chipsRef } = React.use(ComboboxContext);
 
   return (
     <ComboboxPrimitive.Chips

--- a/packages/ui/src/components/input-otp.tsx
+++ b/packages/ui/src/components/input-otp.tsx
@@ -44,7 +44,7 @@ function InputOTPSlot({
 }: React.ComponentProps<"div"> & {
   index: number;
 }) {
-  const inputOTPContext = React.useContext(OTPInputContext);
+  const inputOTPContext = React.use(OTPInputContext);
   const { char, hasFakeCaret, isActive } = inputOTPContext.slots[index] ?? {};
 
   return (

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -66,9 +66,9 @@ function Select<Value, Multiple extends boolean | undefined = false>({
     );
 
   return (
-    <SelectItemDisplaysContext.Provider value={itemDisplays}>
+    <SelectItemDisplaysContext value={itemDisplays}>
       {root}
-    </SelectItemDisplaysContext.Provider>
+    </SelectItemDisplaysContext>
   );
 }
 
@@ -106,7 +106,7 @@ function SelectValue({
   placeholder,
   ...props
 }: SelectPrimitive.Value.Props) {
-  const displays = React.useContext(SelectItemDisplaysContext);
+  const displays = React.use(SelectItemDisplaysContext);
 
   // If the consumer passed children OR there are no rich displays
   // registered, defer to Base UI's default rendering — same plain


### PR DESCRIPTION
## Summary

Two coherent hygiene cleanups bundled into one PR.

### apps/api — error-handling discipline

Five files migrate `throw new Error` to the established convention:

- `mcp/auth.ts` — `extractMcpSession` now throws the existing `McpAuthenticationError` for missing JWT claims, matching the class the wrapping `authenticateMcpRequest` already uses.
- `handlers/case-law/ingestion/adapters/retry.ts:152` — `panic()` on the documented-unreachable tail of `fetchWithRetry`. `return panic(...)` keeps the `consistent-return` lint happy in the async function context.
- `lib/db/assert-migrations-applied.ts`, `env.ts`, `db-url.ts` — boot-time invariant throws (no migration files, schema drift, missing required env, malformed DB URL) become `panic()`. Same behavior, matches the existing apps/api convention used in `mcp/field-markers.ts`, `mcp/context.ts`, `mcp/anonymization-core.ts`, `lib/document-counter.ts`.

`panic` from better-result throws a `Panic` instance extending `Error` with the same `message`, so `.toThrow(string)` and `.toThrow(/regex/)` assertions are unaffected — verified by `db-url.test.ts` (26/26) and `mcp/auth.test.ts` (5/5).

### packages/ui — React 19 sweep

Three files brought in line with the convention applied in #416 and #418:

- `combobox.tsx` — `<ComboboxContext.Provider>` → `<ComboboxContext>`, two `React.useContext` → `React.use`
- `select.tsx` — same shape: `<SelectItemDisplaysContext.Provider>` → `<SelectItemDisplaysContext>`, `React.useContext` → `React.use`
- `input-otp.tsx` — `React.useContext(OTPInputContext)` → `React.use(OTPInputContext)`

Existing `React.useMemo` retained — packages/ui is consumed by multiple apps and we cannot assume every consumer has the React Compiler enabled.

## Out of scope (separate follow-ups if pursued)

- `infosoud.ts:119` `SchedulerAborted` and `sk-us.ts` adapter throws — these need new TaggedError classes; design decision worth its own PR
- `packages/folio` — AGPL boundary, "intertwined" posture per project notes; not touched
- Web Crypto in `lib/content-encryption.ts` — Bun has no native AES-GCM, `crypto.subtle` is the right tool

## Test plan

- [x] `bun run format`
- [x] `bun run lint` (oxlint type-aware, 520 rules, all 22 packages)
- [x] `bun --filter @stll/api typecheck`
- [x] `bun --filter @stll/web typecheck`
- [x] `bun --filter @stll/ui typecheck`
- [x] `bun --filter @stll/api test src/db-url.test.ts` (26 pass)
- [x] `bun --filter @stll/api test src/mcp/auth.test.ts` (5 pass)
- [ ] Browser smoke for combobox/select/input-otp in their primary callsites (auth flows, contact picker, organization settings)