### PR TITLE
feat: queue chat messages sent while a response streams

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -800,6 +800,8 @@ const FileChatOverlayInner = ({
     messages,
     resendLatestMessage,
     sendMessage,
+    queuedMessages,
+    removeQueuedMessage,
     stop,
     isGenerating,
     alwaysApprovedTools,
@@ -976,7 +978,9 @@ const FileChatOverlayInner = ({
                 onAskUserSubmit={handleAskUserSubmit}
                 onCreateDocumentResolve={handleCreateDocumentResolve}
                 onOpenCreatedDocument={handleOpenCreatedDocument}
+                onRemoveQueuedMessage={removeQueuedMessage}
                 onResend={resendLatestMessage}
+                queuedMessages={queuedMessages}
                 showThinkingIndicator
                 showToolCallDetails={showToolCallDetails}
                 streamdownComponents={streamdownComponents}
@@ -1029,6 +1033,7 @@ const FileChatOverlayInner = ({
           onTogglePanel={() => setPanelOpen((v) => !v)}
           panelOpen={panelOpen}
           pendingCount={0}
+          queueWhileGenerating
           sendDisabledReason={
             activeFile && docxEditorRef && !editorReady
               ? "editor-loading"

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -988,6 +988,13 @@ type PromptBarProps = {
    * into a dead context.
    */
   sendDisabledReason?: "editor-loading" | undefined;
+  /**
+   * When true the composer keeps accepting input while a response
+   * streams: a send is queued by `useChatSession` and dispatched
+   * once the turn finishes. A dedicated Stop button appears beside
+   * Send instead of the send button morphing into Stop.
+   */
+  queueWhileGenerating?: boolean | undefined;
 };
 
 /**
@@ -1060,6 +1067,7 @@ export function PromptBar(props: PromptBarProps) {
     emptyPlaceholder,
     attentionPulseSeq,
     sendDisabledReason,
+    queueWhileGenerating = false,
   } = props;
 
   const t = useTranslations();
@@ -1074,6 +1082,15 @@ export function PromptBar(props: PromptBarProps) {
   const isSendBlocked = sendDisabledReason !== undefined;
   const inputDisabled = isSendBlocked;
   const submitDisabled = busy || isSendBlocked;
+  // With queuing enabled the composer keeps accepting input while a
+  // response streams — `useChatSession` holds the send until the
+  // turn finishes. The send button stays a send button; a dedicated
+  // Stop button sits beside it instead of the send button morphing.
+  const composerSubmitDisabled = queueWhileGenerating
+    ? status === "applying" || isSendBlocked
+    : submitDisabled;
+  const morphSendToStop = showStop && !queueWhileGenerating;
+  const showQueueStopButton = showStop && queueWhileGenerating;
 
   // Glow on attention pulse — kicked from the inspector when the
   // user clicks the AI-suggestions chip so they see the bar light
@@ -1107,7 +1124,7 @@ export function PromptBar(props: PromptBarProps) {
     inputDisabled,
     onSubmit: handleComposerSubmit,
     onSubmitGuard: canSubmitNow,
-    submitDisabled,
+    submitDisabled: composerSubmitDisabled,
   });
 
   return (
@@ -1192,17 +1209,39 @@ export function PromptBar(props: PromptBarProps) {
         </Tooltip>
       )}
 
+      {showQueueStopButton && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                aria-label={t("chat.stopResponse")}
+                className="rounded-full"
+                onClick={() => onStop()}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+              >
+                <SquareIcon aria-hidden="true" className="size-3.5" />
+              </Button>
+            }
+          />
+          <TooltipPopup side="top">{t("chat.stopResponse")}</TooltipPopup>
+        </Tooltip>
+      )}
+
       <Tooltip>
         <TooltipTrigger
           render={
             <Button
               aria-label={
-                showStop ? t("chat.stopResponse") : t("chat.sendPrompt")
+                morphSendToStop ? t("chat.stopResponse") : t("chat.sendPrompt")
               }
               className="rounded-full"
-              disabled={showStop ? false : submitDisabled || !canSubmit}
+              disabled={
+                morphSendToStop ? false : composerSubmitDisabled || !canSubmit
+              }
               onClick={() => {
-                if (showStop) {
+                if (morphSendToStop) {
                   onStop();
                   return;
                 }
@@ -1211,7 +1250,7 @@ export function PromptBar(props: PromptBarProps) {
               size="icon"
               type="button"
             >
-              {showStop ? (
+              {morphSendToStop ? (
                 <SquareIcon aria-hidden="true" />
               ) : (
                 <ArrowUpIcon aria-hidden="true" />
@@ -1221,7 +1260,7 @@ export function PromptBar(props: PromptBarProps) {
         />
         <TooltipPopup side="top">
           {(() => {
-            if (showStop) {
+            if (morphSendToStop) {
               return t("chat.stopResponse");
             }
             if (canSubmit) {

--- a/apps/web/src/components/chat-input-surface.tsx
+++ b/apps/web/src/components/chat-input-surface.tsx
@@ -70,11 +70,10 @@ export const ChatInputSurface = ({
     removeFile,
   } = controller;
   const inputDisabled = disabled;
-  // While the assistant is streaming we render Stop in place of Send,
-  // but Enter still calls submit unless we gate it here. Without this
-  // guard, a user pressing Enter during a turn fires an overlapping
-  // `sendMessage` and the two responses interleave.
-  const submitDisabled = disabled || isGenerating;
+  // Submitting stays enabled while the assistant streams: a send
+  // during a turn is queued by `useChatSession` and dispatched once
+  // the response finishes, so overlapping requests can't happen.
+  const submitDisabled = disabled;
 
   const { submitDraft } = useChatComposerWiring({
     controller,
@@ -164,19 +163,22 @@ export const ChatInputSurface = ({
           ref={fileInputRef}
           type="file"
         />
-        {isGenerating && onStop ? (
+        <div className="ms-auto flex items-center gap-1">
+          {isGenerating && onStop && (
+            <Button
+              aria-label={t("chat.stopResponse")}
+              className="shrink-0"
+              onClick={onStop}
+              size="icon-sm"
+              variant="outline"
+            >
+              <SquareIcon className="size-3.5" />
+            </Button>
+          )}
           <Button
-            className="ms-auto shrink-0"
-            onClick={onStop}
-            size="icon-sm"
-            variant="outline"
-          >
-            <SquareIcon className="size-3.5" />
-          </Button>
-        ) : (
-          <Button
+            aria-label={t("chat.sendPrompt")}
             className={cn(
-              "bg-foreground text-background hover:bg-foreground/90 ms-auto shrink-0",
+              "bg-foreground text-background hover:bg-foreground/90 shrink-0",
               (submitDisabled || !canSubmit) && "opacity-50",
             )}
             disabled={submitDisabled || !canSubmit}
@@ -188,7 +190,7 @@ export const ChatInputSurface = ({
           >
             <ArrowUpIcon className="size-3.5" />
           </Button>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -3,7 +3,14 @@ import type { ComponentProps } from "react";
 
 import { isToolUIPart } from "ai";
 import type { FileUIPart } from "ai";
-import { CopyIcon, FileTextIcon, RotateCcwIcon } from "lucide-react";
+import {
+  ClockIcon,
+  CopyIcon,
+  FileTextIcon,
+  PaperclipIcon,
+  RotateCcwIcon,
+  XIcon,
+} from "lucide-react";
 import type { PluggableList } from "unified";
 import { useTranslations } from "use-intl";
 
@@ -36,6 +43,7 @@ import { ToolApprovalCard } from "@/components/chat/tool-approval-card";
 import { ToolCallCard } from "@/components/chat/tool-call-card";
 import type { TranslationKey } from "@/i18n/types";
 import { getUserFileContentUrl } from "@/lib/user-files";
+import type { QueuedChatMessage } from "@/routes/_protected.chat/-hooks/use-chat-session";
 
 const USER_STREAMDOWN_COMPONENTS = {
   a: (props: ComponentProps<"a">) => (
@@ -457,6 +465,13 @@ type ChatThreadMessagesProps = {
   showThinkingIndicator?: boolean | undefined;
   showToolCallDetails?: boolean | undefined;
   showToolCalls?: boolean | undefined;
+  /**
+   * Messages the user composed while a response was streaming.
+   * Rendered as dimmed "pending" bubbles below the transcript;
+   * `useChatSession` dispatches them once the turn finishes.
+   */
+  queuedMessages?: readonly QueuedChatMessage[] | undefined;
+  onRemoveQueuedMessage?: ((id: string) => void) | undefined;
   streamdownComponents: {
     a: (props: ComponentProps<"a">) => React.ReactNode;
     "stll-anon"?: (
@@ -483,6 +498,8 @@ export const ChatThreadMessages = ({
   showThinkingIndicator = false,
   showToolCallDetails,
   showToolCalls,
+  queuedMessages,
+  onRemoveQueuedMessage,
   streamdownComponents,
   workspaceId,
 }: ChatThreadMessagesProps) => {
@@ -574,7 +591,76 @@ export const ChatThreadMessages = ({
       {showThinkingIndicator &&
         isGenerating &&
         !hasVisibleContent(messages) && <ThinkingIndicator />}
+      {onRemoveQueuedMessage &&
+        queuedMessages !== undefined &&
+        queuedMessages.length > 0 && (
+          <QueuedUserMessages
+            messages={queuedMessages}
+            onRemove={onRemoveQueuedMessage}
+          />
+        )}
     </>
+  );
+};
+
+type QueuedUserMessagesProps = {
+  messages: readonly QueuedChatMessage[];
+  onRemove: (id: string) => void;
+};
+
+/**
+ * Pending user messages — composed mid-stream and waiting their
+ * turn. Rendered below the live transcript as dimmed bubbles so the
+ * user can see what is queued and cancel any of it before it sends.
+ */
+const QueuedUserMessages = ({
+  messages,
+  onRemove,
+}: QueuedUserMessagesProps) => {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-muted-foreground ms-auto flex items-center gap-1 text-xs">
+        <ClockIcon aria-hidden="true" className="size-3" />
+        {t("chat.queuedNotice")}
+      </p>
+      {messages.map((queued) => {
+        const text = queued.text.trim()
+          ? normalizeUserMessageTextForDisplay(queued.text)
+          : "";
+        return (
+          <Message from="user" key={queued.id}>
+            <div className="ms-auto flex max-w-full items-start gap-1">
+              <Button
+                aria-label={t("chat.cancelQueuedMessage")}
+                className="mt-0.5 shrink-0"
+                onClick={() => onRemove(queued.id)}
+                size="icon-xs"
+                variant="ghost"
+              >
+                <XIcon className="size-3.5" />
+              </Button>
+              <MessageContent className="opacity-60">
+                {text.length > 0 && (
+                  <UserMessageText
+                    restorationPairs={EMPTY_RESTORATION_PAIRS}
+                    text={text}
+                  />
+                )}
+                {queued.fileCount > 0 && (
+                  <span className="text-muted-foreground flex items-center gap-1 text-xs">
+                    <PaperclipIcon aria-hidden="true" className="size-3" />
+                    {t("chat.queuedAttachmentCount", {
+                      count: queued.fileCount,
+                    })}
+                  </span>
+                )}
+              </MessageContent>
+            </div>
+          </Message>
+        );
+      })}
+    </div>
   );
 };
 

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -343,6 +343,7 @@
     "attachFile": "Připojit soubor",
     "attachedImage": "Přiložený obrázek",
     "attachment": "Příloha",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Zeptejte se na toto rozhodnutí — plný text je k dispozici.",
     "chatAbout": "Vložit do AI chatu",
     "contextPlaceholder": "Chat o {context}, / pro dovednosti, @ pro přidání kontextu",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Začni s jedním z těchto"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(odebrat)",
     "resend": "Odeslat znovu",
     "resizeThread": "Změnit velikost konverzace",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -343,6 +343,7 @@
     "attachFile": "Datei anhängen",
     "attachedImage": "Angehängtes Bild",
     "attachment": "Anhang",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Stelle Fragen zu dieser Entscheidung — der vollständige Text ist hier verfügbar.",
     "chatAbout": "In AI-Chat einfügen",
     "contextPlaceholder": "Chat über {context}, / für Skills, @ für Kontext",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Probiere einen davon zum Start"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(entfernen)",
     "resend": "Erneut senden",
     "resizeThread": "Konversation vergrößern oder verkleinern",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -343,6 +343,7 @@
     "attachFile": "Attach file",
     "attachedImage": "Attached image",
     "attachment": "Attachment",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Ask about this decision — its full text is available here.",
     "chatAbout": "Chat about this",
     "contextPlaceholder": "Chat about {context}, / for prompts, @ to add context",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Try one of these to start"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(remove)",
     "resend": "Resend",
     "resizeThread": "Resize conversation",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -343,6 +343,7 @@
     "attachFile": "Adjuntar archivo",
     "attachedImage": "Imagen adjunta",
     "attachment": "Adjunto",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Pregunta sobre esta decisión — el texto completo está disponible aquí.",
     "chatAbout": "Insertar en chat de IA",
     "contextPlaceholder": "Chat sobre {context}, / para skills, @ para añadir contexto",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Prueba uno de estos para empezar"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(eliminar)",
     "resend": "Reenviar",
     "resizeThread": "Cambiar tamaño de la conversación",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -343,6 +343,7 @@
     "attachFile": "Lisa fail",
     "attachedImage": "Manustatud pilt",
     "attachment": "Manus",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Esita küsimusi selle otsuse kohta — täistekst on siin saadaval.",
     "chatAbout": "Lisa AI vestlusesse",
     "contextPlaceholder": "Vestle teemal {context}, / oskuste jaoks, @ konteksti lisamiseks",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Alusta ühe nendest"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(eemalda)",
     "resend": "Saada uuesti",
     "resizeThread": "Muuda vestluse suurust",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -343,6 +343,7 @@
     "attachFile": "Joindre un fichier",
     "attachedImage": "Image jointe",
     "attachment": "Pièce jointe",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Pose des questions sur cette décision — le texte complet est disponible ici.",
     "chatAbout": "Insérer dans le chat IA",
     "contextPlaceholder": "Chat sur {context}, / pour les skills, @ pour ajouter du contexte",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Essaie l'un d'entre eux pour commencer"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(supprimer)",
     "resend": "Renvoyer",
     "resizeThread": "Redimensionner la conversation",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -343,6 +343,7 @@
     "attachFile": "Fájl csatolása",
     "attachedImage": "Csatolt kép",
     "attachment": "Melléklet",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Kérdezz erről a határozatról — a teljes szöveg itt elérhető.",
     "chatAbout": "Beszúrás az AI chatbe",
     "contextPlaceholder": "Chat erről: {context}, / a skillekhez, @ kontextus hozzáadásához",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Próbáld ki valamelyiket"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(eltávolítás)",
     "resend": "Újraküldés",
     "resizeThread": "Beszélgetés méretezése",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -343,6 +343,7 @@
     "attachFile": "Prisegti failą",
     "attachedImage": "Pridėtas vaizdas",
     "attachment": "Priedas",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Klausk apie šį sprendimą — visas tekstas pasiekiamas čia.",
     "chatAbout": "Įterpti į AI pokalbį",
     "contextPlaceholder": "Pokalbis apie {context}, / įgūdžiams, @ kontekstui pridėti",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Pradėk vienu iš šių"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(pašalinti)",
     "resend": "Siųsti dar kartą",
     "resizeThread": "Keisti pokalbio dydį",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -343,6 +343,7 @@
     "attachFile": "Pievienot failu",
     "attachedImage": "Pievienots attēls",
     "attachment": "Pielikums",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Uzdod jautājumus par šo lēmumu — pilns teksts ir pieejams šeit.",
     "chatAbout": "Ievietot AI čatā",
     "contextPlaceholder": "Tērzēt par {context}, / prasmēm, @ konteksta pievienošanai",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Izmēģini vienu no tiem"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(noņemt)",
     "resend": "Nosūtīt vēlreiz",
     "resizeThread": "Mainīt sarunas izmēru",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -346,6 +346,7 @@ type Messages = {
     "attachFile": "Attach file";
     "attachedImage": "Attached image";
     "attachment": "Attachment";
+    "cancelQueuedMessage": "Cancel queued message";
     "caseLawGreeting": "Ask about this decision — its full text is available here.";
     "chatAbout": "Chat about this";
     "contextPlaceholder": "Chat about {context}, / for prompts, @ to add context";
@@ -429,6 +430,8 @@ type Messages = {
       };
       "tryOne": "Try one of these to start";
     };
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}";
+    "queuedNotice": "Queued — sends when the current response finishes";
     "removeSuggestion": "(remove)";
     "resend": "Resend";
     "resizeThread": "Resize conversation";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -343,6 +343,7 @@
     "attachFile": "Załącz plik",
     "attachedImage": "Załączony obraz",
     "attachment": "Załącznik",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Zapytaj mnie o to orzeczenie — mam dostęp do pełnej treści.",
     "chatAbout": "Omów na czacie",
     "contextPlaceholder": "Czat o {context}, / dla umiejętności, @ aby dodać kontekst",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Zacznij od jednego z tych"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(usuń)",
     "resend": "Wyślij ponownie",
     "resizeThread": "Zmień rozmiar konwersacji",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -343,6 +343,7 @@
     "attachFile": "Anexar arquivo",
     "attachedImage": "Imagem anexada",
     "attachment": "Anexo",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Pergunte sobre esta decisão; o texto completo está disponível aqui.",
     "chatAbout": "Converse sobre isso",
     "contextPlaceholder": "Converse sobre {context}, / para habilidades, @ para adicionar contexto",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Experimente um destes para começar"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(remover)",
     "resend": "Reenviar",
     "resizeThread": "Redimensionar conversa",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -343,6 +343,7 @@
     "attachFile": "Priložiť súbor",
     "attachedImage": "Priložený obrázok",
     "attachment": "Príloha",
+    "cancelQueuedMessage": "Cancel queued message",
     "caseLawGreeting": "Spýtajte sa na toto rozhodnutie — plný text je k dispozícii.",
     "chatAbout": "Vložiť do AI chatu",
     "contextPlaceholder": "Chat o {context}, / pre zručnosti, @ na pridanie kontextu",
@@ -426,6 +427,8 @@
       },
       "tryOne": "Začni s jedným z týchto"
     },
+    "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
+    "queuedNotice": "Queued — sends when the current response finishes",
     "removeSuggestion": "(odstrániť)",
     "resend": "Odoslať znova",
     "resizeThread": "Zmeniť veľkosť konverzácie",

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -129,7 +129,12 @@ export const ChatThreadPage = ({
     isLoadingCreateDocumentMatters,
     streamdownComponents,
     approvalPendingMessageId,
-  } = useChatSession({ chat, conversationId: threadRef.threadId, workspaceId });
+  } = useChatSession({
+    chat,
+    conversationId: threadRef.threadId,
+    getSendMode,
+    workspaceId,
+  });
   const sentMessageHistoryHtml = useMemo(
     () => getUserMessageHtmlHistory(messages),
     [messages],

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -112,6 +112,8 @@ export const ChatThreadPage = ({
     messages,
     resendLatestMessage,
     sendMessage,
+    queuedMessages,
+    removeQueuedMessage,
     stop,
     isGenerating,
     alwaysApprovedTools,
@@ -268,8 +270,10 @@ export const ChatThreadPage = ({
                   onAskUserSubmit={handleAskUserSubmit}
                   onCreateDocumentResolve={handleCreateDocumentResolve}
                   onOpenCreatedDocument={handleOpenCreatedDocument}
+                  onRemoveQueuedMessage={removeQueuedMessage}
                   onResend={resendLatestMessage}
                   onSendWithoutAnonymization={sendWithoutAnonymization}
+                  queuedMessages={queuedMessages}
                   showThinkingIndicator
                   showToolCallDetails={showToolCallDetails}
                   streamdownComponents={streamdownComponents}

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -53,6 +53,7 @@ type CreateDocumentSuccess = Extract<CreateDocumentOutput, { success: true }>;
 type UseChatSessionOptions = {
   chat: Chat<PersistedChatMessage>;
   conversationId: string;
+  getSendMode?: (() => ChatSendMode) | undefined;
   workspaceId?: string | undefined;
 };
 
@@ -78,6 +79,9 @@ const EMPTY_MCP_CONNECTOR_IDENTITIES: readonly McpConnectorApprovalIdentity[] =
 type ChatSendMessageInput = NonNullable<
   Parameters<Chat<PersistedChatMessage>["sendMessage"]>[0]
 >;
+type ChatSendMessageOptions = Parameters<
+  Chat<PersistedChatMessage>["sendMessage"]
+>[1];
 
 /**
  * A user message composed while a response was still streaming.
@@ -96,6 +100,7 @@ export type QueuedChatMessage = {
 type QueuedChatEntry = QueuedChatMessage & {
   /** Fully-built payload handed to the AI SDK on dispatch. */
   message: ChatSendMessageInput;
+  options: ChatSendMessageOptions;
 };
 
 /**
@@ -113,6 +118,7 @@ const describeQueuedMessage = (
 export const useChatSession = ({
   chat,
   conversationId,
+  getSendMode,
   workspaceId,
 }: UseChatSessionOptions) => {
   const navigate = useNavigate();
@@ -157,11 +163,28 @@ export const useChatSession = ({
     setQueuedMessages(next);
   }, []);
 
+  const withSendModeSnapshot = useCallback(
+    (options: ChatSendMessageOptions): ChatSendMessageOptions => {
+      const sendMode = getSendMode?.();
+      if (sendMode === undefined) {
+        return options;
+      }
+      return {
+        ...options,
+        body: {
+          sendMode,
+          ...options?.body,
+        },
+      };
+    },
+    [getSendMode],
+  );
+
   const enqueueMessage = useCallback(
-    (message: ChatSendMessageInput) => {
+    (message: ChatSendMessageInput, options: ChatSendMessageOptions) => {
       replaceQueuedMessages([
         ...queueRef.current,
-        { id: uuidv7(), message, ...describeQueuedMessage(message) },
+        { id: uuidv7(), message, options, ...describeQueuedMessage(message) },
       ]);
     },
     [replaceQueuedMessages],
@@ -177,7 +200,7 @@ export const useChatSession = ({
   }, [replaceQueuedMessages]);
 
   const sendMessage = useCallback(
-    async (message: ChatSendMessageInput) => {
+    async (message: ChatSendMessageInput, options?: ChatSendMessageOptions) => {
       if (conversationIdRef.current !== conversationId) {
         conversationIdRef.current = conversationId;
         isGeneratingRef.current = false;
@@ -185,8 +208,9 @@ export const useChatSession = ({
         replaceQueuedMessages([]);
       }
 
+      const requestOptions = withSendModeSnapshot(options);
       if (isGeneratingRef.current) {
-        enqueueMessage(message);
+        enqueueMessage(message, requestOptions);
         return;
       }
 
@@ -194,16 +218,16 @@ export const useChatSession = ({
       // should resume the queue without reordering the transcript:
       // append the new prompt, then dispatch the oldest waiting one.
       if (queueRef.current.length > 0) {
-        enqueueMessage(message);
+        enqueueMessage(message, requestOptions);
         const next = takeOldestQueuedMessage();
         if (next) {
           isGeneratingRef.current = true;
-          await sendChatMessage(next.message);
+          await sendChatMessage(next.message, next.options);
         }
         return;
       }
 
-      await sendChatMessage(message);
+      await sendChatMessage(message, requestOptions);
     },
     [
       conversationId,
@@ -211,6 +235,7 @@ export const useChatSession = ({
       replaceQueuedMessages,
       sendChatMessage,
       takeOldestQueuedMessage,
+      withSendModeSnapshot,
     ],
   );
 

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -149,6 +149,7 @@ export const useChatSession = ({
   const isGeneratingRef = useRef(false);
   const queueRef = useRef<QueuedChatEntry[]>([]);
   const wasGeneratingRef = useRef(false);
+  const conversationIdRef = useRef(conversationId);
   const [queuedMessages, setQueuedMessages] = useState<QueuedChatEntry[]>([]);
 
   const replaceQueuedMessages = useCallback((next: QueuedChatEntry[]) => {
@@ -177,6 +178,13 @@ export const useChatSession = ({
 
   const sendMessage = useCallback(
     async (message: ChatSendMessageInput) => {
+      if (conversationIdRef.current !== conversationId) {
+        conversationIdRef.current = conversationId;
+        isGeneratingRef.current = false;
+        wasGeneratingRef.current = false;
+        replaceQueuedMessages([]);
+      }
+
       if (isGeneratingRef.current) {
         enqueueMessage(message);
         return;
@@ -197,7 +205,13 @@ export const useChatSession = ({
 
       await sendChatMessage(message);
     },
-    [enqueueMessage, sendChatMessage, takeOldestQueuedMessage],
+    [
+      conversationId,
+      enqueueMessage,
+      replaceQueuedMessages,
+      sendChatMessage,
+      takeOldestQueuedMessage,
+    ],
   );
 
   const removeQueuedMessage = useCallback(
@@ -428,6 +442,8 @@ export const useChatSession = ({
   }, [queuedMessages]);
 
   useEffect(() => {
+    conversationIdRef.current = conversationId;
+    isGeneratingRef.current = false;
     replaceQueuedMessages([]);
     wasGeneratingRef.current = false;
   }, [conversationId, replaceQueuedMessages]);

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -143,35 +143,71 @@ export const useChatSession = ({
 
   // Mirror `isGenerating` (computed below) and the live queue into
   // refs so the stable `sendMessage` callback can branch on the
-  // latest committed values. The refs are assigned in effects (not
-  // during render) so a concurrent re-render that bails out can't
-  // strand them ahead of committed state.
+  // latest committed values. The refs are updated in effects or
+  // queue-event helpers (not during render) so a concurrent re-render
+  // that bails out can't strand them ahead of committed state.
   const isGeneratingRef = useRef(false);
   const queueRef = useRef<QueuedChatEntry[]>([]);
+  const wasGeneratingRef = useRef(false);
   const [queuedMessages, setQueuedMessages] = useState<QueuedChatEntry[]>([]);
+
+  const replaceQueuedMessages = useCallback((next: QueuedChatEntry[]) => {
+    queueRef.current = next;
+    setQueuedMessages(next);
+  }, []);
+
+  const enqueueMessage = useCallback(
+    (message: ChatSendMessageInput) => {
+      replaceQueuedMessages([
+        ...queueRef.current,
+        { id: uuidv7(), message, ...describeQueuedMessage(message) },
+      ]);
+    },
+    [replaceQueuedMessages],
+  );
+
+  const takeOldestQueuedMessage = useCallback(() => {
+    const next = queueRef.current.at(0);
+    if (!next) {
+      return null;
+    }
+    replaceQueuedMessages(queueRef.current.slice(1));
+    return next;
+  }, [replaceQueuedMessages]);
 
   const sendMessage = useCallback(
     async (message: ChatSendMessageInput) => {
-      // Enqueue while a turn is streaming — and also when the queue
-      // already has items waiting (e.g. after an errored turn that
-      // gated the queue). Sending directly in that case would jump
-      // the new message ahead of the buffered ones and reorder the
-      // transcript.
-      if (isGeneratingRef.current || queueRef.current.length > 0) {
-        setQueuedMessages((prev) => [
-          ...prev,
-          { id: uuidv7(), message, ...describeQueuedMessage(message) },
-        ]);
+      if (isGeneratingRef.current) {
+        enqueueMessage(message);
         return;
       }
+
+      // When the queue is gated after an errored turn, a manual send
+      // should resume the queue without reordering the transcript:
+      // append the new prompt, then dispatch the oldest waiting one.
+      if (queueRef.current.length > 0) {
+        enqueueMessage(message);
+        const next = takeOldestQueuedMessage();
+        if (next) {
+          isGeneratingRef.current = true;
+          await sendChatMessage(next.message);
+        }
+        return;
+      }
+
       await sendChatMessage(message);
     },
-    [sendChatMessage],
+    [enqueueMessage, sendChatMessage, takeOldestQueuedMessage],
   );
 
-  const removeQueuedMessage = useCallback((id: string) => {
-    setQueuedMessages((prev) => prev.filter((entry) => entry.id !== id));
-  }, []);
+  const removeQueuedMessage = useCallback(
+    (id: string) => {
+      replaceQueuedMessages(
+        queueRef.current.filter((entry) => entry.id !== id),
+      );
+    },
+    [replaceQueuedMessages],
+  );
 
   const resendLatestMessage = useCallback(
     async ({ messageId, sendMode }: ResendLatestMessageOptions = {}) => {
@@ -391,6 +427,11 @@ export const useChatSession = ({
     queueRef.current = queuedMessages;
   }, [queuedMessages]);
 
+  useEffect(() => {
+    replaceQueuedMessages([]);
+    wasGeneratingRef.current = false;
+  }, [conversationId, replaceQueuedMessages]);
+
   // Drain the queue one message per turn. When the response
   // finishes (`isGenerating` falls back to false) the oldest queued
   // message is dispatched; sending it flips the status straight
@@ -400,7 +441,6 @@ export const useChatSession = ({
   // into a failing provider just burns quota and spams the user
   // with repeats of the same error. The next manual send (or a
   // successful `regenerate`) lifts the gate.
-  const wasGeneratingRef = useRef(isGenerating);
   useEffect(() => {
     const finishedTurn = wasGeneratingRef.current && !isGenerating;
     wasGeneratingRef.current = isGenerating;
@@ -411,9 +451,16 @@ export const useChatSession = ({
     if (!next) {
       return;
     }
-    setQueuedMessages((prev) => prev.slice(1));
+    replaceQueuedMessages(queuedMessages.slice(1));
+    isGeneratingRef.current = true;
     void sendChatMessage(next.message);
-  }, [isGenerating, queuedMessages, sendChatMessage, status]);
+  }, [
+    isGenerating,
+    queuedMessages,
+    replaceQueuedMessages,
+    sendChatMessage,
+    status,
+  ]);
 
   useEffect(() => {
     setConversationApprovedTools(readConversationApprovedTools(conversationId));

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import type { ComponentProps } from "react";
@@ -12,6 +13,7 @@ import type { Chat } from "@ai-sdk/react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate, useRouteContext } from "@tanstack/react-router";
 import { isToolUIPart } from "ai";
+import { v7 as uuidv7 } from "uuid";
 
 import type { ChatSendMode } from "@stll/anonymize-chat";
 
@@ -67,6 +69,47 @@ export type ResendLatestMessageOptions = {
 const EMPTY_MCP_CONNECTOR_IDENTITIES: readonly McpConnectorApprovalIdentity[] =
   [];
 
+/**
+ * Payload shape accepted by the AI SDK's `sendMessage`. Surfaces
+ * only ever pass `{ text }`, `{ files }`, or `{ text, files }`, but
+ * the queue keeps the SDK's full union so it can hold whatever a
+ * caller hands `sendMessage`.
+ */
+type ChatSendMessageInput = NonNullable<
+  Parameters<Chat<PersistedChatMessage>["sendMessage"]>[0]
+>;
+
+/**
+ * A user message composed while a response was still streaming.
+ * `useChatSession` holds these in a queue and dispatches them —
+ * oldest first — once the turn finishes. `text` is the raw editor
+ * HTML (rendered like any sent user message); `fileCount` lets the
+ * pending bubble show an attachment hint without the view ever
+ * touching the file payloads.
+ */
+export type QueuedChatMessage = {
+  id: string;
+  text: string;
+  fileCount: number;
+};
+
+type QueuedChatEntry = QueuedChatMessage & {
+  /** Fully-built payload handed to the AI SDK on dispatch. */
+  message: ChatSendMessageInput;
+};
+
+/**
+ * Pull a display preview out of an outgoing chat payload. The SDK
+ * union has no discriminator, so the `text`/`files` shapes our
+ * surfaces send are told apart structurally with `in`.
+ */
+const describeQueuedMessage = (
+  message: ChatSendMessageInput,
+): Pick<QueuedChatMessage, "fileCount" | "text"> => ({
+  text: "text" in message ? message.text : "",
+  fileCount: "files" in message ? message.files.length : 0,
+});
+
 export const useChatSession = ({
   chat,
   conversationId,
@@ -98,12 +141,32 @@ export const useChatSession = ({
     addToolOutput,
   } = useChat({ chat });
 
+  // Mirrors `isGenerating` (computed below) so the stable
+  // `sendMessage` callback can branch on the live value without
+  // being rebuilt on every status change.
+  const isGeneratingRef = useRef(false);
+  const [queuedMessages, setQueuedMessages] = useState<QueuedChatEntry[]>([]);
+
   const sendMessage = useCallback(
-    async (message: Parameters<typeof sendChatMessage>[0]) => {
+    async (message: ChatSendMessageInput) => {
+      // A response is still streaming — hold the message in the
+      // queue instead of firing an overlapping request. The drain
+      // effect below dispatches it once the turn finishes.
+      if (isGeneratingRef.current) {
+        setQueuedMessages((prev) => [
+          ...prev,
+          { id: uuidv7(), message, ...describeQueuedMessage(message) },
+        ]);
+        return;
+      }
       await sendChatMessage(message);
     },
     [sendChatMessage],
   );
+
+  const removeQueuedMessage = useCallback((id: string) => {
+    setQueuedMessages((prev) => prev.filter((entry) => entry.id !== id));
+  }, []);
 
   const resendLatestMessage = useCallback(
     async ({ messageId, sendMode }: ResendLatestMessageOptions = {}) => {
@@ -316,6 +379,31 @@ export const useChatSession = ({
   );
   const isGenerating =
     status === "submitted" || status === "streaming" || hasRunningToolCall;
+  isGeneratingRef.current = isGenerating;
+
+  // Drain the queue one message per turn. When the response
+  // finishes (`isGenerating` falls back to false) the oldest queued
+  // message is dispatched; sending it flips the status straight
+  // back, so the next queued message waits for that turn to end
+  // too — queued messages never overlap a stream. We hold the
+  // queue if the turn ended in error: firing every queued message
+  // into a failing provider just burns quota and spams the user
+  // with repeats of the same error. The next manual send (or a
+  // successful `regenerate`) lifts the gate.
+  const wasGeneratingRef = useRef(isGenerating);
+  useEffect(() => {
+    const finishedTurn = wasGeneratingRef.current && !isGenerating;
+    wasGeneratingRef.current = isGenerating;
+    if (!finishedTurn || status === "error") {
+      return;
+    }
+    const next = queuedMessages.at(0);
+    if (!next) {
+      return;
+    }
+    setQueuedMessages((prev) => prev.slice(1));
+    void sendChatMessage(next.message);
+  }, [isGenerating, queuedMessages, sendChatMessage, status]);
 
   useEffect(() => {
     setConversationApprovedTools(readConversationApprovedTools(conversationId));
@@ -375,6 +463,8 @@ export const useChatSession = ({
     messages,
     resendLatestMessage,
     sendMessage,
+    queuedMessages,
+    removeQueuedMessage,
     stop,
     isGenerating,
     alwaysApprovedTools,

--- a/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
+++ b/apps/web/src/routes/_protected.chat/-hooks/use-chat-session.ts
@@ -141,18 +141,23 @@ export const useChatSession = ({
     addToolOutput,
   } = useChat({ chat });
 
-  // Mirrors `isGenerating` (computed below) so the stable
-  // `sendMessage` callback can branch on the live value without
-  // being rebuilt on every status change.
+  // Mirror `isGenerating` (computed below) and the live queue into
+  // refs so the stable `sendMessage` callback can branch on the
+  // latest committed values. The refs are assigned in effects (not
+  // during render) so a concurrent re-render that bails out can't
+  // strand them ahead of committed state.
   const isGeneratingRef = useRef(false);
+  const queueRef = useRef<QueuedChatEntry[]>([]);
   const [queuedMessages, setQueuedMessages] = useState<QueuedChatEntry[]>([]);
 
   const sendMessage = useCallback(
     async (message: ChatSendMessageInput) => {
-      // A response is still streaming — hold the message in the
-      // queue instead of firing an overlapping request. The drain
-      // effect below dispatches it once the turn finishes.
-      if (isGeneratingRef.current) {
+      // Enqueue while a turn is streaming — and also when the queue
+      // already has items waiting (e.g. after an errored turn that
+      // gated the queue). Sending directly in that case would jump
+      // the new message ahead of the buffered ones and reorder the
+      // transcript.
+      if (isGeneratingRef.current || queueRef.current.length > 0) {
         setQueuedMessages((prev) => [
           ...prev,
           { id: uuidv7(), message, ...describeQueuedMessage(message) },
@@ -379,7 +384,12 @@ export const useChatSession = ({
   );
   const isGenerating =
     status === "submitted" || status === "streaming" || hasRunningToolCall;
-  isGeneratingRef.current = isGenerating;
+  useEffect(() => {
+    isGeneratingRef.current = isGenerating;
+  }, [isGenerating]);
+  useEffect(() => {
+    queueRef.current = queuedMessages;
+  }, [queuedMessages]);
 
   // Drain the queue one message per turn. When the response
   // finishes (`isGenerating` falls back to false) the oldest queued

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -192,6 +192,8 @@ export const ChatTabPanel = ({
     messages,
     resendLatestMessage,
     sendMessage,
+    queuedMessages,
+    removeQueuedMessage,
     stop,
     isGenerating,
     alwaysApprovedTools,
@@ -332,8 +334,10 @@ export const ChatTabPanel = ({
                   onAskUserSubmit={handleAskUserSubmit}
                   onCreateDocumentResolve={handleCreateDocumentResolve}
                   onOpenCreatedDocument={handleOpenCreatedDocument}
+                  onRemoveQueuedMessage={removeQueuedMessage}
                   onResend={resendLatestMessage}
                   onSendWithoutAnonymization={sendWithoutAnonymization}
+                  queuedMessages={queuedMessages}
                   showThinkingIndicator
                   showToolCallDetails={showToolCallDetails}
                   streamdownComponents={streamdownComponents}
@@ -376,6 +380,7 @@ export const ChatTabPanel = ({
             }}
             panelOpen={false}
             pendingCount={0}
+            queueWhileGenerating
             showThreadToggle={false}
             status={isGenerating ? "generating" : "idle"}
           />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -212,6 +212,7 @@ export const ChatTabPanel = ({
   } = useChatSession({
     chat,
     conversationId: threadRef.threadId,
+    getSendMode,
     workspaceId: tabWorkspaceId,
   });
 


### PR DESCRIPTION
Closes #9.

While an AI response is streaming the composer now stays editable: a send during a turn is held in `useChatSession`'s queue and dispatched, oldest first, once the turn finishes. Requests never overlap a stream.

### Why turn-completion is the only dispatch point

The agentic tool loop runs server-side inside one stream (`streamText` multi-step), so the client can't observe inter-tool-call boundaries — turn completion is the only race-free dispatch point. The issue lists this as the primary acceptable behaviour.

### Changes

- `use-chat-session.ts` owns the queue: enqueue while `isGenerating`, drain on the generating→idle falling edge (skipped when `status === \"error\"` so queued messages don't fan out into a failing provider), expose `removeQueuedMessage`.
- `chat-thread-messages.tsx` renders queued items as dimmed pending bubbles with a cancel control — single render site, all three surfaces inherit it.
- `chat-input-surface.tsx` and `host.tsx` (`PromptBar`) keep the composer editable while streaming; a dedicated Stop button sits beside Send. `PromptBar`'s queue mode is opt-in via the new \`queueWhileGenerating\` prop so the host's internal `use-ai-suggestion-thread` flow keeps its current single-morph-button UX.
- Wired through all three chat surfaces: `chat-thread-page.tsx`, `chat-tab-panel.tsx`, `file-chat-overlay.tsx`.
- i18n: 3 new `chat.*` keys, `i18n:sync` propagated them across 13 locales (non-en hold the en string pending translation).

### Verification

typecheck · lint · format · 356 tests · production build — all green.

No hook unit test added: web has no `renderHook` precedent and the queue logic is tightly coupled to `useChat`, so a test would mean new infra plus heavy SDK mocking. Manual streaming verification recommended.