### PR TITLE
feat: generate AI thread title

### DIFF
--- a/apps/api/drizzle/20260523144218_chat-threads-title-source/migration.sql
+++ b/apps/api/drizzle/20260523144218_chat-threads-title-source/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "chat_threads" ADD COLUMN "title_source" varchar(4) NOT NULL DEFAULT 'user';

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -2634,6 +2634,11 @@ export const chatThreads = p.pgTable(
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
     title: p.varchar({ length: 255 }).notNull(),
+    titleSource: p
+      .varchar("title_source", { length: 4 })
+      .$type<"ai" | "user">()
+      .notNull()
+      .default("user"),
     /**
      * Matters the chat draws context from. Empty array (the
      * default) means "no specific matters pinned" — the AI

--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -1,0 +1,158 @@
+import { generateText } from "ai";
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db";
+import { chatThreads } from "@/api/db/schema";
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import type { OrgAIConfig } from "@/api/lib/ai-models";
+import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import { captureError } from "@/api/lib/analytics";
+import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+
+const TITLE_MAX_LENGTH = 60;
+const TITLE_CONTEXT_MAX_LENGTH = 500;
+const TITLE_MAX_OUTPUT_TOKENS = 32;
+const TITLE_GENERATION_TIMEOUT_MS = 10_000;
+
+type GenerateThreadTitleProps = {
+  messages: [ChatMessage, ChatMessage]; // [userMessage, AIMessage]
+  orgAIConfig: OrgAIConfig | null;
+  recordAuditEvent: AuditRecorder;
+  safeDb: SafeDb;
+  threadId: SafeId<"chatThread">;
+  threadWorkspaceId: SafeId<"workspace"> | null;
+};
+
+export const generateThreadTitle = async ({
+  messages,
+  orgAIConfig,
+  recordAuditEvent,
+  safeDb,
+  threadId,
+  threadWorkspaceId,
+}: GenerateThreadTitleProps): Promise<void> => {
+  const aiAnalytics = createAIAnalyticsCallbacks({
+    feature: "chat.thread_title",
+    modelRole: "fast",
+    orgAIConfig,
+    properties: threadWorkspaceId ? { workspace_id: threadWorkspaceId } : {},
+    traceId: Bun.randomUUIDv7(),
+  });
+
+  try {
+    const [userMessage, assistantMessage] = messages;
+    const userText = extractTitleContext(userMessage);
+    const assistantText = extractTitleContext(assistantMessage);
+
+    const { text } = await generateText({
+      abortSignal: AbortSignal.timeout(TITLE_GENERATION_TIMEOUT_MS),
+      maxOutputTokens: TITLE_MAX_OUTPUT_TOKENS,
+      model: getModelForRole("fast", orgAIConfig),
+      prompt: `Given this conversation, reply with a short thread title (max 6 words). Reply with the title only, nothing else.
+
+User: ${userText}
+Assistant: ${assistantText}`,
+      temperature: getTemperatureForRole("fast"),
+      ...aiAnalytics.stepCallbacks,
+    });
+
+    const title = cleanGeneratedTitle(text);
+    if (!title) {
+      return;
+    }
+
+    const updateResult = await safeDb(async (tx) => {
+      const currentThread = await tx.query.chatThreads.findFirst({
+        where: {
+          id: { eq: threadId },
+        },
+        columns: {
+          title: true,
+          titleSource: true,
+        },
+      });
+
+      if (!currentThread || currentThread.titleSource !== "user") {
+        return;
+      }
+
+      const updatedRows = await tx
+        .update(chatThreads)
+        .set({ title, titleSource: "ai" })
+        .where(
+          and(
+            eq(chatThreads.id, threadId),
+            eq(chatThreads.titleSource, "user"),
+          ),
+        )
+        .returning({ id: chatThreads.id });
+
+      if (updatedRows.length === 0) {
+        return;
+      }
+
+      await recordAuditEvent(tx, {
+        action: AUDIT_ACTION.UPDATE,
+        resourceType: AUDIT_RESOURCE_TYPE.CHAT_THREAD,
+        resourceId: threadId,
+        workspaceId: threadWorkspaceId,
+        changes: {
+          title: { old: currentThread.title, new: title },
+          titleSource: { old: currentThread.titleSource, new: "ai" },
+        },
+      });
+    });
+
+    if (Result.isError(updateResult)) {
+      captureError(updateResult.error, { threadId });
+    }
+  } catch (error) {
+    aiAnalytics.captureError(error);
+    captureError(error, { threadId });
+  }
+};
+
+const extractTitleContext = (message: ChatMessage): string =>
+  message.parts
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .join(" ")
+    .replaceAll(/\s+/gu, " ")
+    .trim()
+    .slice(0, TITLE_CONTEXT_MAX_LENGTH);
+
+const isWrappingQuote = (char: string): boolean => char === '"' || char === "'";
+
+const trimWrappingQuotes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && isWrappingQuote(value.charAt(start))) {
+    start += 1;
+  }
+  while (end > start && isWrappingQuote(value.charAt(end - 1))) {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+};
+
+const stripTitlePrefix = (value: string): string => {
+  const prefix = "title:";
+  if (value.slice(0, prefix.length).toLowerCase() !== prefix) {
+    return value;
+  }
+
+  return value.slice(prefix.length).trimStart();
+};
+
+const stripTitleWrapper = (value: string): string => {
+  const unquoted = trimWrappingQuotes(value.trim()).trim();
+  return trimWrappingQuotes(stripTitlePrefix(unquoted).trim()).trim();
+};
+
+const cleanGeneratedTitle = (text: string): string =>
+  stripTitleWrapper(text).slice(0, TITLE_MAX_LENGTH);

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -33,6 +33,7 @@ import {
   extractIncomingMessageWorkspaceIds,
 } from "@/api/handlers/chat/data-scope";
 import { ChatError } from "@/api/handlers/chat/errors";
+import { generateThreadTitle } from "@/api/handlers/chat/generate-thread-title";
 import { isExternalMcpToolPart } from "@/api/handlers/chat/mcp-tool-parts";
 import type { MessagePersistencePlan } from "@/api/handlers/chat/persist-message";
 import {
@@ -499,7 +500,6 @@ const sendMessage = createSafeRootHandler(
                     });
                     return;
                   }
-
                   const persistResult = await persistMessage({
                     persistencePlan,
                     recordAuditEvent,
@@ -512,6 +512,21 @@ const sendMessage = createSafeRootHandler(
                   if (Result.isError(persistResult)) {
                     captureError(persistResult.error, {
                       threadId: body.threadId,
+                    });
+                  } else if (
+                    thread.type === "created" &&
+                    body.sendMode !== CHAT_SEND_MODE.anonymized
+                  ) {
+                    void generateThreadTitle({
+                      messages: [
+                        parsedMessage.message,
+                        resolvedResponseMessage,
+                      ],
+                      orgAIConfig,
+                      recordAuditEvent,
+                      safeDb,
+                      threadId: body.threadId,
+                      threadWorkspaceId: workspaceId,
                     });
                   }
                 } finally {


### PR DESCRIPTION
Closes #310

## What this does

After the first user/assistant exchange in a new thread, generates a short AI-produced title and updates the thread with `titleSource: "ai"`. Threads created by the user's first message keep `titleSource: "user"` until the AI title lands.

## Changes

- `schema.ts`: adds `titleSource` column (`"ai" | "user"`, default `"user"`) to `chat_threads`
- `generate-thread-title.ts`: new handler that calls the AI, trims the result, and updates the thread row
- `send-message.ts`: wires `generateThreadTitle` into the `onFinish` callback, fire-and-forget, only on newly created threads
- Migration: `20260523144218_chat-threads-title-source`

## Known limitation

The title updates after a page refresh. 
