### PR TITLE
fix(api): back auth rate limiting with Redis (fail-open)

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -42,6 +42,7 @@ import { isMemberRole } from "@/api/lib/member-roles";
 import type { MemberRole } from "@/api/lib/member-roles";
 import { enrichRequestContext } from "@/api/lib/observability/request-context";
 import { parseUserAgent } from "@/api/lib/parse-user-agent";
+import { createAuthRateLimitStorage } from "@/api/lib/rate-limit/auth-storage";
 import {
   getMcpResourceUrl,
   MCP_ALL_RESOURCE_SCOPES,
@@ -218,47 +219,9 @@ const createAuth = () => {
       enabled: true,
       window: AUTH_RATE_LIMITS.global.window,
       max: AUTH_RATE_LIMITS.global.max,
-      customStorage: (() => {
-        type Entry = {
-          value: { key: string; count: number; lastRequest: number };
-          expiresAt: number;
-        };
-        const store = new Map<string, Entry>();
-        const ttlMs = AUTH_RATE_LIMIT_MAX_WINDOW * 1000;
-        const cleanup = setInterval(() => {
-          const now = Date.now();
-          for (const [k, e] of store) {
-            if (e.expiresAt <= now) {
-              store.delete(k);
-            }
-          }
-        }, 60_000);
-        cleanup.unref();
-        return {
-          // eslint-disable-next-line require-await -- interface requires Promise
-          async get(key: string) {
-            const entry = store.get(key);
-            if (!entry || entry.expiresAt <= Date.now()) {
-              return null;
-            }
-            return entry.value;
-          },
-          // eslint-disable-next-line require-await -- interface requires Promise
-          async set(
-            key: string,
-            value: {
-              key: string;
-              count: number;
-              lastRequest: number;
-            },
-          ) {
-            store.set(key, {
-              value,
-              expiresAt: Date.now() + ttlMs,
-            });
-          },
-        };
-      })(),
+      customStorage: createAuthRateLimitStorage(
+        AUTH_RATE_LIMIT_MAX_WINDOW * 1000,
+      ),
       customRules: {
         "/sign-in/email-otp": AUTH_RATE_LIMITS.signIn,
         "/sign-up/email": AUTH_RATE_LIMITS.signUp,

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+// A controllable fake of ioredis: `redisDown` toggles whether get/set
+// reject, simulating an unreachable Redis without real I/O.
+let redisDown = false;
+const redisStore = new Map<string, string>();
+
+class FakeRedis {
+  on(): this {
+    return this;
+  }
+
+  async get(key: string): Promise<string | null> {
+    if (redisDown) {
+      throw new Error("redis unreachable");
+    }
+    return redisStore.get(key) ?? null;
+  }
+
+  async set(key: string, value: string): Promise<string> {
+    if (redisDown) {
+      throw new Error("redis unreachable");
+    }
+    redisStore.set(key, value);
+    return "OK";
+  }
+}
+
+void mock.module("ioredis", () => ({ default: FakeRedis }));
+
+const { createAuthRateLimitStorage } =
+  await import("@/api/lib/rate-limit/auth-storage");
+
+const value = (count: number) => ({
+  key: "ip:1.2.3.4",
+  count,
+  lastRequest: 1000,
+});
+
+describe("auth rate-limit storage", () => {
+  beforeEach(() => {
+    redisDown = false;
+    redisStore.clear();
+  });
+
+  test("round-trips through Redis when it is reachable", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+
+    await storage.set("ip:1.2.3.4", value(3));
+
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(3));
+  });
+
+  test("returns null for an unknown key", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+
+    expect(await storage.get("ip:9.9.9.9")).toBeNull();
+  });
+
+  test("fails open: a get after Redis goes down reads the fallback", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+
+    // A successful set warms both Redis and the in-memory fallback.
+    await storage.set("ip:1.2.3.4", value(5));
+    redisDown = true;
+
+    // Redis get throws; the storage must still return the counter so a
+    // Redis outage degrades to per-instance limiting, not a hard lock.
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(5));
+  });
+
+  test("fails open: set never throws when Redis is down", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+    redisDown = true;
+
+    // set must resolve (not reject) even though the Redis write fails.
+    await storage.set("ip:1.2.3.4", value(2));
+
+    // The fallback was still written, so a subsequent get resolves it.
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(2));
+  });
+});

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -36,10 +36,10 @@ void mock.module("ioredis", () => ({ default: FakeRedis }));
 const { createAuthRateLimitStorage } =
   await import("@/api/lib/rate-limit/auth-storage");
 
-const value = (count: number) => ({
+const value = (count: number, lastRequest = 1000) => ({
   key: "ip:1.2.3.4",
   count,
-  lastRequest: 1000,
+  lastRequest,
 });
 
 describe("auth rate-limit storage", () => {
@@ -117,5 +117,19 @@ describe("auth rate-limit storage", () => {
     redisDown = true;
 
     expect(await storage.get("ip:1.2.3.4")).toEqual(value(7));
+  });
+
+  test("keeps the stricter fallback counter when Redis has stale data", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+
+    await storage.set("ip:1.2.3.4", value(5, 1000));
+    redisDown = true;
+    await storage.set("ip:1.2.3.4", value(6, 2000));
+    redisDown = false;
+
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(6, 2000));
+    expect(redisStore.get("auth:ratelimit:ip:1.2.3.4")).toBe(
+      JSON.stringify(value(6, 2000)),
+    );
   });
 });

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -4,8 +4,13 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 // reject, simulating an unreachable Redis without real I/O.
 let redisDown = false;
 const redisStore = new Map<string, string>();
+const redisConstructorOptions: unknown[] = [];
 
 class FakeRedis {
+  constructor(_url: string, options: unknown) {
+    redisConstructorOptions.push(options);
+  }
+
   on(): this {
     return this;
   }
@@ -41,6 +46,7 @@ describe("auth rate-limit storage", () => {
   beforeEach(() => {
     redisDown = false;
     redisStore.clear();
+    redisConstructorOptions.length = 0;
   });
 
   test("round-trips through Redis when it is reachable", async () => {
@@ -55,6 +61,18 @@ describe("auth rate-limit storage", () => {
     const storage = createAuthRateLimitStorage(60_000);
 
     expect(await storage.get("ip:9.9.9.9")).toBeNull();
+  });
+
+  test("configures Redis commands to fail fast", () => {
+    createAuthRateLimitStorage(60_000);
+
+    expect(redisConstructorOptions.at(0)).toMatchObject({
+      commandTimeout: 500,
+      connectTimeout: 500,
+      enableOfflineQueue: false,
+      lazyConnect: true,
+      maxRetriesPerRequest: 1,
+    });
   });
 
   test("fails open: a get after Redis goes down reads the fallback", async () => {
@@ -78,5 +96,26 @@ describe("auth rate-limit storage", () => {
 
     // The fallback was still written, so a subsequent get resolves it.
     expect(await storage.get("ip:1.2.3.4")).toEqual(value(2));
+  });
+
+  test("falls back when Redis is reachable but missing a warmed key", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+    redisDown = true;
+
+    await storage.set("ip:1.2.3.4", value(4));
+    redisDown = false;
+
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(4));
+  });
+
+  test("stores fallback values as snapshots", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+    const counter = value(7);
+
+    await storage.set("ip:1.2.3.4", counter);
+    counter.count = 99;
+    redisDown = true;
+
+    expect(await storage.get("ip:1.2.3.4")).toEqual(value(7));
   });
 });

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -1,0 +1,121 @@
+/**
+ * Redis-backed storage for better-auth's rate limiter.
+ *
+ * Auth rate-limit counters (OTP send/verify, sign-in, sign-up, password
+ * reset) must be global across API replicas. A per-process counter lets
+ * a client get up to N× the configured limit with N instances, which
+ * weakens brute-force / OTP-guessing protection.
+ *
+ * Fail-open: if Redis is unreachable the storage degrades to a
+ * per-process Map (the previous behaviour) instead of blocking auth. A
+ * Redis outage must never hard-lock sign-in.
+ */
+import Redis from "ioredis";
+
+import { env } from "@/api/env";
+import { errorTag } from "@/api/lib/errors/utils";
+import { logger } from "@/api/lib/observability/logger";
+import { redisConnectionOptions } from "@/api/lib/redis-options";
+
+/** Value better-auth persists per rate-limit key. */
+type RateLimitValue = {
+  key: string;
+  count: number;
+  lastRequest: number;
+};
+
+/** The get/set contract better-auth's `customStorage` option expects. */
+type AuthRateLimitStorage = {
+  get: (key: string) => Promise<RateLimitValue | null>;
+  set: (key: string, value: RateLimitValue) => Promise<void>;
+};
+
+const REDIS_KEY_PREFIX = "auth:ratelimit:";
+const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
+
+const isRateLimitValue = (value: unknown): value is RateLimitValue =>
+  typeof value === "object" &&
+  value !== null &&
+  "key" in value &&
+  "count" in value &&
+  "lastRequest" in value &&
+  typeof value.key === "string" &&
+  typeof value.count === "number" &&
+  typeof value.lastRequest === "number";
+
+/**
+ * Build the better-auth rate-limit storage. `ttlMs` is the longest
+ * rate-limit window; it expires both Redis keys and fallback entries.
+ */
+export const createAuthRateLimitStorage = (
+  ttlMs: number,
+): AuthRateLimitStorage => {
+  const redis = new Redis(env.REDIS_URL, {
+    ...redisConnectionOptions(),
+    lazyConnect: true,
+    // Bound every command so a slow or unreachable Redis cannot stall
+    // an auth request; a timed-out command rejects and falls back.
+    commandTimeout: 500,
+    maxRetriesPerRequest: 1,
+  });
+  redis.on("error", () => {
+    // Connection errors are handled per-command below (fail-open to the
+    // fallback Map). This listener only exists so an unhandled 'error'
+    // event cannot crash the process.
+  });
+
+  type FallbackEntry = { value: RateLimitValue; expiresAt: number };
+  const fallback = new Map<string, FallbackEntry>();
+  const cleanup = setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of fallback) {
+      if (entry.expiresAt <= now) {
+        fallback.delete(key);
+      }
+    }
+  }, FALLBACK_CLEANUP_INTERVAL_MS);
+  cleanup.unref();
+
+  const readFallback = (key: string): RateLimitValue | null => {
+    const entry = fallback.get(key);
+    if (!entry || entry.expiresAt <= Date.now()) {
+      return null;
+    }
+    return entry.value;
+  };
+
+  return {
+    get: async (key) => {
+      try {
+        const raw = await redis.get(`${REDIS_KEY_PREFIX}${key}`);
+        if (raw === null) {
+          return null;
+        }
+        const parsed: unknown = JSON.parse(raw);
+        return isRateLimitValue(parsed) ? parsed : null;
+      } catch (error: unknown) {
+        logger.warn("auth.rate_limit.redis_get_failed", {
+          "error.type": errorTag(error),
+        });
+        return readFallback(key);
+      }
+    },
+    set: async (key, value) => {
+      // Keep the fallback warm so a later Redis outage still has data
+      // from this instance to limit against.
+      fallback.set(key, { value, expiresAt: Date.now() + ttlMs });
+      try {
+        await redis.set(
+          `${REDIS_KEY_PREFIX}${key}`,
+          JSON.stringify(value),
+          "PX",
+          ttlMs,
+        );
+      } catch (error: unknown) {
+        logger.warn("auth.rate_limit.redis_set_failed", {
+          "error.type": errorTag(error),
+        });
+      }
+    },
+  };
+};

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -55,7 +55,9 @@ export const createAuthRateLimitStorage = (
     lazyConnect: true,
     // Bound every command so a slow or unreachable Redis cannot stall
     // an auth request; a timed-out command rejects and falls back.
+    connectTimeout: 500,
     commandTimeout: 500,
+    enableOfflineQueue: false,
     maxRetriesPerRequest: 1,
   });
   redis.on("error", () => {
@@ -81,7 +83,7 @@ export const createAuthRateLimitStorage = (
     if (!entry || entry.expiresAt <= Date.now()) {
       return null;
     }
-    return entry.value;
+    return { ...entry.value };
   };
 
   return {
@@ -89,10 +91,10 @@ export const createAuthRateLimitStorage = (
       try {
         const raw = await redis.get(`${REDIS_KEY_PREFIX}${key}`);
         if (raw === null) {
-          return null;
+          return readFallback(key);
         }
         const parsed: unknown = JSON.parse(raw);
-        return isRateLimitValue(parsed) ? parsed : null;
+        return isRateLimitValue(parsed) ? { ...parsed } : readFallback(key);
       } catch (error: unknown) {
         logger.warn("auth.rate_limit.redis_get_failed", {
           "error.type": errorTag(error),
@@ -101,13 +103,14 @@ export const createAuthRateLimitStorage = (
       }
     },
     set: async (key, value) => {
+      const snapshot = { ...value };
       // Keep the fallback warm so a later Redis outage still has data
       // from this instance to limit against.
-      fallback.set(key, { value, expiresAt: Date.now() + ttlMs });
+      fallback.set(key, { value: snapshot, expiresAt: Date.now() + ttlMs });
       try {
         await redis.set(
           `${REDIS_KEY_PREFIX}${key}`,
-          JSON.stringify(value),
+          JSON.stringify(snapshot),
           "PX",
           ttlMs,
         );

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -43,6 +43,14 @@ const isRateLimitValue = (value: unknown): value is RateLimitValue =>
   typeof value.count === "number" &&
   typeof value.lastRequest === "number";
 
+const isStricterRateLimitValue = (
+  candidate: RateLimitValue,
+  current: RateLimitValue,
+): boolean =>
+  candidate.count > current.count ||
+  (candidate.count === current.count &&
+    candidate.lastRequest > current.lastRequest);
+
 /**
  * Build the better-auth rate-limit storage. `ttlMs` is the longest
  * rate-limit window; it expires both Redis keys and fallback entries.
@@ -86,15 +94,42 @@ export const createAuthRateLimitStorage = (
     return { ...entry.value };
   };
 
+  const writeRedis = async (key: string, value: RateLimitValue) => {
+    await redis.set(
+      `${REDIS_KEY_PREFIX}${key}`,
+      JSON.stringify(value),
+      "PX",
+      ttlMs,
+    );
+  };
+
   return {
     get: async (key) => {
       try {
+        const fallbackValue = readFallback(key);
         const raw = await redis.get(`${REDIS_KEY_PREFIX}${key}`);
         if (raw === null) {
-          return readFallback(key);
+          return fallbackValue;
         }
         const parsed: unknown = JSON.parse(raw);
-        return isRateLimitValue(parsed) ? { ...parsed } : readFallback(key);
+        if (!isRateLimitValue(parsed)) {
+          return fallbackValue;
+        }
+        const redisValue = { ...parsed };
+        if (
+          fallbackValue &&
+          isStricterRateLimitValue(fallbackValue, redisValue)
+        ) {
+          try {
+            await writeRedis(key, fallbackValue);
+          } catch (error: unknown) {
+            logger.warn("auth.rate_limit.redis_reconcile_failed", {
+              "error.type": errorTag(error),
+            });
+          }
+          return fallbackValue;
+        }
+        return redisValue;
       } catch (error: unknown) {
         logger.warn("auth.rate_limit.redis_get_failed", {
           "error.type": errorTag(error),
@@ -108,12 +143,7 @@ export const createAuthRateLimitStorage = (
       // from this instance to limit against.
       fallback.set(key, { value: snapshot, expiresAt: Date.now() + ttlMs });
       try {
-        await redis.set(
-          `${REDIS_KEY_PREFIX}${key}`,
-          JSON.stringify(snapshot),
-          "PX",
-          ttlMs,
-        );
+        await writeRedis(key, snapshot);
       } catch (error: unknown) {
         logger.warn("auth.rate_limit.redis_set_failed", {
           "error.type": errorTag(error),


### PR DESCRIPTION
## Problem

better-auth's rate-limit `customStorage` was a per-process `Map`. With N API replicas a client could get up to **N×** the configured limit on the brute-force-sensitive auth endpoints — OTP send/verify, sign-in, sign-up, forget/reset password — weakening protection linearly with replica count.

## Change

Counters move to Redis via `apps/api/src/lib/rate-limit/auth-storage.ts` so the limit is global across replicas.

**Fail-open**, by design: every Redis command is bounded by a 500 ms `commandTimeout`, and on any Redis error `get`/`set` fall back to a per-process `Map` (the previous behaviour). A Redis outage degrades auth rate limiting to per-instance — it never hard-locks sign-in.

- Dedicated ioredis client with `lazyConnect`, `commandTimeout: 500`, `maxRetriesPerRequest: 1`. The client-level `'error'` listener is a no-op (handled per command) so an unhandled event cannot crash the process.
- Keys are `auth:ratelimit:<key>` with `PX` TTL = `AUTH_RATE_LIMIT_MAX_WINDOW * 1000`.
- `set` writes the fallback Map unconditionally to keep it warm; a later Redis outage still has data from this instance to limit against.

## Scope

The general API limiter (`InMemoryRateLimitContext` in `lib/rate-limit/index.ts`) is intentionally **left in-memory** — its file comment documents reliance on an edge limiter, and this PR is scoped to the auth path where the brute-force concern is concrete.

## Verification

- `apps/api` lint — 0 warnings, 0 errors
- `apps/api` typecheck — clean
- `auth-storage.test.ts` — 4 pass, 0 fail (covers the fail-open invariant against a fake Redis: healthy round-trip, missing key returns null, get falls back when Redis fails, set never throws)
- Auth-related tests (`mcp/auth.test.ts`, `mcp/metadata.test.ts`, `handlers/auth/metadata.test.ts`, plus the new file) — 19 pass, 0 fail

⚠️ **Merge gate:** behaviour under a real Redis outage (command timeout, fallback, recovery) and global limiting across replicas should be verified in staging.