### PR TITLE
feat(api): add Matter view templates (#14)

### DIFF
--- a/apps/api/drizzle/20260515100000_workspace-view-templates/migration.sql
+++ b/apps/api/drizzle/20260515100000_workspace-view-templates/migration.sql
@@ -1,0 +1,69 @@
+CREATE TABLE "workspace_view_templates" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"organization_id" varchar(128) NOT NULL,
+	"user_id" text NOT NULL,
+	"name" varchar(256) NOT NULL,
+	"layout" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "workspace_view_templates" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "workspace_view_templates" ADD CONSTRAINT "workspace_view_templates_organization_id_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+--> statement-breakpoint
+ALTER TABLE "workspace_view_templates" ADD CONSTRAINT "workspace_view_templates_user_id_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "workspace_view_templates_user_name_uidx" ON "workspace_view_templates" USING btree ("organization_id","user_id","name");
+--> statement-breakpoint
+CREATE INDEX "workspace_view_templates_user_created_idx" ON "workspace_view_templates" USING btree ("organization_id","user_id","created_at");
+--> statement-breakpoint
+CREATE POLICY "workspace_view_template_select" ON "workspace_view_templates" AS PERMISSIVE FOR SELECT TO "stella" USING ((
+  organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )) AND user_id =
+  (SELECT current_setting(
+    'app.user_id', true
+  ))
+));
+--> statement-breakpoint
+CREATE POLICY "workspace_view_template_insert" ON "workspace_view_templates" AS PERMISSIVE FOR INSERT TO "stella" WITH CHECK ((
+  organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )) AND user_id =
+  (SELECT current_setting(
+    'app.user_id', true
+  ))
+));
+--> statement-breakpoint
+CREATE POLICY "workspace_view_template_update" ON "workspace_view_templates" AS PERMISSIVE FOR UPDATE TO "stella" USING ((
+  organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )) AND user_id =
+  (SELECT current_setting(
+    'app.user_id', true
+  ))
+)) WITH CHECK ((
+  organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )) AND user_id =
+  (SELECT current_setting(
+    'app.user_id', true
+  ))
+));
+--> statement-breakpoint
+CREATE POLICY "workspace_view_template_delete" ON "workspace_view_templates" AS PERMISSIVE FOR DELETE TO "stella" USING ((
+  organization_id =
+  (SELECT current_setting(
+    'app.organization_id', true
+  )) AND user_id =
+  (SELECT current_setting(
+    'app.user_id', true
+  ))
+));
+--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE "workspace_view_templates" TO stella;

--- a/apps/api/drizzle/20260515103000_workspace-view-template-properties/migration.sql
+++ b/apps/api/drizzle/20260515103000_workspace-view-template-properties/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workspace_view_templates"
+ADD COLUMN "template_properties" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/apps/api/src/db/rls.ts
+++ b/apps/api/src/db/rls.ts
@@ -380,6 +380,34 @@ export const promptShortcutPolicies = () => [
   }),
 ];
 
+const workspaceViewTemplateCheck = sql`(
+  ${organizationCheck} AND ${userCheck}
+)`;
+
+export const workspaceViewTemplatePolicies = () => [
+  p.pgPolicy("workspace_view_template_select", {
+    for: "select",
+    to: stella,
+    using: workspaceViewTemplateCheck,
+  }),
+  p.pgPolicy("workspace_view_template_insert", {
+    for: "insert",
+    to: stella,
+    withCheck: workspaceViewTemplateCheck,
+  }),
+  p.pgPolicy("workspace_view_template_update", {
+    for: "update",
+    to: stella,
+    using: workspaceViewTemplateCheck,
+    withCheck: workspaceViewTemplateCheck,
+  }),
+  p.pgPolicy("workspace_view_template_delete", {
+    for: "delete",
+    to: stella,
+    using: workspaceViewTemplateCheck,
+  }),
+];
+
 const agentSkillVisibleCheck = sql`(
   ${organizationCheck} AND (scope = 'team' OR ${userCheck})
 )`;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -25,6 +25,7 @@ import {
   stella,
   userPolicies,
   workspaceIdCheck,
+  workspaceViewTemplatePolicies,
   wsPolicies,
 } from "@/api/db/rls";
 import type {
@@ -55,7 +56,10 @@ import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId, SafeIdType } from "@/api/lib/branded-types";
 import type { CentsAmount } from "@/api/lib/money";
 import { unsafeCents } from "@/api/lib/money";
-import type { ViewLayout } from "@/api/lib/views-schema";
+import type {
+  ViewLayout,
+  ViewTemplateProperty,
+} from "@/api/lib/views-schema";
 
 /** Metadata stored on link entities created by the web clipper. */
 export type LinkMetadata = {
@@ -3022,6 +3026,41 @@ export const workspaceViews = p.pgTable(
   ],
 );
 
+export const workspaceViewTemplates = p.pgTable(
+  "workspace_view_templates",
+  {
+    id: pUuid<"workspaceViewTemplate">().primaryKey(),
+    organizationId: safeOrganizationId("organization_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    userId: p
+      .text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    name: p.varchar({ length: 256 }).notNull(),
+    layout: jsonb().$type<ViewLayout>().notNull(),
+    templateProperties: jsonb("template_properties")
+      .$type<ViewTemplateProperty[]>()
+      .notNull()
+      .default([]),
+    createdAt: p.timestamp("created_at").notNull().defaultNow(),
+    updatedAt: p
+      .timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [
+    p
+      .uniqueIndex("workspace_view_templates_user_name_uidx")
+      .on(table.organizationId, table.userId, table.name),
+    p
+      .index("workspace_view_templates_user_created_idx")
+      .on(table.organizationId, table.userId, table.createdAt),
+    ...workspaceViewTemplatePolicies(),
+  ],
+);
+
 // -- Prompt Shortcuts --
 
 export const PROMPT_SHORTCUT_SCOPES = ["team", "private"] as const;
@@ -3242,6 +3281,7 @@ export const relations = defineRelations(
     mcpOAuthState,
     userFiles,
     workspaceViews,
+    workspaceViewTemplates,
     promptShortcuts,
   },
   (r) => ({
@@ -3990,6 +4030,12 @@ export const relations = defineRelations(
       workspace: r.one.workspaces({
         from: r.workspaceViews.workspaceId,
         to: r.workspaces.id,
+      }),
+    },
+    workspaceViewTemplates: {
+      user: r.one.user({
+        from: r.workspaceViewTemplates.userId,
+        to: r.user.id,
       }),
     },
     agentSkills: {

--- a/apps/api/src/handlers/properties/create.ts
+++ b/apps/api/src/handlers/properties/create.ts
@@ -10,6 +10,7 @@ import {
   propertyConditionSchema,
 } from "@/api/db/schema-validators";
 import type { PropertyContent, PropertyTool } from "@/api/db/schema-validators";
+import { lockWorkspacePropertyWrites } from "@/api/handlers/properties/property-lock";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -166,15 +167,13 @@ const createProperty = createSafeHandler(
 
     const txResult = yield* Result.await(
       safeDb(async (tx) => {
-        // Lock rows then count to serialize concurrent adds.
-        // PG rejects FOR UPDATE with aggregate functions.
-        const lockedRows = await tx
+        await lockWorkspacePropertyWrites(tx, workspaceId);
+        const existingRows = await tx
           .select({ id: properties.id })
           .from(properties)
-          .where(eq(properties.workspaceId, workspaceId))
-          .for("update");
+          .where(eq(properties.workspaceId, workspaceId));
 
-        if (lockedRows.length >= LIMITS.propertiesCount) {
+        if (existingRows.length >= LIMITS.propertiesCount) {
           return {
             ok: false as const,
             status: 400 as const,

--- a/apps/api/src/handlers/properties/property-lock.ts
+++ b/apps/api/src/handlers/properties/property-lock.ts
@@ -1,0 +1,11 @@
+import { sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db";
+import type { SafeId } from "@/api/lib/branded-types";
+
+export const lockWorkspacePropertyWrites = async (
+  tx: Transaction,
+  workspaceId: SafeId<"workspace">,
+): Promise<void> => {
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${workspaceId}))`);
+};

--- a/apps/api/src/handlers/view-templates/create.ts
+++ b/apps/api/src/handlers/view-templates/create.ts
@@ -1,0 +1,136 @@
+import { panic, Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { workspaceViewTemplates } from "@/api/db/schema";
+import { collectTemplateProperties } from "@/api/handlers/view-templates/properties";
+import {
+  cleanStalePropertyIds,
+  hasDuplicateSorts,
+  hasMultipleKindFilters,
+} from "@/api/handlers/views/utils";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tDefaultVarchar } from "@/api/lib/custom-schema";
+import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { LIMITS } from "@/api/lib/limits";
+import { PG_ERROR } from "@/api/lib/pg-error";
+import { parseViewLayout, tViewLayoutSchema } from "@/api/lib/views-schema";
+
+const createViewTemplateBodySchema = t.Object(
+  {
+    name: tDefaultVarchar,
+    layout: tViewLayoutSchema,
+  },
+  { additionalProperties: false },
+);
+
+const config = {
+  permissions: { view: ["create"] },
+  body: createViewTemplateBodySchema,
+} satisfies HandlerConfig;
+
+const createViewTemplate = createSafeHandler(
+  config,
+  async function* ({ safeDb, workspaceId, session, user, body }) {
+    const layout = parseViewLayout(body.layout);
+
+    if (hasDuplicateSorts(layout.sorts)) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Duplicate sort property" }),
+      );
+    }
+
+    if (hasMultipleKindFilters(layout.filters)) {
+      return Result.err(
+        new HandlerError({ status: 400, message: "Multiple kind filters" }),
+      );
+    }
+
+    const existingCount = yield* Result.await(
+      safeDb((tx) =>
+        tx.$count(
+          workspaceViewTemplates,
+          and(
+            eq(
+              workspaceViewTemplates.organizationId,
+              session.activeOrganizationId,
+            ),
+            eq(workspaceViewTemplates.userId, user.id),
+          ),
+        ),
+      ),
+    );
+
+    if (existingCount >= LIMITS.viewTemplatesPerUser) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "View template limit reached",
+        }),
+      );
+    }
+
+    const workspaceProperties = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.properties.findMany({
+          where: { workspaceId: { eq: workspaceId } },
+          columns: {
+            id: true,
+            name: true,
+            content: true,
+            tool: true,
+            system: true,
+          },
+        }),
+      ),
+    );
+    cleanStalePropertyIds(
+      layout,
+      workspaceProperties.map((property) => property.id),
+    );
+    const templateProperties = collectTemplateProperties({
+      layout,
+      properties: workspaceProperties,
+    });
+
+    const insertResult = await safeDb((tx) =>
+      tx
+        .insert(workspaceViewTemplates)
+        .values({
+          organizationId: session.activeOrganizationId,
+          userId: user.id,
+          name: body.name,
+          layout,
+          templateProperties,
+        })
+        .returning({
+          id: workspaceViewTemplates.id,
+        }),
+    );
+
+    if (Result.isError(insertResult)) {
+      if (
+        DatabaseError.is(insertResult.error) &&
+        insertResult.error.code === PG_ERROR.UNIQUE_VIOLATION
+      ) {
+        return Result.err(
+          new HandlerError({
+            status: 409,
+            message: "A view template with this name already exists",
+          }),
+        );
+      }
+      return Result.err(insertResult.error);
+    }
+
+    const row = insertResult.value.at(0);
+    if (!row) {
+      panic("Failed to create view template");
+    }
+
+    return Result.ok({ id: row.id });
+  },
+);
+
+export default createViewTemplate;

--- a/apps/api/src/handlers/view-templates/create.ts
+++ b/apps/api/src/handlers/view-templates/create.ts
@@ -85,6 +85,18 @@ const createViewTemplate = createSafeHandler(
         }),
       ),
     );
+    const workspaceDependencies = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.propertyDependencies.findMany({
+          where: { workspaceId: { eq: workspaceId } },
+          columns: {
+            propertyId: true,
+            dependsOnPropertyId: true,
+            condition: true,
+          },
+        }),
+      ),
+    );
     cleanStalePropertyIds(
       layout,
       workspaceProperties.map((property) => property.id),
@@ -92,6 +104,7 @@ const createViewTemplate = createSafeHandler(
     const templateProperties = collectTemplateProperties({
       layout,
       properties: workspaceProperties,
+      dependencies: workspaceDependencies,
     });
 
     const insertResult = await safeDb((tx) =>

--- a/apps/api/src/handlers/view-templates/create.ts
+++ b/apps/api/src/handlers/view-templates/create.ts
@@ -11,6 +11,7 @@ import {
 } from "@/api/handlers/views/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tDefaultVarchar } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
@@ -31,7 +32,14 @@ const config = {
 
 const createViewTemplate = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, session, user, body }) {
+  async function* ({
+    safeDb,
+    workspaceId,
+    session,
+    user,
+    body,
+    recordAuditEvent,
+  }) {
     const layout = parseViewLayout(body.layout);
 
     if (hasDuplicateSorts(layout.sorts)) {
@@ -128,6 +136,22 @@ const createViewTemplate = createSafeHandler(
             message: "A view template with this name already exists",
           };
         }
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.VIEW_TEMPLATE,
+          resourceId: row.id,
+          changes: {
+            created: {
+              old: null,
+              new: {
+                name: body.name,
+                layoutType: layout.type,
+                templatePropertyCount: templateProperties.length,
+              },
+            },
+          },
+        });
 
         return { ok: true as const, id: row.id };
       }),

--- a/apps/api/src/handlers/view-templates/create.ts
+++ b/apps/api/src/handlers/view-templates/create.ts
@@ -1,5 +1,5 @@
-import { panic, Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { Result } from "better-result";
+import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { workspaceViewTemplates } from "@/api/db/schema";
@@ -12,9 +12,8 @@ import {
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { tDefaultVarchar } from "@/api/lib/custom-schema";
-import { DatabaseError, HandlerError } from "@/api/lib/errors/tagged-errors";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
-import { PG_ERROR } from "@/api/lib/pg-error";
 import { parseViewLayout, tViewLayoutSchema } from "@/api/lib/views-schema";
 
 const createViewTemplateBodySchema = t.Object(
@@ -47,9 +46,13 @@ const createViewTemplate = createSafeHandler(
       );
     }
 
-    const existingCount = yield* Result.await(
-      safeDb((tx) =>
-        tx.$count(
+    const insertResult = yield* Result.await(
+      safeDb(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${session.activeOrganizationId}), hashtext(${user.id}))`,
+        );
+
+        const existingCount = await tx.$count(
           workspaceViewTemplates,
           and(
             eq(
@@ -58,22 +61,17 @@ const createViewTemplate = createSafeHandler(
             ),
             eq(workspaceViewTemplates.userId, user.id),
           ),
-        ),
-      ),
-    );
+        );
 
-    if (existingCount >= LIMITS.viewTemplatesPerUser) {
-      return Result.err(
-        new HandlerError({
-          status: 400,
-          message: "View template limit reached",
-        }),
-      );
-    }
+        if (existingCount >= LIMITS.viewTemplatesPerUser) {
+          return {
+            ok: false as const,
+            status: 400 as const,
+            message: "View template limit reached",
+          };
+        }
 
-    const workspaceProperties = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.properties.findMany({
+        const workspaceProperties = await tx.query.properties.findMany({
           where: { workspaceId: { eq: workspaceId } },
           columns: {
             id: true,
@@ -82,67 +80,69 @@ const createViewTemplate = createSafeHandler(
             tool: true,
             system: true,
           },
-        }),
-      ),
-    );
-    const workspaceDependencies = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.propertyDependencies.findMany({
-          where: { workspaceId: { eq: workspaceId } },
-          columns: {
-            propertyId: true,
-            dependsOnPropertyId: true,
-            condition: true,
-          },
-        }),
-      ),
-    );
-    cleanStalePropertyIds(
-      layout,
-      workspaceProperties.map((property) => property.id),
-    );
-    const templateProperties = collectTemplateProperties({
-      layout,
-      properties: workspaceProperties,
-      dependencies: workspaceDependencies,
-    });
-
-    const insertResult = await safeDb((tx) =>
-      tx
-        .insert(workspaceViewTemplates)
-        .values({
-          organizationId: session.activeOrganizationId,
-          userId: user.id,
-          name: body.name,
+        });
+        const workspaceDependencies =
+          await tx.query.propertyDependencies.findMany({
+            where: { workspaceId: { eq: workspaceId } },
+            columns: {
+              propertyId: true,
+              dependsOnPropertyId: true,
+              condition: true,
+            },
+          });
+        cleanStalePropertyIds(
           layout,
-          templateProperties,
-        })
-        .returning({
-          id: workspaceViewTemplates.id,
-        }),
+          workspaceProperties.map((property) => property.id),
+        );
+        const templateProperties = collectTemplateProperties({
+          layout,
+          properties: workspaceProperties,
+          dependencies: workspaceDependencies,
+        });
+
+        const rows = await tx
+          .insert(workspaceViewTemplates)
+          .values({
+            organizationId: session.activeOrganizationId,
+            userId: user.id,
+            name: body.name,
+            layout,
+            templateProperties,
+          })
+          .onConflictDoNothing({
+            target: [
+              workspaceViewTemplates.organizationId,
+              workspaceViewTemplates.userId,
+              workspaceViewTemplates.name,
+            ],
+          })
+          .returning({
+            id: workspaceViewTemplates.id,
+          });
+
+        const row = rows.at(0);
+        if (!row) {
+          return {
+            ok: false as const,
+            status: 409 as const,
+            message: "A view template with this name already exists",
+          };
+        }
+
+        return { ok: true as const, id: row.id };
+      }),
     );
 
-    if (Result.isError(insertResult)) {
-      if (
-        DatabaseError.is(insertResult.error) &&
-        insertResult.error.code === PG_ERROR.UNIQUE_VIOLATION
-      ) {
-        return Result.err(
-          new HandlerError({
-            status: 409,
-            message: "A view template with this name already exists",
-          }),
-        );
-      }
-      return Result.err(insertResult.error);
+    if (!insertResult.ok) {
+      return Result.err(
+        new HandlerError({
+          status: insertResult.status,
+          message: insertResult.message,
+        }),
+      );
     }
 
-    const row = insertResult.value.at(0);
-    if (!row) {
-      panic("Failed to create view template");
-    }
-
-    return Result.ok({ id: row.id });
+    return Result.ok({ id: insertResult.id });
   },
 );
 

--- a/apps/api/src/handlers/view-templates/delete.ts
+++ b/apps/api/src/handlers/view-templates/delete.ts
@@ -5,6 +5,7 @@ import { t } from "elysia";
 import { workspaceViewTemplates } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tSafeId } from "@/api/lib/custom-schema";
 
 const config = {
@@ -16,10 +17,10 @@ const config = {
 
 const deleteViewTemplate = createSafeHandler(
   config,
-  async function* ({ safeDb, session, user, params }) {
+  async function* ({ safeDb, session, user, params, recordAuditEvent }) {
     yield* Result.await(
-      safeDb((tx) =>
-        tx
+      safeDb(async (tx) => {
+        const deleted = await tx
           .delete(workspaceViewTemplates)
           .where(
             and(
@@ -30,8 +31,29 @@ const deleteViewTemplate = createSafeHandler(
               ),
               eq(workspaceViewTemplates.userId, user.id),
             ),
-          ),
-      ),
+          )
+          .returning({
+            id: workspaceViewTemplates.id,
+            name: workspaceViewTemplates.name,
+          });
+
+        const deletedTemplate = deleted.at(0);
+        if (!deletedTemplate) {
+          return;
+        }
+
+        await recordAuditEvent(tx, {
+          action: AUDIT_ACTION.DELETE,
+          resourceType: AUDIT_RESOURCE_TYPE.VIEW_TEMPLATE,
+          resourceId: deletedTemplate.id,
+          changes: {
+            deleted: {
+              old: { name: deletedTemplate.name },
+              new: null,
+            },
+          },
+        });
+      }),
     );
 
     return Result.ok(undefined);

--- a/apps/api/src/handlers/view-templates/delete.ts
+++ b/apps/api/src/handlers/view-templates/delete.ts
@@ -1,0 +1,41 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { workspaceViewTemplates } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+
+const config = {
+  permissions: { view: ["delete"] },
+  params: t.Object({
+    templateId: tSafeId("workspaceViewTemplate"),
+  }),
+} satisfies HandlerConfig;
+
+const deleteViewTemplate = createSafeHandler(
+  config,
+  async function* ({ safeDb, session, user, params }) {
+    yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .delete(workspaceViewTemplates)
+          .where(
+            and(
+              eq(workspaceViewTemplates.id, params.templateId),
+              eq(
+                workspaceViewTemplates.organizationId,
+                session.activeOrganizationId,
+              ),
+              eq(workspaceViewTemplates.userId, user.id),
+            ),
+          ),
+      ),
+    );
+
+    return Result.ok(undefined);
+  },
+);
+
+export default deleteViewTemplate;

--- a/apps/api/src/handlers/view-templates/list.ts
+++ b/apps/api/src/handlers/view-templates/list.ts
@@ -1,0 +1,54 @@
+import { Result } from "better-result";
+import { and, desc, eq } from "drizzle-orm";
+
+import { workspaceViewTemplates } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { LIMITS } from "@/api/lib/limits";
+import { parseViewLayout } from "@/api/lib/views-schema";
+
+const config = {
+  permissions: { workspace: ["read"] },
+} satisfies HandlerConfig;
+
+const toResponse = (template: typeof workspaceViewTemplates.$inferSelect) => {
+  const layout = parseViewLayout(template.layout);
+  return {
+    version: 1 as const,
+    id: template.id,
+    name: template.name,
+    layout,
+    templateProperties: template.templateProperties,
+    layoutType: layout.type,
+    createdAt: template.createdAt.toISOString(),
+    updatedAt: template.updatedAt.toISOString(),
+  };
+};
+
+const listViewTemplates = createSafeHandler(
+  config,
+  async function* ({ safeDb, session, user }) {
+    const rows = yield* Result.await(
+      safeDb((tx) =>
+        tx
+          .select()
+          .from(workspaceViewTemplates)
+          .where(
+            and(
+              eq(
+                workspaceViewTemplates.organizationId,
+                session.activeOrganizationId,
+              ),
+              eq(workspaceViewTemplates.userId, user.id),
+            ),
+          )
+          .orderBy(desc(workspaceViewTemplates.createdAt))
+          .limit(LIMITS.viewTemplatesPerUser),
+      ),
+    );
+
+    return Result.ok(rows.map(toResponse));
+  },
+);
+
+export default listViewTemplates;

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -181,7 +181,7 @@ describe("resolveTemplateProperties", () => {
       status: 422,
       message: "Circular template dependency detected",
     });
-    expect(returningMock).toHaveBeenCalledTimes(2);
+    expect(returningMock).not.toHaveBeenCalled();
     expect(dependencyValuesMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, mock, test } from "bun:test";
 
 import type { Transaction } from "@/api/db";
 import { properties, propertyDependencies } from "@/api/db/schema";
-import { resolveTemplateProperties } from "@/api/handlers/view-templates/properties";
+import {
+  collectTemplateProperties,
+  resolveTemplateProperties,
+} from "@/api/handlers/view-templates/properties";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { ViewLayout, ViewTemplateProperty } from "@/api/lib/views-schema";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
@@ -130,6 +133,86 @@ const createTemplateReuseTx = () => {
     tx: asTestRaw<Transaction>(tx),
   };
 };
+
+describe("collectTemplateProperties", () => {
+  test("marks hidden dependency sources creatable without creating unrelated hidden columns", () => {
+    const aiProperty = {
+      id: "ai_summary",
+      name: "Summary",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "ai-model", prompt: "Summarize" },
+      system: false,
+    } as const;
+    const dependencyProperty = {
+      id: "source_notes",
+      name: "Source notes",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "manual-input" },
+      system: false,
+    } as const;
+    const unrelatedHiddenProperty = {
+      id: "scratchpad",
+      name: "Scratchpad",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "manual-input" },
+      system: false,
+    } as const;
+    const layout: ViewLayout = {
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [dependencyProperty.id, unrelatedHiddenProperty.id],
+      columnOrder: [aiProperty.id],
+      columnPinning: [],
+    };
+
+    const templateProperties = collectTemplateProperties({
+      layout,
+      properties: [aiProperty, dependencyProperty, unrelatedHiddenProperty],
+      dependencies: [
+        {
+          propertyId: aiProperty.id,
+          dependsOnPropertyId: dependencyProperty.id,
+          condition: null,
+        },
+      ],
+    });
+
+    expect(templateProperties).toEqual([
+      {
+        version: 1,
+        sourceId: aiProperty.id,
+        name: aiProperty.name,
+        content: aiProperty.content,
+        tool: aiProperty.tool,
+        createIfMissing: true,
+        dependencies: [
+          {
+            dependsOnSourceId: dependencyProperty.id,
+            condition: null,
+          },
+        ],
+      },
+      {
+        version: 1,
+        sourceId: dependencyProperty.id,
+        name: dependencyProperty.name,
+        content: dependencyProperty.content,
+        tool: dependencyProperty.tool,
+        createIfMissing: true,
+      },
+      {
+        version: 1,
+        sourceId: unrelatedHiddenProperty.id,
+        name: unrelatedHiddenProperty.name,
+        content: unrelatedHiddenProperty.content,
+        tool: unrelatedHiddenProperty.tool,
+        createIfMissing: false,
+      },
+    ]);
+  });
+});
 
 describe("resolveTemplateProperties", () => {
   test("rejects file template columns with AI tools before inserting", async () => {

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -44,6 +44,9 @@ const createTemplatePropertyValidationTx = () => {
       properties: {
         findMany: mock(async () => []),
       },
+      propertyDependencies: {
+        findMany: mock(async () => []),
+      },
     },
     insert: insertMock,
   };
@@ -87,6 +90,9 @@ const createTemplateDependencyTx = () => {
       properties: {
         findMany: mock(async () => []),
       },
+      propertyDependencies: {
+        findMany: mock(async () => []),
+      },
     },
     insert: insertMock,
   };
@@ -115,9 +121,12 @@ const defaultExistingTemplateReuseProperty = {
 
 const createTemplateReuseTx = (
   existingProperty: ExistingTemplateReuseProperty = defaultExistingTemplateReuseProperty,
+  existingDependencies: {
+    propertyId: string;
+  }[] = [],
 ) => {
   const returningMock = mock(async () => [{ id: "created_property" }]);
-  const propertyValuesMock = mock(() => ({
+  const propertyValuesMock = mock((_row: typeof properties.$inferInsert) => ({
     returning: returningMock,
   }));
   const dependencyValuesMock = mock(() => ({
@@ -138,11 +147,15 @@ const createTemplateReuseTx = (
       properties: {
         findMany: mock(async () => [existingProperty]),
       },
+      propertyDependencies: {
+        findMany: mock(async () => existingDependencies),
+      },
     },
     insert: insertMock,
   };
 
   return {
+    propertyValuesMock,
     returningMock,
     tx: asTestRaw<Transaction>(tx),
   };
@@ -403,6 +416,93 @@ describe("resolveTemplateProperties", () => {
       propertyIds: ["existing_property", "created_property"],
     });
     expect(returningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reuse AI shape matches when either side has dependencies", async () => {
+    const { returningMock, tx } = createTemplateReuseTx(
+      {
+        id: "existing_property",
+        name: "Summary",
+        content: { version: 1, type: "text" },
+        tool: { version: 1, type: "ai-model", prompt: "Summarize" },
+      },
+      [{ propertyId: "existing_property" }],
+    );
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_summary",
+      name: "Summary",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "ai-model", prompt: "Summarize" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+    const layout: ViewLayout = {
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: [templateProperty.sourceId],
+      columnPinning: [],
+    };
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout,
+      templateProperties: [templateProperty],
+      canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      layout: {
+        ...layout,
+        columnOrder: ["created_property"],
+      },
+      propertyIds: ["existing_property", "created_property"],
+    });
+    expect(returningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("sanitizes AI prompt markup before persisting template-created columns", async () => {
+    const { propertyValuesMock, returningMock, tx } = createTemplateReuseTx({
+      id: "existing_property",
+      name: "Other",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "manual-input" },
+    });
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_unsafe_ai",
+      name: "Unsafe",
+      content: { version: 1, type: "text" },
+      tool: {
+        version: 1,
+        type: "ai-model",
+        prompt: '<script>alert("xss")</script><b>Bold</b>',
+      },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout: tableLayout(templateProperty.sourceId),
+      templateProperties: [templateProperty],
+      canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(returningMock).toHaveBeenCalledTimes(1);
+    const persistedTool = propertyValuesMock.mock.calls[0]?.[0].tool;
+    expect(persistedTool?.type).toBe("ai-model");
+    const prompt =
+      persistedTool?.type === "ai-model" ? persistedTool.prompt : "";
+    expect(prompt).not.toContain("<script>");
+    expect(prompt).toContain("**Bold**");
   });
 
   test("does not reuse shape matches with different config", async () => {

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -23,7 +23,9 @@ const createTemplatePropertyValidationTx = () => {
   const insertMock = mock(() => {
     throw new Error("Unexpected template property insert");
   });
+  const executeMock = mock(async () => undefined);
   const tx = {
+    execute: executeMock,
     select: mock(() => ({
       from: mock(() => ({
         where: mock(() => ({
@@ -40,6 +42,7 @@ const createTemplatePropertyValidationTx = () => {
   };
 
   return {
+    executeMock,
     insertMock,
     tx: asTestRaw<Transaction>(tx),
   };
@@ -63,7 +66,9 @@ const createTemplateDependencyTx = () => {
     }
     throw new Error("Unexpected table insert");
   });
+  const executeMock = mock(async () => undefined);
   const tx = {
+    execute: executeMock,
     select: mock(() => ({
       from: mock(() => ({
         where: mock(() => ({
@@ -81,6 +86,7 @@ const createTemplateDependencyTx = () => {
 
   return {
     dependencyValuesMock,
+    executeMock,
     returningMock,
     tx: asTestRaw<Transaction>(tx),
   };
@@ -111,6 +117,35 @@ describe("resolveTemplateProperties", () => {
       status: 422,
       message: "File template columns must use manual input",
     });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects duplicate template source IDs before inserting", async () => {
+    const { executeMock, insertMock, tx } =
+      createTemplatePropertyValidationTx();
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_duplicate",
+      name: "Duplicate",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "manual-input" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout: tableLayout(templateProperty.sourceId),
+      templateProperties: [templateProperty, templateProperty],
+      canCreateProperties: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      message: "Duplicate template property sourceId",
+    });
+    expect(executeMock).not.toHaveBeenCalled();
     expect(insertMock).not.toHaveBeenCalled();
   });
 
@@ -147,7 +182,7 @@ describe("resolveTemplateProperties", () => {
   });
 
   test("rejects cyclic dependencies between newly created template columns", async () => {
-    const { dependencyValuesMock, returningMock, tx } =
+    const { dependencyValuesMock, executeMock, returningMock, tx } =
       createTemplateDependencyTx();
     const propertyA = {
       version: 1,
@@ -181,6 +216,7 @@ describe("resolveTemplateProperties", () => {
       status: 422,
       message: "Circular template dependency detected",
     });
+    expect(executeMock).toHaveBeenCalledTimes(1);
     expect(returningMock).not.toHaveBeenCalled();
     expect(dependencyValuesMock).not.toHaveBeenCalled();
   });

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import type { Transaction } from "@/api/db";
+import { resolveTemplateProperties } from "@/api/handlers/view-templates/properties";
+import { toSafeId } from "@/api/lib/branded-types";
+import type { ViewLayout, ViewTemplateProperty } from "@/api/lib/views-schema";
+import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
+
+const workspaceId = toSafeId<"workspace">("workspace_1");
+
+const tableLayout = (propertyId: string): ViewLayout => ({
+  version: 1,
+  type: "table",
+  filters: [],
+  sorts: [],
+  hiddenProperties: [],
+  columnOrder: [propertyId],
+  columnPinning: [],
+});
+
+const createTemplatePropertyValidationTx = () => {
+  const insertMock = mock(() => {
+    throw new Error("Unexpected template property insert");
+  });
+  const tx = {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          for: mock(async () => []),
+        })),
+      })),
+    })),
+    query: {
+      properties: {
+        findMany: mock(async () => []),
+      },
+    },
+    insert: insertMock,
+  };
+
+  return {
+    insertMock,
+    tx: asTestRaw<Transaction>(tx),
+  };
+};
+
+describe("resolveTemplateProperties", () => {
+  test("rejects file template columns with AI tools before inserting", async () => {
+    const { insertMock, tx } = createTemplatePropertyValidationTx();
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_file",
+      name: "File",
+      content: { version: 1, type: "file" },
+      tool: { version: 1, type: "ai-model", prompt: "Extract" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout: tableLayout(templateProperty.sourceId),
+      templateProperties: [templateProperty],
+      canCreateProperties: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      message: "File template columns must use manual input",
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects select template fallbacks that are not valid options", async () => {
+    const { insertMock, tx } = createTemplatePropertyValidationTx();
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_select",
+      name: "Status",
+      content: {
+        version: 1,
+        type: "single-select",
+        options: [{ color: "green", value: "Open" }],
+        fallback: "Closed",
+      },
+      tool: { version: 1, type: "manual-input" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout: tableLayout(templateProperty.sourceId),
+      templateProperties: [templateProperty],
+      canCreateProperties: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      message: "Fallback must match one of the supplied options",
+    });
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -6,11 +6,15 @@ import {
   collectTemplateProperties,
   resolveTemplateProperties,
 } from "@/api/handlers/view-templates/properties";
+import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { ViewLayout, ViewTemplateProperty } from "@/api/lib/views-schema";
 import { asTestRaw } from "@/api/tests/helpers/test-tool-set";
 
 const workspaceId = toSafeId<"workspace">("workspace_1");
+const noopAuditRecorder: AuditRecorder = async () => {
+  await Promise.resolve();
+};
 
 const tableLayout = (propertyId: string): ViewLayout => ({
   version: 1,
@@ -232,6 +236,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout(templateProperty.sourceId),
       templateProperties: [templateProperty],
       canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
     });
 
     expect(result).toEqual({
@@ -260,6 +265,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout(templateProperty.sourceId),
       templateProperties: [templateProperty, templateProperty],
       canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
     });
 
     expect(result).toEqual({
@@ -293,6 +299,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout(templateProperty.sourceId),
       templateProperties: [templateProperty],
       canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
     });
 
     expect(result).toEqual({
@@ -331,6 +338,7 @@ describe("resolveTemplateProperties", () => {
       layout: tableLayout(propertyA.sourceId),
       templateProperties: [propertyA, propertyB],
       canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
     });
 
     expect(result).toEqual({
@@ -373,6 +381,7 @@ describe("resolveTemplateProperties", () => {
       layout,
       templateProperties: [firstProperty, secondProperty],
       canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
     });
 
     expect(result).toEqual({

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { Transaction } from "@/api/db";
+import { properties, propertyDependencies } from "@/api/db/schema";
 import { resolveTemplateProperties } from "@/api/handlers/view-templates/properties";
 import { toSafeId } from "@/api/lib/branded-types";
 import type { ViewLayout, ViewTemplateProperty } from "@/api/lib/views-schema";
@@ -40,6 +41,47 @@ const createTemplatePropertyValidationTx = () => {
 
   return {
     insertMock,
+    tx: asTestRaw<Transaction>(tx),
+  };
+};
+
+const createTemplateDependencyTx = () => {
+  const createdPropertyIds = ["created_a", "created_b"];
+  const returningMock = mock(async () => [{ id: createdPropertyIds.shift() }]);
+  const propertyValuesMock = mock(() => ({
+    returning: returningMock,
+  }));
+  const dependencyValuesMock = mock(() => ({
+    onConflictDoNothing: mock(async () => undefined),
+  }));
+  const insertMock = mock((table: unknown) => {
+    if (table === properties) {
+      return { values: propertyValuesMock };
+    }
+    if (table === propertyDependencies) {
+      return { values: dependencyValuesMock };
+    }
+    throw new Error("Unexpected table insert");
+  });
+  const tx = {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          for: mock(async () => []),
+        })),
+      })),
+    })),
+    query: {
+      properties: {
+        findMany: mock(async () => []),
+      },
+    },
+    insert: insertMock,
+  };
+
+  return {
+    dependencyValuesMock,
+    returningMock,
     tx: asTestRaw<Transaction>(tx),
   };
 };
@@ -102,5 +144,44 @@ describe("resolveTemplateProperties", () => {
       message: "Fallback must match one of the supplied options",
     });
     expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects cyclic dependencies between newly created template columns", async () => {
+    const { dependencyValuesMock, returningMock, tx } =
+      createTemplateDependencyTx();
+    const propertyA = {
+      version: 1,
+      sourceId: "source_a",
+      name: "A",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "ai-model", prompt: "Extract A" },
+      createIfMissing: true,
+      dependencies: [{ dependsOnSourceId: "source_b", condition: null }],
+    } satisfies ViewTemplateProperty;
+    const propertyB = {
+      version: 1,
+      sourceId: "source_b",
+      name: "B",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "ai-model", prompt: "Extract B" },
+      createIfMissing: true,
+      dependencies: [{ dependsOnSourceId: "source_a", condition: null }],
+    } satisfies ViewTemplateProperty;
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout: tableLayout(propertyA.sourceId),
+      templateProperties: [propertyA, propertyB],
+      canCreateProperties: true,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 422,
+      message: "Circular template dependency detected",
+    });
+    expect(returningMock).toHaveBeenCalledTimes(2);
+    expect(dependencyValuesMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -99,13 +99,23 @@ const createTemplateDependencyTx = () => {
   };
 };
 
-const createTemplateReuseTx = () => {
-  const existingProperty = {
-    id: "existing_property",
-    name: "Status",
-    content: { version: 1, type: "text" },
-    tool: { version: 1, type: "manual-input" },
-  };
+type ExistingTemplateReuseProperty = {
+  id: string;
+  name: string;
+  content: typeof properties.$inferSelect.content;
+  tool: typeof properties.$inferSelect.tool;
+};
+
+const defaultExistingTemplateReuseProperty = {
+  id: "existing_property",
+  name: "Status",
+  content: { version: 1, type: "text" },
+  tool: { version: 1, type: "manual-input" },
+} satisfies ExistingTemplateReuseProperty;
+
+const createTemplateReuseTx = (
+  existingProperty: ExistingTemplateReuseProperty = defaultExistingTemplateReuseProperty,
+) => {
   const returningMock = mock(async () => [{ id: "created_property" }]);
   const propertyValuesMock = mock(() => ({
     returning: returningMock,
@@ -389,6 +399,61 @@ describe("resolveTemplateProperties", () => {
       layout: {
         ...layout,
         columnOrder: ["existing_property", "created_property"],
+      },
+      propertyIds: ["existing_property", "created_property"],
+    });
+    expect(returningMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not reuse shape matches with different config", async () => {
+    const { returningMock, tx } = createTemplateReuseTx({
+      id: "existing_property",
+      name: "Status",
+      content: {
+        version: 1,
+        type: "single-select",
+        options: [{ color: "green", value: "Open" }],
+        fallback: "Open",
+      },
+      tool: { version: 1, type: "manual-input" },
+    });
+    const templateProperty = {
+      version: 1,
+      sourceId: "source_status",
+      name: "Status",
+      content: {
+        version: 1,
+        type: "single-select",
+        options: [{ color: "red", value: "Closed" }],
+        fallback: "Closed",
+      },
+      tool: { version: 1, type: "manual-input" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+    const layout: ViewLayout = {
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: [templateProperty.sourceId],
+      columnPinning: [],
+    };
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout,
+      templateProperties: [templateProperty],
+      canCreateProperties: true,
+      recordAuditEvent: noopAuditRecorder,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      layout: {
+        ...layout,
+        columnOrder: ["created_property"],
       },
       propertyIds: ["existing_property", "created_property"],
     });

--- a/apps/api/src/handlers/view-templates/properties.test.ts
+++ b/apps/api/src/handlers/view-templates/properties.test.ts
@@ -92,6 +92,45 @@ const createTemplateDependencyTx = () => {
   };
 };
 
+const createTemplateReuseTx = () => {
+  const existingProperty = {
+    id: "existing_property",
+    name: "Status",
+    content: { version: 1, type: "text" },
+    tool: { version: 1, type: "manual-input" },
+  };
+  const returningMock = mock(async () => [{ id: "created_property" }]);
+  const propertyValuesMock = mock(() => ({
+    returning: returningMock,
+  }));
+  const dependencyValuesMock = mock(() => ({
+    onConflictDoNothing: mock(async () => undefined),
+  }));
+  const insertMock = mock((table: unknown) => {
+    if (table === properties) {
+      return { values: propertyValuesMock };
+    }
+    if (table === propertyDependencies) {
+      return { values: dependencyValuesMock };
+    }
+    throw new Error("Unexpected table insert");
+  });
+  const tx = {
+    execute: mock(async () => undefined),
+    query: {
+      properties: {
+        findMany: mock(async () => [existingProperty]),
+      },
+    },
+    insert: insertMock,
+  };
+
+  return {
+    returningMock,
+    tx: asTestRaw<Transaction>(tx),
+  };
+};
+
 describe("resolveTemplateProperties", () => {
   test("rejects file template columns with AI tools before inserting", async () => {
     const { insertMock, tx } = createTemplatePropertyValidationTx();
@@ -219,5 +258,48 @@ describe("resolveTemplateProperties", () => {
     expect(executeMock).toHaveBeenCalledTimes(1);
     expect(returningMock).not.toHaveBeenCalled();
     expect(dependencyValuesMock).not.toHaveBeenCalled();
+  });
+
+  test("reuses existing shape matches only once", async () => {
+    const { returningMock, tx } = createTemplateReuseTx();
+    const firstProperty = {
+      version: 1,
+      sourceId: "source_a",
+      name: "Status",
+      content: { version: 1, type: "text" },
+      tool: { version: 1, type: "manual-input" },
+      createIfMissing: true,
+    } satisfies ViewTemplateProperty;
+    const secondProperty = {
+      ...firstProperty,
+      sourceId: "source_b",
+    } satisfies ViewTemplateProperty;
+    const layout: ViewLayout = {
+      version: 1,
+      type: "table",
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      columnOrder: [firstProperty.sourceId, secondProperty.sourceId],
+      columnPinning: [],
+    };
+
+    const result = await resolveTemplateProperties({
+      tx,
+      workspaceId,
+      layout,
+      templateProperties: [firstProperty, secondProperty],
+      canCreateProperties: true,
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      layout: {
+        ...layout,
+        columnOrder: ["existing_property", "created_property"],
+      },
+      propertyIds: ["existing_property", "created_property"],
+    });
+    expect(returningMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -3,6 +3,7 @@ import { eq } from "drizzle-orm";
 import type { Transaction } from "@/api/db";
 import { properties, propertyDependencies } from "@/api/db/schema";
 import type { PropertyCondition } from "@/api/db/schema-validators";
+import { lockWorkspacePropertyWrites } from "@/api/handlers/properties/property-lock";
 import type { AuditContext } from "@/api/lib/audit-log";
 import {
   AUDIT_ACTION,
@@ -114,16 +115,12 @@ export const resolveTemplateProperties = async ({
     return { ok: true, layout, propertyIds };
   }
 
-  // Lock all existing property rows in this workspace before the
-  // limit check and any inserts. Without this, two concurrent
-  // template-apply requests can both pass the count guard and exceed
-  // LIMITS.propertiesCount. Matches the pattern in
-  // handlers/properties/create.ts.
-  await tx
-    .select({ id: properties.id })
-    .from(properties)
-    .where(eq(properties.workspaceId, workspaceId))
-    .for("update");
+  const validationError = validateTemplateProperties(templateProperties);
+  if (validationError) {
+    return validationError;
+  }
+
+  await lockWorkspacePropertyWrites(tx, workspaceId);
 
   const existingProperties = await tx.query.properties.findMany({
     where: { workspaceId: { eq: workspaceId } },
@@ -142,11 +139,6 @@ export const resolveTemplateProperties = async ({
   let projectedPropertyCount = nextPropertyIds.length;
 
   for (const templateProperty of templateProperties) {
-    const validationError = validateTemplatePropertyConfig(templateProperty);
-    if (validationError) {
-      return validationError;
-    }
-
     const existingById = existingProperties.find(
       (property) => property.id === templateProperty.sourceId,
     );
@@ -389,6 +381,30 @@ const readPropertyIds = async (
     .from(properties)
     .where(eq(properties.workspaceId, workspaceId));
   return rows.map((row) => row.id);
+};
+
+const validateTemplateProperties = (
+  templateProperties: readonly ViewTemplateProperty[],
+): ResolveTemplatePropertiesResult | null => {
+  const sourceIds = new Set<string>();
+
+  for (const templateProperty of templateProperties) {
+    if (sourceIds.has(templateProperty.sourceId)) {
+      return {
+        ok: false,
+        status: 422,
+        message: "Duplicate template property sourceId",
+      };
+    }
+    sourceIds.add(templateProperty.sourceId);
+
+    const validationError = validateTemplatePropertyConfig(templateProperty);
+    if (validationError) {
+      return validationError;
+    }
+  }
+
+  return null;
 };
 
 const validateTemplatePropertyConfig = (

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -1,7 +1,8 @@
 import { eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
-import { properties } from "@/api/db/schema";
+import { properties, propertyDependencies } from "@/api/db/schema";
+import type { PropertyCondition } from "@/api/db/schema-validators";
 import type { AuditContext } from "@/api/lib/audit-log";
 import {
   AUDIT_ACTION,
@@ -10,6 +11,7 @@ import {
 } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
+import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import type {
   ViewFilterCondition,
   ViewLayout,
@@ -22,6 +24,12 @@ type WorkspacePropertyTemplateSource = {
   content: typeof properties.$inferSelect.content;
   tool: typeof properties.$inferSelect.tool;
   system: boolean;
+};
+
+type WorkspacePropertyDependencySource = {
+  propertyId: string;
+  dependsOnPropertyId: string;
+  condition: PropertyCondition | null;
 };
 
 type ResolveTemplatePropertiesOptions = {
@@ -40,9 +48,11 @@ type ResolveTemplatePropertiesResult =
 export const collectTemplateProperties = ({
   layout,
   properties: workspaceProperties,
+  dependencies,
 }: {
   layout: ViewLayout;
   properties: readonly WorkspacePropertyTemplateSource[];
+  dependencies: readonly WorkspacePropertyDependencySource[];
 }): ViewTemplateProperty[] => {
   const referencedPropertyIds = collectLayoutPropertyIds(layout);
   const visiblePropertyIds = collectVisibleTemplatePropertyIds({
@@ -54,6 +64,19 @@ export const collectTemplateProperties = ({
     ...visiblePropertyIds,
   ]);
 
+  const dependenciesByPropertyId = new Map<
+    string,
+    { dependsOnSourceId: string; condition: PropertyCondition | null }[]
+  >();
+  for (const dep of dependencies) {
+    const list = dependenciesByPropertyId.get(dep.propertyId) ?? [];
+    list.push({
+      dependsOnSourceId: dep.dependsOnPropertyId,
+      condition: dep.condition,
+    });
+    dependenciesByPropertyId.set(dep.propertyId, list);
+  }
+
   return workspaceProperties
     .filter((property) => !property.system)
     .filter(
@@ -61,14 +84,21 @@ export const collectTemplateProperties = ({
         creatablePropertyIds.has(property.id) ||
         layout.hiddenProperties.includes(property.id),
     )
-    .map((property) => ({
-      version: 1,
-      sourceId: property.id,
-      name: property.name,
-      content: property.content,
-      tool: property.tool,
-      createIfMissing: creatablePropertyIds.has(property.id),
-    }));
+    .map((property): ViewTemplateProperty => {
+      const propertyDeps = dependenciesByPropertyId.get(property.id);
+      const result: ViewTemplateProperty = {
+        version: 1,
+        sourceId: property.id,
+        name: property.name,
+        content: property.content,
+        tool: property.tool,
+        createIfMissing: creatablePropertyIds.has(property.id),
+      };
+      if (propertyDeps && propertyDeps.length > 0) {
+        result.dependencies = propertyDeps;
+      }
+      return result;
+    });
 };
 
 export const resolveTemplateProperties = async ({
@@ -83,6 +113,17 @@ export const resolveTemplateProperties = async ({
     const propertyIds = await readPropertyIds(tx, workspaceId);
     return { ok: true, layout, propertyIds };
   }
+
+  // Lock all existing property rows in this workspace before the
+  // limit check and any inserts. Without this, two concurrent
+  // template-apply requests can both pass the count guard and exceed
+  // LIMITS.propertiesCount. Matches the pattern in
+  // handlers/properties/create.ts.
+  await tx
+    .select({ id: properties.id })
+    .from(properties)
+    .where(eq(properties.workspaceId, workspaceId))
+    .for("update");
 
   const existingProperties = await tx.query.properties.findMany({
     where: { workspaceId: { eq: workspaceId } },
@@ -183,8 +224,68 @@ export const resolveTemplateProperties = async ({
     }
   }
 
+  await recreateTemplateDependencies({
+    tx,
+    workspaceId,
+    templateProperties,
+    propertyIdBySourceId,
+  });
+
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
   return { ok: true, layout, propertyIds: nextPropertyIds };
+};
+
+const recreateTemplateDependencies = async ({
+  tx,
+  workspaceId,
+  templateProperties,
+  propertyIdBySourceId,
+}: {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  templateProperties: readonly ViewTemplateProperty[];
+  propertyIdBySourceId: ReadonlyMap<string, string>;
+}): Promise<void> => {
+  const rows = templateProperties.flatMap((templateProperty) => {
+    const propertyId = propertyIdBySourceId.get(templateProperty.sourceId);
+    if (!propertyId || !templateProperty.dependencies) {
+      return [];
+    }
+    return templateProperty.dependencies.flatMap((dep) => {
+      const dependsOnPropertyId = propertyIdBySourceId.get(
+        dep.dependsOnSourceId,
+      );
+      // Drop edges where either endpoint failed to remap; the
+      // missing-property branch above already declined to create
+      // them, so the workflow planner will treat the property as
+      // having no inputs rather than crashing.
+      if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
+        return [];
+      }
+      return [
+        {
+          workspaceId,
+          propertyId: brandPersistedPropertyId(propertyId),
+          dependsOnPropertyId: brandPersistedPropertyId(dependsOnPropertyId),
+          condition: dep.condition,
+        },
+      ];
+    });
+  });
+
+  if (rows.length === 0) {
+    return;
+  }
+
+  await tx
+    .insert(propertyDependencies)
+    .values(rows)
+    .onConflictDoNothing({
+      target: [
+        propertyDependencies.propertyId,
+        propertyDependencies.dependsOnPropertyId,
+      ],
+    });
 };
 
 const readPropertyIds = async (

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -91,6 +91,7 @@ export const resolveTemplateProperties = async ({
       name: true,
       content: true,
     },
+    orderBy: { createdAt: "asc" },
   });
   const nextPropertyIds = existingProperties.map((property) => property.id);
   const propertyIdBySourceId = new Map<string, string>();

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -1,3 +1,4 @@
+import { deepEquals } from "bun";
 import { eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
@@ -9,6 +10,7 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
+import { sortDeep } from "@/api/lib/sort-deep";
 import type {
   ViewFilterCondition,
   ViewLayout,
@@ -500,8 +502,8 @@ const findUniquePropertyByShape = (
   existingProperties: readonly {
     id: string;
     name: string;
-    content: { type: string };
-    tool: { type: string };
+    content: typeof properties.$inferSelect.content;
+    tool: typeof properties.$inferSelect.tool;
   }[],
   templateProperty: ViewTemplateProperty,
   consumedExistingPropertyIds: ReadonlySet<string>,
@@ -512,11 +514,27 @@ const findUniquePropertyByShape = (
       normalizePropertyName(property.name) ===
         normalizePropertyName(templateProperty.name) &&
       property.content.type === templateProperty.content.type &&
-      property.tool.type === templateProperty.tool.type,
+      property.tool.type === templateProperty.tool.type &&
+      hasSamePropertyConfig(property, templateProperty),
   );
 
   return matches.length === 1 ? matches[0] : undefined;
 };
+
+const hasSamePropertyConfig = (
+  property: Pick<WorkspacePropertyTemplateSource, "content" | "tool">,
+  templateProperty: ViewTemplateProperty,
+): boolean =>
+  deepEquals(
+    sortDeep({
+      content: property.content,
+      tool: property.tool,
+    }),
+    sortDeep({
+      content: templateProperty.content,
+      tool: templateProperty.tool,
+    }),
+  );
 
 const collectVisibleTemplatePropertyIds = ({
   layout,

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -90,6 +90,7 @@ export const resolveTemplateProperties = async ({
       id: true,
       name: true,
       content: true,
+      tool: true,
     },
     orderBy: { createdAt: "asc" },
   });
@@ -109,7 +110,8 @@ export const resolveTemplateProperties = async ({
       (property) =>
         normalizePropertyName(property.name) ===
           normalizePropertyName(templateProperty.name) &&
-        property.content.type === templateProperty.content.type,
+        property.content.type === templateProperty.content.type &&
+        property.tool.type === templateProperty.tool.type,
     );
     if (existingByShape) {
       propertyIdBySourceId.set(templateProperty.sourceId, existingByShape.id);

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -60,11 +60,6 @@ export const collectTemplateProperties = ({
     layout,
     properties: workspaceProperties,
   });
-  const creatablePropertyIds = new Set([
-    ...referencedPropertyIds,
-    ...visiblePropertyIds,
-  ]);
-
   const dependenciesByPropertyId = new Map<
     string,
     { dependsOnSourceId: string; condition: PropertyCondition | null }[]
@@ -77,6 +72,11 @@ export const collectTemplateProperties = ({
     });
     dependenciesByPropertyId.set(dep.propertyId, list);
   }
+  const creatablePropertyIds = new Set([
+    ...referencedPropertyIds,
+    ...visiblePropertyIds,
+  ]);
+  addDependencySourceIds(creatablePropertyIds, dependenciesByPropertyId);
 
   return workspaceProperties
     .filter((property) => !property.system)
@@ -100,6 +100,29 @@ export const collectTemplateProperties = ({
       }
       return result;
     });
+};
+
+const addDependencySourceIds = (
+  creatablePropertyIds: Set<string>,
+  dependenciesByPropertyId: ReadonlyMap<
+    string,
+    readonly {
+      dependsOnSourceId: string;
+      condition: PropertyCondition | null;
+    }[]
+  >,
+): void => {
+  const queue = [...creatablePropertyIds];
+
+  for (const propertyId of queue) {
+    for (const dependency of dependenciesByPropertyId.get(propertyId) ?? []) {
+      if (creatablePropertyIds.has(dependency.dependsOnSourceId)) {
+        continue;
+      }
+      creatablePropertyIds.add(dependency.dependsOnSourceId);
+      queue.push(dependency.dependsOnSourceId);
+    }
+  }
 };
 
 export const resolveTemplateProperties = async ({

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -147,12 +147,9 @@ export const resolveTemplateProperties = async ({
       continue;
     }
 
-    const existingByShape = existingProperties.find(
-      (property) =>
-        normalizePropertyName(property.name) ===
-          normalizePropertyName(templateProperty.name) &&
-        property.content.type === templateProperty.content.type &&
-        property.tool.type === templateProperty.tool.type,
+    const existingByShape = findUniquePropertyByShape(
+      existingProperties,
+      templateProperty,
     );
     if (existingByShape) {
       propertyIdBySourceId.set(templateProperty.sourceId, existingByShape.id);
@@ -301,6 +298,26 @@ const readPropertyIds = async (
 
 const normalizePropertyName = (name: string): string =>
   name.trim().toLocaleLowerCase();
+
+const findUniquePropertyByShape = (
+  existingProperties: readonly {
+    id: string;
+    name: string;
+    content: { type: string };
+    tool: { type: string };
+  }[],
+  templateProperty: ViewTemplateProperty,
+) => {
+  const matches = existingProperties.filter(
+    (property) =>
+      normalizePropertyName(property.name) ===
+        normalizePropertyName(templateProperty.name) &&
+      property.content.type === templateProperty.content.type &&
+      property.tool.type === templateProperty.tool.type,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+};
 
 const collectVisibleTemplatePropertyIds = ({
   layout,

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -138,6 +138,8 @@ export const resolveTemplateProperties = async ({
   const nextPropertyIds = existingProperties.map((property) => property.id);
   const propertyIdBySourceId = new Map<string, string>();
   const createdPropertySourceIds = new Set<string>();
+  const templatePropertiesToCreate: ViewTemplateProperty[] = [];
+  let projectedPropertyCount = nextPropertyIds.length;
 
   for (const templateProperty of templateProperties) {
     const validationError = validateTemplatePropertyConfig(templateProperty);
@@ -174,7 +176,7 @@ export const resolveTemplateProperties = async ({
       };
     }
 
-    if (nextPropertyIds.length >= LIMITS.propertiesCount) {
+    if (projectedPropertyCount >= LIMITS.propertiesCount) {
       return {
         ok: false,
         status: 400,
@@ -182,6 +184,25 @@ export const resolveTemplateProperties = async ({
       };
     }
 
+    createdPropertySourceIds.add(templateProperty.sourceId);
+    templatePropertiesToCreate.push(templateProperty);
+    projectedPropertyCount += 1;
+  }
+
+  if (
+    hasTemplateDependencyCycle({
+      templateProperties,
+      createdPropertySourceIds,
+    })
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      message: "Circular template dependency detected",
+    };
+  }
+
+  for (const templateProperty of templatePropertiesToCreate) {
     const [inserted] = await tx
       .insert(properties)
       .values({
@@ -202,7 +223,6 @@ export const resolveTemplateProperties = async ({
     }
 
     propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
-    createdPropertySourceIds.add(templateProperty.sourceId);
     nextPropertyIds.push(inserted.id);
 
     if (auditContext) {
@@ -226,20 +246,6 @@ export const resolveTemplateProperties = async ({
         tx,
       );
     }
-  }
-
-  if (
-    hasTemplateDependencyCycle({
-      templateProperties,
-      propertyIdBySourceId,
-      createdPropertySourceIds,
-    })
-  ) {
-    return {
-      ok: false,
-      status: 422,
-      message: "Circular template dependency detected",
-    };
   }
 
   await recreateTemplateDependencies({
@@ -315,11 +321,9 @@ const recreateTemplateDependencies = async ({
 
 const hasTemplateDependencyCycle = ({
   templateProperties,
-  propertyIdBySourceId,
   createdPropertySourceIds,
 }: {
   templateProperties: readonly ViewTemplateProperty[];
-  propertyIdBySourceId: ReadonlyMap<string, string>;
   createdPropertySourceIds: ReadonlySet<string>;
 }): boolean => {
   const graph = new Map<string, string[]>();
@@ -329,17 +333,16 @@ const hasTemplateDependencyCycle = ({
       continue;
     }
 
-    const propertyId = propertyIdBySourceId.get(templateProperty.sourceId);
-    if (!propertyId || !templateProperty.dependencies) {
+    if (!templateProperty.dependencies) {
       continue;
     }
 
     const dependencySourceIds: string[] = [];
     for (const dep of templateProperty.dependencies) {
-      const dependsOnPropertyId = propertyIdBySourceId.get(
-        dep.dependsOnSourceId,
-      );
-      if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
+      if (
+        dep.dependsOnSourceId === templateProperty.sourceId ||
+        !createdPropertySourceIds.has(dep.dependsOnSourceId)
+      ) {
         continue;
       }
       dependencySourceIds.push(dep.dependsOnSourceId);

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -43,7 +43,7 @@ type ResolveTemplatePropertiesOptions = {
 
 type ResolveTemplatePropertiesResult =
   | { ok: true; layout: ViewLayout; propertyIds: string[] }
-  | { ok: false; status: 400 | 403; message: string };
+  | { ok: false; status: 400 | 403 | 422; message: string };
 
 export const collectTemplateProperties = ({
   layout,
@@ -140,6 +140,11 @@ export const resolveTemplateProperties = async ({
   const createdPropertySourceIds = new Set<string>();
 
   for (const templateProperty of templateProperties) {
+    const validationError = validateTemplatePropertyConfig(templateProperty);
+    if (validationError) {
+      return validationError;
+    }
+
     const existingById = existingProperties.find(
       (property) => property.id === templateProperty.sourceId,
     );
@@ -303,6 +308,54 @@ const readPropertyIds = async (
     .from(properties)
     .where(eq(properties.workspaceId, workspaceId));
   return rows.map((row) => row.id);
+};
+
+const validateTemplatePropertyConfig = (
+  templateProperty: ViewTemplateProperty,
+): ResolveTemplatePropertiesResult | null => {
+  if (
+    templateProperty.content.type === "file" &&
+    templateProperty.tool.type !== "manual-input"
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      message: "File template columns must use manual input",
+    };
+  }
+
+  if (
+    templateProperty.tool.type !== "ai-model" &&
+    templateProperty.dependencies &&
+    templateProperty.dependencies.length > 0
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      message: "Only AI template columns can declare dependencies",
+    };
+  }
+
+  if (
+    templateProperty.content.type === "single-select" ||
+    templateProperty.content.type === "multi-select"
+  ) {
+    const fallback = templateProperty.content.fallback;
+    if (
+      fallback !== null &&
+      !templateProperty.content.options.some(
+        (option) => option.value === fallback,
+      )
+    ) {
+      return {
+        ok: false,
+        status: 400,
+        message: "Fallback must match one of the supplied options",
+      };
+    }
+  }
+
+  return null;
 };
 
 const normalizePropertyName = (name: string): string =>

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -135,6 +135,7 @@ export const resolveTemplateProperties = async ({
   const nextPropertyIds = existingProperties.map((property) => property.id);
   const propertyIdBySourceId = new Map<string, string>();
   const createdPropertySourceIds = new Set<string>();
+  const consumedExistingPropertyIds = new Set<string>();
   const templatePropertiesToCreate: ViewTemplateProperty[] = [];
   let projectedPropertyCount = nextPropertyIds.length;
 
@@ -144,15 +145,18 @@ export const resolveTemplateProperties = async ({
     );
     if (existingById) {
       propertyIdBySourceId.set(templateProperty.sourceId, existingById.id);
+      consumedExistingPropertyIds.add(existingById.id);
       continue;
     }
 
     const existingByShape = findUniquePropertyByShape(
       existingProperties,
       templateProperty,
+      consumedExistingPropertyIds,
     );
     if (existingByShape) {
       propertyIdBySourceId.set(templateProperty.sourceId, existingByShape.id);
+      consumedExistingPropertyIds.add(existingByShape.id);
       continue;
     }
 
@@ -466,9 +470,11 @@ const findUniquePropertyByShape = (
     tool: { type: string };
   }[],
   templateProperty: ViewTemplateProperty,
+  consumedExistingPropertyIds: ReadonlySet<string>,
 ) => {
   const matches = existingProperties.filter(
     (property) =>
+      !consumedExistingPropertyIds.has(property.id) &&
       normalizePropertyName(property.name) ===
         normalizePropertyName(templateProperty.name) &&
       property.content.type === templateProperty.content.type &&

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -4,12 +4,8 @@ import type { Transaction } from "@/api/db";
 import { properties, propertyDependencies } from "@/api/db/schema";
 import type { PropertyCondition } from "@/api/db/schema-validators";
 import { lockWorkspacePropertyWrites } from "@/api/handlers/properties/property-lock";
-import type { AuditContext } from "@/api/lib/audit-log";
-import {
-  AUDIT_ACTION,
-  AUDIT_RESOURCE_TYPE,
-  writeAuditLog,
-} from "@/api/lib/audit-log";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
@@ -39,7 +35,7 @@ type ResolveTemplatePropertiesOptions = {
   layout: ViewLayout;
   templateProperties: readonly ViewTemplateProperty[] | undefined;
   canCreateProperties: boolean;
-  auditContext?: AuditContext;
+  recordAuditEvent: AuditRecorder;
 };
 
 type ResolveTemplatePropertiesResult =
@@ -131,7 +127,7 @@ export const resolveTemplateProperties = async ({
   layout,
   templateProperties,
   canCreateProperties,
-  auditContext,
+  recordAuditEvent,
 }: ResolveTemplatePropertiesOptions): Promise<ResolveTemplatePropertiesResult> => {
   if (!templateProperties || templateProperties.length === 0) {
     const propertyIds = await readPropertyIds(tx, workspaceId);
@@ -244,27 +240,21 @@ export const resolveTemplateProperties = async ({
     propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
     nextPropertyIds.push(inserted.id);
 
-    if (auditContext) {
-      await writeAuditLog(
-        {
-          ...auditContext,
-          action: AUDIT_ACTION.CREATE,
-          resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
-          resourceId: inserted.id,
-          changes: {
-            createdFromViewTemplate: {
-              old: null,
-              new: {
-                name: templateProperty.name,
-                contentType: templateProperty.content.type,
-                toolType: templateProperty.tool.type,
-              },
-            },
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.CREATE,
+      resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
+      resourceId: inserted.id,
+      changes: {
+        createdFromViewTemplate: {
+          old: null,
+          new: {
+            name: templateProperty.name,
+            contentType: templateProperty.content.type,
+            toolType: templateProperty.tool.type,
           },
         },
-        tx,
-      );
-    }
+      },
+    });
   }
 
   await recreateTemplateDependencies({
@@ -273,6 +263,7 @@ export const resolveTemplateProperties = async ({
     templateProperties,
     propertyIdBySourceId,
     createdPropertySourceIds,
+    recordAuditEvent,
   });
 
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
@@ -285,12 +276,14 @@ const recreateTemplateDependencies = async ({
   templateProperties,
   propertyIdBySourceId,
   createdPropertySourceIds,
+  recordAuditEvent,
 }: {
   tx: Transaction;
   workspaceId: SafeId<"workspace">;
   templateProperties: readonly ViewTemplateProperty[];
   propertyIdBySourceId: ReadonlyMap<string, string>;
   createdPropertySourceIds: ReadonlySet<string>;
+  recordAuditEvent: AuditRecorder;
 }): Promise<void> => {
   const rows = templateProperties.flatMap((templateProperty) => {
     if (!createdPropertySourceIds.has(templateProperty.sourceId)) {
@@ -336,6 +329,24 @@ const recreateTemplateDependencies = async ({
         propertyDependencies.dependsOnPropertyId,
       ],
     });
+
+  await recordAuditEvent(
+    tx,
+    rows.map((row) => ({
+      action: AUDIT_ACTION.UPDATE,
+      resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
+      resourceId: row.propertyId,
+      changes: {
+        dependencyCreatedFromViewTemplate: {
+          old: null,
+          new: {
+            dependsOnPropertyId: row.dependsOnPropertyId,
+            condition: row.condition,
+          },
+        },
+      },
+    })),
+  );
 };
 
 const hasTemplateDependencyCycle = ({

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -137,6 +137,7 @@ export const resolveTemplateProperties = async ({
   });
   const nextPropertyIds = existingProperties.map((property) => property.id);
   const propertyIdBySourceId = new Map<string, string>();
+  const createdPropertySourceIds = new Set<string>();
 
   for (const templateProperty of templateProperties) {
     const existingById = existingProperties.find(
@@ -196,6 +197,7 @@ export const resolveTemplateProperties = async ({
     }
 
     propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
+    createdPropertySourceIds.add(templateProperty.sourceId);
     nextPropertyIds.push(inserted.id);
 
     if (auditContext) {
@@ -226,6 +228,7 @@ export const resolveTemplateProperties = async ({
     workspaceId,
     templateProperties,
     propertyIdBySourceId,
+    createdPropertySourceIds,
   });
 
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
@@ -237,13 +240,19 @@ const recreateTemplateDependencies = async ({
   workspaceId,
   templateProperties,
   propertyIdBySourceId,
+  createdPropertySourceIds,
 }: {
   tx: Transaction;
   workspaceId: SafeId<"workspace">;
   templateProperties: readonly ViewTemplateProperty[];
   propertyIdBySourceId: ReadonlyMap<string, string>;
+  createdPropertySourceIds: ReadonlySet<string>;
 }): Promise<void> => {
   const rows = templateProperties.flatMap((templateProperty) => {
+    if (!createdPropertySourceIds.has(templateProperty.sourceId)) {
+      return [];
+    }
+
     const propertyId = propertyIdBySourceId.get(templateProperty.sourceId);
     if (!propertyId || !templateProperty.dependencies) {
       return [];

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -55,7 +55,7 @@ export const collectTemplateProperties = ({
   ]);
 
   return workspaceProperties
-    .filter((property) => property.content.type !== "file" && !property.system)
+    .filter((property) => !property.system)
     .filter(
       (property) =>
         creatablePropertyIds.has(property.id) ||
@@ -206,10 +206,6 @@ const collectVisibleTemplatePropertyIds = ({
   properties: readonly WorkspacePropertyTemplateSource[];
 }): Set<string> => {
   const ids = new Set<string>();
-
-  if (layout.type !== "table") {
-    return ids;
-  }
 
   for (const property of workspaceProperties) {
     if (!layout.hiddenProperties.includes(property.id)) {

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -228,6 +228,20 @@ export const resolveTemplateProperties = async ({
     }
   }
 
+  if (
+    hasTemplateDependencyCycle({
+      templateProperties,
+      propertyIdBySourceId,
+      createdPropertySourceIds,
+    })
+  ) {
+    return {
+      ok: false,
+      status: 422,
+      message: "Circular template dependency detected",
+    };
+  }
+
   await recreateTemplateDependencies({
     tx,
     workspaceId,
@@ -297,6 +311,70 @@ const recreateTemplateDependencies = async ({
         propertyDependencies.dependsOnPropertyId,
       ],
     });
+};
+
+const hasTemplateDependencyCycle = ({
+  templateProperties,
+  propertyIdBySourceId,
+  createdPropertySourceIds,
+}: {
+  templateProperties: readonly ViewTemplateProperty[];
+  propertyIdBySourceId: ReadonlyMap<string, string>;
+  createdPropertySourceIds: ReadonlySet<string>;
+}): boolean => {
+  const graph = new Map<string, string[]>();
+
+  for (const templateProperty of templateProperties) {
+    if (!createdPropertySourceIds.has(templateProperty.sourceId)) {
+      continue;
+    }
+
+    const propertyId = propertyIdBySourceId.get(templateProperty.sourceId);
+    if (!propertyId || !templateProperty.dependencies) {
+      continue;
+    }
+
+    const dependencySourceIds: string[] = [];
+    for (const dep of templateProperty.dependencies) {
+      const dependsOnPropertyId = propertyIdBySourceId.get(
+        dep.dependsOnSourceId,
+      );
+      if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
+        continue;
+      }
+      dependencySourceIds.push(dep.dependsOnSourceId);
+    }
+    graph.set(templateProperty.sourceId, dependencySourceIds);
+  }
+
+  const visited = new Set<string>();
+  const visiting = new Set<string>();
+  const visit = (sourceId: string): boolean => {
+    if (visiting.has(sourceId)) {
+      return true;
+    }
+    if (visited.has(sourceId)) {
+      return false;
+    }
+
+    visiting.add(sourceId);
+    for (const dependencySourceId of graph.get(sourceId) ?? []) {
+      if (visit(dependencySourceId)) {
+        return true;
+      }
+    }
+    visiting.delete(sourceId);
+    visited.add(sourceId);
+    return false;
+  };
+
+  for (const sourceId of graph.keys()) {
+    if (visit(sourceId)) {
+      return true;
+    }
+  }
+
+  return false;
 };
 
 const readPropertyIds = async (

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -1,0 +1,326 @@
+import { eq } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db";
+import { properties } from "@/api/db/schema";
+import type { AuditContext } from "@/api/lib/audit-log";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  writeAuditLog,
+} from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { LIMITS } from "@/api/lib/limits";
+import type {
+  ViewFilterCondition,
+  ViewLayout,
+  ViewTemplateProperty,
+} from "@/api/lib/views-schema";
+
+type WorkspacePropertyTemplateSource = {
+  id: string;
+  name: string;
+  content: typeof properties.$inferSelect.content;
+  tool: typeof properties.$inferSelect.tool;
+  system: boolean;
+};
+
+type ResolveTemplatePropertiesOptions = {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  layout: ViewLayout;
+  templateProperties: readonly ViewTemplateProperty[] | undefined;
+  canCreateProperties: boolean;
+  auditContext?: AuditContext;
+};
+
+type ResolveTemplatePropertiesResult =
+  | { ok: true; layout: ViewLayout; propertyIds: string[] }
+  | { ok: false; status: 400 | 403; message: string };
+
+export const collectTemplateProperties = ({
+  layout,
+  properties: workspaceProperties,
+}: {
+  layout: ViewLayout;
+  properties: readonly WorkspacePropertyTemplateSource[];
+}): ViewTemplateProperty[] => {
+  const referencedPropertyIds = collectLayoutPropertyIds(layout);
+  const visiblePropertyIds = collectVisibleTemplatePropertyIds({
+    layout,
+    properties: workspaceProperties,
+  });
+  const creatablePropertyIds = new Set([
+    ...referencedPropertyIds,
+    ...visiblePropertyIds,
+  ]);
+
+  return workspaceProperties
+    .filter((property) => property.content.type !== "file" && !property.system)
+    .filter(
+      (property) =>
+        creatablePropertyIds.has(property.id) ||
+        layout.hiddenProperties.includes(property.id),
+    )
+    .map((property) => ({
+      version: 1,
+      sourceId: property.id,
+      name: property.name,
+      content: property.content,
+      tool: property.tool,
+      createIfMissing: creatablePropertyIds.has(property.id),
+    }));
+};
+
+export const resolveTemplateProperties = async ({
+  tx,
+  workspaceId,
+  layout,
+  templateProperties,
+  canCreateProperties,
+  auditContext,
+}: ResolveTemplatePropertiesOptions): Promise<ResolveTemplatePropertiesResult> => {
+  if (!templateProperties || templateProperties.length === 0) {
+    const propertyIds = await readPropertyIds(tx, workspaceId);
+    return { ok: true, layout, propertyIds };
+  }
+
+  const existingProperties = await tx.query.properties.findMany({
+    where: { workspaceId: { eq: workspaceId } },
+    columns: {
+      id: true,
+      name: true,
+      content: true,
+    },
+  });
+  const nextPropertyIds = existingProperties.map((property) => property.id);
+  const propertyIdBySourceId = new Map<string, string>();
+
+  for (const templateProperty of templateProperties) {
+    const existingById = existingProperties.find(
+      (property) => property.id === templateProperty.sourceId,
+    );
+    if (existingById) {
+      propertyIdBySourceId.set(templateProperty.sourceId, existingById.id);
+      continue;
+    }
+
+    const existingByShape = existingProperties.find(
+      (property) =>
+        normalizePropertyName(property.name) ===
+          normalizePropertyName(templateProperty.name) &&
+        property.content.type === templateProperty.content.type,
+    );
+    if (existingByShape) {
+      propertyIdBySourceId.set(templateProperty.sourceId, existingByShape.id);
+      continue;
+    }
+
+    if (!templateProperty.createIfMissing) {
+      continue;
+    }
+
+    if (!canCreateProperties) {
+      return {
+        ok: false,
+        status: 403,
+        message: "Missing permission to create template columns",
+      };
+    }
+
+    if (nextPropertyIds.length >= LIMITS.propertiesCount) {
+      return {
+        ok: false,
+        status: 400,
+        message: "Properties limit reached",
+      };
+    }
+
+    const [inserted] = await tx
+      .insert(properties)
+      .values({
+        workspaceId,
+        name: templateProperty.name,
+        content: templateProperty.content,
+        tool: templateProperty.tool,
+        status: templateProperty.tool.type === "ai-model" ? "stale" : "fresh",
+      })
+      .returning({ id: properties.id });
+
+    if (!inserted) {
+      return {
+        ok: false,
+        status: 400,
+        message: "Failed to create template column",
+      };
+    }
+
+    propertyIdBySourceId.set(templateProperty.sourceId, inserted.id);
+    nextPropertyIds.push(inserted.id);
+
+    if (auditContext) {
+      await writeAuditLog(
+        {
+          ...auditContext,
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.PROPERTY,
+          resourceId: inserted.id,
+          changes: {
+            createdFromViewTemplate: {
+              old: null,
+              new: {
+                name: templateProperty.name,
+                contentType: templateProperty.content.type,
+                toolType: templateProperty.tool.type,
+              },
+            },
+          },
+        },
+        tx,
+      );
+    }
+  }
+
+  remapLayoutPropertyIds(layout, propertyIdBySourceId);
+  return { ok: true, layout, propertyIds: nextPropertyIds };
+};
+
+const readPropertyIds = async (
+  tx: Transaction,
+  workspaceId: SafeId<"workspace">,
+): Promise<string[]> => {
+  const rows = await tx
+    .select({ id: properties.id })
+    .from(properties)
+    .where(eq(properties.workspaceId, workspaceId));
+  return rows.map((row) => row.id);
+};
+
+const normalizePropertyName = (name: string): string =>
+  name.trim().toLocaleLowerCase();
+
+const collectVisibleTemplatePropertyIds = ({
+  layout,
+  properties: workspaceProperties,
+}: {
+  layout: ViewLayout;
+  properties: readonly WorkspacePropertyTemplateSource[];
+}): Set<string> => {
+  const ids = new Set<string>();
+
+  if (layout.type !== "table") {
+    return ids;
+  }
+
+  for (const property of workspaceProperties) {
+    if (!layout.hiddenProperties.includes(property.id)) {
+      ids.add(property.id);
+    }
+  }
+
+  return ids;
+};
+
+const collectLayoutPropertyIds = (layout: ViewLayout): Set<string> => {
+  const ids = new Set<string>();
+  const add = (id: string) => {
+    if (!isInternalPropertyId(id)) {
+      ids.add(id);
+    }
+  };
+
+  for (const sort of layout.sorts) {
+    add(sort.propertyId);
+  }
+
+  for (const filter of layout.filters) {
+    if (filter.field === "property") {
+      add(filter.propertyId);
+    }
+  }
+
+  if (layout.type === "table") {
+    for (const id of layout.columnOrder) {
+      add(id);
+    }
+    for (const id of layout.columnPinning) {
+      add(id);
+    }
+  }
+
+  if (layout.type === "kanban" && layout.groupByPropertyId) {
+    add(layout.groupByPropertyId);
+  }
+
+  if (layout.type === "calendar") {
+    add(layout.datePropertyId);
+    if (layout.endDatePropertyId) {
+      add(layout.endDatePropertyId);
+    }
+    for (const id of layout.additionalDatePropertyIds ?? []) {
+      add(id);
+    }
+  }
+
+  if (layout.type === "timeline") {
+    add(layout.startDatePropertyId);
+    add(layout.endDatePropertyId);
+    if (layout.groupByPropertyId) {
+      add(layout.groupByPropertyId);
+    }
+  }
+
+  return ids;
+};
+
+const remapLayoutPropertyIds = (
+  layout: ViewLayout,
+  propertyIdBySourceId: ReadonlyMap<string, string>,
+): void => {
+  const remap = (id: string): string => propertyIdBySourceId.get(id) ?? id;
+
+  layout.hiddenProperties = layout.hiddenProperties.map(remap);
+  layout.sorts = layout.sorts.map((sort) => ({
+    ...sort,
+    propertyId: remap(sort.propertyId),
+  }));
+  layout.filters = layout.filters.map((filter): ViewFilterCondition => {
+    if (filter.field !== "property") {
+      return filter;
+    }
+
+    return {
+      ...filter,
+      propertyId: remap(filter.propertyId),
+    };
+  });
+
+  if (layout.type === "table") {
+    layout.columnOrder = layout.columnOrder.map(remap);
+    layout.columnPinning = layout.columnPinning.map(remap);
+  }
+
+  if (layout.type === "kanban" && layout.groupByPropertyId) {
+    layout.groupByPropertyId = remap(layout.groupByPropertyId);
+  }
+
+  if (layout.type === "calendar") {
+    layout.datePropertyId = remap(layout.datePropertyId);
+    if (layout.endDatePropertyId) {
+      layout.endDatePropertyId = remap(layout.endDatePropertyId);
+    }
+    if (layout.additionalDatePropertyIds) {
+      layout.additionalDatePropertyIds =
+        layout.additionalDatePropertyIds.map(remap);
+    }
+  }
+
+  if (layout.type === "timeline") {
+    layout.startDatePropertyId = remap(layout.startDatePropertyId);
+    layout.endDatePropertyId = remap(layout.endDatePropertyId);
+    if (layout.groupByPropertyId) {
+      layout.groupByPropertyId = remap(layout.groupByPropertyId);
+    }
+  }
+};
+
+const isInternalPropertyId = (id: string): boolean => id.startsWith("_");

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -9,6 +9,7 @@ import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { LIMITS } from "@/api/lib/limits";
+import { serializeAITool } from "@/api/lib/markdown/ai-tool";
 import { brandPersistedPropertyId } from "@/api/lib/safe-id-boundaries";
 import { sortDeep } from "@/api/lib/sort-deep";
 import type {
@@ -153,6 +154,13 @@ export const resolveTemplateProperties = async ({
     },
     orderBy: { createdAt: "asc" },
   });
+  const existingDependencyEdges = await tx.query.propertyDependencies.findMany({
+    where: { workspaceId: { eq: workspaceId } },
+    columns: { propertyId: true },
+  });
+  const propertyIdsWithDependencies = new Set(
+    existingDependencyEdges.map((edge) => edge.propertyId),
+  );
   const nextPropertyIds = existingProperties.map((property) => property.id);
   const propertyIdBySourceId = new Map<string, string>();
   const createdPropertySourceIds = new Set<string>();
@@ -174,6 +182,7 @@ export const resolveTemplateProperties = async ({
       existingProperties,
       templateProperty,
       consumedExistingPropertyIds,
+      propertyIdsWithDependencies,
     );
     if (existingByShape) {
       propertyIdBySourceId.set(templateProperty.sourceId, existingByShape.id);
@@ -226,7 +235,7 @@ export const resolveTemplateProperties = async ({
         workspaceId,
         name: templateProperty.name,
         content: templateProperty.content,
-        tool: templateProperty.tool,
+        tool: sanitizeTemplatePropertyTool(templateProperty.tool),
         status: templateProperty.tool.type === "ai-model" ? "stale" : "fresh",
       })
       .returning({ id: properties.id });
@@ -270,6 +279,22 @@ export const resolveTemplateProperties = async ({
 
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
   return { ok: true, layout, propertyIds: nextPropertyIds };
+};
+
+const sanitizeTemplatePropertyTool = (
+  tool: ViewTemplateProperty["tool"],
+): typeof properties.$inferSelect.tool => {
+  if (tool.type === "manual-input") {
+    return tool;
+  }
+
+  const { prompt } = serializeAITool({
+    version: 1,
+    type: "ai-model",
+    prompt: tool.prompt,
+    dependencies: [],
+  });
+  return { version: 1, type: "ai-model", prompt };
 };
 
 const recreateTemplateDependencies = async ({
@@ -507,7 +532,14 @@ const findUniquePropertyByShape = (
   }[],
   templateProperty: ViewTemplateProperty,
   consumedExistingPropertyIds: ReadonlySet<string>,
+  propertyIdsWithDependencies: ReadonlySet<string>,
 ) => {
+  // Reusing an AI column would silently inherit its existing dependency
+  // graph, so only fall back when neither side carries dependencies.
+  const templateHasDependencies =
+    templateProperty.tool.type === "ai-model" &&
+    (templateProperty.dependencies?.length ?? 0) > 0;
+
   const matches = existingProperties.filter(
     (property) =>
       !consumedExistingPropertyIds.has(property.id) &&
@@ -515,7 +547,10 @@ const findUniquePropertyByShape = (
         normalizePropertyName(templateProperty.name) &&
       property.content.type === templateProperty.content.type &&
       property.tool.type === templateProperty.tool.type &&
-      hasSamePropertyConfig(property, templateProperty),
+      hasSamePropertyConfig(property, templateProperty) &&
+      !(
+        templateHasDependencies || propertyIdsWithDependencies.has(property.id)
+      ),
   );
 
   return matches.length === 1 ? matches[0] : undefined;

--- a/apps/api/src/handlers/view-templates/routes.ts
+++ b/apps/api/src/handlers/view-templates/routes.ts
@@ -1,0 +1,19 @@
+import Elysia from "elysia";
+
+import createViewTemplate from "@/api/handlers/view-templates/create";
+import deleteViewTemplate from "@/api/handlers/view-templates/delete";
+import listViewTemplates from "@/api/handlers/view-templates/list";
+import { workspaceAccessMacro } from "@/api/lib/auth";
+
+export const viewTemplatesRoute = new Elysia({
+  prefix: "/view-templates/:workspaceId",
+})
+  .use(workspaceAccessMacro)
+  .guard({ validateWorkspaceAccess: true })
+  .get("/", listViewTemplates.handler)
+  .put("/", createViewTemplate.handler, {
+    body: createViewTemplate.config.body,
+  })
+  .delete("/:templateId", deleteViewTemplate.handler, {
+    params: deleteViewTemplate.config.params,
+  });

--- a/apps/api/src/handlers/views/create.ts
+++ b/apps/api/src/handlers/views/create.ts
@@ -1,14 +1,22 @@
 import { Result } from "better-result";
 import { eq, sql } from "drizzle-orm";
 
+import { roles } from "@stll/permissions";
+
 import { workspaceViews } from "@/api/db/schema";
+import { resolveTemplateProperties } from "@/api/handlers/view-templates/properties";
 import {
+  cleanStalePropertyIds,
   hasDuplicateSorts,
   hasMultipleKindFilters,
 } from "@/api/handlers/views/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createAuditContext,
+} from "@/api/lib/audit-log";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { broadcast } from "@/api/lib/sse";
@@ -24,7 +32,17 @@ const config = {
 
 const createView = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, body, recordAuditEvent }) {
+  async function* ({
+    safeDb,
+    workspaceId,
+    memberRole,
+    session,
+    user,
+    request,
+    server,
+    body,
+    recordAuditEvent,
+  }) {
     const layout = parseViewLayout(body.layout);
 
     if (hasDuplicateSorts(layout.sorts)) {
@@ -66,6 +84,32 @@ const createView = createSafeHandler(
             message: "Views limit reached",
           };
         }
+
+        const resolvedTemplateProperties = await resolveTemplateProperties({
+          tx,
+          workspaceId,
+          layout,
+          templateProperties: body.templateProperties,
+          canCreateProperties: roles[memberRole.role].authorize({
+            property: ["create"],
+          }).success,
+          auditContext: createAuditContext({
+            organizationId: session.activeOrganizationId,
+            workspaceId,
+            userId: user.id,
+            request,
+            server,
+          }),
+        });
+
+        if (!resolvedTemplateProperties.ok) {
+          return {
+            ok: false as const,
+            status: resolvedTemplateProperties.status,
+            message: resolvedTemplateProperties.message,
+          };
+        }
+        cleanStalePropertyIds(layout, resolvedTemplateProperties.propertyIds);
 
         const [maxRow] = await tx
           .select({

--- a/apps/api/src/handlers/views/create.ts
+++ b/apps/api/src/handlers/views/create.ts
@@ -12,11 +12,7 @@ import {
 } from "@/api/handlers/views/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import {
-  AUDIT_ACTION,
-  AUDIT_RESOURCE_TYPE,
-  createAuditContext,
-} from "@/api/lib/audit-log";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { LIMITS } from "@/api/lib/limits";
 import { broadcast } from "@/api/lib/sse";
@@ -36,10 +32,6 @@ const createView = createSafeHandler(
     safeDb,
     workspaceId,
     memberRole,
-    session,
-    user,
-    request,
-    server,
     body,
     recordAuditEvent,
   }) {
@@ -93,13 +85,7 @@ const createView = createSafeHandler(
           canCreateProperties: roles[memberRole.role].authorize({
             property: ["create"],
           }).success,
-          auditContext: createAuditContext({
-            organizationId: session.activeOrganizationId,
-            workspaceId,
-            userId: user.id,
-            request,
-            server,
-          }),
+          recordAuditEvent,
         });
 
         if (!resolvedTemplateProperties.ok) {

--- a/apps/api/src/handlers/views/update.ts
+++ b/apps/api/src/handlers/views/update.ts
@@ -12,11 +12,7 @@ import {
 } from "@/api/handlers/views/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import {
-  AUDIT_ACTION,
-  AUDIT_RESOURCE_TYPE,
-  createAuditContext,
-} from "@/api/lib/audit-log";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { broadcast } from "@/api/lib/sse";
@@ -35,10 +31,6 @@ const updateView = createSafeHandler(
     safeDb,
     workspaceId,
     memberRole,
-    session,
-    user,
-    request,
-    server,
     params: { viewId },
     body,
     recordAuditEvent,
@@ -114,13 +106,7 @@ const updateView = createSafeHandler(
             canCreateProperties: roles[memberRole.role].authorize({
               property: ["create"],
             }).success,
-            auditContext: createAuditContext({
-              organizationId: session.activeOrganizationId,
-              workspaceId,
-              userId: user.id,
-              request,
-              server,
-            }),
+            recordAuditEvent,
           });
 
           if (!resolvedTemplateProperties.ok) {

--- a/apps/api/src/handlers/views/update.ts
+++ b/apps/api/src/handlers/views/update.ts
@@ -1,14 +1,22 @@
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 
+import { roles } from "@stll/permissions";
+
 import { workspaceViews } from "@/api/db/schema";
+import { resolveTemplateProperties } from "@/api/handlers/view-templates/properties";
 import {
+  cleanStalePropertyIds,
   hasDuplicateSorts,
   hasMultipleKindFilters,
 } from "@/api/handlers/views/utils";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import {
+  AUDIT_ACTION,
+  AUDIT_RESOURCE_TYPE,
+  createAuditContext,
+} from "@/api/lib/audit-log";
 import { tSafeId, workspaceParams } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { broadcast } from "@/api/lib/sse";
@@ -26,6 +34,11 @@ const updateView = createSafeHandler(
   async function* ({
     safeDb,
     workspaceId,
+    memberRole,
+    session,
+    user,
+    request,
+    server,
     params: { viewId },
     body,
     recordAuditEvent,
@@ -90,8 +103,36 @@ const updateView = createSafeHandler(
       return Result.ok(undefined);
     }
 
-    yield* Result.await(
+    const updateResult = yield* Result.await(
       safeDb(async (tx) => {
+        if (parsedLayout !== undefined) {
+          const resolvedTemplateProperties = await resolveTemplateProperties({
+            tx,
+            workspaceId,
+            layout: parsedLayout,
+            templateProperties: body.templateProperties,
+            canCreateProperties: roles[memberRole.role].authorize({
+              property: ["create"],
+            }).success,
+            auditContext: createAuditContext({
+              organizationId: session.activeOrganizationId,
+              workspaceId,
+              userId: user.id,
+              request,
+              server,
+            }),
+          });
+
+          if (!resolvedTemplateProperties.ok) {
+            return resolvedTemplateProperties;
+          }
+          cleanStalePropertyIds(
+            parsedLayout,
+            resolvedTemplateProperties.propertyIds,
+          );
+          updates.layout = parsedLayout;
+        }
+
         await tx
           .update(workspaceViews)
           .set(updates)
@@ -119,8 +160,19 @@ const updateView = createSafeHandler(
           resourceId: viewId,
           changes,
         });
+
+        return { ok: true as const };
       }),
     );
+
+    if (!updateResult.ok) {
+      return Result.err(
+        new HandlerError({
+          status: updateResult.status,
+          message: updateResult.message,
+        }),
+      );
+    }
 
     broadcast(workspaceId, {
       type: "invalidate-query",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -45,6 +45,7 @@ import {
 import { timeEntriesRoute } from "@/api/handlers/time-entries/routes";
 import { userFilesRoute } from "@/api/handlers/user-files/routes";
 import { verifyAuthRoute, verifyRoute } from "@/api/handlers/verify/routes";
+import { viewTemplatesRoute } from "@/api/handlers/view-templates/routes";
 import { viewsRoute } from "@/api/handlers/views/routes";
 import { workspaceEventsRoute } from "@/api/handlers/workspaces/events";
 import { workspacesRoute } from "@/api/handlers/workspaces/routes";
@@ -356,6 +357,7 @@ const api = new Elysia()
       .use(userFilesRoute)
       .use(skillsRoute)
       .use(shortcutsRoute)
+      .use(viewTemplatesRoute)
       .use(viewsRoute)
       .use(tasksRoute)
       .use(myTasksRoute)

--- a/apps/api/src/lib/audit-log.ts
+++ b/apps/api/src/lib/audit-log.ts
@@ -44,6 +44,7 @@ export const AUDIT_RESOURCE_TYPE = {
   TIME_ENTRY: "time_entry",
   USER_FILE: "user_file",
   VIEW: "view",
+  VIEW_TEMPLATE: "view_template",
   WORKSPACE: "workspace",
   WORKSPACE_CONTACT: "workspace_contact",
   WORKSPACE_MEMBER: "workspace_member",

--- a/apps/api/src/lib/branded-types.ts
+++ b/apps/api/src/lib/branded-types.ts
@@ -66,6 +66,7 @@ export type SafeIdType =
   | "workspaceContact"
   | "workspaceMember"
   | "workspaceView"
+  | "workspaceViewTemplate"
   | "entityLink";
 
 export type SafeId<T extends SafeIdType> = string & {

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -10,6 +10,7 @@ export const LIMITS = {
   calendarTasksMax: 200,
   entitySummariesPageSize: 200,
   viewsCount: 20,
+  viewTemplatesPerUser: 50,
   templatesCount: 50,
   clauseCategoriesCount: 100,
   templateCategoriesCount: 100,

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -1,6 +1,10 @@
+import { Value } from "@sinclair/typebox/value";
 import { describe, expect, test } from "bun:test";
 
-import { parseViewLayout } from "@/api/lib/views-schema";
+import {
+  parseViewLayout,
+  tViewTemplatePropertySchema,
+} from "@/api/lib/views-schema";
 import type { ViewLayout } from "@/api/lib/views-schema";
 
 describe("parseViewLayout", () => {
@@ -29,5 +33,20 @@ describe("parseViewLayout", () => {
     };
 
     expect(() => parseViewLayout(layout)).toThrow();
+  });
+});
+
+describe("view template property validation", () => {
+  test("accepts saved AI properties with empty prompts", () => {
+    expect(
+      Value.Check(tViewTemplatePropertySchema, {
+        version: 1,
+        sourceId: "source_summary",
+        name: "Summary",
+        content: { version: 1, type: "text" },
+        tool: { version: 1, type: "ai-model", prompt: "" },
+        createIfMissing: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -3,9 +3,9 @@ import { t } from "elysia";
 import * as v from "valibot";
 
 import {
+  manualInputToolSchema,
   propertyConditionSchema,
   propertyContentSchema,
-  propertyToolSchema,
 } from "@/api/db/schema-validators";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 
@@ -283,13 +283,22 @@ export const tViewLayoutSchema = Type.Unsafe<ViewLayout>({
   ...tViewLayoutDefinition,
 });
 
+const tViewTemplatePropertyToolSchema = t.Union([
+  t.Object({
+    version: t.Literal(1),
+    type: t.Literal("ai-model"),
+    prompt: t.String({ maxLength: 1000 }),
+  }),
+  manualInputToolSchema,
+]);
+
 export const tViewTemplatePropertySchema = t.Object(
   {
     version: t.Literal(1),
     sourceId: t.String({ minLength: 1 }),
     name: tDefaultVarchar,
     content: propertyContentSchema,
-    tool: propertyToolSchema,
+    tool: tViewTemplatePropertyToolSchema,
     createIfMissing: t.Boolean(),
     dependencies: t.Optional(
       t.Array(

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -2,6 +2,10 @@ import { Type } from "@sinclair/typebox";
 import { t } from "elysia";
 import * as v from "valibot";
 
+import {
+  propertyContentSchema,
+  propertyToolSchema,
+} from "@/api/db/schema-validators";
 import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
 
 const v1 = v.literal(1);
@@ -278,11 +282,26 @@ export const tViewLayoutSchema = Type.Unsafe<ViewLayout>({
   ...tViewLayoutDefinition,
 });
 
+export const tViewTemplatePropertySchema = t.Object(
+  {
+    version: t.Literal(1),
+    sourceId: t.String({ minLength: 1 }),
+    name: tDefaultVarchar,
+    content: propertyContentSchema,
+    tool: propertyToolSchema,
+    createIfMissing: t.Boolean(),
+  },
+  strictObjectOptions,
+);
+
+export type ViewTemplateProperty = typeof tViewTemplatePropertySchema.static;
+
 export const tCreateViewInputSchema = t.Object(
   {
     id: tSafeId("workspaceView"),
     name: tDefaultVarchar,
     layout: tViewLayoutSchema,
+    templateProperties: t.Optional(t.Array(tViewTemplatePropertySchema)),
   },
   strictObjectOptions,
 );
@@ -291,6 +310,7 @@ export const tUpdateViewBodySchema = t.Object(
   {
     name: t.Optional(tDefaultVarchar),
     layout: t.Optional(tViewLayoutSchema),
+    templateProperties: t.Optional(t.Array(tViewTemplatePropertySchema)),
   },
   strictObjectOptions,
 );

--- a/apps/api/src/lib/views-schema.ts
+++ b/apps/api/src/lib/views-schema.ts
@@ -3,6 +3,7 @@ import { t } from "elysia";
 import * as v from "valibot";
 
 import {
+  propertyConditionSchema,
   propertyContentSchema,
   propertyToolSchema,
 } from "@/api/db/schema-validators";
@@ -290,6 +291,17 @@ export const tViewTemplatePropertySchema = t.Object(
     content: propertyContentSchema,
     tool: propertyToolSchema,
     createIfMissing: t.Boolean(),
+    dependencies: t.Optional(
+      t.Array(
+        t.Object(
+          {
+            dependsOnSourceId: t.String({ minLength: 1 }),
+            condition: t.Union([propertyConditionSchema, t.Null()]),
+          },
+          strictObjectOptions,
+        ),
+      ),
+    ),
   },
   strictObjectOptions,
 );

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -49,6 +49,7 @@ export type {
 export type ViewLayout = ViewSchemas.ViewLayout;
 export type ViewLayoutType = ViewSchemas.ViewLayoutType;
 export type ViewFilterCondition = ViewSchemas.ViewFilterCondition;
+export type ViewTemplateProperty = ViewSchemas.ViewTemplateProperty;
 export type { ChatMentionsData } from "@/api/handlers/chat/types";
 export type { ChatSourceDocument } from "@/api/handlers/chat/tools/chat-source-document";
 export type { UserFileUrl } from "@/api/handlers/user-files/types";

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Nepodařilo se smazat klienta",
     "failedToDeleteEntities": "Nepodařilo se smazat entity",
     "failedToDeleteProperty": "Nepodařilo se smazat vlastnost",
+    "failedToDeleteTemplate": "Nepodařilo se smazat šablonu",
     "failedToDeleteView": "Smazání zobrazení se nezdařilo",
     "failedToDeleteWorkspace": "Nepodařilo se smazat spis",
     "failedToDuplicateView": "Duplikování zobrazení se nezdařilo",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Nepodařilo se přejmenovat spis",
     "failedToReorderViews": "Změna pořadí zobrazení se nezdařila",
     "failedToResendInvitation": "Nepodařilo se znovu odeslat pozvánku",
+    "failedToSaveTemplate": "Nepodařilo se uložit šablonu",
     "failedToSelectOrganization": "Nepodařilo se vybrat organizaci",
     "failedToSendInvitation": "Nepodařilo se odeslat pozvánku",
     "failedToSendVerificationCode": "Nepodařilo se odeslat ověřovací kód",
@@ -2268,7 +2270,21 @@
         "timeline": "Časová osa"
       },
       "newView": "Nový {layout}",
+      "saveAsTemplate": "Uložit jako šablonu…",
       "selectProperty": "Vybrat vlastnost",
+      "templates": {
+        "created": "Šablona uložena",
+        "delete": "Smazat šablonu",
+        "deleteConfirmDescription": "Smazat šablonu „{name}“? Tuto akci nelze vrátit zpět.",
+        "deleted": "Šablona smazána",
+        "description": "Uložte si rozložení aktuálního pohledu jako šablonu pro opakované použití.",
+        "empty": "Žádné šablony. Uložte aktuální pohled jako první šablonu.",
+        "nameLabel": "Název šablony",
+        "namePlaceholder": "např. Aktivní spisy",
+        "save": "Uložit šablonu",
+        "title": "Šablony pohledů",
+        "use": "Použít šablonu"
+      },
       "timeline": {
         "day": "Den",
         "endDate": "Datum ukončení",
@@ -2278,7 +2294,8 @@
         "showTable": "Zobrazit tabulku",
         "startDate": "Datum zahájení",
         "week": "Týden"
-      }
+      },
+      "useTemplate": "Použít šablonu…"
     },
     "workflow": {
       "allManualInputsDescription": "Pro spuštění pracovního postupu přidejte alespoň jednu AI vlastnost",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Klient konnte nicht gelöscht werden",
     "failedToDeleteEntities": "Entitäten konnten nicht gelöscht werden",
     "failedToDeleteProperty": "Eigenschaft konnte nicht gelöscht werden",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Ansicht konnte nicht gelöscht werden",
     "failedToDeleteWorkspace": "Akte konnte nicht gelöscht werden",
     "failedToDuplicateView": "Ansicht konnte nicht dupliziert werden",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Akte konnte nicht umbenannt werden",
     "failedToReorderViews": "Ansichten konnten nicht neu angeordnet werden",
     "failedToResendInvitation": "Einladung konnte nicht erneut gesendet werden",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Organisation konnte nicht ausgewählt werden",
     "failedToSendInvitation": "Einladung konnte nicht gesendet werden",
     "failedToSendVerificationCode": "Bestätigungscode konnte nicht gesendet werden",
@@ -2268,7 +2270,21 @@
         "timeline": "Zeitleiste"
       },
       "newView": "Neue {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Eigenschaft auswählen",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Tag",
         "endDate": "Enddatum",
@@ -2278,7 +2294,8 @@
         "showTable": "Tabelle anzeigen",
         "startDate": "Startdatum",
         "week": "Woche"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Fügen Sie mindestens eine KI-Eigenschaft hinzu, um den Arbeitsablauf zu starten",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Failed to delete client",
     "failedToDeleteEntities": "Failed to delete entities",
     "failedToDeleteProperty": "Failed to delete property",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Failed to delete view",
     "failedToDeleteWorkspace": "Failed to delete matter",
     "failedToDuplicateView": "Failed to duplicate view",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Failed to rename matter",
     "failedToReorderViews": "Failed to reorder views",
     "failedToResendInvitation": "Failed to resend invitation",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Failed to select organization",
     "failedToSendInvitation": "Failed to send invitation",
     "failedToSendVerificationCode": "Failed to send verification code",
@@ -2268,7 +2270,21 @@
         "timeline": "Timeline"
       },
       "newView": "New {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Select property",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Day",
         "endDate": "End date",
@@ -2278,7 +2294,8 @@
         "showTable": "Show table",
         "startDate": "Start date",
         "week": "Week"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Please add at least one AI property to start the workflow",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "No se pudo eliminar el cliente",
     "failedToDeleteEntities": "No se pudieron eliminar las entidades",
     "failedToDeleteProperty": "No se pudo eliminar la propiedad",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Error al eliminar la vista",
     "failedToDeleteWorkspace": "No se pudo eliminar el asunto",
     "failedToDuplicateView": "Error al duplicar la vista",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "No se pudo renombrar el asunto",
     "failedToReorderViews": "Error al reordenar las vistas",
     "failedToResendInvitation": "No se pudo reenviar la invitación",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "No se pudo seleccionar la organización",
     "failedToSendInvitation": "No se pudo enviar la invitación",
     "failedToSendVerificationCode": "No se pudo enviar el código de verificación",
@@ -2268,7 +2270,21 @@
         "timeline": "Línea de tiempo"
       },
       "newView": "Nueva {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Seleccionar propiedad",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Día",
         "endDate": "Fecha de fin",
@@ -2278,7 +2294,8 @@
         "showTable": "Mostrar tabla",
         "startDate": "Fecha de inicio",
         "week": "Semana"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Añada al menos una propiedad de IA para iniciar el flujo de trabajo",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Kliendi kustutamine ebaõnnestus",
     "failedToDeleteEntities": "Kirjete kustutamine ebaõnnestus",
     "failedToDeleteProperty": "Omaduse kustutamine ebaõnnestus",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Vaate kustutamine ebaõnnestus",
     "failedToDeleteWorkspace": "Toimiku kustutamine ebaõnnestus",
     "failedToDuplicateView": "Vaate dubleerimine ebaõnnestus",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Toimiku ümbernimetamine ebaõnnestus",
     "failedToReorderViews": "Vaadete ümbersorteerimine ebaõnnestus",
     "failedToResendInvitation": "Kutse uuesti saatmine ebaõnnestus",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Organisatsiooni valimine ebaõnnestus",
     "failedToSendInvitation": "Kutse saatmine ebaõnnestus",
     "failedToSendVerificationCode": "Kinnituskoodi saatmine ebaõnnestus",
@@ -2268,7 +2270,21 @@
         "timeline": "Ajajoon"
       },
       "newView": "Uus {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Valige omadus",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Päev",
         "endDate": "Lõppkuupäev",
@@ -2278,7 +2294,8 @@
         "showTable": "Näita tabelit",
         "startDate": "Alguskuupäev",
         "week": "Nädal"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Töövoo käivitamiseks lisage vähemalt üks tehisintellekti omadus",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Impossible de supprimer le client",
     "failedToDeleteEntities": "Impossible de supprimer les entités",
     "failedToDeleteProperty": "Impossible de supprimer la propriété",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Impossible de supprimer la vue",
     "failedToDeleteWorkspace": "Impossible de supprimer le dossier",
     "failedToDuplicateView": "Impossible de dupliquer la vue",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Impossible de renommer le dossier",
     "failedToReorderViews": "Impossible de réorganiser les vues",
     "failedToResendInvitation": "Impossible de renvoyer l'invitation",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Impossible de sélectionner l'organisation",
     "failedToSendInvitation": "Impossible d'envoyer l'invitation",
     "failedToSendVerificationCode": "Impossible d'envoyer le code de vérification",
@@ -2268,7 +2270,21 @@
         "timeline": "Chronologie"
       },
       "newView": "Nouvelle {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Sélectionner une propriété",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Jour",
         "endDate": "Date de fin",
@@ -2278,7 +2294,8 @@
         "showTable": "Afficher le tableau",
         "startDate": "Date de début",
         "week": "Semaine"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Veuillez ajouter au moins une propriété IA pour démarrer le flux de travail",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Nem sikerült törölni az ügyfelet",
     "failedToDeleteEntities": "Nem sikerült törölni az entitásokat",
     "failedToDeleteProperty": "Nem sikerült törölni a tulajdonságot",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "A nézet törlése nem sikerült",
     "failedToDeleteWorkspace": "Nem sikerült törölni az ügyet",
     "failedToDuplicateView": "A nézet duplikálása nem sikerült",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Nem sikerült átnevezni az ügyet",
     "failedToReorderViews": "A nézetek átrendezése nem sikerült",
     "failedToResendInvitation": "Nem sikerült újraküldeni a meghívót",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Nem sikerült kiválasztani a szervezetet",
     "failedToSendInvitation": "Nem sikerült elküldeni a meghívót",
     "failedToSendVerificationCode": "Nem sikerült elküldeni az ellenőrző kódot",
@@ -2268,7 +2270,21 @@
         "timeline": "Idővonal"
       },
       "newView": "Új {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Tulajdonság kiválasztása",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Nap",
         "endDate": "Befejező dátum",
@@ -2278,7 +2294,8 @@
         "showTable": "Táblázat megjelenítése",
         "startDate": "Kezdő dátum",
         "week": "Hét"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "A munkafolyamat indításához adjon hozzá legalább egy AI tulajdonságot",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Nepavyko ištrinti kliento",
     "failedToDeleteEntities": "Nepavyko ištrinti įrašų",
     "failedToDeleteProperty": "Nepavyko ištrinti savybės",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Nepavyko ištrinti rodinio",
     "failedToDeleteWorkspace": "Nepavyko ištrinti bylos",
     "failedToDuplicateView": "Nepavyko dublikuoti rodinio",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Nepavyko pervadinti bylos",
     "failedToReorderViews": "Nepavyko pertvarkyti rodinių",
     "failedToResendInvitation": "Nepavyko pakartotinai išsiųsti kvietimo",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Nepavyko pasirinkti organizacijos",
     "failedToSendInvitation": "Nepavyko išsiųsti kvietimo",
     "failedToSendVerificationCode": "Nepavyko išsiųsti patvirtinimo kodo",
@@ -2268,7 +2270,21 @@
         "timeline": "Laiko juosta"
       },
       "newView": "Naujas {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Pasirinkti savybę",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Diena",
         "endDate": "Pabaigos data",
@@ -2278,7 +2294,8 @@
         "showTable": "Rodyti lentelę",
         "startDate": "Pradžios data",
         "week": "Savaitė"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Norėdami paleisti darbo eigą, pridėkite bent vieną AI savybę",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Neizdevās dzēst klientu",
     "failedToDeleteEntities": "Neizdevās dzēst ierakstus",
     "failedToDeleteProperty": "Neizdevās dzēst rekvizītu",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Neizdevās dzēst skatu",
     "failedToDeleteWorkspace": "Neizdevās dzēst lietu",
     "failedToDuplicateView": "Neizdevās dublēt skatu",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Neizdevās pārdēvēt lietu",
     "failedToReorderViews": "Neizdevās pārkārtot skatus",
     "failedToResendInvitation": "Neizdevās atkārtoti nosūtīt uzaicinājumu",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Neizdevās izvēlēties organizāciju",
     "failedToSendInvitation": "Neizdevās nosūtīt uzaicinājumu",
     "failedToSendVerificationCode": "Neizdevās nosūtīt verifikācijas kodu",
@@ -2268,7 +2270,21 @@
         "timeline": "Laika skala"
       },
       "newView": "Jauns {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Izvēlieties rekvizītu",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Diena",
         "endDate": "Beigu datums",
@@ -2278,7 +2294,8 @@
         "showTable": "Rādīt tabulu",
         "startDate": "Sākuma datums",
         "week": "Nedēļa"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Lai palaistu darbplūsmu, pievienojiet vismaz vienu AI rekvizītu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -908,6 +908,7 @@ type Messages = {
     "failedToDeleteContact": "Failed to delete client";
     "failedToDeleteEntities": "Failed to delete entities";
     "failedToDeleteProperty": "Failed to delete property";
+    "failedToDeleteTemplate": "Failed to delete template";
     "failedToDeleteView": "Failed to delete view";
     "failedToDeleteWorkspace": "Failed to delete matter";
     "failedToDuplicateView": "Failed to duplicate view";
@@ -921,6 +922,7 @@ type Messages = {
     "failedToRenameWorkspace": "Failed to rename matter";
     "failedToReorderViews": "Failed to reorder views";
     "failedToResendInvitation": "Failed to resend invitation";
+    "failedToSaveTemplate": "Failed to save template";
     "failedToSelectOrganization": "Failed to select organization";
     "failedToSendInvitation": "Failed to send invitation";
     "failedToSendVerificationCode": "Failed to send verification code";
@@ -2271,7 +2273,21 @@ type Messages = {
         "timeline": "Timeline";
       };
       "newView": "New {layout}";
+      "saveAsTemplate": "Save as template…";
       "selectProperty": "Select property";
+      "templates": {
+        "created": "Template saved";
+        "delete": "Delete template";
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.";
+        "deleted": "Template deleted";
+        "description": "Save the current view’s layout as a template you can reuse.";
+        "empty": "No templates yet. Save the current view to create one.";
+        "nameLabel": "Template name";
+        "namePlaceholder": "e.g. Active matters";
+        "save": "Save template";
+        "title": "View templates";
+        "use": "Use template";
+      };
       "timeline": {
         "day": "Day";
         "endDate": "End date";
@@ -2282,6 +2298,7 @@ type Messages = {
         "startDate": "Start date";
         "week": "Week";
       };
+      "useTemplate": "Use template…";
     };
     "workflow": {
       "allManualInputsDescription": "Please add at least one AI property to start the workflow";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Nie udało się usunąć klienta",
     "failedToDeleteEntities": "Nie udało się usunąć encji",
     "failedToDeleteProperty": "Nie udało się usunąć właściwości",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Nie udało się usunąć widoku",
     "failedToDeleteWorkspace": "Nie udało się usunąć sprawy",
     "failedToDuplicateView": "Nie udało się zduplikować widoku",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Nie udało się zmienić nazwy sprawy",
     "failedToReorderViews": "Nie udało się zmienić kolejności widoków",
     "failedToResendInvitation": "Nie udało się ponownie wysłać zaproszenia",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Nie udało się wybrać organizacji",
     "failedToSendInvitation": "Nie udało się wysłać zaproszenia",
     "failedToSendVerificationCode": "Nie udało się wysłać kodu weryfikacyjnego",
@@ -2268,7 +2270,21 @@
         "timeline": "Oś czasu"
       },
       "newView": "Nowy {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Wybierz właściwość",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Dzień",
         "endDate": "Data zakończenia",
@@ -2278,7 +2294,8 @@
         "showTable": "Pokaż tabelę",
         "startDate": "Data rozpoczęcia",
         "week": "Tydzień"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Dodaj co najmniej jedną właściwość AI, aby uruchomić proces",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Falha ao excluir cliente",
     "failedToDeleteEntities": "Falha ao excluir entidades",
     "failedToDeleteProperty": "Falha ao excluir propriedade",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Falha ao excluir visualização",
     "failedToDeleteWorkspace": "Falha ao excluir caso",
     "failedToDuplicateView": "Falha ao duplicar a visualização",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Falha ao renomear caso",
     "failedToReorderViews": "Falha ao reordenar as visualizações",
     "failedToResendInvitation": "Falha ao reenviar o convite",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Falha ao selecionar a organização",
     "failedToSendInvitation": "Falha ao enviar convite",
     "failedToSendVerificationCode": "Falha ao enviar o código de verificação",
@@ -2268,7 +2270,21 @@
         "timeline": "Linha do tempo"
       },
       "newView": "Novo {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Selecione a propriedade",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Dia",
         "endDate": "Data de término",
@@ -2278,7 +2294,8 @@
         "showTable": "Mostrar tabela",
         "startDate": "Data de início",
         "week": "Semana"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Adicione pelo menos uma propriedade de IA para iniciar o fluxo de trabalho",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -905,6 +905,7 @@
     "failedToDeleteContact": "Nepodarilo sa vymazať klienta",
     "failedToDeleteEntities": "Nepodarilo sa vymazať entity",
     "failedToDeleteProperty": "Nepodarilo sa vymazať vlastnosť",
+    "failedToDeleteTemplate": "Failed to delete template",
     "failedToDeleteView": "Odstránenie zobrazenia sa nepodarilo",
     "failedToDeleteWorkspace": "Nepodarilo sa vymazať spis",
     "failedToDuplicateView": "Duplikovanie zobrazenia sa nepodarilo",
@@ -918,6 +919,7 @@
     "failedToRenameWorkspace": "Nepodarilo sa premenovať spis",
     "failedToReorderViews": "Zmena poradia zobrazení sa nepodarila",
     "failedToResendInvitation": "Nepodarilo sa znovu odoslať pozvánku",
+    "failedToSaveTemplate": "Failed to save template",
     "failedToSelectOrganization": "Nepodarilo sa vybrať organizáciu",
     "failedToSendInvitation": "Nepodarilo sa odoslať pozvánku",
     "failedToSendVerificationCode": "Nepodarilo sa odoslať overovací kód",
@@ -2268,7 +2270,21 @@
         "timeline": "Časová os"
       },
       "newView": "Nový {layout}",
+      "saveAsTemplate": "Save as template…",
       "selectProperty": "Vybrať vlastnosť",
+      "templates": {
+        "created": "Template saved",
+        "delete": "Delete template",
+        "deleteConfirmDescription": "Delete template “{name}”? This cannot be undone.",
+        "deleted": "Template deleted",
+        "description": "Save the current view’s layout as a template you can reuse.",
+        "empty": "No templates yet. Save the current view to create one.",
+        "nameLabel": "Template name",
+        "namePlaceholder": "e.g. Active matters",
+        "save": "Save template",
+        "title": "View templates",
+        "use": "Use template"
+      },
       "timeline": {
         "day": "Deň",
         "endDate": "Dátum ukončenia",
@@ -2278,7 +2294,8 @@
         "showTable": "Zobraziť tabuľku",
         "startDate": "Dátum začiatku",
         "week": "Týždeň"
-      }
+      },
+      "useTemplate": "Use template…"
     },
     "workflow": {
       "allManualInputsDescription": "Na spustenie pracovného postupu pridajte aspoň jednu AI vlastnosť",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -20,6 +20,7 @@ export type {
   AgendaItemSource,
   ViewLayout,
   ViewLayoutType,
+  ViewTemplateProperty,
 } from "@stll/api/types";
 
 export type RouterToPath = FileRouteTypes["to"];

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/save-as-template-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/save-as-template-dialog.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+
+import { useTranslations } from "use-intl";
+
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { Field, FieldLabel } from "@stll/ui/components/field";
+import { Form } from "@stll/ui/components/form";
+import { Input } from "@stll/ui/components/input";
+import { stellaToast } from "@stll/ui/components/toast";
+
+import type { ViewLayout } from "@/lib/types";
+import { useCreateViewTemplate } from "@/routes/_protected.workspaces/$workspaceId/-mutations/view-templates";
+
+type SaveAsTemplateDialogProps = {
+  workspaceId: string;
+  layout: ViewLayout;
+  defaultName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export const SaveAsTemplateDialog = ({
+  workspaceId,
+  layout,
+  defaultName,
+  open,
+  onOpenChange,
+}: SaveAsTemplateDialogProps) => {
+  const t = useTranslations();
+  const [name, setName] = useState(defaultName);
+  const createTemplate = useCreateViewTemplate();
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      setName(defaultName);
+    }
+    onOpenChange(next);
+  };
+
+  const trimmed = name.trim();
+  const canSubmit = trimmed.length > 0 && !createTemplate.isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit) {
+      return;
+    }
+    createTemplate.mutate(
+      { workspaceId, name: trimmed, layout },
+      {
+        onSuccess: () => {
+          stellaToast.add({
+            title: t("workspaces.views.templates.created"),
+            type: "success",
+          });
+          onOpenChange(false);
+        },
+        onError: () => {
+          stellaToast.add({
+            title: t("errors.failedToSaveTemplate"),
+            type: "error",
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog onOpenChange={handleOpenChange} open={open}>
+      <DialogPopup className="sm:max-w-sm">
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <DialogHeader>
+            <DialogTitle>{t("workspaces.views.saveAsTemplate")}</DialogTitle>
+            <DialogDescription>
+              {t("workspaces.views.templates.description")}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel>
+            <Field>
+              <FieldLabel>
+                {t("workspaces.views.templates.nameLabel")}
+              </FieldLabel>
+              <Input
+                autoFocus
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t("workspaces.views.templates.namePlaceholder")}
+                value={name}
+              />
+            </Field>
+          </DialogPanel>
+          <DialogFooter>
+            <DialogClose render={<Button variant="ghost" />}>
+              {t("common.cancel")}
+            </DialogClose>
+            <Button
+              disabled={!canSubmit}
+              loading={createTemplate.isPending}
+              type="submit"
+            >
+              {t("workspaces.views.templates.save")}
+            </Button>
+          </DialogFooter>
+        </Form>
+      </DialogPopup>
+    </Dialog>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog.tsx
@@ -1,0 +1,329 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
+import {
+  CalendarIcon,
+  FolderTreeIcon,
+  GanttChartIcon,
+  KanbanIcon,
+  LayoutDashboardIcon,
+  TableIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import type { ViewLayoutType } from "@stll/api/types";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@stll/ui/components/alert-dialog";
+import { Button } from "@stll/ui/components/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "@stll/ui/components/dialog";
+import { ScrollArea } from "@stll/ui/components/scroll-area";
+import { stellaToast } from "@stll/ui/components/toast";
+
+import { usePermissions } from "@/hooks/use-permissions";
+import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
+import { useDeleteViewTemplate } from "@/routes/_protected.workspaces/$workspaceId/-mutations/view-templates";
+import { useCreateView } from "@/routes/_protected.workspaces/$workspaceId/-mutations/views";
+import type { WorkspaceViewTemplate } from "@/routes/_protected.workspaces/$workspaceId/-queries/view-templates";
+import { viewTemplatesOptions } from "@/routes/_protected.workspaces/$workspaceId/-queries/view-templates";
+
+const layoutIcons = {
+  overview: LayoutDashboardIcon,
+  table: TableIcon,
+  filesystem: FolderTreeIcon,
+  kanban: KanbanIcon,
+  calendar: CalendarIcon,
+  timeline: GanttChartIcon,
+} as const satisfies Record<ViewLayoutType, React.ElementType>;
+
+type TemplatePickerDialogProps = {
+  workspaceId: string;
+  disallowedLayoutTypes: ReadonlySet<ViewLayoutType>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (viewId: string) => void;
+};
+
+export const TemplatePickerDialog = ({
+  workspaceId,
+  disallowedLayoutTypes,
+  open,
+  onOpenChange,
+  onCreated,
+}: TemplatePickerDialogProps) => {
+  const t = useTranslations();
+  const organizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
+  const canDeleteTemplate = usePermissions({ view: ["delete"] });
+  const { data: templates, isPending } = useQuery({
+    ...viewTemplatesOptions({
+      key: { organizationId },
+      context: { workspaceId },
+    }),
+    enabled: open,
+  });
+  const visibleTemplates = templates?.filter(
+    (template) => !disallowedLayoutTypes.has(template.layoutType),
+  );
+
+  const createView = useCreateView(workspaceId);
+  const deleteTemplate = useDeleteViewTemplate();
+  const startWorkflow = useStartWorkflow(workspaceId);
+
+  const handleUse = (template: WorkspaceViewTemplate) => {
+    const newId = crypto.randomUUID();
+    const hasAITemplateProperty = template.templateProperties.some(
+      (p) => p.createIfMissing && p.tool.type === "ai-model",
+    );
+    createView.mutate(
+      {
+        id: newId,
+        name: template.name,
+        layout: template.layout,
+        templateProperties: template.templateProperties,
+      },
+      {
+        onSuccess: () => {
+          onCreated(newId);
+          onOpenChange(false);
+          if (hasAITemplateProperty) {
+            void startWorkflow();
+          }
+        },
+        onError: () => {
+          stellaToast.add({
+            title: t("errors.failedToCreateView"),
+            type: "error",
+          });
+        },
+      },
+    );
+  };
+
+  const handleDelete = (templateId: string) => {
+    deleteTemplate.mutate(
+      { workspaceId, templateId },
+      {
+        onSuccess: () => {
+          stellaToast.add({
+            title: t("workspaces.views.templates.deleted"),
+            type: "success",
+          });
+        },
+        onError: () => {
+          stellaToast.add({
+            title: t("errors.failedToDeleteTemplate"),
+            type: "error",
+          });
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogPopup className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("workspaces.views.templates.title")}</DialogTitle>
+          <DialogDescription>
+            {t("workspaces.views.templates.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogPanel>
+          <TemplateList
+            canDeleteTemplate={canDeleteTemplate}
+            isMutating={createView.isPending || deleteTemplate.isPending}
+            isPending={isPending}
+            onDelete={handleDelete}
+            onUse={handleUse}
+            templates={visibleTemplates}
+          />
+        </DialogPanel>
+        <DialogFooter>
+          <Button onClick={() => onOpenChange(false)} variant="ghost">
+            {t("common.close")}
+          </Button>
+        </DialogFooter>
+      </DialogPopup>
+    </Dialog>
+  );
+};
+
+type TemplateListProps = {
+  templates: WorkspaceViewTemplate[] | undefined;
+  isPending: boolean;
+  isMutating: boolean;
+  canDeleteTemplate: boolean;
+  onUse: (template: WorkspaceViewTemplate) => void;
+  onDelete: (templateId: string) => void;
+};
+
+const TemplateList = ({
+  templates,
+  isPending,
+  isMutating,
+  canDeleteTemplate,
+  onUse,
+  onDelete,
+}: TemplateListProps) => {
+  const t = useTranslations();
+
+  if (isPending) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {t("common.loading")}
+      </p>
+    );
+  }
+
+  if (!templates || templates.length === 0) {
+    return (
+      <p className="text-muted-foreground py-6 text-center text-sm">
+        {t("workspaces.views.templates.empty")}
+      </p>
+    );
+  }
+
+  return (
+    <ScrollArea className="max-h-72">
+      <ul className="flex flex-col gap-1">
+        {templates.map((template) => (
+          <TemplateRow
+            canDelete={canDeleteTemplate}
+            isPending={isMutating}
+            key={template.id}
+            onDelete={() => onDelete(template.id)}
+            onUse={() => onUse(template)}
+            template={template}
+          />
+        ))}
+      </ul>
+    </ScrollArea>
+  );
+};
+
+type TemplateRowProps = {
+  template: WorkspaceViewTemplate;
+  canDelete: boolean;
+  isPending: boolean;
+  onUse: () => void;
+  onDelete: () => void;
+};
+
+const TemplateRow = ({
+  template,
+  canDelete,
+  isPending,
+  onUse,
+  onDelete,
+}: TemplateRowProps) => {
+  const t = useTranslations();
+  const Icon = layoutIcons[template.layoutType];
+
+  return (
+    <li className="hover:bg-muted/50 flex items-center gap-2 rounded p-2">
+      <Icon className="text-muted-foreground size-4 shrink-0" />
+      <button
+        className="min-w-0 flex-1 truncate text-start text-sm"
+        disabled={isPending}
+        onClick={onUse}
+        type="button"
+      >
+        {template.name}
+      </button>
+      {canDelete && (
+        <DeleteTemplateConfirm
+          name={template.name}
+          onConfirm={onDelete}
+          pending={isPending}
+        />
+      )}
+      <Button
+        disabled={isPending}
+        onClick={onUse}
+        size="xs"
+        variant="secondary"
+      >
+        {t("workspaces.views.templates.use")}
+      </Button>
+    </li>
+  );
+};
+
+type DeleteTemplateConfirmProps = {
+  name: string;
+  pending: boolean;
+  onConfirm: () => void;
+};
+
+const DeleteTemplateConfirm = ({
+  name,
+  pending,
+  onConfirm,
+}: DeleteTemplateConfirmProps) => {
+  const t = useTranslations();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <AlertDialog onOpenChange={setOpen} open={open}>
+      <AlertDialogTrigger
+        render={
+          <Button
+            aria-label={t("workspaces.views.templates.delete")}
+            disabled={pending}
+            size="icon-xs"
+            variant="ghost"
+          />
+        }
+      >
+        <Trash2Icon />
+      </AlertDialogTrigger>
+      <AlertDialogPopup>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("workspaces.views.templates.delete")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("workspaces.views.templates.deleteConfirmDescription", { name })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogClose render={<Button variant="ghost" />}>
+            {t("common.cancel")}
+          </AlertDialogClose>
+          <AlertDialogClose
+            render={
+              <Button
+                onClick={() => {
+                  onConfirm();
+                }}
+                variant="destructive"
+              />
+            }
+          >
+            {t("common.delete")}
+          </AlertDialogClose>
+        </AlertDialogFooter>
+      </AlertDialogPopup>
+    </AlertDialog>
+  );
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/view/view-switcher.tsx
@@ -7,6 +7,8 @@ import {
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import {
+  BookmarkIcon,
+  BookmarkPlusIcon,
   CalendarIcon,
   CopyIcon,
   EllipsisVerticalIcon,
@@ -51,6 +53,8 @@ import { usePermissions } from "@/hooks/use-permissions";
 import type { TranslationKey } from "@/i18n/types";
 import type { WorkspaceView } from "@/lib/types";
 import { InlineEdit } from "@/routes/_protected.workspaces/$workspaceId/-components/inline-edit";
+import { SaveAsTemplateDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/view/save-as-template-dialog";
+import { TemplatePickerDialog } from "@/routes/_protected.workspaces/$workspaceId/-components/view/template-picker-dialog";
 import {
   useConvertView,
   useCreateView,
@@ -160,10 +164,14 @@ export const ViewSwitcher = ({
   const { data: views } = useSuspenseQuery(viewsOptions(workspaceId));
   const createView = useCreateView(workspaceId);
   const reorderViews = useReorderViews(workspaceId);
+  const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
   const hasOverviewView = views.some((view) => view.layout.type === "overview");
   const createLayoutOptions = hasOverviewView
     ? LAYOUT_OPTIONS.filter((layoutType) => layoutType !== "overview")
     : LAYOUT_OPTIONS;
+  const disallowedTemplateLayouts = new Set<ViewLayoutType>(
+    hasOverviewView ? ["overview"] : [],
+  );
 
   const handleReorder = (draggedId: string, targetId: string) => {
     const ids = views.map((v) => v.id);
@@ -262,8 +270,22 @@ export const ViewSwitcher = ({
                 </MenuItem>
               );
             })}
+            <MenuSeparator />
+            <MenuItem onClick={() => setIsTemplatePickerOpen(true)}>
+              <BookmarkIcon />
+              {t("workspaces.views.useTemplate")}
+            </MenuItem>
           </MenuPopup>
         </Menu>
+      )}
+      {canCreateView && (
+        <TemplatePickerDialog
+          disallowedLayoutTypes={disallowedTemplateLayouts}
+          onCreated={onViewChange}
+          onOpenChange={setIsTemplatePickerOpen}
+          open={isTemplatePickerOpen}
+          workspaceId={workspaceId}
+        />
       )}
     </div>
   );
@@ -440,6 +462,7 @@ const ViewTabMenu = ({
   const createView = useCreateView(workspaceId);
   const convertView = useConvertView(workspaceId);
   const deleteView = useDeleteView(workspaceId);
+  const [isSaveTemplateOpen, setIsSaveTemplateOpen] = useState(false);
 
   const Icon = layoutIcons[layout.type];
 
@@ -479,102 +502,123 @@ const ViewTabMenu = ({
   };
 
   return (
-    <Menu>
-      <MenuTrigger
-        render={<Button className={className} size="icon-xs" variant="ghost" />}
-      >
-        <EllipsisVerticalIcon />
-      </MenuTrigger>
-      <MenuPopup>
-        {canUpdateView && (
-          <MenuItem onClick={onRename}>
-            <PencilIcon />
-            {t("common.rename")}
-          </MenuItem>
-        )}
-        {canCreateView && layout.type !== "overview" && (
-          <MenuItem onClick={handleDuplicate}>
-            <CopyIcon />
-            {t("common.duplicate")}
-          </MenuItem>
-        )}
-        {canUpdateView && (
-          <MenuSub>
-            <MenuSubTrigger>
-              <Icon />
-              {t("common.convertTo")}
-            </MenuSubTrigger>
-            <MenuSubPopup>
-              {LAYOUT_OPTIONS.filter(
-                (l) => l !== layout.type && l !== "overview",
-              ).map((l) => {
-                const LayoutIcon = layoutIcons[l];
-                return (
-                  <MenuItem
-                    key={l}
-                    onClick={() => {
-                      convertView.mutate(
-                        {
-                          viewId: id,
-                          targetType: l,
-                        },
-                        {
-                          onError: () => {
-                            stellaToast.add({
-                              title: t("errors.failedToChangeViewType"),
-                              type: "error",
-                            });
+    <>
+      {canCreateView && (
+        <SaveAsTemplateDialog
+          defaultName={name}
+          layout={layout}
+          onOpenChange={setIsSaveTemplateOpen}
+          open={isSaveTemplateOpen}
+          workspaceId={workspaceId}
+        />
+      )}
+      <Menu>
+        <MenuTrigger
+          render={
+            <Button className={className} size="icon-xs" variant="ghost" />
+          }
+        >
+          <EllipsisVerticalIcon />
+        </MenuTrigger>
+        <MenuPopup>
+          {canUpdateView && (
+            <MenuItem onClick={onRename}>
+              <PencilIcon />
+              {t("common.rename")}
+            </MenuItem>
+          )}
+          {canCreateView && layout.type !== "overview" && (
+            <MenuItem onClick={handleDuplicate}>
+              <CopyIcon />
+              {t("common.duplicate")}
+            </MenuItem>
+          )}
+          {canCreateView && (
+            <MenuItem onClick={() => setIsSaveTemplateOpen(true)}>
+              <BookmarkPlusIcon />
+              {t("workspaces.views.saveAsTemplate")}
+            </MenuItem>
+          )}
+          {canUpdateView && (
+            <MenuSub>
+              <MenuSubTrigger>
+                <Icon />
+                {t("common.convertTo")}
+              </MenuSubTrigger>
+              <MenuSubPopup>
+                {LAYOUT_OPTIONS.filter(
+                  (l) => l !== layout.type && l !== "overview",
+                ).map((l) => {
+                  const LayoutIcon = layoutIcons[l];
+                  return (
+                    <MenuItem
+                      key={l}
+                      onClick={() => {
+                        convertView.mutate(
+                          {
+                            viewId: id,
+                            targetType: l,
                           },
-                        },
-                      );
-                    }}
+                          {
+                            onError: () => {
+                              stellaToast.add({
+                                title: t("errors.failedToChangeViewType"),
+                                type: "error",
+                              });
+                            },
+                          },
+                        );
+                      }}
+                    >
+                      <LayoutIcon />
+                      {t(LAYOUT_LABEL_KEYS[l])}
+                    </MenuItem>
+                  );
+                })}
+              </MenuSubPopup>
+            </MenuSub>
+          )}
+          {(canUpdateView || canCreateView) && canDeleteView && (
+            <MenuSeparator />
+          )}
+          {canDeleteView && (
+            <AlertDialog>
+              <AlertDialogTrigger
+                disabled={!canDelete}
+                nativeButton={false}
+                render={<MenuItem closeOnClick={false} variant="destructive" />}
+              >
+                <Trash2Icon />
+                {t("common.delete")}
+              </AlertDialogTrigger>
+              <AlertDialogPopup>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>
+                    {t("workspaces.views.deleteView")}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {t("common.deleteConfirmDescription", {
+                      name,
+                    })}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogClose render={<Button variant="ghost" />}>
+                    {t("common.cancel")}
+                  </AlertDialogClose>
+                  <AlertDialogClose
+                    render={
+                      <Button onClick={handleDelete} variant="destructive" />
+                    }
                   >
-                    <LayoutIcon />
-                    {t(LAYOUT_LABEL_KEYS[l])}
-                  </MenuItem>
-                );
-              })}
-            </MenuSubPopup>
-          </MenuSub>
-        )}
-        {(canUpdateView || canCreateView) && canDeleteView && <MenuSeparator />}
-        {canDeleteView && (
-          <AlertDialog>
-            <AlertDialogTrigger
-              disabled={!canDelete}
-              nativeButton={false}
-              render={<MenuItem closeOnClick={false} variant="destructive" />}
-            >
-              <Trash2Icon />
-              {t("common.delete")}
-            </AlertDialogTrigger>
-            <AlertDialogPopup>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  {t("workspaces.views.deleteView")}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {t("common.deleteConfirmDescription", {
-                    name,
-                  })}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogClose render={<Button variant="ghost" />}>
-                  {t("common.cancel")}
-                </AlertDialogClose>
-                <AlertDialogClose
-                  render={
-                    <Button onClick={handleDelete} variant="destructive" />
-                  }
-                >
-                  {t("common.delete")}
-                </AlertDialogClose>
-              </AlertDialogFooter>
-            </AlertDialogPopup>
-          </AlertDialog>
-        )}
-      </MenuPopup>
-    </Menu>
+                    {t("common.delete")}
+                  </AlertDialogClose>
+                </AlertDialogFooter>
+              </AlertDialogPopup>
+            </AlertDialog>
+          )}
+        </MenuPopup>
+      </Menu>
+    </>
   );
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
@@ -27,10 +27,10 @@ export const useCreateViewTemplate = () => {
       }
       return { data: response.data, workspaceId };
     },
-    onSuccess: ({ workspaceId }) => {
+    onSuccess: () => {
       // eslint-disable-next-line typescript/no-floating-promises
       queryClient.invalidateQueries({
-        queryKey: viewTemplateKeys.all(workspaceId),
+        queryKey: viewTemplateKeys.all(),
       });
     },
     onError: (error) => {
@@ -60,10 +60,10 @@ export const useDeleteViewTemplate = () => {
       }
       return { data: response.data, workspaceId };
     },
-    onSuccess: ({ workspaceId }) => {
+    onSuccess: () => {
       // eslint-disable-next-line typescript/no-floating-promises
       queryClient.invalidateQueries({
-        queryKey: viewTemplateKeys.all(workspaceId),
+        queryKey: viewTemplateKeys.all(),
       });
     },
     onError: (error) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
@@ -1,0 +1,73 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { useAnalytics } from "@/lib/analytics/provider";
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import { toSafeId } from "@/lib/safe-id";
+import type { ViewLayout } from "@/lib/types";
+import { viewTemplateKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/view-templates";
+
+type CreateViewTemplateVars = {
+  workspaceId: string;
+  name: string;
+  layout: ViewLayout;
+};
+
+export const useCreateViewTemplate = () => {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ workspaceId, ...body }: CreateViewTemplateVars) => {
+      const response = await api["view-templates"]({
+        workspaceId: toSafeId<"workspace">(workspaceId),
+      }).put(body);
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return { data: response.data, workspaceId };
+    },
+    onSuccess: ({ workspaceId }) => {
+      // eslint-disable-next-line typescript/no-floating-promises
+      queryClient.invalidateQueries({
+        queryKey: viewTemplateKeys.all(workspaceId),
+      });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+    },
+  });
+};
+
+type DeleteViewTemplateVars = {
+  workspaceId: string;
+  templateId: string;
+};
+
+export const useDeleteViewTemplate = () => {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ workspaceId, templateId }: DeleteViewTemplateVars) => {
+      const response = await api["view-templates"]({
+        workspaceId: toSafeId<"workspace">(workspaceId),
+      })({
+        templateId: toSafeId<"workspaceViewTemplate">(templateId),
+      }).delete();
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return { data: response.data, workspaceId };
+    },
+    onSuccess: ({ workspaceId }) => {
+      // eslint-disable-next-line typescript/no-floating-promises
+      queryClient.invalidateQueries({
+        queryKey: viewTemplateKeys.all(workspaceId),
+      });
+    },
+    onError: (error) => {
+      analytics.captureError(error);
+    },
+  });
+};

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/view-templates.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouteContext } from "@tanstack/react-router";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
@@ -16,6 +17,10 @@ type CreateViewTemplateVars = {
 export const useCreateViewTemplate = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
+  const organizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   return useMutation({
     mutationFn: async ({ workspaceId, ...body }: CreateViewTemplateVars) => {
@@ -30,7 +35,7 @@ export const useCreateViewTemplate = () => {
     onSuccess: () => {
       // eslint-disable-next-line typescript/no-floating-promises
       queryClient.invalidateQueries({
-        queryKey: viewTemplateKeys.all(),
+        queryKey: viewTemplateKeys.all({ organizationId }),
       });
     },
     onError: (error) => {
@@ -47,6 +52,10 @@ type DeleteViewTemplateVars = {
 export const useDeleteViewTemplate = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
+  const organizationId = useRouteContext({
+    from: "/_protected",
+    select: (ctx) => ctx.user.activeOrganizationId,
+  });
 
   return useMutation({
     mutationFn: async ({ workspaceId, templateId }: DeleteViewTemplateVars) => {
@@ -63,7 +72,7 @@ export const useDeleteViewTemplate = () => {
     onSuccess: () => {
       // eslint-disable-next-line typescript/no-floating-promises
       queryClient.invalidateQueries({
-        queryKey: viewTemplateKeys.all(),
+        queryKey: viewTemplateKeys.all({ organizationId }),
       });
     },
     onError: (error) => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-mutations/views.ts
@@ -4,13 +4,20 @@ import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
-import type { ViewLayout, ViewLayoutType, WorkspaceView } from "@/lib/types";
+import type {
+  ViewLayout,
+  ViewLayoutType,
+  ViewTemplateProperty,
+  WorkspaceView,
+} from "@/lib/types";
+import { propertiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/properties";
 import { viewsKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/views";
 
 type CreateViewVars = {
   id: string;
   name: string;
   layout: ViewLayout;
+  templateProperties?: ViewTemplateProperty[];
 };
 
 export const useCreateView = (workspaceId: string) => {
@@ -27,11 +34,24 @@ export const useCreateView = (workspaceId: string) => {
       }
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       // eslint-disable-next-line typescript/no-floating-promises
       queryClient.invalidateQueries({
         queryKey: viewsKeys.all(workspaceId),
       });
+      // Applying a template can create properties in this matter.
+      // Without invalidating, the table renders with a stale property
+      // list and TanStack silently strips the new column IDs from the
+      // newly-created view's columnOrder on the next layout update.
+      if (
+        variables.templateProperties &&
+        variables.templateProperties.length > 0
+      ) {
+        // eslint-disable-next-line typescript/no-floating-promises
+        queryClient.invalidateQueries({
+          queryKey: propertiesKeys.all(workspaceId),
+        });
+      }
     },
     onError: (error) => {
       analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
@@ -2,6 +2,7 @@ import { queryOptions } from "@tanstack/react-query";
 
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
+import type { QueryOptionsInput } from "@/lib/react-query";
 import { toSafeId } from "@/lib/safe-id";
 import type {
   ViewLayout,
@@ -20,17 +21,30 @@ export type WorkspaceViewTemplate = {
   updatedAt: string;
 };
 
-export const viewTemplateKeys = {
-  all: () => ["view-templates"] as const,
+export type ViewTemplatesKey = {
+  organizationId: string;
 };
 
-export const viewTemplatesOptions = (workspaceId: string) =>
-  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- templates are scoped per-user-per-organization on the backend, so any workspaceId the caller has access to returns the same list. The path param only satisfies the workspace-access auth macro.
+export const viewTemplateKeys = {
+  all: ({ organizationId }: ViewTemplatesKey) =>
+    ["view-templates", organizationId] as const,
+};
+
+export type ViewTemplatesOptionsInput = QueryOptionsInput<
+  ViewTemplatesKey,
+  { workspaceId: string }
+>;
+
+export const viewTemplatesOptions = ({
+  key,
+  context,
+}: ViewTemplatesOptionsInput) =>
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- workspaceId is a path param to satisfy the workspace-access auth macro; the backend returns a per-user-per-organization list, so it must not be part of the cache identity.
   queryOptions({
-    queryKey: viewTemplateKeys.all(),
+    queryKey: viewTemplateKeys.all(key),
     queryFn: async ({ signal }): Promise<WorkspaceViewTemplate[]> => {
       const response = await api["view-templates"]({
-        workspaceId: toSafeId<"workspace">(workspaceId),
+        workspaceId: toSafeId<"workspace">(context.workspaceId),
       }).get({ fetch: { signal } });
 
       if (response.error) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
@@ -21,12 +21,13 @@ export type WorkspaceViewTemplate = {
 };
 
 export const viewTemplateKeys = {
-  all: (workspaceId: string) => ["view-templates", workspaceId] as const,
+  all: () => ["view-templates"] as const,
 };
 
 export const viewTemplatesOptions = (workspaceId: string) =>
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps -- templates are scoped per-user-per-organization on the backend, so any workspaceId the caller has access to returns the same list. The path param only satisfies the workspace-access auth macro.
   queryOptions({
-    queryKey: viewTemplateKeys.all(workspaceId),
+    queryKey: viewTemplateKeys.all(),
     queryFn: async ({ signal }): Promise<WorkspaceViewTemplate[]> => {
       const response = await api["view-templates"]({
         workspaceId: toSafeId<"workspace">(workspaceId),

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-queries/view-templates.ts
@@ -1,0 +1,41 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import { toSafeId } from "@/lib/safe-id";
+import type {
+  ViewLayout,
+  ViewLayoutType,
+  ViewTemplateProperty,
+} from "@/lib/types";
+
+export type WorkspaceViewTemplate = {
+  version: 1;
+  id: string;
+  name: string;
+  layout: ViewLayout;
+  templateProperties: ViewTemplateProperty[];
+  layoutType: ViewLayoutType;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const viewTemplateKeys = {
+  all: (workspaceId: string) => ["view-templates", workspaceId] as const,
+};
+
+export const viewTemplatesOptions = (workspaceId: string) =>
+  queryOptions({
+    queryKey: viewTemplateKeys.all(workspaceId),
+    queryFn: async ({ signal }): Promise<WorkspaceViewTemplate[]> => {
+      const response = await api["view-templates"]({
+        workspaceId: toSafeId<"workspace">(workspaceId),
+      }).get({ fetch: { signal } });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+
+      return response.data;
+    },
+  });


### PR DESCRIPTION
## Summary
Resurfaces a prior local implementation of saved Matter view templates (issue #14).
Backend foundation only — UI integration in the view switcher will land in a follow-up.

- `workspace_view_templates` table (per-user, organization-scoped, RLS-gated) with optional template-property payloads
- `view-templates` route group: list / create / delete + `resolveTemplateProperties` helper, wired into `views/{create,update}` so applying a template can auto-create or reuse properties
- `tViewTemplatePropertySchema` + `templateProperties` field on create/update view inputs
- `viewTemplatesPerUser` limit (50), `workspaceViewTemplate` SafeIdType brand
- Frontend `viewTemplatesOptions` query + create/delete mutations (unused until the UI lands)

Refs #14

## Test plan
- [ ] Run drizzle migrations against a scratch DB
- [ ] Create / list / delete a template via Eden treaty from a script
- [ ] Verify RLS isolation between users in the same workspace
- [ ] Follow-up PR: wire the view-switcher UI + i18n keys to expose templates to users