### PR TITLE
feat(table): lock manually overridden cells from AI rerun

### DIFF
--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -195,6 +195,10 @@ export const fieldContentSchema = t.Union([
 
 export type FieldContent = Static<typeof fieldContentSchema>;
 
+export const cellLockReasonSchema = t.UnionEnum(["manual-edit", "explicit"]);
+
+export type CellLockReason = Static<typeof cellLockReasonSchema>;
+
 export const cellMetadataSchema = t.Object({
   version: v1,
   manualFlags: t.Array(t.String({ minLength: 1, maxLength: 64 }), {
@@ -208,6 +212,14 @@ export const cellMetadataSchema = t.Object({
         addedAt: t.String({ format: "date-time" }),
       }),
     ),
+  ),
+  locked: t.Optional(t.Boolean()),
+  lockProvenance: t.Optional(
+    t.Object({
+      lockedBy: t.String({ minLength: 1 }),
+      lockedAt: t.String({ format: "date-time" }),
+      reason: cellLockReasonSchema,
+    }),
   ),
 });
 

--- a/apps/api/src/db/schema-validators.ts
+++ b/apps/api/src/db/schema-validators.ts
@@ -195,9 +195,7 @@ export const fieldContentSchema = t.Union([
 
 export type FieldContent = Static<typeof fieldContentSchema>;
 
-export const cellLockReasonSchema = t.UnionEnum(["manual-edit", "explicit"]);
-
-export type CellLockReason = Static<typeof cellLockReasonSchema>;
+const cellLockReasonSchema = t.UnionEnum(["manual-edit", "explicit"]);
 
 export const cellMetadataSchema = t.Object({
   version: v1,

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -185,15 +185,15 @@ const enrichCellMetadata = (
   actorMap: Map<string, CellMetadataActor>,
 ): CellMetadataResult => {
   const provenanceEntries = Object.entries(metadata.flagProvenance ?? {});
+  const lockActor = metadata.lockProvenance
+    ? actorMap.get(metadata.lockProvenance.lockedBy)
+    : undefined;
   const lockProvenance = metadata.lockProvenance
-    ? (() => {
-        const actor = actorMap.get(metadata.lockProvenance.lockedBy);
-        return {
-          ...metadata.lockProvenance,
-          lockedByName: actor?.name ?? null,
-          lockedByImage: actor?.image ?? null,
-        };
-      })()
+    ? {
+        ...metadata.lockProvenance,
+        lockedByName: lockActor?.name ?? null,
+        lockedByImage: lockActor?.image ?? null,
+      }
     : undefined;
 
   return {

--- a/apps/api/src/handlers/entities/query-entities.ts
+++ b/apps/api/src/handlers/entities/query-entities.ts
@@ -49,8 +49,17 @@ type CellMetadataFlagProvenanceResult = {
   addedByImage: string | null;
 };
 
-type CellMetadataResult = Omit<CellMetadata, "flagProvenance"> & {
+type CellLockProvenanceResult = NonNullable<CellMetadata["lockProvenance"]> & {
+  lockedByName: string | null;
+  lockedByImage: string | null;
+};
+
+type CellMetadataResult = Omit<
+  CellMetadata,
+  "flagProvenance" | "lockProvenance"
+> & {
   flagProvenance?: Record<string, CellMetadataFlagProvenanceResult>;
+  lockProvenance?: CellLockProvenanceResult;
 };
 
 export type QueryEntityResult = {
@@ -158,6 +167,9 @@ const getCellMetadataActorIds = (
     for (const provenance of Object.values(row.metadata.flagProvenance ?? {})) {
       userIds.add(provenance.addedBy);
     }
+    if (row.metadata.lockProvenance) {
+      userIds.add(row.metadata.lockProvenance.lockedBy);
+    }
   }
   return [...userIds];
 };
@@ -173,28 +185,37 @@ const enrichCellMetadata = (
   actorMap: Map<string, CellMetadataActor>,
 ): CellMetadataResult => {
   const provenanceEntries = Object.entries(metadata.flagProvenance ?? {});
-  if (provenanceEntries.length === 0) {
-    return {
-      manualFlags: metadata.manualFlags,
-      version: metadata.version,
-    };
-  }
+  const lockProvenance = metadata.lockProvenance
+    ? (() => {
+        const actor = actorMap.get(metadata.lockProvenance.lockedBy);
+        return {
+          ...metadata.lockProvenance,
+          lockedByName: actor?.name ?? null,
+          lockedByImage: actor?.image ?? null,
+        };
+      })()
+    : undefined;
 
   return {
-    ...metadata,
-    flagProvenance: Object.fromEntries(
-      provenanceEntries.map(([flag, provenance]) => {
-        const actor = actorMap.get(provenance.addedBy);
-        return [
-          flag,
-          {
-            ...provenance,
-            addedByName: actor?.name ?? null,
-            addedByImage: actor?.image ?? null,
-          },
-        ];
-      }),
-    ),
+    version: metadata.version,
+    manualFlags: metadata.manualFlags,
+    ...(provenanceEntries.length > 0 && {
+      flagProvenance: Object.fromEntries(
+        provenanceEntries.map(([flag, provenance]) => {
+          const actor = actorMap.get(provenance.addedBy);
+          return [
+            flag,
+            {
+              ...provenance,
+              addedByName: actor?.name ?? null,
+              addedByImage: actor?.image ?? null,
+            },
+          ];
+        }),
+      ),
+    }),
+    ...(metadata.locked === true && { locked: true }),
+    ...(lockProvenance && { lockProvenance }),
   };
 };
 

--- a/apps/api/src/handlers/fields/update-cell-metadata.ts
+++ b/apps/api/src/handlers/fields/update-cell-metadata.ts
@@ -22,6 +22,7 @@ const config = {
     entityId: tSafeId("entity"),
     baseManualFlags: t.Optional(manualFlagsSchema),
     manualFlags: manualFlagsSchema,
+    locked: t.Optional(t.Boolean()),
   }),
 } satisfies HandlerConfig;
 
@@ -55,6 +56,34 @@ const mergeManualFlags = ({
     ...currentManualFlags.filter((flag) => !removedFlagSet.has(flag)),
     ...addedFlags,
   ]);
+};
+
+type ResolveLockProvenanceArgs = {
+  nextLocked: boolean;
+  wasLocked: boolean;
+  existingMetadata: CellMetadata | undefined;
+  userId: string;
+  addedAt: string;
+};
+
+const resolveLockProvenance = ({
+  nextLocked,
+  wasLocked,
+  existingMetadata,
+  userId,
+  addedAt,
+}: ResolveLockProvenanceArgs): CellMetadata["lockProvenance"] => {
+  if (!nextLocked) {
+    return undefined;
+  }
+  if (wasLocked) {
+    return existingMetadata?.lockProvenance;
+  }
+  return {
+    lockedBy: userId,
+    lockedAt: addedAt,
+    reason: "explicit",
+  };
 };
 
 const updateCellMetadata = createSafeHandler(
@@ -128,7 +157,10 @@ const updateCellMetadata = createSafeHandler(
           requestedManualFlags,
         });
 
-        if (manualFlags.length === 0) {
+        const wasLocked = existingMetadata?.locked === true;
+        const nextLocked = body.locked ?? wasLocked;
+
+        if (manualFlags.length === 0 && !nextLocked) {
           await tx
             .delete(cellMetadata)
             .where(
@@ -141,7 +173,15 @@ const updateCellMetadata = createSafeHandler(
         }
 
         const existingProvenance = existingMetadata?.flagProvenance ?? {};
-        const addedAt = new Date().toISOString();
+        const now = new Date();
+        const addedAt = now.toISOString();
+        const lockProvenance = resolveLockProvenance({
+          nextLocked,
+          wasLocked,
+          existingMetadata,
+          userId: user.id,
+          addedAt,
+        });
         const metadata: CellMetadata = {
           version: 1,
           manualFlags,
@@ -154,6 +194,8 @@ const updateCellMetadata = createSafeHandler(
               },
             ]),
           ),
+          ...(nextLocked && { locked: true }),
+          ...(lockProvenance && { lockProvenance }),
         };
 
         await tx

--- a/apps/api/src/handlers/fields/update-cell-metadata.ts
+++ b/apps/api/src/handlers/fields/update-cell-metadata.ts
@@ -6,6 +6,7 @@ import { cellMetadata, entities, properties } from "@/api/db/schema";
 import type { CellMetadata } from "@/api/db/schema-validators";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { acquireCellLock } from "@/api/lib/cell-lock";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
@@ -131,6 +132,12 @@ const updateCellMetadata = createSafeHandler(
         }
 
         const entityVersionId = entity.currentVersionId;
+        await acquireCellLock({
+          tx,
+          entityVersionId,
+          propertyId: property.id,
+        });
+
         const existingMetadataRows = await tx
           .select({ metadata: cellMetadata.metadata })
           .from(cellMetadata)

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -9,6 +9,7 @@ import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import type { SafeId } from "@/api/lib/branded-types";
+import { acquireCellLock } from "@/api/lib/cell-lock";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -75,6 +76,8 @@ const lockCellOnManualEdit = async ({
   propertyId,
   userId,
 }: LockCellArgs) => {
+  await acquireCellLock({ tx, entityVersionId, propertyId });
+
   const existingRows = await tx
     .select({ metadata: cellMetadata.metadata })
     .from(cellMetadata)
@@ -84,8 +87,7 @@ const lockCellOnManualEdit = async ({
         eq(cellMetadata.propertyId, propertyId),
       ),
     )
-    .limit(1)
-    .for("update");
+    .limit(1);
   const existing = existingRows.at(0)?.metadata;
 
   // Preserve an explicit lock so we don't overwrite its provenance/reason.

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -2,10 +2,13 @@ import { panic, Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
-import { entities, fields } from "@/api/db/schema";
+import type { Transaction } from "@/api/db";
+import { cellMetadata, entities, fields } from "@/api/db/schema";
+import type { CellMetadata } from "@/api/db/schema-validators";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getSearchProvider } from "@/api/lib/search/provider";
@@ -44,13 +47,90 @@ const config = {
         value: t.Integer(),
         currency: t.Nullable(t.String({ minLength: 3, maxLength: 3 })),
       }),
+      t.Object({
+        version: t.Literal(1),
+        type: t.Literal("clip"),
+        url: t.String({ maxLength: 2048 }),
+        snippet: t.Optional(t.String({ maxLength: 10_000 })),
+        citation: t.Optional(t.String({ maxLength: 1000 })),
+        jurisdiction: t.Optional(t.String({ maxLength: 128 })),
+        sourceType: t.Optional(t.String({ maxLength: 64 })),
+      }),
     ]),
   }),
 } satisfies HandlerConfig;
 
+type LockCellArgs = {
+  tx: Transaction;
+  workspaceId: SafeId<"workspace">;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyId: SafeId<"property">;
+  userId: string;
+};
+
+const lockCellOnManualEdit = async ({
+  tx,
+  workspaceId,
+  entityVersionId,
+  propertyId,
+  userId,
+}: LockCellArgs) => {
+  const existingRows = await tx
+    .select({ metadata: cellMetadata.metadata })
+    .from(cellMetadata)
+    .where(
+      and(
+        eq(cellMetadata.entityVersionId, entityVersionId),
+        eq(cellMetadata.propertyId, propertyId),
+      ),
+    )
+    .limit(1)
+    .for("update");
+  const existing = existingRows.at(0)?.metadata;
+
+  // Preserve an explicit lock so we don't overwrite its provenance/reason.
+  const lockProvenance =
+    existing?.locked === true
+      ? existing.lockProvenance
+      : {
+          lockedBy: userId,
+          lockedAt: new Date().toISOString(),
+          reason: "manual-edit" as const,
+        };
+
+  const metadata: CellMetadata = {
+    version: 1,
+    manualFlags: existing?.manualFlags ?? [],
+    ...(existing?.flagProvenance && {
+      flagProvenance: existing.flagProvenance,
+    }),
+    locked: true,
+    ...(lockProvenance && { lockProvenance }),
+  };
+
+  await tx
+    .insert(cellMetadata)
+    .values({
+      workspaceId,
+      entityVersionId,
+      propertyId,
+      metadata,
+      createdBy: userId,
+      updatedBy: userId,
+    })
+    .onConflictDoUpdate({
+      target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
+      set: {
+        metadata,
+        updatedBy: userId,
+        updatedAt: new Date(),
+      },
+    });
+};
+
 const upsertField = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, body }) {
+  async function* ({ safeDb, workspaceId, body, user }) {
     const property = yield* Result.await(
       safeDb((tx) =>
         tx.query.properties.findFirst({
@@ -133,6 +213,13 @@ const upsertField = createSafeHandler(
                 eq(fields.entityVersionId, entityVersionId),
               ),
             );
+          await lockCellOnManualEdit({
+            tx,
+            workspaceId,
+            entityVersionId,
+            propertyId: property.id,
+            userId: user.id,
+          });
           await tx
             .update(entities)
             .set({ updatedAt: new Date() })
@@ -159,6 +246,14 @@ const upsertField = createSafeHandler(
           propertyId: property.id,
           entityVersionId,
           content: body.content,
+        });
+
+        await lockCellOnManualEdit({
+          tx,
+          workspaceId,
+          entityVersionId,
+          propertyId: property.id,
+          userId: user.id,
         });
 
         await tx

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -163,38 +163,6 @@ const upsertField = createSafeHandler(
       );
     }
 
-    const entity = yield* Result.await(
-      safeDb((tx) =>
-        tx.query.entities.findFirst({
-          columns: { id: true, currentVersionId: true, readOnly: true },
-          where: {
-            id: { eq: body.entityId },
-            workspaceId: { eq: workspaceId },
-          },
-        }),
-      ),
-    );
-
-    if (!entity) {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Entity not found in workspace",
-        }),
-      );
-    }
-    if (entity.readOnly) {
-      return Result.err(
-        new HandlerError({ status: 409, message: "Entity is read-only" }),
-      );
-    }
-
-    if (!entity.currentVersionId) {
-      panic("Entity has no current version");
-    }
-
-    const entityVersionId = entity.currentVersionId;
-
     const isEmpty =
       body.content.value === null ||
       body.content.value === "" ||
@@ -204,37 +172,40 @@ const upsertField = createSafeHandler(
       getSearchProvider().indexEntity(body.entityId).catch(captureError);
     };
 
-    if (isEmpty) {
-      yield* Result.await(
-        safeDb(async (tx) => {
-          await lockCellOnManualEdit({
-            tx,
-            workspaceId,
-            entityVersionId,
-            propertyId: property.id,
-            userId: user.id,
-          });
-
-          await tx
-            .delete(fields)
-            .where(
-              and(
-                eq(fields.propertyId, property.id),
-                eq(fields.entityVersionId, entityVersionId),
-              ),
-            );
-          await tx
-            .update(entities)
-            .set({ updatedAt: new Date() })
-            .where(eq(entities.id, body.entityId));
-        }),
-      );
-      reindex();
-      return Result.ok(undefined);
-    }
-
-    yield* Result.await(
+    const writeResult = yield* Result.await(
       safeDb(async (tx) => {
+        // Lock acquisition order (entity row → advisory cell lock)
+        // must match update-cell-metadata.ts. Reversing here would
+        // deadlock against a concurrent manual-flag update on the
+        // same cell.
+        const entityRows = await tx
+          .select({
+            id: entities.id,
+            currentVersionId: entities.currentVersionId,
+            readOnly: entities.readOnly,
+          })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.id, body.entityId),
+              eq(entities.workspaceId, workspaceId),
+            ),
+          )
+          .for("update");
+        const entity = entityRows.at(0);
+
+        if (!entity) {
+          return { status: "entity-not-found" as const };
+        }
+        if (entity.readOnly) {
+          return { status: "entity-read-only" as const };
+        }
+        if (!entity.currentVersionId) {
+          panic("Entity has no current version");
+        }
+
+        const entityVersionId = entity.currentVersionId;
+
         await lockCellOnManualEdit({
           tx,
           workspaceId,
@@ -252,19 +223,38 @@ const upsertField = createSafeHandler(
             ),
           );
 
-        await tx.insert(fields).values({
-          workspaceId,
-          propertyId: property.id,
-          entityVersionId,
-          content: body.content,
-        });
+        if (!isEmpty) {
+          await tx.insert(fields).values({
+            workspaceId,
+            propertyId: property.id,
+            entityVersionId,
+            content: body.content,
+          });
+        }
 
         await tx
           .update(entities)
           .set({ updatedAt: new Date() })
           .where(eq(entities.id, body.entityId));
+
+        return { status: "ok" as const };
       }),
     );
+
+    if (writeResult.status === "entity-not-found") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Entity not found in workspace",
+        }),
+      );
+    }
+    if (writeResult.status === "entity-read-only") {
+      return Result.err(
+        new HandlerError({ status: 409, message: "Entity is read-only" }),
+      );
+    }
+
     reindex();
     return Result.ok(undefined);
   },

--- a/apps/api/src/handlers/fields/upsert-by-id.ts
+++ b/apps/api/src/handlers/fields/upsert-by-id.ts
@@ -207,6 +207,14 @@ const upsertField = createSafeHandler(
     if (isEmpty) {
       yield* Result.await(
         safeDb(async (tx) => {
+          await lockCellOnManualEdit({
+            tx,
+            workspaceId,
+            entityVersionId,
+            propertyId: property.id,
+            userId: user.id,
+          });
+
           await tx
             .delete(fields)
             .where(
@@ -215,13 +223,6 @@ const upsertField = createSafeHandler(
                 eq(fields.entityVersionId, entityVersionId),
               ),
             );
-          await lockCellOnManualEdit({
-            tx,
-            workspaceId,
-            entityVersionId,
-            propertyId: property.id,
-            userId: user.id,
-          });
           await tx
             .update(entities)
             .set({ updatedAt: new Date() })
@@ -234,6 +235,14 @@ const upsertField = createSafeHandler(
 
     yield* Result.await(
       safeDb(async (tx) => {
+        await lockCellOnManualEdit({
+          tx,
+          workspaceId,
+          entityVersionId,
+          propertyId: property.id,
+          userId: user.id,
+        });
+
         await tx
           .delete(fields)
           .where(
@@ -248,14 +257,6 @@ const upsertField = createSafeHandler(
           propertyId: property.id,
           entityVersionId,
           content: body.content,
-        });
-
-        await lockCellOnManualEdit({
-          tx,
-          workspaceId,
-          entityVersionId,
-          propertyId: property.id,
-          userId: user.id,
         });
 
         await tx

--- a/apps/api/src/lib/cell-lock.ts
+++ b/apps/api/src/lib/cell-lock.ts
@@ -1,0 +1,51 @@
+import { sql } from "drizzle-orm";
+
+import type { Transaction } from "@/api/db";
+import type { SafeId } from "@/api/lib/branded-types";
+
+// Postgres' `SELECT … FOR UPDATE` only locks rows that already exist.
+// A cell with no `cell_metadata` row yet cannot be predicate-locked
+// at READ COMMITTED, so a manual edit can `INSERT` a locked row
+// concurrently with an AI write tx and the AI tx will still clobber
+// the manual value. Advisory locks live in shared memory keyed by an
+// int4 pair, so both paths serialize even when the underlying row
+// doesn't exist.
+//
+// Callers must hold the locks for the full extent of any
+// `cell_metadata` read-then-write sequence; `pg_advisory_xact_lock`
+// auto-releases at COMMIT/ROLLBACK.
+
+export const acquireCellLock = async ({
+  tx,
+  entityVersionId,
+  propertyId,
+}: {
+  tx: Transaction;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyId: SafeId<"property">;
+}): Promise<void> => {
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${entityVersionId}), hashtext(${propertyId}))`,
+  );
+};
+
+export const acquireCellLocks = async ({
+  tx,
+  entityVersionId,
+  propertyIds,
+}: {
+  tx: Transaction;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyIds: readonly SafeId<"property">[];
+}): Promise<void> => {
+  if (propertyIds.length === 0) {
+    return;
+  }
+  // Sort so concurrent callers with overlapping candidate sets
+  // acquire locks in the same order; otherwise interleaved batches
+  // can deadlock.
+  const sorted = [...propertyIds].sort();
+  for (const propertyId of sorted) {
+    await acquireCellLock({ tx, entityVersionId, propertyId });
+  }
+};

--- a/apps/api/src/lib/cell-lock.ts
+++ b/apps/api/src/lib/cell-lock.ts
@@ -14,6 +14,14 @@ import type { SafeId } from "@/api/lib/branded-types";
 // Callers must hold the locks for the full extent of any
 // `cell_metadata` read-then-write sequence; `pg_advisory_xact_lock`
 // auto-releases at COMMIT/ROLLBACK.
+//
+// **Lock ordering invariant**: if the transaction also takes an
+// entity row lock (`SELECT entities ... FOR UPDATE` or any
+// `UPDATE entities` that implicitly takes one), acquire that entity
+// lock FIRST and the cell advisory lock SECOND. Reversing the order
+// in any one caller produces a classic AB/BA deadlock against the
+// other handlers, since `update-cell-metadata` and `upsert-by-id`
+// both touch the same (entity, cell) pair.
 
 export const acquireCellLock = async ({
   tx,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1173,6 +1173,7 @@ const processOneBatch = async ({
                   inArray(cellMetadata.propertyId, candidatePropertyIds),
                 ),
               )
+              .for("update")
           : [];
       const lockedAtWrite = new Set<string>(
         lockedRowsAtWrite

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1147,7 +1147,9 @@ const processOneBatch = async ({
 
     await scopedDb(async (tx) => {
       // Re-check locks inside the write tx: a manual edit could have landed
-      // between prepareBatch() and now, and we must not clobber it.
+      // between prepareBatch() and now. SELECT FOR UPDATE serializes with
+      // lockCellOnManualEdit so we either see the new lock or block the
+      // manual edit until our write commits.
       const lockedRowsAtWrite =
         candidatePropertyIds.length > 0
           ? await tx
@@ -1162,6 +1164,7 @@ const processOneBatch = async ({
                   inArray(cellMetadata.propertyId, candidatePropertyIds),
                 ),
               )
+              .for("update")
           : [];
       const lockedAtWrite = new Set<string>(
         lockedRowsAtWrite

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1416,16 +1416,46 @@ const setFieldsStatus = async ({
   const propertyIds = batch.properties.map((p) => p.id);
 
   await scopedDb(async (tx) => {
+    // Re-check locks under the per-cell advisory lock. The
+    // lockedPropertyIds snapshot above (line ~1007) is taken
+    // outside any lock, so a manual edit that lands between that
+    // snapshot and this write would otherwise have its field value
+    // clobbered by the `pending` placeholder before the final AI
+    // write tx gets a chance to filter it out.
+    await acquireCellLocks({ tx, entityVersionId, propertyIds });
+    const lockedRows = await tx
+      .select({
+        propertyId: cellMetadata.propertyId,
+        metadata: cellMetadata.metadata,
+      })
+      .from(cellMetadata)
+      .where(
+        and(
+          eq(cellMetadata.entityVersionId, entityVersionId),
+          inArray(cellMetadata.propertyId, propertyIds),
+        ),
+      );
+    const lockedNow = new Set<string>(
+      lockedRows
+        .filter((row) => row.metadata.locked === true)
+        .map((row) => row.propertyId),
+    );
+    const writablePropertyIds = propertyIds.filter((id) => !lockedNow.has(id));
+
+    if (writablePropertyIds.length === 0) {
+      return;
+    }
+
     await tx
       .delete(fields)
       .where(
         and(
           eq(fields.entityVersionId, entityVersionId),
-          inArray(fields.propertyId, propertyIds),
+          inArray(fields.propertyId, writablePropertyIds),
         ),
       );
 
-    const fieldValues = propertyIds.map((propertyId) => ({
+    const fieldValues = writablePropertyIds.map((propertyId) => ({
       id: createSafeId<"field">(),
       workspaceId,
       propertyId,
@@ -1433,9 +1463,7 @@ const setFieldsStatus = async ({
       content: { type: contentType, version: 1 as const },
     }));
 
-    if (fieldValues.length > 0) {
-      await tx.insert(fields).values(fieldValues);
-    }
+    await tx.insert(fields).values(fieldValues);
   });
 };
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -7,7 +7,13 @@ import Redis from "ioredis";
 import { isMockAI } from "@/api/consts";
 import type { ScopedDb } from "@/api/db";
 import { jsonField } from "@/api/db/json-utils";
-import { entities, fields, justifications, properties } from "@/api/db/schema";
+import {
+  cellMetadata,
+  entities,
+  fields,
+  justifications,
+  properties,
+} from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
 import { env } from "@/api/env";
 import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
@@ -997,7 +1003,27 @@ const processOneBatch = async ({
     batchFields.map((f) => [f.propertyId, f.contentType]),
   );
 
-  const batch = prepareBatch(rawBatch, fieldContentMap);
+  const lockedCellRows = await scopedDb((tx) =>
+    tx
+      .select({
+        propertyId: cellMetadata.propertyId,
+        metadata: cellMetadata.metadata,
+      })
+      .from(cellMetadata)
+      .where(
+        and(
+          eq(cellMetadata.entityVersionId, entityVersionId),
+          inArray(cellMetadata.propertyId, propertyIds),
+        ),
+      ),
+  );
+  const lockedPropertyIds = new Set<string>(
+    lockedCellRows
+      .filter((row) => row.metadata.locked === true)
+      .map((row) => row.propertyId),
+  );
+
+  const batch = prepareBatch(rawBatch, fieldContentMap, lockedPropertyIds);
 
   if (batch.properties.length === 0) {
     return;
@@ -1113,13 +1139,39 @@ const processOneBatch = async ({
     }
 
     // Write AI results to DB
-    const allPropertyIds = [
+    const candidatePropertyIds = [
       ...processedFields.aiResults.map((r) => r.propertyId),
       ...processedFields.unsupportedPropertyIds,
       ...processedFields.skippedPropertyIds,
     ];
 
     await scopedDb(async (tx) => {
+      // Re-check locks inside the write tx: a manual edit could have landed
+      // between prepareBatch() and now, and we must not clobber it.
+      const lockedRowsAtWrite =
+        candidatePropertyIds.length > 0
+          ? await tx
+              .select({
+                propertyId: cellMetadata.propertyId,
+                metadata: cellMetadata.metadata,
+              })
+              .from(cellMetadata)
+              .where(
+                and(
+                  eq(cellMetadata.entityVersionId, entityVersionId),
+                  inArray(cellMetadata.propertyId, candidatePropertyIds),
+                ),
+              )
+          : [];
+      const lockedAtWrite = new Set<string>(
+        lockedRowsAtWrite
+          .filter((row) => row.metadata.locked === true)
+          .map((row) => row.propertyId),
+      );
+      const allPropertyIds = candidatePropertyIds.filter(
+        (id) => !lockedAtWrite.has(id),
+      );
+
       if (allPropertyIds.length > 0) {
         await tx
           .delete(fields)
@@ -1132,22 +1184,24 @@ const processOneBatch = async ({
       }
 
       const fieldValues = [
-        ...processedFields.aiResults.map(
-          ({ fieldId, propertyId, content }) => ({
+        ...processedFields.aiResults
+          .filter(({ propertyId }) => !lockedAtWrite.has(propertyId))
+          .map(({ fieldId, propertyId, content }) => ({
             id: fieldId,
             workspaceId,
             propertyId,
             entityVersionId,
             content,
-          }),
-        ),
-        ...processedFields.unsupportedPropertyIds.map((propertyId) => ({
-          id: createSafeId<"field">(),
-          workspaceId,
-          propertyId,
-          entityVersionId,
-          content: { type: "unsupported" as const, version: 1 as const },
-        })),
+          })),
+        ...processedFields.unsupportedPropertyIds
+          .filter((propertyId) => !lockedAtWrite.has(propertyId))
+          .map((propertyId) => ({
+            id: createSafeId<"field">(),
+            workspaceId,
+            propertyId,
+            entityVersionId,
+            content: { type: "unsupported" as const, version: 1 as const },
+          })),
       ];
 
       if (fieldValues.length > 0) {
@@ -1155,15 +1209,25 @@ const processOneBatch = async ({
       }
 
       if (processedFields.aiJustifications.length > 0) {
-        await tx.insert(justifications).values(
-          processedFields.aiJustifications.map((j) => ({
-            id: j.justificationId,
-            workspaceId,
-            fieldId: j.fieldId,
-            content: j.content,
-            fileFieldIds: j.fileFieldIds,
-          })),
+        const aiResultFieldIdsForLockedProps = new Set(
+          processedFields.aiResults
+            .filter(({ propertyId }) => lockedAtWrite.has(propertyId))
+            .map(({ fieldId }) => fieldId),
         );
+        const liveJustifications = processedFields.aiJustifications.filter(
+          (j) => !aiResultFieldIdsForLockedProps.has(j.fieldId),
+        );
+        if (liveJustifications.length > 0) {
+          await tx.insert(justifications).values(
+            liveJustifications.map((j) => ({
+              id: j.justificationId,
+              workspaceId,
+              fieldId: j.fieldId,
+              content: j.content,
+              fileFieldIds: j.fileFieldIds,
+            })),
+          );
+        }
       }
     });
 

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -20,6 +20,7 @@ import { loadOrgAIConfig } from "@/api/lib/ai-config-loader";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeId } from "@/api/lib/branded-types";
 import type { SafeId } from "@/api/lib/branded-types";
+import { acquireCellLocks } from "@/api/lib/cell-lock";
 import { errorTag } from "@/api/lib/errors/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
@@ -1146,10 +1147,18 @@ const processOneBatch = async ({
     ];
 
     await scopedDb(async (tx) => {
-      // Re-check locks inside the write tx: a manual edit could have landed
-      // between prepareBatch() and now. SELECT FOR UPDATE serializes with
-      // lockCellOnManualEdit so we either see the new lock or block the
-      // manual edit until our write commits.
+      // Acquire per-cell advisory locks before re-checking lock state.
+      // `SELECT FOR UPDATE` alone cannot block a manual edit that
+      // inserts a brand-new `cell_metadata` row (READ COMMITTED takes
+      // no gap lock); `acquireCellLocks` serializes with
+      // `acquireCellLock` in lockCellOnManualEdit on a key derived
+      // from (entityVersionId, propertyId), so we either see the new
+      // lock here or the manual edit waits for our COMMIT.
+      await acquireCellLocks({
+        tx,
+        entityVersionId,
+        propertyIds: candidatePropertyIds,
+      });
       const lockedRowsAtWrite =
         candidatePropertyIds.length > 0
           ? await tx
@@ -1164,7 +1173,6 @@ const processOneBatch = async ({
                   inArray(cellMetadata.propertyId, candidatePropertyIds),
                 ),
               )
-              .for("update")
           : [];
       const lockedAtWrite = new Set<string>(
         lockedRowsAtWrite

--- a/apps/api/src/lib/workflow/utils.test.ts
+++ b/apps/api/src/lib/workflow/utils.test.ts
@@ -318,4 +318,31 @@ describe("prepareBatch", () => {
     expect(result.id).toBe("empty-batch");
     expect(result.inputs).toEqual([propertyId("dep")]);
   });
+
+  test("excludes locked properties even when status is stale", () => {
+    const rawBatch = createRawBatch([
+      createBatchProperty("p1", { status: "stale" }),
+      createBatchProperty("p2", { status: "stale" }),
+    ]);
+    const fieldContentMap = new Map<string, FieldContent["type"]>();
+    const locked = new Set<string>([propertyId("p1")]);
+
+    const result = prepareBatch(rawBatch, fieldContentMap, locked);
+
+    expect(result.properties.map((p) => p.id)).toEqual([propertyId("p2")]);
+  });
+
+  test("excludes locked properties even when content type would normally trigger re-extraction", () => {
+    const rawBatch = createRawBatch([
+      createBatchProperty("p1", { status: "fresh" }),
+    ]);
+    const fieldContentMap = new Map<string, FieldContent["type"]>([
+      ["p1", "error"],
+    ]);
+    const locked = new Set<string>([propertyId("p1")]);
+
+    const result = prepareBatch(rawBatch, fieldContentMap, locked);
+
+    expect(result.properties).toHaveLength(0);
+  });
 });

--- a/apps/api/src/lib/workflow/utils.ts
+++ b/apps/api/src/lib/workflow/utils.ts
@@ -7,8 +7,13 @@ import type { PropertyBatch } from "@/api/lib/workflow/get-execution-plan";
 export const prepareBatch = (
   rawBatch: PropertyBatch,
   fieldContentMap: Map<string, FieldContent["type"]>,
+  lockedPropertyIds: ReadonlySet<string> = new Set(),
 ): PropertyBatch => {
   const propertiesToProcess = rawBatch.properties.filter((prop) => {
+    if (lockedPropertyIds.has(prop.id)) {
+      return false;
+    }
+
     const fieldContentType = fieldContentMap.get(prop.id);
 
     return (

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2213,6 +2213,10 @@
         "verified": "Ověřeno",
         "verifiedDescription": "Ručně potvrzeno."
       },
+      "lock": {
+        "locked": "Zamčeno",
+        "unlock": "Odemknout buňku"
+      },
       "reorderReadOnly": "Řádky tabulky se řídí aktuálním řazením",
       "tightContent": "Těsně",
       "wrapContent": "Obtékat text"

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2213,6 +2213,10 @@
         "verified": "Verifiziert",
         "verifiedDescription": "Manuell bestätigt."
       },
+      "lock": {
+        "locked": "Gesperrt",
+        "unlock": "Zelle entsperren"
+      },
       "reorderReadOnly": "Tabellenzeilen folgen der aktuellen Sortierung",
       "tightContent": "Kompakt",
       "wrapContent": "Text umbrechen"

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2213,6 +2213,10 @@
         "verified": "Verified",
         "verifiedDescription": "Manually confirmed."
       },
+      "lock": {
+        "locked": "Locked",
+        "unlock": "Unlock cell"
+      },
       "reorderReadOnly": "Table rows follow the current sort",
       "tightContent": "Tight",
       "wrapContent": "Wrap content"

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2213,6 +2213,10 @@
         "verified": "Verificado",
         "verifiedDescription": "Confirmado manualmente."
       },
+      "lock": {
+        "locked": "Bloqueada",
+        "unlock": "Desbloquear celda"
+      },
       "reorderReadOnly": "Las filas de la tabla siguen el orden actual",
       "tightContent": "Compacto",
       "wrapContent": "Ajustar texto"

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2213,6 +2213,10 @@
         "verified": "Kinnitatud",
         "verifiedDescription": "Käsitsi kinnitatud."
       },
+      "lock": {
+        "locked": "Lukus",
+        "unlock": "Vabasta lahter"
+      },
       "reorderReadOnly": "Tabeliread järgivad praegust sortimist",
       "tightContent": "Kompaktne",
       "wrapContent": "Murra tekst"

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2213,6 +2213,10 @@
         "verified": "Vérifié",
         "verifiedDescription": "Confirmé manuellement."
       },
+      "lock": {
+        "locked": "Verrouillée",
+        "unlock": "Déverrouiller la cellule"
+      },
       "reorderReadOnly": "Les lignes du tableau suivent le tri actuel",
       "tightContent": "Compact",
       "wrapContent": "Retour à la ligne"

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2213,6 +2213,10 @@
         "verified": "Ellenőrizve",
         "verifiedDescription": "Kézzel megerősítve."
       },
+      "lock": {
+        "locked": "Zárolva",
+        "unlock": "Cella feloldása"
+      },
       "reorderReadOnly": "A táblázatsorok az aktuális rendezést követik",
       "tightContent": "Kompakt",
       "wrapContent": "Szöveg tördelése"

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2213,6 +2213,10 @@
         "verified": "Patvirtinta",
         "verifiedDescription": "Patvirtinta rankiniu būdu."
       },
+      "lock": {
+        "locked": "Užrakinta",
+        "unlock": "Atrakinti langelį"
+      },
       "reorderReadOnly": "Lentelės eilutės laikosi dabartinio rūšiavimo",
       "tightContent": "Kompaktiškai",
       "wrapContent": "Laužyti tekstą"

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2213,6 +2213,10 @@
         "verified": "Pārbaudīts",
         "verifiedDescription": "Manuāli apstiprināts."
       },
+      "lock": {
+        "locked": "Bloķēta",
+        "unlock": "Atbloķēt šūnu"
+      },
       "reorderReadOnly": "Tabulas rindas seko pašreizējai kārtošanai",
       "tightContent": "Kompakti",
       "wrapContent": "Aplauzt tekstu"

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2216,6 +2216,10 @@ type Messages = {
         "verified": "Verified";
         "verifiedDescription": "Manually confirmed.";
       };
+      "lock": {
+        "locked": "Locked";
+        "unlock": "Unlock cell";
+      };
       "reorderReadOnly": "Table rows follow the current sort";
       "tightContent": "Tight";
       "wrapContent": "Wrap content";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2213,6 +2213,10 @@
         "verified": "Zweryfikowane",
         "verifiedDescription": "Potwierdzone ręcznie."
       },
+      "lock": {
+        "locked": "Zablokowana",
+        "unlock": "Odblokuj komórkę"
+      },
       "reorderReadOnly": "Wiersze tabeli są zgodne z bieżącym sortowaniem",
       "tightContent": "Kompaktowo",
       "wrapContent": "Zawijaj tekst"

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2213,6 +2213,10 @@
         "verified": "Verificado",
         "verifiedDescription": "Confirmado manualmente."
       },
+      "lock": {
+        "locked": "Bloqueada",
+        "unlock": "Desbloquear célula"
+      },
       "reorderReadOnly": "As linhas da tabela seguem a classificação atual",
       "tightContent": "Compacto",
       "wrapContent": "Quebrar linhas"

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2213,6 +2213,10 @@
         "verified": "Overené",
         "verifiedDescription": "Ručne potvrdené."
       },
+      "lock": {
+        "locked": "Uzamknuté",
+        "unlock": "Odomknúť bunku"
+      },
       "reorderReadOnly": "Riadky tabuľky sa riadia aktuálnym zoradením",
       "tightContent": "Tesne",
       "wrapContent": "Zalomiť text"

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -184,6 +184,14 @@ export type WorkspaceCellMetadata = {
       addedByImage: string | null;
     }
   >;
+  locked?: boolean;
+  lockProvenance?: {
+    lockedBy: string;
+    lockedAt: string;
+    lockedByName: string | null;
+    lockedByImage: string | null;
+    reason: "manual-edit" | "explicit";
+  };
 };
 
 export type EntityField = {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -293,12 +293,17 @@ const CellLockBadge = ({ provenance }: CellLockBadgeProps) => {
       className="max-w-72 text-wrap"
       content={tooltipContent}
       render={
-        <span
+        <button
           aria-label={t("workspaces.table.lock.locked")}
-          className="bg-background/55 text-foreground-ghost absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px]"
+          className="bg-background/55 text-foreground-ghost focus-visible:ring-ring absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px] outline-none focus-visible:ring-1"
+          data-row-expansion-ignore
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+          type="button"
         >
           <LockIcon className="size-2.5" strokeWidth={2.5} />
-        </span>
+        </button>
       }
     />
   );

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -296,11 +296,11 @@ const CellLockBadge = ({ provenance }: CellLockBadgeProps) => {
         <span
           aria-label={t("workspaces.table.lock.locked")}
           className="bg-background/55 text-foreground-ghost pointer-events-none absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px]"
-        />
+        >
+          <LockIcon className="size-2.5" strokeWidth={2.5} />
+        </span>
       }
-    >
-      <LockIcon className="size-2.5" strokeWidth={2.5} />
-    </Tooltip>
+    />
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -295,7 +295,7 @@ const CellLockBadge = ({ provenance }: CellLockBadgeProps) => {
       render={
         <span
           aria-label={t("workspaces.table.lock.locked")}
-          className="bg-background/55 text-foreground-ghost pointer-events-none absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px]"
+          className="bg-background/55 text-foreground-ghost absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px]"
         >
           <LockIcon className="size-2.5" strokeWidth={2.5} />
         </span>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags.tsx
@@ -6,6 +6,8 @@ import {
   CheckIcon,
   CheckCircle2Icon,
   HelpCircleIcon,
+  LockIcon,
+  LockOpenIcon,
   MessageSquareWarningIcon,
   ShieldAlertIcon,
   StarIcon,
@@ -101,6 +103,8 @@ type FlagProvenance = NonNullable<
   WorkspaceCellMetadata["flagProvenance"]
 >[string];
 
+type LockProvenance = NonNullable<WorkspaceCellMetadata["lockProvenance"]>;
+
 const useFlagLabel = () => {
   const t = useTranslations();
   return (flagId: CellFlagId) => t(FLAG_LABEL_KEYS[flagId]);
@@ -115,6 +119,7 @@ const haveSameFlags = (a: string[], b: string[]) =>
 type UpdateCellMetadataVariables = {
   baseManualFlags: string[];
   manualFlags: string[];
+  locked?: boolean;
 };
 
 type CellMetadataFlagsProps = {
@@ -131,19 +136,24 @@ export const CellMetadataFlags = ({
   metadata,
 }: CellMetadataFlagsProps) => {
   const getFlagLabel = useFlagLabel();
-  const { decorativeFlags, hasVerifiedFlag, toggleFlag } = useCellMetadataFlags(
-    {
-      entityId,
-      metadata,
-      propertyId,
-      workspaceId,
-    },
-  );
+  const {
+    decorativeFlags,
+    hasVerifiedFlag,
+    isLocked,
+    lockProvenance,
+    toggleFlag,
+  } = useCellMetadataFlags({
+    entityId,
+    metadata,
+    propertyId,
+    workspaceId,
+  });
   const cornerFlag = decorativeFlags.at(0);
   const verifiedProvenance = metadata?.flagProvenance?.[VERIFIED_FLAG_ID];
 
   return (
     <>
+      {isLocked && <CellLockBadge provenance={lockProvenance} />}
       {cornerFlag ? (
         <CellCornerFlag
           flags={decorativeFlags}
@@ -246,6 +256,54 @@ const CellCornerFlag = ({ flags, metadata, onDrop }: CellCornerFlagProps) => {
   );
 };
 
+type CellLockBadgeProps = {
+  provenance: LockProvenance | undefined;
+};
+
+const CellLockBadge = ({ provenance }: CellLockBadgeProps) => {
+  const t = useTranslations();
+  const locale = useLocale();
+  const displayName = provenance?.lockedByName ?? null;
+  const relativeTime = provenance
+    ? formatRelativeTime(provenance.lockedAt, locale)
+    : null;
+
+  const tooltipContent = provenance ? (
+    <span className="flex min-w-0 items-center gap-2">
+      <UserAvatar
+        className="size-5 shrink-0 text-[8px]"
+        image={provenance.lockedByImage}
+        name={displayName}
+      />
+      <span className="min-w-0">
+        <span className="block truncate font-medium">
+          {t("workspaces.table.lock.locked")}
+        </span>
+        <span className="text-muted-foreground block truncate text-xs">
+          {displayName ? `${displayName} · ${relativeTime}` : relativeTime}
+        </span>
+      </span>
+    </span>
+  ) : (
+    <span>{t("workspaces.table.lock.locked")}</span>
+  );
+
+  return (
+    <Tooltip
+      className="max-w-72 text-wrap"
+      content={tooltipContent}
+      render={
+        <span
+          aria-label={t("workspaces.table.lock.locked")}
+          className="bg-background/55 text-foreground-ghost pointer-events-none absolute start-1 top-1 z-20 flex size-3 items-center justify-center rounded-full backdrop-blur-[2px]"
+        />
+      }
+    >
+      <LockIcon className="size-2.5" strokeWidth={2.5} />
+    </Tooltip>
+  );
+};
+
 type FlagProvenanceTooltipProps = {
   flag: CellFlagDefinition;
   metadata: FlagProvenance | undefined;
@@ -291,12 +349,13 @@ export const CellMetadataMenuSection = ({
   metadata,
 }: CellMetadataFlagsProps) => {
   const t = useTranslations();
-  const { activeFlags, clearFlags, toggleFlag } = useCellMetadataFlags({
-    entityId,
-    metadata,
-    propertyId,
-    workspaceId,
-  });
+  const { activeFlags, clearFlags, isLocked, setLocked, toggleFlag } =
+    useCellMetadataFlags({
+      entityId,
+      metadata,
+      propertyId,
+      workspaceId,
+    });
 
   return (
     <>
@@ -326,6 +385,20 @@ export const CellMetadataMenuSection = ({
           );
         })}
       </MenuGroup>
+      {isLocked && (
+        <>
+          <MenuSeparator />
+          <MenuItem
+            className="min-h-7 py-0.5 text-sm"
+            onClick={() => setLocked(false)}
+          >
+            <LockOpenIcon className="size-3.5 shrink-0 opacity-75" />
+            <span className="min-w-0 flex-1 truncate">
+              {t("workspaces.table.lock.unlock")}
+            </span>
+          </MenuItem>
+        </>
+      )}
       {activeFlags.length > 0 && (
         <>
           <MenuSeparator />
@@ -391,6 +464,7 @@ const useCellMetadataFlags = ({
     mutationFn: async ({
       baseManualFlags,
       manualFlags,
+      locked,
     }: UpdateCellMetadataVariables) => {
       const response = await api
         .fields({ workspaceId: toSafeId<"workspace">(workspaceId) })
@@ -400,6 +474,7 @@ const useCellMetadataFlags = ({
           propertyId: toSafeId<"property">(propertyId),
           baseManualFlags,
           manualFlags,
+          ...(locked !== undefined && { locked }),
         });
 
       if (response.error) {
@@ -445,11 +520,26 @@ const useCellMetadataFlags = ({
     updateMetadata.mutate({ baseManualFlags: current, manualFlags: [] });
   };
 
+  const setLocked = (locked: boolean) => {
+    const current = pendingManualFlagsRef.current ?? metadataManualFlags;
+    updateMetadata.mutate({
+      baseManualFlags: current,
+      manualFlags: current,
+      locked,
+    });
+  };
+
+  const isLocked = metadata?.locked === true;
+  const lockProvenance = metadata?.lockProvenance;
+
   return {
     activeFlags,
     clearFlags,
     decorativeFlags,
     hasVerifiedFlag,
+    isLocked,
+    lockProvenance,
+    setLocked,
     toggleFlag,
   };
 };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -116,10 +116,7 @@ type EditFieldDialogProps = {
   entityKind: EntityKind;
   options: WorkspacePropertyOption[];
   fieldContent: EditableFieldContent;
-  className?: string;
-  /** When provided, the dialog is fully controlled and no built-in trigger renders. */
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  className: string;
 };
 
 export const EditFieldDialog = ({
@@ -130,19 +127,9 @@ export const EditFieldDialog = ({
   options,
   fieldContent,
   className,
-  open: controlledOpen,
-  onOpenChange,
 }: EditFieldDialogProps) => {
-  const isControlled = controlledOpen !== undefined;
   const t = useTranslations();
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
-  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
-  const setIsOpen = (next: boolean) => {
-    if (!isControlled) {
-      setUncontrolledOpen(next);
-    }
-    onOpenChange?.(next);
-  };
+  const [isOpen, setIsOpen] = useState(false);
   const isWorkflowRunning = useIsWorkflowRunning(workspaceId);
   const upsertField = useUpsertField();
   const startWorkflow = useStartWorkflow(workspaceId);
@@ -197,11 +184,9 @@ export const EditFieldDialog = ({
       }}
       open={isOpen}
     >
-      {!isControlled && (
-        <DialogTrigger className={className} render={<Button size="xs" />}>
-          {t("common.edit")}
-        </DialogTrigger>
-      )}
+      <DialogTrigger className={className} render={<Button size="xs" />}>
+        {t("common.edit")}
+      </DialogTrigger>
       <DialogPopup className="sm:max-w-sm">
         <form.Subscribe selector={(s) => toFormErrors(s.fieldMeta)}>
           {(errors) => (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/edit-field-dialog.tsx
@@ -116,7 +116,10 @@ type EditFieldDialogProps = {
   entityKind: EntityKind;
   options: WorkspacePropertyOption[];
   fieldContent: EditableFieldContent;
-  className: string;
+  className?: string;
+  /** When provided, the dialog is fully controlled and no built-in trigger renders. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 };
 
 export const EditFieldDialog = ({
@@ -127,9 +130,19 @@ export const EditFieldDialog = ({
   options,
   fieldContent,
   className,
+  open: controlledOpen,
+  onOpenChange,
 }: EditFieldDialogProps) => {
+  const isControlled = controlledOpen !== undefined;
   const t = useTranslations();
-  const [isOpen, setIsOpen] = useState(false);
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
+  const setIsOpen = (next: boolean) => {
+    if (!isControlled) {
+      setUncontrolledOpen(next);
+    }
+    onOpenChange?.(next);
+  };
   const isWorkflowRunning = useIsWorkflowRunning(workspaceId);
   const upsertField = useUpsertField();
   const startWorkflow = useStartWorkflow(workspaceId);
@@ -184,9 +197,11 @@ export const EditFieldDialog = ({
       }}
       open={isOpen}
     >
-      <DialogTrigger className={className} render={<Button size="xs" />}>
-        {t("common.edit")}
-      </DialogTrigger>
+      {!isControlled && (
+        <DialogTrigger className={className} render={<Button size="xs" />}>
+          {t("common.edit")}
+        </DialogTrigger>
+      )}
       <DialogPopup className="sm:max-w-sm">
         <form.Subscribe selector={(s) => toFormErrors(s.fieldMeta)}>
           {(errors) => (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/editable-field.tsx
@@ -118,6 +118,22 @@ const ReadOnlyDisplay = ({
     );
   }
 
+  if (content.type === "unsupported") {
+    return (
+      <span className="text-muted-foreground block truncate text-sm italic">
+        {t("workspaces.fields.formatNotSupported")}
+      </span>
+    );
+  }
+
+  if (content.type === "clip") {
+    return (
+      <span className="text-muted-foreground block truncate text-sm">
+        {content.url}
+      </span>
+    );
+  }
+
   return <span className="text-muted-foreground text-sm">—</span>;
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -152,7 +152,15 @@ const PropertyCell = ({
             propertyId={property.id}
             workspaceId={property.workspaceId}
           />
-          <CellResult field={field} property={property} />
+          <EditableField
+            content={fieldContent}
+            entityId={entity.entityId}
+            entityKind={entity.kind}
+            property={property}
+            propertyId={property.id}
+            showDateIcon={false}
+            workspaceId={property.workspaceId}
+          />
         </WithOpenEntityButton>
       );
     }
@@ -166,7 +174,15 @@ const PropertyCell = ({
         propertyId={property.id}
         workspaceId={property.workspaceId}
       />
-      <CellResult field={field} property={property} />
+      <EditableField
+        content={fieldContent}
+        entityId={entity.entityId}
+        entityKind={entity.kind}
+        property={property}
+        propertyId={property.id}
+        showDateIcon={false}
+        workspaceId={property.workspaceId}
+      />
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Manually editing a cell now auto-locks it in `cell_metadata`; the AI workflow skips locked properties on subsequent reruns and the manual value is preserved.
- The AI write transaction re-checks the lock to avoid clobbering a lock that landed mid-batch.
- Locked cells show a corner lock badge with provenance; the cell context menu exposes "Unlock cell".
- Closes #308.