### PR TITLE
feat(lint): enable promise, iframe-sandbox, and dead-write rules

### DIFF
--- a/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
+++ b/apps/api/src/handlers/case-law/ingestion/parsers/cz-ns.ts
@@ -300,21 +300,6 @@ const isCentered = (el: cheerio.Cheerio<AnyNode>): boolean => {
 export const extractRawChunks = ($: cheerio.CheerioAPI): RawChunk[] => {
   const chunks: RawChunk[] = [];
 
-  const metaTable = $("#box-table-a");
-  let siblings = metaTable.nextAll();
-
-  if (siblings.length === 0) {
-    const body = $("body");
-    let foundTable = false;
-    siblings = body.children().filter((_, el) => {
-      if ($(el).is("#box-table-a")) {
-        foundTable = true;
-        return false;
-      }
-      return foundTable;
-    });
-  }
-
   const trimLineBreaks = (inlines: Inline[]): Inline[] => {
     while (inlines.length > 0 && inlines[0]?.type === "line-break") {
       inlines.shift();

--- a/apps/api/src/handlers/clauses/import.ts
+++ b/apps/api/src/handlers/clauses/import.ts
@@ -193,6 +193,7 @@ const importHandler = async function* ({
           if (Result.isError(searchVectorResult)) {
             captureError(searchVectorResult.error, { clauseId: c.id });
           }
+          return;
         })
         .catch((error: unknown) => {
           captureError(error, { clauseId: c.id });

--- a/apps/api/src/scheduler/index.ts
+++ b/apps/api/src/scheduler/index.ts
@@ -18,6 +18,7 @@ await new Promise<void>((resolve) => {
         "scheduler.runner_id": loop.runnerId,
       });
       resolve();
+      return;
     });
   };
 

--- a/apps/collab/src/server.test.ts
+++ b/apps/collab/src/server.test.ts
@@ -353,6 +353,9 @@ describe("collaboration server", () => {
     });
     const ydoc = new Doc();
     let authenticationFailed = false;
+    // `null` init is load-bearing: if the constructor below throws, the
+    // finally block still needs to null-check before calling destroy().
+    // oxlint-disable-next-line eslint/no-useless-assignment
     let provider: HocuspocusProvider | null = null;
 
     try {

--- a/apps/desktop/src/mainview/App.tsx
+++ b/apps/desktop/src/mainview/App.tsx
@@ -425,6 +425,7 @@ export default function App() {
       }
     }).then((unlisten) => {
       cleanup = unlisten;
+      return;
     });
 
     return () => {
@@ -453,6 +454,7 @@ export default function App() {
       });
     }).then((unlisten) => {
       cleanup = unlisten;
+      return;
     });
 
     const syncState = async () => {

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -1033,6 +1033,7 @@ const FileChatOverlayInner = ({
               // and want to see the response stream in.
               setPanelOpen(true);
               void sendMessage({ text: prompt });
+              return;
             });
           }}
           onTogglePanel={() => setPanelOpen((v) => !v)}

--- a/apps/web/src/components/empty-screen.tsx
+++ b/apps/web/src/components/empty-screen.tsx
@@ -462,6 +462,7 @@ const EmptyScreenVideoOverlay = ({
               className="aspect-video w-full"
               loading="lazy"
               referrerPolicy="strict-origin-when-cross-origin"
+              sandbox="allow-scripts allow-presentation allow-popups"
               src={playableVideo.src}
               title={playableVideo.title}
             />

--- a/apps/web/src/routes/_protected.knowledge/-components/clause-import-dialog.tsx
+++ b/apps/web/src/routes/_protected.knowledge/-components/clause-import-dialog.tsx
@@ -67,6 +67,7 @@ export const ClauseImportDialog = ({
           }
           const { clauses } = parsed;
           setPreviewCount(Array.isArray(clauses) ? clauses.length : 0);
+          return;
         })
         .catch(() => {
           setPreviewCount(null);

--- a/apps/web/src/routes/_protected.settings/organization.members.tsx
+++ b/apps/web/src/routes/_protected.settings/organization.members.tsx
@@ -110,7 +110,7 @@ function Members() {
       : data.members;
 
     const sorted = [...filtered].sort((a, b) => {
-      let cmp = 0;
+      let cmp: number;
       if (sort.key === "name") {
         cmp = a.user.name.localeCompare(b.user.name);
       } else if (sort.key === "role") {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/calendar/calendar-view.tsx
@@ -401,6 +401,7 @@ export const CalendarView = ({ view, workspaceId }: CalendarViewProps) => {
         })
         .then(() => {
           void invalidateCalendarTasks();
+          return;
         })
         .catch(() => {
           // non-critical
@@ -416,6 +417,7 @@ export const CalendarView = ({ view, workspaceId }: CalendarViewProps) => {
         })
         .then(() => {
           void invalidateCalendarTasks();
+          return;
         })
         .catch(() => {
           // non-critical

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -326,6 +326,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
           }
           setDetectedAnonymizationTerms([...byCanonical.values()]);
           markRan();
+          return;
         })
         .catch(() => {
           inFlightUntil = 0;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/existing-file-organizer-dialog.tsx
@@ -554,6 +554,7 @@ export const ExistingFileOrganizerDialog = ({
           title: t("workspaces.importOrganizer.organized"),
           timeout: undefined,
         });
+        return;
       })
       .catch((error: unknown) => {
         analytics.captureError(error);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/inspector/chat-tab-panel.tsx
@@ -374,6 +374,7 @@ export const ChatTabPanel = ({
                 // backend already parses `<entity-mention>` tags out
                 // of the `text` field, so we forward unchanged.
                 void sendMessage({ text: prompt });
+                return;
               });
             }}
             onTogglePanel={() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-detail-panel.tsx
@@ -140,6 +140,7 @@ export const TaskDetailPanel = ({
                   queryKey: workspacesKeys.overview(workspaceId),
                 }),
               ]);
+              return;
             })
             .catch(() => {
               /* non-critical */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/route.tsx
@@ -102,6 +102,7 @@ export const Route = createFileRoute("/_protected/workspaces/$workspaceId")({
           if (response.error) {
             onPrefetchError(toAPIError(response.error));
           }
+          return;
         })
         .catch(onPrefetchError);
     }

--- a/apps/web/src/routes/auth/otp.tsx
+++ b/apps/web/src/routes/auth/otp.tsx
@@ -132,6 +132,7 @@ function OTP() {
           if (timezones.includes(browserTz)) {
             await authClient.updateUser({ timezoneId: browserTz });
           }
+          return;
         })
         .catch((error: unknown) => {
           analytics.captureError(error);

--- a/apps/web/src/workers/anonymize-chat-worker.ts
+++ b/apps/web/src/workers/anonymize-chat-worker.ts
@@ -102,5 +102,6 @@ scope.addEventListener("message", (event: MessageEvent<AnonRequest>) => {
     // window.postMessage); the lint rule is window-specific.
     // eslint-disable-next-line unicorn/require-post-message-target-origin
     scope.postMessage(response);
+    return;
   });
 });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -46,6 +46,14 @@ export default defineConfig({
     "logical-assignment-operators": "off",
 
     "react/rules-of-hooks": "error",
+    "react/style-prop-object": "error",
+    "react/jsx-no-comment-textnodes": "error",
+    "react/iframe-missing-sandbox": "error",
+    "react/jsx-no-script-url": "error",
+    "react/button-has-type": "error",
+    "promise/always-return": "error",
+    "promise/no-return-in-finally": "error",
+    "no-useless-assignment": "error",
 
     "import/no-cycle": "error",
     "no-restricted-imports": [

--- a/packages/folio/src/components/TextContextMenu.tsx
+++ b/packages/folio/src/components/TextContextMenu.tsx
@@ -963,6 +963,7 @@ export function useTextContextMenu(
             .readText()
             .then((text) => {
               document.execCommand("insertText", false, text);
+              return;
             })
             .catch(() => {
               // Fallback - just try regular paste

--- a/packages/folio/src/core/docx/documentParser.ts
+++ b/packages/folio/src/core/docx/documentParser.ts
@@ -553,7 +553,6 @@ function scanRunForTextBoxDrawings(xmlRun: XmlElement): TextBoxRunScan {
       const fallback = branches.find(
         (b) => getLocalName(b.name ?? "") === "Fallback",
       );
-      let foundInBranch = false;
       const tryBranch = (branch: XmlElement | undefined): boolean => {
         if (!branch) {
           return false;
@@ -567,7 +566,7 @@ function scanRunForTextBoxDrawings(xmlRun: XmlElement): TextBoxRunScan {
         }
         return found;
       };
-      foundInBranch = tryBranch(choice);
+      let foundInBranch = tryBranch(choice);
       if (!foundInBranch) {
         foundInBranch = tryBranch(fallback);
       }

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -396,7 +396,7 @@ export function calculateHeaderFooterVisualBounds(
       // participate in the cursorY flow — they're positioned absolutely by
       // the renderer and can overlap surrounding HF content (Word
       // semantics for unwrapped floating tables).
-      let blockHeight = 0;
+      let blockHeight: number;
       let advancesCursor = true;
       if (block.kind === "table" && measure.kind === "table") {
         blockHeight = measure.totalHeight;
@@ -495,7 +495,7 @@ export function calculateHeaderFooterMarginPushBounds(
       // anchored images don't participate in HF flow either.
       continue;
     } else {
-      let blockHeight = 0;
+      let blockHeight: number;
       let advancesCursor = true;
       if (block.kind === "table" && measure.kind === "table") {
         blockHeight = measure.totalHeight;

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -508,6 +508,7 @@ export function selectionToRects(
             }
 
             // Check each paragraph in the cell
+            let blockY = 0;
             for (let blockIdx = 0; blockIdx < cell.blocks.length; blockIdx++) {
               const cellBlock = cell.blocks[blockIdx];
               const cellBlockMeasure = cellMeasure.blocks[blockIdx];
@@ -530,7 +531,6 @@ export function selectionToRects(
                 selTo,
               );
 
-              let blockY = 0;
               for (const { line, index } of intersectingLines) {
                 const range = computeLinePmRange(paragraphBlock, line);
                 if (range.pmStart === undefined || range.pmEnd === undefined) {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -698,7 +698,7 @@ function extractFloatingImagesFromParagraph(
     }
 
     // Determine vertical position
-    let y = 0;
+    let y: number;
 
     if (position?.vertical) {
       const v = position.vertical;

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1078,11 +1078,11 @@ export function renderLine(
 
   // Calculate justify spacing if needed
   const isJustify = alignment === "justify";
-  let shouldJustify = false;
 
   if (isJustify && options) {
     // Justify all lines except the last line (unless it ends with line break)
-    shouldJustify = !options.isLastLine || options.paragraphEndsWithLineBreak;
+    const shouldJustify =
+      !options.isLastLine || options.paragraphEndsWithLineBreak;
 
     if (shouldJustify) {
       // Use CSS text-align: justify with text-align-last: justify
@@ -1135,7 +1135,7 @@ export function renderLine(
   // Track current X position for tab calculations
   // Tab stops are measured from the content area left edge (page text area)
   // We need to track where on that coordinate system our text is
-  let currentX = 0;
+  let currentX: number;
   const leftIndentPx = options?.leftIndentPx ?? 0;
 
   if (options?.isFirstLine) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1708,7 +1708,7 @@ function convertImage(image: Image): PMNode {
   //   even though they don't carve a text-wrap exclusion zone)
   // - square / tight / through with cssFloat → float
   // - everything else (centered etc.) → block
-  let displayMode: "inline" | "block" | "float" = "inline";
+  let displayMode: "inline" | "block" | "float";
   if (wrapType === "inline") {
     displayMode = "inline";
   } else if (wrapType === "topAndBottom") {

--- a/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ImagePasteExtension.ts
@@ -67,8 +67,8 @@ async function insertImageFiles(
       continue;
     }
 
-    let naturalWidth = 1;
-    let naturalHeight = 1;
+    let naturalWidth: number;
+    let naturalHeight: number;
     try {
       ({ width: naturalWidth, height: naturalHeight } =
         await loadImageSize(dataUrl));

--- a/packages/folio/src/hooks/useTableSelection.ts
+++ b/packages/folio/src/hooks/useTableSelection.ts
@@ -146,7 +146,7 @@ export function useTableSelection({
       }
 
       let newTable: Table | null = null;
-      let newDoc: Document | null = null;
+      let newDoc: Document;
       let newRowIndex = state.rowIndex;
       let newColumnIndex = state.columnIndex;
 

--- a/packages/folio/src/paged-editor/SelectionOverlay.tsx
+++ b/packages/folio/src/paged-editor/SelectionOverlay.tsx
@@ -240,6 +240,7 @@ export function useSelectionOverlay(
           setSelectionRects(rects);
           setCaretPosition(null);
         }
+        return;
       },
     );
   }, [pmSelection, layout, blocks, measures]);


### PR DESCRIPTION
## Summary
- Enables nine high-signal oxlint rules: `promise/always-return`, `promise/no-return-in-finally`, `react/style-prop-object`, `react/jsx-no-comment-textnodes`, `react/jsx-no-script-url`, `react/iframe-missing-sandbox`, `react/button-has-type`, and `no-useless-assignment`.
- Fixes the 32 violations they surface across the monorepo (`apps/api`, `apps/collab`, `apps/desktop`, `apps/web`, `packages/folio`).
- `react/jsx-no-constructed-context-values` evaluated and dropped: redundant with the React Compiler, which already memoises inline context values.

## Notable
The dead-write rule caught a real bug in `packages/folio/src/core/layout-bridge/selectionRects.ts`: `let blockY = 0;` was scoped inside the per-paragraph loop, so the `blockY += paragraphMeasure.totalHeight;` accumulator was reset on every iteration. Selection rects across multi-paragraph table cells stacked at `y = 0` instead of advancing down the cell. Hoisting the declaration above the loop restores the intended accumulation.

One false positive in `apps/collab/src/server.test.ts` suppressed with a comment: the `null` initialiser is observed in the `finally` block if the constructor throws.

## Test plan
- [x] `bun run lint` clean across 22 packages
- [x] `bun run typecheck` clean across 22 packages
- [x] `bun --filter @stll/folio test` — 738 pass, 0 fail
- [ ] Visual sanity check: open a DOCX with a table whose cell contains 2+ paragraphs, select across them, confirm highlight rects stack correctly
- [ ] Visual sanity check: open the empty-screen YouTube embed, confirm video still plays after dropping `allow-same-origin` from the sandbox attribute