### PR TITLE
refactor(folio): harden canonical document boundaries

### DIFF
--- a/.agents/plans/039-folio-canonical-document-model.md
+++ b/.agents/plans/039-folio-canonical-document-model.md
@@ -1,0 +1,118 @@
+# Plan: Folio Canonical Document Model
+
+Date: 2026-05-24
+
+## Goal
+
+Make `@stll/docx-core/model` the canonical document contract for Folio so
+DOCX import, ProseMirror editing, layout, save, and export all pass through one
+typed and validated representation. The goal is to reduce document-corruption
+risk while keeping the editor maintainable for a single maintainer.
+
+## Design Decisions
+
+- **Use the existing docx-core model, not a new parallel model.** The model in
+  `packages/docx-core/src/model/*` already defines documents, paragraphs, runs,
+  tables, comments, sections, relationships, media, styles, and numbering. The
+  project needs stricter ownership of that model, not another abstraction.
+- **Treat ProseMirror as an adapter, not the source of truth.** ProseMirror
+  nodes and attrs are an editing format. Semantic document state should enter
+  and leave through typed adapter functions instead of raw `node.attrs` and
+  `mark.attrs` casts spread across conversion, layout, and components.
+- **Keep preservation data explicit.** Unsupported Word/OOXML data can be
+  preserved opaquely, but it should live in named preservation fields with
+  invariants rather than accidental plumbing through editor attrs.
+- **Validate before save/export.** Saving a legal document should fail loudly if
+  the canonical model is structurally invalid: broken comments, missing media
+  relationships, invalid table shape, orphaned numbering, duplicate IDs, or
+  section/header/footer loss.
+- **Ship as one PR with reviewable commits.** The PR should progress from
+  planning, to validation, to typed boundaries, to parse/save integration, so
+  reviewers can assess each layer independently.
+
+## Scope
+
+**In scope:**
+
+- Canonical model ownership around `@stll/docx-core/model`
+- Runtime validation/invariant checks for the document model
+- Typed ProseMirror attr readers and writers
+- Conversion boundary cleanup: DOCX to model to PM to model to DOCX
+- Save/export safety gates
+- Roundtrip and fixture tests for legal-document structures
+- Reducing broad Folio lint/type relaxations where adapter boundaries make them
+  unnecessary
+
+**Out of scope:**
+
+- Replacing ProseMirror
+- Rewriting the OOXML parser or serializer from scratch
+- Real-time collaboration changes
+- Major UI redesign
+- Perfect preservation of every obscure OOXML feature in the first pass
+
+## Implementation
+
+- `packages/docx-core/src/model/*` — keep these as the canonical semantic model.
+  Clarify semantic fields versus preservation payload only where needed.
+- `packages/docx-core/src/validate/docx.ts` — expand validation beyond package
+  shape into canonical model invariants: comments, media, relationships,
+  numbering, sections, tables, tracked changes, and IDs.
+- `packages/folio/src/core/prosemirror/attrs/` — add typed attr readers/writers,
+  for example `readParagraphAttrs(node)`, `readTableAttrs(node)`, and
+  `readRunMarkAttrs(mark)`. This becomes the approved place to touch raw
+  `node.attrs` and `mark.attrs`.
+- `packages/folio/src/core/prosemirror/conversion/toProseDoc.ts` — use typed
+  attr writers when converting canonical model objects into PM nodes.
+- `packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts` — replace
+  direct casts such as `node.attrs as ParagraphAttrs` with typed readers and
+  validation/narrowing.
+- `packages/folio/src/core/layout-bridge/toFlowBlocks.ts` — stop reading raw PM
+  attrs directly where possible. Consume typed projection helpers so layout
+  depends on a stable shape.
+- `packages/folio/src/core/docx/parser.ts` — after parsing, run canonical-model
+  validation and return warnings/errors in a structured way.
+- `packages/folio/src/core/docx/rezip.ts` and
+  `packages/folio/src/core/docx/selectiveSave.ts` — run save/export invariants
+  before patching or repacking. Keep existing fidelity checks, but make them
+  part of a broader validation gate.
+- `packages/folio/src/core/docx/__tests__/` — add fixture-oriented tests for
+  comments, tracked changes, headers/footers, footnotes, numbering, tables,
+  section breaks, images, and Czech/Slovak text.
+- `oxlint.config.ts` — after adapter boundaries exist, tighten Folio overrides
+  gradually. The goal is not zero casts everywhere; it is casts only at named
+  adapter and FFI files.
+
+## Test Cases
+
+- DOCX parse produces a valid canonical model for existing fixtures.
+- Model to PM to model preserves paragraphs, runs, tables, comments, tracked
+  changes, sections, numbering, headers/footers, footnotes, and media
+  relationships.
+- Save fails before writing if validation finds broken relationships or
+  structural corruption.
+- Selective save cannot drop section properties or header/footer references.
+- Unsupported OOXML preservation fields survive an edit when the user does not
+  touch the related structure.
+- Typed PM attr readers reject malformed attrs in unit tests.
+- Property tests cover generated paragraphs, tables, marks, comments, and
+  tracked changes.
+- Fixture roundtrips assert semantic invariants rather than byte equality.
+
+## Commit Stack
+
+- `docs: plan folio canonical document model`
+- `feat(docx-core): validate canonical document invariants`
+- `feat(folio): add typed prosemirror attr boundaries`
+- `fix(folio): validate parsed and saved documents`
+- `refactor(folio): route conversion through typed attrs`
+
+## Open Questions
+
+- Should validation live entirely in `@stll/docx-core`, or should Folio own
+  editor-specific invariants separately?
+- What should the first legal DOCX corpus contain: synthetic fixtures,
+  anonymized real documents, or both?
+- Should save/export validation be blocking immediately, or warning-only for one
+  migration phase?
+- Should ProseMirror attr access be lint-enforced once typed readers exist?

--- a/apps/api/drizzle/20260525153000_folio_collab_stella_grants/migration.sql
+++ b/apps/api/drizzle/20260525153000_folio_collab_stella_grants/migration.sql
@@ -1,0 +1,4 @@
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+  "folio_collab_sessions",
+  "folio_collab_session_tokens"
+TO stella;

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.test.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.test.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
+import type { AuditRecorder } from "@/api/lib/audit-log";
 import { toSafeId } from "@/api/lib/branded-types";
 import { DatabaseRlsError } from "@/api/lib/errors/tagged-errors";
 
@@ -14,6 +15,7 @@ describe("open desktop edit session", () => {
       message: "Database row-level security rejected the request",
     });
     const safeDb: SafeDb = async <T>() => Result.err<T, SafeDbError>(rlsError);
+    const recordAuditEvent: AuditRecorder = async () => undefined;
 
     const result = await Result.gen(() =>
       openDesktopEditSessionHandler({
@@ -26,6 +28,7 @@ describe("open desktop edit session", () => {
         organizationId: toSafeId<"organization">(
           "019e6000-0000-7000-8000-000000000003",
         ),
+        recordAuditEvent,
         safeDb,
         userId: toSafeId<"user">("019e6000-0000-7000-8000-000000000004"),
         workspaceId: toSafeId<"workspace">(

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.test.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.test.ts
@@ -1,0 +1,43 @@
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { SafeDb, SafeDbError } from "@/api/db";
+import { toSafeId } from "@/api/lib/branded-types";
+import { DatabaseRlsError } from "@/api/lib/errors/tagged-errors";
+
+import { openDesktopEditSessionHandler } from "./open-desktop-edit-session";
+
+describe("open desktop edit session", () => {
+  test("propagates safeDb errors so logs keep the database error type", async () => {
+    const rlsError = new DatabaseRlsError({
+      code: "42501",
+      message: "Database row-level security rejected the request",
+    });
+    const safeDb: SafeDb = async <T>() => Result.err<T, SafeDbError>(rlsError);
+
+    const result = await Result.gen(() =>
+      openDesktopEditSessionHandler({
+        body: {
+          entityId: toSafeId<"entity">("019e6000-0000-7000-8000-000000000001"),
+          propertyId: toSafeId<"property">(
+            "019e6000-0000-7000-8000-000000000002",
+          ),
+        },
+        organizationId: toSafeId<"organization">(
+          "019e6000-0000-7000-8000-000000000003",
+        ),
+        safeDb,
+        userId: toSafeId<"user">("019e6000-0000-7000-8000-000000000004"),
+        workspaceId: toSafeId<"workspace">(
+          "019e6000-0000-7000-8000-000000000005",
+        ),
+      }),
+    );
+
+    if (Result.isOk(result)) {
+      throw new Error("Expected openDesktopEditSessionHandler to fail");
+    }
+
+    expect(result.error).toBe(rlsError);
+  });
+});

--- a/apps/api/src/handlers/entities/open-desktop-edit-session.ts
+++ b/apps/api/src/handlers/entities/open-desktop-edit-session.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
-import type { SafeDb, Transaction } from "@/api/db";
+import type { SafeDb, SafeDbError, Transaction } from "@/api/db";
 import {
   desktopEditSessions,
   entityVersions,
@@ -58,6 +58,9 @@ type OpenDesktopEditSessionHandlerProps = {
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace">;
 };
+
+const isUniqueViolationSafeDbError = (error: SafeDbError): boolean =>
+  "cause" in error && isPgError(error.cause, PG_ERROR.UNIQUE_VIOLATION);
 
 type ExistingOpenDesktopEditSession = {
   baseVersionId: SafeId<"entityVersion">;
@@ -416,12 +419,10 @@ export const openDesktopEditSessionHandler = async function* ({
   // Handle unique violation: retry without insert, then with insert
   if (Result.isError(firstAttempt)) {
     const error = firstAttempt.error;
-    if ("cause" in error && isPgError(error.cause, PG_ERROR.UNIQUE_VIOLATION)) {
+    if (isUniqueViolationSafeDbError(error)) {
       const retryResult = await runOpenSession({ allowInsert: false });
       if (Result.isError(retryResult)) {
-        return Result.err(
-          new HandlerError({ status: 500, message: "Internal server error" }),
-        );
+        return Result.err(retryResult.error);
       }
       if (retryResult.value === null) {
         return Result.err(
@@ -430,9 +431,7 @@ export const openDesktopEditSessionHandler = async function* ({
       }
       firstAttempt = retryResult;
     } else {
-      return Result.err(
-        new HandlerError({ status: 500, message: "Internal server error" }),
-      );
+      return Result.err(error);
     }
   }
 

--- a/apps/api/src/tests/security/rls-table-grants.test.ts
+++ b/apps/api/src/tests/security/rls-table-grants.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+
+const DRIZZLE_DIR = resolve(import.meta.dir, "../../../drizzle");
+const BOOTSTRAP_MIGRATION = "20260510140000_document_rls_role_bootstrap";
+
+// These migrations were already in the tree when the bootstrap migration
+// introduced the `stella` RLS role and dynamically granted all existing
+// RLS tables. Do not add new migrations here; post-bootstrap tables need
+// an explicit table grant so existing deployed databases cannot drift.
+const BOOTSTRAP_COVERED_RLS_MIGRATIONS = new Set([
+  "20260429152450_entity-version-ai-summaries",
+  "20260429205610_global-search-indexes",
+  "20260429220500_global-search-unaccent",
+  "20260430131000_agenda_scheduler_infosoud",
+  "20260430211000_type-jsonb-metadata",
+  "20260501090000_entity-name-not-null",
+  "20260501115500_jsonb-driver-casts",
+  "20260501130000_chat-threads-context-matter-ids",
+  "20260501131500_case-law-offset-cursors",
+  "20260502093000_user-word-edit-preferences",
+  "20260502100000_property-status-cleanup",
+  "20260503100000_chat-threads-data-workspace-ids",
+  "20260503120000_anonymization_blacklist_entries",
+  "20260503150000_personal-matters",
+  "20260503184500_docx-folio-justifications-types",
+  "20260504000000_prompt-shortcuts",
+  "20260504100000_chat-threads-organization-scope",
+  "20260506100000_cell-metadata",
+  "20260507110000_practice-jurisdictions",
+  "20260507130000_mcp_connectors",
+  "20260507140000_mcp_connection_enabled",
+  "20260508152000_mcp_connection_resource_url",
+  "20260508161000_mcp_connection_authorization_server_url",
+  "20260509220000_disabled-native-tools",
+]);
+
+const SQL_IDENTIFIER_PATTERN = /"([^"]+)"|([a-z_][a-z0-9_]*)/giu;
+
+type RlsTableIntroduction = {
+  migration: string;
+  table: string;
+};
+
+const identifierNamesFromSql = (sqlList: string): string[] =>
+  [...sqlList.matchAll(SQL_IDENTIFIER_PATTERN)].map((match) => {
+    if (match[1] !== undefined) {
+      return match[1];
+    }
+
+    return match[2]?.toLowerCase() ?? "";
+  });
+
+const tableNameFromSql = (sqlTarget: string): string | null =>
+  identifierNamesFromSql(sqlTarget)
+    .toReversed()
+    .find((name) => name !== "public") ?? null;
+
+const stripSqlLineComments = (contents: string): string =>
+  contents
+    .split(/\r?\n/u)
+    .map((line) => {
+      const commentStart = line.indexOf("--");
+      return commentStart === -1 ? line : line.slice(0, commentStart);
+    })
+    .join("\n");
+
+const sqlStatements = (contents: string): string[] =>
+  stripSqlLineComments(contents)
+    .split(";")
+    .map((statement) => statement.replace(/\s+/gu, " ").trim())
+    .filter((statement) => statement.length > 0);
+
+const isStellaIdentifier = (value: string): boolean =>
+  value.trim().toLowerCase() === "stella" ||
+  value.trim().toLowerCase() === '"stella"';
+
+const migrationSqlFiles = () =>
+  readdirSync(DRIZZLE_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => resolve(DRIZZLE_DIR, entry.name, "migration.sql"))
+    .filter((path) => existsSync(path))
+    .toSorted();
+
+const enableRlsTableName = (statement: string): string | null => {
+  const prefix = "ALTER TABLE ";
+  const suffix = " ENABLE ROW LEVEL SECURITY";
+  const upperStatement = statement.toUpperCase();
+
+  if (!upperStatement.startsWith(prefix) || !upperStatement.endsWith(suffix)) {
+    return null;
+  }
+
+  return tableNameFromSql(statement.slice(prefix.length, -suffix.length));
+};
+
+const explicitStellaGrantTables = (statement: string): string[] => {
+  const prefix = "GRANT ";
+  const onTableMarker = " ON TABLE ";
+  const toMarker = " TO ";
+  const upperStatement = statement.toUpperCase();
+
+  if (!upperStatement.startsWith(prefix)) {
+    return [];
+  }
+
+  const onTableIndex = upperStatement.indexOf(onTableMarker);
+  const toIndex = upperStatement.lastIndexOf(toMarker);
+  if (onTableIndex === -1 || toIndex <= onTableIndex) {
+    return [];
+  }
+
+  const privilegesSql = statement.slice(prefix.length, onTableIndex);
+  const tablesSql = statement.slice(
+    onTableIndex + onTableMarker.length,
+    toIndex,
+  );
+  const targetRoleSql = statement.slice(toIndex + toMarker.length);
+
+  if (!isStellaIdentifier(targetRoleSql)) {
+    return [];
+  }
+
+  const privileges = new Set(identifierNamesFromSql(privilegesSql));
+  const grantsTableDml =
+    privileges.has("select") &&
+    privileges.has("insert") &&
+    privileges.has("update") &&
+    privileges.has("delete");
+  if (!grantsTableDml) {
+    return [];
+  }
+
+  return identifierNamesFromSql(tablesSql).filter((name) => name !== "public");
+};
+
+const collectRlsGrantState = () => {
+  const rlsTables: RlsTableIntroduction[] = [];
+  const explicitGrantMigrationsByTable = new Map<string, string[]>();
+
+  for (const path of migrationSqlFiles()) {
+    const migration = basename(resolve(path, ".."));
+    const statements = sqlStatements(readFileSync(path, "utf-8"));
+
+    for (const statement of statements) {
+      const rlsTable = enableRlsTableName(statement);
+      if (
+        rlsTable &&
+        migration !== BOOTSTRAP_MIGRATION &&
+        !BOOTSTRAP_COVERED_RLS_MIGRATIONS.has(migration)
+      ) {
+        rlsTables.push({ migration, table: rlsTable });
+      }
+
+      for (const table of explicitStellaGrantTables(statement)) {
+        const migrations = explicitGrantMigrationsByTable.get(table) ?? [];
+        migrations.push(migration);
+        explicitGrantMigrationsByTable.set(table, migrations);
+      }
+    }
+  }
+
+  return { explicitGrantMigrationsByTable, rlsTables };
+};
+
+describe("RLS table grants", () => {
+  test("post-bootstrap RLS tables explicitly grant stella table privileges", () => {
+    const { explicitGrantMigrationsByTable, rlsTables } =
+      collectRlsGrantState();
+
+    const missingGrants = rlsTables
+      .filter(
+        ({ migration, table }) =>
+          !explicitGrantMigrationsByTable
+            .get(table)
+            ?.some((grantMigration) => grantMigration >= migration),
+      )
+      .map(({ migration, table }) => `${migration}: ${table}`);
+
+    expect(missingGrants).toEqual([]);
+  });
+});

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Ukončit editaci",
     "fontColor": "Barva písma",
     "fontGroup": "Písmo",
+    "fontSize": "Velikost písma",
     "formattingToolbar": "Panel formátování",
     "hideDetails": "Skrýt podrobnosti",
     "historyGroup": "Historie",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Bearbeitung beenden",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Finish editing",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Terminar edición",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Lõpeta muutmine",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Terminer la modification",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Szerkesztés befejezése",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Baigti redagavimą",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Beigt rediģēšanu",
     "fontColor": "Font color",
     "fontGroup": "Font",
+    "fontSize": "Font size",
     "formattingToolbar": "Formatting toolbar",
     "hideDetails": "Hide details",
     "historyGroup": "History",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1072,6 +1072,7 @@ type Messages = {
     "finishEditing": "Finish editing";
     "fontColor": "Font color";
     "fontGroup": "Font";
+    "fontSize": "Font size";
     "formattingToolbar": "Formatting toolbar";
     "hideDetails": "Hide details";
     "historyGroup": "History";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Zakończ edycję",
     "fontColor": "Kolor czcionki",
     "fontGroup": "Czcionka",
+    "fontSize": "Rozmiar czcionki",
     "formattingToolbar": "Pasek formatowania",
     "hideDetails": "Ukryj szczegóły",
     "historyGroup": "Historia",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Concluir a edição",
     "fontColor": "Cor da fonte",
     "fontGroup": "Fonte",
+    "fontSize": "Tamanho da fonte",
     "formattingToolbar": "Barra de ferramentas de formatação",
     "hideDetails": "Ocultar detalhes",
     "historyGroup": "Histórico",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1069,6 +1069,7 @@
     "finishEditing": "Ukončiť úpravy",
     "fontColor": "Farba písma",
     "fontGroup": "Písmo",
+    "fontSize": "Veľkosť písma",
     "formattingToolbar": "Panel formátovania",
     "hideDetails": "Skryť detaily",
     "historyGroup": "História",

--- a/bun.lock
+++ b/bun.lock
@@ -352,6 +352,7 @@
       "name": "@stll/docx-core",
       "version": "0.1.0",
       "dependencies": {
+        "better-result": "catalog:",
         "jszip": "catalog:",
       },
       "devDependencies": {

--- a/packages/docx-core/package.json
+++ b/packages/docx-core/package.json
@@ -16,6 +16,7 @@
     "format": "oxfmt ."
   },
   "dependencies": {
+    "better-result": "catalog:",
     "jszip": "catalog:"
   },
   "devDependencies": {

--- a/packages/docx-core/src/index.ts
+++ b/packages/docx-core/src/index.ts
@@ -33,5 +33,13 @@ export type {
   LegalSourceParseResult,
 } from "./legal-source";
 export { serializeDocumentToDocx } from "./serialize/docx";
-export { validateDocxPackage } from "./validate/docx";
-export type { ValidateDocxPackageResult } from "./validate/docx";
+export {
+  assertValidDocumentModel,
+  validateDocxPackage,
+  validateDocumentModel,
+} from "./validate/docx";
+export type {
+  ValidateDocumentModelIssue,
+  ValidateDocumentModelResult,
+  ValidateDocxPackageResult,
+} from "./validate/docx";

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1055,6 +1055,19 @@ export type TableCellPropertyChange = {
 };
 
 /**
+ * Section property change (w:sectPrChange)
+ */
+export type SectionPropertyChange = {
+  type: "sectionPropertyChange";
+  /** Tracked change metadata */
+  info: PropertyChangeInfo;
+  /** Section properties before the tracked change */
+  previousProperties?: SectionProperties;
+  /** Section properties after the tracked change (editor model convenience) */
+  currentProperties?: SectionProperties;
+};
+
+/**
  * Table structural tracked change metadata (row/cell insert/delete/merge)
  */
 export type TableStructuralChangeInfo = {
@@ -1480,6 +1493,9 @@ export type SectionProperties = {
   rtlGutter?: boolean;
   /** Relationship id for printer settings */
   printerSettingsRelationshipId?: string;
+
+  /** Section-level tracked property changes (w:sectPrChange) */
+  propertyChanges?: SectionPropertyChange[];
 };
 
 // ============================================================================

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1452,6 +1452,8 @@ export type SectionProperties = {
   // Footnote/Endnote properties
   /** Footnote properties for this section */
   footnotePr?: FootnoteProperties;
+  /** Number of footnote columns in this section (`w15:footnoteColumns`) */
+  footnoteColumns?: number;
   /** Endnote properties for this section */
   endnotePr?: EndnoteProperties;
 

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -125,6 +125,7 @@ export type {
   TablePropertyChange,
   TableRowPropertyChange,
   TableCellPropertyChange,
+  SectionPropertyChange,
   TableStructuralChangeInfo,
   SdtType,
   SdtProperties,

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  BlockContent,
+  Comment,
+  Document,
+  Paragraph,
+  ParagraphContent,
+  Run,
+} from "../model/document";
+import { assertValidDocumentModel, validateDocumentModel } from "./docx";
+
+const textRun = (text = "Text"): Run => ({
+  type: "run",
+  content: [{ type: "text", text }],
+});
+
+const paragraph = (content: ParagraphContent[] = [textRun()]): Paragraph => ({
+  type: "paragraph",
+  content,
+});
+
+type CreateDocumentOptions = {
+  content?: BlockContent[];
+  comments?: Comment[];
+  footnotes?: Document["package"]["footnotes"];
+  headers?: Document["package"]["headers"];
+  numbering?: Document["package"]["numbering"];
+};
+
+const createDocument = ({
+  content = [paragraph()],
+  comments,
+  footnotes,
+  headers,
+  numbering,
+}: CreateDocumentOptions = {}): Document => ({
+  package: {
+    document: {
+      content,
+      ...(comments !== undefined ? { comments } : {}),
+    },
+    ...(footnotes !== undefined ? { footnotes } : {}),
+    ...(headers !== undefined ? { headers } : {}),
+    ...(numbering !== undefined ? { numbering } : {}),
+  },
+});
+
+describe("canonical DOCX document model validation", () => {
+  test("accepts a document with balanced comments and numbering", () => {
+    const doc = createDocument({
+      content: [
+        paragraph([
+          { type: "commentRangeStart", id: 1 },
+          textRun("Reviewed clause"),
+          { type: "commentRangeEnd", id: 1 },
+          { type: "commentReference", id: 1 },
+        ]),
+        {
+          type: "paragraph",
+          formatting: { numPr: { numId: 7, ilvl: 0 } },
+          content: [textRun("Numbered clause")],
+        },
+      ],
+      comments: [
+        {
+          id: 1,
+          author: "Reviewer",
+          content: [paragraph([textRun("Looks good")])],
+        },
+      ],
+      numbering: {
+        abstractNums: [
+          {
+            abstractNumId: 3,
+            levels: [{ ilvl: 0, numFmt: "decimal", lvlText: "%1." }],
+          },
+        ],
+        nums: [{ numId: 7, abstractNumId: 3 }],
+      },
+    });
+
+    const result = validateDocumentModel(doc);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+    expect(() => assertValidDocumentModel(doc)).not.toThrow();
+  });
+
+  test("rejects comment anchors without a matching comment", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [paragraph([{ type: "commentReference", id: 42 }])],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Comment 42 is referenced but not present in comments.xml.",
+    );
+  });
+
+  test("rejects unbalanced comment ranges", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [paragraph([{ type: "commentRangeStart", id: 5 }, textRun()])],
+        comments: [{ id: 5, author: "Reviewer", content: [paragraph()] }],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Unbalanced comment range 5: commentRangeStart=1, commentRangeEnd=0.",
+    );
+  });
+
+  test("rejects invalid table shape", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          {
+            type: "table",
+            rows: [
+              {
+                type: "tableRow",
+                cells: [{ type: "tableCell", content: [] }],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Table cell must contain block content.",
+    );
+  });
+
+  test("rejects missing numbering definitions", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          {
+            type: "paragraph",
+            formatting: { numPr: { numId: 9, ilvl: 0 } },
+            content: [textRun()],
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Numbering definition 9 is missing.",
+    );
+  });
+
+  test("rejects missing footnote packages", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            { type: "run", content: [{ type: "footnoteRef", id: 12 }] },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Footnote 12 is referenced but not present in the package.",
+    );
+  });
+
+  test("rejects section header references without a matching header part", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          {
+            type: "paragraph",
+            content: [textRun()],
+            sectionProperties: {
+              headerReferences: [{ type: "default", rId: "rIdHeader1" }],
+            },
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.message)).toContain(
+      "Section references missing header rIdHeader1.",
+    );
+  });
+});

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -113,6 +113,26 @@ describe("canonical DOCX document model validation", () => {
     );
   });
 
+  test("warns but accepts unbalanced bookmarks from real-world DOCX files", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            { type: "bookmarkStart", id: 1, name: "orphaned" },
+            textRun(),
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toContainEqual({
+      path: "package.document",
+      message: "Unbalanced bookmark 1: bookmarkStart=1, bookmarkEnd=0.",
+      severity: "warning",
+    });
+  });
+
   test("rejects invalid table shape", () => {
     const result = validateDocumentModel(
       createDocument({
@@ -153,6 +173,48 @@ describe("canonical DOCX document model validation", () => {
     expect(result.issues.map((issue) => issue.message)).toContain(
       "Numbering definition 9 is missing.",
     );
+  });
+
+  test("warns but accepts numbering levels beyond Word's standard range", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          {
+            type: "paragraph",
+            formatting: { numPr: { ilvl: 9 } },
+            content: [textRun()],
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toContainEqual({
+      path: "package.document.content[0].formatting.numPr.ilvl",
+      message: "List level is outside Word's standard 0-8 range.",
+      severity: "warning",
+    });
+  });
+
+  test("rejects negative numbering levels", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          {
+            type: "paragraph",
+            formatting: { numPr: { ilvl: -1 } },
+            content: [textRun()],
+          },
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContainEqual({
+      path: "package.document.content[0].formatting.numPr.ilvl",
+      message: "List level must be zero or greater.",
+      severity: "error",
+    });
   });
 
   test("rejects missing footnote packages", () => {
@@ -200,6 +262,39 @@ describe("canonical DOCX document model validation", () => {
 
     expect(result.valid).toBe(true);
     expect(result.issues).toEqual([]);
+  });
+
+  test("warns but accepts zero-size drawings from real-world DOCX files", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            {
+              type: "run",
+              content: [
+                {
+                  type: "drawing",
+                  image: {
+                    type: "image",
+                    rId: "",
+                    src: "data:image/png;base64,",
+                    size: { width: 9525, height: 0 },
+                    wrap: { type: "inline" },
+                  },
+                },
+              ],
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toContainEqual({
+      path: "package.document.content[0].content[0].content[0].image.size.height",
+      message: "Size is zero; the drawing may be invisible.",
+      severity: "warning",
+    });
   });
 
   test("rejects section header references without a matching header part", () => {

--- a/packages/docx-core/src/validate/docx.test.ts
+++ b/packages/docx-core/src/validate/docx.test.ts
@@ -172,6 +172,36 @@ describe("canonical DOCX document model validation", () => {
     );
   });
 
+  test("accepts opaque drawing XML placeholders without image relationships", () => {
+    const result = validateDocumentModel(
+      createDocument({
+        content: [
+          paragraph([
+            {
+              type: "run",
+              content: [
+                {
+                  type: "drawing",
+                  rawXml: "<mc:AlternateContent />",
+                  image: {
+                    type: "image",
+                    rId: "",
+                    src: "",
+                    size: { width: 9525, height: 9525 },
+                    wrap: { type: "inline" },
+                  },
+                },
+              ],
+            },
+          ]),
+        ],
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
   test("rejects section header references without a matching header part", () => {
     const result = validateDocumentModel(
       createDocument({

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -137,6 +137,7 @@ export const validateDocumentModel = (
     startName: "bookmarkStart",
     endName: "bookmarkEnd",
     ctx,
+    severity: "warning",
   });
   validateCounterPairs(ctx.moveFromStarts, ctx.moveFromEnds, {
     label: "move-from range",
@@ -520,8 +521,8 @@ const validateImage = (
     addError(ctx, `${path}.rId`, "Image must have a relationship id.");
   }
 
-  validatePositiveSize(image.size.width, `${path}.size.width`, ctx);
-  validatePositiveSize(image.size.height, `${path}.size.height`, ctx);
+  validateNonNegativeSize(image.size.width, `${path}.size.width`, ctx);
+  validateNonNegativeSize(image.size.height, `${path}.size.height`, ctx);
 };
 
 const validateShape = (
@@ -529,21 +530,26 @@ const validateShape = (
   path: string,
   ctx: ValidationContext,
 ): void => {
-  validatePositiveSize(shape.size.width, `${path}.size.width`, ctx);
-  validatePositiveSize(shape.size.height, `${path}.size.height`, ctx);
+  validateNonNegativeSize(shape.size.width, `${path}.size.width`, ctx);
+  validateNonNegativeSize(shape.size.height, `${path}.size.height`, ctx);
 
   if (shape.textBody) {
     validateParagraphs(shape.textBody.content, `${path}.textBody.content`, ctx);
   }
 };
 
-const validatePositiveSize = (
+const validateNonNegativeSize = (
   value: number,
   path: string,
   ctx: ValidationContext,
 ): void => {
-  if (value <= 0) {
-    addError(ctx, path, "Size must be greater than zero.");
+  if (value < 0) {
+    addError(ctx, path, "Size must be zero or greater.");
+    return;
+  }
+
+  if (value === 0) {
+    addWarning(ctx, path, "Size is zero; the drawing may be invisible.");
   }
 };
 
@@ -611,8 +617,18 @@ const validateNumbering = (
   }
 
   const ilvl = numPr.ilvl ?? 0;
-  if (ilvl < 0 || ilvl > 8) {
-    addError(ctx, `${path}.formatting.numPr.ilvl`, "List level must be 0-8.");
+  if (ilvl < 0) {
+    addError(
+      ctx,
+      `${path}.formatting.numPr.ilvl`,
+      "List level must be zero or greater.",
+    );
+  } else if (ilvl > 8) {
+    addWarning(
+      ctx,
+      `${path}.formatting.numPr.ilvl`,
+      "List level is outside Word's standard 0-8 range.",
+    );
   }
 
   if (numPr.numId === undefined || numPr.numId === 0) {
@@ -803,12 +819,19 @@ type ValidateCounterPairsOptions = {
   startName: string;
   endName: string;
   ctx: ValidationContext;
+  severity?: ValidateDocumentModelIssue["severity"];
 };
 
 const validateCounterPairs = (
   starts: CounterMap,
   ends: CounterMap,
-  { label, startName, endName, ctx }: ValidateCounterPairsOptions,
+  {
+    label,
+    startName,
+    endName,
+    ctx,
+    severity = "error",
+  }: ValidateCounterPairsOptions,
 ): void => {
   const ids = new Set([...starts.keys(), ...ends.keys()]);
   for (const id of ids) {
@@ -818,10 +841,11 @@ const validateCounterPairs = (
       continue;
     }
 
-    addError(
-      ctx,
-      "package.document",
-      `Unbalanced ${label} ${id}: ${startName}=${startCount}, ${endName}=${endCount}.`,
-    );
+    const message = `Unbalanced ${label} ${id}: ${startName}=${startCount}, ${endName}=${endCount}.`;
+    if (severity === "warning") {
+      addWarning(ctx, "package.document", message);
+      continue;
+    }
+    addError(ctx, "package.document", message);
   }
 };

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -433,7 +433,9 @@ const validateRunContent = (
   ctx: ValidationContext,
 ): void => {
   if (content.type === "drawing") {
-    validateImage(content.image, `${path}.image`, ctx);
+    validateImage(content.image, `${path}.image`, ctx, {
+      hasPreservedRawDrawing: content.rawXml?.trim() !== "",
+    });
     return;
   }
 
@@ -507,8 +509,13 @@ const validateImage = (
   image: Image,
   path: string,
   ctx: ValidationContext,
+  options: { hasPreservedRawDrawing?: boolean } = {},
 ): void => {
-  if (!image.rId && !image.src?.startsWith("data:")) {
+  if (
+    !image.rId &&
+    !image.src?.startsWith("data:") &&
+    !options.hasPreservedRawDrawing
+  ) {
     addError(ctx, `${path}.rId`, "Image must have a relationship id.");
   }
 

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -1,8 +1,39 @@
 import JSZip from "jszip";
 
+import type {
+  BlockContent,
+  Comment,
+  Document,
+  HeaderFooter,
+  HeaderFooterType,
+  Hyperlink,
+  Image,
+  Paragraph,
+  ParagraphContent,
+  Run,
+  RunContent,
+  SectionProperties,
+  Shape,
+  Table,
+  TableCell,
+  TableRow,
+  TrackedRunChange,
+} from "../model/document";
+
 export type ValidateDocxPackageResult =
   | { valid: true }
   | { valid: false; error: string };
+
+export type ValidateDocumentModelIssue = {
+  path: string;
+  message: string;
+  severity: "error" | "warning";
+};
+
+export type ValidateDocumentModelResult = {
+  valid: boolean;
+  issues: ValidateDocumentModelIssue[];
+};
 
 export const validateDocxPackage = async (
   buffer: ArrayBuffer | Uint8Array,
@@ -52,5 +83,737 @@ export const validateDocxPackage = async (
       valid: false,
       error: error instanceof Error ? error.message : "Invalid DOCX package.",
     };
+  }
+};
+
+type CounterMap = Map<number, number>;
+
+type ValidationContext = {
+  issues: ValidateDocumentModelIssue[];
+  commentIds: Set<number>;
+  referencedCommentIds: Map<number, string[]>;
+  commentRangeStarts: CounterMap;
+  commentRangeEnds: CounterMap;
+  bookmarkStarts: CounterMap;
+  bookmarkEnds: CounterMap;
+  moveFromStarts: CounterMap;
+  moveFromEnds: CounterMap;
+  moveToStarts: CounterMap;
+  moveToEnds: CounterMap;
+  noteRefs: {
+    footnote: Map<number, string[]>;
+    endnote: Map<number, string[]>;
+  };
+  paraIds: Map<string, string>;
+  numberingNums: Set<number>;
+  headers: Map<string, HeaderFooter> | undefined;
+  footers: Map<string, HeaderFooter> | undefined;
+};
+
+export const validateDocumentModel = (
+  document: Document,
+): ValidateDocumentModelResult => {
+  const ctx = createValidationContext(document);
+  validateBlocks(
+    document.package.document.content,
+    "package.document.content",
+    ctx,
+  );
+
+  validateHeaderFooterMap(document.package.headers, "package.headers", ctx);
+  validateHeaderFooterMap(document.package.footers, "package.footers", ctx);
+  validateComments(document.package.document.comments ?? [], ctx);
+  validateNotes(document, ctx);
+  validateMedia(document, ctx);
+  validateCounterPairs(ctx.commentRangeStarts, ctx.commentRangeEnds, {
+    label: "comment range",
+    startName: "commentRangeStart",
+    endName: "commentRangeEnd",
+    ctx,
+  });
+  validateCounterPairs(ctx.bookmarkStarts, ctx.bookmarkEnds, {
+    label: "bookmark",
+    startName: "bookmarkStart",
+    endName: "bookmarkEnd",
+    ctx,
+  });
+  validateCounterPairs(ctx.moveFromStarts, ctx.moveFromEnds, {
+    label: "move-from range",
+    startName: "moveFromRangeStart",
+    endName: "moveFromRangeEnd",
+    ctx,
+  });
+  validateCounterPairs(ctx.moveToStarts, ctx.moveToEnds, {
+    label: "move-to range",
+    startName: "moveToRangeStart",
+    endName: "moveToRangeEnd",
+    ctx,
+  });
+
+  const hasErrors = ctx.issues.some((issue) => issue.severity === "error");
+  return {
+    valid: !hasErrors,
+    issues: ctx.issues,
+  };
+};
+
+export const assertValidDocumentModel = (document: Document): void => {
+  const result = validateDocumentModel(document);
+  if (result.valid) {
+    return;
+  }
+
+  const details = result.issues
+    .filter((issue) => issue.severity === "error")
+    .map((issue) => `${issue.path}: ${issue.message}`)
+    .join("\n");
+  throw new Error(`Invalid DOCX document model:\n${details}`);
+};
+
+const createValidationContext = (document: Document): ValidationContext => ({
+  issues: [],
+  commentIds: new Set(
+    (document.package.document.comments ?? []).map((comment) => comment.id),
+  ),
+  referencedCommentIds: new Map(),
+  commentRangeStarts: new Map(),
+  commentRangeEnds: new Map(),
+  bookmarkStarts: new Map(),
+  bookmarkEnds: new Map(),
+  moveFromStarts: new Map(),
+  moveFromEnds: new Map(),
+  moveToStarts: new Map(),
+  moveToEnds: new Map(),
+  noteRefs: {
+    footnote: new Map(),
+    endnote: new Map(),
+  },
+  paraIds: new Map(),
+  numberingNums: new Set(
+    (document.package.numbering?.nums ?? []).map((num) => num.numId),
+  ),
+  headers: document.package.headers,
+  footers: document.package.footers,
+});
+
+const addIssue = (
+  ctx: ValidationContext,
+  issue: ValidateDocumentModelIssue,
+): void => {
+  ctx.issues.push(issue);
+};
+
+const addError = (
+  ctx: ValidationContext,
+  path: string,
+  message: string,
+): void => {
+  addIssue(ctx, { path, message, severity: "error" });
+};
+
+const addWarning = (
+  ctx: ValidationContext,
+  path: string,
+  message: string,
+): void => {
+  addIssue(ctx, { path, message, severity: "warning" });
+};
+
+const increment = (map: CounterMap, id: number): void => {
+  map.set(id, (map.get(id) ?? 0) + 1);
+};
+
+const recordPath = (
+  map: Map<number, string[]>,
+  id: number,
+  path: string,
+): void => {
+  const existing = map.get(id);
+  if (existing) {
+    existing.push(path);
+    return;
+  }
+  map.set(id, [path]);
+};
+
+const validateBlocks = (
+  blocks: readonly BlockContent[],
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  for (const [index, block] of blocks.entries()) {
+    validateBlock(block, `${path}[${index}]`, ctx);
+  }
+};
+
+const validateBlock = (
+  block: BlockContent,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (block.type === "paragraph") {
+    validateParagraph(block, path, ctx);
+    return;
+  }
+
+  if (block.type === "table") {
+    validateTable(block, path, ctx);
+    return;
+  }
+
+  if (block.content.length === 0) {
+    addWarning(ctx, `${path}.content`, "Block content control is empty.");
+    return;
+  }
+
+  validateBlocks(block.content, `${path}.content`, ctx);
+};
+
+const validateParagraph = (
+  paragraph: Paragraph,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (paragraph.paraId) {
+    const existingPath = ctx.paraIds.get(paragraph.paraId);
+    if (existingPath) {
+      addWarning(
+        ctx,
+        `${path}.paraId`,
+        `Duplicate paragraph id also appears at ${existingPath}.`,
+      );
+    } else {
+      ctx.paraIds.set(paragraph.paraId, path);
+    }
+  }
+
+  validateNumbering(paragraph, path, ctx);
+  if (paragraph.sectionProperties) {
+    validateSectionProperties(
+      paragraph.sectionProperties,
+      `${path}.sectionProperties`,
+      ctx,
+    );
+  }
+
+  for (const [index, content] of paragraph.content.entries()) {
+    validateParagraphContent(content, `${path}.content[${index}]`, ctx);
+  }
+};
+
+const validateParagraphContent = (
+  content: ParagraphContent,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (content.type === "run") {
+    validateRun(content, path, ctx);
+    return;
+  }
+
+  if (content.type === "hyperlink") {
+    validateHyperlink(content, path, ctx);
+    return;
+  }
+
+  if (content.type === "simpleField") {
+    for (const [index, child] of content.content.entries()) {
+      validateFieldChild(child, `${path}.content[${index}]`, ctx);
+    }
+    return;
+  }
+
+  if (content.type === "complexField") {
+    validateRuns(content.fieldCode, `${path}.fieldCode`, ctx);
+    validateRuns(content.fieldResult, `${path}.fieldResult`, ctx);
+    return;
+  }
+
+  if (content.type === "inlineSdt") {
+    for (const [index, child] of content.content.entries()) {
+      validateFieldChild(child, `${path}.content[${index}]`, ctx);
+    }
+    return;
+  }
+
+  if (content.type === "commentRangeStart") {
+    increment(ctx.commentRangeStarts, content.id);
+    recordPath(ctx.referencedCommentIds, content.id, path);
+    return;
+  }
+
+  if (content.type === "commentRangeEnd") {
+    increment(ctx.commentRangeEnds, content.id);
+    recordPath(ctx.referencedCommentIds, content.id, path);
+    return;
+  }
+
+  if (content.type === "commentReference") {
+    recordPath(ctx.referencedCommentIds, content.id, path);
+    return;
+  }
+
+  if (
+    content.type === "insertion" ||
+    content.type === "deletion" ||
+    content.type === "moveFrom" ||
+    content.type === "moveTo"
+  ) {
+    validateTrackedRunChange(content, path, ctx);
+    return;
+  }
+
+  if (content.type === "bookmarkStart") {
+    increment(ctx.bookmarkStarts, content.id);
+    return;
+  }
+
+  if (content.type === "bookmarkEnd") {
+    increment(ctx.bookmarkEnds, content.id);
+    return;
+  }
+
+  if (content.type === "moveFromRangeStart") {
+    increment(ctx.moveFromStarts, content.id);
+    return;
+  }
+
+  if (content.type === "moveFromRangeEnd") {
+    increment(ctx.moveFromEnds, content.id);
+    return;
+  }
+
+  if (content.type === "moveToRangeStart") {
+    increment(ctx.moveToStarts, content.id);
+    return;
+  }
+
+  if (content.type === "moveToRangeEnd") {
+    increment(ctx.moveToEnds, content.id);
+    return;
+  }
+
+  if (content.ommlXml.trim() === "") {
+    addError(ctx, `${path}.ommlXml`, "Math equation must preserve OMML XML.");
+  }
+};
+
+const validateFieldChild = (
+  child: Run | Hyperlink,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (child.type === "run") {
+    validateRun(child, path, ctx);
+    return;
+  }
+
+  validateHyperlink(child, path, ctx);
+};
+
+const validateRuns = (
+  runs: readonly Run[],
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  for (const [index, run] of runs.entries()) {
+    validateRun(run, `${path}[${index}]`, ctx);
+  }
+};
+
+const validateRun = (run: Run, path: string, ctx: ValidationContext): void => {
+  for (const [index, content] of run.content.entries()) {
+    validateRunContent(content, `${path}.content[${index}]`, ctx);
+  }
+};
+
+const validateRunContent = (
+  content: RunContent,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (content.type === "drawing") {
+    validateImage(content.image, `${path}.image`, ctx);
+    return;
+  }
+
+  if (content.type === "shape") {
+    validateShape(content.shape, `${path}.shape`, ctx);
+    return;
+  }
+
+  if (content.type === "footnoteRef" || content.type === "endnoteRef") {
+    const noteType = content.type === "footnoteRef" ? "footnote" : "endnote";
+    recordPath(ctx.noteRefs[noteType], content.id, path);
+    return;
+  }
+
+  if (content.type === "symbol" && content.char.trim() === "") {
+    addError(ctx, `${path}.char`, "Symbol content must include a character.");
+  }
+};
+
+const validateHyperlink = (
+  hyperlink: Hyperlink,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (!hyperlink.rId && !hyperlink.href && !hyperlink.anchor) {
+    addWarning(
+      ctx,
+      path,
+      "Hyperlink has no relationship, href, or internal anchor.",
+    );
+  }
+
+  for (const [index, child] of hyperlink.children.entries()) {
+    validateHyperlinkChild(child, `${path}.children[${index}]`, ctx);
+  }
+};
+
+const validateHyperlinkChild = (
+  child: Hyperlink["children"][number],
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (child.type === "run") {
+    validateRun(child, path, ctx);
+    return;
+  }
+
+  if (child.type === "bookmarkStart") {
+    increment(ctx.bookmarkStarts, child.id);
+    return;
+  }
+
+  increment(ctx.bookmarkEnds, child.id);
+};
+
+const validateTrackedRunChange = (
+  change: TrackedRunChange,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (change.info.author.trim() === "") {
+    addError(ctx, `${path}.info.author`, "Tracked change author is empty.");
+  }
+
+  for (const [index, child] of change.content.entries()) {
+    validateFieldChild(child, `${path}.content[${index}]`, ctx);
+  }
+};
+
+const validateImage = (
+  image: Image,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (!image.rId && !image.src?.startsWith("data:")) {
+    addError(ctx, `${path}.rId`, "Image must have a relationship id.");
+  }
+
+  validatePositiveSize(image.size.width, `${path}.size.width`, ctx);
+  validatePositiveSize(image.size.height, `${path}.size.height`, ctx);
+};
+
+const validateShape = (
+  shape: Shape,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  validatePositiveSize(shape.size.width, `${path}.size.width`, ctx);
+  validatePositiveSize(shape.size.height, `${path}.size.height`, ctx);
+
+  if (shape.textBody) {
+    validateParagraphs(shape.textBody.content, `${path}.textBody.content`, ctx);
+  }
+};
+
+const validatePositiveSize = (
+  value: number,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (value <= 0) {
+    addError(ctx, path, "Size must be greater than zero.");
+  }
+};
+
+const validateTable = (
+  table: Table,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (table.rows.length === 0) {
+    addError(ctx, `${path}.rows`, "Table must contain at least one row.");
+    return;
+  }
+
+  for (const [index, row] of table.rows.entries()) {
+    validateTableRow(row, `${path}.rows[${index}]`, ctx);
+  }
+};
+
+const validateTableRow = (
+  row: TableRow,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (row.cells.length === 0) {
+    addError(ctx, `${path}.cells`, "Table row must contain at least one cell.");
+    return;
+  }
+
+  for (const [index, cell] of row.cells.entries()) {
+    validateTableCell(cell, `${path}.cells[${index}]`, ctx);
+  }
+};
+
+const validateTableCell = (
+  cell: TableCell,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (cell.content.length === 0) {
+    addError(ctx, `${path}.content`, "Table cell must contain block content.");
+    return;
+  }
+
+  validateBlocks(cell.content, `${path}.content`, ctx);
+};
+
+const validateParagraphs = (
+  paragraphs: readonly Paragraph[],
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  for (const [index, paragraph] of paragraphs.entries()) {
+    validateParagraph(paragraph, `${path}[${index}]`, ctx);
+  }
+};
+
+const validateNumbering = (
+  paragraph: Paragraph,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  const numPr = paragraph.formatting?.numPr;
+  if (!numPr) {
+    return;
+  }
+
+  const ilvl = numPr.ilvl ?? 0;
+  if (ilvl < 0 || ilvl > 8) {
+    addError(ctx, `${path}.formatting.numPr.ilvl`, "List level must be 0-8.");
+  }
+
+  if (numPr.numId === undefined || numPr.numId === 0) {
+    return;
+  }
+
+  if (!ctx.numberingNums.has(numPr.numId)) {
+    addError(
+      ctx,
+      `${path}.formatting.numPr.numId`,
+      `Numbering definition ${numPr.numId} is missing.`,
+    );
+  }
+};
+
+const validateSectionProperties = (
+  section: SectionProperties,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  validateHeaderFooterReferences(
+    section.headerReferences ?? [],
+    ctx.headers,
+    `${path}.headerReferences`,
+    "header",
+    ctx,
+  );
+  validateHeaderFooterReferences(
+    section.footerReferences ?? [],
+    ctx.footers,
+    `${path}.footerReferences`,
+    "footer",
+    ctx,
+  );
+};
+
+const validateHeaderFooterReferences = (
+  refs: readonly { type: HeaderFooterType; rId: string }[],
+  map: Map<string, HeaderFooter> | undefined,
+  path: string,
+  label: "header" | "footer",
+  ctx: ValidationContext,
+): void => {
+  for (const [index, ref] of refs.entries()) {
+    if (!map?.has(ref.rId)) {
+      addError(
+        ctx,
+        `${path}[${index}].rId`,
+        `Section references missing ${label} ${ref.rId}.`,
+      );
+    }
+  }
+};
+
+const validateHeaderFooterMap = (
+  map: Map<string, HeaderFooter> | undefined,
+  path: string,
+  ctx: ValidationContext,
+): void => {
+  if (!map) {
+    return;
+  }
+
+  for (const [rId, headerFooter] of map.entries()) {
+    validateBlocks(headerFooter.content, `${path}.${rId}.content`, ctx);
+  }
+};
+
+const validateComments = (
+  comments: readonly Comment[],
+  ctx: ValidationContext,
+): void => {
+  const seen = new Set<number>();
+  for (const [index, comment] of comments.entries()) {
+    const path = `package.document.comments[${index}]`;
+    if (seen.has(comment.id)) {
+      addError(ctx, `${path}.id`, `Duplicate comment id ${comment.id}.`);
+    }
+    seen.add(comment.id);
+
+    if (comment.author.trim() === "") {
+      addError(ctx, `${path}.author`, "Comment author is empty.");
+    }
+
+    if (
+      comment.parentId !== undefined &&
+      !ctx.commentIds.has(comment.parentId)
+    ) {
+      addError(
+        ctx,
+        `${path}.parentId`,
+        `Parent comment ${comment.parentId} is missing.`,
+      );
+    }
+
+    validateParagraphs(comment.content, `${path}.content`, ctx);
+  }
+
+  for (const [id, paths] of ctx.referencedCommentIds.entries()) {
+    if (!ctx.commentIds.has(id)) {
+      addError(
+        ctx,
+        paths.at(0) ?? "package.document",
+        `Comment ${id} is referenced but not present in comments.xml.`,
+      );
+    }
+  }
+};
+
+const validateNotes = (document: Document, ctx: ValidationContext): void => {
+  validateNoteCollection({
+    refs: ctx.noteRefs.footnote,
+    notes: document.package.footnotes ?? [],
+    path: "package.footnotes",
+    label: "Footnote",
+    ctx,
+  });
+  validateNoteCollection({
+    refs: ctx.noteRefs.endnote,
+    notes: document.package.endnotes ?? [],
+    path: "package.endnotes",
+    label: "Endnote",
+    ctx,
+  });
+};
+
+type ValidateNoteCollectionOptions = {
+  refs: Map<number, string[]>;
+  notes: readonly { id: number; content: readonly BlockContent[] }[];
+  path: string;
+  label: "Footnote" | "Endnote";
+  ctx: ValidationContext;
+};
+
+const validateNoteCollection = ({
+  refs,
+  notes,
+  path,
+  label,
+  ctx,
+}: ValidateNoteCollectionOptions): void => {
+  const ids = new Set<number>();
+  for (const [index, note] of notes.entries()) {
+    if (ids.has(note.id)) {
+      addError(
+        ctx,
+        `${path}[${index}].id`,
+        `Duplicate ${label} id ${note.id}.`,
+      );
+    }
+    ids.add(note.id);
+    validateBlocks(note.content, `${path}[${index}].content`, ctx);
+  }
+
+  for (const [id, paths] of refs.entries()) {
+    if (!ids.has(id)) {
+      addError(
+        ctx,
+        paths.at(0) ?? path,
+        `${label} ${id} is referenced but not present in the package.`,
+      );
+    }
+  }
+};
+
+const validateMedia = (document: Document, ctx: ValidationContext): void => {
+  const media = document.package.media;
+  if (!media) {
+    return;
+  }
+
+  for (const [path, file] of media.entries()) {
+    const issuePath = `package.media.${path}`;
+    if (file.path.trim() === "") {
+      addError(ctx, `${issuePath}.path`, "Media file path is empty.");
+    }
+    if (file.mimeType.trim() === "") {
+      addError(ctx, `${issuePath}.mimeType`, "Media MIME type is empty.");
+    }
+    if (file.data.byteLength === 0) {
+      addWarning(ctx, `${issuePath}.data`, "Media file has no binary data.");
+    }
+  }
+};
+
+type ValidateCounterPairsOptions = {
+  label: string;
+  startName: string;
+  endName: string;
+  ctx: ValidationContext;
+};
+
+const validateCounterPairs = (
+  starts: CounterMap,
+  ends: CounterMap,
+  { label, startName, endName, ctx }: ValidateCounterPairsOptions,
+): void => {
+  const ids = new Set([...starts.keys(), ...ends.keys()]);
+  for (const id of ids) {
+    const startCount = starts.get(id) ?? 0;
+    const endCount = ends.get(id) ?? 0;
+    if (startCount === endCount) {
+      continue;
+    }
+
+    addError(
+      ctx,
+      "package.document",
+      `Unbalanced ${label} ${id}: ${startName}=${startCount}, ${endName}=${endCount}.`,
+    );
   }
 };

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import JSZip from "jszip";
 
 import type {
@@ -167,7 +168,7 @@ export const assertValidDocumentModel = (document: Document): void => {
     .filter((issue) => issue.severity === "error")
     .map((issue) => `${issue.path}: ${issue.message}`)
     .join("\n");
-  throw new Error(`Invalid DOCX document model:\n${details}`);
+  panic(`Invalid DOCX document model:\n${details}`);
 };
 
 const createValidationContext = (document: Document): ValidationContext => ({

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -37,6 +37,7 @@ import {
 import type { ToolbarProps, FormattingAction } from "./toolbarPrimitives";
 import { AlignmentButtons } from "./ui/AlignmentButtons";
 import { FontPicker } from "./ui/FontPicker";
+import { FontSizePicker } from "./ui/FontSizePicker";
 import { ListButtons, createDefaultListState } from "./ui/ListButtons";
 import { StylePicker } from "./ui/StylePicker";
 
@@ -92,6 +93,7 @@ export function FormattingBar(props: FormattingBarProps) {
     children,
     showStylePicker = true,
     showFontPicker = true,
+    showFontSizePicker = true,
     showTextColorPicker = true,
     showAlignmentButtons = true,
     showListButtons = true,
@@ -134,6 +136,16 @@ export function FormattingBar(props: FormattingBarProps) {
     (fontFamily: string) => {
       if (!disabled && onFormat) {
         onFormat({ type: "fontFamily", value: fontFamily });
+        requestAnimationFrame(() => onRefocusEditor?.());
+      }
+    },
+    [disabled, onFormat, onRefocusEditor],
+  );
+
+  const handleFontSizeChange = useCallback(
+    (sizePt: number) => {
+      if (!disabled && onFormat) {
+        onFormat({ type: "fontSize", value: sizePt });
         requestAnimationFrame(() => onRefocusEditor?.());
       }
     },
@@ -369,6 +381,18 @@ export function FormattingBar(props: FormattingBarProps) {
             disabled={disabled}
             width={108}
             placeholder="Arial"
+          />
+        )}
+        {showFontSizePicker && (
+          <FontSizePicker
+            value={
+              currentFormatting.fontSize !== undefined
+                ? currentFormatting.fontSize / 2
+                : undefined
+            }
+            onChange={handleFontSizeChange}
+            disabled={disabled}
+            placeholder={t("fontSize")}
           />
         )}
         {showTextColorPicker && (

--- a/packages/folio/src/components/hooks/useImageHandlers.ts
+++ b/packages/folio/src/components/hooks/useImageHandlers.ts
@@ -2,6 +2,20 @@ import { useCallback, useState } from "react";
 
 import type { EditorView } from "prosemirror-view";
 
+import {
+  expectImageAttrs,
+  mergeImageAttrs,
+} from "../../core/prosemirror/attrs";
+import type {
+  ImageAttrs,
+  ImagePositionAttrs,
+} from "../../core/prosemirror/schema/nodes";
+import {
+  IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
+  IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
+  IMAGE_VERTICAL_ALIGNMENT_VALUES,
+  IMAGE_VERTICAL_RELATIVE_TO_VALUES,
+} from "../../core/types/documentEnumValues";
 import { isSafeImageFile } from "../../core/utils/imageValidation";
 import type { ImagePositionData } from "../dialogs/ImagePositionDialog";
 import type { ImagePropertiesData } from "../dialogs/ImagePropertiesDialog";
@@ -107,28 +121,29 @@ export const useImageHandlers = ({
         return;
       }
 
-      // Map wrap type to image display mode + cssFloat
-      let imgDisplayMode = "inline";
-      let cssFloat: string | null = null;
-      let resolvedWrapType = wrapType;
+      let imgDisplayMode: ImageAttrs["displayMode"] = "inline";
+      let cssFloat: ImageAttrs["cssFloat"];
+      let resolvedWrapType: ImageAttrs["wrapType"];
 
       switch (wrapType) {
         case "inline":
+          resolvedWrapType = "inline";
           imgDisplayMode = "inline";
-          cssFloat = null;
           break;
         case "square":
         case "tight":
         case "through":
+          resolvedWrapType = wrapType;
           imgDisplayMode = "float";
           cssFloat = "left";
           break;
         case "topAndBottom":
+          resolvedWrapType = "topAndBottom";
           imgDisplayMode = "block";
-          cssFloat = null;
           break;
         case "behind":
         case "inFront":
+          resolvedWrapType = wrapType;
           imgDisplayMode = "float";
           cssFloat = "none";
           break;
@@ -143,15 +158,18 @@ export const useImageHandlers = ({
           resolvedWrapType = "square";
           break;
         default:
-          break;
+          return;
       }
 
-      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        wrapType: resolvedWrapType,
-        displayMode: imgDisplayMode,
-        cssFloat,
-      });
+      const tr = view.state.tr.setNodeMarkup(
+        pos,
+        undefined,
+        mergeImageAttrs(node, {
+          wrapType: resolvedWrapType,
+          displayMode: imgDisplayMode,
+          cssFloat,
+        }),
+      );
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
     },
@@ -172,7 +190,7 @@ export const useImageHandlers = ({
         return;
       }
 
-      const currentTransform = (node.attrs["transform"] as string) || "";
+      const currentTransform = expectImageAttrs(node).transform ?? "";
 
       // Parse current rotation and flip state
       const rotateMatch = /rotate\((-?\d+(?:\.\d+)?)deg\)/u.exec(
@@ -211,12 +229,13 @@ export const useImageHandlers = ({
       if (hasFlipV) {
         parts.push("scaleY(-1)");
       }
-      const newTransform = parts.length > 0 ? parts.join(" ") : null;
+      const newTransform = parts.length > 0 ? parts.join(" ") : undefined;
 
-      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        transform: newTransform,
-      });
+      const tr = view.state.tr.setNodeMarkup(
+        pos,
+        undefined,
+        mergeImageAttrs(node, { transform: newTransform }),
+      );
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
     },
@@ -237,17 +256,26 @@ export const useImageHandlers = ({
         return;
       }
 
-      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        position: {
-          horizontal: data.horizontal,
-          vertical: data.vertical,
-        },
-        distTop: data.distTop ?? node.attrs["distTop"],
-        distBottom: data.distBottom ?? node.attrs["distBottom"],
-        distLeft: data.distLeft ?? node.attrs["distLeft"],
-        distRight: data.distRight ?? node.attrs["distRight"],
-      });
+      const attrs = expectImageAttrs(node);
+      const horizontal = normalizeHorizontalPosition(data.horizontal);
+      const vertical = normalizeVerticalPosition(data.vertical);
+      const tr = view.state.tr.setNodeMarkup(
+        pos,
+        undefined,
+        mergeImageAttrs(node, {
+          position:
+            horizontal || vertical
+              ? {
+                  ...(horizontal ? { horizontal } : {}),
+                  ...(vertical ? { vertical } : {}),
+                }
+              : undefined,
+          distTop: data.distTop ?? attrs.distTop,
+          distBottom: data.distBottom ?? attrs.distBottom,
+          distLeft: data.distLeft ?? attrs.distLeft,
+          distRight: data.distRight ?? attrs.distRight,
+        }),
+      );
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
     },
@@ -273,13 +301,16 @@ export const useImageHandlers = ({
         return;
       }
 
-      const tr = view.state.tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        alt: data.alt ?? null,
-        borderWidth: data.borderWidth ?? null,
-        borderColor: data.borderColor ?? null,
-        borderStyle: data.borderStyle ?? null,
-      });
+      const tr = view.state.tr.setNodeMarkup(
+        pos,
+        undefined,
+        mergeImageAttrs(node, {
+          alt: data.alt,
+          borderWidth: data.borderWidth,
+          borderColor: data.borderColor,
+          borderStyle: data.borderStyle,
+        }),
+      );
       view.dispatch(tr.scrollIntoView());
       focusActiveEditor();
     },
@@ -299,6 +330,56 @@ export const useImageHandlers = ({
     handleApplyImageProperties,
   };
 };
+
+const normalizeHorizontalPosition = (
+  data: ImagePositionData["horizontal"],
+): ImagePositionAttrs["horizontal"] | undefined => {
+  if (!data) {
+    return undefined;
+  }
+  if (!isOneOf(data.relativeTo, IMAGE_HORIZONTAL_RELATIVE_TO_VALUES)) {
+    return undefined;
+  }
+
+  const align = isOneOf(data.align, IMAGE_HORIZONTAL_ALIGNMENT_VALUES)
+    ? data.align
+    : undefined;
+  return {
+    relativeTo: data.relativeTo,
+    ...(typeof data.posOffset === "number"
+      ? { posOffset: data.posOffset }
+      : {}),
+    ...(align ? { align } : {}),
+  };
+};
+
+const normalizeVerticalPosition = (
+  data: ImagePositionData["vertical"],
+): ImagePositionAttrs["vertical"] | undefined => {
+  if (!data) {
+    return undefined;
+  }
+  if (!isOneOf(data.relativeTo, IMAGE_VERTICAL_RELATIVE_TO_VALUES)) {
+    return undefined;
+  }
+
+  const align = isOneOf(data.align, IMAGE_VERTICAL_ALIGNMENT_VALUES)
+    ? data.align
+    : undefined;
+  return {
+    relativeTo: data.relativeTo,
+    ...(typeof data.posOffset === "number"
+      ? { posOffset: data.posOffset }
+      : {}),
+    ...(align ? { align } : {}),
+  };
+};
+
+const isOneOf = <T extends string>(
+  value: string | undefined,
+  values: readonly T[],
+): value is T =>
+  value !== undefined && values.some((allowed) => allowed === value);
 
 async function insertSelectedImage(
   file: File,

--- a/packages/folio/src/components/ui/FontSizePicker.tsx
+++ b/packages/folio/src/components/ui/FontSizePicker.tsx
@@ -1,0 +1,89 @@
+/**
+ * Font Size Picker — uses Stella's Select component.
+ * Values are points; internally the editor stores half-points (OOXML w:sz).
+ */
+
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "@stll/ui/components/select";
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+export type FontSizePickerProps = {
+  /** Current size in points. */
+  value?: number | undefined;
+  /** Called with the new size in points. */
+  onChange?: ((sizePt: number) => void) | undefined;
+  /** Override the default size list. Values in points. */
+  sizes?: number[] | undefined;
+  disabled?: boolean | undefined;
+  placeholder?: string | undefined;
+  width?: number | string | undefined;
+};
+
+// Word's standard size ladder, in points.
+const DEFAULT_SIZES = [
+  8, 9, 10, 10.5, 11, 12, 14, 16, 18, 20, 22, 24, 26, 28, 36, 48, 72,
+] as const;
+
+const NUMERIC_FORMATTER = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 1,
+  useGrouping: false,
+});
+
+function formatSize(pt: number): string {
+  return NUMERIC_FORMATTER.format(pt);
+}
+
+export function FontSizePicker({
+  value,
+  onChange,
+  sizes,
+  disabled = false,
+  placeholder = "",
+  width = 56,
+}: FontSizePickerProps) {
+  const sizeOptions = sizes ?? Array.from(DEFAULT_SIZES);
+  const selectedLabel = value === undefined ? undefined : formatSize(value);
+
+  return (
+    <Select
+      value={selectedLabel}
+      onValueChange={(label) => {
+        const parsed = Number.parseFloat(label);
+        if (!Number.isFinite(parsed) || parsed <= 0) {
+          return;
+        }
+        onChange?.(parsed);
+      }}
+      disabled={disabled}
+    >
+      <SelectTrigger
+        size="sm"
+        className="min-h-0 min-w-0 border-transparent bg-transparent text-sm text-[var(--doc-text-muted)] tabular-nums shadow-none hover:bg-[var(--doc-primary-light)] hover:text-[var(--doc-text)] data-[pressed]:bg-[var(--doc-primary-light)]"
+        style={{
+          width: typeof width === "number" ? `${width}px` : width,
+          height: 28,
+        }}
+      >
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectPopup>
+        {sizeOptions.map((size) => {
+          const label = formatSize(size);
+          return (
+            <SelectItem key={label} value={label}>
+              {label}
+            </SelectItem>
+          );
+        })}
+      </SelectPopup>
+    </Select>
+  );
+}

--- a/packages/folio/src/components/ui/FontSizePicker.tsx
+++ b/packages/folio/src/components/ui/FontSizePicker.tsx
@@ -56,6 +56,9 @@ export function FontSizePicker({
     <Select
       value={selectedLabel}
       onValueChange={(label) => {
+        if (typeof label !== "string") {
+          return;
+        }
         const parsed = Number.parseFloat(label);
         if (!Number.isFinite(parsed) || parsed <= 0) {
           return;

--- a/packages/folio/src/core/docx/blockContentParser.ts
+++ b/packages/folio/src/core/docx/blockContentParser.ts
@@ -8,6 +8,8 @@
  */
 
 import type {
+  BookmarkEnd,
+  BookmarkStart,
   MediaFile,
   Paragraph,
   RelationshipMap,
@@ -17,6 +19,12 @@ import type {
   Table,
   Theme,
 } from "../types/document";
+import { parseBookmarkEnd, parseBookmarkStart } from "./bookmarkParser";
+import {
+  appendBookmarkMarkerToLastParagraphInBlocks,
+  prependBookmarkMarkersToFirstParagraphInBlocks,
+} from "./bookmarkPlacement";
+import type { BookmarkMarker } from "./bookmarkPlacement";
 import { convertBulletToUnicode } from "./bulletMarkers";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
@@ -362,11 +370,13 @@ const parseBlockContentWithState = (
 ): (Paragraph | Table)[] => {
   const content: (Paragraph | Table)[] = [];
   const children = getChildElements(parent);
+  const pendingBookmarkMarkers: BookmarkMarker[] = [];
 
   for (const child of children) {
     const name = child.name ?? "";
+    const localName = getLocalName(name);
 
-    if (name === "w:p" || name.endsWith(":p")) {
+    if (localName === "p") {
       const paragraph = parseParagraph(
         child,
         styles,
@@ -376,6 +386,7 @@ const parseBlockContentWithState = (
         media,
         state.options,
       );
+      prependPendingBookmarkMarkers(paragraph, pendingBookmarkMarkers);
       enrichParagraphTextBoxes(
         paragraph,
         child,
@@ -395,7 +406,7 @@ const parseBlockContentWithState = (
       continue;
     }
 
-    if (name === "w:tbl" || name.endsWith(":tbl")) {
+    if (localName === "tbl") {
       const table = parseTable(
         child,
         styles,
@@ -405,31 +416,83 @@ const parseBlockContentWithState = (
         media,
         state.options,
       );
+      if (
+        prependBookmarkMarkersToFirstParagraphInBlocks(
+          [table],
+          pendingBookmarkMarkers,
+        )
+      ) {
+        pendingBookmarkMarkers.length = 0;
+      }
       content.push(table);
       continue;
     }
 
-    if (name === "w:sdt" || name.endsWith(":sdt")) {
+    if (localName === "sdt") {
       const sdtContent = (child.elements ?? []).find(
         (el: XmlElement) =>
           el.type === "element" &&
           (el.name === "w:sdtContent" || el.name?.endsWith(":sdtContent")),
       );
       if (sdtContent) {
-        content.push(
-          ...parseBlockContentWithState(
-            sdtContent,
-            styles,
-            theme,
-            numbering,
-            rels,
-            media,
-            state,
-          ),
+        const sdtBlockContent = parseBlockContentWithState(
+          sdtContent,
+          styles,
+          theme,
+          numbering,
+          rels,
+          media,
+          state,
         );
+        if (
+          prependBookmarkMarkersToFirstParagraphInBlocks(
+            sdtBlockContent,
+            pendingBookmarkMarkers,
+          )
+        ) {
+          pendingBookmarkMarkers.length = 0;
+        }
+        content.push(...sdtBlockContent);
+      }
+      continue;
+    }
+
+    if (localName === "bookmarkStart" || localName === "bookmarkEnd") {
+      const marker = parseBookmarkMarker(child, localName);
+      if (!appendBookmarkMarkerToLastParagraphInBlocks(content, marker)) {
+        pendingBookmarkMarkers.push(marker);
       }
     }
   }
 
+  if (pendingBookmarkMarkers.length > 0) {
+    content.push({
+      type: "paragraph",
+      content: [...pendingBookmarkMarkers],
+    });
+  }
+
   return content;
+};
+
+const parseBookmarkMarker = (
+  child: XmlElement,
+  localName: "bookmarkStart" | "bookmarkEnd",
+): BookmarkStart | BookmarkEnd => {
+  if (localName === "bookmarkStart") {
+    return parseBookmarkStart(child);
+  }
+  return parseBookmarkEnd(child);
+};
+
+const prependPendingBookmarkMarkers = (
+  paragraph: Paragraph,
+  pendingBookmarkMarkers: BookmarkMarker[],
+): void => {
+  if (pendingBookmarkMarkers.length === 0) {
+    return;
+  }
+
+  paragraph.content.unshift(...pendingBookmarkMarkers);
+  pendingBookmarkMarkers.length = 0;
 };

--- a/packages/folio/src/core/docx/bookmarkPlacement.ts
+++ b/packages/folio/src/core/docx/bookmarkPlacement.ts
@@ -1,0 +1,119 @@
+import type {
+  BlockContent,
+  BookmarkEnd,
+  BookmarkStart,
+  Table,
+  TableCell,
+} from "../types/document";
+
+export type BookmarkMarker = BookmarkStart | BookmarkEnd;
+
+export const appendBookmarkMarkerToLastParagraphInBlocks = (
+  blocks: readonly BlockContent[],
+  marker: BookmarkMarker,
+): boolean => {
+  for (let index = blocks.length - 1; index >= 0; index -= 1) {
+    const block = blocks[index];
+    if (block && appendBookmarkMarkerToLastParagraph(block, marker)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const prependBookmarkMarkersToFirstParagraphInBlocks = (
+  blocks: readonly BlockContent[],
+  markers: readonly BookmarkMarker[],
+): boolean => {
+  if (markers.length === 0) {
+    return true;
+  }
+
+  for (const block of blocks) {
+    if (prependBookmarkMarkersToFirstParagraph(block, markers)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const appendBookmarkMarkerToLastParagraphInCells = (
+  cells: readonly TableCell[],
+  marker: BookmarkMarker,
+): boolean => {
+  for (let index = cells.length - 1; index >= 0; index -= 1) {
+    const cell = cells[index];
+    if (
+      cell &&
+      appendBookmarkMarkerToLastParagraphInBlocks(cell.content, marker)
+    ) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const prependBookmarkMarkersToFirstParagraphInCell = (
+  cell: TableCell,
+  markers: readonly BookmarkMarker[],
+): boolean =>
+  prependBookmarkMarkersToFirstParagraphInBlocks(cell.content, markers);
+
+const appendBookmarkMarkerToLastParagraph = (
+  block: BlockContent,
+  marker: BookmarkMarker,
+): boolean => {
+  if (block.type === "paragraph") {
+    block.content.push(marker);
+    return true;
+  }
+
+  if (block.type === "table") {
+    return appendBookmarkMarkerToLastParagraphInTable(block, marker);
+  }
+
+  return appendBookmarkMarkerToLastParagraphInBlocks(block.content, marker);
+};
+
+const appendBookmarkMarkerToLastParagraphInTable = (
+  table: Table,
+  marker: BookmarkMarker,
+): boolean => {
+  for (let rowIndex = table.rows.length - 1; rowIndex >= 0; rowIndex -= 1) {
+    const row = table.rows[rowIndex];
+    if (row && appendBookmarkMarkerToLastParagraphInCells(row.cells, marker)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const prependBookmarkMarkersToFirstParagraph = (
+  block: BlockContent,
+  markers: readonly BookmarkMarker[],
+): boolean => {
+  if (block.type === "paragraph") {
+    block.content.unshift(...markers);
+    return true;
+  }
+
+  if (block.type === "table") {
+    return prependBookmarkMarkersToFirstParagraphInTable(block, markers);
+  }
+
+  return prependBookmarkMarkersToFirstParagraphInBlocks(block.content, markers);
+};
+
+const prependBookmarkMarkersToFirstParagraphInTable = (
+  table: Table,
+  markers: readonly BookmarkMarker[],
+): boolean => {
+  for (const row of table.rows) {
+    for (const cell of row.cells) {
+      if (prependBookmarkMarkersToFirstParagraphInCell(cell, markers)) {
+        return true;
+      }
+    }
+  }
+  return false;
+};

--- a/packages/folio/src/core/docx/commentReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/commentReferenceNormalization.test.ts
@@ -126,4 +126,49 @@ describe("comment reference normalization", () => {
       id: 0,
     });
   });
+
+  test("re-anchors out-of-order valid range markers as point comments", () => {
+    const documentBody: DocumentBody = {
+      comments: [
+        {
+          id: 0,
+          author: "Reviewer",
+          content: [{ type: "paragraph", content: [] }],
+        },
+      ],
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "commentRangeEnd", id: 0 },
+            {
+              type: "run",
+              content: [{ type: "text", text: "Text" }],
+            },
+            { type: "commentRangeStart", id: 0 },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeCommentReferences({
+      documentBody,
+      comments: documentBody.comments ?? [],
+    });
+
+    expect(result).toEqual({
+      removedDanglingReferences: 0,
+      reanchoredUnbalancedRanges: 2,
+    });
+    const paragraph = documentBody.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "commentReference",
+      "run",
+      "commentReference",
+    ]);
+  });
 });

--- a/packages/folio/src/core/docx/commentReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/commentReferenceNormalization.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Comment, DocumentBody, HeaderFooter } from "../types/document";
+import { normalizeCommentReferences } from "./commentReferenceNormalization";
+
+describe("comment reference normalization", () => {
+  test("removes markers whose comments.xml entries are missing", () => {
+    const documentBody: DocumentBody = {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "commentRangeStart", id: 0 },
+            {
+              type: "run",
+              content: [{ type: "text", text: "Visible" }],
+            },
+            { type: "commentRangeEnd", id: 0 },
+            { type: "commentReference", id: 1 },
+          ],
+        },
+      ],
+    };
+    const comments: Comment[] = [
+      {
+        id: 1,
+        author: "Reviewer",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "commentReference", id: 404 },
+              {
+                type: "run",
+                content: [{ type: "text", text: "Comment body" }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const headers = new Map<string, HeaderFooter>([
+      [
+        "rIdHeader",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "commentReference", id: 404 }],
+            },
+          ],
+        },
+      ],
+    ]);
+
+    const result = normalizeCommentReferences({
+      documentBody,
+      comments,
+      headers,
+    });
+
+    expect(result).toEqual({
+      removedDanglingReferences: 4,
+      reanchoredUnbalancedRanges: 0,
+    });
+    const paragraph = documentBody.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "run",
+      "commentReference",
+    ]);
+    expect(
+      comments[0]?.content[0]?.content.map((content) => content.type),
+    ).toEqual(["run"]);
+    expect(
+      headers
+        .get("rIdHeader")
+        ?.content[0]?.content.map((content) => content.type),
+    ).toEqual([]);
+  });
+
+  test("re-anchors unbalanced valid ranges as point comments", () => {
+    const documentBody: DocumentBody = {
+      comments: [
+        {
+          id: 0,
+          author: "Reviewer",
+          content: [{ type: "paragraph", content: [] }],
+        },
+      ],
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "commentRangeStart", id: 0 },
+            {
+              type: "run",
+              content: [{ type: "text", text: "Text" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeCommentReferences({
+      documentBody,
+      comments: documentBody.comments ?? [],
+    });
+
+    expect(result).toEqual({
+      removedDanglingReferences: 0,
+      reanchoredUnbalancedRanges: 1,
+    });
+    const paragraph = documentBody.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.content.at(0)).toEqual({
+      type: "commentReference",
+      id: 0,
+    });
+  });
+});

--- a/packages/folio/src/core/docx/commentReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/commentReferenceNormalization.ts
@@ -141,23 +141,39 @@ const reanchorUnbalancedCommentRanges = (
 
   let reanchoredCount = 0;
   for (const markers of byId.values()) {
-    const starts = markers.filter(
-      (marker) => marker.type === "commentRangeStart",
-    );
-    const ends = markers.filter((marker) => marker.type === "commentRangeEnd");
-    const unbalanced =
-      starts.length > ends.length
-        ? starts.slice(ends.length)
-        : ends.slice(starts.length);
-    for (const marker of unbalanced) {
-      marker.content[marker.index] = {
-        type: "commentReference",
-        id: marker.id,
-      };
+    let openStart: CommentRangeMarkerRef | null = null;
+    for (const marker of markers) {
+      if (marker.type === "commentRangeStart") {
+        if (openStart) {
+          reanchorCommentRangeMarker(marker);
+          reanchoredCount += 1;
+          continue;
+        }
+        openStart = marker;
+        continue;
+      }
+
+      if (!openStart) {
+        reanchorCommentRangeMarker(marker);
+        reanchoredCount += 1;
+        continue;
+      }
+      openStart = null;
+    }
+
+    if (openStart) {
+      reanchorCommentRangeMarker(openStart);
       reanchoredCount += 1;
     }
   }
   return reanchoredCount;
+};
+
+const reanchorCommentRangeMarker = (marker: CommentRangeMarkerRef): void => {
+  marker.content[marker.index] = {
+    type: "commentReference",
+    id: marker.id,
+  };
 };
 
 const isCommentMarker = (

--- a/packages/folio/src/core/docx/commentReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/commentReferenceNormalization.ts
@@ -1,0 +1,180 @@
+import type {
+  BlockContent,
+  Comment,
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Paragraph,
+  ParagraphContent,
+  Table,
+} from "../types/document";
+
+type NormalizeCommentReferencesInput = {
+  documentBody: DocumentBody;
+  comments: readonly Comment[];
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+  footnotes?: readonly Footnote[];
+  endnotes?: readonly Endnote[];
+};
+
+type NormalizeCommentReferencesResult = {
+  removedDanglingReferences: number;
+  reanchoredUnbalancedRanges: number;
+};
+
+type CommentRangeMarkerRef = {
+  content: ParagraphContent[];
+  index: number;
+  id: number;
+  type: "commentRangeStart" | "commentRangeEnd";
+};
+
+export const normalizeCommentReferences = ({
+  documentBody,
+  comments,
+  headers,
+  footers,
+  footnotes,
+  endnotes,
+}: NormalizeCommentReferencesInput): NormalizeCommentReferencesResult => {
+  const validCommentIds = new Set(comments.map((comment) => comment.id));
+  const rangeMarkers: CommentRangeMarkerRef[] = [];
+  let removedDanglingReferences = 0;
+
+  const normalizeParagraph = (paragraph: Paragraph): void => {
+    const nextContent: ParagraphContent[] = [];
+    for (const content of paragraph.content) {
+      if (isCommentMarker(content) && !validCommentIds.has(content.id)) {
+        removedDanglingReferences += 1;
+        continue;
+      }
+      nextContent.push(content);
+      if (isCommentRangeMarker(content)) {
+        rangeMarkers.push({
+          content: nextContent,
+          index: nextContent.length - 1,
+          id: content.id,
+          type: content.type,
+        });
+      }
+    }
+    paragraph.content = nextContent;
+  };
+
+  const normalizeTable = (table: Table): void => {
+    for (const row of table.rows) {
+      for (const cell of row.cells) {
+        normalizeParagraphTableBlocks(cell.content);
+      }
+    }
+  };
+
+  const normalizeBlock = (block: BlockContent): void => {
+    if (block.type === "paragraph") {
+      normalizeParagraph(block);
+      return;
+    }
+    if (block.type === "table") {
+      normalizeTable(block);
+      return;
+    }
+    normalizeParagraphTableBlocks(block.content);
+  };
+
+  const normalizeBlocks = (blocks: BlockContent[]): void => {
+    for (const block of blocks) {
+      normalizeBlock(block);
+    }
+  };
+
+  const normalizeParagraphTableBlocks = (
+    blocks: (Paragraph | Table)[],
+  ): void => {
+    for (const block of blocks) {
+      if (block.type === "paragraph") {
+        normalizeParagraph(block);
+        continue;
+      }
+      normalizeTable(block);
+    }
+  };
+
+  normalizeBlocks(documentBody.content);
+  for (const header of headers?.values() ?? []) {
+    normalizeParagraphTableBlocks(header.content);
+  }
+  for (const footer of footers?.values() ?? []) {
+    normalizeParagraphTableBlocks(footer.content);
+  }
+  for (const footnote of footnotes ?? []) {
+    normalizeParagraphTableBlocks(footnote.content);
+  }
+  for (const endnote of endnotes ?? []) {
+    normalizeParagraphTableBlocks(endnote.content);
+  }
+  for (const comment of comments) {
+    for (const paragraph of comment.content) {
+      normalizeParagraph(paragraph);
+    }
+  }
+
+  return {
+    removedDanglingReferences,
+    reanchoredUnbalancedRanges: reanchorUnbalancedCommentRanges(rangeMarkers),
+  };
+};
+
+const reanchorUnbalancedCommentRanges = (
+  rangeMarkers: readonly CommentRangeMarkerRef[],
+): number => {
+  const byId = new Map<number, CommentRangeMarkerRef[]>();
+  for (const marker of rangeMarkers) {
+    const markers = byId.get(marker.id);
+    if (markers) {
+      markers.push(marker);
+      continue;
+    }
+    byId.set(marker.id, [marker]);
+  }
+
+  let reanchoredCount = 0;
+  for (const markers of byId.values()) {
+    const starts = markers.filter(
+      (marker) => marker.type === "commentRangeStart",
+    );
+    const ends = markers.filter((marker) => marker.type === "commentRangeEnd");
+    const unbalanced =
+      starts.length > ends.length
+        ? starts.slice(ends.length)
+        : ends.slice(starts.length);
+    for (const marker of unbalanced) {
+      marker.content[marker.index] = {
+        type: "commentReference",
+        id: marker.id,
+      };
+      reanchoredCount += 1;
+    }
+  }
+  return reanchoredCount;
+};
+
+const isCommentMarker = (
+  content: ParagraphContent,
+): content is Extract<
+  ParagraphContent,
+  | { type: "commentRangeStart" }
+  | { type: "commentRangeEnd" }
+  | { type: "commentReference" }
+> =>
+  content.type === "commentRangeStart" ||
+  content.type === "commentRangeEnd" ||
+  content.type === "commentReference";
+
+const isCommentRangeMarker = (
+  content: ParagraphContent,
+): content is Extract<
+  ParagraphContent,
+  { type: "commentRangeStart" } | { type: "commentRangeEnd" }
+> => content.type === "commentRangeStart" || content.type === "commentRangeEnd";

--- a/packages/folio/src/core/docx/documentParser.test.ts
+++ b/packages/folio/src/core/docx/documentParser.test.ts
@@ -391,3 +391,47 @@ describe("parseDocumentBody text box enrichment", () => {
     expect(cardTitles).toEqual(["Card 1", "Card 2", "Card 3"]);
   });
 });
+
+describe("parseDocumentBody bookmark placement", () => {
+  test("attaches body-level bookmark markers to adjacent paragraphs", () => {
+    const body = parseDocumentBody(`${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:bookmarkStart w:id="1" w:name="beforeFirst"/>
+    <w:p>
+      <w:r><w:t>First</w:t></w:r>
+      <w:bookmarkStart w:id="2" w:name="afterParagraph"/>
+    </w:p>
+    <w:bookmarkEnd w:id="2"/>
+    <w:p><w:r><w:t>Second</w:t></w:r></w:p>
+    <w:bookmarkEnd w:id="1"/>
+  </w:body>
+</w:document>`);
+
+    const firstParagraph = body.content.at(0);
+    expect(firstParagraph?.type).toBe("paragraph");
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      return;
+    }
+
+    expect(firstParagraph.content.at(0)).toMatchObject({
+      type: "bookmarkStart",
+      id: 1,
+    });
+    expect(firstParagraph.content.at(-1)).toMatchObject({
+      type: "bookmarkEnd",
+      id: 2,
+    });
+
+    const secondParagraph = body.content.at(1);
+    expect(secondParagraph?.type).toBe("paragraph");
+    if (!secondParagraph || secondParagraph.type !== "paragraph") {
+      return;
+    }
+
+    expect(secondParagraph.content.at(-1)).toMatchObject({
+      type: "bookmarkEnd",
+      id: 1,
+    });
+  });
+});

--- a/packages/folio/src/core/docx/documentParser.ts
+++ b/packages/folio/src/core/docx/documentParser.ts
@@ -243,7 +243,7 @@ export function parseDocumentBody(
   // Parse final section properties (w:body/w:sectPr)
   const finalSectPr = findChild(bodyEl, "w", "sectPr");
   if (finalSectPr) {
-    result.finalSectionProperties = parseSectionProperties(finalSectPr, rels);
+    result.finalSectionProperties = parseSectionProperties(finalSectPr);
   }
 
   // Build sections from content

--- a/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
@@ -7,6 +7,7 @@ import type {
   SectionProperties,
 } from "../types/document";
 import { normalizeHeaderFooterReferences } from "./headerFooterReferenceNormalization";
+import { getParagraphText } from "./paragraphParser";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { repackDocx } from "./rezip";
@@ -125,6 +126,30 @@ describe("normalizeHeaderFooterReferences", () => {
     expect(reparsedBlock.sectionProperties?.footerReferences).toEqual([
       { type: "default", rId: "rId2" },
     ]);
+  });
+
+  test("prefers the exact relationship target path over matching basenames", async () => {
+    const buffer = await createCollidingHeaderBasenameFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const header = doc.package.headers?.get("rId1");
+    const headerBlock = header?.content.at(0);
+
+    expect(headerBlock?.type).toBe("paragraph");
+    if (headerBlock?.type !== "paragraph") {
+      throw new Error("Expected first header block to be a paragraph");
+    }
+    expect(getParagraphText(headerBlock)).toBe("Custom header");
+
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+    const reparsedHeader = reparsed.package.headers?.get("rId1");
+    const reparsedHeaderBlock = reparsedHeader?.content.at(0);
+
+    expect(reparsedHeaderBlock?.type).toBe("paragraph");
+    if (reparsedHeaderBlock?.type !== "paragraph") {
+      throw new Error("Expected first reparsed header block to be a paragraph");
+    }
+    expect(getParagraphText(reparsedHeaderBlock)).toBe("Custom header");
   });
 });
 
@@ -249,3 +274,63 @@ const createNonNumberedHeaderFooterReferenceFixture =
     );
     return zip.generateAsync({ type: "arraybuffer" });
   };
+
+const createCollidingHeaderBasenameFixture = async (): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/custom/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.header}" Target="custom/header1.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:sectPr>
+          <w:headerReference w:type="default" r:id="rId1"/>
+        </w:sectPr>
+      </w:pPr>
+      <w:r><w:t>Body</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  zip.file(
+    "word/header1.xml",
+    `${XML_DECLARATION}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Top-level header</w:t></w:r></w:p>
+</w:hdr>`,
+  );
+  zip.file(
+    "word/custom/header1.xml",
+    `${XML_DECLARATION}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Custom header</w:t></w:r></w:p>
+</w:hdr>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};

--- a/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
@@ -82,6 +82,50 @@ describe("normalizeHeaderFooterReferences", () => {
       { type: "default", rId: "rId1" },
     ]);
   });
+
+  test("preserves non-numbered relationship-targeted header and footer parts", async () => {
+    const buffer = await createNonNumberedHeaderFooterReferenceFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const block = doc.package.document.content.at(0);
+
+    expect(doc.package.headers?.has("rId1")).toBe(true);
+    expect(doc.package.footers?.has("rId2")).toBe(true);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.sectionProperties?.headerReferences).toEqual([
+      { type: "default", rId: "rId1" },
+    ]);
+    expect(block.sectionProperties?.footerReferences).toEqual([
+      { type: "default", rId: "rId2" },
+    ]);
+    expect(doc.warnings ?? []).not.toContain(
+      "Removed 1 dangling header reference(s) whose header parts are missing.",
+    );
+    expect(doc.warnings ?? []).not.toContain(
+      "Removed 1 dangling footer reference(s) whose footer parts are missing.",
+    );
+
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+    const zip = await JSZip.loadAsync(repacked);
+    expect(zip.file("word/customHeaders/defaultHeader.xml")).toBeTruthy();
+    expect(zip.file("word/customFooters/defaultFooter.xml")).toBeTruthy();
+
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+    const reparsedBlock = reparsed.package.document.content.at(0);
+
+    expect(reparsedBlock?.type).toBe("paragraph");
+    if (reparsedBlock?.type !== "paragraph") {
+      throw new Error("Expected first reparsed block to be a paragraph");
+    }
+    expect(reparsedBlock.sectionProperties?.headerReferences).toEqual([
+      { type: "default", rId: "rId1" },
+    ]);
+    expect(reparsedBlock.sectionProperties?.footerReferences).toEqual([
+      { type: "default", rId: "rId2" },
+    ]);
+  });
 });
 
 const headerFooter = (type: "header" | "footer"): HeaderFooter => ({
@@ -142,3 +186,66 @@ const createDanglingFooterReferenceFixture = async (): Promise<ArrayBuffer> => {
   );
   return zip.generateAsync({ type: "arraybuffer" });
 };
+
+const createNonNumberedHeaderFooterReferenceFixture =
+  async (): Promise<ArrayBuffer> => {
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/customHeaders/defaultHeader.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/customFooters/defaultFooter.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.header}" Target="customHeaders/defaultHeader.xml"/>
+  <Relationship Id="rId2" Type="${RELATIONSHIP_TYPES.footer}" Target="customFooters/defaultFooter.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:sectPr>
+          <w:headerReference w:type="default" r:id="rId1"/>
+          <w:footerReference w:type="default" r:id="rId2"/>
+        </w:sectPr>
+      </w:pPr>
+      <w:r><w:t>Body</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/customHeaders/defaultHeader.xml",
+      `${XML_DECLARATION}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Header</w:t></w:r></w:p>
+</w:hdr>`,
+    );
+    zip.file(
+      "word/customFooters/defaultFooter.xml",
+      `${XML_DECLARATION}
+<w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Footer</w:t></w:r></w:p>
+</w:ftr>`,
+    );
+    return zip.generateAsync({ type: "arraybuffer" });
+  };

--- a/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/headerFooterReferenceNormalization.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type {
+  DocumentBody,
+  HeaderFooter,
+  SectionProperties,
+} from "../types/document";
+import { normalizeHeaderFooterReferences } from "./headerFooterReferenceNormalization";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
+
+const XML_DECLARATION =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+describe("normalizeHeaderFooterReferences", () => {
+  test("removes dangling section header and footer references", () => {
+    const sectionProperties: SectionProperties = {
+      headerReferences: [
+        { type: "default", rId: "rIdHeader" },
+        { type: "even", rId: "rIdMissingHeader" },
+      ],
+      footerReferences: [
+        { type: "default", rId: "rIdFooter" },
+        { type: "first", rId: "rIdMissingFooter" },
+      ],
+    };
+    const documentBody: DocumentBody = {
+      content: [
+        {
+          type: "paragraph",
+          sectionProperties,
+          content: [],
+        },
+      ],
+    };
+
+    const result = normalizeHeaderFooterReferences({
+      documentBody,
+      headers: new Map([["rIdHeader", headerFooter("header")]]),
+      footers: new Map([["rIdFooter", headerFooter("footer")]]),
+    });
+
+    expect(result).toEqual({
+      removedDanglingHeaderReferences: 1,
+      removedDanglingFooterReferences: 1,
+    });
+    expect(sectionProperties.headerReferences).toEqual([
+      { type: "default", rId: "rIdHeader" },
+    ]);
+    expect(sectionProperties.footerReferences).toEqual([
+      { type: "default", rId: "rIdFooter" },
+    ]);
+  });
+
+  test("parses and saves documents with dangling footer references", async () => {
+    const buffer = await createDanglingFooterReferenceFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const block = doc.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.sectionProperties?.footerReferences).toEqual([
+      { type: "default", rId: "rId1" },
+    ]);
+    expect(doc.warnings).toContain(
+      "Removed 1 dangling footer reference(s) whose footer parts are missing.",
+    );
+
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+    const reparsedBlock = reparsed.package.document.content.at(0);
+
+    expect(reparsedBlock?.type).toBe("paragraph");
+    if (reparsedBlock?.type !== "paragraph") {
+      throw new Error("Expected first reparsed block to be a paragraph");
+    }
+    expect(reparsedBlock.sectionProperties?.footerReferences).toEqual([
+      { type: "default", rId: "rId1" },
+    ]);
+  });
+});
+
+const headerFooter = (type: "header" | "footer"): HeaderFooter => ({
+  type,
+  hdrFtrType: "default",
+  content: [],
+});
+
+const createDanglingFooterReferenceFixture = async (): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/footer1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.footer}" Target="footer1.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:sectPr>
+          <w:footerReference w:type="default" r:id="rId1"/>
+          <w:footerReference w:type="even" r:id="rId12"/>
+        </w:sectPr>
+      </w:pPr>
+      <w:r><w:t>Body</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  zip.file(
+    "word/footer1.xml",
+    `${XML_DECLARATION}
+<w:ftr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Footer</w:t></w:r></w:p>
+</w:ftr>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};

--- a/packages/folio/src/core/docx/headerFooterReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/headerFooterReferenceNormalization.ts
@@ -1,0 +1,143 @@
+import type {
+  BlockContent,
+  DocumentBody,
+  HeaderFooter,
+  Paragraph,
+  SectionProperties,
+  Table,
+} from "../types/document";
+
+type NormalizeHeaderFooterReferencesInput = {
+  documentBody: DocumentBody;
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+};
+
+type NormalizeHeaderFooterReferencesResult = {
+  removedDanglingHeaderReferences: number;
+  removedDanglingFooterReferences: number;
+};
+
+export const normalizeHeaderFooterReferences = ({
+  documentBody,
+  headers,
+  footers,
+}: NormalizeHeaderFooterReferencesInput): NormalizeHeaderFooterReferencesResult => {
+  const seenSectionProperties = new Set<SectionProperties>();
+  let removedDanglingHeaderReferences = 0;
+  let removedDanglingFooterReferences = 0;
+
+  const normalizeSectionProperties = (
+    sectionProperties: SectionProperties | undefined,
+  ): void => {
+    if (!sectionProperties || seenSectionProperties.has(sectionProperties)) {
+      return;
+    }
+    seenSectionProperties.add(sectionProperties);
+
+    const headerResult = removeDanglingReferences(
+      sectionProperties.headerReferences,
+      headers,
+    );
+    if (headerResult.changed) {
+      removedDanglingHeaderReferences += headerResult.removed;
+      if (headerResult.references.length > 0) {
+        sectionProperties.headerReferences = headerResult.references;
+      } else {
+        delete sectionProperties.headerReferences;
+      }
+    }
+
+    const footerResult = removeDanglingReferences(
+      sectionProperties.footerReferences,
+      footers,
+    );
+    if (footerResult.changed) {
+      removedDanglingFooterReferences += footerResult.removed;
+      if (footerResult.references.length > 0) {
+        sectionProperties.footerReferences = footerResult.references;
+      } else {
+        delete sectionProperties.footerReferences;
+      }
+    }
+  };
+
+  const normalizeParagraph = (paragraph: Paragraph): void => {
+    normalizeSectionProperties(paragraph.sectionProperties);
+  };
+
+  const normalizeTable = (table: Table): void => {
+    for (const row of table.rows) {
+      for (const cell of row.cells) {
+        normalizeParagraphTableBlocks(cell.content);
+      }
+    }
+  };
+
+  const normalizeBlock = (block: BlockContent): void => {
+    if (block.type === "paragraph") {
+      normalizeParagraph(block);
+      return;
+    }
+    if (block.type === "table") {
+      normalizeTable(block);
+      return;
+    }
+    normalizeParagraphTableBlocks(block.content);
+  };
+
+  const normalizeBlocks = (blocks: BlockContent[]): void => {
+    for (const block of blocks) {
+      normalizeBlock(block);
+    }
+  };
+
+  const normalizeParagraphTableBlocks = (
+    blocks: (Paragraph | Table)[],
+  ): void => {
+    for (const block of blocks) {
+      if (block.type === "paragraph") {
+        normalizeParagraph(block);
+        continue;
+      }
+      normalizeTable(block);
+    }
+  };
+
+  normalizeBlocks(documentBody.content);
+  normalizeSectionProperties(documentBody.finalSectionProperties);
+  for (const section of documentBody.sections ?? []) {
+    normalizeSectionProperties(section.properties);
+  }
+
+  return {
+    removedDanglingHeaderReferences,
+    removedDanglingFooterReferences,
+  };
+};
+
+type HeaderFooterReference = {
+  rId: string;
+};
+
+type RemoveDanglingReferencesResult<T extends HeaderFooterReference> = {
+  changed: boolean;
+  references: T[];
+  removed: number;
+};
+
+const removeDanglingReferences = <T extends HeaderFooterReference>(
+  references: T[] | undefined,
+  validParts: Map<string, HeaderFooter> | undefined,
+): RemoveDanglingReferencesResult<T> => {
+  if (!references || !validParts) {
+    return { changed: false, references: references ?? [], removed: 0 };
+  }
+
+  const kept = references.filter((reference) => validParts.has(reference.rId));
+  return {
+    changed: kept.length !== references.length,
+    references: kept,
+    removed: references.length - kept.length,
+  };
+};

--- a/packages/folio/src/core/docx/modelValidation.ts
+++ b/packages/folio/src/core/docx/modelValidation.ts
@@ -1,0 +1,42 @@
+import { validateDocumentModel } from "@stll/docx-core";
+import type {
+  ValidateDocumentModelIssue,
+  ValidateDocumentModelResult,
+} from "@stll/docx-core";
+
+import type { Document } from "../types/document";
+
+export class DocxModelValidationError extends Error {
+  readonly issues: ValidateDocumentModelIssue[];
+
+  constructor(context: string, issues: ValidateDocumentModelIssue[]) {
+    super(`${context}:\n${formatDocumentModelIssues(issues).join("\n")}`);
+    this.name = "DocxModelValidationError";
+    this.issues = issues;
+  }
+}
+
+export const validateFolioDocumentModel = (
+  document: Document,
+): ValidateDocumentModelResult => validateDocumentModel(document);
+
+export const assertValidFolioDocumentModel = (
+  document: Document,
+  context: string,
+): void => {
+  const validation = validateFolioDocumentModel(document);
+  if (validation.valid) {
+    return;
+  }
+
+  throw new DocxModelValidationError(context, validation.issues);
+};
+
+export const formatDocumentModelIssues = (
+  issues: ValidateDocumentModelIssue[],
+): string[] =>
+  issues.map((issue) => {
+    const prefix =
+      issue.severity === "warning" ? "DOCX model warning" : "DOCX model error";
+    return `${prefix} at ${issue.path}: ${issue.message}`;
+  });

--- a/packages/folio/src/core/docx/numberingReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/numberingReferenceNormalization.test.ts
@@ -39,6 +39,37 @@ describe("normalizeNumberingReferences", () => {
     expect(block.formatting?.numPr).toBeUndefined();
   });
 
+  test("removes missing numbering references from comment paragraphs", () => {
+    const documentBody: DocumentBody = {
+      content: [],
+      comments: [
+        {
+          id: 1,
+          author: "Reviewer",
+          content: [
+            {
+              type: "paragraph",
+              formatting: { numPr: { numId: 2, ilvl: 0 } },
+              content: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeNumberingReferences({
+      documentBody,
+      numbering: parseNumbering(null),
+    });
+
+    expect(result).toEqual({
+      removedMissingNumberingReferences: 1,
+    });
+    expect(
+      documentBody.comments?.at(0)?.content.at(0)?.formatting?.numPr,
+    ).toBeUndefined();
+  });
+
   test("parses and saves documents that reference a missing numbering part", async () => {
     const buffer = await createMissingNumberingReferenceFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });

--- a/packages/folio/src/core/docx/numberingReferenceNormalization.test.ts
+++ b/packages/folio/src/core/docx/numberingReferenceNormalization.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { DocumentBody } from "../types/document";
+import { parseNumbering } from "./numberingParser";
+import { normalizeNumberingReferences } from "./numberingReferenceNormalization";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
+
+const XML_DECLARATION =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+describe("normalizeNumberingReferences", () => {
+  test("removes paragraph numbering references with no numbering definition", () => {
+    const documentBody: DocumentBody = {
+      content: [
+        {
+          type: "paragraph",
+          formatting: { numPr: { numId: 2, ilvl: 0 } },
+          content: [],
+        },
+      ],
+    };
+
+    const result = normalizeNumberingReferences({
+      documentBody,
+      numbering: parseNumbering(null),
+    });
+
+    expect(result).toEqual({
+      removedMissingNumberingReferences: 1,
+    });
+    const block = documentBody.content.at(0);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.formatting?.numPr).toBeUndefined();
+  });
+
+  test("parses and saves documents that reference a missing numbering part", async () => {
+    const buffer = await createMissingNumberingReferenceFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const block = doc.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.formatting?.numPr).toBeUndefined();
+    expect(doc.warnings).toContain(
+      "Removed 1 numbering reference(s) whose numbering definitions are missing.",
+    );
+
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+    const zip = await JSZip.loadAsync(repacked);
+    const documentXml = await zip.file("word/document.xml")?.async("string");
+
+    expect(documentXml).not.toContain("<w:numPr>");
+
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+    const reparsedBlock = reparsed.package.document.content.at(0);
+
+    expect(reparsedBlock?.type).toBe("paragraph");
+    if (reparsedBlock?.type !== "paragraph") {
+      throw new Error("Expected first reparsed block to be a paragraph");
+    }
+    expect(reparsedBlock.formatting?.numPr).toBeUndefined();
+  });
+});
+
+const createMissingNumberingReferenceFixture =
+  async (): Promise<ArrayBuffer> => {
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr>
+        <w:numPr>
+          <w:ilvl w:val="0"/>
+          <w:numId w:val="2"/>
+        </w:numPr>
+      </w:pPr>
+      <w:r><w:t>Body</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+    );
+    return zip.generateAsync({ type: "arraybuffer" });
+  };

--- a/packages/folio/src/core/docx/numberingReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/numberingReferenceNormalization.ts
@@ -1,16 +1,11 @@
 import type {
-  BlockContent,
   DocumentBody,
   Endnote,
   Footnote,
   HeaderFooter,
-  Hyperlink,
-  Paragraph,
-  ParagraphContent,
-  Run,
-  Table,
 } from "../types/document";
 import type { NumberingMap } from "./numberingParser";
+import { visitDocxParagraphs } from "./paragraphTraversal";
 
 type NormalizeNumberingReferencesInput = {
   documentBody: DocumentBody;
@@ -33,146 +28,23 @@ export const normalizeNumberingReferences = ({
   footnotes,
   endnotes,
 }: NormalizeNumberingReferencesInput): NormalizeNumberingReferencesResult => {
-  const seenParagraphs = new WeakSet<Paragraph>();
   let removedMissingNumberingReferences = 0;
 
-  const normalizeParagraph = (paragraph: Paragraph): void => {
-    if (seenParagraphs.has(paragraph)) {
-      return;
-    }
-    seenParagraphs.add(paragraph);
-
-    const numId = paragraph.formatting?.numPr?.numId;
-    if (numId !== undefined && numId !== 0 && !numbering.hasNumbering(numId)) {
-      delete paragraph.formatting?.numPr;
-      delete paragraph.listRendering;
-      removedMissingNumberingReferences += 1;
-    }
-
-    for (const content of paragraph.content) {
-      normalizeParagraphContent(content);
-    }
-  };
-
-  const normalizeRun = (run: Run): void => {
-    for (const content of run.content) {
-      if (content.type === "shape" && content.shape.textBody) {
-        for (const paragraph of content.shape.textBody.content) {
-          normalizeParagraph(paragraph);
-        }
+  visitDocxParagraphs(
+    { documentBody, headers, footers, footnotes, endnotes },
+    (paragraph) => {
+      const numId = paragraph.formatting?.numPr?.numId;
+      if (
+        numId !== undefined &&
+        numId !== 0 &&
+        !numbering.hasNumbering(numId)
+      ) {
+        delete paragraph.formatting?.numPr;
+        delete paragraph.listRendering;
+        removedMissingNumberingReferences += 1;
       }
-    }
-  };
-
-  const normalizeHyperlink = (hyperlink: Hyperlink): void => {
-    for (const child of hyperlink.children) {
-      if (child.type === "run") {
-        normalizeRun(child);
-      }
-    }
-  };
-
-  const normalizeInlineContent = (
-    content: readonly (Run | Hyperlink)[],
-  ): void => {
-    for (const child of content) {
-      if (child.type === "run") {
-        normalizeRun(child);
-        continue;
-      }
-      normalizeHyperlink(child);
-    }
-  };
-
-  const normalizeParagraphContent = (content: ParagraphContent): void => {
-    if (content.type === "run") {
-      normalizeRun(content);
-      return;
-    }
-    if (content.type === "hyperlink") {
-      normalizeHyperlink(content);
-      return;
-    }
-    if (
-      content.type === "simpleField" ||
-      content.type === "inlineSdt" ||
-      content.type === "insertion" ||
-      content.type === "deletion" ||
-      content.type === "moveFrom" ||
-      content.type === "moveTo"
-    ) {
-      normalizeInlineContent(content.content);
-      return;
-    }
-    if (content.type === "complexField") {
-      for (const run of content.fieldCode) {
-        normalizeRun(run);
-      }
-      for (const run of content.fieldResult) {
-        normalizeRun(run);
-      }
-    }
-  };
-
-  const normalizeTable = (table: Table): void => {
-    for (const row of table.rows) {
-      for (const cell of row.cells) {
-        normalizeParagraphTableBlocks(cell.content);
-      }
-    }
-  };
-
-  const normalizeBlock = (block: BlockContent): void => {
-    if (block.type === "paragraph") {
-      normalizeParagraph(block);
-      return;
-    }
-    if (block.type === "table") {
-      normalizeTable(block);
-      return;
-    }
-    normalizeParagraphTableBlocks(block.content);
-  };
-
-  const normalizeBlocks = (blocks: readonly BlockContent[]): void => {
-    for (const block of blocks) {
-      normalizeBlock(block);
-    }
-  };
-
-  const normalizeParagraphTableBlocks = (
-    blocks: readonly (Paragraph | Table)[],
-  ): void => {
-    for (const block of blocks) {
-      if (block.type === "paragraph") {
-        normalizeParagraph(block);
-        continue;
-      }
-      normalizeTable(block);
-    }
-  };
-
-  normalizeBlocks(documentBody.content);
-  for (const section of documentBody.sections ?? []) {
-    normalizeBlocks(section.content);
-  }
-  for (const header of headers?.values() ?? []) {
-    normalizeParagraphTableBlocks(header.content);
-  }
-  for (const footer of footers?.values() ?? []) {
-    normalizeParagraphTableBlocks(footer.content);
-  }
-  for (const footnote of footnotes ?? []) {
-    normalizeParagraphTableBlocks(footnote.content);
-  }
-  for (const endnote of endnotes ?? []) {
-    normalizeParagraphTableBlocks(endnote.content);
-  }
-  for (const comment of documentBody.comments ?? []) {
-    for (const paragraph of comment.content) {
-      normalizeParagraph(paragraph);
-    }
-  }
+    },
+  );
 
   return { removedMissingNumberingReferences };
 };

--- a/packages/folio/src/core/docx/numberingReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/numberingReferenceNormalization.ts
@@ -1,0 +1,178 @@
+import type {
+  BlockContent,
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Hyperlink,
+  Paragraph,
+  ParagraphContent,
+  Run,
+  Table,
+} from "../types/document";
+import type { NumberingMap } from "./numberingParser";
+
+type NormalizeNumberingReferencesInput = {
+  documentBody: DocumentBody;
+  numbering: NumberingMap;
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+  footnotes?: readonly Footnote[];
+  endnotes?: readonly Endnote[];
+};
+
+type NormalizeNumberingReferencesResult = {
+  removedMissingNumberingReferences: number;
+};
+
+export const normalizeNumberingReferences = ({
+  documentBody,
+  numbering,
+  headers,
+  footers,
+  footnotes,
+  endnotes,
+}: NormalizeNumberingReferencesInput): NormalizeNumberingReferencesResult => {
+  const seenParagraphs = new WeakSet<Paragraph>();
+  let removedMissingNumberingReferences = 0;
+
+  const normalizeParagraph = (paragraph: Paragraph): void => {
+    if (seenParagraphs.has(paragraph)) {
+      return;
+    }
+    seenParagraphs.add(paragraph);
+
+    const numId = paragraph.formatting?.numPr?.numId;
+    if (numId !== undefined && numId !== 0 && !numbering.hasNumbering(numId)) {
+      delete paragraph.formatting?.numPr;
+      delete paragraph.listRendering;
+      removedMissingNumberingReferences += 1;
+    }
+
+    for (const content of paragraph.content) {
+      normalizeParagraphContent(content);
+    }
+  };
+
+  const normalizeRun = (run: Run): void => {
+    for (const content of run.content) {
+      if (content.type === "shape" && content.shape.textBody) {
+        for (const paragraph of content.shape.textBody.content) {
+          normalizeParagraph(paragraph);
+        }
+      }
+    }
+  };
+
+  const normalizeHyperlink = (hyperlink: Hyperlink): void => {
+    for (const child of hyperlink.children) {
+      if (child.type === "run") {
+        normalizeRun(child);
+      }
+    }
+  };
+
+  const normalizeInlineContent = (
+    content: readonly (Run | Hyperlink)[],
+  ): void => {
+    for (const child of content) {
+      if (child.type === "run") {
+        normalizeRun(child);
+        continue;
+      }
+      normalizeHyperlink(child);
+    }
+  };
+
+  const normalizeParagraphContent = (content: ParagraphContent): void => {
+    if (content.type === "run") {
+      normalizeRun(content);
+      return;
+    }
+    if (content.type === "hyperlink") {
+      normalizeHyperlink(content);
+      return;
+    }
+    if (
+      content.type === "simpleField" ||
+      content.type === "inlineSdt" ||
+      content.type === "insertion" ||
+      content.type === "deletion" ||
+      content.type === "moveFrom" ||
+      content.type === "moveTo"
+    ) {
+      normalizeInlineContent(content.content);
+      return;
+    }
+    if (content.type === "complexField") {
+      for (const run of content.fieldCode) {
+        normalizeRun(run);
+      }
+      for (const run of content.fieldResult) {
+        normalizeRun(run);
+      }
+    }
+  };
+
+  const normalizeTable = (table: Table): void => {
+    for (const row of table.rows) {
+      for (const cell of row.cells) {
+        normalizeParagraphTableBlocks(cell.content);
+      }
+    }
+  };
+
+  const normalizeBlock = (block: BlockContent): void => {
+    if (block.type === "paragraph") {
+      normalizeParagraph(block);
+      return;
+    }
+    if (block.type === "table") {
+      normalizeTable(block);
+      return;
+    }
+    normalizeParagraphTableBlocks(block.content);
+  };
+
+  const normalizeBlocks = (blocks: readonly BlockContent[]): void => {
+    for (const block of blocks) {
+      normalizeBlock(block);
+    }
+  };
+
+  const normalizeParagraphTableBlocks = (
+    blocks: readonly (Paragraph | Table)[],
+  ): void => {
+    for (const block of blocks) {
+      if (block.type === "paragraph") {
+        normalizeParagraph(block);
+        continue;
+      }
+      normalizeTable(block);
+    }
+  };
+
+  normalizeBlocks(documentBody.content);
+  for (const section of documentBody.sections ?? []) {
+    normalizeBlocks(section.content);
+  }
+  for (const header of headers?.values() ?? []) {
+    normalizeParagraphTableBlocks(header.content);
+  }
+  for (const footer of footers?.values() ?? []) {
+    normalizeParagraphTableBlocks(footer.content);
+  }
+  for (const footnote of footnotes ?? []) {
+    normalizeParagraphTableBlocks(footnote.content);
+  }
+  for (const endnote of endnotes ?? []) {
+    normalizeParagraphTableBlocks(endnote.content);
+  }
+  for (const comment of documentBody.comments ?? []) {
+    for (const paragraph of comment.content) {
+      normalizeParagraph(paragraph);
+    }
+  }
+
+  return { removedMissingNumberingReferences };
+};

--- a/packages/folio/src/core/docx/paragraphParser.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser.test.ts
@@ -100,6 +100,59 @@ describe("parseParagraph tracked-change hardening", () => {
     expect(insertion.info.date).toBeUndefined();
   });
 
+  test("preserves tracked-change metadata for marker-only wrappers", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:ins w:id="12" w:author="Reviewer">
+          <w:bookmarkStart w:id="5" w:name="insertedMarker"/>
+        </w:ins>
+      </w:p>
+    `);
+
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "insertion",
+      "bookmarkStart",
+    ]);
+    const insertion = paragraph.content.at(0);
+    expect(insertion?.type).toBe("insertion");
+    if (!insertion || insertion.type !== "insertion") {
+      return;
+    }
+    expect(insertion.info).toMatchObject({ id: 12, author: "Reviewer" });
+    expect(insertion.content).toHaveLength(0);
+  });
+
+  test("preserves inline SDT metadata for marker-only controls", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr>
+            <w:alias w:val="Clause marker"/>
+            <w:tag w:val="clause-marker"/>
+          </w:sdtPr>
+          <w:sdtContent>
+            <w:bookmarkStart w:id="9" w:name="controlledMarker"/>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "inlineSdt",
+      "bookmarkStart",
+    ]);
+    const sdt = paragraph.content.at(0);
+    expect(sdt?.type).toBe("inlineSdt");
+    if (!sdt || sdt.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.properties).toMatchObject({
+      alias: "Clause marker",
+      tag: "clause-marker",
+    });
+    expect(sdt.content).toHaveLength(0);
+  });
+
   test("preserves point comment references from runs", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/packages/folio/src/core/docx/paragraphParser.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser.test.ts
@@ -117,6 +117,28 @@ describe("parseParagraph tracked-change hardening", () => {
       id: 42,
     });
   });
+
+  test("lifts bookmark markers out of tracked-change wrappers", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:bookmarkStart w:id="5" w:name="deletedRange"/>
+        <w:del w:id="7" w:author="Reviewer">
+          <w:r><w:delText>removed</w:delText></w:r>
+          <w:bookmarkEnd w:id="5"/>
+        </w:del>
+      </w:p>
+    `);
+
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "bookmarkStart",
+      "deletion",
+      "bookmarkEnd",
+    ]);
+    expect(paragraph.content.at(2)).toMatchObject({
+      type: "bookmarkEnd",
+      id: 5,
+    });
+  });
 });
 
 describe("parseParagraph rendered page break markers", () => {

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -27,12 +27,7 @@ import type {
   TabStop,
   RelationshipMap,
   MediaFile,
-  InlineSdt,
   SdtProperties,
-  Insertion,
-  Deletion,
-  MoveFrom,
-  MoveTo,
   ParagraphPropertyChange,
   TrackedChangeInfo,
   MathEquation,
@@ -894,6 +889,11 @@ function paragraphStartsWithRenderedPageBreak(node: XmlElement): boolean {
 }
 
 type TrackedChangeParseContext = "default" | "deletion";
+type TrackedChangeWrapperType =
+  | "insertion"
+  | "deletion"
+  | "moveFrom"
+  | "moveTo";
 
 function replaceLocalName(name: string | undefined, localName: string): string {
   if (!name) {
@@ -989,6 +989,115 @@ function parseParagraphPropertyChanges(
     .filter((change) => change.previousFormatting || change.currentFormatting);
 
   return changes.length > 0 ? changes : undefined;
+}
+
+function isTrackedChangeWrapperChild(
+  content: ParagraphContent,
+): content is Run | Hyperlink {
+  return content.type === "run" || content.type === "hyperlink";
+}
+
+type PushTrackedChangeWrapperParams = {
+  contents: ParagraphContent[];
+  type: TrackedChangeWrapperType;
+  info: TrackedChangeInfo;
+  content: readonly (Run | Hyperlink)[];
+};
+
+function pushTrackedChangeWrapper({
+  contents,
+  type,
+  info,
+  content,
+}: PushTrackedChangeWrapperParams): void {
+  if (content.length === 0) {
+    return;
+  }
+
+  if (type === "insertion") {
+    contents.push({ type: "insertion", info, content: [...content] });
+    return;
+  }
+
+  if (type === "deletion") {
+    contents.push({ type: "deletion", info, content: [...content] });
+    return;
+  }
+
+  if (type === "moveFrom") {
+    contents.push({ type: "moveFrom", info, content: [...content] });
+    return;
+  }
+
+  contents.push({ type: "moveTo", info, content: [...content] });
+}
+
+type PushTrackedChangeSegmentsParams = {
+  contents: ParagraphContent[];
+  type: TrackedChangeWrapperType;
+  info: TrackedChangeInfo;
+  parsedContent: readonly ParagraphContent[];
+};
+
+function pushTrackedChangeSegments({
+  contents,
+  type,
+  info,
+  parsedContent,
+}: PushTrackedChangeSegmentsParams): void {
+  const segment: (Run | Hyperlink)[] = [];
+
+  for (const content of parsedContent) {
+    if (isTrackedChangeWrapperChild(content)) {
+      segment.push(content);
+      continue;
+    }
+
+    pushTrackedChangeWrapper({ contents, type, info, content: segment });
+    segment.length = 0;
+    contents.push(content);
+  }
+
+  pushTrackedChangeWrapper({ contents, type, info, content: segment });
+}
+
+type PushInlineSdtSegmentsParams = {
+  contents: ParagraphContent[];
+  properties: SdtProperties;
+  parsedContent: readonly ParagraphContent[];
+};
+
+function pushInlineSdtSegments({
+  contents,
+  properties,
+  parsedContent,
+}: PushInlineSdtSegmentsParams): void {
+  const segment: (Run | Hyperlink)[] = [];
+
+  const pushSegment = (): void => {
+    if (segment.length === 0) {
+      return;
+    }
+
+    contents.push({
+      type: "inlineSdt",
+      properties,
+      content: [...segment],
+    });
+    segment.length = 0;
+  };
+
+  for (const content of parsedContent) {
+    if (isTrackedChangeWrapperChild(content)) {
+      segment.push(content);
+      continue;
+    }
+
+    pushSegment();
+    contents.push(content);
+  }
+
+  pushSegment();
 }
 
 /**
@@ -1250,15 +1359,11 @@ function parseParagraphContents(
             trackedContext,
           );
           const properties = parseSdtProperties(sdtPr ?? null);
-          const inlineSdt: InlineSdt = {
-            type: "inlineSdt",
+          pushInlineSdtSegments({
+            contents,
             properties,
-            content: sdtParsed.filter(
-              (c): c is Run | Hyperlink =>
-                c.type === "run" || c.type === "hyperlink",
-            ),
-          };
-          contents.push(inlineSdt);
+            parsedContent: sdtParsed,
+          });
         }
         break;
       }
@@ -1274,15 +1379,12 @@ function parseParagraphContents(
           rels,
           media,
         );
-        const insertion: Insertion = {
+        pushTrackedChangeSegments({
+          contents,
           type: "insertion",
           info: insInfo,
-          content: insContent.filter(
-            (c): c is Run | Hyperlink =>
-              c.type === "run" || c.type === "hyperlink",
-          ),
-        };
-        contents.push(insertion);
+          parsedContent: insContent,
+        });
         break;
       }
       case "del": {
@@ -1297,15 +1399,12 @@ function parseParagraphContents(
           media,
           "deletion",
         );
-        const deletion: Deletion = {
+        pushTrackedChangeSegments({
+          contents,
           type: "deletion",
           info: delInfo,
-          content: delContent.filter(
-            (c): c is Run | Hyperlink =>
-              c.type === "run" || c.type === "hyperlink",
-          ),
-        };
-        contents.push(deletion);
+          parsedContent: delContent,
+        });
         break;
       }
       case "moveFrom": {
@@ -1319,15 +1418,12 @@ function parseParagraphContents(
           media,
           "deletion",
         );
-        const moveFrom: MoveFrom = {
+        pushTrackedChangeSegments({
+          contents,
           type: "moveFrom",
           info: moveFromInfo,
-          content: moveFromContent.filter(
-            (c): c is Run | Hyperlink =>
-              c.type === "run" || c.type === "hyperlink",
-          ),
-        };
-        contents.push(moveFrom);
+          parsedContent: moveFromContent,
+        });
         break;
       }
 
@@ -1341,15 +1437,12 @@ function parseParagraphContents(
           rels,
           media,
         );
-        const moveTo: MoveTo = {
+        pushTrackedChangeSegments({
+          contents,
           type: "moveTo",
           info: moveToInfo,
-          content: moveToContent.filter(
-            (c): c is Run | Hyperlink =>
-              c.type === "run" || c.type === "hyperlink",
-          ),
-        };
-        contents.push(moveTo);
+          parsedContent: moveToContent,
+        });
         break;
       }
 

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -1624,7 +1624,7 @@ export function parseParagraph(
     // Check for section properties within paragraph (marks end of a section)
     const sectPr = findChild(pPr, "w", "sectPr");
     if (sectPr) {
-      paragraph.sectionProperties = parseSectionProperties(sectPr, rels);
+      paragraph.sectionProperties = parseSectionProperties(sectPr);
     }
   }
 

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -1002,6 +1002,7 @@ type PushTrackedChangeWrapperParams = {
   type: TrackedChangeWrapperType;
   info: TrackedChangeInfo;
   content: readonly (Run | Hyperlink)[];
+  preserveEmpty?: boolean;
 };
 
 function pushTrackedChangeWrapper({
@@ -1009,8 +1010,9 @@ function pushTrackedChangeWrapper({
   type,
   info,
   content,
+  preserveEmpty = false,
 }: PushTrackedChangeWrapperParams): void {
-  if (content.length === 0) {
+  if (content.length === 0 && !preserveEmpty) {
     return;
   }
 
@@ -1045,6 +1047,18 @@ function pushTrackedChangeSegments({
   info,
   parsedContent,
 }: PushTrackedChangeSegmentsParams): void {
+  if (!parsedContent.some(isTrackedChangeWrapperChild)) {
+    pushTrackedChangeWrapper({
+      contents,
+      type,
+      info,
+      content: [],
+      preserveEmpty: true,
+    });
+    contents.push(...parsedContent);
+    return;
+  }
+
   const segment: (Run | Hyperlink)[] = [];
 
   for (const content of parsedContent) {
@@ -1072,6 +1086,16 @@ function pushInlineSdtSegments({
   properties,
   parsedContent,
 }: PushInlineSdtSegmentsParams): void {
+  if (!parsedContent.some(isTrackedChangeWrapperChild)) {
+    contents.push({
+      type: "inlineSdt",
+      properties,
+      content: [],
+    });
+    contents.push(...parsedContent);
+    return;
+  }
+
   const segment: (Run | Hyperlink)[] = [];
 
   const pushSegment = (): void => {

--- a/packages/folio/src/core/docx/paragraphTraversal.ts
+++ b/packages/folio/src/core/docx/paragraphTraversal.ts
@@ -1,0 +1,164 @@
+import type {
+  BlockContent,
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  Hyperlink,
+  Paragraph,
+  ParagraphContent,
+  Run,
+  Table,
+} from "../types/document";
+
+type VisitDocxParagraphsInput = {
+  documentBody: DocumentBody;
+  headers?: Map<string, HeaderFooter> | undefined;
+  footers?: Map<string, HeaderFooter> | undefined;
+  footnotes?: readonly Footnote[] | undefined;
+  endnotes?: readonly Endnote[] | undefined;
+};
+
+export const visitDocxParagraphs = (
+  {
+    documentBody,
+    headers,
+    footers,
+    footnotes,
+    endnotes,
+  }: VisitDocxParagraphsInput,
+  visit: (paragraph: Paragraph) => void,
+): void => {
+  const seenParagraphs = new WeakSet<Paragraph>();
+
+  const visitParagraph = (paragraph: Paragraph): void => {
+    if (seenParagraphs.has(paragraph)) {
+      return;
+    }
+    seenParagraphs.add(paragraph);
+
+    visit(paragraph);
+    for (const content of paragraph.content) {
+      visitParagraphContent(content);
+    }
+  };
+
+  const visitRun = (run: Run): void => {
+    for (const content of run.content) {
+      if (content.type !== "shape" || !content.shape.textBody) {
+        continue;
+      }
+      for (const paragraph of content.shape.textBody.content) {
+        visitParagraph(paragraph);
+      }
+    }
+  };
+
+  const visitHyperlink = (hyperlink: Hyperlink): void => {
+    for (const child of hyperlink.children) {
+      if (child.type === "run") {
+        visitRun(child);
+      }
+    }
+  };
+
+  const visitInlineContent = (content: readonly (Run | Hyperlink)[]): void => {
+    for (const child of content) {
+      if (child.type === "run") {
+        visitRun(child);
+        continue;
+      }
+      visitHyperlink(child);
+    }
+  };
+
+  const visitParagraphContent = (content: ParagraphContent): void => {
+    if (content.type === "run") {
+      visitRun(content);
+      return;
+    }
+    if (content.type === "hyperlink") {
+      visitHyperlink(content);
+      return;
+    }
+    if (
+      content.type === "simpleField" ||
+      content.type === "inlineSdt" ||
+      content.type === "insertion" ||
+      content.type === "deletion" ||
+      content.type === "moveFrom" ||
+      content.type === "moveTo"
+    ) {
+      visitInlineContent(content.content);
+      return;
+    }
+    if (content.type === "complexField") {
+      for (const run of content.fieldCode) {
+        visitRun(run);
+      }
+      for (const run of content.fieldResult) {
+        visitRun(run);
+      }
+    }
+  };
+
+  const visitTable = (table: Table): void => {
+    for (const row of table.rows) {
+      for (const cell of row.cells) {
+        visitParagraphTableBlocks(cell.content);
+      }
+    }
+  };
+
+  const visitBlock = (block: BlockContent): void => {
+    if (block.type === "paragraph") {
+      visitParagraph(block);
+      return;
+    }
+    if (block.type === "table") {
+      visitTable(block);
+      return;
+    }
+    visitParagraphTableBlocks(block.content);
+  };
+
+  const visitBlocks = (blocks: readonly BlockContent[]): void => {
+    for (const block of blocks) {
+      visitBlock(block);
+    }
+  };
+
+  const visitParagraphTableBlocks = (
+    blocks: readonly (Paragraph | Table)[],
+  ): void => {
+    for (const block of blocks) {
+      if (block.type === "paragraph") {
+        visitParagraph(block);
+        continue;
+      }
+      visitTable(block);
+    }
+  };
+
+  visitBlocks(documentBody.content);
+  for (const section of documentBody.sections ?? []) {
+    visitBlocks(section.content);
+  }
+  for (const header of headers?.values() ?? []) {
+    visitParagraphTableBlocks(header.content);
+  }
+  for (const footer of footers?.values() ?? []) {
+    visitParagraphTableBlocks(footer.content);
+  }
+  for (const footnote of footnotes ?? []) {
+    visitParagraphTableBlocks(footnote.content);
+  }
+  for (const endnote of endnotes ?? []) {
+    visitParagraphTableBlocks(endnote.content);
+  }
+  for (const comment of documentBody.comments ?? []) {
+    for (const paragraph of comment.content) {
+      visitParagraph(paragraph);
+    }
+  }
+};

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -46,6 +46,11 @@ import {
 } from "./documentParser";
 import { parseFootnotes, parseEndnotes } from "./footnoteParser";
 import { parseHeader, parseFooter } from "./headerFooterParser";
+import {
+  DocxModelValidationError,
+  formatDocumentModelIssues,
+  validateFolioDocumentModel,
+} from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
 import type { NumberingMap } from "./numberingParser";
 import { parseRelationships, RELATIONSHIP_TYPES } from "./relsParser";
@@ -317,8 +322,20 @@ export async function parseDocx(
       originalBuffer: buffer,
       ...(templateVariables !== undefined ? { templateVariables } : {}),
       ...(requiredFonts.length > 0 ? { requiredFonts } : {}),
-      ...(warnings.length > 0 ? { warnings } : {}),
     };
+
+    const validation = validateFolioDocumentModel(document);
+    const parsedCompleteModel = parseHeadersFooters && parseNotes;
+    if (!validation.valid && parsedCompleteModel) {
+      throw new DocxModelValidationError(
+        "Parsed DOCX produced an invalid document model",
+        validation.issues,
+      );
+    }
+    warnings.push(...formatDocumentModelIssues(validation.issues));
+    if (warnings.length > 0) {
+      document.warnings = warnings;
+    }
 
     onProgress("Complete", 100);
     return document;

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -64,6 +64,7 @@ import {
 import { parseStyles, parseStyleDefinitions } from "./styleParser";
 import type { StyleMap } from "./styleParser";
 import { parseTheme } from "./themeParser";
+import { normalizeTrackedMoveRanges } from "./trackedMoveRangeNormalization";
 import { unzipDocx, getMediaMimeType, mediaToDataUrl } from "./unzip";
 import type { DocxUnzipLimits, RawDocxContent } from "./unzip";
 
@@ -321,6 +322,18 @@ export async function parseDocx(
     if (numberingReferenceNormalization.removedMissingNumberingReferences > 0) {
       warnings.push(
         `Removed ${numberingReferenceNormalization.removedMissingNumberingReferences} numbering reference(s) whose numbering definitions are missing.`,
+      );
+    }
+    const trackedMoveRangeNormalization = normalizeTrackedMoveRanges({
+      documentBody,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+      ...(footnotes !== undefined ? { footnotes } : {}),
+      ...(endnotes !== undefined ? { endnotes } : {}),
+    });
+    if (trackedMoveRangeNormalization.removedUnbalancedMoveRangeMarkers > 0) {
+      warnings.push(
+        `Removed ${trackedMoveRangeNormalization.removedUnbalancedMoveRangeMarkers} unbalanced tracked move range marker(s).`,
       );
     }
 

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -149,6 +149,7 @@ export async function parseDocx(
     const raw = await timeStageAsync("unzip", () =>
       unzipDocx(buffer, unzipLimits),
     );
+    warnings.push(...raw.warnings);
     onProgress("Extracted DOCX", 10);
 
     // ========================================================================

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -40,6 +40,7 @@ import {
   isTiffMimeType,
 } from "../utils/tiffConverter";
 import { parseComments } from "./commentParser";
+import { normalizeCommentReferences } from "./commentReferenceNormalization";
 import {
   parseDocumentBody,
   extractAllTemplateVariables,
@@ -265,6 +266,24 @@ export async function parseDocx(
     );
     if (comments.length > 0) {
       documentBody.comments = comments;
+    }
+    const commentReferenceNormalization = normalizeCommentReferences({
+      documentBody,
+      comments,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+      ...(footnotes !== undefined ? { footnotes } : {}),
+      ...(endnotes !== undefined ? { endnotes } : {}),
+    });
+    if (commentReferenceNormalization.removedDanglingReferences > 0) {
+      warnings.push(
+        `Removed ${commentReferenceNormalization.removedDanglingReferences} dangling comment reference marker(s) whose comments.xml entries are missing.`,
+      );
+    }
+    if (commentReferenceNormalization.reanchoredUnbalancedRanges > 0) {
+      warnings.push(
+        `Re-anchored ${commentReferenceNormalization.reanchoredUnbalancedRanges} unbalanced comment range marker(s) as point comments.`,
+      );
     }
 
     // ========================================================================

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -55,7 +55,11 @@ import {
 } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
 import type { NumberingMap } from "./numberingParser";
-import { parseRelationships, RELATIONSHIP_TYPES } from "./relsParser";
+import {
+  parseRelationships,
+  RELATIONSHIP_TYPES,
+  resolveRelativePath,
+} from "./relsParser";
 import { parseStyles, parseStyleDefinitions } from "./styleParser";
 import type { StyleMap } from "./styleParser";
 import { parseTheme } from "./themeParser";
@@ -491,6 +495,31 @@ function getMapCaseInsensitive<T>(
   return undefined;
 }
 
+const DOCUMENT_RELATIONSHIPS_PATH = "word/_rels/document.xml.rels";
+
+function getRelationshipPartPath(target: string): string {
+  return resolveRelativePath(DOCUMENT_RELATIONSHIPS_PATH, target);
+}
+
+function getRelationshipsPathForPart(partPath: string): string {
+  const lastSlash = partPath.lastIndexOf("/");
+  const directory = lastSlash === -1 ? "" : partPath.slice(0, lastSlash);
+  const filename = lastSlash === -1 ? partPath : partPath.slice(lastSlash + 1);
+  return `${directory ? `${directory}/` : ""}_rels/${filename}.rels`;
+}
+
+function getHeaderFooterXml(
+  raw: RawDocxContent,
+  partPath: string,
+  indexedParts: Map<string, string>,
+): string | undefined {
+  const filename = partPath.split("/").pop() ?? partPath;
+  return (
+    getMapCaseInsensitive(indexedParts, filename) ??
+    getMapCaseInsensitive(raw.allXml, partPath)
+  );
+}
+
 function parseHeadersAndFooters(
   raw: RawDocxContent,
   styles: StyleMap | null,
@@ -510,12 +539,12 @@ function parseHeadersAndFooters(
     if (rel.type === RELATIONSHIP_TYPES.header && rel.target) {
       // Get the header XML for this relationship
       // Use case-insensitive lookup since ZIP files may have inconsistent casing
-      const filename = rel.target.split("/").pop() || rel.target;
-      const headerXml = getMapCaseInsensitive(raw.headers, filename);
+      const partPath = getRelationshipPartPath(rel.target);
+      const headerXml = getHeaderFooterXml(raw, partPath, raw.headers);
 
       if (headerXml) {
         // Get header-specific relationships (e.g., word/_rels/header1.xml.rels)
-        const headerRelsPath = `word/_rels/${filename}.rels`;
+        const headerRelsPath = getRelationshipsPathForPart(partPath);
         const headerRelsXml = getMapCaseInsensitive(raw.allXml, headerRelsPath);
         const headerRels = headerRelsXml
           ? parseRelationships(headerRelsXml)
@@ -534,12 +563,12 @@ function parseHeadersAndFooters(
       }
     } else if (rel.type === RELATIONSHIP_TYPES.footer && rel.target) {
       // Use case-insensitive lookup since ZIP files may have inconsistent casing
-      const filename = rel.target.split("/").pop() || rel.target;
-      const footerXml = getMapCaseInsensitive(raw.footers, filename);
+      const partPath = getRelationshipPartPath(rel.target);
+      const footerXml = getHeaderFooterXml(raw, partPath, raw.footers);
 
       if (footerXml) {
         // Get footer-specific relationships (e.g., word/_rels/footer1.xml.rels)
-        const footerRelsPath = `word/_rels/${filename}.rels`;
+        const footerRelsPath = getRelationshipsPathForPart(partPath);
         const footerRelsXml = getMapCaseInsensitive(raw.allXml, footerRelsPath);
         const footerRels = footerRelsXml
           ? parseRelationships(footerRelsXml)

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -529,8 +529,8 @@ function getHeaderFooterXml(
 ): string | undefined {
   const filename = partPath.split("/").pop() ?? partPath;
   return (
-    getMapCaseInsensitive(indexedParts, filename) ??
-    getMapCaseInsensitive(raw.allXml, partPath)
+    getMapCaseInsensitive(raw.allXml, partPath) ??
+    getMapCaseInsensitive(indexedParts, filename)
   );
 }
 

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -55,6 +55,7 @@ import {
 } from "./modelValidation";
 import { parseNumbering } from "./numberingParser";
 import type { NumberingMap } from "./numberingParser";
+import { normalizeNumberingReferences } from "./numberingReferenceNormalization";
 import {
   parseRelationships,
   RELATIONSHIP_TYPES,
@@ -307,6 +308,19 @@ export async function parseDocx(
     ) {
       warnings.push(
         `Removed ${headerFooterReferenceNormalization.removedDanglingFooterReferences} dangling footer reference(s) whose footer parts are missing.`,
+      );
+    }
+    const numberingReferenceNormalization = normalizeNumberingReferences({
+      documentBody,
+      numbering,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+      ...(footnotes !== undefined ? { footnotes } : {}),
+      ...(endnotes !== undefined ? { endnotes } : {}),
+    });
+    if (numberingReferenceNormalization.removedMissingNumberingReferences > 0) {
+      warnings.push(
+        `Removed ${numberingReferenceNormalization.removedMissingNumberingReferences} numbering reference(s) whose numbering definitions are missing.`,
       );
     }
 

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -47,6 +47,7 @@ import {
 } from "./documentParser";
 import { parseFootnotes, parseEndnotes } from "./footnoteParser";
 import { parseHeader, parseFooter } from "./headerFooterParser";
+import { normalizeHeaderFooterReferences } from "./headerFooterReferenceNormalization";
 import {
   DocxModelValidationError,
   formatDocumentModelIssues,
@@ -283,6 +284,25 @@ export async function parseDocx(
     if (commentReferenceNormalization.reanchoredUnbalancedRanges > 0) {
       warnings.push(
         `Re-anchored ${commentReferenceNormalization.reanchoredUnbalancedRanges} unbalanced comment range marker(s) as point comments.`,
+      );
+    }
+    const headerFooterReferenceNormalization = normalizeHeaderFooterReferences({
+      documentBody,
+      ...(headers !== undefined ? { headers } : {}),
+      ...(footers !== undefined ? { footers } : {}),
+    });
+    if (
+      headerFooterReferenceNormalization.removedDanglingHeaderReferences > 0
+    ) {
+      warnings.push(
+        `Removed ${headerFooterReferenceNormalization.removedDanglingHeaderReferences} dangling header reference(s) whose header parts are missing.`,
+      );
+    }
+    if (
+      headerFooterReferenceNormalization.removedDanglingFooterReferences > 0
+    ) {
+      warnings.push(
+        `Removed ${headerFooterReferenceNormalization.removedDanglingFooterReferences} dangling footer reference(s) whose footer parts are missing.`,
       );
     }
 

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -319,7 +319,7 @@ export async function parseDocx(
 
     const document: Document = {
       package: pkg,
-      originalBuffer: buffer,
+      originalBuffer: raw.originalBuffer,
       ...(templateVariables !== undefined ? { templateVariables } : {}),
       ...(requiredFonts.length > 0 ? { requiredFonts } : {}),
     };

--- a/packages/folio/src/core/docx/parserEnums.ts
+++ b/packages/folio/src/core/docx/parserEnums.ts
@@ -22,33 +22,40 @@
 
 import * as v from "valibot";
 
-import type {
-  EmphasisMark,
-  FieldType,
-  FloatingTableProperties,
-  ImagePosition,
-  ImageWrap,
-  LevelSuffix,
-  LineSpacingRule,
-  NumberFormat,
-  ParagraphAlignment,
-  ParagraphFormatting,
-  SdtProperties,
-  ShadingProperties,
-  ShapeOutline,
-  Style,
-  StyleType,
-  TableCellFormatting,
-  TableRowFormatting,
-  TableWidthType,
-  TabLeader,
-  TabStopAlignment,
-  TextEffect,
-  TextFormatting,
-  ThemeColorSlot,
-  UnderlineStyle,
-  KnownBorderStyle,
-} from "../types/document";
+import {
+  BORDER_STYLE_VALUES,
+  CONDITIONAL_STYLE_TYPE_VALUES,
+  EMPHASIS_MARK_VALUES,
+  FIELD_TYPE_VALUES,
+  FLOATING_TABLE_X_SPEC_VALUES,
+  FLOATING_TABLE_Y_SPEC_VALUES,
+  FONT_THEME_VALUES,
+  FRAME_WRAP_VALUES,
+  FRAME_X_ALIGN_VALUES,
+  FRAME_Y_ALIGN_VALUES,
+  HIGHLIGHT_COLOR_VALUES,
+  IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
+  IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
+  IMAGE_VERTICAL_ALIGNMENT_VALUES,
+  IMAGE_VERTICAL_RELATIVE_TO_VALUES,
+  IMAGE_WRAP_TEXT_VALUES,
+  LEVEL_SUFFIX_VALUES,
+  LINE_SPACING_RULE_VALUES,
+  NUMBER_FORMAT_VALUES,
+  PARAGRAPH_ALIGNMENT_VALUES,
+  SDT_LOCK_VALUES,
+  SHADING_PATTERN_VALUES,
+  SHAPE_OUTLINE_STYLE_VALUES,
+  STYLE_TYPE_VALUES,
+  TABLE_CELL_TEXT_DIRECTION_VALUES,
+  TABLE_ROW_HEIGHT_RULE_VALUES,
+  TABLE_WIDTH_TYPE_VALUES,
+  TAB_LEADER_VALUES,
+  TAB_STOP_ALIGNMENT_VALUES,
+  TEXT_EFFECT_VALUES,
+  THEME_COLOR_SLOT_VALUES,
+  UNDERLINE_STYLE_VALUES,
+} from "../types/documentEnumValues";
 
 /**
  * Narrow a raw attribute string to a picklist member, or `undefined`
@@ -71,535 +78,128 @@ export const narrowEnum = <T extends string>(
 // Theme & shading enums
 // ---------------------------------------------------------------------------
 
-export const ThemeColorSlotSchema = v.picklist([
-  "dk1",
-  "lt1",
-  "dk2",
-  "lt2",
-  "accent1",
-  "accent2",
-  "accent3",
-  "accent4",
-  "accent5",
-  "accent6",
-  "hlink",
-  "folHlink",
-  "background1",
-  "text1",
-  "background2",
-  "text2",
-] as const satisfies readonly ThemeColorSlot[]);
+export const ThemeColorSlotSchema = v.picklist(THEME_COLOR_SLOT_VALUES);
 
-export const BorderStyleSchema = v.picklist([
-  "none",
-  "single",
-  "double",
-  "dotted",
-  "dashed",
-  "thick",
-  "triple",
-  "thinThickSmallGap",
-  "thickThinSmallGap",
-  "thinThickMediumGap",
-  "thickThinMediumGap",
-  "thinThickLargeGap",
-  "thickThinLargeGap",
-  "wave",
-  "doubleWave",
-  "dashSmallGap",
-  "dashDotStroked",
-  "threeDEmboss",
-  "threeDEngrave",
-  "outset",
-  "inset",
-  "nil",
-] as const satisfies readonly KnownBorderStyle[]);
+export const BorderStyleSchema = v.picklist(BORDER_STYLE_VALUES);
 
 // ---------------------------------------------------------------------------
 // Run formatting enums
 // ---------------------------------------------------------------------------
 
-export const UnderlineStyleSchema = v.picklist([
-  "none",
-  "single",
-  "words",
-  "double",
-  "thick",
-  "dotted",
-  "dottedHeavy",
-  "dash",
-  "dashedHeavy",
-  "dashLong",
-  "dashLongHeavy",
-  "dotDash",
-  "dashDotHeavy",
-  "dotDotDash",
-  "dashDotDotHeavy",
-  "wave",
-  "wavyHeavy",
-  "wavyDouble",
-] as const satisfies readonly UnderlineStyle[]);
+export const UnderlineStyleSchema = v.picklist(UNDERLINE_STYLE_VALUES);
 
-export const HighlightColorSchema = v.picklist([
-  "black",
-  "blue",
-  "cyan",
-  "darkBlue",
-  "darkCyan",
-  "darkGray",
-  "darkGreen",
-  "darkMagenta",
-  "darkRed",
-  "darkYellow",
-  "green",
-  "lightGray",
-  "magenta",
-  "none",
-  "red",
-  "white",
-  "yellow",
-] as const satisfies readonly NonNullable<TextFormatting["highlight"]>[]);
+export const HighlightColorSchema = v.picklist(HIGHLIGHT_COLOR_VALUES);
 
-export const TextEffectSchema = v.picklist([
-  "none",
-  "blinkBackground",
-  "lights",
-  "antsBlack",
-  "antsRed",
-  "shimmer",
-  "sparkle",
-] as const satisfies readonly TextEffect[]);
+export const TextEffectSchema = v.picklist(TEXT_EFFECT_VALUES);
 
-export const EmphasisMarkSchema = v.picklist([
-  "none",
-  "dot",
-  "comma",
-  "circle",
-  "underDot",
-] as const satisfies readonly EmphasisMark[]);
+export const EmphasisMarkSchema = v.picklist(EMPHASIS_MARK_VALUES);
 
-type FontTheme = NonNullable<
-  NonNullable<TextFormatting["fontFamily"]>["asciiTheme"]
->;
-
-export const FontThemeSchema = v.picklist([
-  "majorAscii",
-  "majorHAnsi",
-  "majorEastAsia",
-  "majorBidi",
-  "minorAscii",
-  "minorHAnsi",
-  "minorEastAsia",
-  "minorBidi",
-] as const satisfies readonly FontTheme[]);
+export const FontThemeSchema = v.picklist(FONT_THEME_VALUES);
 
 // ---------------------------------------------------------------------------
 // Paragraph formatting enums
 // ---------------------------------------------------------------------------
 
-export const ParagraphAlignmentSchema = v.picklist([
-  "left",
-  "center",
-  "right",
-  "both",
-  "distribute",
-  "mediumKashida",
-  "highKashida",
-  "lowKashida",
-  "thaiDistribute",
-] as const satisfies readonly ParagraphAlignment[]);
+export const ParagraphAlignmentSchema = v.picklist(PARAGRAPH_ALIGNMENT_VALUES);
 
-export const LineSpacingRuleSchema = v.picklist([
-  "auto",
-  "exact",
-  "atLeast",
-] as const satisfies readonly LineSpacingRule[]);
+export const LineSpacingRuleSchema = v.picklist(LINE_SPACING_RULE_VALUES);
 
-export const TabStopAlignmentSchema = v.picklist([
-  "left",
-  "center",
-  "right",
-  "decimal",
-  "bar",
-  "clear",
-  "num",
-] as const satisfies readonly TabStopAlignment[]);
+export const TabStopAlignmentSchema = v.picklist(TAB_STOP_ALIGNMENT_VALUES);
 
-export const TabLeaderSchema = v.picklist([
-  "none",
-  "dot",
-  "hyphen",
-  "underscore",
-  "heavy",
-  "middleDot",
-] as const satisfies readonly TabLeader[]);
+export const TabLeaderSchema = v.picklist(TAB_LEADER_VALUES);
 
-type Frame = NonNullable<ParagraphFormatting["frame"]>;
+export const FrameXAlignSchema = v.picklist(FRAME_X_ALIGN_VALUES);
 
-export const FrameXAlignSchema = v.picklist([
-  "left",
-  "center",
-  "right",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<Frame["xAlign"]>[]);
+export const FrameYAlignSchema = v.picklist(FRAME_Y_ALIGN_VALUES);
 
-export const FrameYAlignSchema = v.picklist([
-  "top",
-  "center",
-  "bottom",
-  "inside",
-  "outside",
-  "inline",
-] as const satisfies readonly NonNullable<Frame["yAlign"]>[]);
-
-export const FrameWrapSchema = v.picklist([
-  "around",
-  "auto",
-  "none",
-  "notBeside",
-  "through",
-  "tight",
-] as const satisfies readonly NonNullable<Frame["wrap"]>[]);
+export const FrameWrapSchema = v.picklist(FRAME_WRAP_VALUES);
 
 // ---------------------------------------------------------------------------
 // Structured document tag (SDT) enums
 // ---------------------------------------------------------------------------
 
-export const SdtLockSchema = v.picklist([
-  "sdtLocked",
-  "contentLocked",
-  "sdtContentLocked",
-  "unlocked",
-] as const satisfies readonly NonNullable<SdtProperties["lock"]>[]);
+export const SdtLockSchema = v.picklist(SDT_LOCK_VALUES);
 
 // ---------------------------------------------------------------------------
 // Field types
 // ---------------------------------------------------------------------------
 
-export const FieldTypeSchema = v.picklist([
-  "PAGE",
-  "NUMPAGES",
-  "NUMWORDS",
-  "NUMCHARS",
-  "DATE",
-  "TIME",
-  "CREATEDATE",
-  "SAVEDATE",
-  "PRINTDATE",
-  "AUTHOR",
-  "TITLE",
-  "SUBJECT",
-  "KEYWORDS",
-  "COMMENTS",
-  "FILENAME",
-  "FILESIZE",
-  "TEMPLATE",
-  "DOCPROPERTY",
-  "DOCVARIABLE",
-  "REF",
-  "PAGEREF",
-  "NOTEREF",
-  "HYPERLINK",
-  "TOC",
-  "TOA",
-  "INDEX",
-  "SEQ",
-  "STYLEREF",
-  "AUTONUM",
-  "AUTONUMLGL",
-  "AUTONUMOUT",
-  "IF",
-  "MERGEFIELD",
-  "NEXT",
-  "NEXTIF",
-  "ASK",
-  "SET",
-  "QUOTE",
-  "INCLUDETEXT",
-  "INCLUDEPICTURE",
-  "SYMBOL",
-  "ADVANCE",
-  "EDITTIME",
-  "REVNUM",
-  "SECTION",
-  "SECTIONPAGES",
-  "USERADDRESS",
-  "USERNAME",
-  "USERINITIALS",
-  "UNKNOWN",
-] as const satisfies readonly FieldType[]);
+export const FieldTypeSchema = v.picklist(FIELD_TYPE_VALUES);
 
 // ---------------------------------------------------------------------------
 // Style enums
 // ---------------------------------------------------------------------------
 
-export const StyleTypeSchema = v.picklist([
-  "paragraph",
-  "character",
-  "numbering",
-  "table",
-] as const satisfies readonly StyleType[]);
+export const StyleTypeSchema = v.picklist(STYLE_TYPE_VALUES);
 
-type ConditionalStyleType = NonNullable<Style["tblStylePr"]>[number]["type"];
-
-export const ConditionalStyleTypeSchema = v.picklist([
-  "band1Horz",
-  "band1Vert",
-  "band2Horz",
-  "band2Vert",
-  "firstCol",
-  "firstRow",
-  "lastCol",
-  "lastRow",
-  "neCell",
-  "nwCell",
-  "seCell",
-  "swCell",
-  "wholeTable",
-] as const satisfies readonly ConditionalStyleType[]);
+export const ConditionalStyleTypeSchema = v.picklist(
+  CONDITIONAL_STYLE_TYPE_VALUES,
+);
 
 // ---------------------------------------------------------------------------
 // Table enums
 // ---------------------------------------------------------------------------
 
-export const TableWidthTypeSchema = v.picklist([
-  "auto",
-  "dxa",
-  "nil",
-  "pct",
-] as const satisfies readonly TableWidthType[]);
+export const TableWidthTypeSchema = v.picklist(TABLE_WIDTH_TYPE_VALUES);
 
-export const TableRowHeightRuleSchema = v.picklist([
-  "auto",
-  "atLeast",
-  "exact",
-] as const satisfies readonly NonNullable<TableRowFormatting["heightRule"]>[]);
+export const TableRowHeightRuleSchema = v.picklist(
+  TABLE_ROW_HEIGHT_RULE_VALUES,
+);
 
-export const TableCellTextDirectionSchema = v.picklist([
-  "lr",
-  "lrV",
-  "rl",
-  "rlV",
-  "tb",
-  "tbV",
-  "tbRl",
-  "tbRlV",
-  "btLr",
-] as const satisfies readonly NonNullable<
-  TableCellFormatting["textDirection"]
->[]);
+export const TableCellTextDirectionSchema = v.picklist(
+  TABLE_CELL_TEXT_DIRECTION_VALUES,
+);
 
 // ---------------------------------------------------------------------------
 // Shading enums
 // ---------------------------------------------------------------------------
 
-export const ShadingPatternSchema = v.picklist([
-  "clear",
-  "solid",
-  "horzStripe",
-  "vertStripe",
-  "reverseDiagStripe",
-  "diagStripe",
-  "horzCross",
-  "diagCross",
-  "thinHorzStripe",
-  "thinVertStripe",
-  "thinReverseDiagStripe",
-  "thinDiagStripe",
-  "thinHorzCross",
-  "thinDiagCross",
-  "pct5",
-  "pct10",
-  "pct12",
-  "pct15",
-  "pct20",
-  "pct25",
-  "pct30",
-  "pct35",
-  "pct37",
-  "pct40",
-  "pct45",
-  "pct50",
-  "pct55",
-  "pct60",
-  "pct62",
-  "pct65",
-  "pct70",
-  "pct75",
-  "pct80",
-  "pct85",
-  "pct87",
-  "pct90",
-  "pct95",
-  "nil",
-] as const satisfies readonly NonNullable<ShadingProperties["pattern"]>[]);
+export const ShadingPatternSchema = v.picklist(SHADING_PATTERN_VALUES);
 
 // ---------------------------------------------------------------------------
 // Floating table position enums
 // ---------------------------------------------------------------------------
 
-export const FloatingTableXSpecSchema = v.picklist([
-  "left",
-  "center",
-  "right",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<
-  FloatingTableProperties["tblpXSpec"]
->[]);
+export const FloatingTableXSpecSchema = v.picklist(
+  FLOATING_TABLE_X_SPEC_VALUES,
+);
 
-export const FloatingTableYSpecSchema = v.picklist([
-  "top",
-  "center",
-  "bottom",
-  "inside",
-  "outside",
-  "inline",
-] as const satisfies readonly NonNullable<
-  FloatingTableProperties["tblpYSpec"]
->[]);
+export const FloatingTableYSpecSchema = v.picklist(
+  FLOATING_TABLE_Y_SPEC_VALUES,
+);
 
 // ---------------------------------------------------------------------------
 // Image positioning / wrap enums
 // ---------------------------------------------------------------------------
 
-export const ImageHorizontalRelativeToSchema = v.picklist([
-  "character",
-  "column",
-  "insideMargin",
-  "leftMargin",
-  "margin",
-  "outsideMargin",
-  "page",
-  "rightMargin",
-] as const satisfies readonly ImagePosition["horizontal"]["relativeTo"][]);
+export const ImageHorizontalRelativeToSchema = v.picklist(
+  IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
+);
 
-export const ImageHorizontalAlignmentSchema = v.picklist([
-  "left",
-  "right",
-  "center",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<
-  ImagePosition["horizontal"]["alignment"]
->[]);
+export const ImageHorizontalAlignmentSchema = v.picklist(
+  IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
+);
 
-export const ImageVerticalRelativeToSchema = v.picklist([
-  "insideMargin",
-  "line",
-  "margin",
-  "outsideMargin",
-  "page",
-  "paragraph",
-  "topMargin",
-  "bottomMargin",
-] as const satisfies readonly ImagePosition["vertical"]["relativeTo"][]);
+export const ImageVerticalRelativeToSchema = v.picklist(
+  IMAGE_VERTICAL_RELATIVE_TO_VALUES,
+);
 
-export const ImageVerticalAlignmentSchema = v.picklist([
-  "top",
-  "bottom",
-  "center",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<
-  ImagePosition["vertical"]["alignment"]
->[]);
+export const ImageVerticalAlignmentSchema = v.picklist(
+  IMAGE_VERTICAL_ALIGNMENT_VALUES,
+);
 
-export const ImageWrapTextSchema = v.picklist([
-  "bothSides",
-  "left",
-  "right",
-  "largest",
-] as const satisfies readonly NonNullable<ImageWrap["wrapText"]>[]);
+export const ImageWrapTextSchema = v.picklist(IMAGE_WRAP_TEXT_VALUES);
 
 // ---------------------------------------------------------------------------
 // Shape outline enums
 // ---------------------------------------------------------------------------
 
-export const ShapeOutlineStyleSchema = v.picklist([
-  "solid",
-  "dot",
-  "dash",
-  "lgDash",
-  "dashDot",
-  "lgDashDot",
-  "lgDashDotDot",
-  "sysDot",
-  "sysDash",
-  "sysDashDot",
-  "sysDashDotDot",
-] as const satisfies readonly NonNullable<ShapeOutline["style"]>[]);
+export const ShapeOutlineStyleSchema = v.picklist(SHAPE_OUTLINE_STYLE_VALUES);
 
 // ---------------------------------------------------------------------------
 // Numbering enums
 // ---------------------------------------------------------------------------
 
-export const NumberFormatSchema = v.picklist([
-  "decimal",
-  "upperRoman",
-  "lowerRoman",
-  "upperLetter",
-  "lowerLetter",
-  "ordinal",
-  "cardinalText",
-  "ordinalText",
-  "hex",
-  "chicago",
-  "ideographDigital",
-  "japaneseCounting",
-  "aiueo",
-  "iroha",
-  "decimalFullWidth",
-  "decimalHalfWidth",
-  "japaneseLegal",
-  "japaneseDigitalTenThousand",
-  "decimalEnclosedCircle",
-  "decimalFullWidth2",
-  "aiueoFullWidth",
-  "irohaFullWidth",
-  "decimalZero",
-  "bullet",
-  "ganada",
-  "chosung",
-  "decimalEnclosedFullstop",
-  "decimalEnclosedParen",
-  "decimalEnclosedCircleChinese",
-  "ideographEnclosedCircle",
-  "ideographTraditional",
-  "ideographZodiac",
-  "ideographZodiacTraditional",
-  "taiwaneseCounting",
-  "ideographLegalTraditional",
-  "taiwaneseCountingThousand",
-  "taiwaneseDigital",
-  "chineseCounting",
-  "chineseLegalSimplified",
-  "chineseCountingThousand",
-  "koreanDigital",
-  "koreanCounting",
-  "koreanLegal",
-  "koreanDigital2",
-  "vietnameseCounting",
-  "russianLower",
-  "russianUpper",
-  "none",
-  "numberInDash",
-  "hebrew1",
-  "hebrew2",
-  "arabicAlpha",
-  "arabicAbjad",
-  "hindiVowels",
-  "hindiConsonants",
-  "hindiNumbers",
-  "hindiCounting",
-  "thaiLetters",
-  "thaiNumbers",
-  "thaiCounting",
-] as const satisfies readonly NumberFormat[]);
+export const NumberFormatSchema = v.picklist(NUMBER_FORMAT_VALUES);
 
-export const LevelSuffixSchema = v.picklist([
-  "tab",
-  "space",
-  "nothing",
-] as const satisfies readonly LevelSuffix[]);
+export const LevelSuffixSchema = v.picklist(LEVEL_SUFFIX_VALUES);

--- a/packages/folio/src/core/docx/rezip.test.ts
+++ b/packages/folio/src/core/docx/rezip.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 
 import type { Document } from "../types/document";
+import { DocxModelValidationError } from "./modelValidation";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { DocxPackageFidelityError, repackDocx } from "./rezip";
@@ -198,6 +199,34 @@ async function createMultiSectionFirstHeaderImageFixture(): Promise<ArrayBuffer>
 }
 
 describe("repackDocx", () => {
+  test("rejects an invalid document model before full repack", async () => {
+    const originalBuffer = await createHeaderFixture();
+    const document: Document = {
+      originalBuffer,
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "commentReference", id: 404 }],
+            },
+          ],
+        },
+        relationships: new Map(),
+      },
+    };
+
+    try {
+      await repackDocx(document, { updateModifiedDate: false });
+    } catch (error) {
+      expect(error).toBeInstanceOf(DocxModelValidationError);
+      expect(String(error)).toContain("Comment 404 is referenced");
+      return;
+    }
+
+    throw new Error("Expected repackDocx to reject");
+  });
+
   test("registers newly inserted header images in the header relationship part", async () => {
     const originalBuffer = await createHeaderFixture();
     const document: Document = {

--- a/packages/folio/src/core/docx/rezip.test.ts
+++ b/packages/folio/src/core/docx/rezip.test.ts
@@ -63,6 +63,22 @@ async function createHeaderFixture(): Promise<ArrayBuffer> {
   return zip.generateAsync({ type: "arraybuffer" });
 }
 
+function truncateAfterEndOfCentralDirectoryCounts(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  for (let offset = bytes.byteLength - 22; offset >= 0; offset -= 1) {
+    if (
+      bytes[offset] === 0x50 &&
+      bytes[offset + 1] === 0x4b &&
+      bytes[offset + 2] === 0x05 &&
+      bytes[offset + 3] === 0x06
+    ) {
+      return bytes.slice(0, offset + 12).buffer;
+    }
+  }
+
+  throw new Error("Could not find ZIP end-of-central-directory record");
+}
+
 async function createAlternateContentImageFixture(): Promise<ArrayBuffer> {
   const zip = new JSZip();
   zip.file(
@@ -225,6 +241,19 @@ describe("repackDocx", () => {
     }
 
     throw new Error("Expected repackDocx to reject");
+  });
+
+  test("uses parser-repaired package buffers for full repack", async () => {
+    const originalBuffer = await createHeaderFixture();
+    const truncated = truncateAfterEndOfCentralDirectoryCounts(originalBuffer);
+    const document = await parseDocx(truncated, { preloadFonts: false });
+
+    expect(document.originalBuffer?.byteLength).toBe(originalBuffer.byteLength);
+
+    const repacked = await repackDocx(document, { updateModifiedDate: false });
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+
+    expect(reparsed.package.document.content).toHaveLength(1);
   });
 
   test("registers newly inserted header images in the header relationship part", async () => {

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -39,6 +39,7 @@ import type {
   Hyperlink,
 } from "../types/content";
 import type { Document } from "../types/document";
+import { assertValidFolioDocumentModel } from "./modelValidation";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
@@ -582,6 +583,11 @@ export async function repackDocx(
   );
   await processNewHyperlinks(newHyperlinks, newZip, compressionLevel);
 
+  assertValidFolioDocumentModel(
+    exportDocument,
+    "Cannot repack invalid DOCX document model",
+  );
+
   // Serialize and update document.xml (after image/hyperlink rIds have been rewritten)
   const documentXml = serializeDocument(exportDocument);
   const originalDocumentXml = await originalZip
@@ -686,6 +692,11 @@ export async function repackDocxFromRaw(
     exportDocument.package.document.content,
   );
   await processNewHyperlinks(newHyperlinks, newZip, compressionLevel);
+
+  assertValidFolioDocumentModel(
+    exportDocument,
+    "Cannot repack invalid DOCX document model",
+  );
 
   const documentXml = serializeDocument(exportDocument);
   if (rawContent.documentXml) {

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -40,7 +40,7 @@ import type {
 } from "../types/content";
 import type { Document } from "../types/document";
 import { assertValidFolioDocumentModel } from "./modelValidation";
-import { RELATIONSHIP_TYPES } from "./relsParser";
+import { RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
@@ -1085,6 +1085,7 @@ export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
     return updates;
   }
 
+  const documentRelsPath = "word/_rels/document.xml.rels";
   const parts: {
     map: Map<string, HeaderFooter> | undefined;
     type: string;
@@ -1100,9 +1101,7 @@ export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
     for (const [rId, headerFooter] of map.entries()) {
       const rel = rels.get(rId);
       if (rel && rel.type === type && rel.target) {
-        const filename = rel.target.startsWith("/")
-          ? rel.target.slice(1)
-          : `word/${rel.target}`;
+        const filename = resolveRelativePath(documentRelsPath, rel.target);
         updates.set(filename, serializeHeaderFooter(headerFooter));
       }
     }

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -74,7 +74,7 @@ const countDocumentSections = (xml: string): number =>
   Array.from(xml.matchAll(/<w:sectPr\b/gu)).length;
 
 type HeaderFooterReference = {
-  element: string;
+  element: "headerReference" | "footerReference";
   type: string;
   rId: string;
 };
@@ -89,7 +89,10 @@ const extractHeaderFooterReferences = (
     const type = /\bw:type="([^"]+)"/u.exec(tag)?.at(1) ?? "default";
     const rId = /\br:id="([^"]+)"/u.exec(tag)?.at(1);
     const element = match[1];
-    if (!rId || !element) {
+    if (
+      !rId ||
+      (element !== "headerReference" && element !== "footerReference")
+    ) {
       continue;
     }
     references.push({ element, type, rId });
@@ -97,9 +100,21 @@ const extractHeaderFooterReferences = (
   return references;
 };
 
+const hasParsedHeaderFooterPart = (
+  doc: Document,
+  ref: HeaderFooterReference,
+): boolean => {
+  const map =
+    ref.element === "headerReference"
+      ? doc.package.headers
+      : doc.package.footers;
+  return map?.has(ref.rId) ?? false;
+};
+
 function assertDocumentPackageFidelity(
   originalDocumentXml: string,
   serializedDocumentXml: string,
+  doc: Document,
 ): void {
   const originalSectionCount = countDocumentSections(originalDocumentXml);
   const serializedSectionCount = countDocumentSections(serializedDocumentXml);
@@ -115,7 +130,9 @@ function assertDocumentPackageFidelity(
     ),
   );
   const missingRefs = extractHeaderFooterReferences(originalDocumentXml).filter(
-    (ref) => !serializedRefs.has(`${ref.element}:${ref.type}:${ref.rId}`),
+    (ref) =>
+      hasParsedHeaderFooterPart(doc, ref) &&
+      !serializedRefs.has(`${ref.element}:${ref.type}:${ref.rId}`),
   );
   if (missingRefs.length > 0) {
     throw new DocxPackageFidelityError(
@@ -594,7 +611,11 @@ export async function repackDocx(
     .file("word/document.xml")
     ?.async("text");
   if (originalDocumentXml) {
-    assertDocumentPackageFidelity(originalDocumentXml, documentXml);
+    assertDocumentPackageFidelity(
+      originalDocumentXml,
+      documentXml,
+      exportDocument,
+    );
   }
   newZip.file("word/document.xml", documentXml, {
     compression: "DEFLATE",
@@ -700,7 +721,11 @@ export async function repackDocxFromRaw(
 
   const documentXml = serializeDocument(exportDocument);
   if (rawContent.documentXml) {
-    assertDocumentPackageFidelity(rawContent.documentXml, documentXml);
+    assertDocumentPackageFidelity(
+      rawContent.documentXml,
+      documentXml,
+      exportDocument,
+    );
   }
   newZip.file("word/document.xml", documentXml, {
     compression: "DEFLATE",

--- a/packages/folio/src/core/docx/sectionParser.ts
+++ b/packages/folio/src/core/docx/sectionParser.ts
@@ -59,6 +59,7 @@ const serializedSectionPropertyChildNames = new Set([
   "headerReference",
   "footerReference",
   "footnotePr",
+  "footnoteColumns",
   "endnotePr",
   "type",
   "pgSz",
@@ -671,6 +672,14 @@ export function parseSectionProperties(
     const fnProps = parseFootnoteProperties(footnotePr);
     if (Object.keys(fnProps).length > 0) {
       props.footnotePr = fnProps;
+    }
+  }
+
+  const footnoteColumns = findChild(sectPr, "w15", "footnoteColumns");
+  if (footnoteColumns) {
+    const columns = parseNumericAttribute(footnoteColumns, "w", "val");
+    if (columns !== undefined) {
+      props.footnoteColumns = columns;
     }
   }
 

--- a/packages/folio/src/core/docx/sectionParser.ts
+++ b/packages/folio/src/core/docx/sectionParser.ts
@@ -22,6 +22,7 @@
 
 import type {
   SectionProperties,
+  SectionPropertyChange,
   PageOrientation,
   SectionStart,
   VerticalAlign,
@@ -29,7 +30,6 @@ import type {
   Column,
   BorderSpec,
   ColorValue,
-  RelationshipMap,
 } from "../types/document";
 import {
   parseHeaderReference,
@@ -79,6 +79,7 @@ const serializedSectionPropertyChildNames = new Set([
   "rtlGutter",
   "docGrid",
   "printerSettings",
+  "sectPrChange",
 ]);
 
 const unserializedSectionPropertyChildNames = Symbol(
@@ -132,6 +133,28 @@ function parseColorValue(
   }
 
   return Object.keys(color).length > 0 ? color : undefined;
+}
+
+function parsePropertyChangeInfo(
+  node: XmlElement,
+): SectionPropertyChange["info"] {
+  const rawId = getAttribute(node, "w", "id");
+  const parsedId = rawId ? Number.parseInt(rawId, 10) : 0;
+  const author = (getAttribute(node, "w", "author") ?? "").trim();
+  const date = (getAttribute(node, "w", "date") ?? "").trim();
+  const rsid = (getAttribute(node, "w", "rsid") ?? "").trim();
+
+  const info: SectionPropertyChange["info"] = {
+    id: Number.isInteger(parsedId) && parsedId >= 0 ? parsedId : 0,
+    author: author.length > 0 ? author : "Unknown",
+  };
+  if (date.length > 0) {
+    info.date = date;
+  }
+  if (rsid.length > 0) {
+    info.rsid = rsid;
+  }
+  return info;
 }
 
 /**
@@ -284,12 +307,10 @@ function parseLineNumberRestart(
  * Parse section properties (w:sectPr)
  *
  * @param sectPr - The w:sectPr element
- * @param rels - Optional relationships for resolving header/footer references
  * @returns SectionProperties object
  */
 export function parseSectionProperties(
   sectPr: XmlElement | null,
-  _rels?: RelationshipMap | null,
 ): SectionProperties {
   const props: SectionProperties = {};
 
@@ -765,6 +786,23 @@ export function parseSectionProperties(
     if (relationshipId) {
       props.printerSettingsRelationshipId = relationshipId;
     }
+  }
+
+  const propertyChanges = findChildren(sectPr, "w", "sectPrChange").map(
+    (changeElement): SectionPropertyChange => {
+      const previousSectPr = findChild(changeElement, "w", "sectPr");
+      const change: SectionPropertyChange = {
+        type: "sectionPropertyChange",
+        info: parsePropertyChangeInfo(changeElement),
+      };
+      if (previousSectPr) {
+        change.previousProperties = parseSectionProperties(previousSectPr);
+      }
+      return change;
+    },
+  );
+  if (propertyChanges.length > 0) {
+    props.propertyChanges = propertyChanges;
   }
 
   Object.defineProperty(props, unserializedSectionPropertyChildNames, {

--- a/packages/folio/src/core/docx/selectiveSave.test.ts
+++ b/packages/folio/src/core/docx/selectiveSave.test.ts
@@ -301,6 +301,24 @@ describe("Selective XML Patch with real DOCX", () => {
 // ============================================================================
 
 describe("attemptSelectiveSave", () => {
+  test("returns null for an invalid document model", async () => {
+    const buffer = await loadFixture("example-with-image.docx");
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    doc.package.document.content.unshift({
+      type: "paragraph",
+      content: [{ type: "commentReference", id: 999 }],
+    });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
   test("returns null when structural change occurred", async () => {
     const buffer = await loadFixture("example-with-image.docx");
     const doc = await parseDocx(buffer, { preloadFonts: false });

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Document, BlockContent } from "../types/document";
+import { validateFolioDocumentModel } from "./modelValidation";
 import { RELATIONSHIP_TYPES } from "./relsParser";
 import {
   applyUpdatesToZip,
@@ -96,6 +97,9 @@ export async function attemptSelectiveSave(
   // Check for new images/hyperlinks that need relationship management
   const content = doc.package.document.content;
   if (hasNewImagesOrHyperlinks(content)) {
+    return null;
+  }
+  if (!validateFolioDocumentModel(doc).valid) {
     return null;
   }
 

--- a/packages/folio/src/core/docx/serializer/runSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.test.ts
@@ -182,6 +182,9 @@ describe("shape EMU attributes are integer-only (issue #417)", () => {
     expect(xml).toContain('tIns="45720"');
     expect(xml).toContain('rIns="91441"');
     expect(xml).toContain('bIns="45720"');
+    expect(xml.match(/<wps:wsp>/gu)).toHaveLength(1);
+    expect(xml).toContain('<wps:cNvSpPr txBox="1"/>');
+    expect(xml).toContain("<wps:txbx><w:txbxContent>");
   });
 });
 

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -37,6 +37,7 @@ import type {
   Paragraph,
   RunPropertyChange,
 } from "../../types/document";
+import { HIGHLIGHT_COLOR_VALUES } from "../../types/documentEnumValues";
 // oxlint-disable-next-line import/no-cycle
 import { serializeParagraph } from "./paragraphSerializer";
 import { escapeXml, intAttr } from "./xmlUtils";
@@ -69,24 +70,9 @@ function getUniqueId(id: string | number | undefined): string {
 }
 
 /** Valid OOXML highlight color names (ECMA-376 §17.18.40) */
-const VALID_HIGHLIGHT_COLORS = new Set([
-  "black",
-  "blue",
-  "cyan",
-  "darkBlue",
-  "darkCyan",
-  "darkGray",
-  "darkGreen",
-  "darkMagenta",
-  "darkRed",
-  "darkYellow",
-  "green",
-  "lightGray",
-  "magenta",
-  "red",
-  "white",
-  "yellow",
-]);
+const VALID_HIGHLIGHT_COLORS = new Set(
+  HIGHLIGHT_COLOR_VALUES.filter((color) => color !== "none"),
+);
 
 // ============================================================================
 // COLOR SERIALIZATION

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -157,4 +157,20 @@ describe("serializeSectionProperties", () => {
       '<w:sectPr><w:pgNumType w:fmt="decimal" w:start="3" w:chapStyle="2" w:chapSep="hyphen"/><w:formProt/><w:noEndnote w:val="0"/><w:rtlGutter/><w:printerSettings r:id="rIdPrinter"/></w:sectPr>',
     );
   });
+
+  test("round-trips section footnote columns", () => {
+    const section = parseSectPr(`
+      <w:sectPr
+        xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"
+      >
+        <w15:footnoteColumns w:val="2"/>
+      </w:sectPr>
+    `);
+
+    expect(section.footnoteColumns).toBe(2);
+    expect(serializeSectionProperties(section)).toBe(
+      '<w:sectPr><w15:footnoteColumns w:val="2"/></w:sectPr>',
+    );
+  });
 });

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.test.ts
@@ -54,24 +54,33 @@ describe("serializeSectionProperties", () => {
         `),
       ),
     ).toBe("");
-    expect(
-      serializeSectionProperties(
-        parseSectPr(`
-          <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-            <w:sectPrChange/>
+  });
+
+  test("round-trips tracked section property changes", () => {
+    const section = parseSectPr(`
+      <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pgSz w:w="11906" w:h="16838"/>
+        <w:pgMar w:top="1276" w:right="991" w:bottom="1417" w:left="851"/>
+        <w:sectPrChange w:id="86" w:author="szp@applet.cz" w:date="2023-01-12T10:39:00Z">
+          <w:sectPr>
+            <w:pgMar w:top="1276" w:right="1417" w:bottom="1417" w:left="1417"/>
           </w:sectPr>
-        `),
-      ),
-    ).toBe("");
-    expect(
-      serializeSectionProperties({
-        ...parseSectPr(`
-          <w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-            <w:sectPrChange/>
-          </w:sectPr>
-        `),
-      }),
-    ).toBe("");
+        </w:sectPrChange>
+      </w:sectPr>
+    `);
+
+    expect(section.propertyChanges?.at(0)?.info).toEqual({
+      id: 86,
+      author: "szp@applet.cz",
+      date: "2023-01-12T10:39:00Z",
+    });
+
+    const xml = serializeSectionProperties(section);
+
+    expect(xml).toContain("<w:sectPrChange");
+    expect(xml).toContain('w:id="86"');
+    expect(xml).toContain('w:author="szp@applet.cz"');
+    expect(xml).toContain('w:right="1417"');
   });
 
   test("preserves unknown page border styles for fallback rendering", () => {

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -83,6 +83,12 @@ function serializeFootnoteProperties(
     : "";
 }
 
+function serializeFootnoteColumns(props: SectionProperties): string {
+  return props.footnoteColumns !== undefined
+    ? `<w15:footnoteColumns w:val="${intAttr(props.footnoteColumns)}"/>`
+    : "";
+}
+
 function serializeEndnoteProperties(
   props: EndnoteProperties | undefined,
 ): string {
@@ -359,6 +365,11 @@ export function serializeSectionProperties(
   const footnotePrXml = serializeFootnoteProperties(props.footnotePr);
   if (footnotePrXml) {
     parts.push(footnotePrXml);
+  }
+
+  const footnoteColumnsXml = serializeFootnoteColumns(props);
+  if (footnoteColumnsXml) {
+    parts.push(footnoteColumnsXml);
   }
 
   const endnotePrXml = serializeEndnoteProperties(props.endnotePr);

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -4,10 +4,11 @@ import type {
   FooterReference,
   FootnoteProperties,
   HeaderReference,
+  SectionPropertyChange,
   SectionProperties,
 } from "../../types/document";
 import { getUnserializedSectionPropertyChildNames } from "../sectionParser";
-import { intAttr } from "./xmlUtils";
+import { escapeXml, intAttr } from "./xmlUtils";
 
 function serializeBorder(
   border: BorderSpec | undefined,
@@ -347,6 +348,35 @@ function serializeOnOffElement(
   return value ? `<w:${name}/>` : `<w:${name} w:val="0"/>`;
 }
 
+function serializeSectionPropertyChange(change: SectionPropertyChange): string {
+  const normalizedId =
+    Number.isInteger(change.info.id) && change.info.id >= 0
+      ? change.info.id
+      : 0;
+  const authorCandidate =
+    typeof change.info.author === "string" ? change.info.author.trim() : "";
+  const normalizedAuthor =
+    authorCandidate.length > 0 ? authorCandidate : "Unknown";
+  const normalizedDate =
+    typeof change.info.date === "string" ? change.info.date.trim() : undefined;
+  const normalizedRsid =
+    typeof change.info.rsid === "string" ? change.info.rsid.trim() : undefined;
+  const attrs = [
+    `w:id="${normalizedId}"`,
+    `w:author="${escapeXml(normalizedAuthor)}"`,
+  ];
+  if (normalizedDate) {
+    attrs.push(`w:date="${escapeXml(normalizedDate)}"`);
+  }
+  if (normalizedRsid) {
+    attrs.push(`w:rsid="${escapeXml(normalizedRsid)}"`);
+  }
+
+  const previousSectPrXml =
+    serializeSectionProperties(change.previousProperties) || "<w:sectPr/>";
+  return `<w:sectPrChange ${attrs.join(" ")}>${previousSectPrXml}</w:sectPrChange>`;
+}
+
 export function serializeSectionProperties(
   props: SectionProperties | undefined,
 ): string {
@@ -422,6 +452,9 @@ export function serializeSectionProperties(
     parts.push(
       `<w:printerSettings r:id="${props.printerSettingsRelationshipId}"/>`,
     );
+  }
+  for (const change of props.propertyChanges ?? []) {
+    parts.push(serializeSectionPropertyChange(change));
   }
 
   const unserializedChildNames =

--- a/packages/folio/src/core/docx/tableParser.test.ts
+++ b/packages/folio/src/core/docx/tableParser.test.ts
@@ -108,3 +108,48 @@ describe("table borders", () => {
     });
   });
 });
+
+describe("table bookmark placement", () => {
+  test("attaches cell-level and row-level bookmark markers to adjacent paragraphs", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:tr>
+        <w:tc>
+          <w:bookmarkStart w:id="1" w:name="cellRange"/>
+          <w:p>
+            <w:r><w:t>First</w:t></w:r>
+            <w:bookmarkStart w:id="2" w:name="rowRange"/>
+          </w:p>
+          <w:bookmarkEnd w:id="1"/>
+        </w:tc>
+        <w:bookmarkEnd w:id="2"/>
+        <w:tc><w:p><w:r><w:t>Second</w:t></w:r></w:p></w:tc>
+      </w:tr>
+    </w:tbl>`);
+
+    const firstParagraph = table.rows.at(0)?.cells.at(0)?.content.at(0);
+    expect(firstParagraph?.type).toBe("paragraph");
+    if (!firstParagraph || firstParagraph.type !== "paragraph") {
+      return;
+    }
+
+    expect(firstParagraph.content.map((content) => content.type)).toEqual([
+      "bookmarkStart",
+      "run",
+      "bookmarkStart",
+      "bookmarkEnd",
+      "bookmarkEnd",
+    ]);
+    expect(firstParagraph.content.at(0)).toMatchObject({
+      type: "bookmarkStart",
+      id: 1,
+    });
+    expect(firstParagraph.content.at(-2)).toMatchObject({
+      type: "bookmarkEnd",
+      id: 1,
+    });
+    expect(firstParagraph.content.at(-1)).toMatchObject({
+      type: "bookmarkEnd",
+      id: 2,
+    });
+  });
+});

--- a/packages/folio/src/core/docx/tableParser.test.ts
+++ b/packages/folio/src/core/docx/tableParser.test.ts
@@ -90,6 +90,42 @@ describe("inferImplicitSingleCellRowSpans", () => {
   });
 });
 
+describe("table structured document tag wrappers", () => {
+  test("extracts cells wrapped by row-level content controls", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:tr>
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="Cell control"/></w:sdtPr>
+          <w:sdtContent>
+            <w:tc><w:tcPr><w:vMerge w:val="restart"/></w:tcPr><w:p/></w:tc>
+            <w:tc><w:p/></w:tc>
+          </w:sdtContent>
+        </w:sdt>
+      </w:tr>
+    </w:tbl>`);
+
+    expect(table.rows).toHaveLength(1);
+    expect(table.rows[0]?.cells).toHaveLength(2);
+    expect(table.rows[0]?.cells[0]?.formatting?.vMerge).toBe("restart");
+  });
+
+  test("extracts rows wrapped by table-level content controls", () => {
+    const table = parseTableXml(`<w:tbl ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:alias w:val="Row control"/></w:sdtPr>
+        <w:sdtContent>
+          <w:tr><w:tc><w:p/></w:tc></w:tr>
+          <w:tr><w:tc><w:p/></w:tc></w:tr>
+        </w:sdtContent>
+      </w:sdt>
+    </w:tbl>`);
+
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows[0]?.cells).toHaveLength(1);
+    expect(table.rows[1]?.cells).toHaveLength(1);
+  });
+});
+
 describe("table borders", () => {
   test("preserves unknown border styles for fallback rendering", () => {
     const table = parseTableXml(`<w:tbl ${NS}>

--- a/packages/folio/src/core/docx/tableParser.ts
+++ b/packages/folio/src/core/docx/tableParser.ts
@@ -45,7 +45,17 @@ import type {
   ColorValue,
   RelationshipMap,
   MediaFile,
+  BookmarkEnd,
+  BookmarkStart,
 } from "../types/document";
+import { parseBookmarkEnd, parseBookmarkStart } from "./bookmarkParser";
+import {
+  appendBookmarkMarkerToLastParagraphInBlocks,
+  appendBookmarkMarkerToLastParagraphInCells,
+  prependBookmarkMarkersToFirstParagraphInBlocks,
+  prependBookmarkMarkersToFirstParagraphInCell,
+} from "./bookmarkPlacement";
+import type { BookmarkMarker } from "./bookmarkPlacement";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
 import {
@@ -62,6 +72,7 @@ import {
   findChild,
   findChildren,
   getAttribute,
+  getChildElements,
   parseNumericAttribute,
   parseBooleanElement,
 } from "./xmlParser";
@@ -1203,16 +1214,17 @@ function parseCellContent(
   options?: { inHeaderFooter?: boolean },
 ): (Paragraph | Table)[] {
   const content: (Paragraph | Table)[] = [];
+  const pendingBookmarkMarkers: BookmarkMarker[] = [];
 
   // Get all child elements
-  const elements = tcElement.elements || [];
+  const elements = getChildElements(tcElement);
 
   for (const child of elements) {
     if (!child.name) {
       continue;
     }
 
-    const localName = child.name.split(":").pop();
+    const localName = getLocalName(child.name);
 
     if (localName === "p") {
       // Parse paragraph
@@ -1225,6 +1237,7 @@ function parseCellContent(
         media,
         options,
       );
+      prependPendingBookmarkMarkers(para, pendingBookmarkMarkers);
       content.push(para);
     } else if (localName === "tbl") {
       // Parse nested table (recursive)
@@ -1237,7 +1250,20 @@ function parseCellContent(
         media,
         options,
       );
+      if (
+        prependBookmarkMarkersToFirstParagraphInBlocks(
+          [table],
+          pendingBookmarkMarkers,
+        )
+      ) {
+        pendingBookmarkMarkers.length = 0;
+      }
       content.push(table);
+    } else if (localName === "bookmarkStart" || localName === "bookmarkEnd") {
+      const marker = parseBookmarkMarker(child, localName);
+      if (!appendBookmarkMarkerToLastParagraphInBlocks(content, marker)) {
+        pendingBookmarkMarkers.push(marker);
+      }
     }
     // Other content types in cells are rare but could be added
   }
@@ -1246,8 +1272,13 @@ function parseCellContent(
   if (content.length === 0) {
     content.push({
       type: "paragraph",
-      content: [],
+      content: [...pendingBookmarkMarkers],
     });
+  } else if (pendingBookmarkMarkers.length > 0) {
+    appendBookmarkMarkersToLastParagraphInBlocks(
+      content,
+      pendingBookmarkMarkers,
+    );
   }
 
   return content;
@@ -1359,21 +1390,98 @@ export function parseTableRow(
   }
 
   // Parse cells
-  const cells = findChildren(trElement, "w", "tc");
-  for (const cellElement of cells) {
-    const cell = parseTableCell(
-      cellElement,
-      styles,
-      theme,
-      numbering,
-      rels,
-      media,
-      options,
-    );
-    row.cells.push(cell);
+  const pendingBookmarkMarkers: BookmarkMarker[] = [];
+  for (const child of getChildElements(trElement)) {
+    const localName = getLocalName(child.name);
+    if (localName === "tc") {
+      const cell = parseTableCell(
+        child,
+        styles,
+        theme,
+        numbering,
+        rels,
+        media,
+        options,
+      );
+      if (pendingBookmarkMarkers.length > 0) {
+        prependBookmarkMarkersToFirstParagraphInCell(
+          cell,
+          pendingBookmarkMarkers,
+        );
+        pendingBookmarkMarkers.length = 0;
+      }
+      row.cells.push(cell);
+      continue;
+    }
+
+    if (localName !== "bookmarkStart" && localName !== "bookmarkEnd") {
+      continue;
+    }
+
+    const marker = parseBookmarkMarker(child, localName);
+    if (!appendBookmarkMarkerToLastParagraphInCells(row.cells, marker)) {
+      pendingBookmarkMarkers.push(marker);
+    }
+  }
+
+  if (pendingBookmarkMarkers.length > 0) {
+    appendBookmarkMarkersToLastCell(row, pendingBookmarkMarkers);
   }
 
   return row;
+}
+
+function getLocalName(name: string | undefined): string {
+  if (!name) {
+    return "";
+  }
+  const colonIndex = name.indexOf(":");
+  return colonIndex === -1 ? name : name.slice(colonIndex + 1);
+}
+
+function parseBookmarkMarker(
+  child: XmlElement,
+  localName: "bookmarkStart" | "bookmarkEnd",
+): BookmarkStart | BookmarkEnd {
+  if (localName === "bookmarkStart") {
+    return parseBookmarkStart(child);
+  }
+  return parseBookmarkEnd(child);
+}
+
+function prependPendingBookmarkMarkers(
+  paragraph: Paragraph,
+  pendingBookmarkMarkers: BookmarkMarker[],
+): void {
+  if (pendingBookmarkMarkers.length === 0) {
+    return;
+  }
+
+  paragraph.content.unshift(...pendingBookmarkMarkers);
+  pendingBookmarkMarkers.length = 0;
+}
+
+function appendBookmarkMarkersToLastParagraphInBlocks(
+  blocks: readonly (Paragraph | Table)[],
+  markers: readonly BookmarkMarker[],
+): void {
+  for (const marker of markers) {
+    appendBookmarkMarkerToLastParagraphInBlocks(blocks, marker);
+  }
+}
+
+function appendBookmarkMarkersToLastCell(
+  row: TableRow,
+  markers: readonly BookmarkMarker[],
+): void {
+  const lastCell = row.cells.at(-1);
+  if (!lastCell) {
+    return;
+  }
+
+  for (const marker of markers) {
+    appendBookmarkMarkerToLastParagraphInBlocks(lastCell.content, marker);
+  }
 }
 
 // ============================================================================

--- a/packages/folio/src/core/docx/tableParser.ts
+++ b/packages/folio/src/core/docx/tableParser.ts
@@ -70,6 +70,7 @@ import {
 import type { StyleMap } from "./styleParser";
 import {
   findChild,
+  findChildByLocalName,
   findChildren,
   getAttribute,
   getChildElements,
@@ -1391,7 +1392,7 @@ export function parseTableRow(
 
   // Parse cells
   const pendingBookmarkMarkers: BookmarkMarker[] = [];
-  for (const child of getChildElements(trElement)) {
+  const parseRowChild = (child: XmlElement): void => {
     const localName = getLocalName(child.name);
     if (localName === "tc") {
       const cell = parseTableCell(
@@ -1411,17 +1412,32 @@ export function parseTableRow(
         pendingBookmarkMarkers.length = 0;
       }
       row.cells.push(cell);
-      continue;
+      return;
+    }
+
+    if (localName === "sdt") {
+      const sdtContent = findChildByLocalName(child, "sdtContent");
+      if (!sdtContent) {
+        return;
+      }
+      for (const sdtChild of getChildElements(sdtContent)) {
+        parseRowChild(sdtChild);
+      }
+      return;
     }
 
     if (localName !== "bookmarkStart" && localName !== "bookmarkEnd") {
-      continue;
+      return;
     }
 
     const marker = parseBookmarkMarker(child, localName);
     if (!appendBookmarkMarkerToLastParagraphInCells(row.cells, marker)) {
       pendingBookmarkMarkers.push(marker);
     }
+  };
+
+  for (const child of getChildElements(trElement)) {
+    parseRowChild(child);
   }
 
   if (pendingBookmarkMarkers.length > 0) {
@@ -1653,22 +1669,42 @@ export function parseTable(
   }
 
   // Parse rows
-  const rows = findChildren(tblElement, "w", "tr");
   const rowsWithGridOffsets = new Set<number>();
-  for (const [rowIndex, rowElement] of rows.entries()) {
-    const row = parseTableRow(
-      rowElement,
-      styles,
-      theme,
-      numbering,
-      rels,
-      media,
-      options,
-    );
-    table.rows.push(row);
-    if (hasRowGridOffsets(rowElement)) {
-      rowsWithGridOffsets.add(rowIndex);
+  const parseTableChild = (child: XmlElement): void => {
+    const localName = getLocalName(child.name);
+    if (localName === "tr") {
+      const rowIndex = table.rows.length;
+      const row = parseTableRow(
+        child,
+        styles,
+        theme,
+        numbering,
+        rels,
+        media,
+        options,
+      );
+      table.rows.push(row);
+      if (hasRowGridOffsets(child)) {
+        rowsWithGridOffsets.add(rowIndex);
+      }
+      return;
     }
+
+    if (localName !== "sdt") {
+      return;
+    }
+
+    const sdtContent = findChildByLocalName(child, "sdtContent");
+    if (!sdtContent) {
+      return;
+    }
+    for (const sdtChild of getChildElements(sdtContent)) {
+      parseTableChild(sdtChild);
+    }
+  };
+
+  for (const child of getChildElements(tblElement)) {
+    parseTableChild(child);
   }
 
   inferImplicitSingleCellRowSpans(table, rowsWithGridOffsets);

--- a/packages/folio/src/core/docx/trackedMoveRangeNormalization.test.ts
+++ b/packages/folio/src/core/docx/trackedMoveRangeNormalization.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { DocumentBody } from "../types/document";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx } from "./rezip";
+import { normalizeTrackedMoveRanges } from "./trackedMoveRangeNormalization";
+
+const XML_DECLARATION =
+  '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+describe("normalizeTrackedMoveRanges", () => {
+  test("removes unbalanced tracked move range markers", () => {
+    const documentBody: DocumentBody = {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "moveToRangeStart", id: 34, name: "moveA" },
+            {
+              type: "run",
+              content: [{ type: "text", text: "Destination" }],
+            },
+            { type: "moveFromRangeStart", id: 60, name: "moveB" },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeTrackedMoveRanges({ documentBody });
+
+    expect(result).toEqual({
+      removedUnbalancedMoveRangeMarkers: 2,
+    });
+    const paragraph = documentBody.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(paragraph.content.map((content) => content.type)).toEqual(["run"]);
+  });
+
+  test("removes out-of-order tracked move range markers", () => {
+    const documentBody: DocumentBody = {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "moveFromRangeEnd", id: 8 },
+            {
+              type: "run",
+              content: [{ type: "text", text: "Moved" }],
+            },
+            { type: "moveFromRangeStart", id: 8, name: "moveA" },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeTrackedMoveRanges({ documentBody });
+
+    expect(result).toEqual({
+      removedUnbalancedMoveRangeMarkers: 2,
+    });
+    const paragraph = documentBody.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(paragraph.content.map((content) => content.type)).toEqual(["run"]);
+  });
+
+  test("parses and saves documents with unbalanced tracked move ranges", async () => {
+    const buffer = await createUnbalancedMoveRangeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    const block = doc.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      throw new Error("Expected first block to be a paragraph");
+    }
+    expect(block.content.map((content) => content.type)).toEqual(["run"]);
+    expect(doc.warnings).toContain(
+      "Removed 2 unbalanced tracked move range marker(s).",
+    );
+
+    const repacked = await repackDocx(doc, { updateModifiedDate: false });
+    const zip = await JSZip.loadAsync(repacked);
+    const documentXml = await zip.file("word/document.xml")?.async("string");
+
+    expect(documentXml).not.toContain("moveFromRangeStart");
+    expect(documentXml).not.toContain("moveToRangeStart");
+
+    const reparsed = await parseDocx(repacked, { preloadFonts: false });
+    expect(reparsed.warnings ?? []).not.toContain(
+      "Removed 2 unbalanced tracked move range marker(s).",
+    );
+  });
+});
+
+const createUnbalancedMoveRangeFixture = async (): Promise<ArrayBuffer> => {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML_DECLARATION}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML_DECLARATION}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML_DECLARATION}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:moveToRangeStart w:id="34" w:name="moveA"/>
+      <w:r><w:t>Moved text</w:t></w:r>
+      <w:moveFromRangeStart w:id="60" w:name="moveB"/>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+};

--- a/packages/folio/src/core/docx/trackedMoveRangeNormalization.test.ts
+++ b/packages/folio/src/core/docx/trackedMoveRangeNormalization.test.ts
@@ -71,6 +71,42 @@ describe("normalizeTrackedMoveRanges", () => {
     expect(paragraph.content.map((content) => content.type)).toEqual(["run"]);
   });
 
+  test("removes unbalanced tracked move range markers from comments", () => {
+    const documentBody: DocumentBody = {
+      content: [],
+      comments: [
+        {
+          id: 1,
+          author: "Reviewer",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "moveToRangeStart", id: 34, name: "moveA" },
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Moved" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = normalizeTrackedMoveRanges({ documentBody });
+
+    expect(result).toEqual({
+      removedUnbalancedMoveRangeMarkers: 1,
+    });
+    expect(
+      documentBody.comments
+        ?.at(0)
+        ?.content.at(0)
+        ?.content.map((content) => content.type),
+    ).toEqual(["run"]);
+  });
+
   test("parses and saves documents with unbalanced tracked move ranges", async () => {
     const buffer = await createUnbalancedMoveRangeFixture();
     const doc = await parseDocx(buffer, { preloadFonts: false });

--- a/packages/folio/src/core/docx/trackedMoveRangeNormalization.ts
+++ b/packages/folio/src/core/docx/trackedMoveRangeNormalization.ts
@@ -1,0 +1,160 @@
+import type {
+  DocumentBody,
+  Endnote,
+  Footnote,
+  HeaderFooter,
+  ParagraphContent,
+} from "../types/document";
+import { visitDocxParagraphs } from "./paragraphTraversal";
+
+type NormalizeTrackedMoveRangesInput = {
+  documentBody: DocumentBody;
+  headers?: Map<string, HeaderFooter>;
+  footers?: Map<string, HeaderFooter>;
+  footnotes?: readonly Footnote[];
+  endnotes?: readonly Endnote[];
+};
+
+type NormalizeTrackedMoveRangesResult = {
+  removedUnbalancedMoveRangeMarkers: number;
+};
+
+type MoveRangeMarkerRef = {
+  content: ParagraphContent[];
+  index: number;
+  id: number;
+  kind: "moveFrom" | "moveTo";
+  side: "start" | "end";
+};
+
+export const normalizeTrackedMoveRanges = ({
+  documentBody,
+  headers,
+  footers,
+  footnotes,
+  endnotes,
+}: NormalizeTrackedMoveRangesInput): NormalizeTrackedMoveRangesResult => {
+  const rangeMarkers: MoveRangeMarkerRef[] = [];
+
+  visitDocxParagraphs(
+    { documentBody, headers, footers, footnotes, endnotes },
+    (paragraph) => {
+      for (const [index, content] of paragraph.content.entries()) {
+        const marker = toMoveRangeMarkerRef(paragraph.content, index, content);
+        if (marker) {
+          rangeMarkers.push(marker);
+        }
+      }
+    },
+  );
+
+  return {
+    removedUnbalancedMoveRangeMarkers:
+      removeUnbalancedMoveRangeMarkers(rangeMarkers),
+  };
+};
+
+const removeUnbalancedMoveRangeMarkers = (
+  rangeMarkers: readonly MoveRangeMarkerRef[],
+): number => {
+  const byRange = new Map<string, MoveRangeMarkerRef[]>();
+  for (const marker of rangeMarkers) {
+    const key = `${marker.kind}:${marker.id}`;
+    const markers = byRange.get(key);
+    if (markers) {
+      markers.push(marker);
+      continue;
+    }
+    byRange.set(key, [marker]);
+  }
+
+  const removals = new Map<ParagraphContent[], Set<number>>();
+  const markForRemoval = (marker: MoveRangeMarkerRef): void => {
+    const indexes = removals.get(marker.content);
+    if (indexes) {
+      indexes.add(marker.index);
+      return;
+    }
+    removals.set(marker.content, new Set([marker.index]));
+  };
+
+  for (const markers of byRange.values()) {
+    let openStart: MoveRangeMarkerRef | null = null;
+    for (const marker of markers) {
+      if (marker.side === "start") {
+        if (openStart) {
+          markForRemoval(marker);
+          continue;
+        }
+        openStart = marker;
+        continue;
+      }
+
+      if (!openStart) {
+        markForRemoval(marker);
+        continue;
+      }
+      openStart = null;
+    }
+
+    if (openStart) {
+      markForRemoval(openStart);
+    }
+  }
+
+  let removedCount = 0;
+  for (const [content, indexes] of removals.entries()) {
+    if (indexes.size === 0) {
+      continue;
+    }
+    const nextContent = content.filter((_, index) => !indexes.has(index));
+    removedCount += content.length - nextContent.length;
+    content.length = 0;
+    content.push(...nextContent);
+  }
+  return removedCount;
+};
+
+const toMoveRangeMarkerRef = (
+  content: ParagraphContent[],
+  index: number,
+  marker: ParagraphContent,
+): MoveRangeMarkerRef | null => {
+  if (marker.type === "moveFromRangeStart") {
+    return {
+      content,
+      index,
+      id: marker.id,
+      kind: "moveFrom",
+      side: "start",
+    };
+  }
+  if (marker.type === "moveFromRangeEnd") {
+    return {
+      content,
+      index,
+      id: marker.id,
+      kind: "moveFrom",
+      side: "end",
+    };
+  }
+  if (marker.type === "moveToRangeStart") {
+    return {
+      content,
+      index,
+      id: marker.id,
+      kind: "moveTo",
+      side: "start",
+    };
+  }
+  if (marker.type === "moveToRangeEnd") {
+    return {
+      content,
+      index,
+      id: marker.id,
+      kind: "moveTo",
+      side: "end",
+    };
+  }
+  return null;
+};

--- a/packages/folio/src/core/docx/unzip.test.ts
+++ b/packages/folio/src/core/docx/unzip.test.ts
@@ -28,6 +28,23 @@ describe("unzipDocx security limits", () => {
     expect(error).toBeInstanceOf(DocxSecurityError);
   });
 
+  test("repairs archives missing the end-of-central-directory tail", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    const truncated = truncateAfterEndOfCentralDirectoryCounts(buffer);
+    const content = await unzipDocx(truncated);
+
+    expect(content.documentXml).toBe("<w:document />");
+    expect(content.originalBuffer.byteLength).toBe(buffer.byteLength);
+    expect(getFileList(content)).toEqual([
+      "[Content_Types].xml",
+      "word/document.xml",
+    ]);
+  });
+
   test("rejects unsafe archive paths", async () => {
     const zip = new JSZip();
     zip.file("/word/document.xml", "<w:document />");
@@ -100,6 +117,22 @@ describe("unzipDocx security limits", () => {
     expect(getFileList(content)).toContain("word/media/image1.emf");
   });
 });
+
+function truncateAfterEndOfCentralDirectoryCounts(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  for (let offset = bytes.byteLength - 22; offset >= 0; offset -= 1) {
+    if (
+      bytes[offset] === 0x50 &&
+      bytes[offset + 1] === 0x4b &&
+      bytes[offset + 2] === 0x05 &&
+      bytes[offset + 3] === 0x06
+    ) {
+      return bytes.slice(0, offset + 12).buffer;
+    }
+  }
+
+  throw new Error("Could not find ZIP end-of-central-directory record");
+}
 
 const getRejectedError = async (promise: Promise<unknown>) =>
   promise.then(() => null).catch((error: unknown) => error);

--- a/packages/folio/src/core/docx/unzip.test.ts
+++ b/packages/folio/src/core/docx/unzip.test.ts
@@ -28,6 +28,42 @@ describe("unzipDocx security limits", () => {
     expect(error).toBeInstanceOf(DocxSecurityError);
   });
 
+  test("accepts large document XML entries within the default limit", async () => {
+    const zip = new JSZip();
+    const largeBody = "x".repeat(26 * 1024 * 1024);
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", `<w:document>${largeBody}</w:document>`);
+
+    const content = await unzipDocx(
+      await zip.generateAsync({
+        compression: "DEFLATE",
+        type: "arraybuffer",
+      }),
+    );
+
+    expect(content.documentXml?.length).toBe(
+      "<w:document></w:document>".length + largeBody.length,
+    );
+  });
+
+  test("accepts media-heavy packages within the default file-count limit", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    for (let index = 0; index < 3800; index += 1) {
+      zip.file(
+        `word/media/image${index}.png`,
+        new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00]),
+      );
+    }
+
+    const content = await unzipDocx(
+      await zip.generateAsync({ type: "arraybuffer" }),
+    );
+
+    expect(content.media.size).toBe(3800);
+  });
+
   test("repairs archives missing the end-of-central-directory tail", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", "<Types />");

--- a/packages/folio/src/core/docx/unzip.test.ts
+++ b/packages/folio/src/core/docx/unzip.test.ts
@@ -46,6 +46,25 @@ describe("unzipDocx security limits", () => {
     );
   });
 
+  test("accepts large header XML entries within the default limit", async () => {
+    const zip = new JSZip();
+    const largeHeader = "x".repeat(65 * 1024 * 1024);
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/header3.xml", `<w:hdr>${largeHeader}</w:hdr>`);
+
+    const content = await unzipDocx(
+      await zip.generateAsync({
+        compression: "DEFLATE",
+        type: "arraybuffer",
+      }),
+    );
+
+    expect(content.headers.get("header3.xml")?.length).toBe(
+      "<w:hdr></w:hdr>".length + largeHeader.length,
+    );
+  });
+
   test("accepts media-heavy packages within the default file-count limit", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", "<Types />");
@@ -147,6 +166,23 @@ describe("unzipDocx security limits", () => {
 
     const content = await unzipDocx(
       await zip.generateAsync({ type: "arraybuffer" }),
+    );
+
+    expect(content.media.size).toBe(0);
+    expect(getFileList(content)).toContain("word/media/image1.emf");
+  });
+
+  test("preserves large vector image entries without extracting them", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/media/image1.emf", new Uint8Array(26 * 1024 * 1024));
+
+    const content = await unzipDocx(
+      await zip.generateAsync({
+        compression: "DEFLATE",
+        type: "arraybuffer",
+      }),
     );
 
     expect(content.media.size).toBe(0);

--- a/packages/folio/src/core/docx/unzip.test.ts
+++ b/packages/folio/src/core/docx/unzip.test.ts
@@ -188,6 +188,21 @@ describe("unzipDocx security limits", () => {
     expect(content.media.size).toBe(0);
     expect(getFileList(content)).toContain("word/media/image1.emf");
   });
+
+  test("skips oversized embedded fonts without rejecting the document", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/fonts/font1.odttf", new Uint8Array([1, 2, 3, 4]));
+
+    const content = await unzipDocx(
+      await zip.generateAsync({ type: "arraybuffer" }),
+      { maxFontBytes: 3 },
+    );
+
+    expect(content.fonts.size).toBe(0);
+    expect(getFileList(content)).toContain("word/fonts/font1.odttf");
+  });
 });
 
 function truncateAfterEndOfCentralDirectoryCounts(buffer: ArrayBuffer) {

--- a/packages/folio/src/core/docx/unzip.test.ts
+++ b/packages/folio/src/core/docx/unzip.test.ts
@@ -139,6 +139,24 @@ describe("unzipDocx security limits", () => {
     expect(content.media.has("word/media/image1.png")).toBe(true);
   });
 
+  test("skips oversized raster media instead of rejecting the document", async () => {
+    const zip = new JSZip();
+    zip.file("[Content_Types].xml", "<Types />");
+    zip.file("word/document.xml", "<w:document />");
+    zip.file("word/media/image1.png", new Uint8Array([0x89, 0x50, 0x4e, 0x47]));
+
+    const content = await unzipDocx(
+      await zip.generateAsync({ type: "arraybuffer" }),
+      { maxMediaBytes: 3 },
+    );
+
+    expect(content.media.size).toBe(0);
+    expect(getFileList(content)).toContain("word/media/image1.png");
+    expect(content.warnings).toContain(
+      "Skipped oversized media file: word/media/image1.png; original entry preserved for round-trip.",
+    );
+  });
+
   test("does not expose active or embedded payload entries for preservation", async () => {
     const zip = new JSZip();
     zip.file("[Content_Types].xml", "<Types />");

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -82,6 +82,22 @@ type ZipEntryWithMetadata = {
   };
 };
 
+type LoadedZip = {
+  zip: JSZip;
+  buffer: ArrayBuffer;
+};
+
+type CentralDirectoryInfo = {
+  offset: number;
+  size: number;
+};
+
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06_05_4b_50;
+const ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE = 0x02_01_4b_50;
+const ZIP_END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+const ZIP_END_OF_CENTRAL_DIRECTORY_WITH_COUNTS_SIZE = 12;
+const ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIZE = 46;
+
 /**
  * Raw extracted content from a DOCX file
  */
@@ -159,7 +175,12 @@ export async function unzipDocx(
     throw new DocxSecurityError("DOCX file exceeds the maximum allowed size");
   }
 
-  const zip = await JSZip.loadAsync(buffer);
+  const loaded = await loadDocxZip(buffer, limits.maxFiles);
+  if (loaded.buffer.byteLength > limits.maxInputBytes) {
+    throw new DocxSecurityError("DOCX file exceeds the maximum allowed size");
+  }
+
+  const { zip } = loaded;
   const entries = Object.entries(zip.files).filter(([, file]) => !file.dir);
 
   if (entries.length > limits.maxFiles) {
@@ -191,7 +212,7 @@ export async function unzipDocx(
     fonts: new Map(),
     allXml: new Map(),
     originalZip: zip,
-    originalBuffer: buffer,
+    originalBuffer: loaded.buffer,
   };
 
   let totalUncompressedBytes = 0;
@@ -292,6 +313,186 @@ export async function unzipDocx(
   }
 
   return content;
+}
+
+async function loadDocxZip(
+  buffer: ArrayBuffer,
+  maxFiles: number,
+): Promise<LoadedZip> {
+  try {
+    return { zip: await JSZip.loadAsync(buffer), buffer };
+  } catch (error) {
+    const repairedBuffer = repairTruncatedEndOfCentralDirectory(
+      buffer,
+      maxFiles,
+    );
+    if (!repairedBuffer) {
+      throw error;
+    }
+
+    try {
+      return {
+        zip: await JSZip.loadAsync(repairedBuffer),
+        buffer: repairedBuffer,
+      };
+    } catch {
+      throw error;
+    }
+  }
+}
+
+function repairTruncatedEndOfCentralDirectory(
+  buffer: ArrayBuffer,
+  maxFiles: number,
+): ArrayBuffer | null {
+  const bytes = new Uint8Array(buffer);
+  const view = new DataView(buffer);
+  const eocdOffset = findLastSignature(
+    view,
+    bytes.byteLength,
+    ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE,
+  );
+  if (eocdOffset === -1) {
+    return null;
+  }
+
+  const eocdBytes = bytes.byteLength - eocdOffset;
+  if (
+    eocdBytes >= ZIP_END_OF_CENTRAL_DIRECTORY_SIZE ||
+    eocdBytes < ZIP_END_OF_CENTRAL_DIRECTORY_WITH_COUNTS_SIZE
+  ) {
+    return null;
+  }
+
+  const diskNumber = view.getUint16(eocdOffset + 4, true);
+  const centralDirectoryDisk = view.getUint16(eocdOffset + 6, true);
+  const diskEntryCount = view.getUint16(eocdOffset + 8, true);
+  const totalEntryCount = view.getUint16(eocdOffset + 10, true);
+
+  if (
+    diskNumber !== 0 ||
+    centralDirectoryDisk !== 0 ||
+    diskEntryCount !== totalEntryCount ||
+    totalEntryCount > maxFiles
+  ) {
+    return null;
+  }
+
+  const centralDirectory = findCentralDirectory(
+    view,
+    eocdOffset,
+    totalEntryCount,
+  );
+  if (!centralDirectory) {
+    return null;
+  }
+
+  const repaired = new Uint8Array(
+    eocdOffset + ZIP_END_OF_CENTRAL_DIRECTORY_SIZE,
+  );
+  repaired.set(bytes.subarray(0, eocdOffset));
+  const repairedView = new DataView(repaired.buffer);
+
+  repairedView.setUint32(
+    eocdOffset,
+    ZIP_END_OF_CENTRAL_DIRECTORY_SIGNATURE,
+    true,
+  );
+  repairedView.setUint16(eocdOffset + 4, 0, true);
+  repairedView.setUint16(eocdOffset + 6, 0, true);
+  repairedView.setUint16(eocdOffset + 8, totalEntryCount, true);
+  repairedView.setUint16(eocdOffset + 10, totalEntryCount, true);
+  repairedView.setUint32(eocdOffset + 12, centralDirectory.size, true);
+  repairedView.setUint32(eocdOffset + 16, centralDirectory.offset, true);
+  repairedView.setUint16(eocdOffset + 20, 0, true);
+
+  return repaired.buffer;
+}
+
+function findCentralDirectory(
+  view: DataView,
+  eocdOffset: number,
+  entryCount: number,
+): CentralDirectoryInfo | null {
+  for (
+    let offset = 0;
+    offset <= eocdOffset - ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIZE;
+    offset += 1
+  ) {
+    if (
+      view.getUint32(offset, true) !==
+      ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE
+    ) {
+      continue;
+    }
+
+    const parsed = parseCentralDirectoryAt(
+      view,
+      offset,
+      eocdOffset,
+      entryCount,
+    );
+    if (parsed) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function parseCentralDirectoryAt(
+  view: DataView,
+  startOffset: number,
+  eocdOffset: number,
+  entryCount: number,
+): CentralDirectoryInfo | null {
+  let offset = startOffset;
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (
+      offset + ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIZE > eocdOffset ||
+      view.getUint32(offset, true) !==
+        ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIGNATURE
+    ) {
+      return null;
+    }
+
+    const filenameLength = view.getUint16(offset + 28, true);
+    const extraLength = view.getUint16(offset + 30, true);
+    const commentLength = view.getUint16(offset + 32, true);
+    offset +=
+      ZIP_CENTRAL_DIRECTORY_FILE_HEADER_SIZE +
+      filenameLength +
+      extraLength +
+      commentLength;
+  }
+
+  if (offset !== eocdOffset) {
+    return null;
+  }
+
+  return {
+    offset: startOffset,
+    size: eocdOffset - startOffset,
+  };
+}
+
+function findLastSignature(
+  view: DataView,
+  byteLength: number,
+  signature: number,
+): number {
+  for (
+    let offset = byteLength - ZIP_END_OF_CENTRAL_DIRECTORY_WITH_COUNTS_SIZE;
+    offset >= 0;
+    offset -= 1
+  ) {
+    if (view.getUint32(offset, true) === signature) {
+      return offset;
+    }
+  }
+
+  return -1;
 }
 
 function createUnzipLimits(options: PartialDocxUnzipLimits): DocxUnzipLimits {

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -160,6 +160,10 @@ export type RawDocxContent = {
 
   // Original buffer for round-trip
   originalBuffer: ArrayBuffer;
+
+  // Non-fatal extraction warnings. The original ZIP remains available for
+  // round-trip preservation when optional payloads are skipped.
+  warnings: string[];
 };
 
 /**
@@ -215,6 +219,7 @@ export async function unzipDocx(
     allXml: new Map(),
     originalZip: zip,
     originalBuffer: loaded.buffer,
+    warnings: [],
   };
 
   let totalUncompressedBytes = 0;
@@ -298,9 +303,19 @@ export async function unzipDocx(
       if (!limits.allowedMediaMimeTypes.has(mimeType)) {
         continue;
       }
-      assertEntrySize(path, declaredSize, limits.maxMediaBytes);
+      if (isEntryTooLarge(declaredSize, limits.maxMediaBytes)) {
+        content.warnings.push(
+          `Skipped oversized media file: ${path}; original entry preserved for round-trip.`,
+        );
+        continue;
+      }
       const binaryContent = await file.async("arraybuffer");
-      assertExtractedSize(path, binaryContent.byteLength, limits.maxMediaBytes);
+      if (binaryContent.byteLength > limits.maxMediaBytes) {
+        content.warnings.push(
+          `Skipped oversized media file: ${path}; original entry preserved for round-trip.`,
+        );
+        continue;
+      }
       if (!isMediaContentAllowed(binaryContent, mimeType)) {
         continue;
       }

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -59,13 +59,15 @@ const PRESERVABLE_MEDIA_MIME_TYPES = new Set([
   "image/x-emf",
 ]);
 
+const MEBIBYTE = 1024 * 1024;
+
 const DEFAULT_UNZIP_LIMITS: DocxUnzipLimits = {
-  maxInputBytes: 50 * 1024 * 1024,
-  maxFiles: 2000,
-  maxXmlBytes: 25 * 1024 * 1024,
-  maxMediaBytes: 25 * 1024 * 1024,
-  maxFontBytes: 10 * 1024 * 1024,
-  maxTotalUncompressedBytes: 250 * 1024 * 1024,
+  maxInputBytes: 50 * MEBIBYTE,
+  maxFiles: 5000,
+  maxXmlBytes: 64 * MEBIBYTE,
+  maxMediaBytes: 25 * MEBIBYTE,
+  maxFontBytes: 10 * MEBIBYTE,
+  maxTotalUncompressedBytes: 250 * MEBIBYTE,
   allowedMediaMimeTypes: DEFAULT_ALLOWED_MEDIA_MIME_TYPES,
 };
 

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -306,10 +306,15 @@ export async function unzipDocx(
       }
       content.media.set(path, binaryContent);
     } else if (lowerPath.startsWith("word/fonts/")) {
-      // Embedded fonts
-      assertEntrySize(path, declaredSize, limits.maxFontBytes);
+      // Embedded fonts are optional for editing and original ZIP preservation.
+      // Skip oversized fonts instead of rejecting otherwise readable documents.
+      if (isEntryTooLarge(declaredSize, limits.maxFontBytes)) {
+        continue;
+      }
       const binaryContent = await file.async("arraybuffer");
-      assertExtractedSize(path, binaryContent.byteLength, limits.maxFontBytes);
+      if (binaryContent.byteLength > limits.maxFontBytes) {
+        continue;
+      }
       content.fonts.set(path, binaryContent);
     }
   }
@@ -553,9 +558,16 @@ function assertEntrySize(
   declaredSize: number | null,
   maxBytes: number,
 ): void {
-  if (declaredSize !== null && declaredSize > maxBytes) {
+  if (isEntryTooLarge(declaredSize, maxBytes)) {
     throw new DocxSecurityError(`DOCX entry exceeds maximum size: ${path}`);
   }
+}
+
+function isEntryTooLarge(
+  declaredSize: number | null,
+  maxBytes: number,
+): boolean {
+  return declaredSize !== null && declaredSize > maxBytes;
 }
 
 function assertExtractedSize(

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -285,10 +285,10 @@ export async function unzipDocx(
         content.appPropsXml = xmlContent;
       } else if (lowerPath === "docprops/custom.xml") {
         content.customPropsXml = xmlContent;
-      } else if (/^word\/header\d+\.xml$/u.test(lowerPath)) {
+      } else if (/^word\/header[^/]*\.xml$/u.test(lowerPath)) {
         const filename = path.split("/").pop() || path;
         content.headers.set(filename, xmlContent);
-      } else if (/^word\/footer\d+\.xml$/u.test(lowerPath)) {
+      } else if (/^word\/footer[^/]*\.xml$/u.test(lowerPath)) {
         const filename = path.split("/").pop() || path;
         content.footers.set(filename, xmlContent);
       }

--- a/packages/folio/src/core/docx/unzip.ts
+++ b/packages/folio/src/core/docx/unzip.ts
@@ -64,7 +64,7 @@ const MEBIBYTE = 1024 * 1024;
 const DEFAULT_UNZIP_LIMITS: DocxUnzipLimits = {
   maxInputBytes: 50 * MEBIBYTE,
   maxFiles: 5000,
-  maxXmlBytes: 64 * MEBIBYTE,
+  maxXmlBytes: 128 * MEBIBYTE,
   maxMediaBytes: 25 * MEBIBYTE,
   maxFontBytes: 10 * MEBIBYTE,
   maxTotalUncompressedBytes: 250 * MEBIBYTE,
@@ -295,10 +295,10 @@ export async function unzipDocx(
     } else if (lowerPath.startsWith("word/media/")) {
       // Media files (images, etc.)
       const mimeType = getMediaMimeType(path);
-      assertEntrySize(path, declaredSize, limits.maxMediaBytes);
       if (!limits.allowedMediaMimeTypes.has(mimeType)) {
         continue;
       }
+      assertEntrySize(path, declaredSize, limits.maxMediaBytes);
       const binaryContent = await file.async("arraybuffer");
       assertExtractedSize(path, binaryContent.byteLength, limits.maxMediaBytes);
       if (!isMediaContentAllowed(binaryContent, mimeType)) {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -60,14 +60,18 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(() => toFlowBlocks(mathDoc)).toThrow("math.attrs.ommlXml");
   });
 
-  test("rejects malformed text box attrs at the layout boundary", () => {
-    const doc = schema.node("doc", null, [
+  test("rejects malformed shape and text box attrs at the layout boundary", () => {
+    const shapeDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.node("shape", { width: "wide" })]),
+    ]);
+    const textBoxDoc = schema.node("doc", null, [
       schema.node("textBox", { width: "wide" }, [
         schema.node("paragraph", null, [schema.text("Invalid text box")]),
       ]),
     ]);
 
-    expect(() => toFlowBlocks(doc)).toThrow("textBox.attrs.width");
+    expect(() => toFlowBlocks(shapeDoc)).toThrow("shape.attrs.width");
+    expect(() => toFlowBlocks(textBoxDoc)).toThrow("textBox.attrs.width");
   });
 
   test("does not convert absent paragraph spacing defaults to zero line height", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -26,6 +26,15 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(() => toFlowBlocks(doc)).toThrow("paragraph.attrs.lineSpacing");
   });
 
+  test("rejects malformed mark attrs at the layout boundary", () => {
+    const fontSize = schema.mark("fontSize", { size: "large" });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Invalid mark", [fontSize])]),
+    ]);
+
+    expect(() => toFlowBlocks(doc)).toThrow("fontSize.attrs.size");
+  });
+
   test("does not convert absent paragraph spacing defaults to zero line height", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First paragraph")]),

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -16,6 +16,16 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(second).toEqual(first);
   });
 
+  test("rejects malformed paragraph attrs at the layout boundary", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { lineSpacing: "240" }, [
+        schema.text("Invalid paragraph"),
+      ]),
+    ]);
+
+    expect(() => toFlowBlocks(doc)).toThrow("paragraph.attrs.lineSpacing");
+  });
+
   test("does not convert absent paragraph spacing defaults to zero line height", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First paragraph")]),

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -35,6 +35,41 @@ describe("toFlowBlocks paragraph formatting", () => {
     expect(() => toFlowBlocks(doc)).toThrow("fontSize.attrs.size");
   });
 
+  test("rejects malformed field and math attrs at the layout boundary", () => {
+    const fieldDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("field", {
+          fieldType: "NOT_A_FIELD",
+          instruction: " PAGE ",
+          displayText: "1",
+          fieldKind: "simple",
+        }),
+      ]),
+    ]);
+    const mathDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("math", {
+          display: "inline",
+          ommlXml: 42,
+          plainText: "x",
+        }),
+      ]),
+    ]);
+
+    expect(() => toFlowBlocks(fieldDoc)).toThrow("field.attrs.fieldType");
+    expect(() => toFlowBlocks(mathDoc)).toThrow("math.attrs.ommlXml");
+  });
+
+  test("rejects malformed text box attrs at the layout boundary", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("textBox", { width: "wide" }, [
+        schema.node("paragraph", null, [schema.text("Invalid text box")]),
+      ]),
+    ]);
+
+    expect(() => toFlowBlocks(doc)).toThrow("textBox.attrs.width");
+  });
+
   test("does not convert absent paragraph spacing defaults to zero line height", () => {
     const doc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("First paragraph")]),
@@ -256,7 +291,7 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
         schema.node(
           "field",
           {
-            fieldType: "OTHER",
+            fieldType: "PAGEREF",
             instruction: " PAGEREF _Toc1 \\h ",
             displayText: "5",
             fieldKind: "complex",

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -63,6 +63,7 @@ import type {
   ImageAttrs,
   ParagraphAttrs as PMParagraphAttrs,
 } from "../prosemirror/schema/nodes";
+import { assertValidProseMirrorDocument } from "../prosemirror/validation";
 import type {
   ColorValue,
   Theme,
@@ -1825,6 +1826,11 @@ export function toFlowBlocks(
   doc: PMNode,
   options: ToFlowBlocksOptions = {},
 ): FlowBlock[] {
+  assertValidProseMirrorDocument(
+    doc,
+    "Cannot layout invalid ProseMirror document",
+  );
+
   resetBlockIdCounter();
 
   const opts: ToFlowBlocksOptions = {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -36,13 +36,23 @@ import {
   DEFAULT_TEXTBOX_MARGINS,
   DEFAULT_TEXTBOX_WIDTH,
 } from "../layout-engine/types";
+import {
+  expectImageAttrs,
+  expectParagraphAttrs,
+  expectTableAttrs,
+  expectTableCellAttrs,
+  expectTableRowAttrs,
+} from "../prosemirror/attrs";
 import type {
   TextColorAttrs,
   UnderlineAttrs,
   FontSizeAttrs,
   FontFamilyAttrs,
 } from "../prosemirror/schema/marks";
-import type { ParagraphAttrs as PMParagraphAttrs } from "../prosemirror/schema/nodes";
+import type {
+  ImageAttrs,
+  ParagraphAttrs as PMParagraphAttrs,
+} from "../prosemirror/schema/nodes";
 import type {
   ColorValue,
   Theme,
@@ -732,48 +742,48 @@ function paragraphRunDefaults(
  * to satisfy exactOptionalPropertyTypes.
  */
 function buildImageRun(
-  attrs: Record<string, unknown>,
+  attrs: ImageAttrs,
   constrained: { width: number; height: number },
   pmStart: number,
   pmEnd: number,
 ): ImageRun {
   const run: ImageRun = {
     kind: "image",
-    src: attrs["src"] as string,
+    src: attrs.src,
     width: constrained.width,
     height: constrained.height,
     pmStart,
     pmEnd,
   };
-  if (attrs["alt"] !== undefined && attrs["alt"] !== null) {
-    run.alt = attrs["alt"] as string;
+  if (attrs.alt !== undefined) {
+    run.alt = attrs.alt;
   }
-  if (attrs["transform"] !== undefined && attrs["transform"] !== null) {
-    run.transform = attrs["transform"] as string;
+  if (attrs.transform !== undefined) {
+    run.transform = attrs.transform;
   }
-  if (attrs["wrapType"] !== undefined && attrs["wrapType"] !== null) {
-    run.wrapType = attrs["wrapType"] as string;
+  if (attrs.wrapType !== undefined) {
+    run.wrapType = attrs.wrapType;
   }
-  if (attrs["displayMode"] !== undefined && attrs["displayMode"] !== null) {
-    run.displayMode = attrs["displayMode"] as "inline" | "block" | "float";
+  if (attrs.displayMode !== undefined) {
+    run.displayMode = attrs.displayMode;
   }
-  if (attrs["cssFloat"] !== undefined && attrs["cssFloat"] !== null) {
-    run.cssFloat = attrs["cssFloat"] as "left" | "right" | "none";
+  if (attrs.cssFloat !== undefined) {
+    run.cssFloat = attrs.cssFloat;
   }
-  if (attrs["distTop"] !== undefined && attrs["distTop"] !== null) {
-    run.distTop = attrs["distTop"] as number;
+  if (attrs.distTop !== undefined) {
+    run.distTop = attrs.distTop;
   }
-  if (attrs["distBottom"] !== undefined && attrs["distBottom"] !== null) {
-    run.distBottom = attrs["distBottom"] as number;
+  if (attrs.distBottom !== undefined) {
+    run.distBottom = attrs.distBottom;
   }
-  if (attrs["distLeft"] !== undefined && attrs["distLeft"] !== null) {
-    run.distLeft = attrs["distLeft"] as number;
+  if (attrs.distLeft !== undefined) {
+    run.distLeft = attrs.distLeft;
   }
-  if (attrs["distRight"] !== undefined && attrs["distRight"] !== null) {
-    run.distRight = attrs["distRight"] as number;
+  if (attrs.distRight !== undefined) {
+    run.distRight = attrs.distRight;
   }
-  if (attrs["position"] !== undefined && attrs["position"] !== null) {
-    run.position = attrs["position"] as NonNullable<ImageRun["position"]>;
+  if (attrs.position !== undefined) {
+    run.position = attrs.position;
   }
   return run;
 }
@@ -814,11 +824,9 @@ function paragraphToRuns(
   const runs: Run[] = [];
   const offset = startPos + 1; // +1 for opening tag
   const theme = _options.theme;
-  const paraDefaults = paragraphRunDefaults(
-    node.attrs as PMParagraphAttrs,
-    theme,
-  );
-  const paragraphStyleId = (node.attrs as PMParagraphAttrs).styleId;
+  const pmAttrs = expectParagraphAttrs(node);
+  const paraDefaults = paragraphRunDefaults(pmAttrs, theme);
+  const paragraphStyleId = pmAttrs.styleId;
   const inTocParagraph =
     typeof paragraphStyleId === "string" && TOC_STYLE_ID.test(paragraphStyleId);
 
@@ -860,10 +868,10 @@ function paragraphToRuns(
       runs.push(run);
     } else if (child.type.name === "image") {
       // Image within paragraph
-      const attrs = child.attrs;
+      const attrs = expectImageAttrs(child);
       const constrained = constrainImageToPage(
-        (attrs["width"] as number) || 100,
-        (attrs["height"] as number) || 100,
+        attrs.width || 100,
+        attrs.height || 100,
         _options.pageContentHeight,
       );
       const run = buildImageRun(
@@ -956,10 +964,10 @@ function paragraphToRuns(
           };
           runs.push(run);
         } else if (sdtChild.type.name === "image") {
-          const attrs = sdtChild.attrs;
+          const attrs = expectImageAttrs(sdtChild);
           const sdtConstrained = constrainImageToPage(
-            (attrs["width"] as number) || 100,
-            (attrs["height"] as number) || 100,
+            attrs.width || 100,
+            attrs.height || 100,
             _options.pageContentHeight,
           );
           const run = buildImageRun(
@@ -1303,7 +1311,7 @@ function convertParagraph(
   startPos: number,
   options: ToFlowBlocksOptions,
 ): ParagraphBlock {
-  const pmAttrs = node.attrs as PMParagraphAttrs;
+  const pmAttrs = expectParagraphAttrs(node);
   const runs = paragraphToRuns(node, startPos, options);
   const attrs = convertParagraphAttrs(
     pmAttrs,
@@ -1391,23 +1399,24 @@ export function convertBorderSpecToLayout(
  * Borders are full BorderSpec objects with style/size/color.
  */
 function extractCellBorders(
-  attrs: Record<string, unknown>,
+  borders:
+    | Record<
+        string,
+        {
+          style?: string;
+          size?: number;
+          color?: {
+            rgb?: string;
+            themeColor?: string;
+            themeTint?: string;
+            themeShade?: string;
+          };
+        }
+      >
+    | null
+    | undefined,
   theme?: Theme | null,
 ): CellBorders | undefined {
-  const borders = attrs["borders"] as Record<
-    string,
-    {
-      style?: string;
-      size?: number;
-      color?: {
-        rgb?: string;
-        themeColor?: string;
-        themeTint?: string;
-        themeShade?: string;
-      };
-    }
-  > | null;
-
   if (!borders) {
     return undefined;
   }
@@ -1454,13 +1463,11 @@ function convertTableCell(
     offset += child.nodeSize;
   });
 
-  const attrs = node.attrs;
+  const attrs = expectTableCellAttrs(node);
 
   // Convert cell margins (twips) to pixel padding
   // OOXML TableNormal defaults: top=0, bottom=0, left=108 twips (~7px), right=108 twips (~7px)
-  const margins = attrs["margins"] as
-    | { top?: number; bottom?: number; left?: number; right?: number }
-    | undefined;
+  const margins = attrs.margins;
   const resolvePaddingSide = (
     side: TablePaddingSide,
     cellTwips: number | undefined,
@@ -1491,23 +1498,20 @@ function convertTableCell(
   const cell: TableCell = {
     id: nextBlockId(),
     blocks,
-    colSpan: attrs["colspan"] as number,
-    rowSpan: attrs["rowspan"] as number,
+    colSpan: attrs.colspan,
+    rowSpan: attrs.rowspan,
     padding,
   };
-  if (attrs["width"]) {
-    cell.width = twipsToPixels(attrs["width"] as number);
+  if (attrs.width) {
+    cell.width = twipsToPixels(attrs.width);
   }
-  if (attrs["verticalAlign"]) {
-    cell.verticalAlign = attrs["verticalAlign"] as "top" | "center" | "bottom";
+  if (attrs.verticalAlign) {
+    cell.verticalAlign = attrs.verticalAlign;
   }
-  if (attrs["backgroundColor"]) {
-    cell.background = `#${attrs["backgroundColor"]}`;
+  if (attrs.backgroundColor) {
+    cell.background = `#${attrs.backgroundColor}`;
   }
-  const cellBorders = extractCellBorders(
-    attrs as Record<string, unknown>,
-    options.theme,
-  );
+  const cellBorders = extractCellBorders(attrs.borders, options.theme);
   if (cellBorders) {
     cell.borders = cellBorders;
   }
@@ -1539,19 +1543,19 @@ function convertTableRow(
     offset += child.nodeSize;
   });
 
-  const attrs = node.attrs;
+  const attrs = expectTableRowAttrs(node);
   const row: TableRow = {
     id: nextBlockId(),
     cells,
   };
-  if (attrs["height"]) {
-    row.height = twipsToPixels(attrs["height"] as number);
+  if (attrs.height) {
+    row.height = twipsToPixels(attrs.height);
   }
-  if (attrs["heightRule"]) {
-    row.heightRule = attrs["heightRule"] as "auto" | "atLeast" | "exact";
+  if (attrs.heightRule) {
+    row.heightRule = attrs.heightRule;
   }
-  if (attrs["isHeader"]) {
-    row.isHeader = attrs["isHeader"] as boolean;
+  if (attrs.isHeader) {
+    row.isHeader = attrs.isHeader;
   }
   return row;
 }
@@ -1566,9 +1570,8 @@ function convertTable(
 ): TableBlock {
   const rows: TableRow[] = [];
   let offset = startPos + 1; // +1 for opening tag
-  const tableCellMargins = node.attrs["cellMargins"] as
-    | { top?: number; bottom?: number; left?: number; right?: number }
-    | undefined;
+  const attrs = expectTableAttrs(node);
+  const tableCellMargins = attrs.cellMargins;
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((child) => {
@@ -1579,11 +1582,11 @@ function convertTable(
   });
 
   // Extract columnWidths from node attributes and convert from twips to pixels
-  const columnWidthsTwips = node.attrs["columnWidths"] as number[] | undefined;
+  const columnWidthsTwips = attrs.columnWidths;
   let columnWidths = columnWidthsTwips?.map(twipsToPixels);
 
-  const width = node.attrs["width"] as number | undefined;
-  const widthType = node.attrs["widthType"] as string | undefined;
+  const width = attrs.width;
+  const widthType = attrs.widthType;
 
   // Fallback: compute column widths from first row cell widths if table attr is missing
   if (!columnWidths && rows.length > 0) {
@@ -1597,14 +1600,10 @@ function convertTable(
   }
 
   // Extract justification
-  const justification = node.attrs["justification"] as
-    | "left"
-    | "center"
-    | "right"
-    | undefined;
+  const justification = attrs.justification;
 
   // Extract table indent from _originalFormatting (w:tblInd)
-  const originalFormatting = node.attrs["_originalFormatting"] as
+  const originalFormatting = attrs._originalFormatting as
     | { indent?: { value: number; type: string } }
     | undefined;
   const indentPx =
@@ -1613,7 +1612,7 @@ function convertTable(
       ? twipsToPixels(originalFormatting.indent.value)
       : undefined;
 
-  const floating = node.attrs["floating"] as
+  const floating = attrs.floating as
     | {
         horzAnchor?: "margin" | "page" | "text";
         vertAnchor?: "margin" | "page" | "text";
@@ -1706,8 +1705,8 @@ function convertImage(
   startPos: number,
   pageContentHeight?: number,
 ): ImageBlock {
-  const attrs = node.attrs;
-  const wrapType = attrs["wrapType"] as string | undefined;
+  const attrs = expectImageAttrs(node);
+  const wrapType = attrs.wrapType;
 
   // Only anchor images with 'behind' or 'inFront' wrap types
   // Other wrap types (square, tight, through, topAndBottom) need text wrapping
@@ -1715,41 +1714,41 @@ function convertImage(
   const shouldAnchor = wrapType === "behind" || wrapType === "inFront";
 
   const constrained = constrainImageToPage(
-    (attrs["width"] as number) || 100,
-    (attrs["height"] as number) || 100,
+    attrs.width || 100,
+    attrs.height || 100,
     pageContentHeight,
   );
 
   const imgBlock: ImageBlock = {
     kind: "image",
     id: nextBlockId(),
-    src: attrs["src"] as string,
+    src: attrs.src,
     width: constrained.width,
     height: constrained.height,
     pmStart: startPos,
     pmEnd: startPos + node.nodeSize,
   };
-  if (attrs["alt"]) {
-    imgBlock.alt = attrs["alt"] as string;
+  if (attrs.alt) {
+    imgBlock.alt = attrs.alt;
   }
-  if (attrs["transform"]) {
-    imgBlock.transform = attrs["transform"] as string;
+  if (attrs.transform) {
+    imgBlock.transform = attrs.transform;
   }
   if (shouldAnchor) {
     const anchor: NonNullable<ImageBlock["anchor"]> = {
       isAnchored: true,
       behindDoc: wrapType === "behind",
     };
-    if (attrs["distLeft"] !== undefined && attrs["distLeft"] !== null) {
-      anchor.offsetH = attrs["distLeft"] as number;
+    if (attrs.distLeft !== undefined) {
+      anchor.offsetH = attrs.distLeft;
     }
-    if (attrs["distTop"] !== undefined && attrs["distTop"] !== null) {
-      anchor.offsetV = attrs["distTop"] as number;
+    if (attrs.distTop !== undefined) {
+      anchor.offsetV = attrs.distTop;
     }
     imgBlock.anchor = anchor;
   }
-  if (attrs["hlinkHref"]) {
-    imgBlock.hlinkHref = attrs["hlinkHref"] as string;
+  if (attrs.hlinkHref) {
+    imgBlock.hlinkHref = attrs.hlinkHref;
   }
   return imgBlock;
 }
@@ -1852,7 +1851,7 @@ export function toFlowBlocks(
     switch (node.type.name) {
       case "paragraph": {
         const block = convertParagraph(node, pos, opts);
-        const pmAttrs = node.attrs as PMParagraphAttrs;
+        const pmAttrs = expectParagraphAttrs(node);
 
         blocks.push(block);
 

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -40,17 +40,20 @@ import {
   expectCharacterSpacingMarkAttrs,
   expectCommentMarkAttrs,
   expectEmphasisMarkAttrs,
+  expectFieldAttrs,
   expectFontFamilyMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
   expectHighlightMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
+  expectMathAttrs,
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
+  expectTextBoxAttrs,
   expectTextColorMarkAttrs,
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
@@ -896,7 +899,8 @@ function paragraphToRuns(
       // visible text was authored as underlined (e.g. cross-references like
       // "Exhibit A" / "Section 1.3" in NVCA-style templates) render with no
       // underline. Reuse the same extractor text runs use.
-      const ft = child.attrs["fieldType"] as string;
+      const attrs = expectFieldAttrs(child);
+      const ft = attrs.fieldType;
       let mappedType: FieldRun["fieldType"] = "OTHER";
       if (ft === "PAGE") {
         mappedType = "PAGE";
@@ -918,7 +922,7 @@ function paragraphToRuns(
       const run: FieldRun = {
         kind: "field",
         fieldType: mappedType,
-        fallback: (child.attrs["displayText"] as string) || "",
+        fallback: attrs.displayText || "",
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
         ...fieldFormatting,
@@ -926,7 +930,7 @@ function paragraphToRuns(
       runs.push(run);
     } else if (child.type.name === "math") {
       // Math node — render as plain text fallback in layout
-      const text = (child.attrs["plainText"] as string) || "[equation]";
+      const text = expectMathAttrs(child).plainText || "[equation]";
       const run: TextRun = {
         kind: "text",
         text,
@@ -1767,7 +1771,7 @@ function convertTextBoxNode(
   startPos: number,
   opts: ToFlowBlocksOptions,
 ): TextBoxBlock {
-  const attrs = node.attrs;
+  const attrs = expectTextBoxAttrs(node);
   const contentBlocks: ParagraphBlock[] = [];
 
   // Convert child paragraphs inside the text box
@@ -1782,39 +1786,31 @@ function convertTextBoxNode(
   const textBox: TextBoxBlock = {
     kind: "textBox",
     id: nextBlockId(),
-    width: (attrs["width"] as number | undefined) ?? DEFAULT_TEXTBOX_WIDTH,
+    width: attrs.width ?? DEFAULT_TEXTBOX_WIDTH,
     margins: {
-      top:
-        (attrs["marginTop"] as number | undefined) ??
-        DEFAULT_TEXTBOX_MARGINS.top,
-      bottom:
-        (attrs["marginBottom"] as number | undefined) ??
-        DEFAULT_TEXTBOX_MARGINS.bottom,
-      left:
-        (attrs["marginLeft"] as number | undefined) ??
-        DEFAULT_TEXTBOX_MARGINS.left,
-      right:
-        (attrs["marginRight"] as number | undefined) ??
-        DEFAULT_TEXTBOX_MARGINS.right,
+      top: attrs.marginTop ?? DEFAULT_TEXTBOX_MARGINS.top,
+      bottom: attrs.marginBottom ?? DEFAULT_TEXTBOX_MARGINS.bottom,
+      left: attrs.marginLeft ?? DEFAULT_TEXTBOX_MARGINS.left,
+      right: attrs.marginRight ?? DEFAULT_TEXTBOX_MARGINS.right,
     },
     content: contentBlocks,
     pmStart: startPos,
     pmEnd: startPos + node.nodeSize,
   };
-  if (attrs["height"] != null) {
-    textBox.height = attrs["height"] as number;
+  if (attrs.height !== undefined) {
+    textBox.height = attrs.height;
   }
-  if (attrs["fillColor"] != null) {
-    textBox.fillColor = attrs["fillColor"] as string;
+  if (attrs.fillColor !== undefined) {
+    textBox.fillColor = attrs.fillColor;
   }
-  if (attrs["outlineWidth"] != null) {
-    textBox.outlineWidth = attrs["outlineWidth"] as number;
+  if (attrs.outlineWidth !== undefined) {
+    textBox.outlineWidth = attrs.outlineWidth;
   }
-  if (attrs["outlineColor"] != null) {
-    textBox.outlineColor = attrs["outlineColor"] as string;
+  if (attrs.outlineColor !== undefined) {
+    textBox.outlineColor = attrs.outlineColor;
   }
-  if (attrs["outlineStyle"] != null) {
-    textBox.outlineStyle = attrs["outlineStyle"] as string;
+  if (attrs.outlineStyle !== undefined) {
+    textBox.outlineStyle = attrs.outlineStyle;
   }
   return textBox;
 }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -37,18 +37,25 @@ import {
   DEFAULT_TEXTBOX_WIDTH,
 } from "../layout-engine/types";
 import {
+  expectCharacterSpacingMarkAttrs,
+  expectCommentMarkAttrs,
+  expectEmphasisMarkAttrs,
+  expectFontFamilyMarkAttrs,
+  expectFontSizeMarkAttrs,
+  expectFootnoteRefMarkAttrs,
+  expectHighlightMarkAttrs,
+  expectHyperlinkMarkAttrs,
   expectImageAttrs,
   expectParagraphAttrs,
+  expectRunFormattingOverrideMarkAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
+  expectTextColorMarkAttrs,
+  expectTrackedChangeMarkAttrs,
+  expectUnderlineMarkAttrs,
 } from "../prosemirror/attrs";
-import type {
-  TextColorAttrs,
-  UnderlineAttrs,
-  FontSizeAttrs,
-  FontFamilyAttrs,
-} from "../prosemirror/schema/marks";
+import type { RunFormattingOverrideAttrs } from "../prosemirror/schema/marks";
 import type {
   ImageAttrs,
   ParagraphAttrs as PMParagraphAttrs,
@@ -360,7 +367,7 @@ function extractRunFormatting(
         break;
 
       case "underline": {
-        const attrs = mark.attrs as UnderlineAttrs;
+        const attrs = expectUnderlineMarkAttrs(mark);
         if (attrs.style || attrs.color) {
           const underlineObj: { style?: string; color?: string } = {};
           if (attrs.style) {
@@ -381,7 +388,7 @@ function extractRunFormatting(
         break;
 
       case "textColor": {
-        const attrs = mark.attrs as TextColorAttrs;
+        const attrs = expectTextColorMarkAttrs(mark);
         if (attrs.themeColor || attrs.rgb) {
           const colorArg: ColorValue = {};
           if (attrs.rgb) {
@@ -406,19 +413,19 @@ function extractRunFormatting(
 
       case "highlight":
         formatting.highlight = resolveHighlightToCss(
-          mark.attrs["color"] as string,
+          expectHighlightMarkAttrs(mark).color,
         );
         break;
 
       case "fontSize": {
-        const attrs = mark.attrs as FontSizeAttrs;
+        const attrs = expectFontSizeMarkAttrs(mark);
         // Convert half-points to points
         formatting.fontSize = attrs.size / 2;
         break;
       }
 
       case "fontFamily": {
-        const attrs = mark.attrs as FontFamilyAttrs;
+        const attrs = expectFontFamilyMarkAttrs(mark);
         const font = attrs.ascii || attrs.hAnsi;
         if (font) {
           formatting.fontFamily = font;
@@ -427,22 +434,17 @@ function extractRunFormatting(
       }
 
       case "characterSpacing": {
-        const attrs = mark.attrs as {
-          spacing: number | null;
-          position: number | null;
-          scale: number | null;
-          kerning: number | null;
-        };
-        if (attrs.spacing != null && attrs.spacing !== 0) {
+        const attrs = expectCharacterSpacingMarkAttrs(mark);
+        if (attrs.spacing !== undefined && attrs.spacing !== 0) {
           formatting.letterSpacing = twipsToPixels(attrs.spacing);
         }
-        if (attrs.position != null && attrs.position !== 0) {
+        if (attrs.position !== undefined && attrs.position !== 0) {
           formatting.positionPx = halfPointsToPixels(attrs.position);
         }
-        if (attrs.scale != null && attrs.scale !== 100) {
+        if (attrs.scale !== undefined && attrs.scale !== 100) {
           formatting.horizontalScale = attrs.scale;
         }
-        if (attrs.kerning != null && attrs.kerning > 0) {
+        if (attrs.kerning !== undefined && attrs.kerning > 0) {
           formatting.kerningMinPt = halfPointsToPoints(attrs.kerning);
         }
         break;
@@ -473,18 +475,14 @@ function extractRunFormatting(
         break;
 
       case "runFormattingOverride":
-        applyRunFormattingOverrides(formatting, mark);
+        applyRunFormattingOverrides(
+          formatting,
+          expectRunFormattingOverrideMarkAttrs(mark),
+        );
         break;
 
       case "emphasisMark": {
-        const type = mark.attrs["type"] as string | undefined;
-        formatting.emphasisMark =
-          type === "dot" ||
-          type === "comma" ||
-          type === "circle" ||
-          type === "underDot"
-            ? type
-            : "dot";
+        formatting.emphasisMark = expectEmphasisMarkAttrs(mark).type ?? "dot";
         break;
       }
 
@@ -497,7 +495,7 @@ function extractRunFormatting(
         break;
 
       case "hyperlink": {
-        const attrs = mark.attrs as { href: string; tooltip?: string };
+        const attrs = expectHyperlinkMarkAttrs(mark);
         const link: RunFormatting["hyperlink"] & object = {
           href: attrs.href,
         };
@@ -509,7 +507,7 @@ function extractRunFormatting(
       }
 
       case "footnoteRef": {
-        const attrs = mark.attrs as { id: string | number; noteType?: string };
+        const attrs = expectFootnoteRefMarkAttrs(mark);
         const id =
           typeof attrs.id === "string"
             ? Number.parseInt(attrs.id, 10)
@@ -523,7 +521,7 @@ function extractRunFormatting(
       }
 
       case "comment": {
-        const commentId = mark.attrs["commentId"] as number;
+        const commentId = expectCommentMarkAttrs(mark).commentId;
         if (commentId) {
           if (!formatting.commentIds) {
             formatting.commentIds = [];
@@ -533,19 +531,27 @@ function extractRunFormatting(
         break;
       }
 
-      case "insertion":
+      case "insertion": {
+        const attrs = expectTrackedChangeMarkAttrs(mark);
         formatting.isInsertion = true;
-        formatting.changeAuthor = mark.attrs["author"] as string;
-        formatting.changeDate = mark.attrs["date"] as string;
-        formatting.changeRevisionId = mark.attrs["revisionId"] as number;
+        formatting.changeAuthor = attrs.author;
+        if (attrs.date !== undefined) {
+          formatting.changeDate = attrs.date;
+        }
+        formatting.changeRevisionId = attrs.revisionId;
         break;
+      }
 
-      case "deletion":
+      case "deletion": {
+        const attrs = expectTrackedChangeMarkAttrs(mark);
         formatting.isDeletion = true;
-        formatting.changeAuthor = mark.attrs["author"] as string;
-        formatting.changeDate = mark.attrs["date"] as string;
-        formatting.changeRevisionId = mark.attrs["revisionId"] as number;
+        formatting.changeAuthor = attrs.author;
+        if (attrs.date !== undefined) {
+          formatting.changeDate = attrs.date;
+        }
+        formatting.changeRevisionId = attrs.revisionId;
         break;
+      }
       default:
         break;
     }
@@ -591,36 +597,36 @@ function mergeRunFormatting(
 
 function applyRunFormattingOverrides(
   formatting: RunFormatting,
-  mark: Mark,
+  attrs: RunFormattingOverrideAttrs,
 ): void {
-  if (mark.attrs["bold"] === false) {
+  if (attrs.bold === false) {
     formatting.bold = false;
   }
-  if (mark.attrs["italic"] === false) {
+  if (attrs.italic === false) {
     formatting.italic = false;
   }
-  if (mark.attrs["underline"] === "none") {
+  if (attrs.underline === "none") {
     formatting.underline = false;
   }
-  if (mark.attrs["strike"] === false) {
+  if (attrs.strike === false) {
     formatting.strike = false;
   }
-  if (mark.attrs["allCaps"] === false) {
+  if (attrs.allCaps === false) {
     formatting.allCaps = false;
   }
-  if (mark.attrs["smallCaps"] === false) {
+  if (attrs.smallCaps === false) {
     formatting.smallCaps = false;
   }
-  if (mark.attrs["emboss"] === false) {
+  if (attrs.emboss === false) {
     formatting.emboss = false;
   }
-  if (mark.attrs["imprint"] === false) {
+  if (attrs.imprint === false) {
     formatting.imprint = false;
   }
-  if (mark.attrs["shadow"] === false) {
+  if (attrs.shadow === false) {
     formatting.textShadow = false;
   }
-  if (mark.attrs["outline"] === false) {
+  if (attrs.outline === false) {
     formatting.textOutline = false;
   }
 }

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -149,6 +149,38 @@ describe("render page fingerprint", () => {
       computePageFingerprint(page, lookup(blockWithComment(123))),
     );
   });
+
+  test("changes when a text run gains a bold mark without layout geometry changing", () => {
+    const plain: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "hello", pmStart: 1, pmEnd: 6 }],
+    };
+    const bolded: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "hello", pmStart: 1, pmEnd: 6, bold: true }],
+    };
+    expect(computePageFingerprint(page, lookup(plain))).not.toBe(
+      computePageFingerprint(page, lookup(bolded)),
+    );
+  });
+
+  test("changes when run text content changes without layout geometry changing", () => {
+    const before: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "hello", pmStart: 1, pmEnd: 6 }],
+    };
+    const after: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [{ kind: "text", text: "world", pmStart: 1, pmEnd: 6 }],
+    };
+    expect(computePageFingerprint(page, lookup(before))).not.toBe(
+      computePageFingerprint(page, lookup(after)),
+    );
+  });
 });
 
 describe("page font fallback", () => {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2085,6 +2085,10 @@ export function computePageFingerprint(
       if (annotationFingerprint) {
         fp += `,ann:${annotationFingerprint}`;
       }
+      const contentFingerprint = block ? computeContentFingerprint(block) : "";
+      if (contentFingerprint) {
+        fp += `,c:${contentFingerprint}`;
+      }
     }
 
     parts.push(fp);
@@ -2096,6 +2100,20 @@ export function computePageFingerprint(
 function computeAnnotationFingerprint(block: FlowBlock): string {
   const parts: string[] = [];
   collectAnnotationFingerprint(block, parts);
+  return parts.join(";");
+}
+
+/**
+ * Fingerprint of run-level content + formatting that the painter applies via
+ * `applyRunStyles`. Geometry alone is insufficient: a mark-only edit (toggle
+ * bold/italic/color/etc.) can leave fragment width/height/line counts
+ * identical, in which case the geometry fingerprint matches and the
+ * incremental render path would skip repopulating the page, leaving the new
+ * formatting unpainted.
+ */
+function computeContentFingerprint(block: FlowBlock): string {
+  const parts: string[] = [];
+  collectContentFingerprint(block, parts);
   return parts.join(";");
 }
 
@@ -2144,6 +2162,137 @@ function collectAnnotationFingerprint(block: FlowBlock, parts: string[]): void {
       collectAnnotationFingerprint(child, parts);
     }
   }
+}
+
+function collectContentFingerprint(block: FlowBlock, parts: string[]): void {
+  if (block.kind === "paragraph") {
+    if (block.attrs?.styleId) {
+      parts.push(`p:st:${block.attrs.styleId}`);
+    }
+    if (block.attrs?.alignment) {
+      parts.push(`p:al:${block.attrs.alignment}`);
+    }
+    for (let index = 0; index < block.runs.length; index++) {
+      const run = block.runs[index];
+      if (!run) {
+        continue;
+      }
+      parts.push(`${index}:${runContentKey(run)}`);
+    }
+    return;
+  }
+
+  if (block.kind === "table") {
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        for (const child of cell.blocks) {
+          collectContentFingerprint(child, parts);
+        }
+      }
+    }
+    return;
+  }
+
+  if (block.kind === "textBox") {
+    for (const child of block.content) {
+      collectContentFingerprint(child, parts);
+    }
+  }
+}
+
+function runContentKey(run: Run): string {
+  if (run.kind === "lineBreak") {
+    return "lb";
+  }
+  if (run.kind === "image") {
+    return `img:${run.src}|${run.width}x${run.height}${run.transform ? `|tr:${run.transform}` : ""}`;
+  }
+
+  // Remaining kinds (text, tab, field) all carry RunFormatting.
+  const parts: string[] = [run.kind];
+  if (run.kind === "text") {
+    parts.push(`t:${run.text}`);
+  } else if (run.kind === "tab") {
+    if (run.width !== undefined) {
+      parts.push(`w:${run.width}`);
+    }
+  } else {
+    parts.push(`ft:${run.fieldType}`);
+    if (run.fallback !== undefined) {
+      parts.push(`fb:${run.fallback}`);
+    }
+  }
+
+  // Marks/format attrs the painter consumes via applyRunStyles. Keep in sync
+  // with renderParagraph.ts so toggling any of these triggers a re-paint.
+  if (run.bold) {
+    parts.push("b");
+  }
+  if (run.italic) {
+    parts.push("i");
+  }
+  if (run.underline) {
+    parts.push(
+      typeof run.underline === "boolean"
+        ? "u"
+        : `u:${run.underline.style ?? ""}:${run.underline.color ?? ""}`,
+    );
+  }
+  if (run.strike) {
+    parts.push("s");
+  }
+  if (run.color) {
+    parts.push(`c:${run.color}`);
+  }
+  if (run.highlight) {
+    parts.push(`hi:${run.highlight}`);
+  }
+  if (run.fontFamily) {
+    parts.push(`ff:${run.fontFamily}`);
+  }
+  if (run.fontSize !== undefined) {
+    parts.push(`fs:${run.fontSize}`);
+  }
+  if (run.letterSpacing !== undefined) {
+    parts.push(`ls:${run.letterSpacing}`);
+  }
+  if (run.superscript) {
+    parts.push("sup");
+  }
+  if (run.subscript) {
+    parts.push("sub");
+  }
+  if (run.allCaps) {
+    parts.push("ac");
+  }
+  if (run.smallCaps) {
+    parts.push("sc");
+  }
+  if (run.positionPx !== undefined) {
+    parts.push(`pp:${run.positionPx}`);
+  }
+  if (run.horizontalScale !== undefined && run.horizontalScale !== 100) {
+    parts.push(`hs:${run.horizontalScale}`);
+  }
+  if (run.imprint) {
+    parts.push("imp");
+  }
+  if (run.emboss) {
+    parts.push("emb");
+  }
+  if (run.textShadow) {
+    parts.push("sh");
+  }
+  if (run.textOutline) {
+    parts.push("ol");
+  }
+  if (run.emphasisMark) {
+    parts.push(`emk:${run.emphasisMark}`);
+  }
+  if (run.hyperlink) {
+    parts.push(`hl:${run.hyperlink.href}`);
+  }
+  return parts.join("|");
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/adapterBoundary.test.ts
+++ b/packages/folio/src/core/prosemirror/adapterBoundary.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+const ADAPTER_BOUNDARY_FILES = [
+  "src/core/prosemirror/conversion/fromProseDoc.ts",
+  "src/core/layout-bridge/toFlowBlocks.ts",
+  "src/core/prosemirror/validation.ts",
+] as const;
+
+const FORBIDDEN_RAW_ATTR_PATTERNS = [
+  {
+    pattern:
+      /\b(?:node|child|rowNode|cellNode|contentNode|sdtChild)\.attrs\s+as\b/u,
+    reason: "Raw node attrs must be narrowed through the typed attr readers.",
+  },
+  {
+    pattern: /\b(?:node|child|rowNode|cellNode|contentNode|sdtChild)\.attrs\[/u,
+    reason: "Bracket attr reads bypass path-aware validation diagnostics.",
+  },
+  {
+    pattern:
+      /\bconst\s+attrs\s*=\s*(?:node|child|rowNode|cellNode|contentNode|sdtChild)\.attrs\b/u,
+    reason: "Do not alias raw attrs at conversion/layout boundaries.",
+  },
+] as const;
+
+describe("ProseMirror adapter attr boundaries", () => {
+  test("keep conversion and layout attr reads behind typed readers", async () => {
+    const violations: string[] = [];
+
+    for (const file of ADAPTER_BOUNDARY_FILES) {
+      const source = await Bun.file(file).text();
+      const lines = source.split("\n");
+
+      for (const [index, line] of lines.entries()) {
+        for (const { pattern, reason } of FORBIDDEN_RAW_ATTR_PATTERNS) {
+          if (!pattern.test(line)) {
+            continue;
+          }
+          violations.push(`${file}:${index + 1}: ${reason}`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, test } from "bun:test";
 
 import {
   expectParagraphAttrs,
+  readCommentMarkAttrs,
+  readFontSizeMarkAttrs,
+  readHighlightMarkAttrs,
   readHyperlinkMarkAttrs,
   readImageAttrs,
   readParagraphAttrs,
+  readTrackedChangeMarkAttrs,
+  readUnderlineMarkAttrs,
   readTableAttrs,
   readTableCellAttrs,
   readTableRowAttrs,
@@ -138,5 +143,73 @@ describe("ProseMirror attr readers", () => {
       path: "hyperlink.attrs.href",
       message: "Expected a string.",
     });
+  });
+
+  test("rejects malformed text formatting mark attrs", () => {
+    const underline = schema.marks.underline.create({
+      style: "diagonal",
+      color: { rgb: 123 },
+    });
+    const fontSize = schema.marks.fontSize.create({ size: "24" });
+    const highlight = schema.marks.highlight.create({ color: "customYellow" });
+
+    const underlineResult = readUnderlineMarkAttrs(underline);
+    const fontSizeResult = readFontSizeMarkAttrs(fontSize);
+    const highlightResult = readHighlightMarkAttrs(highlight);
+
+    expect(underlineResult.ok).toBe(false);
+    if (!underlineResult.ok) {
+      expect(underlineResult.issues.map((issue) => issue.path)).toContain(
+        "underline.attrs.style",
+      );
+      expect(underlineResult.issues.map((issue) => issue.path)).toContain(
+        "underline.attrs.color.rgb",
+      );
+    }
+    expect(fontSizeResult.ok).toBe(false);
+    if (!fontSizeResult.ok) {
+      expect(fontSizeResult.issues).toContainEqual({
+        path: "fontSize.attrs.size",
+        message: "Expected a number.",
+      });
+    }
+    expect(highlightResult.ok).toBe(false);
+    if (!highlightResult.ok) {
+      expect(highlightResult.issues.map((issue) => issue.path)).toContain(
+        "highlight.attrs.color",
+      );
+    }
+  });
+
+  test("rejects malformed comment and tracked-change mark attrs", () => {
+    const comment = schema.marks.comment.create({ commentId: "7" });
+    const insertion = schema.marks.insertion.create({
+      revisionId: "42",
+      author: 12,
+      moveKind: "moveAround",
+    });
+
+    const commentResult = readCommentMarkAttrs(comment);
+    const insertionResult = readTrackedChangeMarkAttrs(insertion);
+
+    expect(commentResult.ok).toBe(false);
+    if (!commentResult.ok) {
+      expect(commentResult.issues).toContainEqual({
+        path: "comment.attrs.commentId",
+        message: "Expected a number.",
+      });
+    }
+    expect(insertionResult.ok).toBe(false);
+    if (!insertionResult.ok) {
+      expect(insertionResult.issues.map((issue) => issue.path)).toContain(
+        "insertion.attrs.revisionId",
+      );
+      expect(insertionResult.issues.map((issue) => issue.path)).toContain(
+        "insertion.attrs.author",
+      );
+      expect(insertionResult.issues.map((issue) => issue.path)).toContain(
+        "insertion.attrs.moveKind",
+      );
+    }
   });
 });

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  readFieldAttrs,
   expectParagraphAttrs,
   readCommentMarkAttrs,
   readFontSizeMarkAttrs,
   readHighlightMarkAttrs,
   readHyperlinkMarkAttrs,
   readImageAttrs,
+  readMathAttrs,
   readParagraphAttrs,
+  readSdtAttrs,
+  readShapeAttrs,
+  readTextBoxAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
   readTableAttrs,
@@ -128,6 +133,108 @@ describe("ProseMirror attr readers", () => {
     expect(result.issues.map((issue) => issue.path)).toContain(
       "image.attrs.position.horizontal.posOffset",
     );
+  });
+
+  test("rejects malformed field and math attrs", () => {
+    const field = schema.nodes.field.create({
+      fieldType: "NOT_A_FIELD",
+      fieldKind: "nested",
+      fldLock: "true",
+    });
+    const math = schema.nodes.math.create({
+      display: "display",
+      ommlXml: 42,
+    });
+
+    const fieldResult = readFieldAttrs(field);
+    const mathResult = readMathAttrs(math);
+
+    expect(fieldResult.ok).toBe(false);
+    if (!fieldResult.ok) {
+      expect(fieldResult.issues.map((issue) => issue.path)).toContain(
+        "field.attrs.fieldType",
+      );
+      expect(fieldResult.issues.map((issue) => issue.path)).toContain(
+        "field.attrs.fieldKind",
+      );
+      expect(fieldResult.issues.map((issue) => issue.path)).toContain(
+        "field.attrs.fldLock",
+      );
+    }
+    expect(mathResult.ok).toBe(false);
+    if (!mathResult.ok) {
+      expect(mathResult.issues.map((issue) => issue.path)).toContain(
+        "math.attrs.display",
+      );
+      expect(mathResult.issues.map((issue) => issue.path)).toContain(
+        "math.attrs.ommlXml",
+      );
+    }
+  });
+
+  test("rejects malformed SDT list item attrs", () => {
+    const sdt = schema.nodes.sdt.create({
+      sdtType: "custom",
+      lock: "frozen",
+      listItems: JSON.stringify([{ displayText: 7, value: null }]),
+      checked: "true",
+    });
+
+    const result = readSdtAttrs(sdt);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected SDT attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "sdt.attrs.sdtType",
+    );
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "sdt.attrs.lock",
+    );
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "sdt.attrs.listItems[0].displayText",
+    );
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "sdt.attrs.checked",
+    );
+  });
+
+  test("rejects malformed shape and text box attrs", () => {
+    const shape = schema.nodes.shape.create({
+      fillType: "custom",
+      gradientStops: JSON.stringify([{ position: "0", color: 7 }]),
+      displayMode: "sideways",
+    });
+    const textBox = schema.nodes.textBox.create({
+      width: "wide",
+      cssFloat: "center",
+    });
+
+    const shapeResult = readShapeAttrs(shape);
+    const textBoxResult = readTextBoxAttrs(textBox);
+
+    expect(shapeResult.ok).toBe(false);
+    if (!shapeResult.ok) {
+      expect(shapeResult.issues.map((issue) => issue.path)).toContain(
+        "shape.attrs.fillType",
+      );
+      expect(shapeResult.issues.map((issue) => issue.path)).toContain(
+        "shape.attrs.gradientStops[0].position",
+      );
+      expect(shapeResult.issues.map((issue) => issue.path)).toContain(
+        "shape.attrs.displayMode",
+      );
+    }
+    expect(textBoxResult.ok).toBe(false);
+    if (!textBoxResult.ok) {
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs.width",
+      );
+      expect(textBoxResult.issues.map((issue) => issue.path)).toContain(
+        "textBox.attrs.cssFloat",
+      );
+    }
   });
 
   test("rejects malformed hyperlink mark attrs", () => {

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   readFieldAttrs,
   expectParagraphAttrs,
+  readHardBreakAttrs,
   readCommentMarkAttrs,
   readFontSizeMarkAttrs,
   readHighlightMarkAttrs,
@@ -248,6 +249,22 @@ describe("ProseMirror attr readers", () => {
         "math.attrs.ommlXml",
       );
     }
+  });
+
+  test("rejects malformed hard break attrs", () => {
+    const node = schema.nodes.hardBreak.create({
+      breakType: "page",
+    });
+
+    const result = readHardBreakAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected hard break attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "hardBreak.attrs.breakType",
+    );
   });
 
   test("rejects malformed SDT list item attrs", () => {

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -10,6 +10,7 @@ import {
   readHyperlinkMarkAttrs,
   readImageAttrs,
   readMathAttrs,
+  mergeImageAttrs,
   readParagraphAttrs,
   readSdtAttrs,
   readShapeAttrs,
@@ -241,6 +242,39 @@ describe("ProseMirror attr readers", () => {
     expect(result.issues.map((issue) => issue.path)).toContain(
       "image.attrs.position.horizontal.posOffset",
     );
+  });
+
+  test("clears image attrs with explicit undefined patches", () => {
+    const node = schema.nodes.image.create({
+      src: "media/image.png",
+      transform: "rotate(90deg)",
+      alt: "Existing alt text",
+      borderWidth: 2,
+      borderColor: "currentColor",
+      borderStyle: "solid",
+    });
+
+    const retainedNode = schema.nodes.image.create(
+      mergeImageAttrs(node, { width: 120 }),
+    );
+    expect(retainedNode.attrs["transform"]).toBe("rotate(90deg)");
+    expect(retainedNode.attrs["alt"]).toBe("Existing alt text");
+
+    const clearedNode = schema.nodes.image.create(
+      mergeImageAttrs(node, {
+        transform: undefined,
+        alt: undefined,
+        borderWidth: undefined,
+        borderColor: undefined,
+        borderStyle: undefined,
+      }),
+    );
+
+    expect(clearedNode.attrs["transform"]).toBeNull();
+    expect(clearedNode.attrs["alt"]).toBeNull();
+    expect(clearedNode.attrs["borderWidth"]).toBeNull();
+    expect(clearedNode.attrs["borderColor"]).toBeNull();
+    expect(clearedNode.attrs["borderStyle"]).toBeNull();
   });
 
   test("rejects malformed field and math attrs", () => {

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, test } from "bun:test";
 import {
   expectParagraphAttrs,
   readHyperlinkMarkAttrs,
+  readImageAttrs,
   readParagraphAttrs,
   readTableAttrs,
   readTableCellAttrs,
+  readTableRowAttrs,
 } from ".";
 import { schema } from "../schema";
 
@@ -69,6 +71,22 @@ describe("ProseMirror attr readers", () => {
     );
   });
 
+  test("rejects invalid table row finite attrs", () => {
+    const node = schema.nodes.tableRow.create({
+      heightRule: "sometimes",
+    });
+
+    const result = readTableRowAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected table row attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "tableRow.attrs.heightRule",
+    );
+  });
+
   test("accepts nullable ProseMirror table cell colwidth", () => {
     const node = schema.nodes.tableCell.create({
       colspan: 1,
@@ -79,6 +97,32 @@ describe("ProseMirror attr readers", () => {
     const result = readTableCellAttrs(node);
 
     expect(result.ok).toBe(true);
+  });
+
+  test("rejects invalid image finite and nested position attrs", () => {
+    const node = schema.nodes.image.create({
+      src: "media/image.png",
+      wrapText: "diagonal",
+      position: {
+        horizontal: { relativeTo: "viewport", posOffset: "bad" },
+      },
+    });
+
+    const result = readImageAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected image attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "image.attrs.wrapText",
+    );
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "image.attrs.position.horizontal.relativeTo",
+    );
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "image.attrs.position.horizontal.posOffset",
+    );
   });
 
   test("rejects malformed hyperlink mark attrs", () => {

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -65,6 +65,52 @@ describe("ProseMirror attr readers", () => {
     );
   });
 
+  test("rejects malformed paragraph preservation payloads", () => {
+    const node = schema.nodes.paragraph.create({
+      borders: { top: { style: "warp", size: "wide" } },
+      shading: { pattern: "confetti", fill: { rgb: 12 } },
+      tabs: [{ position: "720", alignment: "edge", leader: "spark" }],
+      defaultTextFormatting: {
+        bold: "yes",
+        highlight: "neon",
+        underline: { style: "zigzag" },
+      },
+      _sectionProperties: { pageWidth: "wide", orientation: "diagonal" },
+      _propertyChanges: [
+        {
+          type: "runPropertyChange",
+          info: { id: "1", author: 7 },
+        },
+      ],
+    });
+
+    const result = readParagraphAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected paragraph attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        "paragraph.attrs.borders.top.style",
+        "paragraph.attrs.borders.top.size",
+        "paragraph.attrs.shading.pattern",
+        "paragraph.attrs.shading.fill.rgb",
+        "paragraph.attrs.tabs[0].position",
+        "paragraph.attrs.tabs[0].alignment",
+        "paragraph.attrs.tabs[0].leader",
+        "paragraph.attrs.defaultTextFormatting.bold",
+        "paragraph.attrs.defaultTextFormatting.highlight",
+        "paragraph.attrs.defaultTextFormatting.underline.style",
+        "paragraph.attrs._sectionProperties.pageWidth",
+        "paragraph.attrs._sectionProperties.orientation",
+        "paragraph.attrs._propertyChanges[0].type",
+        "paragraph.attrs._propertyChanges[0].info.id",
+        "paragraph.attrs._propertyChanges[0].info.author",
+      ]),
+    );
+  });
+
   test("rejects malformed table column widths", () => {
     const node = schema.nodes.table.create({
       columnWidths: [1200, "bad"],
@@ -107,6 +153,38 @@ describe("ProseMirror attr readers", () => {
     const result = readTableCellAttrs(node);
 
     expect(result.ok).toBe(true);
+  });
+
+  test("rejects malformed table preservation payloads", () => {
+    const table = schema.nodes.table.create({
+      cellMargins: { top: "tight" },
+    });
+    const cell = schema.nodes.tableCell.create({
+      colspan: 1,
+      rowspan: 1,
+      borders: { left: { style: "cloud", color: { auto: "yes" } } },
+      margins: { bottom: "low" },
+    });
+
+    const tableResult = readTableAttrs(table);
+    const cellResult = readTableCellAttrs(cell);
+
+    expect(tableResult.ok).toBe(false);
+    if (!tableResult.ok) {
+      expect(tableResult.issues.map((issue) => issue.path)).toContain(
+        "table.attrs.cellMargins.top",
+      );
+    }
+    expect(cellResult.ok).toBe(false);
+    if (!cellResult.ok) {
+      expect(cellResult.issues.map((issue) => issue.path)).toEqual(
+        expect.arrayContaining([
+          "tableCell.attrs.borders.left.style",
+          "tableCell.attrs.borders.left.color.auto",
+          "tableCell.attrs.margins.bottom",
+        ]),
+      );
+    }
   });
 
   test("rejects invalid image finite and nested position attrs", () => {

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  expectParagraphAttrs,
+  readHyperlinkMarkAttrs,
+  readParagraphAttrs,
+  readTableAttrs,
+  readTableCellAttrs,
+} from ".";
+import { schema } from "../schema";
+
+const issueMessages = (result: ReturnType<typeof readParagraphAttrs>) => {
+  if (result.ok) {
+    return [];
+  }
+
+  return result.issues.map((issue) => issue.message);
+};
+
+describe("ProseMirror attr readers", () => {
+  test("accepts valid paragraph attrs with preservation payloads", () => {
+    const node = schema.nodes.paragraph.create({
+      paraId: "para-1",
+      numPr: { numId: 4, ilvl: 1 },
+      bookmarks: [{ id: 7, name: "_Ref7" }],
+      _sectionProperties: { sectionStart: "nextPage" },
+      _propertyChanges: [],
+    });
+
+    const result = readParagraphAttrs(node);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected paragraph attrs to parse");
+    }
+    expect(result.value.numPr?.numId).toBe(4);
+    expect(result.value.bookmarks?.at(0)?.name).toBe("_Ref7");
+    expect(expectParagraphAttrs(node).paraId).toBe("para-1");
+  });
+
+  test("rejects malformed paragraph attrs", () => {
+    const node = schema.nodes.paragraph.create({
+      numPr: { numId: "bad" },
+      bookmarks: [{ id: "bad", name: 7 }],
+    });
+
+    const result = readParagraphAttrs(node);
+
+    expect(result.ok).toBe(false);
+    expect(issueMessages(result)).toContain("Expected a number.");
+    expect(() => expectParagraphAttrs(node)).toThrow(
+      "Invalid ProseMirror paragraph attrs",
+    );
+  });
+
+  test("rejects malformed table column widths", () => {
+    const node = schema.nodes.table.create({
+      columnWidths: [1200, "bad"],
+    });
+
+    const result = readTableAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected table attrs to be rejected");
+    }
+    expect(result.issues.map((issue) => issue.path)).toContain(
+      "table.attrs.columnWidths[1]",
+    );
+  });
+
+  test("accepts nullable ProseMirror table cell colwidth", () => {
+    const node = schema.nodes.tableCell.create({
+      colspan: 1,
+      rowspan: 1,
+      colwidth: null,
+    });
+
+    const result = readTableCellAttrs(node);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects malformed hyperlink mark attrs", () => {
+    const mark = schema.marks.hyperlink.create({ href: 42 });
+
+    const result = readHyperlinkMarkAttrs(mark);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected hyperlink attrs to be rejected");
+    }
+    expect(result.issues).toContainEqual({
+      path: "hyperlink.attrs.href",
+      message: "Expected a string.",
+    });
+  });
+});

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -56,12 +56,19 @@ describe("ProseMirror attr readers", () => {
     const node = schema.nodes.paragraph.create({
       numPr: { numId: "bad" },
       bookmarks: [{ id: "bad", name: 7 }],
+      _emptyHyperlinks: [{ offset: -1, href: 42 }],
     });
 
     const result = readParagraphAttrs(node);
 
     expect(result.ok).toBe(false);
     expect(issueMessages(result)).toContain("Expected a number.");
+    expect(result.ok ? [] : result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        "paragraph.attrs._emptyHyperlinks[0].offset",
+        "paragraph.attrs._emptyHyperlinks[0].href",
+      ]),
+    );
     expect(() => expectParagraphAttrs(node)).toThrow(
       "Invalid ProseMirror paragraph attrs",
     );

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -98,7 +98,7 @@ describe("ProseMirror attr readers", () => {
 
   test("rejects malformed paragraph preservation payloads", () => {
     const node = schema.nodes.paragraph.create({
-      borders: { top: { style: "warp", size: "wide" } },
+      borders: { top: { style: 4, size: "wide" } },
       shading: { pattern: "confetti", fill: { rgb: 12 } },
       tabs: [{ position: "720", alignment: "edge", leader: "spark" }],
       defaultTextFormatting: {
@@ -186,6 +186,20 @@ describe("ProseMirror attr readers", () => {
     expect(result.ok).toBe(true);
   });
 
+  test("accepts unknown OOXML border style strings", () => {
+    const paragraph = schema.nodes.paragraph.create({
+      borders: { top: { style: "dashDotDot", size: 8 } },
+    });
+    const cell = schema.nodes.tableCell.create({
+      colspan: 1,
+      rowspan: 1,
+      borders: { bottom: { style: "0", size: 0 } },
+    });
+
+    expect(readParagraphAttrs(paragraph).ok).toBe(true);
+    expect(readTableCellAttrs(cell).ok).toBe(true);
+  });
+
   test("rejects malformed table preservation payloads", () => {
     const table = schema.nodes.table.create({
       cellMargins: { top: "tight" },
@@ -193,7 +207,7 @@ describe("ProseMirror attr readers", () => {
     const cell = schema.nodes.tableCell.create({
       colspan: 1,
       rowspan: 1,
-      borders: { left: { style: "cloud", color: { auto: "yes" } } },
+      borders: { left: { style: 4, color: { auto: "yes" } } },
       margins: { bottom: "low" },
     });
 

--- a/packages/folio/src/core/prosemirror/attrs/index.test.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.test.ts
@@ -14,6 +14,7 @@ import {
   readSdtAttrs,
   readShapeAttrs,
   readTextBoxAttrs,
+  readTextColorMarkAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
   readTableAttrs,
@@ -64,6 +65,27 @@ describe("ProseMirror attr readers", () => {
     expect(() => expectParagraphAttrs(node)).toThrow(
       "Invalid ProseMirror paragraph attrs",
     );
+  });
+
+  test("rejects non-integer paragraph numbering attrs", () => {
+    const node = schema.nodes.paragraph.create({
+      numPr: { numId: 1.5, ilvl: -1 },
+    });
+
+    const result = readParagraphAttrs(node);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected paragraph attrs to be rejected");
+    }
+    expect(result.issues).toContainEqual({
+      path: "paragraph.attrs.numPr.numId",
+      message: "Expected a non-negative integer.",
+    });
+    expect(result.issues).toContainEqual({
+      path: "paragraph.attrs.numPr.ilvl",
+      message: "Expected a non-negative integer.",
+    });
   });
 
   test("rejects malformed paragraph preservation payloads", () => {
@@ -350,12 +372,16 @@ describe("ProseMirror attr readers", () => {
   test("rejects malformed text formatting mark attrs", () => {
     const underline = schema.marks.underline.create({
       style: "diagonal",
-      color: { rgb: 123 },
+      color: { rgb: 123, themeColor: "brandAccent" },
+    });
+    const textColor = schema.marks.textColor.create({
+      themeColor: "brandAccent",
     });
     const fontSize = schema.marks.fontSize.create({ size: "24" });
     const highlight = schema.marks.highlight.create({ color: "customYellow" });
 
     const underlineResult = readUnderlineMarkAttrs(underline);
+    const textColorResult = readTextColorMarkAttrs(textColor);
     const fontSizeResult = readFontSizeMarkAttrs(fontSize);
     const highlightResult = readHighlightMarkAttrs(highlight);
 
@@ -366,6 +392,15 @@ describe("ProseMirror attr readers", () => {
       );
       expect(underlineResult.issues.map((issue) => issue.path)).toContain(
         "underline.attrs.color.rgb",
+      );
+      expect(underlineResult.issues.map((issue) => issue.path)).toContain(
+        "underline.attrs.color.themeColor",
+      );
+    }
+    expect(textColorResult.ok).toBe(false);
+    if (!textColorResult.ok) {
+      expect(textColorResult.issues.map((issue) => issue.path)).toContain(
+        "textColor.attrs.themeColor",
       );
     }
     expect(fontSizeResult.ok).toBe(false);

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -929,6 +929,63 @@ export const readHyperlinkMarkAttrs = (
 export const expectHyperlinkMarkAttrs = (mark: Mark): HyperlinkAttrs =>
   expectAttrs(readHyperlinkMarkAttrs(mark), "hyperlink attrs");
 
+type NodeAttrReader<T extends object> = (
+  node: PMNode,
+) => ReadProseMirrorAttrsResult<T>;
+
+type NodeAttrPatch<T extends object> = {
+  [K in keyof T]?: T[K] | undefined;
+};
+
+const mergeNodeAttrs = <T extends object>(
+  node: PMNode,
+  readAttrs: NodeAttrReader<T>,
+  label: string,
+  patch: NodeAttrPatch<T>,
+): T => {
+  const currentAttrs = expectAttrs(readAttrs(node), label);
+  const mergedAttrs: Record<string, unknown> = { ...currentAttrs, ...patch };
+  const nextAttrs: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(mergedAttrs)) {
+    if (value !== undefined) {
+      nextAttrs[key] = value;
+    }
+  }
+
+  // SAFETY: `currentAttrs` has been validated by the node-specific reader, and
+  // `patch` is typed against the same attr shape. Undefined patch values are
+  // treated as deletions so ProseMirror can restore schema defaults.
+  return nextAttrs as T;
+};
+
+export const mergeImageAttrs = (
+  node: PMNode,
+  patch: NodeAttrPatch<ImageAttrs>,
+): ImageAttrs => mergeNodeAttrs(node, readImageAttrs, "image attrs", patch);
+
+export const mergeParagraphAttrs = (
+  node: PMNode,
+  patch: NodeAttrPatch<ParagraphAttrs>,
+): ParagraphAttrs =>
+  mergeNodeAttrs(node, readParagraphAttrs, "paragraph attrs", patch);
+
+export const mergeTableAttrs = (
+  node: PMNode,
+  patch: NodeAttrPatch<TableAttrs>,
+): TableAttrs => mergeNodeAttrs(node, readTableAttrs, "table attrs", patch);
+
+export const mergeTableRowAttrs = (
+  node: PMNode,
+  patch: NodeAttrPatch<TableRowAttrs>,
+): TableRowAttrs =>
+  mergeNodeAttrs(node, readTableRowAttrs, "table row attrs", patch);
+
+export const mergeTableCellAttrs = (
+  node: PMNode,
+  patch: NodeAttrPatch<TableCellAttrs>,
+): TableCellAttrs =>
+  mergeNodeAttrs(node, readTableCellAttrs, "table cell attrs", patch);
+
 const attrsRecord = (attrs: unknown): Record<string, unknown> => {
   if (isRecord(attrs)) {
     return attrs;

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -23,6 +23,7 @@ import {
   TABLE_WIDTH_TYPE_VALUES,
   TAB_LEADER_VALUES,
   TAB_STOP_ALIGNMENT_VALUES,
+  THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
 import type {
@@ -1401,7 +1402,13 @@ const optionalTextColorFields = (
   issues: ProseMirrorAttrIssue[],
 ): void => {
   optionalString(attrs, "rgb", `${path}.rgb`, issues);
-  optionalString(attrs, "themeColor", `${path}.themeColor`, issues);
+  optionalOneOf(
+    attrs,
+    "themeColor",
+    `${path}.themeColor`,
+    issues,
+    THEME_COLOR_SLOT_VALUES,
+  );
   optionalString(attrs, "themeTint", `${path}.themeTint`, issues);
   optionalString(attrs, "themeShade", `${path}.themeShade`, issues);
 };
@@ -1512,7 +1519,13 @@ const optionalColorValue = (
 
   optionalString(value, "rgb", `${path}.rgb`, issues);
   optionalBoolean(value, "auto", `${path}.auto`, issues);
-  optionalString(value, "themeColor", `${path}.themeColor`, issues);
+  optionalOneOf(
+    value,
+    "themeColor",
+    `${path}.themeColor`,
+    issues,
+    THEME_COLOR_SLOT_VALUES,
+  );
   optionalString(value, "themeTint", `${path}.themeTint`, issues);
   optionalString(value, "themeShade", `${path}.themeShade`, issues);
 };
@@ -1902,27 +1915,39 @@ const validateNumPr = (
   value: unknown,
   issues: ProseMirrorAttrIssue[],
 ): void => {
-  if (value === undefined || value === null || Array.isArray(value)) {
+  if (value === undefined || value === null || !isRecord(value)) {
     return;
   }
 
-  if (typeof value !== "object") {
+  validateNonNegativeInteger(
+    value["numId"],
+    "paragraph.attrs.numPr.numId",
+    issues,
+  );
+  // Some real DOCX files use ilvl > 8; docx-core warns but preserves them.
+  validateNonNegativeInteger(
+    value["ilvl"],
+    "paragraph.attrs.numPr.ilvl",
+    issues,
+  );
+};
+
+const validateNonNegativeInteger = (
+  value: unknown,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (value === undefined || value === null) {
     return;
   }
 
-  const numPr = value as Record<string, unknown>;
-  if (numPr["numId"] !== undefined && typeof numPr["numId"] !== "number") {
-    issues.push({
-      path: "paragraph.attrs.numPr.numId",
-      message: "Expected a number.",
-    });
+  if (typeof value !== "number") {
+    issues.push({ path, message: "Expected a number." });
+    return;
   }
 
-  if (numPr["ilvl"] !== undefined && typeof numPr["ilvl"] !== "number") {
-    issues.push({
-      path: "paragraph.attrs.numPr.ilvl",
-      message: "Expected a number.",
-    });
+  if (!Number.isInteger(value) || value < 0) {
+    issues.push({ path, message: "Expected a non-negative integer." });
   }
 };
 

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1,12 +1,24 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import type {
+  CharacterSpacingAttrs,
+  CommentAttrs,
+  EmphasisMarkAttrs,
+  FontFamilyAttrs,
+  FontSizeAttrs,
+  FootnoteRefAttrs,
+  HighlightAttrs,
   HyperlinkAttrs,
   ImageAttrs,
   ParagraphAttrs,
+  RunFormattingOverrideAttrs,
+  StrikeAttrs,
   TableAttrs,
   TableCellAttrs,
   TableRowAttrs,
+  TextColorAttrs,
+  TrackedChangeMarkAttrs,
+  UnderlineAttrs,
 } from "../schema";
 
 export type ProseMirrorAttrIssue = {
@@ -88,6 +100,26 @@ const TABLE_CELL_TEXT_DIRECTIONS = [
   "btLr",
 ] as const satisfies readonly NonNullable<TableCellAttrs["textDirection"]>[];
 
+const HIGHLIGHT_COLORS = [
+  "black",
+  "blue",
+  "cyan",
+  "darkBlue",
+  "darkCyan",
+  "darkGray",
+  "darkGreen",
+  "darkMagenta",
+  "darkRed",
+  "darkYellow",
+  "green",
+  "lightGray",
+  "magenta",
+  "none",
+  "red",
+  "white",
+  "yellow",
+] as const satisfies readonly HighlightAttrs["color"][];
+
 const IMAGE_WRAP_TYPES = [
   "inline",
   "square",
@@ -162,6 +194,58 @@ const IMAGE_VERTICAL_ALIGNMENTS = [
 ] as const satisfies readonly NonNullable<
   ImageVerticalPositionAttrs["align"]
 >[];
+
+const UNDERLINE_STYLES = [
+  "none",
+  "single",
+  "words",
+  "double",
+  "thick",
+  "dotted",
+  "dottedHeavy",
+  "dash",
+  "dashedHeavy",
+  "dashLong",
+  "dashLongHeavy",
+  "dotDash",
+  "dashDotHeavy",
+  "dotDotDash",
+  "dashDotDotHeavy",
+  "wave",
+  "wavyHeavy",
+  "wavyDouble",
+] as const satisfies readonly NonNullable<UnderlineAttrs["style"]>[];
+
+const EMPHASIS_MARK_TYPES = [
+  "dot",
+  "comma",
+  "circle",
+  "underDot",
+] as const satisfies readonly NonNullable<EmphasisMarkAttrs["type"]>[];
+
+const NOTE_TYPES = [
+  "footnote",
+  "endnote",
+] as const satisfies readonly NonNullable<FootnoteRefAttrs["noteType"]>[];
+
+const TRACKED_CHANGE_MOVE_KINDS = [
+  "moveTo",
+  "moveFrom",
+] as const satisfies readonly NonNullable<TrackedChangeMarkAttrs["moveKind"]>[];
+
+const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
+  "bold",
+  "italic",
+  "strike",
+  "doubleStrike",
+  "allCaps",
+  "smallCaps",
+  "hidden",
+  "emboss",
+  "imprint",
+  "shadow",
+  "outline",
+] as const satisfies readonly (keyof RunFormattingOverrideAttrs)[];
 
 export const readParagraphAttrs = (
   node: PMNode,
@@ -509,6 +593,259 @@ export const readImageAttrs = (
 export const expectImageAttrs = (node: PMNode): ImageAttrs =>
   expectAttrs(readImageAttrs(node), "image attrs");
 
+export const readUnderlineMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<UnderlineAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "underline", issues);
+
+  optionalOneOf(
+    attrs,
+    "style",
+    "underline.attrs.style",
+    issues,
+    UNDERLINE_STYLES,
+  );
+  optionalTextColor(attrs, "color", "underline.attrs.color", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectUnderlineMarkAttrs = (mark: Mark): UnderlineAttrs =>
+  expectAttrs(readUnderlineMarkAttrs(mark), "underline attrs");
+
+export const readStrikeMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<StrikeAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "strike", issues);
+
+  optionalBoolean(attrs, "double", "strike.attrs.double", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectStrikeMarkAttrs = (mark: Mark): StrikeAttrs =>
+  expectAttrs(readStrikeMarkAttrs(mark), "strike attrs");
+
+export const readTextColorMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<TextColorAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "textColor", issues);
+
+  optionalTextColorFields(attrs, "textColor.attrs", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTextColorMarkAttrs = (mark: Mark): TextColorAttrs =>
+  expectAttrs(readTextColorMarkAttrs(mark), "text color attrs");
+
+export const readHighlightMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<HighlightAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "highlight", issues);
+
+  requiredOneOf(
+    attrs,
+    "color",
+    "highlight.attrs.color",
+    issues,
+    HIGHLIGHT_COLORS,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectHighlightMarkAttrs = (mark: Mark): HighlightAttrs =>
+  expectAttrs(readHighlightMarkAttrs(mark), "highlight attrs");
+
+export const readFontSizeMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<FontSizeAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "fontSize", issues);
+
+  requiredNumber(attrs, "size", "fontSize.attrs.size", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectFontSizeMarkAttrs = (mark: Mark): FontSizeAttrs =>
+  expectAttrs(readFontSizeMarkAttrs(mark), "font size attrs");
+
+export const readFontFamilyMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<FontFamilyAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "fontFamily", issues);
+
+  optionalString(attrs, "ascii", "fontFamily.attrs.ascii", issues);
+  optionalString(attrs, "hAnsi", "fontFamily.attrs.hAnsi", issues);
+  optionalString(attrs, "eastAsia", "fontFamily.attrs.eastAsia", issues);
+  optionalString(attrs, "cs", "fontFamily.attrs.cs", issues);
+  optionalString(attrs, "asciiTheme", "fontFamily.attrs.asciiTheme", issues);
+  optionalString(attrs, "hAnsiTheme", "fontFamily.attrs.hAnsiTheme", issues);
+  optionalString(
+    attrs,
+    "eastAsiaTheme",
+    "fontFamily.attrs.eastAsiaTheme",
+    issues,
+  );
+  optionalString(attrs, "csTheme", "fontFamily.attrs.csTheme", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectFontFamilyMarkAttrs = (mark: Mark): FontFamilyAttrs =>
+  expectAttrs(readFontFamilyMarkAttrs(mark), "font family attrs");
+
+export const readCharacterSpacingMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<CharacterSpacingAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "characterSpacing", issues);
+
+  optionalNumber(attrs, "spacing", "characterSpacing.attrs.spacing", issues);
+  optionalNumber(attrs, "position", "characterSpacing.attrs.position", issues);
+  optionalNumber(attrs, "scale", "characterSpacing.attrs.scale", issues);
+  optionalNumber(attrs, "kerning", "characterSpacing.attrs.kerning", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectCharacterSpacingMarkAttrs = (
+  mark: Mark,
+): CharacterSpacingAttrs =>
+  expectAttrs(readCharacterSpacingMarkAttrs(mark), "character spacing attrs");
+
+export const readEmphasisMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<EmphasisMarkAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "emphasisMark", issues);
+
+  optionalOneOf(
+    attrs,
+    "type",
+    "emphasisMark.attrs.type",
+    issues,
+    EMPHASIS_MARK_TYPES,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectEmphasisMarkAttrs = (mark: Mark): EmphasisMarkAttrs =>
+  expectAttrs(readEmphasisMarkAttrs(mark), "emphasis mark attrs");
+
+export const readFootnoteRefMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<FootnoteRefAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "footnoteRef", issues);
+
+  requiredStringOrNumber(attrs, "id", "footnoteRef.attrs.id", issues);
+  optionalOneOf(
+    attrs,
+    "noteType",
+    "footnoteRef.attrs.noteType",
+    issues,
+    NOTE_TYPES,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectFootnoteRefMarkAttrs = (mark: Mark): FootnoteRefAttrs =>
+  expectAttrs(readFootnoteRefMarkAttrs(mark), "footnote reference attrs");
+
+export const readCommentMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<CommentAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "comment", issues);
+
+  requiredNumber(attrs, "commentId", "comment.attrs.commentId", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectCommentMarkAttrs = (mark: Mark): CommentAttrs =>
+  expectAttrs(readCommentMarkAttrs(mark), "comment attrs");
+
+export const readTrackedChangeMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<TrackedChangeMarkAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkTypeOneOf(mark, ["insertion", "deletion"], issues);
+
+  requiredNumber(
+    attrs,
+    "revisionId",
+    `${mark.type.name}.attrs.revisionId`,
+    issues,
+  );
+  requiredString(attrs, "author", `${mark.type.name}.attrs.author`, issues);
+  optionalString(attrs, "date", `${mark.type.name}.attrs.date`, issues);
+  optionalOneOf(
+    attrs,
+    "moveKind",
+    `${mark.type.name}.attrs.moveKind`,
+    issues,
+    TRACKED_CHANGE_MOVE_KINDS,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTrackedChangeMarkAttrs = (
+  mark: Mark,
+): TrackedChangeMarkAttrs =>
+  expectAttrs(readTrackedChangeMarkAttrs(mark), "tracked change attrs");
+
+export const readRunFormattingOverrideMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<RunFormattingOverrideAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "runFormattingOverride", issues);
+
+  for (const key of RUN_FORMATTING_OVERRIDE_FALSE_KEYS) {
+    optionalFalse(attrs, key, `runFormattingOverride.attrs.${key}`, issues);
+  }
+  optionalOneOf(
+    attrs,
+    "underline",
+    "runFormattingOverride.attrs.underline",
+    issues,
+    ["none"],
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectRunFormattingOverrideMarkAttrs = (
+  mark: Mark,
+): RunFormattingOverrideAttrs =>
+  expectAttrs(
+    readRunFormattingOverrideMarkAttrs(mark),
+    "run formatting override attrs",
+  );
+
 export const readHyperlinkMarkAttrs = (
   mark: Mark,
 ): ReadProseMirrorAttrsResult<HyperlinkAttrs> => {
@@ -611,6 +948,19 @@ const expectMarkType = (
   }
 };
 
+const expectMarkTypeOneOf = (
+  mark: Mark,
+  expected: readonly string[],
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (!expected.includes(mark.type.name)) {
+    issues.push({
+      path: "mark.type.name",
+      message: `Expected one of ${expected.join(", ")}, got ${mark.type.name}.`,
+    });
+  }
+};
+
 const requiredString = (
   attrs: Record<string, unknown>,
   key: string,
@@ -619,6 +969,18 @@ const requiredString = (
 ): void => {
   if (typeof attrs[key] !== "string") {
     issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const requiredStringOrNumber = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (typeof value !== "string" && typeof value !== "number") {
+    issues.push({ path, message: "Expected a string or number." });
   }
 };
 
@@ -631,6 +993,18 @@ const optionalString = (
   const value = attrs[key];
   if (value !== undefined && value !== null && typeof value !== "string") {
     issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const optionalFalse = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && value !== false) {
+    issues.push({ path, message: "Expected false." });
   }
 };
 
@@ -657,6 +1031,57 @@ const optionalOneOf = (
       message: `Expected one of ${allowed.join(", ")}.`,
     });
   }
+};
+
+const requiredOneOf = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+  allowed: readonly string[],
+): void => {
+  const value = attrs[key];
+  if (typeof value !== "string") {
+    issues.push({ path, message: "Expected a string." });
+    return;
+  }
+
+  if (!allowed.includes(value)) {
+    issues.push({
+      path,
+      message: `Expected one of ${allowed.join(", ")}.`,
+    });
+  }
+};
+
+const optionalTextColor = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalTextColorFields(value, path, issues);
+};
+
+const optionalTextColorFields = (
+  attrs: Record<string, unknown>,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  optionalString(attrs, "rgb", `${path}.rgb`, issues);
+  optionalString(attrs, "themeColor", `${path}.themeColor`, issues);
+  optionalString(attrs, "themeTint", `${path}.themeTint`, issues);
+  optionalString(attrs, "themeShade", `${path}.themeShade`, issues);
 };
 
 const requiredNumber = (

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -498,6 +498,12 @@ export const readTableCellAttrs = (
     "tableCell.attrs._preserveVMergeRestart",
     issues,
   );
+  optionalArray(
+    attrs,
+    "_docxVMergeContinuationCells",
+    "tableCell.attrs._docxVMergeContinuationCells",
+    issues,
+  );
 
   return attrsResult(attrs, issues);
 };
@@ -1469,6 +1475,18 @@ const optionalRecord = (
   const value = attrs[key];
   if (value !== undefined && value !== null && !isRecord(value)) {
     issues.push({ path, message: "Expected an object." });
+  }
+};
+
+const optionalArray = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && !Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array." });
   }
 };
 

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -493,6 +493,12 @@ export const readTableCellAttrs = (
     "tableCell.attrs._originalFormatting",
     issues,
   );
+  optionalBoolean(
+    attrs,
+    "_preserveVMergeRestart",
+    "tableCell.attrs._preserveVMergeRestart",
+    issues,
+  );
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -556,6 +556,7 @@ export const readImageAttrs = (
     IMAGE_WRAP_TEXT_VALUES,
   );
   optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
+  optionalString(attrs, "_docxRawXml", "image.attrs._docxRawXml", issues);
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -2,7 +2,6 @@ import { panic } from "better-result";
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import {
-  BORDER_STYLE_VALUES,
   FIELD_TYPE_VALUES,
   HIGHLIGHT_COLOR_VALUES,
   IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
@@ -1506,7 +1505,7 @@ const validateBorderSpec = (
     return;
   }
 
-  optionalOneOf(value, "style", `${path}.style`, issues, BORDER_STYLE_VALUES);
+  optionalString(value, "style", `${path}.style`, issues);
   optionalNumber(value, "size", `${path}.size`, issues);
   optionalNumber(value, "space", `${path}.space`, issues);
   optionalBoolean(value, "shadow", `${path}.shadow`, issues);

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1,6 +1,7 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import {
+  BORDER_STYLE_VALUES,
   FIELD_TYPE_VALUES,
   HIGHLIGHT_COLOR_VALUES,
   IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
@@ -13,11 +14,14 @@ import {
   PARAGRAPH_ALIGNMENT_VALUES,
   SDT_LOCK_VALUES,
   SDT_TYPE_VALUES,
+  SHADING_PATTERN_VALUES,
   TABLE_CELL_TEXT_DIRECTION_VALUES,
   TABLE_CELL_VERTICAL_ALIGNMENT_VALUES,
   TABLE_JUSTIFICATION_VALUES,
   TABLE_ROW_HEIGHT_RULE_VALUES,
   TABLE_WIDTH_TYPE_VALUES,
+  TAB_LEADER_VALUES,
+  TAB_STOP_ALIGNMENT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
 import type {
@@ -129,6 +133,37 @@ const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
   "shadow",
   "outline",
 ] as const satisfies readonly (keyof RunFormattingOverrideAttrs)[];
+
+const TEXT_FORMATTING_BOOLEAN_KEYS = [
+  "bold",
+  "boldCs",
+  "italic",
+  "italicCs",
+  "strike",
+  "doubleStrike",
+  "smallCaps",
+  "allCaps",
+  "hidden",
+  "emboss",
+  "imprint",
+  "shadow",
+  "outline",
+] as const;
+
+const SECTION_ORIENTATIONS = ["portrait", "landscape"] as const;
+const SECTION_START_TYPES = [
+  "continuous",
+  "nextPage",
+  "oddPage",
+  "evenPage",
+  "nextColumn",
+] as const;
+const SECTION_VERTICAL_ALIGNMENTS = [
+  "top",
+  "center",
+  "both",
+  "bottom",
+] as const;
 
 export const readParagraphAttrs = (
   node: PMNode,
@@ -251,16 +286,23 @@ export const readParagraphAttrs = (
     "paragraph.attrs.listAbstractNumId",
     issues,
   );
-  optionalRecord(attrs, "borders", "paragraph.attrs.borders", issues);
-  optionalRecord(attrs, "shading", "paragraph.attrs.shading", issues);
-  optionalArray(attrs, "tabs", "paragraph.attrs.tabs", issues);
+  optionalBorderMap(attrs, "borders", "paragraph.attrs.borders", issues, [
+    "top",
+    "bottom",
+    "left",
+    "right",
+    "between",
+    "bar",
+  ]);
+  optionalShading(attrs, "shading", "paragraph.attrs.shading", issues);
+  optionalTabStops(attrs, "tabs", "paragraph.attrs.tabs", issues);
   optionalRecord(
     attrs,
     "spacingExplicit",
     "paragraph.attrs.spacingExplicit",
     issues,
   );
-  optionalRecord(
+  optionalTextFormatting(
     attrs,
     "defaultTextFormatting",
     "paragraph.attrs.defaultTextFormatting",
@@ -269,17 +311,18 @@ export const readParagraphAttrs = (
   optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
   validateNumPr(attrs["numPr"], issues);
   optionalBookmarkArray(attrs["bookmarks"], issues);
-  optionalRecord(
+  optionalSectionProperties(
     attrs,
     "_sectionProperties",
     "paragraph.attrs._sectionProperties",
     issues,
   );
-  optionalArray(
+  optionalPropertyChanges(
     attrs,
     "_propertyChanges",
     "paragraph.attrs._propertyChanges",
     issues,
+    ["paragraphPropertyChange"],
   );
 
   return attrsResult(attrs, issues);
@@ -318,7 +361,7 @@ export const readTableAttrs = (
     issues,
   );
   optionalRecord(attrs, "floating", "table.attrs.floating", issues);
-  optionalRecord(attrs, "cellMargins", "table.attrs.cellMargins", issues);
+  optionalInsetMap(attrs, "cellMargins", "table.attrs.cellMargins", issues);
   optionalRecord(attrs, "look", "table.attrs.look", issues);
   optionalRecord(
     attrs,
@@ -403,8 +446,13 @@ export const readTableCellAttrs = (
     TABLE_CELL_TEXT_DIRECTION_VALUES,
   );
   optionalBoolean(attrs, "noWrap", "tableCell.attrs.noWrap", issues);
-  optionalRecord(attrs, "borders", "tableCell.attrs.borders", issues);
-  optionalRecord(attrs, "margins", "tableCell.attrs.margins", issues);
+  optionalBorderMap(attrs, "borders", "tableCell.attrs.borders", issues, [
+    "top",
+    "bottom",
+    "left",
+    "right",
+  ]);
+  optionalInsetMap(attrs, "margins", "tableCell.attrs.margins", issues);
   optionalRecord(
     attrs,
     "_originalFormatting",
@@ -1365,6 +1413,324 @@ const optionalRecord = (
   }
 };
 
+const optionalBorderMap = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+  sides: readonly string[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  for (const side of sides) {
+    validateBorderSpec(value[side], `${path}.${side}`, issues);
+  }
+};
+
+const validateBorderSpec = (
+  value: unknown,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalOneOf(value, "style", `${path}.style`, issues, BORDER_STYLE_VALUES);
+  optionalNumber(value, "size", `${path}.size`, issues);
+  optionalNumber(value, "space", `${path}.space`, issues);
+  optionalBoolean(value, "shadow", `${path}.shadow`, issues);
+  optionalBoolean(value, "frame", `${path}.frame`, issues);
+  optionalColorValue(value, "color", `${path}.color`, issues);
+};
+
+const optionalColorValue = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalString(value, "rgb", `${path}.rgb`, issues);
+  optionalBoolean(value, "auto", `${path}.auto`, issues);
+  optionalString(value, "themeColor", `${path}.themeColor`, issues);
+  optionalString(value, "themeTint", `${path}.themeTint`, issues);
+  optionalString(value, "themeShade", `${path}.themeShade`, issues);
+};
+
+const optionalShading = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalColorValue(value, "color", `${path}.color`, issues);
+  optionalColorValue(value, "fill", `${path}.fill`, issues);
+  optionalOneOf(
+    value,
+    "pattern",
+    `${path}.pattern`,
+    issues,
+    SHADING_PATTERN_VALUES,
+  );
+};
+
+const optionalTabStops = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array." });
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    const itemPath = `${path}[${index}]`;
+    if (!isRecord(item)) {
+      issues.push({ path: itemPath, message: "Expected an object." });
+      continue;
+    }
+    requiredNumber(item, "position", `${itemPath}.position`, issues);
+    requiredOneOf(
+      item,
+      "alignment",
+      `${itemPath}.alignment`,
+      issues,
+      TAB_STOP_ALIGNMENT_VALUES,
+    );
+    optionalOneOf(
+      item,
+      "leader",
+      `${itemPath}.leader`,
+      issues,
+      TAB_LEADER_VALUES,
+    );
+  }
+};
+
+const optionalTextFormatting = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  for (const booleanKey of TEXT_FORMATTING_BOOLEAN_KEYS) {
+    optionalBoolean(value, booleanKey, `${path}.${booleanKey}`, issues);
+  }
+  optionalNumber(value, "fontSize", `${path}.fontSize`, issues);
+  optionalNumber(value, "fontSizeCs", `${path}.fontSizeCs`, issues);
+  optionalOneOf(
+    value,
+    "highlight",
+    `${path}.highlight`,
+    issues,
+    HIGHLIGHT_COLOR_VALUES,
+  );
+  optionalColorValue(value, "color", `${path}.color`, issues);
+  optionalShading(value, "shading", `${path}.shading`, issues);
+
+  const underline = value["underline"];
+  if (underline !== undefined && underline !== null) {
+    if (!isRecord(underline)) {
+      issues.push({
+        path: `${path}.underline`,
+        message: "Expected an object.",
+      });
+    } else {
+      requiredOneOf(
+        underline,
+        "style",
+        `${path}.underline.style`,
+        issues,
+        UNDERLINE_STYLE_VALUES,
+      );
+      optionalColorValue(underline, "color", `${path}.underline.color`, issues);
+    }
+  }
+};
+
+const optionalInsetMap = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalNumber(value, "top", `${path}.top`, issues);
+  optionalNumber(value, "bottom", `${path}.bottom`, issues);
+  optionalNumber(value, "left", `${path}.left`, issues);
+  optionalNumber(value, "right", `${path}.right`, issues);
+};
+
+const optionalSectionProperties = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  for (const numberKey of [
+    "pageWidth",
+    "pageHeight",
+    "marginTop",
+    "marginBottom",
+    "marginLeft",
+    "marginRight",
+    "headerDistance",
+    "footerDistance",
+    "gutter",
+    "columnCount",
+    "columnSpace",
+  ]) {
+    optionalNumber(value, numberKey, `${path}.${numberKey}`, issues);
+  }
+  optionalOneOf(
+    value,
+    "orientation",
+    `${path}.orientation`,
+    issues,
+    SECTION_ORIENTATIONS,
+  );
+  optionalOneOf(
+    value,
+    "sectionStart",
+    `${path}.sectionStart`,
+    issues,
+    SECTION_START_TYPES,
+  );
+  optionalOneOf(
+    value,
+    "verticalAlign",
+    `${path}.verticalAlign`,
+    issues,
+    SECTION_VERTICAL_ALIGNMENTS,
+  );
+  optionalBoolean(value, "equalWidth", `${path}.equalWidth`, issues);
+  optionalBoolean(value, "separator", `${path}.separator`, issues);
+  optionalBoolean(value, "bidi", `${path}.bidi`, issues);
+  optionalBoolean(value, "titlePg", `${path}.titlePg`, issues);
+  optionalBoolean(
+    value,
+    "evenAndOddHeaders",
+    `${path}.evenAndOddHeaders`,
+    issues,
+  );
+};
+
+const optionalPropertyChanges = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+  allowedTypes: readonly string[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array." });
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    const itemPath = `${path}[${index}]`;
+    if (!isRecord(item)) {
+      issues.push({ path: itemPath, message: "Expected an object." });
+      continue;
+    }
+    requiredOneOf(item, "type", `${itemPath}.type`, issues, allowedTypes);
+    validatePropertyChangeInfo(item["info"], `${itemPath}.info`, issues);
+    optionalRecord(
+      item,
+      "previousFormatting",
+      `${itemPath}.previousFormatting`,
+      issues,
+    );
+    optionalRecord(
+      item,
+      "currentFormatting",
+      `${itemPath}.currentFormatting`,
+      issues,
+    );
+  }
+};
+
+const validatePropertyChangeInfo = (
+  value: unknown,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  requiredNumber(value, "id", `${path}.id`, issues);
+  requiredString(value, "author", `${path}.author`, issues);
+  optionalString(value, "date", `${path}.date`, issues);
+  optionalString(value, "rsid", `${path}.rsid`, issues);
+};
+
 const optionalImagePosition = (
   attrs: Record<string, unknown>,
   key: string,
@@ -1429,18 +1795,6 @@ const validateImagePositionAxis = (
   );
   optionalNumber(value, "posOffset", `${path}.posOffset`, options.issues);
   optionalOneOf(value, "align", `${path}.align`, options.issues, options.align);
-};
-
-const optionalArray = (
-  attrs: Record<string, unknown>,
-  key: string,
-  path: string,
-  issues: ProseMirrorAttrIssue[],
-): void => {
-  const value = attrs[key];
-  if (value !== undefined && value !== null && !Array.isArray(value)) {
-    issues.push({ path, message: "Expected an array." });
-  }
 };
 
 type OptionalNumberArrayOptions = {

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -323,6 +323,7 @@ export const readParagraphAttrs = (
   optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
   validateNumPr(attrs["numPr"], issues);
   optionalBookmarkArray(attrs["bookmarks"], issues);
+  optionalEmptyHyperlinkArray(attrs["_emptyHyperlinks"], issues);
   optionalSectionProperties(
     attrs,
     "_sectionProperties",
@@ -1989,5 +1990,35 @@ const optionalBookmarkArray = (
         message: "Expected a string.",
       });
     }
+  }
+};
+
+const optionalEmptyHyperlinkArray = (
+  value: unknown,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({
+      path: "paragraph.attrs._emptyHyperlinks",
+      message: "Expected an array of empty hyperlinks.",
+    });
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    const itemPath = `paragraph.attrs._emptyHyperlinks[${index}]`;
+    if (!isRecord(item)) {
+      issues.push({ path: itemPath, message: "Expected an object." });
+      continue;
+    }
+    validateNonNegativeInteger(item["offset"], `${itemPath}.offset`, issues);
+    optionalString(item, "href", `${itemPath}.href`, issues);
+    optionalString(item, "anchor", `${itemPath}.anchor`, issues);
+    optionalString(item, "tooltip", `${itemPath}.tooltip`, issues);
+    optionalString(item, "rId", `${itemPath}.rId`, issues);
   }
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1,0 +1,506 @@
+import type { Mark, Node as PMNode } from "prosemirror-model";
+
+import type {
+  HyperlinkAttrs,
+  ImageAttrs,
+  ParagraphAttrs,
+  TableAttrs,
+  TableCellAttrs,
+  TableRowAttrs,
+} from "../schema";
+
+export type ProseMirrorAttrIssue = {
+  path: string;
+  message: string;
+};
+
+export type ReadProseMirrorAttrsResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; issues: ProseMirrorAttrIssue[] };
+
+export const readParagraphAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<ParagraphAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "paragraph", issues);
+
+  optionalString(attrs, "paraId", "paragraph.attrs.paraId", issues);
+  optionalString(attrs, "textId", "paragraph.attrs.textId", issues);
+  optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
+  optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
+  optionalNumber(attrs, "spaceAfter", "paragraph.attrs.spaceAfter", issues);
+  optionalNumber(attrs, "lineSpacing", "paragraph.attrs.lineSpacing", issues);
+  optionalNumber(attrs, "outlineLevel", "paragraph.attrs.outlineLevel", issues);
+  optionalNumber(
+    attrs,
+    "listMarkerFontSize",
+    "paragraph.attrs.listMarkerFontSize",
+    issues,
+  );
+  optionalNumber(
+    attrs,
+    "listStartOverride",
+    "paragraph.attrs.listStartOverride",
+    issues,
+  );
+  optionalBoolean(
+    attrs,
+    "renderedPageBreakBefore",
+    "paragraph.attrs.renderedPageBreakBefore",
+    issues,
+  );
+  optionalBoolean(
+    attrs,
+    "runInWithNext",
+    "paragraph.attrs.runInWithNext",
+    issues,
+  );
+  optionalStringArray(
+    attrs,
+    "listLevelNumFmts",
+    "paragraph.attrs.listLevelNumFmts",
+    issues,
+  );
+  optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
+  validateNumPr(attrs["numPr"], issues);
+  optionalBookmarkArray(attrs["bookmarks"], issues);
+  optionalRecord(
+    attrs,
+    "_sectionProperties",
+    "paragraph.attrs._sectionProperties",
+    issues,
+  );
+  optionalArray(
+    attrs,
+    "_propertyChanges",
+    "paragraph.attrs._propertyChanges",
+    issues,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectParagraphAttrs = (node: PMNode): ParagraphAttrs =>
+  expectAttrs(readParagraphAttrs(node), "paragraph attrs");
+
+export const readTableAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TableAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "table", issues);
+
+  optionalString(attrs, "styleId", "table.attrs.styleId", issues);
+  optionalNumber(attrs, "width", "table.attrs.width", issues);
+  optionalString(attrs, "widthType", "table.attrs.widthType", issues);
+  optionalNumberArray(
+    attrs,
+    "columnWidths",
+    "table.attrs.columnWidths",
+    issues,
+  );
+  optionalRecord(attrs, "floating", "table.attrs.floating", issues);
+  optionalRecord(attrs, "cellMargins", "table.attrs.cellMargins", issues);
+  optionalRecord(attrs, "look", "table.attrs.look", issues);
+  optionalRecord(
+    attrs,
+    "_originalFormatting",
+    "table.attrs._originalFormatting",
+    issues,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTableAttrs = (node: PMNode): TableAttrs =>
+  expectAttrs(readTableAttrs(node), "table attrs");
+
+export const readTableRowAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TableRowAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "tableRow", issues);
+
+  optionalNumber(attrs, "height", "tableRow.attrs.height", issues);
+  optionalString(attrs, "heightRule", "tableRow.attrs.heightRule", issues);
+  optionalBoolean(attrs, "isHeader", "tableRow.attrs.isHeader", issues);
+  optionalRecord(
+    attrs,
+    "_originalFormatting",
+    "tableRow.attrs._originalFormatting",
+    issues,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTableRowAttrs = (node: PMNode): TableRowAttrs =>
+  expectAttrs(readTableRowAttrs(node), "table row attrs");
+
+export const readTableCellAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TableCellAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "tableCell", issues);
+
+  requiredNumber(attrs, "colspan", "tableCell.attrs.colspan", issues);
+  requiredNumber(attrs, "rowspan", "tableCell.attrs.rowspan", issues);
+  optionalNumberArray(attrs, "colwidth", "tableCell.attrs.colwidth", issues, {
+    allowNull: true,
+  });
+  optionalNumber(attrs, "width", "tableCell.attrs.width", issues);
+  optionalString(attrs, "widthType", "tableCell.attrs.widthType", issues);
+  optionalString(
+    attrs,
+    "verticalAlign",
+    "tableCell.attrs.verticalAlign",
+    issues,
+  );
+  optionalString(
+    attrs,
+    "backgroundColor",
+    "tableCell.attrs.backgroundColor",
+    issues,
+  );
+  optionalString(
+    attrs,
+    "textDirection",
+    "tableCell.attrs.textDirection",
+    issues,
+  );
+  optionalBoolean(attrs, "noWrap", "tableCell.attrs.noWrap", issues);
+  optionalRecord(attrs, "borders", "tableCell.attrs.borders", issues);
+  optionalRecord(attrs, "margins", "tableCell.attrs.margins", issues);
+  optionalRecord(
+    attrs,
+    "_originalFormatting",
+    "tableCell.attrs._originalFormatting",
+    issues,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTableCellAttrs = (node: PMNode): TableCellAttrs =>
+  expectAttrs(readTableCellAttrs(node), "table cell attrs");
+
+export const readImageAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<ImageAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "image", issues);
+
+  requiredString(attrs, "src", "image.attrs.src", issues);
+  optionalString(attrs, "alt", "image.attrs.alt", issues);
+  optionalString(attrs, "title", "image.attrs.title", issues);
+  optionalString(attrs, "rId", "image.attrs.rId", issues);
+  optionalNumber(attrs, "width", "image.attrs.width", issues);
+  optionalNumber(attrs, "height", "image.attrs.height", issues);
+  optionalString(attrs, "wrapType", "image.attrs.wrapType", issues);
+  optionalString(attrs, "displayMode", "image.attrs.displayMode", issues);
+  optionalString(attrs, "cssFloat", "image.attrs.cssFloat", issues);
+  optionalRecord(attrs, "position", "image.attrs.position", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectImageAttrs = (node: PMNode): ImageAttrs =>
+  expectAttrs(readImageAttrs(node), "image attrs");
+
+export const readHyperlinkMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<HyperlinkAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "hyperlink", issues);
+
+  requiredString(attrs, "href", "hyperlink.attrs.href", issues);
+  optionalString(attrs, "tooltip", "hyperlink.attrs.tooltip", issues);
+  optionalString(attrs, "rId", "hyperlink.attrs.rId", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectHyperlinkMarkAttrs = (mark: Mark): HyperlinkAttrs =>
+  expectAttrs(readHyperlinkMarkAttrs(mark), "hyperlink attrs");
+
+const attrsRecord = (attrs: unknown): Record<string, unknown> => {
+  if (attrs && typeof attrs === "object" && !Array.isArray(attrs)) {
+    return attrs as Record<string, unknown>;
+  }
+
+  return {};
+};
+
+const attrsResult = <T>(
+  attrs: Record<string, unknown>,
+  issues: ProseMirrorAttrIssue[],
+): ReadProseMirrorAttrsResult<T> => {
+  if (issues.length > 0) {
+    return { ok: false, issues };
+  }
+
+  // SAFETY: this module is the ProseMirror FFI boundary. The checks above
+  // validate the attrs this code relies on before exposing the typed shape.
+  return { ok: true, value: attrs as T };
+};
+
+const expectAttrs = <T>(
+  result: ReadProseMirrorAttrsResult<T>,
+  label: string,
+): T => {
+  if (result.ok) {
+    return result.value;
+  }
+
+  const details = result.issues
+    .map((issue) => `${issue.path}: ${issue.message}`)
+    .join("\n");
+  throw new Error(`Invalid ProseMirror ${label}:\n${details}`);
+};
+
+const expectNodeType = (
+  node: PMNode,
+  expected: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (node.type.name !== expected) {
+    issues.push({
+      path: "node.type.name",
+      message: `Expected ${expected}, got ${node.type.name}.`,
+    });
+  }
+};
+
+const expectMarkType = (
+  mark: Mark,
+  expected: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (mark.type.name !== expected) {
+    issues.push({
+      path: "mark.type.name",
+      message: `Expected ${expected}, got ${mark.type.name}.`,
+    });
+  }
+};
+
+const requiredString = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (typeof attrs[key] !== "string") {
+    issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const optionalString = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && typeof value !== "string") {
+    issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const requiredNumber = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (typeof attrs[key] !== "number") {
+    issues.push({ path, message: "Expected a number." });
+  }
+};
+
+const optionalNumber = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && typeof value !== "number") {
+    issues.push({ path, message: "Expected a number." });
+  }
+};
+
+const optionalBoolean = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && typeof value !== "boolean") {
+    issues.push({ path, message: "Expected a boolean." });
+  }
+};
+
+const optionalRecord = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (
+    value !== undefined &&
+    value !== null &&
+    (typeof value !== "object" || Array.isArray(value))
+  ) {
+    issues.push({ path, message: "Expected an object." });
+  }
+};
+
+const optionalArray = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value !== undefined && value !== null && !Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array." });
+  }
+};
+
+type OptionalNumberArrayOptions = {
+  allowNull?: boolean;
+};
+
+const optionalNumberArray = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+  options: OptionalNumberArrayOptions = {},
+): void => {
+  const value = attrs[key];
+  if (value === null && options.allowNull === true) {
+    return;
+  }
+
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array of numbers." });
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "number") {
+      issues.push({
+        path: `${path}[${index}]`,
+        message: "Expected a number.",
+      });
+    }
+  }
+};
+
+const optionalStringArray = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({ path, message: "Expected an array of strings." });
+    return;
+  }
+
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string") {
+      issues.push({
+        path: `${path}[${index}]`,
+        message: "Expected a string.",
+      });
+    }
+  }
+};
+
+const validateNumPr = (
+  value: unknown,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (value === undefined || value === null || Array.isArray(value)) {
+    return;
+  }
+
+  if (typeof value !== "object") {
+    return;
+  }
+
+  const numPr = value as Record<string, unknown>;
+  if (numPr["numId"] !== undefined && typeof numPr["numId"] !== "number") {
+    issues.push({
+      path: "paragraph.attrs.numPr.numId",
+      message: "Expected a number.",
+    });
+  }
+
+  if (numPr["ilvl"] !== undefined && typeof numPr["ilvl"] !== "number") {
+    issues.push({
+      path: "paragraph.attrs.numPr.ilvl",
+      message: "Expected a number.",
+    });
+  }
+};
+
+const optionalBookmarkArray = (
+  value: unknown,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!Array.isArray(value)) {
+    issues.push({
+      path: "paragraph.attrs.bookmarks",
+      message: "Expected an array of bookmarks.",
+    });
+    return;
+  }
+
+  for (const [index, bookmark] of value.entries()) {
+    if (!bookmark || typeof bookmark !== "object" || Array.isArray(bookmark)) {
+      issues.push({
+        path: `paragraph.attrs.bookmarks[${index}]`,
+        message: "Expected a bookmark object.",
+      });
+      continue;
+    }
+
+    const attrs = bookmark as Record<string, unknown>;
+    if (typeof attrs["id"] !== "number") {
+      issues.push({
+        path: `paragraph.attrs.bookmarks[${index}].id`,
+        message: "Expected a number.",
+      });
+    }
+    if (typeof attrs["name"] !== "string") {
+      issues.push({
+        path: `paragraph.attrs.bookmarks[${index}].name`,
+        message: "Expected a string.",
+      });
+    }
+  }
+};

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -35,6 +35,7 @@ import type {
   FootnoteRefAttrs,
   HighlightAttrs,
   HyperlinkAttrs,
+  HardBreakAttrs,
   ImageAttrs,
   MathAttrs,
   ParagraphAttrs,
@@ -125,6 +126,10 @@ const TRACKED_CHANGE_MOVE_KINDS = [
   "moveTo",
   "moveFrom",
 ] as const satisfies readonly NonNullable<TrackedChangeMarkAttrs["moveKind"]>[];
+
+const HARD_BREAK_TYPES = ["column"] as const satisfies readonly NonNullable<
+  HardBreakAttrs["breakType"]
+>[];
 
 const RUN_FORMATTING_OVERRIDE_FALSE_KEYS = [
   "bold",
@@ -336,6 +341,27 @@ export const readParagraphAttrs = (
 
 export const expectParagraphAttrs = (node: PMNode): ParagraphAttrs =>
   expectAttrs(readParagraphAttrs(node), "paragraph attrs");
+
+export const readHardBreakAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<HardBreakAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "hardBreak", issues);
+
+  optionalOneOf(
+    attrs,
+    "breakType",
+    "hardBreak.attrs.breakType",
+    issues,
+    HARD_BREAK_TYPES,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectHardBreakAttrs = (node: PMNode): HardBreakAttrs =>
+  expectAttrs(readHardBreakAttrs(node), "hard break attrs");
 
 export const readTableAttrs = (
   node: PMNode,

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1,5 +1,25 @@
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
+import {
+  FIELD_TYPE_VALUES,
+  HIGHLIGHT_COLOR_VALUES,
+  IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
+  IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
+  IMAGE_VERTICAL_ALIGNMENT_VALUES,
+  IMAGE_VERTICAL_RELATIVE_TO_VALUES,
+  IMAGE_WRAP_TEXT_VALUES,
+  IMAGE_WRAP_TYPE_VALUES,
+  LINE_SPACING_RULE_VALUES,
+  PARAGRAPH_ALIGNMENT_VALUES,
+  SDT_LOCK_VALUES,
+  SDT_TYPE_VALUES,
+  TABLE_CELL_TEXT_DIRECTION_VALUES,
+  TABLE_CELL_VERTICAL_ALIGNMENT_VALUES,
+  TABLE_JUSTIFICATION_VALUES,
+  TABLE_ROW_HEIGHT_RULE_VALUES,
+  TABLE_WIDTH_TYPE_VALUES,
+  UNDERLINE_STYLE_VALUES,
+} from "../../types/documentEnumValues";
 import type {
   CharacterSpacingAttrs,
   CommentAttrs,
@@ -35,105 +55,12 @@ export type ReadProseMirrorAttrsResult<T> =
   | { ok: true; value: T }
   | { ok: false; issues: ProseMirrorAttrIssue[] };
 
-type ImageHorizontalPositionAttrs = NonNullable<
-  NonNullable<ImageAttrs["position"]>["horizontal"]
->;
-
-type ImageVerticalPositionAttrs = NonNullable<
-  NonNullable<ImageAttrs["position"]>["vertical"]
->;
-
-const PARAGRAPH_ALIGNMENTS = [
-  "left",
-  "center",
-  "right",
-  "both",
-  "distribute",
-  "mediumKashida",
-  "highKashida",
-  "lowKashida",
-  "thaiDistribute",
-] as const satisfies readonly NonNullable<ParagraphAttrs["alignment"]>[];
-
-const LINE_SPACING_RULES = [
-  "auto",
-  "exact",
-  "atLeast",
-] as const satisfies readonly NonNullable<ParagraphAttrs["lineSpacingRule"]>[];
-
 const SECTION_BREAK_TYPES = [
   "nextPage",
   "continuous",
   "oddPage",
   "evenPage",
 ] as const satisfies readonly NonNullable<ParagraphAttrs["sectionBreakType"]>[];
-
-const TABLE_WIDTH_TYPES = [
-  "auto",
-  "dxa",
-  "nil",
-  "pct",
-] as const satisfies readonly NonNullable<TableAttrs["widthType"]>[];
-
-const TABLE_JUSTIFICATIONS = [
-  "left",
-  "center",
-  "right",
-] as const satisfies readonly NonNullable<TableAttrs["justification"]>[];
-
-const TABLE_ROW_HEIGHT_RULES = [
-  "auto",
-  "atLeast",
-  "exact",
-] as const satisfies readonly NonNullable<TableRowAttrs["heightRule"]>[];
-
-const TABLE_CELL_VERTICAL_ALIGNMENTS = [
-  "top",
-  "center",
-  "bottom",
-] as const satisfies readonly NonNullable<TableCellAttrs["verticalAlign"]>[];
-
-const TABLE_CELL_TEXT_DIRECTIONS = [
-  "lr",
-  "lrV",
-  "rl",
-  "rlV",
-  "tb",
-  "tbV",
-  "tbRl",
-  "tbRlV",
-  "btLr",
-] as const satisfies readonly NonNullable<TableCellAttrs["textDirection"]>[];
-
-const HIGHLIGHT_COLORS = [
-  "black",
-  "blue",
-  "cyan",
-  "darkBlue",
-  "darkCyan",
-  "darkGray",
-  "darkGreen",
-  "darkMagenta",
-  "darkRed",
-  "darkYellow",
-  "green",
-  "lightGray",
-  "magenta",
-  "none",
-  "red",
-  "white",
-  "yellow",
-] as const satisfies readonly HighlightAttrs["color"][];
-
-const IMAGE_WRAP_TYPES = [
-  "inline",
-  "square",
-  "tight",
-  "through",
-  "topAndBottom",
-  "behind",
-  "inFront",
-] as const satisfies readonly NonNullable<ImageAttrs["wrapType"]>[];
 
 const IMAGE_DISPLAY_MODES = [
   "inline",
@@ -147,112 +74,6 @@ const IMAGE_CSS_FLOATS = [
   "none",
 ] as const satisfies readonly NonNullable<ImageAttrs["cssFloat"]>[];
 
-const IMAGE_WRAP_TEXTS = [
-  "bothSides",
-  "left",
-  "right",
-  "largest",
-] as const satisfies readonly NonNullable<ImageAttrs["wrapText"]>[];
-
-const IMAGE_HORIZONTAL_RELATIVE_TO = [
-  "character",
-  "column",
-  "insideMargin",
-  "leftMargin",
-  "margin",
-  "outsideMargin",
-  "page",
-  "rightMargin",
-] as const satisfies readonly NonNullable<
-  ImageHorizontalPositionAttrs["relativeTo"]
->[];
-
-const IMAGE_HORIZONTAL_ALIGNMENTS = [
-  "left",
-  "right",
-  "center",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<
-  ImageHorizontalPositionAttrs["align"]
->[];
-
-const IMAGE_VERTICAL_RELATIVE_TO = [
-  "insideMargin",
-  "line",
-  "margin",
-  "outsideMargin",
-  "page",
-  "paragraph",
-  "topMargin",
-  "bottomMargin",
-] as const satisfies readonly NonNullable<
-  ImageVerticalPositionAttrs["relativeTo"]
->[];
-
-const IMAGE_VERTICAL_ALIGNMENTS = [
-  "top",
-  "bottom",
-  "center",
-  "inside",
-  "outside",
-] as const satisfies readonly NonNullable<
-  ImageVerticalPositionAttrs["align"]
->[];
-
-const FIELD_TYPES = [
-  "PAGE",
-  "NUMPAGES",
-  "NUMWORDS",
-  "NUMCHARS",
-  "DATE",
-  "TIME",
-  "CREATEDATE",
-  "SAVEDATE",
-  "PRINTDATE",
-  "AUTHOR",
-  "TITLE",
-  "SUBJECT",
-  "KEYWORDS",
-  "COMMENTS",
-  "FILENAME",
-  "FILESIZE",
-  "TEMPLATE",
-  "DOCPROPERTY",
-  "DOCVARIABLE",
-  "REF",
-  "PAGEREF",
-  "NOTEREF",
-  "HYPERLINK",
-  "TOC",
-  "TOA",
-  "INDEX",
-  "SEQ",
-  "STYLEREF",
-  "AUTONUM",
-  "AUTONUMLGL",
-  "AUTONUMOUT",
-  "IF",
-  "MERGEFIELD",
-  "NEXT",
-  "NEXTIF",
-  "ASK",
-  "SET",
-  "QUOTE",
-  "INCLUDETEXT",
-  "INCLUDEPICTURE",
-  "SYMBOL",
-  "ADVANCE",
-  "EDITTIME",
-  "REVNUM",
-  "SECTION",
-  "SECTIONPAGES",
-  "USERADDRESS",
-  "USERNAME",
-  "USERINITIALS",
-  "UNKNOWN",
-] as const satisfies readonly FieldAttrs["fieldType"][];
-
 const FIELD_KINDS = [
   "simple",
   "complex",
@@ -262,26 +83,6 @@ const MATH_DISPLAYS = [
   "inline",
   "block",
 ] as const satisfies readonly NonNullable<MathAttrs["display"]>[];
-
-const SDT_TYPES = [
-  "richText",
-  "plainText",
-  "date",
-  "dropdown",
-  "comboBox",
-  "checkbox",
-  "picture",
-  "buildingBlockGallery",
-  "group",
-  "unknown",
-] as const satisfies readonly SdtAttrs["sdtType"][];
-
-const SDT_LOCKS = [
-  "sdtLocked",
-  "contentLocked",
-  "sdtContentLocked",
-  "unlocked",
-] as const satisfies readonly NonNullable<SdtAttrs["lock"]>[];
 
 const SHAPE_FILL_TYPES = [
   "none",
@@ -297,27 +98,6 @@ const SHAPE_GRADIENT_TYPES = [
   "rectangular",
   "path",
 ] as const satisfies readonly NonNullable<ShapeAttrs["gradientType"]>[];
-
-const UNDERLINE_STYLES = [
-  "none",
-  "single",
-  "words",
-  "double",
-  "thick",
-  "dotted",
-  "dottedHeavy",
-  "dash",
-  "dashedHeavy",
-  "dashLong",
-  "dashLongHeavy",
-  "dotDash",
-  "dashDotHeavy",
-  "dotDotDash",
-  "dashDotDotHeavy",
-  "wave",
-  "wavyHeavy",
-  "wavyDouble",
-] as const satisfies readonly NonNullable<UnderlineAttrs["style"]>[];
 
 const EMPHASIS_MARK_TYPES = [
   "dot",
@@ -364,7 +144,7 @@ export const readParagraphAttrs = (
     "alignment",
     "paragraph.attrs.alignment",
     issues,
-    PARAGRAPH_ALIGNMENTS,
+    PARAGRAPH_ALIGNMENT_VALUES,
   );
   optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
   optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
@@ -375,7 +155,7 @@ export const readParagraphAttrs = (
     "lineSpacingRule",
     "paragraph.attrs.lineSpacingRule",
     issues,
-    LINE_SPACING_RULES,
+    LINE_SPACING_RULE_VALUES,
   );
   optionalNumber(attrs, "indentLeft", "paragraph.attrs.indentLeft", issues);
   optionalNumber(attrs, "indentRight", "paragraph.attrs.indentRight", issues);
@@ -522,14 +302,14 @@ export const readTableAttrs = (
     "widthType",
     "table.attrs.widthType",
     issues,
-    TABLE_WIDTH_TYPES,
+    TABLE_WIDTH_TYPE_VALUES,
   );
   optionalOneOf(
     attrs,
     "justification",
     "table.attrs.justification",
     issues,
-    TABLE_JUSTIFICATIONS,
+    TABLE_JUSTIFICATION_VALUES,
   );
   optionalNumberArray(
     attrs,
@@ -566,7 +346,7 @@ export const readTableRowAttrs = (
     "heightRule",
     "tableRow.attrs.heightRule",
     issues,
-    TABLE_ROW_HEIGHT_RULES,
+    TABLE_ROW_HEIGHT_RULE_VALUES,
   );
   optionalBoolean(attrs, "isHeader", "tableRow.attrs.isHeader", issues);
   optionalRecord(
@@ -600,14 +380,14 @@ export const readTableCellAttrs = (
     "widthType",
     "tableCell.attrs.widthType",
     issues,
-    TABLE_WIDTH_TYPES,
+    TABLE_WIDTH_TYPE_VALUES,
   );
   optionalOneOf(
     attrs,
     "verticalAlign",
     "tableCell.attrs.verticalAlign",
     issues,
-    TABLE_CELL_VERTICAL_ALIGNMENTS,
+    TABLE_CELL_VERTICAL_ALIGNMENT_VALUES,
   );
   optionalString(
     attrs,
@@ -620,7 +400,7 @@ export const readTableCellAttrs = (
     "textDirection",
     "tableCell.attrs.textDirection",
     issues,
-    TABLE_CELL_TEXT_DIRECTIONS,
+    TABLE_CELL_TEXT_DIRECTION_VALUES,
   );
   optionalBoolean(attrs, "noWrap", "tableCell.attrs.noWrap", issues);
   optionalRecord(attrs, "borders", "tableCell.attrs.borders", issues);
@@ -656,7 +436,7 @@ export const readImageAttrs = (
     "wrapType",
     "image.attrs.wrapType",
     issues,
-    IMAGE_WRAP_TYPES,
+    IMAGE_WRAP_TYPE_VALUES,
   );
   optionalOneOf(
     attrs,
@@ -686,7 +466,7 @@ export const readImageAttrs = (
     "wrapText",
     "image.attrs.wrapText",
     issues,
-    IMAGE_WRAP_TEXTS,
+    IMAGE_WRAP_TEXT_VALUES,
   );
   optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
 
@@ -708,7 +488,7 @@ export const readFieldAttrs = (
     "fieldType",
     "field.attrs.fieldType",
     issues,
-    FIELD_TYPES,
+    FIELD_TYPE_VALUES,
   );
   requiredString(attrs, "instruction", "field.attrs.instruction", issues);
   requiredString(attrs, "displayText", "field.attrs.displayText", issues);
@@ -752,10 +532,10 @@ export const readSdtAttrs = (
   const issues: ProseMirrorAttrIssue[] = [];
   expectNodeType(node, "sdt", issues);
 
-  requiredOneOf(attrs, "sdtType", "sdt.attrs.sdtType", issues, SDT_TYPES);
+  requiredOneOf(attrs, "sdtType", "sdt.attrs.sdtType", issues, SDT_TYPE_VALUES);
   optionalString(attrs, "alias", "sdt.attrs.alias", issues);
   optionalString(attrs, "tag", "sdt.attrs.tag", issues);
-  optionalOneOf(attrs, "lock", "sdt.attrs.lock", issues, SDT_LOCKS);
+  optionalOneOf(attrs, "lock", "sdt.attrs.lock", issues, SDT_LOCK_VALUES);
   optionalString(attrs, "placeholder", "sdt.attrs.placeholder", issues);
   optionalBoolean(
     attrs,
@@ -891,7 +671,7 @@ export const readUnderlineMarkAttrs = (
     "style",
     "underline.attrs.style",
     issues,
-    UNDERLINE_STYLES,
+    UNDERLINE_STYLE_VALUES,
   );
   optionalTextColor(attrs, "color", "underline.attrs.color", issues);
 
@@ -943,7 +723,7 @@ export const readHighlightMarkAttrs = (
     "color",
     "highlight.attrs.color",
     issues,
-    HIGHLIGHT_COLORS,
+    HIGHLIGHT_COLOR_VALUES,
   );
 
   return attrsResult(attrs, issues);
@@ -1547,15 +1327,15 @@ const optionalImagePosition = (
   validateImagePositionAxis(value, {
     key: "horizontal",
     path,
-    relativeTo: IMAGE_HORIZONTAL_RELATIVE_TO,
-    align: IMAGE_HORIZONTAL_ALIGNMENTS,
+    relativeTo: IMAGE_HORIZONTAL_RELATIVE_TO_VALUES,
+    align: IMAGE_HORIZONTAL_ALIGNMENT_VALUES,
     issues,
   });
   validateImagePositionAxis(value, {
     key: "vertical",
     path,
-    relativeTo: IMAGE_VERTICAL_RELATIVE_TO,
-    align: IMAGE_VERTICAL_ALIGNMENTS,
+    relativeTo: IMAGE_VERTICAL_RELATIVE_TO_VALUES,
+    align: IMAGE_VERTICAL_ALIGNMENT_VALUES,
     issues,
   });
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1018,6 +1018,11 @@ export const readHyperlinkMarkAttrs = (
   requiredString(attrs, "href", "hyperlink.attrs.href", issues);
   optionalString(attrs, "tooltip", "hyperlink.attrs.tooltip", issues);
   optionalString(attrs, "rId", "hyperlink.attrs.rId", issues);
+  validateNonNegativeInteger(
+    attrs["_docxHyperlinkIndex"],
+    "hyperlink.attrs._docxHyperlinkIndex",
+    issues,
+  );
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -1,3 +1,4 @@
+import { panic } from "better-result";
 import type { Mark, Node as PMNode } from "prosemirror-model";
 
 import {
@@ -1077,7 +1078,7 @@ const expectAttrs = <T>(
   const details = result.issues
     .map((issue) => `${issue.path}: ${issue.message}`)
     .join("\n");
-  throw new Error(`Invalid ProseMirror ${label}:\n${details}`);
+  panic(`Invalid ProseMirror ${label}:\n${details}`);
 };
 
 const expectNodeType = (

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -4,18 +4,23 @@ import type {
   CharacterSpacingAttrs,
   CommentAttrs,
   EmphasisMarkAttrs,
+  FieldAttrs,
   FontFamilyAttrs,
   FontSizeAttrs,
   FootnoteRefAttrs,
   HighlightAttrs,
   HyperlinkAttrs,
   ImageAttrs,
+  MathAttrs,
   ParagraphAttrs,
   RunFormattingOverrideAttrs,
+  SdtAttrs,
+  ShapeAttrs,
   StrikeAttrs,
   TableAttrs,
   TableCellAttrs,
   TableRowAttrs,
+  TextBoxAttrs,
   TextColorAttrs,
   TrackedChangeMarkAttrs,
   UnderlineAttrs,
@@ -194,6 +199,104 @@ const IMAGE_VERTICAL_ALIGNMENTS = [
 ] as const satisfies readonly NonNullable<
   ImageVerticalPositionAttrs["align"]
 >[];
+
+const FIELD_TYPES = [
+  "PAGE",
+  "NUMPAGES",
+  "NUMWORDS",
+  "NUMCHARS",
+  "DATE",
+  "TIME",
+  "CREATEDATE",
+  "SAVEDATE",
+  "PRINTDATE",
+  "AUTHOR",
+  "TITLE",
+  "SUBJECT",
+  "KEYWORDS",
+  "COMMENTS",
+  "FILENAME",
+  "FILESIZE",
+  "TEMPLATE",
+  "DOCPROPERTY",
+  "DOCVARIABLE",
+  "REF",
+  "PAGEREF",
+  "NOTEREF",
+  "HYPERLINK",
+  "TOC",
+  "TOA",
+  "INDEX",
+  "SEQ",
+  "STYLEREF",
+  "AUTONUM",
+  "AUTONUMLGL",
+  "AUTONUMOUT",
+  "IF",
+  "MERGEFIELD",
+  "NEXT",
+  "NEXTIF",
+  "ASK",
+  "SET",
+  "QUOTE",
+  "INCLUDETEXT",
+  "INCLUDEPICTURE",
+  "SYMBOL",
+  "ADVANCE",
+  "EDITTIME",
+  "REVNUM",
+  "SECTION",
+  "SECTIONPAGES",
+  "USERADDRESS",
+  "USERNAME",
+  "USERINITIALS",
+  "UNKNOWN",
+] as const satisfies readonly FieldAttrs["fieldType"][];
+
+const FIELD_KINDS = [
+  "simple",
+  "complex",
+] as const satisfies readonly FieldAttrs["fieldKind"][];
+
+const MATH_DISPLAYS = [
+  "inline",
+  "block",
+] as const satisfies readonly NonNullable<MathAttrs["display"]>[];
+
+const SDT_TYPES = [
+  "richText",
+  "plainText",
+  "date",
+  "dropdown",
+  "comboBox",
+  "checkbox",
+  "picture",
+  "buildingBlockGallery",
+  "group",
+  "unknown",
+] as const satisfies readonly SdtAttrs["sdtType"][];
+
+const SDT_LOCKS = [
+  "sdtLocked",
+  "contentLocked",
+  "sdtContentLocked",
+  "unlocked",
+] as const satisfies readonly NonNullable<SdtAttrs["lock"]>[];
+
+const SHAPE_FILL_TYPES = [
+  "none",
+  "solid",
+  "gradient",
+  "pattern",
+  "picture",
+] as const satisfies readonly NonNullable<ShapeAttrs["fillType"]>[];
+
+const SHAPE_GRADIENT_TYPES = [
+  "linear",
+  "radial",
+  "rectangular",
+  "path",
+] as const satisfies readonly NonNullable<ShapeAttrs["gradientType"]>[];
 
 const UNDERLINE_STYLES = [
   "none",
@@ -592,6 +695,189 @@ export const readImageAttrs = (
 
 export const expectImageAttrs = (node: PMNode): ImageAttrs =>
   expectAttrs(readImageAttrs(node), "image attrs");
+
+export const readFieldAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<FieldAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "field", issues);
+
+  requiredOneOf(
+    attrs,
+    "fieldType",
+    "field.attrs.fieldType",
+    issues,
+    FIELD_TYPES,
+  );
+  requiredString(attrs, "instruction", "field.attrs.instruction", issues);
+  requiredString(attrs, "displayText", "field.attrs.displayText", issues);
+  requiredOneOf(
+    attrs,
+    "fieldKind",
+    "field.attrs.fieldKind",
+    issues,
+    FIELD_KINDS,
+  );
+  optionalBoolean(attrs, "fldLock", "field.attrs.fldLock", issues);
+  optionalBoolean(attrs, "dirty", "field.attrs.dirty", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectFieldAttrs = (node: PMNode): FieldAttrs =>
+  expectAttrs(readFieldAttrs(node), "field attrs");
+
+export const readMathAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<MathAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "math", issues);
+
+  optionalOneOf(attrs, "display", "math.attrs.display", issues, MATH_DISPLAYS);
+  requiredString(attrs, "ommlXml", "math.attrs.ommlXml", issues);
+  optionalString(attrs, "plainText", "math.attrs.plainText", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectMathAttrs = (node: PMNode): MathAttrs =>
+  expectAttrs(readMathAttrs(node), "math attrs");
+
+export const readSdtAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<SdtAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "sdt", issues);
+
+  requiredOneOf(attrs, "sdtType", "sdt.attrs.sdtType", issues, SDT_TYPES);
+  optionalString(attrs, "alias", "sdt.attrs.alias", issues);
+  optionalString(attrs, "tag", "sdt.attrs.tag", issues);
+  optionalOneOf(attrs, "lock", "sdt.attrs.lock", issues, SDT_LOCKS);
+  optionalString(attrs, "placeholder", "sdt.attrs.placeholder", issues);
+  optionalBoolean(
+    attrs,
+    "showingPlaceholder",
+    "sdt.attrs.showingPlaceholder",
+    issues,
+  );
+  optionalString(attrs, "dateFormat", "sdt.attrs.dateFormat", issues);
+  optionalSdtListItems(attrs, "listItems", "sdt.attrs.listItems", issues);
+  optionalBoolean(attrs, "checked", "sdt.attrs.checked", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectSdtAttrs = (node: PMNode): SdtAttrs =>
+  expectAttrs(readSdtAttrs(node), "sdt attrs");
+
+export const readShapeAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<ShapeAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "shape", issues);
+
+  optionalString(attrs, "shapeType", "shape.attrs.shapeType", issues);
+  optionalString(attrs, "shapeId", "shape.attrs.shapeId", issues);
+  optionalNumber(attrs, "width", "shape.attrs.width", issues);
+  optionalNumber(attrs, "height", "shape.attrs.height", issues);
+  optionalString(attrs, "fillColor", "shape.attrs.fillColor", issues);
+  optionalOneOf(
+    attrs,
+    "fillType",
+    "shape.attrs.fillType",
+    issues,
+    SHAPE_FILL_TYPES,
+  );
+  optionalOneOf(
+    attrs,
+    "gradientType",
+    "shape.attrs.gradientType",
+    issues,
+    SHAPE_GRADIENT_TYPES,
+  );
+  optionalNumber(attrs, "gradientAngle", "shape.attrs.gradientAngle", issues);
+  optionalGradientStops(
+    attrs,
+    "gradientStops",
+    "shape.attrs.gradientStops",
+    issues,
+  );
+  optionalNumber(attrs, "outlineWidth", "shape.attrs.outlineWidth", issues);
+  optionalString(attrs, "outlineColor", "shape.attrs.outlineColor", issues);
+  optionalString(attrs, "outlineStyle", "shape.attrs.outlineStyle", issues);
+  optionalString(attrs, "transform", "shape.attrs.transform", issues);
+  optionalOneOf(
+    attrs,
+    "displayMode",
+    "shape.attrs.displayMode",
+    issues,
+    IMAGE_DISPLAY_MODES,
+  );
+  optionalOneOf(
+    attrs,
+    "cssFloat",
+    "shape.attrs.cssFloat",
+    issues,
+    IMAGE_CSS_FLOATS,
+  );
+  optionalString(attrs, "wrapType", "shape.attrs.wrapType", issues);
+  optionalString(attrs, "shadowColor", "shape.attrs.shadowColor", issues);
+  optionalNumber(attrs, "shadowBlur", "shape.attrs.shadowBlur", issues);
+  optionalNumber(attrs, "shadowOffsetX", "shape.attrs.shadowOffsetX", issues);
+  optionalNumber(attrs, "shadowOffsetY", "shape.attrs.shadowOffsetY", issues);
+  optionalString(attrs, "glowColor", "shape.attrs.glowColor", issues);
+  optionalNumber(attrs, "glowRadius", "shape.attrs.glowRadius", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectShapeAttrs = (node: PMNode): ShapeAttrs =>
+  expectAttrs(readShapeAttrs(node), "shape attrs");
+
+export const readTextBoxAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<TextBoxAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "textBox", issues);
+
+  optionalNumber(attrs, "width", "textBox.attrs.width", issues);
+  optionalNumber(attrs, "height", "textBox.attrs.height", issues);
+  optionalString(attrs, "textBoxId", "textBox.attrs.textBoxId", issues);
+  optionalString(attrs, "fillColor", "textBox.attrs.fillColor", issues);
+  optionalNumber(attrs, "outlineWidth", "textBox.attrs.outlineWidth", issues);
+  optionalString(attrs, "outlineColor", "textBox.attrs.outlineColor", issues);
+  optionalString(attrs, "outlineStyle", "textBox.attrs.outlineStyle", issues);
+  optionalNumber(attrs, "marginTop", "textBox.attrs.marginTop", issues);
+  optionalNumber(attrs, "marginBottom", "textBox.attrs.marginBottom", issues);
+  optionalNumber(attrs, "marginLeft", "textBox.attrs.marginLeft", issues);
+  optionalNumber(attrs, "marginRight", "textBox.attrs.marginRight", issues);
+  optionalString(attrs, "verticalAlign", "textBox.attrs.verticalAlign", issues);
+  optionalOneOf(
+    attrs,
+    "displayMode",
+    "textBox.attrs.displayMode",
+    issues,
+    IMAGE_DISPLAY_MODES,
+  );
+  optionalOneOf(
+    attrs,
+    "cssFloat",
+    "textBox.attrs.cssFloat",
+    issues,
+    IMAGE_CSS_FLOATS,
+  );
+  optionalString(attrs, "wrapType", "textBox.attrs.wrapType", issues);
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTextBoxAttrs = (node: PMNode): TextBoxAttrs =>
+  expectAttrs(readTextBoxAttrs(node), "text box attrs");
 
 export const readUnderlineMarkAttrs = (
   mark: Mark,
@@ -993,6 +1279,117 @@ const optionalString = (
   const value = attrs[key];
   if (value !== undefined && value !== null && typeof value !== "string") {
     issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const optionalSdtListItems = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (typeof value !== "string") {
+    issues.push({ path, message: "Expected a JSON string." });
+    return;
+  }
+
+  const parsed = parseJson(value, path, issues);
+  if (!parsed.ok) {
+    return;
+  }
+
+  if (!Array.isArray(parsed.value)) {
+    issues.push({ path, message: "Expected a JSON array." });
+    return;
+  }
+
+  for (const [index, item] of parsed.value.entries()) {
+    if (!isRecord(item)) {
+      issues.push({
+        path: `${path}[${index}]`,
+        message: "Expected a list item object.",
+      });
+      continue;
+    }
+    if (typeof item["displayText"] !== "string") {
+      issues.push({
+        path: `${path}[${index}].displayText`,
+        message: "Expected a string.",
+      });
+    }
+    if (typeof item["value"] !== "string") {
+      issues.push({
+        path: `${path}[${index}].value`,
+        message: "Expected a string.",
+      });
+    }
+  }
+};
+
+const optionalGradientStops = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (typeof value !== "string") {
+    issues.push({ path, message: "Expected a JSON string." });
+    return;
+  }
+
+  const parsed = parseJson(value, path, issues);
+  if (!parsed.ok) {
+    return;
+  }
+
+  if (!Array.isArray(parsed.value)) {
+    issues.push({ path, message: "Expected a JSON array." });
+    return;
+  }
+
+  for (const [index, item] of parsed.value.entries()) {
+    if (!isRecord(item)) {
+      issues.push({
+        path: `${path}[${index}]`,
+        message: "Expected a gradient stop object.",
+      });
+      continue;
+    }
+    if (typeof item["position"] !== "number") {
+      issues.push({
+        path: `${path}[${index}].position`,
+        message: "Expected a number.",
+      });
+    }
+    if (typeof item["color"] !== "string") {
+      issues.push({
+        path: `${path}[${index}].color`,
+        message: "Expected a string.",
+      });
+    }
+  }
+};
+
+const parseJson = (
+  value: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): { ok: true; value: unknown } | { ok: false } => {
+  try {
+    return { ok: true, value: JSON.parse(value) as unknown };
+  } catch {
+    issues.push({ path, message: "Expected valid JSON." });
+    return { ok: false };
   }
 };
 

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -18,6 +18,151 @@ export type ReadProseMirrorAttrsResult<T> =
   | { ok: true; value: T }
   | { ok: false; issues: ProseMirrorAttrIssue[] };
 
+type ImageHorizontalPositionAttrs = NonNullable<
+  NonNullable<ImageAttrs["position"]>["horizontal"]
+>;
+
+type ImageVerticalPositionAttrs = NonNullable<
+  NonNullable<ImageAttrs["position"]>["vertical"]
+>;
+
+const PARAGRAPH_ALIGNMENTS = [
+  "left",
+  "center",
+  "right",
+  "both",
+  "distribute",
+  "mediumKashida",
+  "highKashida",
+  "lowKashida",
+  "thaiDistribute",
+] as const satisfies readonly NonNullable<ParagraphAttrs["alignment"]>[];
+
+const LINE_SPACING_RULES = [
+  "auto",
+  "exact",
+  "atLeast",
+] as const satisfies readonly NonNullable<ParagraphAttrs["lineSpacingRule"]>[];
+
+const SECTION_BREAK_TYPES = [
+  "nextPage",
+  "continuous",
+  "oddPage",
+  "evenPage",
+] as const satisfies readonly NonNullable<ParagraphAttrs["sectionBreakType"]>[];
+
+const TABLE_WIDTH_TYPES = [
+  "auto",
+  "dxa",
+  "nil",
+  "pct",
+] as const satisfies readonly NonNullable<TableAttrs["widthType"]>[];
+
+const TABLE_JUSTIFICATIONS = [
+  "left",
+  "center",
+  "right",
+] as const satisfies readonly NonNullable<TableAttrs["justification"]>[];
+
+const TABLE_ROW_HEIGHT_RULES = [
+  "auto",
+  "atLeast",
+  "exact",
+] as const satisfies readonly NonNullable<TableRowAttrs["heightRule"]>[];
+
+const TABLE_CELL_VERTICAL_ALIGNMENTS = [
+  "top",
+  "center",
+  "bottom",
+] as const satisfies readonly NonNullable<TableCellAttrs["verticalAlign"]>[];
+
+const TABLE_CELL_TEXT_DIRECTIONS = [
+  "lr",
+  "lrV",
+  "rl",
+  "rlV",
+  "tb",
+  "tbV",
+  "tbRl",
+  "tbRlV",
+  "btLr",
+] as const satisfies readonly NonNullable<TableCellAttrs["textDirection"]>[];
+
+const IMAGE_WRAP_TYPES = [
+  "inline",
+  "square",
+  "tight",
+  "through",
+  "topAndBottom",
+  "behind",
+  "inFront",
+] as const satisfies readonly NonNullable<ImageAttrs["wrapType"]>[];
+
+const IMAGE_DISPLAY_MODES = [
+  "inline",
+  "float",
+  "block",
+] as const satisfies readonly NonNullable<ImageAttrs["displayMode"]>[];
+
+const IMAGE_CSS_FLOATS = [
+  "left",
+  "right",
+  "none",
+] as const satisfies readonly NonNullable<ImageAttrs["cssFloat"]>[];
+
+const IMAGE_WRAP_TEXTS = [
+  "bothSides",
+  "left",
+  "right",
+  "largest",
+] as const satisfies readonly NonNullable<ImageAttrs["wrapText"]>[];
+
+const IMAGE_HORIZONTAL_RELATIVE_TO = [
+  "character",
+  "column",
+  "insideMargin",
+  "leftMargin",
+  "margin",
+  "outsideMargin",
+  "page",
+  "rightMargin",
+] as const satisfies readonly NonNullable<
+  ImageHorizontalPositionAttrs["relativeTo"]
+>[];
+
+const IMAGE_HORIZONTAL_ALIGNMENTS = [
+  "left",
+  "right",
+  "center",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<
+  ImageHorizontalPositionAttrs["align"]
+>[];
+
+const IMAGE_VERTICAL_RELATIVE_TO = [
+  "insideMargin",
+  "line",
+  "margin",
+  "outsideMargin",
+  "page",
+  "paragraph",
+  "topMargin",
+  "bottomMargin",
+] as const satisfies readonly NonNullable<
+  ImageVerticalPositionAttrs["relativeTo"]
+>[];
+
+const IMAGE_VERTICAL_ALIGNMENTS = [
+  "top",
+  "bottom",
+  "center",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<
+  ImageVerticalPositionAttrs["align"]
+>[];
+
 export const readParagraphAttrs = (
   node: PMNode,
 ): ReadProseMirrorAttrsResult<ParagraphAttrs> => {
@@ -27,11 +172,60 @@ export const readParagraphAttrs = (
 
   optionalString(attrs, "paraId", "paragraph.attrs.paraId", issues);
   optionalString(attrs, "textId", "paragraph.attrs.textId", issues);
+  optionalOneOf(
+    attrs,
+    "alignment",
+    "paragraph.attrs.alignment",
+    issues,
+    PARAGRAPH_ALIGNMENTS,
+  );
   optionalString(attrs, "styleId", "paragraph.attrs.styleId", issues);
   optionalNumber(attrs, "spaceBefore", "paragraph.attrs.spaceBefore", issues);
   optionalNumber(attrs, "spaceAfter", "paragraph.attrs.spaceAfter", issues);
   optionalNumber(attrs, "lineSpacing", "paragraph.attrs.lineSpacing", issues);
+  optionalOneOf(
+    attrs,
+    "lineSpacingRule",
+    "paragraph.attrs.lineSpacingRule",
+    issues,
+    LINE_SPACING_RULES,
+  );
+  optionalNumber(attrs, "indentLeft", "paragraph.attrs.indentLeft", issues);
+  optionalNumber(attrs, "indentRight", "paragraph.attrs.indentRight", issues);
+  optionalNumber(
+    attrs,
+    "indentFirstLine",
+    "paragraph.attrs.indentFirstLine",
+    issues,
+  );
+  optionalBoolean(
+    attrs,
+    "hangingIndent",
+    "paragraph.attrs.hangingIndent",
+    issues,
+  );
   optionalNumber(attrs, "outlineLevel", "paragraph.attrs.outlineLevel", issues);
+  optionalString(attrs, "listNumFmt", "paragraph.attrs.listNumFmt", issues);
+  optionalBoolean(
+    attrs,
+    "listIsBullet",
+    "paragraph.attrs.listIsBullet",
+    issues,
+  );
+  optionalBoolean(attrs, "listIsLegal", "paragraph.attrs.listIsLegal", issues);
+  optionalString(attrs, "listMarker", "paragraph.attrs.listMarker", issues);
+  optionalBoolean(
+    attrs,
+    "listMarkerHidden",
+    "paragraph.attrs.listMarkerHidden",
+    issues,
+  );
+  optionalString(
+    attrs,
+    "listMarkerFontFamily",
+    "paragraph.attrs.listMarkerFontFamily",
+    issues,
+  );
   optionalNumber(
     attrs,
     "listMarkerFontSize",
@@ -46,6 +240,12 @@ export const readParagraphAttrs = (
   );
   optionalBoolean(
     attrs,
+    "pageBreakBefore",
+    "paragraph.attrs.pageBreakBefore",
+    issues,
+  );
+  optionalBoolean(
+    attrs,
     "renderedPageBreakBefore",
     "paragraph.attrs.renderedPageBreakBefore",
     issues,
@@ -56,10 +256,47 @@ export const readParagraphAttrs = (
     "paragraph.attrs.runInWithNext",
     issues,
   );
+  optionalBoolean(attrs, "keepNext", "paragraph.attrs.keepNext", issues);
+  optionalBoolean(attrs, "keepLines", "paragraph.attrs.keepLines", issues);
+  optionalBoolean(
+    attrs,
+    "contextualSpacing",
+    "paragraph.attrs.contextualSpacing",
+    issues,
+  );
+  optionalBoolean(attrs, "bidi", "paragraph.attrs.bidi", issues);
+  optionalOneOf(
+    attrs,
+    "sectionBreakType",
+    "paragraph.attrs.sectionBreakType",
+    issues,
+    SECTION_BREAK_TYPES,
+  );
   optionalStringArray(
     attrs,
     "listLevelNumFmts",
     "paragraph.attrs.listLevelNumFmts",
+    issues,
+  );
+  optionalNumber(
+    attrs,
+    "listAbstractNumId",
+    "paragraph.attrs.listAbstractNumId",
+    issues,
+  );
+  optionalRecord(attrs, "borders", "paragraph.attrs.borders", issues);
+  optionalRecord(attrs, "shading", "paragraph.attrs.shading", issues);
+  optionalArray(attrs, "tabs", "paragraph.attrs.tabs", issues);
+  optionalRecord(
+    attrs,
+    "spacingExplicit",
+    "paragraph.attrs.spacingExplicit",
+    issues,
+  );
+  optionalRecord(
+    attrs,
+    "defaultTextFormatting",
+    "paragraph.attrs.defaultTextFormatting",
     issues,
   );
   optionalRecord(attrs, "numPr", "paragraph.attrs.numPr", issues);
@@ -93,7 +330,20 @@ export const readTableAttrs = (
 
   optionalString(attrs, "styleId", "table.attrs.styleId", issues);
   optionalNumber(attrs, "width", "table.attrs.width", issues);
-  optionalString(attrs, "widthType", "table.attrs.widthType", issues);
+  optionalOneOf(
+    attrs,
+    "widthType",
+    "table.attrs.widthType",
+    issues,
+    TABLE_WIDTH_TYPES,
+  );
+  optionalOneOf(
+    attrs,
+    "justification",
+    "table.attrs.justification",
+    issues,
+    TABLE_JUSTIFICATIONS,
+  );
   optionalNumberArray(
     attrs,
     "columnWidths",
@@ -124,7 +374,13 @@ export const readTableRowAttrs = (
   expectNodeType(node, "tableRow", issues);
 
   optionalNumber(attrs, "height", "tableRow.attrs.height", issues);
-  optionalString(attrs, "heightRule", "tableRow.attrs.heightRule", issues);
+  optionalOneOf(
+    attrs,
+    "heightRule",
+    "tableRow.attrs.heightRule",
+    issues,
+    TABLE_ROW_HEIGHT_RULES,
+  );
   optionalBoolean(attrs, "isHeader", "tableRow.attrs.isHeader", issues);
   optionalRecord(
     attrs,
@@ -144,7 +400,7 @@ export const readTableCellAttrs = (
 ): ReadProseMirrorAttrsResult<TableCellAttrs> => {
   const attrs = attrsRecord(node.attrs);
   const issues: ProseMirrorAttrIssue[] = [];
-  expectNodeType(node, "tableCell", issues);
+  expectNodeTypeOneOf(node, ["tableCell", "tableHeader"], issues);
 
   requiredNumber(attrs, "colspan", "tableCell.attrs.colspan", issues);
   requiredNumber(attrs, "rowspan", "tableCell.attrs.rowspan", issues);
@@ -152,12 +408,19 @@ export const readTableCellAttrs = (
     allowNull: true,
   });
   optionalNumber(attrs, "width", "tableCell.attrs.width", issues);
-  optionalString(attrs, "widthType", "tableCell.attrs.widthType", issues);
-  optionalString(
+  optionalOneOf(
+    attrs,
+    "widthType",
+    "tableCell.attrs.widthType",
+    issues,
+    TABLE_WIDTH_TYPES,
+  );
+  optionalOneOf(
     attrs,
     "verticalAlign",
     "tableCell.attrs.verticalAlign",
     issues,
+    TABLE_CELL_VERTICAL_ALIGNMENTS,
   );
   optionalString(
     attrs,
@@ -165,11 +428,12 @@ export const readTableCellAttrs = (
     "tableCell.attrs.backgroundColor",
     issues,
   );
-  optionalString(
+  optionalOneOf(
     attrs,
     "textDirection",
     "tableCell.attrs.textDirection",
     issues,
+    TABLE_CELL_TEXT_DIRECTIONS,
   );
   optionalBoolean(attrs, "noWrap", "tableCell.attrs.noWrap", issues);
   optionalRecord(attrs, "borders", "tableCell.attrs.borders", issues);
@@ -200,10 +464,44 @@ export const readImageAttrs = (
   optionalString(attrs, "rId", "image.attrs.rId", issues);
   optionalNumber(attrs, "width", "image.attrs.width", issues);
   optionalNumber(attrs, "height", "image.attrs.height", issues);
-  optionalString(attrs, "wrapType", "image.attrs.wrapType", issues);
-  optionalString(attrs, "displayMode", "image.attrs.displayMode", issues);
-  optionalString(attrs, "cssFloat", "image.attrs.cssFloat", issues);
-  optionalRecord(attrs, "position", "image.attrs.position", issues);
+  optionalOneOf(
+    attrs,
+    "wrapType",
+    "image.attrs.wrapType",
+    issues,
+    IMAGE_WRAP_TYPES,
+  );
+  optionalOneOf(
+    attrs,
+    "displayMode",
+    "image.attrs.displayMode",
+    issues,
+    IMAGE_DISPLAY_MODES,
+  );
+  optionalOneOf(
+    attrs,
+    "cssFloat",
+    "image.attrs.cssFloat",
+    issues,
+    IMAGE_CSS_FLOATS,
+  );
+  optionalString(attrs, "transform", "image.attrs.transform", issues);
+  optionalNumber(attrs, "distTop", "image.attrs.distTop", issues);
+  optionalNumber(attrs, "distBottom", "image.attrs.distBottom", issues);
+  optionalNumber(attrs, "distLeft", "image.attrs.distLeft", issues);
+  optionalNumber(attrs, "distRight", "image.attrs.distRight", issues);
+  optionalImagePosition(attrs, "position", "image.attrs.position", issues);
+  optionalNumber(attrs, "borderWidth", "image.attrs.borderWidth", issues);
+  optionalString(attrs, "borderColor", "image.attrs.borderColor", issues);
+  optionalString(attrs, "borderStyle", "image.attrs.borderStyle", issues);
+  optionalOneOf(
+    attrs,
+    "wrapText",
+    "image.attrs.wrapText",
+    issues,
+    IMAGE_WRAP_TEXTS,
+  );
+  optionalString(attrs, "hlinkHref", "image.attrs.hlinkHref", issues);
 
   return attrsResult(attrs, issues);
 };
@@ -229,12 +527,15 @@ export const expectHyperlinkMarkAttrs = (mark: Mark): HyperlinkAttrs =>
   expectAttrs(readHyperlinkMarkAttrs(mark), "hyperlink attrs");
 
 const attrsRecord = (attrs: unknown): Record<string, unknown> => {
-  if (attrs && typeof attrs === "object" && !Array.isArray(attrs)) {
-    return attrs as Record<string, unknown>;
+  if (isRecord(attrs)) {
+    return attrs;
   }
 
   return {};
 };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
 
 const attrsResult = <T>(
   attrs: Record<string, unknown>,
@@ -244,9 +545,17 @@ const attrsResult = <T>(
     return { ok: false, issues };
   }
 
+  const normalizedAttrs: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value !== null) {
+      normalizedAttrs[key] = value;
+    }
+  }
+
   // SAFETY: this module is the ProseMirror FFI boundary. The checks above
-  // validate the attrs this code relies on before exposing the typed shape.
-  return { ok: true, value: attrs as T };
+  // validate the attrs this code relies on before exposing the typed shape,
+  // and null ProseMirror defaults are normalized to absent optional fields.
+  return { ok: true, value: normalizedAttrs as T };
 };
 
 const expectAttrs = <T>(
@@ -272,6 +581,19 @@ const expectNodeType = (
     issues.push({
       path: "node.type.name",
       message: `Expected ${expected}, got ${node.type.name}.`,
+    });
+  }
+};
+
+const expectNodeTypeOneOf = (
+  node: PMNode,
+  expected: readonly string[],
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  if (!expected.includes(node.type.name)) {
+    issues.push({
+      path: "node.type.name",
+      message: `Expected one of ${expected.join(", ")}, got ${node.type.name}.`,
     });
   }
 };
@@ -309,6 +631,31 @@ const optionalString = (
   const value = attrs[key];
   if (value !== undefined && value !== null && typeof value !== "string") {
     issues.push({ path, message: "Expected a string." });
+  }
+};
+
+const optionalOneOf = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+  allowed: readonly string[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (typeof value !== "string") {
+    issues.push({ path, message: "Expected a string." });
+    return;
+  }
+
+  if (!allowed.includes(value)) {
+    issues.push({
+      path,
+      message: `Expected one of ${allowed.join(", ")}.`,
+    });
   }
 };
 
@@ -354,13 +701,75 @@ const optionalRecord = (
   issues: ProseMirrorAttrIssue[],
 ): void => {
   const value = attrs[key];
-  if (
-    value !== undefined &&
-    value !== null &&
-    (typeof value !== "object" || Array.isArray(value))
-  ) {
+  if (value !== undefined && value !== null && !isRecord(value)) {
     issues.push({ path, message: "Expected an object." });
   }
+};
+
+const optionalImagePosition = (
+  attrs: Record<string, unknown>,
+  key: string,
+  path: string,
+  issues: ProseMirrorAttrIssue[],
+): void => {
+  const value = attrs[key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  validateImagePositionAxis(value, {
+    key: "horizontal",
+    path,
+    relativeTo: IMAGE_HORIZONTAL_RELATIVE_TO,
+    align: IMAGE_HORIZONTAL_ALIGNMENTS,
+    issues,
+  });
+  validateImagePositionAxis(value, {
+    key: "vertical",
+    path,
+    relativeTo: IMAGE_VERTICAL_RELATIVE_TO,
+    align: IMAGE_VERTICAL_ALIGNMENTS,
+    issues,
+  });
+};
+
+type ImagePositionAxisValidation = {
+  key: "horizontal" | "vertical";
+  path: string;
+  relativeTo: readonly string[];
+  align: readonly string[];
+  issues: ProseMirrorAttrIssue[];
+};
+
+const validateImagePositionAxis = (
+  attrs: Record<string, unknown>,
+  options: ImagePositionAxisValidation,
+): void => {
+  const value = attrs[options.key];
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  const path = `${options.path}.${options.key}`;
+  if (!isRecord(value)) {
+    options.issues.push({ path, message: "Expected an object." });
+    return;
+  }
+
+  optionalOneOf(
+    value,
+    "relativeTo",
+    `${path}.relativeTo`,
+    options.issues,
+    options.relativeTo,
+  );
+  optionalNumber(value, "posOffset", `${path}.posOffset`, options.issues);
+  optionalOneOf(value, "align", `${path}.align`, options.issues, options.align);
 };
 
 const optionalArray = (

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -116,6 +116,11 @@ const NOTE_TYPES = [
   "endnote",
 ] as const satisfies readonly NonNullable<FootnoteRefAttrs["noteType"]>[];
 
+const TEXT_BOX_DOCX_PLACEMENTS = [
+  "standalone",
+  "inlineWithPrevious",
+] as const satisfies readonly NonNullable<TextBoxAttrs["_docxPlacement"]>[];
+
 const TRACKED_CHANGE_MOVE_KINDS = [
   "moveTo",
   "moveFrom",
@@ -701,6 +706,14 @@ export const readTextBoxAttrs = (
     IMAGE_CSS_FLOATS,
   );
   optionalString(attrs, "wrapType", "textBox.attrs.wrapType", issues);
+  optionalOneOf(
+    attrs,
+    "_docxPlacement",
+    "textBox.attrs._docxPlacement",
+    issues,
+    TEXT_BOX_DOCX_PLACEMENTS,
+  );
+  optionalString(attrs, "_docxGroupId", "textBox.attrs._docxGroupId", issues);
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -374,6 +374,64 @@ describe("fromProseDoc", () => {
     expect(table.rows.at(1)?.cells.at(1)?.formatting?.vMerge).toBe("continue");
   });
 
+  test("preserves fully vertically merged continuation rows", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "restart" },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Merged" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "continue" },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
+    expect(table.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBe("continue");
+  });
+
   test("preserves empty hyperlinks through ProseMirror attrs", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -480,6 +480,72 @@ describe("fromProseDoc", () => {
     );
   });
 
+  test("preserves skipped vertical-merge continuation cell content", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "restart" },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Merged" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    cellWithText("Top right"),
+                  ],
+                },
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "continue" },
+                      content: [
+                        { type: "paragraph", content: [] },
+                        { type: "paragraph", content: [] },
+                      ],
+                    },
+                    cellWithText("Bottom right"),
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    const continuationCell = table.rows.at(1)?.cells.at(0);
+    expect(continuationCell?.formatting?.vMerge).toBe("continue");
+    expect(continuationCell?.content).toHaveLength(2);
+    expect(paragraphText(table.rows.at(1)?.cells.at(1)?.content.at(0))).toBe(
+      "Bottom right",
+    );
+  });
+
   test("preserves unmatched vertical-merge continuation cells", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -46,6 +46,64 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow("insertion.attrs.revisionId");
   });
 
+  test("rejects malformed field and math attrs at the conversion boundary", () => {
+    const fieldDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("field", {
+          fieldType: "NOT_A_FIELD",
+          instruction: " PAGE ",
+          displayText: "1",
+          fieldKind: "simple",
+        }),
+      ]),
+    ]);
+    const mathDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node("math", {
+          display: "inline",
+          ommlXml: 42,
+          plainText: "x",
+        }),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(fieldDoc)).toThrow("field.attrs.fieldType");
+    expect(() => fromProseDoc(mathDoc)).toThrow("math.attrs.ommlXml");
+  });
+
+  test("rejects malformed SDT attrs at the conversion boundary", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.node(
+          "sdt",
+          {
+            sdtType: "dropdown",
+            listItems: JSON.stringify([{ displayText: 7, value: "x" }]),
+          },
+          [schema.text("Choice")],
+        ),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow(
+      "sdt.attrs.listItems[0].displayText",
+    );
+  });
+
+  test("rejects malformed shape and text box attrs at the conversion boundary", () => {
+    const shapeDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.node("shape", { width: "wide" })]),
+    ]);
+    const textBoxDoc = schema.node("doc", null, [
+      schema.node("textBox", { width: "wide" }, [
+        schema.node("paragraph", null, [schema.text("Inside")]),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(shapeDoc)).toThrow("shape.attrs.width");
+    expect(() => fromProseDoc(textBoxDoc)).toThrow("textBox.attrs.width");
+  });
+
   test("accepts table header cell attrs at the table-cell boundary", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("table", null, [

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
 import { EditorState } from "prosemirror-state";
 
 import type {
@@ -95,6 +96,166 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow(
       "sdt.attrs.listItems[0].displayText",
     );
+  });
+
+  test("round-trips tracked-change image atoms", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "deletion",
+                  info: {
+                    id: 7,
+                    author: "Reviewer",
+                    date: "2022-02-07T10:00:00Z",
+                  },
+                  content: [
+                    {
+                      type: "run",
+                      content: [
+                        {
+                          type: "drawing",
+                          image: {
+                            type: "image",
+                            rId: "rIdImage",
+                            src: "data:image/png;base64,AA==",
+                            size: { width: 914_400, height: 457_200 },
+                            wrap: { type: "inFront" },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const image = firstDescendant(pmDoc, "image");
+    expect(image?.marks.some((mark) => mark.type.name === "deletion")).toBe(
+      true,
+    );
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    const deletion = paragraph.content.at(0);
+    expect(deletion?.type).toBe("deletion");
+    if (deletion?.type !== "deletion") {
+      return;
+    }
+    expect(deletion.info).toEqual({
+      id: 7,
+      author: "Reviewer",
+      date: "2022-02-07T10:00:00Z",
+    });
+    const run = deletion.content.at(0);
+    expect(run?.type).toBe("run");
+    if (run?.type !== "run") {
+      return;
+    }
+    expect(run.content.at(0)?.type).toBe("drawing");
+  });
+
+  test("preserves drawing content in vMerge continuation cells", () => {
+    const rawXml = "<w:drawing><wp:anchor/></w:drawing>";
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "restart" },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+                {
+                  cells: [
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "continue" },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [
+                                {
+                                  type: "drawing",
+                                  rawXml,
+                                  image: {
+                                    type: "image",
+                                    rId: "",
+                                    src: "",
+                                    size: {
+                                      width: 12_191,
+                                      height: 9_177_528,
+                                    },
+                                    wrap: { type: "behind" },
+                                  },
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(countDescendants(pmDoc, "image")).toBe(1);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    const restartCell = table.rows.at(0)?.cells.at(0);
+    const continuationCell = table.rows.at(1)?.cells.at(0);
+    expect(restartCell?.formatting?.vMerge).toBe("restart");
+    expect(continuationCell?.formatting?.vMerge).toBe("continue");
+    const continuationParagraph = continuationCell?.content.at(0);
+    expect(continuationParagraph?.type).toBe("paragraph");
+    if (continuationParagraph?.type !== "paragraph") {
+      return;
+    }
+    const run = continuationParagraph.content.at(0);
+    expect(run?.type).toBe("run");
+    if (run?.type !== "run") {
+      return;
+    }
+    const drawing = run.content.at(0);
+    expect(drawing?.type).toBe("drawing");
+    if (drawing?.type !== "drawing") {
+      return;
+    }
+    expect(drawing.rawXml).toBe(rawXml);
   });
 
   test("rejects malformed shape and text box attrs at the conversion boundary", () => {
@@ -1157,5 +1318,27 @@ function countShapes(paragraph: Paragraph): number {
       }
     }
   }
+  return count;
+}
+
+function firstDescendant(node: PMNode, typeName: string): PMNode | undefined {
+  let found: PMNode | undefined;
+  node.descendants((child) => {
+    if (child.type.name !== typeName) {
+      return true;
+    }
+    found = child;
+    return false;
+  });
+  return found;
+}
+
+function countDescendants(node: PMNode, typeName: string): number {
+  let count = 0;
+  node.descendants((child) => {
+    if (child.type.name === typeName) {
+      count += 1;
+    }
+  });
   return count;
 }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 
 import type { Document, Paragraph, Table } from "../../types/document";
+import { expectHardBreakAttrs } from "../attrs";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
@@ -190,6 +191,93 @@ describe("fromProseDoc", () => {
     expect(paragraphStartsWithPageBreak(secondBlock)).toBe(true);
   });
 
+  test("keeps page breaks before tables on the previous paragraph", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Before")]),
+      schema.node("pageBreak"),
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("Cell")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const firstBlock = document.package.document.content.at(0);
+    const secondBlock = document.package.document.content.at(1);
+
+    expect(document.package.document.content).toHaveLength(2);
+    expect(firstBlock?.type).toBe("paragraph");
+    expect(secondBlock?.type).toBe("table");
+    if (firstBlock?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraphEndsWithPageBreak(firstBlock)).toBe(true);
+  });
+
+  test("round-trips imported trailing page breaks before tables without inventing paragraphs", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "text", text: "Before" },
+                    { type: "break", breakType: "page" },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [
+                    {
+                      type: "tableCell",
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Cell" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const firstBlock = roundTripped.package.document.content.at(0);
+    const secondBlock = roundTripped.package.document.content.at(1);
+
+    expect(pmDoc.child(1).type.name).toBe("pageBreak");
+    expect(roundTripped.package.document.content).toHaveLength(2);
+    expect(firstBlock?.type).toBe("paragraph");
+    expect(secondBlock?.type).toBe("table");
+    if (firstBlock?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraphEndsWithPageBreak(firstBlock)).toBe(true);
+  });
+
   test("serializes table rowspans as vertical merge continuation cells", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("table", null, [
@@ -285,6 +373,70 @@ describe("fromProseDoc", () => {
       return;
     }
     expect(firstShapeType(block)).toBe("textBox");
+  });
+
+  test("keeps a wrapper paragraph when text-box-only content ends a section", () => {
+    const document = documentWithTextBoxParagraph({
+      includeText: false,
+      sectionProperties: { sectionStart: "continuous" },
+    });
+    const pmDoc = toProseDoc(document);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.child(0).type.name).toBe("paragraph");
+    expect(pmDoc.child(1).type.name).toBe("textBox");
+    expect(roundTripped.package.document.content).toHaveLength(1);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.sectionProperties).toEqual({ sectionStart: "continuous" });
+    expect(firstShapeType(block)).toBe("textBox");
+  });
+
+  test("preserves imported column breaks", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "text", text: "Left column" },
+                    { type: "break", breakType: "column" },
+                    { type: "text", text: "Right column" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const hardBreak = pmDoc.firstChild?.child(1);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(hardBreak?.type.name).toBe("hardBreak");
+    expect(
+      hardBreak ? expectHardBreakAttrs(hardBreak).breakType : undefined,
+    ).toBe("column");
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    const runContents = block.content.flatMap((content) =>
+      content.type === "run" ? content.content : [],
+    );
+    expect(runContents).toContainEqual({ type: "break", breakType: "column" });
   });
 
   test("keeps imported page-break text-box-only paragraphs as one wrapper", () => {
@@ -559,6 +711,15 @@ function paragraphStartsWithPageBreak(paragraph: Paragraph): boolean {
   );
 }
 
+function paragraphEndsWithPageBreak(paragraph: Paragraph): boolean {
+  const lastContent = paragraph.content.at(-1);
+  const lastRunContent =
+    lastContent?.type === "run" ? lastContent.content.at(-1) : undefined;
+  return (
+    lastRunContent?.type === "break" && lastRunContent.breakType === "page"
+  );
+}
+
 function paragraphText(block: Paragraph | Table | undefined): string {
   if (!block || block.type !== "paragraph") {
     return "";
@@ -578,10 +739,12 @@ function documentWithTextBoxParagraph({
   includeText,
   includePageBreak = false,
   textBoxCount = 1,
+  sectionProperties,
 }: {
   includeText: boolean;
   includePageBreak?: boolean;
   textBoxCount?: number;
+  sectionProperties?: Paragraph["sectionProperties"];
 }): Document {
   const content: Paragraph["content"] = [];
   if (includePageBreak) {
@@ -628,7 +791,7 @@ function documentWithTextBoxParagraph({
   return {
     package: {
       document: {
-        content: [{ type: "paragraph", content }],
+        content: [{ type: "paragraph", content, sectionProperties }],
       },
     },
   };

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -689,6 +689,36 @@ describe("fromProseDoc", () => {
     expect(countShapes(block)).toBe(2);
   });
 
+  test("keeps page breaks before grouped standalone text boxes", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "textBox",
+        { _docxPlacement: "standalone", _docxGroupId: "a" },
+        [schema.node("paragraph", null, [schema.text("A")])],
+      ),
+      schema.node("pageBreak"),
+      schema.node(
+        "textBox",
+        { _docxPlacement: "standalone", _docxGroupId: "a" },
+        [schema.node("paragraph", null, [schema.text("B")])],
+      ),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const firstBlock = document.package.document.content.at(0);
+    const secondBlock = document.package.document.content.at(1);
+
+    expect(document.package.document.content).toHaveLength(2);
+    expect(firstBlock?.type).toBe("paragraph");
+    expect(secondBlock?.type).toBe("paragraph");
+    if (firstBlock?.type !== "paragraph" || secondBlock?.type !== "paragraph") {
+      return;
+    }
+    expect(countShapes(firstBlock)).toBe(1);
+    expect(paragraphHasPageBreakBeforeFirstShape(secondBlock)).toBe(true);
+    expect(countShapes(secondBlock)).toBe(1);
+  });
+
   test("does not merge adjacent standalone text boxes from different source paragraphs", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node(

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -6,6 +6,44 @@ import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 describe("fromProseDoc", () => {
+  test("rejects malformed paragraph attrs at the conversion boundary", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: 12 }, [schema.text("invalid")]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow("paragraph.attrs.paraId");
+  });
+
+  test("rejects malformed hyperlink attrs at the conversion boundary", () => {
+    const hyperlinkMark = schema.mark("hyperlink", { href: 123 });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("linked", [hyperlinkMark])]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow("hyperlink.attrs.href");
+  });
+
+  test("accepts table header cell attrs at the table-cell boundary", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableHeader", null, [
+            schema.node("paragraph", null, [schema.text("Header")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const table = document.package.document.content[0];
+
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    expect(table.rows[0]?.cells[0]?.content[0]?.type).toBe("paragraph");
+  });
+
   test("preserves comment ranges added to selected text", () => {
     const commentMark = schema.mark("comment", { commentId: 123 });
     const pmDoc = schema.node("doc", null, [

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 
-import type { Document, Paragraph, Table } from "../../types/document";
+import type {
+  Document,
+  Paragraph,
+  Table,
+  TableCell,
+} from "../../types/document";
 import { expectHardBreakAttrs } from "../attrs";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
@@ -312,6 +317,110 @@ describe("fromProseDoc", () => {
     expect(paragraphText(table.rows.at(1)?.cells.at(1)?.content.at(0))).toBe(
       "Bottom",
     );
+  });
+
+  test("preserves unmatched vertical-merge continuation cells", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  type: "tableRow",
+                  cells: [cellWithText("Top left"), cellWithText("Top right")],
+                },
+                {
+                  type: "tableRow",
+                  cells: [
+                    cellWithText("Bottom left"),
+                    {
+                      type: "tableCell",
+                      formatting: { vMerge: "continue" },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [
+                            {
+                              type: "run",
+                              content: [{ type: "text", text: "Metadata" }],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const table = roundTripped.package.document.content.at(0);
+
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+    expect(table.rows.at(1)?.cells).toHaveLength(2);
+    expect(paragraphText(table.rows.at(1)?.cells.at(1)?.content.at(0))).toBe(
+      "Metadata",
+    );
+    expect(table.rows.at(1)?.cells.at(1)?.formatting?.vMerge).toBe("continue");
+  });
+
+  test("preserves empty hyperlinks through ProseMirror attrs", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "run", content: [{ type: "text", text: "Before" }] },
+                {
+                  type: "hyperlink",
+                  href: "https://example.test",
+                  rId: "rId9",
+                  children: [],
+                },
+                { type: "run", content: [{ type: "text", text: "After" }] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const paragraph = roundTripped.package.document.content.at(0);
+
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "run",
+      "hyperlink",
+      "run",
+    ]);
+    expect(paragraphText(paragraph)).toBe("BeforeAfter");
+    const hyperlink = paragraph.content.find(
+      (content) => content.type === "hyperlink",
+    );
+    expect(hyperlink?.type).toBe("hyperlink");
+    if (hyperlink?.type !== "hyperlink") {
+      return;
+    }
+    expect(hyperlink.href).toBe("https://example.test");
+    expect(hyperlink.rId).toBe("rId9");
+    expect(hyperlink.children).toHaveLength(0);
   });
 
   test("converts textBox nodes back to DOCX text box shapes", () => {
@@ -833,6 +942,18 @@ function documentWithTextBoxParagraph({
         content: [{ type: "paragraph", content, sectionProperties }],
       },
     },
+  };
+}
+
+function cellWithText(text: string): TableCell {
+  return {
+    type: "tableCell",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "run", content: [{ type: "text", text }] }],
+      },
+    ],
   };
 }
 

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -769,6 +769,26 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
+  test("keeps empty imported text boxes as text boxes", () => {
+    const document = documentWithTextBoxParagraph({
+      includeText: false,
+      emptyTextBoxContent: true,
+    });
+    const pmDoc = toProseDoc(document);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(1);
+    expect(pmDoc.firstChild?.type.name).toBe("textBox");
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(firstShapeType(block)).toBe("textBox");
+    expect(firstShapeTextBody(block)?.content).toHaveLength(1);
+  });
+
   test("keeps page breaks before inline text boxes on the source paragraph", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("paragraph", null, [schema.text("Before")]),
@@ -1288,11 +1308,13 @@ function documentWithTextBoxParagraph({
   includeText,
   includePageBreak = false,
   textBoxCount = 1,
+  emptyTextBoxContent = false,
   sectionProperties,
 }: {
   includeText: boolean;
   includePageBreak?: boolean;
   textBoxCount?: number;
+  emptyTextBoxContent?: boolean;
   sectionProperties?: Paragraph["sectionProperties"];
 }): Document {
   const content: Paragraph["content"] = [];
@@ -1319,17 +1341,19 @@ function documentWithTextBoxParagraph({
             shapeType: "textBox",
             size: { width: 914_400, height: 457_200 },
             textBody: {
-              content: [
-                {
-                  type: "paragraph",
-                  content: [
+              content: emptyTextBoxContent
+                ? []
+                : [
                     {
-                      type: "run",
-                      content: [{ type: "text", text: `Inside ${index}` }],
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "run",
+                          content: [{ type: "text", text: `Inside ${index}` }],
+                        },
+                      ],
                     },
                   ],
-                },
-              ],
             },
           },
         },
@@ -1359,13 +1383,21 @@ function cellWithText(text: string): TableCell {
 }
 
 function firstShapeType(paragraph: Paragraph): string | undefined {
+  return firstShapeContent(paragraph)?.shape.shapeType;
+}
+
+function firstShapeTextBody(paragraph: Paragraph) {
+  return firstShapeContent(paragraph)?.shape.textBody;
+}
+
+function firstShapeContent(paragraph: Paragraph) {
   for (const content of paragraph.content) {
     if (content.type !== "run") {
       continue;
     }
     for (const runContent of content.content) {
       if (runContent.type === "shape") {
-        return runContent.shape.shapeType;
+        return runContent;
       }
     }
   }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -7,7 +7,7 @@ import type {
   Table,
   TableCell,
 } from "../../types/document";
-import { expectHardBreakAttrs } from "../attrs";
+import { expectHardBreakAttrs, expectParagraphAttrs } from "../attrs";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
@@ -582,6 +582,44 @@ describe("fromProseDoc", () => {
       return;
     }
     expect(block.sectionProperties).toEqual({ sectionStart: "continuous" });
+    expect(firstShapeType(block)).toBe("textBox");
+  });
+
+  test("keeps a wrapper paragraph when text-box-only content carries boundary attrs", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const sourceBlock = document.package.document.content.at(0);
+
+    expect(sourceBlock?.type).toBe("paragraph");
+    if (sourceBlock?.type !== "paragraph") {
+      return;
+    }
+    sourceBlock.content.unshift(
+      { type: "bookmarkStart", id: 7, name: "box-boundary" },
+      { type: "hyperlink", href: "https://example.test", children: [] },
+    );
+    sourceBlock.content.push({ type: "bookmarkEnd", id: 7 });
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.child(0).type.name).toBe("paragraph");
+    expect(pmDoc.child(1).type.name).toBe("textBox");
+    const attrs = expectParagraphAttrs(pmDoc.child(0));
+    expect(attrs.bookmarks).toEqual([{ id: 7, name: "box-boundary" }]);
+    expect(attrs._emptyHyperlinks).toHaveLength(1);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(
+      block.content.some((content) => content.type === "bookmarkStart"),
+    ).toBe(true);
+    expect(block.content.some((content) => content.type === "hyperlink")).toBe(
+      true,
+    );
     expect(firstShapeType(block)).toBe("textBox");
   });
 

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -23,6 +23,29 @@ describe("fromProseDoc", () => {
     expect(() => fromProseDoc(pmDoc)).toThrow("hyperlink.attrs.href");
   });
 
+  test("rejects malformed comment attrs at the conversion boundary", () => {
+    const commentMark = schema.mark("comment", { commentId: "123" });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("commented", [commentMark])]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow("comment.attrs.commentId");
+  });
+
+  test("rejects malformed tracked-change attrs at the conversion boundary", () => {
+    const insertionMark = schema.mark("insertion", {
+      revisionId: "bad",
+      author: "Reviewer",
+    });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("inserted", [insertionMark]),
+      ]),
+    ]);
+
+    expect(() => fromProseDoc(pmDoc)).toThrow("insertion.attrs.revisionId");
+  });
+
   test("accepts table header cell attrs at the table-cell boundary", () => {
     const pmDoc = schema.node("doc", null, [
       schema.node("table", null, [

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -884,6 +884,54 @@ describe("fromProseDoc", () => {
     );
   });
 
+  test("keeps adjacent imported same-target hyperlinks separate", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  anchor: "br6",
+                  children: [
+                    { type: "run", content: [{ type: "text", text: "IV.1" }] },
+                  ],
+                },
+                {
+                  type: "hyperlink",
+                  anchor: "br6",
+                  children: [
+                    { type: "run", content: [{ type: "text", text: " " }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+
+    const hyperlinks = block.content.filter(
+      (content) => content.type === "hyperlink",
+    );
+    expect(hyperlinks).toHaveLength(2);
+    expect(hyperlinks.map((hyperlink) => hyperlink.anchor)).toEqual([
+      "br6",
+      "br6",
+    ]);
+  });
+
   test("preserves ProseMirror addMark comments spanning block boundaries", () => {
     const commentId = 999;
     const commentMark = schema.mark("comment", { commentId });

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { EditorState } from "prosemirror-state";
 
+import type { Document, Paragraph, Table } from "../../types/document";
 import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
@@ -123,6 +124,216 @@ describe("fromProseDoc", () => {
       return;
     }
     expect(table.rows[0]?.cells[0]?.content[0]?.type).toBe("paragraph");
+  });
+
+  test("coalesces page break blocks into the following paragraph for DOCX output", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Before")]),
+      schema.node("pageBreak"),
+      schema.node("paragraph", null, [schema.text("After")]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const firstBlock = document.package.document.content.at(0);
+    const secondBlock = document.package.document.content.at(1);
+
+    expect(document.package.document.content).toHaveLength(2);
+    expect(firstBlock?.type).toBe("paragraph");
+    expect(secondBlock?.type).toBe("paragraph");
+    if (secondBlock?.type !== "paragraph") {
+      return;
+    }
+
+    expect(paragraphStartsWithPageBreak(secondBlock)).toBe(true);
+  });
+
+  test("round-trips imported leading page breaks without inventing paragraphs", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "break", breakType: "page" },
+                    { type: "text", text: "After" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const secondBlock = roundTripped.package.document.content.at(1);
+
+    expect(roundTripped.package.document.content).toHaveLength(2);
+    expect(secondBlock?.type).toBe("paragraph");
+    if (secondBlock?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraphStartsWithPageBreak(secondBlock)).toBe(true);
+  });
+
+  test("serializes table rowspans as vertical merge continuation cells", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", { rowspan: 2 }, [
+            schema.node("paragraph", null, [schema.text("Merged")]),
+          ]),
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("Top")]),
+          ]),
+        ]),
+        schema.node("tableRow", null, [
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("Bottom")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const table = document.package.document.content.at(0);
+
+    expect(table?.type).toBe("table");
+    if (table?.type !== "table") {
+      return;
+    }
+
+    expect(table.rows.at(0)?.cells.at(0)?.formatting?.vMerge).toBe("restart");
+    expect(table.rows.at(1)?.cells).toHaveLength(2);
+    expect(table.rows.at(1)?.cells.at(0)?.formatting?.vMerge).toBe("continue");
+    expect(table.rows.at(1)?.cells.at(0)?.content).toHaveLength(1);
+    expect(paragraphText(table.rows.at(1)?.cells.at(1)?.content.at(0))).toBe(
+      "Bottom",
+    );
+  });
+
+  test("converts textBox nodes back to DOCX text box shapes", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("textBox", { width: 120, height: 60 }, [
+        schema.node("paragraph", null, [schema.text("Inside")]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const block = document.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+
+    const firstRun = block.content.at(0);
+    const firstRunContent =
+      firstRun?.type === "run" ? firstRun.content.at(0) : undefined;
+
+    expect(firstRunContent?.type).toBe("shape");
+    if (firstRunContent?.type !== "shape") {
+      return;
+    }
+    expect(firstRunContent.shape.shapeType).toBe("textBox");
+    expect(firstRunContent.shape.textBody?.content).toHaveLength(1);
+  });
+
+  test("reattaches imported mixed-paragraph text boxes to their source paragraph", () => {
+    const document = documentWithTextBoxParagraph({ includeText: true });
+    const pmDoc = toProseDoc(document);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(2);
+    expect(roundTripped.package.document.content).toHaveLength(1);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(block.content).toHaveLength(2);
+    expect(firstShapeType(block)).toBe("textBox");
+  });
+
+  test("keeps imported text-box-only paragraphs as standalone wrappers", () => {
+    const document = documentWithTextBoxParagraph({ includeText: false });
+    const pmDoc = toProseDoc(document);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(1);
+    expect(pmDoc.firstChild?.type.name).toBe("textBox");
+    expect(roundTripped.package.document.content).toHaveLength(1);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(firstShapeType(block)).toBe("textBox");
+  });
+
+  test("keeps imported page-break text-box-only paragraphs as one wrapper", () => {
+    const document = documentWithTextBoxParagraph({
+      includeText: false,
+      includePageBreak: true,
+      textBoxCount: 2,
+    });
+    const pmDoc = toProseDoc(document);
+
+    const roundTripped = fromProseDoc(pmDoc, document);
+    const block = roundTripped.package.document.content.at(0);
+
+    expect(pmDoc.childCount).toBe(3);
+    expect(pmDoc.child(0).type.name).toBe("pageBreak");
+    expect(pmDoc.child(1).type.name).toBe("textBox");
+    expect(pmDoc.child(2).type.name).toBe("textBox");
+    expect(roundTripped.package.document.content).toHaveLength(1);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraphStartsWithPageBreak(block)).toBe(true);
+    expect(countShapes(block)).toBe(2);
+  });
+
+  test("does not merge adjacent standalone text boxes from different source paragraphs", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "textBox",
+        { _docxPlacement: "standalone", _docxGroupId: "a" },
+        [schema.node("paragraph", null, [schema.text("A")])],
+      ),
+      schema.node(
+        "textBox",
+        { _docxPlacement: "standalone", _docxGroupId: "b" },
+        [schema.node("paragraph", null, [schema.text("B")])],
+      ),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+
+    expect(document.package.document.content).toHaveLength(2);
+    for (const block of document.package.document.content) {
+      expect(block.type).toBe("paragraph");
+      if (block.type === "paragraph") {
+        expect(countShapes(block)).toBe(1);
+      }
+    }
   });
 
   test("preserves comment ranges added to selected text", () => {
@@ -259,6 +470,42 @@ describe("fromProseDoc", () => {
     expect(hyperlink?.attrs.href).toBe("https://stella.law");
   });
 
+  test("keeps adjacent same-target hyperlinks with distinct relationship ids separate", () => {
+    const firstLink = schema.mark("hyperlink", {
+      href: "mailto:reviewer@example.test",
+      rId: "rId1",
+    });
+    const secondLink = schema.mark("hyperlink", {
+      href: "mailto:reviewer@example.test",
+      rId: "rId2",
+    });
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("mailto:", [firstLink]),
+        schema.text("reviewer@example.test", [secondLink]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const block = document.package.document.content.at(0);
+
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+
+    const hyperlinks = block.content.filter(
+      (content) => content.type === "hyperlink",
+    );
+    expect(hyperlinks).toHaveLength(2);
+    expect(hyperlinks.at(0)?.type === "hyperlink" && hyperlinks.at(0).rId).toBe(
+      "rId1",
+    );
+    expect(hyperlinks.at(1)?.type === "hyperlink" && hyperlinks.at(1).rId).toBe(
+      "rId2",
+    );
+  });
+
   test("preserves ProseMirror addMark comments spanning block boundaries", () => {
     const commentId = 999;
     const commentMark = schema.mark("comment", { commentId });
@@ -302,3 +549,116 @@ describe("fromProseDoc", () => {
     expect(markedTexts).toEqual(["before", "cell one", "cell two", "after"]);
   });
 });
+
+function paragraphStartsWithPageBreak(paragraph: Paragraph): boolean {
+  const firstContent = paragraph.content.at(0);
+  const firstRunContent =
+    firstContent?.type === "run" ? firstContent.content.at(0) : undefined;
+  return (
+    firstRunContent?.type === "break" && firstRunContent.breakType === "page"
+  );
+}
+
+function paragraphText(block: Paragraph | Table | undefined): string {
+  if (!block || block.type !== "paragraph") {
+    return "";
+  }
+  return block.content
+    .flatMap((content) =>
+      content.type === "run"
+        ? content.content.flatMap((runContent) =>
+            runContent.type === "text" ? [runContent.text] : [],
+          )
+        : [],
+    )
+    .join("");
+}
+
+function documentWithTextBoxParagraph({
+  includeText,
+  includePageBreak = false,
+  textBoxCount = 1,
+}: {
+  includeText: boolean;
+  includePageBreak?: boolean;
+  textBoxCount?: number;
+}): Document {
+  const content: Paragraph["content"] = [];
+  if (includePageBreak) {
+    content.push({
+      type: "run",
+      content: [{ type: "break", breakType: "page" }],
+    });
+  }
+  if (includeText) {
+    content.push({
+      type: "run",
+      content: [{ type: "text", text: "Before" }],
+    });
+  }
+  for (let index = 0; index < textBoxCount; index += 1) {
+    content.push({
+      type: "run",
+      content: [
+        {
+          type: "shape",
+          shape: {
+            type: "shape",
+            shapeType: "textBox",
+            size: { width: 914_400, height: 457_200 },
+            textBody: {
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: `Inside ${index}` }],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      ],
+    });
+  }
+
+  return {
+    package: {
+      document: {
+        content: [{ type: "paragraph", content }],
+      },
+    },
+  };
+}
+
+function firstShapeType(paragraph: Paragraph): string | undefined {
+  for (const content of paragraph.content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    for (const runContent of content.content) {
+      if (runContent.type === "shape") {
+        return runContent.shape.shapeType;
+      }
+    }
+  }
+  return undefined;
+}
+
+function countShapes(paragraph: Paragraph): number {
+  let count = 0;
+  for (const content of paragraph.content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    for (const runContent of content.content) {
+      if (runContent.type === "shape") {
+        count += 1;
+      }
+    }
+  }
+  return count;
+}

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.test.ts
@@ -375,6 +375,27 @@ describe("fromProseDoc", () => {
     expect(firstShapeType(block)).toBe("textBox");
   });
 
+  test("keeps page breaks before inline text boxes on the source paragraph", () => {
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("Before")]),
+      schema.node("pageBreak"),
+      schema.node("textBox", { _docxPlacement: "inlineWithPrevious" }, [
+        schema.node("paragraph", null, [schema.text("Inside")]),
+      ]),
+    ]);
+
+    const document = fromProseDoc(pmDoc);
+    const block = document.package.document.content.at(0);
+
+    expect(document.package.document.content).toHaveLength(1);
+    expect(block?.type).toBe("paragraph");
+    if (block?.type !== "paragraph") {
+      return;
+    }
+    expect(paragraphHasPageBreakBeforeFirstShape(block)).toBe(true);
+    expect(firstShapeType(block)).toBe("textBox");
+  });
+
   test("keeps a wrapper paragraph when text-box-only content ends a section", () => {
     const document = documentWithTextBoxParagraph({
       includeText: false,
@@ -718,6 +739,24 @@ function paragraphEndsWithPageBreak(paragraph: Paragraph): boolean {
   return (
     lastRunContent?.type === "break" && lastRunContent.breakType === "page"
   );
+}
+
+function paragraphHasPageBreakBeforeFirstShape(paragraph: Paragraph): boolean {
+  let sawPageBreak = false;
+  for (const content of paragraph.content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    for (const runContent of content.content) {
+      if (runContent.type === "break" && runContent.breakType === "page") {
+        sawPageBreak = true;
+      }
+      if (runContent.type === "shape") {
+        return sawPageBreak;
+      }
+    }
+  }
+  return false;
 }
 
 function paragraphText(block: Paragraph | Table | undefined): string {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -524,6 +524,7 @@ function extractParagraphContent(
   let currentRun: Run | null = null;
   let currentMarksKey: string | null = null;
   let currentHyperlink: Hyperlink | null = null;
+  let currentHyperlinkKey: string | null = null;
   const openedComments = new Set<number>();
 
   const flushCurrentInline = () => {
@@ -535,6 +536,7 @@ function extractParagraphContent(
     if (currentHyperlink) {
       content.push(currentHyperlink);
       currentHyperlink = null;
+      currentHyperlinkKey = null;
     }
   };
 
@@ -674,10 +676,7 @@ function extractParagraphContent(
       // Start or continue hyperlink
       const linkKey = getLinkKey(linkMark);
 
-      const currentKey = currentHyperlink
-        ? getHyperlinkKey(currentHyperlink)
-        : "";
-      if (currentHyperlink && currentKey === linkKey) {
+      if (currentHyperlink && currentHyperlinkKey === linkKey) {
         // Continue current hyperlink
         addNodeToHyperlink(currentHyperlink, node);
       } else {
@@ -686,6 +685,7 @@ function extractParagraphContent(
 
         // Start new hyperlink
         currentHyperlink = createHyperlink(linkMark);
+        currentHyperlinkKey = linkKey;
         addNodeToHyperlink(currentHyperlink, node);
       }
       return;
@@ -852,13 +852,12 @@ function buildDocumentTrackedChangeCounts(pmDoc: PMNode): TrackedChangeCounts {
  */
 function getLinkKey(mark: Mark): string {
   const attrs = expectHyperlinkMarkAttrs(mark);
-  return [attrs.href, attrs.rId ?? "", attrs.tooltip ?? ""].join("\u0000");
-}
-
-function getHyperlinkKey(hyperlink: Hyperlink): string {
-  const href =
-    hyperlink.href || (hyperlink.anchor ? `#${hyperlink.anchor}` : "");
-  return [href, hyperlink.rId ?? "", hyperlink.tooltip ?? ""].join("\u0000");
+  return [
+    attrs.href,
+    attrs.rId ?? "",
+    attrs.tooltip ?? "",
+    attrs._docxHyperlinkIndex ?? "",
+  ].join("\u0000");
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1730,6 +1730,7 @@ function convertPMTable(
 type ActiveVerticalMerge = {
   remainingRows: number;
   colspan: number;
+  continuationCells?: TableCell[];
 };
 
 function convertPMTableRows(
@@ -1913,7 +1914,11 @@ function convertPMTableRow(
 
     let activeMerge = activeVerticalMerges.get(gridColumn);
     while (activeMerge) {
-      cells.push(createVerticalMergeContinuationCell(activeMerge.colspan));
+      const preservedCell = activeMerge.continuationCells?.shift();
+      cells.push(
+        preservedCell ??
+          createVerticalMergeContinuationCell(activeMerge.colspan),
+      );
       activeMerge.remainingRows -= 1;
       if (activeMerge.remainingRows <= 0) {
         activeVerticalMerges.delete(gridColumn);
@@ -1934,9 +1939,13 @@ function convertPMTableRow(
       const colspan = Math.max(cellAttrs.colspan, 1);
       cells.push(convertPMTableCell(cellNode, documentCounts));
       if (cellAttrs.rowspan > 1) {
+        const continuationCells = cellAttrs._docxVMergeContinuationCells;
         activeVerticalMerges?.set(gridColumn, {
           remainingRows: cellAttrs.rowspan - 1,
           colspan,
+          ...(continuationCells
+            ? { continuationCells: [...continuationCells] }
+            : {}),
         });
       }
       gridColumn += colspan;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -138,23 +138,97 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
 function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
   const blocks: (Paragraph | Table)[] = [];
   const documentCounts = buildDocumentTrackedChangeCounts(pmDoc);
+  let pendingPageBreaks = 0;
+  let previousStandaloneTextBox: PreviousStandaloneTextBox | null = null;
+
+  const flushPendingPageBreaks = (): void => {
+    for (let index = 0; index < pendingPageBreaks; index += 1) {
+      blocks.push(createPageBreakParagraph());
+    }
+    pendingPageBreaks = 0;
+  };
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   pmDoc.forEach((node) => {
+    if (node.type.name === "pageBreak") {
+      pendingPageBreaks += 1;
+      previousStandaloneTextBox = null;
+      return;
+    }
+
     if (node.type.name === "paragraph") {
-      blocks.push(convertPMParagraph(node, documentCounts));
+      const paragraph = convertPMParagraph(node, documentCounts);
+      prependPageBreaks(paragraph, pendingPageBreaks);
+      pendingPageBreaks = 0;
+      blocks.push(paragraph);
+      previousStandaloneTextBox = null;
     } else if (node.type.name === "table") {
+      flushPendingPageBreaks();
       blocks.push(convertPMTable(node, documentCounts));
+      previousStandaloneTextBox = null;
     } else if (node.type.name === "textBox") {
-      // Convert text box back to a paragraph containing a shape with text body
-      blocks.push(convertPMTextBox(node));
-    } else if (node.type.name === "pageBreak") {
-      // Convert page break node to a paragraph with a page break run
-      blocks.push(createPageBreakParagraph());
+      previousStandaloneTextBox = appendTextBoxBlock(blocks, node, {
+        pendingPageBreaks,
+        previousStandaloneTextBox,
+      });
+      pendingPageBreaks = 0;
     }
   });
 
+  if (pendingPageBreaks > 0) {
+    const previousBlock = blocks.at(-1);
+    if (previousBlock?.type === "paragraph") {
+      appendPageBreaks(previousBlock, pendingPageBreaks);
+    } else {
+      flushPendingPageBreaks();
+    }
+  }
+
   return blocks;
+}
+
+type AppendTextBoxBlockOptions = {
+  pendingPageBreaks: number;
+  previousStandaloneTextBox: PreviousStandaloneTextBox | null;
+};
+
+type PreviousStandaloneTextBox = {
+  paragraph: Paragraph;
+  groupId: string;
+};
+
+function appendTextBoxBlock(
+  blocks: (Paragraph | Table)[],
+  node: PMNode,
+  options: AppendTextBoxBlockOptions,
+): PreviousStandaloneTextBox | null {
+  const attrs = expectTextBoxAttrs(node);
+  const paragraph = convertPMTextBox(node);
+  const previousBlock = blocks.at(-1);
+  if (
+    attrs._docxPlacement === "inlineWithPrevious" &&
+    previousBlock?.type === "paragraph"
+  ) {
+    previousBlock.content.push(...paragraph.content);
+    return null;
+  }
+
+  if (
+    attrs._docxPlacement === "standalone" &&
+    attrs._docxGroupId &&
+    options.previousStandaloneTextBox?.groupId === attrs._docxGroupId
+  ) {
+    options.previousStandaloneTextBox.paragraph.content.push(
+      ...paragraph.content,
+    );
+    return options.previousStandaloneTextBox;
+  }
+
+  prependPageBreaks(paragraph, options.pendingPageBreaks);
+  blocks.push(paragraph);
+  return attrs._docxPlacement === "standalone" && attrs._docxGroupId
+    ? { paragraph, groupId: attrs._docxGroupId }
+    : null;
 }
 
 /**
@@ -167,6 +241,25 @@ function createPageBreakParagraph(): Paragraph {
     type: "paragraph",
     content: [run],
   };
+}
+
+function createPageBreakRun(): Run {
+  return {
+    type: "run",
+    content: [{ type: "break", breakType: "page" }],
+  };
+}
+
+function prependPageBreaks(paragraph: Paragraph, count: number): void {
+  for (let index = 0; index < count; index += 1) {
+    paragraph.content.unshift(createPageBreakRun());
+  }
+}
+
+function appendPageBreaks(paragraph: Paragraph, count: number): void {
+  for (let index = 0; index < count; index += 1) {
+    paragraph.content.push(createPageBreakRun());
+  }
 }
 
 /**
@@ -547,9 +640,9 @@ function extractParagraphContent(
       // Start or continue hyperlink
       const linkKey = getLinkKey(linkMark);
 
-      const currentKey =
-        currentHyperlink?.href ||
-        (currentHyperlink?.anchor ? `#${currentHyperlink.anchor}` : "");
+      const currentKey = currentHyperlink
+        ? getHyperlinkKey(currentHyperlink)
+        : "";
       if (currentHyperlink && currentKey === linkKey) {
         // Continue current hyperlink
         addNodeToHyperlink(currentHyperlink, node);
@@ -669,7 +762,14 @@ function buildDocumentTrackedChangeCounts(pmDoc: PMNode): TrackedChangeCounts {
  * Create a unique key for a link mark
  */
 function getLinkKey(mark: Mark): string {
-  return expectHyperlinkMarkAttrs(mark).href;
+  const attrs = expectHyperlinkMarkAttrs(mark);
+  return [attrs.href, attrs.rId ?? "", attrs.tooltip ?? ""].join("\u0000");
+}
+
+function getHyperlinkKey(hyperlink: Hyperlink): string {
+  const href =
+    hyperlink.href || (hyperlink.anchor ? `#${hyperlink.anchor}` : "");
+  return [href, hyperlink.rId ?? "", hyperlink.tooltip ?? ""].join("\u0000");
 }
 
 /**
@@ -1420,14 +1520,7 @@ function convertPMTable(
   documentCounts?: TrackedChangeCounts,
 ): Table {
   const attrs = expectTableAttrs(node);
-  const rows: TableRow[] = [];
-
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  node.forEach((rowNode) => {
-    if (rowNode.type.name === "tableRow") {
-      rows.push(convertPMTableRow(rowNode, documentCounts));
-    }
-  });
+  const rows = convertPMTableRows(node, documentCounts);
 
   const formatting = tableAttrsToFormatting(attrs) || undefined;
   if (!formatting?.borders) {
@@ -1459,6 +1552,30 @@ function convertPMTable(
     table.formatting = formatting;
   }
   return table;
+}
+
+type ActiveVerticalMerge = {
+  remainingRows: number;
+  colspan: number;
+};
+
+function convertPMTableRows(
+  node: PMNode,
+  documentCounts?: TrackedChangeCounts,
+): TableRow[] {
+  const rows: TableRow[] = [];
+  const activeVerticalMerges = new Map<number, ActiveVerticalMerge>();
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((rowNode) => {
+    if (rowNode.type.name === "tableRow") {
+      rows.push(
+        convertPMTableRow(rowNode, documentCounts, activeVerticalMerges),
+      );
+    }
+  });
+
+  return rows;
 }
 
 /**
@@ -1610,19 +1727,49 @@ function tableAttrsToFormatting(
 function convertPMTableRow(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
+  activeVerticalMerges?: Map<number, ActiveVerticalMerge>,
 ): TableRow {
   const attrs = expectTableRowAttrs(node);
   const cells: TableCell[] = [];
+  let gridColumn = 0;
+
+  const appendActiveVerticalMerges = (): void => {
+    if (!activeVerticalMerges) {
+      return;
+    }
+
+    let activeMerge = activeVerticalMerges.get(gridColumn);
+    while (activeMerge) {
+      cells.push(createVerticalMergeContinuationCell(activeMerge.colspan));
+      activeMerge.remainingRows -= 1;
+      if (activeMerge.remainingRows <= 0) {
+        activeVerticalMerges.delete(gridColumn);
+      }
+      gridColumn += activeMerge.colspan;
+      activeMerge = activeVerticalMerges.get(gridColumn);
+    }
+  };
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   node.forEach((cellNode) => {
+    appendActiveVerticalMerges();
     if (
       cellNode.type.name === "tableCell" ||
       cellNode.type.name === "tableHeader"
     ) {
+      const cellAttrs = expectTableCellAttrs(cellNode);
+      const colspan = Math.max(cellAttrs.colspan, 1);
       cells.push(convertPMTableCell(cellNode, documentCounts));
+      if (cellAttrs.rowspan > 1) {
+        activeVerticalMerges?.set(gridColumn, {
+          remainingRows: cellAttrs.rowspan - 1,
+          colspan,
+        });
+      }
+      gridColumn += colspan;
     }
   });
+  appendActiveVerticalMerges();
 
   const row: TableRow = { type: "tableRow", cells };
   const rowFormatting = tableRowAttrsToFormatting(attrs);
@@ -1630,6 +1777,18 @@ function convertPMTableRow(
     row.formatting = rowFormatting;
   }
   return row;
+}
+
+function createVerticalMergeContinuationCell(colspan: number): TableCell {
+  const formatting: TableCellFormatting = { vMerge: "continue" };
+  if (colspan > 1) {
+    formatting.gridSpan = colspan;
+  }
+  return {
+    type: "tableCell",
+    content: [{ type: "paragraph", content: [] }],
+    formatting,
+  };
 }
 
 /**
@@ -1737,6 +1896,11 @@ function tableCellAttrsToFormatting(
     if (attrs.colspan > 1) {
       result.gridSpan = attrs.colspan;
     }
+    if (attrs.rowspan > 1) {
+      result.vMerge = "restart";
+    } else if (result.vMerge === "restart") {
+      delete result.vMerge;
+    }
     const cellWidth = attrs.width;
     // Width: keep null absent while preserving explicit width=0 values.
     if (cellWidth !== undefined) {
@@ -1795,6 +1959,9 @@ function tableCellAttrsToFormatting(
   if (attrs.colspan > 1) {
     f.gridSpan = attrs.colspan;
   }
+  if (attrs.rowspan > 1) {
+    f.vMerge = "restart";
+  }
   if (cellWidth !== undefined) {
     f.width = {
       value: cellWidth,
@@ -1843,7 +2010,7 @@ function convertPMTextBox(node: PMNode): Paragraph {
   // Build shape with text body
   const shape: Shape = {
     type: "shape",
-    shapeType: "rect",
+    shapeType: "textBox",
     size: {
       width: attrs.width ? pixelsToEmu(attrs.width) : 0,
       height: attrs.height ? pixelsToEmu(attrs.height) : 0,

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -47,7 +47,6 @@ import type {
   NoteReferenceContent,
   SimpleField,
   ComplexField,
-  FieldType,
   InlineSdt,
   SdtProperties,
   TrackedChangeInfo,
@@ -60,24 +59,27 @@ import {
   expectCharacterSpacingMarkAttrs,
   expectCommentMarkAttrs,
   expectEmphasisMarkAttrs,
+  expectFieldAttrs,
   expectFontFamilyMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
   expectHighlightMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
+  expectMathAttrs,
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
+  expectSdtAttrs,
+  expectShapeAttrs,
   expectStrikeMarkAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
+  expectTextBoxAttrs,
   expectTextColorMarkAttrs,
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../attrs";
-import type { ShapeAttrs } from "../extensions/nodes/ShapeExtension";
-import type { TextBoxAttrs } from "../extensions/nodes/TextBoxExtension";
 import type { RunFormattingOverrideAttrs } from "../schema/marks";
 import type {
   ParagraphAttrs,
@@ -787,14 +789,7 @@ function createFieldFromNode(
   node: PMNode,
   marks?: readonly Mark[],
 ): SimpleField | ComplexField {
-  const attrs = node.attrs as {
-    fieldType: string;
-    instruction: string;
-    displayText: string;
-    fieldKind: string;
-    fldLock: boolean;
-    dirty: boolean;
-  };
+  const attrs = expectFieldAttrs(node);
 
   const formatting =
     marks && marks.length > 0 ? marksToTextFormatting(marks) : undefined;
@@ -825,7 +820,7 @@ function createFieldFromNode(
     const complex: ComplexField = {
       type: "complexField",
       instruction: attrs.instruction,
-      fieldType: attrs.fieldType as FieldType,
+      fieldType: attrs.fieldType,
       fieldCode: [],
       fieldResult: [displayRun],
     };
@@ -841,7 +836,7 @@ function createFieldFromNode(
   const simple: SimpleField = {
     type: "simpleField",
     instruction: attrs.instruction,
-    fieldType: attrs.fieldType as FieldType,
+    fieldType: attrs.fieldType,
     content: [displayRun],
   };
   if (attrs.fldLock) {
@@ -857,15 +852,11 @@ function createFieldFromNode(
  * Create a MathEquation from a PM math node
  */
 function createMathFromNode(node: PMNode): MathEquation {
-  const attrs = node.attrs as {
-    display: string;
-    ommlXml: string;
-    plainText: string;
-  };
+  const attrs = expectMathAttrs(node);
 
   const math: MathEquation = {
     type: "mathEquation",
-    display: (attrs.display as "inline" | "block" | undefined) ?? "inline",
+    display: attrs.display ?? "inline",
     ommlXml: attrs.ommlXml,
   };
   if (attrs.plainText) {
@@ -878,38 +869,34 @@ function createMathFromNode(node: PMNode): MathEquation {
  * Create an InlineSdt from a PM sdt node
  */
 function createInlineSdtFromNode(node: PMNode): InlineSdt {
-  const attrs = node.attrs as Record<string, unknown>;
+  const attrs = expectSdtAttrs(node);
 
   const properties: SdtProperties = {
-    sdtType:
-      (attrs["sdtType"] as SdtProperties["sdtType"] | undefined) ?? "richText",
+    sdtType: attrs.sdtType,
   };
-  if (attrs["alias"]) {
-    properties.alias = attrs["alias"] as string;
+  if (attrs.alias) {
+    properties.alias = attrs.alias;
   }
-  if (attrs["tag"]) {
-    properties.tag = attrs["tag"] as string;
+  if (attrs.tag) {
+    properties.tag = attrs.tag;
   }
-  if (attrs["lock"]) {
-    properties.lock = attrs["lock"] as NonNullable<SdtProperties["lock"]>;
+  if (attrs.lock) {
+    properties.lock = attrs.lock;
   }
-  if (attrs["placeholder"]) {
-    properties.placeholder = attrs["placeholder"] as string;
+  if (attrs.placeholder) {
+    properties.placeholder = attrs.placeholder;
   }
-  if (
-    attrs["showingPlaceholder"] !== undefined &&
-    attrs["showingPlaceholder"] !== null
-  ) {
-    properties.showingPlaceholder = attrs["showingPlaceholder"] as boolean;
+  if (attrs.showingPlaceholder !== undefined) {
+    properties.showingPlaceholder = attrs.showingPlaceholder;
   }
-  if (attrs["dateFormat"]) {
-    properties.dateFormat = attrs["dateFormat"] as string;
+  if (attrs.dateFormat) {
+    properties.dateFormat = attrs.dateFormat;
   }
-  if (attrs["listItems"]) {
-    properties.listItems = JSON.parse(attrs["listItems"] as string);
+  if (attrs.listItems) {
+    properties.listItems = parseSdtListItems(attrs.listItems);
   }
-  if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
-    properties.checked = attrs["checked"] as boolean;
+  if (attrs.checked !== undefined) {
+    properties.checked = attrs.checked;
   }
 
   // Extract content from the sdt node's children
@@ -923,6 +910,35 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
     properties,
     content,
   };
+}
+
+function parseSdtListItems(
+  rawItems: string,
+): NonNullable<SdtProperties["listItems"]> {
+  const parsed = JSON.parse(rawItems) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new TypeError(
+      "Invalid ProseMirror sdt attrs: listItems is not an array",
+    );
+  }
+
+  return parsed.map((item): NonNullable<SdtProperties["listItems"]>[number] => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) {
+      throw new TypeError(
+        "Invalid ProseMirror sdt attrs: listItems contains an invalid item",
+      );
+    }
+    const itemAttrs = item as { displayText?: unknown; value?: unknown };
+    if (
+      typeof itemAttrs.displayText !== "string" ||
+      typeof itemAttrs.value !== "string"
+    ) {
+      throw new TypeError(
+        "Invalid ProseMirror sdt attrs: listItems contains an invalid item",
+      );
+    }
+    return { displayText: itemAttrs.displayText, value: itemAttrs.value };
+  });
 }
 
 /**
@@ -1063,7 +1079,7 @@ function createImageRun(node: PMNode): Run {
  * Create a Run from a ProseMirror shape node
  */
 function createShapeRun(node: PMNode): Run {
-  const attrs = node.attrs as ShapeAttrs;
+  const attrs = expectShapeAttrs(node);
 
   const shape: Shape = {
     type: "shape",
@@ -1108,7 +1124,7 @@ function createShapeRun(node: PMNode): Run {
     }
   } else if (attrs.fillColor) {
     shape.fill = {
-      type: (attrs.fillType || "solid") as "solid" | "none",
+      type: attrs.fillType ?? "solid",
       color: { rgb: attrs.fillColor.replace("#", "") },
     };
   } else if (attrs.fillType === "none") {
@@ -1806,7 +1822,7 @@ function tableCellAttrsToFormatting(
  * The text box content becomes a Shape with textBody.
  */
 function convertPMTextBox(node: PMNode): Paragraph {
-  const attrs = node.attrs as TextBoxAttrs;
+  const attrs = expectTextBoxAttrs(node);
 
   // Extract child paragraphs from the text box content
   const childParagraphs: Paragraph[] = [];

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -592,27 +592,14 @@ function extractParagraphContent(
 
   const processInlineNode = (node: PMNode): void => {
     syncCommentRanges(node);
+    const linkMark = node.marks.find((m) => m.type.name === "hyperlink");
 
     // Check for footnote/endnote reference mark
     const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
-    if (noteRefMark) {
+    if (noteRefMark && !linkMark) {
       // Finish any current content
       flushCurrentInline();
-      const noteAttrs = expectFootnoteRefMarkAttrs(noteRefMark);
-      const noteType =
-        noteAttrs.noteType === "endnote" ? "endnoteRef" : "footnoteRef";
-      const noteId =
-        typeof noteAttrs.id === "string"
-          ? Number.parseInt(noteAttrs.id, 10) || 0
-          : noteAttrs.id;
-      const noteRef: NoteReferenceContent = {
-        type: noteType,
-        id: noteId,
-      };
-      content.push({
-        type: "run",
-        content: [noteRef],
-      });
+      content.push(createNoteReferenceRun(noteRefMark));
       return;
     }
 
@@ -668,9 +655,6 @@ function extractParagraphContent(
       }
       return;
     }
-
-    // Check for hyperlink mark
-    const linkMark = node.marks.find((m) => m.type.name === "hyperlink");
 
     if (linkMark) {
       // Start or continue hyperlink
@@ -911,6 +895,12 @@ function createHyperlink(linkMark: Mark): Hyperlink {
  * Add a node to a hyperlink
  */
 function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
+  const noteRefMark = node.marks.find((m) => m.type.name === "footnoteRef");
+  if (noteRefMark) {
+    hyperlink.children.push(createNoteReferenceRun(noteRefMark));
+    return;
+  }
+
   const nonLinkMarks = node.marks.filter((m) => m.type.name !== "hyperlink");
   if (node.isText && node.text) {
     const run = createRunFromText(node.text, nonLinkMarks);
@@ -938,6 +928,24 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
   if (node.type.name === "shape") {
     hyperlink.children.push(createShapeRun(node));
   }
+}
+
+function createNoteReferenceRun(noteRefMark: Mark): Run {
+  const noteAttrs = expectFootnoteRefMarkAttrs(noteRefMark);
+  const noteType =
+    noteAttrs.noteType === "endnote" ? "endnoteRef" : "footnoteRef";
+  const noteId =
+    typeof noteAttrs.id === "string"
+      ? Number.parseInt(noteAttrs.id, 10) || 0
+      : noteAttrs.id;
+  const noteRef: NoteReferenceContent = {
+    type: noteType,
+    id: noteId,
+  };
+  return {
+    type: "run",
+    content: [noteRef],
+  };
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1993,7 +1993,7 @@ function tableCellAttrsToFormatting(
     }
     if (attrs.rowspan > 1) {
       result.vMerge = "restart";
-    } else if (result.vMerge === "restart") {
+    } else if (result.vMerge === "restart" && !attrs._preserveVMergeRestart) {
       delete result.vMerge;
     }
     const cellWidth = attrs.width;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -911,10 +911,32 @@ function createHyperlink(linkMark: Mark): Hyperlink {
  * Add a node to a hyperlink
  */
 function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
+  const nonLinkMarks = node.marks.filter((m) => m.type.name !== "hyperlink");
   if (node.isText && node.text) {
-    const nonLinkMarks = node.marks.filter((m) => m.type.name !== "hyperlink");
     const run = createRunFromText(node.text, nonLinkMarks);
     hyperlink.children.push(run);
+    return;
+  }
+
+  if (node.type.name === "hardBreak") {
+    hyperlink.children.push(
+      createBreakRun(readHardBreakType(node), nonLinkMarks),
+    );
+    return;
+  }
+
+  if (node.type.name === "tab") {
+    hyperlink.children.push(createTabRun(nonLinkMarks));
+    return;
+  }
+
+  if (node.type.name === "image") {
+    hyperlink.children.push(createImageRun(node));
+    return;
+  }
+
+  if (node.type.name === "shape") {
+    hyperlink.children.push(createShapeRun(node));
   }
 }
 
@@ -922,17 +944,28 @@ function addNodeToHyperlink(hyperlink: Hyperlink, node: PMNode): void {
  * Create a Run from text and marks
  */
 function createRunFromText(text: string, marks: readonly Mark[]): Run {
-  const formatting = marksToTextFormatting(marks);
+  const formatting = getRunFormattingFromMarks(marks);
   const textContent: TextContent = {
     type: "text",
     text,
   };
 
   const run: Run = { type: "run", content: [textContent] };
-  if (Object.keys(formatting).length > 0) {
+  if (formatting) {
     run.formatting = formatting;
   }
   return run;
+}
+
+function getRunFormattingFromMarks(
+  marks: readonly Mark[] | undefined,
+): TextFormatting | undefined {
+  if (!marks || marks.length === 0) {
+    return undefined;
+  }
+
+  const formatting = marksToTextFormatting(marks);
+  return Object.keys(formatting).length > 0 ? formatting : undefined;
 }
 
 /**
@@ -952,16 +985,22 @@ function appendTextToRun(run: Run, text: string): void {
  */
 function createBreakRun(
   breakType: BreakContent["breakType"] = "textWrapping",
+  marks?: readonly Mark[],
 ): Run {
   const breakContent: BreakContent = {
     type: "break",
     breakType,
   };
 
-  return {
+  const run: Run = {
     type: "run",
     content: [breakContent],
   };
+  const formatting = getRunFormattingFromMarks(marks);
+  if (formatting) {
+    run.formatting = formatting;
+  }
+  return run;
 }
 
 function readHardBreakType(node: PMNode): BreakContent["breakType"] {
@@ -971,15 +1010,20 @@ function readHardBreakType(node: PMNode): BreakContent["breakType"] {
 /**
  * Create a Run containing a tab
  */
-function createTabRun(): Run {
+function createTabRun(marks?: readonly Mark[]): Run {
   const tabContent: TabContent = {
     type: "tab",
   };
 
-  return {
+  const run: Run = {
     type: "run",
     content: [tabContent],
   };
+  const formatting = getRunFormattingFromMarks(marks);
+  if (formatting) {
+    run.formatting = formatting;
+  }
+  return run;
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -56,6 +56,14 @@ import type {
   CellMargins,
 } from "../../types/document";
 import { pixelsToEmu } from "../../utils/units";
+import {
+  expectHyperlinkMarkAttrs,
+  expectImageAttrs,
+  expectParagraphAttrs,
+  expectTableAttrs,
+  expectTableCellAttrs,
+  expectTableRowAttrs,
+} from "../attrs";
 import { applyRunFormattingOverrideMark } from "../extensions/marks/RunFormattingOverrideExtension";
 import type { ShapeAttrs } from "../extensions/nodes/ShapeExtension";
 import type { TextBoxAttrs } from "../extensions/nodes/TextBoxExtension";
@@ -66,7 +74,6 @@ import type {
 } from "../schema/marks";
 import type {
   ParagraphAttrs,
-  ImageAttrs,
   TableAttrs,
   TableRowAttrs,
   TableCellAttrs,
@@ -154,7 +161,7 @@ function convertPMParagraph(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
 ): Paragraph {
-  const attrs = node.attrs as ParagraphAttrs;
+  const attrs = expectParagraphAttrs(node);
   let content = extractParagraphContent(node, documentCounts);
 
   // Emit BookmarkStart/End from bookmarks attr (for TOC anchors, cross-references)
@@ -649,7 +656,7 @@ function buildDocumentTrackedChangeCounts(pmDoc: PMNode): TrackedChangeCounts {
  * Create a unique key for a link mark
  */
 function getLinkKey(mark: Mark): string {
-  return mark.attrs["href"] || "";
+  return expectHyperlinkMarkAttrs(mark).href;
 }
 
 /**
@@ -671,23 +678,32 @@ function getMarksKey(marks: readonly Mark[]): string {
  * Create a Hyperlink from a link mark
  */
 function createHyperlink(linkMark: Mark): Hyperlink {
-  const href = linkMark.attrs["href"] as string;
+  const attrs = expectHyperlinkMarkAttrs(linkMark);
+  const href = attrs.href;
   // Internal bookmark links use the anchor property in OOXML
   if (href.startsWith("#")) {
-    return {
+    const hyperlink: Hyperlink = {
       type: "hyperlink",
       anchor: href.slice(1),
-      tooltip: linkMark.attrs["tooltip"] || undefined,
       children: [],
     };
+    if (attrs.tooltip) {
+      hyperlink.tooltip = attrs.tooltip;
+    }
+    return hyperlink;
   }
-  return {
+  const hyperlink: Hyperlink = {
     type: "hyperlink",
     href,
-    tooltip: linkMark.attrs["tooltip"] || undefined,
-    rId: linkMark.attrs["rId"] || undefined,
     children: [],
   };
+  if (attrs.tooltip) {
+    hyperlink.tooltip = attrs.tooltip;
+  }
+  if (attrs.rId) {
+    hyperlink.rId = attrs.rId;
+  }
+  return hyperlink;
 }
 
 /**
@@ -908,7 +924,7 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
  * Create a Run containing an image
  */
 function createImageRun(node: PMNode): Run {
-  const attrs = node.attrs as ImageAttrs;
+  const attrs = expectImageAttrs(node);
 
   // Determine wrap type from attrs (default: inline)
   const wrapType = attrs.wrapType || "inline";
@@ -929,7 +945,7 @@ function createImageRun(node: PMNode): Run {
 
   // Restore wrapText from PM attr
   if (attrs.wrapText) {
-    wrap.wrapText = attrs.wrapText as NonNullable<ImageWrap["wrapText"]>;
+    wrap.wrapText = attrs.wrapText;
   }
 
   const image: Image = {
@@ -971,31 +987,27 @@ function createImageRun(node: PMNode): Run {
 
   // Round-trip floating image position (ImagePositionAttrs uses loose strings;
   // cast to the strict OOXML union types for the Document model)
-  if (attrs.position?.horizontal && attrs.position.vertical) {
-    const pos = attrs.position;
-    type HRelativeTo = ImagePosition["horizontal"]["relativeTo"];
-    type HAlignment = ImagePosition["horizontal"]["alignment"];
-    type VRelativeTo = ImagePosition["vertical"]["relativeTo"];
-    type VAlignment = ImagePosition["vertical"]["alignment"];
-
+  const horizontalPosition = attrs.position?.horizontal;
+  const verticalPosition = attrs.position?.vertical;
+  if (horizontalPosition && verticalPosition) {
     const horizontal: ImagePosition["horizontal"] = {
-      relativeTo: (pos.horizontal?.relativeTo || "column") as HRelativeTo,
+      relativeTo: horizontalPosition.relativeTo || "column",
     };
-    if (pos.horizontal?.align) {
-      horizontal.alignment = pos.horizontal.align as NonNullable<HAlignment>;
+    if (horizontalPosition.align) {
+      horizontal.alignment = horizontalPosition.align;
     }
-    if (pos.horizontal?.posOffset !== undefined) {
-      horizontal.posOffset = pos.horizontal.posOffset;
+    if (horizontalPosition.posOffset !== undefined) {
+      horizontal.posOffset = horizontalPosition.posOffset;
     }
 
     const vertical: ImagePosition["vertical"] = {
-      relativeTo: (pos.vertical?.relativeTo || "paragraph") as VRelativeTo,
+      relativeTo: verticalPosition.relativeTo || "paragraph",
     };
-    if (pos.vertical?.align) {
-      vertical.alignment = pos.vertical.align as NonNullable<VAlignment>;
+    if (verticalPosition.align) {
+      vertical.alignment = verticalPosition.align;
     }
-    if (pos.vertical?.posOffset !== undefined) {
-      vertical.posOffset = pos.vertical.posOffset;
+    if (verticalPosition.posOffset !== undefined) {
+      vertical.posOffset = verticalPosition.posOffset;
     }
 
     image.position = { horizontal, vertical };
@@ -1332,7 +1344,7 @@ function convertPMTable(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
 ): Table {
-  const attrs = node.attrs as TableAttrs;
+  const attrs = expectTableAttrs(node);
   const rows: TableRow[] = [];
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
@@ -1442,21 +1454,15 @@ function tableAttrsToFormatting(
       }
     }
     // Width: check if changed
-    const tableWidth = Reflect.get(attrs, "width");
-    const tableWidthType = Reflect.get(attrs, "widthType");
+    const tableWidth = attrs.width;
+    const tableWidthType = attrs.widthType;
     const origWidthVal = orig.width?.value;
     const origWidthType = orig.width?.type;
     if (tableWidth !== origWidthVal || tableWidthType !== origWidthType) {
-      if (
-        typeof tableWidth === "number" ||
-        typeof tableWidthType === "string"
-      ) {
+      if (tableWidth !== undefined || tableWidthType !== undefined) {
         result.width = {
-          value: typeof tableWidth === "number" ? tableWidth : 0,
-          type:
-            typeof tableWidthType === "string"
-              ? (tableWidthType as "auto" | "dxa" | "pct" | "nil")
-              : "dxa",
+          value: tableWidth ?? 0,
+          type: tableWidthType ?? "dxa",
         };
       } else {
         delete result.width;
@@ -1472,12 +1478,12 @@ function tableAttrsToFormatting(
 
   // Fallback: reconstruct formatting from individual attrs (e.g. for
   // newly created tables that don't have _originalFormatting)
-  const tableWidth = Reflect.get(attrs, "width");
-  const tableWidthType = Reflect.get(attrs, "widthType");
+  const tableWidth = attrs.width;
+  const tableWidthType = attrs.widthType;
   const hasFormatting =
     attrs.styleId ||
-    typeof tableWidth === "number" ||
-    typeof tableWidthType === "string" ||
+    tableWidth !== undefined ||
+    tableWidthType !== undefined ||
     attrs.justification ||
     attrs.floating ||
     attrs.cellMargins ||
@@ -1494,13 +1500,10 @@ function tableAttrsToFormatting(
 
   // Restore width — handle width=0 with type="auto" (common OOXML pattern)
   let width: TableFormatting["width"];
-  if (typeof tableWidth === "number" || typeof tableWidthType === "string") {
+  if (tableWidth !== undefined || tableWidthType !== undefined) {
     width = {
-      value: typeof tableWidth === "number" ? tableWidth : 0,
-      type:
-        typeof tableWidthType === "string"
-          ? (tableWidthType as "auto" | "dxa" | "pct" | "nil")
-          : "dxa",
+      value: tableWidth ?? 0,
+      type: tableWidthType ?? "dxa",
     };
   }
 
@@ -1533,7 +1536,7 @@ function convertPMTableRow(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
 ): TableRow {
-  const attrs = node.attrs as TableRowAttrs;
+  const attrs = expectTableRowAttrs(node);
   const cells: TableCell[] = [];
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
@@ -1577,7 +1580,7 @@ function tableRowAttrsToFormatting(
     }
     if (attrs.heightRule !== (orig.heightRule ?? undefined)) {
       if (attrs.heightRule) {
-        result.heightRule = attrs.heightRule as "auto" | "atLeast" | "exact";
+        result.heightRule = attrs.heightRule;
       } else {
         delete result.heightRule;
       }
@@ -1605,7 +1608,7 @@ function tableRowAttrsToFormatting(
     f.height = { value: attrs.height, type: "dxa" };
   }
   if (attrs.heightRule) {
-    f.heightRule = attrs.heightRule as "auto" | "atLeast" | "exact";
+    f.heightRule = attrs.heightRule;
   }
   if (attrs.isHeader) {
     f.header = attrs.isHeader;
@@ -1620,7 +1623,7 @@ function convertPMTableCell(
   node: PMNode,
   documentCounts?: TrackedChangeCounts,
 ): TableCell {
-  const attrs = node.attrs as TableCellAttrs;
+  const attrs = expectTableCellAttrs(node);
   const content: (Paragraph | Table)[] = [];
 
   // Extract cell content (paragraphs and nested tables)
@@ -1659,16 +1662,12 @@ function tableCellAttrsToFormatting(
     if (attrs.colspan > 1) {
       result.gridSpan = attrs.colspan;
     }
-    const cellWidth = Reflect.get(attrs, "width");
+    const cellWidth = attrs.width;
     // Width: keep null absent while preserving explicit width=0 values.
-    if (typeof cellWidth === "number") {
-      const cellWidthType = Reflect.get(attrs, "widthType");
+    if (cellWidth !== undefined) {
       result.width = {
         value: cellWidth,
-        type:
-          typeof cellWidthType === "string"
-            ? (cellWidthType as "auto" | "dxa" | "pct" | "nil")
-            : "dxa",
+        type: attrs.widthType ?? "dxa",
       };
     }
     if (attrs.verticalAlign !== (orig.verticalAlign ?? undefined)) {
@@ -1685,18 +1684,14 @@ function tableCellAttrsToFormatting(
       delete result.shading;
     }
     if (attrs.borders) {
-      result.borders = attrs.borders as NonNullable<
-        TableCellFormatting["borders"]
-      >;
+      result.borders = attrs.borders;
     }
     if (attrs.margins) {
       result.margins = buildCellMarginsFromAttrs(attrs.margins);
     }
     if (attrs.textDirection !== (orig.textDirection ?? undefined)) {
       if (attrs.textDirection) {
-        result.textDirection = attrs.textDirection as NonNullable<
-          TableCellFormatting["textDirection"]
-        >;
+        result.textDirection = attrs.textDirection;
       } else {
         delete result.textDirection;
       }
@@ -1706,11 +1701,11 @@ function tableCellAttrsToFormatting(
   }
 
   // Fallback: reconstruct formatting from individual attrs
-  const cellWidth = Reflect.get(attrs, "width");
+  const cellWidth = attrs.width;
   const hasFormatting =
     attrs.colspan > 1 ||
     attrs.rowspan > 1 ||
-    typeof cellWidth === "number" ||
+    cellWidth !== undefined ||
     attrs.verticalAlign ||
     attrs.backgroundColor ||
     attrs.borders ||
@@ -1725,29 +1720,23 @@ function tableCellAttrsToFormatting(
   if (attrs.colspan > 1) {
     f.gridSpan = attrs.colspan;
   }
-  if (typeof cellWidth === "number") {
-    const cellWidthType = Reflect.get(attrs, "widthType");
+  if (cellWidth !== undefined) {
     f.width = {
       value: cellWidth,
-      type:
-        typeof cellWidthType === "string"
-          ? (cellWidthType as "auto" | "dxa" | "pct" | "nil")
-          : "dxa",
+      type: attrs.widthType ?? "dxa",
     };
   }
   if (attrs.verticalAlign) {
     f.verticalAlign = attrs.verticalAlign;
   }
   if (attrs.textDirection) {
-    f.textDirection = attrs.textDirection as NonNullable<
-      TableCellFormatting["textDirection"]
-    >;
+    f.textDirection = attrs.textDirection;
   }
   if (attrs.backgroundColor) {
     f.shading = { fill: { rgb: attrs.backgroundColor } };
   }
   if (attrs.borders) {
-    f.borders = attrs.borders as NonNullable<TableCellFormatting["borders"]>;
+    f.borders = attrs.borders;
   }
   if (attrs.margins) {
     f.margins = buildCellMarginsFromAttrs(attrs.margins);

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -87,11 +87,17 @@ import type {
   TableRowAttrs,
   TableCellAttrs,
 } from "../schema/nodes";
+import { assertValidProseMirrorDocument } from "../validation";
 
 /**
  * Convert a ProseMirror document to our Document type
  */
 export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
+  assertValidProseMirrorDocument(
+    pmDoc,
+    "Cannot convert invalid ProseMirror document to DOCX model",
+  );
+
   const blocks = extractBlocks(pmDoc);
 
   // Preserve section properties (margins, headers, footers) from base document

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -63,6 +63,7 @@ import {
   expectFontFamilyMarkAttrs,
   expectFontSizeMarkAttrs,
   expectFootnoteRefMarkAttrs,
+  expectHardBreakAttrs,
   expectHighlightMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
@@ -147,6 +148,15 @@ function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
     }
     pendingPageBreaks = 0;
   };
+  const appendPendingPageBreaksToPreviousParagraph = (): boolean => {
+    const previousBlock = blocks.at(-1);
+    if (previousBlock?.type !== "paragraph") {
+      return false;
+    }
+    appendPageBreaks(previousBlock, pendingPageBreaks);
+    pendingPageBreaks = 0;
+    return true;
+  };
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
   pmDoc.forEach((node) => {
@@ -163,7 +173,12 @@ function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
       blocks.push(paragraph);
       previousStandaloneTextBox = null;
     } else if (node.type.name === "table") {
-      flushPendingPageBreaks();
+      if (
+        pendingPageBreaks > 0 &&
+        !appendPendingPageBreaksToPreviousParagraph()
+      ) {
+        flushPendingPageBreaks();
+      }
       blocks.push(convertPMTable(node, documentCounts));
       previousStandaloneTextBox = null;
     } else if (node.type.name === "textBox") {
@@ -175,13 +190,8 @@ function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
     }
   });
 
-  if (pendingPageBreaks > 0) {
-    const previousBlock = blocks.at(-1);
-    if (previousBlock?.type === "paragraph") {
-      appendPageBreaks(previousBlock, pendingPageBreaks);
-    } else {
-      flushPendingPageBreaks();
-    }
+  if (pendingPageBreaks > 0 && !appendPendingPageBreaksToPreviousParagraph()) {
+    flushPendingPageBreaks();
   }
 
   return blocks;
@@ -680,7 +690,7 @@ function extractParagraphContent(
     } else if (node.type.name === "hardBreak") {
       // Hard break ends current run
       flushCurrentInline();
-      content.push(createBreakRun());
+      content.push(createBreakRun(readHardBreakType(node)));
     } else if (node.type.name === "image") {
       // Image ends current run
       flushCurrentInline();
@@ -862,16 +872,22 @@ function appendTextToRun(run: Run, text: string): void {
 /**
  * Create a Run containing a line break
  */
-function createBreakRun(): Run {
+function createBreakRun(
+  breakType: BreakContent["breakType"] = "textWrapping",
+): Run {
   const breakContent: BreakContent = {
     type: "break",
-    breakType: "textWrapping",
+    breakType,
   };
 
   return {
     type: "run",
     content: [breakContent],
   };
+}
+
+function readHardBreakType(node: PMNode): BreakContent["breakType"] {
+  return expectHardBreakAttrs(node).breakType ?? "textWrapping";
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -57,21 +57,28 @@ import type {
 } from "../../types/document";
 import { pixelsToEmu } from "../../utils/units";
 import {
+  expectCharacterSpacingMarkAttrs,
+  expectCommentMarkAttrs,
+  expectEmphasisMarkAttrs,
+  expectFontFamilyMarkAttrs,
+  expectFontSizeMarkAttrs,
+  expectFootnoteRefMarkAttrs,
+  expectHighlightMarkAttrs,
   expectHyperlinkMarkAttrs,
   expectImageAttrs,
   expectParagraphAttrs,
+  expectRunFormattingOverrideMarkAttrs,
+  expectStrikeMarkAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
   expectTableRowAttrs,
+  expectTextColorMarkAttrs,
+  expectTrackedChangeMarkAttrs,
+  expectUnderlineMarkAttrs,
 } from "../attrs";
-import { applyRunFormattingOverrideMark } from "../extensions/marks/RunFormattingOverrideExtension";
 import type { ShapeAttrs } from "../extensions/nodes/ShapeExtension";
 import type { TextBoxAttrs } from "../extensions/nodes/TextBoxExtension";
-import type {
-  TextColorAttrs,
-  UnderlineAttrs,
-  FontFamilyAttrs,
-} from "../schema/marks";
+import type { RunFormattingOverrideAttrs } from "../schema/marks";
 import type {
   ParagraphAttrs,
   TableAttrs,
@@ -454,13 +461,16 @@ function extractParagraphContent(
     if (noteRefMark) {
       // Finish any current content
       flushCurrentInline();
+      const noteAttrs = expectFootnoteRefMarkAttrs(noteRefMark);
       const noteType =
-        noteRefMark.attrs["noteType"] === "endnote"
-          ? "endnoteRef"
-          : "footnoteRef";
+        noteAttrs.noteType === "endnote" ? "endnoteRef" : "footnoteRef";
+      const noteId =
+        typeof noteAttrs.id === "string"
+          ? Number.parseInt(noteAttrs.id, 10) || 0
+          : noteAttrs.id;
       const noteRef: NoteReferenceContent = {
         type: noteType,
-        id: Number.parseInt(noteRefMark.attrs["id"], 10) || 0,
+        id: noteId,
       };
       content.push({
         type: "run",
@@ -480,6 +490,7 @@ function extractParagraphContent(
       if (!changeMark) {
         return;
       }
+      const changeAttrs = expectTrackedChangeMarkAttrs(changeMark);
       // Filter out the tracked change mark for text formatting extraction
       const otherMarks = node.marks.filter(
         (m) => m.type.name !== "insertion" && m.type.name !== "deletion",
@@ -493,12 +504,11 @@ function extractParagraphContent(
       };
 
       const info: TrackedChangeInfo = {
-        id: changeMark.attrs["revisionId"] as number,
-        author: (changeMark.attrs["author"] as string) || "Unknown",
+        id: changeAttrs.revisionId,
+        author: changeAttrs.author || "Unknown",
       };
-      const dateStr = changeMark.attrs["date"] as string;
-      if (dateStr) {
-        info.date = dateStr;
+      if (changeAttrs.date) {
+        info.date = changeAttrs.date;
       }
       // The mark itself records whether it originated as a
       // `w:moveTo` / `w:moveFrom`. The previous "is there both an
@@ -508,14 +518,13 @@ function extractParagraphContent(
       // typically don't), and unrelated `w:ins w:id="5"` /
       // `w:del w:id="5"` from different reviewers would coincidentally
       // fuse into a phantom move pair.
-      const moveKind = changeMark.attrs["moveKind"];
       if (insertionMark) {
-        if (moveKind === "moveTo") {
+        if (changeAttrs.moveKind === "moveTo") {
           content.push({ type: "moveTo", info, content: [run] });
         } else {
           content.push({ type: "insertion", info, content: [run] });
         }
-      } else if (moveKind === "moveFrom") {
+      } else if (changeAttrs.moveKind === "moveFrom") {
         content.push({ type: "moveFrom", info, content: [run] });
       } else {
         content.push({ type: "deletion", info, content: [run] });
@@ -611,7 +620,7 @@ function getCommentMarkIds(marks: readonly Mark[]): Set<number> {
   const commentIds = new Set<number>();
   for (const mark of marks) {
     if (mark.type.name === "comment") {
-      commentIds.add(mark.attrs["commentId"] as number);
+      commentIds.add(expectCommentMarkAttrs(mark).commentId);
     }
   }
   return commentIds;
@@ -636,16 +645,12 @@ function buildDocumentTrackedChangeCounts(pmDoc: PMNode): TrackedChangeCounts {
     const deletionMark = node.marks.find((m) => m.type.name === "deletion");
 
     if (insertionMark) {
-      const revisionId = Number(insertionMark.attrs["revisionId"]);
-      if (Number.isFinite(revisionId)) {
-        insertionById.set(revisionId, (insertionById.get(revisionId) ?? 0) + 1);
-      }
+      const { revisionId } = expectTrackedChangeMarkAttrs(insertionMark);
+      insertionById.set(revisionId, (insertionById.get(revisionId) ?? 0) + 1);
     }
     if (deletionMark) {
-      const revisionId = Number(deletionMark.attrs["revisionId"]);
-      if (Number.isFinite(revisionId)) {
-        deletionById.set(revisionId, (deletionById.get(revisionId) ?? 0) + 1);
-      }
+      const { revisionId } = expectTrackedChangeMarkAttrs(deletionMark);
+      deletionById.set(revisionId, (deletionById.get(revisionId) ?? 0) + 1);
     }
   });
 
@@ -1156,7 +1161,7 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
 
       case "underline": {
-        const attrs = mark.attrs as UnderlineAttrs;
+        const attrs = expectUnderlineMarkAttrs(mark);
         const uline: NonNullable<TextFormatting["underline"]> = {
           style: attrs.style || "single",
         };
@@ -1168,7 +1173,7 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
       }
 
       case "strike":
-        if (mark.attrs["double"]) {
+        if (expectStrikeMarkAttrs(mark).double) {
           formatting.doubleStrike = true;
         } else {
           formatting.strike = true;
@@ -1176,7 +1181,7 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
 
       case "textColor": {
-        const attrs = mark.attrs as TextColorAttrs;
+        const attrs = expectTextColorMarkAttrs(mark);
         const colorVal: ColorValue = {};
         if (attrs.rgb) {
           colorVal.rgb = attrs.rgb;
@@ -1195,16 +1200,18 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
       }
 
       case "highlight":
-        formatting.highlight = mark.attrs["color"];
+        formatting.highlight = expectHighlightMarkAttrs(mark).color;
         break;
 
-      case "fontSize":
-        formatting.fontSize = mark.attrs["size"];
-        formatting.fontSizeCs = mark.attrs["size"];
+      case "fontSize": {
+        const attrs = expectFontSizeMarkAttrs(mark);
+        formatting.fontSize = attrs.size;
+        formatting.fontSizeCs = attrs.size;
         break;
+      }
 
       case "fontFamily": {
-        const attrs = mark.attrs as FontFamilyAttrs;
+        const attrs = expectFontFamilyMarkAttrs(mark);
         const ff: NonNullable<TextFormatting["fontFamily"]> = {};
         if (attrs.ascii) {
           ff.ascii = attrs.ascii;
@@ -1256,17 +1263,18 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
 
       case "characterSpacing": {
-        if (mark.attrs["spacing"] !== null) {
-          formatting.spacing = mark.attrs["spacing"];
+        const attrs = expectCharacterSpacingMarkAttrs(mark);
+        if (attrs.spacing !== undefined) {
+          formatting.spacing = attrs.spacing;
         }
-        if (mark.attrs["position"] !== null) {
-          formatting.position = mark.attrs["position"];
+        if (attrs.position !== undefined) {
+          formatting.position = attrs.position;
         }
-        if (mark.attrs["scale"] !== null) {
-          formatting.scale = mark.attrs["scale"];
+        if (attrs.scale !== undefined) {
+          formatting.scale = attrs.scale;
         }
-        if (mark.attrs["kerning"] !== null) {
-          formatting.kerning = mark.attrs["kerning"];
+        if (attrs.kerning !== undefined) {
+          formatting.kerning = attrs.kerning;
         }
         break;
       }
@@ -1284,7 +1292,7 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
 
       case "emphasisMark":
-        formatting.emphasisMark = mark.attrs["type"] || "dot";
+        formatting.emphasisMark = expectEmphasisMarkAttrs(mark).type || "dot";
         break;
 
       case "textOutline":
@@ -1292,7 +1300,10 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         break;
 
       case "runFormattingOverride":
-        applyRunFormattingOverrideMark(formatting, mark);
+        applyRunFormattingOverrideAttrs(
+          formatting,
+          expectRunFormattingOverrideMarkAttrs(mark),
+        );
         break;
 
       // hyperlink is handled separately
@@ -1302,6 +1313,48 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
   }
 
   return formatting;
+}
+
+function applyRunFormattingOverrideAttrs(
+  formatting: TextFormatting,
+  attrs: RunFormattingOverrideAttrs,
+): void {
+  if (attrs.bold === false) {
+    formatting.bold = false;
+  }
+  if (attrs.italic === false) {
+    formatting.italic = false;
+  }
+  if (attrs.underline === "none") {
+    formatting.underline = { style: "none" };
+  }
+  if (attrs.strike === false) {
+    formatting.strike = false;
+  }
+  if (attrs.doubleStrike === false) {
+    formatting.doubleStrike = false;
+  }
+  if (attrs.allCaps === false) {
+    formatting.allCaps = false;
+  }
+  if (attrs.smallCaps === false) {
+    formatting.smallCaps = false;
+  }
+  if (attrs.hidden === false) {
+    formatting.hidden = false;
+  }
+  if (attrs.emboss === false) {
+    formatting.emboss = false;
+  }
+  if (attrs.imprint === false) {
+    formatting.imprint = false;
+  }
+  if (attrs.shadow === false) {
+    formatting.shadow = false;
+  }
+  if (attrs.outline === false) {
+    formatting.outline = false;
+  }
 }
 
 // ============================================================================

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -619,13 +619,10 @@ function extractParagraphContent(
       const otherMarks = node.marks.filter(
         (m) => m.type.name !== "insertion" && m.type.name !== "deletion",
       );
-      const formatting = marksToTextFormatting(otherMarks);
-      const run: Run = {
-        type: "run",
-        content:
-          node.isText && node.text ? [{ type: "text", text: node.text }] : [],
-        ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
-      };
+      const run = createTrackedChangeRun(node, otherMarks);
+      if (!run) {
+        return;
+      }
 
       const info: TrackedChangeInfo = {
         id: changeAttrs.revisionId,
@@ -769,6 +766,33 @@ function extractParagraphContent(
   }
 
   return content;
+}
+
+function createTrackedChangeRun(
+  node: PMNode,
+  marks: readonly Mark[],
+): Run | null {
+  if (node.isText) {
+    const formatting = marksToTextFormatting(marks);
+    return {
+      type: "run",
+      content: node.text ? [{ type: "text", text: node.text }] : [],
+      ...(Object.keys(formatting).length > 0 ? { formatting } : {}),
+    };
+  }
+  if (node.type.name === "hardBreak") {
+    return createBreakRun(readHardBreakType(node));
+  }
+  if (node.type.name === "image") {
+    return createImageRun(node);
+  }
+  if (node.type.name === "shape") {
+    return createShapeRun(node);
+  }
+  if (node.type.name === "tab") {
+    return createTabRun();
+  }
+  return null;
 }
 
 function createEmptyHyperlink(
@@ -1320,6 +1344,9 @@ function createImageRun(node: PMNode): Run {
     type: "drawing",
     image,
   };
+  if (attrs._docxRawXml) {
+    drawingContent.rawXml = attrs._docxRawXml;
+  }
 
   return {
     type: "run",

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -281,7 +281,11 @@ function convertPMParagraph(
   documentCounts?: TrackedChangeCounts,
 ): Paragraph {
   const attrs = expectParagraphAttrs(node);
-  let content = extractParagraphContent(node, documentCounts);
+  let content = extractParagraphContent(
+    node,
+    documentCounts,
+    attrs._emptyHyperlinks ?? undefined,
+  );
 
   // Emit BookmarkStart/End from bookmarks attr (for TOC anchors, cross-references)
   const bookmarks = attrs.bookmarks as
@@ -505,8 +509,16 @@ function extractParagraphContent(
   // — `moveFrom`/`moveTo` round-trip is now driven by the explicit
   // `moveKind` mark attribute set by `toProseDoc`.
   _documentCounts?: TrackedChangeCounts,
+  emptyHyperlinks?: NonNullable<ParagraphAttrs["_emptyHyperlinks"]>,
 ): ParagraphContent[] {
   const content: ParagraphContent[] = [];
+  const sortedEmptyHyperlinks = (emptyHyperlinks ?? [])
+    .map((attrs, order) => ({ attrs, order }))
+    .toSorted(
+      (left, right) =>
+        left.attrs.offset - right.attrs.offset || left.order - right.order,
+    );
+  let nextEmptyHyperlink = 0;
 
   // Track current run being built
   let currentRun: Run | null = null;
@@ -564,8 +576,19 @@ function extractParagraphContent(
     }
   };
 
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  paragraph.forEach((node) => {
+  const flushEmptyHyperlinksThroughOffset = (offset: number): void => {
+    while (nextEmptyHyperlink < sortedEmptyHyperlinks.length) {
+      const item = sortedEmptyHyperlinks[nextEmptyHyperlink];
+      if (!item || item.attrs.offset > offset) {
+        break;
+      }
+      nextEmptyHyperlink += 1;
+      flushCurrentInline();
+      content.push(createEmptyHyperlink(item.attrs));
+    }
+  };
+
+  const processInlineNode = (node: PMNode): void => {
     syncCommentRanges(node);
 
     // Check for footnote/endnote reference mark
@@ -717,7 +740,43 @@ function extractParagraphContent(
       flushCurrentInline();
       content.push(createMathFromNode(node));
     }
+  };
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  paragraph.forEach((node, offset) => {
+    flushEmptyHyperlinksThroughOffset(offset);
+
+    if (node.isText && node.text) {
+      let consumed = 0;
+      const textEndOffset = offset + node.nodeSize;
+      while (nextEmptyHyperlink < sortedEmptyHyperlinks.length) {
+        const item = sortedEmptyHyperlinks[nextEmptyHyperlink];
+        if (!item || item.attrs.offset >= textEndOffset) {
+          break;
+        }
+
+        const splitOffset = Math.max(item.attrs.offset - offset, consumed);
+        const segment = node.text.slice(consumed, splitOffset);
+        if (segment) {
+          processInlineNode(node.type.schema.text(segment, node.marks));
+        }
+        flushCurrentInline();
+        content.push(createEmptyHyperlink(item.attrs));
+        nextEmptyHyperlink += 1;
+        consumed = splitOffset;
+      }
+
+      const remainder = node.text.slice(consumed);
+      if (remainder) {
+        processInlineNode(node.type.schema.text(remainder, node.marks));
+      }
+      return;
+    }
+
+    processInlineNode(node);
   });
+
+  flushEmptyHyperlinksThroughOffset(Number.POSITIVE_INFINITY);
 
   // Don't forget the last run/hyperlink
   flushCurrentInline();
@@ -726,6 +785,25 @@ function extractParagraphContent(
   }
 
   return content;
+}
+
+function createEmptyHyperlink(
+  attrs: NonNullable<ParagraphAttrs["_emptyHyperlinks"]>[number],
+): Hyperlink {
+  const hyperlink: Hyperlink = { type: "hyperlink", children: [] };
+  if (attrs.href !== undefined) {
+    hyperlink.href = attrs.href;
+  }
+  if (attrs.anchor !== undefined) {
+    hyperlink.anchor = attrs.anchor;
+  }
+  if (attrs.tooltip !== undefined) {
+    hyperlink.tooltip = attrs.tooltip;
+  }
+  if (attrs.rId !== undefined) {
+    hyperlink.rId = attrs.rId;
+  }
+  return hyperlink;
 }
 
 function getCommentMarkIds(marks: readonly Mark[]): Set<number> {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -219,6 +219,7 @@ function appendTextBoxBlock(
     attrs._docxPlacement === "inlineWithPrevious" &&
     previousBlock?.type === "paragraph"
   ) {
+    appendPageBreaks(previousBlock, options.pendingPageBreaks);
     previousBlock.content.push(...paragraph.content);
     return null;
   }

--- a/packages/folio/src/core/prosemirror/conversion/index.ts
+++ b/packages/folio/src/core/prosemirror/conversion/index.ts
@@ -15,3 +15,12 @@ export {
   updateDocumentContent,
   proseDocToBlocks,
 } from "./fromProseDoc";
+export {
+  assertValidProseMirrorDocument,
+  formatProseMirrorDocumentIssues,
+  validateProseMirrorDocument,
+} from "../validation";
+export type {
+  ProseMirrorDocumentValidationIssue,
+  ValidateProseMirrorDocumentResult,
+} from "../validation";

--- a/packages/folio/src/core/prosemirror/conversion/realDocxFixtures.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/realDocxFixtures.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseDocx } from "../../docx/parser";
+import { validateProseMirrorDocument } from "../validation";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const FIXTURE_NAMES = ["sample.docx", "docx-editor-demo.docx"] as const;
+
+describe("real DOCX fixture ProseMirror boundary", () => {
+  for (const fixtureName of FIXTURE_NAMES) {
+    test(`${fixtureName} parses into valid canonical ProseMirror attrs`, async () => {
+      const buffer = await Bun.file(
+        new URL(
+          `../../../../tests/visual/fixtures/${fixtureName}`,
+          import.meta.url,
+        ),
+      ).arrayBuffer();
+
+      const document = await parseDocx(buffer, { preloadFonts: false });
+      const pmDoc = toProseDoc(document, {
+        styles: document.package.styles,
+        theme: document.package.theme,
+      });
+      const validation = validateProseMirrorDocument(pmDoc);
+
+      expect(validation.issues).toEqual([]);
+      expect(validation.valid).toBe(true);
+
+      const roundtripped = fromProseDoc(pmDoc, document);
+      expect(roundtripped.package.document.content.length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Document,
+  MathEquation,
+  Paragraph,
+  Run,
+  ShapeContent,
+  SimpleField,
+  InlineSdt,
+} from "../../types/document";
+import { pixelsToEmu } from "../../utils/units";
+import { validateProseMirrorDocument } from "../validation";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const runText = (text: string, formatting?: Run["formatting"]): Run => {
+  const run: Run = {
+    type: "run",
+    content: [{ type: "text", text }],
+  };
+  if (formatting) {
+    run.formatting = formatting;
+  }
+  return run;
+};
+
+const firstParagraph = (document: Document): Paragraph => {
+  const block = document.package.document.content.at(0);
+  if (block?.type !== "paragraph") {
+    throw new Error("Expected first block to be a paragraph");
+  }
+  return block;
+};
+
+const paragraphAt = (document: Document, index: number): Paragraph => {
+  const block = document.package.document.content.at(index);
+  if (block?.type !== "paragraph") {
+    throw new Error(`Expected block ${index} to be a paragraph`);
+  }
+  return block;
+};
+
+const textOfRun = (run: Run): string =>
+  run.content
+    .filter((content) => content.type === "text")
+    .map((content) => content.text)
+    .join("");
+
+const findRunText = (paragraph: Paragraph, text: string): Run => {
+  for (const content of paragraph.content) {
+    if (content.type === "run" && textOfRun(content) === text) {
+      return content;
+    }
+  }
+  throw new Error(`Expected run text ${text}`);
+};
+
+const findSimpleField = (paragraph: Paragraph): SimpleField => {
+  const field = paragraph.content.find(
+    (content): content is SimpleField => content.type === "simpleField",
+  );
+  if (!field) {
+    throw new Error("Expected simple field");
+  }
+  return field;
+};
+
+const findInlineSdt = (paragraph: Paragraph): InlineSdt => {
+  const sdt = paragraph.content.find(
+    (content): content is InlineSdt => content.type === "inlineSdt",
+  );
+  if (!sdt) {
+    throw new Error("Expected inline SDT");
+  }
+  return sdt;
+};
+
+const findMathEquation = (paragraph: Paragraph): MathEquation => {
+  const math = paragraph.content.find(
+    (content): content is MathEquation => content.type === "mathEquation",
+  );
+  if (!math) {
+    throw new Error("Expected math equation");
+  }
+  return math;
+};
+
+const firstShapeContent = (paragraph: Paragraph): ShapeContent => {
+  for (const content of paragraph.content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    const shape = content.content.find(
+      (runContent): runContent is ShapeContent => runContent.type === "shape",
+    );
+    if (shape) {
+      return shape;
+    }
+  }
+  throw new Error("Expected shape content");
+};
+
+const buildSemanticFixture = (): Document => ({
+  package: {
+    document: {
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "commentRangeStart", id: 7 },
+            runText("Clause ", {
+              bold: true,
+              color: { rgb: "C00000" },
+              highlight: "yellow",
+            }),
+            {
+              type: "simpleField",
+              instruction: " PAGE ",
+              fieldType: "PAGE",
+              content: [runText("1", { italic: true })],
+            },
+            {
+              type: "inlineSdt",
+              properties: {
+                sdtType: "dropdown",
+                alias: "Party choice",
+                tag: "party",
+                listItems: [{ displayText: "Acme", value: "acme" }],
+              },
+              content: [runText("Acme")],
+            },
+            {
+              type: "mathEquation",
+              display: "inline",
+              ommlXml: "<m:oMath />",
+              plainText: "x=1",
+            },
+            {
+              type: "run",
+              content: [
+                {
+                  type: "shape",
+                  shape: {
+                    type: "shape",
+                    shapeType: "rect",
+                    id: "shape-1",
+                    size: {
+                      width: pixelsToEmu(80),
+                      height: pixelsToEmu(40),
+                    },
+                    fill: {
+                      type: "solid",
+                      color: { rgb: "FFAA00" },
+                    },
+                    outline: {
+                      width: pixelsToEmu(1),
+                      style: "solid",
+                      color: { rgb: "000000" },
+                    },
+                  },
+                },
+              ],
+            },
+            { type: "commentRangeEnd", id: 7 },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [
+                {
+                  type: "shape",
+                  shape: {
+                    type: "shape",
+                    shapeType: "rect",
+                    id: "text-box-1",
+                    size: {
+                      width: pixelsToEmu(220),
+                      height: pixelsToEmu(90),
+                    },
+                    fill: {
+                      type: "solid",
+                      color: { rgb: "FFFFFF" },
+                    },
+                    textBody: {
+                      margins: {
+                        top: pixelsToEmu(4),
+                        bottom: pixelsToEmu(4),
+                        left: pixelsToEmu(7),
+                        right: pixelsToEmu(7),
+                      },
+                      content: [
+                        {
+                          type: "paragraph",
+                          content: [runText("Inside text box")],
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
+
+describe("semantic ProseMirror round-trip fixture", () => {
+  test("preserves canonical inline and drawing semantics", () => {
+    const document = buildSemanticFixture();
+    const pmDoc = toProseDoc(document);
+    const pmValidation = validateProseMirrorDocument(pmDoc);
+    const roundtripped = fromProseDoc(pmDoc, document);
+    const paragraph = firstParagraph(roundtripped);
+
+    expect(pmValidation.valid).toBe(true);
+    expect(paragraph.content.map((content) => content.type)).toEqual([
+      "commentRangeStart",
+      "run",
+      "commentRangeEnd",
+      "simpleField",
+      "commentRangeStart",
+      "inlineSdt",
+      "commentRangeEnd",
+      "mathEquation",
+      "run",
+    ]);
+    expect(findRunText(paragraph, "Clause ").formatting).toMatchObject({
+      bold: true,
+      color: { rgb: "C00000" },
+      highlight: "yellow",
+    });
+    expect(findSimpleField(paragraph)).toMatchObject({
+      instruction: " PAGE ",
+      fieldType: "PAGE",
+    });
+    expect(findInlineSdt(paragraph).properties).toMatchObject({
+      sdtType: "dropdown",
+      alias: "Party choice",
+      tag: "party",
+      listItems: [{ displayText: "Acme", value: "acme" }],
+    });
+    expect(findMathEquation(paragraph)).toMatchObject({
+      display: "inline",
+      ommlXml: "<m:oMath />",
+      plainText: "x=1",
+    });
+    expect(firstShapeContent(paragraph).shape).toMatchObject({
+      type: "shape",
+      shapeType: "rect",
+      id: "shape-1",
+      fill: { type: "solid", color: { rgb: "FFAA00" } },
+    });
+
+    const textBoxShape = firstShapeContent(paragraphAt(roundtripped, 1)).shape;
+    expect(textBoxShape).toMatchObject({
+      type: "shape",
+      shapeType: "rect",
+      id: "text-box-1",
+      textBody: {
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "run",
+                content: [{ type: "text", text: "Inside text box" }],
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
@@ -260,7 +260,7 @@ describe("semantic ProseMirror round-trip fixture", () => {
     const textBoxShape = firstShapeContent(paragraphAt(roundtripped, 1)).shape;
     expect(textBoxShape).toMatchObject({
       type: "shape",
-      shapeType: "rect",
+      shapeType: "textBox",
       id: "text-box-1",
       textBody: {
         content: [

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Document, Hyperlink, Paragraph } from "../../types/document";
+import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
 const docWithHyperlink = (hyperlink: Hyperlink): Document => {
@@ -72,6 +73,54 @@ describe("convertHyperlink preserves non-text run content", () => {
     }
   });
 
+  test("round-trips a w:tab inside one hyperlink wrapper", () => {
+    const document = docWithHyperlink({
+      type: "hyperlink",
+      href: "https://example.test/catalog",
+      rId: "rId7",
+      children: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "item" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "tab" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "text", text: "sku.html" }],
+        },
+      ],
+    });
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+
+    expect(paragraph.content).toHaveLength(1);
+    const hyperlink = paragraph.content.at(0);
+    expect(hyperlink?.type).toBe("hyperlink");
+    if (hyperlink?.type !== "hyperlink") {
+      return;
+    }
+
+    expect(hyperlink.rId).toBe("rId7");
+    expect(hyperlink.children.map((child) => child.type)).toEqual([
+      "run",
+      "run",
+      "run",
+    ]);
+    expect(
+      hyperlink.children.map((child) =>
+        child.type === "run" ? child.content.at(0)?.type : child.type,
+      ),
+    ).toEqual(["text", "tab", "text"]);
+  });
+
   test("preserves a w:br inside a hyperlink", () => {
     const hyperlink: Hyperlink = {
       type: "hyperlink",
@@ -102,5 +151,46 @@ describe("convertHyperlink preserves non-text run content", () => {
     }
     expect(childTypes).toContain("hardBreak");
     expect(childTypes.filter((n) => n === "text")).toHaveLength(2);
+  });
+
+  test("round-trips a w:br inside one hyperlink wrapper", () => {
+    const document = docWithHyperlink({
+      type: "hyperlink",
+      href: "https://example.test",
+      children: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "Line A" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "break", breakType: "textWrapping" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "text", text: "Line B" }],
+        },
+      ],
+    });
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+
+    expect(paragraph.content).toHaveLength(1);
+    const hyperlink = paragraph.content.at(0);
+    expect(hyperlink?.type).toBe("hyperlink");
+    if (hyperlink?.type !== "hyperlink") {
+      return;
+    }
+
+    expect(
+      hyperlink.children.map((child) =>
+        child.type === "run" ? child.content.at(0)?.type : child.type,
+      ),
+    ).toEqual(["text", "break", "text"]);
   });
 });

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-hyperlink-content.test.ts
@@ -193,4 +193,45 @@ describe("convertHyperlink preserves non-text run content", () => {
       ),
     ).toEqual(["text", "break", "text"]);
   });
+
+  test("round-trips a footnote reference inside one hyperlink wrapper", () => {
+    const document = docWithHyperlink({
+      type: "hyperlink",
+      anchor: "bookmark0",
+      children: [
+        {
+          type: "run",
+          content: [{ type: "text", text: "y" }],
+        },
+        {
+          type: "run",
+          content: [{ type: "footnoteRef", id: 1 }],
+        },
+        {
+          type: "run",
+          content: [{ type: "text", text: ";" }],
+        },
+      ],
+    });
+
+    const roundTripped = fromProseDoc(toProseDoc(document), document);
+    const paragraph = roundTripped.package.document.content.at(0);
+    expect(paragraph?.type).toBe("paragraph");
+    if (paragraph?.type !== "paragraph") {
+      return;
+    }
+
+    expect(paragraph.content).toHaveLength(1);
+    const hyperlink = paragraph.content.at(0);
+    expect(hyperlink?.type).toBe("hyperlink");
+    if (hyperlink?.type !== "hyperlink") {
+      return;
+    }
+
+    expect(
+      hyperlink.children.map((child) =>
+        child.type === "run" ? child.content.at(0)?.type : child.type,
+      ),
+    ).toEqual(["text", "footnoteRef", "text"]);
+  });
 });

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -499,6 +499,39 @@ describe("toProseDoc", () => {
     expect(field?.attrs.fieldKind).toBe("simple");
   });
 
+  test("converts inline content controls without synthetic marks", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "inlineSdt",
+                  properties: { sdtType: "plainText" },
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "Controlled" }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const sdt = doc.firstChild?.firstChild;
+
+    expect(sdt?.type.name).toBe("sdt");
+    expect(sdt?.marks).toEqual([]);
+    expect(sdt?.firstChild?.text).toBe("Controlled");
+  });
+
   test("anchors point comments to nearby text for display", () => {
     const document: Document = {
       package: {
@@ -564,7 +597,7 @@ describe("toProseDoc", () => {
                 },
                 {
                   type: "insertion",
-                  info: { id: "rev-1", author: "User" },
+                  info: { id: 1, author: "User" },
                   content: [
                     {
                       type: "run",

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -218,6 +218,45 @@ describe("toProseDoc", () => {
     expect(tableCellBorderColor(attrs, "top")?.themeColor).toBeUndefined();
   });
 
+  test("accepts unknown table-cell border styles preserved from OOXML", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "table",
+              rows: [
+                {
+                  cells: [
+                    {
+                      formatting: {
+                        borders: {
+                          bottom: {
+                            style: "0",
+                            size: 0,
+                            color: { rgb: "000000" },
+                          },
+                        },
+                      },
+                      content: [{ type: "paragraph", content: [] }],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const attrs = firstTableCellAttrs(document);
+    const borders = attrs["borders"] as
+      | { bottom?: { style?: string } }
+      | undefined;
+
+    expect(borders?.bottom?.style).toBe("0");
+  });
+
   test("resolves themed table-cell border color with themeTint to the modified RGB", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -85,6 +85,7 @@ export function toProseDoc(
 
   const styleResolver = createStyleResolver(options?.styles);
   const theme = options?.theme ?? document.package.theme ?? null;
+  let textBoxGroupIndex = 0;
 
   for (const block of paragraphs) {
     if (block.type === "paragraph") {
@@ -96,7 +97,14 @@ export function toProseDoc(
       if (pbPos === "before") {
         nodes.push(schema.node("pageBreak"));
       }
-      nodes.push(...convertParagraphWithTextBoxes(block, styleResolver));
+      nodes.push(
+        ...convertParagraphWithTextBoxes(
+          block,
+          styleResolver,
+          String(textBoxGroupIndex),
+        ),
+      );
+      textBoxGroupIndex += 1;
       if (pbPos === "after") {
         nodes.push(schema.node("pageBreak"));
       }
@@ -2157,6 +2165,7 @@ function convertShape(shape: Shape): PMNode {
 function convertParagraphWithTextBoxes(
   block: Paragraph,
   styleResolver: StyleResolver | null,
+  textBoxGroupId: string,
 ): PMNode[] {
   const textBoxes = extractTextBoxesFromParagraph(block);
   const pmParagraph = convertParagraph(block, styleResolver);
@@ -2167,7 +2176,12 @@ function convertParagraphWithTextBoxes(
     nodes.push(pmParagraph);
   }
   for (const tb of textBoxes) {
-    nodes.push(convertTextBox(tb, styleResolver));
+    nodes.push(
+      convertTextBox(tb, styleResolver, {
+        placement: isEmptyAfterExtraction ? "standalone" : "inlineWithPrevious",
+        groupId: textBoxGroupId,
+      }),
+    );
   }
   return nodes;
 }
@@ -2224,6 +2238,10 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
 function convertTextBox(
   textBox: TextBox,
   styleResolver: StyleResolver | null,
+  options: {
+    placement?: "standalone" | "inlineWithPrevious";
+    groupId?: string;
+  } = {},
 ): PMNode {
   const textBoxData: { size?: Partial<TextBox["size"]> } = textBox;
   const textBoxSize = textBoxData.size;
@@ -2290,6 +2308,8 @@ function convertTextBox(
       marginBottom,
       marginLeft,
       marginRight,
+      _docxPlacement: options.placement,
+      _docxGroupId: options.groupId,
     },
     contentNodes,
   );
@@ -2312,10 +2332,18 @@ export function headerFooterToProseDoc(
     ? createStyleResolver(options.styles)
     : null;
   const theme = options?.theme ?? null;
+  let textBoxGroupIndex = 0;
 
   for (const block of content) {
     if (block.type === "paragraph") {
-      nodes.push(...convertParagraphWithTextBoxes(block, styleResolver));
+      nodes.push(
+        ...convertParagraphWithTextBoxes(
+          block,
+          styleResolver,
+          String(textBoxGroupIndex),
+        ),
+      );
+      textBoxGroupIndex += 1;
     } else {
       nodes.push(convertTable(block, styleResolver, theme));
     }

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -146,6 +146,7 @@ function convertParagraph(
   let emptyHyperlinks:
     | NonNullable<ParagraphAttrs["_emptyHyperlinks"]>
     | undefined;
+  let hyperlinkIndex = 0;
 
   // Track active comment ranges for this paragraph
   const commentIds = activeCommentIds ?? new Set<number>();
@@ -224,10 +225,13 @@ function convertParagraph(
         ),
       );
     } else if (content.type === "hyperlink") {
+      const currentHyperlinkIndex = hyperlinkIndex;
+      hyperlinkIndex += 1;
       const linkNodes = convertHyperlink(
         content,
         getInheritedRunFormatting,
         styleResolver,
+        currentHyperlinkIndex,
       );
       if (linkNodes.length === 0) {
         emptyHyperlinks ??= [];
@@ -336,6 +340,7 @@ function convertTrackedChange(
   moveKind: "moveFrom" | "moveTo" | null = null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
+  let hyperlinkIndex = 0;
   for (const item of change.content) {
     if (item.type === "run") {
       nodes.push(
@@ -346,8 +351,15 @@ function convertTrackedChange(
         ),
       );
     } else {
+      const currentHyperlinkIndex = hyperlinkIndex;
+      hyperlinkIndex += 1;
       nodes.push(
-        ...convertHyperlink(item, getInheritedRunFormatting, styleResolver),
+        ...convertHyperlink(
+          item,
+          getInheritedRunFormatting,
+          styleResolver,
+          currentHyperlinkIndex,
+        ),
       );
     }
   }
@@ -1556,6 +1568,7 @@ function convertInlineSdt(
 ): PMNode | null {
   const props = sdt.properties;
   const inlineNodes: PMNode[] = [];
+  let hyperlinkIndex = 0;
 
   for (const content of sdt.content) {
     if (content.type === "run") {
@@ -1566,10 +1579,13 @@ function convertInlineSdt(
       );
       inlineNodes.push(...runNodes);
     } else {
+      const currentHyperlinkIndex = hyperlinkIndex;
+      hyperlinkIndex += 1;
       const linkNodes = convertHyperlink(
         content,
         getInheritedRunFormatting,
         styleResolver,
+        currentHyperlinkIndex,
       );
       inlineNodes.push(...linkNodes);
     }
@@ -1931,6 +1947,7 @@ function convertHyperlink(
   hyperlink: Hyperlink,
   getInheritedRunFormatting: RunFormattingResolver,
   styleResolver?: StyleResolver | null,
+  hyperlinkIndex?: number,
 ): PMNode[] {
   const nodes: PMNode[] = [];
 
@@ -1941,6 +1958,7 @@ function convertHyperlink(
     href,
     tooltip: hyperlink.tooltip,
     rId: hyperlink.rId,
+    _docxHyperlinkIndex: hyperlinkIndex,
   });
 
   for (const child of hyperlink.children) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1585,7 +1585,10 @@ function convertRunContent(
       if (content.breakType === "textWrapping" || !content.breakType) {
         return [schema.node("hardBreak")];
       }
-      // Page breaks not supported in inline content
+      if (content.breakType === "column") {
+        return [schema.node("hardBreak", { breakType: "column" })];
+      }
+      // Page breaks are represented as block separators by paragraphPageBreakPosition.
       return [];
 
     case "tab":
@@ -2172,18 +2175,27 @@ function convertParagraphWithTextBoxes(
   const nodes: PMNode[] = [];
   const isEmptyAfterExtraction =
     textBoxes.length > 0 && pmParagraph.content.size === 0;
-  if (!isEmptyAfterExtraction) {
+  const keepWrapperParagraph =
+    isEmptyAfterExtraction && hasParagraphBoundaryPayload(block);
+  if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
   for (const tb of textBoxes) {
     nodes.push(
       convertTextBox(tb, styleResolver, {
-        placement: isEmptyAfterExtraction ? "standalone" : "inlineWithPrevious",
+        placement:
+          isEmptyAfterExtraction && !keepWrapperParagraph
+            ? "standalone"
+            : "inlineWithPrevious",
         groupId: textBoxGroupId,
       }),
     );
   }
   return nodes;
+}
+
+function hasParagraphBoundaryPayload(block: Paragraph): boolean {
+  return Boolean(block.sectionProperties || block.propertyChanges?.length);
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1755,7 +1755,7 @@ function convertRunContent(
       // Shapes with text body are handled as text boxes at block level
       // Other shapes render as inline SVG
       const shp = content.shape;
-      if (shp.textBody && shp.textBody.content.length > 0) {
+      if (shp.textBody) {
         // Skip - handled by extractTextBoxesFromParagraph
         return [];
       }
@@ -2387,7 +2387,7 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
       for (const rc of content.content) {
         if (rc.type === "shape") {
           const shape = rc.shape as Shape;
-          if (shape.textBody && shape.textBody.content.length > 0) {
+          if (shape.textBody) {
             // Convert shape with text body to TextBox
             const textBox: TextBox = {
               type: "textBox",

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -54,6 +54,7 @@ import type {
 } from "../schema/nodes";
 import { createStyleResolver } from "../styles";
 import type { StyleResolver } from "../styles";
+import { assertValidProseMirrorDocument } from "../validation";
 
 /**
  * Options for document conversion
@@ -110,7 +111,12 @@ export function toProseDoc(
     nodes.push(schema.node("paragraph", {}, []));
   }
 
-  return schema.node("doc", null, nodes);
+  const pmDoc = schema.node("doc", null, nodes);
+  assertValidProseMirrorDocument(
+    pmDoc,
+    "Document conversion produced an invalid ProseMirror document",
+  );
+  return pmDoc;
 }
 
 /**
@@ -2319,7 +2325,12 @@ export function headerFooterToProseDoc(
     nodes.push(schema.node("paragraph", {}, []));
   }
 
-  return schema.node("doc", null, nodes);
+  const pmDoc = schema.node("doc", null, nodes);
+  assertValidProseMirrorDocument(
+    pmDoc,
+    "Header/footer conversion produced an invalid ProseMirror document",
+  );
+  return pmDoc;
 }
 
 export function footnoteToProseDoc(

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -141,7 +141,11 @@ function convertParagraph(
 ): PMNode {
   const attrs = paragraphFormattingToAttrs(paragraph, styleResolver);
   const inlineNodes: PMNode[] = [];
+  let inlineOffset = 0;
   let bookmarksArr: { id: number; name: string }[] | undefined;
+  let emptyHyperlinks:
+    | NonNullable<ParagraphAttrs["_emptyHyperlinks"]>
+    | undefined;
 
   // Track active comment ranges for this paragraph
   const commentIds = activeCommentIds ?? new Set<number>();
@@ -149,7 +153,11 @@ function convertParagraph(
     if (nodes.length === 0) {
       return;
     }
-    inlineNodes.push(...applyCommentMarks(nodes, commentIds));
+    const markedNodes = applyCommentMarks(nodes, commentIds);
+    inlineNodes.push(...markedNodes);
+    for (const node of markedNodes) {
+      inlineOffset += node.nodeSize;
+    }
   };
   const emitInlineNode = (node: PMNode | null): void => {
     if (!node) {
@@ -216,9 +224,25 @@ function convertParagraph(
         ),
       );
     } else if (content.type === "hyperlink") {
-      emitInlineNodes(
-        convertHyperlink(content, getInheritedRunFormatting, styleResolver),
+      const linkNodes = convertHyperlink(
+        content,
+        getInheritedRunFormatting,
+        styleResolver,
       );
+      if (linkNodes.length === 0) {
+        emptyHyperlinks ??= [];
+        emptyHyperlinks.push({
+          offset: inlineOffset,
+          ...(content.href !== undefined ? { href: content.href } : {}),
+          ...(content.anchor !== undefined ? { anchor: content.anchor } : {}),
+          ...(content.tooltip !== undefined
+            ? { tooltip: content.tooltip }
+            : {}),
+          ...(content.rId !== undefined ? { rId: content.rId } : {}),
+        });
+        continue;
+      }
+      emitInlineNodes(linkNodes);
     } else if (
       content.type === "simpleField" ||
       content.type === "complexField"
@@ -254,6 +278,9 @@ function convertParagraph(
 
   if (bookmarksArr) {
     attrs.bookmarks = bookmarksArr;
+  }
+  if (emptyHyperlinks) {
+    attrs._emptyHyperlinks = emptyHyperlinks;
   }
 
   return schema.node("paragraph", attrs, inlineNodes);
@@ -759,15 +786,22 @@ function calculateRowSpans(
         activeMerges.set(colIndex, rowIndex);
         result.set(key, { rowSpan: 1, skip: false });
       } else if (vMerge === "continue") {
-        // Continuation of a merge - this cell should be skipped
+        // Continuation of a merge - only skip it when the parsed grid has a
+        // matching restart in this exact column. Real DOCX tables can be
+        // ragged, and treating an unmatched continuation as merged-away drops
+        // its placeholder paragraph and cell metadata.
         const startRow = activeMerges.get(colIndex);
-        if (startRow !== undefined) {
-          // Increment rowSpan of the starting cell
-          const startKey = `${startRow}-${colIndex}`;
-          const startCell = result.get(startKey);
-          if (startCell) {
-            startCell.rowSpan++;
-          }
+        if (startRow === undefined) {
+          result.set(key, { rowSpan: 1, skip: false });
+          colIndex += colspan;
+          continue;
+        }
+
+        // Increment rowSpan of the starting cell
+        const startKey = `${startRow}-${colIndex}`;
+        const startCell = result.get(startKey);
+        if (startCell) {
+          startCell.rowSpan++;
         }
         result.set(key, { rowSpan: 1, skip: true });
       } else {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2238,7 +2238,7 @@ function convertParagraphWithTextBoxes(
   const isEmptyAfterExtraction =
     textBoxes.length > 0 && pmParagraph.content.size === 0;
   const keepWrapperParagraph =
-    isEmptyAfterExtraction && hasParagraphBoundaryPayload(block);
+    isEmptyAfterExtraction && hasParagraphBoundaryPayload(block, pmParagraph);
   if (!isEmptyAfterExtraction || keepWrapperParagraph) {
     nodes.push(pmParagraph);
   }
@@ -2256,8 +2256,18 @@ function convertParagraphWithTextBoxes(
   return nodes;
 }
 
-function hasParagraphBoundaryPayload(block: Paragraph): boolean {
-  return Boolean(block.sectionProperties || block.propertyChanges?.length);
+function hasParagraphBoundaryPayload(
+  block: Paragraph,
+  pmParagraph: PMNode,
+): boolean {
+  const bookmarks = pmParagraph.attrs["bookmarks"];
+  const emptyHyperlinks = pmParagraph.attrs["_emptyHyperlinks"];
+  return Boolean(
+    block.sectionProperties ||
+    block.propertyChanges?.length ||
+    (Array.isArray(bookmarks) && bookmarks.length > 0) ||
+    (Array.isArray(emptyHyperlinks) && emptyHyperlinks.length > 0),
+  );
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -760,10 +760,14 @@ function resolveParagraphDefaultTextFormatting(
  * OOXML uses vMerge="restart" to start a vertical merge and vMerge="continue" for cells that should be merged.
  * This function converts that to rowSpan values and marks which cells should be skipped.
  */
-function calculateRowSpans(
-  table: Table,
-): Map<string, { rowSpan: number; skip: boolean }> {
-  const result = new Map<string, { rowSpan: number; skip: boolean }>();
+type RowSpanInfo = {
+  rowSpan: number;
+  skip: boolean;
+  preserveVMergeRestart?: boolean;
+};
+
+function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
+  const result = new Map<string, RowSpanInfo>();
   const numRows = table.rows.length;
 
   // Track active vertical merges per column (stores the row index where merge started)
@@ -774,31 +778,51 @@ function calculateRowSpans(
     // SAFETY: rowIndex < numRows <= table.rows.length
     const row = table.rows[rowIndex]!;
     let colIndex = 0;
-
-    for (const cellIndex_item of row.cells) {
-      const cell = cellIndex_item;
+    const rowCells = row.cells.map((cell) => {
       const colspan = cell.formatting?.gridSpan ?? 1;
       const vMerge = cell.formatting?.vMerge;
-      const key = `${rowIndex}-${colIndex}`;
+      const startRow =
+        vMerge === "continue" ? activeMerges.get(colIndex) : undefined;
+      const info = {
+        colIndex,
+        colspan,
+        vMerge,
+        startRow,
+        shouldSkip: vMerge === "continue" && startRow !== undefined,
+      };
+      colIndex += colspan;
+      return info;
+    });
+    const rowWouldBeEmpty =
+      rowCells.length > 0 && rowCells.every((cell) => cell.shouldSkip);
+
+    for (const cellInfo of rowCells) {
+      const { colIndex: cellColIndex, vMerge, startRow } = cellInfo;
+      const key = `${rowIndex}-${cellColIndex}`;
 
       if (vMerge === "restart") {
         // Start of a new vertical merge
-        activeMerges.set(colIndex, rowIndex);
+        activeMerges.set(cellColIndex, rowIndex);
         result.set(key, { rowSpan: 1, skip: false });
       } else if (vMerge === "continue") {
         // Continuation of a merge - only skip it when the parsed grid has a
         // matching restart in this exact column. Real DOCX tables can be
         // ragged, and treating an unmatched continuation as merged-away drops
         // its placeholder paragraph and cell metadata.
-        const startRow = activeMerges.get(colIndex);
-        if (startRow === undefined) {
+        if (startRow === undefined || rowWouldBeEmpty) {
           result.set(key, { rowSpan: 1, skip: false });
-          colIndex += colspan;
+          if (rowWouldBeEmpty && startRow !== undefined) {
+            const restartCell = result.get(`${startRow}-${cellColIndex}`);
+            if (restartCell) {
+              restartCell.preserveVMergeRestart = true;
+            }
+            activeMerges.delete(cellColIndex);
+          }
           continue;
         }
 
         // Increment rowSpan of the starting cell
-        const startKey = `${startRow}-${colIndex}`;
+        const startKey = `${startRow}-${cellColIndex}`;
         const startCell = result.get(startKey);
         if (startCell) {
           startCell.rowSpan++;
@@ -806,11 +830,9 @@ function calculateRowSpans(
         result.set(key, { rowSpan: 1, skip: true });
       } else {
         // No vMerge - clear any active merge for this column
-        activeMerges.delete(colIndex);
+        activeMerges.delete(cellColIndex);
         result.set(key, { rowSpan: 1, skip: false });
       }
-
-      colIndex += colspan;
     }
   }
 
@@ -1037,7 +1059,7 @@ function convertTableRow(
   rowIndex?: number,
   totalRows?: number,
   totalColumns?: number,
-  rowSpanMap?: Map<string, { rowSpan: number; skip: boolean }>,
+  rowSpanMap?: Map<string, RowSpanInfo>,
   defaultCellMargins?: {
     top?: number;
     bottom?: number;
@@ -1083,6 +1105,7 @@ function convertTableRow(
     const rowSpanInfo = rowSpanMap?.get(rowSpanKey);
     const shouldSkip = rowSpanInfo?.skip ?? false;
     const calculatedRowSpan = rowSpanInfo?.rowSpan ?? 1;
+    const preserveVMergeRestart = rowSpanInfo?.preserveVMergeRestart ?? false;
 
     // Calculate the width for this cell from columnWidths if cell doesn't have own width
     let gridWidth: number | undefined;
@@ -1252,6 +1275,7 @@ function convertTableRow(
         isFirstCol,
         isLastCol,
         calculatedRowSpan,
+        preserveVMergeRestart,
         defaultCellMargins,
         theme,
       ),
@@ -1312,6 +1336,7 @@ function convertTableCell(
   isFirstCol?: boolean,
   isLastCol?: boolean,
   calculatedRowSpan?: number,
+  preserveVMergeRestart?: boolean,
   defaultCellMargins?: {
     top?: number;
     bottom?: number;
@@ -1426,6 +1451,9 @@ function convertTableCell(
   }
   if (formatting) {
     attrs._originalFormatting = formatting;
+  }
+  if (preserveVMergeRestart) {
+    attrs._preserveVMergeRestart = true;
   }
 
   // Convert cell content (paragraphs and nested tables)

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1661,20 +1661,25 @@ function convertRunContent(
 
     case "break":
       if (content.breakType === "textWrapping" || !content.breakType) {
-        return [schema.node("hardBreak")];
+        return [withHyperlinkBoundaryMarks(schema.node("hardBreak"), marks)];
       }
       if (content.breakType === "column") {
-        return [schema.node("hardBreak", { breakType: "column" })];
+        return [
+          withHyperlinkBoundaryMarks(
+            schema.node("hardBreak", { breakType: "column" }),
+            marks,
+          ),
+        ];
       }
       // Page breaks are represented as block separators by paragraphPageBreakPosition.
       return [];
 
     case "tab":
       // Convert to tab node for proper rendering
-      return [schema.node("tab")];
+      return [withHyperlinkBoundaryMarks(schema.node("tab"), marks)];
 
     case "drawing":
-      return [convertImage(content.image)];
+      return [withHyperlinkBoundaryMarks(convertImage(content.image), marks)];
 
     case "shape": {
       // Shapes with text body are handled as text boxes at block level
@@ -1684,7 +1689,7 @@ function convertRunContent(
         // Skip - handled by extractTextBoxesFromParagraph
         return [];
       }
-      return [convertShape(shp)];
+      return [withHyperlinkBoundaryMarks(convertShape(shp), marks)];
     }
 
     case "footnoteRef": {
@@ -1722,6 +1727,17 @@ function convertRunContent(
       // character is available; otherwise drop.
       return content.char ? [schema.text(content.char, marks)] : [];
   }
+}
+
+function withHyperlinkBoundaryMarks(
+  node: PMNode,
+  marks: ReturnType<typeof schema.mark>[],
+): PMNode {
+  if (!marks.some((mark) => mark.type.name === "hyperlink")) {
+    return node;
+  }
+
+  return node.mark(marks);
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -788,6 +788,7 @@ type RowSpanInfo = {
   rowSpan: number;
   skip: boolean;
   preserveVMergeRestart?: boolean;
+  continuationCells?: TableCell[];
 };
 
 function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
@@ -808,6 +809,7 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
       const startRow =
         vMerge === "continue" ? activeMerges.get(colIndex) : undefined;
       const info = {
+        cell,
         colIndex,
         colspan,
         vMerge,
@@ -860,6 +862,8 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
         const startCell = result.get(startKey);
         if (startCell) {
           startCell.rowSpan++;
+          startCell.continuationCells ??= [];
+          startCell.continuationCells.push(cellInfo.cell);
         }
         result.set(key, { rowSpan: 1, skip: true });
       } else {
@@ -1344,6 +1348,7 @@ function convertTableRow(
         isLastCol,
         calculatedRowSpan,
         preserveVMergeRestart,
+        rowSpanInfo?.continuationCells,
         defaultCellMargins,
         theme,
       ),
@@ -1405,6 +1410,7 @@ function convertTableCell(
   isLastCol?: boolean,
   calculatedRowSpan?: number,
   preserveVMergeRestart?: boolean,
+  vMergeContinuationCells?: TableCell[],
   defaultCellMargins?: {
     top?: number;
     bottom?: number;
@@ -1522,6 +1528,9 @@ function convertTableCell(
   }
   if (preserveVMergeRestart) {
     attrs._preserveVMergeRestart = true;
+  }
+  if (vMergeContinuationCells && vMergeContinuationCells.length > 0) {
+    attrs._docxVMergeContinuationCells = vMergeContinuationCells;
   }
 
   // Convert cell content (paragraphs and nested tables)

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -12,7 +12,7 @@
  * - Inline properties (highest priority)
  */
 
-import type { Node as PMNode } from "prosemirror-model";
+import type { MarkType, Node as PMNode } from "prosemirror-model";
 
 import type {
   Document,
@@ -373,11 +373,23 @@ function convertTrackedChange(
   });
 
   return nodes.map((node) => {
-    if (node.isText) {
+    if (canCarryTrackedRunMark(node, mark.type)) {
       return node.mark(mark.addToSet(node.marks));
     }
     return node;
   });
+}
+
+function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
+  return (
+    node.isText ||
+    (node.isInline &&
+      node.type.allowsMarkType(markType) &&
+      (node.type.name === "image" ||
+        node.type.name === "shape" ||
+        node.type.name === "hardBreak" ||
+        node.type.name === "tab"))
+  );
 }
 
 /**
@@ -800,6 +812,7 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
         colspan,
         vMerge,
         startRow,
+        hasMeaningfulContent: tableCellHasMeaningfulContent(cell),
         shouldSkip: vMerge === "continue" && startRow !== undefined,
       };
       colIndex += colspan;
@@ -809,7 +822,12 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
       rowCells.length > 0 && rowCells.every((cell) => cell.shouldSkip);
 
     for (const cellInfo of rowCells) {
-      const { colIndex: cellColIndex, vMerge, startRow } = cellInfo;
+      const {
+        colIndex: cellColIndex,
+        vMerge,
+        startRow,
+        hasMeaningfulContent,
+      } = cellInfo;
       const key = `${rowIndex}-${cellColIndex}`;
 
       if (vMerge === "restart") {
@@ -818,12 +836,16 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
         result.set(key, { rowSpan: 1, skip: false });
       } else if (vMerge === "continue") {
         // Continuation of a merge - only skip it when the parsed grid has a
-        // matching restart in this exact column. Real DOCX tables can be
-        // ragged, and treating an unmatched continuation as merged-away drops
-        // its placeholder paragraph and cell metadata.
-        if (startRow === undefined || rowWouldBeEmpty) {
+        // matching restart in this exact column and the continuation is only a
+        // structural placeholder. Real DOCX tables can be ragged, and some
+        // continuation cells contain drawings or other payload that must not be
+        // merged away.
+        if (startRow === undefined || rowWouldBeEmpty || hasMeaningfulContent) {
           result.set(key, { rowSpan: 1, skip: false });
-          if (rowWouldBeEmpty && startRow !== undefined) {
+          if (
+            (rowWouldBeEmpty || hasMeaningfulContent) &&
+            startRow !== undefined
+          ) {
             const restartCell = result.get(`${startRow}-${cellColIndex}`);
             if (restartCell) {
               restartCell.preserveVMergeRestart = true;
@@ -849,6 +871,40 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
   }
 
   return result;
+}
+
+function tableCellHasMeaningfulContent(cell: TableCell): boolean {
+  return cell.content.some(blockHasMeaningfulContent);
+}
+
+function blockHasMeaningfulContent(block: Paragraph | Table): boolean {
+  if (block.type === "table") {
+    return block.rows.some((row) =>
+      row.cells.some((cell) => tableCellHasMeaningfulContent(cell)),
+    );
+  }
+
+  return block.content.some(paragraphContentHasMeaningfulContent);
+}
+
+function paragraphContentHasMeaningfulContent(
+  content: Paragraph["content"][number],
+): boolean {
+  if (content.type === "run") {
+    return content.content.length > 0;
+  }
+  if (content.type === "hyperlink") {
+    return content.children.some(paragraphContentHasMeaningfulContent);
+  }
+  if (
+    content.type === "insertion" ||
+    content.type === "deletion" ||
+    content.type === "moveFrom" ||
+    content.type === "moveTo"
+  ) {
+    return content.content.some(paragraphContentHasMeaningfulContent);
+  }
+  return true;
 }
 
 function convertTable(
@@ -1679,7 +1735,12 @@ function convertRunContent(
       return [withHyperlinkBoundaryMarks(schema.node("tab"), marks)];
 
     case "drawing":
-      return [withHyperlinkBoundaryMarks(convertImage(content.image), marks)];
+      return [
+        withHyperlinkBoundaryMarks(
+          convertImage(content.image, content.rawXml),
+          marks,
+        ),
+      ];
 
     case "shape": {
       // Shapes with text body are handled as text boxes at block level
@@ -1760,7 +1821,7 @@ function withHyperlinkBoundaryMarks(
 type PartialImagePosition = Partial<NonNullable<Image["position"]>>;
 type PartialImageSize = Partial<Image["size"]>;
 
-function convertImage(image: Image): PMNode {
+function convertImage(image: Image, rawXml?: string): PMNode {
   // Convert EMU to pixels for proper sizing
   const imageData: { size?: PartialImageSize } = image;
   const imageSize = imageData.size;
@@ -1950,6 +2011,7 @@ function convertImage(image: Image): PMNode {
     borderStyle,
     wrapText,
     hlinkHref: image.hlinkHref,
+    _docxRawXml: rawXml,
   });
 }
 

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -22,6 +22,7 @@ import type {
 } from "../../../types/document";
 import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
+import { expectParagraphAttrs } from "../../attrs";
 import type { ParagraphAttrs } from "../../schema/nodes";
 import { createNodeExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
@@ -420,7 +421,7 @@ const paragraphNodeSpec: NodeSpec = {
     })),
   ],
   toDOM(node) {
-    const attrs = node.attrs as ParagraphAttrs;
+    const attrs = expectParagraphAttrs(node);
     const style = paragraphAttrsToDOMStyle(attrs);
     const listClass = getListClass(
       attrs.numPr,

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -359,6 +359,7 @@ const paragraphNodeSpec: NodeSpec = {
     bidi: { default: null },
     outlineLevel: { default: null },
     bookmarks: { default: null },
+    _emptyHyperlinks: { default: null },
     _originalFormatting: { default: null },
     _sectionProperties: { default: null },
     _propertyChanges: { default: null },

--- a/packages/folio/src/core/prosemirror/extensions/marks/CharacterSpacingExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/CharacterSpacingExtension.ts
@@ -8,6 +8,7 @@
  */
 
 import { twipsToPixels, formatPx } from "../../../utils/units";
+import { expectCharacterSpacingMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
 function halfPointsToPixels(halfPoints: number): number {
@@ -42,45 +43,32 @@ export const CharacterSpacingExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: CharacterSpacing attrs always match this shape per schema
-      const spacing =
-        typeof mark.attrs["spacing"] === "number"
-          ? mark.attrs["spacing"]
-          : null;
-      const position =
-        typeof mark.attrs["position"] === "number"
-          ? mark.attrs["position"]
-          : null;
-      const scale =
-        typeof mark.attrs["scale"] === "number" ? mark.attrs["scale"] : null;
-      const kerning =
-        typeof mark.attrs["kerning"] === "number"
-          ? mark.attrs["kerning"]
-          : null;
+      const { spacing, position, scale, kerning } =
+        expectCharacterSpacingMarkAttrs(mark);
 
       const styles: string[] = [];
       const dataAttrs: Record<string, string> = {
         class: "docx-char-spacing",
       };
 
-      if (spacing !== null && spacing !== 0) {
+      if (spacing !== undefined && spacing !== 0) {
         styles.push(`letter-spacing: ${formatPx(twipsToPixels(spacing))}`);
         dataAttrs["data-spacing"] = String(spacing);
       }
 
-      if (position !== null && position !== 0) {
+      if (position !== undefined && position !== 0) {
         const px = halfPointsToPixels(position);
         styles.push(`vertical-align: ${formatPx(px)}`);
         dataAttrs["data-position"] = String(position);
       }
 
-      if (scale !== null && scale !== 100) {
+      if (scale !== undefined && scale !== 100) {
         styles.push(`transform: scaleX(${scale / 100})`);
         styles.push("display: inline-block");
         dataAttrs["data-scale"] = String(scale);
       }
 
-      if (kerning !== null) {
+      if (kerning !== undefined) {
         dataAttrs["data-kerning"] = String(kerning);
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/marks/CommentExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/CommentExtension.ts
@@ -5,6 +5,7 @@
  * The comment ID links to the Comment object in the document model.
  */
 
+import { expectCommentMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
 export const CommentExtension = createMarkExtension({
@@ -27,11 +28,12 @@ export const CommentExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
+      const { commentId } = expectCommentMarkAttrs(mark);
       return [
         "span",
         {
           class: "docx-comment",
-          "data-comment-id": String(mark.attrs["commentId"]),
+          "data-comment-id": String(commentId),
           style:
             "background-color: var(--doc-comment-bg, rgba(255, 212, 0, 0.08)); border-bottom: 1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24));",
         },

--- a/packages/folio/src/core/prosemirror/extensions/marks/FontFamilyExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FontFamilyExtension.ts
@@ -4,6 +4,7 @@
 
 import { panic } from "better-result";
 
+import { expectFontFamilyMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { setMark, removeMark } from "./markUtils";
@@ -38,15 +39,7 @@ export const FontFamilyExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: fontFamily mark attrs always have ascii/hAnsi per schema
-      const ascii =
-        typeof mark.attrs["ascii"] === "string"
-          ? mark.attrs["ascii"]
-          : undefined;
-      const hAnsi =
-        typeof mark.attrs["hAnsi"] === "string"
-          ? mark.attrs["hAnsi"]
-          : undefined;
+      const { ascii, hAnsi } = expectFontFamilyMarkAttrs(mark);
       const fontName = ascii ?? hAnsi;
       if (!fontName) {
         return ["span", 0];

--- a/packages/folio/src/core/prosemirror/extensions/marks/FontSizeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FontSizeExtension.ts
@@ -4,6 +4,7 @@
 
 import { panic } from "better-result";
 
+import { expectFontSizeMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { setMark, removeMark } from "./markUtils";
@@ -38,8 +39,7 @@ export const FontSizeExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: mark.attrs.size is always a number per the attrs spec above
-      const size = Number(mark.attrs["size"]);
+      const { size } = expectFontSizeMarkAttrs(mark);
       const pt = size / 2;
       const lineHeight = (pt * 1.15).toFixed(2);
       return [

--- a/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/FootnoteRefExtension.ts
@@ -7,6 +7,7 @@
 import { panic } from "better-result";
 import type { Command } from "prosemirror-state";
 
+import { expectFootnoteRefMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
@@ -28,9 +29,9 @@ export const FootnoteRefExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: FootnoteRef attrs always have id/noteType per schema
-      const id = String(mark.attrs["id"]);
-      const noteType = String(mark.attrs["noteType"]);
+      const attrs = expectFootnoteRefMarkAttrs(mark);
+      const id = String(attrs.id);
+      const noteType = attrs.noteType ?? "footnote";
       return [
         "sup",
         {

--- a/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
@@ -5,6 +5,7 @@
 import { panic } from "better-result";
 
 import { resolveHighlightToCss } from "../../../utils/colorResolver";
+import { expectHighlightMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { setMark, removeMark } from "./markUtils";
@@ -31,8 +32,7 @@ export const HighlightExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: mark.attrs.color is always a string per the attrs spec above
-      const color = String(mark.attrs["color"]);
+      const { color } = expectHighlightMarkAttrs(mark);
       // Resolve OOXML named highlight color (e.g., 'yellow' → '#FFFF00')
       const cssColor = resolveHighlightToCss(color);
       return ["mark", { style: `background-color: ${cssColor}` }, 0];

--- a/packages/folio/src/core/prosemirror/extensions/marks/HyperlinkExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HyperlinkExtension.ts
@@ -5,6 +5,7 @@
 import { panic } from "better-result";
 import type { Command, EditorState } from "prosemirror-state";
 
+import { expectHyperlinkMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { isMarkActive } from "./markUtils";
@@ -35,12 +36,7 @@ export function getHyperlinkAttrs(
     const marks = state.storedMarks ?? $from.marks();
     for (const mark of marks) {
       if (mark.type === hlType) {
-        // SAFETY: HyperlinkAttrs always has href/tooltip per schema
-        const href = String(mark.attrs["href"]);
-        const tooltip =
-          mark.attrs["tooltip"] !== null
-            ? String(mark.attrs["tooltip"])
-            : undefined;
+        const { href, tooltip } = expectHyperlinkMarkAttrs(mark);
         return { href, ...(tooltip !== undefined ? { tooltip } : {}) };
       }
     }
@@ -52,12 +48,7 @@ export function getHyperlinkAttrs(
     if (node.isText && attrs === null) {
       const mark = hlType.isInSet(node.marks);
       if (mark) {
-        // SAFETY: HyperlinkAttrs always has href/tooltip per schema
-        const href = String(mark.attrs["href"]);
-        const tooltip =
-          mark.attrs["tooltip"] !== null
-            ? String(mark.attrs["tooltip"])
-            : undefined;
+        const { href, tooltip } = expectHyperlinkMarkAttrs(mark);
         attrs = { href, ...(tooltip !== undefined ? { tooltip } : {}) };
         return false;
       }
@@ -101,10 +92,7 @@ export const HyperlinkExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: HyperlinkAttrs always has href/tooltip per schema
-      const href = String(mark.attrs["href"]);
-      const tooltip =
-        mark.attrs["tooltip"] !== null ? String(mark.attrs["tooltip"]) : null;
+      const { href, tooltip } = expectHyperlinkMarkAttrs(mark);
       const domAttrs: Record<string, string> = {
         href,
         target: "_blank",

--- a/packages/folio/src/core/prosemirror/extensions/marks/HyperlinkExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HyperlinkExtension.ts
@@ -79,6 +79,7 @@ export const HyperlinkExtension = createMarkExtension({
       href: {},
       tooltip: { default: null },
       rId: { default: null },
+      _docxHyperlinkIndex: { default: null },
     },
     inclusive: false,
     parseDOM: [

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
@@ -9,6 +9,7 @@
 import type { Mark } from "prosemirror-model";
 
 import type { TextFormatting } from "../../../types/document";
+import { expectRunFormattingOverrideMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
 type RunFormattingOverrideAttrs = Record<string, false | "none">;
@@ -66,40 +67,41 @@ export function applyRunFormattingOverrideMark(
   formatting: TextFormatting,
   mark: Mark,
 ): void {
-  if (mark.attrs["bold"] === false) {
+  const attrs = expectRunFormattingOverrideMarkAttrs(mark);
+  if (attrs.bold === false) {
     formatting.bold = false;
   }
-  if (mark.attrs["italic"] === false) {
+  if (attrs.italic === false) {
     formatting.italic = false;
   }
-  if (mark.attrs["underline"] === "none") {
+  if (attrs.underline === "none") {
     formatting.underline = { style: "none" };
   }
-  if (mark.attrs["strike"] === false) {
+  if (attrs.strike === false) {
     formatting.strike = false;
   }
-  if (mark.attrs["doubleStrike"] === false) {
+  if (attrs.doubleStrike === false) {
     formatting.doubleStrike = false;
   }
-  if (mark.attrs["allCaps"] === false) {
+  if (attrs.allCaps === false) {
     formatting.allCaps = false;
   }
-  if (mark.attrs["smallCaps"] === false) {
+  if (attrs.smallCaps === false) {
     formatting.smallCaps = false;
   }
-  if (mark.attrs["hidden"] === false) {
+  if (attrs.hidden === false) {
     formatting.hidden = false;
   }
-  if (mark.attrs["emboss"] === false) {
+  if (attrs.emboss === false) {
     formatting.emboss = false;
   }
-  if (mark.attrs["imprint"] === false) {
+  if (attrs.imprint === false) {
     formatting.imprint = false;
   }
-  if (mark.attrs["shadow"] === false) {
+  if (attrs.shadow === false) {
     formatting.shadow = false;
   }
-  if (mark.attrs["outline"] === false) {
+  if (attrs.outline === false) {
     formatting.outline = false;
   }
 }
@@ -123,27 +125,25 @@ export const RunFormattingOverrideExtension = createMarkExtension({
       outline: { default: null },
     },
     toDOM(mark) {
+      const attrs = expectRunFormattingOverrideMarkAttrs(mark);
       const styles: string[] = [];
 
-      if (mark.attrs["bold"] === false) {
+      if (attrs.bold === false) {
         styles.push("font-weight: normal");
       }
-      if (mark.attrs["italic"] === false) {
+      if (attrs.italic === false) {
         styles.push("font-style: normal");
       }
-      if (
-        mark.attrs["underline"] === "none" ||
-        mark.attrs["strike"] === false
-      ) {
+      if (attrs.underline === "none" || attrs.strike === false) {
         styles.push("text-decoration: none");
       }
-      if (mark.attrs["allCaps"] === false) {
+      if (attrs.allCaps === false) {
         styles.push("text-transform: none");
       }
-      if (mark.attrs["smallCaps"] === false) {
+      if (attrs.smallCaps === false) {
         styles.push("font-variant-caps: normal");
       }
-      if (mark.attrs["hidden"] === false) {
+      if (attrs.hidden === false) {
         styles.push("visibility: visible");
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/marks/TextColorExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TextColorExtension.ts
@@ -4,8 +4,8 @@
 
 import { panic } from "better-result";
 
-import type { ThemeColorSlot } from "../../../types/document";
 import { textToStyle } from "../../../utils/formatToStyle";
+import { expectTextColorMarkAttrs } from "../../attrs";
 import type { TextColorAttrs } from "../../schema/marks";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
@@ -35,28 +35,7 @@ export const TextColorExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: textColor mark attrs always match TextColorAttrs shape per schema;
-      // themeColor is a valid ThemeColorSlot string when present
-      const rgb =
-        typeof mark.attrs["rgb"] === "string" ? mark.attrs["rgb"] : undefined;
-      const themeColor =
-        typeof mark.attrs["themeColor"] === "string"
-          ? (mark.attrs["themeColor"] as ThemeColorSlot)
-          : undefined;
-      const themeTint =
-        typeof mark.attrs["themeTint"] === "string"
-          ? mark.attrs["themeTint"]
-          : undefined;
-      const themeShade =
-        typeof mark.attrs["themeShade"] === "string"
-          ? mark.attrs["themeShade"]
-          : undefined;
-      const colorAttrs: TextColorAttrs = {
-        ...(rgb !== undefined ? { rgb } : {}),
-        ...(themeColor !== undefined ? { themeColor } : {}),
-        ...(themeTint !== undefined ? { themeTint } : {}),
-        ...(themeShade !== undefined ? { themeShade } : {}),
-      };
+      const colorAttrs = expectTextColorMarkAttrs(mark);
       const style = textToStyle({ color: colorAttrs });
       const cssColor: unknown = style.color;
       const cssString =

--- a/packages/folio/src/core/prosemirror/extensions/marks/TextEffectsExtensions.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TextEffectsExtensions.ts
@@ -5,6 +5,7 @@
  * Emphasis Marks (w:em), Text Outline (w:outline)
  */
 
+import { expectEmphasisMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
 /**
@@ -90,8 +91,7 @@ export const EmphasisMarkExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: EmphasisMark attrs.type is always a string per schema
-      const emType = String(mark.attrs["type"]);
+      const emType = expectEmphasisMarkAttrs(mark).type ?? "dot";
       // CSS text-emphasis for emphasis marks
       let emStyle = "filled dot";
       switch (emType) {

--- a/packages/folio/src/core/prosemirror/extensions/marks/TrackedChangeExtensions.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TrackedChangeExtensions.ts
@@ -7,6 +7,7 @@
  */
 
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../../../utils/authorColors";
+import { expectTrackedChangeMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 
 /**
@@ -54,16 +55,11 @@ export const InsertionExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: TrackedChange attrs always match this shape per schema
-      const revisionId = Number(mark.attrs["revisionId"]);
-      const author = String(mark.attrs["author"]);
-      // SAFETY: date is null or a date string per schema default
-      const date =
-        mark.attrs["date"] !== null ? String(mark.attrs["date"]) : null;
+      const { revisionId, author, date } = expectTrackedChangeMarkAttrs(mark);
       const idx = getAuthorColorIdx(author);
       // SAFETY: getAuthorColorIdx returns modulo AUTHOR_COLORS.length
       const color = AUTHOR_COLORS[idx] ?? "#000000";
-      const datePart = date !== null ? new Date(date).toLocaleDateString() : "";
+      const datePart = date ? new Date(date).toLocaleDateString() : "";
       const titleParts = [author, datePart].filter(Boolean);
       return [
         "span",
@@ -72,7 +68,7 @@ export const InsertionExtension = createMarkExtension({
           "data-revision-id": String(revisionId),
           "data-author": author,
           "data-tc-author-idx": String(idx),
-          ...(date !== null ? { "data-date": date } : {}),
+          ...(date ? { "data-date": date } : {}),
           ...(titleParts.length > 0
             ? { title: `Inserted: ${titleParts.join(", ")}` }
             : {}),
@@ -117,16 +113,11 @@ export const DeletionExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: TrackedChange attrs always match this shape per schema
-      const revisionId = Number(mark.attrs["revisionId"]);
-      const author = String(mark.attrs["author"]);
-      // SAFETY: date is null or a date string per schema default
-      const date =
-        mark.attrs["date"] !== null ? String(mark.attrs["date"]) : null;
+      const { revisionId, author, date } = expectTrackedChangeMarkAttrs(mark);
       const idx = getAuthorColorIdx(author);
       // SAFETY: getAuthorColorIdx returns modulo AUTHOR_COLORS.length
       const color = AUTHOR_COLORS[idx] ?? "#000000";
-      const datePart = date !== null ? new Date(date).toLocaleDateString() : "";
+      const datePart = date ? new Date(date).toLocaleDateString() : "";
       const titleParts = [author, datePart].filter(Boolean);
       return [
         "span",
@@ -135,7 +126,7 @@ export const DeletionExtension = createMarkExtension({
           "data-revision-id": String(revisionId),
           "data-author": author,
           "data-tc-author-idx": String(idx),
-          ...(date !== null ? { "data-date": date } : {}),
+          ...(date ? { "data-date": date } : {}),
           ...(titleParts.length > 0
             ? { title: `Deleted: ${titleParts.join(", ")}` }
             : {}),

--- a/packages/folio/src/core/prosemirror/extensions/marks/UnderlineExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/UnderlineExtension.ts
@@ -5,6 +5,7 @@
 import { panic } from "better-result";
 import { toggleMark } from "prosemirror-commands";
 
+import { expectUnderlineMarkAttrs } from "../../attrs";
 import type { TextColorAttrs } from "../../schema/marks";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
@@ -26,17 +27,9 @@ export const UnderlineExtension = createMarkExtension({
       },
     ],
     toDOM(mark) {
-      // SAFETY: underline mark attrs always match UnderlineAttrs shape per schema
-      const style =
-        typeof mark.attrs["style"] === "string"
-          ? mark.attrs["style"]
-          : undefined;
-      // Access color.rgb via Reflect.get to avoid unsafe-type-assertion on `any`
-      const colorObj: unknown = Reflect.get(mark.attrs, "color");
-      const colorRgb: unknown =
-        typeof colorObj === "object" && colorObj !== null
-          ? Reflect.get(colorObj, "rgb")
-          : undefined;
+      const attrs = expectUnderlineMarkAttrs(mark);
+      const style = attrs.style;
+      const colorRgb = attrs.color?.rgb;
       const cssStyle: string[] = ["text-decoration: underline"];
 
       if (style && style !== "single") {
@@ -52,7 +45,7 @@ export const UnderlineExtension = createMarkExtension({
         }
       }
 
-      if (typeof colorRgb === "string" && colorRgb) {
+      if (colorRgb) {
         cssStyle.push(`text-decoration-color: #${colorRgb}`);
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/FieldExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/FieldExtension.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseFieldInstruction } from "../../../docx/fieldParser";
+import { expectFieldAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
 
 export const FieldExtension = createNodeExtension({
@@ -46,13 +47,8 @@ export const FieldExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      // SAFETY: Field node attrs always match this shape per schema
-      const fieldType = String(node.attrs["fieldType"]);
-      const instruction = String(node.attrs["instruction"]);
-      const displayText = String(node.attrs["displayText"]);
-      const fieldKind = String(node.attrs["fieldKind"]);
-      const fldLock = Boolean(node.attrs["fldLock"]);
-      const dirty = Boolean(node.attrs["dirty"]);
+      const { fieldType, instruction, displayText, fieldKind, fldLock, dirty } =
+        expectFieldAttrs(node);
 
       // Dynamic fields show a placeholder; static fields show their display text
       let text = displayText || "";

--- a/packages/folio/src/core/prosemirror/extensions/nodes/HardBreakExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/HardBreakExtension.ts
@@ -13,9 +13,26 @@ export const HardBreakExtension = createNodeExtension({
   nodeSpec: {
     inline: true,
     group: "inline",
+    attrs: {
+      breakType: { default: null },
+    },
     selectable: false,
-    parseDOM: [{ tag: "br" }],
-    toDOM() {
+    parseDOM: [
+      {
+        tag: "br",
+        getAttrs(node) {
+          if (!(node instanceof HTMLElement)) {
+            return null;
+          }
+          const breakType = node.dataset["docxBreakType"];
+          return breakType === "column" ? { breakType } : null;
+        },
+      },
+    ],
+    toDOM(node) {
+      if (node.attrs["breakType"] === "column") {
+        return ["br", { "data-docx-break-type": "column" }];
+      }
       return ["br"];
     },
   },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
@@ -2,6 +2,7 @@
  * Image Extension — inline/floating image node
  */
 
+import { expectImageAttrs } from "../../attrs";
 import type { ImageAttrs } from "../../schema/nodes";
 import { createNodeExtension } from "../create";
 
@@ -74,7 +75,7 @@ export const ImageExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      const attrs = node.attrs as ImageAttrs;
+      const attrs = expectImageAttrs(node);
       const domAttrs: Record<string, string> = {
         src: attrs.src,
         class: "docx-image",

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
@@ -12,6 +12,7 @@ export const ImageExtension = createNodeExtension({
   nodeSpec: {
     inline: true,
     group: "inline",
+    marks: "_",
     draggable: true,
     attrs: {
       src: {},
@@ -34,6 +35,7 @@ export const ImageExtension = createNodeExtension({
       borderStyle: { default: null },
       wrapText: { default: null },
       hlinkHref: { default: null },
+      _docxRawXml: { default: null },
     },
     parseDOM: [
       {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/MathExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/MathExtension.ts
@@ -6,6 +6,7 @@
  * text fallback in the editor.
  */
 
+import { expectMathAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
 
 export const MathExtension = createNodeExtension({
@@ -37,10 +38,10 @@ export const MathExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      // SAFETY: Math node attrs always match this shape per schema
-      const display = String(node.attrs["display"]);
-      const ommlXml = String(node.attrs["ommlXml"]);
-      const plainText = String(node.attrs["plainText"]);
+      const attrs = expectMathAttrs(node);
+      const display = attrs.display ?? "inline";
+      const ommlXml = attrs.ommlXml;
+      const plainText = attrs.plainText ?? "";
 
       const text = plainText || "[equation]";
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
@@ -5,19 +5,8 @@
  * Supports: richText, plainText, date, dropdown, comboBox, checkbox.
  */
 
+import { expectSdtAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
-
-type SdtAttrs = {
-  sdtType: string;
-  alias: string | null;
-  tag: string | null;
-  lock: string | null;
-  placeholder: string | null;
-  showingPlaceholder: boolean;
-  dateFormat: string | null;
-  listItems: string | null;
-  checked: string | boolean | null;
-};
 
 export const SdtExtension = createNodeExtension({
   name: "sdt",
@@ -77,7 +66,7 @@ export const SdtExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      const attrs = node.attrs as SdtAttrs;
+      const attrs = expectSdtAttrs(node);
       const dataAttrs: Record<string, string> = {
         class: `docx-sdt docx-sdt-${attrs.sdtType}`,
         "data-sdt-type": attrs.sdtType,
@@ -104,7 +93,7 @@ export const SdtExtension = createNodeExtension({
       if (attrs.listItems) {
         dataAttrs["data-list-items"] = attrs.listItems;
       }
-      if (attrs.checked !== null) {
+      if (attrs.checked !== undefined) {
         dataAttrs["data-checked"] = String(attrs.checked);
       }
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -5,6 +5,7 @@
  * Supports fill color, outline, transforms, and selection.
  */
 
+import { expectShapeAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
 
 export type ShapeAttrs = {
@@ -404,7 +405,7 @@ export const ShapeExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      const attrs = node.attrs as ShapeAttrs;
+      const attrs = expectShapeAttrs(node);
       const w = sanitizeShapeDimension(attrs.width, 100);
       const h = sanitizeShapeDimension(attrs.height, 80);
 

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -527,6 +527,7 @@ const tableCellSpec: NodeSpec = {
     noWrap: { default: false },
     _originalFormatting: { default: null },
     _preserveVMergeRestart: { default: null },
+    _docxVMergeContinuationCells: { default: null },
   },
   parseDOM: [
     {
@@ -593,6 +594,8 @@ const tableHeaderSpec: NodeSpec = {
     textDirection: { default: null },
     noWrap: { default: false },
     _originalFormatting: { default: null },
+    _preserveVMergeRestart: { default: null },
+    _docxVMergeContinuationCells: { default: null },
   },
   parseDOM: [
     {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -32,11 +32,7 @@ import {
   mergeTableCellAttrs,
   mergeTableRowAttrs,
 } from "../../attrs";
-import type {
-  TableAttrs,
-  TableRowAttrs,
-  TableCellAttrs,
-} from "../../schema/nodes";
+import type { TableAttrs, TableCellAttrs } from "../../schema/nodes";
 import { createNodeExtension, createExtension } from "../create";
 import type {
   ExtensionContext,
@@ -323,7 +319,7 @@ const tableSpec: NodeSpec = {
     },
   ],
   toDOM(node) {
-    const attrs = node.attrs as TableAttrs;
+    const attrs = expectTableAttrs(node);
     const domAttrs: Record<string, string> = { class: "docx-table" };
 
     if (attrs.styleId) {
@@ -367,7 +363,7 @@ const tableRowSpec: NodeSpec = {
   },
   parseDOM: [{ tag: "tr" }],
   toDOM(node) {
-    const attrs = node.attrs as TableRowAttrs;
+    const attrs = expectTableRowAttrs(node);
     const domAttrs: Record<string, string> = {};
 
     if (typeof attrs.height === "number") {
@@ -538,7 +534,7 @@ const tableCellSpec: NodeSpec = {
     },
   ],
   toDOM(node) {
-    const attrs = node.attrs as TableCellAttrs;
+    const attrs = expectTableCellAttrs(node);
     const domAttrs: Record<string, string> = { class: "docx-table-cell" };
 
     if (attrs.colspan > 1) {
@@ -604,7 +600,7 @@ const tableHeaderSpec: NodeSpec = {
     },
   ],
   toDOM(node) {
-    const attrs = node.attrs as TableCellAttrs;
+    const attrs = expectTableCellAttrs(node);
     const domAttrs: Record<string, string> = { class: "docx-table-header" };
 
     if (attrs.colspan > 1) {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -526,6 +526,7 @@ const tableCellSpec: NodeSpec = {
     textDirection: { default: null },
     noWrap: { default: false },
     _originalFormatting: { default: null },
+    _preserveVMergeRestart: { default: null },
   },
   parseDOM: [
     {

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TableExtension.ts
@@ -19,7 +19,19 @@ import {
 import { Decoration, DecorationSet } from "prosemirror-view";
 
 import type { ColorValue, BorderSpec } from "../../../types/colors";
+import {
+  TABLE_CELL_TEXT_DIRECTION_VALUES,
+  TABLE_WIDTH_TYPE_VALUES,
+} from "../../../types/documentEnumValues";
 import { resolveColor } from "../../../utils/colorResolver";
+import {
+  expectTableAttrs,
+  expectTableCellAttrs,
+  expectTableRowAttrs,
+  mergeTableAttrs,
+  mergeTableCellAttrs,
+  mergeTableRowAttrs,
+} from "../../attrs";
 import type {
   TableAttrs,
   TableRowAttrs,
@@ -32,9 +44,20 @@ import type {
   AnyExtension,
 } from "../types";
 
+type TableCellBorders = NonNullable<TableCellAttrs["borders"]>;
+type TableCellBorderSide = keyof TableCellBorders;
+
 // ============================================================================
 // CSS PASTE HELPERS — Extract formatting from inline styles (Google Docs, etc.)
 // ============================================================================
+
+const isOneOf = <T extends string>(
+  value: string | null | undefined,
+  values: readonly T[],
+): value is T =>
+  value !== null &&
+  value !== undefined &&
+  values.some((allowed) => allowed === value);
 
 /** Map CSS border-style to OOXML border style. */
 function cssBorderStyleToOoxml(cssStyle: string): BorderSpec["style"] {
@@ -1322,11 +1345,14 @@ export const TablePluginExtension = createExtension({
                 cell.type.name === "tableCell" ||
                 cell.type.name === "tableHeader"
               ) {
-                tr = tr.setNodeMarkup(cellPos, undefined, {
-                  ...cell.attrs,
-                  width: newColWidthPercent,
-                  widthType: "pct",
-                });
+                tr = tr.setNodeMarkup(
+                  cellPos,
+                  undefined,
+                  mergeTableCellAttrs(cell, {
+                    width: newColWidthPercent,
+                    widthType: "pct",
+                  }),
+                );
               }
               cellPos += cell.nodeSize;
             });
@@ -1334,15 +1360,20 @@ export const TablePluginExtension = createExtension({
 
           // Update table columnWidths so full-width tables resize correctly.
           const colCount = firstRow.childCount;
-          const tableWidthTwips =
-            (updatedTable.attrs["width"] as number) || 9360;
+          const tableWidthTwips = expectTableAttrs(updatedTable).width ?? 9360;
           const colWidthTwips = Math.floor(
             tableWidthTwips / Math.max(1, colCount),
           );
-          tr = tr.setNodeMarkup(context.tablePos, undefined, {
-            ...updatedTable.attrs,
-            columnWidths: Array.from({ length: colCount }, () => colWidthTwips),
-          });
+          tr = tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(updatedTable, {
+              columnWidths: Array.from(
+                { length: colCount },
+                () => colWidthTwips,
+              ),
+            }),
+          );
         }
 
         dispatch(tr.scrollIntoView());
@@ -1427,11 +1458,14 @@ export const TablePluginExtension = createExtension({
                 cell.type.name === "tableCell" ||
                 cell.type.name === "tableHeader"
               ) {
-                tr = tr.setNodeMarkup(cellPos, undefined, {
-                  ...cell.attrs,
-                  width: newColWidthPercent,
-                  widthType: "pct",
-                });
+                tr = tr.setNodeMarkup(
+                  cellPos,
+                  undefined,
+                  mergeTableCellAttrs(cell, {
+                    width: newColWidthPercent,
+                    widthType: "pct",
+                  }),
+                );
               }
               cellPos += cell.nodeSize;
             });
@@ -1439,15 +1473,20 @@ export const TablePluginExtension = createExtension({
 
           // Update table columnWidths so full-width tables resize correctly.
           const colCount = firstRow.childCount;
-          const tableWidthTwips =
-            (updatedTable.attrs["width"] as number) || 9360;
+          const tableWidthTwips = expectTableAttrs(updatedTable).width ?? 9360;
           const colWidthTwips = Math.floor(
             tableWidthTwips / Math.max(1, colCount),
           );
-          tr = tr.setNodeMarkup(context.tablePos, undefined, {
-            ...updatedTable.attrs,
-            columnWidths: Array.from({ length: colCount }, () => colWidthTwips),
-          });
+          tr = tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(updatedTable, {
+              columnWidths: Array.from(
+                { length: colCount },
+                () => colWidthTwips,
+              ),
+            }),
+          );
         }
 
         dispatch(tr.scrollIntoView());
@@ -1520,11 +1559,14 @@ export const TablePluginExtension = createExtension({
                 cell.type.name === "tableCell" ||
                 cell.type.name === "tableHeader"
               ) {
-                tr = tr.setNodeMarkup(cellPos, undefined, {
-                  ...cell.attrs,
-                  width: newColWidthPercent,
-                  widthType: "pct",
-                });
+                tr = tr.setNodeMarkup(
+                  cellPos,
+                  undefined,
+                  mergeTableCellAttrs(cell, {
+                    width: newColWidthPercent,
+                    widthType: "pct",
+                  }),
+                );
               }
               cellPos += cell.nodeSize;
             });
@@ -1532,15 +1574,20 @@ export const TablePluginExtension = createExtension({
 
           // Update table columnWidths to match new column count.
           const colCount = firstRow.childCount;
-          const tableWidthTwips =
-            (updatedTable.attrs["width"] as number) || 9360;
+          const tableWidthTwips = expectTableAttrs(updatedTable).width ?? 9360;
           const colWidthTwips = Math.floor(
             tableWidthTwips / Math.max(1, colCount),
           );
-          tr = tr.setNodeMarkup(context.tablePos, undefined, {
-            ...updatedTable.attrs,
-            columnWidths: Array.from({ length: colCount }, () => colWidthTwips),
-          });
+          tr = tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(updatedTable, {
+              columnWidths: Array.from(
+                { length: colCount },
+                () => colWidthTwips,
+              ),
+            }),
+          );
         }
 
         dispatch(tr.scrollIntoView());
@@ -1743,7 +1790,7 @@ export const TablePluginExtension = createExtension({
         // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
         row.forEach((cell, cellOffset) => {
           const pos = tableStart + rowOffset + cellOffset + 2;
-          const colspan = (cell.attrs["colspan"] as number) || 1;
+          const colspan = expectTableCellAttrs(cell).colspan || 1;
           cellByPos.set(pos, { rowIdx, colIdx, colspan, pos, node: cell });
           cellByRC.set(`${rowIdx},${colIdx}`, pos);
           colIdx += colspan;
@@ -1774,12 +1821,12 @@ export const TablePluginExtension = createExtension({
           const tableStart = context.tablePos;
 
           // Use provided spec or default to thin black border
-          const solidBorder = borderSpec ?? {
+          const solidBorder: BorderSpec = borderSpec ?? {
             style: "single",
             size: 4,
             color: { rgb: "000000" },
           };
-          const noBorder = { style: "none" as const };
+          const noBorder: BorderSpec = { style: "none" };
 
           const { cellByPos, cellByRC } = buildTableGrid(table, tableStart);
 
@@ -1802,10 +1849,10 @@ export const TablePluginExtension = createExtension({
           }
 
           // Track which cells we've already modified (avoid double-modify)
-          const modified = new Map<number, Record<string, unknown>>();
+          const modified = new Map<number, TableCellAttrs>();
           const getAttrs = (pos: number, node: PMNode) =>
-            modified.get(pos) ?? { ...node.attrs };
-          const setAttrs = (pos: number, attrs: Record<string, unknown>) => {
+            modified.get(pos) ?? expectTableCellAttrs(node);
+          const setAttrs = (pos: number, attrs: TableCellAttrs) => {
             modified.set(pos, attrs);
           };
 
@@ -1822,10 +1869,7 @@ export const TablePluginExtension = createExtension({
             const isRightEdge = info.colIdx + info.colspan - 1 === maxCol;
 
             // Determine which borders to set on this cell
-            let cellBorders: Record<
-              string,
-              typeof solidBorder | typeof noBorder
-            > = {};
+            let cellBorders: TableCellBorders = {};
             switch (preset) {
               case "all":
                 cellBorders = {
@@ -1865,11 +1909,7 @@ export const TablePluginExtension = createExtension({
 
             // Update target cell
             const attrs = getAttrs(pos, info.node);
-            const existingBorders =
-              (attrs["borders"] as
-                | Record<string, unknown>
-                | null
-                | undefined) ?? {};
+            const existingBorders = attrs.borders ?? {};
             setAttrs(pos, {
               ...attrs,
               borders: { ...existingBorders, ...cellBorders },
@@ -1877,7 +1917,7 @@ export const TablePluginExtension = createExtension({
 
             // Update adjacent cells' matching edges (edge-based borders like Google Docs)
             // Top edge → adjacent cell above needs matching bottom
-            if (cellBorders["top"]) {
+            if (cellBorders.top) {
               const adjPos = cellByRC.get(`${info.rowIdx - 1},${info.colIdx}`);
               if (adjPos !== undefined) {
                 const adj = cellByPos.get(adjPos);
@@ -1885,19 +1925,15 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? {};
+                const adjBorders = adjAttrs.borders ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
-                  borders: { ...adjBorders, bottom: cellBorders["top"] },
+                  borders: { ...adjBorders, bottom: cellBorders.top },
                 });
               }
             }
             // Bottom edge → adjacent cell below needs matching top
-            if (cellBorders["bottom"]) {
+            if (cellBorders.bottom) {
               const adjPos = cellByRC.get(`${info.rowIdx + 1},${info.colIdx}`);
               if (adjPos !== undefined) {
                 const adj = cellByPos.get(adjPos);
@@ -1905,19 +1941,15 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? {};
+                const adjBorders = adjAttrs.borders ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
-                  borders: { ...adjBorders, top: cellBorders["bottom"] },
+                  borders: { ...adjBorders, top: cellBorders.bottom },
                 });
               }
             }
             // Left edge → adjacent cell to the left needs matching right
-            if (cellBorders["left"]) {
+            if (cellBorders.left) {
               const adjPos = cellByRC.get(`${info.rowIdx},${info.colIdx - 1}`);
               if (adjPos !== undefined) {
                 const adj = cellByPos.get(adjPos);
@@ -1925,19 +1957,15 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? {};
+                const adjBorders = adjAttrs.borders ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
-                  borders: { ...adjBorders, right: cellBorders["left"] },
+                  borders: { ...adjBorders, right: cellBorders.left },
                 });
               }
             }
             // Right edge → adjacent cell to the right needs matching left
-            if (cellBorders["right"]) {
+            if (cellBorders.right) {
               const adjPos = cellByRC.get(
                 `${info.rowIdx},${info.colIdx + info.colspan}`,
               );
@@ -1947,14 +1975,10 @@ export const TablePluginExtension = createExtension({
                   continue;
                 }
                 const adjAttrs = getAttrs(adjPos, adj.node);
-                const adjBorders =
-                  (adjAttrs["borders"] as
-                    | Record<string, unknown>
-                    | null
-                    | undefined) ?? {};
+                const adjBorders = adjAttrs.borders ?? {};
                 setAttrs(adjPos, {
                   ...adjAttrs,
-                  borders: { ...adjBorders, left: cellBorders["right"] },
+                  borders: { ...adjBorders, left: cellBorders.right },
                 });
               }
             }
@@ -1985,13 +2009,14 @@ export const TablePluginExtension = createExtension({
         if (dispatch) {
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
-          const bgColor = color ? color.replace(/^#/u, "") : null;
+          const bgColor = color ? color.replace(/^#/u, "") : undefined;
 
           for (const { pos, node } of cells) {
-            tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
-              ...node.attrs,
-              backgroundColor: bgColor,
-            });
+            tr.setNodeMarkup(
+              tr.mapping.map(pos),
+              undefined,
+              mergeTableCellAttrs(node, { backgroundColor: bgColor }),
+            );
           }
           dispatch(tr.scrollIntoView());
         }
@@ -2018,24 +2043,23 @@ export const TablePluginExtension = createExtension({
         if (dispatch) {
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
-          const borderValue = spec ?? { style: "none" };
-          const noBorder = { style: "none" as const };
+          const borderValue: BorderSpec = spec ?? { style: "none" };
+          const noBorder: BorderSpec = { style: "none" };
           const allSides = ["top", "bottom", "left", "right"] as const;
           const { cellByPos, cellByRC } = buildTableGrid(
             context.table,
             context.tablePos,
           );
 
-          const modified = new Map<number, Record<string, unknown>>();
+          const modified = new Map<number, TableCellAttrs>();
           const getAttrs = (p: number, n: PMNode) =>
-            modified.get(p) ?? { ...n.attrs };
-          const setAttrs = (p: number, a: Record<string, unknown>) =>
-            modified.set(p, a);
+            modified.get(p) ?? expectTableCellAttrs(n);
+          const setAttrs = (p: number, a: TableCellAttrs) => modified.set(p, a);
 
           // Map of side → adjacent side + row/col offset
           const adjacentMap: Record<
-            string,
-            { adjSide: string; dRow: number; dCol: number }
+            TableCellBorderSide,
+            { adjSide: TableCellBorderSide; dRow: number; dCol: number }
           > = {
             top: { adjSide: "bottom", dRow: -1, dCol: 0 },
             bottom: { adjSide: "top", dRow: 1, dCol: 0 },
@@ -2046,15 +2070,12 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as
-                | Record<string, unknown>
-                | null
-                | undefined) ?? {};
+            const currentBorders = attrs.borders ?? {};
 
-            const sides = side === "all" ? allSides : [side];
+            const sides: readonly TableCellBorderSide[] =
+              side === "all" ? allSides : [side];
             // When clearOthers is true, start with all sides cleared (preset behavior)
-            const newBorders: Record<string, unknown> = clearOthers
+            const newBorders: TableCellBorders = clearOthers
               ? {
                   top: noBorder,
                   bottom: noBorder,
@@ -2072,9 +2093,6 @@ export const TablePluginExtension = createExtension({
               for (const s of sidesToSync) {
                 const syncValue = newBorders[s];
                 const adj = adjacentMap[s];
-                if (!adj) {
-                  continue;
-                }
                 const adjColIdx =
                   s === "right"
                     ? info.colIdx + info.colspan
@@ -2088,11 +2106,7 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as
-                      | Record<string, unknown>
-                      | null
-                      | undefined) ?? {};
+                  const adjBorders = adjAttrs.borders ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: syncValue },
@@ -2128,10 +2142,11 @@ export const TablePluginExtension = createExtension({
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
           for (const { pos, node } of cells) {
-            tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
-              ...node.attrs,
-              verticalAlign: align,
-            });
+            tr.setNodeMarkup(
+              tr.mapping.map(pos),
+              undefined,
+              mergeTableCellAttrs(node, { verticalAlign: align }),
+            );
           }
           dispatch(tr.scrollIntoView());
         }
@@ -2160,16 +2175,13 @@ export const TablePluginExtension = createExtension({
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
           for (const { pos, node } of cells) {
-            const currentMargins =
-              (node.attrs["margins"] as
-                | Record<string, unknown>
-                | null
-                | undefined) ?? {};
+            const currentMargins = expectTableCellAttrs(node).margins ?? {};
             const newMargins = { ...currentMargins, ...margins };
-            tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
-              ...node.attrs,
-              margins: newMargins,
-            });
+            tr.setNodeMarkup(
+              tr.mapping.map(pos),
+              undefined,
+              mergeTableCellAttrs(node, { margins: newMargins }),
+            );
           }
           dispatch(tr.scrollIntoView());
         }
@@ -2190,13 +2202,23 @@ export const TablePluginExtension = createExtension({
         }
 
         if (dispatch) {
+          if (
+            direction !== null &&
+            !isOneOf(direction, TABLE_CELL_TEXT_DIRECTION_VALUES)
+          ) {
+            return false;
+          }
+
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
           for (const { pos, node } of cells) {
-            tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
-              ...node.attrs,
-              textDirection: direction,
-            });
+            tr.setNodeMarkup(
+              tr.mapping.map(pos),
+              undefined,
+              mergeTableCellAttrs(node, {
+                textDirection: direction ?? undefined,
+              }),
+            );
           }
           dispatch(tr.scrollIntoView());
         }
@@ -2220,10 +2242,12 @@ export const TablePluginExtension = createExtension({
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
           for (const { pos, node } of cells) {
-            tr.setNodeMarkup(tr.mapping.map(pos), undefined, {
-              ...node.attrs,
-              noWrap: node.attrs["noWrap"] !== true,
-            });
+            const attrs = expectTableCellAttrs(node);
+            tr.setNodeMarkup(
+              tr.mapping.map(pos),
+              undefined,
+              mergeTableCellAttrs(node, { noWrap: attrs.noWrap !== true }),
+            );
           }
           dispatch(tr.scrollIntoView());
         }
@@ -2254,12 +2278,14 @@ export const TablePluginExtension = createExtension({
             const node = $from.node(d);
             if (node.type.name === "tableRow") {
               const pos = $from.before(d);
-              const newAttrs = {
-                ...node.attrs,
-                height,
-                heightRule: height !== null ? (rule ?? "atLeast") : null,
-              };
-              tr.setNodeMarkup(pos, undefined, newAttrs);
+              tr.setNodeMarkup(
+                pos,
+                undefined,
+                mergeTableRowAttrs(node, {
+                  height: height ?? undefined,
+                  heightRule: height !== null ? (rule ?? "atLeast") : undefined,
+                }),
+              );
               dispatch(tr.scrollIntoView());
               return true;
             }
@@ -2289,7 +2315,7 @@ export const TablePluginExtension = createExtension({
           const colCount = context.columnCount;
 
           // Calculate total table width from existing column widths or use default
-          const existingWidths = table.attrs["columnWidths"] as number[] | null;
+          const existingWidths = expectTableAttrs(table).columnWidths;
           const totalWidthTwips = existingWidths
             ? existingWidths.reduce((sum: number, w: number) => sum + w, 0)
             : 9360; // Default content width in twips
@@ -2307,12 +2333,15 @@ export const TablePluginExtension = createExtension({
                   cell.type.name === "tableCell" ||
                   cell.type.name === "tableHeader"
                 ) {
-                  tr = tr.setNodeMarkup(cellPos, undefined, {
-                    ...cell.attrs,
-                    width: equalWidth,
-                    widthType: "dxa",
-                    colwidth: null,
-                  });
+                  tr = tr.setNodeMarkup(
+                    cellPos,
+                    undefined,
+                    mergeTableCellAttrs(cell, {
+                      width: equalWidth,
+                      widthType: "dxa",
+                      colwidth: null,
+                    }),
+                  );
                 }
                 cellPos += cell.nodeSize;
               });
@@ -2325,10 +2354,11 @@ export const TablePluginExtension = createExtension({
             { length: colCount },
             () => equalWidth,
           );
-          tr = tr.setNodeMarkup(context.tablePos, undefined, {
-            ...table.attrs,
-            columnWidths: newColumnWidths,
-          });
+          tr = tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(table, { columnWidths: newColumnWidths }),
+          );
 
           dispatch(tr.scrollIntoView());
         }
@@ -2364,12 +2394,15 @@ export const TablePluginExtension = createExtension({
                   cell.type.name === "tableCell" ||
                   cell.type.name === "tableHeader"
                 ) {
-                  tr = tr.setNodeMarkup(cellPos, undefined, {
-                    ...cell.attrs,
-                    width: null,
-                    widthType: null,
-                    colwidth: null,
-                  });
+                  tr = tr.setNodeMarkup(
+                    cellPos,
+                    undefined,
+                    mergeTableCellAttrs(cell, {
+                      width: undefined,
+                      widthType: undefined,
+                      colwidth: null,
+                    }),
+                  );
                 }
                 cellPos += cell.nodeSize;
               });
@@ -2378,12 +2411,15 @@ export const TablePluginExtension = createExtension({
           });
 
           // Remove table-level column widths and set auto width
-          tr = tr.setNodeMarkup(context.tablePos, undefined, {
-            ...table.attrs,
-            columnWidths: null,
-            width: null,
-            widthType: "auto",
-          });
+          tr = tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(table, {
+              columnWidths: undefined,
+              width: undefined,
+              widthType: "auto",
+            }),
+          );
 
           dispatch(tr.scrollIntoView());
         }
@@ -2470,10 +2506,11 @@ export const TablePluginExtension = createExtension({
           const tableBorders = styleData.tableBorders;
 
           // Update table node attrs with styleId
-          tr = tr.setNodeMarkup(tablePos, undefined, {
-            ...table.attrs,
-            styleId: styleData.styleId,
-          });
+          tr = tr.setNodeMarkup(
+            tablePos,
+            undefined,
+            mergeTableAttrs(table, { styleId: styleData.styleId }),
+          );
 
           // Walk through all rows and cells to apply conditional formatting
           let dataRowIndex = 0;
@@ -2530,48 +2567,48 @@ export const TablePluginExtension = createExtension({
                 ? conditionals[cellCondType]
                 : undefined;
 
-              // Build new cell attrs
-              const newAttrs = { ...cell.attrs };
-
-              // Apply background color
-              if (cond?.backgroundColor) {
-                newAttrs["backgroundColor"] = cond.backgroundColor;
-              } else {
-                newAttrs["backgroundColor"] = null;
-              }
-
               // Apply borders: conditional borders override table borders
-              const cellBorders: Record<string, unknown> = {};
+              const cellBorders: TableCellBorders = {};
               const sides = ["top", "bottom", "left", "right"] as const;
               for (const side of sides) {
                 if (cond?.borders && cond.borders[side] !== undefined) {
-                  cellBorders[side] = cond.borders[side];
+                  const border = cond.borders[side];
+                  if (border) {
+                    cellBorders[side] = border;
+                  }
                 } else if (tableBorders) {
                   // Map table-level border to cell: insideH for top/bottom between rows, insideV for left/right between cols
+                  let border: BorderSpec | undefined;
                   if (
                     (side === "top" && rowIdx > 0) ||
                     (side === "bottom" && rowIdx < totalRows - 1)
                   ) {
-                    cellBorders[side] =
-                      tableBorders.insideH ?? tableBorders[side];
+                    border = tableBorders.insideH ?? tableBorders[side];
                   } else if (
                     (side === "left" && colIdx > 0) ||
                     (side === "right" && colIdx < totalCols - 1)
                   ) {
-                    cellBorders[side] =
-                      tableBorders.insideV ?? tableBorders[side];
+                    border = tableBorders.insideV ?? tableBorders[side];
                   } else {
-                    cellBorders[side] = tableBorders[side];
+                    border = tableBorders[side];
+                  }
+                  if (border) {
+                    cellBorders[side] = border;
                   }
                 }
               }
-              if (Object.keys(cellBorders).length > 0) {
-                newAttrs["borders"] = cellBorders;
-              } else {
-                newAttrs["borders"] = null;
-              }
 
-              tr = tr.setNodeMarkup(cellPos, undefined, newAttrs);
+              tr = tr.setNodeMarkup(
+                cellPos,
+                undefined,
+                mergeTableCellAttrs(cell, {
+                  backgroundColor: cond?.backgroundColor,
+                  borders:
+                    Object.keys(cellBorders).length > 0
+                      ? cellBorders
+                      : undefined,
+                }),
+              );
               cellOffset += cell.nodeSize;
             }
 
@@ -2591,6 +2628,14 @@ export const TablePluginExtension = createExtension({
       justification?: "left" | "center" | "right" | null;
     }): Command {
       return (state, dispatch) => {
+        if (
+          props.widthType !== undefined &&
+          props.widthType !== null &&
+          !isOneOf(props.widthType, TABLE_WIDTH_TYPE_VALUES)
+        ) {
+          return false;
+        }
+
         const context = getTableContext(state);
         if (
           !context.isInTable ||
@@ -2602,17 +2647,19 @@ export const TablePluginExtension = createExtension({
 
         if (dispatch) {
           const tr = state.tr;
-          const newAttrs = { ...context.table.attrs };
-          if ("width" in props) {
-            newAttrs["width"] = props.width;
-          }
-          if ("widthType" in props) {
-            newAttrs["widthType"] = props.widthType;
-          }
-          if ("justification" in props) {
-            newAttrs["justification"] = props.justification;
-          }
-          tr.setNodeMarkup(context.tablePos, undefined, newAttrs);
+          tr.setNodeMarkup(
+            context.tablePos,
+            undefined,
+            mergeTableAttrs(context.table, {
+              ...("width" in props ? { width: props.width ?? undefined } : {}),
+              ...("widthType" in props
+                ? { widthType: props.widthType ?? undefined }
+                : {}),
+              ...("justification" in props
+                ? { justification: props.justification ?? undefined }
+                : {}),
+            }),
+          );
           dispatch(tr.scrollIntoView());
         }
 
@@ -2639,11 +2686,12 @@ export const TablePluginExtension = createExtension({
             const node = $from.node(d);
             if (node.type.name === "tableRow") {
               const pos = $from.before(d);
-              const newAttrs = {
-                ...node.attrs,
-                isHeader: node.attrs["isHeader"] !== true,
-              };
-              tr.setNodeMarkup(pos, undefined, newAttrs);
+              const attrs = expectTableRowAttrs(node);
+              tr.setNodeMarkup(
+                pos,
+                undefined,
+                mergeTableRowAttrs(node, { isHeader: attrs.isHeader !== true }),
+              );
               dispatch(tr.scrollIntoView());
               return true;
             }
@@ -2669,21 +2717,20 @@ export const TablePluginExtension = createExtension({
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
           const rgb = color.replace(/^#/u, "");
-          const defaultBorder = { style: "single", size: 4 };
+          const defaultBorder: BorderSpec = { style: "single", size: 4 };
           const { cellByPos, cellByRC } = buildTableGrid(
             context.table,
             context.tablePos,
           );
 
-          const modified = new Map<number, Record<string, unknown>>();
+          const modified = new Map<number, TableCellAttrs>();
           const getAttrs = (p: number, n: PMNode) =>
-            modified.get(p) ?? { ...n.attrs };
-          const setAttrs = (p: number, a: Record<string, unknown>) =>
-            modified.set(p, a);
+            modified.get(p) ?? expectTableCellAttrs(n);
+          const setAttrs = (p: number, a: TableCellAttrs) => modified.set(p, a);
 
           const adjacentMap: Record<
-            string,
-            { adjSide: string; dRow: number; dCol: number }
+            TableCellBorderSide,
+            { adjSide: TableCellBorderSide; dRow: number; dCol: number }
           > = {
             top: { adjSide: "bottom", dRow: -1, dCol: 0 },
             bottom: { adjSide: "top", dRow: 1, dCol: 0 },
@@ -2694,15 +2741,11 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as
-                | Record<string, Record<string, unknown>>
-                | null
-                | undefined) ?? {};
-            const newBorders: Record<string, unknown> = {};
+            const currentBorders = attrs.borders ?? {};
+            const newBorders: TableCellBorders = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
-              const borderVal = {
+              const borderVal: BorderSpec = {
                 ...defaultBorder,
                 ...currentBorders[side],
                 color: { rgb },
@@ -2712,9 +2755,6 @@ export const TablePluginExtension = createExtension({
               // Sync adjacent cell's matching edge
               if (info) {
                 const adj = adjacentMap[side];
-                if (!adj) {
-                  continue;
-                }
                 const adjColIdx =
                   side === "right"
                     ? info.colIdx + info.colspan
@@ -2728,11 +2768,7 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as
-                      | Record<string, unknown>
-                      | null
-                      | undefined) ?? {};
+                  const adjBorders = adjAttrs.borders ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },
@@ -2770,21 +2806,23 @@ export const TablePluginExtension = createExtension({
         if (dispatch) {
           const tr = state.tr;
           const cells = getTargetCellPositions(state);
-          const defaultBorder = { style: "single", color: { rgb: "000000" } };
+          const defaultBorder: BorderSpec = {
+            style: "single",
+            color: { rgb: "000000" },
+          };
           const { cellByPos, cellByRC } = buildTableGrid(
             context.table,
             context.tablePos,
           );
 
-          const modified = new Map<number, Record<string, unknown>>();
+          const modified = new Map<number, TableCellAttrs>();
           const getAttrs = (p: number, n: PMNode) =>
-            modified.get(p) ?? { ...n.attrs };
-          const setAttrs = (p: number, a: Record<string, unknown>) =>
-            modified.set(p, a);
+            modified.get(p) ?? expectTableCellAttrs(n);
+          const setAttrs = (p: number, a: TableCellAttrs) => modified.set(p, a);
 
           const adjacentMap: Record<
-            string,
-            { adjSide: string; dRow: number; dCol: number }
+            TableCellBorderSide,
+            { adjSide: TableCellBorderSide; dRow: number; dCol: number }
           > = {
             top: { adjSide: "bottom", dRow: -1, dCol: 0 },
             bottom: { adjSide: "top", dRow: 1, dCol: 0 },
@@ -2795,15 +2833,11 @@ export const TablePluginExtension = createExtension({
           for (const { pos, node } of cells) {
             const info = cellByPos.get(pos);
             const attrs = getAttrs(pos, node);
-            const currentBorders =
-              (attrs["borders"] as
-                | Record<string, Record<string, unknown>>
-                | null
-                | undefined) ?? {};
-            const newBorders: Record<string, unknown> = {};
+            const currentBorders = attrs.borders ?? {};
+            const newBorders: TableCellBorders = {};
 
             for (const side of ["top", "bottom", "left", "right"] as const) {
-              const borderVal = {
+              const borderVal: BorderSpec = {
                 ...defaultBorder,
                 ...currentBorders[side],
                 size,
@@ -2813,9 +2847,6 @@ export const TablePluginExtension = createExtension({
               // Sync adjacent cell's matching edge
               if (info) {
                 const adj = adjacentMap[side];
-                if (!adj) {
-                  continue;
-                }
                 const adjColIdx =
                   side === "right"
                     ? info.colIdx + info.colspan
@@ -2829,11 +2860,7 @@ export const TablePluginExtension = createExtension({
                     continue;
                   }
                   const adjAttrs = getAttrs(adjPos, adjInfo.node);
-                  const adjBorders =
-                    (adjAttrs["borders"] as
-                      | Record<string, unknown>
-                      | null
-                      | undefined) ?? {};
+                  const adjBorders = adjAttrs.borders ?? {};
                   setAttrs(adjPos, {
                     ...adjAttrs,
                     borders: { ...adjBorders, [adj.adjSide]: borderVal },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -6,6 +6,7 @@
  * Supports inline and floating positioning.
  */
 
+import { expectTextBoxAttrs } from "../../attrs";
 import { createNodeExtension } from "../create";
 
 export type TextBoxAttrs = {
@@ -116,7 +117,7 @@ export const TextBoxExtension = createNodeExtension({
       },
     ],
     toDOM(node) {
-      const attrs = node.attrs as TextBoxAttrs;
+      const attrs = expectTextBoxAttrs(node);
       const domAttrs: Record<string, string> = {
         class: "docx-textbox",
       };

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -40,6 +40,10 @@ export type TextBoxAttrs = {
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
   wrapType?: string;
+  /** Original DOCX placement hint for save-path reconstruction. */
+  _docxPlacement?: "standalone" | "inlineWithPrevious";
+  /** Original DOCX paragraph group for standalone text-box reconstruction. */
+  _docxGroupId?: string;
 };
 
 export const TextBoxExtension = createNodeExtension({
@@ -66,6 +70,8 @@ export const TextBoxExtension = createNodeExtension({
       displayMode: { default: "inline" },
       cssFloat: { default: null },
       wrapType: { default: "inline" },
+      _docxPlacement: { default: null },
+      _docxGroupId: { default: null },
     },
     parseDOM: [
       {

--- a/packages/folio/src/core/prosemirror/index.ts
+++ b/packages/folio/src/core/prosemirror/index.ts
@@ -31,6 +31,17 @@ export {
 } from "./conversion";
 export type { ToProseDocOptions } from "./conversion";
 
+// Validation
+export {
+  assertValidProseMirrorDocument,
+  formatProseMirrorDocumentIssues,
+  validateProseMirrorDocument,
+} from "./validation";
+export type {
+  ProseMirrorDocumentValidationIssue,
+  ValidateProseMirrorDocumentResult,
+} from "./validation";
+
 // Styles
 export { StyleResolver, createStyleResolver } from "./styles";
 export type { ResolvedParagraphStyle } from "./styles";

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -12,6 +12,7 @@ import { createStarterKit } from "../extensions/StarterKit";
 
 // Re-export type interfaces (used by toProseDoc, fromProseDoc, and other modules)
 export type {
+  HardBreakAttrs,
   ParagraphAttrs,
   FieldAttrs,
   ImageAttrs,

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -13,11 +13,16 @@ import { createStarterKit } from "../extensions/StarterKit";
 // Re-export type interfaces (used by toProseDoc, fromProseDoc, and other modules)
 export type {
   ParagraphAttrs,
+  FieldAttrs,
   ImageAttrs,
   ImagePositionAttrs,
+  MathAttrs,
+  SdtAttrs,
+  ShapeAttrs,
   TableAttrs,
   TableRowAttrs,
   TableCellAttrs,
+  TextBoxAttrs,
 } from "./nodes";
 export type {
   TextColorAttrs,

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -22,8 +22,16 @@ export type {
 export type {
   TextColorAttrs,
   UnderlineAttrs,
+  StrikeAttrs,
   FontSizeAttrs,
   FontFamilyAttrs,
+  HighlightAttrs,
+  CharacterSpacingAttrs,
+  EmphasisMarkAttrs,
+  FootnoteRefAttrs,
+  CommentAttrs,
+  TrackedChangeMarkAttrs,
+  RunFormattingOverrideAttrs,
   HyperlinkAttrs,
 } from "./marks";
 

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -113,4 +113,5 @@ export type HyperlinkAttrs = {
   href: string;
   tooltip?: string;
   rId?: string;
+  _docxHyperlinkIndex?: number;
 };

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -6,7 +6,12 @@
  * to the extension system (extensions/marks/).
  */
 
-import type { UnderlineStyle, ThemeColorSlot } from "../../types/document";
+import type {
+  EmphasisMark,
+  TextFormatting,
+  ThemeColorSlot,
+  UnderlineStyle,
+} from "../../types/document";
 
 /**
  * Text color mark attributes
@@ -24,6 +29,10 @@ export type TextColorAttrs = {
 export type UnderlineAttrs = {
   style?: UnderlineStyle;
   color?: TextColorAttrs;
+};
+
+export type StrikeAttrs = {
+  double?: boolean;
 };
 
 /**
@@ -45,6 +54,56 @@ export type FontFamilyAttrs = {
   hAnsiTheme?: string;
   eastAsiaTheme?: string;
   csTheme?: string;
+};
+
+export type HighlightAttrs = {
+  color: NonNullable<TextFormatting["highlight"]>;
+};
+
+export type CharacterSpacingAttrs = {
+  spacing?: number;
+  position?: number;
+  scale?: number;
+  kerning?: number;
+};
+
+export type EmphasisMarkAttrs = {
+  type?: Exclude<EmphasisMark, "none">;
+};
+
+export type FootnoteRefAttrs = {
+  id: string | number;
+  noteType?: "footnote" | "endnote";
+};
+
+export type CommentAttrs = {
+  commentId: number;
+};
+
+export type TrackedChangeMarkAttrs = {
+  revisionId: number;
+  author: string;
+  date?: string;
+  moveKind?: "moveTo" | "moveFrom";
+};
+
+export type RunFormattingOverrideAttrs = {
+  [K in keyof Pick<
+    TextFormatting,
+    | "bold"
+    | "italic"
+    | "strike"
+    | "doubleStrike"
+    | "allCaps"
+    | "smallCaps"
+    | "hidden"
+    | "emboss"
+    | "imprint"
+    | "shadow"
+    | "outline"
+  >]?: false;
+} & {
+  underline?: "none";
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -11,6 +11,7 @@ import type {
   ParagraphAlignment,
   ParagraphFormatting,
   ParagraphPropertyChange,
+  FieldType,
   LineSpacingRule,
   ImagePosition,
   ImageWrap,
@@ -24,6 +25,9 @@ import type {
   TableCellFormatting,
   TableWidthType,
   SectionProperties,
+  ShapeFill,
+  SdtProperties,
+  SdtType,
 } from "../../types/document";
 import type { SpacingExplicit } from "../../types/formatting";
 
@@ -201,6 +205,146 @@ export type ImageAttrs = {
   wrapText?: NonNullable<ImageWrap["wrapText"]>;
   /** Hyperlink URL for clickable image */
   hlinkHref?: string;
+};
+
+/**
+ * Field node attributes
+ */
+export type FieldAttrs = {
+  /** Field type: PAGE, NUMPAGES, DATE, MERGEFIELD, etc. */
+  fieldType: FieldType;
+  /** Full field instruction (e.g. "PAGE \\* MERGEFORMAT") */
+  instruction: string;
+  /** Current/cached display text */
+  displayText: string;
+  /** Whether the field came from w:fldSimple or a complex fldChar range */
+  fieldKind: "simple" | "complex";
+  /** Field is locked */
+  fldLock?: boolean;
+  /** Field is dirty and should be recalculated by the host application */
+  dirty?: boolean;
+};
+
+/**
+ * Math equation node attributes
+ */
+export type MathAttrs = {
+  /** Whether this is inline OMML or a block equation paragraph */
+  display?: "inline" | "block";
+  /** Raw OMML XML for round-trip preservation */
+  ommlXml: string;
+  /** Plain text fallback used by the editor and layout engine */
+  plainText?: string;
+};
+
+/**
+ * Structured document tag node attributes
+ */
+export type SdtAttrs = {
+  /** SDT type */
+  sdtType: SdtType;
+  /** Alias (friendly name) */
+  alias?: string;
+  /** Tag (developer identifier) */
+  tag?: string;
+  /** Lock setting */
+  lock?: NonNullable<SdtProperties["lock"]>;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Whether showing placeholder */
+  showingPlaceholder?: boolean;
+  /** Date format for date controls */
+  dateFormat?: string;
+  /** Dropdown/combobox list items as JSON string */
+  listItems?: string;
+  /** Checkbox checked state */
+  checked?: boolean;
+};
+
+/**
+ * Shape node attributes
+ */
+export type ShapeAttrs = {
+  /** Shape type preset */
+  shapeType?: string;
+  /** Unique identifier */
+  shapeId?: string;
+  /** Width in pixels */
+  width?: number;
+  /** Height in pixels */
+  height?: number;
+  /** Fill color as CSS color */
+  fillColor?: string;
+  /** Fill type: none, solid, gradient, pattern, picture */
+  fillType?: ShapeFill["type"];
+  /** Gradient type: linear, radial, rectangular, path */
+  gradientType?: NonNullable<ShapeFill["gradient"]>["type"];
+  /** Gradient angle in degrees (for linear) */
+  gradientAngle?: number;
+  /** Gradient stops as JSON string: [{position, color}] */
+  gradientStops?: string;
+  /** Outline width in pixels */
+  outlineWidth?: number;
+  /** Outline color as CSS color */
+  outlineColor?: string;
+  /** Outline style */
+  outlineStyle?: string;
+  /** CSS transform */
+  transform?: string;
+  /** Display mode */
+  displayMode?: "inline" | "float" | "block";
+  /** CSS float */
+  cssFloat?: "left" | "right" | "none";
+  /** Wrap type */
+  wrapType?: string;
+  /** Shadow color as CSS color */
+  shadowColor?: string;
+  /** Shadow blur radius in pixels */
+  shadowBlur?: number;
+  /** Shadow X offset in pixels */
+  shadowOffsetX?: number;
+  /** Shadow Y offset in pixels */
+  shadowOffsetY?: number;
+  /** Glow color as CSS color */
+  glowColor?: string;
+  /** Glow radius in pixels */
+  glowRadius?: number;
+};
+
+/**
+ * Text box node attributes
+ */
+export type TextBoxAttrs = {
+  /** Width in pixels */
+  width?: number;
+  /** Height in pixels */
+  height?: number;
+  /** Unique identifier */
+  textBoxId?: string;
+  /** Fill color as CSS color */
+  fillColor?: string;
+  /** Outline width in pixels */
+  outlineWidth?: number;
+  /** Outline color as CSS color */
+  outlineColor?: string;
+  /** Outline style */
+  outlineStyle?: string;
+  /** Internal margin top in pixels */
+  marginTop?: number;
+  /** Internal margin bottom in pixels */
+  marginBottom?: number;
+  /** Internal margin left in pixels */
+  marginLeft?: number;
+  /** Internal margin right in pixels */
+  marginRight?: number;
+  /** Vertical text alignment */
+  verticalAlign?: string;
+  /** Display mode */
+  displayMode?: "inline" | "float" | "block";
+  /** CSS float direction */
+  cssFloat?: "left" | "right" | "none";
+  /** Wrap type */
+  wrapType?: string;
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -222,6 +222,8 @@ export type ImageAttrs = {
   wrapText?: NonNullable<ImageWrap["wrapText"]>;
   /** Hyperlink URL for clickable image */
   hlinkHref?: string;
+  /** Original OOXML for opaque/unsupported DOCX drawings. */
+  _docxRawXml?: string;
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -345,6 +345,10 @@ export type TextBoxAttrs = {
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
   wrapType?: string;
+  /** Original DOCX placement hint for save-path reconstruction. */
+  _docxPlacement?: "standalone" | "inlineWithPrevious";
+  /** Original DOCX paragraph group for standalone text-box reconstruction. */
+  _docxGroupId?: string;
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -12,6 +12,8 @@ import type {
   ParagraphFormatting,
   ParagraphPropertyChange,
   LineSpacingRule,
+  ImagePosition,
+  ImageWrap,
   BorderSpec,
   ShadingProperties,
   TabStop,
@@ -20,6 +22,7 @@ import type {
   TableFormatting,
   TableRowFormatting,
   TableCellFormatting,
+  TableWidthType,
   SectionProperties,
 } from "../../types/document";
 import type { SpacingExplicit } from "../../types/formatting";
@@ -147,14 +150,14 @@ export type ParagraphAttrs = {
  */
 export type ImagePositionAttrs = {
   horizontal?: {
-    relativeTo?: string;
+    relativeTo?: NonNullable<ImagePosition["horizontal"]["relativeTo"]>;
     posOffset?: number; // In EMU
-    align?: string;
+    align?: NonNullable<ImagePosition["horizontal"]["alignment"]>;
   };
   vertical?: {
-    relativeTo?: string;
+    relativeTo?: NonNullable<ImagePosition["vertical"]["relativeTo"]>;
     posOffset?: number; // In EMU
-    align?: string;
+    align?: NonNullable<ImagePosition["vertical"]["alignment"]>;
   };
 };
 
@@ -171,14 +174,7 @@ export type ImageAttrs = {
   height?: number;
   rId?: string;
   /** Wrap type from DOCX: inline, square, tight, through, topAndBottom, behind, inFront */
-  wrapType?:
-    | "inline"
-    | "square"
-    | "tight"
-    | "through"
-    | "topAndBottom"
-    | "behind"
-    | "inFront";
+  wrapType?: ImageWrap["type"];
   /** Display mode for CSS: inline (flows with text), float (left/right float), block (centered) */
   displayMode?: "inline" | "float" | "block";
   /** CSS float direction for floating images */
@@ -202,7 +198,7 @@ export type ImageAttrs = {
   /** Border style (CSS border-style value) */
   borderStyle?: string;
   /** Wrap text setting from DOCX (left, right, bothSides, largest) for round-trip */
-  wrapText?: string;
+  wrapText?: NonNullable<ImageWrap["wrapText"]>;
   /** Hyperlink URL for clickable image */
   hlinkHref?: string;
 };
@@ -216,7 +212,7 @@ export type TableAttrs = {
   /** Table width (in twips) */
   width?: number;
   /** Table width type ('auto', 'pct', 'dxa') */
-  widthType?: string;
+  widthType?: TableWidthType;
   /** Table justification/alignment */
   justification?: "left" | "center" | "right";
   /** Column widths (in twips) from w:tblGrid */
@@ -243,7 +239,7 @@ export type TableRowAttrs = {
   /** Row height (in twips) */
   height?: number;
   /** Height rule ('auto', 'exact', 'atLeast') */
-  heightRule?: string;
+  heightRule?: NonNullable<TableRowFormatting["heightRule"]>;
   /** Is header row */
   isHeader?: boolean;
   /** Original row formatting from DOCX for lossless round-trip serialization */
@@ -263,13 +259,13 @@ export type TableCellAttrs = {
   /** Cell width (in twips) */
   width?: number;
   /** Cell width type */
-  widthType?: string;
+  widthType?: TableWidthType;
   /** Vertical alignment */
   verticalAlign?: "top" | "center" | "bottom";
   /** Background color (RGB hex) */
   backgroundColor?: string;
   /** OOXML text direction (e.g. 'tbRl', 'btLr') */
-  textDirection?: string;
+  textDirection?: NonNullable<TableCellFormatting["textDirection"]>;
   /** No text wrapping in cell */
   noWrap?: boolean;
   /** Cell borders — full BorderSpec per side (style, color, size) */

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -31,6 +31,10 @@ import type {
 } from "../../types/document";
 import type { SpacingExplicit } from "../../types/formatting";
 
+export type HardBreakAttrs = {
+  breakType?: "column";
+};
+
 /**
  * Paragraph node attributes - maps to ParagraphFormatting
  */

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -444,4 +444,6 @@ export type TableCellAttrs = {
   margins?: { top?: number; bottom?: number; left?: number; right?: number };
   /** Original cell formatting from DOCX for lossless round-trip serialization */
   _originalFormatting?: TableCellFormatting;
+  /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
+  _preserveVMergeRestart?: boolean;
 };

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -12,6 +12,7 @@ import type {
   ParagraphFormatting,
   ParagraphPropertyChange,
   FieldType,
+  Hyperlink,
   LineSpacingRule,
   ImagePosition,
   ImageWrap,
@@ -128,6 +129,18 @@ export type ParagraphAttrs = {
 
   // Bookmarks on this paragraph (for TOC anchors, cross-references)
   bookmarks?: { id: number; name: string }[];
+
+  /** Empty `w:hyperlink` elements cannot be represented as text marks.
+   *  Preserve their relationship metadata at the paragraph boundary so a
+   *  no-edit DOCX round-trip does not silently drop hyperlink elements. */
+  _emptyHyperlinks?: {
+    /** ProseMirror inline offset where the zero-width hyperlink appeared. */
+    offset: number;
+    href?: Hyperlink["href"];
+    anchor?: Hyperlink["anchor"];
+    tooltip?: Hyperlink["tooltip"];
+    rId?: Hyperlink["rId"];
+  }[];
 
   /**
    * Run-in heading flag: this paragraph's mark carries

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -23,6 +23,7 @@ import type {
   NumberFormat,
   TableFormatting,
   TableRowFormatting,
+  TableCell,
   TableCellFormatting,
   TableWidthType,
   SectionProperties,
@@ -448,4 +449,6 @@ export type TableCellAttrs = {
   _originalFormatting?: TableCellFormatting;
   /** Preserve a DOCX vMerge restart even when PM cannot model it as a rowspan. */
   _preserveVMergeRestart?: boolean;
+  /** Original DOCX vMerge continuation cells skipped into this PM rowspan. */
+  _docxVMergeContinuationCells?: TableCell[];
 };

--- a/packages/folio/src/core/prosemirror/selectionState.test.ts
+++ b/packages/folio/src/core/prosemirror/selectionState.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { EditorState, TextSelection } from "prosemirror-state";
+
+import { schema } from "./schema";
+import { extractSelectionState } from "./selectionState";
+
+const bold = schema.marks["bold"]!;
+
+function paragraphWithBoldRun() {
+  // Text node layout: "before " (plain) + "Parent" (bold) + " after" (plain).
+  // Cursor positions (1-indexed inside paragraph):
+  //   1               start of "before "
+  //   8               just after "before " — same-paragraph boundary entering bold
+  //   14              end of "Parent"
+  //   20              end of " after"
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, [
+      schema.text("before "),
+      schema.text("Parent", [bold.create()]),
+      schema.text(" after"),
+    ]),
+  ]);
+}
+
+function stateAt(from: number, to: number): EditorState {
+  const doc = paragraphWithBoldRun();
+  return EditorState.create({ doc }).apply(
+    EditorState.create({ doc }).tr.setSelection(
+      TextSelection.create(doc, from, to),
+    ),
+  );
+}
+
+describe("extractSelectionState — bold detection", () => {
+  test("reports bold for a selection that starts at a same-paragraph non-bold→bold boundary", () => {
+    // Selection: from boundary (8) to 2 chars into "Parent" (10).
+    // $from.marks() is left-biased and would return the prior text node's
+    // marks (non-bold), making the toolbar misreport bold as inactive even
+    // though the selected content is entirely bold. The range walk fixes it.
+    const state = stateAt(8, 10);
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.bold).toBe(true);
+  });
+
+  test("reports bold for a selection fully inside a bold run", () => {
+    const state = stateAt(9, 13);
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.bold).toBe(true);
+  });
+
+  test("reports bold for a mixed selection that crosses bold and non-bold text", () => {
+    // Spans the boundary on both sides: "before " (plain) + "Parent" (bold).
+    // Match toggleMark semantics — bold present anywhere in the range counts.
+    const state = stateAt(3, 12);
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.bold).toBe(true);
+  });
+
+  test("reports bold=false for a selection entirely inside non-bold text", () => {
+    const state = stateAt(2, 6);
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.bold).toBeUndefined();
+  });
+
+  test("empty cursor at a non-bold→bold boundary keeps left-biased semantics", () => {
+    // Empty selection uses storedMarks || $from.marks(); preserves the
+    // existing typing-into-cursor behavior.
+    const state = stateAt(8, 8);
+    const result = extractSelectionState(state);
+
+    expect(result?.textFormatting.bold).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/prosemirror/selectionState.ts
+++ b/packages/folio/src/core/prosemirror/selectionState.ts
@@ -4,6 +4,7 @@
  * Extracts selection state from ProseMirror for toolbar integration.
  */
 
+import type { Mark } from "prosemirror-model";
 import type { EditorState } from "prosemirror-state";
 
 import type { TextFormatting, ParagraphFormatting } from "../types/document";
@@ -74,9 +75,16 @@ export function extractSelectionState(
     "defaultTextFormatting"
   ] as TextFormatting | undefined;
 
-  // For empty selection (cursor), use stored marks or marks at cursor position
-  // For non-empty selection, check marks at the start of selection
-  const marks = state.storedMarks || selection.$from.marks();
+  // For empty selection (cursor), use stored marks or marks at cursor position.
+  // For non-empty selections, $from.marks() is left-biased — when the selection
+  // starts at a text-node boundary it returns marks of the node before $from,
+  // not of the selected content. That makes the toolbar misreport bold/italic/
+  // etc. on selections that start at the first character of a marked run.
+  // Match toggleMark's "any inline child in range has the mark" semantics so
+  // the toolbar's active state agrees with what a toggle click will toggle.
+  const marks = empty
+    ? state.storedMarks || selection.$from.marks()
+    : collectMarksInRange(doc, from, to);
 
   // If in empty paragraph with no marks but has defaultTextFormatting, use that
   if (isEmptyParagraph && marks.length === 0 && paragraphDefaultFormatting) {
@@ -181,4 +189,30 @@ export function extractSelectionState(
     startParagraphIndex,
     endParagraphIndex,
   };
+}
+
+/**
+ * Collect the first occurrence of each mark type found on any text node within
+ * the range. Mirrors the "any inline child has this mark" semantics that
+ * prosemirror-commands' toggleMark uses to decide add-vs-remove, so the
+ * toolbar's active state stays consistent with what a toggle click will do.
+ */
+function collectMarksInRange(
+  doc: EditorState["doc"],
+  from: number,
+  to: number,
+): Mark[] {
+  const seen = new Map<string, Mark>();
+  doc.nodesBetween(from, to, (node) => {
+    if (!node.isText) {
+      return;
+    }
+    for (const mark of node.marks) {
+      const name = mark.type.name;
+      if (!seen.has(name)) {
+        seen.set(name, mark);
+      }
+    }
+  });
+  return Array.from(seen.values());
 }

--- a/packages/folio/src/core/prosemirror/validation.test.ts
+++ b/packages/folio/src/core/prosemirror/validation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "./schema";
+import {
+  assertValidProseMirrorDocument,
+  validateProseMirrorDocument,
+} from "./validation";
+
+describe("ProseMirror document validation", () => {
+  test("reports attr issues with document paths", () => {
+    const highlight = schema.mark("highlight", { color: "customYellow" });
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { paraId: 12 }, [
+        schema.text("bad", [highlight]),
+        schema.node("field", {
+          fieldType: "NOT_A_FIELD",
+          instruction: " PAGE ",
+          displayText: "1",
+          fieldKind: "simple",
+        }),
+      ]),
+    ]);
+
+    const result = validateProseMirrorDocument(doc);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        "doc.content[0].paragraph.attrs.paraId",
+        "doc.content[0].content[0].marks[0].highlight.attrs.color",
+        "doc.content[0].content[1].field.attrs.fieldType",
+      ]),
+    );
+  });
+
+  test("throws a formatted validation error", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", { lineSpacing: "240" }, [
+        schema.text("invalid"),
+      ]),
+    ]);
+
+    expect(() =>
+      assertValidProseMirrorDocument(doc, "Cannot use invalid PM document"),
+    ).toThrow(
+      "ProseMirror document error at doc.content[0].paragraph.attrs.lineSpacing",
+    );
+  });
+});

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -1,0 +1,272 @@
+import type { Mark, Node as PMNode } from "prosemirror-model";
+
+import type { ProseMirrorAttrIssue, ReadProseMirrorAttrsResult } from "./attrs";
+import {
+  readCharacterSpacingMarkAttrs,
+  readCommentMarkAttrs,
+  readEmphasisMarkAttrs,
+  readFieldAttrs,
+  readFontFamilyMarkAttrs,
+  readFontSizeMarkAttrs,
+  readFootnoteRefMarkAttrs,
+  readHighlightMarkAttrs,
+  readHyperlinkMarkAttrs,
+  readImageAttrs,
+  readMathAttrs,
+  readParagraphAttrs,
+  readRunFormattingOverrideMarkAttrs,
+  readSdtAttrs,
+  readShapeAttrs,
+  readStrikeMarkAttrs,
+  readTableAttrs,
+  readTableCellAttrs,
+  readTableRowAttrs,
+  readTextBoxAttrs,
+  readTextColorMarkAttrs,
+  readTrackedChangeMarkAttrs,
+  readUnderlineMarkAttrs,
+} from "./attrs";
+
+export type ProseMirrorDocumentValidationIssue = {
+  path: string;
+  message: string;
+};
+
+export type ValidateProseMirrorDocumentResult = {
+  valid: boolean;
+  issues: ProseMirrorDocumentValidationIssue[];
+};
+
+export class ProseMirrorDocumentValidationError extends Error {
+  readonly issues: ProseMirrorDocumentValidationIssue[];
+
+  constructor(context: string, issues: ProseMirrorDocumentValidationIssue[]) {
+    super(`${context}:\n${formatProseMirrorDocumentIssues(issues).join("\n")}`);
+    this.name = "ProseMirrorDocumentValidationError";
+    this.issues = issues;
+  }
+}
+
+export const validateProseMirrorDocument = (
+  doc: PMNode,
+): ValidateProseMirrorDocumentResult => {
+  const issues: ProseMirrorDocumentValidationIssue[] = [];
+
+  if (doc.type.name !== "doc") {
+    issues.push({
+      path: "doc.type.name",
+      message: `Expected doc, got ${doc.type.name}.`,
+    });
+  }
+
+  validateNode(doc, "doc", issues);
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+};
+
+export const assertValidProseMirrorDocument = (
+  doc: PMNode,
+  context: string,
+): void => {
+  const validation = validateProseMirrorDocument(doc);
+  if (validation.valid) {
+    return;
+  }
+
+  throw new ProseMirrorDocumentValidationError(context, validation.issues);
+};
+
+export const formatProseMirrorDocumentIssues = (
+  issues: ProseMirrorDocumentValidationIssue[],
+): string[] =>
+  issues.map(
+    (issue) => `ProseMirror document error at ${issue.path}: ${issue.message}`,
+  );
+
+const validateNode = (
+  node: PMNode,
+  path: string,
+  issues: ProseMirrorDocumentValidationIssue[],
+): void => {
+  validateNodeAttrs(node, path, issues);
+  validateMarks(node.marks, path, issues);
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child, _offset, index) => {
+    validateNode(child, `${path}.content[${index}]`, issues);
+  });
+};
+
+const validateNodeAttrs = (
+  node: PMNode,
+  path: string,
+  issues: ProseMirrorDocumentValidationIssue[],
+): void => {
+  switch (node.type.name) {
+    case "doc":
+    case "text":
+    case "hardBreak":
+    case "horizontalRule":
+    case "pageBreak":
+    case "tab":
+      return;
+
+    case "paragraph":
+      appendAttrIssues(path, readParagraphAttrs(node), issues);
+      return;
+
+    case "table":
+      appendAttrIssues(path, readTableAttrs(node), issues);
+      return;
+
+    case "tableRow":
+      appendAttrIssues(path, readTableRowAttrs(node), issues);
+      return;
+
+    case "tableCell":
+    case "tableHeader":
+      appendAttrIssues(path, readTableCellAttrs(node), issues);
+      return;
+
+    case "image":
+      appendAttrIssues(path, readImageAttrs(node), issues);
+      return;
+
+    case "field":
+      appendAttrIssues(path, readFieldAttrs(node), issues);
+      return;
+
+    case "math":
+      appendAttrIssues(path, readMathAttrs(node), issues);
+      return;
+
+    case "sdt":
+      appendAttrIssues(path, readSdtAttrs(node), issues);
+      return;
+
+    case "shape":
+      appendAttrIssues(path, readShapeAttrs(node), issues);
+      return;
+
+    case "textBox":
+      appendAttrIssues(path, readTextBoxAttrs(node), issues);
+      return;
+
+    default:
+      issues.push({
+        path: `${path}.type.name`,
+        message: `Unsupported ProseMirror node type ${node.type.name}.`,
+      });
+  }
+};
+
+const validateMarks = (
+  marks: readonly Mark[],
+  path: string,
+  issues: ProseMirrorDocumentValidationIssue[],
+): void => {
+  for (const [index, mark] of marks.entries()) {
+    const markPath = `${path}.marks[${index}]`;
+    switch (mark.type.name) {
+      case "bold":
+      case "italic":
+      case "subscript":
+      case "superscript":
+      case "allCaps":
+      case "smallCaps":
+      case "emboss":
+      case "imprint":
+      case "textShadow":
+      case "textOutline":
+        continue;
+
+      case "underline":
+        appendAttrIssues(markPath, readUnderlineMarkAttrs(mark), issues);
+        continue;
+
+      case "strike":
+        appendAttrIssues(markPath, readStrikeMarkAttrs(mark), issues);
+        continue;
+
+      case "textColor":
+        appendAttrIssues(markPath, readTextColorMarkAttrs(mark), issues);
+        continue;
+
+      case "highlight":
+        appendAttrIssues(markPath, readHighlightMarkAttrs(mark), issues);
+        continue;
+
+      case "fontSize":
+        appendAttrIssues(markPath, readFontSizeMarkAttrs(mark), issues);
+        continue;
+
+      case "fontFamily":
+        appendAttrIssues(markPath, readFontFamilyMarkAttrs(mark), issues);
+        continue;
+
+      case "characterSpacing":
+        appendAttrIssues(markPath, readCharacterSpacingMarkAttrs(mark), issues);
+        continue;
+
+      case "emphasisMark":
+        appendAttrIssues(markPath, readEmphasisMarkAttrs(mark), issues);
+        continue;
+
+      case "footnoteRef":
+        appendAttrIssues(markPath, readFootnoteRefMarkAttrs(mark), issues);
+        continue;
+
+      case "comment":
+        appendAttrIssues(markPath, readCommentMarkAttrs(mark), issues);
+        continue;
+
+      case "insertion":
+      case "deletion":
+        appendAttrIssues(markPath, readTrackedChangeMarkAttrs(mark), issues);
+        continue;
+
+      case "runFormattingOverride":
+        appendAttrIssues(
+          markPath,
+          readRunFormattingOverrideMarkAttrs(mark),
+          issues,
+        );
+        continue;
+
+      case "hyperlink":
+        appendAttrIssues(markPath, readHyperlinkMarkAttrs(mark), issues);
+        continue;
+
+      default:
+        issues.push({
+          path: `${markPath}.type.name`,
+          message: `Unsupported ProseMirror mark type ${mark.type.name}.`,
+        });
+    }
+  }
+};
+
+const appendAttrIssues = <T>(
+  path: string,
+  result: ReadProseMirrorAttrsResult<T>,
+  issues: ProseMirrorDocumentValidationIssue[],
+): void => {
+  if (result.ok) {
+    return;
+  }
+
+  for (const issue of result.issues) {
+    issues.push(withPathPrefix(path, issue));
+  }
+};
+
+const withPathPrefix = (
+  prefix: string,
+  issue: ProseMirrorAttrIssue,
+): ProseMirrorDocumentValidationIssue => ({
+  path: `${prefix}.${issue.path}`,
+  message: issue.message,
+});

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -9,6 +9,7 @@ import {
   readFontFamilyMarkAttrs,
   readFontSizeMarkAttrs,
   readFootnoteRefMarkAttrs,
+  readHardBreakAttrs,
   readHighlightMarkAttrs,
   readHyperlinkMarkAttrs,
   readImageAttrs,
@@ -108,10 +109,13 @@ const validateNodeAttrs = (
   switch (node.type.name) {
     case "doc":
     case "text":
-    case "hardBreak":
     case "horizontalRule":
     case "pageBreak":
     case "tab":
+      return;
+
+    case "hardBreak":
+      appendAttrIssues(path, readHardBreakAttrs(node), issues);
       return;
 
     case "paragraph":

--- a/packages/folio/src/core/types/documentEnumValues.ts
+++ b/packages/folio/src/core/types/documentEnumValues.ts
@@ -1,0 +1,555 @@
+import type {
+  EmphasisMark,
+  FieldType,
+  FloatingTableProperties,
+  ImagePosition,
+  ImageWrap,
+  LevelSuffix,
+  LineSpacingRule,
+  NumberFormat,
+  ParagraphAlignment,
+  ParagraphFormatting,
+  SdtProperties,
+  SdtType,
+  ShadingProperties,
+  ShapeOutline,
+  Style,
+  StyleType,
+  TableCellFormatting,
+  TableFormatting,
+  TableRowFormatting,
+  TableWidthType,
+  TabLeader,
+  TabStopAlignment,
+  TextEffect,
+  TextFormatting,
+  ThemeColorSlot,
+  UnderlineStyle,
+  KnownBorderStyle,
+} from "./document";
+
+export const THEME_COLOR_SLOT_VALUES = [
+  "dk1",
+  "lt1",
+  "dk2",
+  "lt2",
+  "accent1",
+  "accent2",
+  "accent3",
+  "accent4",
+  "accent5",
+  "accent6",
+  "hlink",
+  "folHlink",
+  "background1",
+  "text1",
+  "background2",
+  "text2",
+] as const satisfies readonly ThemeColorSlot[];
+
+export const BORDER_STYLE_VALUES = [
+  "none",
+  "single",
+  "double",
+  "dotted",
+  "dashed",
+  "thick",
+  "triple",
+  "thinThickSmallGap",
+  "thickThinSmallGap",
+  "thinThickMediumGap",
+  "thickThinMediumGap",
+  "thinThickLargeGap",
+  "thickThinLargeGap",
+  "wave",
+  "doubleWave",
+  "dashSmallGap",
+  "dashDotStroked",
+  "threeDEmboss",
+  "threeDEngrave",
+  "outset",
+  "inset",
+  "nil",
+] as const satisfies readonly KnownBorderStyle[];
+
+export const UNDERLINE_STYLE_VALUES = [
+  "none",
+  "single",
+  "words",
+  "double",
+  "thick",
+  "dotted",
+  "dottedHeavy",
+  "dash",
+  "dashedHeavy",
+  "dashLong",
+  "dashLongHeavy",
+  "dotDash",
+  "dashDotHeavy",
+  "dotDotDash",
+  "dashDotDotHeavy",
+  "wave",
+  "wavyHeavy",
+  "wavyDouble",
+] as const satisfies readonly UnderlineStyle[];
+
+export const HIGHLIGHT_COLOR_VALUES = [
+  "black",
+  "blue",
+  "cyan",
+  "darkBlue",
+  "darkCyan",
+  "darkGray",
+  "darkGreen",
+  "darkMagenta",
+  "darkRed",
+  "darkYellow",
+  "green",
+  "lightGray",
+  "magenta",
+  "none",
+  "red",
+  "white",
+  "yellow",
+] as const satisfies readonly NonNullable<TextFormatting["highlight"]>[];
+
+export const TEXT_EFFECT_VALUES = [
+  "none",
+  "blinkBackground",
+  "lights",
+  "antsBlack",
+  "antsRed",
+  "shimmer",
+  "sparkle",
+] as const satisfies readonly TextEffect[];
+
+export const EMPHASIS_MARK_VALUES = [
+  "none",
+  "dot",
+  "comma",
+  "circle",
+  "underDot",
+] as const satisfies readonly EmphasisMark[];
+
+type FontTheme = NonNullable<
+  NonNullable<TextFormatting["fontFamily"]>["asciiTheme"]
+>;
+
+export const FONT_THEME_VALUES = [
+  "majorAscii",
+  "majorHAnsi",
+  "majorEastAsia",
+  "majorBidi",
+  "minorAscii",
+  "minorHAnsi",
+  "minorEastAsia",
+  "minorBidi",
+] as const satisfies readonly FontTheme[];
+
+export const PARAGRAPH_ALIGNMENT_VALUES = [
+  "left",
+  "center",
+  "right",
+  "both",
+  "distribute",
+  "mediumKashida",
+  "highKashida",
+  "lowKashida",
+  "thaiDistribute",
+] as const satisfies readonly ParagraphAlignment[];
+
+export const LINE_SPACING_RULE_VALUES = [
+  "auto",
+  "exact",
+  "atLeast",
+] as const satisfies readonly LineSpacingRule[];
+
+export const TAB_STOP_ALIGNMENT_VALUES = [
+  "left",
+  "center",
+  "right",
+  "decimal",
+  "bar",
+  "clear",
+  "num",
+] as const satisfies readonly TabStopAlignment[];
+
+export const TAB_LEADER_VALUES = [
+  "none",
+  "dot",
+  "hyphen",
+  "underscore",
+  "heavy",
+  "middleDot",
+] as const satisfies readonly TabLeader[];
+
+type Frame = NonNullable<ParagraphFormatting["frame"]>;
+
+export const FRAME_X_ALIGN_VALUES = [
+  "left",
+  "center",
+  "right",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<Frame["xAlign"]>[];
+
+export const FRAME_Y_ALIGN_VALUES = [
+  "top",
+  "center",
+  "bottom",
+  "inside",
+  "outside",
+  "inline",
+] as const satisfies readonly NonNullable<Frame["yAlign"]>[];
+
+export const FRAME_WRAP_VALUES = [
+  "around",
+  "auto",
+  "none",
+  "notBeside",
+  "through",
+  "tight",
+] as const satisfies readonly NonNullable<Frame["wrap"]>[];
+
+export const SDT_LOCK_VALUES = [
+  "sdtLocked",
+  "contentLocked",
+  "sdtContentLocked",
+  "unlocked",
+] as const satisfies readonly NonNullable<SdtProperties["lock"]>[];
+
+export const SDT_TYPE_VALUES = [
+  "richText",
+  "plainText",
+  "date",
+  "dropdown",
+  "comboBox",
+  "checkbox",
+  "picture",
+  "buildingBlockGallery",
+  "group",
+  "unknown",
+] as const satisfies readonly SdtType[];
+
+export const FIELD_TYPE_VALUES = [
+  "PAGE",
+  "NUMPAGES",
+  "NUMWORDS",
+  "NUMCHARS",
+  "DATE",
+  "TIME",
+  "CREATEDATE",
+  "SAVEDATE",
+  "PRINTDATE",
+  "AUTHOR",
+  "TITLE",
+  "SUBJECT",
+  "KEYWORDS",
+  "COMMENTS",
+  "FILENAME",
+  "FILESIZE",
+  "TEMPLATE",
+  "DOCPROPERTY",
+  "DOCVARIABLE",
+  "REF",
+  "PAGEREF",
+  "NOTEREF",
+  "HYPERLINK",
+  "TOC",
+  "TOA",
+  "INDEX",
+  "SEQ",
+  "STYLEREF",
+  "AUTONUM",
+  "AUTONUMLGL",
+  "AUTONUMOUT",
+  "IF",
+  "MERGEFIELD",
+  "NEXT",
+  "NEXTIF",
+  "ASK",
+  "SET",
+  "QUOTE",
+  "INCLUDETEXT",
+  "INCLUDEPICTURE",
+  "SYMBOL",
+  "ADVANCE",
+  "EDITTIME",
+  "REVNUM",
+  "SECTION",
+  "SECTIONPAGES",
+  "USERADDRESS",
+  "USERNAME",
+  "USERINITIALS",
+  "UNKNOWN",
+] as const satisfies readonly FieldType[];
+
+export const STYLE_TYPE_VALUES = [
+  "paragraph",
+  "character",
+  "numbering",
+  "table",
+] as const satisfies readonly StyleType[];
+
+type ConditionalStyleType = NonNullable<Style["tblStylePr"]>[number]["type"];
+
+export const CONDITIONAL_STYLE_TYPE_VALUES = [
+  "band1Horz",
+  "band1Vert",
+  "band2Horz",
+  "band2Vert",
+  "firstCol",
+  "firstRow",
+  "lastCol",
+  "lastRow",
+  "neCell",
+  "nwCell",
+  "seCell",
+  "swCell",
+  "wholeTable",
+] as const satisfies readonly ConditionalStyleType[];
+
+export const TABLE_WIDTH_TYPE_VALUES = [
+  "auto",
+  "dxa",
+  "nil",
+  "pct",
+] as const satisfies readonly TableWidthType[];
+
+export const TABLE_JUSTIFICATION_VALUES = [
+  "left",
+  "center",
+  "right",
+] as const satisfies readonly NonNullable<TableFormatting["justification"]>[];
+
+export const TABLE_ROW_HEIGHT_RULE_VALUES = [
+  "auto",
+  "atLeast",
+  "exact",
+] as const satisfies readonly NonNullable<TableRowFormatting["heightRule"]>[];
+
+export const TABLE_CELL_VERTICAL_ALIGNMENT_VALUES = [
+  "top",
+  "center",
+  "bottom",
+] as const satisfies readonly NonNullable<
+  TableCellFormatting["verticalAlign"]
+>[];
+
+export const TABLE_CELL_TEXT_DIRECTION_VALUES = [
+  "lr",
+  "lrV",
+  "rl",
+  "rlV",
+  "tb",
+  "tbV",
+  "tbRl",
+  "tbRlV",
+  "btLr",
+] as const satisfies readonly NonNullable<
+  TableCellFormatting["textDirection"]
+>[];
+
+export const SHADING_PATTERN_VALUES = [
+  "clear",
+  "solid",
+  "horzStripe",
+  "vertStripe",
+  "reverseDiagStripe",
+  "diagStripe",
+  "horzCross",
+  "diagCross",
+  "thinHorzStripe",
+  "thinVertStripe",
+  "thinReverseDiagStripe",
+  "thinDiagStripe",
+  "thinHorzCross",
+  "thinDiagCross",
+  "pct5",
+  "pct10",
+  "pct12",
+  "pct15",
+  "pct20",
+  "pct25",
+  "pct30",
+  "pct35",
+  "pct37",
+  "pct40",
+  "pct45",
+  "pct50",
+  "pct55",
+  "pct60",
+  "pct62",
+  "pct65",
+  "pct70",
+  "pct75",
+  "pct80",
+  "pct85",
+  "pct87",
+  "pct90",
+  "pct95",
+  "nil",
+] as const satisfies readonly NonNullable<ShadingProperties["pattern"]>[];
+
+export const FLOATING_TABLE_X_SPEC_VALUES = [
+  "left",
+  "center",
+  "right",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<
+  FloatingTableProperties["tblpXSpec"]
+>[];
+
+export const FLOATING_TABLE_Y_SPEC_VALUES = [
+  "top",
+  "center",
+  "bottom",
+  "inside",
+  "outside",
+  "inline",
+] as const satisfies readonly NonNullable<
+  FloatingTableProperties["tblpYSpec"]
+>[];
+
+export const IMAGE_WRAP_TYPE_VALUES = [
+  "inline",
+  "square",
+  "tight",
+  "through",
+  "topAndBottom",
+  "behind",
+  "inFront",
+] as const satisfies readonly ImageWrap["type"][];
+
+export const IMAGE_HORIZONTAL_RELATIVE_TO_VALUES = [
+  "character",
+  "column",
+  "insideMargin",
+  "leftMargin",
+  "margin",
+  "outsideMargin",
+  "page",
+  "rightMargin",
+] as const satisfies readonly ImagePosition["horizontal"]["relativeTo"][];
+
+export const IMAGE_HORIZONTAL_ALIGNMENT_VALUES = [
+  "left",
+  "right",
+  "center",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<
+  ImagePosition["horizontal"]["alignment"]
+>[];
+
+export const IMAGE_VERTICAL_RELATIVE_TO_VALUES = [
+  "insideMargin",
+  "line",
+  "margin",
+  "outsideMargin",
+  "page",
+  "paragraph",
+  "topMargin",
+  "bottomMargin",
+] as const satisfies readonly ImagePosition["vertical"]["relativeTo"][];
+
+export const IMAGE_VERTICAL_ALIGNMENT_VALUES = [
+  "top",
+  "bottom",
+  "center",
+  "inside",
+  "outside",
+] as const satisfies readonly NonNullable<
+  ImagePosition["vertical"]["alignment"]
+>[];
+
+export const IMAGE_WRAP_TEXT_VALUES = [
+  "bothSides",
+  "left",
+  "right",
+  "largest",
+] as const satisfies readonly NonNullable<ImageWrap["wrapText"]>[];
+
+export const SHAPE_OUTLINE_STYLE_VALUES = [
+  "solid",
+  "dot",
+  "dash",
+  "lgDash",
+  "dashDot",
+  "lgDashDot",
+  "lgDashDotDot",
+  "sysDot",
+  "sysDash",
+  "sysDashDot",
+  "sysDashDotDot",
+] as const satisfies readonly NonNullable<ShapeOutline["style"]>[];
+
+export const NUMBER_FORMAT_VALUES = [
+  "decimal",
+  "upperRoman",
+  "lowerRoman",
+  "upperLetter",
+  "lowerLetter",
+  "ordinal",
+  "cardinalText",
+  "ordinalText",
+  "hex",
+  "chicago",
+  "ideographDigital",
+  "japaneseCounting",
+  "aiueo",
+  "iroha",
+  "decimalFullWidth",
+  "decimalHalfWidth",
+  "japaneseLegal",
+  "japaneseDigitalTenThousand",
+  "decimalEnclosedCircle",
+  "decimalFullWidth2",
+  "aiueoFullWidth",
+  "irohaFullWidth",
+  "decimalZero",
+  "bullet",
+  "ganada",
+  "chosung",
+  "decimalEnclosedFullstop",
+  "decimalEnclosedParen",
+  "decimalEnclosedCircleChinese",
+  "ideographEnclosedCircle",
+  "ideographTraditional",
+  "ideographZodiac",
+  "ideographZodiacTraditional",
+  "taiwaneseCounting",
+  "ideographLegalTraditional",
+  "taiwaneseCountingThousand",
+  "taiwaneseDigital",
+  "chineseCounting",
+  "chineseLegalSimplified",
+  "chineseCountingThousand",
+  "koreanDigital",
+  "koreanCounting",
+  "koreanLegal",
+  "koreanDigital2",
+  "vietnameseCounting",
+  "russianLower",
+  "russianUpper",
+  "none",
+  "numberInDash",
+  "hebrew1",
+  "hebrew2",
+  "arabicAlpha",
+  "arabicAbjad",
+  "hindiVowels",
+  "hindiConsonants",
+  "hindiNumbers",
+  "hindiCounting",
+  "thaiLetters",
+  "thaiNumbers",
+  "thaiCounting",
+] as const satisfies readonly NumberFormat[];
+
+export const LEVEL_SUFFIX_VALUES = [
+  "tab",
+  "space",
+  "nothing",
+] as const satisfies readonly LevelSuffix[];

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -102,9 +102,19 @@ import type {
 } from "../core/layout-painter/renderPage";
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "../core/prosemirror";
+import {
+  expectImageAttrs,
+  expectTableAttrs,
+  expectTableCellAttrs,
+  mergeImageAttrs,
+  mergeTableAttrs,
+  mergeTableCellAttrs,
+  mergeTableRowAttrs,
+} from "../core/prosemirror/attrs";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { anonymizationDecorationsKey } from "../core/prosemirror/plugins/anonymizationDecorations";
 import type { AnonymizationMatch } from "../core/prosemirror/plugins/anonymizationDecorations";
+import type { ImagePositionAttrs } from "../core/prosemirror/schema/nodes";
 import type { Footnote } from "../core/types/content";
 // Types
 import type {
@@ -3597,15 +3607,20 @@ export function PagedEditor(
           if (node.type.name === "table") {
             const tablePos = $pos.before(d);
             const tr = view.state.tr;
-            const widths = [...(node.attrs["columnWidths"] as number[])];
+            const tableAttrs = expectTableAttrs(node);
+            if (!tableAttrs.columnWidths) {
+              break;
+            }
+            const widths = [...tableAttrs.columnWidths];
             widths[colIdx] = newLeft;
             widths[colIdx + 1] = newRight;
 
             // Update table columnWidths attr
-            tr.setNodeMarkup(tablePos, undefined, {
-              ...node.attrs,
-              columnWidths: widths,
-            });
+            tr.setNodeMarkup(
+              tablePos,
+              undefined,
+              mergeTableAttrs(node, { columnWidths: widths }),
+            );
 
             // Update cell width attrs in each row
             let rowOffset = tablePos + 1;
@@ -3615,15 +3630,19 @@ export function PagedEditor(
               let cellColIdx = 0;
               // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
               row.forEach((cell) => {
-                const colspan = (cell.attrs["colspan"] as number) || 1;
+                const cellAttrs = expectTableCellAttrs(cell);
+                const colspan = cellAttrs.colspan || 1;
                 if (cellColIdx === colIdx || cellColIdx === colIdx + 1) {
                   const newWidth = cellColIdx === colIdx ? newLeft : newRight;
-                  tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
-                    ...cell.attrs,
-                    width: newWidth,
-                    widthType: "dxa",
-                    colwidth: null,
-                  });
+                  tr.setNodeMarkup(
+                    tr.mapping.map(cellOffset),
+                    undefined,
+                    mergeTableCellAttrs(cell, {
+                      width: newWidth,
+                      widthType: "dxa",
+                      colwidth: null,
+                    }),
+                  );
                 }
                 cellOffset += cell.nodeSize;
                 cellColIdx += colspan;
@@ -3666,11 +3685,14 @@ export function PagedEditor(
             // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
             node.forEach((row) => {
               if (idx === rowIdx) {
-                tr.setNodeMarkup(tr.mapping.map(rowOffset), undefined, {
-                  ...row.attrs,
-                  height: newHeight,
-                  heightRule: "atLeast",
-                });
+                tr.setNodeMarkup(
+                  tr.mapping.map(rowOffset),
+                  undefined,
+                  mergeTableRowAttrs(row, {
+                    height: newHeight,
+                    heightRule: "atLeast",
+                  }),
+                );
               }
               rowOffset += row.nodeSize;
               idx++;
@@ -3706,13 +3728,18 @@ export function PagedEditor(
             const tr = view.state.tr;
 
             // Update columnWidths — only change last column
-            const widths = [...(node.attrs["columnWidths"] as number[])];
+            const tableAttrs = expectTableAttrs(node);
+            if (!tableAttrs.columnWidths) {
+              break;
+            }
+            const widths = [...tableAttrs.columnWidths];
             widths[colIdx] = newWidth;
 
-            tr.setNodeMarkup(tablePos, undefined, {
-              ...node.attrs,
-              columnWidths: widths,
-            });
+            tr.setNodeMarkup(
+              tablePos,
+              undefined,
+              mergeTableAttrs(node, { columnWidths: widths }),
+            );
 
             // Update cell width attrs in the last column of each row
             let rowOffset = tablePos + 1;
@@ -3722,14 +3749,18 @@ export function PagedEditor(
               let cellColIdx = 0;
               // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node API
               row.forEach((cell) => {
-                const colspan = (cell.attrs["colspan"] as number) || 1;
+                const cellAttrs = expectTableCellAttrs(cell);
+                const colspan = cellAttrs.colspan || 1;
                 if (cellColIdx === colIdx) {
-                  tr.setNodeMarkup(tr.mapping.map(cellOffset), undefined, {
-                    ...cell.attrs,
-                    width: newWidth,
-                    widthType: "dxa",
-                    colwidth: null,
-                  });
+                  tr.setNodeMarkup(
+                    tr.mapping.map(cellOffset),
+                    undefined,
+                    mergeTableCellAttrs(cell, {
+                      width: newWidth,
+                      widthType: "dxa",
+                      colwidth: null,
+                    }),
+                  );
                 }
                 cellOffset += cell.nodeSize;
                 cellColIdx += colspan;
@@ -4227,11 +4258,11 @@ export function PagedEditor(
           return;
         }
 
-        const tr = view.state.tr.setNodeMarkup(pmPos, undefined, {
-          ...node.attrs,
-          width: newWidth,
-          height: newHeight,
-        });
+        const tr = view.state.tr.setNodeMarkup(
+          pmPos,
+          undefined,
+          mergeImageAttrs(node, { width: newWidth, height: newHeight }),
+        );
         view.dispatch(tr);
 
         // Re-select the image after resize
@@ -4274,12 +4305,12 @@ export function PagedEditor(
           return;
         }
 
+        const attrs = expectImageAttrs(node);
         const isFloating =
-          node.attrs["displayMode"] === "float" ||
-          (node.attrs["wrapType"] &&
-            ["square", "tight", "through"].includes(
-              node.attrs["wrapType"] as string,
-            ));
+          attrs.displayMode === "float" ||
+          attrs.wrapType === "square" ||
+          attrs.wrapType === "tight" ||
+          attrs.wrapType === "through";
 
         if (isFloating) {
           // For floating images: update position attributes so the image
@@ -4319,15 +4350,16 @@ export function PagedEditor(
           const hOffsetEmu = Math.round(dropX * PIXELS_TO_EMU);
           const vOffsetEmu = Math.round(dropY * PIXELS_TO_EMU);
 
-          const newPosition = {
+          const newPosition: ImagePositionAttrs = {
             horizontal: { posOffset: hOffsetEmu, relativeTo: "margin" },
             vertical: { posOffset: vOffsetEmu, relativeTo: "margin" },
           };
 
-          const tr = view.state.tr.setNodeMarkup(pmPos, undefined, {
-            ...node.attrs,
-            position: newPosition,
-          });
+          const tr = view.state.tr.setNodeMarkup(
+            pmPos,
+            undefined,
+            mergeImageAttrs(node, { position: newPosition }),
+          );
           view.dispatch(tr);
           hiddenPMRef.current?.setNodeSelection(pmPos);
         } else {

--- a/packages/folio/src/paged-editor/transactionDirtyRange.test.ts
+++ b/packages/folio/src/paged-editor/transactionDirtyRange.test.ts
@@ -25,4 +25,38 @@ describe("getTransactionDirtyRange", () => {
       to: firstEditPosition + prefixInsertion.length + 1,
     });
   });
+
+  test("reports the mark range for AddMarkStep transactions", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [schema.text("hello world")]),
+    ]);
+    const state = EditorState.create({ doc });
+    const bold = schema.marks["bold"];
+    if (!bold) {
+      throw new Error("bold mark missing from schema");
+    }
+    const transaction = state.tr.addMark(2, 7, bold.create());
+
+    const dirtyRange = getTransactionDirtyRange(transaction);
+
+    expect(dirtyRange).toEqual({ from: 2, to: 7 });
+  });
+
+  test("reports the mark range for RemoveMarkStep transactions", () => {
+    const bold = schema.marks["bold"];
+    if (!bold) {
+      throw new Error("bold mark missing from schema");
+    }
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("hello world", [bold.create()]),
+      ]),
+    ]);
+    const state = EditorState.create({ doc });
+    const transaction = state.tr.removeMark(2, 7, bold);
+
+    const dirtyRange = getTransactionDirtyRange(transaction);
+
+    expect(dirtyRange).toEqual({ from: 2, to: 7 });
+  });
 });

--- a/packages/folio/src/paged-editor/transactionDirtyRange.ts
+++ b/packages/folio/src/paged-editor/transactionDirtyRange.ts
@@ -1,4 +1,5 @@
 import type { Transaction } from "prosemirror-state";
+import { AddMarkStep, RemoveMarkStep } from "prosemirror-transform";
 
 import type { DirtyRange } from "./incrementalMeasure";
 
@@ -41,12 +42,7 @@ function includeStepDirtyRange(
   }
 
   const followingMaps = transaction.mapping.slice(stepIndex + 1);
-  const includeChangedRange = (
-    _oldStart: number,
-    _oldEnd: number,
-    newStart: number,
-    newEnd: number,
-  ) => {
+  const extend = (newStart: number, newEnd: number) => {
     // oxlint-disable-next-line unicorn/no-array-method-this-argument -- ProseMirror Mapping.map(pos, assoc) API
     const finalStart = followingMaps.map(newStart, -1);
     // oxlint-disable-next-line unicorn/no-array-method-this-argument -- ProseMirror Mapping.map(pos, assoc) API
@@ -56,5 +52,16 @@ function includeStepDirtyRange(
   };
 
   // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror StepMap API
-  map.forEach(includeChangedRange);
+  map.forEach((_oldStart, _oldEnd, newStart, newEnd) =>
+    extend(newStart, newEnd),
+  );
+
+  // AddMarkStep / RemoveMarkStep produce an empty StepMap (mark changes don't
+  // move positions), so the loop above misses them and the incremental
+  // measure path falls back to a full re-measure. Read the affected range
+  // directly off the step so mark-only edits stay incremental.
+  const step = transaction.steps[stepIndex];
+  if (step instanceof AddMarkStep || step instanceof RemoveMarkStep) {
+    extend(step.from, step.to);
+  }
 }


### PR DESCRIPTION
## Summary
- Add canonical DOCX document validation in @stll/docx-core and validate Folio parse/save boundaries.
- Centralize typed ProseMirror attrs/enums and route conversion/extension reads through validators.
- Preserve DOCX bookmark boundary markers and add grant coverage for Folio collaboration tables.

Review note: history is intentionally split for commit-by-commit review.