### PR TITLE
feat(folio): sync upstream eigenpal docx-editor fixes (late May 2026)

### DIFF
--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -178,11 +178,26 @@ export type {
 // ============================================================================
 
 /**
+ * Document-wide settings parsed from `word/settings.xml`.
+ * Extend as more settings.xml fields enter the layout pipeline.
+ */
+export type DocumentSettings = {
+  /**
+   * `w:defaultTabStop` (§17.6.13) — interval in twips between default
+   * tab stops applied when a paragraph has no custom `w:tabs`. Word
+   * defaults to 720 twips (½ inch) when absent.
+   */
+  defaultTabStop: number;
+};
+
+/**
  * Complete DOCX package structure
  */
 export type DocxPackage = {
   /** Document body */
   document: DocumentBody;
+  /** Document-wide settings (`word/settings.xml`). */
+  settings?: DocumentSettings;
   /** Style definitions */
   styles?: StyleDefinitions;
   /** Theme */

--- a/packages/docx-core/src/model/lists.ts
+++ b/packages/docx-core/src/model/lists.ts
@@ -168,6 +168,12 @@ export type ListRendering = {
   markerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   markerFontSize?: number;
+  /**
+   * `w:suff` (§17.9.25) — what follows the marker before body text.
+   * `tab` (the OOXML default) grows the marker to the next tab stop; `space`
+   * adds one space glyph; `nothing` lets body text butt against the marker.
+   */
+  markerSuffix?: LevelSuffix;
   /** Number format for each level from 0 through this paragraph's level. */
   levelNumFmts?: NumberFormat[];
   /** Abstract numbering definition shared by one or more numIds. */

--- a/packages/folio/src/core/docx/paragraphParser-numbering-indent.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser-numbering-indent.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseNumbering } from "./numberingParser";
+import { parseParagraph } from "./paragraphParser";
+import type { XmlElement } from "./xmlParser";
+import { parseXmlDocument } from "./xmlParser";
+
+// abstractNum 0 / numId 1 — level 0 carries the canonical numbered-list
+// indent: left=720, hanging=360 (a half-inch hanging slot).
+const NUMBERING_WITH_HANGING = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/>
+      <w:pPr><w:ind w:left="720" w:hanging="360"/></w:pPr>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+</w:numbering>`;
+
+function parseParagraphXml(
+  xml: string,
+  numbering: ReturnType<typeof parseNumbering>,
+) {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML");
+  }
+  return parseParagraph(root, null, null, numbering, null, null);
+}
+
+describe("paragraphParser direct ind vs numbering level indent", () => {
+  const numbering = parseNumbering(NUMBERING_WITH_HANGING);
+
+  test('w:firstLine="0" on a numbered paragraph is neutral (keeps level hanging)', () => {
+    // ECMA-376 §17.3.1.12: a zero-valued direct ind should not suppress
+    // the numbering level's hanging slot. Word + LibreOffice both keep
+    // the bullet hanging here.
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+          <w:ind w:firstLine="0"/>
+        </w:pPr>
+        <w:r><w:t>Item</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.formatting?.indentLeft).toBe(720);
+    expect(paragraph.formatting?.indentFirstLine).toBe(-360);
+    expect(paragraph.formatting?.hangingIndent).toBe(true);
+  });
+
+  test('w:hanging="0" on a numbered paragraph is neutral (keeps level hanging)', () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+          <w:ind w:hanging="0"/>
+        </w:pPr>
+        <w:r><w:t>Item</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.formatting?.indentLeft).toBe(720);
+    expect(paragraph.formatting?.indentFirstLine).toBe(-360);
+    expect(paragraph.formatting?.hangingIndent).toBe(true);
+  });
+
+  test("non-zero w:firstLine overrides the level hanging", () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+          <w:ind w:firstLine="200"/>
+        </w:pPr>
+        <w:r><w:t>Item</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.formatting?.indentFirstLine).toBe(200);
+    expect(paragraph.formatting?.hangingIndent).toBeUndefined();
+  });
+
+  test("non-zero w:hanging overrides the level hanging", () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+          <w:ind w:hanging="180"/>
+        </w:pPr>
+        <w:r><w:t>Item</w:t></w:r>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.formatting?.indentFirstLine).toBe(-180);
+    expect(paragraph.formatting?.hangingIndent).toBe(true);
+  });
+});

--- a/packages/folio/src/core/docx/paragraphParser-numbering-suffix.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser-numbering-suffix.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseNumbering } from "./numberingParser";
+import { parseParagraph } from "./paragraphParser";
+import type { XmlElement } from "./xmlParser";
+import { parseXmlDocument } from "./xmlParser";
+
+const NUMBERING_WITH_SUFFIXES = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="0">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/>
+      <w:suff w:val="space"/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/>
+      <w:suff w:val="nothing"/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:abstractNum w:abstractNumId="2">
+    <w:lvl w:ilvl="0">
+      <w:start w:val="1"/>
+      <w:numFmt w:val="decimal"/>
+      <w:lvlText w:val="%1."/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="0"/></w:num>
+  <w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>
+  <w:num w:numId="3"><w:abstractNumId w:val="2"/></w:num>
+</w:numbering>`;
+
+function parseParagraphXml(
+  xml: string,
+  numbering: ReturnType<typeof parseNumbering>,
+) {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML");
+  }
+  return parseParagraph(root, null, null, numbering, null, null);
+}
+
+describe("paragraphParser propagates w:suff to listRendering", () => {
+  const numbering = parseNumbering(NUMBERING_WITH_SUFFIXES);
+
+  test('w:suff="space" reaches listRendering.markerSuffix', () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="1"/></w:numPr>
+        </w:pPr>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.listRendering?.markerSuffix).toBe("space");
+  });
+
+  test('w:suff="nothing" reaches listRendering.markerSuffix', () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="2"/></w:numPr>
+        </w:pPr>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.listRendering?.markerSuffix).toBe("nothing");
+  });
+
+  test("missing w:suff leaves markerSuffix undefined (callers default to 'tab')", () => {
+    const paragraph = parseParagraphXml(
+      `<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:numPr><w:ilvl w:val="0"/><w:numId w:val="3"/></w:numPr>
+        </w:pPr>
+      </w:p>`,
+      numbering,
+    );
+
+    expect(paragraph.listRendering?.markerSuffix).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -1702,6 +1702,9 @@ export function parseParagraph(
         if (level.rPr?.fontSize) {
           listRendering.markerFontSize = level.rPr.fontSize / 2;
         }
+        if (level.suffix) {
+          listRendering.markerSuffix = level.suffix;
+        }
         paragraph.listRendering = listRendering;
 
         // Apply level's paragraph properties (indentation) as defaults.
@@ -1716,10 +1719,19 @@ export function parseParagraph(
             directInd !== null &&
             (getAttribute(directInd, "w", "left") !== null ||
               getAttribute(directInd, "w", "start") !== null);
+          // ECMA-376 §17.3.1.12: a direct w:ind whose w:firstLine or
+          // w:hanging is "0" is a no-op and must not suppress the numbering
+          // level's hanging slot. Only treat non-zero direct values as
+          // overrides.
+          const directFirstLine = directInd
+            ? parseNumericAttribute(directInd, "w", "firstLine")
+            : undefined;
+          const directHanging = directInd
+            ? parseNumericAttribute(directInd, "w", "hanging")
+            : undefined;
           const hasDirectFirstLineOrHanging =
-            directInd !== null &&
-            (getAttribute(directInd, "w", "firstLine") !== null ||
-              getAttribute(directInd, "w", "hanging") !== null);
+            (directFirstLine !== undefined && directFirstLine !== 0) ||
+            (directHanging !== undefined && directHanging !== 0);
 
           if (!hasDirectLeft && level.pPr.indentLeft !== undefined) {
             paragraph.formatting.indentLeft = level.pPr.indentLeft;

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -61,6 +61,7 @@ import {
   RELATIONSHIP_TYPES,
   resolveRelativePath,
 } from "./relsParser";
+import { parseSettings } from "./settingsParser";
 import { parseStyles, parseStyleDefinitions } from "./styleParser";
 import type { StyleMap } from "./styleParser";
 import { parseTheme } from "./themeParser";
@@ -191,6 +192,13 @@ export async function parseDocx(
       parseNumbering(raw.numberingXml),
     );
     onProgress("Parsed numbering", 35);
+
+    // Settings (`word/settings.xml`) — currently only used for
+    // `w:defaultTabStop`, but staged here so future settings flow through
+    // the same point. Cheap; no separate progress band.
+    const settings = timeStage("settings", () =>
+      parseSettings(raw.settingsXml),
+    );
 
     // ========================================================================
     // STAGE 6: Build media file map (35-40%)
@@ -377,6 +385,7 @@ export async function parseDocx(
 
     const pkg: DocxPackage = {
       document: documentBody,
+      settings,
       ...(styleDefinitions !== undefined ? { styles: styleDefinitions } : {}),
       theme,
       numbering: numbering.definitions,

--- a/packages/folio/src/core/docx/settingsParser.test.ts
+++ b/packages/folio/src/core/docx/settingsParser.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+
+import { DEFAULT_TAB_STOP_TWIPS, parseSettings } from "./settingsParser";
+
+const SETTINGS_HEAD = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:settings xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">`;
+const SETTINGS_TAIL = `</w:settings>`;
+
+function wrap(inner: string): string {
+  return `${SETTINGS_HEAD}${inner}${SETTINGS_TAIL}`;
+}
+
+describe("parseSettings — w:defaultTabStop (§17.6.13)", () => {
+  test("returns OOXML default when settings.xml is missing", () => {
+    expect(parseSettings(null).defaultTabStop).toBe(DEFAULT_TAB_STOP_TWIPS);
+  });
+
+  test("returns OOXML default when w:defaultTabStop element is absent", () => {
+    expect(parseSettings(wrap("")).defaultTabStop).toBe(DEFAULT_TAB_STOP_TWIPS);
+  });
+
+  test("parses w:defaultTabStop val attribute", () => {
+    expect(
+      parseSettings(wrap(`<w:defaultTabStop w:val="1440"/>`)).defaultTabStop,
+    ).toBe(1440);
+  });
+
+  test("ignores non-positive values (Word never emits them)", () => {
+    expect(
+      parseSettings(wrap(`<w:defaultTabStop w:val="0"/>`)).defaultTabStop,
+    ).toBe(DEFAULT_TAB_STOP_TWIPS);
+    expect(
+      parseSettings(wrap(`<w:defaultTabStop w:val="-100"/>`)).defaultTabStop,
+    ).toBe(DEFAULT_TAB_STOP_TWIPS);
+  });
+
+  test("ignores non-numeric values", () => {
+    expect(
+      parseSettings(wrap(`<w:defaultTabStop w:val="banana"/>`)).defaultTabStop,
+    ).toBe(DEFAULT_TAB_STOP_TWIPS);
+  });
+
+  test("ignores values beyond Word's maximum margin (~22 inches)", () => {
+    // 50000 twips ≈ 34.7 inches — past any plausible page width; reject.
+    expect(
+      parseSettings(wrap(`<w:defaultTabStop w:val="50000"/>`)).defaultTabStop,
+    ).toBe(DEFAULT_TAB_STOP_TWIPS);
+  });
+});

--- a/packages/folio/src/core/docx/settingsParser.ts
+++ b/packages/folio/src/core/docx/settingsParser.ts
@@ -1,0 +1,53 @@
+/**
+ * settings.xml parser
+ *
+ * Extracts document-wide settings the layout pipeline consumes at render
+ * time. We deliberately read only the handful of settings that affect
+ * layout; the rest of settings.xml (compatibility flags, view state,
+ * autoformat options) is preserved opaquely by the rezip step and ignored
+ * here.
+ *
+ * See ECMA-376 §17.15 for the full settings part.
+ */
+
+import type { DocumentSettings } from "../types/document";
+import { findChild, getAttribute, parseXmlDocument } from "./xmlParser";
+import type { XmlElement } from "./xmlParser";
+
+export type { DocumentSettings };
+
+/** OOXML default per §17.6.13 when `w:defaultTabStop` is absent. */
+export const DEFAULT_TAB_STOP_TWIPS = 720;
+
+/**
+ * Sanity cap on `w:defaultTabStop`. Word's maximum margin is ~22 inches
+ * (31 680 twips); anything past that is corruption or a hostile input and
+ * we substitute the OOXML default instead.
+ */
+const MAX_TAB_STOP_TWIPS = 31_680;
+
+export function parseSettings(xml: string | null): DocumentSettings {
+  const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
+  return {
+    defaultTabStop: parseDefaultTabStop(root),
+  };
+}
+
+function parseDefaultTabStop(root: XmlElement | null): number {
+  if (!root) {
+    return DEFAULT_TAB_STOP_TWIPS;
+  }
+  const el = findChild(root, "w", "defaultTabStop");
+  if (!el) {
+    return DEFAULT_TAB_STOP_TWIPS;
+  }
+  const raw = getAttribute(el, "w", "val");
+  if (raw === null) {
+    return DEFAULT_TAB_STOP_TWIPS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > MAX_TAB_STOP_TWIPS) {
+    return DEFAULT_TAB_STOP_TWIPS;
+  }
+  return parsed;
+}

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-collect.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-collect.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  FlowBlock,
+  ParagraphBlock,
+  TableBlock,
+  TextBoxBlock,
+} from "../layout-engine/types";
+import { collectFootnoteRefs } from "./footnoteLayout";
+
+function paragraphWithFootnoteRef(
+  id: string,
+  footnoteId: number,
+  pmStart: number,
+): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id,
+    runs: [
+      {
+        kind: "text",
+        text: "x",
+        footnoteRefId: footnoteId,
+        pmStart,
+        pmEnd: pmStart + 1,
+      },
+    ],
+  };
+}
+
+function emptyParagraph(id: string): ParagraphBlock {
+  return { kind: "paragraph", id, runs: [] };
+}
+
+describe("collectFootnoteRefs", () => {
+  test("collects references from top-level paragraphs in document order", () => {
+    const blocks: FlowBlock[] = [
+      paragraphWithFootnoteRef("p1", 1, 10),
+      emptyParagraph("p2"),
+      paragraphWithFootnoteRef("p3", 2, 30),
+    ];
+
+    expect(collectFootnoteRefs(blocks)).toEqual([
+      { footnoteId: 1, pmPos: 10 },
+      { footnoteId: 2, pmPos: 30 },
+    ]);
+  });
+
+  test("recurses into table cells (regression: refs in tables were dropped)", () => {
+    const table: TableBlock = {
+      kind: "table",
+      id: "t1",
+      rows: [
+        {
+          id: "r1",
+          cells: [
+            {
+              id: "c1",
+              blocks: [paragraphWithFootnoteRef("p-cell-1", 5, 100)],
+            },
+            {
+              id: "c2",
+              blocks: [paragraphWithFootnoteRef("p-cell-2", 6, 120)],
+            },
+          ],
+        },
+      ],
+    };
+    const blocks: FlowBlock[] = [
+      paragraphWithFootnoteRef("p-before", 1, 10),
+      table,
+      paragraphWithFootnoteRef("p-after", 9, 200),
+    ];
+
+    expect(collectFootnoteRefs(blocks)).toEqual([
+      { footnoteId: 1, pmPos: 10 },
+      { footnoteId: 5, pmPos: 100 },
+      { footnoteId: 6, pmPos: 120 },
+      { footnoteId: 9, pmPos: 200 },
+    ]);
+  });
+
+  test("recurses into tables nested inside table cells", () => {
+    const innerTable: TableBlock = {
+      kind: "table",
+      id: "inner",
+      rows: [
+        {
+          id: "ir1",
+          cells: [
+            {
+              id: "ic1",
+              blocks: [paragraphWithFootnoteRef("nested-p", 7, 150)],
+            },
+          ],
+        },
+      ],
+    };
+    const outerTable: TableBlock = {
+      kind: "table",
+      id: "outer",
+      rows: [
+        {
+          id: "or1",
+          cells: [{ id: "oc1", blocks: [innerTable] }],
+        },
+      ],
+    };
+
+    expect(collectFootnoteRefs([outerTable])).toEqual([
+      { footnoteId: 7, pmPos: 150 },
+    ]);
+  });
+
+  test("recurses into text box content", () => {
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "tb1",
+      width: 200,
+      content: [paragraphWithFootnoteRef("tb-p", 4, 50)],
+    };
+
+    expect(collectFootnoteRefs([textBox])).toEqual([
+      { footnoteId: 4, pmPos: 50 },
+    ]);
+  });
+
+  test("falls back to pmPos 0 when run lacks pmStart", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p",
+      runs: [{ kind: "text", text: "x", footnoteRefId: 3 }],
+    };
+
+    expect(collectFootnoteRefs([block])).toEqual([{ footnoteId: 3, pmPos: 0 }]);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -40,6 +40,8 @@ export type ConvertFootnoteOptions = {
   styles?: StyleDefinitions | null;
   theme?: Theme | null;
   measureBlocks?: MeasureBlocksFn;
+  /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
+  defaultTabStopTwips?: number;
 };
 
 // ============================================================================
@@ -49,26 +51,42 @@ export type ConvertFootnoteOptions = {
 /**
  * Scan FlowBlocks for runs with footnoteRefId set.
  * Returns a list of { footnoteId, pmPos } in document order.
+ *
+ * Recurses into table cells and text-box content so footnote references
+ * nested in tables (incl. tables-within-cells) and text boxes still reach
+ * the page-assignment step. Without this walk, inline footnote markers
+ * render inside the body but never get an entry in the per-page footnote
+ * area.
  */
 export function collectFootnoteRefs(
   blocks: FlowBlock[],
 ): { footnoteId: number; pmPos: number }[] {
   const refs: { footnoteId: number; pmPos: number }[] = [];
 
-  for (const block of blocks) {
-    if (block.kind !== "paragraph") {
-      continue;
-    }
-    for (const run of block.runs) {
-      if (run.kind === "text" && run.footnoteRefId !== undefined) {
-        refs.push({
-          footnoteId: run.footnoteRefId,
-          pmPos: run.pmStart ?? 0,
-        });
+  const walk = (containerBlocks: FlowBlock[]): void => {
+    for (const block of containerBlocks) {
+      if (block.kind === "paragraph") {
+        for (const run of block.runs) {
+          if (run.kind === "text" && run.footnoteRefId !== undefined) {
+            refs.push({
+              footnoteId: run.footnoteRefId,
+              pmPos: run.pmStart ?? 0,
+            });
+          }
+        }
+      } else if (block.kind === "table") {
+        for (const row of block.rows) {
+          for (const cell of row.cells) {
+            walk(cell.blocks);
+          }
+        }
+      } else if (block.kind === "textBox") {
+        walk(block.content);
       }
     }
-  }
+  };
 
+  walk(blocks);
   return refs;
 }
 
@@ -149,6 +167,9 @@ export function convertFootnoteToContent(
   const flowOptions: Parameters<typeof toFlowBlocks>[1] = {};
   if (options.theme !== undefined) {
     flowOptions.theme = options.theme;
+  }
+  if (options.defaultTabStopTwips !== undefined) {
+    flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
   }
   const blocks = applyFootnotePresentation(
     toFlowBlocks(pmDoc, flowOptions),

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -543,6 +543,8 @@ export type ConvertHeaderFooterOptions = {
   styles?: StyleDefinitions | null;
   theme?: Theme | null;
   measureBlocks: MeasureBlocksFn;
+  /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
+  defaultTabStopTwips?: number;
 };
 
 /**
@@ -577,9 +579,15 @@ export function convertHeaderFooterToContent(
     proseDocOptions.theme = options.theme;
   }
   const pmDoc = headerFooterToProseDoc(headerFooter.content, proseDocOptions);
-  const flowOptions: { theme?: Theme | null } = {};
+  const flowOptions: {
+    theme?: Theme | null;
+    defaultTabStopTwips?: number;
+  } = {};
   if (options.theme !== undefined) {
     flowOptions.theme = options.theme;
+  }
+  if (options.defaultTabStopTwips !== undefined) {
+    flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
   }
   const blocks = toFlowBlocks(pmDoc, flowOptions);
   if (blocks.length === 0) {

--- a/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock } from "../../layout-engine/types";
+import {
+  DEFAULT_TAB_STOP_TWIPS,
+  getListMarkerInlineWidth,
+} from "./listMarkerWidth";
+import { resetCanvasContext } from "./measureContainer";
+
+const DEFAULT_TAB_STOP_PX = (DEFAULT_TAB_STOP_TWIPS / 1440) * 96;
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              // 10px per char — simple, predictable, fine for these tests.
+              return {
+                width: text.length * 10,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+function listBlock(overrides: ParagraphBlock["attrs"]): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id: "p",
+    runs: [{ kind: "text", text: "body" }],
+    attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri", ...overrides },
+  };
+}
+
+describe("getListMarkerInlineWidth", () => {
+  test("no marker → 0", () => {
+    withFakeTextMeasure(() => {
+      expect(getListMarkerInlineWidth(listBlock({}))).toBe(0);
+    });
+  });
+
+  test("hidden marker → 0", () => {
+    withFakeTextMeasure(() => {
+      expect(
+        getListMarkerInlineWidth(
+          listBlock({ listMarker: "1.", listMarkerHidden: true }),
+        ),
+      ).toBe(0);
+    });
+  });
+
+  test("hanging indent: width equals hanging slot", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          indent: { left: 60, hanging: 36 },
+        }),
+      );
+      expect(width).toBe(36);
+    });
+  });
+
+  test('w:suff="nothing" → exactly natural marker width', () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          listMarkerSuffix: "nothing",
+        }),
+      );
+      // Natural width = 2 chars * 10 = 20.
+      expect(width).toBe(20);
+    });
+  });
+
+  test('w:suff="space" → natural + one space glyph', () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          listMarkerSuffix: "space",
+        }),
+      );
+      // 2 chars + 1 space char = 30.
+      expect(width).toBe(30);
+    });
+  });
+
+  // Regression for upstream #600: a long marker like "1.1.1." must grow to
+  // the next default-grid tab stop so body text aligns past it. Folio's
+  // previous behavior used a fixed +12 px gap which broke alignment.
+  test('default suff="tab": long marker aligns body at next default-grid stop', () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.1.1.",
+        }),
+      );
+      // Natural width = 6 chars * 10 = 60. With markerStartPx=0 and a 48 px
+      // default grid, minBodyStart = 60 → next grid is floor(60/48)+1 = 2 →
+      // bodyStart = 96 px. So marker = 96 - 0 = 96.
+      const expectedGrid = Math.floor(60 / DEFAULT_TAB_STOP_PX) + 1;
+      const expectedBodyStart = expectedGrid * DEFAULT_TAB_STOP_PX;
+      expect(width).toBeCloseTo(expectedBodyStart, 5);
+    });
+  });
+
+  test('short marker still aligns body at next default-grid stop with suff="tab"', () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+        }),
+      );
+      // Natural width = 20. minBodyStart=20. Next grid = floor(20/48)+1=1
+      // → bodyStart = 48. Marker = 48.
+      expect(width).toBeCloseTo(DEFAULT_TAB_STOP_PX, 5);
+    });
+  });
+
+  test("custom tab stop closer than default grid wins", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          // 360 twips = 24 px; this is past natural width (20), so it wins
+          // over the default-grid stop at 48 px.
+          tabs: [{ val: "start", pos: 360 }],
+        }),
+      );
+      expect(width).toBeCloseTo(24, 5);
+    });
+  });
+
+  test("tab stops marked `clear` or `bar` are ignored", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          tabs: [
+            { val: "clear", pos: 360 },
+            { val: "bar", pos: 480 },
+          ],
+        }),
+      );
+      // Both ignored → falls back to the default-grid stop at 48 px.
+      expect(width).toBeCloseTo(DEFAULT_TAB_STOP_PX, 5);
+    });
+  });
+
+  test("custom defaultTabStopTwips on the block overrides the OOXML default grid", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          // 1440 twips = 96 px (1 inch grid, as Word renders some templates).
+          defaultTabStopTwips: 1440,
+        }),
+      );
+      // Natural width = 20; next 96 px stop is 96. Marker width = 96.
+      expect(width).toBeCloseTo(96, 5);
+    });
+  });
+
+  test("first-line indent shifts marker start: bodyStart adjusts", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.",
+          indent: { left: 0, firstLine: 24 },
+        }),
+      );
+      // markerStartPx = 24. Natural width = 20 → minBodyStart = 44.
+      // Next default-grid stop past 44 is 48. marker = 48 - 24 = 24.
+      expect(width).toBeCloseTo(DEFAULT_TAB_STOP_PX - 24, 5);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.test.ts
@@ -188,6 +188,55 @@ describe("getListMarkerInlineWidth", () => {
     });
   });
 
+  // Regression for bot review #460: when the marker overflows the hanging
+  // slot, Word advances body text to the next tab stop instead of letting
+  // body collide with the marker. Previously folio returned `hanging`
+  // unconditionally, which produced overlap for long markers like
+  // "1.1.1.1." inside a 36 px hanging slot.
+  test("hanging-indent marker that overflows the slot advances to next tab stop", () => {
+    withFakeTextMeasure(() => {
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "1.1.1.1.",
+          indent: { left: 60, hanging: 36 },
+        }),
+      );
+      // Natural width = 8 chars * 10 = 80. markerStart = 60-36 = 24.
+      // minBodyStart = 24+80 = 104. Hanging is consumed → search past
+      // indentLeft=60. Next default-grid stop past max(104,60)=104 is
+      // ceil(104/48)*48 = 144. marker = 144 - 24 = 120.
+      const expectedBodyStart =
+        Math.ceil(104 / DEFAULT_TAB_STOP_PX) * DEFAULT_TAB_STOP_PX;
+      expect(width).toBeCloseTo(expectedBodyStart - 24, 5);
+    });
+  });
+
+  // Regression for bot review #460 (codex): when `minBodyStart` lands
+  // exactly on a default-grid stop, the old `Math.floor(...)+1` rolled
+  // forward by a full tab interval. The surrounding comment already
+  // states equality must be preserved (§17.9.27); fix the default-grid
+  // arithmetic to match.
+  test("default-grid stop landing exactly on minBodyStart is used as-is", () => {
+    withFakeTextMeasure(() => {
+      // Marker "12345" with default font: 5 chars * 10 = 50 px — exceeds
+      // 48 px so it doesn't land exactly. Use a 24 px firstLine to push
+      // markerStart to 24, so minBodyStart = 24 + 24 (natural for "12.")
+      // = 48 EXACTLY on the default grid.
+      const width = getListMarkerInlineWidth(
+        listBlock({
+          listMarker: "12.",
+          // 480 twips = 32 px; markerStart shifts by 16 px (~ish). Use
+          // a clean firstLine = 18 px in twips (270) → markerStart=18,
+          // natural=30, minBodyStart=48 EXACTLY.
+          indent: { left: 0, firstLine: 18 },
+        }),
+      );
+      // minBodyStart = 18 + 30 = 48 = default-grid stop exactly.
+      // bodyStart MUST be 48, not 96. marker = 48 - 18 = 30.
+      expect(width).toBeCloseTo(DEFAULT_TAB_STOP_PX - 18, 5);
+    });
+  });
+
   test("first-line indent shifts marker start: bodyStart adjusts", () => {
     withFakeTextMeasure(() => {
       const width = getListMarkerInlineWidth(

--- a/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.ts
@@ -78,12 +78,6 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
     return 0;
   }
 
-  const indent = attrs.indent;
-  const hanging = indent?.hanging ?? 0;
-  if (hanging > 0) {
-    return hanging;
-  }
-
   const { fontFamily, fontSize } = resolveListMarkerFont(block);
   const style: FontStyle = { fontFamily, fontSize };
   const naturalWidth = measureTextWidth(attrs.listMarker, style);
@@ -99,17 +93,35 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
 
   // Default suffix is `tab`. Body text aligns at the next stop past
   // `markerStart + naturalWidth`. `>=` (not `>`) is intentional: a tab
-  // landing exactly at the marker's right edge IS valid — Word renders the
-  // body at that column with zero residual gap. §17.9.27.
+  // landing exactly at the marker's right edge IS valid — Word renders
+  // the body at that column with zero residual gap. §17.9.27.
+  const indent = attrs.indent;
   const indentLeft = indent?.left ?? 0;
   const firstLine = indent?.firstLine ?? 0;
-  const markerStartPx = indentLeft + firstLine;
+  const hanging = indent?.hanging ?? 0;
+  const markerStartPx =
+    hanging > 0 ? indentLeft - hanging : indentLeft + firstLine;
   const minBodyStart = markerStartPx + naturalWidth;
 
-  const firstCustomPast = (attrs.tabs ?? [])
+  // Build tab-stop candidates. For hanging lists, the right edge of the
+  // hanging slot (= indentLeft) is the implicit first tab stop after the
+  // marker — body wraps there. Add it explicitly so a fitting marker
+  // snaps to indentLeft rather than to a default-grid stop that happens
+  // to land inside the hanging slot.
+  const customTabs = (attrs.tabs ?? [])
     .filter((t) => t.val !== "clear" && t.val !== "bar")
-    .map((t) => t.pos * TWIPS_TO_PX)
-    .filter((px) => px >= minBodyStart)
+    .map((t) => t.pos * TWIPS_TO_PX);
+  if (hanging > 0) {
+    customTabs.push(indentLeft);
+  }
+
+  // For hanging lists, body must never land inside the hanging slot; clamp
+  // the search past indentLeft so the default grid can't fire there.
+  const searchStart =
+    hanging > 0 ? Math.max(minBodyStart, indentLeft) : minBodyStart;
+
+  const firstCustomPast = customTabs
+    .filter((px) => px >= searchStart)
     .sort((a, b) => a - b)[0];
 
   // Honor the document's `w:defaultTabStop` (§17.6.13) when stamped onto
@@ -117,9 +129,12 @@ export function getListMarkerInlineWidth(block: ParagraphBlock): number {
   const defaultTabStopTwips =
     attrs.defaultTabStopTwips ?? DEFAULT_TAB_STOP_TWIPS;
   const defaultTabStopPx = defaultTabStopTwips * TWIPS_TO_PX;
+  // `Math.ceil` preserves equality (§17.9.27): a tab landing exactly on
+  // `searchStart` IS valid; only advance to the next interval when
+  // `searchStart` is strictly between two stops.
   const firstGridPast =
     defaultTabStopPx > 0
-      ? (Math.floor(minBodyStart / defaultTabStopPx) + 1) * defaultTabStopPx
+      ? Math.ceil(searchStart / defaultTabStopPx) * defaultTabStopPx
       : undefined;
 
   // Closest wins — Word doesn't let a far custom tab override a closer

--- a/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.ts
@@ -1,0 +1,140 @@
+/**
+ * List marker inline-width resolution.
+ *
+ * The painter renders the list marker as an inline-block at the start of the
+ * first body line. To match Word's rendering (ECMA-376 §17.9.25 — default
+ * `w:suff="tab"` after the marker), the inline-block is sized so the body
+ * text aligns at the next tab stop. Long markers like "1.1.1." take their
+ * natural width and the body follows them.
+ *
+ * Both the painter (`renderParagraph.ts`) and the measurer (`measureParagraph`)
+ * call into this so they agree on the marker's footprint — otherwise long
+ * markers overflow the right edge of the first line. The painter applies the
+ * returned width as `min-width`; the measurer subtracts the same value from
+ * the first line's available width.
+ */
+import type { ParagraphBlock, TextRun } from "../../layout-engine/types";
+import { measureTextWidth, ptToPx } from "./measureContainer";
+import type { FontStyle } from "./measureContainer";
+
+const DEFAULT_FONT_FAMILY = "Calibri";
+const DEFAULT_FONT_SIZE = 11;
+
+/**
+ * OOXML default `w:defaultTabStop` (§17.6.13) when settings.xml omits it.
+ * 720 twips = 0.5 inch = 48 CSS px at 96 DPI. Folio doesn't currently parse
+ * settings.xml; documents that override this fall back to the OOXML default.
+ */
+export const DEFAULT_TAB_STOP_TWIPS = 720;
+
+const TWIPS_TO_PX = 96 / 1440;
+
+/**
+ * Marker font resolution per ECMA-376 §17.9.6:
+ *  1. explicit numbering-level rPr (`attrs.listMarkerFont*`),
+ *  2. first body text run's font,
+ *  3. paragraph defaults, then document defaults.
+ */
+export function resolveListMarkerFont(block: ParagraphBlock): {
+  fontFamily: string;
+  fontSize: number;
+} {
+  const attrs = block.attrs;
+  const firstTextRun = block.runs.find((r): r is TextRun => r.kind === "text");
+  const fontFamily =
+    attrs?.listMarkerFontFamily ??
+    firstTextRun?.fontFamily ??
+    attrs?.defaultFontFamily ??
+    DEFAULT_FONT_FAMILY;
+  const fontSize =
+    attrs?.listMarkerFontSize ??
+    firstTextRun?.fontSize ??
+    attrs?.defaultFontSize ??
+    DEFAULT_FONT_SIZE;
+  return { fontFamily, fontSize };
+}
+
+/**
+ * Compute the marker's inline-block width in pixels, or 0 if the paragraph
+ * has no rendered marker.
+ *
+ * Honors:
+ *  - hanging indent — body wraps at `indentLeft`, marker sits at
+ *    `indentLeft - hanging`. Width is `hanging` so the marker fills the slot.
+ *  - `w:suff` (§17.9.25): `nothing` → natural width, `space` → natural +
+ *    one space glyph, `tab` (default) → grow to the next tab stop.
+ *  - `w:tabs` on the paragraph: non-`clear`/non-`bar` stops past the marker.
+ *    `bar` (§17.3.1.37) is a vertical line and doesn't advance the cursor.
+ *  - default tab grid: stops at multiples of `DEFAULT_TAB_STOP_TWIPS`,
+ *    anchored at 0 (start of body content area, NOT `w:ind`).
+ *
+ * Word interleaves the two — both custom tabs and default-grid stops are
+ * candidates; the closest stop past the marker wins (§17.6.13: the default
+ * grid is not erased by custom tabs, just augmented).
+ */
+export function getListMarkerInlineWidth(block: ParagraphBlock): number {
+  const attrs = block.attrs;
+  if (!attrs?.listMarker || attrs.listMarkerHidden) {
+    return 0;
+  }
+
+  const indent = attrs.indent;
+  const hanging = indent?.hanging ?? 0;
+  if (hanging > 0) {
+    return hanging;
+  }
+
+  const { fontFamily, fontSize } = resolveListMarkerFont(block);
+  const style: FontStyle = { fontFamily, fontSize };
+  const naturalWidth = measureTextWidth(attrs.listMarker, style);
+
+  // §17.9.25 — `w:suff` controls what follows the marker before body text.
+  const suffix = attrs.listMarkerSuffix ?? "tab";
+  if (suffix === "nothing") {
+    return naturalWidth;
+  }
+  if (suffix === "space") {
+    return naturalWidth + measureTextWidth(" ", style);
+  }
+
+  // Default suffix is `tab`. Body text aligns at the next stop past
+  // `markerStart + naturalWidth`. `>=` (not `>`) is intentional: a tab
+  // landing exactly at the marker's right edge IS valid — Word renders the
+  // body at that column with zero residual gap. §17.9.27.
+  const indentLeft = indent?.left ?? 0;
+  const firstLine = indent?.firstLine ?? 0;
+  const markerStartPx = indentLeft + firstLine;
+  const minBodyStart = markerStartPx + naturalWidth;
+
+  const firstCustomPast = (attrs.tabs ?? [])
+    .filter((t) => t.val !== "clear" && t.val !== "bar")
+    .map((t) => t.pos * TWIPS_TO_PX)
+    .filter((px) => px >= minBodyStart)
+    .sort((a, b) => a - b)[0];
+
+  // Honor the document's `w:defaultTabStop` (§17.6.13) when stamped onto
+  // the block by `toFlowBlocks`; fall back to the OOXML default otherwise.
+  const defaultTabStopTwips =
+    attrs.defaultTabStopTwips ?? DEFAULT_TAB_STOP_TWIPS;
+  const defaultTabStopPx = defaultTabStopTwips * TWIPS_TO_PX;
+  const firstGridPast =
+    defaultTabStopPx > 0
+      ? (Math.floor(minBodyStart / defaultTabStopPx) + 1) * defaultTabStopPx
+      : undefined;
+
+  // Closest wins — Word doesn't let a far custom tab override a closer
+  // default-grid stop (default grid resumes between custom tabs).
+  let bodyStart: number | undefined;
+  if (firstCustomPast !== undefined && firstGridPast !== undefined) {
+    bodyStart = Math.min(firstCustomPast, firstGridPast);
+  } else {
+    bodyStart = firstCustomPast ?? firstGridPast;
+  }
+
+  if (bodyStart === undefined) {
+    // No tab grid available: fall back to a half-em visual gap so the
+    // marker doesn't butt up against the body text.
+    return naturalWidth + ptToPx(fontSize) * 0.5;
+  }
+  return bodyStart - markerStartPx;
+}

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-list-marker.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-list-marker.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ParagraphBlock } from "../../layout-engine/types";
+import {
+  DEFAULT_TAB_STOP_TWIPS,
+  getListMarkerInlineWidth,
+} from "./listMarkerWidth";
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+const DEFAULT_TAB_STOP_PX = (DEFAULT_TAB_STOP_TWIPS / 1440) * 96;
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              return {
+                width: text.length * 10,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+describe("measureParagraph reserves the marker's tab-stop footprint", () => {
+  // Regression for upstream #600: with the previous "+12 px gap" logic the
+  // first line had `bodyWidth - markerWidth - 12` of text room. Long markers
+  // like "1.1.1." therefore had too much budget — the painter pushed text
+  // past the right edge or wrapped a trailing run prematurely. The new path
+  // subtracts the same width the painter applies as `min-width`, computed
+  // from the next tab stop past the marker.
+  test("long marker on a no-hanging list subtracts the next-tab-stop footprint", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "p",
+        runs: [{ kind: "text", text: "x" }],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+          listMarker: "1.1.1.",
+          indent: { left: 0, firstLine: 0 },
+        },
+      };
+
+      const expectedMarker = getListMarkerInlineWidth(block);
+      // Sanity: long marker, default suff=tab, no custom tabs → next default
+      // grid stop is 2 * defaultTabStopPx (since natural width 60 > 48).
+      expect(expectedMarker).toBeCloseTo(2 * DEFAULT_TAB_STOP_PX, 5);
+
+      // 200 px content; the painter slot for the marker is the same value
+      // measure must subtract from the first-line budget.
+      const measure = measureParagraph(block, 200);
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      // After subtracting the marker footprint, the first line has at most
+      // (200 - markerWidth) of text room. A single 'x' (=10 px) easily fits.
+      // The important assertion is that the line did NOT measure against
+      // the full 200 px width.
+      // (Folio's measurer reports each line's width based on the text it
+      // contains; the constraint we care about is captured by checking the
+      // first line did not promise more room than is actually available.)
+      expect(measure.lines).toHaveLength(1);
+    });
+  });
+
+  // Regression: hanging-indent lists must NOT subtract the marker width a
+  // second time — the hanging slot already widens baseFirstLineWidth via
+  // firstLineOffset (= firstLine − hanging is negative when hanging > 0).
+  test("hanging-indent list does not double-subtract the marker", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "p",
+        runs: [{ kind: "text", text: "body" }],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+          listMarker: "1.",
+          indent: { left: 60, hanging: 36 },
+        },
+      };
+
+      const measure = measureParagraph(block, 300);
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      // 4-char body = 40 px. Should fit on one line — no over-budget wrap.
+      expect(measure.lines).toHaveLength(1);
+      expect(firstLine?.width).toBeGreaterThan(0);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-list-marker.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-list-marker.test.ts
@@ -90,9 +90,46 @@ describe("measureParagraph reserves the marker's tab-stop footprint", () => {
     });
   });
 
-  // Regression: hanging-indent lists must NOT subtract the marker width a
-  // second time — the hanging slot already widens baseFirstLineWidth via
-  // firstLineOffset (= firstLine − hanging is negative when hanging > 0).
+  // Regression for bot review #460 (codex P1): on a hanging-indent list
+  // with `w:suff="space"` or `w:suff="nothing"`, the painter applies the
+  // marker's natural width (< hanging) as `min-width`, so body text starts
+  // BEFORE indentLeft. The measurer must subtract the same value from the
+  // first-line budget. The previous "subtract only the excess past hanging"
+  // logic did nothing here and overestimated by `markerInlineWidth`,
+  // delaying line wrap and producing right-edge overflow.
+  test("hanging-indent + non-tab suffix subtracts the marker's actual footprint", () => {
+    withFakeTextMeasure(() => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: "p",
+        runs: [
+          // 19 'a' chars × 10 px = 190 px of body text.
+          { kind: "text", text: "aaaaaaaaaaaaaaaaaaa" },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+          listMarker: "1.",
+          listMarkerSuffix: "nothing",
+          // Hanging slot = 100 px; first-line content area = 200 px.
+          indent: { left: 100, hanging: 100 },
+        },
+      };
+
+      // maxWidth = 200. First line content area = bodyContentWidth + hanging
+      //                                         = 100 + 100 = 200.
+      // Marker footprint (suff=nothing) = naturalWidth("1.") = 20 px.
+      // Correct first-line text budget = 200 − 20 = 180 px.
+      // 19 'a's = 190 px > 180 → must wrap to ≥ 2 lines.
+      const measure = measureParagraph(block, 200);
+      expect(measure.lines.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // Regression: hanging-indent + suff=tab (the common case) — the marker
+  // exactly fills the hanging slot, so subtracting `markerInlineWidth`
+  // must cancel the `+ hanging` widening from `firstLineOffset`. Net text
+  // budget = bodyContentWidth, same as subsequent lines.
   test("hanging-indent list does not double-subtract the marker", () => {
     withFakeTextMeasure(() => {
       const block: ParagraphBlock = {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-stacked-floats.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-stacked-floats.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(_text: string) {
+              return {
+                width: _text.length * 5,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+describe("measureParagraph skips lines past obstructing floats", () => {
+  // Regression: a float consuming nearly the full content width leaves no
+  // usable horizontal segment for body text. Previously the line tried to
+  // render in the ~tiny remainder, collapsing to ~1 glyph per line. Word
+  // and upstream eigenpal (#596) push the line past the float instead.
+  test("first line is bumped past a near-full-width float", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "p",
+          runs: [
+            {
+              kind: "text",
+              text: "the quick brown fox jumps over the lazy dog",
+            },
+          ],
+          attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri" },
+        },
+        500,
+        {
+          floatingZones: [
+            {
+              leftMargin: 0,
+              rightMargin: 485,
+              topY: 0,
+              bottomY: 120,
+            },
+          ],
+        },
+      );
+
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      // After the skip, the line measures against the full 500px content
+      // (no leftOffset/rightOffset attached). Without the skip, the
+      // line would be ~15px wide and produce dozens of single-glyph rows.
+      expect(firstLine?.rightOffset).toBeUndefined();
+      expect(firstLine?.leftOffset).toBeUndefined();
+      // The skip amount must reach or exceed the float's bottomY so the
+      // line is now in clear vertical space.
+      expect(firstLine?.floatSkipBefore).toBeGreaterThanOrEqual(120);
+      // Total height includes the skip — containers must size correctly.
+      expect(measure.totalHeight).toBeGreaterThanOrEqual(120);
+    });
+  });
+
+  // Regression: two floats stacked vertically, each on a different side,
+  // together cover the entire row at the top. Per upstream #596 the line
+  // must skip past *both* floats, not just the first.
+  test("line is bumped past two stacked floats covering the row", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "p",
+          runs: [{ kind: "text", text: "body text" }],
+          attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri" },
+        },
+        500,
+        {
+          floatingZones: [
+            // Top float on the right — leaves ~10px on the left.
+            {
+              leftMargin: 0,
+              rightMargin: 490,
+              topY: 0,
+              bottomY: 80,
+            },
+            // Stacked just below, on the left — also leaves ~10px on the right.
+            {
+              leftMargin: 490,
+              rightMargin: 0,
+              topY: 80,
+              bottomY: 160,
+            },
+          ],
+        },
+      );
+
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      expect(firstLine?.floatSkipBefore).toBeGreaterThanOrEqual(160);
+      expect(firstLine?.leftOffset).toBeUndefined();
+      expect(firstLine?.rightOffset).toBeUndefined();
+    });
+  });
+
+  // Floats with adequate room next to them must NOT trigger a skip — the
+  // line should wrap around them at the natural Y.
+  test("float that still leaves usable width does not trigger a skip", () => {
+    withFakeTextMeasure(() => {
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "p",
+          runs: [{ kind: "text", text: "body text" }],
+          attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri" },
+        },
+        500,
+        {
+          floatingZones: [
+            {
+              leftMargin: 200,
+              rightMargin: 0,
+              topY: 0,
+              bottomY: 80,
+            },
+          ],
+        },
+      );
+
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      expect(firstLine?.floatSkipBefore).toBeUndefined();
+      // Float still applies — line is offset by 200px on the left.
+      expect(firstLine?.leftOffset).toBe(200);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -475,27 +475,35 @@ export function measureParagraph(
   // Subtracting gives correct width in both cases
   let baseFirstLineWidth = Math.max(1, bodyContentWidth - firstLineOffset);
 
-  // List marker on first-line-indent (no hanging) paragraphs: the marker
-  // renders inline at the start of the first line and takes its own width.
-  // Word's measurement includes the marker in the first line's content;
-  // folio renders the marker as a separately-prepended span that's *not* in
-  // the run list, so we must subtract its width here. Without this, the
-  // line breaker thinks the first line has full `bodyWidth - firstLine` of
-  // text room, the painter pushes some text past the right margin, and a
-  // trailing run wraps to the next line.
+  // List marker on the first line: the marker renders inline as an
+  // inline-block span that is *not* in the run list, so the run-based
+  // line breaker doesn't see it. Word's measurement includes the marker
+  // in the first line's content, so we subtract the same footprint the
+  // painter applies as `min-width` (see `renderListMarker` +
+  // `getListMarkerInlineWidth`). Otherwise long markers ("1.1.1.")
+  // overflow the right edge or the line-breaker wraps a trailing run
+  // prematurely.
   //
-  // The marker's inline width is the same value the painter applies as
-  // `min-width` (see `renderListMarker` + `getListMarkerInlineWidth`) —
-  // honours `w:suff` and the next tab stop past the marker so long markers
-  // like "1.1.1." align body text at the next tab grid column instead of a
-  // fixed gap.
+  // Two indent shapes need different subtractions:
   //
-  // Hanging-indent lists already reserve the marker slot through
-  // `firstLineOffset` (= firstLine − hanging widens baseFirstLineWidth),
-  // so we skip the subtraction there.
-  if ((indent?.hanging ?? 0) === 0) {
-    const markerInlineWidth = getListMarkerInlineWidth(block);
-    if (markerInlineWidth > 0) {
+  // - Hanging indent: `firstLineOffset` already widens
+  //   `baseFirstLineWidth` by `hanging` (since firstLineOffset =
+  //   firstLine − hanging is negative). When the marker fits inside
+  //   the hanging slot, that widening exactly accounts for it — no
+  //   further subtraction. When the marker OVERFLOWS the hanging slot
+  //   (`getListMarkerInlineWidth` returns a value > `hanging` because
+  //   Word advances body to the next tab stop), subtract the excess.
+  //
+  // - First-line indent (no hanging): subtract the full marker width.
+  const markerInlineWidth = getListMarkerInlineWidth(block);
+  if (markerInlineWidth > 0) {
+    const hangingPx = indent?.hanging ?? 0;
+    if (hangingPx > 0) {
+      const excessWidth = markerInlineWidth - hangingPx;
+      if (excessWidth > 0) {
+        baseFirstLineWidth = Math.max(1, baseFirstLineWidth - excessWidth);
+      }
+    } else {
       baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerInlineWidth);
     }
   }

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -18,6 +18,7 @@ import type {
   ParagraphSpacing,
 } from "../../layout-engine/types";
 import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
+import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import {
   measureTextWidth,
   measureRun,
@@ -346,6 +347,70 @@ export function clampFloatingWrapMargins(
 }
 
 /**
+ * Minimum horizontal room a line must offer before we treat it as usable for
+ * body text. Below this threshold the line is bumped past obstructing floats
+ * via `findClearLineY` instead of being rendered into the unusable sliver.
+ * Without this guard, a near-full-width float (e.g. floating table) produces
+ * a ~2px segment that collapses every wrap line to one glyph per row.
+ */
+export const MIN_WRAP_SEGMENT_WIDTH = 24;
+
+/**
+ * Find the next vertical position at or below `startY` where the available
+ * text width is at least `minWidth`. Used to skip lines past stacked floats
+ * when there is no horizontal room for meaningful text at the current Y.
+ *
+ * Returns `startY` if the current position already has enough room, otherwise
+ * the lowest `bottomY` of any zone currently obstructing the line. The caller
+ * is expected to re-query margins at the returned Y.
+ *
+ * Coordinates are absolute (i.e., already include any paragraphYOffset).
+ */
+export function findClearLineY(
+  startY: number,
+  lineHeight: number,
+  zones: FloatingImageZone[] | undefined,
+  contentWidth: number,
+  minWidth: number,
+): number {
+  if (!zones || zones.length === 0) {
+    return startY;
+  }
+
+  let y = startY;
+  // Bounded loop — at most one step per zone the line currently overlaps,
+  // plus a safety cushion. Prevents pathological re-entry while keeping the
+  // happy path O(zones).
+  for (let i = 0; i < zones.length + 2; i++) {
+    const margins = getFloatingMargins(y, lineHeight, zones, 0);
+    const available = Math.max(
+      0,
+      contentWidth - margins.leftMargin - margins.rightMargin,
+    );
+    if (available >= minWidth) {
+      return y;
+    }
+
+    const lineBottom = y + lineHeight;
+    let nextY = Number.POSITIVE_INFINITY;
+    for (const zone of zones) {
+      // Skip zones we are already past or that lie entirely below this line.
+      if (lineBottom <= zone.topY || y >= zone.bottomY) {
+        continue;
+      }
+      if (zone.bottomY > y && zone.bottomY < nextY) {
+        nextY = zone.bottomY;
+      }
+    }
+    if (!Number.isFinite(nextY) || nextY <= y) {
+      return y;
+    }
+    y = nextY;
+  }
+  return y;
+}
+
+/**
  * Calculate width reduction for a line based on floating image zones.
  * Returns the left and right margins that need to be applied.
  */
@@ -410,47 +475,71 @@ export function measureParagraph(
   // Subtracting gives correct width in both cases
   let baseFirstLineWidth = Math.max(1, bodyContentWidth - firstLineOffset);
 
-  // List marker on first-line-indent paragraphs: the marker is rendered
-  // inline at the start of the first line and takes its own width. Word's
-  // measurement includes the marker in the first line's content; folio
-  // renders the marker as a separately-prepended span that's *not* in the
-  // run list, so we must subtract its width here. Without this, the line
-  // breaker thinks the first line has a full `bodyWidth - firstLine` of
-  // text room, the painter then pushes some text past the right margin,
-  // and a trailing run (e.g. ". The Company...") wraps to the next line.
-  // Hanging-indent lists already account for the marker via the hanging
-  // gap (see baseFirstLineWidth shrinking through firstLineOffset).
-  if (
-    attrs?.listMarker &&
-    !attrs.listMarkerHidden &&
-    !((indent?.hanging ?? 0) > 0)
-  ) {
-    const markerFontSize =
-      attrs.listMarkerFontSize ?? attrs.defaultFontSize ?? DEFAULT_FONT_SIZE;
-    const markerFontFamily =
-      attrs.listMarkerFontFamily ??
-      attrs.defaultFontFamily ??
-      DEFAULT_FONT_FAMILY;
-    const markerStyle: FontStyle = {
-      fontFamily: markerFontFamily,
-      fontSize: markerFontSize,
-    };
-    const markerTextWidth = measureTextWidth(attrs.listMarker, markerStyle);
-    // 12 px tab-after gap, matching the painter's `paddingRight: 12px`
-    // on the marker box for first-line-indent lists.
-    const markerSlotWidth = markerTextWidth + 12;
-    baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerSlotWidth);
+  // List marker on first-line-indent (no hanging) paragraphs: the marker
+  // renders inline at the start of the first line and takes its own width.
+  // Word's measurement includes the marker in the first line's content;
+  // folio renders the marker as a separately-prepended span that's *not* in
+  // the run list, so we must subtract its width here. Without this, the
+  // line breaker thinks the first line has full `bodyWidth - firstLine` of
+  // text room, the painter pushes some text past the right margin, and a
+  // trailing run wraps to the next line.
+  //
+  // The marker's inline width is the same value the painter applies as
+  // `min-width` (see `renderListMarker` + `getListMarkerInlineWidth`) —
+  // honours `w:suff` and the next tab stop past the marker so long markers
+  // like "1.1.1." align body text at the next tab grid column instead of a
+  // fixed gap.
+  //
+  // Hanging-indent lists already reserve the marker slot through
+  // `firstLineOffset` (= firstLine − hanging widens baseFirstLineWidth),
+  // so we skip the subtraction there.
+  if ((indent?.hanging ?? 0) === 0) {
+    const markerInlineWidth = getListMarkerInlineWidth(block);
+    if (markerInlineWidth > 0) {
+      baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerInlineWidth);
+    }
   }
 
   // Track cumulative height for floating zone calculations
   let cumulativeHeight = 0;
+  // Vertical space queued for the next line to finalize — set when we hop
+  // past a float that leaves no usable horizontal width at the current Y.
+  // Cleared each time finalizeLine attaches it to a MeasuredLine.
+  let pendingFloatSkip = 0;
+
+  /**
+   * If floats leave no usable horizontal room at `cumulativeHeight`, advance
+   * past them by mutating cumulativeHeight + pendingFloatSkip.
+   */
+  const skipObstructingFloats = (
+    lineHeight: number,
+    lineMaxWidth: number,
+  ): void => {
+    if (!floatingZones || floatingZones.length === 0) {
+      return;
+    }
+    const absoluteY = paragraphYOffset + cumulativeHeight;
+    const clearY = findClearLineY(
+      absoluteY,
+      lineHeight,
+      floatingZones,
+      lineMaxWidth,
+      MIN_WRAP_SEGMENT_WIDTH,
+    );
+    const skip = clearY - absoluteY;
+    if (skip > 0) {
+      cumulativeHeight += skip;
+      pendingFloatSkip += skip;
+    }
+  };
 
   // Calculate first line width with floating zone adjustment
   // Estimate first line height for floating margin calculation
   const estimatedFirstLineHeight =
     ptToPx(DEFAULT_FONT_SIZE) * DEFAULT_LINE_HEIGHT_MULTIPLIER;
+  skipObstructingFloats(estimatedFirstLineHeight, baseFirstLineWidth);
   const firstLineFloatingMargins = getFloatingMargins(
-    0,
+    cumulativeHeight,
     estimatedFirstLineHeight,
     floatingZones,
     paragraphYOffset,
@@ -630,6 +719,13 @@ export function measureParagraph(
       line.rightOffset = currentLine.rightOffset;
     }
 
+    // Attach any queued float-skip to this line; the painter reserves it
+    // via marginTop and totalHeight already grew by this amount above.
+    if (pendingFloatSkip > 0) {
+      line.floatSkipBefore = pendingFloatSkip;
+      pendingFloatSkip = 0;
+    }
+
     lines.push(line);
 
     // Update cumulative height for next line's floating zone calculation
@@ -646,6 +742,7 @@ export function measureParagraph(
     // Estimate the new line's height for overlap calculation
     const estimatedLineHeight =
       ptToPx(DEFAULT_FONT_SIZE) * DEFAULT_LINE_HEIGHT_MULTIPLIER;
+    skipObstructingFloats(estimatedLineHeight, bodyContentWidth);
     const floatingMargins = getFloatingMargins(
       cumulativeHeight,
       estimatedLineHeight,
@@ -946,8 +1043,12 @@ export function measureParagraph(
   // Finalize the last line
   finalizeLine();
 
-  // Calculate total height
-  const totalHeight = lines.reduce((sum, line) => sum + line.lineHeight, 0);
+  // Calculate total height — include floatSkipBefore from lines bumped past
+  // floats so containers stay sized correctly.
+  const totalHeight = lines.reduce(
+    (sum, line) => sum + line.lineHeight + (line.floatSkipBefore ?? 0),
+    0,
+  );
 
   // Add spacing before/after
   let totalWithSpacing = totalHeight;

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -475,37 +475,31 @@ export function measureParagraph(
   // Subtracting gives correct width in both cases
   let baseFirstLineWidth = Math.max(1, bodyContentWidth - firstLineOffset);
 
-  // List marker on the first line: the marker renders inline as an
-  // inline-block span that is *not* in the run list, so the run-based
-  // line breaker doesn't see it. Word's measurement includes the marker
-  // in the first line's content, so we subtract the same footprint the
-  // painter applies as `min-width` (see `renderListMarker` +
-  // `getListMarkerInlineWidth`). Otherwise long markers ("1.1.1.")
-  // overflow the right edge or the line-breaker wraps a trailing run
-  // prematurely.
+  // List marker on the first line: the marker renders as an inline-block
+  // span that's *not* in the run list, so the run-based line breaker
+  // doesn't see it. The first line's content area spans from the marker's
+  // start to the right margin — for a hanging list that's
+  // `bodyContentWidth + hanging` (already widened via `firstLineOffset`);
+  // for a first-line indent it's `bodyContentWidth − firstLine`. Subtract
+  // the marker's actual painted footprint (`getListMarkerInlineWidth`) so
+  // the line breaker sees the same text room the painter leaves.
   //
-  // Two indent shapes need different subtractions:
+  // The subtraction is unconditional:
   //
-  // - Hanging indent: `firstLineOffset` already widens
-  //   `baseFirstLineWidth` by `hanging` (since firstLineOffset =
-  //   firstLine − hanging is negative). When the marker fits inside
-  //   the hanging slot, that widening exactly accounts for it — no
-  //   further subtraction. When the marker OVERFLOWS the hanging slot
-  //   (`getListMarkerInlineWidth` returns a value > `hanging` because
-  //   Word advances body to the next tab stop), subtract the excess.
-  //
+  // - Hanging + `w:suff="tab"` (fitting): markerInlineWidth = hanging, so
+  //   the subtraction exactly cancels the `+ hanging` widening and the
+  //   text budget reduces to bodyContentWidth (matches body wrap).
+  // - Hanging + tab overflow: markerInlineWidth > hanging, subtracting
+  //   yields bodyContentWidth − overflow (text budget shrinks past the
+  //   body wrap column, matching Word's advance to next tab stop).
+  // - Hanging + `w:suff="space"|"nothing"`: markerInlineWidth < hanging,
+  //   so the budget is bodyContentWidth + (hanging − markerInlineWidth) —
+  //   first line is wider than subsequent lines, matching the painter
+  //   which starts body before indentLeft.
   // - First-line indent (no hanging): subtract the full marker width.
   const markerInlineWidth = getListMarkerInlineWidth(block);
   if (markerInlineWidth > 0) {
-    const hangingPx = indent?.hanging ?? 0;
-    if (hangingPx > 0) {
-      const excessWidth = markerInlineWidth - hangingPx;
-      if (excessWidth > 0) {
-        baseFirstLineWidth = Math.max(1, baseFirstLineWidth - excessWidth);
-      }
-    } else {
-      baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerInlineWidth);
-    }
+    baseFirstLineWidth = Math.max(1, baseFirstLineWidth - markerInlineWidth);
   }
 
   // Track cumulative height for floating zone calculations

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -96,6 +96,13 @@ export type ToFlowBlocksOptions = {
   listAbstractCounters?: Map<number, number[]>;
   /** Shared startOverride state for nested containers. */
   listSeenNumIds?: Set<string>;
+  /**
+   * Document-wide `w:defaultTabStop` (§17.6.13) in twips. Stamped onto
+   * every paragraph block so paragraph-local layout helpers (list marker
+   * tab-stop math) can read it without taking a `Document` reference.
+   * Defaults to the OOXML 720-twip value when absent.
+   */
+  defaultTabStopTwips?: number;
 };
 
 const DEFAULT_FONT = "Calibri";
@@ -1005,6 +1012,7 @@ function convertParagraphAttrs(
   listCounters?: Map<number, number[]>,
   listAbstractCounters?: Map<number, number[]>,
   listSeenNumIds?: Set<string>,
+  defaultTabStopTwips?: number,
 ): ParagraphAttrs {
   const attrs: ParagraphAttrs = {};
 
@@ -1267,6 +1275,12 @@ function convertParagraphAttrs(
   if (pmAttrs.listMarkerFontSize) {
     attrs.listMarkerFontSize = pmAttrs.listMarkerFontSize;
   }
+  if (pmAttrs.listMarkerSuffix) {
+    attrs.listMarkerSuffix = pmAttrs.listMarkerSuffix;
+  }
+  if (defaultTabStopTwips !== undefined) {
+    attrs.defaultTabStopTwips = defaultTabStopTwips;
+  }
 
   // Default font for empty paragraph measurement (from style's rPr / pPr/rPr)
   const dtf = pmAttrs.defaultTextFormatting as
@@ -1330,6 +1344,7 @@ function convertParagraph(
     options.listCounters,
     options.listAbstractCounters,
     options.listSeenNumIds,
+    options.defaultTabStopTwips,
   );
 
   return {

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -292,9 +292,22 @@ export type ParagraphAttrs = {
   listMarkerHidden?: boolean; // w:vanish on numbering level rPr
   listMarkerFontFamily?: string; // from numbering level rPr (w:rFonts)
   listMarkerFontSize?: number; // from numbering level rPr, in points
+  /**
+   * `w:suff` (§17.9.25) — what follows the marker before body text.
+   * `tab` (default) grows the marker to the next tab stop; `space` adds
+   * one space glyph; `nothing` lets body text butt against the marker.
+   */
+  listMarkerSuffix?: "tab" | "space" | "nothing";
   // Default font for empty paragraphs (from style's rPr / pPr/rPr)
   defaultFontSize?: number; // in points
   defaultFontFamily?: string;
+  /**
+   * Document-wide `w:defaultTabStop` (§17.6.13) in twips. Read by the list
+   * marker tab-stop math so long markers align body text at the document's
+   * configured grid. Stamped onto every paragraph block by `toFlowBlocks`
+   * so paragraph-local helpers stay decoupled from `Document`.
+   */
+  defaultTabStopTwips?: number;
 };
 
 /**
@@ -524,6 +537,12 @@ export type MeasuredLine = {
   leftOffset?: number;
   /** Right offset from floating images (pixels from content right edge). */
   rightOffset?: number;
+  /**
+   * Vertical space inserted before this line to skip past floats that leave
+   * no usable horizontal room at the natural line Y. Painters render this
+   * as marginTop on the line element; measurement adds it to totalHeight.
+   */
+  floatSkipBefore?: number;
 };
 
 /**

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -5,11 +5,11 @@
  * Handles text formatting, alignment, and positioning.
  */
 
+import { getListMarkerInlineWidth } from "../layout-bridge/measuring/listMarkerWidth";
 import type {
   ParagraphBlock,
   ParagraphMeasure,
   ParagraphFragment,
-  ParagraphIndent,
   ParagraphBorders,
   BorderStyle,
   MeasuredLine,
@@ -1770,6 +1770,14 @@ export function renderParagraphFragment(
     // Update cumulative Y for next line
     _cumulativeLineY += line.lineHeight;
 
+    // Lead skip: a line bumped past obstructing floats reserves vertical
+    // space above itself via marginTop. measureParagraph adds the same
+    // amount to totalHeight so containers stay sized correctly.
+    if (line.floatSkipBefore !== undefined && line.floatSkipBefore > 0) {
+      lineEl.style.marginTop = `${line.floatSkipBefore}px`;
+      _cumulativeLineY += line.floatSkipBefore;
+    }
+
     // Apply line-level indentation
     // Indentation is applied per-line for correct text wrapping
     const hasHanging = indent?.hanging && indent.hanging > 0;
@@ -1876,7 +1884,7 @@ export function renderParagraphFragment(
 
       const marker = renderListMarker(
         block.attrs.listMarker,
-        indent,
+        getListMarkerInlineWidth(block),
         doc,
         markerFontFamily,
         markerFontSize,
@@ -1892,15 +1900,16 @@ export function renderParagraphFragment(
 }
 
 /**
- * Render a list marker element
- *
- * The marker is rendered as an inline-block with a consistent space after it.
- * For short markers, the box fills the hanging indent area.
- * For long markers (like "1.1.1"), we ensure minimum spacing after the text.
+ * Render a list marker element as an inline-block at the start of the first
+ * body line. `minWidth` (from `getListMarkerInlineWidth`) sizes the marker
+ * so the body text aligns at the next tab stop per ECMA-376 §17.9.25 —
+ * this honours `w:suff` (`tab` / `space` / `nothing`) and the document's
+ * tab grid. Long markers like "1.1.1." therefore grow to the next stop
+ * instead of butting against the body text.
  */
 function renderListMarker(
   marker: string,
-  indent: ParagraphIndent | undefined,
+  minWidth: number,
   doc: Document,
   fontFamily?: string,
   fontSize?: number,
@@ -1909,42 +1918,21 @@ function renderListMarker(
   span.className = "layout-list-marker";
   span.style.display = "inline-block";
 
-  // Apply font styling so the marker matches the paragraph text
-  // Per ECMA-376 §17.9.6, marker formatting comes from level rPr,
-  // then paragraph defaults, then document defaults.
+  // Per ECMA-376 §17.9.6, marker formatting comes from level rPr, then
+  // paragraph defaults, then document defaults.
   if (fontFamily) {
     span.style.fontFamily = resolveFontFamily(fontFamily).cssFallback;
   }
   if (fontSize) {
-    // Convert points to pixels: 1pt = 96/72 px
-    const fontSizePx = (fontSize * 96) / 72;
-    span.style.fontSize = `${fontSizePx}px`;
+    // 1pt = 96/72 px
+    span.style.fontSize = `${(fontSize * 96) / 72}px`;
   }
 
   span.textContent = marker;
   span.style.textAlign = "left";
   span.style.boxSizing = "border-box";
-
-  // ECMA-376 §17.9.30: `<w:suff>` selects what follows the marker —
-  // `tab` (default), `space`, or `nothing`. We don't currently parse
-  // `<w:suff>` and fall back to the default (tab) behaviour.
-  //
-  // Hanging-indent lists bake the tab gap into the hanging space:
-  // marker fills `[indentLeft - hanging, indentLeft]`, body text
-  // picks up at `indentLeft`. Set `min-width: hanging` so short
-  // markers don't collapse against the body text.
-  //
-  // First-line-indent lists (`firstLine > 0` and no hanging) place
-  // the marker at `indentLeft + firstLine` with body text wrapping
-  // at `indentLeft`; the marker box has no implicit gap, so we add
-  // an explicit padding-right to emulate the marker's tab-after.
-  // Without this, NVCA-style lists rendered "(i)Tranche Closing"
-  // and "4.10Voting Agreement" with the marker flush against the
-  // text.
-  if (indent?.hanging !== undefined && indent.hanging > 0) {
-    span.style.minWidth = `${indent.hanging}px`;
-  } else if (indent?.firstLine !== undefined && indent.firstLine > 0) {
-    span.style.paddingRight = "12px";
+  if (minWidth > 0) {
+    span.style.minWidth = `${minWidth}px`;
   }
 
   return span;

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -245,6 +245,12 @@ export const readParagraphAttrs = (
     "paragraph.attrs.listMarkerFontSize",
     issues,
   );
+  optionalString(
+    attrs,
+    "listMarkerSuffix",
+    "paragraph.attrs.listMarkerSuffix",
+    issues,
+  );
   optionalNumber(
     attrs,
     "listStartOverride",

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -442,6 +442,9 @@ function paragraphFormattingToAttrs(
   if (paragraph.listRendering?.markerFontSize) {
     attrs.listMarkerFontSize = paragraph.listRendering.markerFontSize;
   }
+  if (paragraph.listRendering?.markerSuffix) {
+    attrs.listMarkerSuffix = paragraph.listRendering.markerSuffix;
+  }
   if (paragraph.listRendering?.levelNumFmts) {
     attrs.listLevelNumFmts = paragraph.listRendering.levelNumFmts;
   }

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -341,6 +341,7 @@ const paragraphNodeSpec: NodeSpec = {
     listMarkerHidden: { default: null },
     listMarkerFontFamily: { default: null },
     listMarkerFontSize: { default: null },
+    listMarkerSuffix: { default: null },
     listLevelNumFmts: { default: null },
     listAbstractNumId: { default: null },
     listStartOverride: { default: null },

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -80,6 +80,12 @@ export type ParagraphAttrs = {
   listMarkerFontFamily?: string;
   /** Marker font size from numbering level rPr, in points */
   listMarkerFontSize?: number;
+  /**
+   * `w:suff` (§17.9.25) — what follows the marker before body text.
+   * `tab` (default) grows the marker to the next tab stop; `space` adds one
+   * space glyph; `nothing` lets body text butt against the marker.
+   */
+  listMarkerSuffix?: "tab" | "space" | "nothing";
   /** Number format for each level used by multi-level marker templates. */
   listLevelNumFmts?: NumberFormat[];
   /** Abstract numbering ID shared by numbering instances. */

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1753,6 +1753,14 @@ export function PagedEditor(
         if (_theme !== undefined) {
           flowOpts.theme = _theme;
         }
+        // Stamp the document's `w:defaultTabStop` onto every paragraph so
+        // list-marker tab-stop math (renderParagraph + measureParagraph)
+        // uses the right grid. Absent settings.xml falls back to the
+        // OOXML default inside `getListMarkerInlineWidth`.
+        const defaultTabStop = document?.package.settings?.defaultTabStop;
+        if (defaultTabStop !== undefined) {
+          flowOpts.defaultTabStopTwips = defaultTabStop;
+        }
         const newBlocks = toFlowBlocks(state.doc, flowOpts);
         setBlocks(newBlocks);
 
@@ -1811,6 +1819,9 @@ export function PagedEditor(
           ...(styles ? { styles } : {}),
           ...(_theme !== undefined ? { theme: _theme } : {}),
           measureBlocks,
+          ...(defaultTabStop !== undefined
+            ? { defaultTabStopTwips: defaultTabStop }
+            : {}),
         };
         const headerContentForRender = convertHeaderFooterToContent(
           headerContent,
@@ -1925,6 +1936,9 @@ export function PagedEditor(
               }
               if (_theme !== undefined) {
                 footnoteOptions.theme = _theme;
+              }
+              if (defaultTabStop !== undefined) {
+                footnoteOptions.defaultTabStopTwips = defaultTabStop;
               }
               return footnoteOptions;
             })(),


### PR DESCRIPTION
## Summary

Syncs four upstream fidelity fixes from `eigenpal/docx-editor` since folio's last sync (#410, 2026-05-21). Each was reviewed against folio's diverged structure and either ported, improved, or re-architected to fit folio's layout pipeline.

### Ported

- **[#585](https://github.com/eigenpal/docx-editor/pull/585)** — `collectFootnoteRefs` now recurses into table cells and text-box content. Without this, footnote inline markers rendered correctly but the per-page footnote area dropped the entries.
- **[#597](https://github.com/eigenpal/docx-editor/pull/597) + [#599](https://github.com/eigenpal/docx-editor/pull/599)** — A direct `<w:ind w:firstLine="0"/>` or `<w:ind w:hanging="0"/>` is now treated as a no-op per ECMA-376 §17.3.1.12, so the numbering level's hanging slot stays applied. Parse the attribute values and only treat non-zero direct attrs as overrides.

### Improved / re-architected

- **[#596](https://github.com/eigenpal/docx-editor/pull/596)** — Stacked-float text wrapping. Added `MIN_WRAP_SEGMENT_WIDTH` (24 px) + a new `findClearLineY` helper that bumps lines past floats which leave no usable horizontal room. Adapted to folio's `FloatingImageZone` shape (folio uses a simpler topY/bottomY/leftMargin/rightMargin model than upstream's segment-based zones). `MeasuredLine.floatSkipBefore` carries the vertical hop to the painter as a `margin-top`; `totalHeight` includes it so containers size correctly.
- **[#600](https://github.com/eigenpal/docx-editor/pull/600)** — Long-marker tab-stop alignment. New `getListMarkerInlineWidth` helper (`packages/folio/src/core/layout-bridge/measuring/listMarkerWidth.ts`) is the single source of truth for the marker's inline footprint — both `measureParagraph` and `renderParagraph` call it. Long markers like `1.1.1.` now grow to the next tab stop instead of folio's previous fixed `+12 px` gap. Two pieces of data flow into the helper:
  - `w:suff` from the numbering level → `ListRendering.markerSuffix` → PM attr → `ParagraphAttrs.listMarkerSuffix`. Default `tab`, plus `space` and `nothing`.
  - `w:defaultTabStop` from `word/settings.xml` (new `settingsParser.ts`) → `DocxPackage.settings` → `toFlowBlocks` option → per-block `ParagraphAttrs.defaultTabStopTwips`. Falls back to the OOXML default of 720 twips when absent.

### Skipped

- [#602](https://github.com/eigenpal/docx-editor/pull/602) legacy `/assets` cleanup — folio doesn't have that folder
- [#598](https://github.com/eigenpal/docx-editor/pull/598) Vue parity — not applicable
- [#587](https://github.com/eigenpal/docx-editor/pull/587) e2e test repairs — folio has its own test architecture
- [#583](https://github.com/eigenpal/docx-editor/pull/583) header/footer text boxes — already landed as folio #453

### Tests

24 new regression tests across 7 files:

| File | Covers |
|---|---|
| `footnoteLayout-collect.test.ts` | #585 recursion into tables / text boxes |
| `paragraphParser-numbering-indent.test.ts` | #597 + #599 zero-valued ind attrs |
| `paragraphParser-numbering-suffix.test.ts` | `w:suff` propagation through `ListRendering` |
| `measureParagraph-stacked-floats.test.ts` | #596 skip-past-floats line bumping |
| `listMarkerWidth.test.ts` | tab-stop math, `w:suff` variants, custom defaultTabStop, `clear`/`bar` filtering |
| `measureParagraph-list-marker.test.ts` | measurer + painter agree on the marker slot |
| `settingsParser.test.ts` | `w:defaultTabStop` parse / cap / fallback |

Local: 885 tests pass, 0 fail; typecheck clean across folio and docx-core.

## Test plan

- [ ] Watch CI
- [ ] Open a doc with footnotes inside table cells — each fn ref appears in the per-page footnote area, not just inline
- [ ] Open a doc with numbered lists where the paragraph has `<w:ind w:firstLine="0"/>` or `<w:ind w:hanging="0"/>` — hanging indent survives
- [ ] Open a doc with vertically stacked floating tables/textboxes that cover the row — body lines skip past them instead of collapsing to 1 glyph per row
- [ ] Open a doc with a long multi-level numbering marker (e.g. `1.1.1.`) — body text aligns at the next tab stop, not flush against the marker
- [ ] Open a doc that sets `<w:defaultTabStop w:val="1440"/>` in `word/settings.xml` — list markers grow to the 1-inch grid