### PR TITLE
perf(folio): improve docx editor performance

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -78,11 +78,16 @@ const loadCollaborationRuntimeModules =
       import("@hocuspocus/provider"),
       import("y-prosemirror"),
       import("yjs"),
-    ]).then(([hocuspocus, yProseMirror, yjs]) => ({
-      hocuspocus,
-      yProseMirror,
-      yjs,
-    }));
+    ])
+      .then(([hocuspocus, yProseMirror, yjs]) => ({
+        hocuspocus,
+        yProseMirror,
+        yjs,
+      }))
+      .catch((error: unknown) => {
+        collaborationRuntimeModulesPromise = null;
+        throw error;
+      });
 
     return await collaborationRuntimeModulesPromise;
   };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/use-folio-collaboration-session.ts
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 
-import { HocuspocusProvider } from "@hocuspocus/provider";
+import type { HocuspocusProvider } from "@hocuspocus/provider";
+import type * as HocuspocusProviderModule from "@hocuspocus/provider";
 import { useQueryClient } from "@tanstack/react-query";
 import { panic } from "better-result";
-import { yCursorPlugin, ySyncPlugin, yUndoPlugin } from "y-prosemirror";
-import * as Y from "yjs";
+import type * as YProseMirror from "y-prosemirror";
+import type * as Yjs from "yjs";
 
 import type { DocxEditorCollaboration } from "@stll/folio";
 
@@ -61,6 +62,30 @@ type UseFolioCollaborationSessionOptions = {
 
 const FOLIO_COLLAB_TOKEN_REFRESH_LEEWAY_MS = 5 * 60 * 1000;
 const SEED_DOCUMENT_DOWNLOAD_TIMEOUT_MS = 10_000;
+
+type CollaborationRuntimeModules = {
+  hocuspocus: typeof HocuspocusProviderModule;
+  yProseMirror: typeof YProseMirror;
+  yjs: typeof Yjs;
+};
+
+let collaborationRuntimeModulesPromise: Promise<CollaborationRuntimeModules> | null =
+  null;
+
+const loadCollaborationRuntimeModules =
+  async (): Promise<CollaborationRuntimeModules> => {
+    collaborationRuntimeModulesPromise ??= Promise.all([
+      import("@hocuspocus/provider"),
+      import("y-prosemirror"),
+      import("yjs"),
+    ]).then(([hocuspocus, yProseMirror, yjs]) => ({
+      hocuspocus,
+      yProseMirror,
+      yjs,
+    }));
+
+    return await collaborationRuntimeModulesPromise;
+  };
 
 const fetchSeedDocumentBuffer = async (seedDownloadUrl: string) => {
   const controller = new AbortController();
@@ -184,6 +209,15 @@ export const useFolioCollaborationSession = ({
         return;
       }
 
+      const collaborationRuntimeModules =
+        await loadCollaborationRuntimeModules();
+      const { hocuspocus, yProseMirror, yjs } = collaborationRuntimeModules;
+
+      if (isDisposed()) {
+        await cancelOpeningSession();
+        return;
+      }
+
       const refreshTokenIfNeeded = async () => {
         if (
           Number.isFinite(tokenExpiresAtMs) &&
@@ -207,10 +241,10 @@ export const useFolioCollaborationSession = ({
         tokenExpiresAtMs = Date.parse(refreshed.data.tokenExpiresAt);
         return token;
       };
-      const ydoc = new Y.Doc();
-      const yXmlFragment = ydoc.get("prosemirror", Y.XmlFragment);
+      const ydoc = new yjs.Doc();
+      const yXmlFragment = ydoc.get("prosemirror", yjs.XmlFragment);
 
-      provider = new HocuspocusProvider({
+      provider = new hocuspocus.HocuspocusProvider({
         document: ydoc,
         name: response.data.roomName,
         token: async () => (await refreshTokenIfNeeded()) ?? "",
@@ -336,9 +370,9 @@ export const useFolioCollaborationSession = ({
       const collaboration = {
         awareness,
         plugins: [
-          ySyncPlugin(yXmlFragment),
-          yCursorPlugin(awareness),
-          yUndoPlugin(),
+          yProseMirror.ySyncPlugin(yXmlFragment),
+          yProseMirror.yCursorPlugin(awareness),
+          yProseMirror.yUndoPlugin(),
         ],
         shouldSeed: response.data.shouldSeed,
         yXmlFragment,

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -19,6 +19,7 @@
     "lint": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --report-unused-disable-directives-severity=error --deny-warnings --type-aware packages/folio",
     "lint:fix": "cd ../.. && bun --bun oxlint -c oxlint.config.ts --type-aware --fix packages/folio",
     "format": "oxfmt .",
+    "perf": "bun scripts/profile-editor.ts",
     "test": "bun test src",
     "test:visual": "bunx playwright test",
     "test:visual:update": "bunx playwright test --update-snapshots",

--- a/packages/folio/scripts/profile-editor.ts
+++ b/packages/folio/scripts/profile-editor.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import process from "node:process";
 
 import type {
+  HiddenEditorPhase,
   HiddenEditorStateReason,
   LayoutInstrumentation,
   LayoutPhase,
@@ -24,6 +25,7 @@ type PerfStats = {
   measureText: CounterBucket;
   getBoundingClientRect: CounterBucket;
   createElement: CounterBucket;
+  hiddenEditorPhases: Record<HiddenEditorPhase, CounterBucket>;
   hiddenStateCreations: Record<HiddenEditorStateReason, number>;
   measureBlockCalls: number;
   layoutCompletions: number;
@@ -82,6 +84,7 @@ declare global {
         layoutPhases: Record<LayoutPhase, CounterBucket>;
         layoutReasons: Record<LayoutRunReason, number>;
         hiddenStateCreations: Record<HiddenEditorStateReason, number>;
+        hiddenEditorPhases: Record<HiddenEditorPhase, CounterBucket>;
         measureBlockCalls: number;
       }
     | undefined;
@@ -352,6 +355,12 @@ async function readStats(page: Page): Promise<PerfStats> {
         totalMs: roundInBrowser(perf.createElement.totalMs),
       },
       hiddenStateCreations: perf.hiddenStateCreations,
+      hiddenEditorPhases: {
+        "editor-state": roundBucket(perf.hiddenEditorPhases["editor-state"]),
+        "editor-view": roundBucket(perf.hiddenEditorPhases["editor-view"]),
+        "to-prose-doc": roundBucket(perf.hiddenEditorPhases["to-prose-doc"]),
+        "update-state": roundBucket(perf.hiddenEditorPhases["update-state"]),
+      },
       measureBlockCalls: perf.measureBlockCalls,
       layoutCompletions: perf.layoutCompletions,
       layoutErrors: perf.layoutErrors,
@@ -406,6 +415,15 @@ async function installCounters(context: BrowserContext): Promise<void> {
       "measure-blocks": { count: 0, totalMs: 0 },
       "render-pages": { count: 0, totalMs: 0 },
     });
+    const makeHiddenEditorPhaseCounters = (): Record<
+      HiddenEditorPhase,
+      CounterBucket
+    > => ({
+      "editor-state": { count: 0, totalMs: 0 },
+      "editor-view": { count: 0, totalMs: 0 },
+      "to-prose-doc": { count: 0, totalMs: 0 },
+      "update-state": { count: 0, totalMs: 0 },
+    });
     const makeHiddenStateCreationCounters = (): Record<
       HiddenEditorStateReason,
       number
@@ -418,6 +436,7 @@ async function installCounters(context: BrowserContext): Promise<void> {
       createElement: { count: 0, totalMs: 0 },
       elements: 0,
       getBoundingClientRect: { count: 0, totalMs: 0 },
+      hiddenEditorPhases: makeHiddenEditorPhaseCounters(),
       hiddenStateCreations: makeHiddenStateCreationCounters(),
       hiddenPmElements: 0,
       layoutCompletions: 0,
@@ -447,6 +466,7 @@ async function installCounters(context: BrowserContext): Promise<void> {
         layoutErrors: [],
         layoutPhases: makeLayoutPhaseCounters(),
         layoutReasons: makeCounters().layoutReasons,
+        hiddenEditorPhases: makeHiddenEditorPhaseCounters(),
         hiddenStateCreations: makeHiddenStateCreationCounters(),
         measureBlockCalls: 0,
       };
@@ -457,10 +477,25 @@ async function installCounters(context: BrowserContext): Promise<void> {
       layoutErrors: [],
       layoutPhases: makeLayoutPhaseCounters(),
       layoutReasons: makeCounters().layoutReasons,
+      hiddenEditorPhases: makeHiddenEditorPhaseCounters(),
       hiddenStateCreations: makeHiddenStateCreationCounters(),
       measureBlockCalls: 0,
     };
     globalThis.__folioLayoutInstrumentation = {
+      onHiddenEditorPhase(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          const bucket = stats.hiddenEditorPhases[event.phase];
+          bucket.count += 1;
+          bucket.totalMs += event.durationMs;
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          const bucket = perf.hiddenEditorPhases[event.phase];
+          bucket.count += 1;
+          bucket.totalMs += event.durationMs;
+        }
+      },
       onHiddenEditorStateCreate(event) {
         const stats = globalThis.__folioLayoutMeasurementStats;
         if (stats) {
@@ -621,6 +656,7 @@ function printSummary(results: PerfResult[]): void {
       rendered: result.stats.renderedPages,
       phases: formatLayoutPhases(result.stats.layoutPhases),
       hiddenStates: JSON.stringify(result.stats.hiddenStateCreations),
+      hiddenPhases: formatBuckets(result.stats.hiddenEditorPhases),
       measureBlocks: result.stats.measureBlockCalls,
       hiddenEls: result.stats.hiddenPmElements,
       visibleEls: result.stats.visiblePageElements,
@@ -634,6 +670,12 @@ function printSummary(results: PerfResult[]): void {
 
 function formatLayoutPhases(
   phases: Record<LayoutPhase, CounterBucket>,
+): string {
+  return formatBuckets(phases);
+}
+
+function formatBuckets<TPhase extends string>(
+  phases: Record<TPhase, CounterBucket>,
 ): string {
   return JSON.stringify(
     Object.fromEntries(

--- a/packages/folio/scripts/profile-editor.ts
+++ b/packages/folio/scripts/profile-editor.ts
@@ -2,6 +2,7 @@ import { chromium, type BrowserContext, type Page } from "@playwright/test";
 import { TaggedError } from "better-result";
 import { spawn } from "node:child_process";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 
 import type {
   HiddenEditorPhase,
@@ -124,7 +125,11 @@ async function main() {
 }
 
 function rootDir(): string {
-  return new URL("../../..", import.meta.url).pathname.replace(/\/$/u, "");
+  let dir = fileURLToPath(new URL("../../..", import.meta.url));
+  while (dir.endsWith("/") || dir.endsWith("\\")) {
+    dir = dir.slice(0, -1);
+  }
+  return dir;
 }
 
 async function runCommand(

--- a/packages/folio/scripts/profile-editor.ts
+++ b/packages/folio/scripts/profile-editor.ts
@@ -1,0 +1,652 @@
+import { chromium, type BrowserContext, type Page } from "@playwright/test";
+import { TaggedError } from "better-result";
+import { spawn } from "node:child_process";
+import process from "node:process";
+
+import type {
+  HiddenEditorStateReason,
+  LayoutInstrumentation,
+  LayoutPhase,
+  LayoutRunReason,
+} from "../src/paged-editor/layoutInstrumentation";
+
+type CounterBucket = {
+  count: number;
+  totalMs: number;
+};
+
+type PerfStats = {
+  pages: number;
+  renderedPages: number;
+  elements: number;
+  hiddenPmElements: number;
+  visiblePageElements: number;
+  measureText: CounterBucket;
+  getBoundingClientRect: CounterBucket;
+  createElement: CounterBucket;
+  hiddenStateCreations: Record<HiddenEditorStateReason, number>;
+  measureBlockCalls: number;
+  layoutCompletions: number;
+  layoutErrors: { message: string; reason: LayoutRunReason }[];
+  layoutPhases: Record<LayoutPhase, CounterBucket>;
+  layoutReasons: Record<LayoutRunReason, number>;
+  longTasks: {
+    count: number;
+    maxMs: number;
+    totalMs: number;
+  };
+};
+
+type BrowserMetrics = {
+  JSHeapUsedSize?: number;
+  LayoutDuration?: number;
+  RecalcStyleDuration?: number;
+  ScriptDuration?: number;
+  TaskDuration?: number;
+};
+
+type PerfResult = {
+  name: string;
+  wallMs: number;
+  browser: {
+    jsHeapMb: number;
+    layoutMs: number;
+    scriptMs: number;
+    styleMs: number;
+    taskMs: number;
+  };
+  stats: PerfStats;
+};
+
+class FolioPerfError extends TaggedError("FolioPerfError")<{
+  message: string;
+  cause?: unknown;
+}>() {}
+
+const HOST = "127.0.0.1";
+const DEFAULT_PORT = 4201;
+const port = Number(process.env["FOLIO_PERF_PORT"] ?? DEFAULT_PORT);
+const baseUrl = process.env["FOLIO_PERF_URL"] ?? `http://${HOST}:${port}`;
+const skipBuild = process.env["FOLIO_PERF_SKIP_BUILD"] === "1";
+const fixtureNames = ["podily-bps.docx", "docx-editor-demo.docx"] as const;
+
+declare global {
+  // Browser-side globals installed with addInitScript.
+  var __folioPerfCounters: PerfStats | undefined;
+  var __resetFolioPerfCounters: (() => void) | undefined;
+  var __folioLayoutInstrumentation: LayoutInstrumentation | undefined;
+  var __folioLayoutMeasurementStats:
+    | {
+        layoutCompletions: number;
+        layoutErrors: { message: string; reason: LayoutRunReason }[];
+        layoutPhases: Record<LayoutPhase, CounterBucket>;
+        layoutReasons: Record<LayoutRunReason, number>;
+        hiddenStateCreations: Record<HiddenEditorStateReason, number>;
+        measureBlockCalls: number;
+      }
+    | undefined;
+}
+
+async function main() {
+  let previewProcess: ReturnType<typeof spawn> | null = null;
+
+  try {
+    if (!process.env["FOLIO_PERF_URL"]) {
+      if (!skipBuild) {
+        await runCommand("bun", ["--filter", "@stll/playground", "build"], {
+          cwd: rootDir(),
+        });
+      }
+
+      previewProcess = spawn(
+        "bunx",
+        ["vite", "preview", "--host", HOST, "--port", String(port)],
+        {
+          cwd: `${rootDir()}/apps/playground`,
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+
+      await waitForServer(baseUrl);
+    }
+
+    const results = await profileScenarios();
+    printSummary(results);
+    console.log(JSON.stringify(results, null, 2));
+  } finally {
+    if (previewProcess) {
+      previewProcess.kill();
+    }
+  }
+}
+
+function rootDir(): string {
+  return new URL("../../..", import.meta.url).pathname.replace(/\/$/u, "");
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  options: { cwd: string },
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: "inherit",
+    });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(
+        new FolioPerfError({
+          message: `${command} ${args.join(" ")} exited with ${code}`,
+        }),
+      );
+    });
+  });
+}
+
+async function waitForServer(url: string): Promise<void> {
+  const startedAt = performance.now();
+  while (performance.now() - startedAt < 15_000) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Server not ready yet.
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 100);
+    });
+  }
+  throw new FolioPerfError({ message: `Timed out waiting for ${url}` });
+}
+
+async function profileScenarios(): Promise<PerfResult[]> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    deviceScaleFactor: 2,
+    viewport: { height: 900, width: 1280 },
+  });
+
+  await installCounters(context);
+
+  try {
+    const results: PerfResult[] = [];
+
+    for (const fixtureName of fixtureNames) {
+      results.push(
+        await profileLoad(
+          context,
+          `load ${fixtureName}`,
+          `/?file=${fixtureName}`,
+          1,
+        ),
+      );
+    }
+
+    results.push(
+      await profileLoad(
+        context,
+        "load generated 1500 paragraphs",
+        "/?paragraphs=1500",
+        20,
+      ),
+    );
+
+    const page = await context.newPage();
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("Performance.enable");
+    await page.goto(`${baseUrl}/?paragraphs=1500`);
+    await waitForEditor(page, 20);
+
+    results.push(
+      await profileAction("typing abc immediate path", page, cdp, async () => {
+        await page
+          .locator(".layout-page")
+          .first()
+          .click({ position: { x: 120, y: 120 } });
+        await page.keyboard.type("abc", { delay: 20 });
+        await page.waitForTimeout(75);
+      }),
+    );
+
+    results.push(
+      await profileAction("typing idle reconcile", page, cdp, async () => {
+        await page.waitForTimeout(400);
+      }),
+    );
+
+    await page.close();
+    return results;
+  } finally {
+    await browser.close();
+  }
+}
+
+async function profileLoad(
+  context: BrowserContext,
+  name: string,
+  path: string,
+  minimumPages: number,
+): Promise<PerfResult> {
+  const page = await context.newPage();
+  const cdp = await context.newCDPSession(page);
+  await cdp.send("Performance.enable");
+
+  try {
+    return await profileAction(name, page, cdp, async () => {
+      await page.goto(`${baseUrl}${path}`);
+      await waitForEditor(page, minimumPages);
+    });
+  } finally {
+    await page.close();
+  }
+}
+
+async function profileAction(
+  name: string,
+  page: Page,
+  cdp: Awaited<ReturnType<BrowserContext["newCDPSession"]>>,
+  action: () => Promise<void>,
+): Promise<PerfResult> {
+  await page.evaluate(() => globalThis.__resetFolioPerfCounters?.());
+
+  const before = await readMetrics(cdp);
+  const startedAt = performance.now();
+  await action();
+  const wallMs = performance.now() - startedAt;
+  const after = await readMetrics(cdp);
+
+  return {
+    name,
+    wallMs: round(wallMs),
+    browser: metricDelta(before, after),
+    stats: await readStats(page),
+  };
+}
+
+async function readMetrics(
+  cdp: Awaited<ReturnType<BrowserContext["newCDPSession"]>>,
+): Promise<BrowserMetrics> {
+  const result = await cdp.send("Performance.getMetrics");
+  return Object.fromEntries(
+    result.metrics.map((metric) => [metric.name, metric.value]),
+  );
+}
+
+function metricDelta(before: BrowserMetrics, after: BrowserMetrics) {
+  return {
+    taskMs: round(
+      ((after.TaskDuration ?? 0) - (before.TaskDuration ?? 0)) * 1000,
+    ),
+    scriptMs: round(
+      ((after.ScriptDuration ?? 0) - (before.ScriptDuration ?? 0)) * 1000,
+    ),
+    layoutMs: round(
+      ((after.LayoutDuration ?? 0) - (before.LayoutDuration ?? 0)) * 1000,
+    ),
+    styleMs: round(
+      ((after.RecalcStyleDuration ?? 0) - (before.RecalcStyleDuration ?? 0)) *
+        1000,
+    ),
+    jsHeapMb: round((after.JSHeapUsedSize ?? 0) / 1024 / 1024),
+  };
+}
+
+async function waitForEditor(page: Page, minimumPages: number): Promise<void> {
+  await page.waitForSelector('[data-testid="folio-editor"]', {
+    timeout: 20_000,
+  });
+  try {
+    await page.waitForFunction(
+      (pageCount) =>
+        document.querySelectorAll(".layout-page").length >= pageCount,
+      minimumPages,
+      { timeout: 20_000 },
+    );
+  } catch (error) {
+    const layoutErrors = await page.evaluate(
+      () => globalThis.__folioPerfCounters?.layoutErrors ?? [],
+    );
+    throw new FolioPerfError({
+      message: `Timed out waiting for ${minimumPages} layout pages. Layout errors: ${JSON.stringify(layoutErrors)}`,
+      cause: error,
+    });
+  }
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await page.waitForTimeout(250);
+}
+
+async function readStats(page: Page): Promise<PerfStats> {
+  const stats = await page.evaluate(() => {
+    const perf = globalThis.__folioPerfCounters;
+    if (!perf) {
+      return null;
+    }
+    return {
+      pages: document.querySelectorAll(".layout-page").length,
+      renderedPages: document.querySelectorAll(".layout-page-content").length,
+      elements: document.querySelectorAll("*").length,
+      hiddenPmElements: document.querySelectorAll(".paged-editor__hidden-pm *")
+        .length,
+      visiblePageElements: document.querySelectorAll(".paged-editor__pages *")
+        .length,
+      measureText: {
+        count: perf.measureText.count,
+        totalMs: roundInBrowser(perf.measureText.totalMs),
+      },
+      getBoundingClientRect: {
+        count: perf.getBoundingClientRect.count,
+        totalMs: roundInBrowser(perf.getBoundingClientRect.totalMs),
+      },
+      createElement: {
+        count: perf.createElement.count,
+        totalMs: roundInBrowser(perf.createElement.totalMs),
+      },
+      hiddenStateCreations: perf.hiddenStateCreations,
+      measureBlockCalls: perf.measureBlockCalls,
+      layoutCompletions: perf.layoutCompletions,
+      layoutErrors: perf.layoutErrors,
+      layoutPhases: {
+        "flow-blocks": roundBucket(perf.layoutPhases["flow-blocks"]),
+        "header-footer": roundBucket(perf.layoutPhases["header-footer"]),
+        "initial-fonts": roundBucket(perf.layoutPhases["initial-fonts"]),
+        "layout-document": roundBucket(perf.layoutPhases["layout-document"]),
+        "measure-blocks": roundBucket(perf.layoutPhases["measure-blocks"]),
+        "render-pages": roundBucket(perf.layoutPhases["render-pages"]),
+      },
+      layoutReasons: perf.layoutReasons,
+      longTasks: {
+        count: perf.longTasks.count,
+        maxMs: roundInBrowser(perf.longTasks.maxMs),
+        totalMs: roundInBrowser(perf.longTasks.totalMs),
+      },
+    };
+
+    function roundInBrowser(value: number): number {
+      return Number(value.toFixed(2));
+    }
+
+    function roundBucket(bucket: CounterBucket): CounterBucket {
+      return {
+        count: bucket.count,
+        totalMs: roundInBrowser(bucket.totalMs),
+      };
+    }
+  });
+
+  if (!stats) {
+    throw new FolioPerfError({
+      message: "Folio perf counters were not installed",
+    });
+  }
+
+  return stats;
+}
+
+async function installCounters(context: BrowserContext): Promise<void> {
+  await context.addInitScript(() => {
+    type BrowserPerfStats = PerfStats & {
+      longTaskDurations: number[];
+    };
+
+    const makeLayoutPhaseCounters = (): Record<LayoutPhase, CounterBucket> => ({
+      "flow-blocks": { count: 0, totalMs: 0 },
+      "header-footer": { count: 0, totalMs: 0 },
+      "initial-fonts": { count: 0, totalMs: 0 },
+      "layout-document": { count: 0, totalMs: 0 },
+      "measure-blocks": { count: 0, totalMs: 0 },
+      "render-pages": { count: 0, totalMs: 0 },
+    });
+    const makeHiddenStateCreationCounters = (): Record<
+      HiddenEditorStateReason,
+      number
+    > => ({
+      "external-document": 0,
+      mount: 0,
+    });
+
+    const makeCounters = (): BrowserPerfStats => ({
+      createElement: { count: 0, totalMs: 0 },
+      elements: 0,
+      getBoundingClientRect: { count: 0, totalMs: 0 },
+      hiddenStateCreations: makeHiddenStateCreationCounters(),
+      hiddenPmElements: 0,
+      layoutCompletions: 0,
+      layoutErrors: [],
+      layoutPhases: makeLayoutPhaseCounters(),
+      layoutReasons: {
+        "font-ready": 0,
+        initial: 0,
+        "layout-input": 0,
+        manual: 0,
+        transaction: 0,
+      },
+      longTaskDurations: [],
+      longTasks: { count: 0, maxMs: 0, totalMs: 0 },
+      measureBlockCalls: 0,
+      measureText: { count: 0, totalMs: 0 },
+      pages: 0,
+      renderedPages: 0,
+      visiblePageElements: 0,
+    });
+
+    globalThis.__folioPerfCounters = makeCounters();
+    globalThis.__resetFolioPerfCounters = () => {
+      globalThis.__folioPerfCounters = makeCounters();
+      globalThis.__folioLayoutMeasurementStats = {
+        layoutCompletions: 0,
+        layoutErrors: [],
+        layoutPhases: makeLayoutPhaseCounters(),
+        layoutReasons: makeCounters().layoutReasons,
+        hiddenStateCreations: makeHiddenStateCreationCounters(),
+        measureBlockCalls: 0,
+      };
+    };
+
+    globalThis.__folioLayoutMeasurementStats = {
+      layoutCompletions: 0,
+      layoutErrors: [],
+      layoutPhases: makeLayoutPhaseCounters(),
+      layoutReasons: makeCounters().layoutReasons,
+      hiddenStateCreations: makeHiddenStateCreationCounters(),
+      measureBlockCalls: 0,
+    };
+    globalThis.__folioLayoutInstrumentation = {
+      onHiddenEditorStateCreate(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.hiddenStateCreations[event.reason] += 1;
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          perf.hiddenStateCreations[event.reason] += 1;
+        }
+      },
+      onLayoutComplete(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.layoutCompletions += 1;
+          stats.layoutReasons[event.reason] += 1;
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          perf.layoutCompletions += 1;
+          perf.layoutReasons[event.reason] += 1;
+        }
+      },
+      onLayoutError(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.layoutErrors.push(event);
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          perf.layoutErrors.push(event);
+        }
+      },
+      onLayoutPhase(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          const bucket = stats.layoutPhases[event.phase];
+          bucket.count += 1;
+          bucket.totalMs += event.durationMs;
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          const bucket = perf.layoutPhases[event.phase];
+          bucket.count += 1;
+          bucket.totalMs += event.durationMs;
+        }
+      },
+      onMeasureBlock() {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.measureBlockCalls += 1;
+        }
+        const perf = globalThis.__folioPerfCounters;
+        if (perf) {
+          perf.measureBlockCalls += 1;
+        }
+      },
+    };
+
+    const measureTextDescriptor = Object.getOwnPropertyDescriptor(
+      CanvasRenderingContext2D.prototype,
+      "measureText",
+    );
+    const measureText = measureTextDescriptor?.value;
+    if (typeof measureText === "function") {
+      Object.defineProperty(CanvasRenderingContext2D.prototype, "measureText", {
+        ...measureTextDescriptor,
+        value(this: CanvasRenderingContext2D, text: string) {
+          const startedAt = performance.now();
+          try {
+            return Reflect.apply(measureText, this, [text]);
+          } finally {
+            recordBucket("measureText", performance.now() - startedAt);
+          }
+        },
+      });
+    }
+
+    const rectDescriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      "getBoundingClientRect",
+    );
+    const rect = rectDescriptor?.value;
+    if (typeof rect === "function") {
+      Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+        ...rectDescriptor,
+        value(this: Element) {
+          const startedAt = performance.now();
+          try {
+            return Reflect.apply(rect, this, []);
+          } finally {
+            recordBucket(
+              "getBoundingClientRect",
+              performance.now() - startedAt,
+            );
+          }
+        },
+      });
+    }
+
+    const createElementDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      "createElement",
+    );
+    const createElement = createElementDescriptor?.value;
+    if (typeof createElement === "function") {
+      Object.defineProperty(Document.prototype, "createElement", {
+        ...createElementDescriptor,
+        value(...args: unknown[]) {
+          const startedAt = performance.now();
+          try {
+            return Reflect.apply(createElement, this, args);
+          } finally {
+            recordBucket("createElement", performance.now() - startedAt);
+          }
+        },
+      });
+    }
+
+    try {
+      new PerformanceObserver((list) => {
+        const perf = globalThis.__folioPerfCounters;
+        if (!perf) {
+          return;
+        }
+        for (const entry of list.getEntries()) {
+          perf.longTasks.count += 1;
+          perf.longTasks.totalMs += entry.duration;
+          perf.longTasks.maxMs = Math.max(perf.longTasks.maxMs, entry.duration);
+        }
+      }).observe({ entryTypes: ["longtask"] });
+    } catch {
+      // Long task entries are not available in every browser mode.
+    }
+
+    function recordBucket(
+      key: "createElement" | "getBoundingClientRect" | "measureText",
+      elapsedMs: number,
+    ): void {
+      const perf = globalThis.__folioPerfCounters;
+      if (!perf) {
+        return;
+      }
+      perf[key].count += 1;
+      perf[key].totalMs += elapsedMs;
+    }
+  });
+}
+
+function printSummary(results: PerfResult[]): void {
+  console.table(
+    results.map((result) => ({
+      scenario: result.name,
+      wallMs: result.wallMs,
+      taskMs: result.browser.taskMs,
+      scriptMs: result.browser.scriptMs,
+      layoutMs: result.browser.layoutMs,
+      pages: result.stats.pages,
+      rendered: result.stats.renderedPages,
+      phases: formatLayoutPhases(result.stats.layoutPhases),
+      hiddenStates: JSON.stringify(result.stats.hiddenStateCreations),
+      measureBlocks: result.stats.measureBlockCalls,
+      hiddenEls: result.stats.hiddenPmElements,
+      visibleEls: result.stats.visiblePageElements,
+      reasons: JSON.stringify(result.stats.layoutReasons),
+      errors: JSON.stringify(result.stats.layoutErrors),
+      measureText: result.stats.measureText.count,
+      longTaskMs: result.stats.longTasks.totalMs,
+    })),
+  );
+}
+
+function formatLayoutPhases(
+  phases: Record<LayoutPhase, CounterBucket>,
+): string {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(phases).map(([phase, bucket]) => [
+        phase,
+        `${bucket.count}x ${round(bucket.totalMs)}ms`,
+      ]),
+    ),
+  );
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(2));
+}
+
+await main();

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1131,8 +1131,16 @@ export function DocxEditor({
   const handleDocumentChange = useCallback(
     (newDocument: Document) => {
       const currentComments = commentsRef.current;
-      const documentWithComments = structuredClone(newDocument);
-      documentWithComments.package.document.comments = currentComments;
+      const documentWithComments = {
+        ...newDocument,
+        package: {
+          ...newDocument.package,
+          document: {
+            ...newDocument.package.document,
+            comments: currentComments,
+          },
+        },
+      };
       pushDocument(documentWithComments);
       onChange?.(documentWithComments);
       // Update outline headings if sidebar is open

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -802,7 +802,7 @@ export function DocxEditor({
     }
 
     const nodes = root.querySelectorAll<HTMLElement>(
-      ".layout-run-text[data-comment-id], .docx-comment[data-comment-id]",
+      ".layout-run-text[data-comment-id]",
     );
     for (const node of nodes) {
       const commentId = Number.parseInt(node.dataset["commentId"] ?? "", 10);

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -221,7 +221,6 @@ import {
   buildSelectionFormatting,
   extractListState,
 } from "./selectionFormattingBuilder";
-import { TextContextMenu } from "./TextContextMenu";
 import type { TextContextAction, TextContextMenuItem } from "./TextContextMenu";
 import { ToolbarButton, ToolbarSeparator } from "./Toolbar";
 import type { FormattingAction } from "./Toolbar";
@@ -238,6 +237,12 @@ import { Tooltip } from "./ui/Tooltip";
 const CommentsSidebar = lazy(() =>
   import("./CommentsSidebar").then((m) => ({
     default: m.CommentsSidebar,
+  })),
+);
+
+const TextContextMenu = lazy(() =>
+  import("./TextContextMenu").then((m) => ({
+    default: m.TextContextMenu,
   })),
 );
 
@@ -3525,17 +3530,21 @@ export function DocxEditor({
           />
 
           {/* Right-click context menu */}
-          <TextContextMenu
-            isOpen={contextMenu.isOpen}
-            position={contextMenu.position}
-            hasSelection={contextMenu.hasSelection}
-            isEditable={!readOnly}
-            items={contextMenuItems}
-            onAction={(action) => {
-              void handleContextMenuAction(action);
-            }}
-            onClose={handleContextMenuClose}
-          />
+          {contextMenu.isOpen && (
+            <Suspense fallback={null}>
+              <TextContextMenu
+                isOpen={contextMenu.isOpen}
+                position={contextMenu.position}
+                hasSelection={contextMenu.hasSelection}
+                isEditable={!readOnly}
+                items={contextMenuItems}
+                onAction={(action) => {
+                  void handleContextMenuAction(action);
+                }}
+                onClose={handleContextMenuClose}
+              />
+            </Suspense>
+          )}
 
           {/* Toast notifications */}
           {/* Toast notifications provided by host app */}

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -10,6 +10,8 @@
  */
 
 import {
+  Suspense,
+  lazy,
   useRef,
   useCallback,
   useState,
@@ -178,7 +180,6 @@ import {
   pruneOrphanedComments,
   removePendingCommentMarkRange,
 } from "./commentsHelpers";
-import { CommentsSidebar } from "./CommentsSidebar";
 import type { TrackedChangeEntry } from "./CommentsSidebar";
 // Dialog hooks and utilities (static imports — lightweight, no UI)
 import type { FindMatch } from "./dialogs/findReplaceUtils";
@@ -233,6 +234,12 @@ import { getBuiltinTableStyle } from "./ui/table-styles";
 import type { TableStylePreset } from "./ui/table-styles";
 import type { TableAction } from "./ui/table-types";
 import { Tooltip } from "./ui/Tooltip";
+
+const CommentsSidebar = lazy(() =>
+  import("./CommentsSidebar").then((m) => ({
+    default: m.CommentsSidebar,
+  })),
+);
 
 // Toast stub — host app provides the real toast system.
 // Uses a temporary DOM banner so the user sees feedback even without
@@ -3159,136 +3166,145 @@ export function DocxEditor({
                       sidebarOverlay={(() => {
                         if (showCommentsSidebar) {
                           return (
-                            <CommentsSidebar
-                              activeCommentId={activeCommentId}
-                              comments={visibleComments}
-                              anchorPositions={anchorPositions}
-                              pageWidth={(() => {
-                                const sp =
-                                  history.state.package.document
-                                    .finalSectionProperties;
-                                return sp?.pageWidth
-                                  ? Math.round(sp.pageWidth / 15)
-                                  : 816;
-                              })()}
-                              editorContainerRef={scrollContainerRef}
-                              onCommentClick={(id) => {
-                                setActiveCommentId(id);
-                              }}
-                              onCommentResolve={(id) => {
-                                updateComments((prev) =>
-                                  prev.map((c) =>
-                                    c.id === id
-                                      ? {
-                                          ...c,
-                                          done: true,
-                                        }
-                                      : c,
-                                  ),
-                                );
-                              }}
-                              onCommentDelete={(id) => {
-                                updateComments((prev) =>
-                                  prev.filter(
-                                    (c) => c.id !== id && c.parentId !== id,
-                                  ),
-                                );
-                                if (activeCommentId === id) {
-                                  setActiveCommentId(null);
-                                }
-                              }}
-                              onCommentReply={(id, text) => {
-                                updateComments((prev) => [
-                                  ...prev,
-                                  createComment(text, author, id),
-                                ]);
-                              }}
-                              onAddComment={(addText) => {
-                                const comment = createComment(addText, author);
-                                // Replace pending comment mark with the real comment ID
-                                const view = pagedEditorRef.current?.getView();
-                                if (!view || !commentSelectionRange) {
-                                  return false;
-                                }
-                                const marked = applyCommentMarkRange(
-                                  view,
-                                  commentSelectionRange,
-                                  comment.id,
-                                  {
-                                    replacePending: true,
-                                  },
-                                );
-                                if (!marked) {
-                                  return false;
-                                }
-                                const commentAuthor = getCommentAuthorKey(
-                                  comment.author,
-                                );
-                                setVisibleCommentAuthors((current) => {
-                                  if (current === null) {
-                                    return null;
-                                  }
-                                  const next = new Set(current);
-                                  next.add(commentAuthor);
-                                  return next;
-                                });
-                                setActiveCommentId(comment.id);
-                                updateComments((prev) => [...prev, comment]);
-                                pagedEditorRef.current?.relayout();
-                                requestAnimationFrame(() => {
-                                  syncCommentHighlightStyles();
-                                  requestAnimationFrame(
-                                    syncCommentHighlightStyles,
+                            <Suspense fallback={null}>
+                              <CommentsSidebar
+                                activeCommentId={activeCommentId}
+                                comments={visibleComments}
+                                anchorPositions={anchorPositions}
+                                pageWidth={(() => {
+                                  const sp =
+                                    history.state.package.document
+                                      .finalSectionProperties;
+                                  return sp?.pageWidth
+                                    ? Math.round(sp.pageWidth / 15)
+                                    : 816;
+                                })()}
+                                editorContainerRef={scrollContainerRef}
+                                onCommentClick={(id) => {
+                                  setActiveCommentId(id);
+                                }}
+                                onCommentResolve={(id) => {
+                                  updateComments((prev) =>
+                                    prev.map((c) =>
+                                      c.id === id
+                                        ? {
+                                            ...c,
+                                            done: true,
+                                          }
+                                        : c,
+                                    ),
                                   );
-                                });
-                                setIsAddingComment(false);
-                                setCommentSelectionRange(null);
-                                setAddCommentYPosition(null);
-                                return true;
-                              }}
-                              onTrackedChangeReply={(revisionId, text) => {
-                                updateComments((prev) => [
-                                  ...prev,
-                                  createComment(text, author, revisionId),
-                                ]);
-                              }}
-                              onCancelAddComment={() => {
-                                // Remove pending comment highlight
-                                const view = pagedEditorRef.current?.getView();
-                                if (view && commentSelectionRange) {
-                                  removePendingCommentMarkRange(
+                                }}
+                                onCommentDelete={(id) => {
+                                  updateComments((prev) =>
+                                    prev.filter(
+                                      (c) => c.id !== id && c.parentId !== id,
+                                    ),
+                                  );
+                                  if (activeCommentId === id) {
+                                    setActiveCommentId(null);
+                                  }
+                                }}
+                                onCommentReply={(id, text) => {
+                                  updateComments((prev) => [
+                                    ...prev,
+                                    createComment(text, author, id),
+                                  ]);
+                                }}
+                                onAddComment={(addText) => {
+                                  const comment = createComment(
+                                    addText,
+                                    author,
+                                  );
+                                  // Replace pending comment mark with the real comment ID
+                                  const view =
+                                    pagedEditorRef.current?.getView();
+                                  if (!view || !commentSelectionRange) {
+                                    return false;
+                                  }
+                                  const marked = applyCommentMarkRange(
                                     view,
                                     commentSelectionRange,
+                                    comment.id,
+                                    {
+                                      replacePending: true,
+                                    },
                                   );
-                                }
-                                setIsAddingComment(false);
-                                setCommentSelectionRange(null);
-                                setAddCommentYPosition(null);
-                              }}
-                              onAcceptChange={(from, to) => {
-                                const view = pagedEditorRef.current?.getView();
-                                if (view) {
-                                  acceptChange(from, to)(
-                                    view.state,
-                                    view.dispatch,
+                                  if (!marked) {
+                                    return false;
+                                  }
+                                  const commentAuthor = getCommentAuthorKey(
+                                    comment.author,
                                   );
-                                  extractTrackedChanges();
-                                }
-                              }}
-                              onRejectChange={(from, to) => {
-                                const view = pagedEditorRef.current?.getView();
-                                if (view) {
-                                  rejectChange(from, to)(
-                                    view.state,
-                                    view.dispatch,
-                                  );
-                                  extractTrackedChanges();
-                                }
-                              }}
-                              isAddingComment={isAddingComment}
-                              addCommentYPosition={addCommentYPosition}
-                              topOffset={0}
-                            />
+                                  setVisibleCommentAuthors((current) => {
+                                    if (current === null) {
+                                      return null;
+                                    }
+                                    const next = new Set(current);
+                                    next.add(commentAuthor);
+                                    return next;
+                                  });
+                                  setActiveCommentId(comment.id);
+                                  updateComments((prev) => [...prev, comment]);
+                                  pagedEditorRef.current?.relayout();
+                                  requestAnimationFrame(() => {
+                                    syncCommentHighlightStyles();
+                                    requestAnimationFrame(
+                                      syncCommentHighlightStyles,
+                                    );
+                                  });
+                                  setIsAddingComment(false);
+                                  setCommentSelectionRange(null);
+                                  setAddCommentYPosition(null);
+                                  return true;
+                                }}
+                                onTrackedChangeReply={(revisionId, text) => {
+                                  updateComments((prev) => [
+                                    ...prev,
+                                    createComment(text, author, revisionId),
+                                  ]);
+                                }}
+                                onCancelAddComment={() => {
+                                  // Remove pending comment highlight
+                                  const view =
+                                    pagedEditorRef.current?.getView();
+                                  if (view && commentSelectionRange) {
+                                    removePendingCommentMarkRange(
+                                      view,
+                                      commentSelectionRange,
+                                    );
+                                  }
+                                  setIsAddingComment(false);
+                                  setCommentSelectionRange(null);
+                                  setAddCommentYPosition(null);
+                                }}
+                                onAcceptChange={(from, to) => {
+                                  const view =
+                                    pagedEditorRef.current?.getView();
+                                  if (view) {
+                                    acceptChange(from, to)(
+                                      view.state,
+                                      view.dispatch,
+                                    );
+                                    extractTrackedChanges();
+                                  }
+                                }}
+                                onRejectChange={(from, to) => {
+                                  const view =
+                                    pagedEditorRef.current?.getView();
+                                  if (view) {
+                                    rejectChange(from, to)(
+                                      view.state,
+                                      view.dispatch,
+                                    );
+                                    extractTrackedChanges();
+                                  }
+                                }}
+                                isAddingComment={isAddingComment}
+                                addCommentYPosition={addCommentYPosition}
+                                topOffset={0}
+                              />
+                            </Suspense>
                           );
                         }
                         return undefined;

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -59,8 +59,6 @@ import {
   applyFolioAIEditOperations,
   createFolioAIEditSnapshot,
 } from "../core/ai-edits";
-import { repackDocx } from "../core/docx/rezip";
-import { attemptSelectiveSave } from "../core/docx/selectiveSave";
 // ProseMirror editor
 import {
   TextSelection,
@@ -245,6 +243,16 @@ const TextContextMenu = lazy(() =>
     default: m.TextContextMenu,
   })),
 );
+
+const loadAttemptSelectiveSave = async () => {
+  const { attemptSelectiveSave } = await import("../core/docx/selectiveSave");
+  return attemptSelectiveSave;
+};
+
+const loadRepackDocx = async () => {
+  const { repackDocx } = await import("../core/docx/rezip");
+  return repackDocx;
+};
 
 // Toast stub — host app provides the real toast system.
 // Uses a temporary DOM banner so the user sees feedback even without
@@ -2436,6 +2444,7 @@ export function DocxEditor({
 
         if (useSelective && view && originalBufferRef.current) {
           const editorState = view.state;
+          const attemptSelectiveSave = await loadAttemptSelectiveSave();
           buffer = await attemptSelectiveSave(doc, originalBufferRef.current, {
             changedParaIds: getChangedParagraphIds(editorState),
             structuralChange: hasStructuralChanges(editorState),
@@ -2444,6 +2453,7 @@ export function DocxEditor({
         }
 
         if (!buffer) {
+          const repackDocx = await loadRepackDocx();
           buffer = await repackDocx(doc);
         }
 

--- a/packages/folio/src/components/hooks/useDocumentLoader.ts
+++ b/packages/folio/src/components/hooks/useDocumentLoader.ts
@@ -119,7 +119,10 @@ export const useDocumentLoader = ({
       try {
         // Skip blocking font preload during parsing; fonts are loaded
         // asynchronously by loadParsedDocument after the first render
-        const doc = await parseDocx(buffer, { preloadFonts: false });
+        const doc = await parseDocx(buffer, {
+          detectVariables: false,
+          preloadFonts: false,
+        });
         // Discard result if a newer load was started while we were parsing
         if (loadGenerationRef.current !== generation) {
           return;

--- a/packages/folio/src/components/ui/Tooltip.tsx
+++ b/packages/folio/src/components/ui/Tooltip.tsx
@@ -1,9 +1,9 @@
-import { cloneElement } from "react";
-import type { ReactElement, ReactNode } from "react";
+import { cloneElement, isValidElement } from "react";
+import type { ReactNode } from "react";
 
 type TooltipProps = {
   content: ReactNode;
-  children: ReactElement<TooltipChildProps>;
+  children: ReactNode;
   side?: "top" | "bottom" | "left" | "right";
   delayMs?: number;
 };
@@ -15,7 +15,7 @@ type TooltipChildProps = {
 
 export function Tooltip({ content, children }: TooltipProps) {
   const label = getTooltipLabel(content);
-  if (!label) {
+  if (!label || !isValidElement<TooltipChildProps>(children)) {
     return children;
   }
 

--- a/packages/folio/src/components/ui/Tooltip.tsx
+++ b/packages/folio/src/components/ui/Tooltip.tsx
@@ -1,40 +1,38 @@
-/**
- * Tooltip adapter
- *
- * Preserves the backward-compatible single-wrapper API (`<Tooltip content="...">child</Tooltip>`)
- * while delegating to Stella's compound tooltip under the hood.
- */
-
-import type * as React from "react";
-
-import {
-  Tooltip as TooltipRoot,
-  TooltipProvider,
-  TooltipTrigger,
-  TooltipPopup,
-} from "@stll/ui/components/tooltip";
+import { cloneElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 type TooltipProps = {
-  content: React.ReactNode;
-  children: React.ReactElement;
+  content: ReactNode;
+  children: ReactElement<TooltipChildProps>;
   side?: "top" | "bottom" | "left" | "right";
   delayMs?: number;
 };
 
-export function Tooltip({
-  content,
-  children,
-  side = "bottom",
-  delayMs = 400,
-}: TooltipProps) {
-  return (
-    <TooltipProvider delay={delayMs}>
-      <TooltipRoot>
-        <TooltipTrigger render={children} />
-        <TooltipPopup side={side} className="max-w-70 text-nowrap">
-          {content}
-        </TooltipPopup>
-      </TooltipRoot>
-    </TooltipProvider>
-  );
+type TooltipChildProps = {
+  "aria-label"?: string | undefined;
+  title?: string | undefined;
+};
+
+export function Tooltip({ content, children }: TooltipProps) {
+  const label = getTooltipLabel(content);
+  if (!label) {
+    return children;
+  }
+
+  return cloneElement(children, {
+    "aria-label": children.props["aria-label"] ?? label,
+    title: children.props.title ?? label,
+  });
+}
+
+function getTooltipLabel(content: ReactNode): string | undefined {
+  if (typeof content === "string") {
+    return content;
+  }
+
+  if (typeof content === "number") {
+    return content.toString();
+  }
+
+  return undefined;
 }

--- a/packages/folio/src/core/docx/numberingParser.ts
+++ b/packages/folio/src/core/docx/numberingParser.ts
@@ -27,7 +27,6 @@ import {
 } from "./parserEnums";
 import {
   parseXmlDocument,
-  findChild,
   findChildren,
   getAttribute,
   parseBooleanElement,
@@ -50,6 +49,70 @@ export type NumberingMap = {
   getInstance: (numId: number) => NumberingInstance | null;
   /** Check if numId exists */
   hasNumbering: (numId: number) => boolean;
+};
+
+const NUMBER_FORMAT_MAP: Record<string, NumberFormat> = {
+  decimal: "decimal",
+  upperRoman: "upperRoman",
+  lowerRoman: "lowerRoman",
+  upperLetter: "upperLetter",
+  lowerLetter: "lowerLetter",
+  ordinal: "ordinal",
+  cardinalText: "cardinalText",
+  ordinalText: "ordinalText",
+  hex: "hex",
+  chicago: "chicago",
+  bullet: "bullet",
+  none: "none",
+  decimalZero: "decimalZero",
+  ganada: "ganada",
+  chosung: "chosung",
+  // CJK formats
+  ideographDigital: "ideographDigital",
+  japaneseCounting: "japaneseCounting",
+  aiueo: "aiueo",
+  iroha: "iroha",
+  decimalFullWidth: "decimalFullWidth",
+  decimalHalfWidth: "decimalHalfWidth",
+  japaneseLegal: "japaneseLegal",
+  japaneseDigitalTenThousand: "japaneseDigitalTenThousand",
+  decimalEnclosedCircle: "decimalEnclosedCircle",
+  decimalFullWidth2: "decimalFullWidth2",
+  aiueoFullWidth: "aiueoFullWidth",
+  irohaFullWidth: "irohaFullWidth",
+  decimalEnclosedFullstop: "decimalEnclosedFullstop",
+  decimalEnclosedParen: "decimalEnclosedParen",
+  decimalEnclosedCircleChinese: "decimalEnclosedCircleChinese",
+  ideographEnclosedCircle: "ideographEnclosedCircle",
+  ideographTraditional: "ideographTraditional",
+  ideographZodiac: "ideographZodiac",
+  ideographZodiacTraditional: "ideographZodiacTraditional",
+  taiwaneseCounting: "taiwaneseCounting",
+  ideographLegalTraditional: "ideographLegalTraditional",
+  taiwaneseCountingThousand: "taiwaneseCountingThousand",
+  taiwaneseDigital: "taiwaneseDigital",
+  chineseCounting: "chineseCounting",
+  chineseLegalSimplified: "chineseLegalSimplified",
+  chineseCountingThousand: "chineseCountingThousand",
+  koreanDigital: "koreanDigital",
+  koreanCounting: "koreanCounting",
+  koreanLegal: "koreanLegal",
+  koreanDigital2: "koreanDigital2",
+  vietnameseCounting: "vietnameseCounting",
+  russianLower: "russianLower",
+  russianUpper: "russianUpper",
+  numberInDash: "numberInDash",
+  hebrew1: "hebrew1",
+  hebrew2: "hebrew2",
+  arabicAlpha: "arabicAlpha",
+  arabicAbjad: "arabicAbjad",
+  hindiVowels: "hindiVowels",
+  hindiConsonants: "hindiConsonants",
+  hindiNumbers: "hindiNumbers",
+  hindiCounting: "hindiCounting",
+  thaiLetters: "thaiLetters",
+  thaiNumbers: "thaiNumbers",
+  thaiCounting: "thaiCounting",
 };
 
 /**
@@ -113,8 +176,38 @@ function parseAbstractNumbering(element: XmlElement): AbstractNumbering | null {
     levels: [],
   };
 
-  // Parse optional attributes/children
-  const multiLevelTypeEl = findChild(element, "w", "multiLevelType");
+  let multiLevelTypeEl: XmlElement | undefined;
+  let nameEl: XmlElement | undefined;
+  let numStyleLinkEl: XmlElement | undefined;
+  let styleLinkEl: XmlElement | undefined;
+  const levelElements: XmlElement[] = [];
+
+  for (const child of element.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    switch (child.name) {
+      case "w:multiLevelType":
+        multiLevelTypeEl ??= child;
+        break;
+      case "w:name":
+        nameEl ??= child;
+        break;
+      case "w:numStyleLink":
+        numStyleLinkEl ??= child;
+        break;
+      case "w:styleLink":
+        styleLinkEl ??= child;
+        break;
+      case "w:lvl":
+        levelElements.push(child);
+        break;
+      default:
+        break;
+    }
+  }
+
   if (multiLevelTypeEl) {
     const mlType = getAttribute(multiLevelTypeEl, "w", "val");
     if (
@@ -127,7 +220,6 @@ function parseAbstractNumbering(element: XmlElement): AbstractNumbering | null {
   }
 
   // Parse name
-  const nameEl = findChild(element, "w", "name");
   if (nameEl) {
     const nameVal = getAttribute(nameEl, "w", "val");
     if (nameVal != null) {
@@ -136,7 +228,6 @@ function parseAbstractNumbering(element: XmlElement): AbstractNumbering | null {
   }
 
   // Parse style links
-  const numStyleLinkEl = findChild(element, "w", "numStyleLink");
   if (numStyleLinkEl) {
     const numStyleLinkVal = getAttribute(numStyleLinkEl, "w", "val");
     if (numStyleLinkVal != null) {
@@ -144,7 +235,6 @@ function parseAbstractNumbering(element: XmlElement): AbstractNumbering | null {
     }
   }
 
-  const styleLinkEl = findChild(element, "w", "styleLink");
   if (styleLinkEl) {
     const styleLinkVal = getAttribute(styleLinkEl, "w", "val");
     if (styleLinkVal != null) {
@@ -153,7 +243,6 @@ function parseAbstractNumbering(element: XmlElement): AbstractNumbering | null {
   }
 
   // Parse levels (w:lvl)
-  const levelElements = findChildren(element, "w", "lvl");
   for (const lvlEl of levelElements) {
     const level = parseListLevel(lvlEl);
     if (level) {
@@ -181,8 +270,23 @@ function parseNumberingInstance(element: XmlElement): NumberingInstance | null {
     return null;
   }
 
-  // Get abstract numbering reference
-  const abstractNumIdEl = findChild(element, "w", "abstractNumId");
+  let abstractNumIdEl: XmlElement | undefined;
+  const overrideElements: XmlElement[] = [];
+  for (const child of element.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    if (child.name === "w:abstractNumId") {
+      abstractNumIdEl ??= child;
+      continue;
+    }
+
+    if (child.name === "w:lvlOverride") {
+      overrideElements.push(child);
+    }
+  }
+
   if (!abstractNumIdEl) {
     return null;
   }
@@ -203,7 +307,6 @@ function parseNumberingInstance(element: XmlElement): NumberingInstance | null {
   };
 
   // Parse level overrides (w:lvlOverride)
-  const overrideElements = findChildren(element, "w", "lvlOverride");
   if (overrideElements.length > 0) {
     instance.levelOverrides = [];
 
@@ -224,8 +327,24 @@ function parseNumberingInstance(element: XmlElement): NumberingInstance | null {
         lvl?: ListLevel;
       } = { ilvl };
 
+      let startOverrideEl: XmlElement | undefined;
+      let lvlEl: XmlElement | undefined;
+      for (const child of overrideEl.elements ?? []) {
+        if (child.type !== "element") {
+          continue;
+        }
+
+        if (child.name === "w:startOverride") {
+          startOverrideEl ??= child;
+          continue;
+        }
+
+        if (child.name === "w:lvl") {
+          lvlEl ??= child;
+        }
+      }
+
       // Check for start override
-      const startOverrideEl = findChild(overrideEl, "w", "startOverride");
       if (startOverrideEl) {
         const startVal = getAttribute(startOverrideEl, "w", "val");
         if (startVal !== null) {
@@ -237,7 +356,6 @@ function parseNumberingInstance(element: XmlElement): NumberingInstance | null {
       }
 
       // Check for full level redefinition
-      const lvlEl = findChild(overrideEl, "w", "lvl");
       if (lvlEl) {
         const parsedLvl = parseListLevel(lvlEl);
         if (parsedLvl != null) {
@@ -272,8 +390,59 @@ function parseListLevel(element: XmlElement): ListLevel | null {
     lvlText: "",
   };
 
+  let startEl: XmlElement | undefined;
+  let numFmtEl: XmlElement | undefined;
+  let lvlTextEl: XmlElement | undefined;
+  let lvlJcEl: XmlElement | undefined;
+  let suffEl: XmlElement | undefined;
+  let isLglEl: XmlElement | undefined;
+  let lvlRestartEl: XmlElement | undefined;
+  let legacyEl: XmlElement | undefined;
+  let pPrEl: XmlElement | undefined;
+  let rPrEl: XmlElement | undefined;
+
+  for (const child of element.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    switch (child.name) {
+      case "w:start":
+        startEl ??= child;
+        break;
+      case "w:numFmt":
+        numFmtEl ??= child;
+        break;
+      case "w:lvlText":
+        lvlTextEl ??= child;
+        break;
+      case "w:lvlJc":
+        lvlJcEl ??= child;
+        break;
+      case "w:suff":
+        suffEl ??= child;
+        break;
+      case "w:isLgl":
+        isLglEl ??= child;
+        break;
+      case "w:lvlRestart":
+        lvlRestartEl ??= child;
+        break;
+      case "w:legacy":
+        legacyEl ??= child;
+        break;
+      case "w:pPr":
+        pPrEl ??= child;
+        break;
+      case "w:rPr":
+        rPrEl ??= child;
+        break;
+      default:
+        break;
+    }
+  }
+
   // Parse start value
-  const startEl = findChild(element, "w", "start");
   if (startEl) {
     const startVal = getAttribute(startEl, "w", "val");
     if (startVal !== null) {
@@ -285,7 +454,6 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse number format
-  const numFmtEl = findChild(element, "w", "numFmt");
   if (numFmtEl) {
     const fmtVal = getAttribute(numFmtEl, "w", "val");
     if (fmtVal) {
@@ -294,13 +462,11 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse level text (the pattern like "%1." or "•")
-  const lvlTextEl = findChild(element, "w", "lvlText");
   if (lvlTextEl) {
     level.lvlText = getAttribute(lvlTextEl, "w", "val") ?? "";
   }
 
   // Parse justification
-  const lvlJcEl = findChild(element, "w", "lvlJc");
   if (lvlJcEl) {
     const jcVal = getAttribute(lvlJcEl, "w", "val");
     if (jcVal === "left" || jcVal === "center" || jcVal === "right") {
@@ -309,7 +475,6 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse suffix
-  const suffEl = findChild(element, "w", "suff");
   if (suffEl) {
     const suffix = narrowEnum(
       getAttribute(suffEl, "w", "val"),
@@ -321,13 +486,11 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse isLgl (legal numbering)
-  const isLglEl = findChild(element, "w", "isLgl");
   if (isLglEl) {
     level.isLgl = parseBooleanElement(isLglEl);
   }
 
   // Parse lvlRestart (restart numbering from a higher level)
-  const lvlRestartEl = findChild(element, "w", "lvlRestart");
   if (lvlRestartEl) {
     const restartVal = getAttribute(lvlRestartEl, "w", "val");
     if (restartVal !== null) {
@@ -339,7 +502,6 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse legacy settings
-  const legacyEl = findChild(element, "w", "legacy");
   if (legacyEl) {
     const legacySpace = parseNumericAttribute(legacyEl, "w", "legacySpace");
     const legacyIndent = parseNumericAttribute(legacyEl, "w", "legacyIndent");
@@ -351,13 +513,11 @@ function parseListLevel(element: XmlElement): ListLevel | null {
   }
 
   // Parse paragraph properties (w:pPr)
-  const pPrEl = findChild(element, "w", "pPr");
   if (pPrEl) {
     level.pPr = parseLevelParagraphProps(pPrEl);
   }
 
   // Parse run properties (w:rPr)
-  const rPrEl = findChild(element, "w", "rPr");
   if (rPrEl) {
     level.rPr = parseLevelRunProps(rPrEl);
   }
@@ -369,72 +529,7 @@ function parseListLevel(element: XmlElement): ListLevel | null {
  * Parse number format string to NumberFormat type
  */
 function parseNumberFormat(format: string): NumberFormat {
-  // Map of known formats
-  const formatMap: Record<string, NumberFormat> = {
-    decimal: "decimal",
-    upperRoman: "upperRoman",
-    lowerRoman: "lowerRoman",
-    upperLetter: "upperLetter",
-    lowerLetter: "lowerLetter",
-    ordinal: "ordinal",
-    cardinalText: "cardinalText",
-    ordinalText: "ordinalText",
-    hex: "hex",
-    chicago: "chicago",
-    bullet: "bullet",
-    none: "none",
-    decimalZero: "decimalZero",
-    ganada: "ganada",
-    chosung: "chosung",
-    // CJK formats
-    ideographDigital: "ideographDigital",
-    japaneseCounting: "japaneseCounting",
-    aiueo: "aiueo",
-    iroha: "iroha",
-    decimalFullWidth: "decimalFullWidth",
-    decimalHalfWidth: "decimalHalfWidth",
-    japaneseLegal: "japaneseLegal",
-    japaneseDigitalTenThousand: "japaneseDigitalTenThousand",
-    decimalEnclosedCircle: "decimalEnclosedCircle",
-    decimalFullWidth2: "decimalFullWidth2",
-    aiueoFullWidth: "aiueoFullWidth",
-    irohaFullWidth: "irohaFullWidth",
-    decimalEnclosedFullstop: "decimalEnclosedFullstop",
-    decimalEnclosedParen: "decimalEnclosedParen",
-    decimalEnclosedCircleChinese: "decimalEnclosedCircleChinese",
-    ideographEnclosedCircle: "ideographEnclosedCircle",
-    ideographTraditional: "ideographTraditional",
-    ideographZodiac: "ideographZodiac",
-    ideographZodiacTraditional: "ideographZodiacTraditional",
-    taiwaneseCounting: "taiwaneseCounting",
-    ideographLegalTraditional: "ideographLegalTraditional",
-    taiwaneseCountingThousand: "taiwaneseCountingThousand",
-    taiwaneseDigital: "taiwaneseDigital",
-    chineseCounting: "chineseCounting",
-    chineseLegalSimplified: "chineseLegalSimplified",
-    chineseCountingThousand: "chineseCountingThousand",
-    koreanDigital: "koreanDigital",
-    koreanCounting: "koreanCounting",
-    koreanLegal: "koreanLegal",
-    koreanDigital2: "koreanDigital2",
-    vietnameseCounting: "vietnameseCounting",
-    russianLower: "russianLower",
-    russianUpper: "russianUpper",
-    numberInDash: "numberInDash",
-    hebrew1: "hebrew1",
-    hebrew2: "hebrew2",
-    arabicAlpha: "arabicAlpha",
-    arabicAbjad: "arabicAbjad",
-    hindiVowels: "hindiVowels",
-    hindiConsonants: "hindiConsonants",
-    hindiNumbers: "hindiNumbers",
-    hindiCounting: "hindiCounting",
-    thaiLetters: "thaiLetters",
-    thaiNumbers: "thaiNumbers",
-    thaiCounting: "thaiCounting",
-  };
-
-  return formatMap[format] ?? "decimal";
+  return NUMBER_FORMAT_MAP[format] ?? "decimal";
 }
 
 /**
@@ -444,8 +539,24 @@ function parseNumberFormat(format: string): NumberFormat {
 function parseLevelParagraphProps(pPr: XmlElement): ParagraphFormatting {
   const formatting: ParagraphFormatting = {};
 
+  let indEl: XmlElement | undefined;
+  let tabsEl: XmlElement | undefined;
+  for (const child of pPr.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    if (child.name === "w:ind") {
+      indEl ??= child;
+      continue;
+    }
+
+    if (child.name === "w:tabs") {
+      tabsEl ??= child;
+    }
+  }
+
   // Parse indentation (w:ind)
-  const indEl = findChild(pPr, "w", "ind");
   if (indEl) {
     const left = parseNumericAttribute(indEl, "w", "left");
     const right = parseNumericAttribute(indEl, "w", "right");
@@ -472,7 +583,6 @@ function parseLevelParagraphProps(pPr: XmlElement): ParagraphFormatting {
   }
 
   // Parse tabs (w:tabs)
-  const tabsEl = findChild(pPr, "w", "tabs");
   if (tabsEl) {
     formatting.tabs = [];
     const tabElements = findChildren(tabsEl, "w", "tab");
@@ -562,8 +672,43 @@ function parseTabLeader(
 function parseLevelRunProps(rPr: XmlElement): TextFormatting {
   const formatting: TextFormatting = {};
 
+  let rFontsEl: XmlElement | undefined;
+  let szEl: XmlElement | undefined;
+  let colorEl: XmlElement | undefined;
+  let bEl: XmlElement | undefined;
+  let iEl: XmlElement | undefined;
+  let vanishEl: XmlElement | undefined;
+
+  for (const child of rPr.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    switch (child.name) {
+      case "w:rFonts":
+        rFontsEl ??= child;
+        break;
+      case "w:sz":
+        szEl ??= child;
+        break;
+      case "w:color":
+        colorEl ??= child;
+        break;
+      case "w:b":
+        bEl ??= child;
+        break;
+      case "w:i":
+        iEl ??= child;
+        break;
+      case "w:vanish":
+        vanishEl ??= child;
+        break;
+      default:
+        break;
+    }
+  }
+
   // Parse fonts (w:rFonts) - important for bullet characters
-  const rFontsEl = findChild(rPr, "w", "rFonts");
   if (rFontsEl) {
     const ascii = getAttribute(rFontsEl, "w", "ascii");
     const hAnsi = getAttribute(rFontsEl, "w", "hAnsi");
@@ -578,7 +723,6 @@ function parseLevelRunProps(rPr: XmlElement): TextFormatting {
   }
 
   // Parse font size (w:sz)
-  const szEl = findChild(rPr, "w", "sz");
   if (szEl) {
     const size = parseNumericAttribute(szEl, "w", "val");
     if (size !== undefined) {
@@ -587,7 +731,6 @@ function parseLevelRunProps(rPr: XmlElement): TextFormatting {
   }
 
   // Parse color (w:color)
-  const colorEl = findChild(rPr, "w", "color");
   if (colorEl) {
     const val = getAttribute(colorEl, "w", "val");
     const themeColor = getAttribute(colorEl, "w", "themeColor");
@@ -609,19 +752,16 @@ function parseLevelRunProps(rPr: XmlElement): TextFormatting {
   }
 
   // Parse bold (w:b)
-  const bEl = findChild(rPr, "w", "b");
   if (bEl) {
     formatting.bold = parseBooleanElement(bEl);
   }
 
   // Parse italic (w:i)
-  const iEl = findChild(rPr, "w", "i");
   if (iEl) {
     formatting.italic = parseBooleanElement(iEl);
   }
 
   // Parse vanish / hidden (w:vanish) — hides the list indicator
-  const vanishEl = findChild(rPr, "w", "vanish");
   if (vanishEl) {
     formatting.hidden = parseBooleanElement(vanishEl);
   }

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -463,6 +463,102 @@ function parseFrameProperties(
 // PARAGRAPH PROPERTIES PARSER
 // ============================================================================
 
+type ParagraphPropertyChildren = {
+  bidi?: XmlElement;
+  contextualSpacing?: XmlElement;
+  framePr?: XmlElement;
+  ind?: XmlElement;
+  jc?: XmlElement;
+  keepLines?: XmlElement;
+  keepNext?: XmlElement;
+  numPr?: XmlElement;
+  outlineLvl?: XmlElement;
+  pageBreakBefore?: XmlElement;
+  pBdr?: XmlElement;
+  pStyle?: XmlElement;
+  rPr?: XmlElement;
+  shd?: XmlElement;
+  spacing?: XmlElement;
+  suppressAutoHyphens?: XmlElement;
+  suppressLineNumbers?: XmlElement;
+  tabs?: XmlElement;
+  widowControl?: XmlElement;
+};
+
+function collectFirstParagraphPropertyChildren(
+  pPr: XmlElement,
+): ParagraphPropertyChildren {
+  const children: ParagraphPropertyChildren = {};
+
+  for (const child of pPr.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+    const localName = getLocalName(child.name);
+    switch (localName) {
+      case "bidi":
+        children.bidi ??= child;
+        break;
+      case "contextualSpacing":
+        children.contextualSpacing ??= child;
+        break;
+      case "framePr":
+        children.framePr ??= child;
+        break;
+      case "ind":
+        children.ind ??= child;
+        break;
+      case "jc":
+        children.jc ??= child;
+        break;
+      case "keepLines":
+        children.keepLines ??= child;
+        break;
+      case "keepNext":
+        children.keepNext ??= child;
+        break;
+      case "numPr":
+        children.numPr ??= child;
+        break;
+      case "outlineLvl":
+        children.outlineLvl ??= child;
+        break;
+      case "pageBreakBefore":
+        children.pageBreakBefore ??= child;
+        break;
+      case "pBdr":
+        children.pBdr ??= child;
+        break;
+      case "pStyle":
+        children.pStyle ??= child;
+        break;
+      case "rPr":
+        children.rPr ??= child;
+        break;
+      case "shd":
+        children.shd ??= child;
+        break;
+      case "spacing":
+        children.spacing ??= child;
+        break;
+      case "suppressAutoHyphens":
+        children.suppressAutoHyphens ??= child;
+        break;
+      case "suppressLineNumbers":
+        children.suppressLineNumbers ??= child;
+        break;
+      case "tabs":
+        children.tabs ??= child;
+        break;
+      case "widowControl":
+        children.widowControl ??= child;
+        break;
+    }
+  }
+
+  return children;
+}
+
 /**
  * Parse paragraph formatting properties (w:pPr)
  *
@@ -491,9 +587,10 @@ export function parseParagraphProperties(
   }
 
   const formatting: ParagraphFormatting = {};
+  const propertyChildren = collectFirstParagraphPropertyChildren(pPr);
 
   // === Alignment ===
-  const jc = findChild(pPr, "w", "jc");
+  const jc = propertyChildren.jc;
   if (jc) {
     const val = narrowEnum(
       getAttribute(jc, "w", "val"),
@@ -505,13 +602,13 @@ export function parseParagraphProperties(
   }
 
   // === Bidi (right-to-left) ===
-  const bidi = findChild(pPr, "w", "bidi");
+  const bidi = propertyChildren.bidi;
   if (bidi) {
     formatting.bidi = parseBooleanElement(bidi);
   }
 
   // === Spacing ===
-  const spacing = findChild(pPr, "w", "spacing");
+  const spacing = propertyChildren.spacing;
   if (spacing) {
     const before = parseNumericAttribute(spacing, "w", "before");
     if (before !== undefined) {
@@ -560,7 +657,7 @@ export function parseParagraphProperties(
   }
 
   // === Indentation ===
-  const ind = findChild(pPr, "w", "ind");
+  const ind = propertyChildren.ind;
   if (ind) {
     const left = parseNumericAttribute(ind, "w", "left");
     if (left !== undefined) {
@@ -597,7 +694,7 @@ export function parseParagraphProperties(
   }
 
   // === Borders ===
-  const pBdr = findChild(pPr, "w", "pBdr");
+  const pBdr = propertyChildren.pBdr;
   if (pBdr) {
     const borders: ParagraphFormatting["borders"] = {};
 
@@ -637,7 +734,7 @@ export function parseParagraphProperties(
   }
 
   // === Shading ===
-  const shd = findChild(pPr, "w", "shd");
+  const shd = propertyChildren.shd;
   if (shd) {
     const shadingResult = parseShadingProperties(shd);
     if (shadingResult !== undefined) {
@@ -646,7 +743,7 @@ export function parseParagraphProperties(
   }
 
   // === Tab Stops ===
-  const tabs = findChild(pPr, "w", "tabs");
+  const tabs = propertyChildren.tabs;
   if (tabs) {
     const tabsResult = parseTabStops(tabs);
     if (tabsResult !== undefined) {
@@ -655,33 +752,33 @@ export function parseParagraphProperties(
   }
 
   // === Page Break Control ===
-  const keepNext = findChild(pPr, "w", "keepNext");
+  const keepNext = propertyChildren.keepNext;
   if (keepNext) {
     formatting.keepNext = parseBooleanElement(keepNext);
   }
 
-  const keepLines = findChild(pPr, "w", "keepLines");
+  const keepLines = propertyChildren.keepLines;
   if (keepLines) {
     formatting.keepLines = parseBooleanElement(keepLines);
   }
 
-  const widowControl = findChild(pPr, "w", "widowControl");
+  const widowControl = propertyChildren.widowControl;
   if (widowControl) {
     formatting.widowControl = parseBooleanElement(widowControl);
   }
 
-  const pageBreakBefore = findChild(pPr, "w", "pageBreakBefore");
+  const pageBreakBefore = propertyChildren.pageBreakBefore;
   if (pageBreakBefore) {
     formatting.pageBreakBefore = parseBooleanElement(pageBreakBefore);
   }
 
-  const contextualSpacing = findChild(pPr, "w", "contextualSpacing");
+  const contextualSpacing = propertyChildren.contextualSpacing;
   if (contextualSpacing) {
     formatting.contextualSpacing = parseBooleanElement(contextualSpacing);
   }
 
   // === Numbering Properties (List Info) ===
-  const numPr = findChild(pPr, "w", "numPr");
+  const numPr = propertyChildren.numPr;
   if (numPr) {
     const numIdEl = findChild(numPr, "w", "numId");
     const ilvlEl = findChild(numPr, "w", "ilvl");
@@ -706,7 +803,7 @@ export function parseParagraphProperties(
   }
 
   // === Outline Level ===
-  const outlineLvl = findChild(pPr, "w", "outlineLvl");
+  const outlineLvl = propertyChildren.outlineLvl;
   if (outlineLvl) {
     const val = parseNumericAttribute(outlineLvl, "w", "val");
     if (val !== undefined) {
@@ -715,7 +812,7 @@ export function parseParagraphProperties(
   }
 
   // === Style Reference ===
-  const pStyle = findChild(pPr, "w", "pStyle");
+  const pStyle = propertyChildren.pStyle;
   if (pStyle) {
     const val = getAttribute(pStyle, "w", "val");
     if (val) {
@@ -724,7 +821,7 @@ export function parseParagraphProperties(
   }
 
   // === Frame Properties ===
-  const framePr = findChild(pPr, "w", "framePr");
+  const framePr = propertyChildren.framePr;
   if (framePr) {
     const frameResult = parseFrameProperties(framePr);
     if (frameResult !== undefined) {
@@ -733,19 +830,19 @@ export function parseParagraphProperties(
   }
 
   // === Suppress Line Numbers ===
-  const suppressLineNumbers = findChild(pPr, "w", "suppressLineNumbers");
+  const suppressLineNumbers = propertyChildren.suppressLineNumbers;
   if (suppressLineNumbers) {
     formatting.suppressLineNumbers = parseBooleanElement(suppressLineNumbers);
   }
 
   // === Suppress Auto Hyphens ===
-  const suppressAutoHyphens = findChild(pPr, "w", "suppressAutoHyphens");
+  const suppressAutoHyphens = propertyChildren.suppressAutoHyphens;
   if (suppressAutoHyphens) {
     formatting.suppressAutoHyphens = parseBooleanElement(suppressAutoHyphens);
   }
 
   // === Default Run Properties ===
-  const rPr = findChild(pPr, "w", "rPr");
+  const rPr = propertyChildren.rPr;
   if (rPr) {
     const runPropsResult = parseRunProperties(rPr, theme, styles);
     if (runPropsResult !== undefined) {

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -204,7 +204,7 @@ export async function parseDocx(
     // STAGE 6: Build media file map (35-40%)
     // ========================================================================
     onProgress("Processing media files...", 35);
-    const media = timeStage("media", () => buildMediaMap(raw, rels));
+    const media = await timeStageAsync("media", () => buildMediaMap(raw, rels));
     onProgress("Processed media", 40);
 
     // ========================================================================
@@ -442,10 +442,10 @@ export class DocxParseError extends TaggedError("DocxParseError")<{
 /**
  * Build media file map from raw content and relationships
  */
-function buildMediaMap(
+async function buildMediaMap(
   raw: RawDocxContent,
   _rels: RelationshipMap,
-): Map<string, MediaFile> {
+): Promise<Map<string, MediaFile>> {
   const media = new Map<string, MediaFile>();
 
   // Process each media file
@@ -461,7 +461,7 @@ function buildMediaMap(
     // with the original TIFF data — the round-trip survives even if the
     // in-browser preview is broken.
     if (isTiffMimeType(mimeType)) {
-      const converted = convertTiffToPngDataUrl(data);
+      const converted = await convertTiffToPngDataUrl(data);
       if (converted) {
         const mediaFile: MediaFile = {
           path,

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -62,7 +62,7 @@ import {
   resolveRelativePath,
 } from "./relsParser";
 import { parseSettings } from "./settingsParser";
-import { parseStyles, parseStyleDefinitions } from "./styleParser";
+import { parseStylesPackage } from "./styleParser";
 import type { StyleMap } from "./styleParser";
 import { parseTheme } from "./themeParser";
 import { normalizeTrackedMoveRanges } from "./trackedMoveRangeNormalization";
@@ -178,8 +178,9 @@ export async function parseDocx(
 
     timeStage("styles", () => {
       if (raw.stylesXml) {
-        styles = parseStyles(raw.stylesXml, theme);
-        styleDefinitions = parseStyleDefinitions(raw.stylesXml, theme, styles);
+        const parsedStyles = parseStylesPackage(raw.stylesXml, theme);
+        styles = parsedStyles.styles;
+        styleDefinitions = parsedStyles.styleDefinitions;
       }
     });
     onProgress("Parsed styles", 30);

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -179,7 +179,7 @@ export async function parseDocx(
     timeStage("styles", () => {
       if (raw.stylesXml) {
         styles = parseStyles(raw.stylesXml, theme);
-        styleDefinitions = parseStyleDefinitions(raw.stylesXml, theme);
+        styleDefinitions = parseStyleDefinitions(raw.stylesXml, theme, styles);
       }
     });
     onProgress("Parsed styles", 30);

--- a/packages/folio/src/core/docx/runParser.ts
+++ b/packages/folio/src/core/docx/runParser.ts
@@ -150,6 +150,144 @@ function parseShadingProperties(
   return Object.keys(props).length > 0 ? props : undefined;
 }
 
+type RunPropertyChildren = {
+  b?: XmlElement;
+  bCs?: XmlElement;
+  caps?: XmlElement;
+  color?: XmlElement;
+  cs?: XmlElement;
+  dstrike?: XmlElement;
+  effect?: XmlElement;
+  em?: XmlElement;
+  emboss?: XmlElement;
+  highlight?: XmlElement;
+  i?: XmlElement;
+  iCs?: XmlElement;
+  imprint?: XmlElement;
+  kern?: XmlElement;
+  outline?: XmlElement;
+  position?: XmlElement;
+  rFonts?: XmlElement;
+  rtl?: XmlElement;
+  rStyle?: XmlElement;
+  shadow?: XmlElement;
+  shd?: XmlElement;
+  smallCaps?: XmlElement;
+  spacing?: XmlElement;
+  strike?: XmlElement;
+  sz?: XmlElement;
+  szCs?: XmlElement;
+  u?: XmlElement;
+  vanish?: XmlElement;
+  vertAlign?: XmlElement;
+  w?: XmlElement;
+};
+
+function collectFirstRunPropertyChildren(rPr: XmlElement): RunPropertyChildren {
+  const children: RunPropertyChildren = {};
+
+  for (const child of rPr.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+    const localName = getLocalName(child.name);
+    switch (localName) {
+      case "b":
+        children.b ??= child;
+        break;
+      case "bCs":
+        children.bCs ??= child;
+        break;
+      case "caps":
+        children.caps ??= child;
+        break;
+      case "color":
+        children.color ??= child;
+        break;
+      case "cs":
+        children.cs ??= child;
+        break;
+      case "dstrike":
+        children.dstrike ??= child;
+        break;
+      case "effect":
+        children.effect ??= child;
+        break;
+      case "em":
+        children.em ??= child;
+        break;
+      case "emboss":
+        children.emboss ??= child;
+        break;
+      case "highlight":
+        children.highlight ??= child;
+        break;
+      case "i":
+        children.i ??= child;
+        break;
+      case "iCs":
+        children.iCs ??= child;
+        break;
+      case "imprint":
+        children.imprint ??= child;
+        break;
+      case "kern":
+        children.kern ??= child;
+        break;
+      case "outline":
+        children.outline ??= child;
+        break;
+      case "position":
+        children.position ??= child;
+        break;
+      case "rFonts":
+        children.rFonts ??= child;
+        break;
+      case "rtl":
+        children.rtl ??= child;
+        break;
+      case "rStyle":
+        children.rStyle ??= child;
+        break;
+      case "shadow":
+        children.shadow ??= child;
+        break;
+      case "shd":
+        children.shd ??= child;
+        break;
+      case "smallCaps":
+        children.smallCaps ??= child;
+        break;
+      case "spacing":
+        children.spacing ??= child;
+        break;
+      case "strike":
+        children.strike ??= child;
+        break;
+      case "sz":
+        children.sz ??= child;
+        break;
+      case "szCs":
+        children.szCs ??= child;
+        break;
+      case "u":
+        children.u ??= child;
+        break;
+      case "vanish":
+        children.vanish ??= child;
+        break;
+      case "vertAlign":
+        children.vertAlign ??= child;
+        break;
+      case "w":
+        children.w ??= child;
+        break;
+    }
+  }
+
+  return children;
+}
+
 /**
  * Parse run formatting properties (w:rPr)
  *
@@ -177,31 +315,32 @@ export function parseRunProperties(
   }
 
   const formatting: TextFormatting = {};
+  const propertyChildren = collectFirstRunPropertyChildren(rPr);
 
   // Bold (w:b)
-  const b = findChild(rPr, "w", "b");
+  const b = propertyChildren.b;
   if (b) {
     formatting.bold = parseBooleanElement(b);
   }
 
-  const bCs = findChild(rPr, "w", "bCs");
+  const bCs = propertyChildren.bCs;
   if (bCs) {
     formatting.boldCs = parseBooleanElement(bCs);
   }
 
   // Italic (w:i)
-  const i = findChild(rPr, "w", "i");
+  const i = propertyChildren.i;
   if (i) {
     formatting.italic = parseBooleanElement(i);
   }
 
-  const iCs = findChild(rPr, "w", "iCs");
+  const iCs = propertyChildren.iCs;
   if (iCs) {
     formatting.italicCs = parseBooleanElement(iCs);
   }
 
   // Underline (w:u)
-  const u = findChild(rPr, "w", "u");
+  const u = propertyChildren.u;
   if (u) {
     const style = narrowEnum(getAttribute(u, "w", "val"), UnderlineStyleSchema);
     if (style) {
@@ -220,19 +359,19 @@ export function parseRunProperties(
   }
 
   // Strikethrough (w:strike)
-  const strike = findChild(rPr, "w", "strike");
+  const strike = propertyChildren.strike;
   if (strike) {
     formatting.strike = parseBooleanElement(strike);
   }
 
   // Double strikethrough (w:dstrike)
-  const dstrike = findChild(rPr, "w", "dstrike");
+  const dstrike = propertyChildren.dstrike;
   if (dstrike) {
     formatting.doubleStrike = parseBooleanElement(dstrike);
   }
 
   // Vertical alignment - superscript/subscript (w:vertAlign)
-  const vertAlign = findChild(rPr, "w", "vertAlign");
+  const vertAlign = propertyChildren.vertAlign;
   if (vertAlign) {
     const val = getAttribute(vertAlign, "w", "val");
     if (val === "superscript" || val === "subscript" || val === "baseline") {
@@ -241,25 +380,25 @@ export function parseRunProperties(
   }
 
   // Small caps (w:smallCaps)
-  const smallCaps = findChild(rPr, "w", "smallCaps");
+  const smallCaps = propertyChildren.smallCaps;
   if (smallCaps) {
     formatting.smallCaps = parseBooleanElement(smallCaps);
   }
 
   // All caps (w:caps)
-  const caps = findChild(rPr, "w", "caps");
+  const caps = propertyChildren.caps;
   if (caps) {
     formatting.allCaps = parseBooleanElement(caps);
   }
 
   // Hidden text (w:vanish)
-  const vanish = findChild(rPr, "w", "vanish");
+  const vanish = propertyChildren.vanish;
   if (vanish) {
     formatting.hidden = parseBooleanElement(vanish);
   }
 
   // Text color (w:color)
-  const color = findChild(rPr, "w", "color");
+  const color = propertyChildren.color;
   if (color) {
     formatting.color = parseColorValue(
       getAttribute(color, "w", "val"),
@@ -270,7 +409,7 @@ export function parseRunProperties(
   }
 
   // Highlight color (w:highlight)
-  const highlight = findChild(rPr, "w", "highlight");
+  const highlight = propertyChildren.highlight;
   if (highlight) {
     const val = narrowEnum(
       getAttribute(highlight, "w", "val"),
@@ -282,7 +421,7 @@ export function parseRunProperties(
   }
 
   // Character shading (w:shd)
-  const shd = findChild(rPr, "w", "shd");
+  const shd = propertyChildren.shd;
   if (shd) {
     const shadingResult = parseShadingProperties(shd);
     if (shadingResult) {
@@ -291,7 +430,7 @@ export function parseRunProperties(
   }
 
   // Font size in half-points (w:sz)
-  const sz = findChild(rPr, "w", "sz");
+  const sz = propertyChildren.sz;
   if (sz) {
     const val = parseNumericAttribute(sz, "w", "val");
     if (val !== undefined) {
@@ -300,7 +439,7 @@ export function parseRunProperties(
   }
 
   // Font size complex script (w:szCs)
-  const szCs = findChild(rPr, "w", "szCs");
+  const szCs = propertyChildren.szCs;
   if (szCs) {
     const val = parseNumericAttribute(szCs, "w", "val");
     if (val !== undefined) {
@@ -309,7 +448,7 @@ export function parseRunProperties(
   }
 
   // Font family (w:rFonts)
-  const rFonts = findChild(rPr, "w", "rFonts");
+  const rFonts = propertyChildren.rFonts;
   if (rFonts) {
     const fontFamily: NonNullable<TextFormatting["fontFamily"]> = {};
     const ascii = getAttribute(rFonts, "w", "ascii");
@@ -380,7 +519,7 @@ export function parseRunProperties(
   }
 
   // Character spacing in twips (w:spacing)
-  const spacing = findChild(rPr, "w", "spacing");
+  const spacing = propertyChildren.spacing;
   if (spacing) {
     const val = parseNumericAttribute(spacing, "w", "val");
     if (val !== undefined) {
@@ -389,7 +528,7 @@ export function parseRunProperties(
   }
 
   // Position - raised/lowered in half-points (w:position)
-  const position = findChild(rPr, "w", "position");
+  const position = propertyChildren.position;
   if (position) {
     const val = parseNumericAttribute(position, "w", "val");
     if (val !== undefined) {
@@ -398,7 +537,7 @@ export function parseRunProperties(
   }
 
   // Horizontal text scale percentage (w:w)
-  const w = findChild(rPr, "w", "w");
+  const w = propertyChildren.w;
   if (w) {
     const val = parseNumericAttribute(w, "w", "val");
     if (val !== undefined) {
@@ -407,7 +546,7 @@ export function parseRunProperties(
   }
 
   // Kerning threshold in half-points (w:kern)
-  const kern = findChild(rPr, "w", "kern");
+  const kern = propertyChildren.kern;
   if (kern) {
     const val = parseNumericAttribute(kern, "w", "val");
     if (val !== undefined) {
@@ -416,7 +555,7 @@ export function parseRunProperties(
   }
 
   // Text effect animation (w:effect)
-  const effect = findChild(rPr, "w", "effect");
+  const effect = propertyChildren.effect;
   if (effect) {
     const val = narrowEnum(getAttribute(effect, "w", "val"), TextEffectSchema);
     if (val) {
@@ -425,7 +564,7 @@ export function parseRunProperties(
   }
 
   // Emphasis mark (w:em)
-  const em = findChild(rPr, "w", "em");
+  const em = propertyChildren.em;
   if (em) {
     const val = narrowEnum(getAttribute(em, "w", "val"), EmphasisMarkSchema);
     if (val) {
@@ -434,43 +573,43 @@ export function parseRunProperties(
   }
 
   // Emboss effect (w:emboss)
-  const emboss = findChild(rPr, "w", "emboss");
+  const emboss = propertyChildren.emboss;
   if (emboss) {
     formatting.emboss = parseBooleanElement(emboss);
   }
 
   // Imprint/engrave effect (w:imprint)
-  const imprint = findChild(rPr, "w", "imprint");
+  const imprint = propertyChildren.imprint;
   if (imprint) {
     formatting.imprint = parseBooleanElement(imprint);
   }
 
   // Outline effect (w:outline)
-  const outline = findChild(rPr, "w", "outline");
+  const outline = propertyChildren.outline;
   if (outline) {
     formatting.outline = parseBooleanElement(outline);
   }
 
   // Shadow effect (w:shadow)
-  const shadow = findChild(rPr, "w", "shadow");
+  const shadow = propertyChildren.shadow;
   if (shadow) {
     formatting.shadow = parseBooleanElement(shadow);
   }
 
   // Right-to-left text (w:rtl)
-  const rtl = findChild(rPr, "w", "rtl");
+  const rtl = propertyChildren.rtl;
   if (rtl) {
     formatting.rtl = parseBooleanElement(rtl);
   }
 
   // Complex script formatting (w:cs)
-  const cs = findChild(rPr, "w", "cs");
+  const cs = propertyChildren.cs;
   if (cs) {
     formatting.cs = parseBooleanElement(cs);
   }
 
   // Character style reference (w:rStyle)
-  const rStyle = findChild(rPr, "w", "rStyle");
+  const rStyle = propertyChildren.rStyle;
   if (rStyle) {
     const val = getAttribute(rStyle, "w", "val");
     if (val) {

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -1645,6 +1645,7 @@ export function parseStyles(stylesXml: string, theme: Theme | null): StyleMap {
 export function parseStyleDefinitions(
   stylesXml: string,
   theme: Theme | null,
+  resolvedStyles?: StyleMap,
 ): StyleDefinitions {
   const result: StyleDefinitions = {
     styles: [],
@@ -1691,7 +1692,7 @@ export function parseStyleDefinitions(
     }
 
     // Parse styles with full inheritance resolution
-    const styleMap = parseStyles(stylesXml, theme);
+    const styleMap = resolvedStyles ?? parseStyles(stylesXml, theme);
     result.styles = Array.from(styleMap.values());
   } catch {
     // Malformed styles return the partial definitions parsed so far.

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -72,6 +72,11 @@ import type { XmlElement } from "./xmlParser";
  */
 export type StyleMap = Map<string, Style>;
 
+export type ParsedStylesPackage = {
+  styleDefinitions: StyleDefinitions;
+  styles: StyleMap;
+};
+
 /**
  * Parse text formatting properties (w:rPr)
  */
@@ -1606,14 +1611,21 @@ function resolveStyleInheritance(
  * @returns StyleMap with resolved inheritance
  */
 export function parseStyles(stylesXml: string, theme: Theme | null): StyleMap {
+  const doc = parseXmlDocument(stylesXml);
+  if (!doc) {
+    return new Map();
+  }
+
+  return parseStylesFromDocument(doc, theme);
+}
+
+function parseStylesFromDocument(
+  doc: XmlElement,
+  theme: Theme | null,
+): StyleMap {
   const styleMap: StyleMap = new Map();
 
   try {
-    const doc = parseXmlDocument(stylesXml);
-    if (!doc) {
-      return styleMap;
-    }
-
     // First pass: parse all styles without inheritance resolution
     const styleElements = findChildren(doc, "w", "style");
     for (const styleEl of styleElements) {
@@ -1647,16 +1659,24 @@ export function parseStyleDefinitions(
   theme: Theme | null,
   resolvedStyles?: StyleMap,
 ): StyleDefinitions {
+  const doc = parseXmlDocument(stylesXml);
+  if (!doc) {
+    return { styles: [] };
+  }
+
+  return parseStyleDefinitionsFromDocument(doc, theme, resolvedStyles);
+}
+
+function parseStyleDefinitionsFromDocument(
+  doc: XmlElement,
+  theme: Theme | null,
+  resolvedStyles?: StyleMap,
+): StyleDefinitions {
   const result: StyleDefinitions = {
     styles: [],
   };
 
   try {
-    const doc = parseXmlDocument(stylesXml);
-    if (!doc) {
-      return result;
-    }
-
     // Parse document defaults
     const docDefaultsEl = findChild(doc, "w", "docDefaults");
     const parsedDocDefaults = parseDocDefaults(docDefaultsEl, theme);
@@ -1692,13 +1712,32 @@ export function parseStyleDefinitions(
     }
 
     // Parse styles with full inheritance resolution
-    const styleMap = resolvedStyles ?? parseStyles(stylesXml, theme);
+    const styleMap = resolvedStyles ?? parseStylesFromDocument(doc, theme);
     result.styles = Array.from(styleMap.values());
   } catch {
     // Malformed styles return the partial definitions parsed so far.
   }
 
   return result;
+}
+
+export function parseStylesPackage(
+  stylesXml: string,
+  theme: Theme | null,
+): ParsedStylesPackage {
+  const doc = parseXmlDocument(stylesXml);
+  if (!doc) {
+    return {
+      styleDefinitions: { styles: [] },
+      styles: new Map(),
+    };
+  }
+
+  const styles = parseStylesFromDocument(doc, theme);
+  return {
+    styleDefinitions: parseStyleDefinitionsFromDocument(doc, theme, styles),
+    styles,
+  };
 }
 
 /**

--- a/packages/folio/src/core/docx/styleParser.ts
+++ b/packages/folio/src/core/docx/styleParser.ts
@@ -62,6 +62,7 @@ import {
   findChild,
   findChildren,
   getAttribute,
+  getLocalName,
   parseBooleanElement,
   parseNumericAttribute,
 } from "./xmlParser";
@@ -1242,6 +1243,88 @@ function parseTableCellProperties(
   return Object.keys(formatting).length > 0 ? formatting : undefined;
 }
 
+type StyleChildren = {
+  basedOn?: XmlElement;
+  hidden?: XmlElement;
+  link?: XmlElement;
+  name?: XmlElement;
+  next?: XmlElement;
+  personal?: XmlElement;
+  pPr?: XmlElement;
+  qFormat?: XmlElement;
+  rPr?: XmlElement;
+  semiHidden?: XmlElement;
+  tblPr?: XmlElement;
+  tblStylePrs: XmlElement[];
+  tcPr?: XmlElement;
+  trPr?: XmlElement;
+  uiPriority?: XmlElement;
+  unhideWhenUsed?: XmlElement;
+};
+
+function collectStyleChildren(styleEl: XmlElement): StyleChildren {
+  const children: StyleChildren = { tblStylePrs: [] };
+
+  for (const child of styleEl.elements ?? []) {
+    if (child.type !== "element") {
+      continue;
+    }
+
+    switch (getLocalName(child.name || "")) {
+      case "basedOn":
+        children.basedOn ??= child;
+        break;
+      case "hidden":
+        children.hidden ??= child;
+        break;
+      case "link":
+        children.link ??= child;
+        break;
+      case "name":
+        children.name ??= child;
+        break;
+      case "next":
+        children.next ??= child;
+        break;
+      case "personal":
+        children.personal ??= child;
+        break;
+      case "pPr":
+        children.pPr ??= child;
+        break;
+      case "qFormat":
+        children.qFormat ??= child;
+        break;
+      case "rPr":
+        children.rPr ??= child;
+        break;
+      case "semiHidden":
+        children.semiHidden ??= child;
+        break;
+      case "tblPr":
+        children.tblPr ??= child;
+        break;
+      case "tblStylePr":
+        children.tblStylePrs.push(child);
+        break;
+      case "tcPr":
+        children.tcPr ??= child;
+        break;
+      case "trPr":
+        children.trPr ??= child;
+        break;
+      case "uiPriority":
+        children.uiPriority ??= child;
+        break;
+      case "unhideWhenUsed":
+        children.unhideWhenUsed ??= child;
+        break;
+    }
+  }
+
+  return children;
+}
+
 /**
  * Parse a single style element (w:style)
  */
@@ -1258,8 +1341,10 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
     style.default = defaultAttr === "1" || defaultAttr === "true";
   }
 
+  const children = collectStyleChildren(styleEl);
+
   // Name
-  const nameEl = findChild(styleEl, "w", "name");
+  const nameEl = children.name;
   if (nameEl) {
     const nameVal = getAttribute(nameEl, "w", "val");
     if (nameVal) {
@@ -1268,7 +1353,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Based on (inheritance)
-  const basedOn = findChild(styleEl, "w", "basedOn");
+  const basedOn = children.basedOn;
   if (basedOn) {
     const basedOnVal = getAttribute(basedOn, "w", "val");
     if (basedOnVal) {
@@ -1277,7 +1362,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Next style
-  const next = findChild(styleEl, "w", "next");
+  const next = children.next;
   if (next) {
     const nextVal = getAttribute(next, "w", "val");
     if (nextVal) {
@@ -1286,7 +1371,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Linked style
-  const link = findChild(styleEl, "w", "link");
+  const link = children.link;
   if (link) {
     const linkVal = getAttribute(link, "w", "val");
     if (linkVal) {
@@ -1295,7 +1380,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // UI Priority
-  const uiPriority = findChild(styleEl, "w", "uiPriority");
+  const uiPriority = children.uiPriority;
   if (uiPriority) {
     const val = parseNumericAttribute(uiPriority, "w", "val");
     if (val !== undefined) {
@@ -1304,36 +1389,36 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Hidden/Semi-hidden
-  const hidden = findChild(styleEl, "w", "hidden");
+  const hidden = children.hidden;
   if (hidden) {
     style.hidden = parseBooleanElement(hidden);
   }
 
-  const semiHidden = findChild(styleEl, "w", "semiHidden");
+  const semiHidden = children.semiHidden;
   if (semiHidden) {
     style.semiHidden = parseBooleanElement(semiHidden);
   }
 
   // Unhide when used
-  const unhideWhenUsed = findChild(styleEl, "w", "unhideWhenUsed");
+  const unhideWhenUsed = children.unhideWhenUsed;
   if (unhideWhenUsed) {
     style.unhideWhenUsed = parseBooleanElement(unhideWhenUsed);
   }
 
   // Quick format
-  const qFormat = findChild(styleEl, "w", "qFormat");
+  const qFormat = children.qFormat;
   if (qFormat) {
     style.qFormat = parseBooleanElement(qFormat);
   }
 
   // Personal/custom style
-  const personal = findChild(styleEl, "w", "personal");
+  const personal = children.personal;
   if (personal) {
     style.personal = parseBooleanElement(personal);
   }
 
   // Paragraph properties
-  const pPr = findChild(styleEl, "w", "pPr");
+  const pPr = children.pPr;
   if (pPr) {
     const pPrResult = parseParagraphProperties(pPr, theme);
     if (pPrResult) {
@@ -1342,7 +1427,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Run properties
-  const rPr = findChild(styleEl, "w", "rPr");
+  const rPr = children.rPr;
   if (rPr) {
     const rPrResult = parseRunProperties(rPr, theme);
     if (rPrResult) {
@@ -1351,7 +1436,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Table properties (for table styles)
-  const tblPr = findChild(styleEl, "w", "tblPr");
+  const tblPr = children.tblPr;
   if (tblPr) {
     const tblPrResult = parseTableProperties(tblPr, theme);
     if (tblPrResult) {
@@ -1360,7 +1445,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Table row properties
-  const trPr = findChild(styleEl, "w", "trPr");
+  const trPr = children.trPr;
   if (trPr) {
     const trPrResult = parseTableRowProperties(trPr);
     if (trPrResult) {
@@ -1369,7 +1454,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Table cell properties
-  const tcPr = findChild(styleEl, "w", "tcPr");
+  const tcPr = children.tcPr;
   if (tcPr) {
     const tcPrResult = parseTableCellProperties(tcPr, theme);
     if (tcPrResult) {
@@ -1378,7 +1463,7 @@ function parseStyle(styleEl: XmlElement, theme: Theme | null): Style {
   }
 
   // Table style conditional formatting (tblStylePr)
-  const tblStylePrs = findChildren(styleEl, "w", "tblStylePr");
+  const tblStylePrs = children.tblStylePrs;
   if (tblStylePrs.length > 0) {
     style.tblStylePr = [];
 

--- a/packages/folio/src/core/docx/xmlParser.test.ts
+++ b/packages/folio/src/core/docx/xmlParser.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { elementToXml, parseXmlDocument } from "./xmlParser";
+
+describe("OOXML parsing", () => {
+  test("preserves legacy inline binary payloads", () => {
+    const document = parseXmlDocument(
+      '<w:p xmlns:w="urn"><w:binData w:name="image1">QUJDRA==</w:binData><w:r><w:t>after</w:t></w:r></w:p>',
+    );
+
+    expect(document?.elements?.at(0)?.name).toBe("w:binData");
+    expect(document?.elements?.at(0)?.elements?.at(0)?.text).toBe("QUJDRA==");
+    expect(document?.elements?.at(1)?.name).toBe("w:r");
+    expect(document ? elementToXml(document) : "").toContain(
+      '<w:binData w:name="image1">QUJDRA==</w:binData>',
+    );
+  });
+});

--- a/packages/folio/src/core/docx/xmlParser.ts
+++ b/packages/folio/src/core/docx/xmlParser.ts
@@ -63,7 +63,13 @@ const fxpParserOptions = {
   // use custom entities.
   processEntities: true,
   htmlEntities: true,
-  // Skip parsing large base64 blobs into memory early
+};
+
+const fxpParserOptionsWithStopNodes = {
+  ...fxpParserOptions,
+  // Skip parsing large base64 blobs into memory early. Enabled only for
+  // XML parts that actually contain legacy inline binary payloads because
+  // fast-xml-parser's stop-node matcher runs on every tag.
   stopNodes: ["*.w:binData"],
 };
 
@@ -76,6 +82,7 @@ const fxpBuilderOptions = {
 };
 
 const fxpParser = new XMLParser(fxpParserOptions);
+const fxpParserWithStopNodes = new XMLParser(fxpParserOptionsWithStopNodes);
 const fxpBuilder = new XMLBuilder(fxpBuilderOptions);
 
 // ---------------------------------------------------------------------------
@@ -180,7 +187,8 @@ export function parseXml(xml: string): XmlElement {
   // IMPORTANT: trimValues is false so whitespace-only text nodes such as
   // <w:t xml:space="preserve"> </w:t> are preserved — matching the old
   // xml-js captureSpacesBetweenElements behaviour.
-  const nodes = fxpParser.parse(xml) as Record<string, unknown>[];
+  const parser = xml.includes("binData") ? fxpParserWithStopNodes : fxpParser;
+  const nodes = parser.parse(xml) as Record<string, unknown>[];
   return fxpToRootElement(nodes);
 }
 

--- a/packages/folio/src/core/layout-bridge/measuring/cache.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/cache.ts
@@ -134,6 +134,7 @@ type FontMetricsEntry = {
   ascent: number;
   descent: number;
   lineHeight: number;
+  singleLineRatio: number;
 };
 
 /**
@@ -148,7 +149,7 @@ let fontCacheMaxSize = DEFAULT_FONT_CACHE_SIZE;
 
 /**
  * LRU cache for font metrics
- * Key format: "fontFamily|fontSize|bold|italic"
+ * Key format: "fontFamily|fontSize|bold|italic|fontVariant"
  */
 const fontMetricsCache = new Map<string, FontMetricsEntry>();
 
@@ -160,8 +161,9 @@ function makeFontKey(
   fontSize: number,
   bold: boolean = false,
   italic: boolean = false,
+  fontVariant?: string,
 ): string {
-  return `${fontFamily}|${fontSize}|${bold}|${italic}`;
+  return `${fontFamily}|${fontSize}|${bold}|${italic}|${fontVariant ?? ""}`;
 }
 
 /**
@@ -185,8 +187,9 @@ export function getCachedFontMetrics(
   fontSize: number,
   bold: boolean = false,
   italic: boolean = false,
+  fontVariant?: string,
 ): FontMetricsEntry | undefined {
-  const key = makeFontKey(fontFamily, fontSize, bold, italic);
+  const key = makeFontKey(fontFamily, fontSize, bold, italic, fontVariant);
   const entry = fontMetricsCache.get(key);
 
   if (entry !== undefined) {
@@ -208,8 +211,9 @@ export function setCachedFontMetrics(
   bold: boolean,
   italic: boolean,
   metrics: FontMetricsEntry,
+  fontVariant?: string,
 ): void {
-  const key = makeFontKey(fontFamily, fontSize, bold, italic);
+  const key = makeFontKey(fontFamily, fontSize, bold, italic, fontVariant);
   fontMetricsCache.set(key, metrics);
   evictFontEntries();
 }

--- a/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureContainer.ts
@@ -15,6 +15,12 @@ import { panic } from "better-result";
 
 import { resolveFontFamily } from "../../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../../utils/fontWeights";
+import {
+  getCachedFontMetrics,
+  getCachedTextWidth,
+  setCachedFontMetrics,
+  setCachedTextWidth,
+} from "./cache";
 
 // Constants for OOXML unit conversions
 const TWIPS_PER_INCH = 1440;
@@ -186,6 +192,27 @@ export function buildFontString(style: FontStyle): string {
 export function getFontMetrics(style: FontStyle): FontMetrics {
   const fontSize = style.fontSize ?? DEFAULT_FONT_SIZE;
   const fontFamily = style.fontFamily ?? DEFAULT_FONT_FAMILY;
+  const bold = style.bold ?? false;
+  const italic = style.italic ?? false;
+  const fontVariant = style.fontVariant;
+
+  const cached = getCachedFontMetrics(
+    fontFamily,
+    fontSize,
+    bold,
+    italic,
+    fontVariant,
+  );
+  if (cached !== undefined) {
+    return {
+      fontSize,
+      ascent: cached.ascent,
+      descent: cached.descent,
+      lineHeight: cached.lineHeight,
+      fontFamily,
+      singleLineRatio: cached.singleLineRatio,
+    };
+  }
 
   // Convert font size from points to pixels
   const fontSizePx = ptToPx(fontSize);
@@ -227,7 +254,7 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
   // Look up OS/2 single-line ratio for OOXML line spacing
   const singleLineRatio = getResolvedData(fontFamily).singleLineRatio;
 
-  return {
+  const result = {
     fontSize, // Keep in points for reference
     ascent,
     descent,
@@ -235,6 +262,8 @@ export function getFontMetrics(style: FontStyle): FontMetrics {
     fontFamily,
     singleLineRatio,
   };
+  setCachedFontMetrics(fontFamily, fontSize, bold, italic, result, fontVariant);
+  return result;
 }
 
 /**
@@ -251,7 +280,16 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   const measuredText = applyTextTransform(text, style);
 
   const ctx = getCanvasContext();
-  ctx.font = buildFontString(style);
+  const font = buildFontString(style);
+  const letterSpacing = style.letterSpacing ?? 0;
+  const horizontalScale = getHorizontalScaleFactor(style);
+  const fontCacheKey = `${font}|scale:${horizontalScale}`;
+  const cached = getCachedTextWidth(measuredText, fontCacheKey, letterSpacing);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  ctx.font = font;
 
   const metrics = ctx.measureText(measuredText);
 
@@ -261,11 +299,13 @@ export function measureTextWidth(text: string, style: FontStyle): number {
   let width = metrics.width;
 
   // Apply letter spacing if specified
-  if (style.letterSpacing && measuredText.length > 1) {
-    width += style.letterSpacing * (measuredText.length - 1);
+  if (letterSpacing && measuredText.length > 1) {
+    width += letterSpacing * (measuredText.length - 1);
   }
 
-  return width * getHorizontalScaleFactor(style);
+  const scaledWidth = width * horizontalScale;
+  setCachedTextWidth(measuredText, fontCacheKey, letterSpacing, scaledWidth);
+  return scaledWidth;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
-import { hashParagraphBlock } from "./cache";
-import { buildFontString, resetCanvasContext } from "./measureContainer";
+import { clearAllCaches, hashParagraphBlock } from "./cache";
+import {
+  buildFontString,
+  getFontMetrics,
+  measureTextWidth,
+  resetCanvasContext,
+} from "./measureContainer";
 import {
   clampFloatingWrapMargins,
   getRunCharWidths,
@@ -10,8 +15,11 @@ import {
 
 const PT_TO_PX = 96 / 72;
 
-function withFakeTextMeasure(runTest: () => void): void {
+function withFakeTextMeasure(
+  runTest: (getMeasureCount: () => number) => void,
+): void {
   const originalDocument = globalThis.document;
+  let measureCount = 0;
   const fakeDocument = {
     createElement() {
       return {
@@ -19,6 +27,7 @@ function withFakeTextMeasure(runTest: () => void): void {
           return {
             font: "",
             measureText(this: { font: string }, text: string) {
+              measureCount += 1;
               let width = 0;
               const isSmallCaps = this.font.includes("small-caps");
               for (const char of text) {
@@ -48,18 +57,75 @@ function withFakeTextMeasure(runTest: () => void): void {
     configurable: true,
     value: fakeDocument,
   });
+  clearAllCaches();
   resetCanvasContext();
 
   try {
-    runTest();
+    runTest(() => measureCount);
   } finally {
     resetCanvasContext();
+    clearAllCaches();
     Object.defineProperty(globalThis, "document", {
       configurable: true,
       value: originalDocument,
     });
   }
 }
+
+describe("text measurement cache", () => {
+  test("reuses canvas text width measurements for identical text and style", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      const style = { fontFamily: "Arial", fontSize: 11 };
+
+      expect(measureTextWidth("Repeated legal text", style)).toBe(
+        measureTextWidth("Repeated legal text", style),
+      );
+      expect(getMeasureCount()).toBe(1);
+    });
+  });
+
+  test("keeps horizontal scale in the text width cache key", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      const text = "scaled";
+      const normalWidth = measureTextWidth(text, {
+        fontFamily: "Arial",
+        fontSize: 11,
+      });
+      const scaledWidth = measureTextWidth(text, {
+        fontFamily: "Arial",
+        fontSize: 11,
+        horizontalScale: 150,
+      });
+
+      expect(scaledWidth).toBe(normalWidth * 1.5);
+      expect(getMeasureCount()).toBe(2);
+    });
+  });
+});
+
+describe("font metrics cache", () => {
+  test("reuses canvas font metrics for identical font styles", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      const style = { fontFamily: "Arial", fontSize: 11 };
+
+      expect(getFontMetrics(style)).toEqual(getFontMetrics(style));
+      expect(getMeasureCount()).toBe(1);
+    });
+  });
+
+  test("keeps font variant in the metrics cache key", () => {
+    withFakeTextMeasure((getMeasureCount) => {
+      getFontMetrics({ fontFamily: "Arial", fontSize: 11 });
+      getFontMetrics({
+        fontFamily: "Arial",
+        fontSize: 11,
+        fontVariant: "small-caps",
+      });
+
+      expect(getMeasureCount()).toBe(2);
+    });
+  });
+});
 
 describe("empty paragraph line-height floor", () => {
   test("empty paragraph with line=1.0 auto is floored to 1.15 times fontSize", () => {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2016,7 +2016,8 @@ function buildPageRenderArgs(
  */
 type PageShellState = {
   element: HTMLElement;
-  fingerprint: string;
+  fingerprint: string | null;
+  renderFingerprint: string | null;
 };
 
 /**
@@ -2050,6 +2051,25 @@ export function computePageFingerprint(
   page: Page,
   blockLookup?: BlockLookup,
 ): string {
+  return computePageFingerprintInternal(page, blockLookup, {
+    includePmPositions: true,
+  });
+}
+
+function computePageRenderFingerprint(
+  page: Page,
+  blockLookup?: BlockLookup,
+): string {
+  return computePageFingerprintInternal(page, blockLookup, {
+    includePmPositions: false,
+  });
+}
+
+function computePageFingerprintInternal(
+  page: Page,
+  blockLookup: BlockLookup | undefined,
+  options: { includePmPositions: boolean },
+): string {
   const parts: string[] = [];
 
   // Page-level properties
@@ -2065,10 +2085,10 @@ export function computePageFingerprint(
   // Each fragment's stable properties
   for (const frag of page.fragments) {
     let fp = `${frag.kind}:${frag.blockId},${frag.x},${frag.y},${frag.width},${frag.height}`;
-    if (frag.pmStart !== undefined) {
+    if (options.includePmPositions && frag.pmStart !== undefined) {
       fp += `,ps:${frag.pmStart}`;
     }
-    if (frag.pmEnd !== undefined) {
+    if (options.includePmPositions && frag.pmEnd !== undefined) {
       fp += `,pe:${frag.pmEnd}`;
     }
 
@@ -2080,7 +2100,7 @@ export function computePageFingerprint(
     if (blockLookup) {
       const block = blockLookup.get(String(frag.blockId))?.block;
       const annotationFingerprint = block
-        ? computeAnnotationFingerprint(block)
+        ? computeAnnotationFingerprint(block, options.includePmPositions)
         : "";
       if (annotationFingerprint) {
         fp += `,ann:${annotationFingerprint}`;
@@ -2097,9 +2117,12 @@ export function computePageFingerprint(
   return parts.join("|");
 }
 
-function computeAnnotationFingerprint(block: FlowBlock): string {
+function computeAnnotationFingerprint(
+  block: FlowBlock,
+  includePmPositions: boolean,
+): string {
   const parts: string[] = [];
-  collectAnnotationFingerprint(block, parts);
+  collectAnnotationFingerprint(block, parts, includePmPositions);
   return parts.join(";");
 }
 
@@ -2117,7 +2140,11 @@ function computeContentFingerprint(block: FlowBlock): string {
   return parts.join(";");
 }
 
-function collectAnnotationFingerprint(block: FlowBlock, parts: string[]): void {
+function collectAnnotationFingerprint(
+  block: FlowBlock,
+  parts: string[],
+  includePmPositions: boolean,
+): void {
   if (block.kind === "paragraph") {
     for (let index = 0; index < block.runs.length; index++) {
       const run = block.runs[index];
@@ -2139,7 +2166,9 @@ function collectAnnotationFingerprint(block: FlowBlock, parts: string[]): void {
       }
       if (runParts.length > 0) {
         parts.push(
-          `${index}:${run.pmStart ?? ""}-${run.pmEnd ?? ""}:${runParts.join("|")}`,
+          includePmPositions
+            ? `${index}:${run.pmStart ?? ""}-${run.pmEnd ?? ""}:${runParts.join("|")}`
+            : `${index}:${runParts.join("|")}`,
         );
       }
     }
@@ -2150,7 +2179,7 @@ function collectAnnotationFingerprint(block: FlowBlock, parts: string[]): void {
     for (const row of block.rows) {
       for (const cell of row.cells) {
         for (const child of cell.blocks) {
-          collectAnnotationFingerprint(child, parts);
+          collectAnnotationFingerprint(child, parts, includePmPositions);
         }
       }
     }
@@ -2159,7 +2188,7 @@ function collectAnnotationFingerprint(block: FlowBlock, parts: string[]): void {
 
   if (block.kind === "textBox") {
     for (const child of block.content) {
-      collectAnnotationFingerprint(child, parts);
+      collectAnnotationFingerprint(child, parts, includePmPositions);
     }
   }
 }
@@ -2369,7 +2398,9 @@ function applyContainerStyles(container: HTMLElement, pageGap: number): void {
  * Number of pages to render above and below the visible area.
  * Keeps nearby pages ready for smooth scrolling.
  */
-const VIRTUALIZATION_BUFFER = 2;
+const VIRTUALIZATION_BUFFER = 1;
+const VIRTUALIZATION_ROOT_MARGIN_PX = 1000;
+const INITIAL_EAGER_RENDER_PAGES = 3;
 
 /**
  * Minimum page count before virtualization kicks in.
@@ -2415,12 +2446,6 @@ export function renderPages(
     const prevDataMap = prevState.pageDataMap;
     const observer = pc.__pageObserver;
 
-    // Compute new fingerprints
-    const newFingerprints: string[] = [];
-    for (const page of pages) {
-      newFingerprints.push(computePageFingerprint(page, options.blockLookup));
-    }
-
     // If total page count changed, NUMPAGES fields in headers/footers are stale.
     // Force re-render of all currently-rendered pages.
     const totalPagesChanged = prevState.totalPages !== totalPages;
@@ -2429,37 +2454,58 @@ export function renderPages(
     const commonCount = Math.min(prevShells.length, pages.length);
     for (let i = 0; i < commonCount; i++) {
       const prev = prevShells[i]!; // SAFETY: i < commonCount <= prevShells.length
-      const newFp = newFingerprints[i]!; // SAFETY: i < commonCount <= pages.length
+      const page = pages[i]!; // SAFETY: i < commonCount <= pages.length
+      const data = prevDataMap.get(prev.element);
+      if (!data) {
+        continue;
+      }
+
+      const oldPage = data.page;
+      data.page = page;
+
+      if (!data.rendered) {
+        prev.fingerprint = null;
+        prev.renderFingerprint = null;
+        applyPageStyles(prev.element, page.size.w, page.size.h, options);
+        syncPageBorderOverlay(
+          prev.element,
+          page,
+          options,
+          options.document ?? document,
+        );
+        prev.element.dataset["pageNumber"] = String(page.number);
+        continue;
+      }
+
+      const newFp = computePageFingerprint(page, options.blockLookup);
 
       if (prev.fingerprint === newFp && !totalPagesChanged) {
-        // Page unchanged — update data map with new page data (references may differ)
-        const data = prevDataMap.get(prev.element);
-        if (data) {
-          data.page = pages[i]!; // SAFETY: i < commonCount <= pages.length
-        }
+        // Page unchanged — data map already points at the fresh page object.
         continue;
       }
 
       // Page changed — update the shell
       const shell = prev.element;
-      const data = prevDataMap.get(shell);
+      const newRenderFp = computePageRenderFingerprint(
+        page,
+        options.blockLookup,
+      );
 
-      // Update data map entry
-      if (data) {
-        data.page = pages[i]!; // SAFETY: i < commonCount <= pages.length
+      const renderChanged =
+        totalPagesChanged || prev.renderFingerprint !== newRenderFp;
+      const positionsSynced =
+        !renderChanged && syncRenderedPmPositionData(shell, oldPage, data.page);
 
-        if (data.rendered) {
-          // Surgically replace only the content area, preserving header/footer
-          repopulatePageContent(shell, prevDataMap, totalPages, options);
-        }
-        // If not rendered, it will be populated when it scrolls into view
+      if (!positionsSynced) {
+        // Surgically replace only the content area, preserving header/footer
+        repopulatePageContent(shell, prevDataMap, totalPages, options);
       }
 
       // Update fingerprint
       prev.fingerprint = newFp;
+      prev.renderFingerprint = newRenderFp;
 
       // Update page styles in case size changed
-      const page = pages[i]!; // SAFETY: i < commonCount <= pages.length
       applyPageStyles(shell, page.size.w, page.size.h, options);
       syncPageBorderOverlay(shell, page, options, options.document ?? document);
       shell.dataset["pageNumber"] = String(page.number);
@@ -2478,7 +2524,11 @@ export function renderPages(
         syncPageBorderOverlay(pageEl, page, options, doc);
         container.append(pageEl);
 
-        prevShells.push({ element: pageEl, fingerprint: newFingerprints[i]! }); // SAFETY: i < pages.length
+        prevShells.push({
+          element: pageEl,
+          fingerprint: null,
+          renderFingerprint: null,
+        });
         prevDataMap.set(pageEl, { page, index: i, rendered: false });
 
         if (observer) {
@@ -2532,11 +2582,9 @@ export function renderPages(
 
   // Build all page shells
   const pageShells: HTMLElement[] = [];
-  const fingerprints: string[] = [];
 
   for (let i = 0; i < pages.length; i++) {
     const page = pages[i]!; // SAFETY: i < pages.length
-    fingerprints.push(computePageFingerprint(page, options.blockLookup));
 
     if (!useVirtualization) {
       // Small document: render all pages eagerly
@@ -2672,7 +2720,7 @@ export function renderPages(
     },
     {
       root: null,
-      rootMargin: "1500px 0px 1500px 0px",
+      rootMargin: `${VIRTUALIZATION_ROOT_MARGIN_PX}px 0px ${VIRTUALIZATION_ROOT_MARGIN_PX}px 0px`,
     },
   );
 
@@ -2685,9 +2733,10 @@ export function renderPages(
   // so the populatePageShell calls below can find state if needed.
   pc.__pageObserver = observer;
   pc.__pageRenderState = {
-    pageStates: pageShells.map((el, i) => ({
+    pageStates: pageShells.map((el) => ({
       element: el,
-      fingerprint: fingerprints[i]!, // SAFETY: fingerprints built with same indices as pageShells
+      fingerprint: null,
+      renderFingerprint: null,
     })),
     totalPages,
     optionsHash: currentOptionsHash,
@@ -2696,7 +2745,7 @@ export function renderPages(
   };
 
   // Eagerly render the first few pages so the initial view isn't blank
-  const initialRenderCount = Math.min(pages.length, VIRTUALIZATION_BUFFER + 3);
+  const initialRenderCount = Math.min(pages.length, INITIAL_EAGER_RENDER_PAGES);
   for (let i = 0; i < initialRenderCount; i++) {
     populatePageShell(pageShells[i]!, pageDataMap, totalPages, options); // SAFETY: i < initialRenderCount <= pages.length
   }
@@ -2740,6 +2789,7 @@ function populatePageShell(
   }
 
   data.rendered = true;
+  syncPageShellFingerprints(shell, data, options);
 }
 
 /**
@@ -2782,6 +2832,126 @@ function repopulatePageContent(
     data.rendered = false;
     populatePageShell(shell, pageDataMap, totalPages, options);
   }
+}
+
+function syncRenderedPmPositionData(
+  shell: HTMLElement,
+  oldPage: Page,
+  newPage: Page,
+): boolean {
+  const delta = getUniformPagePositionDelta(oldPage, newPage);
+  if (delta === null) {
+    return false;
+  }
+  if (delta === 0) {
+    return true;
+  }
+
+  for (const element of shell.querySelectorAll<HTMLElement>(
+    "[data-pm-start], [data-pm-end], [data-table-pm-start]",
+  )) {
+    shiftNumericDatasetValue(element, "pmStart", delta);
+    shiftNumericDatasetValue(element, "pmEnd", delta);
+    shiftNumericDatasetValue(element, "tablePmStart", delta);
+  }
+  return true;
+}
+
+function getUniformPagePositionDelta(
+  oldPage: Page,
+  newPage: Page,
+): number | null {
+  if (oldPage.fragments.length !== newPage.fragments.length) {
+    return null;
+  }
+
+  let delta: number | null = null;
+  for (let i = 0; i < oldPage.fragments.length; i++) {
+    const oldFragment = oldPage.fragments[i];
+    const newFragment = newPage.fragments[i];
+    if (!oldFragment || !newFragment) {
+      return null;
+    }
+    if (
+      oldFragment.kind !== newFragment.kind ||
+      oldFragment.blockId !== newFragment.blockId
+    ) {
+      return null;
+    }
+
+    const startDelta = readPositionDelta(
+      oldFragment.pmStart,
+      newFragment.pmStart,
+    );
+    if (startDelta !== null) {
+      if (delta !== null && delta !== startDelta) {
+        return null;
+      }
+      delta = startDelta;
+    }
+
+    const endDelta = readPositionDelta(oldFragment.pmEnd, newFragment.pmEnd);
+    if (endDelta !== null) {
+      if (delta !== null && delta !== endDelta) {
+        return null;
+      }
+      delta = endDelta;
+    }
+  }
+
+  return delta;
+}
+
+function readPositionDelta(
+  previous: number | undefined,
+  next: number | undefined,
+): number | null {
+  if (previous === undefined && next === undefined) {
+    return null;
+  }
+  if (previous === undefined || next === undefined) {
+    return null;
+  }
+  return next - previous;
+}
+
+function shiftNumericDatasetValue(
+  element: HTMLElement,
+  key: "pmEnd" | "pmStart" | "tablePmStart",
+  delta: number,
+): void {
+  const value = element.dataset[key];
+  if (value === undefined) {
+    return;
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return;
+  }
+
+  element.dataset[key] = String(numeric + delta);
+}
+
+function syncPageShellFingerprints(
+  shell: HTMLElement,
+  data: { page: Page; index: number },
+  options: FullPageOptions,
+): void {
+  const container = shell.parentElement as PageContainer | null;
+  const pageState = container?.__pageRenderState?.pageStates[data.index];
+  if (!pageState || pageState.element !== shell) {
+    return;
+  }
+
+  pageState.fingerprint = computePageFingerprint(
+    data.page,
+    options.blockLookup,
+  );
+  pageState.renderFingerprint = computePageRenderFingerprint(
+    data.page,
+    options.blockLookup,
+  );
 }
 
 /**
@@ -2851,4 +3021,11 @@ function depopulatePageShell(
 
   shell.innerHTML = "";
   data.rendered = false;
+
+  const container = shell.parentElement as PageContainer | null;
+  const pageState = container?.__pageRenderState?.pageStates[data.index];
+  if (pageState?.element === shell) {
+    pageState.fingerprint = null;
+    pageState.renderFingerprint = null;
+  }
 }

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -176,6 +176,35 @@ const SECTION_VERTICAL_ALIGNMENTS = [
   "bottom",
 ] as const;
 
+const paragraphAttrsCache = new WeakMap<PMNode, ParagraphAttrs>();
+const hardBreakAttrsCache = new WeakMap<PMNode, HardBreakAttrs>();
+const tableAttrsCache = new WeakMap<PMNode, TableAttrs>();
+const tableRowAttrsCache = new WeakMap<PMNode, TableRowAttrs>();
+const tableCellAttrsCache = new WeakMap<PMNode, TableCellAttrs>();
+const imageAttrsCache = new WeakMap<PMNode, ImageAttrs>();
+const fieldAttrsCache = new WeakMap<PMNode, FieldAttrs>();
+const mathAttrsCache = new WeakMap<PMNode, MathAttrs>();
+const sdtAttrsCache = new WeakMap<PMNode, SdtAttrs>();
+const shapeAttrsCache = new WeakMap<PMNode, ShapeAttrs>();
+const textBoxAttrsCache = new WeakMap<PMNode, TextBoxAttrs>();
+
+const underlineAttrsCache = new WeakMap<Mark, UnderlineAttrs>();
+const strikeAttrsCache = new WeakMap<Mark, StrikeAttrs>();
+const textColorAttrsCache = new WeakMap<Mark, TextColorAttrs>();
+const highlightAttrsCache = new WeakMap<Mark, HighlightAttrs>();
+const fontSizeAttrsCache = new WeakMap<Mark, FontSizeAttrs>();
+const fontFamilyAttrsCache = new WeakMap<Mark, FontFamilyAttrs>();
+const characterSpacingAttrsCache = new WeakMap<Mark, CharacterSpacingAttrs>();
+const emphasisMarkAttrsCache = new WeakMap<Mark, EmphasisMarkAttrs>();
+const footnoteRefAttrsCache = new WeakMap<Mark, FootnoteRefAttrs>();
+const commentAttrsCache = new WeakMap<Mark, CommentAttrs>();
+const trackedChangeAttrsCache = new WeakMap<Mark, TrackedChangeMarkAttrs>();
+const runFormattingOverrideAttrsCache = new WeakMap<
+  Mark,
+  RunFormattingOverrideAttrs
+>();
+const hyperlinkAttrsCache = new WeakMap<Mark, HyperlinkAttrs>();
+
 export const readParagraphAttrs = (
   node: PMNode,
 ): ReadProseMirrorAttrsResult<ParagraphAttrs> => {
@@ -347,7 +376,12 @@ export const readParagraphAttrs = (
 };
 
 export const expectParagraphAttrs = (node: PMNode): ParagraphAttrs =>
-  expectAttrs(readParagraphAttrs(node), "paragraph attrs");
+  expectCachedNodeAttrs(
+    node,
+    paragraphAttrsCache,
+    readParagraphAttrs,
+    "paragraph attrs",
+  );
 
 export const readHardBreakAttrs = (
   node: PMNode,
@@ -368,7 +402,12 @@ export const readHardBreakAttrs = (
 };
 
 export const expectHardBreakAttrs = (node: PMNode): HardBreakAttrs =>
-  expectAttrs(readHardBreakAttrs(node), "hard break attrs");
+  expectCachedNodeAttrs(
+    node,
+    hardBreakAttrsCache,
+    readHardBreakAttrs,
+    "hard break attrs",
+  );
 
 export const readTableAttrs = (
   node: PMNode,
@@ -413,7 +452,7 @@ export const readTableAttrs = (
 };
 
 export const expectTableAttrs = (node: PMNode): TableAttrs =>
-  expectAttrs(readTableAttrs(node), "table attrs");
+  expectCachedNodeAttrs(node, tableAttrsCache, readTableAttrs, "table attrs");
 
 export const readTableRowAttrs = (
   node: PMNode,
@@ -442,7 +481,12 @@ export const readTableRowAttrs = (
 };
 
 export const expectTableRowAttrs = (node: PMNode): TableRowAttrs =>
-  expectAttrs(readTableRowAttrs(node), "table row attrs");
+  expectCachedNodeAttrs(
+    node,
+    tableRowAttrsCache,
+    readTableRowAttrs,
+    "table row attrs",
+  );
 
 export const readTableCellAttrs = (
   node: PMNode,
@@ -515,7 +559,12 @@ export const readTableCellAttrs = (
 };
 
 export const expectTableCellAttrs = (node: PMNode): TableCellAttrs =>
-  expectAttrs(readTableCellAttrs(node), "table cell attrs");
+  expectCachedNodeAttrs(
+    node,
+    tableCellAttrsCache,
+    readTableCellAttrs,
+    "table cell attrs",
+  );
 
 export const readImageAttrs = (
   node: PMNode,
@@ -574,7 +623,7 @@ export const readImageAttrs = (
 };
 
 export const expectImageAttrs = (node: PMNode): ImageAttrs =>
-  expectAttrs(readImageAttrs(node), "image attrs");
+  expectCachedNodeAttrs(node, imageAttrsCache, readImageAttrs, "image attrs");
 
 export const readFieldAttrs = (
   node: PMNode,
@@ -606,7 +655,7 @@ export const readFieldAttrs = (
 };
 
 export const expectFieldAttrs = (node: PMNode): FieldAttrs =>
-  expectAttrs(readFieldAttrs(node), "field attrs");
+  expectCachedNodeAttrs(node, fieldAttrsCache, readFieldAttrs, "field attrs");
 
 export const readMathAttrs = (
   node: PMNode,
@@ -623,7 +672,7 @@ export const readMathAttrs = (
 };
 
 export const expectMathAttrs = (node: PMNode): MathAttrs =>
-  expectAttrs(readMathAttrs(node), "math attrs");
+  expectCachedNodeAttrs(node, mathAttrsCache, readMathAttrs, "math attrs");
 
 export const readSdtAttrs = (
   node: PMNode,
@@ -651,7 +700,7 @@ export const readSdtAttrs = (
 };
 
 export const expectSdtAttrs = (node: PMNode): SdtAttrs =>
-  expectAttrs(readSdtAttrs(node), "sdt attrs");
+  expectCachedNodeAttrs(node, sdtAttrsCache, readSdtAttrs, "sdt attrs");
 
 export const readShapeAttrs = (
   node: PMNode,
@@ -716,7 +765,7 @@ export const readShapeAttrs = (
 };
 
 export const expectShapeAttrs = (node: PMNode): ShapeAttrs =>
-  expectAttrs(readShapeAttrs(node), "shape attrs");
+  expectCachedNodeAttrs(node, shapeAttrsCache, readShapeAttrs, "shape attrs");
 
 export const readTextBoxAttrs = (
   node: PMNode,
@@ -765,7 +814,12 @@ export const readTextBoxAttrs = (
 };
 
 export const expectTextBoxAttrs = (node: PMNode): TextBoxAttrs =>
-  expectAttrs(readTextBoxAttrs(node), "text box attrs");
+  expectCachedNodeAttrs(
+    node,
+    textBoxAttrsCache,
+    readTextBoxAttrs,
+    "text box attrs",
+  );
 
 export const readUnderlineMarkAttrs = (
   mark: Mark,
@@ -787,7 +841,12 @@ export const readUnderlineMarkAttrs = (
 };
 
 export const expectUnderlineMarkAttrs = (mark: Mark): UnderlineAttrs =>
-  expectAttrs(readUnderlineMarkAttrs(mark), "underline attrs");
+  expectCachedMarkAttrs(
+    mark,
+    underlineAttrsCache,
+    readUnderlineMarkAttrs,
+    "underline attrs",
+  );
 
 export const readStrikeMarkAttrs = (
   mark: Mark,
@@ -802,7 +861,12 @@ export const readStrikeMarkAttrs = (
 };
 
 export const expectStrikeMarkAttrs = (mark: Mark): StrikeAttrs =>
-  expectAttrs(readStrikeMarkAttrs(mark), "strike attrs");
+  expectCachedMarkAttrs(
+    mark,
+    strikeAttrsCache,
+    readStrikeMarkAttrs,
+    "strike attrs",
+  );
 
 export const readTextColorMarkAttrs = (
   mark: Mark,
@@ -817,7 +881,12 @@ export const readTextColorMarkAttrs = (
 };
 
 export const expectTextColorMarkAttrs = (mark: Mark): TextColorAttrs =>
-  expectAttrs(readTextColorMarkAttrs(mark), "text color attrs");
+  expectCachedMarkAttrs(
+    mark,
+    textColorAttrsCache,
+    readTextColorMarkAttrs,
+    "text color attrs",
+  );
 
 export const readHighlightMarkAttrs = (
   mark: Mark,
@@ -838,7 +907,12 @@ export const readHighlightMarkAttrs = (
 };
 
 export const expectHighlightMarkAttrs = (mark: Mark): HighlightAttrs =>
-  expectAttrs(readHighlightMarkAttrs(mark), "highlight attrs");
+  expectCachedMarkAttrs(
+    mark,
+    highlightAttrsCache,
+    readHighlightMarkAttrs,
+    "highlight attrs",
+  );
 
 export const readFontSizeMarkAttrs = (
   mark: Mark,
@@ -853,7 +927,12 @@ export const readFontSizeMarkAttrs = (
 };
 
 export const expectFontSizeMarkAttrs = (mark: Mark): FontSizeAttrs =>
-  expectAttrs(readFontSizeMarkAttrs(mark), "font size attrs");
+  expectCachedMarkAttrs(
+    mark,
+    fontSizeAttrsCache,
+    readFontSizeMarkAttrs,
+    "font size attrs",
+  );
 
 export const readFontFamilyMarkAttrs = (
   mark: Mark,
@@ -880,7 +959,12 @@ export const readFontFamilyMarkAttrs = (
 };
 
 export const expectFontFamilyMarkAttrs = (mark: Mark): FontFamilyAttrs =>
-  expectAttrs(readFontFamilyMarkAttrs(mark), "font family attrs");
+  expectCachedMarkAttrs(
+    mark,
+    fontFamilyAttrsCache,
+    readFontFamilyMarkAttrs,
+    "font family attrs",
+  );
 
 export const readCharacterSpacingMarkAttrs = (
   mark: Mark,
@@ -900,7 +984,12 @@ export const readCharacterSpacingMarkAttrs = (
 export const expectCharacterSpacingMarkAttrs = (
   mark: Mark,
 ): CharacterSpacingAttrs =>
-  expectAttrs(readCharacterSpacingMarkAttrs(mark), "character spacing attrs");
+  expectCachedMarkAttrs(
+    mark,
+    characterSpacingAttrsCache,
+    readCharacterSpacingMarkAttrs,
+    "character spacing attrs",
+  );
 
 export const readEmphasisMarkAttrs = (
   mark: Mark,
@@ -921,7 +1010,12 @@ export const readEmphasisMarkAttrs = (
 };
 
 export const expectEmphasisMarkAttrs = (mark: Mark): EmphasisMarkAttrs =>
-  expectAttrs(readEmphasisMarkAttrs(mark), "emphasis mark attrs");
+  expectCachedMarkAttrs(
+    mark,
+    emphasisMarkAttrsCache,
+    readEmphasisMarkAttrs,
+    "emphasis mark attrs",
+  );
 
 export const readFootnoteRefMarkAttrs = (
   mark: Mark,
@@ -943,7 +1037,12 @@ export const readFootnoteRefMarkAttrs = (
 };
 
 export const expectFootnoteRefMarkAttrs = (mark: Mark): FootnoteRefAttrs =>
-  expectAttrs(readFootnoteRefMarkAttrs(mark), "footnote reference attrs");
+  expectCachedMarkAttrs(
+    mark,
+    footnoteRefAttrsCache,
+    readFootnoteRefMarkAttrs,
+    "footnote reference attrs",
+  );
 
 export const readCommentMarkAttrs = (
   mark: Mark,
@@ -958,7 +1057,12 @@ export const readCommentMarkAttrs = (
 };
 
 export const expectCommentMarkAttrs = (mark: Mark): CommentAttrs =>
-  expectAttrs(readCommentMarkAttrs(mark), "comment attrs");
+  expectCachedMarkAttrs(
+    mark,
+    commentAttrsCache,
+    readCommentMarkAttrs,
+    "comment attrs",
+  );
 
 export const readTrackedChangeMarkAttrs = (
   mark: Mark,
@@ -989,7 +1093,12 @@ export const readTrackedChangeMarkAttrs = (
 export const expectTrackedChangeMarkAttrs = (
   mark: Mark,
 ): TrackedChangeMarkAttrs =>
-  expectAttrs(readTrackedChangeMarkAttrs(mark), "tracked change attrs");
+  expectCachedMarkAttrs(
+    mark,
+    trackedChangeAttrsCache,
+    readTrackedChangeMarkAttrs,
+    "tracked change attrs",
+  );
 
 export const readRunFormattingOverrideMarkAttrs = (
   mark: Mark,
@@ -1015,8 +1124,10 @@ export const readRunFormattingOverrideMarkAttrs = (
 export const expectRunFormattingOverrideMarkAttrs = (
   mark: Mark,
 ): RunFormattingOverrideAttrs =>
-  expectAttrs(
-    readRunFormattingOverrideMarkAttrs(mark),
+  expectCachedMarkAttrs(
+    mark,
+    runFormattingOverrideAttrsCache,
+    readRunFormattingOverrideMarkAttrs,
     "run formatting override attrs",
   );
 
@@ -1040,7 +1151,12 @@ export const readHyperlinkMarkAttrs = (
 };
 
 export const expectHyperlinkMarkAttrs = (mark: Mark): HyperlinkAttrs =>
-  expectAttrs(readHyperlinkMarkAttrs(mark), "hyperlink attrs");
+  expectCachedMarkAttrs(
+    mark,
+    hyperlinkAttrsCache,
+    readHyperlinkMarkAttrs,
+    "hyperlink attrs",
+  );
 
 type NodeAttrReader<T extends object> = (
   node: PMNode,
@@ -1144,6 +1260,38 @@ const expectAttrs = <T>(
     .join("\n");
   panic(`Invalid ProseMirror ${label}:\n${details}`);
 };
+
+function expectCachedNodeAttrs<T extends object>(
+  node: PMNode,
+  cache: WeakMap<PMNode, T>,
+  reader: (node: PMNode) => ReadProseMirrorAttrsResult<T>,
+  label: string,
+): T {
+  const cached = cache.get(node);
+  if (cached) {
+    return cached;
+  }
+
+  const value = expectAttrs(reader(node), label);
+  cache.set(node, value);
+  return value;
+}
+
+function expectCachedMarkAttrs<T extends object>(
+  mark: Mark,
+  cache: WeakMap<Mark, T>,
+  reader: (mark: Mark) => ReadProseMirrorAttrsResult<T>,
+  label: string,
+): T {
+  const cached = cache.get(mark);
+  if (cached) {
+    return cached;
+  }
+
+  const value = expectAttrs(reader(mark), label);
+  cache.set(mark, value);
+  return value;
+}
 
 const expectNodeType = (
   node: PMNode,

--- a/packages/folio/src/core/prosemirror/editor.css
+++ b/packages/folio/src/core/prosemirror/editor.css
@@ -589,6 +589,13 @@
   font-variant: small-caps;
 }
 
+/* Comment marks are view-only styling. Keep this out of inline toDOM styles so
+   ProseMirror's background-color parser never reparses comments as highlights. */
+.prosemirror-editor .ProseMirror .docx-comment {
+  background-color: var(--doc-comment-bg, rgba(255, 212, 0, 0.08));
+  border-bottom: 1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24));
+}
+
 /* Section break indicator */
 .docx-section-break {
   position: relative;

--- a/packages/folio/src/core/prosemirror/extensions/marks/CommentExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/CommentExtension.ts
@@ -34,8 +34,6 @@ export const CommentExtension = createMarkExtension({
         {
           class: "docx-comment",
           "data-comment-id": String(commentId),
-          style:
-            "background-color: var(--doc-comment-bg, rgba(255, 212, 0, 0.08)); border-bottom: 1px solid var(--doc-comment-border, rgba(180, 130, 0, 0.24));",
         },
         0,
       ];

--- a/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HighlightExtension.ts
@@ -4,11 +4,130 @@
 
 import { panic } from "better-result";
 
+import type { TextFormatting } from "../../../types/document";
+import { HIGHLIGHT_COLOR_VALUES } from "../../../types/documentEnumValues";
 import { resolveHighlightToCss } from "../../../utils/colorResolver";
 import { expectHighlightMarkAttrs } from "../../attrs";
 import { createMarkExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 import { setMark, removeMark } from "./markUtils";
+
+type HighlightColor = NonNullable<TextFormatting["highlight"]>;
+
+const CSS_HIGHLIGHT_TO_NAME: Record<string, HighlightColor> = {
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  "#000000": "black",
+  "#00008b": "darkBlue",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  "#0000ff": "blue",
+  "#006400": "darkGreen",
+  "#008000": "darkGreen",
+  "#008080": "darkCyan",
+  "#008b8b": "darkCyan",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  "#00ff00": "green",
+  "#00ffff": "cyan",
+  "#800080": "darkMagenta",
+  "#808000": "darkYellow",
+  "#808080": "darkGray",
+  "#8b0000": "darkRed",
+  "#a9a9a9": "darkGray",
+  "#c0c0c0": "lightGray",
+  "#d3d3d3": "lightGray",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  "#ff0000": "red",
+  "#ff00ff": "magenta",
+  "#ffff00": "yellow",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  "#ffffff": "white",
+  aqua: "cyan",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  black: "black",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  blue: "blue",
+  cyan: "cyan",
+  darkblue: "darkBlue",
+  darkcyan: "darkCyan",
+  darkgray: "darkGray",
+  darkgreen: "darkGreen",
+  darkgrey: "darkGray",
+  darkmagenta: "darkMagenta",
+  darkred: "darkRed",
+  fuchsia: "magenta",
+  gray: "darkGray",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  green: "green",
+  grey: "darkGray",
+  lightgray: "lightGray",
+  lightgrey: "lightGray",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  lime: "green",
+  magenta: "magenta",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  red: "red",
+  // eslint-disable-next-line no-inline-style-colors/no-inline-style-colors -- CSS color parser table, not UI styling.
+  white: "white",
+  yellow: "yellow",
+};
+
+const readHighlightName = (value: string): HighlightColor | null => {
+  for (const color of HIGHLIGHT_COLOR_VALUES) {
+    if (color === value) {
+      return color;
+    }
+  }
+  return null;
+};
+
+const normalizeCssColorKey = (value: string): string => {
+  const compact = value.trim().toLowerCase().replace(/\s+/gu, "");
+  const hexMatch = /^#([0-9a-f]{3}|[0-9a-f]{6})$/u.exec(compact);
+  const hex = hexMatch?.[1];
+  if (hex) {
+    return hex.length === 3
+      ? `#${hex[0]}${hex[0]}${hex[1]}${hex[1]}${hex[2]}${hex[2]}`
+      : `#${hex}`;
+  }
+
+  const rgbMatch = /^rgba?\((\d{1,3}),(\d{1,3}),(\d{1,3})(?:,[^)]+)?\)$/u.exec(
+    compact,
+  );
+  if (!rgbMatch) {
+    return compact;
+  }
+
+  const [, red, green, blue] = rgbMatch;
+  return `#${cssColorComponentToHex(red)}${cssColorComponentToHex(green)}${cssColorComponentToHex(blue)}`;
+};
+
+const cssColorComponentToHex = (value: string | undefined): string => {
+  const component = Number(value);
+  if (!Number.isFinite(component)) {
+    return "00";
+  }
+  return Math.min(255, Math.max(0, component)).toString(16).padStart(2, "0");
+};
+
+const parseDOMHighlightColor = (value: string): HighlightColor | null => {
+  const trimmed = value.trim();
+  if (
+    trimmed === "" ||
+    trimmed === "inherit" ||
+    trimmed === "initial" ||
+    trimmed === "none" ||
+    trimmed === "transparent" ||
+    trimmed === "unset"
+  ) {
+    return null;
+  }
+
+  const namedColor = readHighlightName(trimmed);
+  if (namedColor && namedColor !== "none") {
+    return namedColor;
+  }
+
+  return CSS_HIGHLIGHT_TO_NAME[normalizeCssColorKey(trimmed)] ?? null;
+};
 
 export const HighlightExtension = createMarkExtension({
   name: "highlight",
@@ -24,8 +143,9 @@ export const HighlightExtension = createMarkExtension({
       {
         style: "background-color",
         getAttrs: (value) => {
-          if (value && value !== "transparent" && value !== "inherit") {
-            return { color: value };
+          const color = parseDOMHighlightColor(value);
+          if (color) {
+            return { color };
           }
           return false;
         },
@@ -49,7 +169,9 @@ export const HighlightExtension = createMarkExtension({
           if (!color || color === "none") {
             return removeMark(highlightType);
           }
-          return setMark(highlightType, { color });
+          return setMark(highlightType, {
+            color: parseDOMHighlightColor(color) ?? "yellow",
+          });
         },
         clearHighlight: () => removeMark(highlightType),
       },

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -48,6 +48,9 @@ export class ProseMirrorDocumentValidationError extends Error {
   }
 }
 
+const validDocumentCache = new WeakSet<PMNode>();
+const validNodeCache = new WeakSet<PMNode>();
+
 export const validateProseMirrorDocument = (
   doc: PMNode,
 ): ValidateProseMirrorDocumentResult => {
@@ -72,8 +75,13 @@ export const assertValidProseMirrorDocument = (
   doc: PMNode,
   context: string,
 ): void => {
+  if (validDocumentCache.has(doc)) {
+    return;
+  }
+
   const validation = validateProseMirrorDocument(doc);
   if (validation.valid) {
+    validDocumentCache.add(doc);
     return;
   }
 
@@ -92,6 +100,12 @@ const validateNode = (
   path: string,
   issues: ProseMirrorDocumentValidationIssue[],
 ): void => {
+  if (validNodeCache.has(node)) {
+    return;
+  }
+
+  const issueCountBeforeNode = issues.length;
+
   validateNodeAttrs(node, path, issues);
   validateMarks(node.marks, path, issues);
 
@@ -99,6 +113,10 @@ const validateNode = (
   node.forEach((child, _offset, index) => {
     validateNode(child, `${path}.content[${index}]`, issues);
   });
+
+  if (issues.length === issueCountBeforeNode) {
+    validNodeCache.add(node);
+  }
 };
 
 const validateNodeAttrs = (

--- a/packages/folio/src/core/utils/tiffConverter.ts
+++ b/packages/folio/src/core/utils/tiffConverter.ts
@@ -8,8 +8,6 @@
  * fine for headless round-trips.
  */
 
-import * as UTIF from "utif2";
-
 /**
  * Hard cap on the pixel count we'll attempt to decode. Each pixel costs 4 B
  * for the intermediate RGBA buffer plus another canvas-managed bitmap, so
@@ -29,11 +27,11 @@ export type ConvertedTiff = {
   data: ArrayBuffer;
 };
 
-export function convertTiffToPngDataUrl(
+export async function convertTiffToPngDataUrl(
   tiffData: ArrayBuffer,
-): ConvertedTiff | null {
+): Promise<ConvertedTiff | null> {
   // Bail out before any decode if Canvas isn't available — without it we
-  // can't produce a PNG anyway, and `UTIF.decodeImage` + `toRGBA8` would
+  // can't produce a PNG anyway, and TIFF decoding + RGBA conversion would
   // allocate hundreds of MB and burn CPU for nothing in headless parses.
   if (
     typeof document === "undefined" ||
@@ -43,6 +41,7 @@ export function convertTiffToPngDataUrl(
   }
 
   try {
+    const UTIF = await import("utif2");
     const ifds = UTIF.decode(tiffData);
     const firstImage = ifds[0];
     if (!firstImage) {

--- a/packages/folio/src/hooks/useHistory.ts
+++ b/packages/folio/src/hooks/useHistory.ts
@@ -411,20 +411,26 @@ export function useDocumentHistory<
   document: T,
   options: Omit<UseHistoryOptions<T>, "isEqual"> = {},
 ): UseHistoryReturn<T> {
-  // Compare document content, headers, and footers for detecting changes
+  // Hot path for editor typing: callers produce fresh references for real
+  // document edits, so avoid serializing the whole document to prove equality.
   const isEqual = useCallback((a: T, b: T): boolean => {
-    if (
-      a?.package?.document !== b?.package?.document &&
-      JSON.stringify(a?.package?.document) !==
-        JSON.stringify(b?.package?.document)
-    ) {
+    if (a === b) {
+      return true;
+    }
+
+    const aPackage = a?.package;
+    const bPackage = b?.package;
+    if (!aPackage || !bPackage) {
+      return aPackage === bPackage;
+    }
+
+    if (aPackage.document !== bPackage.document) {
       return false;
     }
-    // Also compare headers/footers (stored as Maps, use reference equality first)
-    if (a?.package?.headers !== b?.package?.headers) {
+    if (aPackage.headers !== bPackage.headers) {
       return false;
     }
-    if (a?.package?.footers !== b?.package?.footers) {
+    if (aPackage.footers !== bPackage.footers) {
       return false;
     }
     return true;

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -45,6 +45,7 @@ import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
 import { suppressHiddenEditorScrollToSelection } from "./hiddenEditorScroll";
 import {
+  recordHiddenEditorPhase,
   recordHiddenEditorStateCreate,
   type HiddenEditorStateReason,
 } from "./layoutInstrumentation";
@@ -340,10 +341,16 @@ function createInitialState(
   const activeSchema = manager?.getSchema() ?? schema;
   let localDoc = createEmptyDoc();
   if (document) {
+    const startedAt = performance.now();
     localDoc =
       styles === undefined || styles === null
         ? toProseDoc(document)
         : toProseDoc(document, { styles });
+    recordHiddenEditorPhase(
+      reason,
+      "to-prose-doc",
+      performance.now() - startedAt,
+    );
   }
 
   if (collaboration) {
@@ -357,11 +364,18 @@ function createInitialState(
       activeSchema,
     );
 
-    return EditorState.create({
+    const startedAt = performance.now();
+    const state = EditorState.create({
       doc,
       schema: activeSchema,
       plugins: [...externalPlugins, ...(manager?.getPlugins() ?? [])],
     });
+    recordHiddenEditorPhase(
+      reason,
+      "editor-state",
+      performance.now() - startedAt,
+    );
+    return state;
   }
 
   // External plugins go first so they can intercept before extension keymaps
@@ -371,11 +385,18 @@ function createInitialState(
     ...(manager?.getPlugins() ?? []),
   ];
 
-  return EditorState.create({
+  const startedAt = performance.now();
+  const state = EditorState.create({
     doc: localDoc,
     schema: activeSchema,
     plugins,
   });
+  recordHiddenEditorPhase(
+    reason,
+    "editor-state",
+    performance.now() - startedAt,
+  );
+  return state;
 }
 
 /**
@@ -577,7 +598,13 @@ export function HiddenProseMirror(
       },
     };
 
+    const viewStartedAt = performance.now();
     viewRef.current = new EditorView(hostRef.current, editorProps);
+    recordHiddenEditorPhase(
+      "mount",
+      "editor-view",
+      performance.now() - viewStartedAt,
+    );
     syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
     isInitializedRef.current = true;
     lastDocumentIdRef.current = getDocumentIdentity(document);
@@ -686,7 +713,13 @@ export function HiddenProseMirror(
       collaboration,
       "external-document",
     );
+    const updateStartedAt = performance.now();
     viewRef.current.updateState(newState);
+    recordHiddenEditorPhase(
+      "external-document",
+      "update-state",
+      performance.now() - updateStartedAt,
+    );
     syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
 
     // Use ref to avoid infinite loop when callback is unstable

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -516,6 +516,8 @@ export function HiddenProseMirror(
 
   const [collaborationModules, setCollaborationModules] =
     useState<CollaborationModules | null>(null);
+  const [collaborationModulesError, setCollaborationModulesError] =
+    useState<unknown>(null);
   const hasCollaboration = collaboration !== undefined;
 
   // Refs
@@ -561,20 +563,24 @@ export function HiddenProseMirror(
   useEffect(() => {
     if (!hasCollaboration) {
       setCollaborationModules(null);
+      setCollaborationModulesError(null);
       return undefined;
     }
 
     let cancelled = false;
+    setCollaborationModulesError(null);
     void loadCollaborationModules().then(
       (modules) => {
         if (!cancelled) {
           setCollaborationModules(modules);
+          setCollaborationModulesError(null);
         }
         return undefined;
       },
-      () => {
+      (error: unknown) => {
         if (!cancelled) {
           setCollaborationModules(null);
+          setCollaborationModulesError(error);
         }
         return undefined;
       },
@@ -1000,6 +1006,18 @@ export function HiddenProseMirror(
     }),
     [],
   );
+
+  if (hasCollaboration && collaborationModulesError) {
+    let detail = "unknown error";
+    if (collaborationModulesError instanceof Error) {
+      detail = collaborationModulesError.message;
+    } else if (typeof collaborationModulesError === "string") {
+      detail = collaborationModulesError;
+    }
+    panic(
+      `Failed to load collaboration editor modules. Reload the document to retry. Cause: ${detail}`,
+    );
+  }
 
   // ========================================================================
   // Render

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -15,9 +15,16 @@
  * so that ProseMirror's internal measurements stay valid.
  */
 
-import { useRef, useEffect, useCallback, useImperativeHandle } from "react";
+import {
+  useRef,
+  useEffect,
+  useCallback,
+  useImperativeHandle,
+  useState,
+} from "react";
 import type { CSSProperties, Ref } from "react";
 
+import { panic } from "better-result";
 import { undo, redo } from "prosemirror-history";
 import type { Transaction, Command, Plugin } from "prosemirror-state";
 import {
@@ -29,14 +36,9 @@ import {
 import { CellSelection } from "prosemirror-tables";
 import { EditorView } from "prosemirror-view";
 import type { DirectEditorProps } from "prosemirror-view";
-import {
-  initProseMirrorDoc,
-  prosemirrorToYXmlFragment,
-  relativePositionToAbsolutePosition,
-  ySyncPluginKey,
-} from "y-prosemirror";
-import * as Y from "yjs";
-import type { XmlFragment } from "yjs";
+import type * as YProseMirror from "y-prosemirror";
+import type { Doc as YDoc, XmlFragment } from "yjs";
+import type * as Yjs from "yjs";
 
 import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
 import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
@@ -56,6 +58,24 @@ import "prosemirror-view/style/prosemirror.css";
 import "../core/prosemirror/editor.css";
 
 const EMPTY_EXTERNAL_PLUGINS: Plugin[] = [];
+
+type YProseMirrorModule = typeof YProseMirror;
+type YjsModule = typeof Yjs;
+type CollaborationModules = {
+  yProseMirror: YProseMirrorModule;
+  yjs: YjsModule;
+};
+
+let collaborationModulesPromise: Promise<CollaborationModules> | null = null;
+
+const loadCollaborationModules = (): Promise<CollaborationModules> => {
+  collaborationModulesPromise ??= Promise.all([
+    import("y-prosemirror"),
+    import("yjs"),
+  ]).then(([yProseMirror, yjs]) => ({ yProseMirror, yjs }));
+
+  return collaborationModulesPromise;
+};
 
 // ============================================================================
 // TYPES
@@ -154,9 +174,11 @@ export type HiddenProseMirrorRef = {
 
 type YSyncState = {
   binding: {
-    mapping: Parameters<typeof relativePositionToAbsolutePosition>[3];
+    mapping: Parameters<
+      YProseMirrorModule["relativePositionToAbsolutePosition"]
+    >[3];
   };
-  doc: Y.Doc;
+  doc: YDoc;
   type: XmlFragment;
 };
 
@@ -173,14 +195,14 @@ type AwarenessUser = {
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
-const isYSyncState = (value: unknown): value is YSyncState => {
+const isYSyncState = (value: unknown, yjs: YjsModule): value is YSyncState => {
   if (!isObjectRecord(value)) {
     return false;
   }
   const binding = value["binding"];
   return (
-    value["doc"] instanceof Y.Doc &&
-    value["type"] instanceof Y.XmlFragment &&
+    value["doc"] instanceof yjs.Doc &&
+    value["type"] instanceof yjs.XmlFragment &&
     isObjectRecord(binding) &&
     binding["mapping"] instanceof Map
   );
@@ -223,9 +245,11 @@ const readAwarenessUser = (state: unknown, clientId: number): AwarenessUser => {
 const collectRemoteSelections = (
   state: EditorState,
   awareness: CollaborationAwareness,
+  collaborationModules: CollaborationModules,
 ): HiddenProseMirrorRemoteSelection[] => {
-  const syncState: unknown = ySyncPluginKey.getState(state);
-  if (!isYSyncState(syncState)) {
+  const syncState: unknown =
+    collaborationModules.yProseMirror.ySyncPluginKey.getState(state);
+  if (!isYSyncState(syncState, collaborationModules.yjs)) {
     return [];
   }
 
@@ -240,18 +264,20 @@ const collectRemoteSelections = (
       continue;
     }
 
-    const anchor = relativePositionToAbsolutePosition(
-      syncState.doc,
-      syncState.type,
-      Y.createRelativePositionFromJSON(cursor.anchor),
-      syncState.binding.mapping,
-    );
-    const head = relativePositionToAbsolutePosition(
-      syncState.doc,
-      syncState.type,
-      Y.createRelativePositionFromJSON(cursor.head),
-      syncState.binding.mapping,
-    );
+    const anchor =
+      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
+        syncState.doc,
+        syncState.type,
+        collaborationModules.yjs.createRelativePositionFromJSON(cursor.anchor),
+        syncState.binding.mapping,
+      );
+    const head =
+      collaborationModules.yProseMirror.relativePositionToAbsolutePosition(
+        syncState.doc,
+        syncState.type,
+        collaborationModules.yjs.createRelativePositionFromJSON(cursor.head),
+        syncState.binding.mapping,
+      );
     if (anchor === null || head === null) {
       continue;
     }
@@ -334,6 +360,7 @@ function createInitialState(
   manager?: ExtensionManager,
   externalPlugins: Plugin[] = [],
   collaboration?: HiddenProseMirrorCollaboration,
+  collaborationModules?: CollaborationModules | null,
   reason: HiddenEditorStateReason = "mount",
 ): EditorState {
   recordHiddenEditorStateCreate(reason);
@@ -354,12 +381,21 @@ function createInitialState(
   }
 
   if (collaboration) {
+    if (!collaborationModules) {
+      panic(
+        "Collaboration modules must be loaded before creating collaborative editor state.",
+      );
+    }
+
     if (collaboration.shouldSeed && collaboration.yXmlFragment.length === 0) {
-      prosemirrorToYXmlFragment(localDoc, collaboration.yXmlFragment);
+      collaborationModules.yProseMirror.prosemirrorToYXmlFragment(
+        localDoc,
+        collaboration.yXmlFragment,
+      );
       collaboration.onSeeded?.();
     }
 
-    const { doc } = initProseMirrorDoc(
+    const { doc } = collaborationModules.yProseMirror.initProseMirrorDoc(
       collaboration.yXmlFragment,
       activeSchema,
     );
@@ -467,11 +503,17 @@ export function HiddenProseMirror(
     onRemoteSelectionsChange,
   } = props;
 
+  const [collaborationModules, setCollaborationModules] =
+    useState<CollaborationModules | null>(null);
+  const hasCollaboration = collaboration !== undefined;
+
   // Refs
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const readOnlyRef = useRef(readOnly);
   const documentRef = useRef(document);
+  const collaborationRef = useRef(collaboration);
+  const collaborationModulesRef = useRef(collaborationModules);
   const isDestroyingRef = useRef(false);
   // Track the document identity to detect truly external changes
   // vs changes that originated from editing (which get passed back through props)
@@ -499,9 +541,30 @@ export function HiddenProseMirror(
   onKeyDownRef.current = onKeyDown;
   onReadOnlyEditAttemptRef.current = onReadOnlyEditAttempt;
   onRemoteSelectionsChangeRef.current = onRemoteSelectionsChange;
+  collaborationRef.current = collaboration;
+  collaborationModulesRef.current = collaborationModules;
 
   // Keep document ref in sync
   documentRef.current = document;
+
+  useEffect(() => {
+    if (!hasCollaboration) {
+      setCollaborationModules(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    void loadCollaborationModules().then((modules) => {
+      if (!cancelled) {
+        setCollaborationModules(modules);
+      }
+      return undefined;
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hasCollaboration]);
 
   // ========================================================================
   // EditorView Lifecycle
@@ -515,6 +578,9 @@ export function HiddenProseMirror(
     if (!hostRef.current || isDestroyingRef.current) {
       return;
     }
+    if (collaboration && !collaborationModules) {
+      return;
+    }
 
     const initialState = createInitialState(
       document,
@@ -522,6 +588,7 @@ export function HiddenProseMirror(
       extensionManager,
       externalPlugins,
       collaboration,
+      collaborationModules,
       "mount",
     );
 
@@ -550,9 +617,15 @@ export function HiddenProseMirror(
           onSelectionChangeRef.current?.(newState);
         }
 
-        if (collaboration?.awareness) {
+        const currentCollaboration = collaborationRef.current;
+        const currentCollaborationModules = collaborationModulesRef.current;
+        if (currentCollaboration?.awareness && currentCollaborationModules) {
           onRemoteSelectionsChangeRef.current?.(
-            collectRemoteSelections(newState, collaboration.awareness),
+            collectRemoteSelections(
+              newState,
+              currentCollaboration.awareness,
+              currentCollaborationModules,
+            ),
           );
         }
       },
@@ -617,13 +690,14 @@ export function HiddenProseMirror(
     styles,
     externalPlugins,
     collaboration,
+    collaborationModules,
     extensionManager,
     // Callbacks removed from dependencies - accessed via refs
   ]);
 
   useEffect(() => {
     const awareness = collaboration?.awareness;
-    if (!awareness || !viewRef.current) {
+    if (!awareness || !viewRef.current || !collaborationModules) {
       onRemoteSelectionsChangeRef.current?.([]);
       return undefined;
     }
@@ -633,7 +707,11 @@ export function HiddenProseMirror(
         return;
       }
       onRemoteSelectionsChangeRef.current?.(
-        collectRemoteSelections(viewRef.current.state, awareness),
+        collectRemoteSelections(
+          viewRef.current.state,
+          awareness,
+          collaborationModules,
+        ),
       );
     };
 
@@ -644,7 +722,7 @@ export function HiddenProseMirror(
       awareness.off("change", publishRemoteSelections);
       onRemoteSelectionsChangeRef.current?.([]);
     };
-  }, [collaboration?.awareness]);
+  }, [collaboration?.awareness, collaborationModules]);
 
   /**
    * Destroy EditorView
@@ -662,18 +740,26 @@ export function HiddenProseMirror(
     }
   }, []);
 
-  // Mount/unmount
   useEffect(() => {
+    if (viewRef.current || isDestroyingRef.current) {
+      return;
+    }
+    if (collaboration && !collaborationModules) {
+      return;
+    }
     createView();
-    return () => destroyView();
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only on mount/unmount
+  }, [collaboration, collaborationModules, createView]);
+
+  useEffect(() => () => destroyView(), [destroyView]);
 
   // Update state when document changes externally (e.g., loading a new file)
   // This should NOT run when the document prop changes due to internal edits
   // being passed back through the parent component's state
   useEffect(() => {
     if (!viewRef.current || isDestroyingRef.current) {
+      return;
+    }
+    if (collaboration && !collaborationModules) {
       return;
     }
 
@@ -711,6 +797,7 @@ export function HiddenProseMirror(
       extensionManager,
       externalPlugins,
       collaboration,
+      collaborationModules,
       "external-document",
     );
     const updateStartedAt = performance.now();
@@ -724,7 +811,14 @@ export function HiddenProseMirror(
 
     // Use ref to avoid infinite loop when callback is unstable
     onSelectionChangeRef.current?.(newState);
-  }, [document, styles, extensionManager, externalPlugins, collaboration]);
+  }, [
+    document,
+    styles,
+    extensionManager,
+    externalPlugins,
+    collaboration,
+    collaborationModules,
+  ]);
   // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
 
   // Update editable state

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -95,6 +95,8 @@ export type HiddenProseMirrorProps = {
   theme?: Theme | null;
   /** Width in pixels (should match document content width) */
   widthPx?: number;
+  /** Delay EditorView creation while the visible editor performs first layout. */
+  deferViewCreation?: boolean;
   /** Whether the editor is read-only */
   readOnly?: boolean;
   /** Callback when document changes via transaction */
@@ -112,6 +114,8 @@ export type HiddenProseMirrorProps = {
   extensionManager?: ExtensionManager;
   /** Callback when EditorView is ready */
   onEditorViewReady?: (view: EditorView) => void;
+  /** Initial state already built by the parent for pre-view layout. */
+  precomputedInitialState?: EditorState | null;
   /** Callback when EditorView is destroyed */
   onEditorViewDestroy?: () => void;
   /** Intercept key events before ProseMirror processes them. Return true to prevent PM handling. */
@@ -359,7 +363,7 @@ const HIDDEN_EDITOR_ATTRIBUTES = {
  * When an ExtensionManager is provided, it supplies the schema and plugins.
  * Otherwise falls back to the default singleton schema with no extension plugins.
  */
-function createInitialState(
+export function createHiddenEditorState(
   document: Document | null,
   styles: StyleDefinitions | null | undefined,
   manager?: ExtensionManager,
@@ -495,6 +499,7 @@ export function HiddenProseMirror(
     styles,
     theme: _theme,
     widthPx = 612, // Default Letter width at 72dpi
+    deferViewCreation = false,
     readOnly = false,
     onTransaction,
     onSelectionChange,
@@ -506,6 +511,7 @@ export function HiddenProseMirror(
     onKeyDown,
     onReadOnlyEditAttempt,
     onRemoteSelectionsChange,
+    precomputedInitialState,
   } = props;
 
   const [collaborationModules, setCollaborationModules] =
@@ -588,6 +594,9 @@ export function HiddenProseMirror(
    * Uses refs for callbacks to avoid infinite re-render loops
    */
   const createView = useCallback(() => {
+    if (deferViewCreation) {
+      return;
+    }
     if (!hostRef.current || isDestroyingRef.current) {
       return;
     }
@@ -595,15 +604,18 @@ export function HiddenProseMirror(
       return;
     }
 
-    const initialState = createInitialState(
-      document,
-      styles,
-      extensionManager,
-      externalPlugins,
-      collaboration,
-      collaborationModules,
-      "mount",
-    );
+    const initialState =
+      precomputedInitialState && !collaboration
+        ? precomputedInitialState
+        : createHiddenEditorState(
+            document,
+            styles,
+            extensionManager,
+            externalPlugins,
+            collaboration,
+            collaborationModules,
+            "mount",
+          );
 
     const editorProps: DirectEditorProps = {
       state: initialState,
@@ -705,6 +717,8 @@ export function HiddenProseMirror(
     collaboration,
     collaborationModules,
     extensionManager,
+    deferViewCreation,
+    precomputedInitialState,
     // Callbacks removed from dependencies - accessed via refs
   ]);
 
@@ -754,6 +768,9 @@ export function HiddenProseMirror(
   }, []);
 
   useEffect(() => {
+    if (deferViewCreation) {
+      return;
+    }
     if (viewRef.current || isDestroyingRef.current) {
       return;
     }
@@ -761,7 +778,7 @@ export function HiddenProseMirror(
       return;
     }
     createView();
-  }, [collaboration, collaborationModules, createView]);
+  }, [collaboration, collaborationModules, createView, deferViewCreation]);
 
   useEffect(() => () => destroyView(), [destroyView]);
 
@@ -804,7 +821,7 @@ export function HiddenProseMirror(
     lastCollaborationFragmentRef.current = currentCollaborationFragment;
 
     // Create new state from document
-    const newState = createInitialState(
+    const newState = createHiddenEditorState(
       document,
       styles,
       extensionManager,

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -72,7 +72,12 @@ const loadCollaborationModules = (): Promise<CollaborationModules> => {
   collaborationModulesPromise ??= Promise.all([
     import("y-prosemirror"),
     import("yjs"),
-  ]).then(([yProseMirror, yjs]) => ({ yProseMirror, yjs }));
+  ])
+    .then(([yProseMirror, yjs]) => ({ yProseMirror, yjs }))
+    .catch((error: unknown) => {
+      collaborationModulesPromise = null;
+      throw error;
+    });
 
   return collaborationModulesPromise;
 };
@@ -554,12 +559,20 @@ export function HiddenProseMirror(
     }
 
     let cancelled = false;
-    void loadCollaborationModules().then((modules) => {
-      if (!cancelled) {
-        setCollaborationModules(modules);
-      }
-      return undefined;
-    });
+    void loadCollaborationModules().then(
+      (modules) => {
+        if (!cancelled) {
+          setCollaborationModules(modules);
+        }
+        return undefined;
+      },
+      () => {
+        if (!cancelled) {
+          setCollaborationModules(null);
+        }
+        return undefined;
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -44,6 +44,10 @@ import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionM
 import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
 import { suppressHiddenEditorScrollToSelection } from "./hiddenEditorScroll";
+import {
+  recordHiddenEditorStateCreate,
+  type HiddenEditorStateReason,
+} from "./layoutInstrumentation";
 import { isReadOnlyEditKey } from "./readOnlyEditAttempt";
 // Import ProseMirror CSS
 import "prosemirror-view/style/prosemirror.css";
@@ -269,23 +273,48 @@ const collectRemoteSelections = (
 // ============================================================================
 
 /**
- * Hidden host styles - visually hidden but focusable
+ * Hidden wrapper styles - visually hidden, focus-safe scroll isolation.
+ *
+ * The focused ProseMirror contenteditable can ask the browser to reveal its
+ * caret. Keeping it inside a tiny overflow-hidden fixed wrapper confines that
+ * native scroll work to the wrapper instead of the visible document viewport.
  */
-const HIDDEN_HOST_STYLES: CSSProperties = {
-  // Position off-screen but in document flow for accessibility
+const HIDDEN_WRAPPER_STYLES: CSSProperties = {
   position: "fixed",
   left: "-9999px",
   top: "0",
-  // Hide visually but keep focusable (NOT visibility:hidden!)
+  width: "1px",
+  height: "1px",
+  overflow: "hidden",
   opacity: 0,
   zIndex: -1,
-  // Prevent interaction with visual layer
   pointerEvents: "none",
-  // Prevent text selection in hidden area
-  userSelect: "none",
-  // Prevent scroll anchoring issues
+  contain: "layout paint",
   overflowAnchor: "none",
-  // Don't set aria-hidden - editor must remain accessible to screen readers
+  // Don't set aria-hidden - the inner editor remains the accessible document.
+};
+
+/**
+ * Hidden host styles - full document-width PM mount inside the isolated wrapper.
+ */
+const HIDDEN_HOST_STYLES: CSSProperties = {
+  position: "absolute",
+  left: "0",
+  top: "0",
+  userSelect: "none",
+  overflowAnchor: "none",
+  // Don't use visibility:hidden - the editor must remain focusable.
+};
+
+const HIDDEN_EDITOR_ATTRIBUTES = {
+  "aria-label": "Document content",
+  "aria-multiline": "true",
+  autocapitalize: "off",
+  autocomplete: "off",
+  autocorrect: "off",
+  role: "textbox",
+  spellcheck: "false",
+  translate: "no",
 };
 
 // ============================================================================
@@ -304,7 +333,10 @@ function createInitialState(
   manager?: ExtensionManager,
   externalPlugins: Plugin[] = [],
   collaboration?: HiddenProseMirrorCollaboration,
+  reason: HiddenEditorStateReason = "mount",
 ): EditorState {
+  recordHiddenEditorStateCreate(reason);
+
   const activeSchema = manager?.getSchema() ?? schema;
   let localDoc = createEmptyDoc();
   if (document) {
@@ -359,6 +391,30 @@ function stateToDocument(
 
   // fromProseDoc preserves the base document structure when provided
   return fromProseDoc(state.doc, originalDoc);
+}
+
+function getDocumentIdentity(doc: Document | null): string {
+  if (!doc) {
+    return "empty";
+  }
+  // Use the document's package id or a hash of its structure.
+  // For simplicity, compare based on whether it has different metadata.
+  const meta = doc.package.properties;
+  const created = meta?.created ? String(meta.created) : "";
+  const modified = meta?.modified ? String(meta.modified) : "";
+  const title = meta?.title ?? "";
+  return `${created}-${modified}-${title}`;
+}
+
+function syncHiddenEditorAccessibility(
+  view: EditorView,
+  readOnly: boolean,
+): void {
+  const { dom } = view;
+  if (!dom.hasAttribute("tabindex")) {
+    dom.tabIndex = 0;
+  }
+  dom.setAttribute("aria-readonly", readOnly ? "true" : "false");
 }
 
 // ============================================================================
@@ -445,10 +501,12 @@ export function HiddenProseMirror(
       extensionManager,
       externalPlugins,
       collaboration,
+      "mount",
     );
 
     const editorProps: DirectEditorProps = {
       state: initialState,
+      attributes: HIDDEN_EDITOR_ATTRIBUTES,
       editable: () => !readOnlyRef.current,
       dispatchTransaction: (transaction: Transaction) => {
         if (!viewRef.current || isDestroyingRef.current) {
@@ -520,6 +578,10 @@ export function HiddenProseMirror(
     };
 
     viewRef.current = new EditorView(hostRef.current, editorProps);
+    syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
+    isInitializedRef.current = true;
+    lastDocumentIdRef.current = getDocumentIdentity(document);
+    lastCollaborationFragmentRef.current = collaboration?.yXmlFragment ?? null;
 
     // Notify that view is ready (use ref to avoid dependency issues)
     onEditorViewReadyRef.current?.(viewRef.current);
@@ -588,23 +650,7 @@ export function HiddenProseMirror(
       return;
     }
 
-    // Generate a simple document identity based on its structure
-    // This helps detect truly different documents vs the same doc passed back after editing
-    const getDocumentId = (doc: Document | null): string => {
-      if (!doc) {
-        return "empty";
-      }
-      // Use the document's package id or a hash of its structure
-      // For simplicity, we compare based on whether it's a different document object
-      // and whether it has different metadata
-      const meta = doc.package.properties;
-      const created = meta?.created ? String(meta.created) : "";
-      const modified = meta?.modified ? String(meta.modified) : "";
-      const title = meta?.title ?? "";
-      return `${created}-${modified}-${title}`;
-    };
-
-    const currentDocId = getDocumentId(document);
+    const currentDocId = getDocumentIdentity(document);
     const currentCollaborationFragment = collaboration?.yXmlFragment ?? null;
     const collaborationSourceChanged =
       currentCollaborationFragment !== lastCollaborationFragmentRef.current;
@@ -638,8 +684,10 @@ export function HiddenProseMirror(
       extensionManager,
       externalPlugins,
       collaboration,
+      "external-document",
     );
     viewRef.current.updateState(newState);
+    syncHiddenEditorAccessibility(viewRef.current, readOnlyRef.current);
 
     // Use ref to avoid infinite loop when callback is unstable
     onSelectionChangeRef.current?.(newState);
@@ -651,7 +699,8 @@ export function HiddenProseMirror(
     if (!viewRef.current) {
       return;
     }
-    // EditorView will call editable() on each check, so we don't need to update
+    // EditorView calls editable() dynamically; ARIA state needs explicit sync.
+    syncHiddenEditorAccessibility(viewRef.current, readOnly);
   }, [readOnly]);
 
   // ========================================================================
@@ -801,13 +850,18 @@ export function HiddenProseMirror(
 
   return (
     <div
-      ref={hostRef}
-      className="paged-editor__hidden-pm"
-      style={{
-        ...HIDDEN_HOST_STYLES,
-        width: widthPx > 0 ? `${widthPx}px` : undefined,
-      }}
-      // DO NOT set aria-hidden - this editor provides semantic structure
-    />
+      className="paged-editor__hidden-pm-wrapper"
+      style={HIDDEN_WRAPPER_STYLES}
+    >
+      <div
+        ref={hostRef}
+        className="paged-editor__hidden-pm"
+        style={{
+          ...HIDDEN_HOST_STYLES,
+          width: widthPx > 0 ? `${widthPx}px` : undefined,
+        }}
+        // DO NOT set aria-hidden - this editor provides semantic structure
+      />
+    </div>
   );
 }

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -18,6 +18,7 @@
 import {
   useRef,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useImperativeHandle,
   useState,
@@ -773,7 +774,7 @@ export function HiddenProseMirror(
     }
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (deferViewCreation) {
       return;
     }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -332,6 +332,23 @@ type EnsureHiddenEditorViewOptions = {
   sync?: boolean;
 };
 
+type TextInputHandler<TView> = (
+  view: TView,
+  from: number,
+  to: number,
+  text: string,
+  defaultTransaction: () => Transaction,
+) => unknown;
+
+type TextInputDispatchTarget<TView> = {
+  dispatch(tr: Transaction): void;
+  someProp(
+    propName: "handleTextInput",
+    f: (handler: TextInputHandler<TView>) => unknown,
+  ): unknown;
+  state: EditorState;
+};
+
 // =============================================================================
 // CONSTANTS
 // =============================================================================
@@ -450,6 +467,23 @@ const replayDeferredKeyDown = (
   eventInit: KeyboardEventInit,
 ) => {
   view.dom.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+};
+
+export const dispatchEditorTextInput = <
+  TView extends TextInputDispatchTarget<TView>,
+>(
+  view: TView,
+  text: string,
+) => {
+  const { from, to } = view.state.selection;
+  const defaultTransaction = () => view.state.tr.insertText(text, from, to);
+  const handled = view.someProp("handleTextInput", (handler) =>
+    handler(view, from, to, text, defaultTransaction),
+  );
+
+  if (!handled) {
+    view.dispatch(defaultTransaction());
+  }
 };
 
 /**
@@ -2199,14 +2233,7 @@ export function PagedEditor(
   );
 
   const queueHiddenEditorTextInput = useCallback((text: string) => {
-    const queuedInput = queuedInputBeforeHiddenEditorRef.current;
-    const lastInput = queuedInput.at(-1);
-    if (lastInput?.type === "text") {
-      lastInput.text += text;
-      return;
-    }
-
-    queuedInput.push({ type: "text", text });
+    queuedInputBeforeHiddenEditorRef.current.push({ type: "text", text });
   }, []);
 
   const queueHiddenEditorKeyDown = useCallback((event: React.KeyboardEvent) => {
@@ -2258,7 +2285,7 @@ export function PagedEditor(
     queuedInputBeforeHiddenEditorRef.current = [];
     for (const input of queuedInput) {
       if (input.type === "text") {
-        view.dispatch(view.state.tr.insertText(input.text));
+        dispatchEditorTextInput(view, input.text);
         continue;
       }
 
@@ -5261,7 +5288,7 @@ export function PagedEditor(
           applyPendingHiddenEditorInput(view);
           if (isPlainTextInputEvent(e)) {
             e.preventDefault();
-            view.dispatch(view.state.tr.insertText(e.key));
+            dispatchEditorTextInput(view, e.key);
             return;
           }
 
@@ -5307,20 +5334,7 @@ export function PagedEditor(
         !e.nativeEvent.isComposing
       ) {
         e.preventDefault();
-        // Route through handleTextInput so plugins (suggestion mode) can intercept
-        const { from, to } = view.state.selection;
-        // ProseMirror's `someProp` is an internal API not exposed on
-        // EditorView's public type. The cast is the FFI boundary.
-        // oxlint-disable-next-line no-any-casts/no-any-casts, typescript/no-explicit-any
-        const handled = (view as any).someProp(
-          "handleTextInput",
-          (
-            f: (v: EditorView, fr: number, t: number, text: string) => boolean,
-          ) => f(view, from, to, " "),
-        );
-        if (!handled) {
-          view.dispatch(view.state.tr.insertText(" "));
-        }
+        dispatchEditorTextInput(view, " ");
         return;
       }
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -103,6 +103,7 @@ import type {
 // Table commands (for quick-action insert buttons)
 import { addRowBelow, addColumnRight } from "../core/prosemirror";
 import {
+  expectFontFamilyMarkAttrs,
   expectImageAttrs,
   expectTableAttrs,
   expectTableCellAttrs,
@@ -151,8 +152,11 @@ import {
 import type { DirtyRange } from "./incrementalMeasure";
 import {
   recordLayoutComplete,
+  recordLayoutError,
+  recordLayoutPhase,
   recordMeasureBlock,
 } from "./layoutInstrumentation";
+import type { LayoutPhase, LayoutRunReason } from "./layoutInstrumentation";
 // Selection sync
 import { LayoutSelectionGate } from "./LayoutSelectionGate";
 import { isReadOnlyEditKey } from "./readOnlyEditAttempt";
@@ -339,6 +343,10 @@ const TABLE_INSERT_EDGE_PROXIMITY = 30;
 const TABLE_INSERT_HIDE_DELAY = 200;
 /** Delay before converting PM state back to the Folio document model. */
 const DOCUMENT_CHANGE_NOTIFY_DELAY = 250;
+/** Short window for coalescing rapid typing transactions into one visual layout. */
+const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
+/** Upper bound for how long visible layout can trail the hidden editor. */
+const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
 /** Keep the visual caret hidden briefly while typed content relayouts. */
 const SELECTION_REVEAL_AFTER_INPUT_DELAY = 120;
 
@@ -403,6 +411,30 @@ type RemoteSelectionOverlayProps = {
   zoom: number;
 };
 
+type LayoutInputSignatureOptions = {
+  columns: ColumnLayout | undefined;
+  contentWidth: number;
+  defaultTabStop: number | undefined;
+  firstPageFooterContent: HeaderFooter | null | undefined;
+  firstPageHeaderContent: HeaderFooter | null | undefined;
+  footerContent: HeaderFooter | null | undefined;
+  headerContent: HeaderFooter | null | undefined;
+  margins: PageMargins;
+  pageGap: number;
+  pageSize: { h: number; w: number };
+  sectionProperties: SectionProperties | null | undefined;
+  styles: StyleDefinitions | null | undefined;
+  theme: Theme | null | undefined;
+};
+
+type PendingLayoutRequest = {
+  dirtyRange: DirtyRange | null;
+  firstScheduledAt: number;
+  rafId: number | null;
+  state: EditorState;
+  timerId: number | null;
+};
+
 const getPageOverlayOffset = (pagesContainer: HTMLDivElement, zoom: number) => {
   const overlay = pagesContainer.parentElement?.querySelector(
     '[data-testid="selection-overlay"]',
@@ -419,6 +451,206 @@ const getPageOverlayOffset = (pagesContainer: HTMLDivElement, zoom: number) => {
     y: (pageRect.top - overlayRect.top) / zoom,
   };
 };
+
+function buildLayoutInputSignature(
+  options: LayoutInputSignatureOptions,
+): string {
+  return stableJsonStringify(options);
+}
+
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, nestedValue: unknown) => {
+    if (nestedValue instanceof Map) {
+      return Array.from(nestedValue.entries());
+    }
+    return nestedValue;
+  });
+}
+
+function getDocumentFontSet(): FontFaceSet | null {
+  if (typeof document === "undefined" || !("fonts" in document)) {
+    return null;
+  }
+  return document.fonts;
+}
+
+function documentFontsAreLoaded(): boolean {
+  const fontSet = getDocumentFontSet();
+  return !fontSet || fontSet.status === "loaded";
+}
+
+const INITIAL_LAYOUT_FONT_TIMEOUT_MS = 2000;
+const INITIAL_FONT_READY_SUPPRESSION_MS = 250;
+const DEFAULT_LAYOUT_FONT_FAMILY = "Calibri";
+const OFFICE_FONT_FAMILY_MAP: Record<string, string> = {
+  Arial: "Arimo",
+  Calibri: "Carlito",
+  Cambria: "Caladea",
+  "Times New Roman": "Tinos",
+  "Courier New": "Cousine",
+};
+const CSS_GENERIC_FONT_FAMILIES = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+]);
+const LAYOUT_FONT_DESCRIPTORS = [
+  { style: "normal", weight: 400 },
+  { style: "italic", weight: 400 },
+  { style: "normal", weight: 700 },
+  { style: "italic", weight: 700 },
+] as const;
+
+function waitForInitialLayoutFonts(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): Promise<boolean> {
+  const fontSet = getDocumentFontSet();
+  if (!fontSet) {
+    return Promise.resolve(true);
+  }
+
+  const families = collectInitialLayoutFontFamilies(documentModel, pmDoc);
+  const loadChecks: string[] = [];
+  for (const family of families) {
+    for (const descriptor of LAYOUT_FONT_DESCRIPTORS) {
+      loadChecks.push(
+        `${descriptor.style} ${descriptor.weight} 16px "${escapeCssFontFamily(family)}"`,
+      );
+    }
+  }
+
+  const loadFonts = Promise.allSettled(
+    loadChecks.map((check) => fontSet.load(check)),
+  )
+    .then(() => fontSet.ready)
+    .then(() => true);
+  return Promise.race([
+    loadFonts,
+    new Promise<boolean>((resolve) => {
+      window.setTimeout(() => resolve(false), INITIAL_LAYOUT_FONT_TIMEOUT_MS);
+    }),
+  ]);
+}
+
+export function collectInitialLayoutFontFamilies(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): Set<string> {
+  const families = new Set<string>();
+  addLayoutFontFamily(families, DEFAULT_LAYOUT_FONT_FAMILY);
+
+  for (const family of documentModel?.requiredFonts ?? []) {
+    addLayoutFontFamily(families, family);
+  }
+
+  addLayoutFontFamily(
+    families,
+    documentModel?.package.theme?.fontScheme?.majorFont?.latin,
+  );
+  addLayoutFontFamily(
+    families,
+    documentModel?.package.theme?.fontScheme?.minorFont?.latin,
+  );
+  addLayoutFontFamily(
+    families,
+    documentModel?.package.styles?.docDefaults?.rPr?.fontFamily,
+  );
+  for (const style of documentModel?.package.styles?.styles ?? []) {
+    addLayoutFontFamily(families, style.rPr?.fontFamily);
+  }
+
+  pmDoc.descendants((node) => {
+    addLayoutFontFamily(families, node.attrs["listMarkerFontFamily"]);
+    for (const mark of node.marks) {
+      if (mark.type.name === "fontFamily") {
+        addLayoutFontFamily(families, expectFontFamilyMarkAttrs(mark));
+      }
+    }
+    return true;
+  });
+
+  return families;
+}
+
+function addLayoutFontFamily(families: Set<string>, value: unknown): void {
+  if (typeof value === "string") {
+    addLayoutFontFamilyName(families, value);
+    return;
+  }
+
+  if (!value || typeof value !== "object") {
+    return;
+  }
+
+  const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
+  addLayoutFontFamily(families, fontFamily.ascii);
+  addLayoutFontFamily(families, fontFamily.hAnsi);
+}
+
+function addLayoutFontFamilyName(families: Set<string>, family: string): void {
+  const normalized = family.trim();
+  if (!normalized || CSS_GENERIC_FONT_FAMILIES.has(normalized)) {
+    return;
+  }
+
+  families.add(normalized);
+  const mappedFamily = OFFICE_FONT_FAMILY_MAP[normalized];
+  if (mappedFamily) {
+    families.add(mappedFamily);
+  }
+}
+
+function escapeCssFontFamily(family: string): string {
+  return family.replace(/\\/gu, "\\\\").replace(/"/gu, '\\"');
+}
+
+function describeInvalidHighlightMarks(doc: EditorState["doc"]): string {
+  const invalidHighlights: string[] = [];
+  const validHighlightColors = new Set([
+    "black",
+    "blue",
+    "cyan",
+    "darkBlue",
+    "darkCyan",
+    "darkGray",
+    "darkGreen",
+    "darkMagenta",
+    "darkRed",
+    "darkYellow",
+    "green",
+    "lightGray",
+    "magenta",
+    "none",
+    "red",
+    "white",
+    "yellow",
+  ]);
+
+  const visit = (node: EditorState["doc"], path: string): void => {
+    for (const [index, mark] of node.marks.entries()) {
+      if (
+        mark.type.name === "highlight" &&
+        !validHighlightColors.has(String(mark.attrs["color"]))
+      ) {
+        invalidHighlights.push(
+          `${path}.marks[${index}]=${JSON.stringify(mark.attrs)}`,
+        );
+      }
+    }
+
+    // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+    node.forEach((child, _offset, index) => {
+      visit(child, `${path}.content[${index}]`);
+    });
+  };
+
+  visit(doc, "doc");
+  return invalidHighlights.join("; ");
+}
 
 const RemoteSelectionOverlay = ({
   blocks,
@@ -1578,6 +1810,10 @@ export function PagedEditor(
     blockWidths: number[];
     measures: Measure[];
   } | null>(null);
+  const lastLaidOutPmDocRef = useRef<EditorState["doc"] | null>(null);
+  const lastLayoutUsedLoadedFontsRef = useRef(false);
+  const pendingInitialFontReadyLayoutRef = useRef(false);
+  const suppressFontReadyUntilRef = useRef(0);
   const [isFocused, setIsFocused] = useState(false);
   const [selectionRects, setSelectionRects] = useState<SelectionRect[]>([]);
   const [caretPosition, setCaretPosition] = useState<CaretPosition | null>(
@@ -1708,6 +1944,40 @@ export function PagedEditor(
     [sectionProperties],
   );
   const contentWidth = pageSize.w - margins.left - margins.right;
+  const defaultTabStop = document?.package.settings?.defaultTabStop;
+  const layoutInputSignature = useMemo(
+    () =>
+      buildLayoutInputSignature({
+        columns,
+        contentWidth,
+        defaultTabStop,
+        firstPageFooterContent,
+        firstPageHeaderContent,
+        footerContent,
+        headerContent,
+        margins,
+        pageGap,
+        pageSize,
+        sectionProperties,
+        styles,
+        theme: _theme,
+      }),
+    [
+      columns,
+      contentWidth,
+      defaultTabStop,
+      firstPageFooterContent,
+      firstPageHeaderContent,
+      footerContent,
+      headerContent,
+      margins,
+      pageGap,
+      pageSize,
+      sectionProperties,
+      styles,
+      _theme,
+    ],
+  );
 
   // Initialize painter using useMemo to ensure it's ready before first render callbacks
   const painter = useMemo(
@@ -1736,8 +2006,20 @@ export function PagedEditor(
   const runLayoutPipeline = useCallback(
     (
       state: EditorState,
-      options: { dirtyRange?: DirtyRange; forceFull?: boolean } = {},
+      options: {
+        dirtyRange?: DirtyRange;
+        forceFull?: boolean;
+        reason?: LayoutRunReason;
+      } = {},
     ) => {
+      const reason = options.reason ?? "manual";
+      const recordPhaseDuration = (
+        phase: LayoutPhase,
+        startedAt: number,
+      ): void => {
+        recordLayoutPhase(reason, phase, performance.now() - startedAt);
+      };
+
       // Capture current state sequence for this layout run
       const currentEpoch = syncCoordinator.getStateSeq();
 
@@ -1746,6 +2028,7 @@ export function PagedEditor(
 
       try {
         // Step 1: Convert PM doc to flow blocks
+        let phaseStartedAt = performance.now();
         const pageContentHeight = pageSize.h - margins.top - margins.bottom;
         const flowOpts: ToFlowBlocksOptions = {
           pageContentHeight,
@@ -1757,14 +2040,15 @@ export function PagedEditor(
         // list-marker tab-stop math (renderParagraph + measureParagraph)
         // uses the right grid. Absent settings.xml falls back to the
         // OOXML default inside `getListMarkerInlineWidth`.
-        const defaultTabStop = document?.package.settings?.defaultTabStop;
         if (defaultTabStop !== undefined) {
           flowOpts.defaultTabStopTwips = defaultTabStop;
         }
         const newBlocks = toFlowBlocks(state.doc, flowOpts);
         setBlocks(newBlocks);
+        recordPhaseDuration("flow-blocks", phaseStartedAt);
 
         // Compute per-block widths accounting for section breaks with different column configs
+        phaseStartedAt = performance.now();
         const bodyLayoutConfig: SectionLayoutConfig = {
           pageSize,
           margins,
@@ -1797,8 +2081,10 @@ export function PagedEditor(
           measures: newMeasures,
         };
         setMeasures(newMeasures);
+        recordPhaseDuration("measure-blocks", phaseStartedAt);
 
         // Step 2.5: Collect footnote references from blocks
+        phaseStartedAt = performance.now();
         const footnoteRefs = collectFootnoteRefs(newBlocks);
         const hasFootnotes =
           footnoteRefs.length > 0 && document?.package.footnotes;
@@ -1890,8 +2176,10 @@ export function PagedEditor(
             sb.margins = extendForHfOverflow(sb.margins);
           }
         }
+        recordPhaseDuration("header-footer", phaseStartedAt);
 
         // Step 3: Layout blocks onto pages (two-pass if footnotes exist)
+        phaseStartedAt = performance.now();
         let newLayout: Layout;
         let pageFootnoteMap = new Map<number, number[]>();
         let footnoteContentMap = new Map<number, FootnoteContent>();
@@ -1981,10 +2269,14 @@ export function PagedEditor(
         }
 
         setLayout(newLayout);
-        recordLayoutComplete();
+        lastLaidOutPmDocRef.current = state.doc;
+        lastLayoutUsedLoadedFontsRef.current = documentFontsAreLoaded();
+        recordLayoutComplete(reason);
+        recordPhaseDuration("layout-document", phaseStartedAt);
 
         // Step 4: Paint to DOM
         if (pagesContainerRef.current && painterRef.current) {
+          phaseStartedAt = performance.now();
           // Build block lookup
           const blockLookup: BlockLookup = new Map();
           for (let i = 0; i < newBlocks.length; i++) {
@@ -2049,32 +2341,19 @@ export function PagedEditor(
             renderOpts.footnotesByPage = footnotesByPage;
           }
           renderPages(newLayout.pages, pagesContainerRef.current, renderOpts);
+          recordPhaseDuration("render-pages", phaseStartedAt);
         }
-
-        // Compute anchor Y positions for comments sidebar (works without DOM queries).
-        // Runs on every layout pass, including incremental typing passes — gating on
-        // forceFull/dirtyRange left cards stuck at stale Y positions until the 200ms
-        // idle reconcile, so they drifted away from their anchor text while editing.
-        // The descendants walk visits every node, but the per-node work is gated by
-        // `isText` plus a comment/insertion/deletion mark check, so it stays cheap
-        // even on long documents; the layout pipeline is RAF-throttled on top of that.
-        // We pass the `state` arg (not the live view) so anchor positions are computed
-        // against the exact same doc snapshot used for `newLayout` / `newMeasures`.
-        if (onAnchorPositionsChange) {
-          const positions = computeAnchorPositions(
-            state,
-            newLayout,
-            newBlocks,
-            newMeasures,
-            pageGap,
-            {
-              includeRevisions: anchorPositionMode === "comments-and-revisions",
-            },
-          );
-          onAnchorPositionsChange(positions);
-        }
-      } catch {
-        // Keep the previous anchor positions if layout measurement fails.
+      } catch (error) {
+        const invalidHighlights = describeInvalidHighlightMarks(state.doc);
+        recordLayoutError(
+          reason,
+          invalidHighlights
+            ? new Error(
+                `${String(error)} Invalid highlights: ${invalidHighlights}`,
+              )
+            : error,
+        );
+        // Keep the previous visible layout if measurement or painting fails.
       }
 
       // Signal layout is complete for this sequence
@@ -2095,9 +2374,9 @@ export function PagedEditor(
       firstPageFooterContent,
       _theme,
       sectionProperties,
-      onAnchorPositionsChange,
-      anchorPositionMode,
       document,
+      defaultTabStop,
+      styles,
     ],
   );
   const runLayoutPipelineRef = useRef(runLayoutPipeline);
@@ -2108,16 +2387,11 @@ export function PagedEditor(
   // =========================================================================
 
   /**
-   * Ref holding a pending requestAnimationFrame ID and the latest state.
-   * Multiple rapid transactions (e.g. typing "hello") within the same frame
-   * are coalesced so only the final state triggers an interactive layout pass.
+   * Ref holding the latest pending transaction layout request. Rapid typing
+   * updates this request in place so only the final state in the short
+   * coalescing window triggers an interactive layout pass.
    */
-  const pendingLayoutRef = useRef<{
-    dirtyRange: DirtyRange | null;
-    rafId: number;
-    state: EditorState;
-  } | null>(null);
-  const idleLayoutTimerRef = useRef<number | null>(null);
+  const pendingLayoutRef = useRef<PendingLayoutRequest | null>(null);
   const documentChangeNotifyTimerRef = useRef<number | null>(null);
 
   const flushDocumentChangeNotification = useCallback(() => {
@@ -2143,71 +2417,95 @@ export function PagedEditor(
     }, DOCUMENT_CHANGE_NOTIFY_DELAY);
   }, [flushDocumentChangeNotification]);
 
-  const scheduleIdleFullLayout = useCallback(
-    (state: EditorState) => {
-      if (idleLayoutTimerRef.current !== null) {
-        window.clearTimeout(idleLayoutTimerRef.current);
+  const flushPendingLayout = useCallback(() => {
+    const pending = pendingLayoutRef.current;
+    if (!pending || pending.rafId !== null) {
+      return;
+    }
+
+    pending.timerId = null;
+    pending.rafId = requestAnimationFrame(() => {
+      const latest = pendingLayoutRef.current;
+      pendingLayoutRef.current = null;
+      if (!latest) {
+        return;
       }
-      idleLayoutTimerRef.current = window.setTimeout(() => {
-        idleLayoutTimerRef.current = null;
-        runLayoutPipeline(state, { forceFull: true });
-      }, 200);
+
+      const layoutOptions: {
+        dirtyRange?: DirtyRange;
+        forceFull?: boolean;
+        reason: LayoutRunReason;
+      } = { reason: "transaction" };
+      if (latest.dirtyRange) {
+        layoutOptions.dirtyRange = latest.dirtyRange;
+      }
+      runLayoutPipeline(latest.state, layoutOptions);
+    });
+  }, [runLayoutPipeline]);
+
+  const armPendingLayoutTimer = useCallback(
+    (pending: PendingLayoutRequest) => {
+      if (pending.rafId !== null) {
+        return;
+      }
+      if (pending.timerId !== null) {
+        window.clearTimeout(pending.timerId);
+      }
+
+      const elapsedMs = performance.now() - pending.firstScheduledAt;
+      const delayMs =
+        elapsedMs >= TRANSACTION_LAYOUT_MAX_DELAY_MS
+          ? 0
+          : Math.min(
+              TRANSACTION_LAYOUT_DEBOUNCE_MS,
+              TRANSACTION_LAYOUT_MAX_DELAY_MS - elapsedMs,
+            );
+
+      pending.timerId = window.setTimeout(flushPendingLayout, delayMs);
     },
-    [runLayoutPipeline],
+    [flushPendingLayout],
   );
 
   /**
-   * Schedule a layout pipeline run for the next animation frame.
-   * If a run is already scheduled, the pending state is replaced so only
-   * the most recent document state gets laid out. A full source-of-truth
-   * reconcile is scheduled after the interactive pass has been idle.
+   * Schedule a layout pipeline run after a short coalescing window.
+   * If more transactions arrive before the timer fires, the pending state
+   * is replaced so rapid typing paints once for the burst while still
+   * enforcing a max latency from the first edit.
    */
   const scheduleLayout = useCallback(
     (state: EditorState, dirtyRange: DirtyRange | null) => {
-      if (idleLayoutTimerRef.current !== null) {
-        window.clearTimeout(idleLayoutTimerRef.current);
-        idleLayoutTimerRef.current = null;
-      }
-
-      if (pendingLayoutRef.current) {
-        // Already scheduled — just update the state to the latest
-        pendingLayoutRef.current.state = state;
-        pendingLayoutRef.current.dirtyRange = mergeDirtyRanges(
-          pendingLayoutRef.current.dirtyRange,
-          dirtyRange,
-        );
+      const pending = pendingLayoutRef.current;
+      if (pending) {
+        pending.state = state;
+        pending.dirtyRange = mergeDirtyRanges(pending.dirtyRange, dirtyRange);
+        armPendingLayoutTimer(pending);
         return;
       }
-      const rafId = requestAnimationFrame(() => {
-        const pending = pendingLayoutRef.current;
-        pendingLayoutRef.current = null;
-        if (pending) {
-          const layoutOptions: {
-            dirtyRange?: DirtyRange;
-            forceFull?: boolean;
-          } = {};
-          if (pending.dirtyRange) {
-            layoutOptions.dirtyRange = pending.dirtyRange;
-          }
-          runLayoutPipeline(pending.state, layoutOptions);
-          scheduleIdleFullLayout(pending.state);
-        }
-      });
-      pendingLayoutRef.current = { dirtyRange, rafId, state };
+
+      const nextPending: PendingLayoutRequest = {
+        dirtyRange,
+        firstScheduledAt: performance.now(),
+        rafId: null,
+        state,
+        timerId: null,
+      };
+      pendingLayoutRef.current = nextPending;
+      armPendingLayoutTimer(nextPending);
     },
-    [runLayoutPipeline, scheduleIdleFullLayout],
+    [armPendingLayoutTimer],
   );
 
   // Clean up pending rAF on unmount
   useEffect(
     () => () => {
       if (pendingLayoutRef.current) {
-        cancelAnimationFrame(pendingLayoutRef.current.rafId);
+        if (pendingLayoutRef.current.timerId !== null) {
+          window.clearTimeout(pendingLayoutRef.current.timerId);
+        }
+        if (pendingLayoutRef.current.rafId !== null) {
+          cancelAnimationFrame(pendingLayoutRef.current.rafId);
+        }
         pendingLayoutRef.current = null;
-      }
-      if (idleLayoutTimerRef.current !== null) {
-        window.clearTimeout(idleLayoutTimerRef.current);
-        idleLayoutTimerRef.current = null;
       }
       if (documentChangeNotifyTimerRef.current !== null) {
         window.clearTimeout(documentChangeNotifyTimerRef.current);
@@ -2564,6 +2862,8 @@ export function PagedEditor(
     [layout, blocks, measures, getCaretFromDom, zoom],
     // NOTE: onSelectionChange removed from dependencies - accessed via ref to prevent infinite loops
   );
+  const updateSelectionOverlayRef = useRef(updateSelectionOverlay);
+  updateSelectionOverlayRef.current = updateSelectionOverlay;
 
   // Project anonymization match ranges onto container-space
   // rectangles. Mirrors the SelectionOverlay flow: prefer real
@@ -4538,11 +4838,41 @@ export function PagedEditor(
    */
   const handleEditorViewReady = useCallback(
     (view: EditorView) => {
-      runLayoutPipeline(view.state);
-      updateSelectionOverlay(view.state);
       anonymizationMatchesRef.current =
         anonymizationDecorationsKey.getState(view.state)?.matches ?? [];
-      updateAnonymizationOverlay();
+
+      const runInitialLayout = (currentView: EditorView) => {
+        runLayoutPipeline(currentView.state, { reason: "initial" });
+        updateSelectionOverlay(currentView.state);
+        updateAnonymizationOverlay();
+      };
+
+      pendingInitialFontReadyLayoutRef.current = true;
+      const fontWaitStartedAt = performance.now();
+      const runAfterFontWait = (fontsLoaded: boolean) => {
+        pendingInitialFontReadyLayoutRef.current = false;
+        const currentView = hiddenPMRef.current?.getView();
+        if (currentView !== view) {
+          return;
+        }
+        recordLayoutPhase(
+          "initial",
+          "initial-fonts",
+          performance.now() - fontWaitStartedAt,
+        );
+        resetCanvasContext();
+        clearAllCaches();
+        runInitialLayout(currentView);
+        if (fontsLoaded) {
+          lastLayoutUsedLoadedFontsRef.current = true;
+          suppressFontReadyUntilRef.current =
+            performance.now() + INITIAL_FONT_READY_SUPPRESSION_MS;
+        }
+      };
+      void waitForInitialLayoutFonts(document, view.state.doc).then(
+        runAfterFontWait,
+        () => runAfterFontWait(false),
+      );
 
       // Auto-focus the editor so the user can start typing immediately
       if (!readOnly) {
@@ -4557,6 +4887,7 @@ export function PagedEditor(
       runLayoutPipeline,
       updateSelectionOverlay,
       updateAnonymizationOverlay,
+      document,
       readOnly,
     ],
   );
@@ -4568,63 +4899,111 @@ export function PagedEditor(
     updateAnonymizationOverlay();
   }, [updateAnonymizationOverlay]);
 
+  // Compute anchor Y positions for comments/revisions sidebar from the current
+  // layout artifacts. Opening the sidebar or switching anchor modes does not
+  // change page geometry, so this intentionally avoids a full layout pass.
+  useEffect(() => {
+    if (!onAnchorPositionsChange || !layout) {
+      return;
+    }
+
+    try {
+      const positions = computeAnchorPositions(
+        hiddenPMRef.current?.getState() ?? null,
+        layout,
+        blocks,
+        measures,
+        pageGap,
+        {
+          includeRevisions: anchorPositionMode === "comments-and-revisions",
+        },
+      );
+      onAnchorPositionsChange(positions);
+    } catch {
+      // Keep the previous anchor positions if layout measurement fails.
+    }
+  }, [
+    anchorPositionMode,
+    blocks,
+    layout,
+    measures,
+    onAnchorPositionsChange,
+    pageGap,
+  ]);
+
   // Re-layout when web fonts finish loading to fix measurements that were
   // computed against fallback fonts during initial render.
   // Uses FontFaceSet.onloadingdone to detect when new fonts complete loading.
   useEffect(() => {
+    const fontSet = getDocumentFontSet();
+    if (!fontSet) {
+      return undefined;
+    }
+
+    const handleFontsLoading = () => {
+      if (performance.now() < suppressFontReadyUntilRef.current) {
+        return;
+      }
+      lastLayoutUsedLoadedFontsRef.current = false;
+    };
+
     const handleFontsLoaded = () => {
+      if (
+        pendingInitialFontReadyLayoutRef.current ||
+        performance.now() < suppressFontReadyUntilRef.current ||
+        lastLayoutUsedLoadedFontsRef.current
+      ) {
+        return;
+      }
+
       const view = hiddenPMRef.current?.getView();
       if (view) {
         // Clear all cached measurements — font metrics have changed
         resetCanvasContext();
         clearAllCaches();
-        runLayoutPipeline(view.state);
-        updateSelectionOverlay(view.state);
+        runLayoutPipelineRef.current(view.state, { reason: "font-ready" });
+        updateSelectionOverlayRef.current(view.state);
       }
     };
 
     // Listen for font loading completion events
-    window.document.fonts.addEventListener("loadingdone", handleFontsLoaded);
+    fontSet.addEventListener("loading", handleFontsLoading);
+    fontSet.addEventListener("loadingdone", handleFontsLoaded);
+    fontSet.addEventListener("loadingerror", handleFontsLoaded);
     return () => {
-      window.document.fonts.removeEventListener(
-        "loadingdone",
-        handleFontsLoaded,
-      );
+      fontSet.removeEventListener("loading", handleFontsLoading);
+      fontSet.removeEventListener("loadingdone", handleFontsLoaded);
+      fontSet.removeEventListener("loadingerror", handleFontsLoaded);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Re-layout when non-document layout inputs change (e.g., after HF editor save,
-  // parent-driven page setup/theme updates, or comment anchor mapping being wired
-  // when the sidebar opens after hidden edits).
+  // Re-layout when non-document layout inputs change (e.g., after HF editor save
+  // or parent-driven page setup/theme updates).
   // runLayoutPipeline includes these values in its deps, but it
   // only runs when explicitly called — this effect triggers it.
   const layoutInputEpochRef = useRef(0);
+  const lastLayoutInputSignatureRef = useRef<string | null>(null);
   useEffect(() => {
     // Skip the initial render — handleEditorViewReady already does the first layout
     if (layoutInputEpochRef.current === 0) {
       layoutInputEpochRef.current = 1;
+      lastLayoutInputSignatureRef.current = layoutInputSignature;
       return;
     }
     const view = hiddenPMRef.current?.getView();
     if (view) {
-      runLayoutPipelineRef.current(view.state);
+      const layoutInputsChanged =
+        lastLayoutInputSignatureRef.current !== layoutInputSignature;
+      lastLayoutInputSignatureRef.current = layoutInputSignature;
+      if (
+        !layoutInputsChanged &&
+        view.state.doc === lastLaidOutPmDocRef.current
+      ) {
+        return;
+      }
+      runLayoutPipelineRef.current(view.state, { reason: "layout-input" });
     }
-  }, [
-    headerContent,
-    footerContent,
-    firstPageHeaderContent,
-    firstPageFooterContent,
-    contentWidth,
-    columns,
-    pageSize,
-    margins,
-    pageGap,
-    sectionProperties,
-    _theme,
-    onAnchorPositionsChange,
-    anchorPositionMode,
-  ]);
+  }, [document, layoutInputSignature]);
 
   // Re-compute selection overlay when the container resizes.
   // Page elements shift during window resize (centering, scrollbar changes),
@@ -4697,7 +5076,7 @@ export function PagedEditor(
       relayout() {
         const state = hiddenPMRef.current?.getState();
         if (state) {
-          runLayoutPipeline(state);
+          runLayoutPipeline(state, { reason: "manual" });
         }
       },
       scrollToPosition: scrollToPositionImpl,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -24,6 +24,7 @@ import React, {
 } from "react";
 import type { CSSProperties, Ref } from "react";
 
+import type { Mark, Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction, Plugin } from "prosemirror-state";
 import type { CellSelection } from "prosemirror-tables";
@@ -124,6 +125,7 @@ import type {
   StyleDefinitions,
   SectionProperties,
   HeaderFooter,
+  TextFormatting,
 } from "../core/types/document";
 import {
   closestHtmlElement,
@@ -503,6 +505,13 @@ const LAYOUT_FONT_DESCRIPTORS = [
   { style: "normal", weight: 700 },
   { style: "italic", weight: 700 },
 ] as const;
+const REGULAR_LAYOUT_FONT_DESCRIPTOR = LAYOUT_FONT_DESCRIPTORS[0];
+
+export type LayoutFontFace = {
+  family: string;
+  style: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["style"];
+  weight: (typeof LAYOUT_FONT_DESCRIPTORS)[number]["weight"];
+};
 
 function waitForInitialLayoutFonts(
   documentModel: Document | null,
@@ -513,14 +522,11 @@ function waitForInitialLayoutFonts(
     return Promise.resolve(true);
   }
 
-  const families = collectInitialLayoutFontFamilies(documentModel, pmDoc);
   const loadChecks: string[] = [];
-  for (const family of families) {
-    for (const descriptor of LAYOUT_FONT_DESCRIPTORS) {
-      loadChecks.push(
-        `${descriptor.style} ${descriptor.weight} 16px "${escapeCssFontFamily(family)}"`,
-      );
-    }
+  for (const face of collectInitialLayoutFontFaces(documentModel, pmDoc)) {
+    loadChecks.push(
+      `${face.style} ${face.weight} 16px "${escapeCssFontFamily(face.family)}"`,
+    );
   }
 
   const loadFonts = Promise.allSettled(
@@ -540,45 +546,159 @@ export function collectInitialLayoutFontFamilies(
   documentModel: Document | null,
   pmDoc: EditorState["doc"],
 ): Set<string> {
-  const families = new Set<string>();
-  addLayoutFontFamily(families, DEFAULT_LAYOUT_FONT_FAMILY);
-
-  for (const family of documentModel?.requiredFonts ?? []) {
-    addLayoutFontFamily(families, family);
-  }
-
-  addLayoutFontFamily(
-    families,
-    documentModel?.package.theme?.fontScheme?.majorFont?.latin,
+  return new Set(
+    collectInitialLayoutFontFaces(documentModel, pmDoc).map(
+      ({ family }) => family,
+    ),
   );
-  addLayoutFontFamily(
-    families,
-    documentModel?.package.theme?.fontScheme?.minorFont?.latin,
-  );
-  addLayoutFontFamily(
-    families,
-    documentModel?.package.styles?.docDefaults?.rPr?.fontFamily,
-  );
-  for (const style of documentModel?.package.styles?.styles ?? []) {
-    addLayoutFontFamily(families, style.rPr?.fontFamily);
-  }
-
-  pmDoc.descendants((node) => {
-    addLayoutFontFamily(families, node.attrs["listMarkerFontFamily"]);
-    for (const mark of node.marks) {
-      if (mark.type.name === "fontFamily") {
-        addLayoutFontFamily(families, expectFontFamilyMarkAttrs(mark));
-      }
-    }
-    return true;
-  });
-
-  return families;
 }
 
-function addLayoutFontFamily(families: Set<string>, value: unknown): void {
+export function collectInitialLayoutFontFaces(
+  documentModel: Document | null,
+  pmDoc: EditorState["doc"],
+): LayoutFontFace[] {
+  const faces = new Map<string, LayoutFontFace>();
+  addLayoutFontFamilyFace(
+    faces,
+    DEFAULT_LAYOUT_FONT_FAMILY,
+    REGULAR_LAYOUT_FONT_DESCRIPTOR,
+  );
+
+  for (const family of documentModel?.requiredFonts ?? []) {
+    addLayoutFontFamilyFace(faces, family, REGULAR_LAYOUT_FONT_DESCRIPTOR);
+  }
+
+  addLayoutFontFamilyFace(
+    faces,
+    documentModel?.package.theme?.fontScheme?.majorFont?.latin,
+    REGULAR_LAYOUT_FONT_DESCRIPTOR,
+  );
+  addLayoutFontFamilyFace(
+    faces,
+    documentModel?.package.theme?.fontScheme?.minorFont?.latin,
+    REGULAR_LAYOUT_FONT_DESCRIPTOR,
+  );
+  addTextFormattingFontFaces(
+    faces,
+    documentModel?.package.styles?.docDefaults?.rPr,
+  );
+  for (const style of documentModel?.package.styles?.styles ?? []) {
+    addTextFormattingFontFaces(faces, style.rPr);
+  }
+
+  collectProseMirrorFontFaces(faces, pmDoc, undefined);
+
+  return Array.from(faces.values());
+}
+
+function addTextFormattingFontFaces(
+  faces: Map<string, LayoutFontFace>,
+  formatting: TextFormatting | undefined,
+): void {
+  addLayoutFontFamilyFace(
+    faces,
+    formatting?.fontFamily,
+    layoutDescriptorFromFormatting(formatting),
+  );
+}
+
+function collectProseMirrorFontFaces(
+  faces: Map<string, LayoutFontFace>,
+  node: PMNode,
+  inheritedTextFormatting: TextFormatting | undefined,
+): void {
+  const paragraphDefaults = readParagraphDefaultTextFormatting(node);
+  const textFormatting = paragraphDefaults ?? inheritedTextFormatting;
+  if (paragraphDefaults) {
+    addTextFormattingFontFaces(faces, paragraphDefaults);
+  }
+
+  if (node.attrs["listMarkerFontFamily"]) {
+    addLayoutFontFamilyFace(
+      faces,
+      node.attrs["listMarkerFontFamily"],
+      REGULAR_LAYOUT_FONT_DESCRIPTOR,
+    );
+  }
+
+  if (node.isText) {
+    const descriptor = layoutDescriptorFromFormattingAndMarks(
+      textFormatting,
+      node.marks,
+    );
+    const markFontFamily = readFontFamilyMarkAttrs(node.marks);
+    addLayoutFontFamilyFace(
+      faces,
+      markFontFamily ??
+        textFormatting?.fontFamily ??
+        DEFAULT_LAYOUT_FONT_FAMILY,
+      descriptor,
+    );
+  }
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child) => {
+    collectProseMirrorFontFaces(faces, child, textFormatting);
+  });
+}
+
+function readParagraphDefaultTextFormatting(
+  node: PMNode,
+): TextFormatting | undefined {
+  const value = node.attrs["defaultTextFormatting"];
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  return value as TextFormatting;
+}
+
+function readFontFamilyMarkAttrs(marks: readonly Mark[]): unknown {
+  for (const mark of marks) {
+    if (mark.type.name === "fontFamily") {
+      return expectFontFamilyMarkAttrs(mark);
+    }
+  }
+  return undefined;
+}
+
+function layoutDescriptorFromFormatting(
+  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
+): Omit<LayoutFontFace, "family"> {
+  return {
+    style: formatting?.italic ? "italic" : "normal",
+    weight: formatting?.bold ? 700 : 400,
+  };
+}
+
+function layoutDescriptorFromFormattingAndMarks(
+  formatting: Pick<TextFormatting, "bold" | "italic"> | undefined,
+  marks: readonly Mark[],
+): Omit<LayoutFontFace, "family"> {
+  let bold = formatting?.bold === true;
+  let italic = formatting?.italic === true;
+
+  for (const mark of marks) {
+    if (mark.type.name === "bold") {
+      bold = true;
+    }
+    if (mark.type.name === "italic") {
+      italic = true;
+    }
+  }
+
+  return {
+    style: italic ? "italic" : "normal",
+    weight: bold ? 700 : 400,
+  };
+}
+
+function addLayoutFontFamilyFace(
+  faces: Map<string, LayoutFontFace>,
+  value: unknown,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
   if (typeof value === "string") {
-    addLayoutFontFamilyName(families, value);
+    addLayoutFontFamilyNameFace(faces, value, descriptor);
     return;
   }
 
@@ -587,21 +707,36 @@ function addLayoutFontFamily(families: Set<string>, value: unknown): void {
   }
 
   const fontFamily = value as { ascii?: unknown; hAnsi?: unknown };
-  addLayoutFontFamily(families, fontFamily.ascii);
-  addLayoutFontFamily(families, fontFamily.hAnsi);
+  addLayoutFontFamilyFace(faces, fontFamily.ascii, descriptor);
+  addLayoutFontFamilyFace(faces, fontFamily.hAnsi, descriptor);
 }
 
-function addLayoutFontFamilyName(families: Set<string>, family: string): void {
+function addLayoutFontFamilyNameFace(
+  faces: Map<string, LayoutFontFace>,
+  family: string,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
   const normalized = family.trim();
   if (!normalized || CSS_GENERIC_FONT_FAMILIES.has(normalized)) {
     return;
   }
 
-  families.add(normalized);
+  addLayoutFontFace(faces, normalized, descriptor);
   const mappedFamily = OFFICE_FONT_FAMILY_MAP[normalized];
   if (mappedFamily) {
-    families.add(mappedFamily);
+    addLayoutFontFace(faces, mappedFamily, descriptor);
   }
+}
+
+function addLayoutFontFace(
+  faces: Map<string, LayoutFontFace>,
+  family: string,
+  descriptor: Omit<LayoutFontFace, "family">,
+): void {
+  faces.set(`${family}|${descriptor.style}|${descriptor.weight}`, {
+    family,
+    ...descriptor,
+  });
 }
 
 function escapeCssFontFamily(family: string): string {

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -58,14 +58,11 @@ import {
   setCachedParagraphMeasure,
 } from "../core/layout-bridge/measuring";
 import type { FloatingImageZone } from "../core/layout-bridge/measuring";
-import {
-  selectionToRects,
-  getCaretPosition,
-} from "../core/layout-bridge/selectionRects";
 import type {
   SelectionRect,
   CaretPosition,
 } from "../core/layout-bridge/selectionRects";
+import type * as SelectionGeometry from "../core/layout-bridge/selectionRects";
 // Layout bridge
 import { toFlowBlocks } from "../core/layout-bridge/toFlowBlocks";
 import type { ToFlowBlocksOptions } from "../core/layout-bridge/toFlowBlocks";
@@ -411,6 +408,20 @@ type RemoteSelectionOverlayProps = {
   pagesContainer: HTMLDivElement | null;
   remoteSelection: HiddenProseMirrorRemoteSelection;
   zoom: number;
+};
+
+type SelectionGeometryModule = typeof SelectionGeometry;
+
+let selectionGeometryPromise: Promise<SelectionGeometryModule> | null = null;
+
+const loadSelectionGeometry = (): Promise<SelectionGeometryModule> => {
+  selectionGeometryPromise ??=
+    import("../core/layout-bridge/selectionRects").catch((error: unknown) => {
+      selectionGeometryPromise = null;
+      throw error;
+    });
+
+  return selectionGeometryPromise;
 };
 
 type LayoutInputSignatureOptions = {
@@ -795,43 +806,91 @@ const RemoteSelectionOverlay = ({
   remoteSelection,
   zoom,
 }: RemoteSelectionOverlayProps) => {
-  if (!pagesContainer) {
-    return null;
-  }
+  const [geometry, setGeometry] = useState<{
+    caretPosition: CaretPosition | null;
+    selectionRects: SelectionRect[];
+  } | null>(null);
 
-  const offset = getPageOverlayOffset(pagesContainer, zoom);
-  if (!offset) {
-    return null;
-  }
+  useEffect(() => {
+    if (!pagesContainer) {
+      setGeometry(null);
+      return undefined;
+    }
 
-  const from = Math.min(remoteSelection.anchor, remoteSelection.head);
-  const to = Math.max(remoteSelection.anchor, remoteSelection.head);
-  const selectionRects = selectionToRects(
-    layout,
+    const offset = getPageOverlayOffset(pagesContainer, zoom);
+    if (!offset) {
+      setGeometry(null);
+      return undefined;
+    }
+
+    let cancelled = false;
+    void loadSelectionGeometry().then(
+      ({ getCaretPosition, selectionToRects }) => {
+        if (cancelled) {
+          return undefined;
+        }
+
+        const from = Math.min(remoteSelection.anchor, remoteSelection.head);
+        const to = Math.max(remoteSelection.anchor, remoteSelection.head);
+        const nextSelectionRects = selectionToRects(
+          layout,
+          blocks,
+          measures,
+          from,
+          to,
+        ).map((rect) => ({
+          height: rect.height,
+          pageIndex: rect.pageIndex,
+          width: rect.width,
+          x: rect.x + offset.x,
+          y: rect.y + offset.y,
+        }));
+        const caretBase = getCaretPosition(
+          layout,
+          blocks,
+          measures,
+          remoteSelection.head,
+        );
+        const caretPosition = caretBase
+          ? {
+              ...caretBase,
+              x: caretBase.x + offset.x,
+              y: caretBase.y + offset.y,
+            }
+          : null;
+
+        setGeometry({
+          caretPosition,
+          selectionRects: nextSelectionRects,
+        });
+        return undefined;
+      },
+      () => {
+        if (!cancelled) {
+          setGeometry(null);
+        }
+        return undefined;
+      },
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
     blocks,
-    measures,
-    from,
-    to,
-  ).map((rect) => ({
-    height: rect.height,
-    pageIndex: rect.pageIndex,
-    width: rect.width,
-    x: rect.x + offset.x,
-    y: rect.y + offset.y,
-  }));
-  const caretBase = getCaretPosition(
     layout,
-    blocks,
     measures,
+    pagesContainer,
+    remoteSelection.anchor,
     remoteSelection.head,
-  );
-  const caretPosition = caretBase
-    ? {
-        ...caretBase,
-        x: caretBase.x + offset.x,
-        y: caretBase.y + offset.y,
-      }
-    : null;
+    zoom,
+  ]);
+
+  if (!geometry) {
+    return null;
+  }
+
+  const { caretPosition, selectionRects } = geometry;
 
   return (
     <>
@@ -885,6 +944,7 @@ function computeAnchorPositions(
   measures: Measure[],
   _renderedPageGap: number,
   options: { includeRevisions: boolean },
+  getCaretPosition: SelectionGeometryModule["getCaretPosition"],
 ): Map<string, number> {
   const positions = new Map<string, number>();
   if (!state) {
@@ -1962,11 +2022,13 @@ export function PagedEditor(
   // doesn't depend on a state setter callback that would trigger
   // its own re-run.
   const anonymizationMatchesRef = useRef<readonly AnonymizationMatch[]>([]);
+  const anonymizationOverlayRequestSeqRef = useRef(0);
   const [remoteSelections, setRemoteSelections] = useState<
     HiddenProseMirrorRemoteSelection[]
   >([]);
   const suppressSelectionOverlayRef = useRef(false);
   const revealSelectionOverlayTimerRef = useRef<number | null>(null);
+  const selectionOverlayRequestSeqRef = useRef(0);
 
   // Image selection state
   const [selectedImageInfo, setSelectedImageInfo] =
@@ -2784,6 +2846,10 @@ export function PagedEditor(
   const updateSelectionOverlay = useCallback(
     (state: EditorState) => {
       const { from, to } = state.selection;
+      const requestSeq = selectionOverlayRequestSeqRef.current + 1;
+      selectionOverlayRequestSeqRef.current = requestSeq;
+      const isCurrentRequest = () =>
+        selectionOverlayRequestSeqRef.current === requestSeq;
 
       // Always notify selection change (for toolbar sync) even if layout not ready
       // Use ref to avoid infinite loops when callback is unstable
@@ -2871,17 +2937,32 @@ export function PagedEditor(
           if (overlay && firstPage) {
             const overlayRect = overlay.getBoundingClientRect();
             const pageRect = firstPage.getBoundingClientRect();
-            const caret = getCaretPosition(layout, blocks, measures, from);
+            setCaretPosition(null);
+            void loadSelectionGeometry().then(
+              ({ getCaretPosition }) => {
+                if (!isCurrentRequest()) {
+                  return undefined;
+                }
 
-            if (caret) {
-              setCaretPosition({
-                ...caret,
-                x: caret.x + (pageRect.left - overlayRect.left) / zoom,
-                y: caret.y + (pageRect.top - overlayRect.top) / zoom,
-              });
-            } else {
-              setCaretPosition(null);
-            }
+                const caret = getCaretPosition(layout, blocks, measures, from);
+                if (caret) {
+                  setCaretPosition({
+                    ...caret,
+                    x: caret.x + (pageRect.left - overlayRect.left) / zoom,
+                    y: caret.y + (pageRect.top - overlayRect.top) / zoom,
+                  });
+                } else {
+                  setCaretPosition(null);
+                }
+                return undefined;
+              },
+              () => {
+                if (isCurrentRequest()) {
+                  setCaretPosition(null);
+                }
+                return undefined;
+              },
+            );
           } else {
             setCaretPosition(null);
           }
@@ -2970,22 +3051,37 @@ export function PagedEditor(
               const pageRect = firstPage.getBoundingClientRect();
               const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
               const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
+              setSelectionRects([]);
+              void loadSelectionGeometry().then(
+                ({ selectionToRects }) => {
+                  if (!isCurrentRequest()) {
+                    return undefined;
+                  }
 
-              const rects = selectionToRects(
-                layout,
-                blocks,
-                measures,
-                from,
-                to,
+                  const rects = selectionToRects(
+                    layout,
+                    blocks,
+                    measures,
+                    from,
+                    to,
+                  );
+                  const adjustedRects = rects.map((rect) => ({
+                    height: rect.height,
+                    pageIndex: rect.pageIndex,
+                    width: rect.width,
+                    x: rect.x + pageOffsetX,
+                    y: rect.y + pageOffsetY,
+                  }));
+                  setSelectionRects(adjustedRects);
+                  return undefined;
+                },
+                () => {
+                  if (isCurrentRequest()) {
+                    setSelectionRects([]);
+                  }
+                  return undefined;
+                },
               );
-              const adjustedRects = rects.map((rect) => ({
-                height: rect.height,
-                pageIndex: rect.pageIndex,
-                width: rect.width,
-                x: rect.x + pageOffsetX,
-                y: rect.y + pageOffsetY,
-              }));
-              setSelectionRects(adjustedRects);
             } else {
               setSelectionRects([]);
             }
@@ -3011,6 +3107,10 @@ export function PagedEditor(
   // ProseMirror's spans are not used — they sit at -9999px and
   // would yield bogus coordinates.
   const updateAnonymizationOverlay = useCallback(() => {
+    const requestSeq = anonymizationOverlayRequestSeqRef.current + 1;
+    anonymizationOverlayRequestSeqRef.current = requestSeq;
+    const isCurrentRequest = () =>
+      anonymizationOverlayRequestSeqRef.current === requestSeq;
     const matches = anonymizationMatchesRef.current;
     if (matches.length === 0) {
       setAnonymizationRectGroups([]);
@@ -3034,8 +3134,10 @@ export function PagedEditor(
     const pageOffsetX = (pageRect.left - overlayRect.left) / zoom;
     const pageOffsetY = (pageRect.top - overlayRect.top) / zoom;
     const pmSpans = findBodyPmSpans(pagesContainer);
+    const layoutFallbackMatches: AnonymizationMatch[] = [];
 
     const rectsForMatch = (
+      match: AnonymizationMatch,
       from: number,
       to: number,
     ): AnonymizationRectGroup["rects"] => {
@@ -3096,20 +3198,13 @@ export function PagedEditor(
       if (!layout || blocks.length === 0) {
         return [];
       }
-      return selectionToRects(layout, blocks, measures, from, to).map(
-        (rect) => ({
-          height: rect.height,
-          pageIndex: rect.pageIndex,
-          width: rect.width,
-          x: rect.x + pageOffsetX,
-          y: rect.y + pageOffsetY,
-        }),
-      );
+      layoutFallbackMatches.push(match);
+      return [];
     };
 
     const groups: AnonymizationRectGroup[] = [];
     for (const match of matches) {
-      const rects = rectsForMatch(match.from, match.to);
+      const rects = rectsForMatch(match, match.from, match.to);
       if (rects.length > 0) {
         groups.push({
           rects,
@@ -3119,10 +3214,53 @@ export function PagedEditor(
       }
     }
     setAnonymizationRectGroups(groups);
+
+    if (layoutFallbackMatches.length === 0 || !layout || blocks.length === 0) {
+      return;
+    }
+
+    void loadSelectionGeometry().then(
+      ({ selectionToRects }) => {
+        if (!isCurrentRequest()) {
+          return undefined;
+        }
+
+        const fallbackGroups: AnonymizationRectGroup[] = [];
+        for (const match of layoutFallbackMatches) {
+          const rects = selectionToRects(
+            layout,
+            blocks,
+            measures,
+            match.from,
+            match.to,
+          ).map((rect) => ({
+            height: rect.height,
+            pageIndex: rect.pageIndex,
+            width: rect.width,
+            x: rect.x + pageOffsetX,
+            y: rect.y + pageOffsetY,
+          }));
+          if (rects.length > 0) {
+            fallbackGroups.push({
+              rects,
+              label: match.label,
+              canonical: match.canonical,
+            });
+          }
+        }
+
+        if (fallbackGroups.length > 0 && isCurrentRequest()) {
+          setAnonymizationRectGroups([...groups, ...fallbackGroups]);
+        }
+        return undefined;
+      },
+      () => undefined,
+    );
   }, [layout, blocks, measures, zoom]);
 
   const hideSelectionOverlayDuringInput = useCallback(
     (state: EditorState) => {
+      selectionOverlayRequestSeqRef.current += 1;
       suppressSelectionOverlayRef.current = true;
       setCaretPosition(null);
       setSelectionRects([]);
@@ -5041,24 +5179,40 @@ export function PagedEditor(
   // change page geometry, so this intentionally avoids a full layout pass.
   useEffect(() => {
     if (!onAnchorPositionsChange || !layout) {
-      return;
+      return undefined;
     }
 
-    try {
-      const positions = computeAnchorPositions(
-        lastLayoutEditorStateRef.current,
-        layout,
-        blocks,
-        measures,
-        pageGap,
-        {
-          includeRevisions: anchorPositionMode === "comments-and-revisions",
-        },
-      );
-      onAnchorPositionsChange(positions);
-    } catch {
-      // Keep the previous anchor positions if layout measurement fails.
-    }
+    let cancelled = false;
+    void loadSelectionGeometry().then(
+      ({ getCaretPosition }) => {
+        if (cancelled) {
+          return undefined;
+        }
+
+        try {
+          const positions = computeAnchorPositions(
+            lastLayoutEditorStateRef.current,
+            layout,
+            blocks,
+            measures,
+            pageGap,
+            {
+              includeRevisions: anchorPositionMode === "comments-and-revisions",
+            },
+            getCaretPosition,
+          );
+          onAnchorPositionsChange(positions);
+        } catch {
+          // Keep the previous anchor positions if layout measurement fails.
+        }
+        return undefined;
+      },
+      () => undefined,
+    );
+
+    return () => {
+      cancelled = true;
+    };
   }, [
     anchorPositionMode,
     blocks,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -1945,6 +1945,7 @@ export function PagedEditor(
     blockWidths: number[];
     measures: Measure[];
   } | null>(null);
+  const lastLayoutEditorStateRef = useRef<EditorState | null>(null);
   const lastLaidOutPmDocRef = useRef<EditorState["doc"] | null>(null);
   const lastLayoutUsedLoadedFontsRef = useRef(false);
   const pendingInitialFontReadyLayoutRef = useRef(false);
@@ -2404,6 +2405,7 @@ export function PagedEditor(
         }
 
         setLayout(newLayout);
+        lastLayoutEditorStateRef.current = state;
         lastLaidOutPmDocRef.current = state.doc;
         lastLayoutUsedLoadedFontsRef.current = documentFontsAreLoaded();
         recordLayoutComplete(reason);
@@ -5044,7 +5046,7 @@ export function PagedEditor(
 
     try {
       const positions = computeAnchorPositions(
-        hiddenPMRef.current?.getState() ?? null,
+        lastLayoutEditorStateRef.current,
         layout,
         blocks,
         measures,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -382,6 +382,7 @@ const DEFERRED_KEYDOWN_REPLAY_KEYS = new Set([
   "Home",
   "PageDown",
   "PageUp",
+  "Tab",
 ]);
 
 const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
@@ -391,8 +392,17 @@ const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
   !event.metaKey &&
   !event.nativeEvent.isComposing;
 
-const isReplayableDeferredKeyDown = (event: React.KeyboardEvent): boolean =>
-  !event.nativeEvent.isComposing && DEFERRED_KEYDOWN_REPLAY_KEYS.has(event.key);
+const isDeferredEditorKeyDown = (event: React.KeyboardEvent): boolean => {
+  if (event.nativeEvent.isComposing) {
+    return true;
+  }
+
+  if (DEFERRED_KEYDOWN_REPLAY_KEYS.has(event.key)) {
+    return true;
+  }
+
+  return isReadOnlyEditKey(event);
+};
 
 const toDeferredKeyboardEventInit = (
   event: React.KeyboardEvent,
@@ -403,6 +413,7 @@ const toDeferredKeyboardEventInit = (
   code: event.code,
   composed: true,
   ctrlKey: event.ctrlKey,
+  isComposing: event.nativeEvent.isComposing,
   key: event.key,
   location: event.location,
   metaKey: event.metaKey,
@@ -5259,7 +5270,7 @@ export function PagedEditor(
             return;
           }
 
-          if (isReplayableDeferredKeyDown(e)) {
+          if (isDeferredEditorKeyDown(e)) {
             e.preventDefault();
             replayDeferredKeyDown(view, toDeferredKeyboardEventInit(e));
             return;
@@ -5272,7 +5283,7 @@ export function PagedEditor(
           return;
         }
 
-        if (isReplayableDeferredKeyDown(e)) {
+        if (isDeferredEditorKeyDown(e)) {
           queueHiddenEditorKeyDown(e);
           e.preventDefault();
         }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2026,6 +2026,7 @@ export function PagedEditor(
     measures: Measure[];
   } | null>(null);
   const precomputedInitialStateRef = useRef<EditorState | null>(null);
+  const precomputedInitialDocumentRef = useRef<Document | null>(null);
   const preHiddenInitialLayoutDoneRef = useRef(false);
   const hiddenEditorViewTimerRef = useRef<number | null>(null);
   const pendingHiddenEditorSelectionRef =
@@ -2056,7 +2057,11 @@ export function PagedEditor(
   const revealSelectionOverlayTimerRef = useRef<number | null>(null);
   const selectionOverlayRequestSeqRef = useRef(0);
 
-  precomputedInitialStateRef.current = precomputedInitialState;
+  const validPrecomputedInitialState =
+    precomputedInitialDocumentRef.current === document
+      ? precomputedInitialState
+      : null;
+  precomputedInitialStateRef.current = validPrecomputedInitialState;
 
   // Image selection state
   const [selectedImageInfo, setSelectedImageInfo] =
@@ -5255,6 +5260,16 @@ export function PagedEditor(
 
   useEffect(() => {
     if (
+      !shouldCreateHiddenEditorView &&
+      preHiddenInitialLayoutDoneRef.current &&
+      precomputedInitialDocumentRef.current !== document
+    ) {
+      preHiddenInitialLayoutDoneRef.current = false;
+      precomputedInitialDocumentRef.current = null;
+      setPrecomputedInitialState(null);
+    }
+
+    if (
       shouldCreateHiddenEditorView ||
       collaboration !== undefined ||
       preHiddenInitialLayoutDoneRef.current
@@ -5276,6 +5291,7 @@ export function PagedEditor(
       null,
       "mount",
     );
+    precomputedInitialDocumentRef.current = document;
     setPrecomputedInitialState(initialState);
     anonymizationMatchesRef.current =
       anonymizationDecorationsKey.getState(initialState)?.matches ?? [];
@@ -5696,7 +5712,7 @@ export function PagedEditor(
         document={document}
         widthPx={contentWidth}
         deferViewCreation={!shouldCreateHiddenEditorView}
-        precomputedInitialState={precomputedInitialState}
+        precomputedInitialState={validPrecomputedInitialState}
         readOnly={readOnly}
         onTransaction={handleTransaction}
         onSelectionChange={handleSelectionChange}

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -23,6 +23,7 @@ import React, {
   useImperativeHandle,
 } from "react";
 import type { CSSProperties, Ref } from "react";
+import { flushSync } from "react-dom";
 
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
@@ -323,6 +324,14 @@ type PendingHiddenEditorSelection =
   | { type: "node"; pos: number }
   | { type: "text"; anchor: number; head?: number };
 
+type QueuedHiddenEditorInput =
+  | { type: "text"; text: string }
+  | { type: "keydown"; eventInit: KeyboardEventInit };
+
+type EnsureHiddenEditorViewOptions = {
+  sync?: boolean;
+};
+
 // =============================================================================
 // CONSTANTS
 // =============================================================================
@@ -361,12 +370,52 @@ const HIDDEN_EDITOR_VIEW_DEFER_MS = 275;
 // Stable empty array to avoid re-creating on each render
 const EMPTY_PLUGINS: Plugin[] = [];
 
+const DEFERRED_KEYDOWN_REPLAY_KEYS = new Set([
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "Backspace",
+  "Delete",
+  "End",
+  "Enter",
+  "Home",
+  "PageDown",
+  "PageUp",
+]);
+
 const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
   event.key.length === 1 &&
   !event.altKey &&
   !event.ctrlKey &&
   !event.metaKey &&
   !event.nativeEvent.isComposing;
+
+const isReplayableDeferredKeyDown = (event: React.KeyboardEvent): boolean =>
+  !event.nativeEvent.isComposing && DEFERRED_KEYDOWN_REPLAY_KEYS.has(event.key);
+
+const toDeferredKeyboardEventInit = (
+  event: React.KeyboardEvent,
+): KeyboardEventInit => ({
+  altKey: event.altKey,
+  bubbles: true,
+  cancelable: true,
+  code: event.code,
+  composed: true,
+  ctrlKey: event.ctrlKey,
+  key: event.key,
+  location: event.location,
+  metaKey: event.metaKey,
+  repeat: event.repeat,
+  shiftKey: event.shiftKey,
+});
+
+const replayDeferredKeyDown = (
+  view: EditorView,
+  eventInit: KeyboardEventInit,
+) => {
+  view.dom.dispatchEvent(new KeyboardEvent("keydown", eventInit));
+};
 
 /**
  * Get the zero-based page index for a node by climbing to its
@@ -2031,7 +2080,9 @@ export function PagedEditor(
   const hiddenEditorViewTimerRef = useRef<number | null>(null);
   const pendingHiddenEditorSelectionRef =
     useRef<PendingHiddenEditorSelection | null>(null);
-  const queuedTextBeforeHiddenEditorRef = useRef("");
+  const queuedInputBeforeHiddenEditorRef = useRef<QueuedHiddenEditorInput[]>(
+    [],
+  );
   const lastLayoutEditorStateRef = useRef<EditorState | null>(null);
   const lastLaidOutPmDocRef = useRef<EditorState["doc"] | null>(null);
   const lastLayoutUsedLoadedFontsRef = useRef(false);
@@ -2099,10 +2150,20 @@ export function PagedEditor(
     hiddenEditorViewTimerRef.current = null;
   }, []);
 
-  const ensureHiddenEditorView = useCallback(() => {
-    clearHiddenEditorViewTimer();
-    setShouldCreateHiddenEditorView(true);
-  }, [clearHiddenEditorViewTimer]);
+  const ensureHiddenEditorView = useCallback(
+    ({ sync = false }: EnsureHiddenEditorViewOptions = {}) => {
+      clearHiddenEditorViewTimer();
+      if (sync) {
+        flushSync(() => {
+          setShouldCreateHiddenEditorView(true);
+        });
+        return;
+      }
+
+      setShouldCreateHiddenEditorView(true);
+    },
+    [clearHiddenEditorViewTimer],
+  );
 
   const scheduleHiddenEditorViewCreation = useCallback(() => {
     if (
@@ -2125,6 +2186,24 @@ export function PagedEditor(
     },
     [ensureHiddenEditorView],
   );
+
+  const queueHiddenEditorTextInput = useCallback((text: string) => {
+    const queuedInput = queuedInputBeforeHiddenEditorRef.current;
+    const lastInput = queuedInput.at(-1);
+    if (lastInput?.type === "text") {
+      lastInput.text += text;
+      return;
+    }
+
+    queuedInput.push({ type: "text", text });
+  }, []);
+
+  const queueHiddenEditorKeyDown = useCallback((event: React.KeyboardEvent) => {
+    queuedInputBeforeHiddenEditorRef.current.push({
+      type: "keydown",
+      eventInit: toDeferredKeyboardEventInit(event),
+    });
+  }, []);
 
   const applyPendingHiddenEditorInput = useCallback((view: EditorView) => {
     const pendingSelection = pendingHiddenEditorSelectionRef.current;
@@ -2160,13 +2239,20 @@ export function PagedEditor(
       }
     }
 
-    const queuedText = queuedTextBeforeHiddenEditorRef.current;
-    if (!queuedText) {
+    const queuedInput = queuedInputBeforeHiddenEditorRef.current;
+    if (queuedInput.length === 0) {
       return;
     }
 
-    queuedTextBeforeHiddenEditorRef.current = "";
-    view.dispatch(view.state.tr.insertText(queuedText));
+    queuedInputBeforeHiddenEditorRef.current = [];
+    for (const input of queuedInput) {
+      if (input.type === "text") {
+        view.dispatch(view.state.tr.insertText(input.text));
+        continue;
+      }
+
+      replayDeferredKeyDown(view, input.eventInit);
+    }
   }, []);
 
   useEffect(
@@ -5160,11 +5246,34 @@ export function PagedEditor(
         return;
       }
 
-      const view = hiddenPMRef.current?.getView();
+      let view = hiddenPMRef.current?.getView();
       if (!view) {
-        ensureHiddenEditorView();
+        ensureHiddenEditorView({ sync: true });
+        view = hiddenPMRef.current?.getView();
+
+        if (view) {
+          applyPendingHiddenEditorInput(view);
+          if (isPlainTextInputEvent(e)) {
+            e.preventDefault();
+            view.dispatch(view.state.tr.insertText(e.key));
+            return;
+          }
+
+          if (isReplayableDeferredKeyDown(e)) {
+            e.preventDefault();
+            replayDeferredKeyDown(view, toDeferredKeyboardEventInit(e));
+            return;
+          }
+        }
+
         if (isPlainTextInputEvent(e)) {
-          queuedTextBeforeHiddenEditorRef.current += e.key;
+          queueHiddenEditorTextInput(e.key);
+          e.preventDefault();
+          return;
+        }
+
+        if (isReplayableDeferredKeyDown(e)) {
+          queueHiddenEditorKeyDown(e);
           e.preventDefault();
         }
         return;
@@ -5226,10 +5335,13 @@ export function PagedEditor(
     },
     [
       copySelectionText,
+      applyPendingHiddenEditorInput,
       ensureHiddenEditorView,
       focusHiddenEditor,
       getScrollContainer,
       onReadOnlyEditAttempt,
+      queueHiddenEditorKeyDown,
+      queueHiddenEditorTextInput,
       readOnly,
     ],
   );

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -364,8 +364,6 @@ const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
 const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
 /** Keep the visual caret hidden briefly while typed content relayouts. */
 const SELECTION_REVEAL_AFTER_INPUT_DELAY = 120;
-/** Defer the hidden EditorView until the first visible layout has painted. */
-const HIDDEN_EDITOR_VIEW_DEFER_MS = 275;
 
 // Stable empty array to avoid re-creating on each render
 const EMPTY_PLUGINS: Plugin[] = [];
@@ -2114,7 +2112,6 @@ export function PagedEditor(
   const precomputedInitialStateRef = useRef<EditorState | null>(null);
   const precomputedInitialDocumentRef = useRef<Document | null>(null);
   const preHiddenInitialLayoutDoneRef = useRef(false);
-  const hiddenEditorViewTimerRef = useRef<number | null>(null);
   const pendingHiddenEditorSelectionRef =
     useRef<PendingHiddenEditorSelection | null>(null);
   const queuedInputBeforeHiddenEditorRef = useRef<QueuedHiddenEditorInput[]>(
@@ -2179,17 +2176,8 @@ export function PagedEditor(
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
 
-  const clearHiddenEditorViewTimer = useCallback(() => {
-    if (hiddenEditorViewTimerRef.current === null) {
-      return;
-    }
-    window.clearTimeout(hiddenEditorViewTimerRef.current);
-    hiddenEditorViewTimerRef.current = null;
-  }, []);
-
   const ensureHiddenEditorView = useCallback(
     ({ sync = false }: EnsureHiddenEditorViewOptions = {}) => {
-      clearHiddenEditorViewTimer();
       if (sync) {
         flushSync(() => {
           setShouldCreateHiddenEditorView(true);
@@ -2199,22 +2187,8 @@ export function PagedEditor(
 
       setShouldCreateHiddenEditorView(true);
     },
-    [clearHiddenEditorViewTimer],
+    [],
   );
-
-  const scheduleHiddenEditorViewCreation = useCallback(() => {
-    if (
-      shouldCreateHiddenEditorView ||
-      hiddenEditorViewTimerRef.current !== null
-    ) {
-      return;
-    }
-
-    hiddenEditorViewTimerRef.current = window.setTimeout(() => {
-      hiddenEditorViewTimerRef.current = null;
-      setShouldCreateHiddenEditorView(true);
-    }, HIDDEN_EDITOR_VIEW_DEFER_MS);
-  }, [shouldCreateHiddenEditorView]);
 
   const queueHiddenEditorSelection = useCallback(
     (selection: PendingHiddenEditorSelection) => {
@@ -2291,11 +2265,6 @@ export function PagedEditor(
       replayDeferredKeyDown(view, input.eventInit);
     }
   }, []);
-
-  useEffect(
-    () => () => clearHiddenEditorViewTimer(),
-    [clearHiddenEditorViewTimer],
-  );
 
   useEffect(() => {
     if (collaboration !== undefined) {
@@ -5316,6 +5285,13 @@ export function PagedEditor(
         return;
       }
 
+      if (
+        pendingHiddenEditorSelectionRef.current ||
+        queuedInputBeforeHiddenEditorRef.current.length > 0
+      ) {
+        applyPendingHiddenEditorInput(view);
+      }
+
       // Ensure hidden PM is focused if user types
       if (!hiddenPMRef.current?.isFocused()) {
         focusHiddenEditor();
@@ -5470,7 +5446,6 @@ export function PagedEditor(
         suppressFontReadyUntilRef.current =
           performance.now() + INITIAL_FONT_READY_SUPPRESSION_MS;
       }
-      scheduleHiddenEditorViewCreation();
     };
 
     void waitForInitialLayoutFonts(document, initialState.doc).then(
@@ -5489,7 +5464,6 @@ export function PagedEditor(
     extensionManager,
     externalPlugins,
     runLayoutPipeline,
-    scheduleHiddenEditorViewCreation,
     shouldCreateHiddenEditorView,
     styles,
     updateAnonymizationOverlay,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -384,6 +384,16 @@ const DEFERRED_KEYDOWN_REPLAY_KEYS = new Set([
   "PageUp",
   "Tab",
 ]);
+const DEFERRED_MODIFIER_KEYDOWN_REPLAY_KEYS = new Set([
+  "a",
+  "b",
+  "i",
+  "u",
+  "v",
+  "x",
+  "y",
+  "z",
+]);
 
 const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
   event.key.length === 1 &&
@@ -392,13 +402,29 @@ const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
   !event.metaKey &&
   !event.nativeEvent.isComposing;
 
-const isDeferredEditorKeyDown = (event: React.KeyboardEvent): boolean => {
+type DeferredEditorKeyDownEvent = {
+  altKey: boolean;
+  ctrlKey: boolean;
+  key: string;
+  metaKey: boolean;
+  nativeEvent: {
+    isComposing: boolean;
+  };
+};
+
+export const isDeferredEditorKeyDown = (
+  event: DeferredEditorKeyDownEvent,
+): boolean => {
   if (event.nativeEvent.isComposing) {
     return true;
   }
 
   if (DEFERRED_KEYDOWN_REPLAY_KEYS.has(event.key)) {
     return true;
+  }
+
+  if (event.metaKey || event.ctrlKey) {
+    return DEFERRED_MODIFIER_KEYDOWN_REPLAY_KEYS.has(event.key.toLowerCase());
   }
 
   return isReadOnlyEditKey(event);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -136,7 +136,10 @@ import {
   computeFirstPageHeaderFooterMarginExtender,
   computeHeaderFooterMarginExtender,
 } from "./headerFooterMargins";
-import { HiddenProseMirror } from "./HiddenProseMirror";
+import {
+  createHiddenEditorState,
+  HiddenProseMirror,
+} from "./HiddenProseMirror";
 import type {
   HiddenProseMirrorCollaboration,
   HiddenProseMirrorRemoteSelection,
@@ -316,6 +319,10 @@ export type PagedEditorRef = {
   scrollToPage(pageNumber: number): void;
 };
 
+type PendingHiddenEditorSelection =
+  | { type: "node"; pos: number }
+  | { type: "text"; anchor: number; head?: number };
+
 // =============================================================================
 // CONSTANTS
 // =============================================================================
@@ -348,9 +355,18 @@ const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
 const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
 /** Keep the visual caret hidden briefly while typed content relayouts. */
 const SELECTION_REVEAL_AFTER_INPUT_DELAY = 120;
+/** Defer the hidden EditorView until the first visible layout has painted. */
+const HIDDEN_EDITOR_VIEW_DEFER_MS = 275;
 
 // Stable empty array to avoid re-creating on each render
 const EMPTY_PLUGINS: Plugin[] = [];
+
+const isPlainTextInputEvent = (event: React.KeyboardEvent): boolean =>
+  event.key.length === 1 &&
+  !event.altKey &&
+  !event.ctrlKey &&
+  !event.metaKey &&
+  !event.nativeEvent.isComposing;
 
 /**
  * Get the zero-based page index for a node by climbing to its
@@ -2000,11 +2016,21 @@ export function PagedEditor(
   const [layout, setLayout] = useState<Layout | null>(null);
   const [blocks, setBlocks] = useState<FlowBlock[]>([]);
   const [measures, setMeasures] = useState<Measure[]>([]);
+  const [shouldCreateHiddenEditorView, setShouldCreateHiddenEditorView] =
+    useState(() => collaboration !== undefined);
+  const [precomputedInitialState, setPrecomputedInitialState] =
+    useState<EditorState | null>(null);
   const layoutArtifactsRef = useRef<{
     blocks: FlowBlock[];
     blockWidths: number[];
     measures: Measure[];
   } | null>(null);
+  const precomputedInitialStateRef = useRef<EditorState | null>(null);
+  const preHiddenInitialLayoutDoneRef = useRef(false);
+  const hiddenEditorViewTimerRef = useRef<number | null>(null);
+  const pendingHiddenEditorSelectionRef =
+    useRef<PendingHiddenEditorSelection | null>(null);
+  const queuedTextBeforeHiddenEditorRef = useRef("");
   const lastLayoutEditorStateRef = useRef<EditorState | null>(null);
   const lastLaidOutPmDocRef = useRef<EditorState["doc"] | null>(null);
   const lastLayoutUsedLoadedFontsRef = useRef(false);
@@ -2029,6 +2055,8 @@ export function PagedEditor(
   const suppressSelectionOverlayRef = useRef(false);
   const revealSelectionOverlayTimerRef = useRef<number | null>(null);
   const selectionOverlayRequestSeqRef = useRef(0);
+
+  precomputedInitialStateRef.current = precomputedInitialState;
 
   // Image selection state
   const [selectedImageInfo, setSelectedImageInfo] =
@@ -2057,6 +2085,95 @@ export function PagedEditor(
   // Drag selection state
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
+
+  const clearHiddenEditorViewTimer = useCallback(() => {
+    if (hiddenEditorViewTimerRef.current === null) {
+      return;
+    }
+    window.clearTimeout(hiddenEditorViewTimerRef.current);
+    hiddenEditorViewTimerRef.current = null;
+  }, []);
+
+  const ensureHiddenEditorView = useCallback(() => {
+    clearHiddenEditorViewTimer();
+    setShouldCreateHiddenEditorView(true);
+  }, [clearHiddenEditorViewTimer]);
+
+  const scheduleHiddenEditorViewCreation = useCallback(() => {
+    if (
+      shouldCreateHiddenEditorView ||
+      hiddenEditorViewTimerRef.current !== null
+    ) {
+      return;
+    }
+
+    hiddenEditorViewTimerRef.current = window.setTimeout(() => {
+      hiddenEditorViewTimerRef.current = null;
+      setShouldCreateHiddenEditorView(true);
+    }, HIDDEN_EDITOR_VIEW_DEFER_MS);
+  }, [shouldCreateHiddenEditorView]);
+
+  const queueHiddenEditorSelection = useCallback(
+    (selection: PendingHiddenEditorSelection) => {
+      pendingHiddenEditorSelectionRef.current = selection;
+      ensureHiddenEditorView();
+    },
+    [ensureHiddenEditorView],
+  );
+
+  const applyPendingHiddenEditorInput = useCallback((view: EditorView) => {
+    const pendingSelection = pendingHiddenEditorSelectionRef.current;
+    pendingHiddenEditorSelectionRef.current = null;
+
+    if (pendingSelection?.type === "node") {
+      try {
+        view.dispatch(
+          view.state.tr.setSelection(
+            NodeSelection.create(view.state.doc, pendingSelection.pos),
+          ),
+        );
+      } catch {
+        // Fall through to queued text insertion at the current selection.
+      }
+    }
+
+    if (pendingSelection?.type === "text") {
+      const docEnd = view.state.doc.content.size;
+      const anchor = Math.max(0, Math.min(pendingSelection.anchor, docEnd));
+      const head =
+        pendingSelection.head === undefined
+          ? anchor
+          : Math.max(0, Math.min(pendingSelection.head, docEnd));
+      try {
+        const selection = TextSelection.between(
+          view.state.doc.resolve(anchor),
+          view.state.doc.resolve(head),
+        );
+        view.dispatch(view.state.tr.setSelection(selection));
+      } catch {
+        // Keep the default selection if the cached visual position went stale.
+      }
+    }
+
+    const queuedText = queuedTextBeforeHiddenEditorRef.current;
+    if (!queuedText) {
+      return;
+    }
+
+    queuedTextBeforeHiddenEditorRef.current = "";
+    view.dispatch(view.state.tr.insertText(queuedText));
+  }, []);
+
+  useEffect(
+    () => () => clearHiddenEditorViewTimer(),
+    [clearHiddenEditorViewTimer],
+  );
+
+  useEffect(() => {
+    if (collaboration !== undefined) {
+      ensureHiddenEditorView();
+    }
+  }, [collaboration, ensureHiddenEditorView]);
 
   // Column resize state
   const isResizingColumnRef = useRef(false);
@@ -3673,9 +3790,12 @@ export function PagedEditor(
       return;
     }
 
+    if (!hiddenPMRef.current?.getView()) {
+      ensureHiddenEditorView();
+    }
     hiddenPMRef.current?.focus();
     setIsFocused(true);
-  }, [readOnly]);
+  }, [ensureHiddenEditorView, readOnly]);
 
   const startPointerTextSelection = useCallback(
     (clientX: number, clientY: number) => {
@@ -3690,7 +3810,11 @@ export function PagedEditor(
 
         isDraggingRef.current = true;
         dragAnchorRef.current = pmPos;
-        hiddenPMRef.current?.setSelection(pmPos);
+        if (hiddenPMRef.current?.getView()) {
+          hiddenPMRef.current.setSelection(pmPos);
+        } else {
+          queueHiddenEditorSelection({ type: "text", anchor: pmPos });
+        }
       } else {
         cellDragAnchorPosRef.current = null;
         isCellDraggingRef.current = false;
@@ -3700,12 +3824,25 @@ export function PagedEditor(
           hiddenPMRef.current?.setSelection(endPos);
           dragAnchorRef.current = endPos;
           isDraggingRef.current = true;
+        } else {
+          const docEnd = Math.max(
+            0,
+            (precomputedInitialStateRef.current?.doc.content.size ?? 1) - 1,
+          );
+          queueHiddenEditorSelection({ type: "text", anchor: docEnd });
+          dragAnchorRef.current = docEnd;
+          isDraggingRef.current = true;
         }
       }
 
       focusHiddenEditor();
     },
-    [findCellPosFromPmPos, focusHiddenEditor, getPositionFromMouse],
+    [
+      findCellPosFromPmPos,
+      focusHiddenEditor,
+      getPositionFromMouse,
+      queueHiddenEditorSelection,
+    ],
   );
 
   const copySelectionText = useCallback(() => {
@@ -3959,7 +4096,11 @@ export function PagedEditor(
         const pmStart = imageEl.dataset["pmStart"];
         if (pmStart !== undefined) {
           const pos = Number.parseInt(pmStart, 10);
-          hiddenPMRef.current.setNodeSelection(pos);
+          if (hiddenPMRef.current.getView()) {
+            hiddenPMRef.current.setNodeSelection(pos);
+          } else {
+            queueHiddenEditorSelection({ type: "node", pos });
+          }
           setSelectedImageInfo(buildImageSelectionInfo(imageEl, pos));
           setSelectionRects([]);
           setCaretPosition(null);
@@ -3988,6 +4129,7 @@ export function PagedEditor(
       clearTableInsertTimer,
       focusHiddenEditor,
       startPointerTextSelection,
+      queueHiddenEditorSelection,
     ],
   );
 
@@ -5013,6 +5155,16 @@ export function PagedEditor(
         return;
       }
 
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        ensureHiddenEditorView();
+        if (isPlainTextInputEvent(e)) {
+          queuedTextBeforeHiddenEditorRef.current += e.key;
+          e.preventDefault();
+        }
+        return;
+      }
+
       // Ensure hidden PM is focused if user types
       if (!hiddenPMRef.current?.isFocused()) {
         focusHiddenEditor();
@@ -5028,27 +5180,19 @@ export function PagedEditor(
         !e.nativeEvent.isComposing
       ) {
         e.preventDefault();
-        const view = hiddenPMRef.current?.getView();
-        if (view) {
-          // Route through handleTextInput so plugins (suggestion mode) can intercept
-          const { from, to } = view.state.selection;
-          // ProseMirror's `someProp` is an internal API not exposed on
-          // EditorView's public type. The cast is the FFI boundary.
-          // oxlint-disable-next-line no-any-casts/no-any-casts, typescript/no-explicit-any
-          const handled = (view as any).someProp(
-            "handleTextInput",
-            (
-              f: (
-                v: EditorView,
-                fr: number,
-                t: number,
-                text: string,
-              ) => boolean,
-            ) => f(view, from, to, " "),
-          );
-          if (!handled) {
-            view.dispatch(view.state.tr.insertText(" "));
-          }
+        // Route through handleTextInput so plugins (suggestion mode) can intercept
+        const { from, to } = view.state.selection;
+        // ProseMirror's `someProp` is an internal API not exposed on
+        // EditorView's public type. The cast is the FFI boundary.
+        // oxlint-disable-next-line no-any-casts/no-any-casts, typescript/no-explicit-any
+        const handled = (view as any).someProp(
+          "handleTextInput",
+          (
+            f: (v: EditorView, fr: number, t: number, text: string) => boolean,
+          ) => f(view, from, to, " "),
+        );
+        if (!handled) {
+          view.dispatch(view.state.tr.insertText(" "));
         }
         return;
       }
@@ -5077,6 +5221,7 @@ export function PagedEditor(
     },
     [
       copySelectionText,
+      ensureHiddenEditorView,
       focusHiddenEditor,
       getScrollContainer,
       onReadOnlyEditAttempt,
@@ -5108,6 +5253,84 @@ export function PagedEditor(
   // Initial Layout
   // =========================================================================
 
+  useEffect(() => {
+    if (
+      shouldCreateHiddenEditorView ||
+      collaboration !== undefined ||
+      preHiddenInitialLayoutDoneRef.current
+    ) {
+      return undefined;
+    }
+
+    if (!document) {
+      ensureHiddenEditorView();
+      return undefined;
+    }
+
+    const initialState = createHiddenEditorState(
+      document,
+      styles,
+      extensionManager,
+      externalPlugins,
+      undefined,
+      null,
+      "mount",
+    );
+    setPrecomputedInitialState(initialState);
+    anonymizationMatchesRef.current =
+      anonymizationDecorationsKey.getState(initialState)?.matches ?? [];
+
+    let cancelled = false;
+    pendingInitialFontReadyLayoutRef.current = true;
+    const fontWaitStartedAt = performance.now();
+    const runAfterFontWait = (fontsLoaded: boolean) => {
+      if (cancelled) {
+        return;
+      }
+
+      pendingInitialFontReadyLayoutRef.current = false;
+      preHiddenInitialLayoutDoneRef.current = true;
+      recordLayoutPhase(
+        "initial",
+        "initial-fonts",
+        performance.now() - fontWaitStartedAt,
+      );
+      resetCanvasContext();
+      clearAllCaches();
+      runLayoutPipeline(initialState, { reason: "initial" });
+      updateSelectionOverlay(initialState);
+      updateAnonymizationOverlay();
+      if (fontsLoaded) {
+        lastLayoutUsedLoadedFontsRef.current = true;
+        suppressFontReadyUntilRef.current =
+          performance.now() + INITIAL_FONT_READY_SUPPRESSION_MS;
+      }
+      scheduleHiddenEditorViewCreation();
+    };
+
+    void waitForInitialLayoutFonts(document, initialState.doc).then(
+      runAfterFontWait,
+      () => runAfterFontWait(false),
+    );
+
+    return () => {
+      cancelled = true;
+      pendingInitialFontReadyLayoutRef.current = false;
+    };
+  }, [
+    collaboration,
+    document,
+    ensureHiddenEditorView,
+    extensionManager,
+    externalPlugins,
+    runLayoutPipeline,
+    scheduleHiddenEditorViewCreation,
+    shouldCreateHiddenEditorView,
+    styles,
+    updateAnonymizationOverlay,
+    updateSelectionOverlay,
+  ]);
+
   /**
    * Run initial layout when document or view changes.
    */
@@ -5115,6 +5338,23 @@ export function PagedEditor(
     (view: EditorView) => {
       anonymizationMatchesRef.current =
         anonymizationDecorationsKey.getState(view.state)?.matches ?? [];
+
+      const focusReadyView = () => {
+        if (!readOnly) {
+          requestAnimationFrame(() => {
+            applyPendingHiddenEditorInput(view);
+            view.focus();
+            setIsFocused(true);
+          });
+        }
+      };
+
+      if (lastLaidOutPmDocRef.current?.eq(view.state.doc)) {
+        updateSelectionOverlay(view.state);
+        updateAnonymizationOverlay();
+        focusReadyView();
+        return;
+      }
 
       const runInitialLayout = (currentView: EditorView) => {
         runLayoutPipeline(currentView.state, { reason: "initial" });
@@ -5150,15 +5390,10 @@ export function PagedEditor(
       );
 
       // Auto-focus the editor so the user can start typing immediately
-      if (!readOnly) {
-        // Use requestAnimationFrame to ensure DOM is ready
-        requestAnimationFrame(() => {
-          view.focus();
-          setIsFocused(true);
-        });
-      }
+      focusReadyView();
     },
     [
+      applyPendingHiddenEditorInput,
       runLayoutPipeline,
       updateSelectionOverlay,
       updateAnonymizationOverlay,
@@ -5460,6 +5695,8 @@ export function PagedEditor(
         ref={hiddenPMRef}
         document={document}
         widthPx={contentWidth}
+        deferViewCreation={!shouldCreateHiddenEditorView}
+        precomputedInitialState={precomputedInitialState}
         readOnly={readOnly}
         onTransaction={handleTransaction}
         onSelectionChange={handleSelectionChange}

--- a/packages/folio/src/paged-editor/deferredEditorKeyDown.test.ts
+++ b/packages/folio/src/paged-editor/deferredEditorKeyDown.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import { isDeferredEditorKeyDown } from "./PagedEditor";
+
+type KeyDownOptions = {
+  ctrlKey?: boolean;
+  isComposing?: boolean;
+  metaKey?: boolean;
+};
+
+const keyEvent = (key: string, options: KeyDownOptions = {}) => ({
+  altKey: false,
+  ctrlKey: options.ctrlKey === true,
+  key,
+  metaKey: options.metaKey === true,
+  nativeEvent: {
+    isComposing: options.isComposing === true,
+  },
+});
+
+describe("deferred editor keydown detection", () => {
+  test("replays edit and navigation keys while the hidden editor is deferred", () => {
+    expect(isDeferredEditorKeyDown(keyEvent("Backspace"))).toBe(true);
+    expect(isDeferredEditorKeyDown(keyEvent("Delete"))).toBe(true);
+    expect(isDeferredEditorKeyDown(keyEvent("Enter"))).toBe(true);
+    expect(isDeferredEditorKeyDown(keyEvent("ArrowLeft"))).toBe(true);
+    expect(isDeferredEditorKeyDown(keyEvent("Tab"))).toBe(true);
+  });
+
+  test("replays editor modifier shortcuts while the hidden editor is deferred", () => {
+    expect(isDeferredEditorKeyDown(keyEvent("a", { metaKey: true }))).toBe(
+      true,
+    );
+    expect(isDeferredEditorKeyDown(keyEvent("A", { ctrlKey: true }))).toBe(
+      true,
+    );
+    expect(isDeferredEditorKeyDown(keyEvent("z", { metaKey: true }))).toBe(
+      true,
+    );
+  });
+
+  test("does not claim unrelated browser modifier shortcuts", () => {
+    expect(isDeferredEditorKeyDown(keyEvent("p", { metaKey: true }))).toBe(
+      false,
+    );
+    expect(isDeferredEditorKeyDown(keyEvent("s", { ctrlKey: true }))).toBe(
+      false,
+    );
+  });
+
+  test("replays composition key events", () => {
+    expect(
+      isDeferredEditorKeyDown(keyEvent("Process", { isComposing: true })),
+    ).toBe(true);
+  });
+});

--- a/packages/folio/src/paged-editor/deferredEditorKeyDown.test.ts
+++ b/packages/folio/src/paged-editor/deferredEditorKeyDown.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
 
-import { isDeferredEditorKeyDown } from "./PagedEditor";
+import {
+  dispatchEditorTextInput,
+  isDeferredEditorKeyDown,
+} from "./PagedEditor";
 
 type KeyDownOptions = {
   ctrlKey?: boolean;
@@ -17,6 +23,64 @@ const keyEvent = (key: string, options: KeyDownOptions = {}) => ({
     isComposing: options.isComposing === true,
   },
 });
+
+type FakeTextInputHandler = (
+  view: FakeTextInputView,
+  from: number,
+  to: number,
+  text: string,
+  defaultTransaction: () => Transaction,
+) => unknown;
+
+type FakeTextInputView = {
+  dispatch(tr: Transaction): void;
+  someProp(
+    propName: "handleTextInput",
+    f: (handler: FakeTextInputHandler) => unknown,
+  ): unknown;
+  state: EditorState;
+};
+
+const schema = new Schema({
+  marks: {},
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: { content: "inline*", group: "block", toDOM: () => ["p", 0] },
+    text: { group: "inline" },
+  },
+});
+
+const createState = (text: string): EditorState => {
+  const doc = schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+
+  return EditorState.create({
+    doc,
+    selection: TextSelection.create(doc, text.length + 1),
+  });
+};
+
+const createFakeTextInputView = (
+  handler?: FakeTextInputHandler,
+): FakeTextInputView => {
+  const view: FakeTextInputView = {
+    dispatch(tr) {
+      view.state = view.state.apply(tr);
+    },
+    someProp(propName, f) {
+      expect(propName).toBe("handleTextInput");
+      if (!handler) {
+        return undefined;
+      }
+
+      return f(handler);
+    },
+    state: createState("Hi"),
+  };
+
+  return view;
+};
 
 describe("deferred editor keydown detection", () => {
   test("replays edit and navigation keys while the hidden editor is deferred", () => {
@@ -52,5 +116,38 @@ describe("deferred editor keydown detection", () => {
     expect(
       isDeferredEditorKeyDown(keyEvent("Process", { isComposing: true })),
     ).toBe(true);
+  });
+});
+
+describe("deferred editor text replay", () => {
+  test("routes text through handleTextInput hooks before dispatching fallback insertion", () => {
+    let fallbackText: string | null = null;
+    const view = createFakeTextInputView(
+      (handlerView, from, to, text, defaultTransaction) => {
+        expect(handlerView).toBe(view);
+        expect(from).toBe(3);
+        expect(to).toBe(3);
+        expect(text).toBe("x");
+
+        fallbackText = defaultTransaction().doc.textContent;
+        handlerView.dispatch(
+          handlerView.state.tr.insertText(`[${text}]`, from, to),
+        );
+        return true;
+      },
+    );
+
+    dispatchEditorTextInput(view, "x");
+
+    expect(fallbackText).toBe("Hix");
+    expect(view.state.doc.textContent).toBe("Hi[x]");
+  });
+
+  test("falls back to ProseMirror text insertion when no text hook handles input", () => {
+    const view = createFakeTextInputView();
+
+    dispatchEditorTextInput(view, "x");
+
+    expect(view.state.doc.textContent).toBe("Hix");
   });
 });

--- a/packages/folio/src/paged-editor/incrementalMeasure.test.ts
+++ b/packages/folio/src/paged-editor/incrementalMeasure.test.ts
@@ -66,6 +66,48 @@ describe("incremental paragraph measurement", () => {
     );
   });
 
+  test("matches full measurement after a localized paragraph edit shifts later positions", () => {
+    fc.assert(
+      fc.property(
+        fc.array(paragraphSpec, { minLength: 2, maxLength: 200 }),
+        fc.integer({ min: 0, max: 20_000 }),
+        fc.string({ minLength: 0, maxLength: 160 }),
+        (paragraphs, dirtyIndexSeed, replacementText) => {
+          const previousBlocks = makeParagraphBlocks(paragraphs);
+          const dirtyIndex = dirtyIndexSeed % paragraphs.length;
+          const nextParagraphs = paragraphs.map((paragraph, index) =>
+            index === dirtyIndex ? { text: replacementText } : paragraph,
+          );
+          const nextBlocks = makeParagraphBlocks(nextParagraphs);
+          const previousMeasures = previousBlocks.map(fakeMeasureBlock);
+          const fullNextMeasures = nextBlocks.map(fakeMeasureBlock);
+          const widths = Array.from({ length: nextBlocks.length }, () => 624);
+          const dirtyBlock = nextBlocks[dirtyIndex];
+          if (!dirtyBlock) {
+            return;
+          }
+
+          const result = tryBuildIncrementalMeasures({
+            previousBlocks,
+            previousMeasures,
+            previousBlockWidths: widths,
+            nextBlocks,
+            nextBlockWidths: widths,
+            dirtyRange: {
+              from: dirtyBlock.pmStart,
+              to: dirtyBlock.pmEnd,
+            },
+            measureBlock: fakeMeasureBlock,
+          });
+
+          expect(result?.measuredBlockIndexes).toEqual([dirtyIndex]);
+          expect(result?.measures).toEqual(fullNextMeasures);
+        },
+      ),
+      { numRuns: 1000 },
+    );
+  });
+
   test("coalesces arbitrary edit ranges without shrinking invalidation", () => {
     fc.assert(
       fc.property(

--- a/packages/folio/src/paged-editor/initialLayoutFonts.test.ts
+++ b/packages/folio/src/paged-editor/initialLayoutFonts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+
+import { toProseDoc } from "../core/prosemirror";
+import { createEmptyDocument } from "../core/utils/createDocument";
+import { collectInitialLayoutFontFamilies } from "./PagedEditor";
+
+describe("initial layout font loading", () => {
+  test("loads only document-driven font families plus metric-compatible fallbacks", () => {
+    const document = createEmptyDocument({ initialText: "Hello" });
+    const pmDoc = toProseDoc(document);
+
+    const families = collectInitialLayoutFontFamilies(document, pmDoc);
+
+    expect(families).toContain("Calibri");
+    expect(families).toContain("Carlito");
+    expect(families).toContain("Arial");
+    expect(families).toContain("Arimo");
+    expect(families).not.toContain("Cambria");
+    expect(families).not.toContain("Times New Roman");
+    expect(families).not.toContain("Courier New");
+  });
+});

--- a/packages/folio/src/paged-editor/initialLayoutFonts.test.ts
+++ b/packages/folio/src/paged-editor/initialLayoutFonts.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { toProseDoc } from "../core/prosemirror";
+import { schema } from "../core/prosemirror/schema";
 import { createEmptyDocument } from "../core/utils/createDocument";
-import { collectInitialLayoutFontFamilies } from "./PagedEditor";
+import {
+  collectInitialLayoutFontFaces,
+  collectInitialLayoutFontFamilies,
+} from "./PagedEditor";
 
 describe("initial layout font loading", () => {
   test("loads only document-driven font families plus metric-compatible fallbacks", () => {
@@ -19,4 +23,75 @@ describe("initial layout font loading", () => {
     expect(families).not.toContain("Times New Roman");
     expect(families).not.toContain("Courier New");
   });
+
+  test("does not load unused italic font faces for plain document text", () => {
+    const document = createEmptyDocument({ initialText: "Hello" });
+    const pmDoc = toProseDoc(document);
+
+    const faces = collectInitialLayoutFontFaces(document, pmDoc).map(
+      fontFaceKey,
+    );
+
+    expect(faces).toContain("Arial|normal|400");
+    expect(faces).toContain("Arimo|normal|400");
+    expect(faces).not.toContain("Arial|italic|400");
+    expect(faces).not.toContain("Arimo|italic|700");
+  });
+
+  test("loads only used bold and italic font faces", () => {
+    const bold = schema.marks["bold"]?.create();
+    const fontFamily = schema.marks["fontFamily"]?.create({
+      ascii: "Cambria",
+      hAnsi: "Cambria",
+    });
+    if (!bold || !fontFamily) {
+      throw new Error("Expected bold and fontFamily marks in schema");
+    }
+
+    const pmDoc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.text("Bold Cambria", [bold, fontFamily]),
+      ]),
+    ]);
+
+    const faces = collectInitialLayoutFontFaces(null, pmDoc).map(fontFaceKey);
+
+    expect(faces).toContain("Cambria|normal|700");
+    expect(faces).toContain("Caladea|normal|700");
+    expect(faces).not.toContain("Cambria|italic|400");
+    expect(faces).not.toContain("Cambria|italic|700");
+  });
+
+  test("combines inherited text formatting with explicit marks", () => {
+    const bold = schema.marks["bold"]?.create();
+    if (!bold) {
+      throw new Error("Expected bold mark in schema");
+    }
+
+    const pmDoc = schema.node("doc", null, [
+      schema.node(
+        "paragraph",
+        {
+          defaultTextFormatting: {
+            fontFamily: { ascii: "Cambria", hAnsi: "Cambria" },
+            italic: true,
+          },
+        },
+        [schema.text("Bold inherited italic", [bold])],
+      ),
+    ]);
+
+    const faces = collectInitialLayoutFontFaces(null, pmDoc).map(fontFaceKey);
+
+    expect(faces).toContain("Cambria|italic|700");
+    expect(faces).toContain("Caladea|italic|700");
+  });
 });
+
+function fontFaceKey(face: {
+  family: string;
+  style: string;
+  weight: number;
+}): string {
+  return `${face.family}|${face.style}|${face.weight}`;
+}

--- a/packages/folio/src/paged-editor/layoutInstrumentation.ts
+++ b/packages/folio/src/paged-editor/layoutInstrumentation.ts
@@ -17,7 +17,18 @@ export type LayoutPhase =
 
 export type HiddenEditorStateReason = "external-document" | "mount";
 
+export type HiddenEditorPhase =
+  | "editor-state"
+  | "editor-view"
+  | "to-prose-doc"
+  | "update-state";
+
 export type LayoutInstrumentation = {
+  onHiddenEditorPhase?: (event: {
+    durationMs: number;
+    phase: HiddenEditorPhase;
+    reason: HiddenEditorStateReason;
+  }) => void;
   onHiddenEditorStateCreate?: (event: {
     reason: HiddenEditorStateReason;
   }) => void;
@@ -78,6 +89,18 @@ export function recordHiddenEditorStateCreate(
   reason: HiddenEditorStateReason,
 ): void {
   globalThis.__folioLayoutInstrumentation?.onHiddenEditorStateCreate?.({
+    reason,
+  });
+}
+
+export function recordHiddenEditorPhase(
+  reason: HiddenEditorStateReason,
+  phase: HiddenEditorPhase,
+  durationMs: number,
+): void {
+  globalThis.__folioLayoutInstrumentation?.onHiddenEditorPhase?.({
+    durationMs,
+    phase,
     reason,
   });
 }

--- a/packages/folio/src/paged-editor/layoutInstrumentation.ts
+++ b/packages/folio/src/paged-editor/layoutInstrumentation.ts
@@ -1,7 +1,33 @@
 import type { FlowBlock } from "../core/layout-engine/types";
 
+export type LayoutRunReason =
+  | "font-ready"
+  | "initial"
+  | "layout-input"
+  | "manual"
+  | "transaction";
+
+export type LayoutPhase =
+  | "flow-blocks"
+  | "header-footer"
+  | "initial-fonts"
+  | "layout-document"
+  | "measure-blocks"
+  | "render-pages";
+
+export type HiddenEditorStateReason = "external-document" | "mount";
+
 export type LayoutInstrumentation = {
-  onLayoutComplete?: () => void;
+  onHiddenEditorStateCreate?: (event: {
+    reason: HiddenEditorStateReason;
+  }) => void;
+  onLayoutComplete?: (event: { reason: LayoutRunReason }) => void;
+  onLayoutError?: (event: { message: string; reason: LayoutRunReason }) => void;
+  onLayoutPhase?: (event: {
+    durationMs: number;
+    phase: LayoutPhase;
+    reason: LayoutRunReason;
+  }) => void;
   onMeasureBlock?: (event: {
     blockIndex: number;
     blockKind: FlowBlock["kind"];
@@ -21,6 +47,37 @@ export function recordMeasureBlock(blockIndex: number, block: FlowBlock): void {
   });
 }
 
-export function recordLayoutComplete(): void {
-  globalThis.__folioLayoutInstrumentation?.onLayoutComplete?.();
+export function recordLayoutComplete(reason: LayoutRunReason = "manual"): void {
+  globalThis.__folioLayoutInstrumentation?.onLayoutComplete?.({ reason });
+}
+
+export function recordLayoutError(
+  reason: LayoutRunReason,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  globalThis.__folioLayoutInstrumentation?.onLayoutError?.({
+    message,
+    reason,
+  });
+}
+
+export function recordLayoutPhase(
+  reason: LayoutRunReason,
+  phase: LayoutPhase,
+  durationMs: number,
+): void {
+  globalThis.__folioLayoutInstrumentation?.onLayoutPhase?.({
+    durationMs,
+    phase,
+    reason,
+  });
+}
+
+export function recordHiddenEditorStateCreate(
+  reason: HiddenEditorStateReason,
+): void {
+  globalThis.__folioLayoutInstrumentation?.onHiddenEditorStateCreate?.({
+    reason,
+  });
 }

--- a/packages/folio/tests/visual/editing-performance.spec.ts
+++ b/packages/folio/tests/visual/editing-performance.spec.ts
@@ -71,24 +71,11 @@ test("typing in a large document does not remeasure every block during the burst
   await page.evaluate(async () => {
     await document.fonts.ready;
   });
-  await page.waitForTimeout(250);
+  await page.waitForTimeout(650);
 
-  const hiddenHost = await readHiddenEditorHostInfo(page);
-  expect(hiddenHost.wrapperClass).toContain("paged-editor__hidden-pm-wrapper");
-  expect(hiddenHost.wrapperHeight).toBe("1px");
-  expect(hiddenHost.wrapperOverflow).toBe("hidden");
-  expect(hiddenHost.wrapperWidth).toBe("1px");
-  expect(hiddenHost.wrapperContain).toContain("layout");
-  expect(hiddenHost.wrapperContain).toContain("paint");
-  expect(hiddenHost.hostPosition).toBe("absolute");
-  expect(hiddenHost.hostAriaHidden).toBeNull();
-  expect(hiddenHost.pmRootAriaHidden).toBeNull();
-  expect(hiddenHost.pmRootAriaReadonly).toBe("false");
-  expect(hiddenHost.pmRootAutocapitalize).toBe("off");
-  expect(hiddenHost.pmRootAutocorrect).toBe("off");
-  expect(hiddenHost.pmRootRole).toBe("textbox");
-  expect(hiddenHost.pmRootSpellcheck).toBe("false");
-  expect(hiddenHost.pmRootTranslate).toBe("no");
+  await expect(
+    page.locator(".paged-editor__hidden-pm .ProseMirror"),
+  ).toHaveCount(0);
 
   const initialStats = await page.evaluate(
     () => globalThis.__folioLayoutMeasurementStats,
@@ -125,6 +112,23 @@ test("typing in a large document does not remeasure every block during the burst
   await page.keyboard.type(TYPING_TEXT, { delay: 20 });
   await page.waitForTimeout(75);
   const elapsedMs = performance.now() - startedAt;
+
+  const hiddenHost = await readHiddenEditorHostInfo(page);
+  expect(hiddenHost.wrapperClass).toContain("paged-editor__hidden-pm-wrapper");
+  expect(hiddenHost.wrapperHeight).toBe("1px");
+  expect(hiddenHost.wrapperOverflow).toBe("hidden");
+  expect(hiddenHost.wrapperWidth).toBe("1px");
+  expect(hiddenHost.wrapperContain).toContain("layout");
+  expect(hiddenHost.wrapperContain).toContain("paint");
+  expect(hiddenHost.hostPosition).toBe("absolute");
+  expect(hiddenHost.hostAriaHidden).toBeNull();
+  expect(hiddenHost.pmRootAriaHidden).toBeNull();
+  expect(hiddenHost.pmRootAriaReadonly).toBe("false");
+  expect(hiddenHost.pmRootAutocapitalize).toBe("off");
+  expect(hiddenHost.pmRootAutocorrect).toBe("off");
+  expect(hiddenHost.pmRootRole).toBe("textbox");
+  expect(hiddenHost.pmRootSpellcheck).toBe("false");
+  expect(hiddenHost.pmRootTranslate).toBe("no");
 
   const stats = await page.evaluate(
     () => globalThis.__folioLayoutMeasurementStats,

--- a/packages/folio/tests/visual/editing-performance.spec.ts
+++ b/packages/folio/tests/visual/editing-performance.spec.ts
@@ -2,14 +2,25 @@ import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
 import type { Layout } from "../../src/core/layout-engine/types";
-import type { LayoutInstrumentation } from "../../src/paged-editor/layoutInstrumentation";
+import type {
+  HiddenEditorStateReason,
+  LayoutInstrumentation,
+} from "../../src/paged-editor/layoutInstrumentation";
 
 const PARAGRAPH_COUNT = 1500;
 const TYPING_TEXT = "abc";
+const INITIAL_LOAD_MEASURE_BLOCK_BUDGET = PARAGRAPH_COUNT + 10;
+const DEMO_INITIAL_MEASURE_BLOCK_BUDGET = 60;
+const INITIAL_RENDERED_PAGE_BUDGET = 4;
+const BURST_LAYOUT_COMPLETION_BUDGET = 2;
 const BURST_MEASURE_BLOCK_BUDGET = 50;
+const IDLE_MEASURE_BLOCK_BUDGET = 50;
 
 type LayoutMeasurementStats = {
+  hiddenStateCreations: Record<HiddenEditorStateReason, number>;
+  hiddenStateReasons: string[];
   layoutCompletions: number;
+  layoutReasons: string[];
   measureBlockCalls: number;
 };
 
@@ -50,26 +61,139 @@ declare global {
 test("typing in a large document does not remeasure every block during the burst", async ({
   page,
 }) => {
-  await page.addInitScript(() => {
-    globalThis.__folioLayoutMeasurementStats = {
-      layoutCompletions: 0,
-      measureBlockCalls: 0,
-    };
-    globalThis.__folioLayoutInstrumentation = {
-      onLayoutComplete() {
-        const stats = globalThis.__folioLayoutMeasurementStats;
-        if (stats) {
-          stats.layoutCompletions += 1;
-        }
-      },
-      onMeasureBlock() {
-        const stats = globalThis.__folioLayoutMeasurementStats;
-        if (stats) {
-          stats.measureBlockCalls += 1;
-        }
-      },
-    };
+  await installLayoutMeasurement(page);
+
+  await page.goto(`/?paragraphs=${PARAGRAPH_COUNT}`);
+  await page.waitForSelector('[data-testid="folio-editor"]');
+  await page.waitForFunction(
+    () => document.querySelectorAll(".layout-page").length >= 20,
+  );
+  await page.evaluate(async () => {
+    await document.fonts.ready;
   });
+  await page.waitForTimeout(250);
+
+  const hiddenHost = await readHiddenEditorHostInfo(page);
+  expect(hiddenHost.wrapperClass).toContain("paged-editor__hidden-pm-wrapper");
+  expect(hiddenHost.wrapperHeight).toBe("1px");
+  expect(hiddenHost.wrapperOverflow).toBe("hidden");
+  expect(hiddenHost.wrapperWidth).toBe("1px");
+  expect(hiddenHost.wrapperContain).toContain("layout");
+  expect(hiddenHost.wrapperContain).toContain("paint");
+  expect(hiddenHost.hostPosition).toBe("absolute");
+  expect(hiddenHost.hostAriaHidden).toBeNull();
+  expect(hiddenHost.pmRootAriaHidden).toBeNull();
+  expect(hiddenHost.pmRootAriaReadonly).toBe("false");
+  expect(hiddenHost.pmRootAutocapitalize).toBe("off");
+  expect(hiddenHost.pmRootAutocorrect).toBe("off");
+  expect(hiddenHost.pmRootRole).toBe("textbox");
+  expect(hiddenHost.pmRootSpellcheck).toBe("false");
+  expect(hiddenHost.pmRootTranslate).toBe("no");
+
+  const initialStats = await page.evaluate(
+    () => globalThis.__folioLayoutMeasurementStats,
+  );
+  console.info("folio initial layout diagnostic", {
+    hiddenStateCreations: initialStats?.hiddenStateCreations,
+    hiddenStateReasons: initialStats?.hiddenStateReasons,
+    initialMeasureBlockCalls: initialStats?.measureBlockCalls,
+    initialReasons: initialStats?.layoutReasons,
+    paragraphCount: PARAGRAPH_COUNT,
+  });
+  expect(initialStats?.measureBlockCalls).toBeLessThanOrEqual(
+    INITIAL_LOAD_MEASURE_BLOCK_BUDGET,
+  );
+  expect(totalHiddenStateCreations(initialStats)).toBe(1);
+
+  await page.evaluate(() => {
+    const stats = globalThis.__folioLayoutMeasurementStats;
+    if (stats) {
+      stats.hiddenStateCreations = { "external-document": 0, mount: 0 };
+      stats.hiddenStateReasons = [];
+      stats.layoutCompletions = 0;
+      stats.layoutReasons = [];
+      stats.measureBlockCalls = 0;
+    }
+  });
+
+  const startedAt = performance.now();
+  const downstreamPmStartBefore = await readFirstPmStartOnRenderedPage(page, 1);
+  await page
+    .locator(".layout-page")
+    .first()
+    .click({ position: { x: 120, y: 120 } });
+  await page.keyboard.type(TYPING_TEXT, { delay: 20 });
+  await page.waitForTimeout(75);
+  const elapsedMs = performance.now() - startedAt;
+
+  const stats = await page.evaluate(
+    () => globalThis.__folioLayoutMeasurementStats,
+  );
+  const downstreamPmStartAfter = await readFirstPmStartOnRenderedPage(page, 1);
+
+  console.info("folio typing burst layout diagnostic", {
+    downstreamPmShift: downstreamPmStartAfter - downstreamPmStartBefore,
+    elapsedMs: Number(elapsedMs.toFixed(3)),
+    hiddenStateCreations: initialStats?.hiddenStateCreations,
+    hiddenStateReasons: initialStats?.hiddenStateReasons,
+    initialMeasureBlockCalls: initialStats?.measureBlockCalls,
+    initialReasons: initialStats?.layoutReasons,
+    layoutCompletions: stats?.layoutCompletions,
+    layoutReasons: stats?.layoutReasons,
+    measureBlockCalls: stats?.measureBlockCalls,
+    paragraphCount: PARAGRAPH_COUNT,
+    typedCharacters: TYPING_TEXT.length,
+  });
+
+  expect(stats?.layoutCompletions).toBeGreaterThan(0);
+  expect(stats?.layoutCompletions).toBeLessThanOrEqual(
+    BURST_LAYOUT_COMPLETION_BUDGET,
+  );
+  expect(stats?.measureBlockCalls).toBeLessThanOrEqual(
+    BURST_MEASURE_BLOCK_BUDGET,
+  );
+  expect(downstreamPmStartAfter).toBe(
+    downstreamPmStartBefore + TYPING_TEXT.length,
+  );
+});
+
+test("fixture initial load does not perform duplicate font-ready relayout", async ({
+  page,
+}) => {
+  await installLayoutMeasurement(page);
+
+  await page.goto("/?file=docx-editor-demo.docx");
+  await page.waitForSelector('[data-testid="folio-editor"]');
+  await page.waitForFunction(
+    () => document.querySelectorAll(".layout-page").length >= 3,
+  );
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await page.waitForTimeout(300);
+
+  const stats = await page.evaluate(
+    () => globalThis.__folioLayoutMeasurementStats,
+  );
+  const fontReadyLayouts =
+    stats?.layoutReasons.filter((reason) => reason === "font-ready") ?? [];
+  console.info("folio fixture initial layout diagnostic", {
+    layoutCompletions: stats?.layoutCompletions,
+    layoutReasons: stats?.layoutReasons,
+    measureBlockCalls: stats?.measureBlockCalls,
+  });
+
+  expect(stats?.layoutCompletions).toBe(1);
+  expect(fontReadyLayouts).toHaveLength(0);
+  expect(stats?.measureBlockCalls).toBeLessThanOrEqual(
+    DEMO_INITIAL_MEASURE_BLOCK_BUDGET,
+  );
+});
+
+test("incremental layout after editing stays stable and matches a fresh full relayout", async ({
+  page,
+}) => {
+  await installLayoutMeasurement(page);
 
   await page.goto(`/?paragraphs=${PARAGRAPH_COUNT}`);
   await page.waitForSelector('[data-testid="folio-editor"]');
@@ -84,68 +208,13 @@ test("typing in a large document does not remeasure every block during the burst
   await page.evaluate(() => {
     const stats = globalThis.__folioLayoutMeasurementStats;
     if (stats) {
+      stats.hiddenStateCreations = { "external-document": 0, mount: 0 };
+      stats.hiddenStateReasons = [];
+      stats.layoutCompletions = 0;
+      stats.layoutReasons = [];
       stats.measureBlockCalls = 0;
     }
   });
-
-  const startedAt = performance.now();
-  await page
-    .locator(".layout-page")
-    .first()
-    .click({ position: { x: 120, y: 120 } });
-  await page.keyboard.type(TYPING_TEXT, { delay: 20 });
-  await page.waitForTimeout(75);
-  const elapsedMs = performance.now() - startedAt;
-
-  const stats = await page.evaluate(
-    () => globalThis.__folioLayoutMeasurementStats,
-  );
-
-  console.info("folio typing burst layout diagnostic", {
-    elapsedMs: Number(elapsedMs.toFixed(3)),
-    measureBlockCalls: stats?.measureBlockCalls,
-    paragraphCount: PARAGRAPH_COUNT,
-    typedCharacters: TYPING_TEXT.length,
-  });
-
-  expect(stats?.measureBlockCalls).toBeLessThanOrEqual(
-    BURST_MEASURE_BLOCK_BUDGET,
-  );
-});
-
-test("idle layout after editing matches a fresh full relayout", async ({
-  page,
-}) => {
-  await page.addInitScript(() => {
-    globalThis.__folioLayoutMeasurementStats = {
-      layoutCompletions: 0,
-      measureBlockCalls: 0,
-    };
-    globalThis.__folioLayoutInstrumentation = {
-      onLayoutComplete() {
-        const stats = globalThis.__folioLayoutMeasurementStats;
-        if (stats) {
-          stats.layoutCompletions += 1;
-        }
-      },
-      onMeasureBlock() {
-        const stats = globalThis.__folioLayoutMeasurementStats;
-        if (stats) {
-          stats.measureBlockCalls += 1;
-        }
-      },
-    };
-  });
-
-  await page.goto(`/?paragraphs=${PARAGRAPH_COUNT}`);
-  await page.waitForSelector('[data-testid="folio-editor"]');
-  await page.waitForFunction(
-    () => document.querySelectorAll(".layout-page").length >= 20,
-  );
-  await page.evaluate(async () => {
-    await document.fonts.ready;
-  });
-  await page.waitForTimeout(250);
 
   await page
     .locator(".layout-page")
@@ -153,6 +222,13 @@ test("idle layout after editing matches a fresh full relayout", async ({
     .click({ position: { x: 120, y: 120 } });
   await page.keyboard.type(TYPING_TEXT, { delay: 20 });
   await page.waitForTimeout(300);
+
+  const idleStats = await page.evaluate(
+    () => globalThis.__folioLayoutMeasurementStats,
+  );
+  expect(idleStats?.measureBlockCalls).toBeLessThanOrEqual(
+    IDLE_MEASURE_BLOCK_BUDGET,
+  );
 
   const idleSnapshot = await readLayoutSnapshot(page);
   const layoutCompletionsBeforeRelayout = await page.evaluate(
@@ -173,6 +249,77 @@ test("idle layout after editing matches a fresh full relayout", async ({
 
   expect(idleSnapshot).toEqual(fullRelayoutSnapshot);
 });
+
+test("virtualized long documents render later pages on scroll", async ({
+  page,
+}) => {
+  await page.goto(`/?paragraphs=${PARAGRAPH_COUNT}`);
+  await page.waitForSelector('[data-testid="folio-editor"]');
+  await page.waitForFunction(
+    () => document.querySelectorAll(".layout-page").length >= 20,
+  );
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await page.waitForTimeout(250);
+
+  const initialRenderedPages = await page
+    .locator(".layout-page-content")
+    .count();
+  expect(initialRenderedPages).toBeLessThanOrEqual(
+    INITIAL_RENDERED_PAGE_BUDGET,
+  );
+
+  const targetPage = page.locator('.layout-page[data-page-index="20"]');
+  await targetPage.scrollIntoViewIfNeeded();
+  await expect(targetPage.locator(".layout-page-content")).toHaveCount(1);
+});
+
+async function installLayoutMeasurement(browserPage: Page): Promise<void> {
+  await browserPage.addInitScript(() => {
+    globalThis.__folioLayoutMeasurementStats = {
+      hiddenStateCreations: { "external-document": 0, mount: 0 },
+      hiddenStateReasons: [],
+      layoutCompletions: 0,
+      layoutReasons: [],
+      measureBlockCalls: 0,
+    };
+    globalThis.__folioLayoutInstrumentation = {
+      onHiddenEditorStateCreate(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.hiddenStateCreations[event.reason] += 1;
+          stats.hiddenStateReasons.push(event.reason);
+        }
+      },
+      onLayoutComplete(event) {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.layoutCompletions += 1;
+          stats.layoutReasons.push(event.reason);
+        }
+      },
+      onMeasureBlock() {
+        const stats = globalThis.__folioLayoutMeasurementStats;
+        if (stats) {
+          stats.measureBlockCalls += 1;
+        }
+      },
+    };
+  });
+}
+
+function totalHiddenStateCreations(
+  stats: LayoutMeasurementStats | undefined,
+): number {
+  if (!stats) {
+    return 0;
+  }
+  return (
+    stats.hiddenStateCreations.mount +
+    stats.hiddenStateCreations["external-document"]
+  );
+}
 
 async function readLayoutSnapshot(browserPage: Page) {
   return browserPage.evaluate((): LayoutSnapshot => {
@@ -205,6 +352,54 @@ async function readLayoutSnapshot(browserPage: Page) {
         })),
         number: layoutPage.number,
       })),
+    };
+  });
+}
+
+async function readFirstPmStartOnRenderedPage(
+  browserPage: Page,
+  pageIndex: number,
+): Promise<number> {
+  const value = await browserPage
+    .locator(`.layout-page[data-page-index="${pageIndex}"] [data-pm-start]`)
+    .first()
+    .getAttribute("data-pm-start");
+
+  if (value === null) {
+    throw new Error(`Expected page ${pageIndex} to expose PM position data`);
+  }
+
+  return Number(value);
+}
+
+async function readHiddenEditorHostInfo(browserPage: Page) {
+  return browserPage.evaluate(() => {
+    const host = document.querySelector<HTMLElement>(
+      ".paged-editor__hidden-pm",
+    );
+    const wrapper = host?.parentElement;
+    const pmRoot = host?.querySelector<HTMLElement>(".ProseMirror");
+    if (!host || !wrapper || !pmRoot) {
+      throw new Error("Expected hidden ProseMirror host to be mounted");
+    }
+
+    const wrapperStyle = getComputedStyle(wrapper);
+    const hostStyle = getComputedStyle(host);
+    return {
+      hostAriaHidden: host.getAttribute("aria-hidden"),
+      hostPosition: hostStyle.position,
+      pmRootAriaHidden: pmRoot.getAttribute("aria-hidden"),
+      pmRootAriaReadonly: pmRoot.getAttribute("aria-readonly"),
+      pmRootAutocapitalize: pmRoot.getAttribute("autocapitalize"),
+      pmRootAutocorrect: pmRoot.getAttribute("autocorrect"),
+      pmRootRole: pmRoot.getAttribute("role"),
+      pmRootSpellcheck: pmRoot.getAttribute("spellcheck"),
+      pmRootTranslate: pmRoot.getAttribute("translate"),
+      wrapperClass: wrapper.className,
+      wrapperContain: wrapperStyle.contain,
+      wrapperHeight: wrapperStyle.height,
+      wrapperOverflow: wrapperStyle.overflow,
+      wrapperWidth: wrapperStyle.width,
     };
   });
 }

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, lazy, useState } from "react";
 import type * as React from "react";
 
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 
-import { HexColorPicker } from "@stll/ui/components/hex-color-picker";
 import { cn } from "@stll/ui/lib/utils";
+
+const HexColorPicker = lazy(async () => {
+  const m = await import("@stll/ui/components/hex-color-picker");
+  return { default: m.HexColorPicker };
+});
 
 // ---------------------------------------------------------------------------
 // Types
@@ -245,11 +249,20 @@ function ColorPickerContent({
         </button>
       ) : (
         <div className="border-border flex flex-col gap-2 border-t pt-2">
-          <HexColorPicker
-            className="ring-border/30 !h-[140px] !w-full overflow-hidden rounded-lg ring-1"
-            color={pickerHex}
-            onChange={(hex) => handlePickerChange(hex.replace("#", ""))}
-          />
+          <Suspense
+            fallback={
+              <div
+                aria-hidden
+                className="ring-border/30 h-[140px] w-full rounded-lg ring-1"
+              />
+            }
+          >
+            <HexColorPicker
+              className="ring-border/30 !h-[140px] !w-full overflow-hidden rounded-lg ring-1"
+              color={pickerHex}
+              onChange={(hex) => handlePickerChange(hex.replace("#", ""))}
+            />
+          </Suspense>
           <div className="flex items-center gap-1.5">
             <span className="text-muted-foreground text-[11px]">#</span>
             <input


### PR DESCRIPTION
## Summary

- Add a repeatable Folio editor perf profiler with phase counters for load, hidden editor work, layout, rendering, and typing.
- Reduce hot-path editor work by caching validation and canvas measurement primitives, reusing resolved style data, and avoiding whole-document reconciliation after local edits.
- Address the remaining initial-load root cause: first visible layout no longer constructs the hidden ProseMirror `EditorView` or its off-screen DOM. Folio now precomputes the editor state for layout, paints visible pages first, then activates the hidden editor shortly after or on first interaction.
- Cut initial editor payload by deferring cold-path runtimes: collaboration, TIFF decoding, comments/sidebar UI, text context menu UI, color picker internals, tooltip runtime, DOCX save/repack code, and fallback selection geometry.
- Speed up DOCX import parsing by avoiding the XML stop-node matcher for normal parts, parsing numbering/run/paragraph/style child nodes in one pass, and parsing `styles.xml` once for both the style map and style definitions.
- Harden the deferred paths so collaboration runtime load failures fail fast, precomputed hidden editor state is invalidated if the document changes before activation, and first edit-intent key input is replayed instead of dropped while the hidden view is deferred.

## Measurements

Baseline is `origin/main` at `a615ea3de`; current head is `4fe818f57`.

| Scenario | Wall | Browser task | Script | Layout | Hidden PM DOM | Long tasks |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `podily-bps.docx` load | 877.28 -> 686.66 ms (-21.7%) | 606.87 -> 405.48 ms (-33.2%) | 331.76 -> 144.21 ms (-56.5%) | 52.10 -> 26.88 ms (-48.4%) | 3419 -> 0 | 399 -> 222 ms |
| demo DOCX load | 505.68 -> 459.30 ms (-9.2%) | 233.59 -> 204.97 ms (-12.3%) | 152.05 -> 103.76 ms (-31.8%) | 20.76 -> 20.76 ms | 598 -> 0 | 144 -> 0 ms |
| 1500 paragraphs load | 657.83 -> 466.71 ms (-29.1%) | 383.08 -> 191.31 ms (-50.1%) | 293.85 -> 101.34 ms (-65.5%) | 36.94 -> 17.49 ms (-52.7%) | 4501 -> 0 | 263 -> 0 ms |
| immediate typing | 294.19 -> 287.56 ms (-2.3%; includes one-time hidden view activation) | 166.71 -> 118.71 ms (-28.8%) | 108.52 -> 46.10 ms (-57.5%) | 5.26 -> 12.96 ms | 4501 -> 4501 | 64 -> 0 ms |
| idle reconcile | 400.66 -> 401.12 ms (fixed wait) | 88.21 -> 27.02 ms (-69.4%) | 84.73 -> 20.43 ms (-75.9%) | 0.10 -> 0.24 ms | 4501 -> 4501 | 0 -> 0 ms |

Latest browser harness at current head:

| Scenario | Wall | Browser task | Script | Layout | Notable phase/counter |
| --- | ---: | ---: | ---: | ---: | --- |
| `podily-bps.docx` load | 686.66 ms | 405.48 ms | 144.21 ms | 26.88 ms | hidden PM DOM `0`; measure-blocks `33.0 ms` |
| demo DOCX load | 459.30 ms | 204.97 ms | 103.76 ms | 20.76 ms | hidden PM DOM `0`; long tasks `0 ms` |
| 1500 paragraphs load | 466.71 ms | 191.31 ms | 101.34 ms | 17.49 ms | hidden PM DOM `0`; long tasks `0 ms` |
| immediate typing | 287.56 ms | 118.71 ms | 46.10 ms | 12.96 ms | one-time `editor-view` activation `14.3 ms` |
| idle reconcile | 401.12 ms | 27.02 ms | 20.43 ms | 0.24 ms | no layout work |

Parser follow-up, measured against the previous pushed PR head before the new parser commits on the same machine with warm medians from `parseDocx(..., { preloadFonts: false })`:

| Fixture | Before | After | Delta |
| --- | ---: | ---: | ---: |
| `podily-bps.docx` | 102.857 ms | 87.066 ms | -15.4% |
| `docx-editor-demo.docx` | 7.200 ms | 7.236 ms | +0.5% (noise-level) |
| `nvca-spa.docx` | 82.637 ms | 79.067 ms | -4.3% |
| `yc-safe-uncapped-mfn.docx` | 26.030 ms | 20.676 ms | -20.6% |

Targeted stage medians for the styles root-cause fix:

| Fixture | Before styles + definitions | After single style package parse | After one-pass style children |
| --- | ---: | ---: | ---: |
| `podily-bps.docx` | 5.95 ms | 4.54 ms | 2.79 ms |
| `docx-editor-demo.docx` | 0.63 ms | 0.38 ms | 0.22 ms |
| `nvca-spa.docx` | 5.69 ms | 3.82 ms | 2.30 ms |
| `yc-safe-uncapped-mfn.docx` | 24.09 ms | 10.07 ms | 6.10 ms |

Other structural counters:

- 1500 paragraph load: measureText calls `54225 -> 1651` (-97.0%), measure block calls `3000 -> 1500` (-50.0%), visible page DOM `649 -> 416` (-35.9%).
- Immediate typing: measureText calls `729 -> 46` (-93.7%), measure block calls `3 -> 1` (-66.7%).
- Main playground JS: `1883.01 -> 1615.44 kB` (-267.57 kB, -14.2%); gzip `578.47 -> 495.36 kB` (-83.11 kB, -14.4%).

Per-change notes:

- XML stop-node matcher skip: normal OOXML parts no longer pay `fast-xml-parser` stop-node matching on every tag; the protected path still runs for XML containing `binData`, with a regression test for inline binary payload preservation.
- Numbering child scan reduction: numbering parser now collects direct child nodes once per numbering element instead of repeatedly scanning the same arrays.
- Run and paragraph property scan reduction: formatted runs and paragraphs now collect direct property children once, avoiding repeated `findChild` walks on high-volume document body nodes.
- Single style package parse: `parseDocx` now builds the `styles.xml` tree once and derives both the resolved style map and style definitions from that tree.
- Style child scan reduction: each `w:style` node is walked once for common child properties and conditional table style entries.
- Deferred key input replay: first keydown while the hidden editor is still deferred now synchronously mounts when possible, applies pending visual selection, and replays edit-intent keys instead of dropping them. Initial load still reports hidden PM DOM `0`.
- Hidden editor view deferral: initial load hidden PM DOM now reports `0` for all load scenarios; the one-time `EditorView` activation moves out of first visual layout and reuses the precomputed state, so it does not repeat document conversion.

## Validation

- `bun --cwd packages/folio typecheck`
- `bun --cwd packages/folio lint`
- `bun --cwd packages/folio test`
- `bun --cwd packages/folio perf`
- Full pre-push hook passed: format, i18n, lint, typecheck.

Security notes: this PR changes the editor/frontend perf surface and does not add API handlers, S3 paths, auth boundaries, or new dependencies. Secret/pattern scan on the diff found no new credential or injection sink.
