### PR TITLE
fix(chat): unstick docx composer and hot-swap new threads

### DIFF
--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -665,7 +665,8 @@ const FileChatOverlayInner = ({
     if (editorReady || !hasDocxEditSurface) {
       return undefined;
     }
-    const ensure = () => docxEditorRef.current?.ensureEditorView();
+    const ensure = () =>
+      docxEditorRef.current?.ensureEditorView({ focus: false });
     ensure();
     const probe = () => {
       if (docxEditorRef.current?.createAIEditSnapshot()) {

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -877,10 +877,15 @@ const FileChatOverlayInner = ({
   // initial mount is skipped (entering the document should not steal
   // focus from whatever the user was doing).
   const previousChatThreadIdRef = useRef(chatThreadId);
+  const shouldFocusComposerAfterNewThreadRef = useRef(false);
   const focusController = editorController.focus;
   const editorInstance = editorController.editor;
   useEffect(() => {
     if (previousChatThreadIdRef.current === chatThreadId) {
+      return undefined;
+    }
+    if (!shouldFocusComposerAfterNewThreadRef.current) {
+      previousChatThreadIdRef.current = chatThreadId;
       return undefined;
     }
     if (!editorInstance || editorInstance.isDestroyed) {
@@ -890,6 +895,7 @@ const FileChatOverlayInner = ({
       return undefined;
     }
     previousChatThreadIdRef.current = chatThreadId;
+    shouldFocusComposerAfterNewThreadRef.current = false;
     // rAF lets TipTap's DOM finish settling so `focus()` lands; without
     // this, focus is silently dropped on the just-remounted instance.
     // Re-check the editor inside the callback — between scheduling and
@@ -1065,6 +1071,7 @@ const FileChatOverlayInner = ({
           layout="floating"
           newThreadLabel={t("chat.newChat")}
           onNewThread={() => {
+            shouldFocusComposerAfterNewThreadRef.current = true;
             setPanelOpen(false);
             onNewThread();
           }}

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -658,6 +658,14 @@ const FileChatOverlayInner = ({
     if (editorReady || !hasDocxEditSurface) {
       return undefined;
     }
+    // Un-defer the hidden editor view. Without this, opening a doc and
+    // going straight to the chat composer (never clicking into the
+    // body) leaves the view null forever, so `createAIEditSnapshot()`
+    // never returns and the composer stays on "Loading editor". The
+    // first call here is a no-op for `pagedEditorRef.current`-null
+    // races; the 80 ms poller below retries `createAIEditSnapshot`
+    // until createView() commits.
+    docxEditorRef.current?.ensureEditorView();
     const probe = () => {
       if (docxEditorRef.current?.createAIEditSnapshot()) {
         setEditorReady(true);
@@ -857,6 +865,33 @@ const FileChatOverlayInner = ({
     placeholder: filePlaceholder,
     threadRef,
   });
+  // Focus the composer when the user explicitly starts a new thread,
+  // so they can type the first message without an extra click. The
+  // initial mount is skipped (entering the document should not steal
+  // focus from whatever the user was doing).
+  const previousChatThreadIdRef = useRef(chatThreadId);
+  const focusController = editorController.focus;
+  const editorInstance = editorController.editor;
+  useEffect(() => {
+    if (previousChatThreadIdRef.current === chatThreadId) {
+      return undefined;
+    }
+    if (!editorInstance || editorInstance.isDestroyed) {
+      // The TipTap editor for the new thread isn't mounted yet; wait
+      // for the next render to retry (this effect re-runs when
+      // `editorInstance` becomes non-null).
+      return undefined;
+    }
+    previousChatThreadIdRef.current = chatThreadId;
+    // rAF lets TipTap's DOM finish settling so `focus()` lands; without
+    // this, focus is silently dropped on the just-remounted instance.
+    const id = requestAnimationFrame(() => {
+      focusController();
+    });
+    return () => {
+      cancelAnimationFrame(id);
+    };
+  }, [chatThreadId, editorInstance, focusController]);
   const canSubmitWithCurrentDocxSnapshot = useEffectEvent(() => {
     if (!hasDocxEditSurface) {
       return true;

--- a/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
+++ b/apps/web/src/components/ai-suggestions/file-chat-overlay.tsx
@@ -653,19 +653,20 @@ const FileChatOverlayInner = ({
   // with "editor is loading" instead of doing real work. Poll until
   // the first non-null snapshot lands, then stop — once ready stays
   // ready for the lifetime of the editor.
-  const [editorReady, setEditorReady] = useState(false);
+  // Initialize from the ref so a transition-induced remount of an
+  // already-ready editor starts ready (without this, useTransition's
+  // Suspense swap unmounts + remounts this subtree with fresh state,
+  // and the poller racing with a second rerender can leave the gate
+  // stuck closed even though the underlying view is live).
+  const [editorReady, setEditorReady] = useState(() =>
+    Boolean(docxEditorRef?.current?.createAIEditSnapshot()),
+  );
   useEffect(() => {
     if (editorReady || !hasDocxEditSurface) {
       return undefined;
     }
-    // Un-defer the hidden editor view. Without this, opening a doc and
-    // going straight to the chat composer (never clicking into the
-    // body) leaves the view null forever, so `createAIEditSnapshot()`
-    // never returns and the composer stays on "Loading editor". The
-    // first call here is a no-op for `pagedEditorRef.current`-null
-    // races; the 80 ms poller below retries `createAIEditSnapshot`
-    // until createView() commits.
-    docxEditorRef.current?.ensureEditorView();
+    const ensure = () => docxEditorRef.current?.ensureEditorView();
+    ensure();
     const probe = () => {
       if (docxEditorRef.current?.createAIEditSnapshot()) {
         setEditorReady(true);
@@ -677,6 +678,11 @@ const FileChatOverlayInner = ({
       return undefined;
     }
     const id = window.setInterval(() => {
+      // Re-call ensure on each tick: when the surrounding tree is in
+      // a concurrent transition (e.g. right after the "new chat" swap),
+      // the first ensure can be coalesced away by React's batching.
+      // The state setter is a no-op once the view is already created.
+      ensure();
       if (probe()) {
         window.clearInterval(id);
       }
@@ -885,7 +891,13 @@ const FileChatOverlayInner = ({
     previousChatThreadIdRef.current = chatThreadId;
     // rAF lets TipTap's DOM finish settling so `focus()` lands; without
     // this, focus is silently dropped on the just-remounted instance.
+    // Re-check the editor inside the callback — between scheduling and
+    // firing, the user might have closed the overlay or swapped threads
+    // again, destroying the instance we captured.
     const id = requestAnimationFrame(() => {
+      if (editorInstance.isDestroyed) {
+        return;
+      }
       focusController();
     });
     return () => {

--- a/apps/web/src/components/ai-suggestions/file-viewer-with-ai.impl.tsx
+++ b/apps/web/src/components/ai-suggestions/file-viewer-with-ai.impl.tsx
@@ -14,7 +14,7 @@
  */
 
 import type { ReactNode, RefObject } from "react";
-import { useState } from "react";
+import { startTransition, useState } from "react";
 
 import type { DocxEditorRef } from "@stll/folio";
 
@@ -99,7 +99,13 @@ export const FileChatOverlayHost = ({
     if (activeFile) {
       useReviewStore.getState().resetSession(activeFile.entityId);
     }
-    setCurrentChatThreadId(createChatThreadId());
+    // Wrap the swap in a transition so React keeps the current chat
+    // visible while `chatThreadOptions` suspends on the new key,
+    // instead of unmounting back to the Suspense spinner. The fresh
+    // thread snaps in atomically once its (empty) state is ready.
+    startTransition(() => {
+      setCurrentChatThreadId(createChatThreadId());
+    });
   };
 
   return (

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1035,7 +1035,7 @@ export function PromptBarShell({
     <div
       {...rest}
       className={cn(
-        "group/bar bg-background/75 relative flex items-end gap-1 rounded-2xl border backdrop-blur-xl backdrop-saturate-150 transition-[box-shadow,border-color]",
+        "group/bar bg-background/75 border-foreground/15 relative flex items-end gap-1 rounded-2xl border backdrop-blur-xl backdrop-saturate-150 transition-[box-shadow,border-color]",
         "shadow-[0_0_0_1px_rgb(0_0_0/0.02),0_1px_2px_rgb(0_0_0/0.03),0_8px_20px_rgb(0_0_0/0.05)]",
         "after:pointer-events-none after:absolute after:-inset-6 after:-z-10 after:rounded-3xl after:bg-[radial-gradient(ellipse_at_center,var(--background)_0%,transparent_75%)] after:opacity-90",
         "w-[min(560px,calc(100%-2rem))] py-1 ps-1.5 pe-1",

--- a/apps/web/src/components/ai-suggestions/host.tsx
+++ b/apps/web/src/components/ai-suggestions/host.tsx
@@ -1037,7 +1037,7 @@ export function PromptBarShell({
       className={cn(
         "group/bar bg-background/75 relative flex items-end gap-1 rounded-2xl border backdrop-blur-xl backdrop-saturate-150 transition-[box-shadow,border-color]",
         "shadow-[0_0_0_1px_rgb(0_0_0/0.02),0_1px_2px_rgb(0_0_0/0.03),0_8px_20px_rgb(0_0_0/0.05)]",
-        "after:pointer-events-none after:absolute after:-inset-4 after:-z-10 after:rounded-2xl after:bg-[radial-gradient(ellipse_at_center,var(--background)_0%,transparent_70%)] after:opacity-50",
+        "after:pointer-events-none after:absolute after:-inset-6 after:-z-10 after:rounded-3xl after:bg-[radial-gradient(ellipse_at_center,var(--background)_0%,transparent_75%)] after:opacity-90",
         "w-[min(560px,calc(100%-2rem))] py-1 ps-1.5 pe-1",
         layout === "floating"
           ? "absolute start-1/2 bottom-8 z-50 -translate-x-1/2"

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -217,10 +217,11 @@ export type DocxEditorRef = {
    * Force-create the underlying editor view if it has been deferred.
    * Surfaces that need a live view before the user interacts with the
    * document body (notably the AI chat composer, which gates "send"
-   * on snapshot availability) must call this once on mount; otherwise
-   * the perf deferral keeps the view null and they wait forever.
+   * on snapshot availability) must call this once on mount with
+   * `focus: false`; otherwise the perf deferral keeps the view null
+   * and they wait forever.
    */
-  ensureEditorView: () => void;
+  ensureEditorView: (options?: { focus?: boolean }) => void;
   /** Create the block snapshot that an external AI editor should reference. */
   createAIEditSnapshot: () => FolioAIEditSnapshot | null;
   /** Apply AI-authored operations against a previously created block snapshot. */

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -213,6 +213,14 @@ export type DocxEditorRef = {
   loadDocument: (doc: Document) => void;
   /** Load a DOCX buffer programmatically (ArrayBuffer, Uint8Array, Blob, or File) */
   loadDocumentBuffer: (buffer: DocxInput) => Promise<void>;
+  /**
+   * Force-create the underlying editor view if it has been deferred.
+   * Surfaces that need a live view before the user interacts with the
+   * document body (notably the AI chat composer, which gates "send"
+   * on snapshot availability) must call this once on mount; otherwise
+   * the perf deferral keeps the view null and they wait forever.
+   */
+  ensureEditorView: () => void;
   /** Create the block snapshot that an external AI editor should reference. */
   createAIEditSnapshot: () => FolioAIEditSnapshot | null;
   /** Apply AI-authored operations against a previously created block snapshot. */

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2517,8 +2517,8 @@ export function DocxEditor({
       print: handleDirectPrint,
       loadDocument: loadParsedDocument,
       loadDocumentBuffer: loadBuffer,
-      ensureEditorView: () => {
-        pagedEditorRef.current?.ensureView();
+      ensureEditorView: (options?: { focus?: boolean }) => {
+        pagedEditorRef.current?.ensureView(options);
       },
       createAIEditSnapshot: () => {
         const view = pagedEditorRef.current?.getView();

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2517,6 +2517,9 @@ export function DocxEditor({
       print: handleDirectPrint,
       loadDocument: loadParsedDocument,
       loadDocumentBuffer: loadBuffer,
+      ensureEditorView: () => {
+        pagedEditorRef.current?.ensureView();
+      },
       createAIEditSnapshot: () => {
         const view = pagedEditorRef.current?.getView();
         return view ? createFolioAIEditSnapshot(view.state.doc) : null;

--- a/packages/folio/src/components/FormattingBar.tsx
+++ b/packages/folio/src/components/FormattingBar.tsx
@@ -475,6 +475,7 @@ export function FormattingBar(props: FormattingBarProps) {
       role="toolbar"
       aria-label={t("formattingToolbar")}
       tabIndex={-1}
+      data-folio-toolbar="true"
       onMouseDown={inline ? undefined : handleBarMouseDown}
       onMouseUp={inline ? undefined : handleBarMouseUp}
     >

--- a/packages/folio/src/components/Toolbar.tsx
+++ b/packages/folio/src/components/Toolbar.tsx
@@ -119,6 +119,7 @@ export function Toolbar({
       aria-label="Formatting toolbar"
       tabIndex={-1}
       data-testid="toolbar"
+      data-folio-toolbar="true"
       onMouseDown={handleToolbarMouseDown}
       onMouseUp={handleToolbarMouseUp}
     >

--- a/packages/folio/src/components/dialogs/findReplaceUtils.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.ts
@@ -14,6 +14,7 @@ import type {
   Run,
 } from "../../core/types/content";
 import type { Document } from "../../core/types/document";
+import { prefersReducedMotionBehavior } from "../../paged-editor/scrollNavigation";
 
 // ============================================================================
 // TYPES
@@ -507,5 +508,8 @@ export function scrollToMatch(
       .querySelectorAll(".layout-paragraph")
       .item(match.paragraphIndex);
 
-  paragraphElement.scrollIntoView({ behavior: "smooth", block: "center" });
+  paragraphElement.scrollIntoView({
+    behavior: prefersReducedMotionBehavior(),
+    block: "center",
+  });
 }

--- a/packages/folio/src/core/layout-painter/index.ts
+++ b/packages/folio/src/core/layout-painter/index.ts
@@ -7,6 +7,7 @@
 
 import { panic } from "better-result";
 
+import { prefersReducedMotionBehavior } from "../../paged-editor/scrollNavigation";
 import type {
   Layout,
   Page,
@@ -340,7 +341,10 @@ export class LayoutPainter {
   scrollToPage(pageNumber: number): void {
     const state = this.pageStates.find((s) => s.pageNumber === pageNumber);
     if (state?.element) {
-      state.element.scrollIntoView({ behavior: "smooth", block: "start" });
+      state.element.scrollIntoView({
+        behavior: prefersReducedMotionBehavior(),
+        block: "start",
+      });
     }
   }
 }

--- a/packages/folio/src/paged-editor/AnonymizationRectsOverlay.tsx
+++ b/packages/folio/src/paged-editor/AnonymizationRectsOverlay.tsx
@@ -28,6 +28,7 @@ import React, { useEffect, useRef } from "react";
 
 import type { SelectionRect } from "../core/layout-bridge/selectionRects";
 import { slugAnonymizationLabel } from "../core/prosemirror/plugins/anonymizationDecorations";
+import { prefersReducedMotionBehavior } from "./scrollNavigation";
 
 export type AnonymizationRectGroup = {
   /** Same shape as SelectionOverlay — adjusted into container space. */
@@ -110,7 +111,10 @@ export const AnonymizationRectsOverlay = ({
     cycleRef.current = { canonical: selectedCanonical, index: nextIndex };
     const el = spans[nextIndex];
     if (el) {
-      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      el.scrollIntoView({
+        block: "center",
+        behavior: prefersReducedMotionBehavior(),
+      });
     }
   }, [selectedCanonical, selectionSeq]);
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5092,10 +5092,14 @@ export function PagedEditor(
     if (relatedTarget && containerRef.current?.contains(relatedTarget)) {
       return; // Focus staying within editor
     }
-    // Keep selection visible when focus moves to toolbar or dropdown portals
+    // Keep selection visible when focus moves to the editor's own
+    // formatting toolbar or dropdown portals. Use `[data-folio-toolbar]`
+    // (not `[role="toolbar"]`) so the AI chat composer — which uses
+    // `role="toolbar"` for accessibility — does NOT count as "still in
+    // the editor" and the caret correctly hides when typing in chat.
     if (
       relatedTarget?.closest(
-        '[role="toolbar"], [data-radix-popper-content-wrapper], [data-radix-select-content], .docx-table-options-dropdown',
+        '[data-folio-toolbar="true"], [data-radix-popper-content-wrapper], [data-radix-select-content], .docx-table-options-dropdown',
       )
     ) {
       return;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -166,6 +166,7 @@ import { isReadOnlyEditKey } from "./readOnlyEditAttempt";
 import {
   getPageScrollTarget,
   isValidPmScrollPosition,
+  prefersReducedMotionBehavior,
 } from "./scrollNavigation";
 import { computePerBlockWidths } from "./sectionBlockWidths";
 import { SelectionOverlay } from "./SelectionOverlay";
@@ -3809,7 +3810,10 @@ export function PagedEditor(
     // instead of jumping straight to the target.
     const exact = findBodyPmAnchor(pageContainer, pmPos);
     if (exact) {
-      exact.scrollIntoView({ behavior: "smooth", block: "center" });
+      exact.scrollIntoView({
+        behavior: prefersReducedMotionBehavior(),
+        block: "center",
+      });
       return;
     }
 
@@ -3830,7 +3834,10 @@ export function PagedEditor(
       }
     }
     if (runMatch) {
-      runMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+      runMatch.scrollIntoView({
+        behavior: prefersReducedMotionBehavior(),
+        block: "center",
+      });
       return;
     }
 
@@ -3849,14 +3856,20 @@ export function PagedEditor(
       return;
     }
     const { element: shell } = shellHit;
-    shell.scrollIntoView({ behavior: "smooth", block: "center" });
+    shell.scrollIntoView({
+      behavior: prefersReducedMotionBehavior(),
+      block: "center",
+    });
 
     let attempts = 0;
     const refine = () => {
       attempts++;
       const exactInShell = findBodyPmAnchor(shell, pmPos);
       if (exactInShell) {
-        exactInShell.scrollIntoView({ behavior: "smooth", block: "center" });
+        exactInShell.scrollIntoView({
+          behavior: prefersReducedMotionBehavior(),
+          block: "center",
+        });
         return;
       }
       let bestEl: HTMLElement | null = null;
@@ -3878,7 +3891,10 @@ export function PagedEditor(
         }
       }
       if (bestEl) {
-        bestEl.scrollIntoView({ behavior: "smooth", block: "center" });
+        bestEl.scrollIntoView({
+          behavior: prefersReducedMotionBehavior(),
+          block: "center",
+        });
         return;
       }
       // IntersectionObserver populates on the next tick; give it

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -298,7 +298,7 @@ export type PagedEditorRef = {
    * Use from surfaces that need a live view before any user
    * interaction (e.g. AI chat reading a snapshot of the doc).
    */
-  ensureView(): void;
+  ensureView(options?: { focus?: boolean }): void;
   /** Focus the editor. */
   focus(): void;
   /** Blur the editor. */
@@ -336,6 +336,7 @@ type QueuedHiddenEditorInput =
   | { type: "keydown"; eventInit: KeyboardEventInit };
 
 type EnsureHiddenEditorViewOptions = {
+  focus?: boolean;
   sync?: boolean;
 };
 
@@ -2143,6 +2144,7 @@ export function PagedEditor(
   const [measures, setMeasures] = useState<Measure[]>([]);
   const [shouldCreateHiddenEditorView, setShouldCreateHiddenEditorView] =
     useState(() => collaboration !== undefined);
+  const shouldFocusHiddenEditorOnReadyRef = useRef(collaboration !== undefined);
   const [precomputedInitialState, setPrecomputedInitialState] =
     useState<EditorState | null>(null);
   const layoutArtifactsRef = useRef<{
@@ -2218,7 +2220,16 @@ export function PagedEditor(
   const dragAnchorRef = useRef<number | null>(null);
 
   const ensureHiddenEditorView = useCallback(
-    ({ sync = false }: EnsureHiddenEditorViewOptions = {}) => {
+    ({ focus = true, sync = false }: EnsureHiddenEditorViewOptions = {}) => {
+      if (focus) {
+        shouldFocusHiddenEditorOnReadyRef.current = true;
+      } else if (
+        !shouldCreateHiddenEditorView &&
+        !hiddenPMRef.current?.getView()
+      ) {
+        shouldFocusHiddenEditorOnReadyRef.current = false;
+      }
+
       if (sync) {
         flushSync(() => {
           setShouldCreateHiddenEditorView(true);
@@ -2228,7 +2239,7 @@ export function PagedEditor(
 
       setShouldCreateHiddenEditorView(true);
     },
-    [],
+    [shouldCreateHiddenEditorView],
   );
 
   const queueHiddenEditorSelection = useCallback(
@@ -5519,13 +5530,19 @@ export function PagedEditor(
         anonymizationDecorationsKey.getState(view.state)?.matches ?? [];
 
       const focusReadyView = () => {
-        if (!readOnly) {
-          requestAnimationFrame(() => {
-            applyPendingHiddenEditorInput(view);
-            view.focus();
-            setIsFocused(true);
-          });
+        if (readOnly || !shouldFocusHiddenEditorOnReadyRef.current) {
+          return;
         }
+
+        requestAnimationFrame(() => {
+          if (hiddenPMRef.current?.getView() !== view) {
+            return;
+          }
+
+          applyPendingHiddenEditorInput(view);
+          view.focus();
+          setIsFocused(true);
+        });
       };
 
       if (lastLaidOutPmDocRef.current?.eq(view.state.doc)) {
@@ -5746,14 +5763,14 @@ export function PagedEditor(
       getView() {
         return hiddenPMRef.current?.getView() ?? null;
       },
-      ensureView() {
+      ensureView(options?: { focus?: boolean }) {
         // Async (no flushSync) so this is safe to call from a consumer's
         // useEffect during a concurrent render — flushSync inside a
         // commit-phase effect throws "flushSync was called from inside
         // a lifecycle method". The state setter still schedules a
         // re-render that runs createView in the next layout effect;
         // callers that need the view immediately can poll.
-        ensureHiddenEditorView();
+        ensureHiddenEditorView(options);
       },
       focus() {
         hiddenPMRef.current?.focus();

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5727,7 +5727,13 @@ export function PagedEditor(
         return hiddenPMRef.current?.getView() ?? null;
       },
       ensureView() {
-        ensureHiddenEditorView({ sync: true });
+        // Async (no flushSync) so this is safe to call from a consumer's
+        // useEffect during a concurrent render — flushSync inside a
+        // commit-phase effect throws "flushSync was called from inside
+        // a lifecycle method". The state setter still schedules a
+        // re-render that runs createView in the next layout effect;
+        // callers that need the view immediately can poll.
+        ensureHiddenEditorView();
       },
       focus() {
         hiddenPMRef.current?.focus();

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -292,6 +292,12 @@ export type PagedEditorRef = {
   getState(): EditorState | null;
   /** Get the ProseMirror EditorView. */
   getView(): EditorView | null;
+  /**
+   * Force-create the hidden editor view if it has been deferred.
+   * Use from surfaces that need a live view before any user
+   * interaction (e.g. AI chat reading a snapshot of the doc).
+   */
+  ensureView(): void;
   /** Focus the editor. */
   focus(): void;
   /** Blur the editor. */
@@ -5720,6 +5726,9 @@ export function PagedEditor(
       getView() {
         return hiddenPMRef.current?.getView() ?? null;
       },
+      ensureView() {
+        ensureHiddenEditorView({ sync: true });
+      },
       focus() {
         hiddenPMRef.current?.focus();
         setIsFocused(true);
@@ -5761,7 +5770,13 @@ export function PagedEditor(
       scrollToPosition: scrollToPositionImpl,
       scrollToPage: scrollToPageImpl,
     }),
-    [layout, runLayoutPipeline, scrollToPageImpl, scrollToPositionImpl],
+    [
+      ensureHiddenEditorView,
+      layout,
+      runLayoutPipeline,
+      scrollToPageImpl,
+      scrollToPositionImpl,
+    ],
   );
 
   useEffect(() => {

--- a/packages/folio/src/paged-editor/scrollNavigation.ts
+++ b/packages/folio/src/paged-editor/scrollNavigation.ts
@@ -13,6 +13,26 @@ export type PageScrollTarget =
 export const isValidPmScrollPosition = (pmPos: number): boolean =>
   Number.isInteger(pmPos) && pmPos >= 0;
 
+/**
+ * Pick a `scrollIntoView` / `scrollTo` `behavior` that respects the
+ * user's `prefers-reduced-motion` setting. Chrome silently no-ops
+ * `behavior: "smooth"` when reduced motion is on (instead of falling
+ * back to instant), so a stale "smooth" call from scroll-to-block
+ * leaves the user wondering why the chip "doesn't work". Use the
+ * helper everywhere we'd otherwise hard-code `"smooth"`.
+ */
+export const prefersReducedMotionBehavior = (): ScrollBehavior => {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return "smooth";
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ? "auto"
+    : "smooth";
+};
+
 export const getPageScrollTarget = (
   layout: Layout | null,
   pageNumber: number,


### PR DESCRIPTION
## Summary

- Add `ensureEditorView()` to `DocxEditorRef` (via `ensureView()` on `PagedEditorRef`) so surfaces that depend on a live ProseMirror view before user interaction can opt in. The chat overlay's polling effect calls it once; the per-surface perf deferral introduced in #466 still applies to surfaces that don't need a view.
- Wrap the "new chat" thread swap in `startTransition` so React keeps the current chat visible while the new thread's `useSuspenseQuery` resolves, instead of flashing the Suspense spinner.
- Focus the chat composer once the new thread commits so the user can type immediately.

## Why

After #466 (`perf(folio): defer hidden editor view creation`), opening a docx and going straight to the chat composer (without clicking into the body) left `pagedEditorRef.current?.getView()` null forever, so `createAIEditSnapshot()` always returned null and the composer stayed on "Loading editor". Once `editorReady` is gated on a snapshot, the gate needed an explicit ensure path.

## Test plan

- [x] Open a docx, do not click the body, observe the chat composer is interactive (no "Loading editor")
- [x] Click "New chat" in the file overlay — no Suspense spinner flash
- [x] After "New chat", keyboard focus lands in the composer
- [x] `bun run lint`, `bun run typecheck`, `bun run format` clean