### PR TITLE
chore: ignore nested Docker build artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,33 @@ tmp
 **/__snapshots__
 *.md
 !README.md
+
+# Recursive local dependency, cache, and build output directories.
+**/node_modules
+**/.turbo
+**/.cache
+**/coverage
+**/dist
+**/build
+**/out
+**/.next
+**/.nitro
+**/.tanstack
+**/.astro
+**/.vite
+**/.react-email
+
+# Native/mobile build outputs.
+**/target
+**/gen
+
+# Local runtime artifacts and generated diagnostics.
+**/.dev-logs
+**/.devtools
+**/*.log
+
+# Heavy local-only data that is not needed for Docker builds.
+**/.agents/reports
+**/.playwright
+**/mock_files
+**/provenance


### PR DESCRIPTION
## Summary
- ignore nested dependency, cache, and build output directories in Docker contexts
- exclude local runtime artifacts and generated diagnostics that are not needed for image builds

Validated with git diff --check, docker build -f apps/api/Dockerfile . --target pruner --progress=plain, and the pre-push format/i18n/lint/typecheck hook.