### PR TITLE
feat(workspaces): retry one AI-extracted cell via right-click

### DIFF
--- a/apps/api/src/handlers/workspaces/cell-retry.ts
+++ b/apps/api/src/handlers/workspaces/cell-retry.ts
@@ -2,13 +2,12 @@ import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
-import { cellMetadata, fields } from "@/api/db/schema";
+import { cellMetadata } from "@/api/db/schema";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { createSafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
-import { startWorkflow } from "@/api/lib/workflow-queue";
+import { isWorkflowRunning, startWorkflow } from "@/api/lib/workflow-queue";
 
 const config = {
   permissions: { workspace: ["update"] },
@@ -83,14 +82,13 @@ const cellRetry = createSafeHandler(
     }
     const entityVersionId = entity.currentVersionId;
 
-    // Reset the cell to `pending` so the workflow's skip logic
-    // (`prepareBatch`) treats it as work-to-do regardless of the
-    // property's `fresh`/`stale` status. The same write also refuses to
-    // run when the cell is manually locked — the locked snapshot is the
-    // user's explicit override and the AI must not stomp it.
-    const resetOutcome = yield* Result.await(
-      safeDb(async (tx) => {
-        const lockedRows = await tx
+    // Fail fast on locked cells so the user sees an explicit 409
+    // instead of a silent no-op (the worker also skips locked cells
+    // inside `processOneBatch`, so omitting this check would still be
+    // safe — just user-hostile).
+    const lockedRows = yield* Result.await(
+      safeDb((tx) =>
+        tx
           .select({ metadata: cellMetadata.metadata })
           .from(cellMetadata)
           .where(
@@ -98,40 +96,24 @@ const cellRetry = createSafeHandler(
               eq(cellMetadata.entityVersionId, entityVersionId),
               eq(cellMetadata.propertyId, propertyId),
             ),
-          );
-        if (lockedRows.at(0)?.metadata.locked === true) {
-          return "locked" as const;
-        }
-
-        // audit: skip — placeholder reset mirrors the workflow's own
-        // pending-state writes, which are not audited.
-        await tx
-          .delete(fields)
-          .where(
-            and(
-              eq(fields.entityVersionId, entityVersionId),
-              eq(fields.propertyId, propertyId),
-            ),
-          );
-
-        // audit: skip — see comment above the matching delete.
-        await tx.insert(fields).values({
-          id: createSafeId<"field">(),
-          workspaceId,
-          propertyId,
-          entityVersionId,
-          content: { type: "pending", version: 1 },
-        });
-
-        return "reset" as const;
-      }),
+          ),
+      ),
     );
+    if (lockedRows.at(0)?.metadata.locked === true) {
+      return Result.err(
+        new HandlerError({ status: 409, message: "Cell is locked" }),
+      );
+    }
 
-    if (resetOutcome === "locked") {
+    // Reject upfront when a workspace-wide workflow is already
+    // running. Catches the common case without mutating the cell so
+    // the user can retry once the workflow finishes. (A startWorkflow
+    // call racing in afterwards is still handled below.)
+    if (await isWorkflowRunning(workspaceId)) {
       return Result.err(
         new HandlerError({
           status: 409,
-          message: "Cell is locked",
+          message: "A workflow is already running in this workspace",
         }),
       );
     }
@@ -155,6 +137,23 @@ const cellRetry = createSafeHandler(
           }),
       }),
     );
+
+    if (result.status === "already-running") {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "A workflow is already running in this workspace",
+        }),
+      );
+    }
+    if (result.status === "failed") {
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: "Failed to enqueue retry",
+        }),
+      );
+    }
 
     return Result.ok(result);
   },

--- a/apps/api/src/handlers/workspaces/cell-retry.ts
+++ b/apps/api/src/handlers/workspaces/cell-retry.ts
@@ -1,0 +1,163 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { cellMetadata, fields } from "@/api/db/schema";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { startWorkflow } from "@/api/lib/workflow-queue";
+
+const config = {
+  permissions: { workspace: ["update"] },
+  body: t.Object({
+    entityId: tSafeId("entity"),
+    propertyId: tSafeId("property"),
+  }),
+} satisfies HandlerConfig;
+
+const cellRetry = createSafeHandler(
+  config,
+  async function* ({ workspaceId, session, user, scopedDb, safeDb, body }) {
+    const { entityId, propertyId } = body;
+
+    const property = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.properties.findFirst({
+          columns: { id: true, tool: true },
+          where: {
+            id: { eq: propertyId },
+            workspaceId: { eq: workspaceId },
+          },
+        }),
+      ),
+    );
+
+    if (!property) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Property not found in workspace",
+        }),
+      );
+    }
+
+    if (property.tool.type !== "ai-model") {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Property is not AI-extracted",
+        }),
+      );
+    }
+
+    const entity = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.entities.findFirst({
+          columns: { id: true, currentVersionId: true, readOnly: true },
+          where: {
+            id: { eq: entityId },
+            workspaceId: { eq: workspaceId },
+          },
+        }),
+      ),
+    );
+
+    if (!entity?.currentVersionId) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Entity not found in workspace",
+        }),
+      );
+    }
+    if (entity.readOnly) {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Entity is read-only",
+        }),
+      );
+    }
+    const entityVersionId = entity.currentVersionId;
+
+    // Reset the cell to `pending` so the workflow's skip logic
+    // (`prepareBatch`) treats it as work-to-do regardless of the
+    // property's `fresh`/`stale` status. The same write also refuses to
+    // run when the cell is manually locked — the locked snapshot is the
+    // user's explicit override and the AI must not stomp it.
+    const resetOutcome = yield* Result.await(
+      safeDb(async (tx) => {
+        const lockedRows = await tx
+          .select({ metadata: cellMetadata.metadata })
+          .from(cellMetadata)
+          .where(
+            and(
+              eq(cellMetadata.entityVersionId, entityVersionId),
+              eq(cellMetadata.propertyId, propertyId),
+            ),
+          );
+        if (lockedRows.at(0)?.metadata.locked === true) {
+          return "locked" as const;
+        }
+
+        // audit: skip — placeholder reset mirrors the workflow's own
+        // pending-state writes, which are not audited.
+        await tx
+          .delete(fields)
+          .where(
+            and(
+              eq(fields.entityVersionId, entityVersionId),
+              eq(fields.propertyId, propertyId),
+            ),
+          );
+
+        // audit: skip — see comment above the matching delete.
+        await tx.insert(fields).values({
+          id: createSafeId<"field">(),
+          workspaceId,
+          propertyId,
+          entityVersionId,
+          content: { type: "pending", version: 1 },
+        });
+
+        return "reset" as const;
+      }),
+    );
+
+    if (resetOutcome === "locked") {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Cell is locked",
+        }),
+      );
+    }
+
+    const result = yield* Result.await(
+      Result.tryPromise({
+        try: async () =>
+          await startWorkflow({
+            workspaceId,
+            organizationId: session.activeOrganizationId,
+            userId: user.id,
+            scopedDb,
+            entityIds: [entityId],
+            propertyIds: [propertyId],
+          }),
+        catch: (cause) =>
+          new HandlerError({
+            status: 500,
+            message: "Internal server error",
+            cause,
+          }),
+      }),
+    );
+
+    return Result.ok(result);
+  },
+);
+
+export default cellRetry;

--- a/apps/api/src/handlers/workspaces/routes.ts
+++ b/apps/api/src/handlers/workspaces/routes.ts
@@ -12,6 +12,7 @@ import {
   readWorkspaceAnonymizationTerms,
 } from "@/api/handlers/workspaces/anonymization-terms";
 import archiveWorkspace from "@/api/handlers/workspaces/archive";
+import cellRetry from "@/api/handlers/workspaces/cell-retry";
 import createWorkspaces from "@/api/handlers/workspaces/create";
 import deleteWorkspace from "@/api/handlers/workspaces/delete-by-id";
 import duplicateWorkspace from "@/api/handlers/workspaces/duplicate";
@@ -197,6 +198,10 @@ export const workspacesRoute = new Elysia({ prefix: "/workspaces" })
         .post("/workflow/start", workflowStart.handler, {
           body: workflowStart.config.body,
           permissions: workflowStart.config.permissions,
+        })
+        .post("/cell-retry", cellRetry.handler, {
+          body: cellRetry.config.body,
+          permissions: cellRetry.config.permissions,
         })
         .post("/justifications/query", readJustifications.handler, {
           body: readJustifications.config.body,

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -86,6 +86,13 @@ type EntityJobData = {
   entityId: string;
   executionPlan: ExecutionLevel[];
   requestId: string;
+  /**
+   * Property IDs the caller wants processed even if their current
+   * content would normally cause `prepareBatch` to skip them (e.g. a
+   * `fresh` cell with a real value). Used by single-cell retry so a
+   * user can re-run an extraction over an already-populated cell.
+   */
+  forcePropertyIds?: string[];
 };
 
 // ── Public API ─────────────────────────────────────────
@@ -236,6 +243,7 @@ type EnqueueEntityJobsArgs = {
   requestId: string;
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace">;
+  forcePropertyIds?: readonly SafeId<"property">[];
 };
 
 const chunkItems = <T>(items: readonly T[], size: number): T[][] => {
@@ -263,6 +271,7 @@ const enqueueEntityJobs = async ({
   requestId,
   userId,
   workspaceId,
+  forcePropertyIds,
 }: EnqueueEntityJobsArgs): Promise<void> => {
   if (entityIds.length === 0) {
     return;
@@ -283,6 +292,10 @@ const enqueueEntityJobs = async ({
           entityId,
           executionPlan,
           requestId,
+          ...(forcePropertyIds &&
+            forcePropertyIds.length > 0 && {
+              forcePropertyIds: [...forcePropertyIds],
+            }),
         } satisfies EntityJobData,
         opts: { jobId },
       };
@@ -603,6 +616,10 @@ export const startWorkflow = async ({
           requestId,
           userId,
           workspaceId,
+          ...(inputPropertyIds &&
+            inputPropertyIds.length > 0 && {
+              forcePropertyIds: inputPropertyIds,
+            }),
         });
       }
     } catch (error: unknown) {
@@ -820,7 +837,9 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
     entityId,
     executionPlan,
     requestId,
+    forcePropertyIds,
   } = data;
+  const forcedPropertyIds: ReadonlySet<string> = new Set(forcePropertyIds);
 
   // Brand IDs at the boundary — job data stores plain strings (JSON).
   const branded = brandValidatedWorkflowActorKey({
@@ -876,6 +895,7 @@ const processEntityJob = async (data: EntityJobData, signal: AbortSignal) => {
             scopedDb,
             requestId,
             signal,
+            forcedPropertyIds,
           }),
       ),
     );
@@ -906,6 +926,7 @@ type ProcessOneBatchArgs = {
   scopedDb: ScopedDb;
   requestId: string;
   signal: AbortSignal;
+  forcedPropertyIds: ReadonlySet<string>;
 };
 
 type BatchPreviewPublisherArgs = {
@@ -990,6 +1011,7 @@ const processOneBatch = async ({
   scopedDb,
   requestId,
   signal,
+  forcedPropertyIds,
 }: ProcessOneBatchArgs) => {
   signal.throwIfAborted();
   const isCurrentRequest = await isCurrentWorkflowRequest({
@@ -1054,7 +1076,12 @@ const processOneBatch = async ({
       .map((row) => row.propertyId),
   );
 
-  const batch = prepareBatch(rawBatch, fieldContentMap, lockedPropertyIds);
+  const batch = prepareBatch(
+    rawBatch,
+    fieldContentMap,
+    lockedPropertyIds,
+    forcedPropertyIds,
+  );
 
   if (batch.properties.length === 0) {
     return;

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -59,6 +59,7 @@ const WORKFLOW_RUN_STATE_FIELDS = [
   "completed",
   "plan-properties",
   "request-id",
+  "scoped",
 ] as const;
 
 const EXTRACTION_PREVIEW_EVENT_TYPE = "workflow-extraction-preview";
@@ -592,6 +593,21 @@ export const startWorkflow = async ({
       "EX",
       RUNNING_LOCK_TTL_SEC,
     );
+
+    // Single-cell retries and other `propertyIds`-scoped runs only
+    // touch a subset of (entity, property) pairs. `finishWorkflow`
+    // must NOT freshen those properties workspace-wide afterwards: the
+    // other entities still hold values from the previous extraction,
+    // so the property is genuinely still stale at workspace scope. The
+    // flag lets us tell scoped runs apart from a full sweep.
+    if (inputPropertyIds && inputPropertyIds.length > 0) {
+      await redis.set(
+        workflowKey(workspaceId, "scoped"),
+        "1",
+        "EX",
+        RUNNING_LOCK_TTL_SEC,
+      );
+    }
 
     // Broadcast running status
     broadcastWorkflowStatus(workspaceId, true);
@@ -1345,6 +1361,10 @@ const onEntityCompleted = async (
       RUNNING_LOCK_TTL_SEC,
     ),
     redis.expire(workflowKey(workspaceId, "request-id"), RUNNING_LOCK_TTL_SEC),
+    // Refresh the scoped flag's TTL for the same reason: if it
+    // expires mid-run, `finishWorkflow` would mistake a long-running
+    // scoped retry for a full sweep and freshen the property globally.
+    redis.expire(workflowKey(workspaceId, "scoped"), RUNNING_LOCK_TTL_SEC),
   ]);
 };
 
@@ -1369,47 +1389,57 @@ const finishWorkflow = async (
     workspaceIds: [workspaceId],
   });
 
-  // Freshen only the properties that were part of this workflow's plan.
-  // Properties created mid-workflow are not in the snapshot — they stay
-  // stale and trigger an automatic follow-up run below.
-  let processedIds: SafeId<"property">[] = [];
-  try {
-    const planRaw = await redis.get(
-      workflowKey(workspaceId, "plan-properties"),
-    );
-    if (planRaw !== null) {
-      const parsed: unknown = JSON.parse(planRaw);
-      if (Array.isArray(parsed)) {
-        processedIds = parsed
-          .filter((value): value is string => typeof value === "string")
-          .map((value) => brandPersistedPropertyId(value));
-      }
-    }
+  // Scoped runs (single-cell retry) only touch a subset of entities
+  // for the chosen property. Workspace-wide freshness and straggler
+  // detection both reason about all entities, so they're meaningless
+  // here and would actively hide still-stale cells from the next full
+  // sweep.
+  const wasScopedRun =
+    (await redis.get(workflowKey(workspaceId, "scoped"))) === "1";
 
-    if (processedIds.length > 0) {
-      await scopedDb((tx) =>
-        tx
-          .update(properties)
-          .set({ status: "fresh" })
-          .where(
-            and(
-              eq(properties.workspaceId, workspaceId),
-              inArray(properties.id, processedIds),
+  if (!wasScopedRun) {
+    // Freshen only the properties that were part of this workflow's
+    // plan. Properties created mid-workflow are not in the snapshot —
+    // they stay stale and trigger an automatic follow-up run below.
+    let processedIds: SafeId<"property">[] = [];
+    try {
+      const planRaw = await redis.get(
+        workflowKey(workspaceId, "plan-properties"),
+      );
+      if (planRaw !== null) {
+        const parsed: unknown = JSON.parse(planRaw);
+        if (Array.isArray(parsed)) {
+          processedIds = parsed
+            .filter((value): value is string => typeof value === "string")
+            .map((value) => brandPersistedPropertyId(value));
+        }
+      }
+
+      if (processedIds.length > 0) {
+        await scopedDb((tx) =>
+          tx
+            .update(properties)
+            .set({ status: "fresh" })
+            .where(
+              and(
+                eq(properties.workspaceId, workspaceId),
+                inArray(properties.id, processedIds),
+              ),
             ),
-          ),
-      );
-    } else {
-      // Backwards-compat: pre-snapshot workflows had no plan recorded.
-      // Behave as before so they still finalize.
-      await scopedDb((tx) =>
-        tx
-          .update(properties)
-          .set({ status: "fresh" })
-          .where(eq(properties.workspaceId, workspaceId)),
-      );
+        );
+      } else {
+        // Backwards-compat: pre-snapshot workflows had no plan recorded.
+        // Behave as before so they still finalize.
+        await scopedDb((tx) =>
+          tx
+            .update(properties)
+            .set({ status: "fresh" })
+            .where(eq(properties.workspaceId, workspaceId)),
+        );
+      }
+    } catch (error: unknown) {
+      captureError(error, { workspaceId });
     }
-  } catch (error: unknown) {
-    captureError(error, { workspaceId });
   }
 
   // Clean up Redis state
@@ -1418,6 +1448,10 @@ const finishWorkflow = async (
   // Broadcast completion
   broadcastWorkflowStatus(workspaceId, false);
   broadcastInvalidation(workspaceId, ["properties", workspaceId]);
+
+  if (wasScopedRun) {
+    return;
+  }
 
   // Catch up on any AI-model properties created mid-workflow. They
   // were left stale by the partial freshen above; kick off a follow-up

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -204,6 +204,13 @@ type StartWorkflowArgs = {
   scopedDb: ScopedDb;
   entityIds?: SafeId<"entity">[];
   entityIdsOrder?: SafeId<"entity">[];
+  /**
+   * Restrict the execution plan to these property IDs only. Used by
+   * single-cell retry to re-run one property for one entity without
+   * touching the rest of the entity's cells. Properties outside the
+   * filter are dropped from every level of the plan.
+   */
+  propertyIds?: SafeId<"property">[];
 };
 
 type StartWorkflowResult = {
@@ -429,6 +436,23 @@ const collectFullWorkflowTargetIds = async ({
   }
 };
 
+const filterPlanByPropertyIds = (
+  plan: ExecutionLevel[],
+  propertyIds: readonly SafeId<"property">[],
+): ExecutionLevel[] => {
+  const allowed = new Set<string>(propertyIds);
+  return plan
+    .map((level) =>
+      level
+        .map((batch) => ({
+          ...batch,
+          properties: batch.properties.filter((p) => allowed.has(p.id)),
+        }))
+        .filter((batch) => batch.properties.length > 0),
+    )
+    .filter((level) => level.length > 0);
+};
+
 /**
  * Start a workflow: build execution plan, enqueue entity jobs.
  */
@@ -439,6 +463,7 @@ export const startWorkflow = async ({
   scopedDb,
   entityIds: inputEntityIds,
   entityIdsOrder: inputOrder,
+  propertyIds: inputPropertyIds,
 }: StartWorkflowArgs): Promise<StartWorkflowResult> => {
   const redis = getRedis();
 
@@ -478,7 +503,12 @@ export const startWorkflow = async ({
           }
         : executionPlanData;
 
-    const executionPlan = getPropertyExecutionPlan(planInput);
+    const fullExecutionPlan = getPropertyExecutionPlan(planInput);
+
+    const executionPlan =
+      inputPropertyIds && inputPropertyIds.length > 0
+        ? filterPlanByPropertyIds(fullExecutionPlan, inputPropertyIds)
+        : fullExecutionPlan;
 
     const hasWork = executionPlan.some((level) =>
       level.some((batch) => batch.properties.length > 0),

--- a/apps/api/src/lib/workflow/utils.ts
+++ b/apps/api/src/lib/workflow/utils.ts
@@ -8,10 +8,15 @@ export const prepareBatch = (
   rawBatch: PropertyBatch,
   fieldContentMap: Map<string, FieldContent["type"]>,
   lockedPropertyIds: ReadonlySet<string> = new Set(),
+  forcedPropertyIds: ReadonlySet<string> = new Set(),
 ): PropertyBatch => {
   const propertiesToProcess = rawBatch.properties.filter((prop) => {
     if (lockedPropertyIds.has(prop.id)) {
       return false;
+    }
+
+    if (forcedPropertyIds.has(prop.id)) {
+      return true;
     }
 
     const fieldContentType = fieldContentMap.get(prop.id);

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -1,9 +1,10 @@
 import type { PropsWithChildren } from "react";
 
-import { EyeIcon } from "lucide-react";
+import { EyeIcon, RefreshCwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
+import { MenuItem } from "@stll/ui/components/menu";
 
 import type { WorkspaceEntity, WorkspaceProperty } from "@/lib/types";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
@@ -11,8 +12,10 @@ import { CellMetadataFlags } from "@/routes/_protected.workspaces/$workspaceId/-
 import { CellResult } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-result";
 import { EditableField } from "@/routes/_protected.workspaces/$workspaceId/-components/editable-field";
 import { useInspectorStore } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/inspector-store";
+import { useAnchoredMenu } from "@/routes/_protected.workspaces/$workspaceId/-components/inspector/use-anchored-menu";
 import { PropertyPopover } from "@/routes/_protected.workspaces/$workspaceId/-components/property-popover";
 import type { TableColumnDef } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
+import { useRetryCell } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell";
 import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 import { getFirstFile } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
@@ -136,38 +139,48 @@ const PropertyCell = ({
 
     if (fileFieldId) {
       return (
-        <WithOpenEntityButton
+        <RetryableCellShell
           entityId={entity.entityId}
-          fieldId={fileFieldId}
-          justificationFieldId={field.id}
-          label={fileName}
-          mimeType={mimeType}
-          pdfFileId={pdfFileId}
           propertyId={property.id}
           workspaceId={property.workspaceId}
         >
-          <CellMetadataFlags
+          <WithOpenEntityButton
             entityId={entity.entityId}
-            metadata={cellMetadata}
+            fieldId={fileFieldId}
+            justificationFieldId={field.id}
+            label={fileName}
+            mimeType={mimeType}
+            pdfFileId={pdfFileId}
             propertyId={property.id}
             workspaceId={property.workspaceId}
-          />
-          <EditableField
-            content={fieldContent}
-            entityId={entity.entityId}
-            entityKind={entity.kind}
-            property={property}
-            propertyId={property.id}
-            showDateIcon={false}
-            workspaceId={property.workspaceId}
-          />
-        </WithOpenEntityButton>
+          >
+            <CellMetadataFlags
+              entityId={entity.entityId}
+              metadata={cellMetadata}
+              propertyId={property.id}
+              workspaceId={property.workspaceId}
+            />
+            <EditableField
+              content={fieldContent}
+              entityId={entity.entityId}
+              entityKind={entity.kind}
+              property={property}
+              propertyId={property.id}
+              showDateIcon={false}
+              workspaceId={property.workspaceId}
+            />
+          </WithOpenEntityButton>
+        </RetryableCellShell>
       );
     }
   }
 
   return (
-    <>
+    <RetryableCellShell
+      entityId={entity.entityId}
+      propertyId={property.id}
+      workspaceId={property.workspaceId}
+    >
       <CellMetadataFlags
         entityId={entity.entityId}
         metadata={cellMetadata}
@@ -183,7 +196,43 @@ const PropertyCell = ({
         showDateIcon={false}
         workspaceId={property.workspaceId}
       />
-    </>
+    </RetryableCellShell>
+  );
+};
+
+type RetryableCellShellProps = {
+  entityId: string;
+  propertyId: string;
+  workspaceId: string;
+};
+
+/**
+ * Adds a right-click menu with "Retry extraction" to AI-model cells.
+ * Wraps children in a div so the contextmenu listener has a DOM node;
+ * `display: contents` keeps the wrapper out of the cell's layout.
+ */
+const RetryableCellShell = ({
+  entityId,
+  propertyId,
+  workspaceId,
+  children,
+}: PropsWithChildren<RetryableCellShellProps>) => {
+  const t = useTranslations();
+  const retryCell = useRetryCell(workspaceId);
+  const menu = useAnchoredMenu({
+    children: (
+      <MenuItem onClick={() => void retryCell({ entityId, propertyId })}>
+        <RefreshCwIcon />
+        {t("common.retry")}
+      </MenuItem>
+    ),
+  });
+
+  return (
+    <div className="contents" onContextMenu={menu.openAt}>
+      {children}
+      {menu.element}
+    </div>
   );
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from "react";
+import { useState, type PropsWithChildren } from "react";
 
 import { EyeIcon, RefreshCwIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
@@ -140,6 +140,7 @@ const PropertyCell = ({
     if (fileFieldId) {
       return (
         <RetryableCellShell
+          disabled={cellMetadata?.locked === true || entity.readOnly}
           entityId={entity.entityId}
           propertyId={property.id}
           workspaceId={property.workspaceId}
@@ -177,6 +178,7 @@ const PropertyCell = ({
 
   return (
     <RetryableCellShell
+      disabled={cellMetadata?.locked === true || entity.readOnly}
       entityId={entity.entityId}
       propertyId={property.id}
       workspaceId={property.workspaceId}
@@ -204,10 +206,17 @@ type RetryableCellShellProps = {
   entityId: string;
   propertyId: string;
   workspaceId: string;
+  /**
+   * `true` when the cell is manually locked or the entity is
+   * read-only. The menu still opens (so the user sees the action
+   * exists) but the retry item is disabled — the server would reject
+   * the request anyway with a 409.
+   */
+  disabled?: boolean;
 };
 
 /**
- * Adds a right-click menu with "Retry extraction" to AI-model cells.
+ * Adds a right-click menu with a "Retry" item to AI-model cells.
  * Wraps children in a div so the contextmenu listener has a DOM node;
  * `display: contents` keeps the wrapper out of the cell's layout.
  */
@@ -215,13 +224,34 @@ const RetryableCellShell = ({
   entityId,
   propertyId,
   workspaceId,
+  disabled,
   children,
 }: PropsWithChildren<RetryableCellShellProps>) => {
   const t = useTranslations();
   const retryCell = useRetryCell(workspaceId);
+  // Block double-submits while the request is in flight; a duplicate
+  // click would otherwise race a second mutation against the server's
+  // workflow-running check and toast a misleading 409.
+  const [isPending, setIsPending] = useState(false);
+
+  const handleRetry = async () => {
+    if (isPending || disabled) {
+      return;
+    }
+    setIsPending(true);
+    try {
+      await retryCell({ entityId, propertyId });
+    } finally {
+      setIsPending(false);
+    }
+  };
+
   const menu = useAnchoredMenu({
     children: (
-      <MenuItem onClick={() => void retryCell({ entityId, propertyId })}>
+      <MenuItem
+        disabled={disabled || isPending}
+        onClick={() => void handleRetry()}
+      >
         <RefreshCwIcon />
         {t("common.retry")}
       </MenuItem>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
@@ -1,19 +1,24 @@
 import { useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "use-intl";
+
+import { stellaToast } from "@stll/ui/components/toast";
 
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
+import { userErrorMessage } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
 
 /**
  * Re-runs AI extraction for one cell (one entity × one property).
- * Resets the cell to `pending` on the server and enqueues a
- * workflow restricted to the target property only.
+ * Enqueues a workflow restricted to the target property only; the
+ * worker itself moves the cell into `pending` and writes the result.
  */
 export const useRetryCell = (workspaceId: string) => {
   const queryClient = useQueryClient();
   const analytics = useAnalytics();
+  const t = useTranslations();
 
   return async ({
     entityId,
@@ -32,6 +37,14 @@ export const useRetryCell = (workspaceId: string) => {
 
       if (response.error) {
         analytics.captureError(new Error("Failed to retry cell"));
+        // Surface server-side rejections (locked cell, concurrent
+        // workflow, read-only entity) — without this the user just
+        // sees the menu close and nothing happens. `userErrorMessage`
+        // hides 5xx detail behind a generic fallback.
+        stellaToast.add({
+          title: userErrorMessage(response.error, t("errors.actionFailed")),
+          type: "error",
+        });
         return undefined;
       }
 
@@ -47,6 +60,10 @@ export const useRetryCell = (workspaceId: string) => {
       return response.data;
     } catch (error) {
       analytics.captureError(error);
+      stellaToast.add({
+        title: t("errors.actionFailed"),
+        type: "error",
+      });
       return undefined;
     }
   };

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-retry-cell.ts
@@ -1,0 +1,53 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import { useAnalytics } from "@/lib/analytics/provider";
+import { api } from "@/lib/api";
+import { toSafeId } from "@/lib/safe-id";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
+import { workspaceKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/workspace";
+
+/**
+ * Re-runs AI extraction for one cell (one entity × one property).
+ * Resets the cell to `pending` on the server and enqueues a
+ * workflow restricted to the target property only.
+ */
+export const useRetryCell = (workspaceId: string) => {
+  const queryClient = useQueryClient();
+  const analytics = useAnalytics();
+
+  return async ({
+    entityId,
+    propertyId,
+  }: {
+    entityId: string;
+    propertyId: string;
+  }) => {
+    try {
+      const response = await api
+        .workspaces({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        ["cell-retry"].post({
+          entityId: toSafeId<"entity">(entityId),
+          propertyId: toSafeId<"property">(propertyId),
+        });
+
+      if (response.error) {
+        analytics.captureError(new Error("Failed to retry cell"));
+        return undefined;
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: entitiesKeys.all(workspaceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: workspaceKeys.workflow(workspaceId),
+        }),
+      ]);
+
+      return response.data;
+    } catch (error) {
+      analytics.captureError(error);
+      return undefined;
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- New `POST /workspaces/:workspaceId/cell-retry`: validates the target property is AI-extracted and the cell isn't locked, resets the field to `pending`, then enqueues a workflow scoped to that single property.
- `startWorkflow` gains an optional `propertyIds` filter so the execution plan can be narrowed to one cell without touching the rest of the entity.
- Right-click on an AI-model table cell now exposes "Retry" via the existing `useAnchoredMenu` primitive (reuses `common.retry`, no new i18n key).

Concurrent full-workspace workflows still take the per-workspace Redis lock, so a retry started during an active run returns `already-running`; the user retries once the run finishes.

Closes #307.