### PR TITLE
perf(web): parallelize independent awaits in chat send and task invalidate

### DIFF
--- a/apps/web/src/routes/_protected.chat/index.tsx
+++ b/apps/web/src/routes/_protected.chat/index.tsx
@@ -355,19 +355,21 @@ function ChatIndex() {
                 // reads the *same* cached instance, so kicking off
                 // `sendMessage` here lets the thread page observe
                 // the in-flight stream as soon as it mounts.
-                const message = await buildChatRequestMessage(draft);
-                const { chat } = await queryClient.ensureQueryData(
-                  chatThreadOptions({
-                    activeOrganizationId,
-                    key: threadRef,
-                    context: {
-                      allowMissingThread: true,
-                      getUserContext,
-                      getContextMatterIds,
-                      getSendMode,
-                    },
-                  }),
-                );
+                const [message, { chat }] = await Promise.all([
+                  buildChatRequestMessage(draft),
+                  queryClient.ensureQueryData(
+                    chatThreadOptions({
+                      activeOrganizationId,
+                      key: threadRef,
+                      context: {
+                        allowMissingThread: true,
+                        getUserContext,
+                        getContextMatterIds,
+                        getSendMode,
+                      },
+                    }),
+                  ),
+                ]);
 
                 // Fire-and-forget: don't block navigation on the
                 // streaming response. The thread page picks up the

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/tasks/task-metadata.tsx
@@ -174,15 +174,17 @@ export const AssigneePicker = ({
   const assignedIds = new Set(assignees.map((a) => a.user.id));
 
   const invalidate = async () => {
-    await queryClient.invalidateQueries({
-      queryKey: taskKeys.detail(workspaceId, taskId),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: entitiesKeys.all(workspaceId),
-    });
-    await queryClient.invalidateQueries({
-      queryKey: workspacesKeys.overview(workspaceId),
-    });
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: taskKeys.detail(workspaceId, taskId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(workspaceId),
+      }),
+      queryClient.invalidateQueries({
+        queryKey: workspacesKeys.overview(workspaceId),
+      }),
+    ]);
   };
 
   const queryKey = entitiesKeys.all(workspaceId);


### PR DESCRIPTION
## Summary

Two surgical fixes from a `react-doctor` pass — only the genuinely real findings; everything else (~1500 hits) was dismissed as false positive for this codebase (React Compiler enabled, invalidation via route macro, stable list keys, etc.).

- **`apps/web/src/routes/_protected.chat/index.tsx`** — new-thread send path was awaiting `buildChatRequestMessage(draft)` and `queryClient.ensureQueryData(chatThreadOptions(...))` sequentially. They have no data dependency, so they now run in parallel via `Promise.all`.
- **`apps/web/src/routes/.../tasks/task-metadata.tsx`** — `AssigneePicker.invalidate` was awaiting three independent `queryClient.invalidateQueries` calls in sequence. Now parallel via `Promise.all`.

No behavior change; just shorter wall-clock latency on these paths.

## Test plan

- [x] `bun --filter @stll/web typecheck`
- [x] `bun --filter @stll/web lint`
- [x] `bun run format`
- [ ] Manual: send a new chat thread; confirm thread page picks up streaming response
- [ ] Manual: assign/unassign a user on a task; confirm task detail, entity list, and workspace overview all refresh