### PR TITLE
feat(workspaces): mark all cells in a column as reviewed

### DIFF
--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -290,9 +290,13 @@ export default createSafeHandler(
           )
           .for("update");
 
-        if (currentCellMetadataRows.length > 0) {
+        const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
+          (row) => row.propertyId !== freshFileField.propertyId,
+        );
+
+        if (cellMetadataRowsToCopy.length > 0) {
           await tx.insert(cellMetadata).values(
-            currentCellMetadataRows.map((row) => ({
+            cellMetadataRowsToCopy.map((row) => ({
               workspaceId,
               entityVersionId: nextVersionId,
               propertyId: row.propertyId,

--- a/apps/api/src/handlers/entities/upload-version.ts
+++ b/apps/api/src/handlers/entities/upload-version.ts
@@ -1,7 +1,13 @@
 import { Result } from "better-result";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
-import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import {
+  cellMetadata,
+  entities,
+  entityVersions,
+  fields,
+  workspaces,
+} from "@/api/db/schema";
 import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
 import { uploadVersionBodySchema } from "@/api/handlers/entities/upload-version-schema";
 import {
@@ -28,6 +34,19 @@ const config = {
   permissions: { entity: ["update"] },
   body: uploadVersionBodySchema,
 } satisfies HandlerConfig;
+
+type UploadVersionWriteResult =
+  | {
+      status: "ok";
+      versionNumber: number;
+    }
+  | {
+      status:
+        | "current-version-not-found"
+        | "entity-not-found"
+        | "entity-read-only"
+        | "missing-file-field";
+    };
 
 export default createSafeHandler(
   config,
@@ -160,18 +179,63 @@ export default createSafeHandler(
       ),
     );
 
-    const nextVersionNumber = currentVersion.versionNumber + 1;
     const nextVersionId = createSafeId<"entityVersion">();
     const fileFieldId = createSafeId<"field">();
-    const nextVersionStamp = buildVersionStamp({
-      docSequence: entity.docSequence,
-      versionNumber: nextVersionNumber,
-      workspaceReference: workspace?.reference ?? null,
-    });
 
     // Create new version in DB
-    yield* Result.await(
-      safeDb(async (tx) => {
+    const writeResult = yield* Result.await(
+      safeDb(async (tx): Promise<UploadVersionWriteResult> => {
+        const entityRows = await tx
+          .select({
+            currentVersionId: entities.currentVersionId,
+            docSequence: entities.docSequence,
+            readOnly: entities.readOnly,
+          })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.id, entityId),
+              eq(entities.workspaceId, workspaceId),
+            ),
+          )
+          .limit(1)
+          .for("update");
+        const lockedEntity = entityRows.at(0);
+
+        if (!lockedEntity?.currentVersionId) {
+          return { status: "entity-not-found" };
+        }
+        if (lockedEntity.readOnly) {
+          return { status: "entity-read-only" };
+        }
+
+        const freshCurrentVersionId = lockedEntity.currentVersionId;
+        const freshCurrentVersion = await tx.query.entityVersions.findFirst({
+          where: { id: { eq: freshCurrentVersionId } },
+          columns: { versionNumber: true },
+          with: {
+            fields: { columns: { content: true, propertyId: true } },
+          },
+        });
+
+        if (!freshCurrentVersion) {
+          return { status: "current-version-not-found" };
+        }
+
+        const freshFileField = freshCurrentVersion.fields.find(
+          (f) => f.content.type === "file",
+        );
+        if (!freshFileField) {
+          return { status: "missing-file-field" };
+        }
+
+        const nextVersionNumber = freshCurrentVersion.versionNumber + 1;
+        const nextVersionStamp = buildVersionStamp({
+          docSequence: lockedEntity.docSequence,
+          versionNumber: nextVersionNumber,
+          workspaceReference: workspace?.reference ?? null,
+        });
+
         await tx.insert(entityVersions).values({
           createdBy: userId,
           entityId,
@@ -184,9 +248,9 @@ export default createSafeHandler(
 
         await tx.insert(fields).values(
           cloneFieldsForRevision({
-            currentFields: currentVersion.fields,
+            currentFields: freshCurrentVersion.fields,
             entityVersionId: nextVersionId,
-            propertyId: fileField.propertyId,
+            propertyId: freshFileField.propertyId,
             replacementFieldId: fileFieldId,
             replacementContent: {
               encrypted: false,
@@ -208,6 +272,39 @@ export default createSafeHandler(
           }),
         );
 
+        const currentCellMetadataRows = await tx
+          .select({
+            createdAt: cellMetadata.createdAt,
+            createdBy: cellMetadata.createdBy,
+            metadata: cellMetadata.metadata,
+            propertyId: cellMetadata.propertyId,
+            updatedAt: cellMetadata.updatedAt,
+            updatedBy: cellMetadata.updatedBy,
+          })
+          .from(cellMetadata)
+          .where(
+            and(
+              eq(cellMetadata.workspaceId, workspaceId),
+              eq(cellMetadata.entityVersionId, freshCurrentVersionId),
+            ),
+          )
+          .for("update");
+
+        if (currentCellMetadataRows.length > 0) {
+          await tx.insert(cellMetadata).values(
+            currentCellMetadataRows.map((row) => ({
+              workspaceId,
+              entityVersionId: nextVersionId,
+              propertyId: row.propertyId,
+              metadata: row.metadata,
+              createdBy: row.createdBy,
+              updatedBy: row.updatedBy,
+              createdAt: row.createdAt,
+              updatedAt: row.updatedAt,
+            })),
+          );
+        }
+
         await tx
           .update(entities)
           .set({
@@ -215,7 +312,12 @@ export default createSafeHandler(
             lastEditedBy: userId,
             updatedAt: new Date(),
           })
-          .where(eq(entities.id, entityId));
+          .where(
+            and(
+              eq(entities.id, entityId),
+              eq(entities.workspaceId, workspaceId),
+            ),
+          );
 
         await tx
           .update(workspaces)
@@ -253,14 +355,44 @@ export default createSafeHandler(
             resourceId: entityId,
             changes: {
               currentVersionId: {
-                old: currentVersionId,
+                old: freshCurrentVersionId,
                 new: nextVersionId,
               },
             },
           },
         ]);
+
+        return { status: "ok", versionNumber: nextVersionNumber };
       }),
     );
+
+    if (writeResult.status !== "ok") {
+      switch (writeResult.status) {
+        case "entity-not-found":
+          return Result.err(
+            new HandlerError({ status: 404, message: "Entity not found" }),
+          );
+        case "entity-read-only":
+          return Result.err(
+            new HandlerError({ status: 409, message: "Entity is read-only" }),
+          );
+        case "current-version-not-found":
+          return Result.err(
+            new HandlerError({
+              status: 404,
+              message: "Current version not found",
+            }),
+          );
+        case "missing-file-field":
+          return Result.err(
+            new HandlerError({
+              status: 400,
+              message: "Entity has no file field",
+            }),
+          );
+      }
+    }
+    const nextVersionNumber = writeResult.versionNumber;
 
     // Fire-and-forget: extraction + diff stats
     processExtraction(entityId).catch((error: unknown) => {

--- a/apps/api/src/handlers/entities/zip-archive.ts
+++ b/apps/api/src/handlers/entities/zip-archive.ts
@@ -136,7 +136,7 @@ export const uniquePath = (seen: Set<string>, path: string): string => {
  * `worker` must not reject: a rejection surfaces from the generator and
  * breaks the consuming stream. Callers wrap failures into the result.
  *
- * @yields each worker result, in the order of `items`.
+ * @yields {R} each worker result, in the order of `items`.
  */
 export const mapOrderedConcurrent = async function* <T, R>(
   items: Iterable<T>,

--- a/apps/api/src/handlers/fields/mark-column-flag.logic.test.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.logic.test.ts
@@ -147,4 +147,35 @@ describe("mark column flag metadata planning", () => {
       updatedCount: 0,
     });
   });
+
+  test("skips cells that would exceed the manual flag cap", () => {
+    const target = createTarget("ent_flag_cap", "ver_flag_cap");
+    const existingFlags = Array.from(
+      { length: 16 },
+      (_, index) => `flag-${index.toString().padStart(2, "0")}`,
+    );
+    const mutation = buildColumnFlagMutation({
+      workspaceId: WORKSPACE_ID,
+      propertyId: PROPERTY_ID,
+      flag: "verified",
+      targets: [target],
+      existingRows: [
+        {
+          entityVersionId: target.entityVersionId,
+          metadata: {
+            version: 1,
+            manualFlags: existingFlags,
+          },
+        },
+      ],
+      userId: USER_ID,
+      addedAt: ADDED_AT,
+    });
+
+    expect(mutation).toEqual({
+      auditEvents: [],
+      insertValues: [],
+      updatedCount: 0,
+    });
+  });
 });

--- a/apps/api/src/handlers/fields/mark-column-flag.logic.test.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.logic.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import { toSafeId } from "@/api/lib/branded-types";
+
+import {
+  buildColumnFlagMutation,
+  sortColumnFlagTargetsForLocking,
+  type ColumnFlagTarget,
+} from "./mark-column-flag.logic";
+
+const WORKSPACE_ID = toSafeId<"workspace">("ws_mark_column_flag");
+const PROPERTY_ID = toSafeId<"property">("prop_mark_column_flag");
+const USER_ID = toSafeId<"user">("user_mark_column_flag");
+const ADDED_AT = "2026-05-28T09:00:00.000Z";
+const LOCKED_AT = "2026-05-28T08:00:00.000Z";
+
+const createTarget = (
+  entityId: string,
+  entityVersionId: string,
+): ColumnFlagTarget => ({
+  entityId: toSafeId<"entity">(entityId),
+  entityVersionId: toSafeId<"entityVersion">(entityVersionId),
+});
+
+describe("mark column flag metadata planning", () => {
+  test("sorts targets before advisory lock acquisition", () => {
+    const first = createTarget("ent_first", "ver_001");
+    const second = createTarget("ent_second", "ver_002");
+    const targets = [second, first];
+
+    expect(sortColumnFlagTargetsForLocking(targets)).toEqual([first, second]);
+    expect(targets).toEqual([second, first]);
+  });
+
+  test("adds the requested flag without overwriting existing flags or locks", () => {
+    const target = createTarget("ent_needs_review", "ver_needs_review");
+    const mutation = buildColumnFlagMutation({
+      workspaceId: WORKSPACE_ID,
+      propertyId: PROPERTY_ID,
+      flag: "verified",
+      targets: [target],
+      existingRows: [
+        {
+          entityVersionId: target.entityVersionId,
+          metadata: {
+            version: 1,
+            manualFlags: ["needs-review"],
+            flagProvenance: {
+              "needs-review": {
+                addedBy: "user_existing",
+                addedAt: "2026-05-28T07:00:00.000Z",
+              },
+            },
+            locked: true,
+            lockProvenance: {
+              lockedBy: "user_lock",
+              lockedAt: LOCKED_AT,
+              reason: "explicit",
+            },
+          },
+        },
+      ],
+      userId: USER_ID,
+      addedAt: ADDED_AT,
+    });
+
+    expect(mutation.updatedCount).toBe(1);
+    expect(mutation.insertValues).toEqual([
+      {
+        workspaceId: WORKSPACE_ID,
+        entityVersionId: target.entityVersionId,
+        propertyId: PROPERTY_ID,
+        metadata: {
+          version: 1,
+          manualFlags: ["needs-review", "verified"],
+          flagProvenance: {
+            "needs-review": {
+              addedBy: "user_existing",
+              addedAt: "2026-05-28T07:00:00.000Z",
+            },
+            verified: {
+              addedBy: USER_ID,
+              addedAt: ADDED_AT,
+            },
+          },
+          locked: true,
+          lockProvenance: {
+            lockedBy: "user_lock",
+            lockedAt: LOCKED_AT,
+            reason: "explicit",
+          },
+        },
+        createdBy: USER_ID,
+        updatedBy: USER_ID,
+      },
+    ]);
+    expect(mutation.auditEvents).toEqual([
+      {
+        action: "update",
+        resourceType: "field",
+        resourceId: `${target.entityVersionId}:${PROPERTY_ID}`,
+        changes: {
+          manualFlags: {
+            old: ["needs-review"],
+            new: ["needs-review", "verified"],
+          },
+        },
+        metadata: {
+          entityId: target.entityId,
+          entityVersionId: target.entityVersionId,
+          propertyId: PROPERTY_ID,
+          bulk: true,
+        },
+      },
+    ]);
+  });
+
+  test("skips cells that already have the requested flag", () => {
+    const target = createTarget("ent_verified", "ver_verified");
+    const mutation = buildColumnFlagMutation({
+      workspaceId: WORKSPACE_ID,
+      propertyId: PROPERTY_ID,
+      flag: "verified",
+      targets: [target],
+      existingRows: [
+        {
+          entityVersionId: target.entityVersionId,
+          metadata: {
+            version: 1,
+            manualFlags: ["verified"],
+            flagProvenance: {
+              verified: {
+                addedBy: "user_existing",
+                addedAt: "2026-05-28T07:00:00.000Z",
+              },
+            },
+          },
+        },
+      ],
+      userId: USER_ID,
+      addedAt: ADDED_AT,
+    });
+
+    expect(mutation).toEqual({
+      auditEvents: [],
+      insertValues: [],
+      updatedCount: 0,
+    });
+  });
+});

--- a/apps/api/src/handlers/fields/mark-column-flag.logic.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.logic.ts
@@ -4,6 +4,7 @@ import type { AuditEvent } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 
 const CELL_METADATA_VERSION = 1;
+const MANUAL_FLAGS_MAX_ITEMS = 16;
 
 type CellMetadataInsert = {
   workspaceId: SafeId<"workspace">;
@@ -70,6 +71,10 @@ export const buildColumnFlagMutation = ({
     const existingFlags = normalizeManualFlags(existing?.manualFlags ?? []);
 
     if (existingFlags.includes(flag)) {
+      continue;
+    }
+
+    if (existingFlags.length >= MANUAL_FLAGS_MAX_ITEMS) {
       continue;
     }
 

--- a/apps/api/src/handlers/fields/mark-column-flag.logic.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.logic.ts
@@ -1,0 +1,124 @@
+import type { CellMetadata } from "@/api/db/schema-validators";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditEvent } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+
+const CELL_METADATA_VERSION = 1;
+
+type CellMetadataInsert = {
+  workspaceId: SafeId<"workspace">;
+  entityVersionId: SafeId<"entityVersion">;
+  propertyId: SafeId<"property">;
+  metadata: CellMetadata;
+  createdBy: string;
+  updatedBy: string;
+};
+
+export type ColumnFlagTarget = {
+  entityId: SafeId<"entity">;
+  entityVersionId: SafeId<"entityVersion">;
+};
+
+type ExistingCellMetadataRow = {
+  entityVersionId: SafeId<"entityVersion">;
+  metadata: CellMetadata;
+};
+
+type BuildColumnFlagMutationArgs = {
+  workspaceId: SafeId<"workspace">;
+  propertyId: SafeId<"property">;
+  flag: string;
+  targets: readonly ColumnFlagTarget[];
+  existingRows: readonly ExistingCellMetadataRow[];
+  userId: string;
+  addedAt: string;
+};
+
+type ColumnFlagMutation = {
+  auditEvents: AuditEvent[];
+  insertValues: CellMetadataInsert[];
+  updatedCount: number;
+};
+
+const normalizeManualFlags = (flags: string[]) =>
+  [...new Set(flags)].toSorted();
+
+export const sortColumnFlagTargetsForLocking = (
+  targets: readonly ColumnFlagTarget[],
+) =>
+  targets.toSorted((a, b) =>
+    a.entityVersionId.localeCompare(b.entityVersionId),
+  );
+
+export const buildColumnFlagMutation = ({
+  workspaceId,
+  propertyId,
+  flag,
+  targets,
+  existingRows,
+  userId,
+  addedAt,
+}: BuildColumnFlagMutationArgs): ColumnFlagMutation => {
+  const existingByVersionId = new Map(
+    existingRows.map((row) => [row.entityVersionId, row.metadata]),
+  );
+  const auditEvents: AuditEvent[] = [];
+  const insertValues: CellMetadataInsert[] = [];
+
+  for (const target of targets) {
+    const existing = existingByVersionId.get(target.entityVersionId);
+    const existingFlags = normalizeManualFlags(existing?.manualFlags ?? []);
+
+    if (existingFlags.includes(flag)) {
+      continue;
+    }
+
+    const manualFlags = normalizeManualFlags([...existingFlags, flag]);
+    const existingProvenance = existing?.flagProvenance ?? {};
+    const flagProvenance = Object.fromEntries(
+      manualFlags.map((manualFlag) => [
+        manualFlag,
+        existingProvenance[manualFlag] ?? { addedBy: userId, addedAt },
+      ]),
+    );
+    const metadata: CellMetadata = {
+      version: CELL_METADATA_VERSION,
+      manualFlags,
+      flagProvenance,
+      ...(existing?.locked === true && { locked: true }),
+      ...(existing?.lockProvenance && {
+        lockProvenance: existing.lockProvenance,
+      }),
+    };
+
+    insertValues.push({
+      workspaceId,
+      entityVersionId: target.entityVersionId,
+      propertyId,
+      metadata,
+      createdBy: userId,
+      updatedBy: userId,
+    });
+
+    auditEvents.push({
+      action: AUDIT_ACTION.UPDATE,
+      resourceType: AUDIT_RESOURCE_TYPE.FIELD,
+      resourceId: `${target.entityVersionId}:${propertyId}`,
+      changes: {
+        manualFlags: { old: existingFlags, new: manualFlags },
+      },
+      metadata: {
+        entityId: target.entityId,
+        entityVersionId: target.entityVersionId,
+        propertyId,
+        bulk: true,
+      },
+    });
+  }
+
+  return {
+    auditEvents,
+    insertValues,
+    updatedCount: insertValues.length,
+  };
+};

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -20,7 +20,12 @@ import type { AuditRecorder } from "@/api/lib/audit-log";
 import type { SafeId } from "@/api/lib/branded-types";
 import { acquireCellLock } from "@/api/lib/cell-lock";
 import { tSafeId } from "@/api/lib/custom-schema";
+import { buildFilterConditions } from "@/api/lib/entity-filters";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  tViewFilterConditionSchema,
+  type ViewFilterCondition,
+} from "@/api/lib/views-schema";
 
 import {
   buildColumnFlagMutation,
@@ -40,6 +45,7 @@ const config = {
   body: t.Object({
     propertyId: tSafeId("property"),
     flag: t.String({ minLength: 1, maxLength: 64 }),
+    filters: t.Array(tViewFilterConditionSchema),
   }),
 } satisfies HandlerConfig;
 
@@ -59,6 +65,7 @@ type ProcessColumnFlagBatchArgs = {
   workspaceId: SafeId<"workspace">;
   propertyId: SafeId<"property">;
   flag: string;
+  filters: ViewFilterCondition[];
   userId: SafeId<"user">;
   cursor: SafeId<"entity"> | null;
   addedAt: string;
@@ -70,6 +77,7 @@ const processColumnFlagBatch = async ({
   workspaceId,
   propertyId,
   flag,
+  filters,
   userId,
   cursor,
   addedAt,
@@ -106,6 +114,7 @@ const processColumnFlagBatch = async ({
           eq(entities.workspaceId, workspaceId),
           isNotNull(entities.currentVersionId),
           notInArray(entities.kind, TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS),
+          ...buildFilterConditions(filters),
           ...(cursorCondition ? [cursorCondition] : []),
         ),
       )
@@ -216,6 +225,7 @@ const markColumnFlag = createSafeHandler(
           workspaceId,
           propertyId: body.propertyId,
           flag: body.flag,
+          filters: body.filters,
           userId: user.id,
           cursor,
           addedAt,

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -1,8 +1,9 @@
 import { Result } from "better-result";
-import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, notInArray, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { cellMetadata, entities, properties } from "@/api/db/schema";
+import type { EntityKind } from "@/api/db/schema-validators";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { acquireCellLock } from "@/api/lib/cell-lock";
@@ -13,6 +14,11 @@ import {
   buildColumnFlagMutation,
   sortColumnFlagTargetsForLocking,
 } from "./mark-column-flag.logic";
+
+const TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS = [
+  "folder",
+  "task",
+] satisfies EntityKind[];
 
 const config = {
   permissions: {
@@ -64,6 +70,10 @@ const markColumnFlag = createSafeHandler(
             and(
               eq(entities.workspaceId, workspaceId),
               isNotNull(entities.currentVersionId),
+              notInArray(
+                entities.kind,
+                TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS,
+              ),
             ),
           )
           .orderBy(asc(entities.id))

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -37,6 +37,7 @@ const TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS = [
   "task",
 ] satisfies EntityKind[];
 const COLUMN_FLAG_TARGET_BATCH_SIZE = 500;
+const VERIFIED_COLUMN_FLAG = "verified";
 
 const config = {
   permissions: {
@@ -44,7 +45,7 @@ const config = {
   },
   body: t.Object({
     propertyId: tSafeId("property"),
-    flag: t.String({ minLength: 1, maxLength: 64 }),
+    flag: t.Literal(VERIFIED_COLUMN_FLAG),
     filters: t.Array(tViewFilterConditionSchema),
   }),
 } satisfies HandlerConfig;

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -1,15 +1,18 @@
 import { Result } from "better-result";
-import { and, eq, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { cellMetadata, entities, properties } from "@/api/db/schema";
-import type { CellMetadata } from "@/api/db/schema-validators";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
-import type { AuditEvent } from "@/api/lib/audit-log";
+import { acquireCellLock } from "@/api/lib/cell-lock";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+import {
+  buildColumnFlagMutation,
+  sortColumnFlagTargetsForLocking,
+} from "./mark-column-flag.logic";
 
 const config = {
   permissions: {
@@ -21,14 +24,20 @@ const config = {
   }),
 } satisfies HandlerConfig;
 
-const normalizeManualFlags = (flags: string[]) =>
-  [...new Set(flags)].toSorted();
+type MarkColumnFlagResult =
+  | {
+      status: "ok";
+      updatedCount: number;
+    }
+  | {
+      status: "property-not-found";
+    };
 
 const markColumnFlag = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, body, user, recordAuditEvent }) {
-    const propertyResult = yield* Result.await(
-      safeDb(async (tx) => {
+    const txResult = yield* Result.await(
+      safeDb(async (tx): Promise<MarkColumnFlagResult> => {
         const propertyRows = await tx
           .select({ id: properties.id })
           .from(properties)
@@ -39,21 +48,12 @@ const markColumnFlag = createSafeHandler(
             ),
           )
           .limit(1);
-        return propertyRows.at(0);
-      }),
-    );
+        const property = propertyRows.at(0);
 
-    if (!propertyResult) {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Property not found in workspace",
-        }),
-      );
-    }
+        if (!property) {
+          return { status: "property-not-found" };
+        }
 
-    const txResult = yield* Result.await(
-      safeDb(async (tx) => {
         const entityRows = await tx
           .select({
             entityId: entities.id,
@@ -67,19 +67,29 @@ const markColumnFlag = createSafeHandler(
             ),
           );
 
-        const targets = entityRows.flatMap((row) =>
-          row.entityVersionId
-            ? [
-                {
-                  entityId: row.entityId,
-                  entityVersionId: row.entityVersionId,
-                },
-              ]
-            : [],
+        const targets = sortColumnFlagTargetsForLocking(
+          entityRows.flatMap((row) =>
+            row.entityVersionId
+              ? [
+                  {
+                    entityId: row.entityId,
+                    entityVersionId: row.entityVersionId,
+                  },
+                ]
+              : [],
+          ),
         );
 
         if (targets.length === 0) {
-          return { updatedCount: 0 };
+          return { status: "ok", updatedCount: 0 };
+        }
+
+        for (const target of targets) {
+          await acquireCellLock({
+            tx,
+            entityVersionId: target.entityVersionId,
+            propertyId: property.id,
+          });
         }
 
         const existingRows = await tx
@@ -91,90 +101,55 @@ const markColumnFlag = createSafeHandler(
           .where(
             and(
               eq(cellMetadata.workspaceId, workspaceId),
-              eq(cellMetadata.propertyId, body.propertyId),
+              eq(cellMetadata.propertyId, property.id),
+              inArray(
+                cellMetadata.entityVersionId,
+                targets.map((target) => target.entityVersionId),
+              ),
             ),
-          );
+          )
+          .for("update");
 
-        const existingByVersionId = new Map(
-          existingRows.map((row) => [row.entityVersionId, row.metadata]),
-        );
+        const mutation = buildColumnFlagMutation({
+          workspaceId,
+          propertyId: property.id,
+          flag: body.flag,
+          targets,
+          existingRows,
+          userId: user.id,
+          addedAt: new Date().toISOString(),
+        });
 
-        const addedAt = new Date().toISOString();
-        const auditEvents: AuditEvent[] = [];
-        let updatedCount = 0;
-
-        for (const target of targets) {
-          const existing = existingByVersionId.get(target.entityVersionId);
-          const existingFlags = normalizeManualFlags(
-            existing?.manualFlags ?? [],
-          );
-          if (existingFlags.includes(body.flag)) {
-            continue;
-          }
-          const manualFlags = normalizeManualFlags([
-            ...existingFlags,
-            body.flag,
-          ]);
-          const existingProvenance = existing?.flagProvenance ?? {};
-          const flagProvenance = Object.fromEntries(
-            manualFlags.map((f) => [
-              f,
-              existingProvenance[f] ?? { addedBy: user.id, addedAt },
-            ]),
-          );
-          const metadata: CellMetadata = {
-            version: 1,
-            manualFlags,
-            flagProvenance,
-            ...(existing?.locked === true && { locked: true }),
-            ...(existing?.lockProvenance && {
-              lockProvenance: existing.lockProvenance,
-            }),
-          };
-
+        if (mutation.insertValues.length > 0) {
           await tx
             .insert(cellMetadata)
-            .values({
-              workspaceId,
-              entityVersionId: target.entityVersionId,
-              propertyId: body.propertyId,
-              metadata,
-              createdBy: user.id,
-              updatedBy: user.id,
-            })
+            .values(mutation.insertValues)
             .onConflictDoUpdate({
               target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
               set: {
-                metadata,
+                metadata: sql`excluded.metadata`,
                 updatedBy: user.id,
                 updatedAt: new Date(),
               },
             });
-
-          auditEvents.push({
-            action: AUDIT_ACTION.UPDATE,
-            resourceType: AUDIT_RESOURCE_TYPE.FIELD,
-            resourceId: `${target.entityVersionId}:${body.propertyId}`,
-            changes: {
-              manualFlags: { old: existingFlags, new: manualFlags },
-            },
-            metadata: {
-              entityId: target.entityId,
-              entityVersionId: target.entityVersionId,
-              propertyId: body.propertyId,
-              bulk: true,
-            },
-          });
-          updatedCount++;
         }
 
-        if (auditEvents.length > 0) {
-          await recordAuditEvent(tx, auditEvents);
+        if (mutation.auditEvents.length > 0) {
+          await recordAuditEvent(tx, mutation.auditEvents);
         }
 
-        return { updatedCount };
+        return { status: "ok", updatedCount: mutation.updatedCount };
       }),
     );
+
+    if (txResult.status === "property-not-found") {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Property not found in workspace",
+        }),
+      );
+    }
 
     return Result.ok({ success: true, updatedCount: txResult.updatedCount });
   },

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -1,0 +1,183 @@
+import { Result } from "better-result";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { t } from "elysia";
+
+import { cellMetadata, entities, properties } from "@/api/db/schema";
+import type { CellMetadata } from "@/api/db/schema-validators";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditEvent } from "@/api/lib/audit-log";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const config = {
+  permissions: {
+    entity: ["update"],
+  },
+  body: t.Object({
+    propertyId: tSafeId("property"),
+    flag: t.String({ minLength: 1, maxLength: 64 }),
+  }),
+} satisfies HandlerConfig;
+
+const normalizeManualFlags = (flags: string[]) =>
+  [...new Set(flags)].toSorted();
+
+const markColumnFlag = createSafeHandler(
+  config,
+  async function* ({ safeDb, workspaceId, body, user, recordAuditEvent }) {
+    const propertyResult = yield* Result.await(
+      safeDb(async (tx) => {
+        const propertyRows = await tx
+          .select({ id: properties.id })
+          .from(properties)
+          .where(
+            and(
+              eq(properties.id, body.propertyId),
+              eq(properties.workspaceId, workspaceId),
+            ),
+          )
+          .limit(1);
+        return propertyRows.at(0);
+      }),
+    );
+
+    if (!propertyResult) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Property not found in workspace",
+        }),
+      );
+    }
+
+    const txResult = yield* Result.await(
+      safeDb(async (tx) => {
+        const entityRows = await tx
+          .select({
+            entityId: entities.id,
+            entityVersionId: entities.currentVersionId,
+          })
+          .from(entities)
+          .where(
+            and(
+              eq(entities.workspaceId, workspaceId),
+              isNotNull(entities.currentVersionId),
+            ),
+          );
+
+        const targets = entityRows.flatMap((row) =>
+          row.entityVersionId
+            ? [
+                {
+                  entityId: row.entityId,
+                  entityVersionId: row.entityVersionId,
+                },
+              ]
+            : [],
+        );
+
+        if (targets.length === 0) {
+          return { updatedCount: 0 };
+        }
+
+        const existingRows = await tx
+          .select({
+            entityVersionId: cellMetadata.entityVersionId,
+            metadata: cellMetadata.metadata,
+          })
+          .from(cellMetadata)
+          .where(
+            and(
+              eq(cellMetadata.workspaceId, workspaceId),
+              eq(cellMetadata.propertyId, body.propertyId),
+            ),
+          );
+
+        const existingByVersionId = new Map(
+          existingRows.map((row) => [row.entityVersionId, row.metadata]),
+        );
+
+        const addedAt = new Date().toISOString();
+        const auditEvents: AuditEvent[] = [];
+        let updatedCount = 0;
+
+        for (const target of targets) {
+          const existing = existingByVersionId.get(target.entityVersionId);
+          const existingFlags = normalizeManualFlags(
+            existing?.manualFlags ?? [],
+          );
+          if (existingFlags.includes(body.flag)) {
+            continue;
+          }
+          const manualFlags = normalizeManualFlags([
+            ...existingFlags,
+            body.flag,
+          ]);
+          const existingProvenance = existing?.flagProvenance ?? {};
+          const flagProvenance = Object.fromEntries(
+            manualFlags.map((f) => [
+              f,
+              existingProvenance[f] ?? { addedBy: user.id, addedAt },
+            ]),
+          );
+          const metadata: CellMetadata = {
+            version: 1,
+            manualFlags,
+            flagProvenance,
+            ...(existing?.locked === true && { locked: true }),
+            ...(existing?.lockProvenance && {
+              lockProvenance: existing.lockProvenance,
+            }),
+          };
+
+          await tx
+            .insert(cellMetadata)
+            .values({
+              workspaceId,
+              entityVersionId: target.entityVersionId,
+              propertyId: body.propertyId,
+              metadata,
+              createdBy: user.id,
+              updatedBy: user.id,
+            })
+            .onConflictDoUpdate({
+              target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
+              set: {
+                metadata,
+                updatedBy: user.id,
+                updatedAt: new Date(),
+              },
+            });
+
+          auditEvents.push({
+            action: AUDIT_ACTION.UPDATE,
+            resourceType: AUDIT_RESOURCE_TYPE.FIELD,
+            resourceId: `${target.entityVersionId}:${body.propertyId}`,
+            changes: {
+              manualFlags: { old: existingFlags, new: manualFlags },
+            },
+            metadata: {
+              entityId: target.entityId,
+              entityVersionId: target.entityVersionId,
+              propertyId: body.propertyId,
+              bulk: true,
+            },
+          });
+          updatedCount++;
+        }
+
+        if (auditEvents.length > 0) {
+          await recordAuditEvent(tx, auditEvents);
+        }
+
+        return { updatedCount };
+      }),
+    );
+
+    return Result.ok({ success: true, updatedCount: txResult.updatedCount });
+  },
+);
+
+export default markColumnFlag;

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { cellMetadata, entities, properties } from "@/api/db/schema";
@@ -65,7 +65,9 @@ const markColumnFlag = createSafeHandler(
               eq(entities.workspaceId, workspaceId),
               isNotNull(entities.currentVersionId),
             ),
-          );
+          )
+          .orderBy(asc(entities.id))
+          .for("update");
 
         const targets = sortColumnFlagTargetsForLocking(
           entityRows.flatMap((row) =>

--- a/apps/api/src/handlers/fields/mark-column-flag.ts
+++ b/apps/api/src/handlers/fields/mark-column-flag.ts
@@ -1,11 +1,23 @@
 import { Result } from "better-result";
-import { and, asc, eq, inArray, isNotNull, notInArray, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  notInArray,
+  sql,
+} from "drizzle-orm";
 import { t } from "elysia";
 
+import type { SafeDb, SafeDbError } from "@/api/db";
 import { cellMetadata, entities, properties } from "@/api/db/schema";
 import type { EntityKind } from "@/api/db/schema-validators";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
 import { acquireCellLock } from "@/api/lib/cell-lock";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
@@ -19,6 +31,7 @@ const TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS = [
   "folder",
   "task",
 ] satisfies EntityKind[];
+const COLUMN_FLAG_TARGET_BATCH_SIZE = 500;
 
 const config = {
   permissions: {
@@ -30,140 +43,205 @@ const config = {
   }),
 } satisfies HandlerConfig;
 
-type MarkColumnFlagResult =
+type MarkColumnFlagBatchResult =
   | {
       status: "ok";
       updatedCount: number;
+      hasMore: boolean;
+      nextCursor: SafeId<"entity"> | null;
     }
   | {
       status: "property-not-found";
     };
 
+type ProcessColumnFlagBatchArgs = {
+  safeDb: SafeDb;
+  workspaceId: SafeId<"workspace">;
+  propertyId: SafeId<"property">;
+  flag: string;
+  userId: SafeId<"user">;
+  cursor: SafeId<"entity"> | null;
+  addedAt: string;
+  recordAuditEvent: AuditRecorder;
+};
+
+const processColumnFlagBatch = async ({
+  safeDb,
+  workspaceId,
+  propertyId,
+  flag,
+  userId,
+  cursor,
+  addedAt,
+  recordAuditEvent,
+}: ProcessColumnFlagBatchArgs): Promise<
+  Result<MarkColumnFlagBatchResult, SafeDbError>
+> =>
+  await safeDb(async (tx): Promise<MarkColumnFlagBatchResult> => {
+    const propertyRows = await tx
+      .select({ id: properties.id })
+      .from(properties)
+      .where(
+        and(
+          eq(properties.id, propertyId),
+          eq(properties.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1);
+    const property = propertyRows.at(0);
+
+    if (!property) {
+      return { status: "property-not-found" };
+    }
+
+    const cursorCondition = cursor ? gt(entities.id, cursor) : undefined;
+    const entityRows = await tx
+      .select({
+        entityId: entities.id,
+        entityVersionId: entities.currentVersionId,
+      })
+      .from(entities)
+      .where(
+        and(
+          eq(entities.workspaceId, workspaceId),
+          isNotNull(entities.currentVersionId),
+          notInArray(entities.kind, TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS),
+          ...(cursorCondition ? [cursorCondition] : []),
+        ),
+      )
+      .orderBy(asc(entities.id))
+      .limit(COLUMN_FLAG_TARGET_BATCH_SIZE)
+      .for("update");
+    const nextCursor = entityRows.at(-1)?.entityId ?? null;
+    const hasMore = entityRows.length === COLUMN_FLAG_TARGET_BATCH_SIZE;
+
+    const targets = sortColumnFlagTargetsForLocking(
+      entityRows.flatMap((row) =>
+        row.entityVersionId
+          ? [
+              {
+                entityId: row.entityId,
+                entityVersionId: row.entityVersionId,
+              },
+            ]
+          : [],
+      ),
+    );
+
+    if (targets.length === 0) {
+      return {
+        status: "ok",
+        updatedCount: 0,
+        hasMore,
+        nextCursor,
+      };
+    }
+
+    for (const target of targets) {
+      await acquireCellLock({
+        tx,
+        entityVersionId: target.entityVersionId,
+        propertyId: property.id,
+      });
+    }
+
+    const existingRows = await tx
+      .select({
+        entityVersionId: cellMetadata.entityVersionId,
+        metadata: cellMetadata.metadata,
+      })
+      .from(cellMetadata)
+      .where(
+        and(
+          eq(cellMetadata.workspaceId, workspaceId),
+          eq(cellMetadata.propertyId, property.id),
+          inArray(
+            cellMetadata.entityVersionId,
+            targets.map((target) => target.entityVersionId),
+          ),
+        ),
+      )
+      .for("update");
+
+    const mutation = buildColumnFlagMutation({
+      workspaceId,
+      propertyId: property.id,
+      flag,
+      targets,
+      existingRows,
+      userId,
+      addedAt,
+    });
+
+    if (mutation.insertValues.length > 0) {
+      await tx
+        .insert(cellMetadata)
+        .values(mutation.insertValues)
+        .onConflictDoUpdate({
+          target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
+          set: {
+            metadata: sql`excluded.metadata`,
+            updatedBy: userId,
+            updatedAt: new Date(),
+          },
+        });
+    }
+
+    if (mutation.auditEvents.length > 0) {
+      await recordAuditEvent(tx, mutation.auditEvents);
+    }
+
+    return {
+      status: "ok",
+      updatedCount: mutation.updatedCount,
+      hasMore,
+      nextCursor,
+    };
+  });
+
 const markColumnFlag = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, body, user, recordAuditEvent }) {
-    const txResult = yield* Result.await(
-      safeDb(async (tx): Promise<MarkColumnFlagResult> => {
-        const propertyRows = await tx
-          .select({ id: properties.id })
-          .from(properties)
-          .where(
-            and(
-              eq(properties.id, body.propertyId),
-              eq(properties.workspaceId, workspaceId),
-            ),
-          )
-          .limit(1);
-        const property = propertyRows.at(0);
+    let updatedCount = 0;
+    let cursor: SafeId<"entity"> | null = null;
+    const addedAt = new Date().toISOString();
 
-        if (!property) {
-          return { status: "property-not-found" };
-        }
-
-        const entityRows = await tx
-          .select({
-            entityId: entities.id,
-            entityVersionId: entities.currentVersionId,
-          })
-          .from(entities)
-          .where(
-            and(
-              eq(entities.workspaceId, workspaceId),
-              isNotNull(entities.currentVersionId),
-              notInArray(
-                entities.kind,
-                TABLE_COLUMN_FLAG_EXCLUDED_ENTITY_KINDS,
-              ),
-            ),
-          )
-          .orderBy(asc(entities.id))
-          .for("update");
-
-        const targets = sortColumnFlagTargetsForLocking(
-          entityRows.flatMap((row) =>
-            row.entityVersionId
-              ? [
-                  {
-                    entityId: row.entityId,
-                    entityVersionId: row.entityVersionId,
-                  },
-                ]
-              : [],
-          ),
-        );
-
-        if (targets.length === 0) {
-          return { status: "ok", updatedCount: 0 };
-        }
-
-        for (const target of targets) {
-          await acquireCellLock({
-            tx,
-            entityVersionId: target.entityVersionId,
-            propertyId: property.id,
-          });
-        }
-
-        const existingRows = await tx
-          .select({
-            entityVersionId: cellMetadata.entityVersionId,
-            metadata: cellMetadata.metadata,
-          })
-          .from(cellMetadata)
-          .where(
-            and(
-              eq(cellMetadata.workspaceId, workspaceId),
-              eq(cellMetadata.propertyId, property.id),
-              inArray(
-                cellMetadata.entityVersionId,
-                targets.map((target) => target.entityVersionId),
-              ),
-            ),
-          )
-          .for("update");
-
-        const mutation = buildColumnFlagMutation({
+    while (true) {
+      const txResult: MarkColumnFlagBatchResult = yield* Result.await<
+        MarkColumnFlagBatchResult,
+        SafeDbError
+      >(
+        processColumnFlagBatch({
+          safeDb,
           workspaceId,
-          propertyId: property.id,
+          propertyId: body.propertyId,
           flag: body.flag,
-          targets,
-          existingRows,
           userId: user.id,
-          addedAt: new Date().toISOString(),
-        });
-
-        if (mutation.insertValues.length > 0) {
-          await tx
-            .insert(cellMetadata)
-            .values(mutation.insertValues)
-            .onConflictDoUpdate({
-              target: [cellMetadata.entityVersionId, cellMetadata.propertyId],
-              set: {
-                metadata: sql`excluded.metadata`,
-                updatedBy: user.id,
-                updatedAt: new Date(),
-              },
-            });
-        }
-
-        if (mutation.auditEvents.length > 0) {
-          await recordAuditEvent(tx, mutation.auditEvents);
-        }
-
-        return { status: "ok", updatedCount: mutation.updatedCount };
-      }),
-    );
-
-    if (txResult.status === "property-not-found") {
-      return Result.err(
-        new HandlerError({
-          status: 404,
-          message: "Property not found in workspace",
+          cursor,
+          addedAt,
+          recordAuditEvent,
         }),
       );
+
+      if (txResult.status === "property-not-found") {
+        return Result.err(
+          new HandlerError({
+            status: 404,
+            message: "Property not found in workspace",
+          }),
+        );
+      }
+
+      updatedCount += txResult.updatedCount;
+
+      if (!txResult.hasMore || !txResult.nextCursor) {
+        break;
+      }
+
+      cursor = txResult.nextCursor;
     }
 
-    return Result.ok({ success: true, updatedCount: txResult.updatedCount });
+    return Result.ok({ success: true, updatedCount });
   },
 );
 

--- a/apps/api/src/handlers/fields/routes.ts
+++ b/apps/api/src/handlers/fields/routes.ts
@@ -1,5 +1,6 @@
 import Elysia from "elysia";
 
+import markColumnFlag from "@/api/handlers/fields/mark-column-flag";
 import updateCellMetadata from "@/api/handlers/fields/update-cell-metadata";
 import upsertField from "@/api/handlers/fields/upsert-by-id";
 import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
@@ -21,4 +22,9 @@ export const fieldsRoute = new Elysia({ prefix: "/fields/:workspaceId" })
     body: updateCellMetadata.config.body,
     invalidateQuery: true,
     permissions: updateCellMetadata.config.permissions,
+  })
+  .patch("/metadata-batch", markColumnFlag.handler, {
+    body: markColumnFlag.config.body,
+    invalidateQuery: true,
+    permissions: markColumnFlag.config.permissions,
   });

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -12,9 +12,7 @@ const loadAnonymizationGazetteerEntriesMock = mock();
 const decryptContentMock = mock();
 const captureErrorMock = mock();
 const analyticsCaptureMock = mock();
-const analyticsFlushMock = mock(async function flushAnalyticsMock() {
-  return;
-});
+const analyticsFlushMock = mock(async () => undefined);
 const getAnalyticsMock = mock(() => ({
   capture: analyticsCaptureMock,
   flush: analyticsFlushMock,

--- a/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs/app-breadcrumbs.tsx
@@ -27,20 +27,46 @@ const deserializeKey = (key: string) =>
   // eslint-disable-next-line typescript/no-unsafe-type-assertion
   key.split(PATH_SEPARATOR) as RouterFullPath[];
 
-type BreadcrumbComponent<TPath extends RouterFullPath> = (
-  params: ResolveParams<TPath>,
-) => React.JSX.Element;
+type BreadcrumbEntry =
+  | React.JSX.Element
+  | ((params: ResolveParams<RouterFullPath>) => React.ReactNode);
+
+const renderPdfBreadcrumb = () => <PdfBreadcrumb />;
+
+const renderWorkspaceBreadcrumb = (params: ResolveParams<RouterFullPath>) => (
+  <WorkspaceBreadcrumb
+    // SAFETY: this renderer is only registered for /workspaces/$workspaceId.
+    {...(params as ResolveParams<"/workspaces/$workspaceId">)}
+  />
+);
+
+const renderContactBreadcrumb = (params: ResolveParams<RouterFullPath>) => (
+  <ContactBreadcrumb
+    // SAFETY: this renderer is only registered for /contacts/$contactId.
+    {...(params as ResolveParams<"/contacts/$contactId">)}
+  />
+);
+
+const renderCaseLawBreadcrumb = (params: ResolveParams<RouterFullPath>) => (
+  <CaseLawBreadcrumb
+    // SAFETY: this renderer is only registered for /knowledge/case/$decisionId.
+    {...(params as ResolveParams<"/knowledge/case/$decisionId">)}
+  />
+);
+
+const renderBreadcrumbEntry = (
+  entry: BreadcrumbEntry,
+  params: ResolveParams<RouterFullPath>,
+): React.ReactNode => (typeof entry === "function" ? entry(params) : entry);
 
 export const AppBreadcrumbs = () => {
   const t = useTranslations();
   const matches = useMatches();
   const id = useId();
 
-  const breadcrumbMap: Partial<
-    Record<string, BreadcrumbComponent<RouterFullPath>>
-  > = useMemo(
+  const breadcrumbMap: Partial<Record<string, BreadcrumbEntry>> = useMemo(
     () => ({
-      [serializeKey(["/workspaces/"])]: () => (
+      [serializeKey(["/workspaces/"])]: (
         <BreadcrumbItem className="min-w-8 shrink">
           <Link
             activeOptions={{ exact: true, includeSearch: false }}
@@ -53,87 +79,80 @@ export const AppBreadcrumbs = () => {
           </Link>
         </BreadcrumbItem>
       ),
-      [serializeKey(["/workspaces/$workspaceId"])]: (params) => (
-        <WorkspaceBreadcrumb {...params} />
-      ),
-      [serializeKey(["/workspaces/$workspaceId/$viewId/document"])]: () => (
-        <PdfBreadcrumb />
-      ),
-      [serializeKey(["/todos/"])]: () => (
+      [serializeKey(["/workspaces/$workspaceId"])]: renderWorkspaceBreadcrumb,
+      [serializeKey(["/workspaces/$workspaceId/$viewId/document"])]:
+        renderPdfBreadcrumb,
+      [serializeKey(["/todos/"])]: (
         <BreadcrumbLink to="/todos">{t("navigation.myTodos")}</BreadcrumbLink>
       ),
-      [serializeKey(["/knowledge"])]: () => (
+      [serializeKey(["/knowledge"])]: (
         <BreadcrumbLink to="/knowledge">
           {t("navigation.knowledge")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/knowledge/templates"])]: () => (
+      [serializeKey(["/knowledge/templates"])]: (
         <BreadcrumbLink to="/knowledge/templates">
           {t("navigation.templates")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/contacts/"])]: () => (
+      [serializeKey(["/contacts/"])]: (
         <BreadcrumbLink to="/contacts">
           {t("navigation.contacts")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/knowledge/clauses"])]: () => (
+      [serializeKey(["/knowledge/clauses"])]: (
         <BreadcrumbLink to="/knowledge/clauses">
           {t("common.clauses")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/contacts/$contactId"])]: (params) => (
-        <ContactBreadcrumb {...params} />
-      ),
-      [serializeKey(["/knowledge/skills"])]: () => (
+      [serializeKey(["/contacts/$contactId"])]: renderContactBreadcrumb,
+      [serializeKey(["/knowledge/skills"])]: (
         <BreadcrumbItem>{t("knowledge.sections.skills.title")}</BreadcrumbItem>
       ),
-      [serializeKey(["/knowledge/prompts"])]: () => (
+      [serializeKey(["/knowledge/prompts"])]: (
         <BreadcrumbItem>{t("knowledge.sections.prompts.title")}</BreadcrumbItem>
       ),
-      [serializeKey(["/knowledge/mcp"])]: () => (
+      [serializeKey(["/knowledge/mcp"])]: (
         <BreadcrumbItem>{t("knowledge.sections.mcp.title")}</BreadcrumbItem>
       ),
-      [serializeKey(["/knowledge/case/"])]: () => (
+      [serializeKey(["/knowledge/case/"])]: (
         <BreadcrumbLink to="/knowledge/case">
           {t("common.caseLaw")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/knowledge/case/$decisionId"])]: (params) => (
-        <CaseLawBreadcrumb {...params} />
-      ),
-      [serializeKey(["/settings"])]: () => (
+      [serializeKey(["/knowledge/case/$decisionId"])]: renderCaseLawBreadcrumb,
+      [serializeKey(["/settings"])]: (
         <BreadcrumbLink to="/settings">{t("settings.title")}</BreadcrumbLink>
       ),
-      [serializeKey(["/settings/account/profile"])]: () => (
+      [serializeKey(["/settings/account/profile"])]: (
         <BreadcrumbLink to="/settings/account/profile">
           {t("settings.account.profile")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/settings/account/desktop"])]: () => (
+      [serializeKey(["/settings/account/desktop"])]: (
         <BreadcrumbLink to="/settings/account/desktop">
           {t("settings.account.desktop")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/settings/organization"])]: () => (
+      [serializeKey(["/settings/organization"])]: (
         <BreadcrumbItem>{t("settings.organization.title")}</BreadcrumbItem>
       ),
-      [serializeKey(["/settings/organization/members"])]: () => (
+      [serializeKey(["/settings/organization/members"])]: (
         <BreadcrumbLink to="/settings/organization/members">
           {t("navigation.members")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/settings/organization/matter-numbering"])]: () => (
+      [serializeKey(["/settings/organization/matter-numbering"])]: (
         <BreadcrumbLink to="/settings/organization/matter-numbering">
           {t("settings.organization.matterNumbering")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/settings/organization/ai"])]: () => (
+      [serializeKey(["/settings/organization/ai"])]: (
         <BreadcrumbLink to="/settings/organization/ai">
           {t("settings.organization.ai")}
         </BreadcrumbLink>
       ),
-      [serializeKey(["/chat"])]: () => (
+      [serializeKey(["/chat"])]: (
         <BreadcrumbLink to="/chat">{t("navigation.chat")}</BreadcrumbLink>
       ),
     }),
@@ -141,20 +160,27 @@ export const AppBreadcrumbs = () => {
   );
 
   const breadcrumbs = useMemo(() => {
-    const results = new Map<string, React.JSX.Element>();
+    const results = new Map<string, React.ReactNode>();
 
     for (const match of matches) {
       for (const key of Object.keys(breadcrumbMap)) {
         const parsedKey = deserializeKey(key);
 
         if (parsedKey.some((path) => match.fullPath.startsWith(path))) {
+          const entry = breadcrumbMap[key];
+
+          if (entry === undefined) {
+            continue;
+          }
+
           // SAFETY: match.params from TanStack Router for known route
-          const result = breadcrumbMap[key]?.(
+          const result = renderBreadcrumbEntry(
+            entry,
             // eslint-disable-next-line typescript/no-unsafe-type-assertion
             match.params as ResolveParams<RouterFullPath>,
           );
 
-          if (result) {
+          if (result !== null && result !== undefined && result !== false) {
             results.set(key, result);
           }
         }

--- a/apps/web/src/components/chat/ask-user-card.tsx
+++ b/apps/web/src/components/chat/ask-user-card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { AnchorHTMLAttributes, ComponentProps, ReactNode } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import type { ToolUIPart } from "ai";
@@ -45,6 +45,15 @@ const escapeRegex = (value: string) => value.replaceAll(REGEX_SPECIALS, "\\$&");
 const EMPTY_RESTORATION_PAIRS: readonly ChatAnonRestoration[] = Object.freeze(
   [],
 );
+
+const createAnalysisAnchor = (workspaceId: string | undefined) =>
+  function AnalysisAnchor(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
+    return <EntityLink {...props} workspaceId={workspaceId} />;
+  };
+
+const renderAnalysisAnonymizedSpan = (
+  props: ComponentProps<"button"> & { ph?: string },
+) => <AnonymizedSpan {...props} />;
 
 /**
  * Walk a plain string and wrap every `original` substring in an
@@ -114,12 +123,8 @@ export const AskUserCard = ({
     restorationPairs ?? EMPTY_RESTORATION_PAIRS;
   const analysisComponents = useMemo(
     () => ({
-      a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-        <EntityLink {...props} workspaceId={workspaceId} />
-      ),
-      "stll-anon": (
-        props: React.ComponentProps<"button"> & { ph?: string },
-      ) => <AnonymizedSpan {...props} />,
+      a: createAnalysisAnchor(workspaceId),
+      "stll-anon": renderAnalysisAnonymizedSpan,
     }),
     [workspaceId],
   );

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -2164,6 +2164,7 @@
       "int": "Celé číslo",
       "keepEmpty": "Ponechat prázdné",
       "manualColumn": "Manuální sloupec",
+      "markAllAsReviewed": "Označit vše jako zkontrolováno",
       "multiSelect": "Vícenásobný výběr",
       "nameProperty": "Vlastnost názvu",
       "newColumn": "Nový sloupec",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -2164,6 +2164,7 @@
       "int": "Ganzzahl",
       "keepEmpty": "Leer lassen",
       "manualColumn": "Manuelle Spalte",
+      "markAllAsReviewed": "Alle als geprüft markieren",
       "multiSelect": "Mehrfachauswahl",
       "nameProperty": "Namenseigenschaft",
       "newColumn": "Neue Spalte",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -2164,6 +2164,7 @@
       "int": "Integer",
       "keepEmpty": "Keep Empty",
       "manualColumn": "Manual column",
+      "markAllAsReviewed": "Mark all as reviewed",
       "multiSelect": "Multi Select",
       "nameProperty": "Name property",
       "newColumn": "New column",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -2164,6 +2164,7 @@
       "int": "Entero",
       "keepEmpty": "Dejar vacío",
       "manualColumn": "Columna manual",
+      "markAllAsReviewed": "Marcar todo como revisado",
       "multiSelect": "Selección múltiple",
       "nameProperty": "Propiedad de nombre",
       "newColumn": "Nueva columna",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -2164,6 +2164,7 @@
       "int": "Täisarv",
       "keepEmpty": "Jäta tühjaks",
       "manualColumn": "Käsitsi veerg",
+      "markAllAsReviewed": "Märgi kõik ülevaadatuks",
       "multiSelect": "Mitmikvalik",
       "nameProperty": "Nimeomadus",
       "newColumn": "Uus veerg",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -2164,6 +2164,7 @@
       "int": "Entier",
       "keepEmpty": "Laisser vide",
       "manualColumn": "Colonne manuelle",
+      "markAllAsReviewed": "Tout marquer comme vérifié",
       "multiSelect": "Sélection multiple",
       "nameProperty": "Propriété du nom",
       "newColumn": "Nouvelle colonne",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -2164,6 +2164,7 @@
       "int": "Egész szám",
       "keepEmpty": "Hagyja üresen",
       "manualColumn": "Kézi oszlop",
+      "markAllAsReviewed": "Mind megjelölése ellenőrzöttként",
       "multiSelect": "Többszörös választás",
       "nameProperty": "Névelőzmény",
       "newColumn": "Új oszlop",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -2164,6 +2164,7 @@
       "int": "Sveikasis skaičius",
       "keepEmpty": "Palikti tuščią",
       "manualColumn": "Rankinis stulpelis",
+      "markAllAsReviewed": "Pažymėti visus kaip peržiūrėtus",
       "multiSelect": "Keli pasirinkimai",
       "nameProperty": "Pavadinimo savybė",
       "newColumn": "Naujas stulpelis",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -2164,6 +2164,7 @@
       "int": "Vesels skaitlis",
       "keepEmpty": "Atstāt tukšu",
       "manualColumn": "Manuāla kolonna",
+      "markAllAsReviewed": "Atzīmēt visus kā pārbaudītus",
       "multiSelect": "Vairāku izvēļu",
       "nameProperty": "Nosaukuma īpašība",
       "newColumn": "Jauna kolonna",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -2167,6 +2167,7 @@ type Messages = {
       "int": "Integer";
       "keepEmpty": "Keep Empty";
       "manualColumn": "Manual column";
+      "markAllAsReviewed": "Mark all as reviewed";
       "multiSelect": "Multi Select";
       "nameProperty": "Name property";
       "newColumn": "New column";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -2164,6 +2164,7 @@
       "int": "Liczba całkowita",
       "keepEmpty": "Pozostaw puste",
       "manualColumn": "Kolumna ręczna",
+      "markAllAsReviewed": "Oznacz wszystkie jako sprawdzone",
       "multiSelect": "Wielokrotny wybór",
       "nameProperty": "Właściwość nazwy",
       "newColumn": "Nowa kolumna",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -2164,6 +2164,7 @@
       "int": "Inteiro",
       "keepEmpty": "Manter vazio",
       "manualColumn": "Coluna manual",
+      "markAllAsReviewed": "Marcar tudo como revisado",
       "multiSelect": "Seleção múltipla",
       "nameProperty": "Propriedade de nome",
       "newColumn": "Nova coluna",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -2164,6 +2164,7 @@
       "int": "Celé číslo",
       "keepEmpty": "Ponechať prázdne",
       "manualColumn": "Manuálny stĺpec",
+      "markAllAsReviewed": "Označiť všetko ako skontrolované",
       "multiSelect": "Viacnásobný výber",
       "nameProperty": "Vlastnosť názvu",
       "newColumn": "Nový stĺpec",

--- a/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
+++ b/apps/web/src/routes/_protected.knowledge/case/-components/decision-table.tsx
@@ -7,6 +7,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import type { CellContext } from "@tanstack/react-table";
 import { useFormatter, useTranslations } from "use-intl";
 
 import { createCaseLawDecisionRouteParam } from "@/lib/case-law-route";
@@ -33,6 +34,39 @@ type DecisionTableProps = {
 
 const columnHelper = createColumnHelper<Decision>();
 
+const renderCaseNumberCell = (info: CellContext<Decision, string>) => {
+  const { id, headline } = info.row.original;
+
+  return (
+    <div>
+      <Link
+        className="text-foreground font-medium hover:underline"
+        params={{
+          decisionId: createCaseLawDecisionRouteParam({
+            caseNumber: info.getValue(),
+            decisionId: id,
+          }),
+        }}
+        to="/knowledge/case/$decisionId"
+      >
+        {info.getValue()}
+      </Link>
+      {headline && (
+        <p
+          className="text-muted-foreground [&_mark]:text-foreground mt-0.5 line-clamp-2 text-xs [&_mark]:bg-yellow-200/50 [&_mark]:font-medium dark:[&_mark]:bg-yellow-500/20"
+          dangerouslySetInnerHTML={{ __html: headline }}
+        />
+      )}
+    </div>
+  );
+};
+
+const renderCountryCell = (info: CellContext<Decision, string>) => (
+  <span className="bg-muted rounded px-1.5 py-0.5 text-xs">
+    {info.getValue()}
+  </span>
+);
+
 export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
   const t = useTranslations();
   const format = useFormatter();
@@ -41,42 +75,14 @@ export const DecisionTable = ({ decisions, isLoading }: DecisionTableProps) => {
     () => [
       columnHelper.accessor("caseNumber", {
         header: t("caseLaw.columns.caseNumber"),
-        cell: (info) => {
-          const { id, headline } = info.row.original;
-          return (
-            <div>
-              <Link
-                className="text-foreground font-medium hover:underline"
-                params={{
-                  decisionId: createCaseLawDecisionRouteParam({
-                    caseNumber: info.getValue(),
-                    decisionId: id,
-                  }),
-                }}
-                to="/knowledge/case/$decisionId"
-              >
-                {info.getValue()}
-              </Link>
-              {headline && (
-                <p
-                  className="text-muted-foreground [&_mark]:text-foreground mt-0.5 line-clamp-2 text-xs [&_mark]:bg-yellow-200/50 [&_mark]:font-medium dark:[&_mark]:bg-yellow-500/20"
-                  dangerouslySetInnerHTML={{ __html: headline }}
-                />
-              )}
-            </div>
-          );
-        },
+        cell: renderCaseNumberCell,
       }),
       columnHelper.accessor("court", {
         header: t("caseLaw.columns.court"),
       }),
       columnHelper.accessor("country", {
         header: t("common.country"),
-        cell: (info) => (
-          <span className="bg-muted rounded px-1.5 py-0.5 text-xs">
-            {info.getValue()}
-          </span>
-        ),
+        cell: renderCountryCell,
       }),
       columnHelper.accessor("decisionDate", {
         header: t("common.date"),

--- a/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
@@ -68,6 +68,7 @@ const LABEL_TRANSLATION_KEY = {
   organization: "common.anonymizationLabels.organization",
   "phone number": "common.anonymizationLabels.phoneNumber",
   address: "common.anonymizationLabels.address",
+  country: "common.country",
   "email address": "common.anonymizationLabels.emailAddress",
   date: "common.anonymizationLabels.date",
   "date of birth": "common.anonymizationLabels.dateOfBirth",

--- a/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
+++ b/apps/web/src/routes/_protected.settings/-components/organization/anonymization-deny-list-card.tsx
@@ -68,7 +68,6 @@ const LABEL_TRANSLATION_KEY = {
   organization: "common.anonymizationLabels.organization",
   "phone number": "common.anonymizationLabels.phoneNumber",
   address: "common.anonymizationLabels.address",
-  country: "common.country",
   "email address": "common.anonymizationLabels.emailAddress",
   date: "common.anonymizationLabels.date",
   "date of birth": "common.anonymizationLabels.dateOfBirth",

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -6,7 +6,8 @@ import {
   useTransition,
 } from "react";
 
-import { EyeOffIcon, PencilLineIcon } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2Icon, EyeOffIcon, PencilLineIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { Button } from "@stll/ui/components/button";
@@ -14,6 +15,9 @@ import { Popover, PopoverPopup } from "@stll/ui/components/popover";
 import { Separator } from "@stll/ui/components/separator";
 import { stellaToast } from "@stll/ui/components/toast";
 
+import { api } from "@/lib/api";
+import { toAPIError } from "@/lib/errors";
+import { toSafeId } from "@/lib/safe-id";
 import type { PropertyDependency, WorkspaceProperty } from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";
 import { DeleteProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/delete-property";
@@ -27,6 +31,7 @@ import {
 import type { TableHeader } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
 import { useUpdateProperty } from "@/routes/_protected.workspaces/$workspaceId/-mutations/properties";
+import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entities";
 
 type PropertyPopoverProps = {
   property: WorkspaceProperty;
@@ -38,6 +43,8 @@ type ReplaceAction = {
   next: PropertyDependency;
 };
 
+const VERIFIED_FLAG = "verified";
+
 export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
   const t = useTranslations();
   const { workspaceId, id, name } = property;
@@ -45,6 +52,37 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
   const [editorOpen, setEditorOpen] = useState(false);
   const updateProperty = useUpdateProperty();
   const startWorkflow = useStartWorkflow(workspaceId);
+  const queryClient = useQueryClient();
+
+  const markAllReviewed = useMutation({
+    mutationFn: async () => {
+      const response = await api
+        .fields({ workspaceId: toSafeId<"workspace">(workspaceId) })
+        ["metadata-batch"].patch({
+          queryKey: entitiesKeys.all(workspaceId),
+          propertyId: toSafeId<"property">(id),
+          flag: VERIFIED_FLAG,
+        });
+
+      if (response.error) {
+        throw toAPIError(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: entitiesKeys.all(workspaceId),
+      });
+    },
+    onError: (error) => {
+      stellaToast.add({
+        title: t("errors.actionFailed"),
+        description:
+          error instanceof Error ? error.message : t("common.unexpectedError"),
+        type: "error",
+      });
+    },
+  });
 
   // The composer's CreatableContentType union excludes "file" by
   // design — file columns are created by upload, not by user choice,
@@ -163,6 +201,19 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
                 workspaceId={workspaceId}
               />
               <PinProperty column={header.column} />
+              <Button
+                className="justify-start gap-1.5"
+                disabled={markAllReviewed.isPending}
+                onClick={() => {
+                  markAllReviewed.mutate();
+                  setIsOpen(false);
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                <CheckCircle2Icon />
+                {t("workspaces.properties.markAllAsReviewed")}
+              </Button>
               <Button
                 className="justify-start gap-1.5"
                 onClick={() => {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -73,6 +73,7 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
       void queryClient.invalidateQueries({
         queryKey: entitiesKeys.all(workspaceId),
       });
+      setIsOpen(false);
     },
     onError: (error) => {
       stellaToast.add({
@@ -206,7 +207,6 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
                 disabled={markAllReviewed.isPending}
                 onClick={() => {
                   markAllReviewed.mutate();
-                  setIsOpen(false);
                 }}
                 size="sm"
                 variant="ghost"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/property-popover.tsx
@@ -18,7 +18,11 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { api } from "@/lib/api";
 import { toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
-import type { PropertyDependency, WorkspaceProperty } from "@/lib/types";
+import type {
+  PropertyDependency,
+  ViewFilterCondition,
+  WorkspaceProperty,
+} from "@/lib/types";
 import { CreateProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/create-property";
 import { DeleteProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/delete-property";
 import { PinProperty } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/pin-property";
@@ -36,6 +40,7 @@ import { entitiesKeys } from "@/routes/_protected.workspaces/$workspaceId/-queri
 type PropertyPopoverProps = {
   property: WorkspaceProperty;
   header: TableHeader;
+  filters: ViewFilterCondition[];
 };
 
 type ReplaceAction = {
@@ -45,7 +50,11 @@ type ReplaceAction = {
 
 const VERIFIED_FLAG = "verified";
 
-export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
+export const PropertyPopover = ({
+  property,
+  header,
+  filters,
+}: PropertyPopoverProps) => {
   const t = useTranslations();
   const { workspaceId, id, name } = property;
   const [isOpen, setIsOpen] = useState(false);
@@ -62,6 +71,7 @@ export const PropertyPopover = ({ property, header }: PropertyPopoverProps) => {
           queryKey: entitiesKeys.all(workspaceId),
           propertyId: toSafeId<"property">(id),
           flag: VERIFIED_FLAG,
+          filters,
         });
 
       if (response.error) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table-column.tsx
@@ -6,7 +6,11 @@ import { useTranslations } from "use-intl";
 import { Button } from "@stll/ui/components/button";
 import { MenuItem } from "@stll/ui/components/menu";
 
-import type { WorkspaceEntity, WorkspaceProperty } from "@/lib/types";
+import type {
+  ViewFilterCondition,
+  WorkspaceEntity,
+  WorkspaceProperty,
+} from "@/lib/types";
 import { ActiveEditBadge } from "@/routes/_protected.workspaces/$workspaceId/-components/active-edit-badge";
 import { CellMetadataFlags } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-metadata-flags";
 import { CellResult } from "@/routes/_protected.workspaces/$workspaceId/-components/cell-result";
@@ -19,13 +23,26 @@ import { useRetryCell } from "@/routes/_protected.workspaces/$workspaceId/-hooks
 import { useWorkspaceStore } from "@/routes/_protected.workspaces/$workspaceId/-store";
 import { getFirstFile } from "@/routes/_protected.workspaces/$workspaceId/-utils";
 
-export const getPropertyColumn = (
-  property: WorkspaceProperty,
-): TableColumnDef => ({
+type PropertyColumnOptions = {
+  filters: ViewFilterCondition[];
+};
+
+export const getPropertyColumn = ({
+  filters,
+  property,
+}: PropertyColumnOptions & {
+  property: WorkspaceProperty;
+}): TableColumnDef => ({
   id: property.id,
   accessorKey: property.id,
   accessorFn: (row) => row.fields[property.id],
-  header: (ctx) => <PropertyPopover header={ctx.header} property={property} />,
+  header: (ctx) => (
+    <PropertyPopover
+      filters={filters}
+      header={ctx.header}
+      property={property}
+    />
+  ),
   size: 200,
   cell: (props) => (
     <PropertyCell entity={props.row.original} property={property} />

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -5,7 +5,9 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import type { CellContext, HeaderContext } from "@tanstack/react-table";
 import { ClockIcon, HashIcon, TableIcon, UserIcon } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useTranslations } from "use-intl";
 
 import { useAIKeyGate } from "@/components/require-ai-key";
@@ -17,8 +19,12 @@ import {
   VersionCell,
 } from "@/routes/_protected.workspaces/$workspaceId/-components/metadata-cells";
 import { MetadataPopover } from "@/routes/_protected.workspaces/$workspaceId/-components/metadata-popover";
+import type { SortHint } from "@/routes/_protected.workspaces/$workspaceId/-components/properties/sort-property";
 import { getPropertyColumn } from "@/routes/_protected.workspaces/$workspaceId/-components/table-column";
-import type { TableColumnDef } from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
+import type {
+  TableColumnDef,
+  TableTreeNode,
+} from "@/routes/_protected.workspaces/$workspaceId/-components/table/types";
 import { WorkspaceTable } from "@/routes/_protected.workspaces/$workspaceId/-components/table/workspace-table";
 import { useSyncJustificationChunks } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-sync-justifications";
 import { useTableState } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-table-state";
@@ -38,6 +44,37 @@ const selectColId = getInternalColId("select");
 const addPropertyColId = getInternalColId("add-property");
 const DEFAULT_COLUMN_MIN_SIZE = 64;
 const ADD_PROPERTY_COLUMN_SIZE = 48;
+
+type MetadataHeaderOptions = {
+  icon: LucideIcon;
+  label: string;
+  sortHint: SortHint;
+};
+
+const createMetadataHeader =
+  ({ icon, label, sortHint }: MetadataHeaderOptions) =>
+  ({ header }: HeaderContext<TableTreeNode, unknown>) => (
+    <MetadataPopover
+      column={header.column}
+      icon={icon}
+      label={label}
+      sortHint={sortHint}
+    />
+  );
+
+const renderAuthorCell = ({ row }: CellContext<TableTreeNode, unknown>) => (
+  <AuthorCell entity={row.original} />
+);
+
+const renderLastUpdatedCell = ({
+  row,
+}: CellContext<TableTreeNode, unknown>) => (
+  <LastUpdatedCell entity={row.original} />
+);
+
+const renderVersionCell = ({ row }: CellContext<TableTreeNode, unknown>) => (
+  <VersionCell entity={row.original} />
+);
 
 type TableLayoutProps = {
   workspaceId: string;
@@ -120,15 +157,12 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       id: getInternalPropertyId("created-by"),
       accessorKey: getInternalPropertyId("created-by"),
       meta: { muted: true },
-      header: (ctx) => (
-        <MetadataPopover
-          column={ctx.header.column}
-          icon={UserIcon}
-          label={t("workspaces.filesystem.author")}
-          sortHint="text"
-        />
-      ),
-      cell: (props) => <AuthorCell entity={props.row.original} />,
+      header: createMetadataHeader({
+        icon: UserIcon,
+        label: t("workspaces.filesystem.author"),
+        sortHint: "text",
+      }),
+      cell: renderAuthorCell,
       size: 160,
     });
 
@@ -136,15 +170,12 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       id: getInternalPropertyId("updated-at"),
       accessorKey: getInternalPropertyId("updated-at"),
       meta: { muted: true },
-      header: (ctx) => (
-        <MetadataPopover
-          column={ctx.header.column}
-          icon={ClockIcon}
-          label={t("workspaces.filesystem.lastUpdated")}
-          sortHint="date"
-        />
-      ),
-      cell: (props) => <LastUpdatedCell entity={props.row.original} />,
+      header: createMetadataHeader({
+        icon: ClockIcon,
+        label: t("workspaces.filesystem.lastUpdated"),
+        sortHint: "date",
+      }),
+      cell: renderLastUpdatedCell,
       size: 140,
     });
 
@@ -152,15 +183,12 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
       id: getInternalPropertyId("version"),
       accessorKey: getInternalPropertyId("version"),
       meta: { muted: true },
-      header: (ctx) => (
-        <MetadataPopover
-          column={ctx.header.column}
-          icon={HashIcon}
-          label={t("workspaces.filesystem.version")}
-          sortHint="number"
-        />
-      ),
-      cell: (props) => <VersionCell entity={props.row.original} />,
+      header: createMetadataHeader({
+        icon: HashIcon,
+        label: t("workspaces.filesystem.version"),
+        sortHint: "number",
+      }),
+      cell: renderVersionCell,
       size: 80,
     });
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/table/table-layout.tsx
@@ -149,7 +149,10 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
     ];
 
     for (const property of properties) {
-      const col = getPropertyColumn(property);
+      const col = getPropertyColumn({
+        filters: view.layout.filters,
+        property,
+      });
       columnDefs.push(col);
     }
 
@@ -206,7 +209,7 @@ export const TableLayout = ({ workspaceId, view }: TableLayoutProps) => {
     });
 
     return columnDefs;
-  }, [properties, t]);
+  }, [properties, t, view.layout.filters]);
 
   const table = useReactTable({
     columnResizeMode: "onChange",

--- a/apps/web/src/routes/auth/index.tsx
+++ b/apps/web/src/routes/auth/index.tsx
@@ -50,6 +50,17 @@ const formSchema = v.strictObject({
 const hasSocialProviders = env.VITE_AUTH_GOOGLE || env.VITE_AUTH_MICROSOFT;
 const termsUrl = sanitizeHref(env.VITE_TERMS_URL) ?? "/terms";
 
+const renderTermsLink = (chunks: React.ReactNode) => (
+  <a
+    className="hover:text-foreground underline"
+    href={termsUrl}
+    rel="noopener"
+    target="_blank"
+  >
+    {chunks}
+  </a>
+);
+
 function LoginOrSignup() {
   const t = useTranslations();
   const analytics = useAnalytics();
@@ -267,16 +278,7 @@ function LoginOrSignup() {
       </Form>
       <p className="text-foreground-muted text-xs">
         {t.rich("onboarding.termsNotice", {
-          terms: (chunks: React.ReactNode) => (
-            <a
-              className="hover:text-foreground underline"
-              href={termsUrl}
-              rel="noopener"
-              target="_blank"
-            >
-              {chunks}
-            </a>
-          ),
+          terms: renderTermsLink,
         })}
       </p>
     </div>

--- a/apps/web/src/routes/dev/-components/ui-playground.tsx
+++ b/apps/web/src/routes/dev/-components/ui-playground.tsx
@@ -201,6 +201,13 @@ import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
 import { DatePickerPopover } from "@/components/date-picker-popover";
 import { AIKeyRequiredDialog } from "@/components/require-ai-key";
 
+const renderPlaygroundAnchor = ({
+  children,
+  ...props
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  <a {...props}>{children}</a>
+);
+
 type ComboboxOption = {
   id: string;
   label: string;
@@ -1334,7 +1341,7 @@ function SharedChatRendererSample() {
             }}
             showToolCalls={false}
             streamdownComponents={{
-              a: ({ children, ...props }) => <a {...props}>{children}</a>,
+              a: renderPlaygroundAnchor,
             }}
           />
         </ChatApprovalContext>

--- a/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
+++ b/apps/web/src/routes/onboarding/-components/onboarding-wizard.tsx
@@ -42,6 +42,7 @@ import {
   JurisdictionStep,
 } from "@/routes/onboarding/-components/steps/jurisdiction-step";
 import { OrganizationStep } from "@/routes/onboarding/-components/steps/organization-step";
+
 type Step =
   | "organization"
   | "jurisdiction"

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -25,7 +25,6 @@ export const DEFAULT_CHAT_ANON_ENTITY_LABELS = [
   "organization",
   "phone number",
   "address",
-  "country",
   "email address",
   "date",
   "date of birth",

--- a/packages/anonymize-chat/src/index.ts
+++ b/packages/anonymize-chat/src/index.ts
@@ -25,6 +25,7 @@ export const DEFAULT_CHAT_ANON_ENTITY_LABELS = [
   "organization",
   "phone number",
   "address",
+  "country",
   "email address",
   "date",
   "date of birth",


### PR DESCRIPTION
## Summary
- Adds a "Mark all as reviewed" action to the column header popover that sets the `verified` flag on every cell of the property in one request.
- New backend endpoint `PATCH /fields/:workspaceId/metadata-batch` upserts cell metadata for every entity's current version, preserving existing flags and lock state. Cells that already carry the flag are skipped, so the action is idempotent.
- Records one audit event per affected cell so existing field-level audit trails stay coherent.
- Adds the `workspaces.properties.markAllAsReviewed` translation in all 12 locales.

## Test plan
- [ ] Open the column popover on a table view and confirm the new "Mark all as reviewed" item appears
- [ ] Click it on a column with existing cell flags and verify only the verified flag is added (other flags preserved)
- [ ] Run a second time and confirm no duplicate audit events / no flag duplication
- [ ] Verify locked cells keep their lock state
- [ ] Verify the action is disabled while in-flight