### PR TITLE
fix(workspaces): cell state alignment and template-apply Documents linking

### DIFF
--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -367,9 +367,13 @@ const recreateTemplateDependencies = async ({
     // Templates strip the workspace-specific Documents id, so an AI
     // column whose only dependency pointed at Documents loses every
     // edge in remap. Fall back to the target workspace's system file
-    // property so the new AI column has a source.
+    // property so the new AI column has a source. Skip when the
+    // template explicitly declared no dependencies (static-prompt
+    // columns), so we don't force a spurious source on them.
     if (
       resolvedEdges.length === 0 &&
+      templateProperty.dependencies !== undefined &&
+      templateProperty.dependencies.length > 0 &&
       templateProperty.tool.type === "ai-model" &&
       systemFilePropertyId !== undefined &&
       systemFilePropertyId !== propertyId

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -1,5 +1,4 @@
 import { deepEquals } from "bun";
-import { eq } from "drizzle-orm";
 
 import type { Transaction } from "@/api/db";
 import { properties, propertyDependencies } from "@/api/db/schema";
@@ -133,8 +132,14 @@ export const resolveTemplateProperties = async ({
   recordAuditEvent,
 }: ResolveTemplatePropertiesOptions): Promise<ResolveTemplatePropertiesResult> => {
   if (!templateProperties || templateProperties.length === 0) {
-    const propertyIds = await readPropertyIds(tx, workspaceId);
-    return { ok: true, layout, propertyIds };
+    const existing = await readExistingProperties(tx, workspaceId);
+    const systemFile = findSystemFileProperty(existing);
+    prependSystemFileToColumnOrder(layout, systemFile);
+    return {
+      ok: true,
+      layout,
+      propertyIds: existing.map((property) => property.id),
+    };
   }
 
   const validationError = validateTemplateProperties(templateProperties);
@@ -144,20 +149,8 @@ export const resolveTemplateProperties = async ({
 
   await lockWorkspacePropertyWrites(tx, workspaceId);
 
-  const existingProperties = await tx.query.properties.findMany({
-    where: { workspaceId: { eq: workspaceId } },
-    columns: {
-      id: true,
-      name: true,
-      content: true,
-      tool: true,
-      system: true,
-    },
-    orderBy: { createdAt: "asc" },
-  });
-  const systemFileProperty = existingProperties.find(
-    (property) => property.system && property.content.type === "file",
-  );
+  const existingProperties = await readExistingProperties(tx, workspaceId);
+  const systemFileProperty = findSystemFileProperty(existingProperties);
   const existingDependencyEdges = await tx.query.propertyDependencies.findMany({
     where: { workspaceId: { eq: workspaceId } },
     columns: { propertyId: true },
@@ -283,19 +276,51 @@ export const resolveTemplateProperties = async ({
   });
 
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
-
-  // Templates strip system properties, so their saved columnOrder never
-  // carries the workspace-specific Documents id. Without this prepend it
-  // lands at the end of the table.
-  if (
-    layout.type === "table" &&
-    systemFileProperty &&
-    !layout.columnOrder.includes(systemFileProperty.id)
-  ) {
-    layout.columnOrder = [systemFileProperty.id, ...layout.columnOrder];
-  }
+  prependSystemFileToColumnOrder(layout, systemFileProperty);
 
   return { ok: true, layout, propertyIds: nextPropertyIds };
+};
+
+const readExistingProperties = (
+  tx: Transaction,
+  workspaceId: SafeId<"workspace">,
+) =>
+  tx.query.properties.findMany({
+    where: { workspaceId: { eq: workspaceId } },
+    columns: {
+      id: true,
+      name: true,
+      content: true,
+      tool: true,
+      system: true,
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+type ExistingProperty = Awaited<
+  ReturnType<typeof readExistingProperties>
+>[number];
+
+const findSystemFileProperty = (existing: readonly ExistingProperty[]) =>
+  existing.find(
+    (property) => property.system && property.content.type === "file",
+  );
+
+// Templates strip system properties, so their saved columnOrder never
+// carries the workspace-specific Documents id. Without this prepend it
+// lands at the end of the table.
+const prependSystemFileToColumnOrder = (
+  layout: ViewLayout,
+  systemFileProperty: ExistingProperty | undefined,
+): void => {
+  if (
+    layout.type !== "table" ||
+    !systemFileProperty ||
+    layout.columnOrder.includes(systemFileProperty.id)
+  ) {
+    return;
+  }
+  layout.columnOrder = [systemFileProperty.id, ...layout.columnOrder];
 };
 
 const sanitizeTemplatePropertyTool = (
@@ -483,17 +508,6 @@ const hasTemplateDependencyCycle = ({
   }
 
   return false;
-};
-
-const readPropertyIds = async (
-  tx: Transaction,
-  workspaceId: SafeId<"workspace">,
-): Promise<string[]> => {
-  const rows = await tx
-    .select({ id: properties.id })
-    .from(properties)
-    .where(eq(properties.workspaceId, workspaceId));
-  return rows.map((row) => row.id);
 };
 
 const validateTemplateProperties = (

--- a/apps/api/src/handlers/view-templates/properties.ts
+++ b/apps/api/src/handlers/view-templates/properties.ts
@@ -151,9 +151,13 @@ export const resolveTemplateProperties = async ({
       name: true,
       content: true,
       tool: true,
+      system: true,
     },
     orderBy: { createdAt: "asc" },
   });
+  const systemFileProperty = existingProperties.find(
+    (property) => property.system && property.content.type === "file",
+  );
   const existingDependencyEdges = await tx.query.propertyDependencies.findMany({
     where: { workspaceId: { eq: workspaceId } },
     columns: { propertyId: true },
@@ -275,9 +279,22 @@ export const resolveTemplateProperties = async ({
     propertyIdBySourceId,
     createdPropertySourceIds,
     recordAuditEvent,
+    systemFilePropertyId: systemFileProperty?.id,
   });
 
   remapLayoutPropertyIds(layout, propertyIdBySourceId);
+
+  // Templates strip system properties, so their saved columnOrder never
+  // carries the workspace-specific Documents id. Without this prepend it
+  // lands at the end of the table.
+  if (
+    layout.type === "table" &&
+    systemFileProperty &&
+    !layout.columnOrder.includes(systemFileProperty.id)
+  ) {
+    layout.columnOrder = [systemFileProperty.id, ...layout.columnOrder];
+  }
+
   return { ok: true, layout, propertyIds: nextPropertyIds };
 };
 
@@ -304,6 +321,7 @@ const recreateTemplateDependencies = async ({
   propertyIdBySourceId,
   createdPropertySourceIds,
   recordAuditEvent,
+  systemFilePropertyId,
 }: {
   tx: Transaction;
   workspaceId: SafeId<"workspace">;
@@ -311,6 +329,7 @@ const recreateTemplateDependencies = async ({
   propertyIdBySourceId: ReadonlyMap<string, string>;
   createdPropertySourceIds: ReadonlySet<string>;
   recordAuditEvent: AuditRecorder;
+  systemFilePropertyId: string | undefined;
 }): Promise<void> => {
   const rows = templateProperties.flatMap((templateProperty) => {
     if (!createdPropertySourceIds.has(templateProperty.sourceId)) {
@@ -318,29 +337,54 @@ const recreateTemplateDependencies = async ({
     }
 
     const propertyId = propertyIdBySourceId.get(templateProperty.sourceId);
-    if (!propertyId || !templateProperty.dependencies) {
+    if (!propertyId) {
       return [];
     }
-    return templateProperty.dependencies.flatMap((dep) => {
-      const dependsOnPropertyId = propertyIdBySourceId.get(
-        dep.dependsOnSourceId,
-      );
-      // Drop edges where either endpoint failed to remap; the
-      // missing-property branch above already declined to create
-      // them, so the workflow planner will treat the property as
-      // having no inputs rather than crashing.
-      if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
-        return [];
-      }
+
+    const resolvedEdges = (templateProperty.dependencies ?? []).flatMap(
+      (dep) => {
+        const dependsOnPropertyId = propertyIdBySourceId.get(
+          dep.dependsOnSourceId,
+        );
+        // Drop edges where either endpoint failed to remap; the
+        // missing-property branch above already declined to create
+        // them, so the workflow planner will treat the property as
+        // having no inputs rather than crashing.
+        if (!dependsOnPropertyId || dependsOnPropertyId === propertyId) {
+          return [];
+        }
+        return [
+          {
+            workspaceId,
+            propertyId: brandPersistedPropertyId(propertyId),
+            dependsOnPropertyId: brandPersistedPropertyId(dependsOnPropertyId),
+            condition: dep.condition,
+          },
+        ];
+      },
+    );
+
+    // Templates strip the workspace-specific Documents id, so an AI
+    // column whose only dependency pointed at Documents loses every
+    // edge in remap. Fall back to the target workspace's system file
+    // property so the new AI column has a source.
+    if (
+      resolvedEdges.length === 0 &&
+      templateProperty.tool.type === "ai-model" &&
+      systemFilePropertyId !== undefined &&
+      systemFilePropertyId !== propertyId
+    ) {
       return [
         {
           workspaceId,
           propertyId: brandPersistedPropertyId(propertyId),
-          dependsOnPropertyId: brandPersistedPropertyId(dependsOnPropertyId),
-          condition: dep.condition,
+          dependsOnPropertyId: brandPersistedPropertyId(systemFilePropertyId),
+          condition: null,
         },
       ];
-    });
+    }
+
+    return resolvedEdges;
   });
 
   if (rows.length === 0) {

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/cell-result.tsx
@@ -4,6 +4,8 @@ import { Result } from "better-result";
 import { Loader2Icon, SquareMinusIcon } from "lucide-react";
 import { useLocale, useTranslations } from "use-intl";
 
+import { cn } from "@stll/ui/lib/utils";
+
 import Tooltip from "@/components/tooltip";
 import { isFileDisplayable } from "@/lib/types";
 import type { WorkspaceField, WorkspaceProperty } from "@/lib/types";
@@ -45,32 +47,31 @@ export const CellResult = ({
           className="text-muted-foreground absolute end-1 top-1 z-20 size-3 shrink-0 animate-spin"
           strokeWidth={2.25}
         />
-        <span
-          className={
-            hasPreview
-              ? "line-clamp-2 min-w-0"
-              : "text-muted-foreground truncate"
-          }
+        <div
+          className={cn(
+            "line-clamp-2 min-w-0",
+            !hasPreview && "text-muted-foreground",
+          )}
         >
           {hasPreview ? preview : t("workspaces.fields.calculating")}
-        </span>
+        </div>
       </>
     );
   }
 
   if (type === "error") {
     return (
-      <span className="text-destructive block truncate italic">
+      <div className="text-destructive line-clamp-2 italic">
         {t("workspaces.fields.errored")}
-      </span>
+      </div>
     );
   }
 
   if (type === "unsupported") {
     return (
-      <span className="text-muted-foreground block truncate italic">
+      <div className="text-muted-foreground line-clamp-2 italic">
         {t("workspaces.fields.formatNotSupported")}
-      </span>
+      </div>
     );
   }
 


### PR DESCRIPTION
## Summary

- Align cell `pending`/`error`/`unsupported` states with the success-text path so loading/error rows no longer sit higher than response rows. All variants now render as a `<div className="line-clamp-2">` inside the cell's `items-center` flex wrapper.
- When applying a view template, link AI columns whose only template-side dependency pointed at the source workspace's Documents id (templates strip system properties, so the id never carries over) to the target workspace's system file property.
- Prepend the workspace's Documents column to `layout.columnOrder` for table layouts on template apply so it renders first instead of falling to the end via TanStack's default for unlisted columns.