### PR TITLE
fix(docx): break infinite render loop in inspector file open

### DIFF
--- a/apps/web/src/lib/slot.tsx
+++ b/apps/web/src/lib/slot.tsx
@@ -39,7 +39,7 @@ type SlotProps = React.HTMLAttributes<HTMLElement> & {
  * callbacks and returns a combined cleanup so React can
  * invoke it on unmount instead of re-calling with `null`.
  */
-const composeRefs =
+export const composeRefs =
   <T,>(
     ...refs: (React.Ref<T> | undefined)[]
   ): ((node: T | null) => (() => void) | undefined) =>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -3,6 +3,7 @@ import {
   Suspense,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -638,6 +639,10 @@ const ReadOnlyDocxDocumentViewer = ({
     scaleOffset,
     0.85,
   );
+  const composedContainerRef = useMemo(
+    () => composeRefs(containerRef, fitZoomRef),
+    [fitZoomRef],
+  );
 
   useLayoutEffect(() => {
     editorRef.current?.setZoom(targetZoom);
@@ -645,10 +650,7 @@ const ReadOnlyDocxDocumentViewer = ({
   useDocxWheelZoom(containerRef, editorRef);
 
   return (
-    <div
-      ref={composeRefs(containerRef, fitZoomRef)}
-      className="h-full overflow-auto"
-    >
+    <div ref={composedContainerRef} className="h-full overflow-auto">
       <ReadOnlyDocxViewer
         ref={editorRef}
         className="folio-docx-preview h-full"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -50,6 +50,7 @@ import {
   usePDFStore,
 } from "@/lib/pdf/pdf-context";
 import { toSafeId } from "@/lib/safe-id";
+import { composeRefs } from "@/lib/slot";
 import { shouldUseDocxBrowserEditor } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.logic";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import {
@@ -633,7 +634,10 @@ const ReadOnlyDocxDocumentViewer = ({
 }) => {
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const targetZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
+  const { containerRef: fitZoomRef, fitZoom: targetZoom } = useDocxFitZoom(
+    scaleOffset,
+    0.85,
+  );
 
   useLayoutEffect(() => {
     editorRef.current?.setZoom(targetZoom);
@@ -641,7 +645,10 @@ const ReadOnlyDocxDocumentViewer = ({
   useDocxWheelZoom(containerRef, editorRef);
 
   return (
-    <div ref={containerRef} className="h-full overflow-auto">
+    <div
+      ref={composeRefs(containerRef, fitZoomRef)}
+      className="h-full overflow-auto"
+    >
       <ReadOnlyDocxViewer
         ref={editorRef}
         className="folio-docx-preview h-full"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -56,6 +56,7 @@ import { StatusMessage } from "@/components/route-components";
 import Tooltip from "@/components/tooltip";
 import { env } from "@/env";
 import { anonymizeChatTextInWorker } from "@/lib/anonymize/anonymize-chat-worker-client";
+import { composeRefs } from "@/lib/slot";
 import { DocxLoadingShell } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell";
 import {
   useDocxFitZoom,
@@ -547,7 +548,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
       : null;
   const [autosaveStatus, setAutosaveStatus] =
     useState<AutosaveStatus>("synced");
-  const targetZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
+  const { containerRef: fitZoomRef, fitZoom: targetZoom } = useDocxFitZoom(
+    scaleOffset,
+    0.85,
+  );
   const t = useTranslations();
   const previewPlaceholder =
     optimisticPreviewRef.current?.fieldId === fieldId
@@ -1408,7 +1412,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
   const collaborationIdentity = collaborationSession?.sessionId ?? "local";
 
   return (
-    <div ref={containerRef} className="flex h-full w-full min-w-0 flex-col">
+    <div
+      ref={composeRefs(containerRef, fitZoomRef)}
+      className="flex h-full w-full min-w-0 flex-col"
+    >
       {/* Folio editor with AI overlay */}
       <div
         className="min-w-0 flex-1 overflow-hidden"

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-browser-editor.tsx
@@ -552,6 +552,10 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
     scaleOffset,
     0.85,
   );
+  const composedContainerRef = useMemo(
+    () => composeRefs(containerRef, fitZoomRef),
+    [fitZoomRef],
+  );
   const t = useTranslations();
   const previewPlaceholder =
     optimisticPreviewRef.current?.fieldId === fieldId
@@ -1413,7 +1417,7 @@ const DocxBrowserEditorContent = (props: DocxBrowserEditorProps) => {
 
   return (
     <div
-      ref={composeRefs(containerRef, fitZoomRef)}
+      ref={composedContainerRef}
       className="flex h-full w-full min-w-0 flex-col"
     >
       {/* Folio editor with AI overlay */}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-loading-shell.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import { useDocxFitZoom } from "@/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom";
 
 export const DOCX_DOCUMENT_SHELL_WIDTH = "min(72vw, 52rem)";
@@ -16,8 +14,7 @@ export const DocxLoadingShell = ({
   scaleOffset = 0,
   zoom,
 }: DocxLoadingShellProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const fitZoom = useDocxFitZoom(containerRef, scaleOffset, 0.85);
+  const { containerRef, fitZoom } = useDocxFitZoom(scaleOffset, 0.85);
   const effectiveZoom = zoom ?? fitZoom;
   const pageWidth = DOCX_PAGE_WIDTH * effectiveZoom;
   const pageHeight = DOCX_PAGE_HEIGHT * effectiveZoom;

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/docx/docx-preview-zoom.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { RefObject } from "react";
 
 // Target the typical Word text area (page minus ~1-inch margins on
@@ -21,58 +21,60 @@ type ZoomableDocxEditor = {
 export const clampDocxZoom = (zoom: number) =>
   Math.max(DOCX_MIN_ZOOM, Math.min(DOCX_MAX_ZOOM, zoom));
 
+type DocxFitZoomResult = {
+  containerRef: (node: HTMLElement | null) => (() => void) | undefined;
+  fitZoom: number;
+};
+
 export const useDocxFitZoom = (
-  containerRef: RefObject<HTMLElement | null>,
   scaleOffset: number = 0,
   maxAutoZoom: number = DOCX_MAX_ZOOM,
-) => {
+): DocxFitZoomResult => {
   const [fitZoom, setFitZoom] = useState(DOCX_DEFAULT_ZOOM);
-  const trackedRef = useRef<HTMLElement | null>(null);
 
-  useLayoutEffect(() => {
-    // The container ref starts null when DocxBrowserEditor renders a
-    // loading fallback; the real `<div ref={containerRef}>` only
-    // appears after the doc buffer loads. A one-shot effect would
-    // bail forever in that case. Re-check the ref on every commit so
-    // we attach the observer as soon as the container appears.
-    const container = containerRef.current;
-    if (container === trackedRef.current) {
-      return undefined;
-    }
-    trackedRef.current = container;
-    if (!container) {
-      return undefined;
-    }
-
-    const updateZoom = () => {
-      const { clientWidth } = container;
-      if (clientWidth <= 0) {
-        return;
+  // Callback ref: React invokes this once when the container
+  // attaches to the DOM and runs the returned cleanup when it
+  // detaches. Subscribing via useEffect on a passed-in RefObject
+  // does not work here because the real container only appears
+  // after a loading fallback unmounts, and useEffect does not
+  // re-run on ref mutation. The callback-ref form attaches the
+  // ResizeObserver exactly once per node lifetime regardless of
+  // parent re-renders.
+  const containerRef = useCallback(
+    (node: HTMLElement | null) => {
+      if (!node) {
+        return undefined;
       }
 
-      const availableWidth = Math.max(1, clientWidth - DOCX_FIT_PADDING * 2);
-      const nextFitZoom = availableWidth / DOCX_TEXT_AREA_WIDTH;
+      const updateZoom = () => {
+        const { clientWidth } = node;
+        if (clientWidth <= 0) {
+          return;
+        }
+        const availableWidth = Math.max(1, clientWidth - DOCX_FIT_PADDING * 2);
+        const nextFitZoom = availableWidth / DOCX_TEXT_AREA_WIDTH;
+        const cappedFitZoom = Math.min(maxAutoZoom, nextFitZoom);
+        setFitZoom(clampDocxZoom(Math.round(cappedFitZoom * 100) / 100));
+      };
 
-      const cappedFitZoom = Math.min(maxAutoZoom, nextFitZoom);
+      updateZoom();
+      // Belt-and-braces retry on the next frame for surfaces
+      // where the parent finishes sizing after our first measure
+      // (e.g., inspector pane expanding on the same commit as
+      // the docx tab opening).
+      const rafId = requestAnimationFrame(updateZoom);
+      const observer = new ResizeObserver(updateZoom);
+      observer.observe(node);
 
-      setFitZoom(clampDocxZoom(Math.round(cappedFitZoom * 100) / 100));
-    };
+      return () => {
+        cancelAnimationFrame(rafId);
+        observer.disconnect();
+      };
+    },
+    [maxAutoZoom],
+  );
 
-    updateZoom();
-    // Belt-and-braces retry on the next frame for surfaces where the
-    // parent finishes sizing after our first measure.
-    const rafId = requestAnimationFrame(updateZoom);
-    const observer = new ResizeObserver(updateZoom);
-    observer.observe(container);
-
-    return () => {
-      trackedRef.current = null;
-      cancelAnimationFrame(rafId);
-      observer.disconnect();
-    };
-  });
-
-  return clampDocxZoom(fitZoom + scaleOffset);
+  return { containerRef, fitZoom: clampDocxZoom(fitZoom + scaleOffset) };
 };
 
 export const useDocxWheelZoom = (

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -37,6 +37,7 @@ import { APIError } from "@/lib/errors";
 import { usePDFStore } from "@/lib/pdf/pdf-context";
 import { PDFPage } from "@/lib/pdf/pdf-page";
 import { PDFViewport } from "@/lib/pdf/pdf-viewport";
+import { composeRefs } from "@/lib/slot";
 import {
   useDocxFitZoom,
   useDocxWheelZoom,
@@ -464,7 +465,8 @@ const PeekDocxViewer = ({
   const analytics = useAnalytics();
   const editorRef = useRef<DocxEditorRef>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const targetZoom = useDocxFitZoom(containerRef, scaleOffset);
+  const { containerRef: fitZoomRef, fitZoom: targetZoom } =
+    useDocxFitZoom(scaleOffset);
   useDocxBlockScroll({ editorRef, fieldId });
 
   // Sync scaleOffset from inspector +/- buttons to Folio zoom
@@ -496,7 +498,10 @@ const PeekDocxViewer = ({
   }, [analytics, fieldId, printActionsRef, workspaceId]);
 
   return (
-    <div ref={containerRef} className="h-full overflow-auto">
+    <div
+      ref={composeRefs(containerRef, fitZoomRef)}
+      className="h-full overflow-auto"
+    >
       <DocxEditor
         ref={editorRef}
         autoOpenReviewSidebar={false}

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/peek/peek-pdf-viewer.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -467,6 +468,10 @@ const PeekDocxViewer = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const { containerRef: fitZoomRef, fitZoom: targetZoom } =
     useDocxFitZoom(scaleOffset);
+  const composedContainerRef = useMemo(
+    () => composeRefs(containerRef, fitZoomRef),
+    [fitZoomRef],
+  );
   useDocxBlockScroll({ editorRef, fieldId });
 
   // Sync scaleOffset from inspector +/- buttons to Folio zoom
@@ -498,10 +503,7 @@ const PeekDocxViewer = ({
   }, [analytics, fieldId, printActionsRef, workspaceId]);
 
   return (
-    <div
-      ref={composeRefs(containerRef, fitZoomRef)}
-      className="h-full overflow-auto"
-    >
+    <div ref={composedContainerRef} className="h-full overflow-auto">
       <DocxEditor
         ref={editorRef}
         autoOpenReviewSidebar={false}


### PR DESCRIPTION
## Summary

- Opening any file in the inspector or peek view crashes with React error #185 (\"Maximum update depth exceeded\"). Regressed in #476 by the change to `useDocxFitZoom` that dropped the dependency array on its `useLayoutEffect` and guarded re-attachment with a `trackedRef`.
- The cleanup nulls `trackedRef.current` before the next effect runs, so the guard `container === trackedRef.current` evaluates false on every commit. The observer re-attaches and `updateZoom()` runs synchronously each render. With `editor.setZoom(targetZoom)` toggling the vertical scrollbar (changing container `clientWidth` by ~15px), `setFitZoom` oscillates until React aborts.
- Swap the `RefObject` + `useLayoutEffect` shape for a callback ref returned from the hook. React invokes it exactly once when the node attaches and runs the returned cleanup on detach, so the ResizeObserver is created per node lifetime regardless of parent re-renders. The original "container appears late after the loading shell" issue (which the #476 rewrite was trying to solve) is handled natively by the callback-ref form.
- Callers that need the DOM node elsewhere (wheel zoom, child queries) keep their `useRef` and compose it with the hook's callback ref via `composeRefs` from `lib/slot` (now exported).

## Test plan

- [ ] Upload a fresh DOCX in a workspace, open it from Documents — inspector renders the file without throwing.
- [ ] Open the same file in peek mode (mention from chat / direct route) — no console errors.
- [ ] DOCX inspector tab on a narrow pane (< 600px) — fit zoom settles, no flicker.
- [ ] Resize the inspector pane — zoom recomputes smoothly.
- [ ] Ctrl/Cmd + wheel inside the docx — wheel zoom still works (unchanged `useDocxWheelZoom`).
- [ ] PDF peek (non-docx path) — unchanged.

## Follow-up

A Playwright smoke covering \"upload file → open in inspector → assert console clean\" would have caught this. None exists today; worth adding in a separate PR.

CC on behalf of @jan-kubica