### PR TITLE
ci(release): generate CONTENT_ENCRYPTION_KEY per smoke run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,10 +188,15 @@ jobs:
           trap cleanup_smoke EXIT
           cleanup_smoke
 
+          # Satisfies the staging/production boot guard in
+          # apps/api/src/env.ts; the smoke never persists data.
+          export CONTENT_ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
           docker run --detach --network host \
             --name stella-api-smoke \
             --env BETTER_AUTH_SECRET \
             --env BETTER_AUTH_URL \
+            --env CONTENT_ENCRYPTION_KEY \
             --env DATABASE_URL \
             --env EMAIL_PROVIDER \
             --env FRONTEND_URL \


### PR DESCRIPTION
Smoke step boots the API container under `NODE_ENV=production`, which trips the `CONTENT_ENCRYPTION_KEY` guard at `apps/api/src/env.ts:184`. Generate a per-run hex key via `openssl rand` so the boot guard passes; no real data flows through it.