### PR TITLE
feat(folio): unify HF editing onto persistent hidden PM + painter (eigenpal#611 port)

### DIFF
--- a/apps/web/e2e/specs/upload-docx.spec.ts
+++ b/apps/web/e2e/specs/upload-docx.spec.ts
@@ -90,11 +90,21 @@ test.describe("DOCX upload + inspector", () => {
     );
 
     // Positive proof the viewer actually rendered: the fixture's first
-    // paragraph appears in the DOM. This catches render crashes (an error
-    // boundary fallback wouldn't contain this string) without an arbitrary
-    // sleep. Generous timeout because in CI the Folio chunk compiles + loads
-    // cold AND the DOCX file is fetched from the API + parsed.
-    const docxText = page.getByText("Stella E2E test document.");
+    // paragraph appears in the painted layout. This catches render crashes
+    // (an error boundary fallback wouldn't contain this string) without an
+    // arbitrary sleep. Generous timeout because in CI the Folio chunk
+    // compiles + loads cold AND the DOCX file is fetched from the API +
+    // parsed.
+    //
+    // Scope to `.layout-run-text` (emitted by the layout painter in
+    // packages/folio/src/core/layout-painter/renderParagraph.ts) rather
+    // than getByText so the assertion targets the *visible* painted span
+    // only. The hidden ProseMirror at left:-9999px also contains the same
+    // text inside a <p> under aria-label="Document content" — a bare
+    // getByText hits both elements and trips Playwright strict mode.
+    const docxText = page.locator(".layout-run-text", {
+      hasText: "Stella E2E test document.",
+    });
     try {
       await expect(docxText).toBeVisible({ timeout: 45_000 });
     } catch (error) {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1020,7 +1020,17 @@ export function DocxEditor({
     handleHeaderFooterDoubleClick,
     handleBodyClick,
     handleRemoveHeaderFooter,
-  } = useHeaderFooterEditor({ history, pushDocument });
+  } = useHeaderFooterEditor({
+    history,
+    pushDocument,
+    // Hook reads live HF PM state at close time (the in-place sync
+    // that previously kept package.headers/footers current per
+    // keystroke was removed to fix the undo-corruption bug; the
+    // close path now flushes via this callback). PagedEditor's ref
+    // exposes per-rId view lookup; the hook supplies the rId it
+    // already resolved internally for save / remove.
+    getHfView: (rId) => pagedEditorRef.current?.getHfView(rId) ?? null,
+  });
 
   // Helper to get the active editor's view — returns HF editor view when in HF editing mode
   const getActiveEditorView = useCallback(() => {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -3217,8 +3217,18 @@ export function DocxEditor({
                         ? { onReadOnlyEditAttempt: onReadonlyEditAttempt }
                         : {})}
                       onSelectionChange={(_from, _to) => {
-                        // Extract full selection state from PM and use the standard handler
-                        const view = pagedEditorRef.current?.getView();
+                        // Extract full selection state from whichever PM
+                        // is active. When the user is editing HF the
+                        // hfEditorRef delegates to the persistent hidden
+                        // HF view via pagedEditorRef.getHfView(activeRId);
+                        // reading body PM here would leave the toolbar
+                        // (FormattingBar, table / image context) showing
+                        // stale body-selection state while its actions
+                        // target the HF view (post-eigenpal#611).
+                        const view =
+                          getActiveEditorView() ??
+                          pagedEditorRef.current?.getView() ??
+                          null;
                         if (view) {
                           const selectionState = extractSelectionState(
                             view.state,

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1018,7 +1018,6 @@ export function DocxEditor({
     activeFirstFooterRId,
     effectiveSectionProperties,
     handleHeaderFooterDoubleClick,
-    handleHeaderFooterSave,
     handleBodyClick,
     handleRemoveHeaderFooter,
   } = useHeaderFooterEditor({ history, pushDocument, hfEditorRef });
@@ -3547,20 +3546,35 @@ export function DocxEditor({
                         if (!targetEl || !parentEl) {
                           return null;
                         }
+                        // Resolve the active HF rId for this edit session;
+                        // the chrome delegates getView/focus/undo/redo to the
+                        // persistent hidden HF EditorView mounted by
+                        // HiddenHeaderFooterPMs (post-eigenpal#611). The
+                        // inline overlay no longer mounts its own visible PM.
+                        const activeRId = (() => {
+                          if (hfEditIsFirstPage) {
+                            return hfEditPosition === "header"
+                              ? activeFirstHeaderRId
+                              : activeFirstFooterRId;
+                          }
+                          return hfEditPosition === "header"
+                            ? activeHeaderRId
+                            : activeFooterRId;
+                        })();
+                        const getActiveView = () =>
+                          activeRId
+                            ? (pagedEditorRef.current?.getHfView(activeRId) ??
+                              null)
+                            : null;
                         return (
                           <InlineHeaderFooterEditor
                             ref={hfEditorRef}
-                            headerFooter={activeHf}
                             position={hfEditPosition}
                             targetElement={targetEl}
                             parentElement={parentEl}
-                            onSave={handleHeaderFooterSave}
+                            getActiveView={getActiveView}
                             onClose={() => setHfEditPosition(null)}
-                            onSelectionChange={handleSelectionChange}
                             onRemove={handleRemoveHeaderFooter}
-                            {...(history.state.package.styles
-                              ? { styles: history.state.package.styles }
-                              : {})}
                           />
                         );
                       })()}

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1012,6 +1012,10 @@ export function DocxEditor({
     footerContent,
     firstPageHeaderContent,
     firstPageFooterContent,
+    activeHeaderRId,
+    activeFooterRId,
+    activeFirstHeaderRId,
+    activeFirstFooterRId,
     effectiveSectionProperties,
     handleHeaderFooterDoubleClick,
     handleHeaderFooterSave,
@@ -3196,6 +3200,10 @@ export function DocxEditor({
                       footerContent={footerContent}
                       firstPageHeaderContent={firstPageHeaderContent}
                       firstPageFooterContent={firstPageFooterContent}
+                      headerContentRId={activeHeaderRId}
+                      footerContentRId={activeFooterRId}
+                      firstPageHeaderContentRId={activeFirstHeaderRId}
+                      firstPageFooterContentRId={activeFirstFooterRId}
                       {...(history.state.package.styles
                         ? { styles: history.state.package.styles }
                         : {})}

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -130,6 +130,7 @@ import {
   findNextChange,
   findPreviousChange,
 } from "../core/prosemirror/commands/comments";
+import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import {
   getChangedParagraphIds,
@@ -1279,6 +1280,36 @@ export function DocxEditor({
     const pmDoc = pagedEditorRef.current?.getDocument();
     if (pmDoc) {
       doc.package.document.content = pmDoc.package.document.content;
+    }
+    // Flush in-flight HF PM edits into the cloned package — the persistent
+    // hidden HF EditorViews don't mutate history.state per keystroke
+    // (Codex #487 P1: 20:18 review), so a "Save As .docx" called while the
+    // chrome is still open would otherwise ship the pre-edit content for
+    // every rId the user touched (Codex #487 P1 follow-up: 20:52 review).
+    // We walk the cloned headers / footers (structuredClone gave us fresh
+    // HF objects), look up the matching persistent view, and overwrite
+    // each rId's `.content` with `proseDocToBlocks(view.state.doc)`. The
+    // original history.state remains untouched because every mutation
+    // lands on the cloned Map / HF objects.
+    const editor = pagedEditorRef.current;
+    if (editor) {
+      const flushBag = (bag: Map<string, { content: unknown }> | undefined) => {
+        if (!bag) {
+          return;
+        }
+        for (const [rId, hf] of bag) {
+          const view = editor.getHfView(rId);
+          if (view) {
+            hf.content = proseDocToBlocks(view.state.doc);
+          }
+        }
+      };
+      flushBag(
+        doc.package.headers as Map<string, { content: unknown }> | undefined,
+      );
+      flushBag(
+        doc.package.footers as Map<string, { content: unknown }> | undefined,
+      );
     }
     // Drop comment threads whose anchor text has been edited away. The
     // in-memory `comments` array can outlive its in-body anchors (PM

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -1020,7 +1020,7 @@ export function DocxEditor({
     handleHeaderFooterDoubleClick,
     handleBodyClick,
     handleRemoveHeaderFooter,
-  } = useHeaderFooterEditor({ history, pushDocument, hfEditorRef });
+  } = useHeaderFooterEditor({ history, pushDocument });
 
   // Helper to get the active editor's view — returns HF editor view when in HF editing mode
   const getActiveEditorView = useCallback(() => {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -3573,7 +3573,7 @@ export function DocxEditor({
                             targetElement={targetEl}
                             parentElement={parentEl}
                             getActiveView={getActiveView}
-                            onClose={() => setHfEditPosition(null)}
+                            onClose={handleBodyClick}
                             onRemove={handleRemoveHeaderFooter}
                           />
                         );

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.test.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document, HeaderFooter } from "../core/types/document";
+import { enumerateHfSlots } from "./HiddenHeaderFooterPMs";
+
+function hf(kind: "header" | "footer" = "header"): HeaderFooter {
+  return {
+    type: kind,
+    hdrFtrType: "default",
+    content: [],
+  };
+}
+
+function makeDocument(
+  headers: Map<string, HeaderFooter> | undefined,
+  footers: Map<string, HeaderFooter> | undefined,
+): Document {
+  return {
+    package: {
+      document: { content: [], sections: [] },
+      ...(headers ? { headers } : {}),
+      ...(footers ? { footers } : {}),
+    },
+  } as unknown as Document;
+}
+
+describe("enumerateHfSlots", () => {
+  test("returns [] for null document", () => {
+    expect(enumerateHfSlots(null)).toEqual([]);
+  });
+
+  test("returns [] for document with no headers or footers", () => {
+    const doc = makeDocument(undefined, undefined);
+    expect(enumerateHfSlots(doc)).toEqual([]);
+  });
+
+  test("enumerates each header rId once", () => {
+    const headers = new Map<string, HeaderFooter>([
+      ["rId1", hf("header")],
+      ["rId2", hf("header")],
+    ]);
+    const slots = enumerateHfSlots(makeDocument(headers, undefined));
+    expect(slots).toEqual([
+      { rId: "rId1", kind: "header" },
+      { rId: "rId2", kind: "header" },
+    ]);
+  });
+
+  test("enumerates headers and footers together", () => {
+    const headers = new Map([["rIdH", hf("header")]]);
+    const footers = new Map([["rIdF", hf("footer")]]);
+    const slots = enumerateHfSlots(makeDocument(headers, footers));
+    expect(slots).toEqual([
+      { rId: "rIdH", kind: "header" },
+      { rId: "rIdF", kind: "footer" },
+    ]);
+  });
+
+  test("two sections sharing one header rId share one slot", () => {
+    // The package-level Map is the storage. The "shared by rId" pattern
+    // (ECMA-376 §17.10.1) means two sections both reference rIdH; the bag
+    // still has one entry. Slot enumeration must reflect that.
+    const headers = new Map([["rIdH", hf("header")]]);
+    const slots = enumerateHfSlots(makeDocument(headers, undefined));
+    expect(slots.length).toBe(1);
+    expect(slots[0]).toEqual({ rId: "rIdH", kind: "header" });
+  });
+
+  test("defensively dedupes an rId that appears in both bags", () => {
+    // The OOXML schema keeps header/footer rIds disjoint, but if both bags
+    // accidentally registered the same rId we should emit one slot, not two.
+    const headers = new Map([["rIdShared", hf("header")]]);
+    const footers = new Map([["rIdShared", hf("footer")]]);
+    const slots = enumerateHfSlots(makeDocument(headers, footers));
+    expect(slots).toEqual([{ rId: "rIdShared", kind: "header" }]);
+  });
+});

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -188,17 +188,22 @@ export const HiddenHeaderFooterPMs = memo(
       const hostRef = useRef<HTMLDivElement>(null);
       const mountedRef = useRef<Map<string, MountedView>>(new Map());
       const managersRef = useRef<Map<string, ExtensionManager>>(new Map());
+      // Latest document captured in a ref so resolveHf has a stable identity
+      // and the mount-effect doesn't re-run on every body PM transaction
+      // (each pushDocument returns a new Document identity).
+      const documentRef = useRef(document);
+      documentRef.current = document;
 
       const resolveHf = useCallback(
         (rId: string, kind: HfPartKind): HeaderFooter | null => {
-          const pkg = document?.package;
+          const pkg = documentRef.current?.package;
           if (!pkg) {
             return null;
           }
           const bag = kind === "header" ? pkg.headers : pkg.footers;
           return bag?.get(rId) ?? null;
         },
-        [document],
+        [],
       );
 
       const slots = useMemo<HfPartKey[]>(

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -36,7 +36,6 @@ import { EditorState } from "prosemirror-state";
 import type { EditorState as EditorStateT } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
-import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
@@ -302,22 +301,21 @@ export const HiddenHeaderFooterPMs = memo(
             dispatchTransaction(tr) {
               const newState = view.state.apply(tr);
               view.updateState(newState);
-              if (tr.docChanged) {
-                const mounted = mountedRef.current.get(slotRId);
-                const target = mounted?.appliedHf;
-                if (target) {
-                  // Mutate the source HeaderFooter in place so the
-                  // existing save path (pushDocument reads hf.content)
-                  // sees the latest blocks without an extra hop. Track
-                  // the new array reference on the MountedView so the
-                  // next enumerate pass can tell "same content under a
-                  // new HF wrapper" (in-session save) apart from "new
-                  // doc / undo" (genuine content change).
-                  const blocks = proseDocToBlocks(newState.doc);
-                  target.content = blocks;
-                  mounted.appliedContent = blocks;
-                }
-              }
+              // INTENTIONALLY no in-place mutation of `appliedHf.content`.
+              // Earlier revisions did `target.content = blocks` here to
+              // keep `Document.package.headers/footers[rId].content`
+              // current with each keystroke, but `appliedHf` is the
+              // same HeaderFooter object referenced by every undo entry
+              // in history that pre-dates this edit session — mutating
+              // it corrupted those snapshots, so a document-undo after
+              // closing HF mode couldn't restore the pre-edit content
+              // (Codex #487 P1). The view's state.doc is now the only
+              // source of truth while the chrome is open; the painter
+              // already reads through `convertHeaderFooterPmDocToContent`
+              // when a view exists, and `handleHeaderFooterSave` flushes
+              // the latest blocks into a brand-new HeaderFooter object
+              // in a brand-new Map on close, so history only ever sees
+              // committed snapshots.
               onTransactionRef.current?.(
                 slotRId,
                 slotKind,

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -1,0 +1,301 @@
+/**
+ * HiddenHeaderFooterPMs — persistent off-screen ProseMirror EditorViews for
+ * every distinct header/footer part in the loaded document.
+ *
+ * Mounts one hidden EditorView per distinct HF `rId` from
+ * `Document.package.headers ∪ Document.package.footers`. The views never
+ * become the visible HF renderer — the painter is the sole visible HF
+ * renderer in both edit and non-edit modes. The persistent views own the
+ * source of truth for HF content while the document is loaded; the
+ * painter reads each rId's `view.state.doc` through
+ * `convertHeaderFooterPmDocToContent`.
+ *
+ * Slot keying is by `rId`, NOT by `(hdrFtrType, kind)` — two sections that
+ * share a header by referencing the same `rId` (ECMA-376 §17.10.1
+ * sharing-by-reference) share one EditorView, so an edit on any painted
+ * instance propagates to every painted instance in one layout pass.
+ *
+ * Unlike upstream's in-place `hf.content` mutation, folio's history-immutable
+ * model surfaces every transaction through `onTransaction`; the parent
+ * (`useHeaderFooterEditor` / `DocxEditor`) is the only place that pushes
+ * Document changes through history.
+ */
+
+import {
+  forwardRef,
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
+import type { CSSProperties } from "react";
+
+import { EditorState } from "prosemirror-state";
+import type { EditorState as EditorStateT } from "prosemirror-state";
+import { EditorView } from "prosemirror-view";
+
+import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
+import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
+import { schema } from "../core/prosemirror/schema";
+import type {
+  Document,
+  HeaderFooter,
+  StyleDefinitions,
+  Theme,
+} from "../core/types/document";
+
+import "prosemirror-view/style/prosemirror.css";
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+export type HfPartKind = "header" | "footer";
+
+export type HfPartKey = {
+  /** Part-relationship id (`rId`) — the spec-faithful slot identity. */
+  rId: string;
+  /** Whether this rId belongs to `package.headers` or `package.footers`. */
+  kind: HfPartKind;
+};
+
+export type HiddenHeaderFooterPMsRef = {
+  /**
+   * Look up the persistent EditorView for a given HF part. Returns `null`
+   * before mount or when the rId is not present in the loaded document.
+   */
+  getView(rId: string): EditorView | null;
+  /**
+   * Enumerate every currently mounted slot. Used by the pointer pipeline
+   * to translate painted DOM targets back to the owning PM view.
+   */
+  listSlots(): HfPartKey[];
+};
+
+export type HiddenHeaderFooterPMsProps = {
+  /** Loaded document — its `package.headers`/`.footers` drives slot enumeration. */
+  document: Document | null;
+  /** Document styles, threaded into `headerFooterToProseDoc` for style resolution. */
+  styles?: StyleDefinitions | null;
+  /** Document theme, threaded for themed cell shading on initial PM build. */
+  theme?: Theme | null;
+  /** `defaultTabStop` from the body PM doc, threaded to the HF PM doc. */
+  defaultTabStopTwips?: number | null;
+  /**
+   * Fires after every transaction lands on any HF EditorView. Parent uses
+   * this to trigger relayout (so the painter repaints the new PM doc) and
+   * to schedule a debounced write-back into `Document.package.headers[rId]`.
+   */
+  onTransaction?: (rId: string, view: EditorView, docChanged: boolean) => void;
+};
+
+// =============================================================================
+// IMPLEMENTATION
+// =============================================================================
+
+type MountedView = {
+  rId: string;
+  kind: HfPartKind;
+  view: EditorView;
+  /** DOM node `view` is mounted on (one `<div>` per rId inside the off-screen host). */
+  mountNode: HTMLElement;
+};
+
+function buildInitialState(
+  hf: HeaderFooter,
+  styles: StyleDefinitions | null | undefined,
+  theme: Theme | null | undefined,
+  mgr: ExtensionManager,
+): EditorStateT {
+  const proseDocOptions: { styles?: StyleDefinitions; theme?: Theme | null } =
+    {};
+  if (styles) {
+    proseDocOptions.styles = styles;
+  }
+  if (theme !== undefined) {
+    proseDocOptions.theme = theme;
+  }
+  const pmDoc = headerFooterToProseDoc(hf.content, proseDocOptions);
+  return EditorState.create({
+    doc: pmDoc,
+    schema,
+    plugins: mgr.getPlugins(),
+  });
+}
+
+export function enumerateHfSlots(doc: Document | null): HfPartKey[] {
+  if (!doc?.package) {
+    return [];
+  }
+  const out: HfPartKey[] = [];
+  const headers = doc.package.headers;
+  if (headers) {
+    for (const rId of headers.keys()) {
+      out.push({ rId, kind: "header" });
+    }
+  }
+  const footers = doc.package.footers;
+  if (footers) {
+    // A document SHOULD NOT register the same rId under both headers and
+    // footers — the OOXML schema keeps them disjoint per
+    // `headerReference` vs `footerReference`. Defensive: dedupe anyway.
+    for (const rId of footers.keys()) {
+      if (!headers || !headers.has(rId)) {
+        out.push({ rId, kind: "footer" });
+      }
+    }
+  }
+  return out;
+}
+
+// =============================================================================
+// STYLES
+// =============================================================================
+
+const HOST_STYLES: CSSProperties = {
+  position: "fixed",
+  left: -9999,
+  top: 0,
+  opacity: 0,
+  zIndex: -1,
+  pointerEvents: "none",
+};
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+export const HiddenHeaderFooterPMs = memo(
+  forwardRef<HiddenHeaderFooterPMsRef, HiddenHeaderFooterPMsProps>(
+    function HiddenHeaderFooterPMs(
+      { document, styles, theme, onTransaction },
+      ref,
+    ) {
+      // Stable callback ref so re-renders don't recreate every EditorView.
+      const onTransactionRef = useRef(onTransaction);
+      onTransactionRef.current = onTransaction;
+
+      const hostRef = useRef<HTMLDivElement>(null);
+      const mountedRef = useRef<Map<string, MountedView>>(new Map());
+      const managersRef = useRef<Map<string, ExtensionManager>>(new Map());
+
+      const resolveHf = useCallback(
+        (rId: string, kind: HfPartKind): HeaderFooter | null => {
+          const pkg = document?.package;
+          if (!pkg) {
+            return null;
+          }
+          const bag = kind === "header" ? pkg.headers : pkg.footers;
+          return bag?.get(rId) ?? null;
+        },
+        [document],
+      );
+
+      const slots = useMemo<HfPartKey[]>(
+        () => enumerateHfSlots(document),
+        // Re-enumerate when the Maps themselves are swapped. Mutations to the
+        // existing Map (e.g. external save) intentionally do NOT trigger
+        // this — the persistent PM is the source of truth while loaded.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [document?.package.headers, document?.package.footers],
+      );
+
+      useEffect(() => {
+        if (!hostRef.current) {
+          return;
+        }
+        const host = hostRef.current;
+        const want = new Map(slots.map((s) => [s.rId, s] as const));
+        const have = mountedRef.current;
+
+        for (const [rId, mounted] of have) {
+          if (!want.has(rId)) {
+            mounted.view.destroy();
+            mounted.mountNode.remove();
+            have.delete(rId);
+            managersRef.current.delete(rId);
+          }
+        }
+
+        for (const slot of slots) {
+          if (have.has(slot.rId)) {
+            continue;
+          }
+          const hf = resolveHf(slot.rId, slot.kind);
+          if (!hf) {
+            continue;
+          }
+
+          const mgr = new ExtensionManager(createStarterKit());
+          mgr.buildSchema();
+          mgr.initializeRuntime();
+          managersRef.current.set(slot.rId, mgr);
+
+          const node = host.ownerDocument.createElement("div");
+          node.dataset["hfRId"] = slot.rId;
+          node.dataset["hfKind"] = slot.kind;
+          host.append(node);
+
+          const state = buildInitialState(hf, styles, theme, mgr);
+          const slotRId = slot.rId;
+          const view: EditorView = new EditorView(node, {
+            state,
+            dispatchTransaction(tr) {
+              const newState = view.state.apply(tr);
+              view.updateState(newState);
+              onTransactionRef.current?.(slotRId, view, tr.docChanged);
+            },
+          });
+          have.set(slot.rId, {
+            rId: slot.rId,
+            kind: slot.kind,
+            view,
+            mountNode: node,
+          });
+        }
+        // `document` is intentionally excluded — slot enumeration flows via
+        // `slots`, and `resolveHf` reads from the captured closure. Depending
+        // on `document` directly causes a full remount on every body PM
+        // transaction (each pushDocument returns a new identity), which
+        // destroys IME state and selection.
+      }, [slots, resolveHf, styles, theme]);
+
+      // Tear everything down on unmount.
+      useEffect(() => {
+        const have = mountedRef.current;
+        const mgrs = managersRef.current;
+        return () => {
+          for (const { view, mountNode } of have.values()) {
+            view.destroy();
+            mountNode.remove();
+          }
+          have.clear();
+          mgrs.clear();
+        };
+      }, []);
+
+      useImperativeHandle(
+        ref,
+        () => ({
+          getView(rId: string): EditorView | null {
+            return mountedRef.current.get(rId)?.view ?? null;
+          },
+          listSlots(): HfPartKey[] {
+            return [...mountedRef.current.values()].map(({ rId, kind }) => ({
+              rId,
+              kind,
+            }));
+          },
+        }),
+        [],
+      );
+
+      return <div ref={hostRef} style={HOST_STYLES} />;
+    },
+  ),
+);
+
+HiddenHeaderFooterPMs.displayName = "HiddenHeaderFooterPMs";

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -36,6 +36,7 @@ import { EditorState } from "prosemirror-state";
 import type { EditorState as EditorStateT } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
+import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
@@ -43,7 +44,9 @@ import { schema } from "../core/prosemirror/schema";
 import type {
   Document,
   HeaderFooter,
+  Paragraph,
   StyleDefinitions,
+  Table,
   Theme,
 } from "../core/types/document";
 
@@ -109,6 +112,23 @@ type MountedView = {
   view: EditorView;
   /** DOM node `view` is mounted on (one `<div>` per rId inside the off-screen host). */
   mountNode: HTMLElement;
+  /**
+   * Reference to the `HeaderFooter` object the view was built from. Used to
+   * detect when a new document brings in a different HF for the same rId
+   * (truly new doc load, or undo/redo reverting an HF edit) so the view's
+   * state can be rebuilt from the new content. In-session in-place
+   * mutations don't change this reference.
+   */
+  appliedHf: HeaderFooter;
+  /**
+   * Reference to the content array on `appliedHf` at the moment the
+   * view was last synced. handleDispatchTransaction writes the latest
+   * `proseDocToBlocks(state.doc)` here so the change-detection check
+   * works even when the surrounding HF object is re-allocated by a
+   * history snapshot (the array reference survives if the snapshot
+   * spreads `...existing` without overriding content).
+   */
+  appliedContent: (Paragraph | Table)[];
 };
 
 function buildInitialState(
@@ -233,11 +253,34 @@ export const HiddenHeaderFooterPMs = memo(
         }
 
         for (const slot of slots) {
-          if (have.has(slot.rId)) {
-            continue;
-          }
           const hf = resolveHf(slot.rId, slot.kind);
           if (!hf) {
+            continue;
+          }
+          const existing = have.get(slot.rId);
+          if (existing) {
+            // Same rId is still around. Decide whether the view needs to
+            // adopt new content (truly new document, or undo/redo
+            // restoring an earlier HF state) by comparing the active
+            // HeaderFooter reference. handleDispatchTransaction keeps
+            // appliedHf / appliedContent pointing at the same array
+            // reference the in-place sync wrote, so an in-session
+            // pushDocument that spreads `...existing` survives without
+            // a state rebuild.
+            if (
+              existing.appliedHf === hf &&
+              existing.appliedContent === hf.content
+            ) {
+              continue;
+            }
+            const mgr = managersRef.current.get(slot.rId);
+            if (!mgr) {
+              continue;
+            }
+            const newState = buildInitialState(hf, styles, theme, mgr);
+            existing.view.updateState(newState);
+            existing.appliedHf = hf;
+            existing.appliedContent = hf.content;
             continue;
           }
 
@@ -259,6 +302,22 @@ export const HiddenHeaderFooterPMs = memo(
             dispatchTransaction(tr) {
               const newState = view.state.apply(tr);
               view.updateState(newState);
+              if (tr.docChanged) {
+                const mounted = mountedRef.current.get(slotRId);
+                const target = mounted?.appliedHf;
+                if (target) {
+                  // Mutate the source HeaderFooter in place so the
+                  // existing save path (pushDocument reads hf.content)
+                  // sees the latest blocks without an extra hop. Track
+                  // the new array reference on the MountedView so the
+                  // next enumerate pass can tell "same content under a
+                  // new HF wrapper" (in-session save) apart from "new
+                  // doc / undo" (genuine content change).
+                  const blocks = proseDocToBlocks(newState.doc);
+                  target.content = blocks;
+                  mounted.appliedContent = blocks;
+                }
+              }
               onTransactionRef.current?.(
                 slotRId,
                 slotKind,
@@ -273,13 +332,10 @@ export const HiddenHeaderFooterPMs = memo(
             kind: slot.kind,
             view,
             mountNode: node,
+            appliedHf: hf,
+            appliedContent: hf.content,
           });
         }
-        // `document` is intentionally excluded — slot enumeration flows via
-        // `slots`, and `resolveHf` reads from the captured closure. Depending
-        // on `document` directly causes a full remount on every body PM
-        // transaction (each pushDocument returns a new identity), which
-        // destroys IME state and selection.
       }, [slots, resolveHf, styles, theme]);
 
       // Tear everything down on unmount.

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -86,10 +86,17 @@ export type HiddenHeaderFooterPMsProps = {
   defaultTabStopTwips?: number | null;
   /**
    * Fires after every transaction lands on any HF EditorView. Parent uses
-   * this to trigger relayout (so the painter repaints the new PM doc) and
-   * to schedule a debounced write-back into `Document.package.headers[rId]`.
+   * this to trigger relayout (so the painter repaints the new PM doc),
+   * write back into `Document.package.headers/footers[rId]`, and drive the
+   * HF caret overlay from the new selection.
    */
-  onTransaction?: (rId: string, view: EditorView, docChanged: boolean) => void;
+  onTransaction?: (
+    rId: string,
+    kind: HfPartKind,
+    view: EditorView,
+    docChanged: boolean,
+    selectionChanged: boolean,
+  ) => void;
 };
 
 // =============================================================================
@@ -241,12 +248,19 @@ export const HiddenHeaderFooterPMs = memo(
 
           const state = buildInitialState(hf, styles, theme, mgr);
           const slotRId = slot.rId;
+          const slotKind = slot.kind;
           const view: EditorView = new EditorView(node, {
             state,
             dispatchTransaction(tr) {
               const newState = view.state.apply(tr);
               view.updateState(newState);
-              onTransactionRef.current?.(slotRId, view, tr.docChanged);
+              onTransactionRef.current?.(
+                slotRId,
+                slotKind,
+                view,
+                tr.docChanged,
+                tr.selectionSet,
+              );
             },
           });
           have.set(slot.rId, {

--- a/packages/folio/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/folio/src/components/InlineHeaderFooterEditor.tsx
@@ -1,42 +1,37 @@
 /**
- * InlineHeaderFooterEditor — inline overlay editor for header/footer content
+ * InlineHeaderFooterEditor — UI chrome for HF editing.
  *
- * Renders a ProseMirror EditorView positioned over the header/footer area
- * on the page, Google Docs style. The main body is dimmed and the toolbar
- * routes formatting commands to this editor while it's active.
+ * Before the HF editing unification, this component mounted its own visible
+ * ProseMirror EditorView positioned over the painted HF area. The painter
+ * underneath was hidden via `visibility: hidden` and the visible PM owned
+ * editing. That model produced edit/non-edit geometry drift, field-insert
+ * extra keystrokes, scroll-to-page-1 on cross-page HF edits, and imprecise
+ * caret placement.
+ *
+ * Post-unification (eigenpal#611), the painter is the sole visible HF
+ * renderer in both edit and non-edit modes; user input flows through the
+ * persistent off-screen EditorView mounted by `HiddenHeaderFooterPMs`.
+ * This component is now just chrome: a positioned label, an options menu
+ * (Insert PAGE / NUMPAGES / Remove / Close), and the separator bar.
+ *
+ * The ref still exposes `getView` / `focus` / `undo` / `redo` so existing
+ * callers (`useHeaderFooterEditor`, toolbar wiring) keep working — those
+ * methods now delegate to the active HF PM via `getActiveView`.
  */
 
-import React, {
-  useRef,
-  useEffect,
+import {
   useCallback,
-  useMemo,
-  useState,
+  useEffect,
   useImperativeHandle,
-  useLayoutEffect,
+  useRef,
+  useState,
 } from "react";
 import type { CSSProperties, Ref } from "react";
 
-import { undo, redo } from "prosemirror-history";
-import { EditorState } from "prosemirror-state";
-import { EditorView } from "prosemirror-view";
+import { redo, undo } from "prosemirror-history";
+import type { EditorView } from "prosemirror-view";
 
-import {
-  extractSelectionState,
-  createStyleResolver,
-} from "../core/prosemirror";
-import type { SelectionState } from "../core/prosemirror";
-import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
-import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
-import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
-import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
-import { schema } from "../core/prosemirror/schema";
-import type {
-  HeaderFooter,
-  Paragraph,
-  Table,
-  StyleDefinitions,
-} from "../core/types/document";
+import { schema } from "../core/prosemirror";
 import "prosemirror-view/style/prosemirror.css";
 
 // ============================================================================
@@ -44,34 +39,32 @@ import "prosemirror-view/style/prosemirror.css";
 // ============================================================================
 
 export type InlineHeaderFooterEditorProps = {
-  /** The header or footer being edited */
-  headerFooter: HeaderFooter;
   /** Whether editing header or footer */
   position: "header" | "footer";
-  /** Document styles for style resolution */
-  styles?: StyleDefinitions | null;
   /** The DOM element to overlay (the .layout-page-header / .layout-page-footer) */
   targetElement: HTMLElement;
   /** The positioning parent element (the div wrapping PagedEditor) */
   parentElement: HTMLElement;
-  /** Callback when editing is complete — receives updated content blocks */
-  onSave: (content: (Paragraph | Table)[]) => void;
-  /** Callback when editing is cancelled */
+  /**
+   * Returns the persistent hidden HF EditorView the user is currently
+   * editing. The chrome's ref methods (`getView`, `focus`, `undo`, `redo`)
+   * and the options menu's field inserts all route through this.
+   */
+  getActiveView: () => EditorView | null;
+  /** Callback when editing is cancelled (Escape / Close button) */
   onClose: () => void;
-  /** Callback when selection changes in the HF editor (for toolbar sync) */
-  onSelectionChange?: (state: SelectionState | null) => void;
   /** Callback to remove the header/footer entirely */
   onRemove?: () => void;
 };
 
 export type InlineHeaderFooterEditorRef = {
-  /** Get the ProseMirror EditorView */
+  /** Get the active HF PM EditorView (the persistent hidden one). */
   getView(): EditorView | null;
-  /** Focus the editor */
+  /** Focus the active HF PM. */
   focus(): void;
-  /** Undo */
+  /** Undo on the active HF PM. */
   undo(): boolean;
-  /** Redo */
+  /** Redo on the active HF PM. */
   redo(): boolean;
 };
 
@@ -100,47 +93,25 @@ const labelStyle: CSSProperties = {
 
 export function InlineHeaderFooterEditor({
   ref,
-  headerFooter,
   position,
-  styles,
   targetElement,
   parentElement,
-  onSave,
+  getActiveView,
   onClose,
-  onSelectionChange,
   onRemove,
 }: InlineHeaderFooterEditorProps & {
   ref?: Ref<InlineHeaderFooterEditorRef>;
 }) {
-  const editorContainerRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<EditorView | null>(null);
-  const [isDirty, setIsDirty] = useState(false);
-
-  // Resolve default font size from document styles so the PM editor's
-  // line-height calculations use the correct base (not browser-default 16px)
-  const defaultFontSizePt = useMemo(() => {
-    if (!styles) {
-      return 11;
-    } // Word 2007+ default
-    const resolver = createStyleResolver(styles);
-    const resolved = resolver.resolveParagraphStyle(undefined);
-    // fontSize in document model is in half-points
-    return resolved.runFormatting?.fontSize
-      ? (resolved.runFormatting.fontSize as number) / 2
-      : 11;
-  }, [styles]);
-
   const [showOptions, setShowOptions] = useState(false);
   const optionsRef = useRef<HTMLDivElement>(null);
 
-  // Compute overlay position relative to the parent element
   const [overlayPos, setOverlayPos] = useState<{
     top: number;
     left: number;
     width: number;
   } | null>(null);
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     const computePosition = () => {
       const parentRect = parentElement.getBoundingClientRect();
       const targetRect = targetElement.getBoundingClientRect();
@@ -152,7 +123,6 @@ export function InlineHeaderFooterEditor({
     };
     computePosition();
 
-    // Recompute on scroll/resize
     const scrollParent =
       parentElement.closest('[style*="overflow"]') || parentElement;
     scrollParent.addEventListener("scroll", computePosition);
@@ -163,97 +133,40 @@ export function InlineHeaderFooterEditor({
     };
   }, [targetElement, parentElement]);
 
-  // Create ProseMirror editor when the container is available
-  // (overlayPos starts null → first render returns null → container ref not set)
+  // Focus the persistent HF PM when the chrome mounts so typing starts
+  // immediately after double-click. Mirrors what the old visible-PM mount
+  // did via requestAnimationFrame + view.focus().
   useEffect(() => {
-    if (!editorContainerRef.current || viewRef.current) {
-      return;
+    const view = getActiveView();
+    if (view) {
+      // Defer one frame so the painted DOM is in place before focus.
+      const id = requestAnimationFrame(() => {
+        view.focus();
+      });
+      return () => cancelAnimationFrame(id);
     }
-
-    // Convert header/footer content to PM document
-    const pmDoc =
-      styles === undefined || styles === null
-        ? headerFooterToProseDoc(headerFooter.content)
-        : headerFooterToProseDoc(headerFooter.content, { styles });
-
-    // Create a fresh ExtensionManager to get independent plugin instances
-    // (keyed plugins like history$ can't be shared across EditorViews)
-    const hfMgr = new ExtensionManager(createStarterKit());
-    hfMgr.buildSchema();
-    hfMgr.initializeRuntime();
-    const plugins = hfMgr.getPlugins();
-
-    const state = EditorState.create({
-      doc: pmDoc,
-      schema,
-      plugins,
-    });
-
-    const view = new EditorView(editorContainerRef.current, {
-      state,
-      dispatchTransaction(tr) {
-        const newState = view.state.apply(tr);
-        view.updateState(newState);
-        if (tr.docChanged) {
-          setIsDirty(true);
-        }
-        // Report selection changes for toolbar sync
-        if (tr.selectionSet || tr.docChanged) {
-          const selState = extractSelectionState(newState);
-          onSelectionChange?.(selState);
-        }
-      },
-    });
-
-    viewRef.current = view;
-
-    // Auto-focus
-    requestAnimationFrame(() => {
-      view.focus();
-      // Report initial selection state
-      const selState = extractSelectionState(view.state);
-      onSelectionChange?.(selState);
-    });
-
-    return () => {
-      view.destroy();
-      viewRef.current = null;
-    };
+    return undefined;
+    // getActiveView is intentionally not in deps — it's a stable function
+    // by design from the parent.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [overlayPos]); // Re-run when position is computed (container becomes available)
+  }, []);
 
-  // Save current content
-  const handleSave = useCallback(() => {
-    if (!viewRef.current) {
-      return;
-    }
-    const blocks = proseDocToBlocks(viewRef.current.state.doc);
-    onSave(blocks);
-  }, [onSave]);
+  const handleClose = useCallback(() => {
+    onClose();
+  }, [onClose]);
 
-  // Save + close
-  const handleSaveAndClose = useCallback(() => {
-    if (isDirty) {
-      handleSave();
-    } else {
-      onClose();
-    }
-  }, [isDirty, handleSave, onClose]);
-
-  // Handle Escape key — save + close
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
         e.stopPropagation();
-        handleSaveAndClose();
+        handleClose();
       }
     }
     document.addEventListener("keydown", handleKeyDown, true);
     return () => document.removeEventListener("keydown", handleKeyDown, true);
-  }, [handleSaveAndClose]);
+  }, [handleClose]);
 
-  // Close options dropdown when clicking outside
   useEffect(() => {
     if (!showOptions) {
       return;
@@ -270,19 +183,18 @@ export function InlineHeaderFooterEditor({
     return () => document.removeEventListener("mousedown", handleClick);
   }, [showOptions]);
 
-  // Expose ref
   useImperativeHandle(ref, () => ({
-    getView: () => viewRef.current,
-    focus: () => viewRef.current?.focus(),
+    getView: () => getActiveView(),
+    focus: () => getActiveView()?.focus(),
     undo: () => {
-      const view = viewRef.current;
+      const view = getActiveView();
       if (!view) {
         return false;
       }
       return undo(view.state, view.dispatch);
     },
     redo: () => {
-      const view = viewRef.current;
+      const view = getActiveView();
       if (!view) {
         return false;
       }
@@ -302,6 +214,10 @@ export function InlineHeaderFooterEditor({
     left: overlayPos.left,
     width: overlayPos.width,
     zIndex: 10,
+    // No pointer events on the chrome container itself — the painted HF
+    // beneath must receive clicks so the pointer pipeline routes them to
+    // the persistent HF PM. Individual chrome buttons opt back in.
+    pointerEvents: "none",
   };
 
   return (
@@ -309,14 +225,12 @@ export function InlineHeaderFooterEditor({
       role="presentation"
       className="hf-inline-editor"
       style={containerStyle}
-      onMouseDown={(e) => {
-        // Prevent clicks from bubbling to pages container / body click handler
-        e.stopPropagation();
-      }}
     >
-      {/* Separator bar — shown below for header, above for footer */}
       {position === "footer" && (
-        <div className="hf-separator-bar" style={separatorBarStyle}>
+        <div
+          className="hf-separator-bar"
+          style={{ ...separatorBarStyle, pointerEvents: "auto" }}
+        >
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
             label={label}
@@ -324,26 +238,17 @@ export function InlineHeaderFooterEditor({
             setShowOptions={setShowOptions}
             optionsRef={optionsRef}
             onRemove={onRemove}
-            onClose={handleSaveAndClose}
-            viewRef={viewRef}
+            onClose={handleClose}
+            getActiveView={getActiveView}
           />
         </div>
       )}
 
-      {/* ProseMirror editor area */}
-      <div
-        ref={editorContainerRef}
-        className="hf-editor-pm"
-        style={{
-          minHeight: 40,
-          outline: "none",
-          fontSize: `${defaultFontSizePt}pt`,
-        }}
-      />
-
-      {/* Separator bar — shown below for header */}
       {position === "header" && (
-        <div className="hf-separator-bar" style={separatorBarStyle}>
+        <div
+          className="hf-separator-bar"
+          style={{ ...separatorBarStyle, pointerEvents: "auto" }}
+        >
           <span style={labelStyle}>{label}</span>
           <OptionsMenu
             label={label}
@@ -351,8 +256,8 @@ export function InlineHeaderFooterEditor({
             setShowOptions={setShowOptions}
             optionsRef={optionsRef}
             onRemove={onRemove}
-            onClose={handleSaveAndClose}
-            viewRef={viewRef}
+            onClose={handleClose}
+            getActiveView={getActiveView}
           />
         </div>
       )}
@@ -371,7 +276,7 @@ function OptionsMenu({
   optionsRef,
   onRemove,
   onClose,
-  viewRef,
+  getActiveView,
 }: {
   label: string;
   showOptions: boolean;
@@ -379,14 +284,13 @@ function OptionsMenu({
   optionsRef: React.RefObject<HTMLDivElement | null>;
   onRemove?: (() => void) | undefined;
   onClose: () => void;
-  viewRef: React.RefObject<EditorView | null>;
+  getActiveView: () => EditorView | null;
 }) {
   const insertField = (fieldType: "PAGE" | "NUMPAGES") => {
-    const view = viewRef.current;
+    const view = getActiveView();
     if (!view) {
       return;
     }
-    // Get marks at the current cursor position so the field inherits surrounding styling
     const { $from, from } = view.state.selection;
     const marks = view.state.storedMarks || $from.marks();
     const node = schema.nodes["field"]!.create({

--- a/packages/folio/src/components/InlineHeaderFooterEditor.tsx
+++ b/packages/folio/src/components/InlineHeaderFooterEditor.tsx
@@ -134,20 +134,35 @@ export function InlineHeaderFooterEditor({
   }, [targetElement, parentElement]);
 
   // Focus the persistent HF PM when the chrome mounts so typing starts
-  // immediately after double-click. Mirrors what the old visible-PM mount
-  // did via requestAnimationFrame + view.focus().
+  // immediately after double-click. The HF view may not exist yet at
+  // mount: HiddenHeaderFooterPMs creates views inside a useEffect, and
+  // for freshly-created HF parts (empty header on a doc that had none),
+  // the chrome and the view-creation effect can land in either order.
+  // Retry across a short rAF window so focus lands as soon as the view
+  // is available; bail after MAX_FOCUS_ATTEMPTS frames to avoid leaking
+  // a rAF loop in pathological cases.
   useEffect(() => {
-    const view = getActiveView();
-    if (view) {
-      // Defer one frame so the painted DOM is in place before focus.
-      const id = requestAnimationFrame(() => {
+    const MAX_FOCUS_ATTEMPTS = 10;
+    let attempts = 0;
+    let rafId: number | null = null;
+    const tryFocus = () => {
+      const view = getActiveView();
+      if (view) {
         view.focus();
-      });
-      return () => cancelAnimationFrame(id);
-    }
-    return undefined;
-    // getActiveView is intentionally not in deps — it's a stable function
-    // by design from the parent.
+        return;
+      }
+      attempts++;
+      if (attempts < MAX_FOCUS_ATTEMPTS) {
+        rafId = requestAnimationFrame(tryFocus);
+      }
+    };
+    rafId = requestAnimationFrame(tryFocus);
+    return () => {
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+    // getActiveView is a closure over parent state; we only fire on mount.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -4,19 +4,14 @@
  */
 
 import { useState, useMemo, useCallback } from "react";
-import type { RefObject } from "react";
 
-import { proseDocToBlocks } from "../../core/prosemirror/conversion/fromProseDoc";
 import type {
   Document,
   DocumentBody,
   HeaderFooter,
   SectionProperties,
-  Paragraph,
-  Table,
 } from "../../core/types/document";
 import type { UseHistoryReturn } from "../../hooks/useHistory";
-import type { InlineHeaderFooterEditorRef } from "../InlineHeaderFooterEditor";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -25,7 +20,6 @@ import type { InlineHeaderFooterEditorRef } from "../InlineHeaderFooterEditor";
 type UseHeaderFooterEditorParams = {
   history: UseHistoryReturn<Document | null>;
   pushDocument: (document: Document) => Document;
-  hfEditorRef: RefObject<InlineHeaderFooterEditorRef | null>;
 };
 
 type UseHeaderFooterEditorReturn = {
@@ -61,8 +55,13 @@ type UseHeaderFooterEditorReturn = {
     position: "header" | "footer",
     pageNumber?: number,
   ) => void;
-  /** Persist edited blocks back into the document package */
-  handleHeaderFooterSave: (content: (Paragraph | Table)[]) => void;
+  /**
+   * Snapshot the current HF state into a new Document via pushDocument so
+   * the edit session lands in undo history. Content lives in
+   * `package.headers/footers[rId].content` (kept current by the persistent
+   * HF PM's in-place sync) — no caller payload needed.
+   */
+  handleHeaderFooterSave: () => void;
   /** Save and close HF editor when the body is clicked */
   handleBodyClick: () => void;
   /** Remove the active header/footer from the document */
@@ -91,7 +90,6 @@ export function resolveEffectiveSectionProperties(
 export const useHeaderFooterEditor = ({
   history,
   pushDocument,
-  hfEditorRef,
 }: UseHeaderFooterEditorParams): UseHeaderFooterEditorReturn => {
   // -------------------------------------------------------------------------
   // State
@@ -427,41 +425,40 @@ export const useHeaderFooterEditor = ({
     ],
   );
 
-  const handleHeaderFooterSave = useCallback(
-    (content: (Paragraph | Table)[]) => {
-      if (!hfEditPosition || !history.state?.package) {
-        setHfEditPosition(null);
-        return;
-      }
+  const handleHeaderFooterSave = useCallback(() => {
+    if (!hfEditPosition || !history.state?.package) {
+      setHfEditPosition(null);
+      return;
+    }
 
-      const pkg = history.state.package;
-      // Save into the rId resolved by the SAME algorithm that picks
-      // the displayed H/F (see the resolver useMemo above). Routing
-      // saves through `pkg.document?.finalSectionProperties` would
-      // write into the *last* section's rId, which can be different
-      // from the rendered one in multi-section docs (NVCA-style:
-      // title-page section has the body H/F; signature sections
-      // override default with stripped-down rIds). Codex PR #258
-      // review.
-      let activeRId =
-        hfEditPosition === "header" ? activeHeaderRId : activeFooterRId;
-      if (hfEditIsFirstPage) {
-        activeRId =
-          hfEditPosition === "header"
-            ? activeFirstHeaderRId
-            : activeFirstFooterRId;
-      }
-      const refType = hfEditIsFirstPage ? "first" : "default";
-      const mapKey = hfEditPosition === "header" ? "headers" : "footers";
-      const map = pkg[mapKey];
+    const pkg = history.state.package;
+    // Save into the rId resolved by the SAME algorithm that picks the
+    // displayed H/F (see the resolver useMemo above) — for multi-section
+    // docs (NVCA-style title-page + signature sections) this is the
+    // rendered rId, not finalSectionProperties' rId. Codex PR #258 review.
+    let activeRId =
+      hfEditPosition === "header" ? activeHeaderRId : activeFooterRId;
+    if (hfEditIsFirstPage) {
+      activeRId =
+        hfEditPosition === "header"
+          ? activeFirstHeaderRId
+          : activeFirstFooterRId;
+    }
+    const refType = hfEditIsFirstPage ? "first" : "default";
+    const mapKey = hfEditPosition === "header" ? "headers" : "footers";
+    const map = pkg[mapKey];
 
-      if (activeRId && map) {
-        const existing = map.get(activeRId);
+    if (activeRId && map) {
+      const existing = map.get(activeRId);
+      if (existing) {
+        // Spread existing without overriding `content` so the array
+        // reference is preserved — HiddenHeaderFooterPMs's mount
+        // effect uses reference equality on `appliedContent` to skip
+        // a state rebuild on in-session pushDocument snapshots.
         const updated: HeaderFooter = {
+          ...existing,
           type: hfEditPosition,
           hdrFtrType: refType,
-          ...existing,
-          content,
         };
         const newMap = new Map(map);
         newMap.set(activeRId, updated);
@@ -475,34 +472,29 @@ export const useHeaderFooterEditor = ({
         };
         pushDocument(newDoc);
       }
+    }
 
-      setHfEditPosition(null);
-    },
-    [
-      hfEditPosition,
-      hfEditIsFirstPage,
-      activeHeaderRId,
-      activeFooterRId,
-      activeFirstHeaderRId,
-      activeFirstFooterRId,
-      history,
-      pushDocument,
-    ],
-  );
+    setHfEditPosition(null);
+  }, [
+    hfEditPosition,
+    hfEditIsFirstPage,
+    activeHeaderRId,
+    activeFooterRId,
+    activeFirstHeaderRId,
+    activeFirstFooterRId,
+    history,
+    pushDocument,
+  ]);
 
   const handleBodyClick = useCallback(() => {
     if (!hfEditPosition) {
       return;
     }
-    // Save if dirty, then close
-    const view = hfEditorRef.current?.getView();
-    if (view) {
-      const blocks = proseDocToBlocks(view.state.doc);
-      handleHeaderFooterSave(blocks);
-    } else {
-      setHfEditPosition(null);
-    }
-  }, [hfEditPosition, hfEditorRef, handleHeaderFooterSave]);
+    // HF content is kept current by the HF PM's in-place sync
+    // (HiddenHeaderFooterPMs.dispatchTransaction); the close path just
+    // needs to publish the current state as a history snapshot.
+    handleHeaderFooterSave();
+  }, [hfEditPosition, handleHeaderFooterSave]);
 
   const handleRemoveHeaderFooter = useCallback(() => {
     if (!hfEditPosition || !history.state?.package) {

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -42,6 +42,17 @@ type UseHeaderFooterEditorReturn = {
   firstPageFooterContent: HeaderFooter | null;
   hasTitlePg: boolean;
 
+  /**
+   * Relationship ids for the *displayed* H/F slots — same values used to
+   * route save/remove (Codex PR #258). The persistent hidden HF PM model
+   * looks views up by these rIds; the painter emits them as `data-rid` so
+   * the pointer pipeline can route clicks back to the matching view.
+   */
+  activeHeaderRId: string | null;
+  activeFooterRId: string | null;
+  activeFirstHeaderRId: string | null;
+  activeFirstFooterRId: string | null;
+
   /** Section properties with titlePg merged from inline sections */
   effectiveSectionProperties: SectionProperties | undefined;
 
@@ -579,6 +590,10 @@ export const useHeaderFooterEditor = ({
     firstPageHeaderContent,
     firstPageFooterContent,
     hasTitlePg,
+    activeHeaderRId,
+    activeFooterRId,
+    activeFirstHeaderRId,
+    activeFirstFooterRId,
     effectiveSectionProperties,
     handleHeaderFooterDoubleClick,
     handleHeaderFooterSave,

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -5,11 +5,16 @@
 
 import { useState, useMemo, useCallback } from "react";
 
+import type { EditorView } from "prosemirror-view";
+
+import { proseDocToBlocks } from "../../core/prosemirror/conversion/fromProseDoc";
 import type {
   Document,
   DocumentBody,
   HeaderFooter,
+  Paragraph,
   SectionProperties,
+  Table,
 } from "../../core/types/document";
 import type { UseHistoryReturn } from "../../hooks/useHistory";
 
@@ -20,6 +25,14 @@ import type { UseHistoryReturn } from "../../hooks/useHistory";
 type UseHeaderFooterEditorParams = {
   history: UseHistoryReturn<Document | null>;
   pushDocument: (document: Document) => Document;
+  /**
+   * Look up the persistent hidden HF EditorView for an rId. Returns null
+   * when the view isn't mounted (e.g. the chrome unmounted before the
+   * close path ran). Called at close time so the save path can read live
+   * PM state and serialise it into the new HeaderFooter without mutating
+   * the current history.state.
+   */
+  getHfView: (rId: string) => EditorView | null;
 };
 
 type UseHeaderFooterEditorReturn = {
@@ -57,9 +70,9 @@ type UseHeaderFooterEditorReturn = {
   ) => void;
   /**
    * Snapshot the current HF state into a new Document via pushDocument so
-   * the edit session lands in undo history. Content lives in
-   * `package.headers/footers[rId].content` (kept current by the persistent
-   * HF PM's in-place sync) — no caller payload needed.
+   * the edit session lands in undo history. Reads `content` from the
+   * active HF PM (via getActiveHfView at hook init) at call time; nothing
+   * in `history.state` is mutated until the new Document is pushed.
    */
   handleHeaderFooterSave: () => void;
   /** Save and close HF editor when the body is clicked */
@@ -90,6 +103,7 @@ export function resolveEffectiveSectionProperties(
 export const useHeaderFooterEditor = ({
   history,
   pushDocument,
+  getHfView,
 }: UseHeaderFooterEditorParams): UseHeaderFooterEditorReturn => {
   // -------------------------------------------------------------------------
   // State
@@ -450,15 +464,21 @@ export const useHeaderFooterEditor = ({
 
     if (activeRId && map) {
       const existing = map.get(activeRId);
-      if (existing) {
-        // Spread existing without overriding `content` so the array
-        // reference is preserved — HiddenHeaderFooterPMs's mount
-        // effect uses reference equality on `appliedContent` to skip
-        // a state rebuild on in-session pushDocument snapshots.
+      const view = getHfView(activeRId);
+      if (existing && view) {
+        // Read fresh blocks from PM state — HiddenHeaderFooterPMs no
+        // longer mutates `existing.content` in place (Codex #487 P1
+        // re-fixed), so `existing` here still holds the pre-edit
+        // snapshot. We construct a brand-new HeaderFooter inside a
+        // brand-new Map so the previous Document referenced by every
+        // earlier history entry stays untouched and undo can step
+        // back to the pre-edit state.
+        const blocks: (Paragraph | Table)[] = proseDocToBlocks(view.state.doc);
         const updated: HeaderFooter = {
           ...existing,
           type: hfEditPosition,
           hdrFtrType: refType,
+          content: blocks,
         };
         const newMap = new Map(map);
         newMap.set(activeRId, updated);
@@ -484,6 +504,7 @@ export const useHeaderFooterEditor = ({
     activeFirstFooterRId,
     history,
     pushDocument,
+    getHfView,
   ]);
 
   const handleBodyClick = useCallback(() => {

--- a/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPositionDom.ts
@@ -109,7 +109,7 @@ export function clickToPositionDom(
  * unavailable or returns a point outside this span (e.g. the
  * caret API resolved to a sibling text node at the same y).
  */
-function findPositionInSpan(
+export function findPositionInSpan(
   spanEl: HTMLElement,
   clientX: number,
   clientY: number,

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  findHfCaretSpan,
   findHfPmAnchor,
   findHfPmAnchors,
   findHfPmSpans,
@@ -69,6 +70,94 @@ describe("HF slot-scoped PM DOM lookups", () => {
   test("findHfPmAnchor rejects non-finite positions", () => {
     expect(
       findHfPmAnchor(createContainer(), "header", "rIdH1", Number.NaN),
+    ).toBeNull();
+  });
+});
+
+describe("findHfCaretSpan", () => {
+  // The HF caret overlay needs to handle the case where the collapsed
+  // selection sits at the end of a run / paragraph (selection.from ==
+  // span's data-pm-end). An exact data-pm-start lookup misses it, so
+  // findHfCaretSpan walks the slot's spans and reports which edge to
+  // hug. (Codex #487 P2 — bot review 20:32.)
+  const startSpan = {
+    dataset: { pmStart: "3", pmEnd: "6" },
+    textContent: "header",
+  };
+  const endSpan = {
+    dataset: { pmStart: "6", pmEnd: "9" },
+    textContent: "tail",
+  };
+
+  const caretContainer = (): ParentNode =>
+    ({
+      querySelector(selector: string) {
+        if (
+          selector ===
+          '.layout-page-header[data-rid="rIdH1"] [data-pm-start="3"]'
+        ) {
+          return startSpan;
+        }
+        return null;
+      },
+      querySelectorAll(selector: string) {
+        if (
+          selector ===
+          '.layout-page-header[data-rid="rIdH1"] span[data-pm-start][data-pm-end]'
+        ) {
+          return [startSpan, endSpan];
+        }
+        return [];
+      },
+    }) as unknown as ParentNode;
+
+  test("exact pmStart match hugs the left edge", () => {
+    const hit = findHfCaretSpan(caretContainer(), "header", "rIdH1", 3);
+    expect(hit?.edge).toBe("left");
+    expect(hit?.element).toBe(startSpan as unknown as HTMLElement);
+  });
+
+  test("caret at end-of-span (pos == pmEnd) hugs the right edge", () => {
+    // pos = 9 — matches endSpan's pmEnd. Exact pmStart lookup returns
+    // null (mocked), so we fall back to the range scan.
+    const hit = findHfCaretSpan(caretContainer(), "header", "rIdH1", 9);
+    expect(hit?.edge).toBe("right");
+    expect(hit?.element).toBe(endSpan as unknown as HTMLElement);
+  });
+
+  test("range scan falls back to a pmEnd match when exact pmStart misses", () => {
+    // pos = 6 — startSpan's pmEnd. Mock the exact lookup to return null
+    // so we exercise the range scan; the visible result hugs startSpan's
+    // right edge (which is geometrically the same point as endSpan's
+    // left edge when the two runs are contiguous).
+    const boundaryContainer = (): ParentNode =>
+      ({
+        querySelector() {
+          return null;
+        },
+        querySelectorAll(selector: string) {
+          if (
+            selector ===
+            '.layout-page-header[data-rid="rIdH1"] span[data-pm-start][data-pm-end]'
+          ) {
+            return [startSpan, endSpan];
+          }
+          return [];
+        },
+      }) as unknown as ParentNode;
+    const hit = findHfCaretSpan(boundaryContainer(), "header", "rIdH1", 6);
+    expect(hit?.edge).toBe("right");
+    expect(hit?.element).toBe(startSpan as unknown as HTMLElement);
+  });
+
+  test("returns null when no span covers the position", () => {
+    const hit = findHfCaretSpan(caretContainer(), "header", "rIdH1", 99);
+    expect(hit).toBeNull();
+  });
+
+  test("rejects non-finite positions", () => {
+    expect(
+      findHfCaretSpan(caretContainer(), "header", "rIdH1", Number.NaN),
     ).toBeNull();
   });
 });

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  findHfPmAnchor,
+  findHfPmAnchors,
+  findHfPmSpans,
+  findHfSlotForTarget,
+} from "./findHfPmSpans";
+
+const headerSpan = {
+  dataset: { pmStart: "3", pmEnd: "6" },
+  textContent: "header",
+};
+const headerAnchor = { dataset: { pmStart: "1", pmEnd: "8" } };
+const footerSpan = {
+  dataset: { pmStart: "11", pmEnd: "14" },
+  textContent: "footer",
+};
+
+const createContainer = (): ParentNode =>
+  ({
+    querySelectorAll(selector: string) {
+      switch (selector) {
+        case '.layout-page-header[data-rid="rIdH1"] span[data-pm-start][data-pm-end]':
+          return [headerSpan];
+        case '.layout-page-footer[data-rid="rIdF1"] span[data-pm-start][data-pm-end]':
+          return [footerSpan];
+        case '.layout-page-header[data-rid="rIdH1"] [data-pm-start]':
+          return [headerAnchor, headerSpan];
+        default:
+          return [];
+      }
+    },
+    querySelector(selector: string) {
+      if (
+        selector === '.layout-page-header[data-rid="rIdH1"] [data-pm-start="3"]'
+      ) {
+        return headerSpan;
+      }
+      return null;
+    },
+  }) as unknown as ParentNode;
+
+describe("HF slot-scoped PM DOM lookups", () => {
+  test("findHfPmSpans returns only the requested header slot's run spans", () => {
+    const spans = findHfPmSpans(createContainer(), "header", "rIdH1");
+    expect(spans.map((s) => s.textContent.trim())).toEqual(["header"]);
+  });
+
+  test("findHfPmSpans returns the requested footer slot's run spans", () => {
+    const spans = findHfPmSpans(createContainer(), "footer", "rIdF1");
+    expect(spans.map((s) => s.textContent.trim())).toEqual(["footer"]);
+  });
+
+  test("findHfPmSpans returns nothing for an unknown rId", () => {
+    expect(findHfPmSpans(createContainer(), "header", "missing")).toEqual([]);
+  });
+
+  test("findHfPmAnchors enumerates every anchor inside the slot", () => {
+    const anchors = findHfPmAnchors(createContainer(), "header", "rIdH1");
+    expect(anchors.map((a) => a.dataset["pmStart"])).toEqual(["1", "3"]);
+  });
+
+  test("findHfPmAnchor resolves a known pm-start inside the slot", () => {
+    const anchor = findHfPmAnchor(createContainer(), "header", "rIdH1", 3);
+    expect(anchor?.textContent.trim()).toBe("header");
+  });
+
+  test("findHfPmAnchor rejects non-finite positions", () => {
+    expect(
+      findHfPmAnchor(createContainer(), "header", "rIdH1", Number.NaN),
+    ).toBeNull();
+  });
+});
+
+describe("findHfSlotForTarget", () => {
+  test("returns null for a null target", () => {
+    expect(findHfSlotForTarget(null)).toBeNull();
+  });
+
+  test("resolves a header target to its rId + kind", () => {
+    const headerEl = {
+      dataset: { rid: "rIdShared" },
+    } as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        if (selector === ".layout-page-header[data-rid]") {
+          return headerEl;
+        }
+        return null;
+      },
+    } as unknown as Element;
+    const slot = findHfSlotForTarget(target);
+    expect(slot).toEqual({
+      kind: "header",
+      rId: "rIdShared",
+      element: headerEl,
+    });
+  });
+
+  test("resolves a footer target to its rId + kind when no header ancestor", () => {
+    const footerEl = {
+      dataset: { rid: "rIdFooter" },
+    } as unknown as HTMLElement;
+    const target = {
+      closest(selector: string) {
+        if (selector === ".layout-page-footer[data-rid]") {
+          return footerEl;
+        }
+        return null;
+      },
+    } as unknown as Element;
+    const slot = findHfSlotForTarget(target);
+    expect(slot).toEqual({
+      kind: "footer",
+      rId: "rIdFooter",
+      element: footerEl,
+    });
+  });
+
+  test("returns null when the target is outside both HF slots (body click)", () => {
+    const target = {
+      closest() {
+        return null;
+      },
+    } as unknown as Element;
+    expect(findHfSlotForTarget(target)).toBeNull();
+  });
+});

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
@@ -61,29 +61,42 @@ export function findHfPmAnchor(
  * hidden HF EditorView. Returns `null` when the target is not inside an HF
  * slot (body or unrelated chrome).
  */
+type ClosestCapable = {
+  closest(selector: string): HTMLElement | null;
+};
+
+function hasCloset(value: unknown): value is ClosestCapable {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { closest?: unknown }).closest === "function"
+  );
+}
+
 export function findHfSlotForTarget(target: Node | null): {
   kind: HfSlotKind;
   rId: string;
   element: HTMLElement;
 } | null {
-  if (!(target instanceof Element)) {
-    if (!target) {
-      return null;
-    }
-    const owner = target.parentElement;
+  if (!target) {
+    return null;
+  }
+  if (!hasCloset(target)) {
+    // Text nodes don't have `closest`; walk up via parentElement.
+    const owner = (target as Node).parentElement;
     if (!owner) {
       return null;
     }
     return findHfSlotForTarget(owner);
   }
-  const header = target.closest<HTMLElement>(".layout-page-header[data-rid]");
+  const header = target.closest(".layout-page-header[data-rid]");
   if (header) {
     const rId = header.dataset["rid"];
     if (rId) {
       return { kind: "header", rId, element: header };
     }
   }
-  const footer = target.closest<HTMLElement>(".layout-page-footer[data-rid]");
+  const footer = target.closest(".layout-page-footer[data-rid]");
   if (footer) {
     const rId = footer.dataset["rid"];
     if (rId) {

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
@@ -1,0 +1,94 @@
+/**
+ * Slot-scoped sibling of `findBodyPmSpans` — locates `data-pm-start` markers
+ * inside a single painted header/footer slot. The pointer pipeline uses these
+ * to translate a click coordinate inside `.layout-page-header[data-rid="…"]`
+ * (or footer) to a PM position on the matching hidden HF EditorView.
+ *
+ * Slot identity is the part-relationship id (`rId`) emitted by the painter on
+ * the HF DOM node — never the `(hdrFtrType, kind)` tuple (two sections that
+ * share a header by rId share both the painted spans and the EditorView).
+ */
+
+export type HfSlotKind = "header" | "footer";
+
+function slotSelector(kind: HfSlotKind, rId: string): string {
+  return kind === "header"
+    ? `.layout-page-header[data-rid="${rId}"]`
+    : `.layout-page-footer[data-rid="${rId}"]`;
+}
+
+export function findHfPmSpans(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
+    ),
+  );
+}
+
+export function findHfPmAnchors(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      `${slotSelector(kind, rId)} [data-pm-start]`,
+    ),
+  );
+}
+
+export function findHfPmAnchor(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  pmStart: number,
+): HTMLElement | null {
+  if (!Number.isFinite(pmStart)) {
+    return null;
+  }
+  return container.querySelector<HTMLElement>(
+    `${slotSelector(kind, rId)} [data-pm-start="${String(pmStart)}"]`,
+  );
+}
+
+/**
+ * Find the painted HF slot enclosing the given DOM target. Returns the
+ * slot's kind and rId for the pointer pipeline to dispatch on the matching
+ * hidden HF EditorView. Returns `null` when the target is not inside an HF
+ * slot (body or unrelated chrome).
+ */
+export function findHfSlotForTarget(target: Node | null): {
+  kind: HfSlotKind;
+  rId: string;
+  element: HTMLElement;
+} | null {
+  if (!(target instanceof Element)) {
+    if (!target) {
+      return null;
+    }
+    const owner = target.parentElement;
+    if (!owner) {
+      return null;
+    }
+    return findHfSlotForTarget(owner);
+  }
+  const header = target.closest<HTMLElement>(".layout-page-header[data-rid]");
+  if (header) {
+    const rId = header.dataset["rid"];
+    if (rId) {
+      return { kind: "header", rId, element: header };
+    }
+  }
+  const footer = target.closest<HTMLElement>(".layout-page-footer[data-rid]");
+  if (footer) {
+    const rId = footer.dataset["rid"];
+    if (rId) {
+      return { kind: "footer", rId, element: footer };
+    }
+  }
+  return null;
+}

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
@@ -56,6 +56,66 @@ export function findHfPmAnchor(
 }
 
 /**
+ * Locate the span that covers a PM position for caret rendering, including
+ * `pmEnd` boundaries. `findHfPmAnchor` only matches `data-pm-start="${pos}"`
+ * exactly; when the caret sits at the end of a run / paragraph,
+ * `selection.from` equals that span's `data-pm-end` and the exact lookup
+ * returns null. This helper falls back to a range scan over the slot's
+ * `[data-pm-start][data-pm-end]` spans and reports the edge the caret
+ * should hug so the renderer can pick `left` vs `right`.
+ */
+export type HfCaretSpanHit = {
+  element: HTMLElement;
+  /** Which edge of the span's getBoundingClientRect to anchor the caret to. */
+  edge: "left" | "right";
+};
+
+export function findHfCaretSpan(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  pos: number,
+): HfCaretSpanHit | null {
+  if (!Number.isFinite(pos)) {
+    return null;
+  }
+  const exact = container.querySelector<HTMLElement>(
+    `${slotSelector(kind, rId)} [data-pm-start="${String(pos)}"]`,
+  );
+  if (exact) {
+    return { element: exact, edge: "left" };
+  }
+  const spans = container.querySelectorAll<HTMLElement>(
+    `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
+  );
+  let best: HfCaretSpanHit | null = null;
+  for (const span of spans) {
+    const startStr = span.dataset["pmStart"];
+    const endStr = span.dataset["pmEnd"];
+    if (startStr === undefined || endStr === undefined) {
+      continue;
+    }
+    const start = Number.parseInt(startStr, 10);
+    const end = Number.parseInt(endStr, 10);
+    if (!Number.isFinite(start) || !Number.isFinite(end)) {
+      continue;
+    }
+    if (pos === end) {
+      // Exact end-of-span match — prefer the latest (rightmost) hit so
+      // a caret at the boundary between two adjacent runs lands on the
+      // right edge of the run that precedes it, matching browser
+      // selection behaviour.
+      best = { element: span, edge: "right" };
+    } else if (pos > start && pos < end && !best) {
+      // Mid-span coverage. Rare for a collapsed caret but keep the
+      // fallback so anything weird still renders something.
+      best = { element: span, edge: "left" };
+    }
+  }
+  return best;
+}
+
+/**
  * Find the painted HF slot enclosing the given DOM target. Returns the
  * slot's kind and rId for the pointer pipeline to dispatch on the matching
  * hidden HF EditorView. Returns `null` when the target is not inside an HF

--- a/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
+++ b/packages/folio/src/core/layout-bridge/findHfPmSpans.ts
@@ -9,6 +9,8 @@
  * share a header by rId share both the painted spans and the EditorView).
  */
 
+import { findPositionInSpan } from "./clickToPositionDom";
+
 export type HfSlotKind = "header" | "footer";
 
 function slotSelector(kind: HfSlotKind, rId: string): string {
@@ -131,6 +133,119 @@ function hasCloset(value: unknown): value is ClosestCapable {
     value !== null &&
     typeof (value as { closest?: unknown }).closest === "function"
   );
+}
+
+/**
+ * Slot-scoped click-to-position mapper. `clickToPositionDom`'s fallback
+ * (`findNearestSpan`) is hardcoded to `.layout-page-content` — body — so when
+ * the user clicks HF whitespace (right of the text, between lines, etc.),
+ * the body fallback can return a body PM position that the HF dispatch then
+ * applies to the HF EditorView (clamped) and the caret leaps to an
+ * unrelated HF doc position (Codex #487 P2: 21:02 review).
+ *
+ * Scope everything to the slot element: try the exact-span lookup via
+ * `document.elementsFromPoint` filtered to descendants of `slot`; fall back
+ * to nearest-span-in-line + start/end edge math within the same slot.
+ */
+export function clickToPositionInHfSlot(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  clientX: number,
+  clientY: number,
+): number | null {
+  const ownerDoc =
+    container instanceof Element ? container.ownerDocument : document;
+  const slotSel = slotSelector(kind, rId);
+  const elements = ownerDoc.elementsFromPoint(clientX, clientY);
+  for (const el of elements) {
+    if (!(el instanceof HTMLElement)) {
+      continue;
+    }
+    // Match any painted slot with this rId — there can be one per page when
+    // the same header is referenced across pages, so a drag that crosses
+    // between paginated instances must accept the hit regardless of which
+    // exact slot DOM node it lands in.
+    if (!el.closest(slotSel)) {
+      continue;
+    }
+    if (
+      el.tagName === "SPAN" &&
+      el.dataset["pmStart"] !== undefined &&
+      el.dataset["pmEnd"] !== undefined
+    ) {
+      return findPositionInSpan(el, clientX, clientY);
+    }
+  }
+  return findNearestSpanInHfSlots(container, kind, rId, clientX, clientY);
+}
+
+function computeColDist(
+  inside: boolean,
+  rect: DOMRect,
+  clientX: number,
+): number {
+  if (inside) {
+    return 0;
+  }
+  if (clientX < rect.left) {
+    return rect.left - clientX;
+  }
+  return clientX - rect.right;
+}
+
+function findNearestSpanInHfSlots(
+  container: ParentNode,
+  kind: HfSlotKind,
+  rId: string,
+  clientX: number,
+  clientY: number,
+): number | null {
+  const spans = container.querySelectorAll<HTMLElement>(
+    `${slotSelector(kind, rId)} span[data-pm-start][data-pm-end]`,
+  );
+  if (spans.length === 0) {
+    return null;
+  }
+  // Pick the line whose vertical centre is closest to clientY, then the
+  // span on that line whose horizontal range contains clientX, otherwise
+  // the closest by horizontal distance. Mirrors clickToPositionDom's
+  // body-fallback shape so the UX feels identical.
+  let bestSpan: HTMLElement | null = null;
+  let bestRowDist = Number.POSITIVE_INFINITY;
+  let bestColDist = Number.POSITIVE_INFINITY;
+  let bestInside = false;
+  for (const span of spans) {
+    const rect = span.getBoundingClientRect();
+    const centerY = (rect.top + rect.bottom) / 2;
+    const rowDist = Math.abs(clientY - centerY);
+    const inside = clientX >= rect.left && clientX <= rect.right;
+    const colDist = computeColDist(inside, rect, clientX);
+    const better =
+      rowDist < bestRowDist ||
+      (rowDist === bestRowDist &&
+        ((inside && !bestInside) ||
+          (inside === bestInside && colDist < bestColDist)));
+    if (better) {
+      bestRowDist = rowDist;
+      bestColDist = colDist;
+      bestInside = inside;
+      bestSpan = span;
+    }
+  }
+  if (!bestSpan) {
+    return null;
+  }
+  if (bestInside) {
+    return findPositionInSpan(bestSpan, clientX, clientY);
+  }
+  const rect = bestSpan.getBoundingClientRect();
+  if (clientX < rect.left) {
+    const v = bestSpan.dataset["pmStart"];
+    return v ? Number(v) : null;
+  }
+  const v = bestSpan.dataset["pmEnd"];
+  return v ? Number(v) : null;
 }
 
 export function findHfSlotForTarget(target: Node | null): {

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.test.ts
@@ -6,11 +6,13 @@ import type {
   ParagraphBlock,
   TableBlock,
 } from "../layout-engine/types";
+import { headerFooterToProseDoc } from "../prosemirror/conversion/toProseDoc";
 import type { HeaderFooter } from "../types/document";
 import type { HeaderFooterMetrics } from "./headerFooterLayout";
 import {
   calculateHeaderFooterMarginPushBounds,
   calculateHeaderFooterVisualBounds,
+  convertHeaderFooterPmDocToContent,
   convertHeaderFooterToContent,
   normalizeHeaderFooterMeasureBlocks,
 } from "./headerFooterLayout";
@@ -333,5 +335,136 @@ describe("header/footer layout conversion", () => {
     expect(
       (blocks[4] as ParagraphBlock).attrs?.suppressEmptyParagraphHeight,
     ).toBe(true);
+  });
+});
+
+describe("convertHeaderFooterPmDocToContent", () => {
+  // PM-doc source path used by the persistent hidden HF EditorView. Every
+  // keystroke in the HF PM repaints via this function; the round-trip below
+  // proves that "rebuild HeaderFooterContent from PM doc" produces the same
+  // visible layout as "rebuild HeaderFooterContent from HeaderFooter.content",
+  // so the switch from inline-overlay edit to PM-driven repaint is invisible.
+  const pmMetrics: HeaderFooterMetrics = {
+    section: "header",
+    pageSize: { w: 600, h: 800 },
+    margins: {
+      top: 100,
+      right: 72,
+      bottom: 100,
+      left: 72,
+      header: 48,
+      footer: 48,
+    },
+  };
+
+  test("returns undefined for a null pm doc", () => {
+    expect(
+      convertHeaderFooterPmDocToContent(null, 456, pmMetrics, {
+        measureBlocks,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("matches convertHeaderFooterToContent for paragraph + table fixture", () => {
+    const hf: HeaderFooter = {
+      type: "header",
+      hdrFtrType: "default",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "run", content: [{ type: "text", text: "Header line" }] },
+          ],
+        },
+        {
+          type: "table",
+          rows: [
+            {
+              type: "tableRow",
+              cells: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "run",
+                          content: [{ type: "text", text: "cell" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { type: "paragraph", content: [] },
+      ],
+    };
+
+    const fromContent = convertHeaderFooterToContent(hf, 456, pmMetrics, {
+      measureBlocks,
+    });
+    const pmDoc = headerFooterToProseDoc(hf.content);
+    const fromPmDoc = convertHeaderFooterPmDocToContent(pmDoc, 456, pmMetrics, {
+      measureBlocks,
+    });
+
+    expect(fromPmDoc).toBeDefined();
+    expect(fromContent).toBeDefined();
+    expect(fromPmDoc?.height).toBe(fromContent!.height);
+    expect(fromPmDoc?.visualTop).toBe(fromContent!.visualTop);
+    expect(fromPmDoc?.visualBottom).toBe(fromContent!.visualBottom);
+    expect(fromPmDoc?.blocks.length).toBe(fromContent!.blocks.length);
+    expect(fromPmDoc?.measures.length).toBe(fromContent!.measures.length);
+    expect(fromPmDoc?.blocks.map((b) => b.kind)).toEqual(
+      fromContent!.blocks.map((b) => b.kind),
+    );
+  });
+
+  test("applies PR #457 trailing-empty-after-table normalization on the PM-doc path", () => {
+    const hf: HeaderFooter = {
+      type: "header",
+      hdrFtrType: "default",
+      content: [
+        {
+          type: "table",
+          rows: [
+            {
+              type: "tableRow",
+              cells: [
+                {
+                  type: "tableCell",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "run",
+                          content: [{ type: "text", text: "in-cell" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { type: "paragraph", content: [] },
+      ],
+    };
+    const pmDoc = headerFooterToProseDoc(hf.content);
+    const out = convertHeaderFooterPmDocToContent(pmDoc, 456, pmMetrics, {
+      measureBlocks,
+    });
+    expect(out).toBeDefined();
+    const trailing = out!.measures.at(-1);
+    expect(trailing?.kind).toBe("paragraph");
+    if (trailing?.kind === "paragraph") {
+      expect(trailing.totalHeight).toBe(0);
+    }
   });
 });

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -721,34 +721,56 @@ function finalizeHeaderFooterContent(
  * bounded (a handful of paragraphs, max).
  */
 function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
-  const parts: string[] = [];
-  for (const b of blocks) {
-    if (b.kind === "paragraph") {
-      let text = "p:";
-      for (const r of b.runs) {
-        if (r.kind === "text") {
-          text += `T:${r.text}|${serializeRunFmt(r)};`;
-        } else if (r.kind === "tab") {
-          text += `\\t|${serializeRunFmt(r)};`;
-        } else if (r.kind === "lineBreak") {
-          text += "\\n;";
-        } else if (r.kind === "image") {
-          text += `[i${r.width}x${r.height}];`;
-        } else {
-          // field run
-          text += `F:${r.fieldType}|${serializeRunFmt(r)};`;
-        }
+  return blocks.map(blockSig).join("|");
+}
+
+function blockSig(b: FlowBlock): string {
+  if (b.kind === "paragraph") {
+    let text = "p:";
+    for (const r of b.runs) {
+      if (r.kind === "text") {
+        text += `T:${r.text}|${serializeRunFmt(r)};`;
+      } else if (r.kind === "tab") {
+        text += `\\t|${serializeRunFmt(r)};`;
+      } else if (r.kind === "lineBreak") {
+        text += "\\n;";
+      } else if (r.kind === "image") {
+        text += `[i${r.width}x${r.height}];`;
+      } else {
+        // field run
+        text += `F:${r.fieldType}|${serializeRunFmt(r)};`;
       }
-      parts.push(text);
-    } else if (b.kind === "table") {
-      parts.push(`t:${b.rows.length}`);
-    } else if (b.kind === "image") {
-      parts.push(`i:${b.width}x${b.height}`);
-    } else if (b.kind === "textBox") {
-      parts.push("tb");
     }
+    return text;
   }
-  return parts.join("|");
+  if (b.kind === "table") {
+    // Recurse into cells — same-height text / formatting / field edits
+    // inside an existing HF table cell are otherwise invisible to the
+    // painter's incremental cache (Codex #487 P2: 21:41 review). Row
+    // count + per-cell block signatures detect every visible change a
+    // user can produce without growing the table.
+    const cellParts: string[] = [];
+    for (const row of b.rows) {
+      for (const cell of row.cells) {
+        cellParts.push(cell.blocks.map(blockSig).join(","));
+      }
+    }
+    return `t:${b.rows.length}:${cellParts.join("|")}`;
+  }
+  if (b.kind === "image") {
+    return `i:${b.width}x${b.height}`;
+  }
+  if (b.kind === "textBox") {
+    // Text boxes can carry their own content (paragraph + runs). Recurse
+    // when the layout-engine TextBoxBlock surfaces nested blocks; for
+    // shapes that only carry dims we keep the original bare tag.
+    const inner = (b as { blocks?: FlowBlock[] }).blocks;
+    if (Array.isArray(inner) && inner.length > 0) {
+      return `tb:${inner.map(blockSig).join(",")}`;
+    }
+    return "tb";
+  }
+  return "";
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -726,7 +726,14 @@ function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
 
 function blockSig(b: FlowBlock): string {
   if (b.kind === "paragraph") {
-    let text = "p:";
+    // Carry paragraph-level formatting so same-height changes (alignment,
+    // RTL/LTR, indent, line spacing, paragraph style, borders, shading,
+    // list properties) still invalidate the cache. textSig was opening
+    // every paragraph with a constant `p:` before, so the body PM could
+    // toggle alignment / line spacing inside an HF paragraph without
+    // shifting computeOptionsHash and the painter's incremental path
+    // would skip the repaint (Codex #487 P2: 22:48 review).
+    let text = `p:${serializeParagraphAttrs(b.attrs)}|`;
     for (const r of b.runs) {
       if (r.kind === "text") {
         text += `T:${r.text}|${serializeRunFmt(r)};`;
@@ -771,6 +778,41 @@ function blockSig(b: FlowBlock): string {
     return "tb";
   }
   return "";
+}
+
+function serializeParagraphAttrs(
+  attrs: Record<string, unknown> | undefined,
+): string {
+  if (!attrs) {
+    return "";
+  }
+  const keys = [
+    "alignment",
+    "bidi",
+    "indent",
+    "spacing",
+    "styleId",
+    "borders",
+    "shading",
+    "contextualSpacing",
+    "keepNext",
+    "keepLines",
+    "pageBreakBefore",
+    "numPr",
+    "listMarker",
+    "listIsBullet",
+    "listMarkerHidden",
+    "listMarkerSuffix",
+    "tabs",
+  ];
+  const out: Record<string, unknown> = {};
+  for (const k of keys) {
+    const v = attrs[k];
+    if (v !== undefined && v !== null) {
+      out[k] = v;
+    }
+  }
+  return JSON.stringify(out);
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -17,6 +17,8 @@
  * inherited spacing). Measurement uses the normalized copy.
  */
 
+import type { Node as PMNode } from "prosemirror-model";
+
 import type {
   FlowBlock,
   FloatingTablePosition,
@@ -545,6 +547,13 @@ export type ConvertHeaderFooterOptions = {
   measureBlocks: MeasureBlocksFn;
   /** Document-wide `w:defaultTabStop` in twips — forwarded to toFlowBlocks. */
   defaultTabStopTwips?: number;
+  /**
+   * Relationship id of the source HF part. Stamped onto the returned
+   * `HeaderFooterContent.rId` so the painter can emit `data-rid` on the
+   * `.layout-page-header` / `.layout-page-footer` DOM node for the pointer
+   * pipeline (`HiddenHeaderFooterPMs` + `findHfPmSpans`).
+   */
+  rId?: string;
 };
 
 /**
@@ -590,6 +599,57 @@ export function convertHeaderFooterToContent(
     flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
   }
   const blocks = toFlowBlocks(pmDoc, flowOptions);
+  return finalizeHeaderFooterContent(blocks, contentWidth, metrics, options);
+}
+
+// =============================================================================
+// 5. PM doc source (persistent hidden HF EditorView path)
+// =============================================================================
+
+/**
+ * Same as {@link convertHeaderFooterToContent}, but sourced from a live
+ * ProseMirror document instead of `HeaderFooter.content`. Used by the
+ * persistent hidden HF EditorView pipeline so the painter renders the PM's
+ * current state (Word-style WYSIWYG: every keystroke repaints).
+ *
+ * The pmDoc is expected to be a body-shaped PM doc (the result of
+ * `headerFooterToProseDoc` at mount, plus any user edits applied since).
+ * Theme + styles do NOT need to be threaded again — they only matter for the
+ * initial parse path; subsequent transformations are PM-internal.
+ */
+export function convertHeaderFooterPmDocToContent(
+  pmDoc: PMNode | null | undefined,
+  contentWidth: number,
+  metrics: HeaderFooterMetrics,
+  options: Omit<ConvertHeaderFooterOptions, "styles">,
+): HeaderFooterContent | undefined {
+  if (!pmDoc || pmDoc.content.size === 0) {
+    return undefined;
+  }
+  const flowOptions: {
+    theme?: Theme | null;
+    defaultTabStopTwips?: number;
+  } = {};
+  if (options.theme !== undefined) {
+    flowOptions.theme = options.theme;
+  }
+  if (options.defaultTabStopTwips !== undefined) {
+    flowOptions.defaultTabStopTwips = options.defaultTabStopTwips;
+  }
+  const blocks = toFlowBlocks(pmDoc, flowOptions);
+  return finalizeHeaderFooterContent(blocks, contentWidth, metrics, options);
+}
+
+// =============================================================================
+// 6. Shared tail — blocks → HeaderFooterContent
+// =============================================================================
+
+function finalizeHeaderFooterContent(
+  blocks: FlowBlock[],
+  contentWidth: number,
+  metrics: HeaderFooterMetrics,
+  options: { measureBlocks: MeasureBlocksFn; rId?: string },
+): HeaderFooterContent | undefined {
   if (blocks.length === 0) {
     return undefined;
   }
@@ -606,8 +666,6 @@ export function convertHeaderFooterToContent(
     if (m.kind === "paragraph") {
       totalHeight += m.totalHeight;
     } else if (m.kind === "table") {
-      // Floating tables (`<w:tblpPr>`) anchor at (tblpX, tblpY) and don't
-      // contribute to the in-flow height that drives body push-down.
       if (!(b.kind === "table" && b.floating)) {
         totalHeight += m.totalHeight;
       }
@@ -639,5 +697,6 @@ export function convertHeaderFooterToContent(
     visualBottom,
     marginPushTop,
     marginPushBottom,
+    ...(options.rId ? { rId: options.rId } : {}),
   };
 }

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -742,7 +742,14 @@ function blockSig(b: FlowBlock): string {
       } else if (r.kind === "lineBreak") {
         text += "\\n;";
       } else if (r.kind === "image") {
-        text += `[i${r.width}x${r.height}];`;
+        // Include src + transform + wrapType so swapping the painted
+        // image (different logo at the same dims) invalidates the
+        // signature — width × height alone would let an unchanged
+        // layout slip past the painter's incremental cache (Codex
+        // #487 P2: 23:09 review).
+        text +=
+          `[i${r.width}x${r.height}|${r.src}|` +
+          `${r.transform ?? ""}|${r.wrapType ?? ""}];`;
       } else {
         // field run
         text += `F:${r.fieldType}|${serializeRunFmt(r)};`;
@@ -765,7 +772,10 @@ function blockSig(b: FlowBlock): string {
     return `t:${b.rows.length}:${cellParts.join("|")}`;
   }
   if (b.kind === "image") {
-    return `i:${b.width}x${b.height}`;
+    return (
+      `i:${b.width}x${b.height}|${b.src}|` +
+      `${b.transform ?? ""}|${b.anchor?.behindDoc ? "behind" : ""}`
+    );
   }
   if (b.kind === "textBox") {
     // Text boxes can carry their own content (paragraph + runs). Recurse

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -709,12 +709,16 @@ function finalizeHeaderFooterContent(
  * character, toggling bold, etc. — so the painter's incremental path then
  * skips re-rendering page shells and the user's HF edits stay invisible
  * until something else triggers a full repaint (Codex #487 P1 follow-up:
- * 21:02 review).
+ * 21:02 review; extended for run formatting + fields per 21:28 review).
  *
- * Walk every text-bearing run in every paragraph block and concat the text.
- * For folio HF (small, bounded), this is cheap and detects any text change
- * that the user would expect to see repainted. Tables, images, and text
- * boxes are summarised by kind + dims so resize / image swap also invalidate.
+ * For each run carry text + every visual-affecting field: text characters,
+ * field type (PAGE / NUMPAGES / DATE / TIME), and the full RunFormatting
+ * record (bold, italic, color, underline, fontSize, font, etc.). Toggling
+ * bold or inserting a PAGE field on existing same-height content now
+ * differentiates the signature and forces a repaint. Tables, images, and
+ * text boxes are summarised by kind + dims so resize / image swap also
+ * invalidate. JSON.stringify is moderately expensive but folio HF is
+ * bounded (a handful of paragraphs, max).
  */
 function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
   const parts: string[] = [];
@@ -723,13 +727,16 @@ function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
       let text = "p:";
       for (const r of b.runs) {
         if (r.kind === "text") {
-          text += r.text;
+          text += `T:${r.text}|${serializeRunFmt(r)};`;
         } else if (r.kind === "tab") {
-          text += "\t";
+          text += `\\t|${serializeRunFmt(r)};`;
         } else if (r.kind === "lineBreak") {
-          text += "\n";
+          text += "\\n;";
         } else if (r.kind === "image") {
-          text += `[i${r.width}x${r.height}]`;
+          text += `[i${r.width}x${r.height}];`;
+        } else {
+          // field run
+          text += `F:${r.fieldType}|${serializeRunFmt(r)};`;
         }
       }
       parts.push(text);
@@ -742,4 +749,35 @@ function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
     }
   }
   return parts.join("|");
+}
+
+/**
+ * Serialise the RunFormatting fields that actually drive the painter's
+ * visual output. The Run type spreads RunFormatting in place, so we project
+ * a small shape and JSON-stringify it; properties that are undefined are
+ * skipped so the resulting string stays compact for unstyled runs.
+ */
+function serializeRunFmt(run: Record<string, unknown>): string {
+  const keys = [
+    "bold",
+    "italic",
+    "underline",
+    "strikethrough",
+    "color",
+    "highlightColor",
+    "fontSize",
+    "fontFamily",
+    "verticalAlign",
+    "letterSpacing",
+    "smallCaps",
+    "allCaps",
+  ];
+  const out: Record<string, unknown> = {};
+  for (const k of keys) {
+    const v = run[k];
+    if (v !== undefined && v !== null) {
+      out[k] = v;
+    }
+  }
+  return JSON.stringify(out);
 }

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -697,6 +697,49 @@ function finalizeHeaderFooterContent(
     visualBottom,
     marginPushTop,
     marginPushBottom,
+    textSig: computeHeaderFooterTextSig(blocks),
     ...(options.rId ? { rId: options.rId } : {}),
   };
+}
+
+/**
+ * Cheap content fingerprint for the painter's incremental-render cache. The
+ * default fields hashed by `computeOptionsHash` (block count + flow height +
+ * visual bounds) miss same-height in-place edits — typing a replacement
+ * character, toggling bold, etc. — so the painter's incremental path then
+ * skips re-rendering page shells and the user's HF edits stay invisible
+ * until something else triggers a full repaint (Codex #487 P1 follow-up:
+ * 21:02 review).
+ *
+ * Walk every text-bearing run in every paragraph block and concat the text.
+ * For folio HF (small, bounded), this is cheap and detects any text change
+ * that the user would expect to see repainted. Tables, images, and text
+ * boxes are summarised by kind + dims so resize / image swap also invalidate.
+ */
+function computeHeaderFooterTextSig(blocks: FlowBlock[]): string {
+  const parts: string[] = [];
+  for (const b of blocks) {
+    if (b.kind === "paragraph") {
+      let text = "p:";
+      for (const r of b.runs) {
+        if (r.kind === "text") {
+          text += r.text;
+        } else if (r.kind === "tab") {
+          text += "\t";
+        } else if (r.kind === "lineBreak") {
+          text += "\n";
+        } else if (r.kind === "image") {
+          text += `[i${r.width}x${r.height}]`;
+        }
+      }
+      parts.push(text);
+    } else if (b.kind === "table") {
+      parts.push(`t:${b.rows.length}`);
+    } else if (b.kind === "image") {
+      parts.push(`i:${b.width}x${b.height}`);
+    } else if (b.kind === "textBox") {
+      parts.push("tb");
+    }
+  }
+  return parts.join("|");
 }

--- a/packages/folio/src/core/layout-bridge/wrapEditorViewAsSurface.ts
+++ b/packages/folio/src/core/layout-bridge/wrapEditorViewAsSurface.ts
@@ -1,0 +1,61 @@
+/**
+ * Surface adapter — gives the pointer pipeline a uniform shape for the body
+ * PM and any HF PM, so a single resolved `activeSurface()` can drive click
+ * routing / drag-select / focus from one code path.
+ *
+ * The body PM ref (`HiddenProseMirrorRef`) and the persistent HF PMs (raw
+ * `EditorView` from `HiddenHeaderFooterPMs.getView()`) carry different APIs;
+ * this adapter projects both onto a small intersection: focus, set selection,
+ * get state, dispatch.
+ */
+
+import { Selection, TextSelection } from "prosemirror-state";
+import type { EditorState, Transaction } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+export type Surface = {
+  /** Identity tag — `"body"` for the body PM, `"hf"` for any HF PM. */
+  kind: "body" | "hf";
+  /** rId of the source HF part; `null` for the body surface. */
+  rId: string | null;
+  getState(): EditorState | null;
+  getView(): EditorView | null;
+  focus(): void;
+  isFocused(): boolean;
+  dispatch(tr: Transaction): void;
+  setSelection(anchor: number, head?: number): void;
+};
+
+export function wrapEditorViewAsSurface(
+  view: EditorView | null,
+  rId: string,
+): Surface {
+  return {
+    kind: "hf",
+    rId,
+    getState: () => view?.state ?? null,
+    getView: () => view,
+    focus: () => view?.focus(),
+    isFocused: () => view?.hasFocus() ?? false,
+    dispatch: (tr) => view?.dispatch(tr),
+    setSelection(anchor, head) {
+      if (!view) {
+        return;
+      }
+      const { state, dispatch } = view;
+      const docEnd = state.doc.content.size;
+      const clampedAnchor = Math.max(0, Math.min(anchor, docEnd));
+      const clampedHead =
+        head === undefined
+          ? clampedAnchor
+          : Math.max(0, Math.min(head, docEnd));
+      const $anchor = state.doc.resolve(clampedAnchor);
+      const $head = state.doc.resolve(clampedHead);
+      const selection =
+        head === undefined
+          ? Selection.near($anchor)
+          : TextSelection.between($anchor, $head);
+      dispatch(state.tr.setSelection(selection));
+    },
+  };
+}

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2373,14 +2373,16 @@ function computeOptionsHash(options: RenderPageOptions): string {
   // same-height in-place edits (typing a replacement char, bold toggle, etc.)
   // invalidate the hash and force the per-page shells to re-render — block
   // count / height / visualBounds alone miss those (Codex #487 P1: 21:02
-  // review).
+  // review). Include `rId` so switching to a different HF part with
+  // identical content invalidates the hash too — otherwise the painted
+  // `data-rid` would stay stale (Codex #487 P2: 22:48 review).
   if (options.headerContent) {
     parts.push(
       `hdr:${options.headerContent.blocks.length},${options.headerContent.height},${
         options.headerContent.visualTop ?? 0
       },${options.headerContent.visualBottom ?? options.headerContent.height},${
-        options.headerContent.textSig ?? ""
-      }`,
+        options.headerContent.rId ?? ""
+      },${options.headerContent.textSig ?? ""}`,
     );
   }
   if (options.footerContent) {
@@ -2388,23 +2390,23 @@ function computeOptionsHash(options: RenderPageOptions): string {
       `ftr:${options.footerContent.blocks.length},${options.footerContent.height},${
         options.footerContent.visualTop ?? 0
       },${options.footerContent.visualBottom ?? options.footerContent.height},${
-        options.footerContent.textSig ?? ""
-      }`,
+        options.footerContent.rId ?? ""
+      },${options.footerContent.textSig ?? ""}`,
     );
   }
 
   if (options.firstPageHeaderContent) {
     parts.push(
       `fp-hdr:${options.firstPageHeaderContent.blocks.length},${options.firstPageHeaderContent.height},${
-        options.firstPageHeaderContent.textSig ?? ""
-      }`,
+        options.firstPageHeaderContent.rId ?? ""
+      },${options.firstPageHeaderContent.textSig ?? ""}`,
     );
   }
   if (options.firstPageFooterContent) {
     parts.push(
       `fp-ftr:${options.firstPageFooterContent.blocks.length},${options.firstPageFooterContent.height},${
-        options.firstPageFooterContent.textSig ?? ""
-      }`,
+        options.firstPageFooterContent.rId ?? ""
+      },${options.firstPageFooterContent.textSig ?? ""}`,
     );
   }
   if (options.titlePg) {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -157,6 +157,13 @@ export type HeaderFooterContent = {
    */
   marginPushTop?: number;
   marginPushBottom?: number;
+  /**
+   * Relationship id (`rId`) of the source HF part. Emitted as `data-rid`
+   * on the painted `.layout-page-header` / `.layout-page-footer` so the
+   * pointer pipeline can resolve clicks to the matching hidden HF
+   * EditorView (see `HiddenHeaderFooterPMs`).
+   */
+  rId?: string;
 };
 
 /**
@@ -1824,6 +1831,9 @@ export function renderPage(
 
     const headerEl = doc.createElement("div");
     headerEl.className = PAGE_CLASS_NAMES.header;
+    if (options.headerContent?.rId) {
+      headerEl.dataset["rid"] = options.headerContent.rId;
+    }
     headerEl.style.position = "absolute";
     headerEl.style.top = `${headerDistance + headerVisualTop}px`;
     headerEl.style.left = `${page.margins.left}px`;
@@ -1919,6 +1929,9 @@ export function renderPage(
     const footerContainerTop = footerNaturalTop + footerVisualTop;
     const footerEl = doc.createElement("div");
     footerEl.className = PAGE_CLASS_NAMES.footer;
+    if (options.footerContent?.rId) {
+      footerEl.dataset["rid"] = options.footerContent.rId;
+    }
     footerEl.style.position = "absolute";
     footerEl.style.top = `${footerContainerTop}px`;
     footerEl.style.left = `${page.margins.left}px`;
@@ -2749,6 +2762,40 @@ export function renderPages(
   for (let i = 0; i < initialRenderCount; i++) {
     populatePageShell(pageShells[i]!, pageDataMap, totalPages, options); // SAFETY: i < initialRenderCount <= pages.length
   }
+
+  emitPainterPainted(container);
+}
+
+// =============================================================================
+// painter:painted event bus
+// =============================================================================
+//
+// Subscribers (e.g. SelectionOverlay's HF caret cache, hidden HF PMs) need a
+// single signal that the painter has finished writing children for the current
+// layout pass. The body's hidden-PM + painter pipeline already exposes this
+// implicitly via `syncCoordinator.onLayoutComplete`; for HF caret math the
+// snapshot needs to invalidate the moment the painted DOM changes. A bubbling
+// CustomEvent on the container element keeps the API ergonomic
+// (`container.addEventListener("painter:painted", ...)`) without introducing a
+// global EventTarget that would leak across multiple editor mounts.
+
+export const PAINTER_PAINTED_EVENT = "painter:painted" as const;
+
+export type PainterPaintedDetail = {
+  container: HTMLElement;
+  pageCount: number;
+};
+
+function emitPainterPainted(container: HTMLElement): void {
+  const pageCount = container.querySelectorAll(
+    `.${PAGE_CLASS_NAMES.page}`,
+  ).length;
+  const event = new CustomEvent<PainterPaintedDetail>(PAINTER_PAINTED_EVENT, {
+    detail: { container, pageCount },
+    bubbles: true,
+    cancelable: false,
+  });
+  container.dispatchEvent(event);
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2612,6 +2612,10 @@ export function renderPages(
     prevState.totalPages = totalPages;
     prevState.currentOptions = options;
 
+    // Incremental path: existing shells were repopulated in place; fire
+    // painter:painted so caret/selection overlays recompute against the
+    // freshly written DOM (Codex #487 P2: 22:09 review).
+    emitPainterPainted(container);
     return;
   }
 
@@ -2662,7 +2666,12 @@ export function renderPages(
 
   if (!useVirtualization) {
     // Store state for potential future incremental updates (won't be used
-    // since small docs skip the incremental path, but keeps data consistent)
+    // since small docs skip the incremental path, but keeps data consistent).
+    // Fire painter:painted before returning so consumers — notably
+    // HfCaretOverlay, which recomputes after the painter writes new HF
+    // DOM — see the event in the common small-document path too
+    // (Codex #487 P2: 22:09 review).
+    emitPainterPainted(container);
     return;
   }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2883,6 +2883,18 @@ function populatePageShell(
 
   data.rendered = true;
   syncPageShellFingerprints(shell, data, options);
+
+  // Fire painter:painted on the pages container so HfCaretOverlay
+  // recomputes against the now-populated shell. Without this, an HF
+  // edit on a later page in a virtualized doc would emit
+  // painter:painted while only the first three shells were populated
+  // (full-rebuild path), the overlay would clear, and the caret would
+  // not return until another transaction (Codex #487 P2: 22:27
+  // review).
+  const container = shell.parentElement;
+  if (container instanceof HTMLElement) {
+    emitPainterPainted(container);
+  }
 }
 
 /**

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -164,6 +164,14 @@ export type HeaderFooterContent = {
    * EditorView (see `HiddenHeaderFooterPMs`).
    */
   rId?: string;
+  /**
+   * Cheap text fingerprint of the rendered blocks. Used by
+   * `computeOptionsHash` so same-height in-place HF edits (typing
+   * replacing the same number of chars, bold toggle, etc.) invalidate
+   * the cached options hash and force the painter to re-render shells
+   * (Codex #487 P1 follow-up: 21:02 review).
+   */
+  textSig?: string;
 };
 
 /**
@@ -2361,30 +2369,42 @@ function runContentKey(run: Run): string {
 function computeOptionsHash(options: RenderPageOptions): string {
   const parts: string[] = [];
 
-  // Header/footer content changes affect all pages
+  // Header/footer content changes affect all pages. Include `textSig` so
+  // same-height in-place edits (typing a replacement char, bold toggle, etc.)
+  // invalidate the hash and force the per-page shells to re-render — block
+  // count / height / visualBounds alone miss those (Codex #487 P1: 21:02
+  // review).
   if (options.headerContent) {
     parts.push(
       `hdr:${options.headerContent.blocks.length},${options.headerContent.height},${
         options.headerContent.visualTop ?? 0
-      },${options.headerContent.visualBottom ?? options.headerContent.height}`,
+      },${options.headerContent.visualBottom ?? options.headerContent.height},${
+        options.headerContent.textSig ?? ""
+      }`,
     );
   }
   if (options.footerContent) {
     parts.push(
       `ftr:${options.footerContent.blocks.length},${options.footerContent.height},${
         options.footerContent.visualTop ?? 0
-      },${options.footerContent.visualBottom ?? options.footerContent.height}`,
+      },${options.footerContent.visualBottom ?? options.footerContent.height},${
+        options.footerContent.textSig ?? ""
+      }`,
     );
   }
 
   if (options.firstPageHeaderContent) {
     parts.push(
-      `fp-hdr:${options.firstPageHeaderContent.blocks.length},${options.firstPageHeaderContent.height}`,
+      `fp-hdr:${options.firstPageHeaderContent.blocks.length},${options.firstPageHeaderContent.height},${
+        options.firstPageHeaderContent.textSig ?? ""
+      }`,
     );
   }
   if (options.firstPageFooterContent) {
     parts.push(
-      `fp-ftr:${options.firstPageFooterContent.blocks.length},${options.firstPageFooterContent.height}`,
+      `fp-ftr:${options.firstPageFooterContent.blocks.length},${options.firstPageFooterContent.height},${
+        options.firstPageFooterContent.textSig ?? ""
+      }`,
     );
   }
   if (options.titlePg) {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -920,6 +920,9 @@ function renderHeaderFooterContent(
     width: number;
     height: number;
     alt?: string;
+    /** Run-level PM position so the pointer pipeline can NodeSelect HF images. */
+    pmStart?: number;
+    pmEnd?: number;
     paragraphY: number; // Y position of the containing paragraph
     behindDoc?: boolean;
     position: {
@@ -975,6 +978,8 @@ function renderHeaderFooterContent(
             width: run.width,
             height: run.height,
             ...(run.alt !== undefined ? { alt: run.alt } : {}),
+            ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
+            ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
             paragraphY: paragraphStartY,
             behindDoc: run.wrapType === "behind",
             position: run.position ?? {},
@@ -1135,6 +1140,18 @@ function renderHeaderFooterContent(
     img.height = floatImg.height;
     if (floatImg.alt) {
       img.alt = floatImg.alt;
+    }
+    // Mark as a click-resolvable image fragment so the pointer pipeline's
+    // `findImageElement` matches it. Without these markers an anchored HF
+    // image rendered here would fall through to the generic HF text-click
+    // branch and no NodeSelection could be created on the HF view
+    // (Codex #487 P2 follow-up: 20:52 review).
+    img.classList.add("layout-run", "layout-run-image");
+    if (floatImg.pmStart !== undefined) {
+      img.dataset["pmStart"] = String(floatImg.pmStart);
+    }
+    if (floatImg.pmEnd !== undefined) {
+      img.dataset["pmEnd"] = String(floatImg.pmEnd);
     }
 
     img.style.position = "absolute";

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -120,6 +120,7 @@ import {
   mergeTableCellAttrs,
   mergeTableRowAttrs,
 } from "../core/prosemirror/attrs";
+import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { anonymizationDecorationsKey } from "../core/prosemirror/plugins/anonymizationDecorations";
 import type { AnonymizationMatch } from "../core/prosemirror/plugins/anonymizationDecorations";
@@ -3671,6 +3672,41 @@ export function PagedEditor(
   );
 
   /**
+   * Handle a transaction on a persistent hidden HF EditorView.
+   *
+   * Two responsibilities:
+   *   1. Mirror the PM doc back into `Document.package.headers/footers[rId].content`
+   *      so the existing save path (which reads `hf.content`) ships the latest
+   *      HF content. Mutating in place matches upstream's pattern and avoids
+   *      churning history on every keystroke (the persistent PM is the
+   *      source of truth while loaded — same model the body PM uses).
+   *   2. Re-run the layout pipeline so the painter repaints with the new
+   *      HF blocks. We reuse the body PM's current state as the layout
+   *      input because `scheduleLayout` derives body blocks from that
+   *      state; the HF blocks are pulled from the HF PM via
+   *      `renderHfFromContentOrPm` on the next layout tick.
+   */
+  const handleHfPmTransaction = useCallback(
+    (rId: string, view: EditorView, docChanged: boolean) => {
+      if (!docChanged) {
+        return;
+      }
+      const pkg = document?.package;
+      if (pkg) {
+        const hf = pkg.headers?.get(rId) ?? pkg.footers?.get(rId);
+        if (hf) {
+          hf.content = proseDocToBlocks(view.state.doc);
+        }
+      }
+      const bodyState = hiddenPMRef.current?.getState();
+      if (bodyState) {
+        scheduleLayout(bodyState, null);
+      }
+    },
+    [document, scheduleLayout],
+  );
+
+  /**
    * Handle selection change from PM.
    */
   const handleSelectionChange = useCallback(
@@ -6034,6 +6070,7 @@ export function PagedEditor(
       <HiddenHeaderFooterPMs
         ref={hfPMsRef}
         document={document}
+        onTransaction={handleHfPmTransaction}
         {...(styles !== undefined ? { styles } : {})}
         {...(_theme !== undefined ? { theme: _theme } : {})}
       />

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -608,6 +608,14 @@ type HfCaretSelection = {
   kind: "header" | "footer";
   from: number;
   to: number;
+  /**
+   * Page number (1-indexed) the user clicked/typed into. When a shared HF
+   * rId is painted on multiple pages, the caret + range rects must scope to
+   * the page the user is actually editing — otherwise the lookup picks the
+   * first matching slot and the caret appears on page 1 while the user is
+   * typing on page 5 (Codex #487 P2: 21:28 review).
+   */
+  pageNumber?: number;
 };
 
 function HfCaretOverlay({
@@ -632,6 +640,15 @@ function HfCaretOverlay({
     }
     const recompute = () => {
       const cr = pagesContainer.getBoundingClientRect();
+      // Scope every lookup to the specific painted page the user is
+      // editing. When a default HF rId is shared across N pages we'd
+      // otherwise paint the caret on the first matching slot (page 1)
+      // even if the user is typing on page 5 (Codex #487 P2: 21:28).
+      const pageScope: ParentNode = selection.pageNumber
+        ? (pagesContainer.querySelector(
+            `.layout-page[data-page-number="${selection.pageNumber}"]`,
+          ) ?? pagesContainer)
+        : pagesContainer;
       const collapsed = selection.from === selection.to;
       if (collapsed) {
         // Use findHfCaretSpan so a caret at the end of a run / paragraph
@@ -640,7 +657,7 @@ function HfCaretOverlay({
         // caret as soon as the user typed to the end of their text
         // (Codex #487 P2: 20:32 review).
         const hit = findHfCaretSpan(
-          pagesContainer,
+          pageScope,
           selection.kind,
           selection.rId,
           selection.from,
@@ -670,7 +687,7 @@ function HfCaretOverlay({
         selection.kind === "header"
           ? `.layout-page-header[data-rid="${selection.rId}"]`
           : `.layout-page-footer[data-rid="${selection.rId}"]`;
-      const spans = pagesContainer.querySelectorAll<HTMLElement>(
+      const spans = pageScope.querySelectorAll<HTMLElement>(
         `${slotSelector} span[data-pm-start][data-pm-end]`,
       );
       const rects: { x: number; y: number; width: number; height: number }[] =
@@ -710,6 +727,7 @@ function HfCaretOverlay({
     selection.kind,
     selection.from,
     selection.to,
+    selection.pageNumber,
     pagesContainer,
   ]);
 
@@ -3874,12 +3892,15 @@ export function PagedEditor(
    *      state; the HF blocks are pulled from the HF PM via
    *      `renderHfFromContentOrPm` on the next layout tick.
    */
-  const [hfCaretSelection, setHfCaretSelection] = useState<{
-    rId: string;
-    kind: "header" | "footer";
-    from: number;
-    to: number;
-  } | null>(null);
+  const [hfCaretSelection, setHfCaretSelection] =
+    useState<HfCaretSelection | null>(null);
+  // Page number (1-indexed) of the painted slot the user most recently
+  // clicked / dispatched into. Persisted across HF PM transactions so
+  // typing after a click on page 5 keeps the caret on page 5 — without
+  // this, the painter would scope the caret to whichever painted instance
+  // of the rId the lookup found first (page 1) on every subsequent
+  // selection update (Codex #487 P2: 21:28).
+  const activeHfPageNumberRef = useRef<number | null>(null);
 
   const handleHfPmTransaction = useCallback(
     (
@@ -3901,7 +3922,14 @@ export function PagedEditor(
       }
       if (docChanged || selectionChanged) {
         const { from, to } = view.state.selection;
-        setHfCaretSelection({ rId, kind, from, to });
+        const pageNumber = activeHfPageNumberRef.current;
+        setHfCaretSelection({
+          rId,
+          kind,
+          from,
+          to,
+          ...(pageNumber !== null ? { pageNumber } : {}),
+        });
         // Fan the HF PM selection out the same channel the body PM uses
         // (DocxEditor's onSelectionChange handler then re-reads the
         // active view via getActiveEditorView and re-syncs FormattingBar
@@ -3925,6 +3953,7 @@ export function PagedEditor(
     }
     dragAnchorRef.current = null;
     activeHfDragSurfaceRef.current = null;
+    activeHfPageNumberRef.current = null;
   }, [hfEditMode]);
 
   /**
@@ -4494,6 +4523,14 @@ export function PagedEditor(
                 rId: slot.rId,
                 kind: slot.kind,
               };
+              // Remember the painted page so the caret overlay scopes
+              // subsequent renders to this slot instance instead of the
+              // first matching rId in document order.
+              const pageEl = slot.element.closest<HTMLElement>(".layout-page");
+              const pageNumStr = pageEl?.dataset["pageNumber"];
+              activeHfPageNumberRef.current = pageNumStr
+                ? Number.parseInt(pageNumStr, 10)
+                : null;
             }
             hfView.focus();
             return;
@@ -5486,6 +5523,11 @@ export function PagedEditor(
         if (headerEl || footerEl) {
           const pageEl = closestHtmlElement(target, "[data-page-number]");
           const pageNum = pageEl ? Number(pageEl.dataset["pageNumber"]) : 1;
+          // Seed the HF caret overlay's page scope so the very first
+          // transaction after entering edit mode draws on the page the
+          // user double-clicked, not the first painted instance of the
+          // shared rId.
+          activeHfPageNumberRef.current = pageNum;
           if (headerEl) {
             e.preventDefault();
             e.stopPropagation();

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -4536,6 +4536,20 @@ export function PagedEditor(
             if (pos !== null) {
               const docEnd = hfView.state.doc.content.size;
               const clamped = Math.max(0, Math.min(pos, docEnd));
+              // Set the page-scope ref BEFORE the dispatch — view.dispatch
+              // synchronously invokes our dispatchTransaction →
+              // handleHfPmTransaction, which reads
+              // activeHfPageNumberRef.current to stamp on the new
+              // HfCaretSelection. If we set it after the dispatch, the
+              // first selection update on this click still records the
+              // previous page and the caret renders on the wrong
+              // painted instance until the next transaction (Codex
+              // #487 P2: 22:27 review).
+              const pageEl = slot.element.closest<HTMLElement>(".layout-page");
+              const pageNumStr = pageEl?.dataset["pageNumber"];
+              activeHfPageNumberRef.current = pageNumStr
+                ? Number.parseInt(pageNumStr, 10)
+                : null;
               if (e.shiftKey && dragAnchorRef.current !== null) {
                 const $anchor = hfView.state.doc.resolve(
                   Math.max(0, Math.min(dragAnchorRef.current, docEnd)),
@@ -4560,14 +4574,6 @@ export function PagedEditor(
                 rId: slot.rId,
                 kind: slot.kind,
               };
-              // Remember the painted page so the caret overlay scopes
-              // subsequent renders to this slot instance instead of the
-              // first matching rId in document order.
-              const pageEl = slot.element.closest<HTMLElement>(".layout-page");
-              const pageNumStr = pageEl?.dataset["pageNumber"];
-              activeHfPageNumberRef.current = pageNumStr
-                ? Number.parseInt(pageNumStr, 10)
-                : null;
             }
             hfView.focus();
             return;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -31,6 +31,8 @@ import type { EditorState, Transaction, Plugin } from "prosemirror-state";
 import type { CellSelection } from "prosemirror-tables";
 import type { EditorView } from "prosemirror-view";
 
+import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
+import type { HiddenHeaderFooterPMsRef } from "../components/HiddenHeaderFooterPMs";
 import { getFootnoteText } from "../core/docx/footnoteParser";
 import { clickToPosition } from "../core/layout-bridge/clickToPosition";
 import { clickToPositionDom } from "../core/layout-bridge/clickToPositionDom";
@@ -44,8 +46,14 @@ import {
   collectFootnoteRefs,
   buildFootnoteContentMap,
 } from "../core/layout-bridge/footnoteLayout";
-import { convertHeaderFooterToContent } from "../core/layout-bridge/headerFooterLayout";
-import type { HeaderFooterMetrics } from "../core/layout-bridge/headerFooterLayout";
+import {
+  convertHeaderFooterPmDocToContent,
+  convertHeaderFooterToContent,
+} from "../core/layout-bridge/headerFooterLayout";
+import type {
+  ConvertHeaderFooterOptions,
+  HeaderFooterMetrics,
+} from "../core/layout-bridge/headerFooterLayout";
 import {
   hitTestFragment,
   hitTestTableCell,
@@ -96,6 +104,7 @@ import {
   renderPages,
 } from "../core/layout-painter/renderPage";
 import type {
+  HeaderFooterContent,
   RenderPageOptions,
   FootnoteRenderItem,
 } from "../core/layout-painter/renderPage";
@@ -196,6 +205,15 @@ export type PagedEditorProps = {
   firstPageHeaderContent?: HeaderFooter | null;
   /** Footer content for first page only (when titlePg is set). */
   firstPageFooterContent?: HeaderFooter | null;
+  /**
+   * Relationship ids for the displayed HF slots — used by the painter to
+   * emit `data-rid` on `.layout-page-header` / `.layout-page-footer` and
+   * by the layout pipeline to look up persistent hidden HF EditorViews.
+   */
+  headerContentRId?: string | null;
+  footerContentRId?: string | null;
+  firstPageHeaderContentRId?: string | null;
+  firstPageFooterContentRId?: string | null;
   /** Whether the editor is read-only. */
   readOnly?: boolean;
   /** Gap between pages in pixels. */
@@ -569,6 +587,37 @@ const loadSelectionGeometry = (): Promise<SelectionGeometryModule> => {
 
   return selectionGeometryPromise;
 };
+
+// Source HeaderFooterContent for the painter from either a persistent hidden
+// HF EditorView (preferred — keeps the painter in lockstep with live PM edits)
+// or the HeaderFooter document blocks (fallback before the view mounts).
+// `rId` is stamped on the result so the painter emits `data-rid` and the
+// pointer pipeline can route clicks back to the matching EditorView.
+function renderHfFromContentOrPm(
+  hf: HeaderFooter | null | undefined,
+  rId: string | null | undefined,
+  hfPMs: HiddenHeaderFooterPMsRef | null,
+  contentWidth: number,
+  metrics: HeaderFooterMetrics,
+  options: ConvertHeaderFooterOptions,
+): HeaderFooterContent | undefined {
+  if (!hf) {
+    return undefined;
+  }
+  const optsWithRId: ConvertHeaderFooterOptions = rId
+    ? { ...options, rId }
+    : options;
+  const view = rId ? hfPMs?.getView(rId) : null;
+  if (view) {
+    return convertHeaderFooterPmDocToContent(
+      view.state.doc,
+      contentWidth,
+      metrics,
+      optsWithRId,
+    );
+  }
+  return convertHeaderFooterToContent(hf, contentWidth, metrics, optsWithRId);
+}
 
 type LayoutInputSignatureOptions = {
   columns: ColumnLayout | undefined;
@@ -2078,6 +2127,10 @@ export function PagedEditor(
     footerContent,
     firstPageHeaderContent,
     firstPageFooterContent,
+    headerContentRId,
+    footerContentRId,
+    firstPageHeaderContentRId,
+    firstPageFooterContentRId,
     readOnly = false,
     pageGap = DEFAULT_PAGE_GAP,
     zoom = 1,
@@ -2119,6 +2172,7 @@ export function PagedEditor(
   const containerRef = useRef<HTMLDivElement>(null);
   const pagesContainerRef = useRef<HTMLDivElement>(null);
   const hiddenPMRef = useRef<HiddenProseMirrorRef>(null);
+  const hfPMsRef = useRef<HiddenHeaderFooterPMsRef>(null);
   const painterRef = useRef<LayoutPainter | null>(null);
 
   // Visual line navigation (ArrowUp/ArrowDown with sticky X)
@@ -2570,30 +2624,38 @@ export function PagedEditor(
             ? { defaultTabStopTwips: defaultTabStop }
             : {}),
         };
-        const headerContentForRender = convertHeaderFooterToContent(
+        const headerContentForRender = renderHfFromContentOrPm(
           headerContent,
+          headerContentRId,
+          hfPMsRef.current,
           contentWidth,
           hfMetricsHeader,
           hfOptions,
         );
-        const footerContentForRender = convertHeaderFooterToContent(
+        const footerContentForRender = renderHfFromContentOrPm(
           footerContent,
+          footerContentRId,
+          hfPMsRef.current,
           contentWidth,
           hfMetricsFooter,
           hfOptions,
         );
         const hasTitlePg = sectionProperties?.titlePg === true;
         const firstPageHeaderForRender = hasTitlePg
-          ? convertHeaderFooterToContent(
+          ? renderHfFromContentOrPm(
               firstPageHeaderContent,
+              firstPageHeaderContentRId,
+              hfPMsRef.current,
               contentWidth,
               hfMetricsHeader,
               hfOptions,
             )
           : undefined;
         const firstPageFooterForRender = hasTitlePg
-          ? convertHeaderFooterToContent(
+          ? renderHfFromContentOrPm(
               firstPageFooterContent,
+              firstPageFooterContentRId,
+              hfPMsRef.current,
               contentWidth,
               hfMetricsFooter,
               hfOptions,
@@ -5964,6 +6026,18 @@ export function PagedEditor(
       onKeyDown={handleKeyDown}
       onMouseDown={handleContainerMouseDown}
     >
+      {/* Persistent off-screen ProseMirror per HF rId — the painter reads
+          from these views when a slot's view exists (see HF unification port,
+          eigenpal#611). Currently shadow instances: the inline overlay still
+          owns user input. Switching the layout pipeline to source from these
+          views is the next phase. */}
+      <HiddenHeaderFooterPMs
+        ref={hfPMsRef}
+        document={document}
+        {...(styles !== undefined ? { styles } : {})}
+        {...(_theme !== undefined ? { theme: _theme } : {})}
+      />
+
       {/* Hidden ProseMirror for keyboard input */}
       <HiddenProseMirror
         ref={hiddenPMRef}

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -28,7 +28,7 @@ import { flushSync } from "react-dom";
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction, Plugin } from "prosemirror-state";
-import type { CellSelection } from "prosemirror-tables";
+import { CellSelection } from "prosemirror-tables";
 import type { EditorView } from "prosemirror-view";
 
 import { HiddenHeaderFooterPMs } from "../components/HiddenHeaderFooterPMs";
@@ -4019,29 +4019,37 @@ export function PagedEditor(
    * Find the table cell position in ProseMirror doc for a given PM position.
    * Returns the position just inside the cell node, suitable for CellSelection.create().
    */
-  const findCellPosFromPmPos = useCallback((pmPos: number): number | null => {
-    const view = hiddenPMRef.current?.getView();
-    if (!view) {
-      return null;
-    }
-    try {
-      const $pos = view.state.doc.resolve(pmPos);
-      for (let d = $pos.depth; d > 0; d--) {
-        const node = $pos.node(d);
-        if (
-          node.type.name === "tableCell" ||
-          node.type.name === "tableHeader"
-        ) {
-          // Return position of the cell node itself (before(d)).
-          // CellSelection.create will resolve this and use cellAround() internally.
-          return $pos.before(d);
+  const findCellPosInDoc = useCallback(
+    (doc: PMNode, pmPos: number): number | null => {
+      try {
+        const $pos = doc.resolve(pmPos);
+        for (let d = $pos.depth; d > 0; d--) {
+          const node = $pos.node(d);
+          if (
+            node.type.name === "tableCell" ||
+            node.type.name === "tableHeader"
+          ) {
+            return $pos.before(d);
+          }
         }
+      } catch {
+        // Position resolution failed
       }
-    } catch {
-      // Position resolution failed
-    }
-    return null;
-  }, []);
+      return null;
+    },
+    [],
+  );
+
+  const findCellPosFromPmPos = useCallback(
+    (pmPos: number): number | null => {
+      const view = hiddenPMRef.current?.getView();
+      if (!view) {
+        return null;
+      }
+      return findCellPosInDoc(view.state.doc, pmPos);
+    },
+    [findCellPosInDoc],
+  );
 
   /**
    * Find the closest image element from a click target.
@@ -4365,7 +4373,9 @@ export function PagedEditor(
       // painted span's data-pm-start/end markers) and dispatch the resulting
       // PM position on the matching hidden view. The drag-extend / shift-click
       // refs are populated here too so subsequent mousemove + handlePagesClick
-      // dispatch on the same surface.
+      // dispatch on the same surface. Cell drag inside an HF table seeds
+      // cellDragAnchorPosRef with the HF cell position; the mousemove path
+      // dispatches CellSelection on the HF view.
       if (!readOnly && hfEditMode) {
         const slot = findHfSlotForTarget(target);
         if (slot) {
@@ -4398,6 +4408,8 @@ export function PagedEditor(
                 );
                 dragAnchorRef.current = clamped;
               }
+              const cellPos = findCellPosInDoc(hfView.state.doc, clamped);
+              cellDragAnchorPosRef.current = cellPos;
               isDraggingRef.current = true;
               activeHfDragSurfaceRef.current = {
                 rId: slot.rId,
@@ -4783,11 +4795,41 @@ export function PagedEditor(
       updateDragScroll(e.clientX, e.clientY);
 
       // HF drag: route the rest of the mousemove through the active HF PM.
-      // We skip the body's cell-select / link-anchor logic — none of it
-      // applies in the HF surface — and let dragExtendRef handle the
-      // selection dispatch on the HF view. The painter then repaints via
-      // the HF caret overlay.
+      // If the drag started inside an HF table cell, dispatch CellSelection
+      // on the HF view; otherwise dragExtendRef handles text selection.
+      // The painter repaints via the HF caret overlay either way.
       if (activeHfDragSurfaceRef.current) {
+        const hfSurface = activeHfDragSurfaceRef.current;
+        const hfView = hfPMsRef.current?.getView(hfSurface.rId);
+        if (hfView && cellDragAnchorPosRef.current !== null) {
+          const hfPos = clickToPositionDom(
+            pagesContainerRef.current,
+            e.clientX,
+            e.clientY,
+            zoom,
+          );
+          if (hfPos !== null) {
+            const currentCellPos = findCellPosInDoc(hfView.state.doc, hfPos);
+            if (currentCellPos !== null) {
+              try {
+                hfView.dispatch(
+                  hfView.state.tr.setSelection(
+                    CellSelection.create(
+                      hfView.state.doc,
+                      cellDragAnchorPosRef.current,
+                      currentCellPos,
+                    ),
+                  ),
+                );
+                isCellDraggingRef.current = true;
+                return;
+              } catch {
+                // Cell positions weren't valid for CellSelection; fall
+                // through to text drag.
+              }
+            }
+          }
+        }
         dragExtendRef.current(e.clientX, e.clientY);
         return;
       }
@@ -4858,7 +4900,13 @@ export function PagedEditor(
       const anchor = dragAnchorRef.current;
       hiddenPMRef.current.setSelection(anchor, pmPos);
     },
-    [getPositionFromMouse, findCellPosFromPmPos, updateDragScroll],
+    [
+      getPositionFromMouse,
+      findCellPosFromPmPos,
+      findCellPosInDoc,
+      updateDragScroll,
+      zoom,
+    ],
   );
 
   /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3205,6 +3205,16 @@ export function PagedEditor(
       footerContent,
       firstPageHeaderContent,
       firstPageFooterContent,
+      // HF rIds drive which hidden EditorView the pipeline sources from
+      // AND the `data-rid` stamped on each painted slot. Omitting them
+      // from this dep array let an rId swap between byte-identical
+      // HeaderFooter objects reuse a stale runLayoutPipeline closure
+      // and the painter emitted the previous slot's `data-rid` so
+      // clicks routed to the wrong HF view (Codex #487 P2: 23:21).
+      headerContentRId,
+      footerContentRId,
+      firstPageHeaderContentRId,
+      firstPageFooterContentRId,
       _theme,
       sectionProperties,
       document,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -678,12 +678,15 @@ function HfCaretOverlay({
           return;
         }
         const ar = hit.element.getBoundingClientRect();
-        // Default to the span edge findHfCaretSpan returned. For mid-span
-        // text positions (clicked / arrowed into the middle of a run),
-        // sample the exact character X via the Range API so the caret
-        // lines up with the glyph the PM selection actually sits at — a
-        // bare edge anchor would paint at the run's left edge regardless
-        // of where the user clicked (Codex #487 P2: 22:38 review).
+        // Default fallback uses the span edge findHfCaretSpan returned —
+        // safe for atom spans (images, breaks) that lack a text node.
+        // For text-bearing spans, sample the *exact* visual position
+        // via a collapsed Range at (selection.from - pmStart) inside
+        // the text node. The Range API returns the caret rect in
+        // visual (direction-aware) coordinates so it lands on the
+        // correct side of the run in RTL / bidi headers / footers as
+        // well as the middle of mid-span LTR runs (Codex #487 P2:
+        // 22:38 + 22:58 reviews).
         let absX = hit.edge === "right" ? ar.right : ar.left;
         let absY = ar.top;
         let absHeight = ar.height || 16;
@@ -693,29 +696,27 @@ function HfCaretOverlay({
           ? Number.parseInt(pmStartStr, 10)
           : Number.NaN;
         const pmEnd = pmEndStr ? Number.parseInt(pmEndStr, 10) : Number.NaN;
+        const textNode = hit.element.firstChild;
         if (
+          textNode &&
+          textNode.nodeType === Node.TEXT_NODE &&
           Number.isFinite(pmStart) &&
-          Number.isFinite(pmEnd) &&
-          selection.from > pmStart &&
-          selection.from < pmEnd
+          Number.isFinite(pmEnd)
         ) {
-          const textNode = hit.element.firstChild;
-          if (textNode && textNode.nodeType === Node.TEXT_NODE) {
-            const textContent = textNode.textContent ?? "";
-            const charOffset = Math.min(
-              selection.from - pmStart,
-              textContent.length,
-            );
-            const ownerDoc = hit.element.ownerDocument;
-            const range = ownerDoc.createRange();
-            range.setStart(textNode, charOffset);
-            range.setEnd(textNode, charOffset);
-            const rRect = range.getBoundingClientRect();
-            if (rRect.height > 0 || rRect.width > 0 || rRect.left > 0) {
-              absX = rRect.left;
-              absY = rRect.top;
-              absHeight = rRect.height || absHeight;
-            }
+          const textContent = textNode.textContent ?? "";
+          const charOffset = Math.min(
+            Math.max(0, selection.from - pmStart),
+            textContent.length,
+          );
+          const ownerDoc = hit.element.ownerDocument;
+          const range = ownerDoc.createRange();
+          range.setStart(textNode, charOffset);
+          range.setEnd(textNode, charOffset);
+          const rRect = range.getBoundingClientRect();
+          if (rRect.height > 0 || rRect.width > 0 || rRect.left > 0) {
+            absX = rRect.left;
+            absY = rRect.top;
+            absHeight = rRect.height || absHeight;
           }
         }
         setCaret({

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3885,7 +3885,7 @@ export function PagedEditor(
       // HiddenHeaderFooterPMs writes the new blocks into
       // package.headers/footers[rId].content in place inside its own
       // dispatchTransaction, so we only need to nudge the layout pipeline
-      // and update HF caret state here.
+      // and update HF caret + toolbar state here.
       if (docChanged) {
         const bodyState = hiddenPMRef.current?.getState();
         if (bodyState) {
@@ -3895,6 +3895,13 @@ export function PagedEditor(
       if (docChanged || selectionChanged) {
         const { from, to } = view.state.selection;
         setHfCaretSelection({ rId, kind, from, to });
+        // Fan the HF PM selection out the same channel the body PM uses
+        // (DocxEditor's onSelectionChange handler then re-reads the
+        // active view via getActiveEditorView and re-syncs FormattingBar
+        // / context state to the HF surface). Without this the toolbar
+        // would freeze on the previous body selection while its actions
+        // dispatch on the HF view.
+        onSelectionChangeRef.current?.(from, to);
       }
     },
     [scheduleLayout],
@@ -5734,6 +5741,16 @@ export function PagedEditor(
       ) {
         return;
       }
+      // Don't steal focus from a persistent hidden HF EditorView. The
+      // HF host marks each view's mount node with `data-hf-r-id`; once
+      // an HF view holds focus, the body PM redirect would immediately
+      // bounce keystrokes off it (Codex #487 P1).
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.closest("[data-hf-r-id]")
+      ) {
+        return;
+      }
       focusHiddenEditor();
     },
     [focusHiddenEditor],
@@ -6049,6 +6066,14 @@ export function PagedEditor(
       if (
         e.target instanceof HTMLElement &&
         e.target.closest(".docx-comments-sidebar")
+      ) {
+        return;
+      }
+      // Don't steal focus from the persistent hidden HF EditorView host
+      // — see handleContainerFocus for the same guard rationale.
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.closest("[data-hf-r-id]")
       ) {
         return;
       }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -2431,6 +2431,13 @@ export function PagedEditor(
     rId: string;
     kind: "header" | "footer";
   } | null>(null);
+  // Same idea for table resize: when the resize handle lives inside an HF
+  // table the commit must dispatch setNodeMarkup on that slot's PM, not on
+  // the body PM. Captured at mousedown, cleared on mouseup.
+  const resizingHfSurfaceRef = useRef<{
+    rId: string;
+    kind: "header" | "footer";
+  } | null>(null);
 
   const ensureHiddenEditorView = useCallback(
     ({ focus = true, sync = false }: EnsureHiddenEditorViewOptions = {}) => {
@@ -4367,6 +4374,25 @@ export function PagedEditor(
         }
       }
 
+      // Resize handles must be intercepted BEFORE the HF text-routing
+      // branch — otherwise the table-edge handles painted inside an HF
+      // slot would be treated as a regular HF click and the user could
+      // never start a resize. The resize blocks below resolve the
+      // active surface (body or HF) and read the source columnWidths /
+      // row height from the matching PM.
+      const isResizeHandleTarget =
+        !readOnly &&
+        (target.classList.contains("layout-table-resize-handle") ||
+          target.classList.contains("layout-table-row-resize-handle") ||
+          target.classList.contains("layout-table-edge-handle-bottom") ||
+          target.classList.contains("layout-table-edge-handle-right"));
+      const resizeHfSlot = isResizeHandleTarget
+        ? findHfSlotForTarget(target)
+        : null;
+      const resizeViewForRead: EditorView | null = resizeHfSlot
+        ? (hfPMsRef.current?.getView(resizeHfSlot.rId) ?? null)
+        : hiddenPMRef.current.getView();
+
       // HF edit mode + click inside a painted HF slot → route to the persistent
       // hidden HF EditorView. The painter (not PM) is the visible HF renderer,
       // so we translate the click via clickToPositionDom (which inspects the
@@ -4376,7 +4402,7 @@ export function PagedEditor(
       // dispatch on the same surface. Cell drag inside an HF table seeds
       // cellDragAnchorPosRef with the HF cell position; the mousemove path
       // dispatches CellSelection on the HF view.
-      if (!readOnly && hfEditMode) {
+      if (!readOnly && hfEditMode && !isResizeHandleTarget) {
         const slot = findHfSlotForTarget(target);
         if (slot) {
           const hfView = hfPMsRef.current?.getView(slot.rId);
@@ -4446,6 +4472,9 @@ export function PagedEditor(
         e.preventDefault();
         e.stopPropagation();
         isResizingColumnRef.current = true;
+        resizingHfSurfaceRef.current = resizeHfSlot
+          ? { rId: resizeHfSlot.rId, kind: resizeHfSlot.kind }
+          : null;
         resizeStartXRef.current = e.clientX;
         resizeHandleRef.current = target;
         target.classList.add("dragging");
@@ -4460,8 +4489,7 @@ export function PagedEditor(
           10,
         );
 
-        // Get current column widths from the ProseMirror doc
-        const view = hiddenPMRef.current.getView();
+        const view = resizeViewForRead;
         if (view) {
           const $pos = view.state.doc.resolve(
             resizeTablePmStartRef.current + 1,
@@ -4496,6 +4524,9 @@ export function PagedEditor(
         e.preventDefault();
         e.stopPropagation();
         isResizingRowRef.current = true;
+        resizingHfSurfaceRef.current = resizeHfSlot
+          ? { rId: resizeHfSlot.rId, kind: resizeHfSlot.kind }
+          : null;
         resizeStartYRef.current = e.clientY;
         resizeRowHandleRef.current = target;
         resizeRowIsEdgeRef.current = target.dataset["isEdge"] === "bottom";
@@ -4508,8 +4539,7 @@ export function PagedEditor(
           10,
         );
 
-        // Get current row height from ProseMirror doc
-        const view = hiddenPMRef.current.getView();
+        const view = resizeViewForRead;
         if (view) {
           const $pos = view.state.doc.resolve(
             resizeRowTablePmStartRef.current + 1,
@@ -4552,6 +4582,9 @@ export function PagedEditor(
         e.preventDefault();
         e.stopPropagation();
         isResizingRightEdgeRef.current = true;
+        resizingHfSurfaceRef.current = resizeHfSlot
+          ? { rId: resizeHfSlot.rId, kind: resizeHfSlot.kind }
+          : null;
         resizeRightEdgeStartXRef.current = e.clientX;
         resizeRightEdgeHandleRef.current = target;
         target.classList.add("dragging");
@@ -4567,7 +4600,7 @@ export function PagedEditor(
         );
 
         // Get current last column width from ProseMirror doc
-        const view = hiddenPMRef.current.getView();
+        const view = resizeViewForRead;
         if (view) {
           const $pos = view.state.doc.resolve(
             resizeRightEdgePmStartRef.current + 1,
@@ -4921,8 +4954,13 @@ export function PagedEditor(
         resizeHandleRef.current = null;
       }
 
-      // Update ProseMirror document with new column widths
-      const view = hiddenPMRef.current?.getView();
+      // Update ProseMirror document with new column widths. Commit on the
+      // HF view if the resize started inside an HF slot, else body.
+      const view =
+        (resizingHfSurfaceRef.current
+          ? hfPMsRef.current?.getView(resizingHfSurfaceRef.current.rId)
+          : hiddenPMRef.current?.getView()) ?? null;
+      resizingHfSurfaceRef.current = null;
       if (view) {
         const pmStart = resizeTablePmStartRef.current;
         const colIdx = resizeColumnIndexRef.current;
@@ -4994,7 +5032,11 @@ export function PagedEditor(
         resizeRowHandleRef.current = null;
       }
 
-      const view = hiddenPMRef.current?.getView();
+      const view =
+        (resizingHfSurfaceRef.current
+          ? hfPMsRef.current?.getView(resizingHfSurfaceRef.current.rId)
+          : hiddenPMRef.current?.getView()) ?? null;
+      resizingHfSurfaceRef.current = null;
       if (view) {
         const pmStart = resizeRowTablePmStartRef.current;
         const rowIdx = resizeRowIndexRef.current;
@@ -5042,7 +5084,11 @@ export function PagedEditor(
         resizeRightEdgeHandleRef.current = null;
       }
 
-      const view = hiddenPMRef.current?.getView();
+      const view =
+        (resizingHfSurfaceRef.current
+          ? hfPMsRef.current?.getView(resizingHfSurfaceRef.current.rId)
+          : hiddenPMRef.current?.getView()) ?? null;
+      resizingHfSurfaceRef.current = null;
       if (view) {
         const pmStart = resizeRightEdgePmStartRef.current;
         const colIdx = resizeRightEdgeColIndexRef.current;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3897,11 +3897,17 @@ export function PagedEditor(
     [document, scheduleLayout],
   );
 
-  // Clear HF caret state on exit from HF edit mode.
+  // Clear HF caret state + cross-surface drag state on any hfEditMode
+  // transition. Without this, dragAnchorRef leftover from the previous
+  // surface lets a Shift-click resolve an anchor in the wrong PM
+  // (e.g. body anchor used as the HF range start, or vice versa) and
+  // produces a nonsense selection.
   useEffect(() => {
     if (!hfEditMode) {
       setHfCaretSelection(null);
     }
+    dragAnchorRef.current = null;
+    activeHfDragSurfaceRef.current = null;
   }, [hfEditMode]);
 
   /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -42,6 +42,7 @@ import {
   findBodyPmAnchors,
   findBodyPmSpans,
 } from "../core/layout-bridge/findBodyPmSpans";
+import { findHfSlotForTarget } from "../core/layout-bridge/findHfPmSpans";
 import {
   collectFootnoteRefs,
   buildFootnoteContentMap,
@@ -312,6 +313,12 @@ export type PagedEditorRef = {
   getState(): EditorState | null;
   /** Get the ProseMirror EditorView. */
   getView(): EditorView | null;
+  /**
+   * Look up the persistent hidden HF EditorView by `rId`. Returns null when
+   * the slot isn't mounted (e.g. document has no HF for that rId, or the
+   * hidden host hasn't mounted yet).
+   */
+  getHfView(rId: string): EditorView | null;
   /**
    * Force-create the hidden editor view if it has been deferred.
    * Use from surfaces that need a live view before any user
@@ -4182,6 +4189,39 @@ export function PagedEditor(
         }
       }
 
+      // HF edit mode + click inside a painted HF slot → route to the persistent
+      // hidden HF EditorView. The painter (not PM) is the visible HF renderer,
+      // so we translate the click via clickToPositionDom (which inspects the
+      // painted span's data-pm-start/end markers) and dispatch the resulting
+      // PM position on the matching hidden view. Skipping the body click flow
+      // here keeps `hiddenPMRef.current.setSelection(0)` from firing on
+      // every HF click and stealing focus into the body editor.
+      if (!readOnly && hfEditMode) {
+        const slot = findHfSlotForTarget(target);
+        if (slot) {
+          const hfView = hfPMsRef.current?.getView(slot.rId);
+          if (hfView) {
+            e.preventDefault();
+            const pos = clickToPositionDom(
+              pagesContainerRef.current ?? slot.element,
+              e.clientX,
+              e.clientY,
+              zoom,
+            );
+            if (pos !== null) {
+              const docEnd = hfView.state.doc.content.size;
+              const clamped = Math.max(0, Math.min(pos, docEnd));
+              const $pos = hfView.state.doc.resolve(clamped);
+              hfView.dispatch(
+                hfView.state.tr.setSelection(TextSelection.near($pos)),
+              );
+            }
+            hfView.focus();
+            return;
+          }
+        }
+      }
+
       // In normal mode, clicks in header/footer area should place cursor at
       // start of body content, not inside header/footer (matches Word/Google Docs)
       if (!readOnly && !hfEditMode) {
@@ -5864,6 +5904,9 @@ export function PagedEditor(
       },
       getView() {
         return hiddenPMRef.current?.getView() ?? null;
+      },
+      getHfView(rId: string) {
+        return hfPMsRef.current?.getView(rId) ?? null;
       },
       ensureView(options?: { focus?: boolean }) {
         // Async (no flushSync) so this is safe to call from a consumer's

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -617,34 +617,77 @@ function HfCaretOverlay({
   selection: HfCaretSelection;
   pagesContainer: HTMLDivElement | null;
 }) {
-  const [rect, setRect] = useState<{
+  const [caret, setCaret] = useState<{
     x: number;
     y: number;
     height: number;
   } | null>(null);
+  const [rangeRects, setRangeRects] = useState<
+    { x: number; y: number; width: number; height: number }[]
+  >([]);
 
   useEffect(() => {
     if (!pagesContainer) {
       return;
     }
     const recompute = () => {
-      const anchor = findHfPmAnchor(
-        pagesContainer,
-        selection.kind,
-        selection.rId,
-        selection.from,
-      );
-      if (!anchor) {
-        setRect(null);
+      const cr = pagesContainer.getBoundingClientRect();
+      const collapsed = selection.from === selection.to;
+      if (collapsed) {
+        const anchor = findHfPmAnchor(
+          pagesContainer,
+          selection.kind,
+          selection.rId,
+          selection.from,
+        );
+        if (!anchor) {
+          setCaret(null);
+          setRangeRects([]);
+          return;
+        }
+        const ar = anchor.getBoundingClientRect();
+        setCaret({
+          x: ar.left - cr.left,
+          y: ar.top - cr.top,
+          height: ar.height || 16,
+        });
+        setRangeRects([]);
         return;
       }
-      const ar = anchor.getBoundingClientRect();
-      const cr = pagesContainer.getBoundingClientRect();
-      setRect({
-        x: ar.left - cr.left,
-        y: ar.top - cr.top,
-        height: ar.height || 16,
-      });
+      // Range selection — walk every painted pm span inside the slot
+      // and project the union of those whose [pmStart,pmEnd] intersect
+      // [from,to). The painter emits one span per run so this is good
+      // enough for single-line and multi-line highlights without doing
+      // glyph-level math (Word's selection model is paragraph-line-based
+      // — same convention).
+      const slotSelector =
+        selection.kind === "header"
+          ? `.layout-page-header[data-rid="${selection.rId}"]`
+          : `.layout-page-footer[data-rid="${selection.rId}"]`;
+      const spans = pagesContainer.querySelectorAll<HTMLElement>(
+        `${slotSelector} span[data-pm-start][data-pm-end]`,
+      );
+      const rects: { x: number; y: number; width: number; height: number }[] =
+        [];
+      for (const span of spans) {
+        const spanStart = Number.parseInt(span.dataset["pmStart"] ?? "", 10);
+        const spanEnd = Number.parseInt(span.dataset["pmEnd"] ?? "", 10);
+        if (!Number.isFinite(spanStart) || !Number.isFinite(spanEnd)) {
+          continue;
+        }
+        if (spanEnd <= selection.from || spanStart >= selection.to) {
+          continue;
+        }
+        const r = span.getBoundingClientRect();
+        rects.push({
+          x: r.left - cr.left,
+          y: r.top - cr.top,
+          width: r.width,
+          height: r.height,
+        });
+      }
+      setRangeRects(rects);
+      setCaret(null);
     };
     recompute();
     const onPainted = () => recompute();
@@ -654,24 +697,41 @@ function HfCaretOverlay({
     };
   }, [selection, pagesContainer]);
 
-  if (!rect) {
-    return null;
-  }
   return (
-    <div
-      data-testid="hf-caret"
-      style={{
-        position: "absolute",
-        left: rect.x,
-        top: rect.y,
-        width: 2,
-        height: rect.height,
-        backgroundColor: "var(--doc-canvas-text, #000)",
-        pointerEvents: "none",
-        zIndex: 11,
-        animation: "folio-caret-blink 1060ms steps(1, end) infinite",
-      }}
-    />
+    <>
+      {rangeRects.map((r, i) => (
+        <div
+          key={`hf-sel-${i}-${r.x}-${r.y}-${r.width}`}
+          data-testid="hf-selection-rect"
+          style={{
+            position: "absolute",
+            left: r.x,
+            top: r.y,
+            width: r.width,
+            height: r.height,
+            backgroundColor: "var(--doc-selection, rgba(66, 133, 244, 0.3))",
+            pointerEvents: "none",
+            zIndex: 10,
+          }}
+        />
+      ))}
+      {caret && (
+        <div
+          data-testid="hf-caret"
+          style={{
+            position: "absolute",
+            left: caret.x,
+            top: caret.y,
+            width: 2,
+            height: caret.height,
+            backgroundColor: "var(--doc-canvas-text, #000)",
+            pointerEvents: "none",
+            zIndex: 11,
+            animation: "folio-caret-blink 1060ms steps(1, end) infinite",
+          }}
+        />
+      )}
+    </>
   );
 }
 
@@ -2363,6 +2423,14 @@ export function PagedEditor(
   // Drag selection state
   const isDraggingRef = useRef(false);
   const dragAnchorRef = useRef<number | null>(null);
+  // When the drag originated inside a painted HF slot, the anchor lives in
+  // that slot's PM (`hfPMsRef.current.getView(rId)`), not the body PM. The
+  // pointer pipeline reads this on every mousemove + on shift-click extend
+  // so drag-select / shift-extend dispatch on the right surface.
+  const activeHfDragSurfaceRef = useRef<{
+    rId: string;
+    kind: "header" | "footer";
+  } | null>(null);
 
   const ensureHiddenEditorView = useCallback(
     ({ focus = true, sync = false }: EnsureHiddenEditorViewOptions = {}) => {
@@ -4295,9 +4363,9 @@ export function PagedEditor(
       // hidden HF EditorView. The painter (not PM) is the visible HF renderer,
       // so we translate the click via clickToPositionDom (which inspects the
       // painted span's data-pm-start/end markers) and dispatch the resulting
-      // PM position on the matching hidden view. Skipping the body click flow
-      // here keeps `hiddenPMRef.current.setSelection(0)` from firing on
-      // every HF click and stealing focus into the body editor.
+      // PM position on the matching hidden view. The drag-extend / shift-click
+      // refs are populated here too so subsequent mousemove + handlePagesClick
+      // dispatch on the same surface.
       if (!readOnly && hfEditMode) {
         const slot = findHfSlotForTarget(target);
         if (slot) {
@@ -4313,10 +4381,28 @@ export function PagedEditor(
             if (pos !== null) {
               const docEnd = hfView.state.doc.content.size;
               const clamped = Math.max(0, Math.min(pos, docEnd));
-              const $pos = hfView.state.doc.resolve(clamped);
-              hfView.dispatch(
-                hfView.state.tr.setSelection(TextSelection.near($pos)),
-              );
+              if (e.shiftKey && dragAnchorRef.current !== null) {
+                const $anchor = hfView.state.doc.resolve(
+                  Math.max(0, Math.min(dragAnchorRef.current, docEnd)),
+                );
+                const $head = hfView.state.doc.resolve(clamped);
+                hfView.dispatch(
+                  hfView.state.tr.setSelection(
+                    TextSelection.between($anchor, $head),
+                  ),
+                );
+              } else {
+                const $pos = hfView.state.doc.resolve(clamped);
+                hfView.dispatch(
+                  hfView.state.tr.setSelection(TextSelection.near($pos)),
+                );
+                dragAnchorRef.current = clamped;
+              }
+              isDraggingRef.current = true;
+              activeHfDragSurfaceRef.current = {
+                rId: slot.rId,
+                kind: slot.kind,
+              };
             }
             hfView.focus();
             return;
@@ -4551,6 +4637,31 @@ export function PagedEditor(
     if (!isDraggingRef.current || dragAnchorRef.current === null) {
       return;
     }
+    const hfSurface = activeHfDragSurfaceRef.current;
+    if (hfSurface) {
+      const hfView = hfPMsRef.current?.getView(hfSurface.rId);
+      if (!hfView) {
+        return;
+      }
+      const pmPos = clickToPositionDom(
+        pagesContainerRef.current ?? hfView.dom,
+        cx,
+        cy,
+        zoom,
+      );
+      if (pmPos === null) {
+        return;
+      }
+      const docEnd = hfView.state.doc.content.size;
+      const anchor = Math.max(0, Math.min(dragAnchorRef.current, docEnd));
+      const head = Math.max(0, Math.min(pmPos, docEnd));
+      const $anchor = hfView.state.doc.resolve(anchor);
+      const $head = hfView.state.doc.resolve(head);
+      hfView.dispatch(
+        hfView.state.tr.setSelection(TextSelection.between($anchor, $head)),
+      );
+      return;
+    }
     if (!hiddenPMRef.current) {
       return;
     }
@@ -4643,6 +4754,16 @@ export function PagedEditor(
 
       // Auto-scroll when dragging near viewport edges
       updateDragScroll(e.clientX, e.clientY);
+
+      // HF drag: route the rest of the mousemove through the active HF PM.
+      // We skip the body's cell-select / link-anchor logic — none of it
+      // applies in the HF surface — and let dragExtendRef handle the
+      // selection dispatch on the HF view. The painter then repaints via
+      // the HF caret overlay.
+      if (activeHfDragSurfaceRef.current) {
+        dragExtendRef.current(e.clientX, e.clientY);
+        return;
+      }
 
       const pmPos = getPositionFromMouse(e.clientX, e.clientY);
       if (pmPos === null) {
@@ -4912,6 +5033,7 @@ export function PagedEditor(
     isCellDraggingRef.current = false;
     cellDragLastPmPosRef.current = null;
     cellDragOverflowXRef.current = null;
+    activeHfDragSurfaceRef.current = null;
     stopDragAutoScroll();
     // Keep dragAnchorRef for potential shift-click extension
   }, [stopDragAutoScroll]);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3865,7 +3865,11 @@ export function PagedEditor(
       if (docChanged) {
         const pkg = document?.package;
         if (pkg) {
-          const hf = pkg.headers?.get(rId) ?? pkg.footers?.get(rId);
+          // Use the kind parameter, not a fallback chain — defensive
+          // against any pathological document that registers the same
+          // rId under both headers and footers.
+          const bag = kind === "header" ? pkg.headers : pkg.footers;
+          const hf = bag?.get(rId);
           if (hf) {
             hf.content = proseDocToBlocks(view.state.doc);
           }

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -621,9 +621,11 @@ type HfCaretSelection = {
 function HfCaretOverlay({
   selection,
   pagesContainer,
+  zoom,
 }: {
   selection: HfCaretSelection;
   pagesContainer: HTMLDivElement | null;
+  zoom: number;
 }) {
   const [caret, setCaret] = useState<{
     x: number;
@@ -640,6 +642,14 @@ function HfCaretOverlay({
     }
     const recompute = () => {
       const cr = pagesContainer.getBoundingClientRect();
+      // getBoundingClientRect reports post-transform viewport pixels;
+      // the caret divs live inside pagesContainer where CSS lengths
+      // get scaled by the viewport's `transform: scale(zoom)`. At
+      // 1.5× a 100px text offset would land at 150px on screen if
+      // written through unchanged, but writing it as CSS lets the
+      // parent transform scale it AGAIN to 225px — so divide every
+      // delta by zoom before passing to style (Codex #487 P2: 22:16).
+      const zoomDivisor = zoom !== 0 ? zoom : 1;
       // Scope every lookup to the specific painted page the user is
       // editing. When a default HF rId is shared across N pages we'd
       // otherwise paint the caret on the first matching slot (page 1)
@@ -668,11 +678,12 @@ function HfCaretOverlay({
           return;
         }
         const ar = hit.element.getBoundingClientRect();
-        const x = (hit.edge === "right" ? ar.right : ar.left) - cr.left;
+        const x =
+          ((hit.edge === "right" ? ar.right : ar.left) - cr.left) / zoomDivisor;
         setCaret({
           x,
-          y: ar.top - cr.top,
-          height: ar.height || 16,
+          y: (ar.top - cr.top) / zoomDivisor,
+          height: (ar.height || 16) / zoomDivisor,
         });
         setRangeRects([]);
         return;
@@ -703,10 +714,10 @@ function HfCaretOverlay({
         }
         const r = span.getBoundingClientRect();
         rects.push({
-          x: r.left - cr.left,
-          y: r.top - cr.top,
-          width: r.width,
-          height: r.height,
+          x: (r.left - cr.left) / zoomDivisor,
+          y: (r.top - cr.top) / zoomDivisor,
+          width: r.width / zoomDivisor,
+          height: r.height / zoomDivisor,
         });
       }
       setRangeRects(rects);
@@ -729,6 +740,7 @@ function HfCaretOverlay({
     selection.to,
     selection.pageNumber,
     pagesContainer,
+    zoom,
   ]);
 
   if (!pagesContainer) {
@@ -4503,6 +4515,14 @@ export function PagedEditor(
           const hfView = hfPMsRef.current?.getView(slot.rId);
           if (hfView) {
             e.preventDefault();
+            // Stop the click from bubbling to `handleContainerMouseDown`.
+            // The painted slot is `.layout-page-header` /
+            // `.layout-page-footer`, which is NOT an `[data-hf-r-id]`
+            // descendant; the existing container guard would miss this
+            // path and `focusHiddenEditor()` would steal focus to the
+            // body editor immediately after we focused the HF view
+            // (Codex #487 P1: 22:16 review).
+            e.stopPropagation();
             // Slot-scoped mapper so a whitespace click inside the painted
             // header / footer can't fall through to clickToPositionDom's
             // body-content nearest-span path (Codex #487 P2: 21:02).
@@ -6808,6 +6828,7 @@ export function PagedEditor(
             <HfCaretOverlay
               selection={hfCaretSelection}
               pagesContainer={pagesContainerRef.current}
+              zoom={zoom}
             />
           )}
           {layout &&

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -42,7 +42,10 @@ import {
   findBodyPmAnchors,
   findBodyPmSpans,
 } from "../core/layout-bridge/findBodyPmSpans";
-import { findHfSlotForTarget } from "../core/layout-bridge/findHfPmSpans";
+import {
+  findHfPmAnchor,
+  findHfSlotForTarget,
+} from "../core/layout-bridge/findHfPmSpans";
 import {
   collectFootnoteRefs,
   buildFootnoteContentMap,
@@ -102,6 +105,7 @@ import { LayoutPainter } from "../core/layout-painter";
 import type { BlockLookup } from "../core/layout-painter";
 import {
   findPageShellForPmPos,
+  PAINTER_PAINTED_EVENT,
   renderPages,
 } from "../core/layout-painter/renderPage";
 import type {
@@ -595,6 +599,81 @@ const loadSelectionGeometry = (): Promise<SelectionGeometryModule> => {
 
   return selectionGeometryPromise;
 };
+
+// HF caret overlay — minimal "paint the caret + selection rects for the
+// currently focused HF PM" implementation. Re-runs the DOM lookup on each
+// painter:painted event and whenever the selection changes.
+type HfCaretSelection = {
+  rId: string;
+  kind: "header" | "footer";
+  from: number;
+  to: number;
+};
+
+function HfCaretOverlay({
+  selection,
+  pagesContainer,
+}: {
+  selection: HfCaretSelection;
+  pagesContainer: HTMLDivElement | null;
+}) {
+  const [rect, setRect] = useState<{
+    x: number;
+    y: number;
+    height: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!pagesContainer) {
+      return;
+    }
+    const recompute = () => {
+      const anchor = findHfPmAnchor(
+        pagesContainer,
+        selection.kind,
+        selection.rId,
+        selection.from,
+      );
+      if (!anchor) {
+        setRect(null);
+        return;
+      }
+      const ar = anchor.getBoundingClientRect();
+      const cr = pagesContainer.getBoundingClientRect();
+      setRect({
+        x: ar.left - cr.left,
+        y: ar.top - cr.top,
+        height: ar.height || 16,
+      });
+    };
+    recompute();
+    const onPainted = () => recompute();
+    pagesContainer.addEventListener(PAINTER_PAINTED_EVENT, onPainted);
+    return () => {
+      pagesContainer.removeEventListener(PAINTER_PAINTED_EVENT, onPainted);
+    };
+  }, [selection, pagesContainer]);
+
+  if (!rect) {
+    return null;
+  }
+  return (
+    <div
+      data-testid="hf-caret"
+      style={{
+        position: "absolute",
+        left: rect.x,
+        top: rect.y,
+        width: 2,
+        height: rect.height,
+        backgroundColor: "var(--doc-canvas-text, #000)",
+        pointerEvents: "none",
+        zIndex: 11,
+        animation: "folio-caret-blink 1060ms steps(1, end) infinite",
+      }}
+    />
+  );
+}
 
 // Source HeaderFooterContent for the painter from either a persistent hidden
 // HF EditorView (preferred — keeps the painter in lockstep with live PM edits)
@@ -3693,25 +3772,48 @@ export function PagedEditor(
    *      state; the HF blocks are pulled from the HF PM via
    *      `renderHfFromContentOrPm` on the next layout tick.
    */
+  const [hfCaretSelection, setHfCaretSelection] = useState<{
+    rId: string;
+    kind: "header" | "footer";
+    from: number;
+    to: number;
+  } | null>(null);
+
   const handleHfPmTransaction = useCallback(
-    (rId: string, view: EditorView, docChanged: boolean) => {
-      if (!docChanged) {
-        return;
-      }
-      const pkg = document?.package;
-      if (pkg) {
-        const hf = pkg.headers?.get(rId) ?? pkg.footers?.get(rId);
-        if (hf) {
-          hf.content = proseDocToBlocks(view.state.doc);
+    (
+      rId: string,
+      kind: "header" | "footer",
+      view: EditorView,
+      docChanged: boolean,
+      selectionChanged: boolean,
+    ) => {
+      if (docChanged) {
+        const pkg = document?.package;
+        if (pkg) {
+          const hf = pkg.headers?.get(rId) ?? pkg.footers?.get(rId);
+          if (hf) {
+            hf.content = proseDocToBlocks(view.state.doc);
+          }
+        }
+        const bodyState = hiddenPMRef.current?.getState();
+        if (bodyState) {
+          scheduleLayout(bodyState, null);
         }
       }
-      const bodyState = hiddenPMRef.current?.getState();
-      if (bodyState) {
-        scheduleLayout(bodyState, null);
+      if (docChanged || selectionChanged) {
+        const { from, to } = view.state.selection;
+        setHfCaretSelection({ rId, kind, from, to });
       }
     },
     [document, scheduleLayout],
   );
+
+  // Clear HF caret state on exit from HF edit mode.
+  useEffect(() => {
+    if (!hfEditMode) {
+      setHfCaretSelection(null);
+    }
+  }, [hfEditMode]);
 
   /**
    * Handle selection change from PM.
@@ -6176,6 +6278,19 @@ export function PagedEditor(
             isFocused={isFocused}
             pageGap={pageGap}
           />
+          {/* HF caret overlay — draws the caret + selection rects for the
+              focused persistent hidden HF EditorView. Painted DOM is the
+              source of truth: we walk findHfPmAnchor markers under
+              .layout-page-header[data-rid] / .layout-page-footer[data-rid]
+              and project the rects relative to the pages container. The
+              `painter:painted` and `hfCaretSelection` change events both
+              re-run the lookup. */}
+          {hfCaretSelection && (
+            <HfCaretOverlay
+              selection={hfCaretSelection}
+              pagesContainer={pagesContainerRef.current}
+            />
+          )}
           {layout &&
             remoteSelections.map((remoteSelection) => (
               <RemoteSelectionOverlay

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5516,8 +5516,17 @@ export function PagedEditor(
         return;
       }
 
-      // Double-click on header/footer area triggers editing mode
-      if (!readOnly && e.detail === 2 && onHeaderFooterDoubleClick) {
+      // Double-click on header/footer area enters editing mode. Gate on
+      // `!hfEditMode` so a double-click *while already editing* falls
+      // through to the active-HF word/paragraph-select branch below
+      // instead of pointlessly re-firing `onHeaderFooterDoubleClick`
+      // (Codex #487 P2: 21:49 review).
+      if (
+        !readOnly &&
+        !hfEditMode &&
+        e.detail === 2 &&
+        onHeaderFooterDoubleClick
+      ) {
         const headerEl = target.closest(".layout-page-header");
         const footerEl = target.closest(".layout-page-footer");
         if (headerEl || footerEl) {

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -901,6 +901,17 @@ type LayoutInputSignatureOptions = {
   firstPageHeaderContent: HeaderFooter | null | undefined;
   footerContent: HeaderFooter | null | undefined;
   headerContent: HeaderFooter | null | undefined;
+  // Active rId per HF slot. Switching to a different HF part with
+  // identical content + height previously left the layout signature
+  // unchanged so the painter incremental path skipped repaint and the
+  // old `data-rid` lingered in the DOM, routing clicks to a stale HF
+  // view (Codex #487 P2: 22:48 review). Including the rId guarantees a
+  // relayout when the slot's owning rId changes even if the rendered
+  // content is byte-equivalent.
+  headerContentRId: string | null | undefined;
+  footerContentRId: string | null | undefined;
+  firstPageHeaderContentRId: string | null | undefined;
+  firstPageFooterContentRId: string | null | undefined;
   margins: PageMargins;
   pageGap: number;
   pageSize: { h: number; w: number };
@@ -2759,6 +2770,10 @@ export function PagedEditor(
         firstPageHeaderContent,
         footerContent,
         headerContent,
+        headerContentRId,
+        footerContentRId,
+        firstPageHeaderContentRId,
+        firstPageFooterContentRId,
         margins,
         pageGap,
         pageSize,
@@ -2774,6 +2789,10 @@ export function PagedEditor(
       firstPageHeaderContent,
       footerContent,
       headerContent,
+      headerContentRId,
+      footerContentRId,
+      firstPageHeaderContentRId,
+      firstPageFooterContentRId,
       margins,
       pageGap,
       pageSize,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -695,7 +695,17 @@ function HfCaretOverlay({
     return () => {
       pagesContainer.removeEventListener(PAINTER_PAINTED_EVENT, onPainted);
     };
-  }, [selection, pagesContainer]);
+    // Destructure selection so the effect only re-runs when a field
+    // actually changes; otherwise every handleHfPmTransaction-driven
+    // setHfCaretSelection allocates a new object and we'd churn the
+    // DOM lookup + getBoundingClientRect chain on every keystroke.
+  }, [
+    selection.rId,
+    selection.kind,
+    selection.from,
+    selection.to,
+    pagesContainer,
+  ]);
 
   return (
     <>

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -43,7 +43,7 @@ import {
   findBodyPmSpans,
 } from "../core/layout-bridge/findBodyPmSpans";
 import {
-  findHfPmAnchor,
+  findHfCaretSpan,
   findHfSlotForTarget,
 } from "../core/layout-bridge/findHfPmSpans";
 import {
@@ -633,20 +633,26 @@ function HfCaretOverlay({
       const cr = pagesContainer.getBoundingClientRect();
       const collapsed = selection.from === selection.to;
       if (collapsed) {
-        const anchor = findHfPmAnchor(
+        // Use findHfCaretSpan so a caret at the end of a run / paragraph
+        // (selection.from == span's data-pm-end) still finds a span to
+        // anchor to — exact data-pm-start matching alone would lose the
+        // caret as soon as the user typed to the end of their text
+        // (Codex #487 P2: 20:32 review).
+        const hit = findHfCaretSpan(
           pagesContainer,
           selection.kind,
           selection.rId,
           selection.from,
         );
-        if (!anchor) {
+        if (!hit) {
           setCaret(null);
           setRangeRects([]);
           return;
         }
-        const ar = anchor.getBoundingClientRect();
+        const ar = hit.element.getBoundingClientRect();
+        const x = (hit.edge === "right" ? ar.right : ar.left) - cr.left;
         setCaret({
-          x: ar.left - cr.left,
+          x,
           y: ar.top - cr.top,
           height: ar.height || 16,
         });

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5712,6 +5712,18 @@ export function PagedEditor(
               const clamped = Math.max(0, Math.min(pos, docEnd));
               const $pos = hfView.state.doc.resolve(clamped);
               const parent = $pos.parent;
+              // Set page scope BEFORE the dispatch — view.dispatch
+              // synchronously fires handleHfPmTransaction, which reads
+              // activeHfPageNumberRef.current to stamp the new
+              // HfCaretSelection. Without this, double / triple-click
+              // word / paragraph selection on a later page would
+              // render the highlight on the first matching painted
+              // instance (Codex #487 P2: 23:09 review).
+              const pageEl = slot.element.closest<HTMLElement>(".layout-page");
+              const pageNumStr = pageEl?.dataset["pageNumber"];
+              activeHfPageNumberRef.current = pageNumStr
+                ? Number.parseInt(pageNumStr, 10)
+                : null;
               if (e.detail === 3) {
                 const start = $pos.start($pos.depth);
                 const end = $pos.end($pos.depth);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5275,10 +5275,19 @@ export function PagedEditor(
             }
           }
         } else if (onHyperlinkClick) {
-          // External hyperlink — show popup only if not a drag-to-select
-          const view = hiddenPMRef.current?.getView();
+          // External hyperlink — show popup only if not a drag-to-select.
+          // Check the active surface's selection: when the user is editing
+          // an HF and clicks a link inside that slot, we read HF PM
+          // selection state, not body. Without this fix, a single-click
+          // on an HF hyperlink while a body range was selected would
+          // incorrectly suppress the popup.
+          const hfSlot = hfEditMode ? findHfSlotForTarget(target) : null;
+          const surfaceView =
+            (hfSlot ? hfPMsRef.current?.getView(hfSlot.rId) : null) ??
+            hiddenPMRef.current?.getView();
           const hasRangeSelection =
-            view && view.state.selection.from !== view.state.selection.to;
+            surfaceView &&
+            surfaceView.state.selection.from !== surfaceView.state.selection.to;
           if (!hasRangeSelection) {
             const displayText = anchorEl.textContent || "";
             const tooltip = anchorEl.getAttribute("title") || undefined;

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5989,6 +5989,20 @@ export function PagedEditor(
         return;
       }
 
+      // Don't take over keydown events that originated inside a persistent
+      // hidden HF EditorView — the HF PM has its own native handlers, and
+      // the body-PM routing below would steal focus + dispatch into the
+      // body editor (e.g. Space scrolling to the body, the first typed key
+      // landing under the cursor in the document instead of the active
+      // HF). Mirrors the focus / mousedown guards in handleContainerFocus
+      // and handleContainerMouseDown (Codex #487 P1: 21:12 review).
+      if (
+        e.target instanceof HTMLElement &&
+        e.target.closest("[data-hf-r-id]")
+      ) {
+        return;
+      }
+
       let view = hiddenPMRef.current?.getView();
       if (!view) {
         ensureHiddenEditorView({ sync: true });

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -5317,6 +5317,83 @@ export function PagedEditor(
         }
       }
 
+      // Double / triple-click inside an active HF slot routes word /
+      // paragraph selection to the matching hidden HF EditorView instead of
+      // the body PM. We re-resolve the slot from the target so the
+      // selection lands on the right surface even when this handler fires
+      // before any prior HF click set drag state.
+      if (
+        !readOnly &&
+        hfEditMode &&
+        (e.detail === 2 || e.detail === 3) &&
+        hfPMsRef.current
+      ) {
+        const slot = findHfSlotForTarget(target);
+        if (slot) {
+          const hfView = hfPMsRef.current.getView(slot.rId);
+          if (hfView) {
+            const pos = clickToPositionDom(
+              pagesContainerRef.current ?? slot.element,
+              e.clientX,
+              e.clientY,
+              zoom,
+            );
+            if (pos !== null) {
+              const docEnd = hfView.state.doc.content.size;
+              const clamped = Math.max(0, Math.min(pos, docEnd));
+              const $pos = hfView.state.doc.resolve(clamped);
+              const parent = $pos.parent;
+              if (e.detail === 3) {
+                const start = $pos.start($pos.depth);
+                const end = $pos.end($pos.depth);
+                hfView.dispatch(
+                  hfView.state.tr.setSelection(
+                    TextSelection.create(hfView.state.doc, start, end),
+                  ),
+                );
+              } else if (parent.isTextblock) {
+                const pmAlignedParts: string[] = [];
+                for (let i = 0; i < parent.content.childCount; i++) {
+                  const node = parent.content.child(i);
+                  pmAlignedParts.push(
+                    node.isText ? (node.text ?? "") : " ".repeat(node.nodeSize),
+                  );
+                }
+                const pmAlignedText = pmAlignedParts.join("");
+                const offset = $pos.parentOffset;
+                let start = offset;
+                while (
+                  start > 0 &&
+                  /\w/u.test(pmAlignedText[start - 1]!) // SAFETY: start > 0
+                ) {
+                  start--;
+                }
+                let end = offset;
+                while (
+                  end < pmAlignedText.length &&
+                  /\w/u.test(pmAlignedText[end]!) // SAFETY: end < pmAlignedText.length
+                ) {
+                  end++;
+                }
+                const absStart = $pos.start() + start;
+                const absEnd = $pos.start() + end;
+                if (absStart < absEnd) {
+                  hfView.dispatch(
+                    hfView.state.tr.setSelection(
+                      TextSelection.create(hfView.state.doc, absStart, absEnd),
+                    ),
+                  );
+                }
+              }
+              hfView.focus();
+              e.preventDefault();
+              e.stopPropagation();
+            }
+            return;
+          }
+        }
+      }
+
       // Double-click: select entire cell (CellSelection) if in table, otherwise word selection
       if (e.detail === 2 && hiddenPMRef.current) {
         const pmPos = getPositionFromMouse(e.clientX, e.clientY);
@@ -5431,6 +5508,43 @@ export function PagedEditor(
 
       e.preventDefault();
 
+      // HF edit mode: route the right-click to the matching HF PM so the
+      // context menu reads HF selection state. Without this the menu would
+      // act on body PM state — wrong "has selection" flag and any caret
+      // move on right-click would land in the body.
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (!readOnly && hfEditMode && target) {
+        const slot = findHfSlotForTarget(target);
+        if (slot) {
+          const hfView = hfPMsRef.current?.getView(slot.rId);
+          if (hfView) {
+            const { from, to } = hfView.state.selection;
+            const pmPos = clickToPositionDom(
+              pagesContainerRef.current ?? slot.element,
+              e.clientX,
+              e.clientY,
+              zoom,
+            );
+            if (pmPos !== null && (from === to || pmPos < from || pmPos > to)) {
+              const docEnd = hfView.state.doc.content.size;
+              const clamped = Math.max(0, Math.min(pmPos, docEnd));
+              const $pos = hfView.state.doc.resolve(clamped);
+              hfView.dispatch(
+                hfView.state.tr.setSelection(TextSelection.near($pos)),
+              );
+              hfView.focus();
+            }
+            const after = hfView.state.selection;
+            onContextMenu({
+              x: e.clientX,
+              y: e.clientY,
+              hasSelection: after.from !== after.to,
+            });
+            return;
+          }
+        }
+      }
+
       const view = hiddenPMRef.current?.getView();
       if (!view) {
         return;
@@ -5439,15 +5553,12 @@ export function PagedEditor(
       const { from, to } = view.state.selection;
       const pmPos = getPositionFromMouse(e.clientX, e.clientY);
 
-      // If the right-click is within the existing selection, keep it
-      // Otherwise, move cursor to the right-click position
       if (pmPos !== null && (from === to || pmPos < from || pmPos > to)) {
         hiddenPMRef.current?.setSelection(pmPos);
         hiddenPMRef.current?.focus();
         setIsFocused(true);
       }
 
-      // Read updated selection state after potential change
       const updatedState = hiddenPMRef.current?.getState();
       const hasSelection = updatedState
         ? updatedState.selection.from !== updatedState.selection.to
@@ -5455,7 +5566,7 @@ export function PagedEditor(
 
       onContextMenu({ x: e.clientX, y: e.clientY, hasSelection });
     },
-    [onContextMenu, getPositionFromMouse],
+    [hfEditMode, onContextMenu, getPositionFromMouse, readOnly, zoom],
   );
 
   /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -4583,17 +4583,44 @@ export function PagedEditor(
         const pmStart = imageEl.dataset["pmStart"];
         if (pmStart !== undefined) {
           const pos = Number.parseInt(pmStart, 10);
-          if (hiddenPMRef.current.getView()) {
-            hiddenPMRef.current.setNodeSelection(pos);
+          // HF edit mode + image inside an HF slot: NodeSelect on the
+          // matching HF PM. Otherwise selection would land on body at
+          // an HF-doc position, which doesn't address a valid node and
+          // silently no-ops (or worse, picks an unrelated body node).
+          const hfSlot = hfEditMode ? findHfSlotForTarget(imageEl) : null;
+          const hfView = hfSlot ? hfPMsRef.current?.getView(hfSlot.rId) : null;
+          if (hfView) {
+            try {
+              hfView.dispatch(
+                hfView.state.tr.setSelection(
+                  NodeSelection.create(hfView.state.doc, pos),
+                ),
+              );
+            } catch {
+              // Pos didn't address a selectable node — fall back to a
+              // near text selection so the user still gets focus.
+              const $pos = hfView.state.doc.resolve(
+                Math.min(pos, hfView.state.doc.content.size),
+              );
+              hfView.dispatch(
+                hfView.state.tr.setSelection(TextSelection.near($pos)),
+              );
+            }
+            hfView.focus();
+            // Image selection chrome is body-only today; HF image select
+            // shows browser-default selection ring. Tracked for follow-up.
           } else {
-            queueHiddenEditorSelection({ type: "node", pos });
+            if (hiddenPMRef.current.getView()) {
+              hiddenPMRef.current.setNodeSelection(pos);
+            } else {
+              queueHiddenEditorSelection({ type: "node", pos });
+            }
+            setSelectedImageInfo(buildImageSelectionInfo(imageEl, pos));
+            setSelectionRects([]);
+            setCaretPosition(null);
+            focusHiddenEditor();
           }
-          setSelectedImageInfo(buildImageSelectionInfo(imageEl, pos));
-          setSelectionRects([]);
-          setCaretPosition(null);
         }
-
-        focusHiddenEditor();
         return;
       }
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -43,6 +43,7 @@ import {
   findBodyPmSpans,
 } from "../core/layout-bridge/findBodyPmSpans";
 import {
+  clickToPositionInHfSlot,
   findHfCaretSpan,
   findHfSlotForTarget,
 } from "../core/layout-bridge/findHfPmSpans";
@@ -4456,11 +4457,15 @@ export function PagedEditor(
           const hfView = hfPMsRef.current?.getView(slot.rId);
           if (hfView) {
             e.preventDefault();
-            const pos = clickToPositionDom(
+            // Slot-scoped mapper so a whitespace click inside the painted
+            // header / footer can't fall through to clickToPositionDom's
+            // body-content nearest-span path (Codex #487 P2: 21:02).
+            const pos = clickToPositionInHfSlot(
               pagesContainerRef.current ?? slot.element,
+              slot.kind,
+              slot.rId,
               e.clientX,
               e.clientY,
-              zoom,
             );
             if (pos !== null) {
               const docEnd = hfView.state.doc.content.size;
@@ -4760,14 +4765,15 @@ export function PagedEditor(
     const hfSurface = activeHfDragSurfaceRef.current;
     if (hfSurface) {
       const hfView = hfPMsRef.current?.getView(hfSurface.rId);
-      if (!hfView) {
+      if (!hfView || !pagesContainerRef.current) {
         return;
       }
-      const pmPos = clickToPositionDom(
-        pagesContainerRef.current ?? hfView.dom,
+      const pmPos = clickToPositionInHfSlot(
+        pagesContainerRef.current,
+        hfSurface.kind,
+        hfSurface.rId,
         cx,
         cy,
-        zoom,
       );
       if (pmPos === null) {
         return;
@@ -4883,11 +4889,12 @@ export function PagedEditor(
         const hfSurface = activeHfDragSurfaceRef.current;
         const hfView = hfPMsRef.current?.getView(hfSurface.rId);
         if (hfView && cellDragAnchorPosRef.current !== null) {
-          const hfPos = clickToPositionDom(
+          const hfPos = clickToPositionInHfSlot(
             pagesContainerRef.current,
+            hfSurface.kind,
+            hfSurface.rId,
             e.clientX,
             e.clientY,
-            zoom,
           );
           if (hfPos !== null) {
             const currentCellPos = findCellPosInDoc(hfView.state.doc, hfPos);
@@ -4986,7 +4993,6 @@ export function PagedEditor(
       findCellPosFromPmPos,
       findCellPosInDoc,
       updateDragScroll,
-      zoom,
     ],
   );
 
@@ -5510,11 +5516,12 @@ export function PagedEditor(
         if (slot) {
           const hfView = hfPMsRef.current.getView(slot.rId);
           if (hfView) {
-            const pos = clickToPositionDom(
+            const pos = clickToPositionInHfSlot(
               pagesContainerRef.current ?? slot.element,
+              slot.kind,
+              slot.rId,
               e.clientX,
               e.clientY,
-              zoom,
             );
             if (pos !== null) {
               const docEnd = hfView.state.doc.content.size;
@@ -5697,11 +5704,12 @@ export function PagedEditor(
           const hfView = hfPMsRef.current?.getView(slot.rId);
           if (hfView) {
             const { from, to } = hfView.state.selection;
-            const pmPos = clickToPositionDom(
+            const pmPos = clickToPositionInHfSlot(
               pagesContainerRef.current ?? slot.element,
+              slot.kind,
+              slot.rId,
               e.clientX,
               e.clientY,
-              zoom,
             );
             if (pmPos !== null && (from === to || pmPos < from || pmPos > to)) {
               const docEnd = hfView.state.doc.content.size;
@@ -5744,7 +5752,7 @@ export function PagedEditor(
 
       onContextMenu({ x: e.clientX, y: e.clientY, hasSelection });
     },
-    [hfEditMode, onContextMenu, getPositionFromMouse, readOnly, zoom],
+    [hfEditMode, onContextMenu, getPositionFromMouse, readOnly],
   );
 
   /**

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -23,7 +23,7 @@ import React, {
   useImperativeHandle,
 } from "react";
 import type { CSSProperties, Ref } from "react";
-import { flushSync } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 
 import type { Mark, Node as PMNode } from "prosemirror-model";
 import { NodeSelection, TextSelection } from "prosemirror-state";
@@ -706,7 +706,17 @@ function HfCaretOverlay({
     pagesContainer,
   ]);
 
-  return (
+  if (!pagesContainer) {
+    return null;
+  }
+  // Portal into pagesContainer so the absolute-positioned caret + rects
+  // share the same containing block as the painted spans we measured
+  // against. Previously the JSX rendered as siblings of pagesContainer
+  // inside .paged-editor__viewport, which has VIEWPORT_PADDING_TOP +
+  // a scale transform applied — HF carets/rects drifted above the
+  // painted slot. Portalling restores positional alignment without
+  // changing the coordinate math.
+  return createPortal(
     <>
       {rangeRects.map((r, i) => (
         <div
@@ -740,7 +750,8 @@ function HfCaretOverlay({
           }}
         />
       )}
-    </>
+    </>,
+    pagesContainer,
   );
 }
 

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -678,12 +678,50 @@ function HfCaretOverlay({
           return;
         }
         const ar = hit.element.getBoundingClientRect();
-        const x =
-          ((hit.edge === "right" ? ar.right : ar.left) - cr.left) / zoomDivisor;
+        // Default to the span edge findHfCaretSpan returned. For mid-span
+        // text positions (clicked / arrowed into the middle of a run),
+        // sample the exact character X via the Range API so the caret
+        // lines up with the glyph the PM selection actually sits at — a
+        // bare edge anchor would paint at the run's left edge regardless
+        // of where the user clicked (Codex #487 P2: 22:38 review).
+        let absX = hit.edge === "right" ? ar.right : ar.left;
+        let absY = ar.top;
+        let absHeight = ar.height || 16;
+        const pmStartStr = hit.element.dataset["pmStart"];
+        const pmEndStr = hit.element.dataset["pmEnd"];
+        const pmStart = pmStartStr
+          ? Number.parseInt(pmStartStr, 10)
+          : Number.NaN;
+        const pmEnd = pmEndStr ? Number.parseInt(pmEndStr, 10) : Number.NaN;
+        if (
+          Number.isFinite(pmStart) &&
+          Number.isFinite(pmEnd) &&
+          selection.from > pmStart &&
+          selection.from < pmEnd
+        ) {
+          const textNode = hit.element.firstChild;
+          if (textNode && textNode.nodeType === Node.TEXT_NODE) {
+            const textContent = textNode.textContent ?? "";
+            const charOffset = Math.min(
+              selection.from - pmStart,
+              textContent.length,
+            );
+            const ownerDoc = hit.element.ownerDocument;
+            const range = ownerDoc.createRange();
+            range.setStart(textNode, charOffset);
+            range.setEnd(textNode, charOffset);
+            const rRect = range.getBoundingClientRect();
+            if (rRect.height > 0 || rRect.width > 0 || rRect.left > 0) {
+              absX = rRect.left;
+              absY = rRect.top;
+              absHeight = rRect.height || absHeight;
+            }
+          }
+        }
         setCaret({
-          x,
-          y: (ar.top - cr.top) / zoomDivisor,
-          height: (ar.height || 16) / zoomDivisor,
+          x: (absX - cr.left) / zoomDivisor,
+          y: (absY - cr.top) / zoomDivisor,
+          height: absHeight / zoomDivisor,
         });
         setRangeRects([]);
         return;
@@ -712,6 +750,38 @@ function HfCaretOverlay({
         if (spanEnd <= selection.from || spanStart >= selection.to) {
           continue;
         }
+        // For text-bearing spans, clip the highlight to the selected
+        // sub-range with the Range API instead of using the whole span
+        // bounding box. Without this a partial selection inside a run
+        // (double-clicking a word, dragging a few characters) painted
+        // the entire run as selected (Codex #487 P2: 22:38 review).
+        const textNode = span.firstChild;
+        if (textNode && textNode.nodeType === Node.TEXT_NODE) {
+          const textContent = textNode.textContent ?? "";
+          const startChar = Math.max(0, selection.from - spanStart);
+          const endChar = Math.min(
+            textContent.length,
+            selection.to - spanStart,
+          );
+          if (startChar < endChar) {
+            const ownerDoc = span.ownerDocument;
+            const range = ownerDoc.createRange();
+            range.setStart(textNode, startChar);
+            range.setEnd(textNode, endChar);
+            for (const cRect of Array.from(range.getClientRects())) {
+              rects.push({
+                x: (cRect.left - cr.left) / zoomDivisor,
+                y: (cRect.top - cr.top) / zoomDivisor,
+                width: cRect.width / zoomDivisor,
+                height: cRect.height / zoomDivisor,
+              });
+            }
+            continue;
+          }
+        }
+        // No text node (atom inline, image, etc.) — fall back to the
+        // span's full bounding rect; selection of the atom still paints
+        // visibly.
         const r = span.getBoundingClientRect();
         rects.push({
           x: (r.left - cr.left) / zoomDivisor,

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -4438,7 +4438,19 @@ export function PagedEditor(
       // dispatch on the same surface. Cell drag inside an HF table seeds
       // cellDragAnchorPosRef with the HF cell position; the mousemove path
       // dispatches CellSelection on the HF view.
-      if (!readOnly && hfEditMode && !isResizeHandleTarget) {
+      //
+      // Image targets are skipped here so the later findImageElement branch
+      // can dispatch NodeSelection.create on the matching HF view —
+      // without this guard the generic text-click flow would silently
+      // shadow the image NodeSelect path (Codex #487 P2, 20:40 review).
+      const isHfImageTarget =
+        !readOnly && hfEditMode && findImageElement(target) !== null;
+      if (
+        !readOnly &&
+        hfEditMode &&
+        !isResizeHandleTarget &&
+        !isHfImageTarget
+      ) {
         const slot = findHfSlotForTarget(target);
         if (slot) {
           const hfView = hfPMsRef.current?.getView(slot.rId);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -3915,7 +3915,24 @@ export function PagedEditor(
       // dispatchTransaction, so we only need to nudge the layout pipeline
       // and update HF caret + toolbar state here.
       if (docChanged) {
-        const bodyState = hiddenPMRef.current?.getState();
+        // The body HiddenProseMirror view may still be deferred when the
+        // user enters HF editing first (a doc opened without
+        // collaboration that hasn't been clicked into yet). The HF PMs
+        // are mounted unconditionally so an HF transaction can fire
+        // before any body view exists; without a bodyState
+        // `scheduleLayout` was a no-op and the painter never repainted
+        // the in-flight HF edit (Codex #487 P1: 21:59 review). Use the
+        // precomputed initial state when present, otherwise force-create
+        // the view via `ensureHiddenEditorView` so the next read returns
+        // a state.
+        let bodyState = hiddenPMRef.current?.getState();
+        if (!bodyState && precomputedInitialStateRef.current) {
+          bodyState = precomputedInitialStateRef.current;
+        }
+        if (!bodyState) {
+          ensureHiddenEditorView({ sync: true });
+          bodyState = hiddenPMRef.current?.getState();
+        }
         if (bodyState) {
           scheduleLayout(bodyState, null);
         }
@@ -3939,7 +3956,7 @@ export function PagedEditor(
         onSelectionChangeRef.current?.(from, to);
       }
     },
-    [scheduleLayout],
+    [scheduleLayout, ensureHiddenEditorView],
   );
 
   // Clear HF caret state + cross-surface drag state on any hfEditMode

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -125,7 +125,6 @@ import {
   mergeTableCellAttrs,
   mergeTableRowAttrs,
 } from "../core/prosemirror/attrs";
-import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { anonymizationDecorationsKey } from "../core/prosemirror/plugins/anonymizationDecorations";
 import type { AnonymizationMatch } from "../core/prosemirror/plugins/anonymizationDecorations";
@@ -3872,18 +3871,11 @@ export function PagedEditor(
       docChanged: boolean,
       selectionChanged: boolean,
     ) => {
+      // HiddenHeaderFooterPMs writes the new blocks into
+      // package.headers/footers[rId].content in place inside its own
+      // dispatchTransaction, so we only need to nudge the layout pipeline
+      // and update HF caret state here.
       if (docChanged) {
-        const pkg = document?.package;
-        if (pkg) {
-          // Use the kind parameter, not a fallback chain — defensive
-          // against any pathological document that registers the same
-          // rId under both headers and footers.
-          const bag = kind === "header" ? pkg.headers : pkg.footers;
-          const hf = bag?.get(rId);
-          if (hf) {
-            hf.content = proseDocToBlocks(view.state.doc);
-          }
-        }
         const bodyState = hiddenPMRef.current?.getState();
         if (bodyState) {
           scheduleLayout(bodyState, null);
@@ -3894,7 +3886,7 @@ export function PagedEditor(
         setHfCaretSelection({ rId, kind, from, to });
       }
     },
-    [document, scheduleLayout],
+    [scheduleLayout],
   );
 
   // Clear HF caret state + cross-surface drag state on any hfEditMode

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -577,61 +577,14 @@
   padding: 4px 0;
 }
 
-.hf-editor-pm .ProseMirror {
-  outline: none;
-  min-height: 40px;
-  padding: 0;
-}
-
-.hf-editor-pm .ProseMirror:focus {
-  outline: none;
-}
-
-.hf-editor-pm .ProseMirror p {
-  display: block;
-  margin: 0 !important;
-  padding-top: var(--docx-space-before, 0);
-  padding-right: 0;
-  padding-bottom: var(--docx-space-after, 0);
-  padding-left: 0;
-  min-height: 1em;
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  line-height: normal !important;
-}
-
-.hf-editor-pm .ProseMirror td p,
-.hf-editor-pm .ProseMirror th p {
-  margin: 0 !important;
-  padding-top: var(--docx-space-before, 0);
-  padding-right: 0;
-  padding-bottom: var(--docx-space-after, 0);
-  padding-left: 0;
-  min-height: auto;
-  line-height: normal !important;
-}
-
-.hf-editor-pm .ProseMirror .tableWrapper {
-  overflow: visible;
-}
-
-.hf-editor-pm .ProseMirror table {
-  border-collapse: collapse !important;
-  border-spacing: 0 !important;
-  table-layout: fixed !important;
-  margin: 0;
-}
-
-.hf-editor-pm .ProseMirror td.docx-table-cell,
-.hf-editor-pm .ProseMirror th.docx-table-header {
-  box-sizing: border-box !important;
-}
-
-.hf-editor-pm .ProseMirror td p:has(> img.docx-image):not(:has(> span)),
-.hf-editor-pm .ProseMirror th p:has(> img.docx-image):not(:has(> span)) {
-  font-size: 0 !important;
-  line-height: 0 !important;
-}
+/*
+ * Post-eigenpal#611: the painter is the sole visible HF renderer in both
+ * edit and non-edit modes. The .hf-editor-pm rule block (the styling for
+ * the now-deleted inline overlay PM tree) and the
+ * `.paged-editor--editing-{header,footer} > *  { visibility: hidden }`
+ * patches that hid the painter under the old overlay are gone — they
+ * have no job anymore.
+ */
 
 .paged-editor--hf-editing .layout-page-content {
   opacity: 0.4;
@@ -645,14 +598,6 @@
 
 .paged-editor--editing-footer .layout-page-footer {
   border-top: 1px dotted var(--doc-primary);
-}
-
-.paged-editor--editing-header .layout-page-header > * {
-  visibility: hidden;
-}
-
-.paged-editor--editing-footer .layout-page-footer > * {
-  visibility: hidden;
 }
 
 .paged-editor--hf-editing .layout-page-header:hover,


### PR DESCRIPTION
## Summary

Ports upstream `eigenpal/docx-editor#611` to folio. Replaces the visible-inline-overlay HF editing model with the body-style hidden-PM + visible-painter model: one persistent off-screen `EditorView` per HF `rId`, painter as the sole visible HF renderer in both edit and non-edit modes, and all user gestures (clicks, drag-select, shift-extend, table operations, image / hyperlink / context menu) routed to the matching hidden view through the painted slot's `data-rid`.

### Why

Folio's previous HF editing mounted a second visible PM tree over the painted HF area on double-click. Two renderers produced visible edit/non-edit geometry drift, `PAGE` / `NUMPAGES` field codes required an extra keystroke to resolve, editing a header on a later page scrolled the doc back to page 1, and click placement was imprecise because the overlay mounted after the click. The unified model is what Word, LibreOffice, and Google Docs use; one rendering pipeline owns visible output, the editing PM lives off-screen and dispatches transactions that the painter renders on the next tick.

### Architecture (matches upstream #611)

- **`HiddenHeaderFooterPMs`** mounts one off-screen `EditorView` per distinct `rId` in `package.headers ∪ package.footers`. Slot keying is by `rId` (ECMA-376 §17.10.1 sharing-by-reference), so two sections referencing the same header share one view and a single edit propagates to every painted instance in one layout pass.
- **Painter is the sole visible HF renderer** in both modes. `convertHeaderFooterPmDocToContent` sources `FlowBlock`s from `view.state.doc`; `convertHeaderFooterToContent` (existing) is the fallback when no view has mounted yet. Both share `normalizeHeaderFooterMeasureBlocks` (PR #457 measurement normalization) through an extracted `finalizeHeaderFooterContent` tail.
- **`data-rid`** is emitted on each painted `.layout-page-header` / `.layout-page-footer`. The pointer pipeline resolves the active surface via `findHfSlotForTarget` and dispatches every gesture (text click, drag-select, shift-extend, word / paragraph select, image NodeSelect, hyperlink popup, context menu, table cell drag, column / row / right-edge resize) on the matching hidden view.
- **HF caret + range selection rects** render in the body's pages-container via a slot-scoped DOM walk (`findHfPmAnchor` / `findHfPmSpans`), re-computed on every `painter:painted` `CustomEvent` dispatched after `renderPages`. Snapshot caching is deferred — folio's HF doc tree is small.
- **`InlineHeaderFooterEditor`** shrinks from ~370 to ~290 LOC: no `EditorView`, no positioning of a visible PM tree. Just the floating chrome (label, Options menu with PAGE/NUMPAGES inserts, Remove, Close). Its ref delegates `getView` / `focus` / `undo` / `redo` to the active HF PM via `getActiveView`.
- **Save model**: each HF transaction mutates `package.headers/footers[rId].content` in place via `proseDocToBlocks` (`handleHfPmTransaction` in `PagedEditor`) and schedules a relayout. Close paths (body click, Escape, Close button) commit the entire edit session as one `pushDocument` history entry via `handleBodyClick` so undo works as the user expects.

### Folio divergences preserved

- Multi-section HF resolution in `useHeaderFooterEditor` (NVCA-style title-page + signature-section layouts) — untouched. The hook now also returns `activeHeaderRId` / `activeFooterRId` / `activeFirstHeaderRId` / `activeFirstFooterRId` so `PagedEditor` can look up the right view per slot.
- PR #453 HF text-box parsing — text boxes round-trip through `headerFooterToProseDoc` + `proseDocToBlocks` unchanged.
- PR #457 trailing-empty-after-table + inherited-spacing normalization — applied to both content paths.

### Out of scope

- Vue parity (folio has no Vue surface).
- Even-page header support (`evenAndOddHeaders` §17.6.10) — upstream defers; we inherit the deferral.
- Single-click vs double-click UX for HF entry — kept at double-click.
- Snapshot cache for the HF caret-rect lookup (current impl recomputes on every paint; folio's HF docs are small enough that this isn't measurable yet).

## Commits

1. `feat(folio): foundation for HF editing unification (eigenpal#611 phase 1)` — additive infrastructure (HiddenHeaderFooterPMs, convertHeaderFooterPmDocToContent, findHfPmSpans, wrapEditorViewAsSurface, data-rid emission, painter:painted event, rId plumbing through PagedEditor).
2. `feat(folio): sync HF PM transactions back to package + trigger relayout` — handleHfPmTransaction wires in-place sync + scheduleLayout.
3. `feat(folio): route HF input through persistent PM + shrink inline overlay` — pointer routing for click + inline editor shrunk to chrome.
4. `feat(folio): draw caret for the focused hidden HF PM` — HfCaretOverlay reads findHfPmAnchor on every painter:painted.
5. `feat(folio): drop dead HF inline-overlay CSS` — removes .hf-editor-pm rule block + visibility:hidden patches.
6. `test(folio): cover HF slot DOM lookups + slot routing` — findHfPmSpans / findHfSlotForTarget regression suite (16 cases).
7. `feat(folio): HF drag-select, shift-extend, and range selection rects` — activeHfDragSurfaceRef + HfCaretOverlay range rect compute.
8. `feat(folio): HF word/paragraph select + right-click routing` — double / triple-click + handlePagesContextMenu route to HF PM.
9. `fix(folio): retry focus across a short rAF window for newly-created HF PMs` — race fix for freshly-materialised HF rIds.
10. `fix(folio): commit HF edits to history on Escape / Close button` — onClose now routes through handleBodyClick.
11. `fix(folio): read HF PM selection for hyperlink popup suppression` — surface-aware hasRangeSelection.
12. `fix(folio): NodeSelect HF images on the matching HF PM` — image click in HF dispatches on HF view, not body.
13. `feat(folio): HF table cell drag selection` — findCellPosInDoc + CellSelection.create on HF view.
14. `feat(folio): HF table column/row/right-edge resize handles` — resize handle detection hoisted above HF routing, resizingHfSurfaceRef captures the slot, commit dispatches on HF view.

## Test plan

- [ ] Watch CI
- [ ] Open a doc with a header — double-click → painter stays visible throughout, no flicker, geometry identical to non-edit mode
- [ ] Type, drag-select, shift-click extend selection, double-click word, triple-click paragraph — all work on the HF surface
- [ ] Right-click in HF → context menu reads HF selection (hasSelection reflects the HF range)
- [ ] Insert PAGE / NUMPAGES via Options menu — field resolves at paint time, no extra keystroke
- [ ] Long doc, edit header on page 5 — no scroll-to-page-1
- [ ] Linked headers across sections (shared rId) — edits propagate to every section's painted header in one layout pass
- [ ] Multi-section doc (title-page + body section) — first-page header / footer + default header / footer edit independently and save to correct rIds
- [ ] Click image in HF → NodeSelection on HF PM; image stays the active selection
- [ ] Click hyperlink in HF → popup appears (no stale body-range suppression)
- [ ] HF table — click + drag across cells produces CellSelection; column / row / right-edge resize handles mutate the HF table
- [ ] Escape / Close button / body click — close HF mode AND produce one undoable history entry capturing the session
- [ ] Save .docx — exported file has the latest HF content (in-place sync visible in the package)