### PR TITLE
docs(changelog): expand v0.3.1 with full v0.2.0..v0.3.1 range

### DIFF
--- a/docs/changelog/v0.3.1.md
+++ b/docs/changelog/v0.3.1.md
@@ -9,3 +9,157 @@ Skills bundle a prompt, reference documents, and read-only resources into one re
 Chat can now browse the web and fetch specific URLs, matter views can be saved as reusable templates, .docx files support live multi-person editing with anchored comments, entities can be copied or moved between matters, and chat messages sent mid-response get queued instead of dropped. And the usual stack of smaller fixes, refinements, and performance work.
 
 Thanks to the several new contributors who landed their first PRs this cycle, and to the returning ones who keep showing up with issues, fixes and questions.
+
+## Changes
+
+
+### ⚙️ Miscellaneous
+
+- release v0.3.1 ([#485](https://github.com/stella/stella/pull/485))
+
+
+### 🚀 Features
+
+- **workspaces**: unify cell context menu and polish flag UX ([#480](https://github.com/stella/stella/pull/480))
+- **chat**: various minor improvements ([#476](https://github.com/stella/stella/pull/476))
+- **workspaces**: mark all cells in a column as reviewed ([#479](https://github.com/stella/stella/pull/479))
+- **workspaces**: retry one AI-extracted cell via right-click ([#475](https://github.com/stella/stella/pull/475))
+- **folio**: use Word w14:paraId as canonical AI block anchor ([#473](https://github.com/stella/stella/pull/473))
+- **folio**: document outline rail + AI-chat readiness fallback ([#472](https://github.com/stella/stella/pull/472))
+- **chat**: add searchInEntityContent tool ([#471](https://github.com/stella/stella/pull/471))
+- **api**: add Matter view templates ([#14](https://github.com/stella/stella/pull/14)) ([#444](https://github.com/stella/stella/pull/444))
+- **chat**: add web search and URL fetch tools ([#449](https://github.com/stella/stella/pull/449))
+- various ux improvements ([#459](https://github.com/stella/stella/pull/459))
+- **folio**: sync upstream eigenpal docx-editor fixes (late May 2026) ([#460](https://github.com/stella/stella/pull/460))
+- generate AI thread title ([#441](https://github.com/stella/stella/pull/441))
+- **api**: bind audit recorder to handler context + audit downloads + enforce coverage ([#450](https://github.com/stella/stella/pull/450))
+- **lint**: enable promise, iframe-sandbox, and dead-write rules ([#452](https://github.com/stella/stella/pull/452))
+- **table**: lock manually overridden cells from AI rerun ([#446](https://github.com/stella/stella/pull/446))
+- **api**: brand untrusted prompt input with sanitizeForPrompt ([#451](https://github.com/stella/stella/pull/451))
+- **lint**: require AbortSignal on fetch calls
+- queue chat messages sent while a response streams
+- refresh Gemini model catalog ([#423](https://github.com/stella/stella/pull/423))
+- **api**: brand MCP secret types and add no-secret-in-log-sink lint ([#415](https://github.com/stella/stella/pull/415))
+- **folio**: sync upstream eigenpal docx-editor fixes (May 2026) ([#410](https://github.com/stella/stella/pull/410))
+- **api**: add BOE (Spanish legislation + BORME) as native tool
+- add Folio collaboration editing
+- copy/move entities between matters
+- **web**: useInlineRename hook + chat contexts
+- **web**: React 19 forms and optimistic UI
+- standardize cursor pagination envelope ([#370](https://github.com/stella/stella/pull/370))
+- paginate chat thread history ([#365](https://github.com/stella/stella/pull/365))
+- window matter table entity loading ([#364](https://github.com/stella/stella/pull/364))
+- add user-managed skills ([#300](https://github.com/stella/stella/pull/300))
+
+### 🐛 Bug Fixes
+
+- **docx**: break infinite render loop in inspector file open ([#483](https://github.com/stella/stella/pull/483))
+- **workspaces**: cell state alignment and template-apply Documents linking ([#482](https://github.com/stella/stella/pull/482))
+- **chat**: unstick docx composer and hot-swap new threads ([#469](https://github.com/stella/stella/pull/469))
+- **ci**: grant contents:read to cross-repo deploy token ([#465](https://github.com/stella/stella/pull/465))
+- address workflow security audit findings
+- **folio**: parse header footer text boxes ([#453](https://github.com/stella/stella/pull/453))
+- **api**: back auth rate limiting with Redis
+- **folio**: keep comment anchors fresh during incremental layouts ([#426](https://github.com/stella/stella/pull/426))
+- **filesystem**: allow cmd/ctrl-click to multi-select folders ([#424](https://github.com/stella/stella/pull/424))
+- rework folder zip download ([#430](https://github.com/stella/stella/pull/430))
+- **api**: fan out desktop-edit session SSE events across instances ([#429](https://github.com/stella/stella/pull/429))
+- scale entity hot paths ([#420](https://github.com/stella/stella/pull/420))
+- use session auth for ai provider validation ([#412](https://github.com/stella/stella/pull/412))
+- tidy api db setup ([#409](https://github.com/stella/stella/pull/409))
+- restore PDF previews without Uint8Array toHex
+- complete web i18n coverage
+- address react doctor findings
+- harden backend endpoint permissions and pagination
+- **chat**: guard chat editor against use-after-destroy
+- require desktop edit event token
+- **folio**: preserve paragraph-level section breaks on repack
+- **folio**: stabilise repack drawing count for textbox-bearing DOCX ([#377](https://github.com/stella/stella/pull/377))
+- add self-host API healthcheck ([#369](https://github.com/stella/stella/pull/369))
+- **case-law**: narrow ingestion to dedicated stella_ingestion role ([#368](https://github.com/stella/stella/pull/368))
+- address react doctor findings ([#367](https://github.com/stella/stella/pull/367))
+- **ci**: trigger landing deploy on docs/changelog changes ([#362](https://github.com/stella/stella/pull/362))
+
+### ⚡ Performance
+
+- **web**: parallelize independent awaits in chat send and task invalidate ([#478](https://github.com/stella/stella/pull/478))
+- **folio**: improve docx editor performance ([#466](https://github.com/stella/stella/pull/466))
+- **web**: defer Folio editor and Streamdown plugins to lazy chunks ([#464](https://github.com/stella/stella/pull/464))
+- **folio**: cut editor re-renders, modernize for React 19 ([#422](https://github.com/stella/stella/pull/422))
+
+### ♻️ Refactor
+
+- **folio**: harden canonical document boundaries ([#457](https://github.com/stella/stella/pull/457))
+- ban bare `throw new Error` via panic() / TaggedError ([#445](https://github.com/stella/stella/pull/445))
+- **api**: build the S3 client lazily instead of at import ([#431](https://github.com/stella/stella/pull/431))
+- **api**: folio-collab handler factory + endpoint split ([#419](https://github.com/stella/stella/pull/419))
+- **api**: tighten folio-collab session pipeline ([#413](https://github.com/stella/stella/pull/413))
+- stabilize file chat threads
+- **api**: consolidate outbound HTTP helpers in lib
+- **anonymize**: drop unused isPending from chat anonymize preview
+- **api**: make ProviderProbeResult a discriminated union
+- **web**: split mega-files ([#399](https://github.com/stella/stella/pull/399))
+- **case-viewer**: tighten AnalysisResponse discriminated union
+- **ai-suggestions**: make AssistantThreadMessage a discriminated union
+- split inspector panel ([#366](https://github.com/stella/stella/pull/366))
+
+### 📚 Documentation
+
+- link GHCR to GitHub Container Registry docs ([#421](https://github.com/stella/stella/pull/421))
+
+### 📦 Dependencies
+
+- **deps**: weekly dep sweep (tiptap, hocuspocus, ai-sdk, vite, anonymize-wasm, posthog, knip) ([#474](https://github.com/stella/stella/pull/474))
+- **deps**: weekly upgrade sweep ([#456](https://github.com/stella/stella/pull/456))
+- **deps**: batched dependency sweep + oxlint 1.65 fixes ([#408](https://github.com/stella/stella/pull/408))
+- **deps**: batched dependency updates ([#363](https://github.com/stella/stella/pull/363))
+
+### ⚙️ Miscellaneous
+
+- release v0.3.0 ([#467](https://github.com/stella/stella/pull/467))
+- refresh provenance artifacts ([#477](https://github.com/stella/stella/pull/477))
+- ignore nested Docker build artifacts ([#470](https://github.com/stella/stella/pull/470))
+- refresh provenance artifacts ([#468](https://github.com/stella/stella/pull/468))
+- add oxlint guardrails
+- enable additional sonarjs guardrails
+- refresh provenance artifacts ([#458](https://github.com/stella/stella/pull/458))
+- bump oven/bun from 1.3.13-slim to 1.3.14-slim in /apps/api ([#455](https://github.com/stella/stella/pull/455))
+- refresh provenance artifacts ([#454](https://github.com/stella/stella/pull/454))
+- **lint**: add must-use-result, no-any-casts, no-dangerous-type-assertions ([#447](https://github.com/stella/stella/pull/447))
+- refresh provenance artifacts ([#448](https://github.com/stella/stella/pull/448))
+- bump the misc group across 1 directory with 3 updates ([#440](https://github.com/stella/stella/pull/440))
+- bump the misc group across 1 directory with 5 updates ([#439](https://github.com/stella/stella/pull/439))
+- bump the actions group with 4 updates ([#438](https://github.com/stella/stella/pull/438))
+- bump the tanstack group across 1 directory with 2 updates ([#436](https://github.com/stella/stella/pull/436))
+- bump the tauri group in /apps/desktop/src-tauri with 2 updates ([#435](https://github.com/stella/stella/pull/435))
+- refresh provenance artifacts ([#434](https://github.com/stella/stella/pull/434))
+- **i18n**: simplify MCP connector description ([#425](https://github.com/stella/stella/pull/425))
+- api error-handling + packages/ui React 19 cleanup ([#432](https://github.com/stella/stella/pull/432))
+- tidy misfiled scripts, stale config, and search query keys ([#428](https://github.com/stella/stella/pull/428))
+- **web**: tree-view debounce + disable-comment hygiene ([#427](https://github.com/stella/stella/pull/427))
+- **web**: finish useContext → use() migration ([#418](https://github.com/stella/stella/pull/418))
+- **api**: tidy presign expiry, db policies, and file-scan ([#417](https://github.com/stella/stella/pull/417))
+- **web**: modernize theme-provider for react 19 ([#416](https://github.com/stella/stella/pull/416))
+- **api**: tighten env validation ([#411](https://github.com/stella/stella/pull/411))
+- refresh provenance artifacts ([#414](https://github.com/stella/stella/pull/414))
+- refresh provenance artifacts ([#407](https://github.com/stella/stella/pull/407))
+- **web**: useEffect cleanup
+- **web**: data fetching modernization
+- **folio**: Valibot enum narrowing for docx parsers
+- **web**: scope org-level query keys by organization
+- refresh provenance artifacts ([#404](https://github.com/stella/stella/pull/404))
+- **web**: state modeling cleanup ([#393](https://github.com/stella/stella/pull/393))
+- **web**: React 19 syntax cleanup ([#392](https://github.com/stella/stella/pull/392))
+- **web**: TanStack Query hygiene ([#394](https://github.com/stella/stella/pull/394))
+- refresh provenance artifacts ([#402](https://github.com/stella/stella/pull/402))
+- tighten static checks
+- tighten API guardrails
+- tighten type-safety across folio + handler tests
+- **docker**: harden selfhost compose and tighten ignore patterns ([#376](https://github.com/stella/stella/pull/376))
+- bump the actions group with 2 updates ([#375](https://github.com/stella/stella/pull/375))
+- bump bullmq in the misc group across 1 directory ([#374](https://github.com/stella/stella/pull/374))
+- bump @tanstack/react-form ([#373](https://github.com/stella/stella/pull/373))
+- bump tokio in /apps/desktop/src-tauri in the async-runtime group ([#372](https://github.com/stella/stella/pull/372))
+- refresh provenance artifacts ([#371](https://github.com/stella/stella/pull/371))
+
+


### PR DESCRIPTION
v0.3.0's GitHub Release never got published (the release workflow's smoke step failed before publish), so 124 commits between v0.2.0 and v0.3.0 are missing from `stll.app/changelog`. Fold the full `git-cliff v0.2.0..v0.3.1` output into v0.3.1's manual notes so the catch-up shows up in one entry.

Raw `git-cliff` output, not editorialised (two `### ⚙️ Miscellaneous` sections from the tag boundary, `release vX.Y.Z` and `refresh provenance artifacts` entries left in). Easy to trim later by hand if any of it reads as noise.

After merge, the v0.3.1 GitHub Release body needs the same content (`gh release edit v0.3.1` — the website renders from there, not from the .md file).

CC on behalf of @jan-kubica