### PR TITLE
chore(api): add fast-check property coverage for pagination + view schemas

### DIFF
--- a/apps/api/src/lib/pagination.test.ts
+++ b/apps/api/src/lib/pagination.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 
 import {
   createCursorPage,
@@ -82,5 +83,135 @@ describe("cursor pagination", () => {
     expect(
       parseDateTimePaginationCursorPart("2026-05-16T10:30:00Z"),
     ).toBeNull();
+  });
+});
+
+describe("cursor pagination — properties", () => {
+  const cursorPrimitive = fc.oneof(
+    fc.string(),
+    fc.integer(),
+    fc
+      .double({ noNaN: true, noDefaultInfinity: true })
+      .filter((n) => !Object.is(n, -0)),
+    fc.boolean(),
+    fc.constant(null),
+  );
+
+  const boundedDate = fc.date({
+    min: new Date("1900-01-01T00:00:00.000Z"),
+    max: new Date("2200-12-31T23:59:59.999Z"),
+    noInvalidDate: true,
+  });
+
+  test("encode → decode round-trips any cursor primitive array", () => {
+    fc.assert(
+      fc.property(fc.array(cursorPrimitive), (parts) => {
+        expect(decodePaginationCursor(encodePaginationCursor(parts))).toEqual(
+          parts,
+        );
+      }),
+    );
+  });
+
+  test("decode is total on arbitrary input — never throws", () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const result = decodePaginationCursor(input);
+        expect(result === null || Array.isArray(result)).toBe(true);
+      }),
+    );
+  });
+
+  test("createCursorPage — items is the prefix slice of rows", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.record({ id: fc.string() }), { maxLength: 50 }),
+        fc.integer({ min: 1, max: 100 }),
+        (rows, limit) => {
+          const page = createCursorPage({
+            rows,
+            limit,
+            cursorForItem: (row) => row.id,
+          });
+
+          expect(page.limit).toBe(limit);
+          expect(page.items.length).toBe(Math.min(rows.length, limit));
+          expect(page.items).toEqual(rows.slice(0, page.items.length));
+        },
+      ),
+    );
+  });
+
+  test("createCursorPage — nextCursor is null iff rows fit within limit", () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.record({ id: fc.string() }), { maxLength: 50 }),
+        fc.integer({ min: 1, max: 100 }),
+        (rows, limit) => {
+          const page = createCursorPage({
+            rows,
+            limit,
+            cursorForItem: (row) => row.id,
+          });
+
+          if (rows.length > limit) {
+            // rows.length > limit ≥ 1, so rows[limit - 1] always exists.
+            expect(page.nextCursor).toBe(rows[limit - 1]?.id ?? null);
+          } else {
+            expect(page.nextCursor).toBeNull();
+          }
+        },
+      ),
+    );
+  });
+
+  test("isDateOnlyPaginationCursorPart accepts every canonical UTC date", () => {
+    fc.assert(
+      fc.property(boundedDate, (d) => {
+        expect(
+          isDateOnlyPaginationCursorPart(d.toISOString().slice(0, 10)),
+        ).toBe(true);
+      }),
+    );
+  });
+
+  test("isDateOnlyPaginationCursorPart only accepts strings that round-trip through Date", () => {
+    fc.assert(
+      fc.property(fc.string(), (s) => {
+        if (!isDateOnlyPaginationCursorPart(s)) {
+          return;
+        }
+        expect(new Date(`${s}T00:00:00.000Z`).toISOString().slice(0, 10)).toBe(
+          s,
+        );
+      }),
+    );
+  });
+
+  test("parseDateTimePaginationCursorPart accepts every canonical ISO datetime", () => {
+    fc.assert(
+      fc.property(boundedDate, (d) => {
+        expect(parseDateTimePaginationCursorPart(d.toISOString())).toEqual(d);
+      }),
+    );
+  });
+
+  test("parseDateTimePaginationCursorPart rejects non-canonical variants", () => {
+    fc.assert(
+      fc.property(boundedDate, (d) => {
+        // Stripping milliseconds produces a valid ISO string but not the canonical form
+        // toISOString() emits — parser must reject to preserve cursor equality semantics.
+        const stripped = d.toISOString().replace(/\.\d{3}Z$/u, "Z");
+        expect(parseDateTimePaginationCursorPart(stripped)).toBeNull();
+      }),
+    );
+  });
+
+  test("isUuidPaginationCursorPart accepts every RFC-4122 UUID", () => {
+    fc.assert(
+      fc.property(fc.uuid(), (id) => {
+        expect(isUuidPaginationCursorPart(id)).toBe(true);
+      }),
+    );
   });
 });

--- a/apps/api/src/lib/search/cursor.test.ts
+++ b/apps/api/src/lib/search/cursor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 
 import { decodeCursor, encodeCursor } from "./cursor";
 
@@ -21,5 +22,38 @@ describe("search cursor encoding", () => {
     expect(decodeCursor(malformed)).toBeNull();
     expect(decodeCursor(missingId)).toBeNull();
     expect(decodeCursor(infiniteScore)).toBeNull();
+  });
+});
+
+describe("search cursor encoding — properties", () => {
+  // The decoder splits on ":" and takes only the first two parts, so ids containing ":"
+  // cannot round-trip. -0 is excluded because String(-0) === "0" loses the sign.
+  const arbId = fc
+    .string({ minLength: 1, maxLength: 32 })
+    .filter((s) => !s.includes(":"));
+  const arbScore = fc
+    .double({ noNaN: true, noDefaultInfinity: true })
+    .filter((n) => !Object.is(n, -0));
+
+  test("encode → decode round-trips finite score + id pairs", () => {
+    fc.assert(
+      fc.property(arbScore, arbId, (score, id) => {
+        expect(decodeCursor(encodeCursor(score, id))).toEqual({ score, id });
+      }),
+    );
+  });
+
+  test("decode is total — never throws on arbitrary strings", () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const result = decodeCursor(input);
+        const ok =
+          result === null ||
+          (Number.isFinite(result.score) &&
+            typeof result.id === "string" &&
+            result.id.length > 0);
+        expect(ok).toBe(true);
+      }),
+    );
   });
 });

--- a/apps/api/src/lib/search/pagination.test.ts
+++ b/apps/api/src/lib/search/pagination.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
 
-import { encodeCursor } from "@/api/lib/search/cursor";
+import { decodeCursor, encodeCursor } from "@/api/lib/search/cursor";
 import {
   GLOBAL_SEARCH_MAX_OFFSET,
   resolveGlobalSearchNextCursor,
@@ -69,5 +70,73 @@ describe("global search pagination", () => {
         hitsLength: 25,
       }),
     ).toBeNull();
+  });
+});
+
+describe("global search pagination — properties", () => {
+  const arbLimit = fc.integer({ min: 1, max: 100 });
+  const arbOffset = fc.integer({
+    min: 0,
+    max: GLOBAL_SEARCH_MAX_OFFSET + 200,
+  });
+  const arbHitsLength = fc.integer({ min: 0, max: 100 });
+  const arbTotalCount = fc.option(fc.integer({ min: 0, max: 5000 }), {
+    nil: null,
+  });
+
+  test("returns null iff any pruning rule fires; otherwise encodes nextOffset", () => {
+    fc.assert(
+      fc.property(
+        arbLimit,
+        arbOffset,
+        arbHitsLength,
+        arbTotalCount,
+        (limit, offset, hitsLength, totalCount) => {
+          const result = resolveGlobalSearchNextCursor({
+            limit,
+            offset,
+            totalCount,
+            hitsLength,
+          });
+          const nextOffset = offset + limit;
+          const shouldStop =
+            nextOffset >= GLOBAL_SEARCH_MAX_OFFSET ||
+            hitsLength < limit ||
+            (totalCount !== null && totalCount <= nextOffset);
+
+          if (shouldStop) {
+            expect(result).toBeNull();
+          } else {
+            expect(result).toBe(encodeCursor(nextOffset, "global"));
+          }
+        },
+      ),
+    );
+  });
+
+  test("non-null cursor decodes to (nextOffset, 'global')", () => {
+    fc.assert(
+      fc.property(
+        arbLimit,
+        arbOffset,
+        arbHitsLength,
+        arbTotalCount,
+        (limit, offset, hitsLength, totalCount) => {
+          const result = resolveGlobalSearchNextCursor({
+            limit,
+            offset,
+            totalCount,
+            hitsLength,
+          });
+          if (result === null) {
+            return;
+          }
+          expect(decodeCursor(result)).toEqual({
+            score: offset + limit,
+            id: "global",
+          });
+        },
+      ),
+    );
   });
 });

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -1,9 +1,15 @@
 import { Value } from "@sinclair/typebox/value";
 import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import * as v from "valibot";
 
 import {
   parseViewLayout,
+  tViewFilterConditionSchema,
+  tViewLayoutSchema,
   tViewTemplatePropertySchema,
+  viewFilterConditionSchema,
+  viewLayoutSchema,
 } from "@/api/lib/views-schema";
 import type { ViewLayout } from "@/api/lib/views-schema";
 
@@ -48,5 +54,195 @@ describe("view template property validation", () => {
         createIfMissing: true,
       }),
     ).toBe(true);
+  });
+});
+
+// Property tests below assert that the two parallel schemas
+// (Valibot for internal parsing, TypeBox for the Elysia HTTP boundary) agree on
+// every layout and filter shape. Drift between them lets payloads slip past the
+// route validator and fail at parseViewLayout, or vice versa.
+
+const arbId = fc.string({ minLength: 1, maxLength: 16 });
+const arbPropertyId = fc.string({ minLength: 1, maxLength: 16 });
+const arbHiddenProperties = fc.array(fc.string({ maxLength: 16 }), {
+  maxLength: 5,
+});
+
+const arbEntityKind = fc.constantFrom(
+  "document",
+  "folder",
+  "task",
+  "message",
+  "link",
+);
+const arbBuiltinField = fc.constantFrom("status", "priority");
+const arbStringOrArray = fc.oneof(
+  fc.string({ maxLength: 16 }),
+  fc.array(fc.string({ maxLength: 16 }), { maxLength: 4 }),
+);
+
+const arbFilter = fc.oneof(
+  fc.record({
+    id: arbId,
+    field: fc.constant("kind" as const),
+    op: fc.constant("in" as const),
+    value: fc.array(arbEntityKind, { maxLength: 5 }),
+  }),
+  fc.record({
+    id: arbId,
+    field: fc.constant("property" as const),
+    propertyId: arbPropertyId,
+    op: fc.constantFrom("eq", "neq", "contains", "is_empty"),
+    value: arbStringOrArray,
+  }),
+  fc.record({
+    id: arbId,
+    field: fc.constant("builtin" as const),
+    builtinField: arbBuiltinField,
+    op: fc.constantFrom("eq", "neq", "in", "is_empty"),
+    value: arbStringOrArray,
+  }),
+);
+
+const arbSort = fc.record({
+  propertyId: arbPropertyId,
+  desc: fc.boolean(),
+});
+
+const baseLayoutFields = {
+  version: fc.constant(1 as const),
+  filters: fc.array(arbFilter, { maxLength: 4 }),
+  sorts: fc.array(arbSort, { maxLength: 4 }),
+  hiddenProperties: arbHiddenProperties,
+};
+
+const arbLayout = fc.oneof(
+  fc.record({ type: fc.constant("overview" as const), ...baseLayoutFields }),
+  fc.record({
+    type: fc.constant("table" as const),
+    columnOrder: fc.array(fc.string({ maxLength: 16 }), { maxLength: 5 }),
+    columnPinning: fc.array(fc.string({ maxLength: 16 }), { maxLength: 5 }),
+    ...baseLayoutFields,
+  }),
+  fc.record({
+    type: fc.constant("filesystem" as const),
+    ...baseLayoutFields,
+  }),
+  fc.record({
+    type: fc.constant("kanban" as const),
+    ...baseLayoutFields,
+    groupByPropertyId: arbPropertyId,
+  }),
+  fc.record({
+    type: fc.constant("calendar" as const),
+    ...baseLayoutFields,
+    datePropertyId: arbPropertyId,
+    endDatePropertyId: arbPropertyId,
+    additionalDatePropertyIds: fc.array(arbPropertyId, { maxLength: 3 }),
+    mode: fc.constantFrom("month", "week", "year"),
+  }),
+  fc.record({
+    type: fc.constant("timeline" as const),
+    ...baseLayoutFields,
+    startDatePropertyId: arbPropertyId,
+    endDatePropertyId: arbPropertyId,
+    zoom: fc.constantFrom("day", "week", "month", "quarter"),
+    groupByPropertyId: arbPropertyId,
+    showTable: fc.boolean(),
+  }),
+);
+
+const declaredLayoutKeys = new Set([
+  "type",
+  "version",
+  "filters",
+  "sorts",
+  "hiddenProperties",
+  "columnOrder",
+  "columnPinning",
+  "groupByPropertyId",
+  "datePropertyId",
+  "endDatePropertyId",
+  "additionalDatePropertyIds",
+  "mode",
+  "startDatePropertyId",
+  "zoom",
+  "showTable",
+]);
+
+// Valibot 1.4.0's strictObject uses `key in this.entries` to detect extra keys,
+// which walks the prototype chain — so names like "valueOf"/"toString" are
+// silently treated as known and stripped from output. TypeBox correctly
+// rejects them. Excluding these names from the parity property keeps the
+// signal clean; the divergence is captured separately below.
+const objectPrototypeKeys = new Set(
+  Object.getOwnPropertyNames(Object.prototype),
+);
+
+describe("viewFilterConditionSchema — properties", () => {
+  test("Valibot and TypeBox agree on every well-formed filter", () => {
+    fc.assert(
+      fc.property(arbFilter, (filter) => {
+        expect(v.is(viewFilterConditionSchema, filter)).toBe(true);
+        expect(Value.Check(tViewFilterConditionSchema, filter)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe("viewLayoutSchema — properties", () => {
+  test("Valibot and TypeBox agree on every well-formed layout", () => {
+    fc.assert(
+      fc.property(arbLayout, (layout) => {
+        expect(v.is(viewLayoutSchema, layout)).toBe(true);
+        expect(Value.Check(tViewLayoutSchema, layout)).toBe(true);
+      }),
+    );
+  });
+
+  test("parseViewLayout is identity on well-formed layouts", () => {
+    fc.assert(
+      fc.property(arbLayout, (layout) => {
+        expect(parseViewLayout(layout)).toEqual(layout as ViewLayout);
+      }),
+    );
+  });
+
+  test("both schemas reject layouts with an undeclared extra key", () => {
+    fc.assert(
+      fc.property(
+        arbLayout,
+        fc
+          .string({ minLength: 1, maxLength: 16 })
+          .filter(
+            (key) =>
+              !declaredLayoutKeys.has(key) && !objectPrototypeKeys.has(key),
+          ),
+        (layout, extraKey) => {
+          const polluted = { ...layout, [extraKey]: "junk" };
+          expect(v.is(viewLayoutSchema, polluted)).toBe(false);
+          expect(Value.Check(tViewLayoutSchema, polluted)).toBe(false);
+        },
+      ),
+    );
+  });
+
+  // Known divergence: Valibot 1.4.0 fails to reject Object.prototype-named extra
+  // keys because its strictObject check walks the prototype chain. TypeBox is
+  // strict. Practical impact is limited (Elysia rejects at the HTTP boundary via
+  // TypeBox), but parseViewLayout is also called on DB rows. If this starts
+  // failing after a Valibot upgrade, swap the comparison and delete this note.
+  test("Valibot accepts Object.prototype-named extra keys that TypeBox rejects", () => {
+    const polluted = {
+      type: "kanban" as const,
+      version: 1 as const,
+      filters: [],
+      sorts: [],
+      hiddenProperties: [],
+      groupByPropertyId: "x",
+      valueOf: "junk",
+    };
+    expect(v.is(viewLayoutSchema, polluted)).toBe(true);
+    expect(Value.Check(tViewLayoutSchema, polluted)).toBe(false);
   });
 });

--- a/apps/api/src/lib/views-schema.test.ts
+++ b/apps/api/src/lib/views-schema.test.ts
@@ -88,20 +88,26 @@ const arbFilter = fc.oneof(
     op: fc.constant("in" as const),
     value: fc.array(arbEntityKind, { maxLength: 5 }),
   }),
-  fc.record({
-    id: arbId,
-    field: fc.constant("property" as const),
-    propertyId: arbPropertyId,
-    op: fc.constantFrom("eq", "neq", "contains", "is_empty"),
-    value: arbStringOrArray,
-  }),
-  fc.record({
-    id: arbId,
-    field: fc.constant("builtin" as const),
-    builtinField: arbBuiltinField,
-    op: fc.constantFrom("eq", "neq", "in", "is_empty"),
-    value: arbStringOrArray,
-  }),
+  fc.record(
+    {
+      id: arbId,
+      field: fc.constant("property" as const),
+      propertyId: arbPropertyId,
+      op: fc.constantFrom("eq", "neq", "contains", "is_empty"),
+      value: arbStringOrArray,
+    },
+    { requiredKeys: ["id", "field", "propertyId", "op"] },
+  ),
+  fc.record(
+    {
+      id: arbId,
+      field: fc.constant("builtin" as const),
+      builtinField: arbBuiltinField,
+      op: fc.constantFrom("eq", "neq", "in", "is_empty"),
+      value: arbStringOrArray,
+    },
+    { requiredKeys: ["id", "field", "builtinField", "op"] },
+  ),
 );
 
 const arbSort = fc.record({
@@ -128,28 +134,61 @@ const arbLayout = fc.oneof(
     type: fc.constant("filesystem" as const),
     ...baseLayoutFields,
   }),
-  fc.record({
-    type: fc.constant("kanban" as const),
-    ...baseLayoutFields,
-    groupByPropertyId: arbPropertyId,
-  }),
-  fc.record({
-    type: fc.constant("calendar" as const),
-    ...baseLayoutFields,
-    datePropertyId: arbPropertyId,
-    endDatePropertyId: arbPropertyId,
-    additionalDatePropertyIds: fc.array(arbPropertyId, { maxLength: 3 }),
-    mode: fc.constantFrom("month", "week", "year"),
-  }),
-  fc.record({
-    type: fc.constant("timeline" as const),
-    ...baseLayoutFields,
-    startDatePropertyId: arbPropertyId,
-    endDatePropertyId: arbPropertyId,
-    zoom: fc.constantFrom("day", "week", "month", "quarter"),
-    groupByPropertyId: arbPropertyId,
-    showTable: fc.boolean(),
-  }),
+  fc.record(
+    {
+      type: fc.constant("kanban" as const),
+      ...baseLayoutFields,
+      groupByPropertyId: arbPropertyId,
+    },
+    {
+      requiredKeys: ["type", "version", "filters", "sorts", "hiddenProperties"],
+    },
+  ),
+  fc.record(
+    {
+      type: fc.constant("calendar" as const),
+      ...baseLayoutFields,
+      datePropertyId: arbPropertyId,
+      endDatePropertyId: arbPropertyId,
+      additionalDatePropertyIds: fc.array(arbPropertyId, { maxLength: 3 }),
+      mode: fc.constantFrom("month", "week", "year"),
+    },
+    {
+      requiredKeys: [
+        "type",
+        "version",
+        "filters",
+        "sorts",
+        "hiddenProperties",
+        "datePropertyId",
+        "mode",
+      ],
+    },
+  ),
+  fc.record(
+    {
+      type: fc.constant("timeline" as const),
+      ...baseLayoutFields,
+      startDatePropertyId: arbPropertyId,
+      endDatePropertyId: arbPropertyId,
+      zoom: fc.constantFrom("day", "week", "month", "quarter"),
+      groupByPropertyId: arbPropertyId,
+      showTable: fc.boolean(),
+    },
+    {
+      requiredKeys: [
+        "type",
+        "version",
+        "filters",
+        "sorts",
+        "hiddenProperties",
+        "startDatePropertyId",
+        "endDatePropertyId",
+        "zoom",
+        "showTable",
+      ],
+    },
+  ),
 );
 
 const declaredLayoutKeys = new Set([


### PR DESCRIPTION
## Summary

- Property-based coverage for `apps/api/src/lib/pagination.ts`, `lib/search/cursor.ts`, `lib/search/pagination.ts`, and `lib/views-schema.ts`. Tests run inside the existing `*.test.ts` files.
- Cursor `encode`/`decode` round-trip for any `CursorPrimitive[]`; `decodePaginationCursor` is total. `createCursorPage` invariants (prefix slice, null-cursor biconditional). Date/datetime/UUID validators each verified canonically.
- Search-side: `encodeCursor`/`decodeCursor` round-trip for finite scores and colon-free ids. `resolveGlobalSearchNextCursor` pruning rules expressed as a single biconditional; non-null cursor decodes to `(nextOffset, "global")`.
- `viewLayoutSchema` (Valibot) and `tViewLayoutSchema` (TypeBox) parity property: every well-formed layout/filter is accepted by both; both reject undeclared extra keys.

## Finding

The schema-parity property surfaced a real divergence between the two view schemas. Valibot 1.4.0's `strictObject` checks for extra keys with `key in this.entries`, which walks the prototype chain — so payload keys named `valueOf`, `toString`, `hasOwnProperty`, etc. are silently treated as known and stripped from output. TypeBox correctly rejects.

End-to-end requests are unaffected because Elysia validates against TypeBox at the HTTP boundary before `parseViewLayout` runs. `parseViewLayout` is also called on DB rows (`handlers/view-templates/list.ts`, `handlers/views/create.ts`), so the defense-in-depth gap is real for any future code path that bypasses the HTTP layer.

This PR documents the divergence with an explicit test rather than fixing it (upstream issue). The test will start failing helpfully if a future Valibot upgrade fixes the bug, prompting a swap of the assertion.

## Test plan

- [x] `bun test src/lib/pagination.test.ts src/lib/views-schema.test.ts src/lib/search/cursor.test.ts src/lib/search/pagination.test.ts` — 35 pass, 2056 expect() calls
- [x] `bun --filter @stll/api typecheck` clean
- [x] `bun --filter @stll/api lint` clean
- [x] Pre-push hook (format + lint + typecheck) passes