### PR TITLE
fix(ci): make IndexNow ping non-blocking on deploy

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -104,6 +104,9 @@ jobs:
         # search engines can verify ownership. The key is intentionally
         # public (it's served at https://stll.app/<key>.txt), so the
         # gitleaks generic-api-key match below is a false positive.
+        # IndexNow is a best-effort SEO notification; a failure here must
+        # not fail the deploy, which has already succeeded by this point.
+        continue-on-error: true
         env:
           INDEXNOW_KEY: 4a9799deb8f64ac9be5f9b9e140407ca # gitleaks:allow
           HOST: stll.app


### PR DESCRIPTION
## Summary
- The IndexNow step in `deploy-landing.yml` failed run [26622814797](https://github.com/stella/stella/actions/runs/26622814797) when CloudFront returned 5xx for the sitemap for ~3 min after the deploy, outlasting the curl retry budget added in #492.
- IndexNow is a best-effort SEO notification; mark the step `continue-on-error: true` so transient post-deploy 5xx blips no longer fail a deploy that has already succeeded.

## Test plan
- [ ] Next push to `main` triggers `Deploy Landing`; deploy stays green even if the IndexNow step itself reports a failure on a transient blip.