### PR TITLE
chore(hooks): drop --type-aware from pre-commit lint

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,7 +14,7 @@ pre-commit:
       run: bun run secrets:check:staged
     lint:
       glob: "**/*.{ts,tsx,js,jsx}"
-      run: bun --bun oxlint -c oxlint.config.ts --threads=2 --deny-warnings --type-aware --no-error-on-unmatched-pattern --fix {staged_files}
+      run: bun --bun oxlint -c oxlint.config.ts --threads=2 --deny-warnings --no-error-on-unmatched-pattern --fix {staged_files}
       stage_fixed: true
     format:
       glob: "**/*.{ts,tsx,js,jsx,json,css}"


### PR DESCRIPTION
## Summary
- Drop `--type-aware` from the `pre-commit` oxlint command so commits don't pay the full TS type-universe load.
- Pre-push (`bun run lint`) and CI both still run type-aware, so the only thing lost is local feedback latency on type-aware rules at commit time.
- Saves ~500 MB RAM and ~30s per commit; pre-commit becomes a purely syntactic pass on staged files.

## Test plan
- [ ] `bun run hooks:install` and commit a TS change — pre-commit lint completes in <2s without spawning `tsgolint`
- [ ] `git push` triggers pre-push lint which still runs with `--type-aware`
- [ ] CI lint job still runs `--type-aware` (unchanged)