### PR TITLE
fix(folio): emit fallback cell for literal empty <w:tr/> rows

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
@@ -123,4 +123,42 @@ describe("toProseDoc — literal empty <w:tr/> rows", () => {
     expect(emptyRow.childCount).toBe(1);
     expect(emptyRow.child(0).attrs["colspan"]).toBe(3);
   });
+
+  test("breaks active vertical merges before inserting a fallback cell", () => {
+    const emptyParagraph = { type: "paragraph" as const, content: [] };
+    const doc = makeDoc({
+      type: "table",
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { vMerge: "restart" },
+              content: [emptyParagraph],
+            },
+            { type: "tableCell", content: [emptyParagraph] },
+          ],
+        },
+        { type: "tableRow", cells: [] },
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              formatting: { vMerge: "continue" },
+              content: [emptyParagraph],
+            },
+            { type: "tableCell", content: [emptyParagraph] },
+          ],
+        },
+      ],
+    });
+
+    const table = firstTable(toProseDoc(doc));
+
+    expect(table.child(0).child(0).attrs["rowspan"]).toBe(1);
+    expect(table.child(1).child(0).attrs["colspan"]).toBe(2);
+    expect(table.child(2).childCount).toBe(2);
+  });
 });

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { Document, Table } from "../../types/document";
+import { toProseDoc } from "./toProseDoc";
+
+function makeDoc(table: Table): Document {
+  return { package: { document: { content: [table] } } };
+}
+
+function firstTable(pmDoc: PMNode): PMNode {
+  let table: PMNode | undefined;
+  pmDoc.descendants((node) => {
+    if (node.type.name === "table") {
+      table = node;
+      return false;
+    }
+    return true;
+  });
+  if (!table) {
+    throw new Error("expected converted doc to contain a table");
+  }
+  return table;
+}
+
+describe("toProseDoc — literal empty <w:tr/> rows", () => {
+  test("renders a fallback cell spanning the table width", () => {
+    const doc = makeDoc({
+      type: "table",
+      columnWidths: [2400, 2400, 2400],
+      rows: [
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    { type: "run", content: [{ type: "text", text: "A" }] },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    { type: "run", content: [{ type: "text", text: "B" }] },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "tableCell",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    { type: "run", content: [{ type: "text", text: "C" }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        { type: "tableRow", cells: [] },
+      ],
+    });
+
+    const table = firstTable(toProseDoc(doc));
+
+    expect(table.childCount).toBe(2);
+    const emptyRow = table.child(1);
+    expect(emptyRow.childCount).toBe(1);
+    expect(emptyRow.child(0).attrs["colspan"]).toBe(3);
+  });
+
+  test("falls back to colspan 1 when the table has no grid columns", () => {
+    const doc = makeDoc({
+      type: "table",
+      rows: [{ type: "tableRow", cells: [] }],
+    });
+
+    const table = firstTable(toProseDoc(doc));
+    const row = table.child(0);
+
+    expect(row.childCount).toBe(1);
+    expect(row.child(0).attrs["colspan"]).toBe(1);
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
@@ -82,14 +82,24 @@ describe("toProseDoc — literal empty <w:tr/> rows", () => {
   test("falls back to colspan 1 when the table has no grid columns", () => {
     const doc = makeDoc({
       type: "table",
+      formatting: {
+        borders: {
+          right: { style: "single" },
+          insideV: { style: "dashed" },
+        },
+      },
       rows: [{ type: "tableRow", cells: [] }],
     });
 
     const table = firstTable(toProseDoc(doc));
     const row = table.child(0);
+    const borders = row.child(0).attrs["borders"] as {
+      right?: { style?: string };
+    } | null;
 
     expect(row.childCount).toBe(1);
     expect(row.child(0).attrs["colspan"]).toBe(1);
+    expect(borders?.right?.style).toBe("single");
   });
 
   test("derives fallback colspan from later rows when the first row is empty", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-empty-table-row.test.ts
@@ -91,4 +91,36 @@ describe("toProseDoc — literal empty <w:tr/> rows", () => {
     expect(row.childCount).toBe(1);
     expect(row.child(0).attrs["colspan"]).toBe(1);
   });
+
+  test("derives fallback colspan from later rows when the first row is empty", () => {
+    const doc = makeDoc({
+      type: "table",
+      rows: [
+        { type: "tableRow", cells: [] },
+        {
+          type: "tableRow",
+          cells: [
+            {
+              type: "tableCell",
+              content: [{ type: "paragraph", content: [] }],
+            },
+            {
+              type: "tableCell",
+              content: [{ type: "paragraph", content: [] }],
+            },
+            {
+              type: "tableCell",
+              content: [{ type: "paragraph", content: [] }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const table = firstTable(toProseDoc(doc));
+    const emptyRow = table.child(0);
+
+    expect(emptyRow.childCount).toBe(1);
+    expect(emptyRow.child(0).attrs["colspan"]).toBe(3);
+  });
 });

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1053,13 +1053,9 @@ function convertTable(
   // Track data row index (excluding header rows) for banding
   let dataRowIndex = 0;
   const totalRows = table.rows.length;
+  const gridColumnCount = columnWidths?.length ?? 0;
   const totalColumns =
-    columnWidths?.length ??
-    table.rows[0]?.cells.reduce(
-      (sum, cell) => sum + (cell.formatting?.gridSpan ?? 1),
-      0,
-    ) ??
-    0;
+    gridColumnCount > 0 ? gridColumnCount : countTableColumns(table.rows);
   const rows = table.rows.map((row, rowIndex) => {
     // Conditional formatting flag: firstRow in tblLook means "apply first-row styling"
     const isFirstRowStyled = rowIndex === 0 && !!look?.firstRow;
@@ -1101,6 +1097,18 @@ function convertTable(
   });
 
   return schema.node("table", attrs, rows);
+}
+
+function countTableColumns(rows: TableRow[]): number {
+  let maxColumns = 0;
+  for (const row of rows) {
+    let rowColumns = 0;
+    for (const cell of row.cells) {
+      rowColumns += cell.formatting?.gridSpan ?? 1;
+    }
+    maxColumns = Math.max(maxColumns, rowColumns);
+  }
+  return maxColumns;
 }
 
 /**
@@ -1165,7 +1173,8 @@ function convertTableRow(
   const rowCnf = row.formatting?.conditionalFormat;
   const rowIsFirstRow = rowCnf?.firstRow ?? isFirstRow;
   const rowIsLastRow = rowCnf?.lastRow ?? isLastRow;
-  const totalCols = totalColumns ?? numCells;
+  const totalCols =
+    totalColumns != null && totalColumns > 0 ? totalColumns : numCells;
 
   // A literal `<w:tr/>` from a non-Word producer parses with zero cells. PM's
   // tableRow content is `(tableCell | tableHeader)+`, so emit one placeholder

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1167,11 +1167,26 @@ function convertTableRow(
   const rowIsLastRow = rowCnf?.lastRow ?? isLastRow;
   const totalCols = totalColumns ?? numCells;
 
+  // A literal `<w:tr/>` from a non-Word producer parses with zero cells. PM's
+  // tableRow content is `(tableCell | tableHeader)+`, so emit one placeholder
+  // cell spanning the table's grid width to keep the row valid.
+  let effectiveCells: TableCell[] = row.cells;
+  if (effectiveCells.length === 0) {
+    const fallback: TableCell = {
+      type: "tableCell",
+      content: [{ type: "paragraph", content: [] }],
+    };
+    if (totalCols > 1) {
+      fallback.formatting = { gridSpan: totalCols };
+    }
+    effectiveCells = [fallback];
+  }
+
   // Track column index for mapping to columnWidths (accounting for colspan)
   let colIndex = 0;
   const cells: PMNode[] = [];
 
-  for (const cellIndex_item of row.cells) {
+  for (const cellIndex_item of effectiveCells) {
     const cell = cellIndex_item;
     const colspan = cell.formatting?.gridSpan ?? 1;
 

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -805,6 +805,10 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
   for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
     // SAFETY: rowIndex < numRows <= table.rows.length
     const row = table.rows[rowIndex]!;
+    if (row.cells.length === 0) {
+      clearActiveVerticalMerges(activeMerges, result);
+      continue;
+    }
     let colIndex = 0;
     const rowCells = row.cells.map((cell) => {
       const colspan = cell.formatting?.gridSpan ?? 1;
@@ -878,6 +882,19 @@ function calculateRowSpans(table: Table): Map<string, RowSpanInfo> {
   }
 
   return result;
+}
+
+function clearActiveVerticalMerges(
+  activeMerges: Map<number, number>,
+  result: Map<string, RowSpanInfo>,
+): void {
+  for (const [colIndex, startRow] of activeMerges) {
+    const restartCell = result.get(`${startRow}-${colIndex}`);
+    if (restartCell) {
+      restartCell.preserveVMergeRestart = true;
+    }
+  }
+  activeMerges.clear();
 }
 
 function tableCellHasMeaningfulContent(cell: TableCell): boolean {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1191,7 +1191,9 @@ function convertTableRow(
   const rowIsFirstRow = rowCnf?.firstRow ?? isFirstRow;
   const rowIsLastRow = rowCnf?.lastRow ?? isLastRow;
   const totalCols =
-    totalColumns != null && totalColumns > 0 ? totalColumns : numCells;
+    totalColumns != null && totalColumns > 0
+      ? totalColumns
+      : Math.max(numCells, 1);
 
   // A literal `<w:tr/>` from a non-Word producer parses with zero cells. PM's
   // tableRow content is `(tableCell | tableHeader)+`, so emit one placeholder


### PR DESCRIPTION
## Summary

`parseTableRow` produces `row.cells: []` when a `<w:tr/>` element has no `<w:tc>` children. PM's `tableRow` schema content is `(tableCell | tableHeader)+`, so conversion crashed with `RangeError: Invalid content for node tableRow: <>` on DOCX files from non-Word producers.

Synthesise one placeholder `tableCell` spanning the table's grid width so the row stays valid.

Ports the empty-row half of eigenpal#626. The vMerge-continuation half is already handled by folio's `rowWouldBeEmpty` path.