### PR TITLE
feat(folio): track paragraph-mark revisions through round-trip and suggesting mode

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1177,6 +1177,20 @@ export type ParagraphContent =
 /**
  * Paragraph (w:p)
  */
+/**
+ * Paragraph-mark tracked-change marker (ECMA-376 §17.13.5).
+ *
+ * Word writes this as a child of `<w:pPr><w:rPr>` — `<w:ins/>` when the
+ * paragraph break itself was inserted in track-changes mode (the user
+ * pressed Enter mid-paragraph), `<w:del/>` when the paragraph break is
+ * pending deletion (Backspace at paragraph start or Delete at paragraph
+ * end). The mark is independent of the inline runs the paragraph carries.
+ */
+export type ParagraphMarkChange = {
+  kind: "ins" | "del";
+  info: TrackedChangeInfo;
+};
+
 export type Paragraph = {
   type: "paragraph";
   /** Unique paragraph ID */
@@ -1187,6 +1201,8 @@ export type Paragraph = {
   formatting?: ParagraphFormatting;
   /** Paragraph-level tracked property changes (w:pPrChange) */
   propertyChanges?: ParagraphPropertyChange[];
+  /** Paragraph-mark insertion / deletion (w:pPr / w:rPr / w:ins | w:del) */
+  pPrMark?: ParagraphMarkChange;
   /** Paragraph content */
   content: ParagraphContent[];
   /** Computed list rendering (if this is a list item) */

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -133,6 +133,7 @@ export type {
   BlockSdt,
   ParagraphContent,
   Paragraph,
+  ParagraphMarkChange,
   HeaderFooterType,
   HeaderReference,
   FooterReference,

--- a/packages/folio/src/core/docx/paragraphParser-pPrMark.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser-pPrMark.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseParagraph } from "./paragraphParser";
+import type { XmlElement } from "./xmlParser";
+import { parseXmlDocument } from "./xmlParser";
+
+function parseParagraphXml(xml: string) {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+describe("parseParagraph — paragraph-mark tracked change (ECMA-376 §17.13.5)", () => {
+  test("reads <w:pPr><w:rPr><w:ins/> as pPrMark.kind = 'ins'", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:rPr>
+            <w:ins w:id="42" w:author="Alice" w:date="2026-05-01T10:00:00Z"/>
+          </w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toEqual({
+      kind: "ins",
+      info: { id: 42, author: "Alice", date: "2026-05-01T10:00:00Z" },
+    });
+  });
+
+  test("reads <w:pPr><w:rPr><w:del/> as pPrMark.kind = 'del'", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:rPr>
+            <w:del w:id="7" w:author="Bob" w:date="2026-05-02T11:00:00Z"/>
+          </w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toEqual({
+      kind: "del",
+      info: { id: 7, author: "Bob", date: "2026-05-02T11:00:00Z" },
+    });
+  });
+
+  test("leaves pPrMark unset when neither ins nor del is present in rPr", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:rPr><w:b/></w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toBeUndefined();
+  });
+
+  test("ins takes precedence over del when both appear (malformed but defensive)", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:rPr>
+            <w:ins w:id="1" w:author="A"/>
+            <w:del w:id="2" w:author="B"/>
+          </w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark?.kind).toBe("ins");
+  });
+
+  test("omits w:date when it is absent on the source element", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:rPr>
+            <w:ins w:id="3" w:author="Carol"/>
+          </w:rPr>
+        </w:pPr>
+      </w:p>
+    `);
+
+    expect(paragraph.pPrMark).toEqual({
+      kind: "ins",
+      info: { id: 3, author: "Carol" },
+    });
+  });
+});

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -28,6 +28,7 @@ import type {
   RelationshipMap,
   MediaFile,
   SdtProperties,
+  ParagraphMarkChange,
   ParagraphPropertyChange,
   TrackedChangeInfo,
   MathEquation,
@@ -1088,6 +1089,33 @@ function parseParagraphPropertyChanges(
   return changes.length > 0 ? changes : undefined;
 }
 
+/**
+ * Parse `<w:pPr><w:rPr><w:ins/>` or `<w:del/>` — the OOXML paragraph-mark
+ * tracked-change marker (ECMA-376 §17.13.5). Returns the first marker
+ * encountered, or undefined when none is present. `ins` and `del` are
+ * mutually exclusive in valid documents.
+ */
+function parseParagraphMarkChange(
+  pPr: XmlElement | null,
+): ParagraphMarkChange | undefined {
+  if (!pPr) {
+    return undefined;
+  }
+  const rPr = findChild(pPr, "w", "rPr");
+  if (!rPr) {
+    return undefined;
+  }
+  const ins = findChild(rPr, "w", "ins");
+  if (ins) {
+    return { kind: "ins", info: parseTrackedChangeInfo(ins) };
+  }
+  const del = findChild(rPr, "w", "del");
+  if (del) {
+    return { kind: "del", info: parseTrackedChangeInfo(del) };
+  }
+  return undefined;
+}
+
 function isTrackedChangeWrapperChild(
   content: ParagraphContent,
 ): content is Run | Hyperlink {
@@ -1716,6 +1744,11 @@ export function parseParagraph(
     );
     if (propertyChangesResult !== undefined) {
       paragraph.propertyChanges = propertyChangesResult;
+    }
+
+    const pPrMarkResult = parseParagraphMarkChange(pPr);
+    if (pPrMarkResult !== undefined) {
+      paragraph.pPrMark = pPrMarkResult;
     }
 
     // Check for section properties within paragraph (marks end of a section)

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
@@ -52,7 +52,7 @@ describe("serializeParagraph — paragraph-mark tracked change", () => {
 
     const xml = serializeParagraph(paragraph);
 
-    const rPrMatch = xml.match(/<w:rPr>([\s\S]*?)<\/w:rPr>/u);
+    const rPrMatch = /<w:rPr>([\s\S]*?)<\/w:rPr>/u.exec(xml);
     expect(rPrMatch).not.toBeNull();
     const inner = rPrMatch?.[1] ?? "";
     const insIdx = inner.indexOf("<w:ins ");

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer-pPrMark.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Paragraph } from "../../types/document";
+import { serializeParagraph } from "./paragraphSerializer";
+
+describe("serializeParagraph — paragraph-mark tracked change", () => {
+  test("emits <w:ins/> inside <w:rPr> when pPrMark.kind is 'ins'", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      pPrMark: {
+        kind: "ins",
+        info: { id: 5, author: "Alice", date: "2026-05-01T10:00:00Z" },
+      },
+      content: [],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml).toContain("<w:pPr>");
+    expect(xml).toContain(
+      '<w:rPr><w:ins w:id="5" w:author="Alice" w:date="2026-05-01T10:00:00Z"/></w:rPr>',
+    );
+  });
+
+  test("emits <w:del/> inside <w:rPr> when pPrMark.kind is 'del'", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      pPrMark: {
+        kind: "del",
+        info: { id: 8, author: "Bob" },
+      },
+      content: [],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml).toContain('<w:rPr><w:del w:id="8" w:author="Bob"/></w:rPr>');
+  });
+
+  test("EG_ParaRPrTrackChanges ordering: pPrMark precedes runProperties inside rPr", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: {
+        runProperties: { bold: true },
+      },
+      pPrMark: {
+        kind: "ins",
+        info: { id: 1, author: "Alice" },
+      },
+      content: [],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    const rPrMatch = xml.match(/<w:rPr>([\s\S]*?)<\/w:rPr>/u);
+    expect(rPrMatch).not.toBeNull();
+    const inner = rPrMatch?.[1] ?? "";
+    const insIdx = inner.indexOf("<w:ins ");
+    const boldIdx = inner.indexOf("<w:b/>");
+    expect(insIdx).toBeGreaterThanOrEqual(0);
+    expect(boldIdx).toBeGreaterThan(insIdx);
+  });
+
+  test("escapes special characters in author / date attributes", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      pPrMark: {
+        kind: "ins",
+        info: { id: 1, author: `O'Brien & "Co"`, date: "2026-05-01T10:00:00Z" },
+      },
+      content: [],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml).toContain("&apos;");
+    expect(xml).toContain("&amp;");
+    expect(xml).toContain("&quot;");
+  });
+
+  test("omits <w:rPr> when no pPrMark, no runProperties, and no specVanish", () => {
+    const paragraph: Paragraph = {
+      type: "paragraph",
+      formatting: { alignment: "center" },
+      content: [],
+    };
+
+    const xml = serializeParagraph(paragraph);
+
+    expect(xml).not.toContain("<w:rPr>");
+  });
+});

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -14,6 +14,7 @@ import type {
   Paragraph,
   ParagraphContent,
   ParagraphFormatting,
+  ParagraphMarkChange,
   Run,
   Hyperlink,
   BookmarkStart,
@@ -32,6 +33,7 @@ import type {
   BorderSpec,
   ShadingProperties,
   TextFormatting,
+  TrackedChangeInfo,
 } from "../../types/document";
 // oxlint-disable-next-line import/no-cycle
 import { serializeRun, serializeTextFormatting } from "./runSerializer";
@@ -409,9 +411,23 @@ function serializeFrameProperties(frame: ParagraphFormatting["frame"]): string {
 /**
  * Serialize paragraph formatting properties to w:pPr XML
  */
+function serializeTrackedChangeAttrs(info: TrackedChangeInfo): string {
+  const parts = [`w:id="${info.id}"`, `w:author="${escapeXml(info.author)}"`];
+  if (info.date !== undefined) {
+    parts.push(`w:date="${escapeXml(info.date)}"`);
+  }
+  return parts.join(" ");
+}
+
+function serializeParagraphMarkChange(mark: ParagraphMarkChange): string {
+  const attrs = serializeTrackedChangeAttrs(mark.info);
+  return `<w:${mark.kind} ${attrs}/>`;
+}
+
 export function serializeParagraphFormatting(
   formatting: ParagraphFormatting | undefined,
   propertyChanges?: ParagraphPropertyChange[],
+  pPrMark?: ParagraphMarkChange,
 ): string {
   const parts: string[] = [];
 
@@ -520,16 +536,23 @@ export function serializeParagraphFormatting(
     // run-in merge. Without serializing it back, saving a doc
     // through Folio loses the soft paragraph break and the heading
     // becomes a normal separate paragraph in Word.
-    if (formatting.runProperties || formatting.runInWithNext) {
+    //
+    // EG_ParaRPrTrackChanges (ECMA-376 §17.13.5 / wml.xsd:1837) puts
+    // <w:ins>/<w:del> FIRST inside the paragraph mark's rPr; strict
+    // readers reject other orderings.
+    if (pPrMark || formatting.runProperties || formatting.runInWithNext) {
+      const pPrMarkXml = pPrMark ? serializeParagraphMarkChange(pPrMark) : "";
       const innerRPr = formatting.runProperties
         ? extractRPrInner(serializeTextFormatting(formatting.runProperties))
         : "";
       const specVanishXml = formatting.runInWithNext ? "<w:specVanish/>" : "";
-      const fullInner = `${innerRPr}${specVanishXml}`;
+      const fullInner = `${pPrMarkXml}${innerRPr}${specVanishXml}`;
       if (fullInner.length > 0) {
         parts.push(`<w:rPr>${fullInner}</w:rPr>`);
       }
     }
+  } else if (pPrMark) {
+    parts.push(`<w:rPr>${serializeParagraphMarkChange(pPrMark)}</w:rPr>`);
   }
 
   if (propertyChanges && propertyChanges.length > 0) {
@@ -995,6 +1018,7 @@ export function serializeParagraph(paragraph: Paragraph): string {
   const pPrXml = serializeParagraphFormatting(
     paragraph.formatting,
     paragraph.propertyChanges,
+    paragraph.pPrMark,
   );
   const sectionPropertiesXml = serializeSectionProperties(
     paragraph.sectionProperties,

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -102,7 +102,7 @@ function resolveChange(
 
       state.doc.nodesBetween(from, to, (node, pos): boolean => {
         if (node.type.name === "paragraph") {
-          const op = collectPPrMarkOp(node, pos, mode, revisionSet);
+          const op = collectPPrMarkOp(node, pos, from, to, mode, revisionSet);
           if (op) {
             pPrMarkOps.push(op);
           }
@@ -181,11 +181,16 @@ type PPrMarkOp = {
 };
 
 function collectPPrMarkOp(
-  node: { attrs: Record<string, unknown> },
+  node: { attrs: Record<string, unknown>; nodeSize: number },
   pos: number,
+  from: number,
+  to: number,
   mode: "accept" | "reject",
   revisionSet: Set<number> | null,
 ): PPrMarkOp | null {
+  if (!rangeCoversParagraphBoundary(from, to, pos, node)) {
+    return null;
+  }
   const pPrMark = node.attrs["pPrMark"];
   if (!isPPrMarkAttr(pPrMark)) {
     return null;
@@ -198,6 +203,17 @@ function collectPPrMarkOp(
   const action: PPrMarkOp["action"] =
     (pPrMark.kind === "ins") === (mode === "accept") ? "clear" : "join";
   return { paragraphPos: pos, action };
+}
+
+function rangeCoversParagraphBoundary(
+  from: number,
+  to: number,
+  pos: number,
+  node: { nodeSize: number },
+): boolean {
+  const boundaryFrom = pos + node.nodeSize - 1;
+  const boundaryTo = pos + node.nodeSize;
+  return from <= boundaryFrom && to >= boundaryTo;
 }
 
 function isPPrMarkAttr(

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -98,10 +98,18 @@ function resolveChange(
     if (dispatch) {
       const tr = state.tr;
       const deleteRanges: { from: number; to: number }[] = [];
+      const pPrMarkOps: PPrMarkOp[] = [];
 
-      state.doc.nodesBetween(from, to, (node, pos) => {
+      state.doc.nodesBetween(from, to, (node, pos): boolean => {
+        if (node.type.name === "paragraph") {
+          const op = collectPPrMarkOp(node, pos, mode, revisionSet);
+          if (op) {
+            pPrMarkOps.push(op);
+          }
+          return true;
+        }
         if (!node.isText) {
-          return;
+          return true;
         }
         const nodeEnd = pos + node.nodeSize;
         const rangeFrom = Math.max(from, pos);
@@ -119,10 +127,44 @@ function resolveChange(
             tr.removeMark(rangeFrom, rangeTo, mark);
           }
         }
+        return true;
       });
 
       for (const range of deleteRanges.toReversed()) {
         tr.delete(range.from, range.to);
+      }
+
+      // Process paragraph-mark ops from end → start so earlier positions stay
+      // valid as later paragraphs collapse. Map every position through the
+      // accumulated transaction so the inline deletes above don't desync the
+      // attr writes or joins below.
+      pPrMarkOps.sort((a, b) => b.paragraphPos - a.paragraphPos);
+      for (const op of pPrMarkOps) {
+        const mappedPos = tr.mapping.map(op.paragraphPos);
+        const paragraph = tr.doc.nodeAt(mappedPos);
+        if (!paragraph || paragraph.type.name !== "paragraph") {
+          continue;
+        }
+        if (op.action === "clear") {
+          tr.setNodeAttribute(mappedPos, "pPrMark", null);
+          continue;
+        }
+        const joinPos = mappedPos + paragraph.nodeSize;
+        if (joinPos >= tr.doc.content.size) {
+          // No next sibling to join with (paragraph terminates the doc).
+          // Leave the marker in place — Word treats this the same way.
+          continue;
+        }
+        try {
+          tr.join(joinPos);
+          // PM's `join` keeps the first paragraph's attrs, so the marker
+          // would survive an otherwise-resolved revision. Drop it now.
+          tr.setNodeAttribute(mappedPos, "pPrMark", null);
+        } catch {
+          // PM rejects the join if the two blocks aren't structurally
+          // compatible (e.g. paragraph followed by a table). Leaving the
+          // marker is the safe fallback.
+        }
       }
 
       if (tr.steps.length > 0) {
@@ -131,6 +173,48 @@ function resolveChange(
     }
     return true;
   };
+}
+
+type PPrMarkOp = {
+  paragraphPos: number;
+  action: "clear" | "join";
+};
+
+function collectPPrMarkOp(
+  node: { attrs: Record<string, unknown> },
+  pos: number,
+  mode: "accept" | "reject",
+  revisionSet: Set<number> | null,
+): PPrMarkOp | null {
+  const pPrMark = node.attrs["pPrMark"];
+  if (!isPPrMarkAttr(pPrMark)) {
+    return null;
+  }
+  if (revisionSet !== null && !revisionSet.has(pPrMark.info.id)) {
+    return null;
+  }
+  // accept-ins / reject-del keep the paragraph break (clear attr).
+  // reject-ins / accept-del remove the paragraph break (join with next).
+  const action: PPrMarkOp["action"] =
+    (pPrMark.kind === "ins") === (mode === "accept") ? "clear" : "join";
+  return { paragraphPos: pos, action };
+}
+
+function isPPrMarkAttr(
+  value: unknown,
+): value is { kind: "ins" | "del"; info: { id: number } } {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const kind = (value as { kind?: unknown }).kind;
+  const info = (value as { info?: unknown }).info;
+  if (kind !== "ins" && kind !== "del") {
+    return false;
+  }
+  if (typeof info !== "object" || info === null) {
+    return false;
+  }
+  return typeof (info as { id?: unknown }).id === "number";
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -152,10 +152,7 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
   });
 
   test("rejectChange + inline insertion on same paragraph resolves both", () => {
-    const insertion = schema.marks["insertion"];
-    if (!insertion) {
-      throw new Error("schema lacks insertion mark");
-    }
+    const insertion = schema.marks["insertion"]!;
     const state = EditorState.create({
       schema,
       doc: schema.node("doc", null, [

--- a/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import {
+  acceptAllChanges,
+  acceptChange,
+  rejectAllChanges,
+  rejectChange,
+} from "./comments";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      content: "text*",
+      group: "block",
+      attrs: { pPrMark: { default: null } },
+    },
+    text: { marks: "_" },
+  },
+  marks: {
+    insertion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      excludes: "",
+      toDOM: () => ["ins", 0],
+    },
+    deletion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      excludes: "",
+      toDOM: () => ["del", 0],
+    },
+  },
+});
+
+const dispatcher = (state: EditorState) => {
+  const view = {
+    state,
+    dispatch(tr: Transaction) {
+      view.state = view.state.apply(tr);
+    },
+  };
+  return view;
+};
+
+const insMark = (info: { id: number; author?: string }) => ({
+  kind: "ins" as const,
+  info: { id: info.id, author: info.author ?? "Alice" },
+});
+
+const delMark = (info: { id: number; author?: string }) => ({
+  kind: "del" as const,
+  info: { id: info.id, author: info.author ?? "Alice" },
+});
+
+const twoParagraphs = (firstPPrMark: unknown) =>
+  EditorState.create({
+    schema,
+    doc: schema.node("doc", null, [
+      schema.node("paragraph", { pPrMark: firstPPrMark }, schema.text("first")),
+      schema.node("paragraph", null, schema.text("second")),
+    ]),
+  });
+
+describe("pPrMark accept / reject — paragraph-mark resolution", () => {
+  test("accept clears pPrMark.kind = 'ins' (the paragraph break stays)", () => {
+    const view = dispatcher(twoParagraphs(insMark({ id: 1 })));
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+    expect(view.state.doc.child(0).textContent).toBe("first");
+    expect(view.state.doc.child(1).textContent).toBe("second");
+  });
+
+  test("reject of pPrMark.kind = 'ins' joins this paragraph with the next", () => {
+    const view = dispatcher(twoParagraphs(insMark({ id: 1 })));
+    rejectAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("firstsecond");
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("accept of pPrMark.kind = 'del' joins this paragraph with the next", () => {
+    const view = dispatcher(twoParagraphs(delMark({ id: 1 })));
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("firstsecond");
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("reject clears pPrMark.kind = 'del' (the paragraph break stays)", () => {
+    const view = dispatcher(twoParagraphs(delMark({ id: 1 })));
+    rejectAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+    expect(view.state.doc.child(0).textContent).toBe("first");
+    expect(view.state.doc.child(1).textContent).toBe("second");
+  });
+
+  test("range-scoped acceptChange ignores paragraphs outside the range", () => {
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node(
+          "paragraph",
+          { pPrMark: insMark({ id: 1 }) },
+          schema.text("p1"),
+        ),
+        schema.node(
+          "paragraph",
+          { pPrMark: insMark({ id: 2 }) },
+          schema.text("p2"),
+        ),
+        schema.node("paragraph", null, schema.text("p3")),
+      ]),
+    });
+    const view = dispatcher(state);
+
+    // Range covers only the first paragraph (positions 0–3).
+    acceptChange(0, 3)(view.state, view.dispatch);
+
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+    expect(view.state.doc.child(1).attrs["pPrMark"]).toEqual(
+      insMark({ id: 2 }),
+    );
+  });
+
+  test("acceptAll on a doc-terminal pPrMark='del' leaves the marker (no next sibling)", () => {
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, schema.text("first")),
+        schema.node(
+          "paragraph",
+          { pPrMark: delMark({ id: 1 }) },
+          schema.text("last"),
+        ),
+      ]),
+    });
+    const view = dispatcher(state);
+    acceptAllChanges()(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(1).attrs["pPrMark"]).toEqual(
+      delMark({ id: 1 }),
+    );
+  });
+
+  test("rejectChange + inline insertion on same paragraph resolves both", () => {
+    const insertion = schema.marks["insertion"];
+    if (!insertion) {
+      throw new Error("schema lacks insertion mark");
+    }
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", { pPrMark: insMark({ id: 1 }) }, [
+          schema.text("kept "),
+          schema.text("inserted", [
+            insertion.create({
+              revisionId: 1,
+              author: "Alice",
+              date: "2026-05-01",
+            }),
+          ]),
+        ]),
+        schema.node("paragraph", null, schema.text("next")),
+      ]),
+    });
+    const view = dispatcher(state);
+
+    rejectChange(0, view.state.doc.content.size)(view.state, view.dispatch);
+
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("kept next");
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+  });
+});

--- a/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/pPrMark-accept-reject.test.ts
@@ -121,13 +121,47 @@ describe("pPrMark accept / reject — paragraph-mark resolution", () => {
     });
     const view = dispatcher(state);
 
-    // Range covers only the first paragraph (positions 0–3).
-    acceptChange(0, 3)(view.state, view.dispatch);
+    // Range covers only the first paragraph, including its closing boundary.
+    acceptChange(0, 4)(view.state, view.dispatch);
 
     expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
     expect(view.state.doc.child(1).attrs["pPrMark"]).toEqual(
       insMark({ id: 2 }),
     );
+  });
+
+  test("range-scoped acceptChange keeps pPrMark when only inline text is selected", () => {
+    const insertion = schema.marks["insertion"]!;
+    const pPrMark = insMark({ id: 1 });
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", { pPrMark }, [
+          schema.text("a"),
+          schema.text("b", [
+            insertion.create({
+              revisionId: 2,
+              author: "Alice",
+              date: "2026-05-01",
+            }),
+          ]),
+        ]),
+        schema.node("paragraph", null, schema.text("next")),
+      ]),
+    });
+    const view = dispatcher(state);
+
+    acceptChange(2, 3)(view.state, view.dispatch);
+
+    let hasInsertion = false;
+    view.state.doc.child(0).descendants((node) => {
+      if (node.isText && node.marks.some((mark) => mark.type === insertion)) {
+        hasInsertion = true;
+      }
+    });
+    expect(hasInsertion).toBe(false);
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toEqual(pPrMark);
+    expect(view.state.doc.childCount).toBe(2);
   });
 
   test("acceptAll on a doc-terminal pPrMark='del' leaves the marker (no next sibling)", () => {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -343,6 +343,10 @@ function convertPMParagraph(
     paragraph.propertyChanges = [...attrs._propertyChanges];
   }
 
+  if (attrs.pPrMark) {
+    paragraph.pPrMark = attrs.pPrMark;
+  }
+
   return paragraph;
 }
 

--- a/packages/folio/src/core/prosemirror/conversion/pPrMark-roundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/pPrMark-roundtrip.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document, Paragraph } from "../../types/document";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+function paragraphWithMark(mark: NonNullable<Paragraph["pPrMark"]>): Document {
+  return {
+    package: {
+      document: {
+        content: [
+          {
+            type: "paragraph",
+            pPrMark: mark,
+            content: [
+              { type: "run", content: [{ type: "text", text: "hello" }] },
+            ],
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe("pPrMark — toProseDoc / fromProseDoc round-trip", () => {
+  test("preserves pPrMark.kind = 'ins' through PM and back", () => {
+    const doc = paragraphWithMark({
+      kind: "ins",
+      info: { id: 1, author: "Alice", date: "2026-05-01T10:00:00Z" },
+    });
+
+    const pmDoc = toProseDoc(doc);
+    const paragraph = pmDoc.firstChild;
+    expect(paragraph?.type.name).toBe("paragraph");
+    expect(paragraph?.attrs["pPrMark"]).toEqual({
+      kind: "ins",
+      info: { id: 1, author: "Alice", date: "2026-05-01T10:00:00Z" },
+    });
+
+    const rebuilt = fromProseDoc(pmDoc, doc);
+    const para = rebuilt.package.document.content.at(0);
+    expect(para?.type).toBe("paragraph");
+    if (para?.type !== "paragraph") {
+      return;
+    }
+    expect(para.pPrMark).toEqual({
+      kind: "ins",
+      info: { id: 1, author: "Alice", date: "2026-05-01T10:00:00Z" },
+    });
+  });
+
+  test("preserves pPrMark.kind = 'del' through PM and back", () => {
+    const doc = paragraphWithMark({
+      kind: "del",
+      info: { id: 9, author: "Bob" },
+    });
+
+    const pmDoc = toProseDoc(doc);
+    const rebuilt = fromProseDoc(pmDoc, doc);
+    const para = rebuilt.package.document.content.at(0);
+    expect(para?.type).toBe("paragraph");
+    if (para?.type !== "paragraph") {
+      return;
+    }
+    expect(para.pPrMark).toEqual({
+      kind: "del",
+      info: { id: 9, author: "Bob" },
+    });
+  });
+
+  test("absent pPrMark stays absent through the round-trip", () => {
+    const doc: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "run", content: [{ type: "text", text: "hello" }] },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(doc);
+    const rebuilt = fromProseDoc(pmDoc, doc);
+    const para = rebuilt.package.document.content.at(0);
+    expect(para?.type).toBe("paragraph");
+    if (para?.type !== "paragraph") {
+      return;
+    }
+    expect(para.pPrMark).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -467,6 +467,9 @@ function paragraphFormattingToAttrs(
   if (paragraph.propertyChanges && paragraph.propertyChanges.length > 0) {
     attrs._propertyChanges = [...paragraph.propertyChanges];
   }
+  if (paragraph.pPrMark) {
+    attrs.pPrMark = paragraph.pPrMark;
+  }
 
   // Helper: assign a value only when defined
   const set = <K extends keyof ParagraphAttrs>(

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -364,6 +364,7 @@ const paragraphNodeSpec: NodeSpec = {
     _originalFormatting: { default: null },
     _sectionProperties: { default: null },
     _propertyChanges: { default: null },
+    pPrMark: { default: null },
   },
   parseDOM: [
     {

--- a/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -105,7 +105,7 @@ const INHERITED_PARA_ATTRS = [
 /** Mark types that represent style-inherited formatting (font, size, color). */
 const STYLE_MARK_NAMES = new Set(["fontFamily", "fontSize", "textColor"]);
 
-const splitBlockClearBorders: Command = (state, dispatch, view) => {
+export const splitBlockClearBorders: Command = (state, dispatch, view) => {
   // Capture source paragraph info BEFORE split (splitBlock resets everything)
   const { $from: preSplitFrom } = state.selection;
   const sourcePara =

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode-pPrMark.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode-pPrMark.test.ts
@@ -130,9 +130,11 @@ describe("suggestion mode — paragraph-mark keymap", () => {
 
     const firstPPrMark = view.state.doc.child(0).attrs["pPrMark"] as {
       kind: "ins" | "del";
-      info: { author: string };
+      info: { id?: unknown; revisionId?: unknown; author: string };
     } | null;
     expect(firstPPrMark?.kind).toBe("ins");
+    expect(typeof firstPPrMark?.info.id).toBe("number");
+    expect(firstPPrMark?.info.revisionId).toBeUndefined();
     expect(firstPPrMark?.info.author).toBe("Tester");
     expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
   });
@@ -170,8 +172,11 @@ describe("suggestion mode — paragraph-mark keymap", () => {
     expect(view.state.doc.child(1).textContent).toBe("second");
     const firstMark = view.state.doc.child(0).attrs["pPrMark"] as {
       kind: "ins" | "del";
+      info: { id?: unknown; revisionId?: unknown };
     } | null;
     expect(firstMark?.kind).toBe("del");
+    expect(typeof firstMark?.info.id).toBe("number");
+    expect(firstMark?.info.revisionId).toBeUndefined();
   });
 
   test("Delete at paragraph end sets pPrMark.kind='del' on the current paragraph", () => {
@@ -189,7 +194,62 @@ describe("suggestion mode — paragraph-mark keymap", () => {
     expect(view.state.doc.child(0).textContent).toBe("first");
     const firstMark = view.state.doc.child(0).attrs["pPrMark"] as {
       kind: "ins" | "del";
+      info: { id?: unknown; revisionId?: unknown };
     } | null;
     expect(firstMark?.kind).toBe("del");
+    expect(typeof firstMark?.info.id).toBe("number");
+    expect(firstMark?.info.revisionId).toBeUndefined();
+  });
+
+  test("Backspace retracts the current author's paragraph-mark insertion", () => {
+    const initial = stateWith([
+      {
+        text: "first",
+        pPrMark: {
+          kind: "ins",
+          info: { id: 99, author: "Tester", date: "2026-05-01" },
+        },
+      },
+      { text: "second" },
+    ]);
+    const state = setCaret(initial, 8);
+    const view = createFakeView(state);
+    const p = plug();
+    const handled = p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Backspace" } as KeyboardEvent,
+    );
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("firstsecond");
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("Delete retracts the current author's paragraph-mark insertion", () => {
+    const initial = stateWith([
+      {
+        text: "first",
+        pPrMark: {
+          kind: "ins",
+          info: { id: 100, author: "Tester", date: "2026-05-01" },
+        },
+      },
+      { text: "second" },
+    ]);
+    const state = setCaret(initial, 6);
+    const view = createFakeView(state);
+    const p = plug();
+    const handled = p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Delete" } as KeyboardEvent,
+    );
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.childCount).toBe(1);
+    expect(view.state.doc.child(0).textContent).toBe("firstsecond");
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toBeNull();
   });
 });

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode-pPrMark.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode-pPrMark.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import { Schema } from "prosemirror-model";
+import type { Plugin } from "prosemirror-state";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import {
+  createSuggestionModePlugin,
+  paragraphBoundaryTarget,
+} from "./suggestionMode";
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      attrs: { pPrMark: { default: null } },
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+  marks: {
+    insertion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      toDOM: () => ["ins", 0],
+    },
+    deletion: {
+      attrs: { revisionId: {}, author: {}, date: {} },
+      toDOM: () => ["del", 0],
+    },
+  },
+});
+
+type FakeView = {
+  state: EditorState;
+  dispatch: EditorView["dispatch"];
+};
+
+function createFakeView(state: EditorState): FakeView {
+  const view: FakeView = {
+    state,
+    dispatch(tr) {
+      view.state = view.state.apply(tr);
+    },
+  };
+  return view;
+}
+
+function plug(): Plugin {
+  return createSuggestionModePlugin(true, "Tester");
+}
+
+function setCaret(state: EditorState, pos: number): EditorState {
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, pos)),
+  );
+}
+
+function makeDoc(paragraphs: { text: string; pPrMark?: unknown }[]) {
+  return schema.node(
+    "doc",
+    null,
+    paragraphs.map((p) =>
+      schema.node(
+        "paragraph",
+        { pPrMark: p.pPrMark ?? null },
+        p.text ? [schema.text(p.text)] : [],
+      ),
+    ),
+  );
+}
+
+function stateWith(paragraphs: { text: string; pPrMark?: unknown }[]) {
+  return EditorState.create({
+    schema,
+    doc: makeDoc(paragraphs),
+    plugins: [plug()],
+  });
+}
+
+describe("paragraphBoundaryTarget", () => {
+  test("returns previous paragraph position when caret is at start of paragraph", () => {
+    const initial = stateWith([{ text: "first" }, { text: "second" }]);
+    // Position of caret at start of "second" — start of "first" is 1,
+    // end is 1 + "first".length + 1 (paragraph close) = 7, start of "second" is 8.
+    const state = setCaret(initial, 8);
+    expect(paragraphBoundaryTarget(state, "backward")).toBe(0);
+  });
+
+  test("returns null when caret is mid-paragraph", () => {
+    const initial = stateWith([{ text: "hello" }, { text: "world" }]);
+    const state = setCaret(initial, 3);
+    expect(paragraphBoundaryTarget(state, "backward")).toBeNull();
+    expect(paragraphBoundaryTarget(state, "forward")).toBeNull();
+  });
+
+  test("returns current paragraph position when caret is at end of paragraph", () => {
+    const initial = stateWith([{ text: "first" }, { text: "second" }]);
+    // End of "first" is 1 + 5 = 6.
+    const state = setCaret(initial, 6);
+    expect(paragraphBoundaryTarget(state, "forward")).toBe(0);
+  });
+
+  test("returns null at document edges (Backspace at doc start, Delete at doc end)", () => {
+    const initial = stateWith([{ text: "lone" }]);
+    const startCaret = setCaret(initial, 1);
+    const endCaret = setCaret(initial, 5);
+    expect(paragraphBoundaryTarget(startCaret, "backward")).toBeNull();
+    expect(paragraphBoundaryTarget(endCaret, "forward")).toBeNull();
+  });
+});
+
+describe("suggestion mode — paragraph-mark keymap", () => {
+  test("Enter mid-paragraph stamps pPrMark.kind='ins' on the first half", () => {
+    const initial = stateWith([{ text: "hello world" }]);
+    const state = setCaret(initial, 6);
+    const view = createFakeView(state);
+    const p = plug();
+    const handled = p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Enter" } as KeyboardEvent,
+    );
+
+    expect(handled).toBe(true);
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(0).textContent).toBe("hello");
+    expect(view.state.doc.child(1).textContent).toBe(" world");
+
+    const firstPPrMark = view.state.doc.child(0).attrs["pPrMark"] as {
+      kind: "ins" | "del";
+      info: { author: string };
+    } | null;
+    expect(firstPPrMark?.kind).toBe("ins");
+    expect(firstPPrMark?.info.author).toBe("Tester");
+    expect(view.state.doc.child(1).attrs["pPrMark"]).toBeNull();
+  });
+
+  test("Enter does not overwrite an existing pPrMark on the source paragraph", () => {
+    const existing = {
+      kind: "ins" as const,
+      info: { id: 99, author: "Other", date: "2026-01-01" },
+    };
+    const initial = stateWith([{ text: "hello world", pPrMark: existing }]);
+    const state = setCaret(initial, 6);
+    const view = createFakeView(state);
+    const p = plug();
+    p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Enter" } as KeyboardEvent,
+    );
+
+    expect(view.state.doc.child(0).attrs["pPrMark"]).toEqual(existing);
+  });
+
+  test("Backspace at paragraph start sets pPrMark.kind='del' on the previous paragraph", () => {
+    const initial = stateWith([{ text: "first" }, { text: "second" }]);
+    const state = setCaret(initial, 8);
+    const view = createFakeView(state);
+    const p = plug();
+    p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Backspace" } as KeyboardEvent,
+    );
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(1).textContent).toBe("second");
+    const firstMark = view.state.doc.child(0).attrs["pPrMark"] as {
+      kind: "ins" | "del";
+    } | null;
+    expect(firstMark?.kind).toBe("del");
+  });
+
+  test("Delete at paragraph end sets pPrMark.kind='del' on the current paragraph", () => {
+    const initial = stateWith([{ text: "first" }, { text: "second" }]);
+    const state = setCaret(initial, 6);
+    const view = createFakeView(state);
+    const p = plug();
+    p.props.handleKeyDown?.call(
+      p,
+      view as unknown as EditorView,
+      { key: "Delete" } as KeyboardEvent,
+    );
+
+    expect(view.state.doc.childCount).toBe(2);
+    expect(view.state.doc.child(0).textContent).toBe("first");
+    const firstMark = view.state.doc.child(0).attrs["pPrMark"] as {
+      kind: "ins" | "del";
+    } | null;
+    expect(firstMark?.kind).toBe("del");
+  });
+});

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -16,6 +16,8 @@ import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import { splitBlockClearBorders } from "../extensions/features/BaseKeymapExtension";
+
 export const suggestionModeKey = new PluginKey<SuggestionModeState>(
   "suggestionMode",
 );
@@ -208,6 +210,143 @@ function applySuggestionInsert(
 }
 
 /**
+ * Track-changes Enter: split the paragraph and stamp `pPrMark = 'ins'` on the
+ * FIRST half of the split (the upper paragraph), per ECMA-376 §17.13.5. The
+ * actual splitting reuses `splitBlockClearBorders` so border/style/stored-mark
+ * behavior stays identical to ordinary editing.
+ *
+ * If the source paragraph already carries a `pPrMark`, leave it alone — a
+ * prior author's revision must not be silently overwritten.
+ */
+function handleSuggestionEnter(
+  view: EditorView,
+  pluginState: SuggestionModeState,
+): boolean {
+  const { $from } = view.state.selection;
+  if ($from.parent.type.name !== "paragraph") {
+    return false;
+  }
+  const sourcePos = $from.before();
+  const sourceAttrs = $from.parent.attrs;
+
+  const captured = { tr: null as Transaction | null };
+  const ok = splitBlockClearBorders(
+    view.state,
+    (tr: Transaction) => {
+      captured.tr = tr;
+    },
+    view,
+  );
+  if (!ok || !captured.tr) {
+    return false;
+  }
+  const tr = captured.tr;
+  if (sourceAttrs["pPrMark"] == null) {
+    const sourceParagraph = tr.doc.nodeAt(sourcePos);
+    if (sourceParagraph?.type.name === "paragraph") {
+      const markInfo: ParagraphMarkAttr = {
+        kind: "ins",
+        info: makeMarkAttrs(pluginState),
+      };
+      tr.setNodeAttribute(sourcePos, "pPrMark", markInfo);
+    }
+  }
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+type ParagraphMarkAttr = {
+  kind: "ins" | "del";
+  info: MarkAttrs;
+};
+
+/**
+ * Detect a caret-at-paragraph-boundary scenario where Backspace/Delete should
+ * record a tracked paragraph-mark deletion instead of joining paragraphs.
+ *
+ * Returns the position of the paragraph whose `pPrMark` should be set, or
+ * `null` if the caret is mid-paragraph (let the normal text-delete path run).
+ *
+ * - Backspace-at-paragraph-start → previous sibling paragraph.
+ * - Delete-at-paragraph-end     → current paragraph.
+ *
+ * Returns `null` when there is no adjacent sibling paragraph (the join would
+ * not produce paragraph-mark merging — e.g. doc start, doc end, or sibling
+ * is a table). The default merge path then runs unchanged.
+ */
+export function paragraphBoundaryTarget(
+  state: EditorState,
+  direction: "backward" | "forward",
+): number | null {
+  const { $from, empty } = state.selection;
+  if (!empty) {
+    return null;
+  }
+  if ($from.parent.type.name !== "paragraph") {
+    return null;
+  }
+  const paragraphStart = $from.before();
+  const paragraphEnd = $from.after();
+
+  if (direction === "backward") {
+    if ($from.parentOffset !== 0) {
+      return null;
+    }
+    if (paragraphStart === 0) {
+      return null;
+    }
+    const $prevEdge = state.doc.resolve(paragraphStart);
+    const prev = $prevEdge.nodeBefore;
+    if (!prev || prev.type.name !== "paragraph") {
+      return null;
+    }
+    return paragraphStart - prev.nodeSize;
+  }
+
+  if ($from.parentOffset !== $from.parent.content.size) {
+    return null;
+  }
+  if (paragraphEnd >= state.doc.content.size) {
+    return null;
+  }
+  const $nextEdge = state.doc.resolve(paragraphEnd);
+  const next = $nextEdge.nodeAfter;
+  if (!next || next.type.name !== "paragraph") {
+    return null;
+  }
+  return paragraphStart;
+}
+
+/**
+ * Mark a paragraph break as a tracked deletion. `target` is the position of
+ * the paragraph whose closing mark is being deleted (per OOXML, that's the
+ * previous paragraph for Backspace-at-start and the current paragraph for
+ * Delete-at-end). Idempotent: a `pPrMark` already set is left alone.
+ */
+function applyPPrDel(
+  view: EditorView,
+  targetParagraphPos: number,
+  pluginState: SuggestionModeState,
+): boolean {
+  const targetNode = view.state.doc.nodeAt(targetParagraphPos);
+  if (!targetNode || targetNode.type.name !== "paragraph") {
+    return false;
+  }
+  if (targetNode.attrs["pPrMark"] != null) {
+    return true;
+  }
+  const tr = view.state.tr;
+  tr.setMeta(SUGGESTION_META, true);
+  const markInfo: ParagraphMarkAttr = {
+    kind: "del",
+    info: makeMarkAttrs(pluginState),
+  };
+  tr.setNodeAttribute(targetParagraphPos, "pPrMark", markInfo);
+  view.dispatch(tr.scrollIntoView());
+  return true;
+}
+
+/**
  * Handle delete (forward or backward) in suggestion mode.
  */
 function handleSuggestionDelete(
@@ -352,18 +491,28 @@ export function createSuggestionModePlugin(
           return false;
         },
       },
-      // Intercept Backspace and Delete to mark as deletion
+      // Intercept Enter / Backspace / Delete so paragraph-mark revisions
+      // (ECMA-376 §17.13.5) get recorded instead of silently splitting or
+      // joining paragraphs.
       handleKeyDown(view: EditorView, event: KeyboardEvent): boolean {
         const pluginState = suggestionModeKey.getState(view.state);
         if (!pluginState?.active) {
           return false;
         }
 
-        if (event.key === "Backspace") {
-          return handleSuggestionDelete(view.state, view.dispatch, "backward");
+        if (event.key === "Enter") {
+          return handleSuggestionEnter(view, pluginState);
         }
-        if (event.key === "Delete") {
-          return handleSuggestionDelete(view.state, view.dispatch, "forward");
+        if (event.key === "Backspace" || event.key === "Delete") {
+          const boundaryTarget = paragraphBoundaryTarget(
+            view.state,
+            event.key === "Backspace" ? "backward" : "forward",
+          );
+          if (boundaryTarget !== null) {
+            return applyPPrDel(view, boundaryTarget, pluginState);
+          }
+          const direction = event.key === "Backspace" ? "backward" : "forward";
+          return handleSuggestionDelete(view.state, view.dispatch, direction);
         }
         return false;
       },

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -16,6 +16,7 @@ import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import type { EditorState, Transaction } from "prosemirror-state";
 import type { EditorView } from "prosemirror-view";
 
+import type { TrackedChangeInfo } from "../../types/document";
 import { splitBlockClearBorders } from "../extensions/features/BaseKeymapExtension";
 
 export const suggestionModeKey = new PluginKey<SuggestionModeState>(
@@ -41,6 +42,17 @@ function makeMarkAttrs(pluginState: SuggestionModeState): MarkAttrs {
     revisionId: nextRevisionId++,
     author: pluginState.author,
     date: new Date().toISOString(),
+  };
+}
+
+function makeParagraphMarkInfo(
+  pluginState: SuggestionModeState,
+): TrackedChangeInfo {
+  const attrs = makeMarkAttrs(pluginState);
+  return {
+    id: attrs.revisionId,
+    author: attrs.author,
+    date: attrs.date,
   };
 }
 
@@ -246,7 +258,7 @@ function handleSuggestionEnter(
     if (sourceParagraph?.type.name === "paragraph") {
       const markInfo: ParagraphMarkAttr = {
         kind: "ins",
-        info: makeMarkAttrs(pluginState),
+        info: makeParagraphMarkInfo(pluginState),
       };
       tr.setNodeAttribute(sourcePos, "pPrMark", markInfo);
     }
@@ -257,7 +269,7 @@ function handleSuggestionEnter(
 
 type ParagraphMarkAttr = {
   kind: "ins" | "del";
-  info: MarkAttrs;
+  info: TrackedChangeInfo;
 };
 
 /**
@@ -321,7 +333,8 @@ export function paragraphBoundaryTarget(
  * Mark a paragraph break as a tracked deletion. `target` is the position of
  * the paragraph whose closing mark is being deleted (per OOXML, that's the
  * previous paragraph for Backspace-at-start and the current paragraph for
- * Delete-at-end). Idempotent: a `pPrMark` already set is left alone.
+ * Delete-at-end). If the existing mark is the current author's insertion,
+ * retract it by joining the paragraphs back together.
  */
 function applyPPrDel(
   view: EditorView,
@@ -332,18 +345,51 @@ function applyPPrDel(
   if (!targetNode || targetNode.type.name !== "paragraph") {
     return false;
   }
-  if (targetNode.attrs["pPrMark"] != null) {
+  const existingMark = targetNode.attrs["pPrMark"];
+  if (isCurrentAuthorParagraphInsertion(existingMark, pluginState.author)) {
+    const tr = view.state.tr;
+    tr.setMeta(SUGGESTION_META, true);
+    const joinPos = targetParagraphPos + targetNode.nodeSize;
+    try {
+      tr.join(joinPos);
+      tr.setNodeAttribute(targetParagraphPos, "pPrMark", null);
+      view.dispatch(tr.scrollIntoView());
+    } catch {
+      return true;
+    }
+    return true;
+  }
+  if (existingMark != null) {
     return true;
   }
   const tr = view.state.tr;
   tr.setMeta(SUGGESTION_META, true);
   const markInfo: ParagraphMarkAttr = {
     kind: "del",
-    info: makeMarkAttrs(pluginState),
+    info: makeParagraphMarkInfo(pluginState),
   };
   tr.setNodeAttribute(targetParagraphPos, "pPrMark", markInfo);
   view.dispatch(tr.scrollIntoView());
   return true;
+}
+
+function isCurrentAuthorParagraphInsertion(
+  value: unknown,
+  author: string,
+): value is ParagraphMarkAttr {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const mark = value as { kind?: unknown; info?: unknown };
+  if (
+    mark.kind !== "ins" ||
+    typeof mark.info !== "object" ||
+    mark.info === null
+  ) {
+    return false;
+  }
+  const info = mark.info as { author?: unknown };
+  return info.author === author;
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -10,6 +10,7 @@ import type { FloatingTableProperties, TableLook } from "../../types";
 import type {
   ParagraphAlignment,
   ParagraphFormatting,
+  ParagraphMarkChange,
   ParagraphPropertyChange,
   FieldType,
   Hyperlink,
@@ -171,6 +172,14 @@ export type ParagraphAttrs = {
    *  `w:pPrChange` history Word relies on for "show previous formatting"
    *  and for reverting an accepted property change. */
   _propertyChanges?: ParagraphPropertyChange[];
+
+  /** Paragraph-mark insertion / deletion (`<w:pPr><w:rPr><w:ins/>` /
+   *  `<w:del/>`). Word emits this when the paragraph break itself was
+   *  authored in track-changes mode — pressing Enter mid-paragraph
+   *  produces an `ins`, Backspace-at-start / Delete-at-end produce a
+   *  `del`. Stored as a discriminated union to mirror folio's
+   *  `TrackedChangeWrapperType` model rather than two parallel attrs. */
+  pPrMark?: ParagraphMarkChange;
 };
 
 /**


### PR DESCRIPTION
## Summary

OOXML records paragraph-mark insertions and deletions as `<w:ins/>` or `<w:del/>` inside `<w:pPr><w:rPr>` — the marker for *"the paragraph break itself was authored in track-changes mode"* (Enter mid-paragraph, or Backspace-at-start / Delete-at-end pending deletion). Folio's parser, serializer, and suggesting-mode keymap previously dropped these markers silently, so any DOCX with paragraph-mark revisions lost them on open + save.

Closes the round-trip data-loss path and adds authoring support, structured into three reviewable commits:

1. **Round-trip** — `Paragraph.pPrMark: { kind: 'ins' | 'del'; info }` in `@stll/docx-core/model`; parser reads `<w:pPr><w:rPr><w:ins|w:del/>`; serializer emits it as the **first** child inside `<w:rPr>` per `EG_ParaRPrTrackChanges` (wml.xsd:1837) — strict readers reject other orderings; PM schema gains the attr; `toProseDoc` / `fromProseDoc` preserve it.
2. **Accept / reject** — `acceptChange` / `rejectChange` (+ bulk variants) walk paragraph nodes alongside inline marks. accept-ins / reject-del clear the attr; reject-ins / accept-del join with the next paragraph and clear. Doc-terminal `pPrMark='del'` is a no-op (matches Word). Ops run from end → start in a single transaction.
3. **Keymap** — Enter composes with `splitBlockClearBorders` (newly exported) and stamps `pPrMark='ins'` on the upper half of the split; Backspace-at-paragraph-start sets `pPrMark='del'` on the previous paragraph; Delete-at-paragraph-end sets it on the current paragraph. Prior author's marker is never silently overwritten. Actual merges are deferred to `acceptChange`.

Modeled as a discriminated union (`{ kind: 'ins' | 'del'; info }`) instead of upstream's two parallel `pPrIns` / `pPrDel` attrs, to mirror folio's existing `TrackedChangeWrapperType`.

## Not included

- Painter cues (pilcrow glyph, change bar) — `pPrMark` has no measurable layout impact today, so the layout cache key stays untouched.
- Sidebar review entries.
- `pPrChange` / `paraRPrChange` (paragraph-property revisions) — separate scope; folio's existing `_propertyChanges` already round-trips `w:pPrChange`.

These can layer in without touching this surface.

## Test surface

28 new tests across parser, serializer, PM round-trip, accept/reject, and keymap. Full folio test suite: 980 pass / 0 fail.