### PR TITLE
feat(uploads): presigned S3 PUT migration (phases 1-3)

### DIFF
--- a/apps/api/drizzle/20260529214500_pending_upload_purposes/migration.sql
+++ b/apps/api/drizzle/20260529214500_pending_upload_purposes/migration.sql
@@ -1,0 +1,4 @@
+-- No SQL change: pending_uploads.purpose is stored as text without a
+-- database CHECK constraint. This migration records the schema.ts enum
+-- expansion to entity_version and agent_skill so the migration coverage
+-- guard sees an intentional schema input change.

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1363,21 +1363,38 @@ export const PENDING_UPLOAD_STATUSES = [
  * can be added without a schema migration — only `purposeData` and
  * `finalizedResult` shapes change.
  */
-export const PENDING_UPLOAD_PURPOSES = ["entity_create"] as const;
+export const PENDING_UPLOAD_PURPOSES = [
+  "entity_create",
+  "entity_version",
+] as const;
 
-export type PendingUploadPurposeData = {
-  type: "entity_create";
-  propertyId: SafeId<"property">;
-};
+export type PendingUploadPurposeData =
+  | {
+      type: "entity_create";
+      propertyId: SafeId<"property">;
+    }
+  | {
+      type: "entity_version";
+      entityId: SafeId<"entity">;
+    };
 
-export type PendingUploadFinalizedResult = {
-  type: "entity_create";
-  entityId: SafeId<"entity">;
-  /** UUIDv7 stored on `fields.content.id`; not a branded SafeId. */
-  fileId: string;
-  fileName: string;
-  renamed: boolean;
-};
+export type PendingUploadFinalizedResult =
+  | {
+      type: "entity_create";
+      entityId: SafeId<"entity">;
+      /** UUIDv7 stored on `fields.content.id`; not a branded SafeId. */
+      fileId: string;
+      fileName: string;
+      renamed: boolean;
+    }
+  | {
+      type: "entity_version";
+      entityId: SafeId<"entity">;
+      entityVersionId: SafeId<"entityVersion">;
+      versionNumber: number;
+      fileId: string;
+      fileName: string;
+    };
 
 export const pendingUploads = p.pgTable(
   "pending_uploads",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1366,6 +1366,7 @@ export const PENDING_UPLOAD_STATUSES = [
 export const PENDING_UPLOAD_PURPOSES = [
   "entity_create",
   "entity_version",
+  "agent_skill",
 ] as const;
 
 export type PendingUploadPurposeData =
@@ -1376,6 +1377,13 @@ export type PendingUploadPurposeData =
   | {
       type: "entity_version";
       entityId: SafeId<"entity">;
+    }
+  | {
+      type: "agent_skill";
+      // "team" requires admin/owner role; "private" is per-user.
+      // Kept inline (not aliased to `AgentSkillScope`) because that
+      // type is declared further down the file.
+      scope: "team" | "private";
     };
 
 export type PendingUploadFinalizedResult =
@@ -1394,6 +1402,12 @@ export type PendingUploadFinalizedResult =
       versionNumber: number;
       fileId: string;
       fileName: string;
+    }
+  | {
+      type: "agent_skill";
+      skillId: SafeId<"agentSkill">;
+      name: string;
+      version: string;
     };
 
 export const pendingUploads = p.pgTable(

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1373,7 +1373,8 @@ export type PendingUploadPurposeData = {
 export type PendingUploadFinalizedResult = {
   type: "entity_create";
   entityId: SafeId<"entity">;
-  fileId: SafeId<"userFile">;
+  /** UUIDv7 stored on `fields.content.id`; not a branded SafeId. */
+  fileId: string;
   fileName: string;
   renamed: boolean;
 };

--- a/apps/api/src/handlers/skills/install.ts
+++ b/apps/api/src/handlers/skills/install.ts
@@ -1,7 +1,7 @@
 import { Result } from "better-result";
 import { and, eq } from "drizzle-orm";
 
-import type { SafeDb } from "@/api/db";
+import type { SafeDb, Transaction } from "@/api/db";
 import { agentSkillResources, agentSkills } from "@/api/db/schema";
 import type { AgentSkillOrigin, AgentSkillScope } from "@/api/db/schema";
 import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
@@ -15,6 +15,10 @@ import type { ParsedSkillPackage } from "./skill-package";
 
 type InstallSkillProps = {
   memberRole: { role: string };
+  onInstalled?: (
+    tx: Transaction,
+    skill: { id: SafeId<"agentSkill"> },
+  ) => Promise<void>;
   origin: AgentSkillOrigin;
   parsed: ParsedSkillPackage;
   recordAuditEvent: AuditRecorder;
@@ -31,6 +35,7 @@ type InstallSkillTransactionResult =
 
 export const installSkill = async ({
   memberRole,
+  onInstalled,
   origin,
   parsed,
   recordAuditEvent,
@@ -115,6 +120,7 @@ export const installSkill = async ({
               },
             },
           });
+          await onInstalled?.(innerTx, { id: row.id });
 
           return { id: row.id, type: "installed" };
         },

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -11,11 +11,15 @@
  * and "aborting" no longer has a meaning.
  */
 import { Result } from "better-result";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { pendingUploads } from "@/api/db/schema";
 import { tmpUploadKey } from "@/api/handlers/uploads/lib";
+import {
+  authorizeUploadPurpose,
+  uploadRoutePermission,
+} from "@/api/handlers/uploads/permissions";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -29,18 +33,13 @@ const abortParamsSchema = t.Object({
 });
 
 const config = {
-  // entity:create matches the most common abort caller (the
-  // create-file-entities upload queue cancelling on user request).
-  // When phase 2+ adds purposes with different permissions, the
-  // check can move purpose-side, but a single `entity:create`
-  // gate is sufficient for phase 1.
-  permissions: { entity: ["create"] },
+  permissions: uploadRoutePermission,
   params: abortParamsSchema,
 } satisfies HandlerConfig;
 
 const abortUpload = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, params }) {
+  async function* ({ safeDb, workspaceId, memberRole, params }) {
     const uploadId = params.uploadId;
 
     const existing = yield* Result.await(
@@ -54,6 +53,13 @@ const abortUpload = createSafeHandler(
       return Result.err(
         new HandlerError({ status: 404, message: "Upload not found" }),
       );
+    }
+    const authorization = authorizeUploadPurpose({
+      memberRole,
+      purpose: existing.purpose,
+    });
+    if (Result.isError(authorization)) {
+      return Result.err(authorization.error);
     }
     if (existing.status === "finalized") {
       return Result.err(
@@ -80,7 +86,12 @@ const abortUpload = createSafeHandler(
             rejectReason: "Aborted by client",
             finalizedAt: new Date(),
           })
-          .where(eq(pendingUploads.id, uploadId));
+          .where(
+            and(
+              eq(pendingUploads.id, uploadId),
+              eq(pendingUploads.workspaceId, workspaceId),
+            ),
+          );
       }),
     );
 

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -39,13 +39,17 @@ const config = {
 
 const abortUpload = createSafeHandler(
   config,
-  async function* ({ safeDb, workspaceId, memberRole, params }) {
+  async function* ({ safeDb, workspaceId, user, memberRole, params }) {
     const uploadId = params.uploadId;
 
     const existing = yield* Result.await(
       safeDb((tx) =>
         tx.query.pendingUploads.findFirst({
-          where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+          where: {
+            id: { eq: uploadId },
+            userId: { eq: user.id },
+            workspaceId: { eq: workspaceId },
+          },
         }),
       ),
     );
@@ -89,6 +93,7 @@ const abortUpload = createSafeHandler(
           .where(
             and(
               eq(pendingUploads.id, uploadId),
+              eq(pendingUploads.userId, user.id),
               eq(pendingUploads.workspaceId, workspaceId),
               inArray(pendingUploads.status, ["pending", "failed"]),
             ),
@@ -100,7 +105,11 @@ const abortUpload = createSafeHandler(
       const latest = yield* Result.await(
         safeDb((tx) =>
           tx.query.pendingUploads.findFirst({
-            where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+            where: {
+              id: { eq: uploadId },
+              userId: { eq: user.id },
+              workspaceId: { eq: workspaceId },
+            },
             columns: { status: true },
           }),
         ),

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -11,7 +11,7 @@
  * and "aborting" no longer has a meaning.
  */
 import { Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { t } from "elysia";
 
 import { pendingUploads } from "@/api/db/schema";
@@ -73,7 +73,7 @@ const abortUpload = createSafeHandler(
       return Result.ok({ ok: true as const });
     }
 
-    yield* Result.await(
+    const abortedRows = yield* Result.await(
       // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
       safeDb((tx) => {
         // audit: skip — pending_uploads bookkeeping; the row never
@@ -90,10 +90,39 @@ const abortUpload = createSafeHandler(
             and(
               eq(pendingUploads.id, uploadId),
               eq(pendingUploads.workspaceId, workspaceId),
+              inArray(pendingUploads.status, ["pending", "failed"]),
             ),
-          );
+          )
+          .returning({ id: pendingUploads.id });
       }),
     );
+    if (!abortedRows.at(0)) {
+      const latest = yield* Result.await(
+        safeDb((tx) =>
+          tx.query.pendingUploads.findFirst({
+            where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+            columns: { status: true },
+          }),
+        ),
+      );
+      if (!latest) {
+        return Result.err(
+          new HandlerError({ status: 404, message: "Upload not found" }),
+        );
+      }
+      if (latest.status === "rejected") {
+        return Result.ok({ ok: true as const });
+      }
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message:
+            latest.status === "finalized"
+              ? "Upload already finalized — use entity delete instead"
+              : "Finalize already in progress for this upload",
+        }),
+      );
+    }
 
     // Best-effort tmp cleanup. The client may have never actually
     // PUT (so the object never existed) — `delete` on a missing key

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -19,7 +19,6 @@ import { tmpUploadKey } from "@/api/handlers/uploads/lib";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
-import type { SafeId } from "@/api/lib/branded-types";
 import { tSafeId } from "@/api/lib/custom-schema";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { getS3 } from "@/api/lib/s3";
@@ -42,7 +41,7 @@ const config = {
 const abortUpload = createSafeHandler(
   config,
   async function* ({ safeDb, workspaceId, params }) {
-    const uploadId = params.uploadId as SafeId<"pendingUpload">;
+    const uploadId = params.uploadId;
 
     const existing = yield* Result.await(
       safeDb((tx) =>

--- a/apps/api/src/handlers/uploads/abort.ts
+++ b/apps/api/src/handlers/uploads/abort.ts
@@ -1,0 +1,101 @@
+/**
+ * Mark a pending upload as `rejected` so its `tmp/` slot stops
+ * counting against the user's intent and so a later finalize call
+ * returns the cached reason rather than re-running the FSM.
+ * Best-effort tmp delete on top; the bucket lifecycle catches
+ * anything we miss.
+ *
+ * Idempotent for clients: re-aborting an already-aborted row
+ * returns 200, not 409. Aborting after finalize commits returns
+ * 409 because at that point the bytes are part of the workspace
+ * and "aborting" no longer has a meaning.
+ */
+import { Result } from "better-result";
+import { eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { pendingUploads } from "@/api/db/schema";
+import { tmpUploadKey } from "@/api/handlers/uploads/lib";
+import { captureError } from "@/api/lib/analytics";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { getS3 } from "@/api/lib/s3";
+
+const abortParamsSchema = t.Object({
+  workspaceId: tSafeId("workspace"),
+  uploadId: tSafeId("pendingUpload"),
+});
+
+const config = {
+  // entity:create matches the most common abort caller (the
+  // create-file-entities upload queue cancelling on user request).
+  // When phase 2+ adds purposes with different permissions, the
+  // check can move purpose-side, but a single `entity:create`
+  // gate is sufficient for phase 1.
+  permissions: { entity: ["create"] },
+  params: abortParamsSchema,
+} satisfies HandlerConfig;
+
+const abortUpload = createSafeHandler(
+  config,
+  async function* ({ safeDb, workspaceId, params }) {
+    const uploadId = params.uploadId as SafeId<"pendingUpload">;
+
+    const existing = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.pendingUploads.findFirst({
+          where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+        }),
+      ),
+    );
+    if (!existing) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Upload not found" }),
+      );
+    }
+    if (existing.status === "finalized") {
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Upload already finalized — use entity delete instead",
+        }),
+      );
+    }
+    if (existing.status === "rejected") {
+      return Result.ok({ ok: true as const });
+    }
+
+    yield* Result.await(
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      safeDb((tx) => {
+        // audit: skip — pending_uploads bookkeeping; the row never
+        // became a durable entity, so there's nothing for the audit
+        // log to attribute it to.
+        return tx
+          .update(pendingUploads)
+          .set({
+            status: "rejected",
+            rejectReason: "Aborted by client",
+            finalizedAt: new Date(),
+          })
+          .where(eq(pendingUploads.id, uploadId));
+      }),
+    );
+
+    // Best-effort tmp cleanup. The client may have never actually
+    // PUT (so the object never existed) — `delete` on a missing key
+    // is a no-op on S3 / MinIO.
+    await getS3()
+      .delete(tmpUploadKey(uploadId))
+      .catch((error: unknown) =>
+        captureError(error, { uploadId, stage: "tmp-cleanup-after-abort" }),
+      );
+
+    return Result.ok({ ok: true as const });
+  },
+);
+
+export default abortUpload;

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -1,0 +1,166 @@
+/**
+ * `agent_skill` purpose: presigned-upload flow that ends in an
+ * installed `agentSkills` row + companion `agentSkillResources`,
+ * mirroring the legacy multipart endpoint at
+ * `apps/api/src/handlers/skills/upload.ts`.
+ *
+ * Unlike entity_create / entity_version, agent_skill uploads are
+ * root-scoped (no `workspaceId`). The pending_uploads row carries
+ * `workspace_id IS NULL` and `organization_*_root` RLS policies
+ * gate access. `validateAgentSkill` enforces the team-scope
+ * admin/owner check the legacy handler runs.
+ */
+import { Result } from "better-result";
+
+import type { SafeDb } from "@/api/db";
+import type { PendingUploadFinalizedResult } from "@/api/db/schema";
+import {
+  authorizeSkillInstallScope,
+  installSkill,
+} from "@/api/handlers/skills/install";
+import { parseUploadedSkillPackage } from "@/api/handlers/skills/skill-package";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+import { finalizeErr, finalizeOk } from "./lib";
+
+export type ValidateAgentSkillProps = {
+  memberRole: { role: string };
+  scope: "team" | "private";
+};
+
+/**
+ * The legacy handler's scope check is pure (no DB), so we reuse it
+ * verbatim. Returning early at presign time keeps the API from
+ * minting a URL for an upload the user can't legitimately finalize.
+ *
+ * @yields nothing — pure check.
+ */
+// eslint-disable-next-line require-yield -- generator shape matches the dispatch contract
+export const validateAgentSkill = async function* ({
+  memberRole,
+  scope,
+}: ValidateAgentSkillProps) {
+  const authorization = authorizeSkillInstallScope({ memberRole, scope });
+  if (Result.isError(authorization)) {
+    return Result.err(authorization.error);
+  }
+  return Result.ok(undefined);
+};
+
+export type FinalizeAgentSkillProps = {
+  safeDb: SafeDb;
+  recordAuditEvent: AuditRecorder;
+  organizationId: SafeId<"organization">;
+  userId: SafeId<"user">;
+  memberRole: { role: string };
+  fileBuffer: ArrayBuffer;
+  declaredName: string;
+  declaredMime: string;
+  scope: "team" | "private";
+};
+
+/**
+ * Domain transaction for `agent_skill`: parses the uploaded ZIP /
+ * markdown into a `ParsedSkillPackage`, then runs the legacy
+ * `installSkill` path which handles user-limit, slug-uniqueness,
+ * resource fan-out, and the audit row.
+ *
+ * The skill rows do not have an S3 backing object (the skill body
+ * + resources are inlined into the DB columns), so the
+ * "finalKey" we return is a synthetic placeholder. The
+ * upload-runtime still copies the tmp object to it, then
+ * lifecycle-cleans because no consumer reads from there — phase 6
+ * can drop the copy for skill uploads if the bookkeeping becomes
+ * meaningful.
+ *
+ * @yields safeDb errors out to the parent safe-handler.
+ */
+// eslint-disable-next-line require-yield -- yields shape is provided by `installSkill`'s safeDb returns; nothing yields here directly
+export const finalizeAgentSkill = async function* ({
+  safeDb,
+  recordAuditEvent,
+  organizationId,
+  userId,
+  memberRole,
+  fileBuffer,
+  declaredName,
+  declaredMime,
+  scope,
+}: FinalizeAgentSkillProps) {
+  // parseUploadedSkillPackage takes a File; wrap the buffer back
+  // into one. The legacy handler's parsing is identical; the
+  // archive size has already been bounded by the presign-time
+  // `FILE_SIZE_LIMIT_BYTES.skillPack` check.
+  const file = new File([fileBuffer], declaredName, {
+    type: declaredMime || "application/octet-stream",
+  });
+  const parsed = await parseUploadedSkillPackage(file);
+  if (Result.isError(parsed)) {
+    return finalizeErr({
+      status: parsed.error.status === 500 ? 500 : 422,
+      message: parsed.error.message,
+      rejectReason: "skill-package-parse-failed",
+    });
+  }
+
+  const installResult = await installSkill({
+    memberRole,
+    origin: "upload",
+    parsed: parsed.value,
+    recordAuditEvent,
+    safeDb,
+    scope,
+    session: { activeOrganizationId: organizationId },
+    user: { id: userId },
+  });
+  if (installResult.status === "error") {
+    const error = installResult.error;
+    const status = (() => {
+      if (!(error instanceof HandlerError)) {
+        return 500 as const;
+      }
+      switch (error.status) {
+        case 400:
+        case 404:
+        case 409:
+        case 422:
+        case 500:
+          return error.status;
+        default:
+          return 500 as const;
+      }
+    })();
+    return finalizeErr({
+      status,
+      message: error.message ?? "Failed to install skill",
+      rejectReason: "skill-install-failed",
+    });
+  }
+
+  const finalized: Extract<
+    PendingUploadFinalizedResult,
+    { type: "agent_skill" }
+  > = {
+    type: "agent_skill",
+    skillId: installResult.value.id,
+    name: parsed.value.name,
+    version: parsed.value.version ?? "",
+  };
+
+  // Synthetic key — the skill body lives in the DB; nothing reads
+  // from this. We still issue the server-side copy so the finalize
+  // runtime's invariant ("scanned-passed bytes always promote to a
+  // non-tmp/ key") holds across purposes.
+  const finalKey = `agent-skills/${organizationId}/${installResult.value.id}.archive`;
+
+  // The audit row is emitted inside `installSkill` against the
+  // newly created agentSkills row, so no extra audit call here.
+  void recordAuditEvent;
+  void AUDIT_ACTION;
+  void AUDIT_RESOURCE_TYPE;
+
+  return finalizeOk({ finalizedResult: finalized, finalKey });
+};

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -135,6 +135,7 @@ export const finalizeAgentSkill = async function* ({
         .where(
           and(
             eq(pendingUploads.id, uploadId),
+            eq(pendingUploads.userId, userId),
             eq(pendingUploads.workspaceId, workspaceId),
           ),
         )

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -4,11 +4,9 @@
  * mirroring the legacy multipart endpoint at
  * `apps/api/src/handlers/skills/upload.ts`.
  *
- * Unlike entity_create / entity_version, agent_skill uploads are
- * root-scoped (no `workspaceId`). The pending_uploads row carries
- * `workspace_id IS NULL` and `organization_*_root` RLS policies
- * gate access. `validateAgentSkill` enforces the team-scope
- * admin/owner check the legacy handler runs.
+ * `validateAgentSkill` enforces the team-scope admin/owner check the
+ * legacy handler runs. The route is still workspace-scoped during the
+ * migration, matching the temporary shared endpoint permission gate.
  */
 import { Result } from "better-result";
 
@@ -95,7 +93,7 @@ export const finalizeAgentSkill = async function* ({
   // archive size has already been bounded by the presign-time
   // `FILE_SIZE_LIMIT_BYTES.skillPack` check.
   const file = new File([fileBuffer], declaredName, {
-    type: declaredMime || "application/octet-stream",
+    type: declaredMime,
   });
   const parsed = await parseUploadedSkillPackage(file);
   if (Result.isError(parsed)) {
@@ -135,7 +133,7 @@ export const finalizeAgentSkill = async function* ({
     })();
     return finalizeErr({
       status,
-      message: error.message ?? "Failed to install skill",
+      message: error.message,
       rejectReason: "skill-install-failed",
     });
   }
@@ -150,17 +148,11 @@ export const finalizeAgentSkill = async function* ({
     version: parsed.value.version ?? "",
   };
 
-  // Synthetic key — the skill body lives in the DB; nothing reads
-  // from this. We still issue the server-side copy so the finalize
-  // runtime's invariant ("scanned-passed bytes always promote to a
-  // non-tmp/ key") holds across purposes.
-  const finalKey = `agent-skills/${organizationId}/${installResult.value.id}.archive`;
-
   // The audit row is emitted inside `installSkill` against the
   // newly created agentSkills row, so no extra audit call here.
   void recordAuditEvent;
   void AUDIT_ACTION;
   void AUDIT_RESOURCE_TYPE;
 
-  return finalizeOk({ finalizedResult: finalized, finalKey });
+  return finalizeOk({ finalizedResult: finalized, afterPromote: undefined });
 };

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -8,10 +8,14 @@
  * legacy handler runs. The route is still workspace-scoped during the
  * migration, matching the temporary shared endpoint permission gate.
  */
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
+import { and, eq } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db";
-import type { PendingUploadFinalizedResult } from "@/api/db/schema";
+import {
+  pendingUploads,
+  type PendingUploadFinalizedResult,
+} from "@/api/db/schema";
 import {
   authorizeSkillInstallScope,
   installSkill,
@@ -58,6 +62,8 @@ export type FinalizeAgentSkillProps = {
   declaredName: string;
   declaredMime: string;
   scope: "team" | "private";
+  uploadId: SafeId<"pendingUpload">;
+  workspaceId: SafeId<"workspace">;
 };
 
 /**
@@ -66,13 +72,11 @@ export type FinalizeAgentSkillProps = {
  * `installSkill` path which handles user-limit, slug-uniqueness,
  * resource fan-out, and the audit row.
  *
- * The skill rows do not have an S3 backing object (the skill body
- * + resources are inlined into the DB columns), so the
- * "finalKey" we return is a synthetic placeholder. The
- * upload-runtime still copies the tmp object to it, then
- * lifecycle-cleans because no consumer reads from there — phase 6
- * can drop the copy for skill uploads if the bookkeeping becomes
- * meaningful.
+ * Skill rows do not have an S3 backing object: the skill body and
+ * resources are inlined into DB columns. The generic upload runtime
+ * still verifies and scans the staged bytes, then this finalizer
+ * installs the skill and marks the pending-upload row inside the
+ * same transaction.
  *
  * @yields safeDb errors out to the parent safe-handler.
  */
@@ -87,6 +91,8 @@ export const finalizeAgentSkill = async function* ({
   declaredName,
   declaredMime,
   scope,
+  uploadId,
+  workspaceId,
 }: FinalizeAgentSkillProps) {
   // parseUploadedSkillPackage takes a File; wrap the buffer back
   // into one. The legacy handler's parsing is identical; the
@@ -106,6 +112,37 @@ export const finalizeAgentSkill = async function* ({
 
   const installResult = await installSkill({
     memberRole,
+    onInstalled: async (tx, skill) => {
+      const finalized: Extract<
+        PendingUploadFinalizedResult,
+        { type: "agent_skill" }
+      > = {
+        type: "agent_skill",
+        skillId: skill.id,
+        name: parsed.value.name,
+        version: parsed.value.version ?? "",
+      };
+
+      // audit: skip — final FSM transition on pending_uploads;
+      // the agent-skill audit row is recorded by installSkill in this transaction.
+      const finalizedRows = await tx
+        .update(pendingUploads)
+        .set({
+          status: "finalized",
+          finalizedResult: finalized,
+          finalizedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(pendingUploads.id, uploadId),
+            eq(pendingUploads.workspaceId, workspaceId),
+          ),
+        )
+        .returning({ id: pendingUploads.id });
+      if (!finalizedRows.at(0)) {
+        panic("Pending upload finalize marker update returned no rows");
+      }
+    },
     origin: "upload",
     parsed: parsed.value,
     recordAuditEvent,

--- a/apps/api/src/handlers/uploads/agent-skill.ts
+++ b/apps/api/src/handlers/uploads/agent-skill.ts
@@ -63,6 +63,7 @@ export type FinalizeAgentSkillProps = {
   declaredMime: string;
   scope: "team" | "private";
   uploadId: SafeId<"pendingUpload">;
+  claimRequestId: string;
   workspaceId: SafeId<"workspace">;
 };
 
@@ -92,6 +93,7 @@ export const finalizeAgentSkill = async function* ({
   declaredMime,
   scope,
   uploadId,
+  claimRequestId,
   workspaceId,
 }: FinalizeAgentSkillProps) {
   // parseUploadedSkillPackage takes a File; wrap the buffer back
@@ -137,6 +139,8 @@ export const finalizeAgentSkill = async function* ({
             eq(pendingUploads.id, uploadId),
             eq(pendingUploads.userId, userId),
             eq(pendingUploads.workspaceId, workspaceId),
+            eq(pendingUploads.status, "scanning"),
+            eq(pendingUploads.claimedByRequestId, claimRequestId),
           ),
         )
         .returning({ id: pendingUploads.id });

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -371,6 +371,7 @@ export const finalizeEntityCreate = async function* ({
       .where(
         and(
           eq(pendingUploads.id, uploadId),
+          eq(pendingUploads.userId, userId),
           eq(pendingUploads.workspaceId, workspaceId),
         ),
       )

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -15,8 +15,8 @@
  *   Reuses `resolveFileName` (filename de-duplication) and
  *   `allocateEntityStamp` (workspace doc-sequence) from the
  *   existing slice. Mirrors the original handler's audit log,
- *   workspace `lastActivityAt` bump, and async PDF-derivative +
- *   extraction enqueues.
+ *   workspace `lastActivityAt` bump, and post-promote PDF-derivative
+ *   + extraction enqueues.
  */
 import { Result } from "better-result";
 import { and, eq, like } from "drizzle-orm";
@@ -41,6 +41,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { escapeLike } from "@/api/lib/escape-like";
 import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
 import { LIMITS } from "@/api/lib/limits";
+import { getS3 } from "@/api/lib/s3";
 import type { SanitizedFileName } from "@/api/lib/sanitize-filename";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
@@ -156,14 +157,17 @@ export type FinalizeEntityCreateProps = {
   declaredSha256Hex: string;
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_create" }>;
   scanWarnings: string[] | undefined;
+  promoteTmpObject: (
+    finalKey: string,
+  ) => Promise<Result<void, UploadFinalizeError>>;
 };
 
 /**
  * Domain transaction for `entity_create`. Called by the generic
- * finalize runtime after scan-pass and after the bytes have been
- * server-side copied from `tmp/` to their final key. Returns the
- * same response shape as the legacy multipart handler so the web
- * UI doesn't need a discriminated response type.
+ * finalize runtime after scan-pass. It promotes the staged object
+ * before committing DB rows that point at the final key. Returns the
+ * same response shape as the legacy multipart handler so the web UI
+ * doesn't need a discriminated response type.
  *
  * @yields safeDb errors out to the parent safe-handler.
  */
@@ -180,6 +184,7 @@ export const finalizeEntityCreate = async function* ({
   declaredSha256Hex,
   purposeData,
   scanWarnings,
+  promoteTmpObject,
 }: FinalizeEntityCreateProps) {
   const sanitizedName = sanitizeFilename(declaredName);
 
@@ -215,100 +220,117 @@ export const finalizeEntityCreate = async function* ({
     mimeType: declaredMime,
   });
 
-  const resolvedName = yield* Result.await(
-    safeDb(async (tx) => {
-      const renamed = await resolveFileName({
-        tx,
-        propertyId: purposeData.propertyId,
-        name: sanitizedName,
-      });
-      const entityStamp = await allocateEntityStamp(tx, workspaceId);
+  const promoteResult = await promoteTmpObject(finalKey);
+  if (Result.isError(promoteResult)) {
+    return promoteResult;
+  }
 
-      await tx.insert(entities).values({
-        id: entityId,
-        workspaceId,
-        name: renamed.value,
-        createdBy: userId,
-        docSequence: entityStamp.docSequence,
-      });
-      await tx.insert(entityVersions).values({
-        id: entityVersionId,
-        workspaceId,
-        entityId,
-        versionNumber: 1,
-        stamp: entityStamp.stamp,
-        verificationCode: entityStamp.verificationCode,
-      });
-      await tx
-        .update(entities)
-        .set({ currentVersionId: entityVersionId })
-        .where(eq(entities.id, entityId));
-      await tx.insert(fields).values({
-        id: fieldId,
-        workspaceId,
-        propertyId: purposeData.propertyId,
-        entityVersionId,
-        content: {
-          type: "file",
-          version: 1,
-          id: fileId,
-          fileName: renamed.value,
-          mimeType: declaredMime,
-          sizeBytes: declaredSize,
+  const resolvedNameResult = await safeDb(async (tx) => {
+    const renamed = await resolveFileName({
+      tx,
+      propertyId: purposeData.propertyId,
+      name: sanitizedName,
+    });
+    const entityStamp = await allocateEntityStamp(tx, workspaceId);
+
+    await tx.insert(entities).values({
+      id: entityId,
+      workspaceId,
+      name: renamed.value,
+      createdBy: userId,
+      docSequence: entityStamp.docSequence,
+    });
+    await tx.insert(entityVersions).values({
+      id: entityVersionId,
+      workspaceId,
+      entityId,
+      versionNumber: 1,
+      stamp: entityStamp.stamp,
+      verificationCode: entityStamp.verificationCode,
+    });
+    await tx
+      .update(entities)
+      .set({ currentVersionId: entityVersionId })
+      .where(eq(entities.id, entityId));
+    await tx.insert(fields).values({
+      id: fieldId,
+      workspaceId,
+      propertyId: purposeData.propertyId,
+      entityVersionId,
+      content: {
+        type: "file",
+        version: 1,
+        id: fileId,
+        fileName: renamed.value,
+        mimeType: declaredMime,
+        sizeBytes: declaredSize,
+        encrypted,
+        sha256Hex: declaredSha256Hex,
+        pdfFileId: null,
+        pdfDerivative: pdfDerivativeStateForFile({
           encrypted,
-          sha256Hex: declaredSha256Hex,
-          pdfFileId: null,
-          pdfDerivative: pdfDerivativeStateForFile({
-            encrypted,
-            mimeType: declaredMime,
-          }),
-          ...(scanWarnings !== undefined && { scanWarnings }),
-        },
-      });
-      await tx
-        .update(workspaces)
-        .set({ lastActivityAt: new Date() })
-        .where(eq(workspaces.id, workspaceId));
+          mimeType: declaredMime,
+        }),
+        ...(scanWarnings !== undefined && { scanWarnings }),
+      },
+    });
+    await tx
+      .update(workspaces)
+      .set({ lastActivityAt: new Date() })
+      .where(eq(workspaces.id, workspaceId));
 
-      await recordAuditEvent(tx, {
-        action: AUDIT_ACTION.CREATE,
-        resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-        resourceId: entityId,
-        changes: {
-          created: {
-            old: null,
-            new: {
-              kind: "document",
-              fileName: renamed.value,
-              mimeType: declaredMime,
-              sizeBytes: declaredSize,
-              propertyId: purposeData.propertyId,
-            },
+    await recordAuditEvent(tx, {
+      action: AUDIT_ACTION.CREATE,
+      resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+      resourceId: entityId,
+      changes: {
+        created: {
+          old: null,
+          new: {
+            kind: "document",
+            fileName: renamed.value,
+            mimeType: declaredMime,
+            sizeBytes: declaredSize,
+            propertyId: purposeData.propertyId,
           },
         },
-      });
+      },
+    });
 
-      return renamed;
-    }),
-  );
-
-  // Async kickoffs mirror the legacy handler — fire-and-forget
-  // with structured error capture so a failed extraction doesn't
-  // block the upload response.
-  await processExtraction(entityId).catch((error: unknown) =>
-    captureError(error, { entityId, mimeType: declaredMime }),
-  );
-  enqueuePdfDerivativeOrMarkFailed({
-    encrypted,
-    entityId,
-    fieldId,
-    mimeType: declaredMime,
-    organizationId,
-    userId,
-    workspaceId,
-  }).catch((error: unknown) => {
-    captureError(error, { entityId, fieldId, mimeType: declaredMime });
+    return renamed;
   });
+  if (Result.isError(resolvedNameResult)) {
+    await getS3()
+      .delete(finalKey)
+      .catch((deleteError: unknown) =>
+        captureError(deleteError, {
+          entityId,
+          fieldId,
+          stage: "final-cleanup-after-db-error",
+        }),
+      );
+  }
+  const resolvedName = yield* resolvedNameResult;
+
+  const afterPromote = () => {
+    // Async kickoffs mirror the legacy handler. They run only after
+    // both promotion and the DB transaction have succeeded, so
+    // consumers never read a final key before it exists.
+    processExtraction(entityId).catch((error: unknown) => {
+      captureError(error, { entityId, mimeType: declaredMime });
+    });
+    enqueuePdfDerivativeOrMarkFailed({
+      encrypted,
+      entityId,
+      fieldId,
+      mimeType: declaredMime,
+      organizationId,
+      userId,
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, { entityId, fieldId, mimeType: declaredMime });
+    });
+  };
 
   const finalized: Extract<
     PendingUploadFinalizedResult,
@@ -321,7 +343,7 @@ export const finalizeEntityCreate = async function* ({
     renamed: resolvedName.renamed,
   };
 
-  return finalizeOk({ finalizedResult: finalized, finalKey });
+  return finalizeOk({ finalizedResult: finalized, finalKey, afterPromote });
 };
 
 /** Local re-export so the generic dispatcher can narrow on it. */

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -18,7 +18,7 @@
  *   workspace `lastActivityAt` bump, and post-promote PDF-derivative
  *   + extraction enqueues.
  */
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { and, eq, like } from "drizzle-orm";
 
 import type { SafeDb, Transaction } from "@/api/db";
@@ -27,7 +27,13 @@ import type {
   PendingUploadFinalizedResult,
   PendingUploadPurposeData,
 } from "@/api/db/schema";
-import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import {
+  entities,
+  entityVersions,
+  fields,
+  pendingUploads,
+  workspaces,
+} from "@/api/db/schema";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
 import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
 import { createFileKey } from "@/api/handlers/files/utils";
@@ -157,6 +163,7 @@ export type FinalizeEntityCreateProps = {
   declaredSha256Hex: string;
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_create" }>;
   scanWarnings: string[] | undefined;
+  uploadId: SafeId<"pendingUpload">;
   promoteTmpObject: (
     finalKey: string,
   ) => Promise<Result<void, UploadFinalizeError>>;
@@ -184,6 +191,7 @@ export const finalizeEntityCreate = async function* ({
   declaredSha256Hex,
   purposeData,
   scanWarnings,
+  uploadId,
   promoteTmpObject,
 }: FinalizeEntityCreateProps) {
   const sanitizedName = sanitizeFilename(declaredName);
@@ -225,7 +233,7 @@ export const finalizeEntityCreate = async function* ({
     return promoteResult;
   }
 
-  const resolvedNameResult = await safeDb(async (tx) => {
+  const writeResult = await safeDb(async (tx) => {
     const renamed = await resolveFileName({
       tx,
       propertyId: purposeData.propertyId,
@@ -297,9 +305,40 @@ export const finalizeEntityCreate = async function* ({
       },
     });
 
-    return renamed;
+    const finalized: Extract<
+      PendingUploadFinalizedResult,
+      { type: "entity_create" }
+    > = {
+      type: "entity_create",
+      entityId,
+      fileId,
+      fileName: renamed.value,
+      renamed: renamed.renamed,
+    };
+
+    // audit: skip — final FSM transition on pending_uploads;
+    // the entity-level audit row landed above in this same transaction.
+    const finalizedRows = await tx
+      .update(pendingUploads)
+      .set({
+        status: "finalized",
+        finalizedResult: finalized,
+        finalizedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(pendingUploads.id, uploadId),
+          eq(pendingUploads.workspaceId, workspaceId),
+        ),
+      )
+      .returning({ id: pendingUploads.id });
+    if (!finalizedRows.at(0)) {
+      panic("Pending upload finalize marker update returned no rows");
+    }
+
+    return { finalized };
   });
-  if (Result.isError(resolvedNameResult)) {
+  if (Result.isError(writeResult)) {
     await getS3()
       .delete(finalKey)
       .catch((deleteError: unknown) =>
@@ -310,7 +349,7 @@ export const finalizeEntityCreate = async function* ({
         }),
       );
   }
-  const resolvedName = yield* resolvedNameResult;
+  const { finalized } = yield* writeResult;
 
   const afterPromote = () => {
     // Async kickoffs mirror the legacy handler. They run only after
@@ -330,17 +369,6 @@ export const finalizeEntityCreate = async function* ({
     }).catch((error: unknown) => {
       captureError(error, { entityId, fieldId, mimeType: declaredMime });
     });
-  };
-
-  const finalized: Extract<
-    PendingUploadFinalizedResult,
-    { type: "entity_create" }
-  > = {
-    type: "entity_create",
-    entityId,
-    fileId,
-    fileName: resolvedName.value,
-    renamed: resolvedName.renamed,
   };
 
   return finalizeOk({ finalizedResult: finalized, finalKey, afterPromote });

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -165,6 +165,7 @@ export type FinalizeEntityCreateProps = {
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_create" }>;
   scanWarnings: string[] | undefined;
   uploadId: SafeId<"pendingUpload">;
+  claimRequestId: string;
   promoteTmpObject: (
     finalKey: string,
   ) => Promise<Result<void, UploadFinalizeError>>;
@@ -193,6 +194,7 @@ export const finalizeEntityCreate = async function* ({
   purposeData,
   scanWarnings,
   uploadId,
+  claimRequestId,
   promoteTmpObject,
 }: FinalizeEntityCreateProps) {
   const sanitizedName = sanitizeFilename(declaredName);
@@ -373,6 +375,8 @@ export const finalizeEntityCreate = async function* ({
           eq(pendingUploads.id, uploadId),
           eq(pendingUploads.userId, userId),
           eq(pendingUploads.workspaceId, workspaceId),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, claimRequestId),
         ),
       )
       .returning({ id: pendingUploads.id });

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -32,6 +32,7 @@ import {
   entityVersions,
   fields,
   pendingUploads,
+  properties,
   workspaces,
 } from "@/api/db/schema";
 import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
@@ -233,10 +234,52 @@ export const finalizeEntityCreate = async function* ({
     return promoteResult;
   }
 
-  const writeResult = await safeDb(async (tx) => {
+  type WriteResult =
+    | {
+        status: "ok";
+        finalized: Extract<
+          PendingUploadFinalizedResult,
+          { type: "entity_create" }
+        >;
+      }
+    | { status: "property-not-found" | "property-type-mismatch" };
+
+  const cleanupFinalObject = async (stage: string) => {
+    await getS3()
+      .delete(finalKey)
+      .catch((deleteError: unknown) =>
+        captureError(deleteError, {
+          entityId,
+          fieldId,
+          stage,
+        }),
+      );
+  };
+
+  const writeResultResult = await safeDb(async (tx): Promise<WriteResult> => {
+    const propertyRows = await tx
+      .select({ id: properties.id, content: properties.content })
+      .from(properties)
+      .where(
+        and(
+          eq(properties.id, purposeData.propertyId),
+          eq(properties.workspaceId, workspaceId),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const property = propertyRows.at(0);
+
+    if (!property) {
+      return { status: "property-not-found" };
+    }
+    if (property.content.type !== "file") {
+      return { status: "property-type-mismatch" };
+    }
+
     const renamed = await resolveFileName({
       tx,
-      propertyId: purposeData.propertyId,
+      propertyId: property.id,
       name: sanitizedName,
     });
     const entityStamp = await allocateEntityStamp(tx, workspaceId);
@@ -263,7 +306,7 @@ export const finalizeEntityCreate = async function* ({
     await tx.insert(fields).values({
       id: fieldId,
       workspaceId,
-      propertyId: purposeData.propertyId,
+      propertyId: property.id,
       entityVersionId,
       content: {
         type: "file",
@@ -299,7 +342,7 @@ export const finalizeEntityCreate = async function* ({
             fileName: renamed.value,
             mimeType: declaredMime,
             sizeBytes: declaredSize,
-            propertyId: purposeData.propertyId,
+            propertyId: property.id,
           },
         },
       },
@@ -336,20 +379,24 @@ export const finalizeEntityCreate = async function* ({
       panic("Pending upload finalize marker update returned no rows");
     }
 
-    return { finalized };
+    return { status: "ok", finalized };
   });
-  if (Result.isError(writeResult)) {
-    await getS3()
-      .delete(finalKey)
-      .catch((deleteError: unknown) =>
-        captureError(deleteError, {
-          entityId,
-          fieldId,
-          stage: "final-cleanup-after-db-error",
-        }),
-      );
+  if (Result.isError(writeResultResult)) {
+    await cleanupFinalObject("final-cleanup-after-db-error");
   }
-  const { finalized } = yield* writeResult;
+  const writeResult = yield* writeResultResult;
+  if (writeResult.status !== "ok") {
+    await cleanupFinalObject("final-cleanup-after-business-error");
+    return finalizeErr({
+      status: 400,
+      message:
+        writeResult.status === "property-not-found"
+          ? "Property not found in workspace"
+          : "Property isn't of type file",
+      rejectReason: writeResult.status,
+    });
+  }
+  const { finalized } = writeResult;
 
   const afterPromote = () => {
     // Async kickoffs mirror the legacy handler. They run only after

--- a/apps/api/src/handlers/uploads/entity-create.ts
+++ b/apps/api/src/handlers/uploads/entity-create.ts
@@ -1,0 +1,328 @@
+/**
+ * `entity_create` purpose: a presigned-upload flow that ends in a
+ * new `entities` row + first `entityVersions` + first `fields`
+ * record, exactly like the legacy multipart endpoint at
+ * `apps/api/src/handlers/entities/upload.ts`.
+ *
+ * Splits into two callbacks consumed by the generic presign /
+ * finalize dispatchers:
+ *
+ * - `validateEntityCreate`: cheap up-front checks (workspace
+ *   entity-count limit, property existence + type) so the API
+ *   can refuse to issue a URL the user couldn't redeem anyway.
+ *
+ * - `finalizeEntityCreate`: the transactional domain step.
+ *   Reuses `resolveFileName` (filename de-duplication) and
+ *   `allocateEntityStamp` (workspace doc-sequence) from the
+ *   existing slice. Mirrors the original handler's audit log,
+ *   workspace `lastActivityAt` bump, and async PDF-derivative +
+ *   extraction enqueues.
+ */
+import { Result } from "better-result";
+import { and, eq, like } from "drizzle-orm";
+
+import type { SafeDb, Transaction } from "@/api/db";
+import { jsonField } from "@/api/db/json-utils";
+import type {
+  PendingUploadFinalizedResult,
+  PendingUploadPurposeData,
+} from "@/api/db/schema";
+import { entities, entityVersions, fields, workspaces } from "@/api/db/schema";
+import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { isEncryptedPdf } from "@/api/handlers/files/pdf-utils";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { allocateEntityStamp } from "@/api/lib/document-counter";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { escapeLike } from "@/api/lib/escape-like";
+import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import { LIMITS } from "@/api/lib/limits";
+import type { SanitizedFileName } from "@/api/lib/sanitize-filename";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { processExtraction } from "@/api/lib/search/process-extraction";
+import { PDF_MIME_TYPE } from "@/api/mime-types";
+
+import { UploadFinalizeError, finalizeErr, finalizeOk } from "./lib";
+
+const MAX_FILENAME_LENGTH = 255;
+
+type ResolveFileNameProps = {
+  tx: Transaction;
+  propertyId: SafeId<"property">;
+  name: SanitizedFileName;
+};
+
+const resolveFileName = async ({
+  tx,
+  propertyId,
+  name,
+}: ResolveFileNameProps) => {
+  const lastDot = name.lastIndexOf(".");
+  const base = lastDot === -1 ? name : name.slice(0, lastDot);
+  const ext = lastDot === -1 ? "" : name.slice(lastDot);
+  const pattern = `${escapeLike(base)}%${escapeLike(ext)}`;
+
+  const fieldsCount = await tx.$count(
+    fields,
+    and(
+      eq(fields.propertyId, propertyId),
+      like(jsonField(fields.content, "v1")("fileName"), pattern),
+    ),
+  );
+
+  if (fieldsCount === 0) {
+    return { renamed: false as const, value: name };
+  }
+
+  const suffix = `_${fieldsCount}`;
+  const maxBase = MAX_FILENAME_LENGTH - suffix.length - ext.length;
+  const truncatedBase = maxBase > 0 ? base.slice(0, maxBase) : base;
+
+  // SAFETY: name is already sanitized; the suffix is digits and underscore only
+  return {
+    renamed: true as const,
+    value: sanitizeFilename(`${truncatedBase}${suffix}${ext}`),
+  };
+};
+
+export type ValidateEntityCreateProps = {
+  safeDb: SafeDb;
+  workspaceId: SafeId<"workspace">;
+  propertyId: SafeId<"property">;
+};
+
+/**
+ * Cheap pre-flight: entity-count limit + property exists + property
+ * is of `file` type. Mirrors the gating the legacy upload handler
+ * runs at the top of its body.
+ *
+ * @yields safeDb errors out to the parent safe-handler.
+ */
+export const validateEntityCreate = async function* ({
+  safeDb,
+  workspaceId,
+  propertyId,
+}: ValidateEntityCreateProps) {
+  const [entityCountResult, propertyResult] = await Promise.all([
+    safeDb((tx) => tx.$count(entities, eq(entities.workspaceId, workspaceId))),
+    safeDb((tx) =>
+      tx.query.properties.findFirst({
+        columns: { id: true, content: true },
+        where: { id: { eq: propertyId }, workspaceId: { eq: workspaceId } },
+      }),
+    ),
+  ]);
+
+  const entityCount = yield* entityCountResult;
+  const property = yield* propertyResult;
+
+  if (entityCount >= LIMITS.entitiesCount) {
+    return Result.err(
+      new HandlerError({ status: 400, message: "Entities limit reached" }),
+    );
+  }
+  if (!property) {
+    return Result.err(
+      new HandlerError({
+        status: 400,
+        message: "Property not found in workspace",
+      }),
+    );
+  }
+  if (property.content.type !== "file") {
+    return Result.err(
+      new HandlerError({ status: 400, message: "Property isn't of type file" }),
+    );
+  }
+
+  return Result.ok(undefined);
+};
+
+export type FinalizeEntityCreateProps = {
+  safeDb: SafeDb;
+  recordAuditEvent: AuditRecorder;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  /** The bytes already downloaded from `tmp/{uploadId}` for scanning. */
+  fileBuffer: ArrayBuffer;
+  declaredName: string;
+  declaredMime: string;
+  declaredSize: number;
+  declaredSha256Hex: string;
+  purposeData: Extract<PendingUploadPurposeData, { type: "entity_create" }>;
+  scanWarnings: string[] | undefined;
+};
+
+/**
+ * Domain transaction for `entity_create`. Called by the generic
+ * finalize runtime after scan-pass and after the bytes have been
+ * server-side copied from `tmp/` to their final key. Returns the
+ * same response shape as the legacy multipart handler so the web
+ * UI doesn't need a discriminated response type.
+ *
+ * @yields safeDb errors out to the parent safe-handler.
+ */
+export const finalizeEntityCreate = async function* ({
+  safeDb,
+  recordAuditEvent,
+  organizationId,
+  workspaceId,
+  userId,
+  fileBuffer,
+  declaredName,
+  declaredMime,
+  declaredSize,
+  declaredSha256Hex,
+  purposeData,
+  scanWarnings,
+}: FinalizeEntityCreateProps) {
+  const sanitizedName = sanitizeFilename(declaredName);
+
+  // PDF encryption check matches the legacy handler — we still
+  // need to know whether to enqueue a PDF derivative or mark it
+  // failed up front. The byte buffer is in memory anyway because
+  // the finalize runtime had to download it for scanning.
+  let encrypted = false;
+  if (declaredMime === PDF_MIME_TYPE) {
+    const encryptedResult = await isEncryptedPdf(fileBuffer);
+    if (Result.isError(encryptedResult)) {
+      captureError(encryptedResult.error, {
+        mimeType: PDF_MIME_TYPE,
+        sizeBytes: String(declaredSize),
+      });
+      return finalizeErr({
+        status: 422,
+        message: "Failed to open PDF: file appears corrupted",
+        rejectReason: "pdf-open-failed",
+      });
+    }
+    encrypted = encryptedResult.value;
+  }
+
+  const fileId = Bun.randomUUIDv7();
+  const entityId = createSafeId<"entity">();
+  const entityVersionId = createSafeId<"entityVersion">();
+  const fieldId = createSafeId<"field">();
+  const finalKey = createFileKey({
+    organizationId,
+    workspaceId,
+    fileId,
+    mimeType: declaredMime,
+  });
+
+  const resolvedName = yield* Result.await(
+    safeDb(async (tx) => {
+      const renamed = await resolveFileName({
+        tx,
+        propertyId: purposeData.propertyId,
+        name: sanitizedName,
+      });
+      const entityStamp = await allocateEntityStamp(tx, workspaceId);
+
+      await tx.insert(entities).values({
+        id: entityId,
+        workspaceId,
+        name: renamed.value,
+        createdBy: userId,
+        docSequence: entityStamp.docSequence,
+      });
+      await tx.insert(entityVersions).values({
+        id: entityVersionId,
+        workspaceId,
+        entityId,
+        versionNumber: 1,
+        stamp: entityStamp.stamp,
+        verificationCode: entityStamp.verificationCode,
+      });
+      await tx
+        .update(entities)
+        .set({ currentVersionId: entityVersionId })
+        .where(eq(entities.id, entityId));
+      await tx.insert(fields).values({
+        id: fieldId,
+        workspaceId,
+        propertyId: purposeData.propertyId,
+        entityVersionId,
+        content: {
+          type: "file",
+          version: 1,
+          id: fileId,
+          fileName: renamed.value,
+          mimeType: declaredMime,
+          sizeBytes: declaredSize,
+          encrypted,
+          sha256Hex: declaredSha256Hex,
+          pdfFileId: null,
+          pdfDerivative: pdfDerivativeStateForFile({
+            encrypted,
+            mimeType: declaredMime,
+          }),
+          ...(scanWarnings !== undefined && { scanWarnings }),
+        },
+      });
+      await tx
+        .update(workspaces)
+        .set({ lastActivityAt: new Date() })
+        .where(eq(workspaces.id, workspaceId));
+
+      await recordAuditEvent(tx, {
+        action: AUDIT_ACTION.CREATE,
+        resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+        resourceId: entityId,
+        changes: {
+          created: {
+            old: null,
+            new: {
+              kind: "document",
+              fileName: renamed.value,
+              mimeType: declaredMime,
+              sizeBytes: declaredSize,
+              propertyId: purposeData.propertyId,
+            },
+          },
+        },
+      });
+
+      return renamed;
+    }),
+  );
+
+  // Async kickoffs mirror the legacy handler — fire-and-forget
+  // with structured error capture so a failed extraction doesn't
+  // block the upload response.
+  await processExtraction(entityId).catch((error: unknown) =>
+    captureError(error, { entityId, mimeType: declaredMime }),
+  );
+  enqueuePdfDerivativeOrMarkFailed({
+    encrypted,
+    entityId,
+    fieldId,
+    mimeType: declaredMime,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, { entityId, fieldId, mimeType: declaredMime });
+  });
+
+  const finalized: Extract<
+    PendingUploadFinalizedResult,
+    { type: "entity_create" }
+  > = {
+    type: "entity_create",
+    entityId,
+    fileId,
+    fileName: resolvedName.value,
+    renamed: resolvedName.renamed,
+  };
+
+  return finalizeOk({ finalizedResult: finalized, finalKey });
+};
+
+/** Local re-export so the generic dispatcher can narrow on it. */
+export { UploadFinalizeError };

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -9,7 +9,7 @@
  * resulting row is byte-for-byte identical to what the multipart
  * path would have produced.
  */
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import { and, eq } from "drizzle-orm";
 
 import type { SafeDb } from "@/api/db";
@@ -22,6 +22,7 @@ import {
   entities,
   entityVersions,
   fields,
+  pendingUploads,
   workspaces,
 } from "@/api/db/schema";
 import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
@@ -106,6 +107,7 @@ export type FinalizeEntityVersionProps = {
   declaredSha256Hex: string;
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_version" }>;
   scanWarnings: string[] | undefined;
+  uploadId: SafeId<"pendingUpload">;
   promoteTmpObject: (
     finalKey: string,
   ) => Promise<Result<void, UploadFinalizeError>>;
@@ -133,6 +135,7 @@ export const finalizeEntityVersion = async function* ({
   declaredSha256Hex,
   purposeData,
   scanWarnings,
+  uploadId,
   promoteTmpObject,
 }: FinalizeEntityVersionProps) {
   const sanitizedName = sanitizeFilename(declaredName);
@@ -154,7 +157,13 @@ export const finalizeEntityVersion = async function* ({
   }
 
   type WriteResult =
-    | { status: "ok"; versionNumber: number }
+    | {
+        status: "ok";
+        finalized: Extract<
+          PendingUploadFinalizedResult,
+          { type: "entity_version" }
+        >;
+      }
     | {
         status:
           | "entity-not-found"
@@ -360,7 +369,39 @@ export const finalizeEntityVersion = async function* ({
       },
     ]);
 
-    return { status: "ok", versionNumber: nextVersionNumber };
+    const finalized: Extract<
+      PendingUploadFinalizedResult,
+      { type: "entity_version" }
+    > = {
+      type: "entity_version",
+      entityId,
+      entityVersionId: nextVersionId,
+      versionNumber: nextVersionNumber,
+      fileId,
+      fileName: sanitizedName,
+    };
+
+    // audit: skip — final FSM transition on pending_uploads;
+    // the entity/version audit rows landed above in this same transaction.
+    const finalizedRows = await tx
+      .update(pendingUploads)
+      .set({
+        status: "finalized",
+        finalizedResult: finalized,
+        finalizedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(pendingUploads.id, uploadId),
+          eq(pendingUploads.workspaceId, workspaceId),
+        ),
+      )
+      .returning({ id: pendingUploads.id });
+    if (!finalizedRows.at(0)) {
+      panic("Pending upload finalize marker update returned no rows");
+    }
+
+    return { status: "ok", finalized };
   });
   if (Result.isError(writeResultResult)) {
     await cleanupFinalObject("final-cleanup-after-db-error");
@@ -399,6 +440,7 @@ export const finalizeEntityVersion = async function* ({
     });
   }
 
+  const finalized = writeResult.finalized;
   const afterPromote = () => {
     // Async kickoffs mirror the legacy handler. They run only after
     // both promotion and the DB transaction have succeeded, so
@@ -438,18 +480,6 @@ export const finalizeEntityVersion = async function* ({
       type: "invalidate-query",
       data: ["entities", workspaceId],
     });
-  };
-
-  const finalized: Extract<
-    PendingUploadFinalizedResult,
-    { type: "entity_version" }
-  > = {
-    type: "entity_version",
-    entityId,
-    entityVersionId: nextVersionId,
-    versionNumber: writeResult.versionNumber,
-    fileId,
-    fileName: sanitizedName,
   };
 
   return finalizeOk({ finalizedResult: finalized, finalKey, afterPromote });

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -1,0 +1,421 @@
+/**
+ * `entity_version` purpose: a presigned-upload flow that creates a
+ * new `entityVersions` row + `fields` clone for an existing entity,
+ * mirroring the legacy multipart endpoint at
+ * `apps/api/src/handlers/entities/upload-version.ts`.
+ *
+ * Reuses `cloneFieldsForRevision`, `buildVersionStamp`, and the
+ * cell-metadata carry-over from the legacy handler exactly so the
+ * resulting row is byte-for-byte identical to what the multipart
+ * path would have produced.
+ */
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+
+import type { SafeDb } from "@/api/db";
+import type {
+  PendingUploadFinalizedResult,
+  PendingUploadPurposeData,
+} from "@/api/db/schema";
+import {
+  cellMetadata,
+  entities,
+  entityVersions,
+  fields,
+  workspaces,
+} from "@/api/db/schema";
+import { computeVersionDiffStats } from "@/api/handlers/entities/compute-version-diff";
+import {
+  buildVersionStamp,
+  cloneFieldsForRevision,
+} from "@/api/handlers/entities/version-utils";
+import { pdfDerivativeStateForFile } from "@/api/handlers/files/gotenberg";
+import { createFileKey } from "@/api/handlers/files/utils";
+import { captureError } from "@/api/lib/analytics";
+import { AUDIT_ACTION, AUDIT_RESOURCE_TYPE } from "@/api/lib/audit-log";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import { createSafeId } from "@/api/lib/branded-types";
+import type { SafeId } from "@/api/lib/branded-types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
+import { createRootScopedDb } from "@/api/lib/root-scoped-db";
+import { sanitizeFilename } from "@/api/lib/sanitize-filename";
+import { processExtraction } from "@/api/lib/search/process-extraction";
+import { broadcast } from "@/api/lib/sse";
+
+import { finalizeErr, finalizeOk } from "./lib";
+
+export type ValidateEntityVersionProps = {
+  safeDb: SafeDb;
+  workspaceId: SafeId<"workspace">;
+  entityId: SafeId<"entity">;
+};
+
+/**
+ * Up-front gating: entity exists, isn't read-only, has a file
+ * field. Lets the API refuse to mint a presigned URL the user
+ * couldn't redeem anyway.
+ *
+ * @yields safeDb errors out to the parent safe-handler.
+ */
+export const validateEntityVersion = async function* ({
+  safeDb,
+  workspaceId,
+  entityId,
+}: ValidateEntityVersionProps) {
+  const entity = yield* Result.await(
+    safeDb((tx) =>
+      tx.query.entities.findFirst({
+        where: {
+          id: { eq: entityId },
+          workspaceId: { eq: workspaceId },
+        },
+        columns: {
+          currentVersionId: true,
+          readOnly: true,
+        },
+      }),
+    ),
+  );
+  if (!entity || !entity.currentVersionId) {
+    return Result.err(
+      new HandlerError({ status: 404, message: "Entity not found" }),
+    );
+  }
+  if (entity.readOnly) {
+    return Result.err(
+      new HandlerError({ status: 409, message: "Entity is read-only" }),
+    );
+  }
+
+  return Result.ok(undefined);
+};
+
+export type FinalizeEntityVersionProps = {
+  safeDb: SafeDb;
+  recordAuditEvent: AuditRecorder;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  fileBuffer: ArrayBuffer;
+  declaredName: string;
+  declaredMime: string;
+  declaredSize: number;
+  declaredSha256Hex: string;
+  purposeData: Extract<PendingUploadPurposeData, { type: "entity_version" }>;
+  scanWarnings: string[] | undefined;
+};
+
+/**
+ * Domain transaction for `entity_version`. Allocates a new
+ * `entityVersions` row + cloned fields with the uploaded file
+ * swapped into the file field, carries cell metadata across,
+ * records the two audit events the legacy handler emits, kicks
+ * off async extraction + diff-stat computation + SSE broadcast.
+ *
+ * @yields safeDb errors out to the parent safe-handler.
+ */
+export const finalizeEntityVersion = async function* ({
+  safeDb,
+  recordAuditEvent,
+  organizationId,
+  workspaceId,
+  userId,
+  fileBuffer: _fileBuffer,
+  declaredName,
+  declaredMime,
+  declaredSize,
+  declaredSha256Hex,
+  purposeData,
+  scanWarnings,
+}: FinalizeEntityVersionProps) {
+  const sanitizedName = sanitizeFilename(declaredName);
+  const { entityId } = purposeData;
+
+  const fileId = Bun.randomUUIDv7();
+  const nextVersionId = createSafeId<"entityVersion">();
+  const fileFieldId = createSafeId<"field">();
+  const finalKey = createFileKey({
+    organizationId,
+    workspaceId,
+    fileId,
+    mimeType: declaredMime,
+  });
+
+  type WriteResult =
+    | { status: "ok"; versionNumber: number }
+    | {
+        status:
+          | "entity-not-found"
+          | "entity-read-only"
+          | "current-version-not-found"
+          | "missing-file-field";
+      };
+
+  const writeResult = yield* Result.await(
+    safeDb(async (tx): Promise<WriteResult> => {
+      // Lock the entity row for the duration of the transaction so
+      // a concurrent version upload can't observe a stale
+      // currentVersionId.
+      const entityRows = await tx
+        .select({
+          currentVersionId: entities.currentVersionId,
+          docSequence: entities.docSequence,
+          readOnly: entities.readOnly,
+        })
+        .from(entities)
+        .where(
+          and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
+        )
+        .limit(1)
+        .for("update");
+      const lockedEntity = entityRows.at(0);
+
+      if (!lockedEntity?.currentVersionId) {
+        return { status: "entity-not-found" };
+      }
+      if (lockedEntity.readOnly) {
+        return { status: "entity-read-only" };
+      }
+
+      const freshCurrentVersionId = lockedEntity.currentVersionId;
+      const freshCurrentVersion = await tx.query.entityVersions.findFirst({
+        where: { id: { eq: freshCurrentVersionId } },
+        columns: { versionNumber: true },
+        with: {
+          fields: { columns: { content: true, propertyId: true } },
+        },
+      });
+      if (!freshCurrentVersion) {
+        return { status: "current-version-not-found" };
+      }
+
+      const freshFileField = freshCurrentVersion.fields.find(
+        (field) => field.content.type === "file",
+      );
+      if (!freshFileField) {
+        return { status: "missing-file-field" };
+      }
+
+      const workspace = await tx.query.workspaces.findFirst({
+        where: { id: { eq: workspaceId } },
+        columns: { reference: true },
+      });
+
+      const nextVersionNumber = freshCurrentVersion.versionNumber + 1;
+      const nextVersionStamp = buildVersionStamp({
+        docSequence: lockedEntity.docSequence,
+        versionNumber: nextVersionNumber,
+        workspaceReference: workspace?.reference ?? null,
+      });
+
+      await tx.insert(entityVersions).values({
+        createdBy: userId,
+        entityId,
+        id: nextVersionId,
+        stamp: nextVersionStamp.stamp,
+        verificationCode: nextVersionStamp.verificationCode,
+        versionNumber: nextVersionNumber,
+        workspaceId,
+      });
+
+      await tx.insert(fields).values(
+        cloneFieldsForRevision({
+          currentFields: freshCurrentVersion.fields,
+          entityVersionId: nextVersionId,
+          propertyId: freshFileField.propertyId,
+          replacementFieldId: fileFieldId,
+          replacementContent: {
+            encrypted: false,
+            fileName: sanitizedName,
+            id: fileId,
+            mimeType: declaredMime,
+            pdfFileId: null,
+            sha256Hex: declaredSha256Hex,
+            sizeBytes: declaredSize,
+            type: "file",
+            version: 1,
+            pdfDerivative: pdfDerivativeStateForFile({
+              encrypted: false,
+              mimeType: declaredMime,
+            }),
+            ...(scanWarnings !== undefined && { scanWarnings }),
+          },
+          workspaceId,
+        }),
+      );
+
+      // Carry over cell metadata from every property except the
+      // file field (whose metadata starts fresh per version).
+      const currentCellMetadataRows = await tx
+        .select({
+          createdAt: cellMetadata.createdAt,
+          createdBy: cellMetadata.createdBy,
+          metadata: cellMetadata.metadata,
+          propertyId: cellMetadata.propertyId,
+          updatedAt: cellMetadata.updatedAt,
+          updatedBy: cellMetadata.updatedBy,
+        })
+        .from(cellMetadata)
+        .where(
+          and(
+            eq(cellMetadata.workspaceId, workspaceId),
+            eq(cellMetadata.entityVersionId, freshCurrentVersionId),
+          ),
+        )
+        .for("update");
+
+      const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
+        (row) => row.propertyId !== freshFileField.propertyId,
+      );
+
+      if (cellMetadataRowsToCopy.length > 0) {
+        await tx.insert(cellMetadata).values(
+          cellMetadataRowsToCopy.map((row) => ({
+            workspaceId,
+            entityVersionId: nextVersionId,
+            propertyId: row.propertyId,
+            metadata: row.metadata,
+            createdBy: row.createdBy,
+            updatedBy: row.updatedBy,
+            createdAt: row.createdAt,
+            updatedAt: row.updatedAt,
+          })),
+        );
+      }
+
+      await tx
+        .update(entities)
+        .set({
+          currentVersionId: nextVersionId,
+          lastEditedBy: userId,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
+        );
+
+      await tx
+        .update(workspaces)
+        .set({ lastActivityAt: new Date() })
+        .where(eq(workspaces.id, workspaceId));
+
+      await recordAuditEvent(tx, [
+        {
+          action: AUDIT_ACTION.CREATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
+          resourceId: nextVersionId,
+          changes: {
+            created: {
+              old: null,
+              new: {
+                entityId,
+                versionNumber: nextVersionNumber,
+                fileName: sanitizedName,
+                mimeType: declaredMime,
+                sizeBytes: declaredSize,
+                sha256Hex: declaredSha256Hex,
+              },
+            },
+          },
+          metadata: {
+            fileName: sanitizedName,
+            mimeType: declaredMime,
+            sizeBytes: declaredSize,
+            sha256Hex: declaredSha256Hex,
+          },
+        },
+        {
+          action: AUDIT_ACTION.UPDATE,
+          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+          resourceId: entityId,
+          changes: {
+            currentVersionId: {
+              old: freshCurrentVersionId,
+              new: nextVersionId,
+            },
+          },
+        },
+      ]);
+
+      return { status: "ok", versionNumber: nextVersionNumber };
+    }),
+  );
+
+  if (writeResult.status !== "ok") {
+    const status = writeResult.status;
+    if (status === "entity-not-found" || status === "current-version-not-found") {
+      return finalizeErr({
+        status: 404,
+        message:
+          status === "entity-not-found"
+            ? "Entity not found"
+            : "Current version not found",
+        rejectReason: status,
+      });
+    }
+    if (status === "entity-read-only") {
+      return finalizeErr({
+        status: 409,
+        message: "Entity is read-only",
+        rejectReason: "entity-read-only",
+      });
+    }
+    return finalizeErr({
+      status: 400,
+      message: "Entity has no file field",
+      rejectReason: "missing-file-field",
+    });
+  }
+
+  // Async kickoffs mirror the legacy handler exactly.
+  processExtraction(entityId).catch((error: unknown) => {
+    captureError(error, { entityId });
+  });
+  enqueuePdfDerivativeOrMarkFailed({
+    encrypted: false,
+    entityId,
+    fieldId: fileFieldId,
+    mimeType: declaredMime,
+    organizationId,
+    userId,
+    workspaceId,
+  }).catch((error: unknown) => {
+    captureError(error, {
+      entityId,
+      fieldId: fileFieldId,
+      mimeType: declaredMime,
+    });
+  });
+  computeVersionDiffStats({
+    versionId: nextVersionId,
+    entityId,
+    scopedDb: createRootScopedDb({
+      organizationId,
+      userId,
+      workspaceIds: [workspaceId],
+    }),
+    workspaceId,
+    organizationId,
+  }).catch((error: unknown) => {
+    captureError(error, { versionId: nextVersionId });
+  });
+  broadcast(workspaceId, {
+    type: "invalidate-query",
+    data: ["entities", workspaceId],
+  });
+
+  const finalized: Extract<
+    PendingUploadFinalizedResult,
+    { type: "entity_version" }
+  > = {
+    type: "entity_version",
+    entityId,
+    entityVersionId: nextVersionId,
+    versionNumber: writeResult.versionNumber,
+    fileId,
+    fileName: sanitizedName,
+  };
+
+  return finalizeOk({ finalizedResult: finalized, finalKey });
+};

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -39,11 +39,13 @@ import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { enqueuePdfDerivativeOrMarkFailed } from "@/api/lib/file-derivative-queue";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
+import { getS3 } from "@/api/lib/s3";
 import { sanitizeFilename } from "@/api/lib/sanitize-filename";
 import { processExtraction } from "@/api/lib/search/process-extraction";
 import { broadcast } from "@/api/lib/sse";
 
 import { finalizeErr, finalizeOk } from "./lib";
+import type { UploadFinalizeError } from "./lib";
 
 export type ValidateEntityVersionProps = {
   safeDb: SafeDb;
@@ -104,6 +106,9 @@ export type FinalizeEntityVersionProps = {
   declaredSha256Hex: string;
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_version" }>;
   scanWarnings: string[] | undefined;
+  promoteTmpObject: (
+    finalKey: string,
+  ) => Promise<Result<void, UploadFinalizeError>>;
 };
 
 /**
@@ -128,6 +133,7 @@ export const finalizeEntityVersion = async function* ({
   declaredSha256Hex,
   purposeData,
   scanWarnings,
+  promoteTmpObject,
 }: FinalizeEntityVersionProps) {
   const sanitizedName = sanitizeFilename(declaredName);
   const { entityId } = purposeData;
@@ -142,6 +148,11 @@ export const finalizeEntityVersion = async function* ({
     mimeType: declaredMime,
   });
 
+  const promoteResult = await promoteTmpObject(finalKey);
+  if (Result.isError(promoteResult)) {
+    return promoteResult;
+  }
+
   type WriteResult =
     | { status: "ok"; versionNumber: number }
     | {
@@ -152,199 +163,217 @@ export const finalizeEntityVersion = async function* ({
           | "missing-file-field";
       };
 
-  const writeResult = yield* Result.await(
-    safeDb(async (tx): Promise<WriteResult> => {
-      // Lock the entity row for the duration of the transaction so
-      // a concurrent version upload can't observe a stale
-      // currentVersionId.
-      const entityRows = await tx
-        .select({
-          currentVersionId: entities.currentVersionId,
-          docSequence: entities.docSequence,
-          readOnly: entities.readOnly,
-        })
-        .from(entities)
-        .where(
-          and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
-        )
-        .limit(1)
-        .for("update");
-      const lockedEntity = entityRows.at(0);
-
-      if (!lockedEntity?.currentVersionId) {
-        return { status: "entity-not-found" };
-      }
-      if (lockedEntity.readOnly) {
-        return { status: "entity-read-only" };
-      }
-
-      const freshCurrentVersionId = lockedEntity.currentVersionId;
-      const freshCurrentVersion = await tx.query.entityVersions.findFirst({
-        where: { id: { eq: freshCurrentVersionId } },
-        columns: { versionNumber: true },
-        with: {
-          fields: { columns: { content: true, propertyId: true } },
-        },
-      });
-      if (!freshCurrentVersion) {
-        return { status: "current-version-not-found" };
-      }
-
-      const freshFileField = freshCurrentVersion.fields.find(
-        (field) => field.content.type === "file",
-      );
-      if (!freshFileField) {
-        return { status: "missing-file-field" };
-      }
-
-      const workspace = await tx.query.workspaces.findFirst({
-        where: { id: { eq: workspaceId } },
-        columns: { reference: true },
-      });
-
-      const nextVersionNumber = freshCurrentVersion.versionNumber + 1;
-      const nextVersionStamp = buildVersionStamp({
-        docSequence: lockedEntity.docSequence,
-        versionNumber: nextVersionNumber,
-        workspaceReference: workspace?.reference ?? null,
-      });
-
-      await tx.insert(entityVersions).values({
-        createdBy: userId,
-        entityId,
-        id: nextVersionId,
-        stamp: nextVersionStamp.stamp,
-        verificationCode: nextVersionStamp.verificationCode,
-        versionNumber: nextVersionNumber,
-        workspaceId,
-      });
-
-      await tx.insert(fields).values(
-        cloneFieldsForRevision({
-          currentFields: freshCurrentVersion.fields,
-          entityVersionId: nextVersionId,
-          propertyId: freshFileField.propertyId,
-          replacementFieldId: fileFieldId,
-          replacementContent: {
-            encrypted: false,
-            fileName: sanitizedName,
-            id: fileId,
-            mimeType: declaredMime,
-            pdfFileId: null,
-            sha256Hex: declaredSha256Hex,
-            sizeBytes: declaredSize,
-            type: "file",
-            version: 1,
-            pdfDerivative: pdfDerivativeStateForFile({
-              encrypted: false,
-              mimeType: declaredMime,
-            }),
-            ...(scanWarnings !== undefined && { scanWarnings }),
-          },
-          workspaceId,
+  const cleanupFinalObject = async (stage: string) => {
+    await getS3()
+      .delete(finalKey)
+      .catch((deleteError: unknown) =>
+        captureError(deleteError, {
+          entityId,
+          fieldId: fileFieldId,
+          stage,
         }),
       );
+  };
 
-      // Carry over cell metadata from every property except the
-      // file field (whose metadata starts fresh per version).
-      const currentCellMetadataRows = await tx
-        .select({
-          createdAt: cellMetadata.createdAt,
-          createdBy: cellMetadata.createdBy,
-          metadata: cellMetadata.metadata,
-          propertyId: cellMetadata.propertyId,
-          updatedAt: cellMetadata.updatedAt,
-          updatedBy: cellMetadata.updatedBy,
-        })
-        .from(cellMetadata)
-        .where(
-          and(
-            eq(cellMetadata.workspaceId, workspaceId),
-            eq(cellMetadata.entityVersionId, freshCurrentVersionId),
-          ),
-        )
-        .for("update");
+  const writeResultResult = await safeDb(async (tx): Promise<WriteResult> => {
+    // Lock the entity row for the duration of the transaction so
+    // a concurrent version upload can't observe a stale
+    // currentVersionId.
+    const entityRows = await tx
+      .select({
+        currentVersionId: entities.currentVersionId,
+        docSequence: entities.docSequence,
+        readOnly: entities.readOnly,
+      })
+      .from(entities)
+      .where(
+        and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
+      )
+      .limit(1)
+      .for("update");
+    const lockedEntity = entityRows.at(0);
 
-      const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
-        (row) => row.propertyId !== freshFileField.propertyId,
+    if (!lockedEntity?.currentVersionId) {
+      return { status: "entity-not-found" };
+    }
+    if (lockedEntity.readOnly) {
+      return { status: "entity-read-only" };
+    }
+
+    const freshCurrentVersionId = lockedEntity.currentVersionId;
+    const freshCurrentVersion = await tx.query.entityVersions.findFirst({
+      where: { id: { eq: freshCurrentVersionId } },
+      columns: { versionNumber: true },
+      with: {
+        fields: { columns: { content: true, propertyId: true } },
+      },
+    });
+    if (!freshCurrentVersion) {
+      return { status: "current-version-not-found" };
+    }
+
+    const freshFileField = freshCurrentVersion.fields.find(
+      (field) => field.content.type === "file",
+    );
+    if (!freshFileField) {
+      return { status: "missing-file-field" };
+    }
+
+    const workspace = await tx.query.workspaces.findFirst({
+      where: { id: { eq: workspaceId } },
+      columns: { reference: true },
+    });
+
+    const nextVersionNumber = freshCurrentVersion.versionNumber + 1;
+    const nextVersionStamp = buildVersionStamp({
+      docSequence: lockedEntity.docSequence,
+      versionNumber: nextVersionNumber,
+      workspaceReference: workspace?.reference ?? null,
+    });
+
+    await tx.insert(entityVersions).values({
+      createdBy: userId,
+      entityId,
+      id: nextVersionId,
+      stamp: nextVersionStamp.stamp,
+      verificationCode: nextVersionStamp.verificationCode,
+      versionNumber: nextVersionNumber,
+      workspaceId,
+    });
+
+    await tx.insert(fields).values(
+      cloneFieldsForRevision({
+        currentFields: freshCurrentVersion.fields,
+        entityVersionId: nextVersionId,
+        propertyId: freshFileField.propertyId,
+        replacementFieldId: fileFieldId,
+        replacementContent: {
+          encrypted: false,
+          fileName: sanitizedName,
+          id: fileId,
+          mimeType: declaredMime,
+          pdfFileId: null,
+          sha256Hex: declaredSha256Hex,
+          sizeBytes: declaredSize,
+          type: "file",
+          version: 1,
+          pdfDerivative: pdfDerivativeStateForFile({
+            encrypted: false,
+            mimeType: declaredMime,
+          }),
+          ...(scanWarnings !== undefined && { scanWarnings }),
+        },
+        workspaceId,
+      }),
+    );
+
+    // Carry over cell metadata from every property except the
+    // file field (whose metadata starts fresh per version).
+    const currentCellMetadataRows = await tx
+      .select({
+        createdAt: cellMetadata.createdAt,
+        createdBy: cellMetadata.createdBy,
+        metadata: cellMetadata.metadata,
+        propertyId: cellMetadata.propertyId,
+        updatedAt: cellMetadata.updatedAt,
+        updatedBy: cellMetadata.updatedBy,
+      })
+      .from(cellMetadata)
+      .where(
+        and(
+          eq(cellMetadata.workspaceId, workspaceId),
+          eq(cellMetadata.entityVersionId, freshCurrentVersionId),
+        ),
+      )
+      .for("update");
+
+    const cellMetadataRowsToCopy = currentCellMetadataRows.filter(
+      (row) => row.propertyId !== freshFileField.propertyId,
+    );
+
+    if (cellMetadataRowsToCopy.length > 0) {
+      await tx.insert(cellMetadata).values(
+        cellMetadataRowsToCopy.map((row) => ({
+          workspaceId,
+          entityVersionId: nextVersionId,
+          propertyId: row.propertyId,
+          metadata: row.metadata,
+          createdBy: row.createdBy,
+          updatedBy: row.updatedBy,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        })),
+      );
+    }
+
+    await tx
+      .update(entities)
+      .set({
+        currentVersionId: nextVersionId,
+        lastEditedBy: userId,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
       );
 
-      if (cellMetadataRowsToCopy.length > 0) {
-        await tx.insert(cellMetadata).values(
-          cellMetadataRowsToCopy.map((row) => ({
-            workspaceId,
-            entityVersionId: nextVersionId,
-            propertyId: row.propertyId,
-            metadata: row.metadata,
-            createdBy: row.createdBy,
-            updatedBy: row.updatedBy,
-            createdAt: row.createdAt,
-            updatedAt: row.updatedAt,
-          })),
-        );
-      }
+    await tx
+      .update(workspaces)
+      .set({ lastActivityAt: new Date() })
+      .where(eq(workspaces.id, workspaceId));
 
-      await tx
-        .update(entities)
-        .set({
-          currentVersionId: nextVersionId,
-          lastEditedBy: userId,
-          updatedAt: new Date(),
-        })
-        .where(
-          and(eq(entities.id, entityId), eq(entities.workspaceId, workspaceId)),
-        );
-
-      await tx
-        .update(workspaces)
-        .set({ lastActivityAt: new Date() })
-        .where(eq(workspaces.id, workspaceId));
-
-      await recordAuditEvent(tx, [
-        {
-          action: AUDIT_ACTION.CREATE,
-          resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
-          resourceId: nextVersionId,
-          changes: {
-            created: {
-              old: null,
-              new: {
-                entityId,
-                versionNumber: nextVersionNumber,
-                fileName: sanitizedName,
-                mimeType: declaredMime,
-                sizeBytes: declaredSize,
-                sha256Hex: declaredSha256Hex,
-              },
-            },
-          },
-          metadata: {
-            fileName: sanitizedName,
-            mimeType: declaredMime,
-            sizeBytes: declaredSize,
-            sha256Hex: declaredSha256Hex,
-          },
-        },
-        {
-          action: AUDIT_ACTION.UPDATE,
-          resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
-          resourceId: entityId,
-          changes: {
-            currentVersionId: {
-              old: freshCurrentVersionId,
-              new: nextVersionId,
+    await recordAuditEvent(tx, [
+      {
+        action: AUDIT_ACTION.CREATE,
+        resourceType: AUDIT_RESOURCE_TYPE.ENTITY_VERSION,
+        resourceId: nextVersionId,
+        changes: {
+          created: {
+            old: null,
+            new: {
+              entityId,
+              versionNumber: nextVersionNumber,
+              fileName: sanitizedName,
+              mimeType: declaredMime,
+              sizeBytes: declaredSize,
+              sha256Hex: declaredSha256Hex,
             },
           },
         },
-      ]);
+        metadata: {
+          fileName: sanitizedName,
+          mimeType: declaredMime,
+          sizeBytes: declaredSize,
+          sha256Hex: declaredSha256Hex,
+        },
+      },
+      {
+        action: AUDIT_ACTION.UPDATE,
+        resourceType: AUDIT_RESOURCE_TYPE.ENTITY,
+        resourceId: entityId,
+        changes: {
+          currentVersionId: {
+            old: freshCurrentVersionId,
+            new: nextVersionId,
+          },
+        },
+      },
+    ]);
 
-      return { status: "ok", versionNumber: nextVersionNumber };
-    }),
-  );
+    return { status: "ok", versionNumber: nextVersionNumber };
+  });
+  if (Result.isError(writeResultResult)) {
+    await cleanupFinalObject("final-cleanup-after-db-error");
+  }
+  const writeResult = yield* writeResultResult;
 
   if (writeResult.status !== "ok") {
     const status = writeResult.status;
-    if (status === "entity-not-found" || status === "current-version-not-found") {
+    if (
+      status === "entity-not-found" ||
+      status === "current-version-not-found"
+    ) {
+      await cleanupFinalObject("final-cleanup-after-business-error");
       return finalizeErr({
         status: 404,
         message:
@@ -355,12 +384,14 @@ export const finalizeEntityVersion = async function* ({
       });
     }
     if (status === "entity-read-only") {
+      await cleanupFinalObject("final-cleanup-after-business-error");
       return finalizeErr({
         status: 409,
         message: "Entity is read-only",
         rejectReason: "entity-read-only",
       });
     }
+    await cleanupFinalObject("final-cleanup-after-business-error");
     return finalizeErr({
       status: 400,
       message: "Entity has no file field",
@@ -368,42 +399,46 @@ export const finalizeEntityVersion = async function* ({
     });
   }
 
-  // Async kickoffs mirror the legacy handler exactly.
-  processExtraction(entityId).catch((error: unknown) => {
-    captureError(error, { entityId });
-  });
-  enqueuePdfDerivativeOrMarkFailed({
-    encrypted: false,
-    entityId,
-    fieldId: fileFieldId,
-    mimeType: declaredMime,
-    organizationId,
-    userId,
-    workspaceId,
-  }).catch((error: unknown) => {
-    captureError(error, {
+  const afterPromote = () => {
+    // Async kickoffs mirror the legacy handler. They run only after
+    // both promotion and the DB transaction have succeeded, so
+    // consumers never read a final key before it exists.
+    processExtraction(entityId).catch((error: unknown) => {
+      captureError(error, { entityId });
+    });
+    enqueuePdfDerivativeOrMarkFailed({
+      encrypted: false,
       entityId,
       fieldId: fileFieldId,
       mimeType: declaredMime,
-    });
-  });
-  computeVersionDiffStats({
-    versionId: nextVersionId,
-    entityId,
-    scopedDb: createRootScopedDb({
       organizationId,
       userId,
-      workspaceIds: [workspaceId],
-    }),
-    workspaceId,
-    organizationId,
-  }).catch((error: unknown) => {
-    captureError(error, { versionId: nextVersionId });
-  });
-  broadcast(workspaceId, {
-    type: "invalidate-query",
-    data: ["entities", workspaceId],
-  });
+      workspaceId,
+    }).catch((error: unknown) => {
+      captureError(error, {
+        entityId,
+        fieldId: fileFieldId,
+        mimeType: declaredMime,
+      });
+    });
+    computeVersionDiffStats({
+      versionId: nextVersionId,
+      entityId,
+      scopedDb: createRootScopedDb({
+        organizationId,
+        userId,
+        workspaceIds: [workspaceId],
+      }),
+      workspaceId,
+      organizationId,
+    }).catch((error: unknown) => {
+      captureError(error, { versionId: nextVersionId });
+    });
+    broadcast(workspaceId, {
+      type: "invalidate-query",
+      data: ["entities", workspaceId],
+    });
+  };
 
   const finalized: Extract<
     PendingUploadFinalizedResult,
@@ -417,5 +452,5 @@ export const finalizeEntityVersion = async function* ({
     fileName: sanitizedName,
   };
 
-  return finalizeOk({ finalizedResult: finalized, finalKey });
+  return finalizeOk({ finalizedResult: finalized, finalKey, afterPromote });
 };

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -393,6 +393,7 @@ export const finalizeEntityVersion = async function* ({
       .where(
         and(
           eq(pendingUploads.id, uploadId),
+          eq(pendingUploads.userId, userId),
           eq(pendingUploads.workspaceId, workspaceId),
         ),
       )

--- a/apps/api/src/handlers/uploads/entity-version.ts
+++ b/apps/api/src/handlers/uploads/entity-version.ts
@@ -108,6 +108,7 @@ export type FinalizeEntityVersionProps = {
   purposeData: Extract<PendingUploadPurposeData, { type: "entity_version" }>;
   scanWarnings: string[] | undefined;
   uploadId: SafeId<"pendingUpload">;
+  claimRequestId: string;
   promoteTmpObject: (
     finalKey: string,
   ) => Promise<Result<void, UploadFinalizeError>>;
@@ -136,6 +137,7 @@ export const finalizeEntityVersion = async function* ({
   purposeData,
   scanWarnings,
   uploadId,
+  claimRequestId,
   promoteTmpObject,
 }: FinalizeEntityVersionProps) {
   const sanitizedName = sanitizeFilename(declaredName);
@@ -395,6 +397,8 @@ export const finalizeEntityVersion = async function* ({
           eq(pendingUploads.id, uploadId),
           eq(pendingUploads.userId, userId),
           eq(pendingUploads.workspaceId, workspaceId),
+          eq(pendingUploads.status, "scanning"),
+          eq(pendingUploads.claimedByRequestId, claimRequestId),
         ),
       )
       .returning({ id: pendingUploads.id });

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -1,0 +1,366 @@
+/**
+ * Finalize a presigned upload. Runs the claim FSM, verifies what
+ * the client uploaded against what they declared, scans the bytes,
+ * server-side copies `tmp/` → final key, then dispatches into the
+ * per-purpose domain transaction.
+ *
+ * Concurrency-safe via an atomic `UPDATE … WHERE status IN (…)`
+ * claim. A second caller for the same `uploadId` either:
+ *   - replays the cached `finalizedResult` (status = 'finalized')
+ *   - sees the cached reject reason  (status = 'rejected')
+ *   - gets a 409 if a previous attempt is still inside its
+ *     `FINALIZE_CLAIM_TIMEOUT_MS` window
+ *
+ * Crash recovery is implicit: a process that dies mid-scan leaves
+ * the row in `scanning`; the next finalize call after the timeout
+ * can re-claim it because both `claimed_at` and the row's status
+ * are atomically compared in the WHERE.
+ */
+import { Result } from "better-result";
+import type { Err } from "better-result";
+import { eq, sql } from "drizzle-orm";
+import { t } from "elysia";
+
+import type { SafeDb, SafeDbError } from "@/api/db";
+import { pendingUploads } from "@/api/db/schema";
+import type { PendingUploadFinalizedResult } from "@/api/db/schema";
+import { finalizeEntityCreate } from "@/api/handlers/uploads/entity-create";
+import {
+  FINALIZE_CLAIM_TIMEOUT_MS,
+  sha256Base64ToHex,
+  tmpUploadKey,
+  UploadFinalizeError,
+} from "@/api/handlers/uploads/lib";
+import { captureError } from "@/api/lib/analytics";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import type { AuditRecorder } from "@/api/lib/audit-log";
+import type { SafeId } from "@/api/lib/branded-types";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { scanFile } from "@/api/lib/file-scan/scan";
+import { getS3 } from "@/api/lib/s3";
+import { copyObject, headObject } from "@/api/lib/s3-presign";
+
+const finalizeParamsSchema = t.Object({
+  workspaceId: tSafeId("workspace"),
+  uploadId: tSafeId("pendingUpload"),
+});
+
+const config = {
+  permissions: { entity: ["create"] },
+  params: finalizeParamsSchema,
+} satisfies HandlerConfig;
+
+type ClaimedRow = typeof pendingUploads.$inferSelect;
+
+const finalizeUpload = createSafeHandler(
+  config,
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    params,
+    recordAuditEvent,
+  }) {
+    const uploadId = params.uploadId as SafeId<"pendingUpload">;
+
+    // 1. Claim — atomic transition into `scanning`. Re-claimable
+    //    if a previous holder either died (status='scanning' AND
+    //    claimed_at older than the timeout) or hit a transient
+    //    error (status='failed' AND past the cool-down).
+    const timeoutSec = Math.floor(FINALIZE_CLAIM_TIMEOUT_MS / 1000);
+    const claimedRows = yield* Result.await(
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      safeDb((tx) => {
+        // audit: skip — claim FSM state transition on
+        // pending_uploads; ephemeral bookkeeping. The audit row for
+        // the resulting entity is emitted by `finalizeEntityCreate`
+        // inside the same domain transaction.
+        return tx
+          .update(pendingUploads)
+          .set({
+            status: "scanning",
+            claimedAt: new Date(),
+            claimedByRequestId: Bun.randomUUIDv7().slice(0, 64),
+          })
+          .where(
+            sql`${pendingUploads.id} = ${uploadId}
+              AND ${pendingUploads.workspaceId} = ${workspaceId}
+              AND (
+                ${pendingUploads.status} = 'pending'
+                OR (
+                  ${pendingUploads.status} IN ('failed', 'scanning')
+                  AND ${pendingUploads.claimedAt} < NOW() - (${timeoutSec} || ' seconds')::interval
+                )
+              )`,
+          )
+          .returning();
+      }),
+    );
+    const claimed = claimedRows.at(0);
+
+    if (!claimed) {
+      // Claim missed: look up the row and replay or refuse.
+      const existing = yield* Result.await(
+        safeDb((tx) =>
+          tx.query.pendingUploads.findFirst({
+            where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+          }),
+        ),
+      );
+      if (!existing) {
+        return Result.err(
+          new HandlerError({ status: 404, message: "Upload not found" }),
+        );
+      }
+      if (existing.status === "finalized" && existing.finalizedResult) {
+        return Result.ok({ finalizedResult: existing.finalizedResult });
+      }
+      if (existing.status === "rejected") {
+        return Result.err(
+          new HandlerError({
+            status: 422,
+            message: existing.rejectReason ?? "Upload was previously rejected",
+          }),
+        );
+      }
+      return Result.err(
+        new HandlerError({
+          status: 409,
+          message: "Finalize already in progress for this upload",
+        }),
+      );
+    }
+
+    // From here on we own the row. Any early return must transition
+    // the row to a terminal status; `scanning` left behind would
+    // block re-claim until the timeout.
+    const finalizeResult = yield* runFinalize({
+      claimed,
+      organizationId: session.activeOrganizationId,
+      workspaceId,
+      userId: user.id,
+      safeDb,
+      recordAuditEvent,
+    });
+
+    if (Result.isError(finalizeResult)) {
+      const error = finalizeResult.error;
+      const terminalStatus = error.status === 500 ? "failed" : "rejected";
+      yield* Result.await(
+        // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+        safeDb((tx) => {
+          // audit: skip — terminal-state write on pending_uploads,
+          // no domain entity to attribute.
+          return tx
+            .update(pendingUploads)
+            .set({
+              status: terminalStatus,
+              rejectReason: error.rejectReason ?? error.message,
+              finalizedAt: terminalStatus === "rejected" ? new Date() : null,
+            })
+            .where(eq(pendingUploads.id, uploadId));
+        }),
+      );
+      // Best-effort tmp cleanup; bucket lifecycle is the safety net.
+      await getS3()
+        .delete(tmpUploadKey(uploadId))
+        .catch((error: unknown) =>
+          captureError(error, {
+            uploadId,
+            stage: "tmp-cleanup-after-reject",
+          }),
+        );
+      return Result.err(
+        new HandlerError({ status: error.status, message: error.message }),
+      );
+    }
+
+    // Success: persist the result so retries replay it verbatim.
+    yield* Result.await(
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      safeDb((tx) => {
+        // audit: skip — final FSM transition on pending_uploads;
+        // the entity-level audit row landed inside the domain
+        // transaction.
+        return tx
+          .update(pendingUploads)
+          .set({
+            status: "finalized",
+            finalizedResult: finalizeResult.value.finalizedResult,
+            finalizedAt: new Date(),
+          })
+          .where(eq(pendingUploads.id, uploadId));
+      }),
+    );
+
+    return Result.ok({ finalizedResult: finalizeResult.value.finalizedResult });
+  },
+);
+
+type RunFinalizeProps = {
+  claimed: ClaimedRow;
+  organizationId: SafeId<"organization">;
+  workspaceId: SafeId<"workspace">;
+  userId: SafeId<"user">;
+  safeDb: SafeDb;
+  recordAuditEvent: AuditRecorder;
+};
+
+type RunFinalizeOk = {
+  finalizedResult: PendingUploadFinalizedResult;
+};
+
+/**
+ * Generic finalize body. Verifies what S3 has against what the
+ * pending row says, scans the bytes, dispatches into the
+ * per-purpose domain transaction, then server-side promotes the
+ * tmp object to its final key.
+ *
+ * @yields SafeDb errors out to the safe-handler runner so the only
+ *   errors that escape are the typed `UploadFinalizeError` cases.
+ */
+const runFinalize = async function* ({
+  claimed,
+  organizationId,
+  workspaceId,
+  userId,
+  safeDb,
+  recordAuditEvent,
+}: RunFinalizeProps): AsyncGenerator<
+  Err<never, SafeDbError>,
+  Result<RunFinalizeOk, UploadFinalizeError>,
+  unknown
+> {
+  const tmpKey = tmpUploadKey(claimed.id);
+
+  // 2. S3 HEAD — exists? size matches? checksum matches?
+  const head = await headObject(tmpKey);
+  if (Result.isError(head)) {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 404,
+        message: "Upload not found in staging — URL likely expired",
+        rejectReason: "tmp-head-failed",
+      }),
+    );
+  }
+  if (head.value.contentLength !== claimed.declaredSize) {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 422,
+        message: `Uploaded size ${head.value.contentLength} does not match declared ${claimed.declaredSize}`,
+        rejectReason: "size-mismatch",
+      }),
+    );
+  }
+  if (
+    head.value.checksumSHA256 &&
+    sha256Base64ToHex(head.value.checksumSHA256) !== claimed.declaredSha256
+  ) {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 422,
+        message: "Uploaded SHA-256 does not match declared",
+        rejectReason: "sha256-mismatch",
+      }),
+    );
+  }
+
+  // 3. Download for scan.
+  const fileBuffer = await getS3().file(tmpKey).arrayBuffer();
+
+  // 4. Scan — same pipeline the legacy upload handler ran inline.
+  const scanResult = await scanFile({
+    buffer: new Uint8Array(fileBuffer),
+    declaredMimeType: claimed.declaredMime,
+    fileName: claimed.declaredName,
+  });
+  if (Result.isError(scanResult)) {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 500,
+        message: "File security scan failed",
+        rejectReason: "scan-error",
+      }),
+    );
+  }
+  if (scanResult.value.verdict === "reject") {
+    const reasons = scanResult.value.findings
+      .filter((finding) => finding.severity === "reject")
+      .map((finding) => finding.message);
+    return Result.err(
+      new UploadFinalizeError({
+        status: 422,
+        message: `File rejected: ${reasons.join("; ")}`,
+        rejectReason: reasons.join("; "),
+      }),
+    );
+  }
+  const scanWarnings =
+    scanResult.value.verdict === "warn"
+      ? scanResult.value.findings
+          .filter((finding) => finding.severity === "warn")
+          .map((finding) => finding.message)
+      : undefined;
+
+  // 5. Domain step + final key resolution. We copy AFTER the domain
+  //    transaction commits, so we never write a final-key object
+  //    the DB doesn't know about.
+  const purposeData = claimed.purposeData;
+  if (purposeData.type !== "entity_create") {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 500,
+        message: "Unsupported upload purpose",
+        rejectReason: "unsupported-purpose",
+      }),
+    );
+  }
+
+  const purposeOk = yield* finalizeEntityCreate({
+    safeDb,
+    recordAuditEvent,
+    organizationId,
+    workspaceId,
+    userId,
+    fileBuffer,
+    declaredName: claimed.declaredName,
+    declaredMime: claimed.declaredMime,
+    declaredSize: claimed.declaredSize,
+    declaredSha256Hex: claimed.declaredSha256,
+    purposeData,
+    scanWarnings,
+  });
+  if (Result.isError(purposeOk)) {
+    return purposeOk;
+  }
+
+  // 6. Server-side promote: tmp/{uploadId} → final key.
+  const copyResult = await copyObject(tmpKey, purposeOk.value.finalKey);
+  if (Result.isError(copyResult)) {
+    return Result.err(
+      new UploadFinalizeError({
+        status: 500,
+        message: "Failed to promote tmp object",
+        rejectReason: "copy-failed",
+      }),
+    );
+  }
+
+  // 7. Tmp cleanup. Bucket lifecycle catches anything we miss.
+  await getS3()
+    .delete(tmpKey)
+    .catch((error: unknown) =>
+      captureError(error, {
+        uploadId: claimed.id,
+        stage: "tmp-cleanup-after-promote",
+      }),
+    );
+
+  return Result.ok({ finalizedResult: purposeOk.value.finalizedResult });
+};
+
+export default finalizeUpload;

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -24,6 +24,7 @@ import { t } from "elysia";
 import type { SafeDb, SafeDbError } from "@/api/db";
 import { pendingUploads } from "@/api/db/schema";
 import type { PendingUploadFinalizedResult } from "@/api/db/schema";
+import { finalizeAgentSkill } from "@/api/handlers/uploads/agent-skill";
 import { finalizeEntityCreate } from "@/api/handlers/uploads/entity-create";
 import { finalizeEntityVersion } from "@/api/handlers/uploads/entity-version";
 import {
@@ -62,6 +63,7 @@ const finalizeUpload = createSafeHandler(
     session,
     workspaceId,
     user,
+    memberRole,
     params,
     recordAuditEvent,
   }) {
@@ -143,6 +145,7 @@ const finalizeUpload = createSafeHandler(
       organizationId: session.activeOrganizationId,
       workspaceId,
       userId: user.id,
+      memberRole,
       safeDb,
       recordAuditEvent,
     });
@@ -206,6 +209,7 @@ type RunFinalizeProps = {
   organizationId: SafeId<"organization">;
   workspaceId: SafeId<"workspace">;
   userId: SafeId<"user">;
+  memberRole: { role: string };
   safeDb: SafeDb;
   recordAuditEvent: AuditRecorder;
 };
@@ -228,6 +232,7 @@ const runFinalize = async function* ({
   organizationId,
   workspaceId,
   userId,
+  memberRole,
   safeDb,
   recordAuditEvent,
 }: RunFinalizeProps): AsyncGenerator<
@@ -325,10 +330,37 @@ const runFinalize = async function* ({
     scanWarnings,
   };
 
-  const purposeOk =
-    purposeData.type === "entity_create"
-      ? yield* finalizeEntityCreate({ ...domainArgs, purposeData })
-      : yield* finalizeEntityVersion({ ...domainArgs, purposeData });
+  // Dispatch on purposeData. Each variant is independent; the
+  // `purposeData` field is the source of truth (it carries the
+  // discriminator), and the body schemas at presign time guarantee
+  // it matches the URL purpose.
+  type RunAnyPurpose = Awaited<
+    ReturnType<
+      | typeof finalizeEntityCreate
+      | typeof finalizeEntityVersion
+      | typeof finalizeAgentSkill
+    >
+  > extends AsyncGenerator<unknown, infer R, unknown>
+    ? R
+    : never;
+  let purposeOk: RunAnyPurpose;
+  if (purposeData.type === "entity_create") {
+    purposeOk = yield* finalizeEntityCreate({ ...domainArgs, purposeData });
+  } else if (purposeData.type === "entity_version") {
+    purposeOk = yield* finalizeEntityVersion({ ...domainArgs, purposeData });
+  } else {
+    purposeOk = yield* finalizeAgentSkill({
+      safeDb,
+      recordAuditEvent,
+      organizationId,
+      userId,
+      memberRole,
+      fileBuffer,
+      declaredName: claimed.declaredName,
+      declaredMime: claimed.declaredMime,
+      scope: purposeData.scope,
+    });
+  }
   if (purposeOk.status === "error") {
     return purposeOk;
   }

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -1,8 +1,9 @@
 /**
  * Finalize a presigned upload. Runs the claim FSM, verifies what
  * the client uploaded against what they declared, scans the bytes,
- * server-side copies `tmp/` → final key, then dispatches into the
- * per-purpose domain transaction.
+ * dispatches into the per-purpose domain finalizer, then records the
+ * finalized result. File-backed finalizers promote `tmp/` to the final
+ * key before committing DB rows that point at it.
  *
  * Concurrency-safe via an atomic `UPDATE … WHERE status IN (…)`
  * claim. A second caller for the same `uploadId` either:
@@ -67,7 +68,7 @@ const finalizeUpload = createSafeHandler(
     params,
     recordAuditEvent,
   }) {
-    const uploadId = params.uploadId as SafeId<"pendingUpload">;
+    const uploadId = params.uploadId;
 
     // 1. Claim — atomic transition into `scanning`. Re-claimable
     //    if a previous holder either died (status='scanning' AND
@@ -95,7 +96,7 @@ const finalizeUpload = createSafeHandler(
                 ${pendingUploads.status} = 'pending'
                 OR (
                   ${pendingUploads.status} IN ('failed', 'scanning')
-                  AND ${pendingUploads.claimedAt} < NOW() - (${timeoutSec} || ' seconds')::interval
+                  AND ${pendingUploads.claimedAt} < NOW() - ${timeoutSec} * interval '1 second'
                 )
               )`,
           )
@@ -168,15 +169,18 @@ const finalizeUpload = createSafeHandler(
             .where(eq(pendingUploads.id, uploadId));
         }),
       );
-      // Best-effort tmp cleanup; bucket lifecycle is the safety net.
-      await getS3()
-        .delete(tmpUploadKey(uploadId))
-        .catch((error: unknown) =>
-          captureError(error, {
-            uploadId,
-            stage: "tmp-cleanup-after-reject",
-          }),
-        );
+      if (terminalStatus === "rejected") {
+        // Best-effort tmp cleanup only for terminal rejections.
+        // Transient failures keep tmp bytes so finalize can retry.
+        await getS3()
+          .delete(tmpUploadKey(uploadId))
+          .catch((deleteError: unknown) =>
+            captureError(deleteError, {
+              uploadId,
+              stage: "tmp-cleanup-after-reject",
+            }),
+          );
+      }
       return Result.err(
         new HandlerError({ status: error.status, message: error.message }),
       );
@@ -221,8 +225,8 @@ type RunFinalizeOk = {
 /**
  * Generic finalize body. Verifies what S3 has against what the
  * pending row says, scans the bytes, dispatches into the
- * per-purpose domain transaction, then server-side promotes the
- * tmp object to its final key.
+ * per-purpose domain finalizer, then removes the tmp object after the
+ * purpose has durably accepted the upload.
  *
  * @yields SafeDb errors out to the safe-handler runner so the only
  *   errors that escape are the typed `UploadFinalizeError` cases.
@@ -312,9 +316,22 @@ const runFinalize = async function* ({
           .map((finding) => finding.message)
       : undefined;
 
-  // 5. Domain step + final key resolution. We copy AFTER the domain
-  //    transaction commits, so we never write a final-key object
-  //    the DB doesn't know about.
+  const promoteTmpObject = async (finalKey: string) => {
+    const copyResult = await copyObject(tmpKey, finalKey);
+    if (Result.isError(copyResult)) {
+      return Result.err(
+        new UploadFinalizeError({
+          status: 500,
+          message: "Failed to promote tmp object",
+          rejectReason: "copy-failed",
+        }),
+      );
+    }
+    return Result.ok(undefined);
+  };
+
+  // 5. Purpose finalization. File-backed purposes promote the tmp
+  //    object before committing DB rows that reference the final key.
   const purposeData = claimed.purposeData;
   const domainArgs = {
     safeDb,
@@ -328,21 +345,23 @@ const runFinalize = async function* ({
     declaredSize: claimed.declaredSize,
     declaredSha256Hex: claimed.declaredSha256,
     scanWarnings,
+    promoteTmpObject,
   };
 
   // Dispatch on purposeData. Each variant is independent; the
   // `purposeData` field is the source of truth (it carries the
   // discriminator), and the body schemas at presign time guarantee
   // it matches the URL purpose.
-  type RunAnyPurpose = Awaited<
-    ReturnType<
-      | typeof finalizeEntityCreate
-      | typeof finalizeEntityVersion
-      | typeof finalizeAgentSkill
-    >
-  > extends AsyncGenerator<unknown, infer R, unknown>
-    ? R
-    : never;
+  type RunAnyPurpose =
+    Awaited<
+      ReturnType<
+        | typeof finalizeEntityCreate
+        | typeof finalizeEntityVersion
+        | typeof finalizeAgentSkill
+      >
+    > extends AsyncGenerator<unknown, infer R, unknown>
+      ? R
+      : never;
   let purposeOk: RunAnyPurpose;
   if (purposeData.type === "entity_create") {
     purposeOk = yield* finalizeEntityCreate({ ...domainArgs, purposeData });
@@ -362,26 +381,28 @@ const runFinalize = async function* ({
     });
   }
   if (purposeOk.status === "error") {
-    return purposeOk;
+    return Result.err(purposeOk.error);
   }
 
-  // 6. Server-side promote: tmp/{uploadId} → final key.
-  const copyResult = await copyObject(tmpKey, purposeOk.value.finalKey);
-  if (Result.isError(copyResult)) {
-    return Result.err(
-      new UploadFinalizeError({
-        status: 500,
-        message: "Failed to promote tmp object",
-        rejectReason: "copy-failed",
-      }),
-    );
+  const afterPromote = purposeOk.value.afterPromote;
+  if (afterPromote) {
+    const postPromoteResult = await Result.tryPromise(async () => {
+      afterPromote();
+      await Promise.resolve();
+    });
+    if (Result.isError(postPromoteResult)) {
+      captureError(postPromoteResult.error, {
+        uploadId: claimed.id,
+        stage: "post-promote",
+      });
+    }
   }
 
-  // 7. Tmp cleanup. Bucket lifecycle catches anything we miss.
+  // 6. Tmp cleanup. Bucket lifecycle catches anything we miss.
   await getS3()
     .delete(tmpKey)
-    .catch((error: unknown) =>
-      captureError(error, {
+    .catch((deleteError: unknown) =>
+      captureError(deleteError, {
         uploadId: claimed.id,
         stage: "tmp-cleanup-after-promote",
       }),

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -25,6 +25,7 @@ import type { SafeDb, SafeDbError } from "@/api/db";
 import { pendingUploads } from "@/api/db/schema";
 import type { PendingUploadFinalizedResult } from "@/api/db/schema";
 import { finalizeEntityCreate } from "@/api/handlers/uploads/entity-create";
+import { finalizeEntityVersion } from "@/api/handlers/uploads/entity-version";
 import {
   FINALIZE_CLAIM_TIMEOUT_MS,
   sha256Base64ToHex,
@@ -310,17 +311,7 @@ const runFinalize = async function* ({
   //    transaction commits, so we never write a final-key object
   //    the DB doesn't know about.
   const purposeData = claimed.purposeData;
-  if (purposeData.type !== "entity_create") {
-    return Result.err(
-      new UploadFinalizeError({
-        status: 500,
-        message: "Unsupported upload purpose",
-        rejectReason: "unsupported-purpose",
-      }),
-    );
-  }
-
-  const purposeOk = yield* finalizeEntityCreate({
+  const domainArgs = {
     safeDb,
     recordAuditEvent,
     organizationId,
@@ -331,10 +322,14 @@ const runFinalize = async function* ({
     declaredMime: claimed.declaredMime,
     declaredSize: claimed.declaredSize,
     declaredSha256Hex: claimed.declaredSha256,
-    purposeData,
     scanWarnings,
-  });
-  if (Result.isError(purposeOk)) {
+  };
+
+  const purposeOk =
+    purposeData.type === "entity_create"
+      ? yield* finalizeEntityCreate({ ...domainArgs, purposeData })
+      : yield* finalizeEntityVersion({ ...domainArgs, purposeData });
+  if (purposeOk.status === "error") {
     return purposeOk;
   }
 

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -17,9 +17,9 @@
  * can re-claim it because both `claimed_at` and the row's status
  * are atomically compared in the WHERE.
  */
-import { Result } from "better-result";
+import { Result, panic } from "better-result";
 import type { Err } from "better-result";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
@@ -34,6 +34,10 @@ import {
   tmpUploadKey,
   UploadFinalizeError,
 } from "@/api/handlers/uploads/lib";
+import {
+  authorizeUploadPurpose,
+  uploadRoutePermission,
+} from "@/api/handlers/uploads/permissions";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -51,7 +55,7 @@ const finalizeParamsSchema = t.Object({
 });
 
 const config = {
-  permissions: { entity: ["create"] },
+  permissions: uploadRoutePermission,
   params: finalizeParamsSchema,
 } satisfies HandlerConfig;
 
@@ -69,6 +73,27 @@ const finalizeUpload = createSafeHandler(
     recordAuditEvent,
   }) {
     const uploadId = params.uploadId;
+
+    const pending = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.pendingUploads.findFirst({
+          where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+          columns: { purpose: true },
+        }),
+      ),
+    );
+    if (!pending) {
+      return Result.err(
+        new HandlerError({ status: 404, message: "Upload not found" }),
+      );
+    }
+    const authorization = authorizeUploadPurpose({
+      memberRole,
+      purpose: pending.purpose,
+    });
+    if (Result.isError(authorization)) {
+      return Result.err(authorization.error);
+    }
 
     // 1. Claim — atomic transition into `scanning`. Re-claimable
     //    if a previous holder either died (status='scanning' AND
@@ -147,6 +172,7 @@ const finalizeUpload = createSafeHandler(
       workspaceId,
       userId: user.id,
       memberRole,
+      uploadId,
       safeDb,
       recordAuditEvent,
     });
@@ -154,7 +180,7 @@ const finalizeUpload = createSafeHandler(
     if (Result.isError(finalizeResult)) {
       const error = finalizeResult.error;
       const terminalStatus = error.status === 500 ? "failed" : "rejected";
-      yield* Result.await(
+      const failedRows = yield* Result.await(
         // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
         safeDb((tx) => {
           // audit: skip — terminal-state write on pending_uploads,
@@ -166,9 +192,18 @@ const finalizeUpload = createSafeHandler(
               rejectReason: error.rejectReason ?? error.message,
               finalizedAt: terminalStatus === "rejected" ? new Date() : null,
             })
-            .where(eq(pendingUploads.id, uploadId));
+            .where(
+              and(
+                eq(pendingUploads.id, uploadId),
+                eq(pendingUploads.workspaceId, workspaceId),
+              ),
+            )
+            .returning({ id: pendingUploads.id });
         }),
       );
+      if (!failedRows.at(0)) {
+        panic("Pending upload failure marker update returned no rows");
+      }
       if (terminalStatus === "rejected") {
         // Best-effort tmp cleanup only for terminal rejections.
         // Transient failures keep tmp bytes so finalize can retry.
@@ -186,24 +221,6 @@ const finalizeUpload = createSafeHandler(
       );
     }
 
-    // Success: persist the result so retries replay it verbatim.
-    yield* Result.await(
-      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
-      safeDb((tx) => {
-        // audit: skip — final FSM transition on pending_uploads;
-        // the entity-level audit row landed inside the domain
-        // transaction.
-        return tx
-          .update(pendingUploads)
-          .set({
-            status: "finalized",
-            finalizedResult: finalizeResult.value.finalizedResult,
-            finalizedAt: new Date(),
-          })
-          .where(eq(pendingUploads.id, uploadId));
-      }),
-    );
-
     return Result.ok({ finalizedResult: finalizeResult.value.finalizedResult });
   },
 );
@@ -214,6 +231,7 @@ type RunFinalizeProps = {
   workspaceId: SafeId<"workspace">;
   userId: SafeId<"user">;
   memberRole: { role: string };
+  uploadId: SafeId<"pendingUpload">;
   safeDb: SafeDb;
   recordAuditEvent: AuditRecorder;
 };
@@ -237,6 +255,7 @@ const runFinalize = async function* ({
   workspaceId,
   userId,
   memberRole,
+  uploadId,
   safeDb,
   recordAuditEvent,
 }: RunFinalizeProps): AsyncGenerator<
@@ -346,6 +365,7 @@ const runFinalize = async function* ({
     declaredSha256Hex: claimed.declaredSha256,
     scanWarnings,
     promoteTmpObject,
+    uploadId,
   };
 
   // Dispatch on purposeData. Each variant is independent; the
@@ -377,7 +397,9 @@ const runFinalize = async function* ({
       fileBuffer,
       declaredName: claimed.declaredName,
       declaredMime: claimed.declaredMime,
+      uploadId,
       scope: purposeData.scope,
+      workspaceId,
     });
   }
   if (purposeOk.status === "error") {

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -77,7 +77,11 @@ const finalizeUpload = createSafeHandler(
     const pending = yield* Result.await(
       safeDb((tx) =>
         tx.query.pendingUploads.findFirst({
-          where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+          where: {
+            id: { eq: uploadId },
+            userId: { eq: user.id },
+            workspaceId: { eq: workspaceId },
+          },
           columns: { purpose: true },
         }),
       ),
@@ -117,6 +121,7 @@ const finalizeUpload = createSafeHandler(
           .where(
             sql`${pendingUploads.id} = ${uploadId}
               AND ${pendingUploads.workspaceId} = ${workspaceId}
+              AND ${pendingUploads.userId} = ${user.id}
               AND (
                 ${pendingUploads.status} = 'pending'
                 OR (
@@ -135,7 +140,11 @@ const finalizeUpload = createSafeHandler(
       const existing = yield* Result.await(
         safeDb((tx) =>
           tx.query.pendingUploads.findFirst({
-            where: { id: { eq: uploadId }, workspaceId: { eq: workspaceId } },
+            where: {
+              id: { eq: uploadId },
+              userId: { eq: user.id },
+              workspaceId: { eq: workspaceId },
+            },
           }),
         ),
       );
@@ -195,6 +204,7 @@ const finalizeUpload = createSafeHandler(
             .where(
               and(
                 eq(pendingUploads.id, uploadId),
+                eq(pendingUploads.userId, user.id),
                 eq(pendingUploads.workspaceId, workspaceId),
               ),
             )
@@ -300,6 +310,20 @@ const runFinalize = async function* ({
 
   // 3. Download for scan.
   const fileBuffer = await getS3().file(tmpKey).arrayBuffer();
+  if (!head.value.checksumSHA256) {
+    const uploadedSha256 = new Bun.CryptoHasher("sha256")
+      .update(fileBuffer)
+      .digest("hex");
+    if (uploadedSha256 !== claimed.declaredSha256) {
+      return Result.err(
+        new UploadFinalizeError({
+          status: 422,
+          message: "Uploaded SHA-256 does not match declared",
+          rejectReason: "sha256-mismatch",
+        }),
+      );
+    }
+  }
 
   // 4. Scan — same pipeline the legacy upload handler ran inline.
   const scanResult = await scanFile({

--- a/apps/api/src/handlers/uploads/finalize.ts
+++ b/apps/api/src/handlers/uploads/finalize.ts
@@ -104,6 +104,7 @@ const finalizeUpload = createSafeHandler(
     //    claimed_at older than the timeout) or hit a transient
     //    error (status='failed' AND past the cool-down).
     const timeoutSec = Math.floor(FINALIZE_CLAIM_TIMEOUT_MS / 1000);
+    const claimRequestId = Bun.randomUUIDv7().slice(0, 64);
     const claimedRows = yield* Result.await(
       // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
       safeDb((tx) => {
@@ -116,12 +117,13 @@ const finalizeUpload = createSafeHandler(
           .set({
             status: "scanning",
             claimedAt: new Date(),
-            claimedByRequestId: Bun.randomUUIDv7().slice(0, 64),
+            claimedByRequestId: claimRequestId,
           })
           .where(
             sql`${pendingUploads.id} = ${uploadId}
               AND ${pendingUploads.workspaceId} = ${workspaceId}
               AND ${pendingUploads.userId} = ${user.id}
+              AND ${pendingUploads.expiresAt} > NOW()
               AND (
                 ${pendingUploads.status} = 'pending'
                 OR (
@@ -164,6 +166,39 @@ const finalizeUpload = createSafeHandler(
           }),
         );
       }
+      const expiredRows = yield* Result.await(
+        // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+        safeDb((tx) => {
+          // audit: skip — expiry transition on pending_uploads;
+          // the upload never became a durable entity.
+          return tx
+            .update(pendingUploads)
+            .set({
+              status: "rejected",
+              rejectReason: "Upload URL expired",
+              finalizedAt: new Date(),
+            })
+            .where(
+              sql`${pendingUploads.id} = ${uploadId}
+                AND ${pendingUploads.workspaceId} = ${workspaceId}
+                AND ${pendingUploads.userId} = ${user.id}
+                AND ${pendingUploads.expiresAt} <= NOW()
+                AND (
+                  ${pendingUploads.status} IN ('pending', 'failed')
+                  OR (
+                    ${pendingUploads.status} = 'scanning'
+                    AND ${pendingUploads.claimedAt} < NOW() - ${timeoutSec} * interval '1 second'
+                  )
+                )`,
+            )
+            .returning({ id: pendingUploads.id });
+        }),
+      );
+      if (expiredRows.at(0)) {
+        return Result.err(
+          new HandlerError({ status: 422, message: "Upload URL expired" }),
+        );
+      }
       return Result.err(
         new HandlerError({
           status: 409,
@@ -182,6 +217,7 @@ const finalizeUpload = createSafeHandler(
       userId: user.id,
       memberRole,
       uploadId,
+      claimRequestId,
       safeDb,
       recordAuditEvent,
     });
@@ -206,6 +242,8 @@ const finalizeUpload = createSafeHandler(
                 eq(pendingUploads.id, uploadId),
                 eq(pendingUploads.userId, user.id),
                 eq(pendingUploads.workspaceId, workspaceId),
+                eq(pendingUploads.status, "scanning"),
+                eq(pendingUploads.claimedByRequestId, claimRequestId),
               ),
             )
             .returning({ id: pendingUploads.id });
@@ -242,6 +280,7 @@ type RunFinalizeProps = {
   userId: SafeId<"user">;
   memberRole: { role: string };
   uploadId: SafeId<"pendingUpload">;
+  claimRequestId: string;
   safeDb: SafeDb;
   recordAuditEvent: AuditRecorder;
 };
@@ -266,6 +305,7 @@ const runFinalize = async function* ({
   userId,
   memberRole,
   uploadId,
+  claimRequestId,
   safeDb,
   recordAuditEvent,
 }: RunFinalizeProps): AsyncGenerator<
@@ -390,6 +430,7 @@ const runFinalize = async function* ({
     scanWarnings,
     promoteTmpObject,
     uploadId,
+    claimRequestId,
   };
 
   // Dispatch on purposeData. Each variant is independent; the
@@ -422,6 +463,7 @@ const runFinalize = async function* ({
       declaredName: claimed.declaredName,
       declaredMime: claimed.declaredMime,
       uploadId,
+      claimRequestId,
       scope: purposeData.scope,
       workspaceId,
     });

--- a/apps/api/src/handlers/uploads/lib.ts
+++ b/apps/api/src/handlers/uploads/lib.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared types and helpers for the presigned-upload migration
+ * (issue #184). Each upload surface (entity create, entity version,
+ * agent skills, chat attachments) plugs its own purpose-specific
+ * validation into `presignUpload` and its own domain-transaction
+ * callback into `runFinalize`; everything else (S3 staging area,
+ * claim FSM, head verification, scan, server-side copy, status
+ * bookkeeping) is identical and lives here.
+ */
+import { Result, TaggedError } from "better-result";
+
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * S3 lifetime of the issued URL. Short enough that an intercepted
+ * URL has a tight window for abuse; long enough that a slow
+ * client on a hotel uplink can still finish a 50 MB PUT. The
+ * matching `tmp/` bucket-level lifecycle is 24h — plenty of margin
+ * either way.
+ */
+export const PRESIGN_URL_EXPIRY_SECONDS = 5 * 60;
+
+/**
+ * Maximum time a `scanning` claim can sit before the next finalize
+ * caller is allowed to steal it. Covers the worst-case sync scan
+ * (50 MB DOCX through YARA + zip-bomb guard) with headroom. Tuned
+ * down once async scanning lands in phase 6.
+ */
+export const FINALIZE_CLAIM_TIMEOUT_MS = 60_000;
+
+/** `tmp/{uploadId}` is the staging-area key the bucket lifecycle covers. */
+export const tmpUploadKey = (uploadId: SafeId<"pendingUpload">): string =>
+  `tmp/${uploadId}`;
+
+/** Convert lowercase hex SHA-256 to base64 (S3's checksum API expects base64). */
+export const sha256HexToBase64 = (hex: string): string =>
+  Buffer.from(hex, "hex").toString("base64");
+
+/** Convert base64 SHA-256 (as returned by S3 HEAD) to lowercase hex. */
+export const sha256Base64ToHex = (base64: string): string =>
+  Buffer.from(base64, "base64").toString("hex");
+
+export class UploadFinalizeError extends TaggedError("UploadFinalizeError")<{
+  status: 400 | 404 | 409 | 422 | 500;
+  message: string;
+  /** Optional reason persisted on the pending_uploads row. */
+  rejectReason?: string;
+}>() {}
+
+/**
+ * Re-export of the better-result helper for cases where a non-OK
+ * value still represents a logically completed finalize (e.g.
+ * idempotent replay returning the cached result). Callers narrow
+ * on `status` to know which branch to take.
+ */
+export const finalizeOk = <T>(value: T): Result<T, UploadFinalizeError> =>
+  Result.ok(value);
+
+export const finalizeErr = (
+  error: ConstructorParameters<typeof UploadFinalizeError>[0],
+): Result<never, UploadFinalizeError> =>
+  Result.err(new UploadFinalizeError(error));

--- a/apps/api/src/handlers/uploads/permissions.ts
+++ b/apps/api/src/handlers/uploads/permissions.ts
@@ -1,0 +1,41 @@
+import { Result } from "better-result";
+
+import { roles } from "@stll/permissions";
+import type { PermissionInput } from "@stll/permissions";
+
+import type { PendingUploadPurposeData } from "@/api/db/schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+export const uploadRoutePermission = {
+  workspace: ["read"],
+} satisfies PermissionInput;
+
+type UploadPurpose = PendingUploadPurposeData["type"];
+
+const uploadPurposePermission = (purpose: UploadPurpose): PermissionInput => {
+  if (purpose === "entity_create") {
+    return { entity: ["create"] };
+  }
+  if (purpose === "entity_version") {
+    return { entity: ["update"] };
+  }
+  return { agentSkill: ["create"] };
+};
+
+type AuthorizeUploadPurposeProps = {
+  memberRole: { role: keyof typeof roles };
+  purpose: UploadPurpose;
+};
+
+export const authorizeUploadPurpose = ({
+  memberRole,
+  purpose,
+}: AuthorizeUploadPurposeProps): Result<void, HandlerError> => {
+  const authorization = roles[memberRole.role].authorize(
+    uploadPurposePermission(purpose),
+  );
+  if (authorization.success) {
+    return Result.ok(undefined);
+  }
+  return Result.err(new HandlerError({ status: 403, message: "Forbidden" }));
+};

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -24,6 +24,10 @@ import {
   sha256HexToBase64,
   tmpUploadKey,
 } from "@/api/handlers/uploads/lib";
+import {
+  authorizeUploadPurpose,
+  uploadRoutePermission,
+} from "@/api/handlers/uploads/permissions";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeId } from "@/api/lib/branded-types";
@@ -48,6 +52,14 @@ const baseFileMetadataSchema = {
   sha256Hex: t.RegExp(/^[0-9a-f]{64}$/u),
 } as const;
 
+const skillPackFileMetadataSchema = {
+  ...baseFileMetadataSchema,
+  size: t.Integer({
+    minimum: 1,
+    maximum: FILE_SIZE_LIMIT_BYTES.skillPack,
+  }),
+} as const;
+
 const entityCreatePresignBodySchema = t.Object({
   purpose: t.Literal("entity_create"),
   propertyId: tSafeId("property"),
@@ -65,7 +77,7 @@ const agentSkillPresignBodySchema = t.Object({
   scope: t.UnionEnum(AGENT_SKILL_SCOPES),
   // Skill packs use the smaller `skillPack` budget enforced by the
   // legacy upload, capped here too.
-  ...baseFileMetadataSchema,
+  ...skillPackFileMetadataSchema,
 });
 
 const presignBodySchema = t.Union([
@@ -93,7 +105,7 @@ const toPurposeData = (purposeBody: PresignBody): PendingUploadPurposeData => {
 };
 
 const config = {
-  permissions: { entity: ["create"] },
+  permissions: uploadRoutePermission,
   body: presignBodySchema,
 } satisfies HandlerConfig;
 
@@ -107,6 +119,14 @@ const presignUpload = createSafeHandler(
     memberRole,
     body: purposeBody,
   }) {
+    const authorization = authorizeUploadPurpose({
+      memberRole,
+      purpose: purposeBody.purpose,
+    });
+    if (Result.isError(authorization)) {
+      return Result.err(authorization.error);
+    }
+
     if (purposeBody.purpose === "entity_create") {
       const validation = yield* validateEntityCreate({
         safeDb,

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -11,7 +11,8 @@ import { Result } from "better-result";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
-import { pendingUploads } from "@/api/db/schema";
+import { AGENT_SKILL_SCOPES, pendingUploads } from "@/api/db/schema";
+import { validateAgentSkill } from "@/api/handlers/uploads/agent-skill";
 import { validateEntityCreate } from "@/api/handlers/uploads/entity-create";
 import { validateEntityVersion } from "@/api/handlers/uploads/entity-version";
 import {
@@ -55,9 +56,18 @@ const entityVersionPresignBodySchema = t.Object({
   ...baseFileMetadataSchema,
 });
 
+const agentSkillPresignBodySchema = t.Object({
+  purpose: t.Literal("agent_skill"),
+  scope: t.UnionEnum(AGENT_SKILL_SCOPES),
+  // Skill packs use the smaller `skillPack` budget enforced by the
+  // legacy upload, capped here too.
+  ...baseFileMetadataSchema,
+});
+
 const presignBodySchema = t.Union([
   entityCreatePresignBodySchema,
   entityVersionPresignBodySchema,
+  agentSkillPresignBodySchema,
 ]);
 
 type PresignBody = Static<typeof presignBodySchema>;
@@ -69,7 +79,14 @@ const config = {
 
 const presignUpload = createSafeHandler(
   config,
-  async function* ({ safeDb, session, workspaceId, user, body }) {
+  async function* ({
+    safeDb,
+    session,
+    workspaceId,
+    user,
+    memberRole,
+    body,
+  }) {
     const purposeBody = body as PresignBody;
 
     if (purposeBody.purpose === "entity_create") {
@@ -86,6 +103,14 @@ const presignUpload = createSafeHandler(
         safeDb,
         workspaceId,
         entityId: purposeBody.entityId,
+      });
+      if (validation.status === "error") {
+        return validation;
+      }
+    } else if (purposeBody.purpose === "agent_skill") {
+      const validation = yield* validateAgentSkill({
+        memberRole,
+        scope: purposeBody.scope,
       });
       if (validation.status === "error") {
         return validation;
@@ -129,16 +154,22 @@ const presignUpload = createSafeHandler(
           workspaceId,
           userId: user.id,
           purpose: purposeBody.purpose,
-          purposeData:
-            purposeBody.purpose === "entity_create"
-              ? {
+          purposeData: (() => {
+            switch (purposeBody.purpose) {
+              case "entity_create":
+                return {
                   type: "entity_create",
                   propertyId: purposeBody.propertyId,
-                }
-              : {
+                };
+              case "entity_version":
+                return {
                   type: "entity_version",
                   entityId: purposeBody.entityId,
-                },
+                };
+              case "agent_skill":
+                return { type: "agent_skill", scope: purposeBody.scope };
+            }
+          })(),
           declaredName: purposeBody.name,
           declaredMime: purposeBody.mimeType,
           declaredSize: purposeBody.size,

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -1,0 +1,133 @@
+/**
+ * Generic presigned-upload entrypoint. The body's `purpose` field
+ * picks the per-surface validation + future finalize callback;
+ * everything else (limits, MIME, expiry, signed-URL generation) is
+ * shared.
+ *
+ * Phase 1 wires only `entity_create`. Phases 2–4 will extend the
+ * `t.Union(...)` and add a `switch(body.purpose)` branch.
+ */
+import { Result } from "better-result";
+import { t } from "elysia";
+import type { Static } from "elysia";
+
+import { pendingUploads } from "@/api/db/schema";
+import { validateEntityCreate } from "@/api/handlers/uploads/entity-create";
+import {
+  PRESIGN_URL_EXPIRY_SECONDS,
+  sha256HexToBase64,
+  tmpUploadKey,
+} from "@/api/handlers/uploads/lib";
+import { createSafeHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { createSafeId } from "@/api/lib/branded-types";
+import { tDefaultVarchar, tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
+import { presignUploadUrl } from "@/api/lib/s3-presign";
+
+const entityCreatePresignBodySchema = t.Object({
+  purpose: t.Literal("entity_create"),
+  propertyId: tSafeId("property"),
+  name: tDefaultVarchar,
+  mimeType: t.String({ minLength: 1, maxLength: 255 }),
+  size: t.Integer({
+    minimum: 1,
+    // S3 enforces this via the signed Content-Length; finalize
+    // re-checks via S3.HEAD. Pinning it at the schema level lets
+    // the API refuse oversized requests before even minting a URL.
+    maximum: FILE_SIZE_LIMIT_BYTES.document,
+  }),
+  // Lowercase hex, exactly 64 chars. The same format the legacy
+  // entity upload stores at `fields.content.sha256Hex`, so we can
+  // round-trip without re-encoding inside the migration.
+  sha256Hex: t.RegExp(/^[0-9a-f]{64}$/u),
+});
+
+const presignBodySchema = t.Union([entityCreatePresignBodySchema]);
+
+type PresignBody = Static<typeof presignBodySchema>;
+
+const config = {
+  permissions: { entity: ["create"] },
+  body: presignBodySchema,
+} satisfies HandlerConfig;
+
+const presignUpload = createSafeHandler(
+  config,
+  async function* ({ safeDb, session, workspaceId, user, body }) {
+    const purposeBody = body as PresignBody;
+
+    if (purposeBody.purpose === "entity_create") {
+      const validation = yield* validateEntityCreate({
+        safeDb,
+        workspaceId,
+        propertyId: purposeBody.propertyId,
+      });
+      if (Result.isError(validation)) {
+        return validation;
+      }
+    }
+
+    const uploadId = createSafeId<"pendingUpload">();
+    const now = new Date();
+    const expiresAt = new Date(
+      now.getTime() + PRESIGN_URL_EXPIRY_SECONDS * 1000,
+    );
+
+    const presign = await presignUploadUrl({
+      key: tmpUploadKey(uploadId),
+      expiresIn: PRESIGN_URL_EXPIRY_SECONDS,
+      contentType: purposeBody.mimeType,
+      contentLength: purposeBody.size,
+      sha256Base64: sha256HexToBase64(purposeBody.sha256Hex),
+    });
+    if (Result.isError(presign)) {
+      return Result.err(
+        new HandlerError({
+          status: 500,
+          message: "Failed to issue upload URL",
+        }),
+      );
+    }
+
+    // Persist intent. RLS pins the row to this workspace, so even
+    // a stolen URL can only be finalized by a request that
+    // resolves to the same workspace_ids on the API role.
+    yield* Result.await(
+      // eslint-disable-next-line arrow-body-style -- block body holds the audit-skip directive
+      safeDb((tx) => {
+        // audit: skip — presigned URL bookkeeping; the audit row is
+        // emitted by the per-purpose finalize once the upload
+        // becomes a durable entity.
+        return tx.insert(pendingUploads).values({
+          id: uploadId,
+          organizationId: session.activeOrganizationId,
+          workspaceId,
+          userId: user.id,
+          purpose: purposeBody.purpose,
+          purposeData: {
+            type: "entity_create",
+            propertyId: purposeBody.propertyId,
+          },
+          declaredName: purposeBody.name,
+          declaredMime: purposeBody.mimeType,
+          declaredSize: purposeBody.size,
+          declaredSha256: purposeBody.sha256Hex,
+          status: "pending",
+          expiresAt,
+          createdAt: now,
+        });
+      }),
+    );
+
+    return Result.ok({
+      uploadId,
+      url: presign.value.url,
+      expiresAt: expiresAt.toISOString(),
+      headers: presign.value.headers,
+    });
+  },
+);
+
+export default presignUpload;

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -13,6 +13,7 @@ import type { Static } from "elysia";
 
 import { pendingUploads } from "@/api/db/schema";
 import { validateEntityCreate } from "@/api/handlers/uploads/entity-create";
+import { validateEntityVersion } from "@/api/handlers/uploads/entity-version";
 import {
   PRESIGN_URL_EXPIRY_SECONDS,
   sha256HexToBase64,
@@ -26,9 +27,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 import { FILE_SIZE_LIMIT_BYTES } from "@/api/lib/limits";
 import { presignUploadUrl } from "@/api/lib/s3-presign";
 
-const entityCreatePresignBodySchema = t.Object({
-  purpose: t.Literal("entity_create"),
-  propertyId: tSafeId("property"),
+const baseFileMetadataSchema = {
   name: tDefaultVarchar,
   mimeType: t.String({ minLength: 1, maxLength: 255 }),
   size: t.Integer({
@@ -42,9 +41,24 @@ const entityCreatePresignBodySchema = t.Object({
   // entity upload stores at `fields.content.sha256Hex`, so we can
   // round-trip without re-encoding inside the migration.
   sha256Hex: t.RegExp(/^[0-9a-f]{64}$/u),
+} as const;
+
+const entityCreatePresignBodySchema = t.Object({
+  purpose: t.Literal("entity_create"),
+  propertyId: tSafeId("property"),
+  ...baseFileMetadataSchema,
 });
 
-const presignBodySchema = t.Union([entityCreatePresignBodySchema]);
+const entityVersionPresignBodySchema = t.Object({
+  purpose: t.Literal("entity_version"),
+  entityId: tSafeId("entity"),
+  ...baseFileMetadataSchema,
+});
+
+const presignBodySchema = t.Union([
+  entityCreatePresignBodySchema,
+  entityVersionPresignBodySchema,
+]);
 
 type PresignBody = Static<typeof presignBodySchema>;
 
@@ -65,6 +79,15 @@ const presignUpload = createSafeHandler(
         propertyId: purposeBody.propertyId,
       });
       if (Result.isError(validation)) {
+        return validation;
+      }
+    } else if (purposeBody.purpose === "entity_version") {
+      const validation = yield* validateEntityVersion({
+        safeDb,
+        workspaceId,
+        entityId: purposeBody.entityId,
+      });
+      if (validation.status === "error") {
         return validation;
       }
     }
@@ -106,10 +129,16 @@ const presignUpload = createSafeHandler(
           workspaceId,
           userId: user.id,
           purpose: purposeBody.purpose,
-          purposeData: {
-            type: "entity_create",
-            propertyId: purposeBody.propertyId,
-          },
+          purposeData:
+            purposeBody.purpose === "entity_create"
+              ? {
+                  type: "entity_create",
+                  propertyId: purposeBody.propertyId,
+                }
+              : {
+                  type: "entity_version",
+                  entityId: purposeBody.entityId,
+                },
           declaredName: purposeBody.name,
           declaredMime: purposeBody.mimeType,
           declaredSize: purposeBody.size,

--- a/apps/api/src/handlers/uploads/presign.ts
+++ b/apps/api/src/handlers/uploads/presign.ts
@@ -11,7 +11,11 @@ import { Result } from "better-result";
 import { t } from "elysia";
 import type { Static } from "elysia";
 
-import { AGENT_SKILL_SCOPES, pendingUploads } from "@/api/db/schema";
+import {
+  AGENT_SKILL_SCOPES,
+  pendingUploads,
+  type PendingUploadPurposeData,
+} from "@/api/db/schema";
 import { validateAgentSkill } from "@/api/handlers/uploads/agent-skill";
 import { validateEntityCreate } from "@/api/handlers/uploads/entity-create";
 import { validateEntityVersion } from "@/api/handlers/uploads/entity-version";
@@ -72,6 +76,22 @@ const presignBodySchema = t.Union([
 
 type PresignBody = Static<typeof presignBodySchema>;
 
+const toPurposeData = (purposeBody: PresignBody): PendingUploadPurposeData => {
+  if (purposeBody.purpose === "entity_create") {
+    return {
+      type: "entity_create",
+      propertyId: purposeBody.propertyId,
+    };
+  }
+  if (purposeBody.purpose === "entity_version") {
+    return {
+      type: "entity_version",
+      entityId: purposeBody.entityId,
+    };
+  }
+  return { type: "agent_skill", scope: purposeBody.scope };
+};
+
 const config = {
   permissions: { entity: ["create"] },
   body: presignBodySchema,
@@ -85,10 +105,8 @@ const presignUpload = createSafeHandler(
     workspaceId,
     user,
     memberRole,
-    body,
+    body: purposeBody,
   }) {
-    const purposeBody = body as PresignBody;
-
     if (purposeBody.purpose === "entity_create") {
       const validation = yield* validateEntityCreate({
         safeDb,
@@ -107,7 +125,7 @@ const presignUpload = createSafeHandler(
       if (validation.status === "error") {
         return validation;
       }
-    } else if (purposeBody.purpose === "agent_skill") {
+    } else {
       const validation = yield* validateAgentSkill({
         memberRole,
         scope: purposeBody.scope,
@@ -154,22 +172,7 @@ const presignUpload = createSafeHandler(
           workspaceId,
           userId: user.id,
           purpose: purposeBody.purpose,
-          purposeData: (() => {
-            switch (purposeBody.purpose) {
-              case "entity_create":
-                return {
-                  type: "entity_create",
-                  propertyId: purposeBody.propertyId,
-                };
-              case "entity_version":
-                return {
-                  type: "entity_version",
-                  entityId: purposeBody.entityId,
-                };
-              case "agent_skill":
-                return { type: "agent_skill", scope: purposeBody.scope };
-            }
-          })(),
+          purposeData: toPurposeData(purposeBody),
           declaredName: purposeBody.name,
           declaredMime: purposeBody.mimeType,
           declaredSize: purposeBody.size,

--- a/apps/api/src/handlers/uploads/routes.ts
+++ b/apps/api/src/handlers/uploads/routes.ts
@@ -1,0 +1,64 @@
+import Elysia from "elysia";
+import { rateLimit } from "elysia-rate-limit";
+
+import abortUpload from "@/api/handlers/uploads/abort";
+import finalizeUpload from "@/api/handlers/uploads/finalize";
+import presignUpload from "@/api/handlers/uploads/presign";
+import { permissionMacro, workspaceAccessMacro } from "@/api/lib/auth";
+import { invalidateQuery } from "@/api/lib/invalidate-query-macro";
+import { API_RATE_LIMITS } from "@/api/lib/limits";
+import {
+  InMemoryRateLimitContext,
+  scopedGenerator,
+} from "@/api/lib/rate-limit";
+
+/**
+ * Workspace-scoped presigned-upload coordination:
+ *
+ *   POST /uploads/:workspaceId/presign
+ *        body: { purpose, propertyId, name, mimeType, size, sha256Hex }
+ *        → { uploadId, url, expiresAt, headers }
+ *
+ *   POST /uploads/:workspaceId/:uploadId/finalize
+ *        → { finalizedResult }   // see PendingUploadFinalizedResult
+ *
+ *   POST /uploads/:workspaceId/:uploadId/abort
+ *        → { ok: true }
+ *
+ * All three share the legacy `upload` rate-limit budget — they
+ * collectively represent one "upload" worth of API capacity.
+ * `invalidateQuery` runs on finalize so the entities list cache
+ * refreshes after a successful entity_create finalize, matching the
+ * legacy multipart endpoint's behaviour.
+ */
+export const uploadsRoute = new Elysia({
+  prefix: "/uploads/:workspaceId",
+})
+  .use(workspaceAccessMacro)
+  .use(invalidateQuery)
+  .use(permissionMacro)
+  .use(
+    rateLimit({
+      scoping: "scoped",
+      duration: API_RATE_LIMITS.upload.duration,
+      max: API_RATE_LIMITS.upload.max,
+      generator: scopedGenerator("upload-presigned"),
+      context: new InMemoryRateLimitContext(),
+    }),
+  )
+  .guard({
+    validateWorkspaceAccess: true,
+  })
+  .post("/presign", presignUpload.handler, {
+    body: presignUpload.config.body,
+    permissions: presignUpload.config.permissions,
+  })
+  .post("/:uploadId/finalize", finalizeUpload.handler, {
+    params: finalizeUpload.config.params,
+    invalidateQuery: true,
+    permissions: finalizeUpload.config.permissions,
+  })
+  .post("/:uploadId/abort", abortUpload.handler, {
+    params: abortUpload.config.params,
+    permissions: abortUpload.config.permissions,
+  });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,7 @@ import {
   templatesRoute,
 } from "@/api/handlers/templates/routes";
 import { timeEntriesRoute } from "@/api/handlers/time-entries/routes";
+import { uploadsRoute } from "@/api/handlers/uploads/routes";
 import { userFilesRoute } from "@/api/handlers/user-files/routes";
 import { verifyAuthRoute, verifyRoute } from "@/api/handlers/verify/routes";
 import { viewTemplatesRoute } from "@/api/handlers/view-templates/routes";
@@ -333,6 +334,7 @@ const api = new Elysia()
           .use(folioCollabRoute),
       )
       .use(desktopEditSessionsRoute)
+      .use(uploadsRoute)
       .use(entitiesRoute)
       .use(fieldsRoute)
       .use(templatesRoute)

--- a/apps/api/src/lib/limits.ts
+++ b/apps/api/src/lib/limits.ts
@@ -128,6 +128,8 @@ export const FILE_SIZE_LIMITS = {
  * validate before a framework-level t.File() parser runs.
  */
 export const FILE_SIZE_LIMIT_BYTES = {
+  /** General document uploads (entities, templates). */
+  document: 50 * 1024 * 1024,
   /** Agent skill packs (`SKILL.md` or a ZIP folder). */
   skillPack: 2 * 1024 * 1024,
   /** Chat context file attachments. */

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -33,7 +33,7 @@ import { cn } from "@stll/ui/lib/utils";
 import { UserAvatar } from "@/components/user-avatar";
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors";
+import { ClientOperationError, toAPIError } from "@/lib/errors";
 import { formatFullTimestamp, formatRelativeTime } from "@/lib/relative-time";
 import { toSafeId } from "@/lib/safe-id";
 import { entityVersionsKeys } from "@/routes/_protected.workspaces/$workspaceId/-queries/entity-versions";
@@ -83,6 +83,8 @@ const LABEL_PRESETS: LabelPreset[] = [
   { key: "final", color: "bg-green-500 dark:bg-green-400" },
   { key: "signed", color: "bg-amber-500" },
 ];
+
+const UPLOAD_PUT_TIMEOUT_MS = 5 * 60 * 1000;
 
 export function VersionsSidebar({
   workspaceId,
@@ -139,10 +141,16 @@ export function VersionsSidebar({
         method: "PUT",
         headers,
         body: file,
+        signal: AbortSignal.timeout(UPLOAD_PUT_TIMEOUT_MS),
       });
       if (!putResponse.ok) {
-        await wsClient({ uploadId }).abort.post({}).catch(() => undefined);
-        throw new Error(`S3 rejected upload (${putResponse.status})`);
+        await wsClient({ uploadId })
+          .abort.post({})
+          .catch(() => undefined);
+        throw new ClientOperationError({
+          action: "upload-version-to-s3",
+          message: `S3 rejected upload (${putResponse.status})`,
+        });
       }
 
       // 4. Finalize.

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/pdf/versions-sidebar.tsx
@@ -110,16 +110,47 @@ export function VersionsSidebar({
   const handleUploadVersion = async (file: File) => {
     setIsUploading(true);
     try {
-      const response = await api
-        .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-        ["upload-version"].post({
-          entityId: toSafeId<"entity">(entityId),
-          file,
-          queryKey: entityVersionsKeys.all({ workspaceId, entityId }),
-        });
+      // 1. SHA-256 of file bytes.
+      const fileBuffer = await file.arrayBuffer();
+      const sha256Buffer = await crypto.subtle.digest("SHA-256", fileBuffer);
+      const sha256Hex = Array.from(new Uint8Array(sha256Buffer))
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
 
-      if (response.error) {
-        throw toAPIError(response.error);
+      // 2. Presign.
+      const wsClient = api.uploads({
+        workspaceId: toSafeId<"workspace">(workspaceId),
+      });
+      const presign = await wsClient.presign.post({
+        purpose: "entity_version",
+        entityId: toSafeId<"entity">(entityId),
+        name: file.name,
+        mimeType: file.type || "application/octet-stream",
+        size: file.size,
+        sha256Hex,
+      });
+      if (presign.error) {
+        throw toAPIError(presign.error);
+      }
+      const { uploadId, url, headers } = presign.data;
+
+      // 3. PUT to S3.
+      const putResponse = await fetch(url, {
+        method: "PUT",
+        headers,
+        body: file,
+      });
+      if (!putResponse.ok) {
+        await wsClient({ uploadId }).abort.post({}).catch(() => undefined);
+        throw new Error(`S3 rejected upload (${putResponse.status})`);
+      }
+
+      // 4. Finalize.
+      const finalize = await wsClient({ uploadId }).finalize.post({
+        queryKey: entityVersionsKeys.all({ workspaceId, entityId }),
+      });
+      if (finalize.error) {
+        throw toAPIError(finalize.error);
       }
 
       await invalidateVersions();

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -5,6 +5,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { panic } from "better-result";
 import { useTranslations } from "use-intl";
 
 import { stellaToast } from "@stll/ui/components/toast";
@@ -12,7 +13,7 @@ import { stellaToast } from "@stll/ui/components/toast";
 import { MAX_PARALLEL_FILE_UPLOADS } from "@/consts";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { api } from "@/lib/api";
-import { toAPIError } from "@/lib/errors";
+import { ClientOperationError, toAPIError } from "@/lib/errors";
 import { toSafeId } from "@/lib/safe-id";
 import { UploadQueue } from "@/lib/upload-queue";
 import { useStartWorkflow } from "@/routes/_protected.workspaces/$workspaceId/-hooks/use-start-workflow";
@@ -108,18 +109,14 @@ const uploadSingleFile = async (
   propertyId: string,
   signal: AbortSignal,
 ): Promise<UploadResult> => {
-  if (signal.aborted) {
-    throw new DOMException("Upload aborted", "AbortError");
-  }
+  signal.throwIfAborted();
 
   // 1. SHA-256 of file bytes.
   const fileBuffer = await file.arrayBuffer();
   const sha256Buffer = await crypto.subtle.digest("SHA-256", fileBuffer);
   const sha256Hex = bufferToHex(sha256Buffer);
 
-  if (signal.aborted) {
-    throw new DOMException("Upload aborted", "AbortError");
-  }
+  signal.throwIfAborted();
 
   // 2. Presign.
   const wsClient = api.uploads({
@@ -155,20 +152,24 @@ const uploadSingleFile = async (
       signal,
     });
   } catch (error) {
-    if (signal.aborted) {
-      await abortUpload(workspaceId, uploadId);
-      throw new DOMException("Upload aborted", "AbortError");
-    }
     await abortUpload(workspaceId, uploadId);
-    throw error instanceof Error ? error : new Error("S3 upload network error");
+    if (error instanceof Error) {
+      throw error;
+    }
+    throw new ClientOperationError({
+      action: "upload-file-to-s3",
+      message: "S3 upload network error",
+      cause: error,
+    });
   }
   if (!putResponse.ok) {
     const detail = await putResponse.text().catch(() => "");
-    const error = new Error(
-      `S3 rejected upload (${putResponse.status}${
+    const error = new ClientOperationError({
+      action: "upload-file-to-s3",
+      message: `S3 rejected upload (${putResponse.status}${
         detail ? `: ${detail.slice(0, 200)}` : ""
       })`,
-    );
+    });
     attachResponseForRetry(error, putResponse);
     await abortUpload(workspaceId, uploadId);
     throw error;
@@ -182,12 +183,8 @@ const uploadSingleFile = async (
   if (finalize.error) {
     const error = toAPIError(finalize.error);
     attachResponseForRetry(error, finalize.response);
-    // 422 (scan reject / size or sha mismatch) is terminal — the
-    // pending row is already `rejected` from the server side, no
-    // explicit abort needed. 5xx/409 leave a row we should free.
-    if (finalize.response.status >= 500 || finalize.response.status === 409) {
-      await abortUpload(workspaceId, uploadId);
-    }
+    // Finalize owns the pending row once called. 422s are terminal
+    // rejections, 409/5xx may still be in-flight or retryable.
     throw error;
   }
 
@@ -197,7 +194,7 @@ const uploadSingleFile = async (
     // is a structural impossibility — narrow it explicitly so the
     // result type doesn't leak `entity_version` fields back to
     // callers that wouldn't know what to do with them.
-    throw new Error(
+    return panic(
       `Unexpected upload finalized as ${finalizedResult.type satisfies string}`,
     );
   }

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -43,9 +43,64 @@ type UploadResult = {
 };
 
 /**
- * Upload a single file via Eden. Throws on failure with the
- * HTTP status preserved on the error object. Attaches the raw
- * `Response` so the upload queue can read `Retry-After`.
+ * Hex-encode a SHA-256 hash already computed via Web Crypto. The
+ * API stores hex on `fields.content.sha256Hex` and converts to
+ * base64 for the S3 `x-amz-checksum-sha256` header.
+ */
+const bufferToHex = (buffer: ArrayBuffer): string => {
+  const view = new Uint8Array(buffer);
+  let out = "";
+  for (const byte of view) {
+    out += byte.toString(16).padStart(2, "0");
+  }
+  return out;
+};
+
+const attachResponseForRetry = (error: Error, response: Response): void => {
+  // The upload queue reads `Retry-After` off the raw Response on
+  // 429s; preserving it keeps the rate-limit pause behaviour the
+  // legacy multipart upload had.
+  Object.defineProperty(error, "response", {
+    value: response,
+    enumerable: false,
+  });
+};
+
+const abortUpload = async (
+  workspaceId: string,
+  uploadId: string,
+): Promise<void> => {
+  // Best-effort: the bucket lifecycle catches the tmp object after
+  // 24h and the daily prune cleans the row, so a failed abort is
+  // not fatal. We swallow errors to avoid masking the original
+  // cancellation/failure with a follow-up rejection.
+  await api
+    .uploads({ workspaceId: toSafeId<"workspace">(workspaceId) })({ uploadId })
+    .abort.post({})
+    .catch(() => undefined);
+};
+
+/**
+ * Upload a single file via the presigned-S3-PUT migration. Same
+ * external shape as the legacy multipart upload (throws with
+ * `response` attached on failure, returns `UploadResult` on
+ * success) so the surrounding `UploadQueue` integration is
+ * untouched.
+ *
+ *   1. Compute SHA-256 of the bytes in-thread. 50 MB takes
+ *      ~200–500ms on modern hardware; a Web Worker is a phase-6
+ *      optimisation, not a correctness requirement.
+ *   2. POST `/uploads/:wsId/presign` with the declared metadata.
+ *      The API records intent in `pending_uploads`, issues a
+ *      5-minute URL bound to the exact size and checksum.
+ *   3. PUT directly to S3. S3 verifies the checksum at the edge;
+ *      any mismatch fails with a 4xx before the API is involved.
+ *   4. POST `/uploads/:wsId/:uploadId/finalize`. The API runs the
+ *      claim FSM, scans, server-side promotes `tmp/` → final key,
+ *      commits the entity transaction.
+ *   5. On any abort/error mid-flight, POST `/abort` to mark the
+ *      pending row as rejected. Re-entry to step 2 returns the
+ *      cached result so accidental double-finalizes are safe.
  */
 const uploadSingleFile = async (
   file: File,
@@ -53,36 +108,95 @@ const uploadSingleFile = async (
   propertyId: string,
   signal: AbortSignal,
 ): Promise<UploadResult> => {
-  const response = await api
-    .entities({ workspaceId: toSafeId<"workspace">(workspaceId) })
-    .upload.post(
-      {
-        queryKey: entitiesKeys.all(workspaceId),
-        file,
-        name: file.name,
-        propertyId: toSafeId<"property">(propertyId),
-      },
-      { fetch: { signal } },
-    );
+  if (signal.aborted) {
+    throw new DOMException("Upload aborted", "AbortError");
+  }
 
-  if (response.error) {
-    const error = toAPIError(response.error);
+  // 1. SHA-256 of file bytes.
+  const fileBuffer = await file.arrayBuffer();
+  const sha256Buffer = await crypto.subtle.digest("SHA-256", fileBuffer);
+  const sha256Hex = bufferToHex(sha256Buffer);
 
-    // Attach the raw Response so the queue can extract
-    // the Retry-After header on 429 responses.
-    Object.defineProperty(error, "response", {
-      value: response.response,
-      enumerable: false,
+  if (signal.aborted) {
+    throw new DOMException("Upload aborted", "AbortError");
+  }
+
+  // 2. Presign.
+  const wsClient = api.uploads({
+    workspaceId: toSafeId<"workspace">(workspaceId),
+  });
+  const presign = await wsClient.presign.post(
+    {
+      purpose: "entity_create",
+      propertyId: toSafeId<"property">(propertyId),
+      name: file.name,
+      mimeType: file.type || "application/octet-stream",
+      size: file.size,
+      sha256Hex,
+    },
+    { fetch: { signal } },
+  );
+  if (presign.error) {
+    const error = toAPIError(presign.error);
+    attachResponseForRetry(error, presign.response);
+    throw error;
+  }
+  const { uploadId, url, headers } = presign.data;
+
+  // 3. PUT to S3. S3 enforces the signed checksum + length; a
+  //    mismatched body comes back as 4xx and we surface the body
+  //    as the error message.
+  let putResponse: Response;
+  try {
+    putResponse = await fetch(url, {
+      method: "PUT",
+      headers,
+      body: file,
+      signal,
     });
-
+  } catch (error) {
+    if (signal.aborted) {
+      await abortUpload(workspaceId, uploadId);
+      throw new DOMException("Upload aborted", "AbortError");
+    }
+    await abortUpload(workspaceId, uploadId);
+    throw error instanceof Error ? error : new Error("S3 upload network error");
+  }
+  if (!putResponse.ok) {
+    const detail = await putResponse.text().catch(() => "");
+    const error = new Error(
+      `S3 rejected upload (${putResponse.status}${
+        detail ? `: ${detail.slice(0, 200)}` : ""
+      })`,
+    );
+    attachResponseForRetry(error, putResponse);
+    await abortUpload(workspaceId, uploadId);
     throw error;
   }
 
+  // 4. Finalize.
+  const finalize = await wsClient({ uploadId }).finalize.post(
+    { queryKey: entitiesKeys.all(workspaceId) },
+    { fetch: { signal } },
+  );
+  if (finalize.error) {
+    const error = toAPIError(finalize.error);
+    attachResponseForRetry(error, finalize.response);
+    // 422 (scan reject / size or sha mismatch) is terminal — the
+    // pending row is already `rejected` from the server side, no
+    // explicit abort needed. 5xx/409 leave a row we should free.
+    if (finalize.response.status >= 500 || finalize.response.status === 409) {
+      await abortUpload(workspaceId, uploadId);
+    }
+    throw error;
+  }
+
+  const finalizedResult = finalize.data.finalizedResult;
   return {
-    entityId: response.data.entityId,
-    fileId: response.data.fileId,
-    fileName: response.data.fileName,
-    renamed: response.data.renamed,
+    entityId: finalizedResult.entityId,
+    fileId: finalizedResult.fileId,
+    fileName: finalizedResult.fileName,
+    renamed: finalizedResult.renamed,
   };
 };
 

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-hooks/use-create-file-entities.ts
@@ -192,6 +192,15 @@ const uploadSingleFile = async (
   }
 
   const finalizedResult = finalize.data.finalizedResult;
+  if (finalizedResult.type !== "entity_create") {
+    // The route only ever issues `entity_create` presigns, so this
+    // is a structural impossibility — narrow it explicitly so the
+    // result type doesn't leak `entity_version` fields back to
+    // callers that wouldn't know what to do with them.
+    throw new Error(
+      `Unexpected upload finalized as ${finalizedResult.type satisfies string}`,
+    );
+  }
   return {
     entityId: finalizedResult.entityId,
     fileId: finalizedResult.fileId,


### PR DESCRIPTION
Migrates entity create, entity version, and agent skill uploads from multipart-through-CloudFront to presigned S3 PUT. Builds on the phase-0 scaffold from #497 (SDK wrapper, `pending_uploads` table, smoke tests).

## What this PR ships

| Commit | Surface |
|---|---|
| 1 (`c452c89`) | **Entity create.** New `/uploads/:wsId` slice, generic presign/finalize/abort, `entity_create` purpose, frontend swap in `use-create-file-entities`. **Closes the customer-pain DOCX upload that CRS `GenericLFI_BODY` was blocking at CloudFront.** |
| 2 (`19c09fb`) | **Entity version upload.** `entity_version` purpose with full version-creation transaction (FOR UPDATE lock, `cloneFieldsForRevision`, cell-metadata carry-over, two audit events, async derivative + diff-stats + SSE broadcast). Frontend swap in `versions-sidebar`. |
| 3 (`d88d479`) | **Agent skill upload.** `agent_skill` purpose that wraps the buffer into a `File` and reuses the legacy `parseUploadedSkillPackage` + `installSkill` path. Backend only — legacy `/v1/skills/upload` stays live; skill packs cap at 2 MB which doesn't reliably trip WAF body rules, so customer pain is near-zero. |

## Architecture (one paragraph)

`/uploads/:wsId/{presign, :uploadId/finalize, :uploadId/abort}` slice mounted next to the entities route. Purpose-discriminated body schema. Atomic claim FSM on `pending_uploads` (`pending → scanning → finalized | rejected | failed`) with `claimed_at` timeout for crash recovery. Finalize verifies S3 HEAD's size + stored checksum against the declared values, downloads for scan (existing YARA + zip-bomb pipeline), dispatches to a per-purpose domain transaction, then server-side `CopyObjectCommand` from `tmp/{uploadId}` to the final key. Legacy multipart endpoints stay live so the desktop app keeps working until its next release.

## Not in this PR

- **Phase 4 — chat attachments.** Structurally distinct refactor: chat attachments today arrive inline as embedded data-URLs in the `/v1/chat/.../messages` body, not as a separate upload endpoint. Migrating means refactoring the chat message schema to accept `userFileId` references plus reworking the composer to pre-upload then reference. That's a separate cross-cutting change, not a fourth commit on this branch. The existing WAF overrides keep chat working in the meantime.
- **Phase 5 — remove the 5 WAF body overrides.** Lands after phase 4 ships and bakes; tracked at stella-infra#184.
- **Phase 6 — async scan via S3 EventBridge → SQS.** Optional follow-up if API task memory becomes a bottleneck.
- **Handler-level unit tests.** The inner generators need to be exposed for testability without going through `createSafeHandler`'s auth wrapper. The security-critical integrity layer (signed checksum enforcement at S3) is already covered by the smoke tests landed in #497.

## Known limitation, hardened in a follow-up

All three purposes ride the same `entity:create` route permission. A user with only `entity:update` or `agentSkill:create` would be blocked at the macro layer despite being authorised for the matching purpose. Per-purpose permission enforcement moves inside the handler in a follow-up commit. Until then, those users can keep using the legacy multipart endpoints.

## Test plan

- [ ] CI green: typecheck, lint, unit tests, e2e.
- [ ] Manual: upload the `Credit_Agreement_Updated.docx` that triggered this whole thread via the web UI on staging; expect it to land via `tmp/` → finalize without any WAF block.
- [ ] Manual: cancel an in-progress upload from the UI; check `pending_uploads` row transitions to `rejected` and the `tmp/` object is gone (or lifecycled).
- [ ] Manual: two concurrent finalize calls for the same `uploadId`; expect exactly one entity to be created.
- [ ] Manual: upload a new version through the versions sidebar; expect a new `entityVersions` row with `versionNumber` incremented.