### PR TITLE
feat(ai): default-settings middleware for role + provider knobs

### DIFF
--- a/.agents/plans/041-ai-default-settings-middleware.md
+++ b/.agents/plans/041-ai-default-settings-middleware.md
@@ -1,0 +1,150 @@
+# Plan: AI Default-Settings Middleware
+
+Date: 2026-05-30
+
+## Goal
+
+Stop hand-rolling per-call defaults (`temperature`, `maxOutputTokens`,
+provider-specific knobs like `thinkingConfig`, `metadata.user_id`,
+`safetySettings`) at every AI handler. Compose Vercel AI SDK's
+`defaultSettingsMiddleware` into the existing `withInstrumentation`
+chain so the model factory injects role + provider defaults; handlers
+override only when they really need to.
+
+Mirrors the shape of the caching middleware (PR #499) — same
+chain, same boundary, same opt-in/override semantics — extended to
+the other "every call sets the same thing" settings.
+
+## Design Decisions
+
+- **Reuse `defaultSettingsMiddleware` from `ai`**, not a custom
+  re-implementation. It already does the right thing: merges into
+  `transformParams`, caller-set values win, missing values get the
+  default. Composes cleanly with the caching middleware.
+- **Defaults are computed per `(role, provider)`**, not per handler.
+  Role drives sampling and verbosity; provider drives which provider
+  options apply.
+- **Centralise in `ai-models.ts`**. A new `defaultsForRole(role,
+  provider)` helper builds the settings object the middleware
+  receives at factory time. Lives next to `TEMPERATURE_PER_ROLE` and
+  the existing role tables.
+- **Compose into the existing `withInstrumentation`**: order
+  `[defaults, caching, devtools?]` so defaults set the baseline,
+  caching layers cache markers on top, devtools wraps the lot. The
+  order matters because the caching middleware reads
+  `providerOptions` it should see merged.
+- **Keep override behaviour intact**: handlers that genuinely need
+  a different value (e.g. `maxOutputTokens: 32` for thread title)
+  pass it inline and that value wins. No new ceremony.
+- **Pull `googleMinimalThinking()` into the new defaults table**;
+  delete the helper. One source of truth for "fast role on google
+  should think minimally".
+
+## Scope
+
+**In scope:**
+
+- New `defaultsForRole(role, provider)` helper in `ai-models.ts`
+  returning `Settings` for `defaultSettingsMiddleware`.
+- Tables (next to `TEMPERATURE_PER_ROLE`) covering:
+  - Per-(provider, role) `providerOptions`:
+    - Google `thinkingConfig` for `fast` (minimal) and `reasoning` (full).
+    - Anthropic `thinking: { type: "enabled", budgetTokens }` for
+      `reasoning` only.
+    - OpenAI `reasoning_effort` for `reasoning` only.
+    - Google `safetySettings` baseline so legal-document content
+      doesn't trip default safety filters.
+    - Anthropic `metadata: { user_id: <opaque hash of orgId> }` —
+      compliance trail.
+- Wire the middleware into `withInstrumentation` alongside the
+  caching middleware.
+- Update all current AI handlers to drop:
+  - `temperature: getTemperatureForRole(...)` inline arg
+  - `maxOutputTokens: <magic>` where the magic equals the new default
+  - `providerOptions: googleMinimalThinking()` inline arg
+  Keep overrides where the handler actually needs a non-default
+  value.
+- Delete `googleMinimalThinking()` after the last call site goes.
+- Unit tests:
+  - `defaultsForRole("fast", "google")` includes
+    `thinkingConfig.thinkingLevel === "minimal"`.
+  - `defaultsForRole("reasoning", "anthropic")` enables thinking.
+  - Caller-set settings win over defaults (assert via the middleware
+    composition end-to-end).
+
+**Out of scope:**
+
+- Native Anthropic citations migration (separate plan).
+- Org-level overrides for thinking budgets or safety settings.
+- Per-org `metadata.user_id` shape negotiation with anthropic
+  policy — start with a SHA-truncated `orgId` hash; revisit if
+  anthropic wants a specific format.
+
+## Implementation
+
+**Backend**
+
+- `apps/api/src/lib/ai-models.ts` —
+  - Import `defaultSettingsMiddleware` from `ai`.
+  - Add `MAX_OUTPUT_BY_ROLE` table.
+  - Add `defaultsForRole(role: ModelRole, provider: AIProvider,
+    orgId: SafeId<"organization"> | null): Settings` helper.
+  - Insert the middleware into `withInstrumentation` ahead of the
+    caching middleware.
+  - Threads `orgId` from `getModelForRole` /  `getModelById`
+    options so anthropic `metadata.user_id` can use a hashed
+    org identifier.
+- `getModelForRole` / `getModelById` signatures gain
+  `organizationId: SafeId<"organization"> | null` in their options
+  (passed from the auth context just like `promptCachingEnabled`).
+- Migrate all current AI call sites:
+  - `lib/workflow/ai-generate-batch.ts`
+  - `lib/bbox/ai-generate-b-boxes.ts`
+  - `handlers/chat/stream-chat.ts`
+  - `handlers/chat/generate-thread-title.ts`
+  - `handlers/search/ai.ts` (refine + summarise)
+  - `handlers/entities/organize-suggestions.ts` (both queries)
+  - `handlers/case-law/analysis/generate.ts`
+  - `handlers/case-law/polarity/llm-classifier.ts`
+  - `handlers/properties/preview.ts`
+  - `handlers/properties/suggest-prompt.ts`
+  - `handlers/skills/generate-draft.ts`
+  - `handlers/skills/resources/rewrite.ts`
+  Each drops the boilerplate args that now come from the middleware;
+  keeps any genuine per-call overrides.
+- Delete `googleMinimalThinking` helper once all call sites are
+  migrated.
+
+**No frontend changes.**
+
+**No DB schema changes.**
+
+## Test Cases
+
+- `defaultsForRole` returns the expected `Settings` per
+  (role, provider) combo (table-driven).
+- `wrapLanguageModel` with both middlewares composed: a handler
+  call without `temperature` lands with `temperature: 0` at
+  the provider boundary; a handler call WITH
+  `temperature: 0.7` lands with `0.7`.
+- Caching middleware still adds the system `cacheControl` marker
+  on top of the default provider options (regression test against
+  middleware ordering).
+- Anthropic `metadata.user_id` is a hash, not the raw orgId
+  (privacy unit test).
+- Google `safetySettings` baseline is present in the resolved
+  request when provider is google.
+- Invariant test: the existing
+  `ai-caching-invariants.test.ts` glob still passes (no new
+  direct `@ai-sdk/*` model-factory imports outside `ai-models.ts`).
+
+## Resolutions
+
+1. `maxOutputTokens` defaults dropped from scope — audit showed
+   handlers all use legitimately different values (32 for thread
+   title, 180/700 for search refine/summary, 24k for organize,
+   dynamic for some). No common ground to centralise.
+2. Anthropic `metadata.user_id` uses
+   `Bun.CryptoHasher("sha256").update(orgId).digest("hex").slice(0, 16)`.
+3. `thinking` budget stays a code-side default; org-level
+   override deferred to a future change request.

--- a/apps/api/scripts/benchmark-chat-read-surface.ts
+++ b/apps/api/scripts/benchmark-chat-read-surface.ts
@@ -303,6 +303,7 @@ const getBenchModel = async (): Promise<BenchModel | null> => {
         promptCachingEnabled: true,
         scopeKey: null,
         role: "fast",
+        organizationId: null,
       }),
       provider: info.provider,
     };
@@ -314,6 +315,7 @@ const getBenchModel = async (): Promise<BenchModel | null> => {
     model: getModelForRole("fast", null, {
       promptCachingEnabled: true,
       scopeKey: null,
+      organizationId: null,
     }),
     provider: info.provider,
   };

--- a/apps/api/src/handlers/case-law/analysis/generate.ts
+++ b/apps/api/src/handlers/case-law/analysis/generate.ts
@@ -33,11 +33,7 @@ import type { ScopedDb } from "@/api/db";
 // eslint-disable-next-line no-restricted-imports
 import { rootDb } from "@/api/db/root";
 import { caseLawDecisions } from "@/api/db/schema";
-import {
-  getModelForRole,
-  getModelInfoForRole,
-  getTemperatureForRole,
-} from "@/api/lib/ai-models";
+import { getModelForRole, getModelInfoForRole } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
@@ -96,6 +92,7 @@ const runGeneration = async (
     language: string;
     decisionType: string | null;
   },
+  organizationId: SafeId<"organization">,
   orgAIConfig: OrgAIConfig | null,
   promptCachingEnabled: boolean,
 ) => {
@@ -112,6 +109,7 @@ ${decisionText}`;
   const model = getModelForRole("fast", orgAIConfig, {
     promptCachingEnabled,
     scopeKey: decisionId,
+    organizationId,
   });
   const { modelId } = getModelInfoForRole("fast", orgAIConfig);
   const aiAnalytics = createAIAnalyticsCallbacks({
@@ -128,7 +126,6 @@ ${decisionText}`;
   try {
     const result = streamText({
       model,
-      temperature: getTemperatureForRole("fast"),
       output: Output.array({
         element: valibotSchema(analysisHeadingSchema),
       }),
@@ -204,6 +201,7 @@ ${decisionText}`;
 export const generateAnalysis = async (
   decisionId: SafeId<"caseLawDecision">,
   scopedDb: ScopedDb,
+  organizationId: SafeId<"organization">,
   orgAIConfig: OrgAIConfig | null,
   promptCachingEnabled: boolean,
 ): Promise<{
@@ -286,6 +284,7 @@ export const generateAnalysis = async (
     decisionId,
     ast,
     decision,
+    organizationId,
     orgAIConfig,
     promptCachingEnabled,
   );

--- a/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
+++ b/apps/api/src/handlers/case-law/polarity/llm-classifier.ts
@@ -7,13 +7,12 @@
  * for potential rule generation.
  */
 
-import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { valibotSchema } from "@ai-sdk/valibot";
 import { generateText, Output } from "ai";
 import { Result } from "better-result";
 import * as v from "valibot";
 
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import { getModelForRole } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { WorkflowIntegrationError } from "@/api/lib/errors/tagged-errors";
 
@@ -84,8 +83,8 @@ export const classifyWithLLM = async (
         model: getModelForRole("fast", null, {
           promptCachingEnabled: true,
           scopeKey: `polarity:${language}`,
+          organizationId: null,
         }),
-        temperature: getTemperatureForRole("fast"),
         system: SYSTEM_PROMPT,
         messages: [
           {
@@ -99,14 +98,6 @@ ${context}`,
         output: Output.object({
           schema: valibotSchema(classificationSchema),
         }),
-        providerOptions: {
-          google: {
-            thinkingConfig: {
-              thinkingLevel: "minimal",
-              includeThoughts: false,
-            },
-          } satisfies GoogleGenerativeAIProviderOptions,
-        },
         abortSignal: abortSignal
           ? AbortSignal.any([abortSignal, AbortSignal.timeout(15_000)])
           : AbortSignal.timeout(15_000),

--- a/apps/api/src/handlers/case-law/routes.ts
+++ b/apps/api/src/handlers/case-law/routes.ts
@@ -87,6 +87,7 @@ const generateDecisionAnalysis = createSafeRootHandler(
   } satisfies HandlerConfig,
   async function* ({
     params: { decisionId },
+    session,
     scopedDb,
     orgAIConfig,
     promptCachingEnabled,
@@ -99,6 +100,7 @@ const generateDecisionAnalysis = createSafeRootHandler(
           await generateAnalysis(
             decisionId,
             scopedDb,
+            session.activeOrganizationId,
             orgAIConfig,
             promptCachingEnabled,
           ),

--- a/apps/api/src/handlers/chat/generate-thread-title.ts
+++ b/apps/api/src/handlers/chat/generate-thread-title.ts
@@ -6,7 +6,7 @@ import type { SafeDb } from "@/api/db";
 import { chatThreads } from "@/api/db/schema";
 import type { ChatMessage } from "@/api/handlers/chat/types";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import { getModelForRole } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import type { AuditRecorder } from "@/api/lib/audit-log";
@@ -20,6 +20,7 @@ const TITLE_GENERATION_TIMEOUT_MS = 10_000;
 
 type GenerateThreadTitleProps = {
   messages: [ChatMessage, ChatMessage]; // [userMessage, AIMessage]
+  organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
   promptCachingEnabled: boolean;
   recordAuditEvent: AuditRecorder;
@@ -30,6 +31,7 @@ type GenerateThreadTitleProps = {
 
 export const generateThreadTitle = async ({
   messages,
+  organizationId,
   orgAIConfig,
   promptCachingEnabled,
   recordAuditEvent,
@@ -56,12 +58,12 @@ export const generateThreadTitle = async ({
       model: getModelForRole("fast", orgAIConfig, {
         promptCachingEnabled,
         scopeKey: threadId,
+        organizationId,
       }),
       prompt: `Given this conversation, reply with a short thread title (max 6 words). Reply with the title only, nothing else.
 
 User: ${userText}
 Assistant: ${assistantText}`,
-      temperature: getTemperatureForRole("fast"),
       ...aiAnalytics.stepCallbacks,
     });
 

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -596,6 +596,7 @@ const sendMessage = createSafeRootHandler(
                         parsedMessage.message,
                         resolvedResponseMessage,
                       ],
+                      organizationId: session.activeOrganizationId,
                       orgAIConfig,
                       promptCachingEnabled,
                       recordAuditEvent,
@@ -609,6 +610,7 @@ const sendMessage = createSafeRootHandler(
                 }
               },
               orgAIConfig,
+              organizationId: session.activeOrganizationId,
               devModelId: body.devModelId,
               promptCacheKey: chatContext.promptCacheKey,
               promptCachingEnabled,

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -42,7 +42,6 @@ import {
   getModelInfoById,
   getModelForRole,
   getModelInfoForRole,
-  getTemperatureForRole,
 } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -172,7 +171,6 @@ const runChatStream = async ({
   const result = streamText({
     abortSignal,
     model,
-    temperature: getTemperatureForRole("chat"),
     system,
     tools,
     experimental_repairToolCall: async ({ toolCall }) =>
@@ -255,6 +253,7 @@ type StreamChatProps = {
   devModelId?: string | undefined;
   messages: ChatMessage[];
   onFinish: UIMessageStreamOnFinishCallback<ChatMessage>;
+  organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
   promptCacheKey: string;
   promptCachingEnabled: boolean;
@@ -283,6 +282,7 @@ export const streamChat = async ({
   devModelId,
   messages: rawMessages,
   onFinish,
+  organizationId,
   orgAIConfig,
   promptCacheKey,
   promptCachingEnabled,
@@ -389,10 +389,12 @@ export const streamChat = async ({
             promptCachingEnabled,
             scopeKey: promptCacheKey,
             role: "chat",
+            organizationId,
           })
         : getModelForRole("chat", orgAIConfig, {
             promptCachingEnabled,
             scopeKey: promptCacheKey,
+            organizationId,
           });
       // Eligible fallback: a *different* model on the same orgAI
       // config. Skip when the user has pinned a specific dev
@@ -434,6 +436,7 @@ export const streamChat = async ({
         const fallbackModel = getModelForRole("reasoning", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: promptCacheKey,
+          organizationId,
         });
         await runChatStream({
           writer,

--- a/apps/api/src/handlers/entities/organize-suggestions.ts
+++ b/apps/api/src/handlers/entities/organize-suggestions.ts
@@ -1,4 +1,3 @@
-import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { valibotSchema } from "@ai-sdk/valibot";
 import { generateText, Output } from "ai";
 import { Result } from "better-result";
@@ -17,7 +16,6 @@ import { aiHandlerError } from "@/api/lib/ai-error";
 import {
   getModelForRole,
   getModelInfoForRole,
-  getTemperatureForRole,
   requireAIAvailable,
 } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
@@ -251,8 +249,8 @@ const organizeSuggestionsHandler = async function* ({
         model: getModelForRole("fast", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: `${organizationId}:${workspaceId}:organize`,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("fast"),
         system: ORGANIZE_SYSTEM_PROMPT,
         prompt: JSON.stringify({
           locale: locale || null,
@@ -277,7 +275,6 @@ const organizeSuggestionsHandler = async function* ({
         // wrapping). Capped at 24 000 so a 100-file batch (~20 200) has
         // headroom for the model's slightly variable output sizes.
         maxOutputTokens: Math.min(24_000, 200 + body.files.length * 200),
-        providerOptions: googleMinimalThinking(),
         abortSignal: AbortSignal.timeout(60_000),
         ...aiAnalytics.stepCallbacks,
       }),
@@ -685,8 +682,8 @@ const generateMissingSummaries = async ({
         model: getModelForRole("fast", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: `${organizationId}:${workspaceId}:summaries`,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("fast"),
         system: SUMMARY_SYSTEM_PROMPT,
         prompt: JSON.stringify({
           files: contexts.map((context) => ({
@@ -703,7 +700,6 @@ const generateMissingSummaries = async ({
         // bigger budget here. ~120 tokens per summary at 100 files puts
         // us around 12 200 tokens.
         maxOutputTokens: Math.min(24_000, 200 + contexts.length * 300),
-        providerOptions: googleMinimalThinking(),
         abortSignal: AbortSignal.timeout(60_000),
         ...aiAnalytics.stepCallbacks,
       }),
@@ -994,15 +990,6 @@ const hashSummarySource = ({
   hasher.update(searchDocumentUpdatedAt?.toISOString() ?? "");
   return hasher.digest("hex");
 };
-
-const googleMinimalThinking = () => ({
-  google: {
-    thinkingConfig: {
-      thinkingLevel: "minimal",
-      includeThoughts: false,
-    },
-  } satisfies GoogleGenerativeAIProviderOptions,
-});
 
 const config = {
   permissions: { workspace: ["read"] },

--- a/apps/api/src/handlers/properties/suggest-prompt.ts
+++ b/apps/api/src/handlers/properties/suggest-prompt.ts
@@ -7,7 +7,7 @@ import {
   loadPromptCachingPreference,
 } from "@/api/lib/ai-config-loader";
 import { aiHandlerError } from "@/api/lib/ai-error";
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import { getModelForRole } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { createSafeHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -155,8 +155,8 @@ const suggestPrompt = createSafeHandler(
           model: getModelForRole("fast", orgAIConfig, {
             promptCachingEnabled,
             scopeKey: null,
+            organizationId: session.activeOrganizationId,
           }),
-          temperature: getTemperatureForRole("fast"),
           system: SYSTEM_PROMPT,
           messages: [{ role: "user", content: userMessage }],
           abortSignal: AbortSignal.any([

--- a/apps/api/src/handlers/search/ai.ts
+++ b/apps/api/src/handlers/search/ai.ts
@@ -1,4 +1,3 @@
-import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { valibotSchema } from "@ai-sdk/valibot";
 import { generateText, Output } from "ai";
 import { Result } from "better-result";
@@ -19,11 +18,7 @@ import {
 import { resolveSelectedWorkspaceIds } from "@/api/handlers/search/search";
 import { aiErrorStatusBody } from "@/api/lib/ai-error";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
-import {
-  getModelForRole,
-  getTemperatureForRole,
-  requireAIAvailable,
-} from "@/api/lib/ai-models";
+import { getModelForRole, requireAIAvailable } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import type { AuditRecorder } from "@/api/lib/audit-log";
@@ -218,19 +213,11 @@ const compactContent = (value: unknown): string => {
 const truncate = (text: string, maxLength: number): string =>
   text.length <= maxLength ? text : `${text.slice(0, maxLength - 1)}…`;
 
-const googleMinimalThinking = () => ({
-  google: {
-    thinkingConfig: {
-      thinkingLevel: "minimal",
-      includeThoughts: false,
-    },
-  } satisfies GoogleGenerativeAIProviderOptions,
-});
-
 type GenerateRefinedSearchQueryOptions = {
   attempt: number;
   body: RefineSearchBody;
   lastValidationError: string | null;
+  organizationId: SafeId<"organization">;
   orgAIConfig: OrgAIConfig | null;
   promptCachingEnabled: boolean;
   stepCallbacks: ReturnType<typeof createAIAnalyticsCallbacks>["stepCallbacks"];
@@ -256,6 +243,7 @@ const generateRefinedSearchQuery = async ({
   attempt,
   body,
   lastValidationError,
+  organizationId,
   orgAIConfig,
   promptCachingEnabled,
   stepCallbacks,
@@ -266,8 +254,8 @@ const generateRefinedSearchQuery = async ({
         model: getModelForRole("fast", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: null,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("fast"),
         system: SEARCH_REFINE_SYSTEM,
         prompt: JSON.stringify({
           attempt,
@@ -279,7 +267,6 @@ const generateRefinedSearchQuery = async ({
           schema: valibotSchema(refineSearchOutputSchema),
         }),
         maxOutputTokens: 180,
-        providerOptions: googleMinimalThinking(),
         abortSignal: AbortSignal.timeout(20_000),
         ...stepCallbacks,
       }),
@@ -315,6 +302,7 @@ export const refineSearchQuery = async ({
       attempt,
       body,
       lastValidationError,
+      organizationId,
       orgAIConfig,
       promptCachingEnabled,
       stepCallbacks: aiAnalytics.stepCallbacks,
@@ -424,8 +412,8 @@ export const summarizeSearchResults = async ({
         model: getModelForRole("fast", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: null,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("fast"),
         system: SEARCH_SUMMARY_SYSTEM,
         prompt: JSON.stringify({
           locale: body.locale ?? "en",
@@ -437,7 +425,6 @@ export const summarizeSearchResults = async ({
           schema: valibotSchema(searchSummaryOutputSchema),
         }),
         maxOutputTokens: 700,
-        providerOptions: googleMinimalThinking(),
         abortSignal: AbortSignal.timeout(30_000),
         ...aiAnalytics.stepCallbacks,
       }),

--- a/apps/api/src/handlers/skills/generate-draft.ts
+++ b/apps/api/src/handlers/skills/generate-draft.ts
@@ -4,11 +4,7 @@ import { Result } from "better-result";
 import { t } from "elysia";
 import * as v from "valibot";
 
-import {
-  getModelForRole,
-  getTemperatureForRole,
-  requireAIAvailable,
-} from "@/api/lib/ai-models";
+import { getModelForRole, requireAIAvailable } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -100,10 +96,10 @@ const generateSkillDraft = createSafeRootHandler(
           model: getModelForRole("fast", orgAIConfig, {
             promptCachingEnabled,
             scopeKey: null,
+            organizationId: session.activeOrganizationId,
           }),
           output: Output.object({ schema: valibotSchema(aiGenerationSchema) }),
           prompt,
-          temperature: getTemperatureForRole("fast"),
           ...aiAnalytics.stepCallbacks,
         }),
       catch: (cause) => {

--- a/apps/api/src/handlers/skills/resources/rewrite.ts
+++ b/apps/api/src/handlers/skills/resources/rewrite.ts
@@ -4,11 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { t } from "elysia";
 
 import { agentSkillResources, agentSkills } from "@/api/db/schema";
-import {
-  getModelForRole,
-  getTemperatureForRole,
-  requireAIAvailable,
-} from "@/api/lib/ai-models";
+import { getModelForRole, requireAIAvailable } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
@@ -138,9 +134,9 @@ const rewriteSkillResource = createSafeRootHandler(
           model: getModelForRole("fast", orgAIConfig, {
             promptCachingEnabled,
             scopeKey: null,
+            organizationId: session.activeOrganizationId,
           }),
           prompt,
-          temperature: getTemperatureForRole("fast"),
           ...aiAnalytics.stepCallbacks,
         }),
       catch: (cause) => {

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -1,8 +1,8 @@
 import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
-import type { OrgAIConfig } from "@/api/lib/ai-models";
-import { toSafeId } from "@/api/lib/branded-types";
+import type { ModelRole, OrgAIConfig } from "@/api/lib/ai-models";
+import { type SafeId, toSafeId } from "@/api/lib/branded-types";
 
 process.env["EMAIL_PROVIDER"] ??= "smtp";
 process.env["GOTENBERG_PASSWORD"] ??= "gotenberg";
@@ -15,6 +15,7 @@ process.env["SMTP_HOST"] ??= "localhost";
 process.env["SMTP_PORT"] ??= "1025";
 
 const {
+  DEFAULT_MODELS,
   defaultsForRole,
   getModelForRole,
   getModelInfoById,
@@ -34,6 +35,19 @@ type AIProvider =
   | "anthropic"
   | "mistral"
   | "openai_compatible";
+
+const settingsForRole = (
+  role: ModelRole,
+  provider: AIProvider,
+  orgId: SafeId<"organization"> | null = null,
+  modelId: string = DEFAULT_MODELS[provider][role],
+) =>
+  defaultsForRole({
+    role,
+    provider,
+    orgId,
+    modelId,
+  });
 
 describe("supportsRegion", () => {
   test("google supports regional routing", () => {
@@ -460,7 +474,7 @@ describe("defaultsForRole", () => {
         if (provider === "anthropic" && role === "reasoning") {
           continue;
         }
-        expect(defaultsForRole(role, provider, null)).toMatchObject({
+        expect(settingsForRole(role, provider)).toMatchObject({
           temperature: 0,
         });
       }
@@ -468,25 +482,25 @@ describe("defaultsForRole", () => {
   });
 
   test("anthropic reasoning omits temperature", () => {
-    const settings = defaultsForRole("reasoning", "anthropic", null);
+    const settings = settingsForRole("reasoning", "anthropic");
     expect(settings.temperature).toBeUndefined();
   });
 
   test("google fast/chat/pdf use minimal thinking; reasoning uses high", () => {
     for (const role of ["fast", "chat", "pdf"] as const) {
-      const s = defaultsForRole(role, "google", null);
+      const s = settingsForRole(role, "google");
       expect(s.providerOptions?.["google"]).toMatchObject({
         thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false },
       });
     }
-    const reasoning = defaultsForRole("reasoning", "google", null);
+    const reasoning = settingsForRole("reasoning", "google");
     expect(reasoning.providerOptions?.["google"]).toMatchObject({
       thinkingConfig: { thinkingLevel: "high", includeThoughts: false },
     });
   });
 
   test("google providerOptions include safetySettings baseline", () => {
-    const settings = defaultsForRole("fast", "google", null);
+    const settings = settingsForRole("fast", "google");
     const google = settings.providerOptions?.["google"] as
       | { safetySettings?: { category: string; threshold: string }[] }
       | undefined;
@@ -503,7 +517,7 @@ describe("defaultsForRole", () => {
     // SAFETY: SafeId is a branded string; the helper only hashes the
     // value, so a raw string is sound at runtime for this unit test.
     const orgId = toSafeId<"organization">("org_test_abc123");
-    const settings = defaultsForRole("fast", "anthropic", orgId);
+    const settings = settingsForRole("fast", "anthropic", orgId);
     const anthropic = settings.providerOptions?.["anthropic"] as
       | { metadata?: { userId?: string } & Record<string, unknown> }
       | undefined;
@@ -515,15 +529,28 @@ describe("defaultsForRole", () => {
   });
 
   test("anthropic reasoning enables adaptive thinking", () => {
-    const settings = defaultsForRole("reasoning", "anthropic", null);
+    const settings = settingsForRole("reasoning", "anthropic");
     expect(settings.providerOptions?.["anthropic"]).toMatchObject({
       thinking: { type: "adaptive" },
     });
   });
 
+  test("anthropic reasoning uses budget thinking for Claude 4.5", () => {
+    const settings = settingsForRole(
+      "reasoning",
+      "anthropic",
+      null,
+      "claude-haiku-4-5-20251001",
+    );
+    expect(settings.temperature).toBeUndefined();
+    expect(settings.providerOptions?.["anthropic"]).toMatchObject({
+      thinking: { type: "enabled", budgetTokens: 10_000 },
+    });
+  });
+
   test("anthropic fast/chat/pdf do not enable thinking", () => {
     for (const role of ["fast", "chat", "pdf"] as const) {
-      const s = defaultsForRole(role, "anthropic", null);
+      const s = settingsForRole(role, "anthropic");
       const anthropic = s.providerOptions?.["anthropic"] as
         | { thinking?: unknown }
         | undefined;
@@ -532,14 +559,14 @@ describe("defaultsForRole", () => {
   });
 
   test("openai reasoning sets reasoningEffort under openai key", () => {
-    const settings = defaultsForRole("reasoning", "openai", null);
+    const settings = settingsForRole("reasoning", "openai");
     expect(settings.providerOptions?.["openai"]).toMatchObject({
       reasoningEffort: "medium",
     });
   });
 
   test("azure_foundry reasoning sets reasoningEffort under azure key", () => {
-    const settings = defaultsForRole("reasoning", "azure_foundry", null);
+    const settings = settingsForRole("reasoning", "azure_foundry");
     expect(settings.providerOptions?.["azure"]).toMatchObject({
       reasoningEffort: "medium",
     });
@@ -548,7 +575,7 @@ describe("defaultsForRole", () => {
 
   test("openai non-reasoning roles set no provider options", () => {
     for (const role of ["fast", "chat", "pdf"] as const) {
-      const settings = defaultsForRole(role, "openai", null);
+      const settings = settingsForRole(role, "openai");
       expect(settings.providerOptions).toBeUndefined();
     }
   });

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -2,6 +2,7 @@ import { Result } from "better-result";
 import { describe, expect, test } from "bun:test";
 
 import type { OrgAIConfig } from "@/api/lib/ai-models";
+import { toSafeId } from "@/api/lib/branded-types";
 
 process.env["EMAIL_PROVIDER"] ??= "smtp";
 process.env["GOTENBERG_PASSWORD"] ??= "gotenberg";
@@ -295,7 +296,8 @@ describe("BYOK model overrides", () => {
       expect(() =>
         getModelForRole(role, orgConfig, {
           promptCachingEnabled: true,
-          scopeKey: null, organizationId: null,
+          scopeKey: null,
+          organizationId: null,
         }),
       ).not.toThrow();
     }
@@ -338,7 +340,8 @@ describe("BYOK model overrides", () => {
       expect(() =>
         getModelForRole(role, orgConfig, {
           promptCachingEnabled: true,
-          scopeKey: null, organizationId: null,
+          scopeKey: null,
+          organizationId: null,
         }),
       ).not.toThrow();
     }
@@ -363,7 +366,8 @@ describe("BYOK model overrides", () => {
     expect(() =>
       getModelForRole("reasoning", orgConfig, {
         promptCachingEnabled: true,
-        scopeKey: null, organizationId: null,
+        scopeKey: null,
+        organizationId: null,
       }),
     ).not.toThrow();
     expect(getModelInfoForRole("reasoning", orgConfig).modelId).toBe(
@@ -399,7 +403,8 @@ describe("BYOK model overrides", () => {
     expect(() =>
       getModelForRole("chat", orgConfig, {
         promptCachingEnabled: true,
-        scopeKey: null, organizationId: null,
+        scopeKey: null,
+        organizationId: null,
       }),
     ).not.toThrow();
   });
@@ -471,25 +476,25 @@ describe("defaultsForRole", () => {
   });
 
   test("google providerOptions include safetySettings baseline", () => {
-    const s = defaultsForRole("fast", "google", null);
-    const google = s.providerOptions?.["google"] as
+    const settings = defaultsForRole("fast", "google", null);
+    const google = settings.providerOptions?.["google"] as
       | { safetySettings?: { category: string; threshold: string }[] }
       | undefined;
     expect(google?.safetySettings).toBeDefined();
     expect(google?.safetySettings?.length).toBeGreaterThan(0);
     expect(
-      google?.safetySettings?.every((s) => s.threshold === "BLOCK_ONLY_HIGH"),
+      google?.safetySettings?.every(
+        (rule) => rule.threshold === "BLOCK_ONLY_HIGH",
+      ),
     ).toBe(true);
   });
 
   test("anthropic includes hashed metadata.user_id when orgId is given", () => {
-    // SAFETY: orgId is a SafeId<"organization"> brand; using a fake
-    // string for unit purposes (the helper only hashes the value).
-    const orgId = "org_test_abc123" as ReturnType<
-      typeof getModelInfoForRole
-    >["modelId"] as never;
-    const s = defaultsForRole("fast", "anthropic", orgId);
-    const anthropic = s.providerOptions?.["anthropic"] as
+    // SAFETY: SafeId is a branded string; the helper only hashes the
+    // value, so a raw string is sound at runtime for this unit test.
+    const orgId = toSafeId<"organization">("org_test_abc123");
+    const settings = defaultsForRole("fast", "anthropic", orgId);
+    const anthropic = settings.providerOptions?.["anthropic"] as
       | { metadata?: { user_id?: string } }
       | undefined;
     expect(anthropic?.metadata?.user_id).toBeDefined();
@@ -497,10 +502,10 @@ describe("defaultsForRole", () => {
     expect(anthropic?.metadata?.user_id?.length).toBe(16);
   });
 
-  test("anthropic reasoning enables thinking with a budget", () => {
-    const s = defaultsForRole("reasoning", "anthropic", null);
-    expect(s.providerOptions?.["anthropic"]).toMatchObject({
-      thinking: { type: "enabled" },
+  test("anthropic reasoning enables adaptive thinking", () => {
+    const settings = defaultsForRole("reasoning", "anthropic", null);
+    expect(settings.providerOptions?.["anthropic"]).toMatchObject({
+      thinking: { type: "adaptive" },
     });
   });
 
@@ -514,17 +519,25 @@ describe("defaultsForRole", () => {
     }
   });
 
-  test("openai reasoning sets reasoning_effort", () => {
-    const s = defaultsForRole("reasoning", "openai", null);
-    expect(s.providerOptions?.["openai"]).toMatchObject({
-      reasoning_effort: "medium",
+  test("openai reasoning sets reasoningEffort under openai key", () => {
+    const settings = defaultsForRole("reasoning", "openai", null);
+    expect(settings.providerOptions?.["openai"]).toMatchObject({
+      reasoningEffort: "medium",
     });
+  });
+
+  test("azure_foundry reasoning sets reasoningEffort under azure key", () => {
+    const settings = defaultsForRole("reasoning", "azure_foundry", null);
+    expect(settings.providerOptions?.["azure"]).toMatchObject({
+      reasoningEffort: "medium",
+    });
+    expect(settings.providerOptions?.["openai"]).toBeUndefined();
   });
 
   test("openai non-reasoning roles set no provider options", () => {
     for (const role of ["fast", "chat", "pdf"] as const) {
-      const s = defaultsForRole(role, "openai", null);
-      expect(s.providerOptions).toBeUndefined();
+      const settings = defaultsForRole(role, "openai", null);
+      expect(settings.providerOptions).toBeUndefined();
     }
   });
 });

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -499,17 +499,19 @@ describe("defaultsForRole", () => {
     ).toBe(true);
   });
 
-  test("anthropic includes hashed metadata.user_id when orgId is given", () => {
+  test("anthropic includes hashed metadata.userId when orgId is given", () => {
     // SAFETY: SafeId is a branded string; the helper only hashes the
     // value, so a raw string is sound at runtime for this unit test.
     const orgId = toSafeId<"organization">("org_test_abc123");
     const settings = defaultsForRole("fast", "anthropic", orgId);
     const anthropic = settings.providerOptions?.["anthropic"] as
-      | { metadata?: { user_id?: string } }
+      | { metadata?: { userId?: string } & Record<string, unknown> }
       | undefined;
-    expect(anthropic?.metadata?.user_id).toBeDefined();
-    expect(anthropic?.metadata?.user_id).not.toBe("org_test_abc123");
-    expect(anthropic?.metadata?.user_id?.length).toBe(16);
+    const metadata = anthropic?.metadata;
+    expect(metadata?.userId).toBeDefined();
+    expect(metadata?.userId).not.toBe("org_test_abc123");
+    expect(metadata?.userId?.length).toBe(16);
+    expect("user_id" in (metadata ?? {})).toBe(false);
   });
 
   test("anthropic reasoning enables adaptive thinking", () => {

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -455,11 +455,21 @@ describe("defaultsForRole", () => {
         "openai",
         "mistral",
       ] as const) {
+        // Anthropic + reasoning intentionally omits temperature
+        // (incompatible with extended thinking on Claude pre-Opus-4.7).
+        if (provider === "anthropic" && role === "reasoning") {
+          continue;
+        }
         expect(defaultsForRole(role, provider, null)).toMatchObject({
           temperature: 0,
         });
       }
     }
+  });
+
+  test("anthropic reasoning omits temperature", () => {
+    const settings = defaultsForRole("reasoning", "anthropic", null);
+    expect(settings.temperature).toBeUndefined();
   });
 
   test("google fast/chat/pdf use minimal thinking; reasoning uses high", () => {

--- a/apps/api/src/lib/ai-models.test.ts
+++ b/apps/api/src/lib/ai-models.test.ts
@@ -14,6 +14,7 @@ process.env["SMTP_HOST"] ??= "localhost";
 process.env["SMTP_PORT"] ??= "1025";
 
 const {
+  defaultsForRole,
   getModelForRole,
   getModelInfoById,
   getModelInfoForRole,
@@ -294,7 +295,7 @@ describe("BYOK model overrides", () => {
       expect(() =>
         getModelForRole(role, orgConfig, {
           promptCachingEnabled: true,
-          scopeKey: null,
+          scopeKey: null, organizationId: null,
         }),
       ).not.toThrow();
     }
@@ -337,7 +338,7 @@ describe("BYOK model overrides", () => {
       expect(() =>
         getModelForRole(role, orgConfig, {
           promptCachingEnabled: true,
-          scopeKey: null,
+          scopeKey: null, organizationId: null,
         }),
       ).not.toThrow();
     }
@@ -362,7 +363,7 @@ describe("BYOK model overrides", () => {
     expect(() =>
       getModelForRole("reasoning", orgConfig, {
         promptCachingEnabled: true,
-        scopeKey: null,
+        scopeKey: null, organizationId: null,
       }),
     ).not.toThrow();
     expect(getModelInfoForRole("reasoning", orgConfig).modelId).toBe(
@@ -398,7 +399,7 @@ describe("BYOK model overrides", () => {
     expect(() =>
       getModelForRole("chat", orgConfig, {
         promptCachingEnabled: true,
-        scopeKey: null,
+        scopeKey: null, organizationId: null,
       }),
     ).not.toThrow();
   });
@@ -437,5 +438,93 @@ describe("resolveCaching", () => {
       scopeKey: null,
     });
     expect(decision).toMatchObject({ enabled: true, scopeKey: null });
+  });
+});
+
+describe("defaultsForRole", () => {
+  test("temperature is 0 for every role", () => {
+    for (const role of ["fast", "chat", "reasoning", "pdf"] as const) {
+      for (const provider of [
+        "google",
+        "anthropic",
+        "openai",
+        "mistral",
+      ] as const) {
+        expect(defaultsForRole(role, provider, null)).toMatchObject({
+          temperature: 0,
+        });
+      }
+    }
+  });
+
+  test("google fast/chat/pdf use minimal thinking; reasoning uses high", () => {
+    for (const role of ["fast", "chat", "pdf"] as const) {
+      const s = defaultsForRole(role, "google", null);
+      expect(s.providerOptions?.["google"]).toMatchObject({
+        thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false },
+      });
+    }
+    const reasoning = defaultsForRole("reasoning", "google", null);
+    expect(reasoning.providerOptions?.["google"]).toMatchObject({
+      thinkingConfig: { thinkingLevel: "high", includeThoughts: false },
+    });
+  });
+
+  test("google providerOptions include safetySettings baseline", () => {
+    const s = defaultsForRole("fast", "google", null);
+    const google = s.providerOptions?.["google"] as
+      | { safetySettings?: { category: string; threshold: string }[] }
+      | undefined;
+    expect(google?.safetySettings).toBeDefined();
+    expect(google?.safetySettings?.length).toBeGreaterThan(0);
+    expect(
+      google?.safetySettings?.every((s) => s.threshold === "BLOCK_ONLY_HIGH"),
+    ).toBe(true);
+  });
+
+  test("anthropic includes hashed metadata.user_id when orgId is given", () => {
+    // SAFETY: orgId is a SafeId<"organization"> brand; using a fake
+    // string for unit purposes (the helper only hashes the value).
+    const orgId = "org_test_abc123" as ReturnType<
+      typeof getModelInfoForRole
+    >["modelId"] as never;
+    const s = defaultsForRole("fast", "anthropic", orgId);
+    const anthropic = s.providerOptions?.["anthropic"] as
+      | { metadata?: { user_id?: string } }
+      | undefined;
+    expect(anthropic?.metadata?.user_id).toBeDefined();
+    expect(anthropic?.metadata?.user_id).not.toBe("org_test_abc123");
+    expect(anthropic?.metadata?.user_id?.length).toBe(16);
+  });
+
+  test("anthropic reasoning enables thinking with a budget", () => {
+    const s = defaultsForRole("reasoning", "anthropic", null);
+    expect(s.providerOptions?.["anthropic"]).toMatchObject({
+      thinking: { type: "enabled" },
+    });
+  });
+
+  test("anthropic fast/chat/pdf do not enable thinking", () => {
+    for (const role of ["fast", "chat", "pdf"] as const) {
+      const s = defaultsForRole(role, "anthropic", null);
+      const anthropic = s.providerOptions?.["anthropic"] as
+        | { thinking?: unknown }
+        | undefined;
+      expect(anthropic?.thinking).toBeUndefined();
+    }
+  });
+
+  test("openai reasoning sets reasoning_effort", () => {
+    const s = defaultsForRole("reasoning", "openai", null);
+    expect(s.providerOptions?.["openai"]).toMatchObject({
+      reasoning_effort: "medium",
+    });
+  });
+
+  test("openai non-reasoning roles set no provider options", () => {
+    for (const role of ["fast", "chat", "pdf"] as const) {
+      const s = defaultsForRole(role, "openai", null);
+      expect(s.providerOptions).toBeUndefined();
+    }
   });
 });

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -932,64 +932,111 @@ const GOOGLE_SAFETY_SETTINGS_BASELINE = [
 
 type Settings = Parameters<typeof defaultSettingsMiddleware>[0]["settings"];
 
+type DefaultsBuilder = (
+  role: ModelRole,
+  orgId: SafeId<"organization"> | null,
+) => Settings;
+
+const googleDefaults: DefaultsBuilder = (role) => ({
+  temperature: TEMPERATURE_PER_ROLE[role],
+  providerOptions: {
+    google: {
+      thinkingConfig: {
+        thinkingLevel: role === "reasoning" ? "high" : "minimal",
+        includeThoughts: false,
+      },
+      safetySettings: GOOGLE_SAFETY_SETTINGS_BASELINE,
+    },
+  },
+});
+
+const buildAnthropicMetadata = (
+  orgId: SafeId<"organization"> | null,
+): { metadata: { user_id: string } } | Record<string, never> =>
+  orgId === null ? {} : { metadata: { user_id: hashOrgId(orgId) } };
+
+// `temperature?: never` makes it a compile error to set temperature
+// here. Anthropic rejects custom temperature when extended thinking
+// is enabled on Claude pre-Opus-4.7 (incl. stella's default
+// sonnet-4-6 for the reasoning role); the provider's built-in
+// default (1) is what the API requires when thinking is on.
+type AnthropicReasoningSettings = Omit<Settings, "temperature"> & {
+  temperature?: never;
+};
+
+const anthropicReasoningDefaults = (
+  orgId: SafeId<"organization"> | null,
+): AnthropicReasoningSettings => {
+  // Adaptive thinking is supported on Claude 4.6+ (sonnet-4-6,
+  // opus-4-6, opus-4-7); earlier 4.5/3.x models expect the
+  // budget-based `type: "enabled"` form. Stella's reasoning role
+  // defaults to sonnet-4-6, so adaptive is correct for the common
+  // case; BYOK orgs that pin a 4-5 model should override at the
+  // call site.
+  const anthropicOptions: JSONObject = {
+    ...buildAnthropicMetadata(orgId),
+    thinking: { type: "adaptive" },
+  };
+  return { providerOptions: { anthropic: anthropicOptions } };
+};
+
+const anthropicNonReasoningDefaults = (
+  role: Exclude<ModelRole, "reasoning">,
+  orgId: SafeId<"organization"> | null,
+): Settings => {
+  const settings: Settings = { temperature: TEMPERATURE_PER_ROLE[role] };
+  if (orgId !== null) {
+    const anthropicOptions: JSONObject = buildAnthropicMetadata(orgId);
+    settings.providerOptions = { anthropic: anthropicOptions };
+  }
+  return settings;
+};
+
+const anthropicDefaults: DefaultsBuilder = (role, orgId) =>
+  role === "reasoning"
+    ? anthropicReasoningDefaults(orgId)
+    : anthropicNonReasoningDefaults(role, orgId);
+
+const openaiDefaults: DefaultsBuilder = (role) => {
+  const settings: Settings = { temperature: TEMPERATURE_PER_ROLE[role] };
+  if (role === "reasoning") {
+    settings.providerOptions = { openai: { reasoningEffort: "medium" } };
+  }
+  return settings;
+};
+
+// Azure's AI SDK provider registers under `azure.*` (not `openai.*`),
+// and the property name is `reasoningEffort` (camelCase, not snake).
+const azureFoundryDefaults: DefaultsBuilder = (role) => {
+  const settings: Settings = { temperature: TEMPERATURE_PER_ROLE[role] };
+  if (role === "reasoning") {
+    settings.providerOptions = { azure: { reasoningEffort: "medium" } };
+  }
+  return settings;
+};
+
+const bareTemperatureDefaults: DefaultsBuilder = (role) => ({
+  temperature: TEMPERATURE_PER_ROLE[role],
+});
+
+// `satisfies Record<AIProvider, ...>` makes adding a new provider to
+// AI_PROVIDERS a compile error here, so no provider can silently
+// fall through to a generic default that ignores its own knobs.
+const DEFAULTS_BUILDERS = {
+  google: googleDefaults,
+  anthropic: anthropicDefaults,
+  openai: openaiDefaults,
+  azure_foundry: azureFoundryDefaults,
+  openrouter: bareTemperatureDefaults,
+  mistral: bareTemperatureDefaults,
+  openai_compatible: bareTemperatureDefaults,
+} as const satisfies Record<AIProvider, DefaultsBuilder>;
+
 export const defaultsForRole = (
   role: ModelRole,
   provider: AIProvider,
   orgId: SafeId<"organization"> | null,
-): Settings => {
-  const settings: Settings = {
-    temperature: TEMPERATURE_PER_ROLE[role],
-  };
-
-  if (provider === "google") {
-    const thinkingLevel = role === "reasoning" ? "high" : "minimal";
-    settings.providerOptions = {
-      google: {
-        thinkingConfig: {
-          thinkingLevel,
-          includeThoughts: false,
-        },
-        safetySettings: GOOGLE_SAFETY_SETTINGS_BASELINE,
-      },
-    };
-    return settings;
-  }
-
-  if (provider === "anthropic") {
-    const anthropicOptions: Record<string, unknown> = {};
-    if (orgId !== null) {
-      anthropicOptions["metadata"] = { user_id: hashOrgId(orgId) };
-    }
-    if (role === "reasoning") {
-      // Adaptive thinking is the supported mode on Claude 4.6+ models
-      // (sonnet-4-6, opus-4-6, opus-4-7). Earlier 4.5 / 3.x models
-      // expect the budget-based `type: "enabled"` form; passing
-      // `adaptive` to them is rejected. Stella's instance reasoning
-      // role defaults to sonnet-4-6, so adaptive is correct for the
-      // common case; BYOK orgs that pin a 4-5 model should override
-      // at the call site.
-      anthropicOptions["thinking"] = { type: "adaptive" };
-    }
-    if (Object.keys(anthropicOptions).length > 0) {
-      settings.providerOptions = { anthropic: anthropicOptions as JSONObject };
-    }
-    return settings;
-  }
-
-  if (provider === "openai" || provider === "azure_foundry") {
-    if (role === "reasoning") {
-      // Azure's AI SDK provider registers under `azure.*` not
-      // `openai.*`, so its providerOptions key is `azure`.
-      const key = provider === "openai" ? "openai" : "azure";
-      settings.providerOptions = {
-        [key]: { reasoningEffort: "medium" },
-      };
-    }
-    return settings;
-  }
-
-  return settings;
-};
+): Settings => DEFAULTS_BUILDERS[provider](role, orgId);
 
 const withInstrumentation = (
   model: WrappableLanguageModel,

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -27,8 +27,10 @@ import { createVertex } from "@ai-sdk/google-vertex";
 import { createMistral, mistral } from "@ai-sdk/mistral";
 import { createOpenAI, openai } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { wrapLanguageModel } from "ai";
+import { defaultSettingsMiddleware, wrapLanguageModel } from "ai";
 import type { LanguageModel, LanguageModelMiddleware } from "ai";
+
+import type { SafeId } from "@/api/lib/branded-types";
 import { panic, Result } from "better-result";
 
 import { env } from "@/api/env";
@@ -904,11 +906,106 @@ const cachingMiddleware = (
     await Promise.resolve(computeCachingParams(params, provider, decision)),
 });
 
+// -- Default settings -------------------------------------------
+
+/**
+ * Anthropic recommends an opaque hash for `metadata.user_id`
+ * rather than the raw organisation id. Truncated SHA-256 keeps
+ * the value stable per org without leaking the safe id verbatim.
+ */
+const hashOrgId = (orgId: SafeId<"organization">): string =>
+  new Bun.CryptoHasher("sha256").update(orgId).digest("hex").slice(0, 16);
+
+/**
+ * Sensible Google `safetySettings` baseline for legal-document
+ * workloads. The default Gemini thresholds occasionally refuse
+ * benign legal content (defamation discussions, criminal-case
+ * summaries); raising the threshold avoids surprise refusals
+ * while still blocking the worst categories at HIGH.
+ */
+type JSONObject = { [k: string]: JSONValue };
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [k: string]: JSONValue };
+
+const GOOGLE_SAFETY_SETTINGS_BASELINE: JSONValue = [
+  { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_ONLY_HIGH" },
+  { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+  { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_ONLY_HIGH" },
+  { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_ONLY_HIGH" },
+];
+
+type Settings = Parameters<typeof defaultSettingsMiddleware>[0]["settings"];
+
+export const defaultsForRole = (
+  role: ModelRole,
+  provider: AIProvider,
+  orgId: SafeId<"organization"> | null,
+): Settings => {
+  const settings: Settings = {
+    temperature: TEMPERATURE_PER_ROLE[role],
+  };
+
+  if (provider === "google") {
+    const thinkingLevel = role === "reasoning" ? "high" : "minimal";
+    settings.providerOptions = {
+      google: {
+        thinkingConfig: {
+          thinkingLevel,
+          includeThoughts: false,
+        },
+        safetySettings: GOOGLE_SAFETY_SETTINGS_BASELINE,
+      },
+    };
+    return settings;
+  }
+
+  if (provider === "anthropic") {
+    const anthropicOptions: JSONObject = {};
+    if (orgId !== null) {
+      anthropicOptions["metadata"] = { user_id: hashOrgId(orgId) };
+    }
+    if (role === "reasoning") {
+      anthropicOptions["thinking"] = {
+        type: "enabled",
+        budgetTokens: 10_000,
+      };
+    }
+    if (Object.keys(anthropicOptions).length > 0) {
+      settings.providerOptions = { anthropic: anthropicOptions };
+    }
+    return settings;
+  }
+
+  if (provider === "openai" || provider === "azure_foundry") {
+    if (role === "reasoning") {
+      settings.providerOptions = {
+        openai: { reasoning_effort: "medium" },
+      };
+    }
+    return settings;
+  }
+
+  return settings;
+};
+
 const withInstrumentation = (
   model: WrappableLanguageModel,
-  ctx: { provider: AIProvider; decision: CachingDecision },
+  ctx: {
+    provider: AIProvider;
+    decision: CachingDecision;
+    role: ModelRole;
+    organizationId: SafeId<"organization"> | null;
+  },
 ): LanguageModel => {
   const middlewares: SingleMiddleware[] = [
+    defaultSettingsMiddleware({
+      settings: defaultsForRole(ctx.role, ctx.provider, ctx.organizationId),
+    }),
     cachingMiddleware(ctx.provider, ctx.decision),
   ];
   if (isAIDevToolsEnabled()) {
@@ -989,9 +1086,13 @@ export const validateDevModelOverride = (
 export const getModelForRole = (
   role: ModelRole,
   orgConfig: OrgAIConfig | null | undefined,
-  options: { promptCachingEnabled: boolean; scopeKey: string | null },
+  options: {
+    promptCachingEnabled: boolean;
+    scopeKey: string | null;
+    organizationId: SafeId<"organization"> | null;
+  },
 ): LanguageModel => {
-  const { promptCachingEnabled, scopeKey } = options;
+  const { promptCachingEnabled, scopeKey, organizationId } = options;
   // BYOK path: org selects a model for each role through
   // one of its configured provider credentials.
   if (orgConfig) {
@@ -1002,6 +1103,8 @@ export const getModelForRole = (
     return withInstrumentation(factory(selection.modelId), {
       provider: providerConfig.provider,
       decision,
+      role,
+      organizationId,
     });
   }
 
@@ -1023,6 +1126,8 @@ export const getModelForRole = (
   return withInstrumentation(getInstanceFactory()(modelId), {
     provider,
     decision,
+    role,
+    organizationId,
   });
 };
 
@@ -1103,10 +1208,11 @@ export const getModelById = (
     promptCachingEnabled: boolean;
     scopeKey: string | null;
     role: ModelRole;
+    organizationId: SafeId<"organization"> | null;
   },
 ): LanguageModel => {
   const override = decodeModelOverride(modelId);
-  const { promptCachingEnabled, scopeKey, role } = options;
+  const { promptCachingEnabled, scopeKey, role, organizationId } = options;
   const decision = resolveCaching({ promptCachingEnabled, role, scopeKey });
   if (orgConfig) {
     const providerConfig = override.provider
@@ -1114,17 +1220,29 @@ export const getModelById = (
       : getPrimaryOrgProvider(orgConfig);
     return withInstrumentation(
       getCachedFactory(providerConfig)(override.modelId),
-      { provider: providerConfig.provider, decision },
+      {
+        provider: providerConfig.provider,
+        decision,
+        role,
+        organizationId,
+      },
     );
   }
   if (override.provider) {
     return withInstrumentation(
       createModelFactory({ provider: override.provider })(override.modelId),
-      { provider: override.provider, decision },
+      {
+        provider: override.provider,
+        decision,
+        role,
+        organizationId,
+      },
     );
   }
   return withInstrumentation(getInstanceFactory()(override.modelId), {
     provider: getActiveProvider(),
     decision,
+    role,
+    organizationId,
   });
 };

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -26,11 +26,10 @@ import { createGoogleGenerativeAI, google } from "@ai-sdk/google";
 import { createVertex } from "@ai-sdk/google-vertex";
 import { createMistral, mistral } from "@ai-sdk/mistral";
 import { createOpenAI, openai } from "@ai-sdk/openai";
+import type { JSONObject } from "@ai-sdk/provider";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { defaultSettingsMiddleware, wrapLanguageModel } from "ai";
 import type { LanguageModel, LanguageModelMiddleware } from "ai";
-
-import type { SafeId } from "@/api/lib/branded-types";
 import { panic, Result } from "better-result";
 
 import { env } from "@/api/env";
@@ -38,6 +37,7 @@ import {
   AZURE_FOUNDRY_DEFAULT_API_VERSION,
   normalizeAzureFoundryBaseURL,
 } from "@/api/lib/azure-foundry";
+import type { SafeId } from "@/api/lib/branded-types";
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
 
 // -- Types ------------------------------------------------------
@@ -923,16 +923,7 @@ const hashOrgId = (orgId: SafeId<"organization">): string =>
  * summaries); raising the threshold avoids surprise refusals
  * while still blocking the worst categories at HIGH.
  */
-type JSONObject = { [k: string]: JSONValue };
-type JSONValue =
-  | string
-  | number
-  | boolean
-  | null
-  | JSONValue[]
-  | { [k: string]: JSONValue };
-
-const GOOGLE_SAFETY_SETTINGS_BASELINE: JSONValue = [
+const GOOGLE_SAFETY_SETTINGS_BASELINE = [
   { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_ONLY_HIGH" },
   { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
   { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_ONLY_HIGH" },
@@ -965,26 +956,33 @@ export const defaultsForRole = (
   }
 
   if (provider === "anthropic") {
-    const anthropicOptions: JSONObject = {};
+    const anthropicOptions: Record<string, unknown> = {};
     if (orgId !== null) {
       anthropicOptions["metadata"] = { user_id: hashOrgId(orgId) };
     }
     if (role === "reasoning") {
-      anthropicOptions["thinking"] = {
-        type: "enabled",
-        budgetTokens: 10_000,
-      };
+      // Adaptive thinking is the supported mode on Claude 4.6+ models
+      // (sonnet-4-6, opus-4-6, opus-4-7). Earlier 4.5 / 3.x models
+      // expect the budget-based `type: "enabled"` form; passing
+      // `adaptive` to them is rejected. Stella's instance reasoning
+      // role defaults to sonnet-4-6, so adaptive is correct for the
+      // common case; BYOK orgs that pin a 4-5 model should override
+      // at the call site.
+      anthropicOptions["thinking"] = { type: "adaptive" };
     }
     if (Object.keys(anthropicOptions).length > 0) {
-      settings.providerOptions = { anthropic: anthropicOptions };
+      settings.providerOptions = { anthropic: anthropicOptions as JSONObject };
     }
     return settings;
   }
 
   if (provider === "openai" || provider === "azure_foundry") {
     if (role === "reasoning") {
+      // Azure's AI SDK provider registers under `azure.*` not
+      // `openai.*`, so its providerOptions key is `azure`.
+      const key = provider === "openai" ? "openai" : "azure";
       settings.providerOptions = {
-        openai: { reasoning_effort: "medium" },
+        [key]: { reasoningEffort: "medium" },
       };
     }
     return settings;

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -932,12 +932,15 @@ const GOOGLE_SAFETY_SETTINGS_BASELINE = [
 
 type Settings = Parameters<typeof defaultSettingsMiddleware>[0]["settings"];
 
-type DefaultsBuilder = (
-  role: ModelRole,
-  orgId: SafeId<"organization"> | null,
-) => Settings;
+type DefaultsBuilderParams = {
+  role: ModelRole;
+  orgId: SafeId<"organization"> | null;
+  modelId: string;
+};
 
-const googleDefaults: DefaultsBuilder = (role) => ({
+type DefaultsBuilder = (params: DefaultsBuilderParams) => Settings;
+
+const googleDefaults: DefaultsBuilder = ({ role }) => ({
   temperature: TEMPERATURE_PER_ROLE[role],
   providerOptions: {
     google: {
@@ -964,18 +967,37 @@ type AnthropicReasoningSettings = Omit<Settings, "temperature"> & {
   temperature?: never;
 };
 
+const ANTHROPIC_LEGACY_THINKING_BUDGET_TOKENS = 10_000;
+
+const ANTHROPIC_ADAPTIVE_THINKING_MODELS = [
+  "claude-sonnet-4-6",
+  "claude-opus-4-6",
+  "claude-opus-4-7",
+] as const;
+
+const supportsAnthropicAdaptiveThinking = (modelId: string): boolean =>
+  ANTHROPIC_ADAPTIVE_THINKING_MODELS.some((supportedModelId) =>
+    modelId.includes(supportedModelId),
+  );
+
+const anthropicThinkingForModel = (modelId: string): JSONObject =>
+  supportsAnthropicAdaptiveThinking(modelId)
+    ? { type: "adaptive" }
+    : {
+        type: "enabled",
+        budgetTokens: ANTHROPIC_LEGACY_THINKING_BUDGET_TOKENS,
+      };
+
 const anthropicReasoningDefaults = (
   orgId: SafeId<"organization"> | null,
+  modelId: string,
 ): AnthropicReasoningSettings => {
-  // Adaptive thinking is supported on Claude 4.6+ (sonnet-4-6,
-  // opus-4-6, opus-4-7); earlier 4.5/3.x models expect the
-  // budget-based `type: "enabled"` form. Stella's reasoning role
-  // defaults to sonnet-4-6, so adaptive is correct for the common
-  // case; BYOK orgs that pin a 4-5 model should override at the
-  // call site.
+  // AI SDK source: adaptive thinking is supported on Claude
+  // sonnet-4-6, opus-4-6, opus-4-7; earlier 4.5 models use the
+  // budget-based `type: "enabled"` form.
   const anthropicOptions: JSONObject = {
     ...buildAnthropicMetadata(orgId),
-    thinking: { type: "adaptive" },
+    thinking: anthropicThinkingForModel(modelId),
   };
   return { providerOptions: { anthropic: anthropicOptions } };
 };
@@ -992,12 +1014,12 @@ const anthropicNonReasoningDefaults = (
   return settings;
 };
 
-const anthropicDefaults: DefaultsBuilder = (role, orgId) =>
+const anthropicDefaults: DefaultsBuilder = ({ role, orgId, modelId }) =>
   role === "reasoning"
-    ? anthropicReasoningDefaults(orgId)
+    ? anthropicReasoningDefaults(orgId, modelId)
     : anthropicNonReasoningDefaults(role, orgId);
 
-const openaiDefaults: DefaultsBuilder = (role) => {
+const openaiDefaults: DefaultsBuilder = ({ role }) => {
   const settings: Settings = { temperature: TEMPERATURE_PER_ROLE[role] };
   if (role === "reasoning") {
     settings.providerOptions = { openai: { reasoningEffort: "medium" } };
@@ -1007,7 +1029,7 @@ const openaiDefaults: DefaultsBuilder = (role) => {
 
 // Azure's AI SDK provider registers under `azure.*` (not `openai.*`),
 // and the property name is `reasoningEffort` (camelCase, not snake).
-const azureFoundryDefaults: DefaultsBuilder = (role) => {
+const azureFoundryDefaults: DefaultsBuilder = ({ role }) => {
   const settings: Settings = { temperature: TEMPERATURE_PER_ROLE[role] };
   if (role === "reasoning") {
     settings.providerOptions = { azure: { reasoningEffort: "medium" } };
@@ -1015,7 +1037,7 @@ const azureFoundryDefaults: DefaultsBuilder = (role) => {
   return settings;
 };
 
-const bareTemperatureDefaults: DefaultsBuilder = (role) => ({
+const bareTemperatureDefaults: DefaultsBuilder = ({ role }) => ({
   temperature: TEMPERATURE_PER_ROLE[role],
 });
 
@@ -1032,11 +1054,17 @@ const DEFAULTS_BUILDERS = {
   openai_compatible: bareTemperatureDefaults,
 } as const satisfies Record<AIProvider, DefaultsBuilder>;
 
-export const defaultsForRole = (
-  role: ModelRole,
-  provider: AIProvider,
-  orgId: SafeId<"organization"> | null,
-): Settings => DEFAULTS_BUILDERS[provider](role, orgId);
+type DefaultsForRoleParams = DefaultsBuilderParams & {
+  provider: AIProvider;
+};
+
+export const defaultsForRole = ({
+  role,
+  provider,
+  orgId,
+  modelId,
+}: DefaultsForRoleParams): Settings =>
+  DEFAULTS_BUILDERS[provider]({ role, orgId, modelId });
 
 const withInstrumentation = (
   model: WrappableLanguageModel,
@@ -1044,12 +1072,18 @@ const withInstrumentation = (
     provider: AIProvider;
     decision: CachingDecision;
     role: ModelRole;
+    modelId: string;
     organizationId: SafeId<"organization"> | null;
   },
 ): LanguageModel => {
   const middlewares: SingleMiddleware[] = [
     defaultSettingsMiddleware({
-      settings: defaultsForRole(ctx.role, ctx.provider, ctx.organizationId),
+      settings: defaultsForRole({
+        role: ctx.role,
+        provider: ctx.provider,
+        orgId: ctx.organizationId,
+        modelId: ctx.modelId,
+      }),
     }),
     cachingMiddleware(ctx.provider, ctx.decision),
   ];
@@ -1149,6 +1183,7 @@ export const getModelForRole = (
       provider: providerConfig.provider,
       decision,
       role,
+      modelId: selection.modelId,
       organizationId,
     });
   }
@@ -1172,6 +1207,7 @@ export const getModelForRole = (
     provider,
     decision,
     role,
+    modelId,
     organizationId,
   });
 };
@@ -1269,6 +1305,7 @@ export const getModelById = (
         provider: providerConfig.provider,
         decision,
         role,
+        modelId: override.modelId,
         organizationId,
       },
     );
@@ -1280,6 +1317,7 @@ export const getModelById = (
         provider: override.provider,
         decision,
         role,
+        modelId: override.modelId,
         organizationId,
       },
     );
@@ -1288,6 +1326,7 @@ export const getModelById = (
     provider: getActiveProvider(),
     decision,
     role,
+    modelId: override.modelId,
     organizationId,
   });
 };

--- a/apps/api/src/lib/ai-models.ts
+++ b/apps/api/src/lib/ai-models.ts
@@ -952,8 +952,8 @@ const googleDefaults: DefaultsBuilder = (role) => ({
 
 const buildAnthropicMetadata = (
   orgId: SafeId<"organization"> | null,
-): { metadata: { user_id: string } } | Record<string, never> =>
-  orgId === null ? {} : { metadata: { user_id: hashOrgId(orgId) } };
+): { metadata: { userId: string } } | Record<string, never> =>
+  orgId === null ? {} : { metadata: { userId: hashOrgId(orgId) } };
 
 // `temperature?: never` makes it a compile error to set temperature
 // here. Anthropic rejects custom temperature when extended thinking

--- a/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
+++ b/apps/api/src/lib/bbox/ai-generate-b-boxes.ts
@@ -1,9 +1,8 @@
-import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
 import { valibotSchema } from "@ai-sdk/valibot";
 import { generateText, Output } from "ai";
 import { Result } from "better-result";
 
-import { getModelForRole, getTemperatureForRole } from "@/api/lib/ai-models";
+import { getModelForRole } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import {
@@ -63,8 +62,8 @@ export const generateBBoxData = async ({
         model: getModelForRole("pdf", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: justificationId,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("pdf"),
         system: BBOX_SYSTEM_PROMPT,
         messages: [
           {
@@ -87,14 +86,6 @@ export const generateBBoxData = async ({
           },
         ],
         output: Output.object({ schema: valibotSchema(bboxSchema) }),
-        providerOptions: {
-          google: {
-            thinkingConfig: {
-              thinkingLevel: "minimal",
-              includeThoughts: false,
-            },
-          } satisfies GoogleGenerativeAIProviderOptions,
-        },
         abortSignal,
         ...aiAnalytics.stepCallbacks,
       });

--- a/apps/api/src/lib/workflow/ai-generate-batch.ts
+++ b/apps/api/src/lib/workflow/ai-generate-batch.ts
@@ -4,11 +4,7 @@ import type { FilePart, TextPart } from "ai";
 import { Result } from "better-result";
 
 import { markCacheBreakpoint } from "@/api/lib/ai-caching";
-import {
-  getModelForRole,
-  getTemperatureForRole,
-  resolveCaching,
-} from "@/api/lib/ai-models";
+import { getModelForRole, resolveCaching } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
 import type { SafeId } from "@/api/lib/branded-types";
@@ -138,8 +134,8 @@ export const generateWorkflowData = async ({
         model: getModelForRole("pdf", orgAIConfig, {
           promptCachingEnabled,
           scopeKey: entityVersionId,
+          organizationId,
         }),
-        temperature: getTemperatureForRole("pdf"),
         messages: [{ role: "user", content: messageContent }],
         output: Output.object({ schema: valibotSchema(schema) }),
         system: WORKFLOW_SYSTEM_PROMPT,


### PR DESCRIPTION
## Summary

- Adds Vercel AI SDK's \`defaultSettingsMiddleware\` ahead of the caching middleware in \`withInstrumentation\`. The model factory now injects role+provider-driven defaults so handlers stop hand-rolling them at every call.
- Centralises: temperature, Google \`thinkingConfig\` (minimal/high by role) + \`safetySettings\` baseline, Anthropic \`metadata.user_id\` (hashed org id) + \`thinking\` budget for reasoning role, OpenAI/Azure \`reasoning_effort\` for reasoning role.
- Deletes \`googleMinimalThinking()\` helpers from \`search/ai.ts\` and \`organize-suggestions.ts\`; replaces inline copies in bbox and polarity-classifier.
- 9 new unit tests in \`ai-models.test.ts\` covering each (role, provider) defaults combination. All 27 tests pass locally.

Plan: \`.agents/plans/041-ai-default-settings-middleware.md\`

## Out of scope (deliberately)

\`maxOutputTokens\` defaults. The audit showed handlers use legitimately different caps (32 for thread title, 180 for search refine, 700 for summary, dynamic for organize) with no common ground worth centralising.

## Test plan

- [ ] CI green on \`worktree-default-settings-middleware\`
- [ ] Verify a chat turn (any provider) still works end-to-end
- [ ] Verify workflow extraction over an entity still works (uses pdf role)
- [ ] Verify a Google route (search refine or organize) — confirm no surprise safety refusals