### PR TITLE
fix(folio): keep dense footnotes inside page bottom

### DIFF
--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -37,6 +37,22 @@ import { toFlowBlocks } from "./toFlowBlocks";
  */
 export const FOOTNOTE_SEPARATOR_HEIGHT = 12;
 
+/**
+ * Per-footnote `marginBottom` painted by `renderFootnoteArea`. Shared
+ * with the painter's clamp helper, the dynamic reservation in
+ * `PagedEditor`, and the static `calculateFootnoteReservedHeights`
+ * path so every reservation matches the painted stack.
+ */
+export const FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
+
+/**
+ * Fallback footnote line height in pixels when a footnote has no
+ * structured content (plain-text fallback rendered at `fontSize: 10px`
+ * × `lineHeight: 1.3`). Shared with the painter so the clamp helper and
+ * the painted fallback stay in lockstep.
+ */
+export const FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
+
 /** Default footnote font size in points */
 const FOOTNOTE_FONT_SIZE = 8;
 
@@ -581,8 +597,14 @@ export function calculateFootnoteReservedHeights(
     }
 
     if (totalHeight > 0) {
-      // Add separator height
+      // Add separator + per-entry margin so the static reservation
+      // matches what `renderFootnoteArea` actually paints (4px
+      // `marginBottom` per fn wrapper). Without this, the painter's
+      // clamp would shift the area upward by `count × margin` and
+      // overlap the body lines the engine laid out against the
+      // smaller reservation.
       totalHeight += FOOTNOTE_SEPARATOR_HEIGHT;
+      totalHeight += footnoteIds.length * FOOTNOTE_ENTRY_MARGIN_BOTTOM;
       reserved.set(pageNumber, totalHeight);
     }
   }

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -25,8 +25,17 @@ import type { Footnote, StyleDefinitions, Theme } from "../types/document";
 import { measureParagraph } from "./measuring";
 import { toFlowBlocks } from "./toFlowBlocks";
 
-/** Separator line height + padding in pixels */
-const SEPARATOR_HEIGHT = 12;
+/**
+ * Footnote separator height in pixels: 0.5 px divider rule + symmetric
+ * vertical margins. Single source of truth for the paginator's
+ * reservation tick, the painter's separator margins, and the per-page
+ * height returned by `calculateFootnoteReservedHeights`. Keeping all
+ * three in lockstep ensures the painted area lands inside the slot the
+ * paginator reserved.
+ *
+ * Mirrors eigenpal/docx-editor#485.
+ */
+export const FOOTNOTE_SEPARATOR_HEIGHT = 12;
 
 /** Default footnote font size in points */
 const FOOTNOTE_FONT_SIZE = 8;
@@ -573,7 +582,7 @@ export function calculateFootnoteReservedHeights(
 
     if (totalHeight > 0) {
       // Add separator height
-      totalHeight += SEPARATOR_HEIGHT;
+      totalHeight += FOOTNOTE_SEPARATOR_HEIGHT;
       reserved.set(pageNumber, totalHeight);
     }
   }

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -7,15 +7,17 @@
 
 import { panic } from "better-result";
 
+import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
 import type { Page, PageMargins, Fragment, ColumnLayout } from "./types";
 
 /**
- * Height of the footnote separator (a 0.5 px divider line + 6 px top
- * + 6 px bottom margin = 12.5 px, rounded up). Reserved once per
- * footnote-bearing page above the fn content. Must match the painter
- * (`renderFootnoteArea`).
+ * Re-export the canonical footnote separator height so engine call
+ * sites do not have to know about the layout-bridge module. The single
+ * source of truth lives in `layout-bridge/footnoteLayout.ts` and is
+ * shared with the painter (`renderFootnoteArea`) and the per-page
+ * reservation map. Mirrors eigenpal/docx-editor#485.
  */
-export const FOOTNOTE_SEPARATOR_HEIGHT = 13;
+export { FOOTNOTE_SEPARATOR_HEIGHT };
 
 /**
  * Current state of a page being laid out.

--- a/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
+++ b/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
@@ -13,7 +13,11 @@ import { describe, expect, test } from "bun:test";
 
 import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
 import { FOOTNOTE_SEPARATOR_HEIGHT as PAGINATOR_FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-engine/paginator";
-import type { Page, ParagraphBlock, ParagraphMeasure } from "../layout-engine/types";
+import type {
+  Page,
+  ParagraphBlock,
+  ParagraphMeasure,
+} from "../layout-engine/types";
 import {
   calculateFootnoteAreaRenderHeight,
   renderPage,
@@ -131,7 +135,9 @@ const PAINTER_FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
 
 describe("calculateFootnoteAreaRenderHeight", () => {
   test("returns separator height when no footnote has measured content", () => {
-    expect(calculateFootnoteAreaRenderHeight([])).toBe(FOOTNOTE_SEPARATOR_HEIGHT);
+    expect(calculateFootnoteAreaRenderHeight([])).toBe(
+      FOOTNOTE_SEPARATOR_HEIGHT,
+    );
   });
 
   test("sums each footnote content height plus per-entry margin and a single separator", () => {

--- a/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
+++ b/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
@@ -11,7 +11,10 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
+import {
+  FOOTNOTE_SEPARATOR_HEIGHT,
+  calculateFootnoteReservedHeights,
+} from "../layout-bridge/footnoteLayout";
 import { FOOTNOTE_SEPARATOR_HEIGHT as PAGINATOR_FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-engine/paginator";
 import type {
   Page,
@@ -249,6 +252,30 @@ describe("footnote separator height parity", () => {
       expect(painterHeight).toBe(
         paginatorHeight + count * PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM,
       );
+    }
+  });
+
+  test("static `calculateFootnoteReservedHeights` matches painter render height", () => {
+    // Bot raised: the static reservation path under-counted by
+    // `count × marginBottom`, so the painter's clamp would shift the
+    // area upward and overlap body lines. Assert the static helper
+    // now matches the painter for 1, 3, and 10 dense footnotes.
+    for (const count of [1, 3, 10]) {
+      const heights = Array.from({ length: count }, (_, index) => 10 + index);
+      const footnoteIds = heights.map((_, index) => index + 1);
+      const footnotes: FootnoteRenderItem[] = heights.map(
+        makeParagraphFootnote,
+      );
+      const pageFootnoteMap = new Map<number, number[]>([[1, footnoteIds]]);
+      const contentMap = new Map(
+        footnoteIds.map((id, index) => [id, { height: heights[index] ?? 0 }]),
+      );
+
+      const reserved =
+        calculateFootnoteReservedHeights(pageFootnoteMap, contentMap).get(1) ??
+        0;
+      const painterHeight = calculateFootnoteAreaRenderHeight(footnotes);
+      expect(reserved).toBe(painterHeight);
     }
   });
 

--- a/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
+++ b/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
@@ -123,29 +123,42 @@ const basePage: Page = {
   fragments: [],
 };
 
+// Painter constants mirrored in `calculateFootnoteAreaRenderHeight`. Kept
+// local to the test so a drift between painter/helper fails here before it
+// fails in production. See `renderPage.ts` for the source values.
+const PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
+const PAINTER_FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
+
 describe("calculateFootnoteAreaRenderHeight", () => {
   test("returns separator height when no footnote has measured content", () => {
     expect(calculateFootnoteAreaRenderHeight([])).toBe(FOOTNOTE_SEPARATOR_HEIGHT);
   });
 
-  test("sums each footnote content height plus a single separator", () => {
+  test("sums each footnote content height plus per-entry margin and a single separator", () => {
     const footnotes: FootnoteRenderItem[] = [
       makeParagraphFootnote(20),
       makeParagraphFootnote(35),
       makeParagraphFootnote(15),
     ];
     expect(calculateFootnoteAreaRenderHeight(footnotes)).toBe(
-      FOOTNOTE_SEPARATOR_HEIGHT + 20 + 35 + 15,
+      FOOTNOTE_SEPARATOR_HEIGHT +
+        20 +
+        35 +
+        15 +
+        3 * PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM,
     );
   });
 
-  test("ignores footnotes without measured content", () => {
+  test("counts fallback line height for footnotes without measured content", () => {
     const footnotes: FootnoteRenderItem[] = [
       { displayNumber: "1", text: "plain" },
       makeParagraphFootnote(40),
     ];
     expect(calculateFootnoteAreaRenderHeight(footnotes)).toBe(
-      FOOTNOTE_SEPARATOR_HEIGHT + 40,
+      FOOTNOTE_SEPARATOR_HEIGHT +
+        PAINTER_FOOTNOTE_FALLBACK_LINE_HEIGHT +
+        40 +
+        2 * PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM,
     );
   });
 });
@@ -216,7 +229,10 @@ describe("renderFootnoteArea overflow clamp", () => {
 });
 
 describe("footnote separator height parity", () => {
-  test("paginator reservation matches painter render height for 1, 3, and 10 footnotes", () => {
+  test("painter render height covers paginator reservation plus per-entry margin for 1, 3, and 10 footnotes", () => {
+    // Paginator reserves separator + sum(content). Painter additionally
+    // draws a `marginBottom` between entries, so the clamp helper must
+    // exceed the paginator reservation by exactly `count * margin`.
     for (const count of [1, 3, 10]) {
       const heights = Array.from({ length: count }, (_, index) => 10 + index);
       const footnotes = heights.map(makeParagraphFootnote);
@@ -224,7 +240,9 @@ describe("footnote separator height parity", () => {
       const paginatorHeight =
         heights.reduce((sum, height) => sum + height, 0) +
         PAGINATOR_FOOTNOTE_SEPARATOR_HEIGHT;
-      expect(painterHeight).toBe(paginatorHeight);
+      expect(painterHeight).toBe(
+        paginatorHeight + count * PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+      );
     }
   });
 

--- a/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
+++ b/packages/folio/src/core/layout-painter/footnoteOverflow.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Regression tests — keep dense footnotes inside the page bottom.
+ *
+ * Ports the upstream defect surfaced in eigenpal/docx-editor#485: when the
+ * paginator under-reserves space for the footnote area (off by a few pixels
+ * on densely stacked footnotes), the painted area extended past the page
+ * bottom. The fix clamps `reservedHeight` to the painter's calculated area
+ * height and clamps the resulting `top` so the area never escapes the page
+ * vertically.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
+import { FOOTNOTE_SEPARATOR_HEIGHT as PAGINATOR_FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-engine/paginator";
+import type { Page, ParagraphBlock, ParagraphMeasure } from "../layout-engine/types";
+import {
+  calculateFootnoteAreaRenderHeight,
+  renderPage,
+  type FootnoteRenderItem,
+} from "./renderPage";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  private ownText = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  get textContent(): string {
+    return (
+      this.ownText + this.children.map((child) => child.textContent).join("")
+    );
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = text;
+    return node;
+  },
+} as unknown as Document;
+
+function findByClass(
+  element: FakeElement,
+  className: string,
+): FakeElement | undefined {
+  if (element.className.split(" ").includes(className)) {
+    return element;
+  }
+  for (const child of element.children) {
+    const found = findByClass(child, className);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+}
+
+function makeParagraphFootnote(height: number): FootnoteRenderItem {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: `fn-${height}`,
+    runs: [{ kind: "text", text: "fn" }],
+  };
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: 2,
+        width: 12,
+        ascent: 8,
+        descent: 2,
+        lineHeight: height,
+      },
+    ],
+    totalHeight: height,
+  };
+  return {
+    displayNumber: "1",
+    content: { blocks: [block], measures: [measure], height },
+  };
+}
+
+const basePage: Page = {
+  number: 1,
+  margins: { top: 72, right: 72, bottom: 72, left: 72 },
+  size: { w: 816, h: 1056 },
+  fragments: [],
+};
+
+describe("calculateFootnoteAreaRenderHeight", () => {
+  test("returns separator height when no footnote has measured content", () => {
+    expect(calculateFootnoteAreaRenderHeight([])).toBe(FOOTNOTE_SEPARATOR_HEIGHT);
+  });
+
+  test("sums each footnote content height plus a single separator", () => {
+    const footnotes: FootnoteRenderItem[] = [
+      makeParagraphFootnote(20),
+      makeParagraphFootnote(35),
+      makeParagraphFootnote(15),
+    ];
+    expect(calculateFootnoteAreaRenderHeight(footnotes)).toBe(
+      FOOTNOTE_SEPARATOR_HEIGHT + 20 + 35 + 15,
+    );
+  });
+
+  test("ignores footnotes without measured content", () => {
+    const footnotes: FootnoteRenderItem[] = [
+      { displayNumber: "1", text: "plain" },
+      makeParagraphFootnote(40),
+    ];
+    expect(calculateFootnoteAreaRenderHeight(footnotes)).toBe(
+      FOOTNOTE_SEPARATOR_HEIGHT + 40,
+    );
+  });
+});
+
+describe("renderFootnoteArea overflow clamp", () => {
+  test("uses the under-reserved height verbatim when content fits within the reservation", () => {
+    const reserved = 200;
+    const fn = makeParagraphFootnote(50);
+    const pageEl = renderPage(
+      { ...basePage, footnoteReservedHeight: reserved, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument, footnoteArea: [fn] },
+    ) as unknown as FakeElement;
+
+    const fnAreaEl = findByClass(pageEl, "layout-footnote-area");
+    expect(fnAreaEl).toBeDefined();
+    const top = Number.parseFloat(fnAreaEl?.style["top"] ?? "0");
+    const contentAreaBottom =
+      basePage.size.h - basePage.margins.bottom - basePage.margins.top;
+    expect(top).toBeCloseTo(contentAreaBottom - reserved, 5);
+  });
+
+  test("clamps reservedHeight upward when the painter would draw a taller area", () => {
+    // Paginator under-reserved by 60 px. Painted area must still start
+    // high enough so its bottom never exceeds the page content bottom.
+    const fnHeights = [40, 50, 60];
+    const footnotes = fnHeights.map(makeParagraphFootnote);
+    const reservedTooSmall = 20;
+    const pageEl = renderPage(
+      {
+        ...basePage,
+        footnoteReservedHeight: reservedTooSmall,
+        fragments: [],
+      },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument, footnoteArea: footnotes },
+    ) as unknown as FakeElement;
+
+    const fnAreaEl = findByClass(pageEl, "layout-footnote-area");
+    expect(fnAreaEl).toBeDefined();
+    const top = Number.parseFloat(fnAreaEl?.style["top"] ?? "0");
+    const contentAreaBottom =
+      basePage.size.h - basePage.margins.bottom - basePage.margins.top;
+    const calculated = calculateFootnoteAreaRenderHeight(footnotes);
+    expect(calculated).toBeGreaterThan(reservedTooSmall);
+    expect(top).toBeCloseTo(contentAreaBottom - calculated, 5);
+  });
+
+  test("clamps top so the area never escapes above the page (negative top margin floor)", () => {
+    // Build a footnote stack taller than the entire content area so the
+    // calculated render height exceeds the body. The top is clamped to
+    // `-page.margins.top` so the area stays anchored to the page.
+    const contentAreaHeight =
+      basePage.size.h - basePage.margins.top - basePage.margins.bottom;
+    const oversized = contentAreaHeight + 500;
+    const fn = makeParagraphFootnote(oversized);
+    const pageEl = renderPage(
+      { ...basePage, footnoteReservedHeight: 0, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument, footnoteArea: [fn] },
+    ) as unknown as FakeElement;
+
+    const fnAreaEl = findByClass(pageEl, "layout-footnote-area");
+    expect(fnAreaEl).toBeDefined();
+    const top = Number.parseFloat(fnAreaEl?.style["top"] ?? "0");
+    expect(top).toBe(-basePage.margins.top);
+  });
+});
+
+describe("footnote separator height parity", () => {
+  test("paginator reservation matches painter render height for 1, 3, and 10 footnotes", () => {
+    for (const count of [1, 3, 10]) {
+      const heights = Array.from({ length: count }, (_, index) => 10 + index);
+      const footnotes = heights.map(makeParagraphFootnote);
+      const painterHeight = calculateFootnoteAreaRenderHeight(footnotes);
+      const paginatorHeight =
+        heights.reduce((sum, height) => sum + height, 0) +
+        PAGINATOR_FOOTNOTE_SEPARATOR_HEIGHT;
+      expect(painterHeight).toBe(paginatorHeight);
+    }
+  });
+
+  test("painter separator margins derive from FOOTNOTE_SEPARATOR_HEIGHT so paint equals measurement", () => {
+    const fn = makeParagraphFootnote(20);
+    const pageEl = renderPage(
+      { ...basePage, footnoteReservedHeight: 100, fragments: [] },
+      { pageNumber: 1, totalPages: 1, section: "body" },
+      { document: fakeDocument, footnoteArea: [fn] },
+    ) as unknown as FakeElement;
+
+    const fnAreaEl = findByClass(pageEl, "layout-footnote-area");
+    expect(fnAreaEl).toBeDefined();
+    const separator = fnAreaEl?.children.at(0);
+    expect(separator).toBeDefined();
+
+    const rule = Number.parseFloat(separator?.style["height"] ?? "0");
+    const marginTop = Number.parseFloat(separator?.style["marginTop"] ?? "0");
+    const marginBottom = Number.parseFloat(
+      separator?.style["marginBottom"] ?? "0",
+    );
+    expect(rule + marginTop + marginBottom).toBeCloseTo(
+      FOOTNOTE_SEPARATOR_HEIGHT,
+      5,
+    );
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -7,7 +7,11 @@
 
 import { panic } from "better-result";
 
-import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
+import {
+  FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+  FOOTNOTE_FALLBACK_LINE_HEIGHT,
+  FOOTNOTE_SEPARATOR_HEIGHT,
+} from "../layout-bridge/footnoteLayout";
 import {
   clampFloatingWrapMargins,
   measureParagraph,
@@ -1186,19 +1190,6 @@ function renderHeaderFooterContent(
 
   return containerEl;
 }
-
-/**
- * Per-footnote `marginBottom` painted in `renderFootnoteArea`. Shared so the
- * clamp helper accounts for the same DOM spacing the painter actually draws.
- */
-const FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
-
-/**
- * Fallback footnote line height when no measured structured content is
- * provided. Mirrors `fontSize: 10px` × `lineHeight: 1.3` applied in
- * `renderFootnoteArea` to single-line plain-text footnotes.
- */
-const FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
 
 /**
  * Calculate the painter's actual footnote-area height in pixels:

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -1188,20 +1188,36 @@ function renderHeaderFooterContent(
 }
 
 /**
+ * Per-footnote `marginBottom` painted in `renderFootnoteArea`. Shared so the
+ * clamp helper accounts for the same DOM spacing the painter actually draws.
+ */
+const FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
+
+/**
+ * Fallback footnote line height when no measured structured content is
+ * provided. Mirrors `fontSize: 10px` × `lineHeight: 1.3` applied in
+ * `renderFootnoteArea` to single-line plain-text footnotes.
+ */
+const FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
+
+/**
  * Calculate the painter's actual footnote-area height in pixels:
- * separator slot + the sum of each footnote's measured content height.
- * Used to clamp the paginator's reservation if it under-estimated, so
- * dense stacks never overflow past the page bottom. Mirrors the
- * upstream helper from eigenpal/docx-editor#485.
+ * separator slot + per-footnote content (or fallback line) + per-footnote
+ * `marginBottom` spacing the painter applies in `renderFootnoteArea`. Used
+ * to clamp the paginator's reservation if it under-estimated, so dense
+ * stacks never overflow past the page bottom. Mirrors the upstream helper
+ * from eigenpal/docx-editor#485, extended for folio's fallback rendering
+ * and inter-footnote margin so the helper matches the painted stack.
  */
 export function calculateFootnoteAreaRenderHeight(
   footnotes: FootnoteRenderItem[],
 ): number {
   let height = FOOTNOTE_SEPARATOR_HEIGHT;
   for (const fn of footnotes) {
-    if (fn.content) {
-      height += fn.content.height;
-    }
+    const entryHeight = fn.content
+      ? fn.content.height
+      : FOOTNOTE_FALLBACK_LINE_HEIGHT;
+    height += entryHeight + FOOTNOTE_ENTRY_MARGIN_BOTTOM;
   }
   return height;
 }
@@ -1236,7 +1252,7 @@ export function renderFootnoteArea(
   // Render each footnote
   for (const fn of footnotes) {
     const fnEl = doc.createElement("div");
-    fnEl.style.marginBottom = "4px";
+    fnEl.style.marginBottom = `${FOOTNOTE_ENTRY_MARGIN_BOTTOM}px`;
     fnEl.style.color = "var(--doc-canvas-text, #000)";
 
     if (fn.content) {
@@ -1244,7 +1260,7 @@ export function renderFootnoteArea(
       fnEl.append(contentEl);
     } else {
       fnEl.style.fontSize = "10px";
-      fnEl.style.lineHeight = "1.3";
+      fnEl.style.lineHeight = `${FOOTNOTE_FALLBACK_LINE_HEIGHT / 10}`;
 
       const sup = doc.createElement("sup");
       sup.textContent = fn.displayNumber;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -7,6 +7,7 @@
 
 import { panic } from "better-result";
 
+import { FOOTNOTE_SEPARATOR_HEIGHT } from "../layout-bridge/footnoteLayout";
 import {
   clampFloatingWrapMargins,
   measureParagraph,
@@ -1187,6 +1188,25 @@ function renderHeaderFooterContent(
 }
 
 /**
+ * Calculate the painter's actual footnote-area height in pixels:
+ * separator slot + the sum of each footnote's measured content height.
+ * Used to clamp the paginator's reservation if it under-estimated, so
+ * dense stacks never overflow past the page bottom. Mirrors the
+ * upstream helper from eigenpal/docx-editor#485.
+ */
+export function calculateFootnoteAreaRenderHeight(
+  footnotes: FootnoteRenderItem[],
+): number {
+  let height = FOOTNOTE_SEPARATOR_HEIGHT;
+  for (const fn of footnotes) {
+    if (fn.content) {
+      height += fn.content.height;
+    }
+  }
+  return height;
+}
+
+/**
  * Render the footnote area at the bottom of a page.
  * Includes a separator line (33% width) and footnote entries.
  */
@@ -1200,13 +1220,17 @@ export function renderFootnoteArea(
   container.className = "layout-footnote-area";
   container.style.width = `${contentWidth}px`;
 
-  // Separator line (33% width, Google Docs style)
+  // Separator line (33% width, Google Docs style). Margins derive from
+  // FOOTNOTE_SEPARATOR_HEIGHT so the painted separator slot matches the
+  // paginator's reservation byte-for-byte. eigenpal/docx-editor#485.
   const separator = doc.createElement("div");
+  const separatorRuleHeight = 0.5;
+  const separatorMargin = (FOOTNOTE_SEPARATOR_HEIGHT - separatorRuleHeight) / 2;
   separator.style.width = "33%";
-  separator.style.height = "0.5px";
+  separator.style.height = `${separatorRuleHeight}px`;
   separator.style.backgroundColor = "var(--doc-canvas-text, #000)";
-  separator.style.marginBottom = "6px";
-  separator.style.marginTop = "6px";
+  separator.style.marginTop = `${separatorMargin}px`;
+  separator.style.marginBottom = `${separatorMargin}px`;
   container.append(separator);
 
   // Render each footnote
@@ -1819,12 +1843,20 @@ export function renderPage(
       context,
     );
     fnAreaEl.style.position = "absolute";
-    // Position at page bottom minus bottom margin (bottom of content area)
-    // The reserved height includes separator + all footnotes
-    const reservedHeight = page.footnoteReservedHeight ?? 0;
+    // Position at page bottom minus bottom margin (bottom of content
+    // area). Clamp the reservation upward to the painter's calculated
+    // area height so a dense stack of footnotes that under-reserved by
+    // a few pixels still ends at the page bottom rather than spilling
+    // past it; clamp the resulting top to `-page.margins.top` so an
+    // oversized area cannot escape above the page entirely.
+    // eigenpal/docx-editor#485.
+    const reservedHeight = Math.max(
+      page.footnoteReservedHeight ?? 0,
+      calculateFootnoteAreaRenderHeight(options.footnoteArea),
+    );
     const contentAreaBottom =
       page.size.h - page.margins.bottom - page.margins.top;
-    fnAreaEl.style.top = `${contentAreaBottom - reservedHeight}px`;
+    fnAreaEl.style.top = `${Math.max(-page.margins.top, contentAreaBottom - reservedHeight)}px`;
     fnAreaEl.style.left = "0";
     fnAreaEl.style.right = "0";
     contentEl.append(fnAreaEl);

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -48,6 +48,7 @@ import {
   findHfSlotForTarget,
 } from "../core/layout-bridge/findHfPmSpans";
 import {
+  FOOTNOTE_ENTRY_MARGIN_BOTTOM,
   collectFootnoteRefs,
   buildFootnoteContentMap,
 } from "../core/layout-bridge/footnoteLayout";
@@ -3066,12 +3067,16 @@ export function PagedEditor(
 
           const footnoteHeightById = new Map<number, number>();
           // Per-fn vertical margin applied by the painter
-          // (`renderFootnoteArea` sets `marginBottom: 4px` on each
-          // fn entry). Reserved alongside content height so the page
-          // accounts for inter-fn whitespace.
-          const FOOTNOTE_ENTRY_MARGIN = 4;
+          // (`renderFootnoteArea` sets `marginBottom` on each fn
+          // entry). Reserved alongside content height so the page
+          // accounts for inter-fn whitespace; constant is owned by
+          // `footnoteLayout` so painter, dynamic, and static paths
+          // stay in lockstep.
           for (const [id, content] of footnoteContentMap) {
-            footnoteHeightById.set(id, content.height + FOOTNOTE_ENTRY_MARGIN);
+            footnoteHeightById.set(
+              id,
+              content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
+            );
           }
           // Note: the layout engine adds the divider's height once
           // per fn-bearing page (in paginator.addFootnoteHeight); we


### PR DESCRIPTION
## Summary

Ports the footnote-overflow fix from eigenpal/docx-editor#485 to folio's in-house fork, scoped to the two gaps folio is still missing on top of the WYSIWYG footnote pipeline it already has.

### What changed

1. **Footnote-area safety clamps** (`renderPage.ts`). The renderer now clamps the paginator's reservation upward to the painter's actual area height and clamps the resulting `top` to `-page.margins.top`:

   ```ts
   const reservedHeight = Math.max(
     page.footnoteReservedHeight ?? 0,
     calculateFootnoteAreaRenderHeight(options.footnoteArea),
   );
   fnAreaEl.style.top = `${Math.max(-page.margins.top, contentAreaBottom - reservedHeight)}px`;
   ```

   The outer clamp prevents densely stacked footnotes from spilling past the page bottom when measurement under-reserved by a few pixels. The inner clamp keeps an oversized area from escaping above the page entirely.

2. **Separator-height unification.** Three competing constants (`SEPARATOR_HEIGHT = 12` in the bridge, `FOOTNOTE_SEPARATOR_HEIGHT = 13` in the paginator, and `0.5 + 6 + 6 = 12.5px` effective in the painter) were collapsed into a single `FOOTNOTE_SEPARATOR_HEIGHT = 12` exported from `layout-bridge/footnoteLayout.ts`. The painter now derives the separator's vertical margins from that constant (`(SEP_HEIGHT - rule) / 2`) so the painted slot matches the paginator's reservation byte-for-byte. The paginator re-exports the constant for engine callers that previously imported it locally.

3. **New helper `calculateFootnoteAreaRenderHeight`** (mirrored verbatim from upstream, with attribution).

The existing WYSIWYG footnote pipeline (`renderFootnoteContent`, `FootnoteContent` type, `content?` field on `FootnoteRenderItem`) was already in folio, so no duplication.

## Test plan

- [x] `calculateFootnoteAreaRenderHeight` returns separator height with no measured content
- [x] `calculateFootnoteAreaRenderHeight` sums each measured content height plus a single separator
- [x] Under-reserved height: rendered `top` shifts up so the bottom does not extend past the page
- [x] Oversized footnote area: `top` is clamped to `-page.margins.top`
- [x] Paginator reservation matches painter render height for 1, 3, and 10 footnotes (separator parity)
- [x] Painter separator margins derive from the constant: rule + margins sum to `FOOTNOTE_SEPARATOR_HEIGHT`
- [x] `bun --filter @stll/folio test` — 1010 pass, 0 fail
- [x] `bun --filter @stll/folio typecheck` — pass