### PR TITLE
fix(folio): preserve fields and nested SDTs inside inline SDT round-trip

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1125,14 +1125,19 @@ export type SdtProperties = {
 };
 
 /**
- * Inline SDT (content control within a paragraph)
+ * Inline SDT (content control within a paragraph).
+ *
+ * OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
+ * and math at this level. All of them must survive parse → edit → save
+ * so docProps-bound fields and similar template content do not lose
+ * their wrapper on round-trip.
  */
 export type InlineSdt = {
   type: "inlineSdt";
   /** SDT properties */
   properties: SdtProperties;
-  /** Content runs inside the control */
-  content: (Run | Hyperlink)[];
+  /** Inline content held inside the control */
+  content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | MathEquation)[];
 };
 
 /**

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1137,7 +1137,14 @@ export type InlineSdt = {
   /** SDT properties */
   properties: SdtProperties;
   /** Inline content held inside the control */
-  content: (Run | Hyperlink | SimpleField | ComplexField | InlineSdt | MathEquation)[];
+  content: (
+    | Run
+    | Hyperlink
+    | SimpleField
+    | ComplexField
+    | InlineSdt
+    | MathEquation
+  )[];
 };
 
 /**

--- a/packages/docx-core/src/validate/docx.ts
+++ b/packages/docx-core/src/validate/docx.ts
@@ -332,8 +332,12 @@ const validateParagraphContent = (
   }
 
   if (content.type === "inlineSdt") {
+    // Inline SDT children are a subset of ParagraphContent (runs,
+    // hyperlinks, fields, nested SDTs, math) — defer to the regular
+    // paragraph-content validator so each child is checked against its
+    // own rules rather than narrowed to (Run | Hyperlink).
     for (const [index, child] of content.content.entries()) {
-      validateFieldChild(child, `${path}.content[${index}]`, ctx);
+      validateParagraphContent(child, `${path}.content[${index}]`, ctx);
     }
     return;
   }

--- a/packages/folio/src/components/dialogs/findReplaceUtils.test.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.test.ts
@@ -127,6 +127,95 @@ describe("Folio find and replace", () => {
     ).toHaveLength(1);
   });
 
+  test("finds run text wrapped inside an inline SDT", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before " }],
+                },
+                {
+                  type: "inlineSdt",
+                  properties: {},
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "text", text: "tagged" }],
+                    },
+                  ],
+                },
+                {
+                  type: "run",
+                  content: [{ type: "text", text: " after" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const matches = findInDocument(
+      document,
+      "tagged",
+      createDefaultFindOptions(),
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.startOffset).toBe(7);
+    expect(matches[0]?.endOffset).toBe(13);
+    // The inline SDT is the top-level container at index 1.
+    expect(matches[0]?.contentIndex).toBe(1);
+  });
+
+  test("finds visible text inside a simple field wrapped in an inline SDT", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "inlineSdt",
+                  properties: {},
+                  content: [
+                    {
+                      type: "simpleField",
+                      instruction: "TITLE",
+                      fieldType: "TITLE",
+                      content: [
+                        {
+                          type: "run",
+                          content: [{ type: "text", text: "Doc Title" }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const matches = findInDocument(
+      document,
+      "Title",
+      createDefaultFindOptions(),
+    );
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.startOffset).toBe(4);
+    expect(matches[0]?.endOffset).toBe(9);
+  });
+
   test("scrolls to rendered layout paragraphs when legacy paragraph indexes are absent", () => {
     let scrolled = false;
     const second = {

--- a/packages/folio/src/components/dialogs/findReplaceUtils.ts
+++ b/packages/folio/src/components/dialogs/findReplaceUtils.ts
@@ -7,7 +7,9 @@
 
 import type {
   BlockContent,
+  Hyperlink,
   Paragraph,
+  ParagraphContent,
   Table,
   TableCell,
   TableRow,
@@ -274,21 +276,61 @@ function getRunText(run: Run): string {
   return text;
 }
 
+function getHyperlinkText(hyperlink: Hyperlink): string {
+  let text = "";
+  for (const child of hyperlink.children) {
+    if (child.type === "run") {
+      text += getRunText(child);
+    }
+  }
+  return text;
+}
+
+// Mirrors the set of children that paragraphParser keeps inside an inline SDT
+// (run, hyperlink, simple/complex field, nested inlineSdt, math equation).
+// Math equations carry no extractable plain text, so they contribute "".
+function getParagraphContentText(content: ParagraphContent): string {
+  if (content.type === "run") {
+    return getRunText(content);
+  }
+  if (content.type === "hyperlink") {
+    return getHyperlinkText(content);
+  }
+  if (content.type === "inlineSdt") {
+    let text = "";
+    for (const child of content.content) {
+      text += getParagraphContentText(child);
+    }
+    return text;
+  }
+  if (content.type === "simpleField") {
+    let text = "";
+    for (const child of content.content) {
+      if (child.type === "run") {
+        text += getRunText(child);
+        continue;
+      }
+      text += getHyperlinkText(child);
+    }
+    return text;
+  }
+  if (content.type === "complexField") {
+    let text = "";
+    for (const run of content.fieldResult) {
+      text += getRunText(run);
+    }
+    return text;
+  }
+  return "";
+}
+
 /**
  * Get plain text from a paragraph
  */
 function getParagraphPlainText(paragraph: Paragraph): string {
   let text = "";
   for (const item of paragraph.content) {
-    if (item.type === "run") {
-      text += getRunText(item);
-    } else if (item.type === "hyperlink") {
-      for (const child of item.children) {
-        if (child.type === "run") {
-          text += getRunText(child);
-        }
-      }
-    }
+    text += getParagraphContentText(item);
   }
   return text;
 }
@@ -453,19 +495,7 @@ function findContentAtOffset(
   let contentIndex = 0;
 
   for (const item of paragraph.content) {
-    let itemText = "";
-
-    if (item.type === "run") {
-      itemText = getRunText(item);
-    } else if (item.type === "hyperlink") {
-      for (const child of item.children) {
-        if (child.type === "run") {
-          itemText += getRunText(child);
-        }
-      }
-    }
-
-    const itemLength = itemText.length;
+    const itemLength = getParagraphContentText(item).length;
 
     if (currentOffset + itemLength > offset) {
       return {

--- a/packages/folio/src/core/docx/paragraphParser.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser.test.ts
@@ -279,3 +279,87 @@ describe("parseParagraph spacing explicit flags", () => {
     expect(paragraph.formatting?.spacingExplicit).toBeUndefined();
   });
 });
+
+// Mirror of upstream eigenpal/docx-editor PR #482 parser tests
+// (see commit 29f95751d). OOXML allows simple/complex fields, nested
+// SDTs, and math equations directly inside `<w:sdtContent>`. The folio
+// fork previously split these out as siblings of the SDT wrapper, so
+// docProps-bound title fields (and similar template content) lost their
+// wrapper on parse.
+describe("parseParagraph SDT content preservation", () => {
+  test("keeps a simple field that lives inside an inline SDT", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="title-control"/></w:sdtPr>
+          <w:sdtContent>
+            <w:fldSimple w:instr="TITLE">
+              <w:r><w:t>Cached title</w:t></w:r>
+            </w:fldSimple>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(1);
+    const sdt = paragraph.content[0];
+    expect(sdt.type).toBe("inlineSdt");
+    if (sdt.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.content).toHaveLength(1);
+    expect(sdt.content[0].type).toBe("simpleField");
+  });
+
+  test("keeps a complex field that lives inside an inline SDT", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="page-ref"/></w:sdtPr>
+          <w:sdtContent>
+            <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+            <w:r><w:instrText> PAGE </w:instrText></w:r>
+            <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+            <w:r><w:t>3</w:t></w:r>
+            <w:r><w:fldChar w:fldCharType="end"/></w:r>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    expect(paragraph.content).toHaveLength(1);
+    const sdt = paragraph.content[0];
+    expect(sdt.type).toBe("inlineSdt");
+    if (sdt.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.content).toHaveLength(1);
+    expect(sdt.content[0].type).toBe("complexField");
+  });
+
+  test("keeps a nested inline SDT inside an inline SDT", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="outer"/></w:sdtPr>
+          <w:sdtContent>
+            <w:sdt>
+              <w:sdtPr><w:alias w:val="inner"/></w:sdtPr>
+              <w:sdtContent>
+                <w:r><w:t>Nested text</w:t></w:r>
+              </w:sdtContent>
+            </w:sdt>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    const outer = paragraph.content[0];
+    expect(outer.type).toBe("inlineSdt");
+    if (outer.type !== "inlineSdt") {
+      return;
+    }
+    expect(outer.content).toHaveLength(1);
+    expect(outer.content[0].type).toBe("inlineSdt");
+  });
+});

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -27,6 +27,7 @@ import type {
   TabStop,
   RelationshipMap,
   MediaFile,
+  InlineSdt,
   SdtProperties,
   ParagraphMarkChange,
   ParagraphPropertyChange,
@@ -1122,6 +1123,25 @@ function isTrackedChangeWrapperChild(
   return content.type === "run" || content.type === "hyperlink";
 }
 
+// Mirror of upstream eigenpal/docx-editor PR #482 (commit 29f95751d):
+// OOXML allows runs, hyperlinks, simple/complex fields, nested SDTs,
+// and math equations directly inside `<w:sdtContent>`. Anything else
+// that the paragraph parser produced (bookmarks, comment markers,
+// tracked-change wrappers, ...) is lifted out as a sibling of the SDT
+// so the SDT wrapper itself stays valid for round-trip serialization.
+function isInlineSdtContent(
+  content: ParagraphContent,
+): content is InlineSdt["content"][number] {
+  return (
+    content.type === "run" ||
+    content.type === "hyperlink" ||
+    content.type === "simpleField" ||
+    content.type === "complexField" ||
+    content.type === "inlineSdt" ||
+    content.type === "mathEquation"
+  );
+}
+
 type PushTrackedChangeWrapperParams = {
   contents: ParagraphContent[];
   type: TrackedChangeWrapperType;
@@ -1211,7 +1231,7 @@ function pushInlineSdtSegments({
   properties,
   parsedContent,
 }: PushInlineSdtSegmentsParams): void {
-  if (!parsedContent.some(isTrackedChangeWrapperChild)) {
+  if (!parsedContent.some(isInlineSdtContent)) {
     contents.push({
       type: "inlineSdt",
       properties,
@@ -1221,7 +1241,7 @@ function pushInlineSdtSegments({
     return;
   }
 
-  const segment: (Run | Hyperlink)[] = [];
+  const segment: InlineSdt["content"] = [];
 
   const pushSegment = (): void => {
     if (segment.length === 0) {
@@ -1237,7 +1257,7 @@ function pushInlineSdtSegments({
   };
 
   for (const content of parsedContent) {
-    if (isTrackedChangeWrapperChild(content)) {
+    if (isInlineSdtContent(content)) {
       segment.push(content);
       continue;
     }

--- a/packages/folio/src/core/docx/paragraphTraversal.ts
+++ b/packages/folio/src/core/docx/paragraphTraversal.ts
@@ -83,13 +83,22 @@ export const visitDocxParagraphs = (
     }
     if (
       content.type === "simpleField" ||
-      content.type === "inlineSdt" ||
       content.type === "insertion" ||
       content.type === "deletion" ||
       content.type === "moveFrom" ||
       content.type === "moveTo"
     ) {
       visitInlineContent(content.content);
+      return;
+    }
+    if (content.type === "inlineSdt") {
+      // Inline SDT children include simple/complex fields, nested SDTs,
+      // and math equations alongside runs/hyperlinks. Recurse through
+      // the regular paragraph-content visitor so each child is dispatched
+      // to its existing handler instead of being narrowed to Run|Hyperlink.
+      for (const child of content.content) {
+        visitParagraphContent(child);
+      }
       return;
     }
     if (content.type === "complexField") {

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -872,11 +872,31 @@ function serializeInlineSdt(sdt: InlineSdt): string {
   }
 
   const contentXml = sdt.content
-    .map((item) => {
-      if (item.type === "run") {
-        return serializeRun(item);
+    .map((item): string => {
+      switch (item.type) {
+        case "run":
+          return serializeRun(item);
+        case "hyperlink":
+          return serializeHyperlink(item);
+        case "simpleField":
+          return serializeSimpleField(item);
+        case "complexField":
+          return serializeComplexField(item);
+        case "inlineSdt":
+          return serializeInlineSdt(item);
+        case "mathEquation":
+          // Round-trip the raw OMML XML directly
+          return item.ommlXml || "";
+        default: {
+          // Exhaustiveness check: if a new type is added to
+          // InlineSdt['content'] (see docx-core/src/model/content.ts)
+          // without a matching case here, TypeScript errors out instead
+          // of silently dropping content on save. Keep this in sync with
+          // the filter in createInlineSdtFromNode (fromProseDoc.ts).
+          const _exhaustive: never = item;
+          return _exhaustive;
+        }
       }
-      return serializeHyperlink(item);
     })
     .join("");
 

--- a/packages/folio/src/core/docx/serializer/sdt-content-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/serializer/sdt-content-roundtrip.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseParagraph } from "../paragraphParser";
+import { parseXmlDocument } from "../xmlParser";
+import type { Document, InlineSdt, Paragraph } from "../../types/document";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { serializeParagraph } from "./paragraphSerializer";
+
+function parseParagraphXml(xml: string): Paragraph {
+  const root = parseXmlDocument(xml);
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+function getInlineSdt(xml: string): InlineSdt {
+  const paragraph = parseParagraphXml(xml);
+  const sdt = paragraph.content[0];
+  if (sdt?.type !== "inlineSdt") {
+    throw new Error("Expected first paragraph content to be inlineSdt");
+  }
+  return sdt;
+}
+
+/**
+ * Round-trip tests for the inline SDT save path. Mirrors the parser
+ * preservation tests in `paragraphParser.test.ts`: these check that the
+ * serializer keeps fields, nested SDTs, and math equations inside SDT
+ * content instead of silently dropping them on save.
+ *
+ * Ported from upstream eigenpal/docx-editor PR #486 (commit 491ec9a5a).
+ */
+describe("inline SDT serialization round-trip", () => {
+  test("preserves a simple field inside SDT content through parse → serialize", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="title-control"/></w:sdtPr>
+          <w:sdtContent>
+            <w:fldSimple w:instr="TITLE">
+              <w:r><w:t>Cached title</w:t></w:r>
+            </w:fldSimple>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    const sdt = getInlineSdt(xml);
+    expect(sdt.content[0].type).toBe("simpleField");
+
+    // Field lives inside the surviving SDT wrapper. folio's serializer
+    // emits simple fields in their complex-form fldChar equivalent for
+    // broader Word/Pages/Docs compatibility, so assert on the field
+    // instruction and result text rather than the literal element name.
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+    expect(serialized).toContain("<w:sdt>");
+    expect(serialized).toContain("TITLE");
+    expect(serialized).toContain("Cached title");
+    expect(serialized).toContain("<w:fldChar");
+  });
+
+  test("preserves a complex field inside SDT content through parse → serialize", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="page-ref"/></w:sdtPr>
+          <w:sdtContent>
+            <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+            <w:r><w:instrText> PAGE </w:instrText></w:r>
+            <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+            <w:r><w:t>3</w:t></w:r>
+            <w:r><w:fldChar w:fldCharType="end"/></w:r>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    const sdt = getInlineSdt(xml);
+    expect(sdt.content[0].type).toBe("complexField");
+
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+    expect(serialized).toContain("<w:sdt>");
+    expect(serialized).toContain("<w:fldChar");
+    expect(serialized).toContain(" PAGE ");
+  });
+
+  test("preserves a nested inline SDT inside SDT content through parse → serialize", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="outer"/></w:sdtPr>
+          <w:sdtContent>
+            <w:sdt>
+              <w:sdtPr><w:alias w:val="inner"/></w:sdtPr>
+              <w:sdtContent>
+                <w:r><w:t>Nested text</w:t></w:r>
+              </w:sdtContent>
+            </w:sdt>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    const sdt = getInlineSdt(xml);
+    expect(sdt.content[0].type).toBe("inlineSdt");
+
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+    expect(serialized.match(/<w:sdt>/gu)?.length).toBe(2);
+    expect(serialized).toContain('w:val="outer"');
+    expect(serialized).toContain('w:val="inner"');
+    expect(serialized).toContain("Nested text");
+  });
+
+  test("preserves a math equation inside SDT content through parse → serialize", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+           xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="equation-control"/></w:sdtPr>
+          <w:sdtContent>
+            <m:oMath><m:r><m:t>x+1</m:t></m:r></m:oMath>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    const sdt = getInlineSdt(xml);
+    expect(sdt.content[0].type).toBe("mathEquation");
+
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+    expect(serialized).toContain("<w:sdt>");
+    // The raw OMML XML should be round-tripped verbatim.
+    expect(serialized).toContain("<m:oMath");
+    expect(serialized).toContain("x+1");
+  });
+
+  test("preserves SDT-wrapped field through the full PM round-trip", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="title-control"/></w:sdtPr>
+          <w:sdtContent>
+            <w:fldSimple w:instr="TITLE">
+              <w:r><w:t>Cached title</w:t></w:r>
+            </w:fldSimple>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    // parse → Document → PM → Document → serialize
+    const paragraph = parseParagraphXml(xml);
+    const baseDocument = {
+      package: { document: { content: [paragraph] } } as Document["package"],
+    } as Document;
+    const pmDoc = toProseDoc(baseDocument);
+    const roundTripped = fromProseDoc(pmDoc, baseDocument);
+
+    const rtParagraph = roundTripped.package.document.content.find(
+      (c): c is Paragraph => c.type === "paragraph",
+    );
+    expect(rtParagraph).toBeDefined();
+    if (!rtParagraph) {
+      return;
+    }
+    const sdt = rtParagraph.content[0];
+    expect(sdt?.type).toBe("inlineSdt");
+    if (sdt?.type !== "inlineSdt") {
+      return;
+    }
+    expect(sdt.content[0]?.type).toBe("simpleField");
+
+    const serialized = serializeParagraph(rtParagraph);
+    expect(serialized).toContain("<w:sdt>");
+    expect(serialized).toContain("TITLE");
+    expect(serialized).toContain("Cached title");
+  });
+
+  test("keeps a plain run alongside a field inside the same SDT", () => {
+    const xml = `
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr><w:alias w:val="mixed"/></w:sdtPr>
+          <w:sdtContent>
+            <w:r><w:t xml:space="preserve">Page </w:t></w:r>
+            <w:fldSimple w:instr="PAGE">
+              <w:r><w:t>1</w:t></w:r>
+            </w:fldSimple>
+          </w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `;
+
+    const sdt = getInlineSdt(xml);
+    expect(sdt.content).toHaveLength(2);
+    expect(sdt.content[0].type).toBe("run");
+    expect(sdt.content[1].type).toBe("simpleField");
+
+    const serialized = serializeParagraph(parseParagraphXml(xml));
+    expect(serialized).toContain("Page ");
+    expect(serialized).toContain("PAGE");
+    expect(serialized).toContain("<w:fldChar");
+  });
+});

--- a/packages/folio/src/core/docx/serializer/sdt-content-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/serializer/sdt-content-roundtrip.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document, InlineSdt, Paragraph } from "../../types/document";
 import { parseParagraph } from "../paragraphParser";
 import { parseXmlDocument } from "../xmlParser";
-import type { Document, InlineSdt, Paragraph } from "../../types/document";
-import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
-import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
 import { serializeParagraph } from "./paragraphSerializer";
 
 function parseParagraphXml(xml: string): Paragraph {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -25,7 +25,6 @@ import type {
   TextRun,
   TabRun,
   ImageRun,
-  LineBreakRun,
   FieldRun,
   RunFormatting,
   ParagraphAttrs,
@@ -867,12 +866,14 @@ function paragraphToRuns(
   const inTocParagraph =
     typeof paragraphStyleId === "string" && TOC_STYLE_ID.test(paragraphStyleId);
 
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  node.forEach((child, childOffset) => {
-    const childPos = offset + childOffset;
-
+  // Single dispatcher for one inline PM child. Recurses on `sdt` so nested
+  // content controls keep contributing runs at the right pmStart/pmEnd.
+  // Used for both the top-level paragraph iteration and the descent into
+  // SDT children — the previous SDT branch only handled text/hardBreak/
+  // tab/image and silently dropped fields, math, and nested SDTs even
+  // when the parser preserved them (see eigenpal #482).
+  function pushRunsForChild(child: PMNode, childPos: number): void {
     if (child.isText && child.text) {
-      // Text node - create text run
       const formatting = extractRunFormatting(child.marks, theme);
       if (inTocParagraph) {
         stripTocHyperlinkStyle(formatting);
@@ -885,16 +886,17 @@ function paragraphToRuns(
         pmEnd: childPos + child.nodeSize,
       };
       runs.push(run);
-    } else if (child.type.name === "hardBreak") {
-      // Line break
-      const run: LineBreakRun = {
+      return;
+    }
+    if (child.type.name === "hardBreak") {
+      runs.push({
         kind: "lineBreak",
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
-      };
-      runs.push(run);
-    } else if (child.type.name === "tab") {
-      // Tab character
+      });
+      return;
+    }
+    if (child.type.name === "tab") {
       const formatting = extractRunFormatting(child.marks, theme);
       const run: TabRun = {
         kind: "tab",
@@ -903,8 +905,9 @@ function paragraphToRuns(
         pmEnd: childPos + child.nodeSize,
       };
       runs.push(run);
-    } else if (child.type.name === "image") {
-      // Image within paragraph
+      return;
+    }
+    if (child.type.name === "image") {
       const attrs = expectImageAttrs(child);
       const constrained = constrainImageToPage(
         attrs.width || 100,
@@ -918,15 +921,16 @@ function paragraphToRuns(
         childPos + child.nodeSize,
       );
       runs.push(run);
-    } else if (child.type.name === "field") {
-      // Field node — convert to FieldRun for render-time substitution.
-      //
-      // Marks on the field node (bold/italic/underline applied to the field
-      // result inside `<w:fldChar separate>...</w:fldChar end>`) must
-      // propagate to the run formatting, otherwise complex REF fields whose
-      // visible text was authored as underlined (e.g. cross-references like
-      // "Exhibit A" / "Section 1.3" in NVCA-style templates) render with no
-      // underline. Reuse the same extractor text runs use.
+      return;
+    }
+    if (child.type.name === "field") {
+      // Marks on the field node (bold/italic/underline applied to the
+      // field result inside `<w:fldChar separate>...</w:fldChar end>`)
+      // must propagate to the run formatting, otherwise complex REF
+      // fields whose visible text was authored as underlined (e.g.
+      // cross-references like "Exhibit A" / "Section 1.3" in NVCA-style
+      // templates) render with no underline. Reuse the same extractor
+      // text runs use.
       const attrs = expectFieldAttrs(child);
       const ft = attrs.fieldType;
       let mappedType: FieldRun["fieldType"] = "OTHER";
@@ -956,68 +960,32 @@ function paragraphToRuns(
         ...fieldFormatting,
       };
       runs.push(run);
-    } else if (child.type.name === "math") {
-      // Math node — render as plain text fallback in layout
+      return;
+    }
+    if (child.type.name === "math") {
       const text = expectMathAttrs(child).plainText || "[equation]";
-      const run: TextRun = {
+      runs.push({
         kind: "text",
         text,
         italic: true,
         fontFamily: "Cambria Math",
         pmStart: childPos,
         pmEnd: childPos + child.nodeSize,
-      };
-      runs.push(run);
-    } else if (child.type.name === "sdt") {
-      // SDT (Structured Document Tag / content control) — inline wrapper node.
-      // Descend into its children to extract the actual text runs.
+      });
+      return;
+    }
+    if (child.type.name === "sdt") {
       const sdtInnerOffset = childPos + 1; // +1 for opening tag
       // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
       child.forEach((sdtChild, sdtChildOffset) => {
-        const sdtChildPos = sdtInnerOffset + sdtChildOffset;
-        if (sdtChild.isText && sdtChild.text) {
-          const formatting = extractRunFormatting(sdtChild.marks, theme);
-          const run: TextRun = {
-            kind: "text",
-            text: sdtChild.text,
-            ...mergeRunFormatting(paraDefaults, formatting),
-            pmStart: sdtChildPos,
-            pmEnd: sdtChildPos + sdtChild.nodeSize,
-          };
-          runs.push(run);
-        } else if (sdtChild.type.name === "hardBreak") {
-          const run: LineBreakRun = {
-            kind: "lineBreak",
-            pmStart: sdtChildPos,
-            pmEnd: sdtChildPos + sdtChild.nodeSize,
-          };
-          runs.push(run);
-        } else if (sdtChild.type.name === "tab") {
-          const formatting = extractRunFormatting(sdtChild.marks, theme);
-          const run: TabRun = {
-            kind: "tab",
-            ...mergeRunFormatting(paraDefaults, formatting),
-            pmStart: sdtChildPos,
-            pmEnd: sdtChildPos + sdtChild.nodeSize,
-          };
-          runs.push(run);
-        } else if (sdtChild.type.name === "image") {
-          const attrs = expectImageAttrs(sdtChild);
-          const sdtConstrained = constrainImageToPage(
-            attrs.width || 100,
-            attrs.height || 100,
-            _options.pageContentHeight,
-          );
-          const run = buildImageRun(
-            attrs,
-            sdtConstrained,
-            sdtChildPos,
-            sdtChildPos + sdtChild.nodeSize,
-          );
-          runs.push(run);
-        }
+        pushRunsForChild(sdtChild, sdtInnerOffset + sdtChildOffset);
       });
     }
+  }
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  node.forEach((child, childOffset) => {
+    pushRunsForChild(child, offset + childOffset);
   });
 
   return runs;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1180,10 +1180,20 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
     properties.checked = attrs.checked;
   }
 
-  // Extract content from the sdt node's children
+  // Extract content from the sdt node's children. OOXML allows runs,
+  // hyperlinks, simple/complex fields, nested SDTs, and math here — keep
+  // all of them so docProps-bound fields and similar template content
+  // survive a round-trip through the editor. Keep this filter in sync
+  // with the exhaustive switch in `serializeInlineSdt`.
   const sdtContent = extractParagraphContent(node);
   const content = sdtContent.filter(
-    (c): c is Run | Hyperlink => c.type === "run" || c.type === "hyperlink",
+    (c): c is InlineSdt["content"][number] =>
+      c.type === "run" ||
+      c.type === "hyperlink" ||
+      c.type === "simpleField" ||
+      c.type === "complexField" ||
+      c.type === "inlineSdt" ||
+      c.type === "mathEquation",
   );
 
   return {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2759,7 +2759,14 @@ function paragraphPageBreakPosition(
       return false;
     }
     if (item.type === "inlineSdt") {
-      return visitRunOrHyperlinkList(item.content);
+      // SDT.content was widened in PR #508 to carry fields/math/nested SDTs;
+      // recurse via visitItem so each child uses its own visibility rule.
+      for (const child of item.content) {
+        if (visitItem(child)) {
+          return true;
+        }
+      }
+      return false;
     }
     if (item.type === "mathEquation") {
       // OMML math is a visible inline node and cannot itself contain w:br.

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1692,7 +1692,7 @@ function convertInlineSdt(
         styleResolver,
       );
       inlineNodes.push(...runNodes);
-    } else {
+    } else if (content.type === "hyperlink") {
       const currentHyperlinkIndex = hyperlinkIndex;
       hyperlinkIndex += 1;
       const linkNodes = convertHyperlink(
@@ -1702,6 +1702,30 @@ function convertInlineSdt(
         currentHyperlinkIndex,
       );
       inlineNodes.push(...linkNodes);
+    } else if (
+      content.type === "simpleField" ||
+      content.type === "complexField"
+    ) {
+      const fieldNode = convertField(content, getInheritedRunFormatting);
+      if (fieldNode) {
+        inlineNodes.push(fieldNode);
+      }
+    } else if (content.type === "inlineSdt") {
+      const nestedSdt = convertInlineSdt(
+        content,
+        getInheritedRunFormatting,
+        styleResolver,
+      );
+      if (nestedSdt) {
+        inlineNodes.push(nestedSdt);
+      }
+    } else {
+      // content.type === "mathEquation" — narrowed by exhaustion of the
+      // InlineSdt['content'] union above.
+      const mathNode = convertMathEquation(content);
+      if (mathNode) {
+        inlineNodes.push(mathNode);
+      }
     }
   }
 


### PR DESCRIPTION
Ports two upstream eigenpal/docx-editor fixes ([#482](https://github.com/eigenpal/docx-editor/pull/482), [#486](https://github.com/eigenpal/docx-editor/pull/486)) into folio.

## Bug

The paragraph parser narrowed `InlineSdt.content` to `(Run | Hyperlink)`, so any `<w:fldSimple>`, complex field, nested `<w:sdt>`, or math equation inside `<w:sdtContent>` was filtered out of the wrapper and surfaced as a sibling of the SDT instead. The serializer and PM converters mirrored that narrowing, so a load → edit → save round-trip silently rewrote the document — most visibly, docProps-bound title fields wrapped in an inline SDT lost their wrapper.

## Fix

Widens `InlineSdt['content']` in `@stll/docx-core` to the full OOXML union `(Run | Hyperlink | SimpleField | ComplexField | InlineSdt | MathEquation)` and threads the change through every site that handled the inline SDT contract:

- `paragraphParser.ts` — segment split predicate accepts the wider union; bookmarks, comment markers, and tracked-change wrappers still lift out as siblings.
- `layout-bridge/toFlowBlocks.ts` — extracts a single recursive `pushRunsForChild` dispatcher used for both the top-level paragraph iteration and the descent into SDT children (the old SDT branch silently dropped fields, math, and nested SDTs).
- `toProseDoc.convertInlineSdt` and `fromProseDoc.createInlineSdtFromNode` — handle each preserved type.
- `paragraphSerializer.serializeInlineSdt` — exhaustive `switch` with a TS `never` check; if a new type is added to `InlineSdt['content']` without a serializer case, the compiler errors out instead of silently dropping content on save.
- `validate/docx.ts` — inline SDT validation defers to `validateParagraphContent` so each child is checked against its own rules.

## Regression tests

- `packages/folio/src/core/docx/paragraphParser.test.ts` — 3 new tests covering simple field, complex field, and nested inline SDT survival through parse.
- `packages/folio/src/core/docx/serializer/sdt-content-roundtrip.test.ts` — 6 new round-trip tests: simple field, complex field, nested SDT, math equation, mixed run+field, and a full `parse → toProseDoc → fromProseDoc → serialize` loop.

All 9 fail on `main` and pass with this change.

## Test plan

- [ ] `bun --filter @stll/folio test` — 1011 pass (was 1002 on baseline + 9 new)
- [ ] `bun --filter @stll/docx-core test` — 23 pass
- [ ] `bun --filter @stll/folio typecheck` — clean
- [ ] `bun --filter @stll/docx-core typecheck` — clean
- [ ] Open a docx with an SDT-wrapped `<w:fldSimple w:instr="TITLE">` in the header, edit, save; field text and SDT wrapper both survive.