### PR TITLE
fix(folio): emit page break in break-only paragraphs (eigenpal #409)

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+
+import type { Document } from "../../types/document";
+import { toProseDoc } from "./toProseDoc";
+
+function childTypeNames(pmDoc: ReturnType<typeof toProseDoc>): string[] {
+  const names: string[] = [];
+  for (let i = 0; i < pmDoc.childCount; i++) {
+    names.push(pmDoc.child(i).type.name);
+  }
+  return names;
+}
+
+describe('toProseDoc — hard page break (`<w:br w:type="page"/>`)', () => {
+  test("emits pageBreak for a paragraph whose only run content is a page break", () => {
+    // <w:p><w:r><w:br w:type="page"/></w:r></w:p>
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "break", breakType: "page" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toContain("pageBreak");
+  });
+
+  test("emits pageBreak after text for a paragraph with text followed by a break", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "text", text: "Before" },
+                    { type: "break", breakType: "page" },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toEqual([
+      "paragraph",
+      "pageBreak",
+      "paragraph",
+    ]);
+  });
+
+  test("emits pageBreak when the break sits inside a hyperlink wrapper", () => {
+    // <w:p><w:hyperlink><w:r><w:br w:type="page"/></w:r></w:hyperlink></w:p>
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  url: "https://example.com",
+                  children: [
+                    {
+                      type: "run",
+                      content: [{ type: "break", breakType: "page" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toContain("pageBreak");
+  });
+
+  test("emits pageBreak when the break sits inside a tracked-change wrapper", () => {
+    // <w:p><w:ins><w:r><w:br w:type="page"/></w:r></w:ins></w:p>
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "insertion",
+                  info: {
+                    id: 1,
+                    author: "Author",
+                    date: "2026-01-01T00:00:00Z",
+                  },
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "break", breakType: "page" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toContain("pageBreak");
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts
@@ -141,6 +141,189 @@ describe('toProseDoc — hard page break (`<w:br w:type="page"/>`)', () => {
     expect(childTypeNames(pmDoc)).toContain("pageBreak");
   });
 
+  test("emits pageBreak when the break sits inside an inlineSdt wrapper", () => {
+    // <w:p><w:sdt><w:sdtContent><w:r><w:br w:type="page"/></w:r></w:sdtContent></w:sdt></w:p>
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "inlineSdt",
+                  properties: { sdtType: "richText" },
+                  content: [
+                    {
+                      type: "run",
+                      content: [{ type: "break", breakType: "page" }],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toContain("pageBreak");
+  });
+
+  test('classifies a break after a softHyphen as "after"', () => {
+    // <w:p><w:r><w:softHyphen/><w:br w:type="page"/></w:r></w:p>
+    // The soft hyphen is visible run content, so the break belongs after the
+    // paragraph (paragraph stays on the current page, next block starts new).
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    { type: "softHyphen" },
+                    { type: "break", breakType: "page" },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toEqual([
+      "paragraph",
+      "pageBreak",
+      "paragraph",
+    ]);
+  });
+
+  test('classifies a break after a mathEquation as "after"', () => {
+    // Math equation is visible inline content; a subsequent break sits "after".
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "mathEquation",
+                  display: "inline",
+                  ommlXml: "<m:oMath/>",
+                },
+                {
+                  type: "run",
+                  content: [{ type: "break", breakType: "page" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "After" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    expect(childTypeNames(pmDoc)).toEqual([
+      "paragraph",
+      "pageBreak",
+      "paragraph",
+    ]);
+  });
+
+  test('classifies a break after an empty hyperlink as "before"', () => {
+    // <w:p><w:hyperlink/><w:r><w:br w:type="page"/></w:r><w:r><w:t>x</w:t></w:r></w:p>
+    // Empty hyperlinks (bookmark-only or round-trip placeholders) carry no
+    // visible content, so the break must still classify as "before" and the
+    // following text belongs on the next page.
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "Before" }],
+                },
+              ],
+            },
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "hyperlink",
+                  url: "https://example.com",
+                  children: [],
+                },
+                {
+                  type: "run",
+                  content: [{ type: "break", breakType: "page" }],
+                },
+                {
+                  type: "run",
+                  content: [{ type: "text", text: "AfterBreak" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    const names = childTypeNames(pmDoc);
+    // pageBreak must appear BEFORE the paragraph containing "AfterBreak"
+    const pageBreakIndex = names.indexOf("pageBreak");
+    expect(pageBreakIndex).toBeGreaterThan(-1);
+    // The trailing paragraph (with "AfterBreak") must come after the break.
+    expect(pageBreakIndex).toBeLessThan(names.length - 1);
+    expect(names[pageBreakIndex + 1]).toBe("paragraph");
+  });
+
   test("emits pageBreak when the break sits inside a tracked-change wrapper", () => {
     // <w:p><w:ins><w:r><w:br w:type="page"/></w:r></w:ins></w:p>
     const document: Document = {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2609,27 +2609,128 @@ export function footnoteToProseDoc(
 /**
  * Determine where a page break appears inside a paragraph.
  *
+ * Per ECMA-376 §17.3.3.1, `<w:br w:type="page"/>` is always a forced break,
+ * including in a paragraph whose only content is the break itself. We previously
+ * searched only top-level runs and missed breaks nested in hyperlinks, tracked
+ * changes, or fields — so those paragraphs silently dropped their forced break
+ * and the following content collapsed onto the previous page (common on legal
+ * signature pages and exhibit covers).
+ * See eigenpal docx-editor #409 (break-only page break sub-fix).
+ *
  * Returns:
- *   "before" — the break is at the very start (before any text); the
- *              paragraph's text belongs on the NEXT page.
- *   "after"  — the break is after some text (or the paragraph is empty);
- *              the paragraph stays on the current page.
+ *   "before" — the break appears before any visible content; the paragraph's
+ *              content belongs on the NEXT page.
+ *   "after"  — the break follows some visible content; the paragraph stays
+ *              on the current page and the next block starts a new page.
  *   null     — no page break found.
  */
 function paragraphPageBreakPosition(
   paragraph: Paragraph,
 ): "before" | "after" | null {
-  let seenText = false;
-  for (const item of paragraph.content) {
+  // Mutated by visitRun during traversal. oxlint flow analysis can't see
+  // closure mutations, so a plain `let` here trips no-unnecessary-condition;
+  // wrap in an object to keep the flag genuinely opaque to the linter.
+  const state = { seenVisibleContent: false };
+
+  function isPageBreak(content: RunContent): boolean {
+    return content.type === "break" && content.breakType === "page";
+  }
+
+  function isVisibleRunContent(content: RunContent): boolean {
+    return (
+      (content.type === "text" && content.text.length > 0) ||
+      content.type === "tab" ||
+      content.type === "drawing" ||
+      content.type === "shape" ||
+      content.type === "symbol" ||
+      content.type === "fieldChar" ||
+      content.type === "instrText" ||
+      content.type === "footnoteRef" ||
+      content.type === "endnoteRef"
+    );
+  }
+
+  function visitRun(run: Run): boolean {
+    for (const content of run.content) {
+      if (isPageBreak(content)) {
+        return true;
+      }
+      if (isVisibleRunContent(content)) {
+        state.seenVisibleContent = true;
+      }
+    }
+    return false;
+  }
+
+  function visitItem(item: Paragraph["content"][number]): boolean {
     if (item.type === "run") {
-      for (const content of (item as Run).content) {
-        if (content.type === "break" && content.breakType === "page") {
-          return seenText ? "after" : "before";
-        }
-        if (content.type === "text" && content.text) {
-          seenText = true;
+      return visitRun(item);
+    }
+    if (item.type === "hyperlink") {
+      for (const child of (item as Hyperlink).children) {
+        if (child.type === "run" && visitRun(child)) {
+          return true;
         }
       }
+      // Hyperlink with non-break content is visible context for any later break.
+      state.seenVisibleContent = true;
+      return false;
+    }
+    if (
+      item.type === "insertion" ||
+      item.type === "deletion" ||
+      item.type === "moveFrom" ||
+      item.type === "moveTo"
+    ) {
+      // Tracked-change wrappers can themselves contain a page break.
+      const wrapper = item as Insertion | Deletion | MoveFrom | MoveTo;
+      for (const inner of wrapper.content) {
+        if (inner.type === "run" && visitRun(inner)) {
+          return true;
+        }
+        if (inner.type === "hyperlink") {
+          for (const child of inner.children) {
+            if (child.type === "run" && visitRun(child)) {
+              return true;
+            }
+          }
+        }
+      }
+      return false;
+    }
+    if (item.type === "simpleField") {
+      for (const inner of (item as SimpleField).content) {
+        if (inner.type === "run" && visitRun(inner)) {
+          return true;
+        }
+        if (inner.type === "hyperlink") {
+          for (const child of inner.children) {
+            if (child.type === "run" && visitRun(child)) {
+              return true;
+            }
+          }
+        }
+      }
+      // Field result (page number, date, etc.) is visible content.
+      state.seenVisibleContent = true;
+      return false;
+    }
+    if (item.type === "complexField") {
+      for (const run of (item as ComplexField).fieldResult) {
+        if (visitRun(run)) {
+          return true;
+        }
+      }
+      // Field result is visible content.
+      state.seenVisibleContent = true;
+      return false;
+    }
+    return false;
+  }
+
+  for (const item of paragraph.content) {
+    if (visitItem(item)) {
+      return state.seenVisibleContent ? "after" : "before";
     }
   }
   return null;

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2646,7 +2646,9 @@ function paragraphPageBreakPosition(
       content.type === "fieldChar" ||
       content.type === "instrText" ||
       content.type === "footnoteRef" ||
-      content.type === "endnoteRef"
+      content.type === "endnoteRef" ||
+      content.type === "noBreakHyphen" ||
+      content.type === "softHyphen"
     );
   }
 
@@ -2662,19 +2664,41 @@ function paragraphPageBreakPosition(
     return false;
   }
 
+  // Walk a hyperlink's children — runs (which may carry the break) plus
+  // bookmark markers we ignore. Mirrors the inner shape of `Hyperlink`.
+  function visitHyperlinkChildren(hyperlink: Hyperlink): boolean {
+    for (const child of hyperlink.children) {
+      if (child.type === "run" && visitRun(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Walk a (Run | Hyperlink)[] list — the shared inner shape of tracked-change
+  // wrappers, simple fields, and inline SDTs. We rely on visitRun to set
+  // state.seenVisibleContent when (and only when) it encounters visible run
+  // content; an empty wrapper must not be treated as visible — an empty
+  // bookmark-only hyperlink before a page break should still classify the
+  // break as "before".
+  function visitRunOrHyperlinkList(children: (Run | Hyperlink)[]): boolean {
+    for (const child of children) {
+      if (child.type === "run" && visitRun(child)) {
+        return true;
+      }
+      if (child.type === "hyperlink" && visitHyperlinkChildren(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   function visitItem(item: Paragraph["content"][number]): boolean {
     if (item.type === "run") {
       return visitRun(item);
     }
     if (item.type === "hyperlink") {
-      for (const child of (item as Hyperlink).children) {
-        if (child.type === "run" && visitRun(child)) {
-          return true;
-        }
-      }
-      // Hyperlink with non-break content is visible context for any later break.
-      state.seenVisibleContent = true;
-      return false;
+      return visitHyperlinkChildren(item);
     }
     if (
       item.type === "insertion" ||
@@ -2682,46 +2706,24 @@ function paragraphPageBreakPosition(
       item.type === "moveFrom" ||
       item.type === "moveTo"
     ) {
-      // Tracked-change wrappers can themselves contain a page break.
-      const wrapper = item as Insertion | Deletion | MoveFrom | MoveTo;
-      for (const inner of wrapper.content) {
-        if (inner.type === "run" && visitRun(inner)) {
-          return true;
-        }
-        if (inner.type === "hyperlink") {
-          for (const child of inner.children) {
-            if (child.type === "run" && visitRun(child)) {
-              return true;
-            }
-          }
-        }
-      }
-      return false;
+      return visitRunOrHyperlinkList(item.content);
     }
     if (item.type === "simpleField") {
-      for (const inner of (item as SimpleField).content) {
-        if (inner.type === "run" && visitRun(inner)) {
-          return true;
-        }
-        if (inner.type === "hyperlink") {
-          for (const child of inner.children) {
-            if (child.type === "run" && visitRun(child)) {
-              return true;
-            }
-          }
-        }
-      }
-      // Field result (page number, date, etc.) is visible content.
-      state.seenVisibleContent = true;
-      return false;
+      return visitRunOrHyperlinkList(item.content);
     }
     if (item.type === "complexField") {
-      for (const run of (item as ComplexField).fieldResult) {
+      for (const run of item.fieldResult) {
         if (visitRun(run)) {
           return true;
         }
       }
-      // Field result is visible content.
+      return false;
+    }
+    if (item.type === "inlineSdt") {
+      return visitRunOrHyperlinkList(item.content);
+    }
+    if (item.type === "mathEquation") {
+      // OMML math is a visible inline node and cannot itself contain w:br.
       state.seenVisibleContent = true;
       return false;
     }


### PR DESCRIPTION
## Summary

Ports the **break-only page break** sub-fix from upstream eigenpal/docx-editor #409 (sha 4e194d7b6).

### Bug

Per ECMA-376 §17.3.3.1, `<w:br w:type="page"/>` is always a forced break, including in a paragraph whose only content is the break itself. In `paragraphPageBreakPosition()` we only searched top-level runs, so a hard page break nested inside a hyperlink, tracked-change wrapper (`w:ins` / `w:del` / `w:moveFrom` / `w:moveTo`), or field (`w:fldSimple` / `w:fldChar`) was silently dropped — the following content collapsed onto the previous page.

This is common in legal documents (signature pages, exhibit covers, table-of-authorities separators) and any paragraph where the break sits inside one of those wrappers.

### Fix

Walk the full paragraph-content tree and treat any hard page break as a forced break regardless of whether visible content precedes it. The existing positional semantics (`"before"` vs `"after"`) are preserved so the caller still emits the `pageBreak` PM node on the correct side of the paragraph.

### Tests

Added `packages/folio/src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts` with four cases:
- Break-only paragraph (the bug)
- Break after text (existing happy path; guard against regression)
- Break nested in a hyperlink wrapper
- Break nested in a tracked-change (`w:ins`) wrapper

All four were red before the fix; all four pass now. Full `@stll/folio` suite: 1006/1006.

### Follow-ups (other #409 sub-fixes)

- **Inline-image clipping** — **NOT ported**. `renderParagraph.ts:551` still sets `verticalAlign = "middle"`; upstream pins it to `"top"`. Worth a separate PR.
- **Top-of-page `spaceBefore`** — **already effectively ported**. `paginator.ts:336-340` uses the explicit `spaceBefore` (not zero) when crossing into a new page/column, matching upstream's intent.

## Test plan

- [x] `bun --filter @stll/folio test src/core/prosemirror/conversion/toProseDoc-pagebreak.test.ts` (4/4 pass)
- [x] `bun --filter @stll/folio test` (1006/1006 pass)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio format`