### PR TITLE
fix(folio): unify tab-stop layout (eigenpal #576)

### DIFF
--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-decimal-tab.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-decimal-tab.test.ts
@@ -1,0 +1,302 @@
+// Regression tests for the bot review on PR #512 (eigenpal #576).
+//
+// Issues covered:
+// 1. measurer must pass `decimalPrefixWidth` to `calculateTabWidth` so it
+//    agrees with the painter on decimal tab advance (gemini HIGH on
+//    measureParagraph.ts:831).
+// 2. `measureInlineWidthAfterTab` must honour all RunFormatting fields on
+//    a trailing FieldRun (gemini medium on measureParagraph.ts:309).
+// 3. `measureInlineWidthAfterTab` must skip floating/anchored images, since
+//    the painter lifts them out of the paragraph flow and only counts
+//    `!isFloatingImageRun(run)` (codex P2 on measureParagraph.ts:305).
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  calculateTabWidth,
+  type TabContext,
+} from "../../prosemirror/utils/tabCalculator";
+import { clearAllCaches } from "./cache";
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+// Mirrors the fake used by the sibling test files: 5px per lowercase glyph,
+// 10px per uppercase glyph. The fake ignores font size, which is fine for
+// the decimal-prefix tests below — `calculateTabWidth` only cares about
+// pixel widths, and the measurer-vs-painter agreement check builds the
+// painter side with the same fake.
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(this: { font: string }, text: string) {
+              let width = 0;
+              for (const char of text) {
+                const isUppercase = char >= "A" && char <= "Z";
+                width += isUppercase ? 10 : 5;
+              }
+              return {
+                width,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    clearAllCaches();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+describe("measureParagraph — decimal tab stop (PR #512 gemini HIGH)", () => {
+  test("decimal tab measurer matches painter (decimalPrefixWidth threaded)", () => {
+    // Decimal stop at 3000 twips (200px). Text "12.34" follows the tab —
+    // the painter aligns "12" left of the stop and "34" right of it via
+    // `decimalPrefixWidth`. With the bug, the measurer omits that argument
+    // and computes the tab as if the whole "12.34" anchored at the stop.
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "decimal-tab",
+        runs: [
+          { kind: "text" as const, text: "x", fontSize: 11 },
+          { kind: "tab" as const },
+          { kind: "text" as const, text: "12.34", fontSize: 11 },
+        ],
+        attrs: {
+          tabs: [{ val: "decimal" as const, pos: 3000 }],
+        },
+      };
+
+      const measure = measureParagraph(block, 400);
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+
+      // What the painter would compute end-to-end at this position.
+      // currentX after "x" = 5px. Following width = "12.34" = 25px.
+      // Decimal prefix = "12" = 10px.
+      const leadingWidth = 5;
+      const followingWidth = 25;
+      const decimalPrefixWidth = 10;
+      const tabContext: TabContext = {
+        explicitStops: [{ val: "decimal", pos: 3000 }],
+      };
+      const tabResult = calculateTabWidth(leadingWidth, tabContext, {
+        followingWidth,
+        decimalPrefixWidth,
+      });
+      const painterLineWidth = leadingWidth + tabResult.width + followingWidth;
+
+      expect(
+        Math.abs((line?.width ?? 0) - painterLineWidth),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+
+  test("decimal tab without a decimal point falls back to left-tab math", () => {
+    // No "." in the trailing content → `decimalPrefixWidth` is 0, so the
+    // tab advances to the stop and the line width is leading + (stop -
+    // leading) + trailing = stop + trailing.
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "decimal-tab-noint",
+        runs: [
+          { kind: "text" as const, text: "x", fontSize: 11 },
+          { kind: "tab" as const },
+          { kind: "text" as const, text: "abc", fontSize: 11 },
+        ],
+        attrs: {
+          tabs: [{ val: "decimal" as const, pos: 3000 }],
+        },
+      };
+
+      const measure = measureParagraph(block, 400);
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+      // Stop is 200px from origin; trailing "abc" = 15px. Total ≈ 215px.
+      expect(line?.width ?? 0).toBeGreaterThan(210);
+      expect(line?.width ?? 0).toBeLessThan(220);
+    });
+  });
+});
+
+describe("measureInlineWidthAfterTab — formatting parity (PR #512 gemini medium)", () => {
+  test("field run with bold/italic measures the same as a styled text run", () => {
+    // Two paragraphs: one with a styled TextRun after the tab, one with the
+    // same fallback text inside a styled FieldRun. The measured line widths
+    // must agree — the previous code hand-rolled `style` for fields and
+    // dropped formatting, so a bold field would measure narrower than a bold
+    // text run with identical glyphs.
+    withFakeTextMeasure(() => {
+      const baseAttrs = { tabs: [{ val: "end" as const, pos: 5000 }] };
+
+      const textBlock = {
+        kind: "paragraph" as const,
+        id: "tab-text",
+        runs: [
+          { kind: "text" as const, text: "Hi", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "text" as const,
+            text: "PAGE",
+            fontSize: 11,
+            bold: true,
+            italic: true,
+          },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const fieldBlock = {
+        kind: "paragraph" as const,
+        id: "tab-field",
+        runs: [
+          { kind: "text" as const, text: "Hi", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "field" as const,
+            fieldType: "OTHER" as const,
+            fallback: "PAGE",
+            fontSize: 11,
+            bold: true,
+            italic: true,
+          },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const textMeasure = measureParagraph(textBlock, 400);
+      const fieldMeasure = measureParagraph(fieldBlock, 400);
+      const textLine = textMeasure.lines.at(0);
+      const fieldLine = fieldMeasure.lines.at(0);
+      expect(textLine).toBeDefined();
+      expect(fieldLine).toBeDefined();
+      expect(
+        Math.abs((textLine?.width ?? 0) - (fieldLine?.width ?? 0)),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+});
+
+describe("measureInlineWidthAfterTab — floating images (PR #512 codex P2)", () => {
+  test("a floating image after a right tab does not contribute to following width", () => {
+    // With the bug, the inline-width helper counts the floating image's
+    // `width` (300px) toward the right-tab anchor's trailing-width budget,
+    // shrinking the tab advance even though the painter lifts the image out
+    // of the line. Compare against a paragraph with NO image — the line
+    // widths should match because both have the same inline content
+    // (the title text only).
+    withFakeTextMeasure(() => {
+      const baseAttrs = { tabs: [{ val: "end" as const, pos: 5000 }] };
+
+      const withFloat = {
+        kind: "paragraph" as const,
+        id: "tab-float",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "image" as const,
+            src: "img.png",
+            width: 300,
+            height: 100,
+            wrapType: "square" as const,
+          },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const withoutFloat = {
+        kind: "paragraph" as const,
+        id: "tab-nofloat",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const a = measureParagraph(withFloat, 400);
+      const b = measureParagraph(withoutFloat, 400);
+      const lineA = a.lines.at(0);
+      const lineB = b.lines.at(0);
+      expect(lineA).toBeDefined();
+      expect(lineB).toBeDefined();
+      expect(
+        Math.abs((lineA?.width ?? 0) - (lineB?.width ?? 0)),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+
+  test("an inline image after a right tab still counts toward following width", () => {
+    // Counter-test: inline images (no wrap type or `inline` displayMode) DO
+    // participate in the line and must continue to be subtracted from the
+    // tab advance — otherwise the right-anchor reserves too much room.
+    withFakeTextMeasure(() => {
+      const baseAttrs = { tabs: [{ val: "end" as const, pos: 5000 }] };
+
+      const withInlineImage = {
+        kind: "paragraph" as const,
+        id: "tab-inline-img",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "image" as const,
+            src: "img.png",
+            width: 40,
+            height: 20,
+          },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const withoutImage = {
+        kind: "paragraph" as const,
+        id: "tab-no-img",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+        ],
+        attrs: baseAttrs,
+      };
+
+      const a = measureParagraph(withInlineImage, 400);
+      const b = measureParagraph(withoutImage, 400);
+      const lineA = a.lines.at(0);
+      const lineB = b.lines.at(0);
+      expect(lineA).toBeDefined();
+      expect(lineB).toBeDefined();
+      // The inline image adds 40px of trailing width that the right-anchor
+      // subtracts from the tab advance, so the lines should still match: the
+      // 40px reappears as image width in `lineA`. Both should be the same
+      // total line width because the image is still rendered.
+      expect(
+        Math.abs((lineA?.width ?? 0) - (lineB?.width ?? 0)),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-right-tab.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-right-tab.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+
+import { calculateTabWidth } from "../../prosemirror/utils/tabCalculator";
+import type { TabContext } from "../../prosemirror/utils/tabCalculator";
+import { clearAllCaches } from "./cache";
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+// Mirrors the fake measurer used in measureParagraph.test.ts (5px lowercase,
+// 10px uppercase) so the test agrees with the rest of the suite on widths.
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(this: { font: string }, text: string) {
+              let width = 0;
+              for (const char of text) {
+                const isUppercase = char >= "A" && char <= "Z";
+                width += isUppercase ? 10 : 5;
+              }
+              return {
+                width,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    clearAllCaches();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+// Regression: the legacy `computeTabWidth` in measureParagraph ignored the
+// tab stop's `val` field, so a right (`end`) or center stop was measured as
+// `stopPx + followingTextWidth`. The painter already right-/center-anchors
+// such content via `calculateTabWidth`, so the wrap fired in the measurer
+// but not in the painter. See eigenpal #576.
+describe("measureParagraph — right/center tab stops (eigenpal #576)", () => {
+  test("right tab followed by short text does not wrap", () => {
+    withFakeTextMeasure(() => {
+      // Right tab stop at 5000 twips ≈ 333.33px. With the bug, the measurer
+      // advances to the stop unconditionally (tab ≈ 308.33px on top of the
+      // 25px title), then the trailing "page" run (20px) overflows the
+      // 340px line and starts a new one. After the fix, end-alignment
+      // subtracts the trailing width: the tab pulls "page" right of the
+      // stop and the whole line fits.
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "right-tab",
+          runs: [
+            { kind: "text", text: "Title", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "page", fontSize: 11 },
+          ],
+          attrs: {
+            tabs: [{ val: "end", pos: 5000 }],
+          },
+        },
+        340,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+    });
+  });
+
+  test("center tab followed by text does not wrap", () => {
+    withFakeTextMeasure(() => {
+      // Center stop at 5000 twips ≈ 333.33px. "center" is 30px, so a
+      // center-aligned anchor needs only `tabWidth = (333.33 - 20) - 15`,
+      // putting the line at 333.33 + 15 = 348.33px — fits in 350. The
+      // legacy measurer would report 20 + 313.33 + 30 = 363.33px and wrap.
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "center-tab",
+          runs: [
+            { kind: "text", text: "left", fontSize: 11 },
+            { kind: "tab" },
+            { kind: "text", text: "center", fontSize: 11 },
+          ],
+          attrs: {
+            tabs: [{ val: "center", pos: 5000 }],
+          },
+        },
+        350,
+      );
+
+      expect(measure.lines).toHaveLength(1);
+    });
+  });
+
+  test("measurer agrees with calculateTabWidth on the right-tab line width", () => {
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "right-tab-width",
+        runs: [
+          { kind: "text" as const, text: "Title", fontSize: 11 },
+          { kind: "tab" as const },
+          { kind: "text" as const, text: "7", fontSize: 11 },
+        ],
+        attrs: {
+          tabs: [{ val: "end" as const, pos: 5000 }],
+        },
+      };
+
+      const measure = measureParagraph(block, 400);
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+
+      // What the painter computes end-to-end:
+      //   title (5 chars × 5px = 25px) +
+      //   tab width that anchors "7" right of the 5000-twip stop +
+      //   "7" (10px)
+      const titleWidth = 25;
+      const followingWidth = 10;
+      const tabContext: TabContext = {
+        explicitStops: [{ val: "end", pos: 5000 }],
+      };
+      const tabResult = calculateTabWidth(titleWidth, tabContext, {
+        followingWidth,
+      });
+      const painterLineWidth = titleWidth + tabResult.width + followingWidth;
+
+      expect(
+        Math.abs((line?.width ?? 0) - painterLineWidth),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -17,6 +17,11 @@ import type {
   FieldRun,
   ParagraphSpacing,
 } from "../../layout-engine/types";
+import {
+  calculateTabWidth,
+  pixelsToTwips,
+} from "../../prosemirror/utils/tabCalculator";
+import type { TabContext } from "../../prosemirror/utils/tabCalculator";
 import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import {
@@ -24,7 +29,6 @@ import {
   measureRun,
   getFontMetrics,
   ptToPx,
-  twipsToPx,
 } from "./measureContainer";
 import type { FontStyle, FontMetrics } from "./measureContainer";
 
@@ -36,29 +40,6 @@ const DEFAULT_LINE_HEIGHT_MULTIPLIER = 1; // OOXML spec default: single spacing 
 // Floating-point tolerance for line breaking (0.5px)
 // Prevents premature line breaks due to measurement rounding
 const WIDTH_TOLERANCE = 0.5;
-
-/**
- * Compute the width a tab character should advance to reach the next tab stop.
- */
-function computeTabWidth(
-  currentPos: number,
-  tabStops: { pos: number; val: string }[] | undefined,
-): number {
-  if (tabStops && tabStops.length > 0) {
-    for (const stop of tabStops) {
-      const stopPx = twipsToPx(stop.pos);
-      if (stopPx > currentPos + 0.5) {
-        return Math.max(1, stopPx - currentPos);
-      }
-    }
-  }
-  // No matching stop — advance to next default interval
-  const remainder = currentPos % DEFAULT_TAB_WIDTH;
-  return Math.max(
-    1,
-    remainder < 0.5 ? DEFAULT_TAB_WIDTH : DEFAULT_TAB_WIDTH - remainder,
-  );
-}
 
 /**
  * Find the longest prefix of `text` that fits within `maxWidth` pixels.
@@ -299,6 +280,35 @@ function isEmptyTextRun(run: TextRun): boolean {
 }
 
 /**
+ * Sum the inline pixel widths of runs after a tab, up to (but not including)
+ * the next tab or line break. Measured per-run so widths reserved match what
+ * the painter draws even when trailing runs use different fonts/sizes.
+ */
+function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
+  let width = 0;
+  for (let i = tabIndex + 1; i < runs.length; i++) {
+    const next = runs[i];
+    if (!next || isTabRun(next) || isLineBreakRun(next)) {
+      break;
+    }
+    if (isTextRun(next)) {
+      width += measureTextWidth(next.text || "", runToFontStyle(next));
+    } else if (isFieldRun(next)) {
+      const style: FontStyle = {
+        fontFamily: next.fontFamily ?? DEFAULT_FONT_FAMILY,
+        fontSize: next.fontSize ?? DEFAULT_FONT_SIZE,
+        ...(next.bold !== undefined ? { bold: next.bold } : {}),
+        ...(next.italic !== undefined ? { italic: next.italic } : {}),
+      };
+      width += measureTextWidth(next.fallback || "1", style);
+    } else if (isImageRun(next)) {
+      width += next.width || 0;
+    }
+  }
+  return width;
+}
+
+/**
  * Find word break points in text
  * Returns array of indices where words end (after space/punctuation)
  */
@@ -315,11 +325,6 @@ function findWordBreaks(text: string): number[] {
 
   return breaks;
 }
-
-/**
- * Default tab width in pixels (0.5 inch at 96 DPI)
- */
-const DEFAULT_TAB_WIDTH = 48;
 
 /**
  * When a float's wrap margins consume the entire content width (or more),
@@ -803,14 +808,27 @@ export function measureParagraph(
     }
 
     if (isTabRun(run)) {
-      // Handle tab run — compute width from paragraph tab stops
       const style = runToFontStyle(run);
       updateMaxFont(style);
 
-      // Compute tab width: advance to the next tab stop position.
-      const tabStops = attrs?.tabs;
-      const currentPos = currentLine.width + currentLine.leftOffset;
-      const tabWidth = computeTabWidth(currentPos, tabStops);
+      const followingWidth = measureInlineWidthAfterTab(runs, runIndex);
+
+      // Tab width comes from the shared tab-stop model (`calculateTabWidth` —
+      // computeTabStops + alignment) that the painter also uses, so measurer
+      // and painter agree on line widths. `calculateTabWidth` works in
+      // content-area coordinates (tab stops are measured from the
+      // content-area left edge), so the indent and any first-line offset are
+      // folded in here; the line-wrap math further down stays indent-relative.
+      const lineX = currentLine.width + currentLine.leftOffset;
+      const isFirstLine = lines.length === 0;
+      const contentX = indentLeft + (isFirstLine ? firstLineOffset : 0) + lineX;
+      const tabContext: TabContext = {
+        ...(attrs?.tabs !== undefined ? { explicitStops: attrs.tabs } : {}),
+        leftIndent: pixelsToTwips(indentLeft),
+      };
+      const tabWidth = calculateTabWidth(contentX, tabContext, {
+        followingWidth,
+      }).width;
 
       if (
         currentLine.width + tabWidth >

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -17,6 +17,7 @@ import type {
   FieldRun,
   ParagraphSpacing,
 } from "../../layout-engine/types";
+import { isFloatingImageRun } from "../../layout-painter/renderUtils";
 import {
   calculateTabWidth,
   pixelsToTwips,
@@ -121,9 +122,12 @@ type LineState = {
 };
 
 /**
- * Extract FontStyle from a text run for measurement
+ * Extract FontStyle from a run that carries RunFormatting (text, tab, or
+ * field). All three share the same formatting shape, so they measure the
+ * same way; widening the parameter keeps tab-following measurement
+ * (FieldRun page numbers, etc.) consistent with TextRun handling.
  */
-function runToFontStyle(run: TextRun | TabRun): FontStyle {
+function runToFontStyle(run: TextRun | TabRun | FieldRun): FontStyle {
   return {
     fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
     fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
@@ -283,6 +287,12 @@ function isEmptyTextRun(run: TextRun): boolean {
  * Sum the inline pixel widths of runs after a tab, up to (but not including)
  * the next tab or line break. Measured per-run so widths reserved match what
  * the painter draws even when trailing runs use different fonts/sizes.
+ *
+ * Floating/anchored images are skipped — the painter lifts them out of the
+ * paragraph flow (see `isFloatingImageRun`) and `measureFollowingContentWidth`
+ * in the painter already excludes them, so counting their width here would
+ * desync measurer and painter on tab advance for paragraphs with a tab
+ * preceding a floating image.
  */
 function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
   let width = 0;
@@ -294,18 +304,50 @@ function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
     if (isTextRun(next)) {
       width += measureTextWidth(next.text || "", runToFontStyle(next));
     } else if (isFieldRun(next)) {
-      const style: FontStyle = {
-        fontFamily: next.fontFamily ?? DEFAULT_FONT_FAMILY,
-        fontSize: next.fontSize ?? DEFAULT_FONT_SIZE,
-        ...(next.bold !== undefined ? { bold: next.bold } : {}),
-        ...(next.italic !== undefined ? { italic: next.italic } : {}),
-      };
-      width += measureTextWidth(next.fallback || "1", style);
-    } else if (isImageRun(next)) {
+      width += measureTextWidth(next.fallback || "1", runToFontStyle(next));
+    } else if (isImageRun(next) && !isFloatingImageRun(next)) {
       width += next.width || 0;
     }
   }
   return width;
+}
+
+/**
+ * Width of the inline content preceding the first `.` in the runs that follow
+ * a tab, used to anchor `decimal` tab stops. Mirrors `getTextAfterTab` +
+ * decimal-prefix measurement in the painter (`renderParagraph.ts`) so the
+ * measurer and painter agree on tab advance for decimal stops.
+ *
+ * Returns 0 when no decimal separator appears before the next tab / line
+ * break — `calculateTabWidth` treats that as "no anchor adjustment".
+ */
+function measureDecimalPrefixWidthAfterTab(
+  runs: Run[],
+  tabIndex: number,
+): number {
+  let text = "";
+  let firstRun: TextRun | FieldRun | undefined;
+  for (let i = tabIndex + 1; i < runs.length; i++) {
+    const next = runs[i];
+    if (!next || isTabRun(next) || isLineBreakRun(next)) {
+      break;
+    }
+    if (isTextRun(next)) {
+      text += next.text || "";
+      firstRun ??= next;
+    } else if (isFieldRun(next)) {
+      text += next.fallback || "1";
+      firstRun ??= next;
+    }
+  }
+  const decimalIndex = text.indexOf(".");
+  if (decimalIndex === -1 || !firstRun) {
+    return 0;
+  }
+  return measureTextWidth(
+    text.slice(0, decimalIndex),
+    runToFontStyle(firstRun),
+  );
 }
 
 /**
@@ -812,6 +854,10 @@ export function measureParagraph(
       updateMaxFont(style);
 
       const followingWidth = measureInlineWidthAfterTab(runs, runIndex);
+      const decimalPrefixWidth = measureDecimalPrefixWidthAfterTab(
+        runs,
+        runIndex,
+      );
 
       // Tab width comes from the shared tab-stop model (`calculateTabWidth` —
       // computeTabStops + alignment) that the painter also uses, so measurer
@@ -828,6 +874,7 @@ export function measureParagraph(
       };
       const tabWidth = calculateTabWidth(contentX, tabContext, {
         followingWidth,
+        decimalPrefixWidth,
       }).width;
 
       if (

--- a/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-decimal-tab.test.ts
@@ -1,0 +1,186 @@
+// Regression test for PR #512 gemini HIGH on renderParagraph.ts:1171.
+//
+// `renderLine` previously measured `decimalPrefixWidth` via
+// `measureText(text)` without passing font size/family/style/scale, so the
+// canvas fell back to 11px Calibri regardless of how the trailing run was
+// formatted. Bold / sized / scaled text after a decimal tab was therefore
+// anchored at the wrong position.
+//
+// The fix resolves the first text/field run after the tab and uses its
+// fontSize, fontFamily, formatting style, and horizontalScale when
+// measuring the prefix. This test asserts the tab span's painted width
+// shrinks when the trailing run uses a larger font.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MeasuredLine,
+  ParagraphBlock,
+  TabStop,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+  textContent = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return this.children.at(0) ?? null;
+  }
+
+  // Font-size-aware canvas: width scales linearly with the px size embedded
+  // in `font`. Falls back to 11px when no font is set (matches the painter's
+  // `createTextMeasurer` default). This lets the test detect whether the
+  // painter resolves the trailing run's font when measuring decimalPrefix.
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    const ctx = {
+      font: "",
+      measureText(text: string): { width: number } {
+        // Parse "<weight?> <px>px <family>" — grab the numeric pixel size.
+        // eslint-disable-next-line sonarjs/slow-regex
+        const match = /(\d+(?:\.\d+)?)px/u.exec(ctx.font);
+        const fontSizePx = match ? Number(match[1]) : (11 * 96) / 72;
+        // 1 char ≈ 0.5 em, so glyph width ≈ fontSizePx / 2.
+        return { width: text.length * (fontSizePx / 2) };
+      },
+    };
+    return ctx;
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function findTabEl(lineEl: FakeElement): FakeElement | undefined {
+  return lineEl.children.find((c) => c.className.includes("layout-run-tab"));
+}
+
+describe("renderLine — decimal tab respects trailing run font", () => {
+  test("larger trailing fontSize shrinks the tab span width", () => {
+    // Decimal stop at 3000 twips ≈ 200px. Leading text empty, trailing run
+    // is "12.34" with two different font sizes. Prefix "12":
+    //   - 11pt run → 14.67px → prefix width = 2 * (14.67/2) = 14.67px → tab ≈ 185.33px
+    //   - 22pt run → 29.33px → prefix width = 2 * (29.33/2) = 29.33px → tab ≈ 170.67px
+    // With the bug, both branches measure the prefix at 11px Calibri and
+    // emit the same tab width.
+    const tabStops: TabStop[] = [{ val: "decimal", pos: 3000 }];
+
+    const renderAtSize = (fontSize: number): number => {
+      const block: ParagraphBlock = {
+        kind: "paragraph",
+        id: `decimal-${fontSize}`,
+        runs: [{ kind: "tab" }, { kind: "text", text: "12.34", fontSize }],
+      };
+      const line: MeasuredLine = {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 1,
+        toChar: 5,
+        width: 400,
+        ascent: 12,
+        descent: 3,
+        lineHeight: 15,
+      };
+      const lineEl = renderLine(block, line, undefined, fakeDocument, {
+        availableWidth: 400,
+        isLastLine: true,
+        isFirstLine: true,
+        paragraphEndsWithLineBreak: false,
+        tabStops,
+        leftIndentPx: 0,
+      }) as unknown as FakeElement;
+
+      const tabEl = findTabEl(lineEl);
+      expect(tabEl).toBeDefined();
+      const widthStr = tabEl?.style["width"] ?? "0px";
+      return Number(widthStr.replace("px", ""));
+    };
+
+    const tab11 = renderAtSize(11);
+    const tab22 = renderAtSize(22);
+
+    // With the fix the prefix at 22pt is wider, so the tab span is narrower.
+    // Gap should be at least ~10px on the test's deliberately exaggerated font
+    // scale; allow generous slack so the assertion doesn't depend on the exact
+    // measurement formula.
+    expect(tab22).toBeLessThan(tab11 - 5);
+  });
+
+  test("bold trailing run is still measured (smoke test for run resolution)", () => {
+    // Sanity: the painter resolves the trailing run even when formatting is
+    // limited to bold/italic with no font size override. Both branches use
+    // 11pt Calibri here, so widths match — the test mainly guards against a
+    // regression where the new helper crashes or returns NaN on a bold run.
+    const tabStops: TabStop[] = [{ val: "decimal", pos: 3000 }];
+
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "decimal-bold",
+      runs: [
+        { kind: "tab" },
+        { kind: "text", text: "1.5", bold: true, italic: true },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 3,
+      width: 400,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 400,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl).toBeDefined();
+    const widthStr = tabEl?.style["width"] ?? "0px";
+    const width = Number(widthStr.replace("px", ""));
+    expect(Number.isFinite(width)).toBe(true);
+    expect(width).toBeGreaterThan(0);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1165,9 +1165,31 @@ export function renderLine(
       );
       const followingText = getTextAfterTab(runsForLine, i, options?.context);
       const decimalIndex = followingText.indexOf(".");
+      // Resolve the first text/field run after the tab and measure the
+      // decimal prefix in *its* font/style. Defaulting to 11px Calibri
+      // (the `measureText` fallback) drifts on sized/bold/italic runs and
+      // breaks decimal alignment — eigenpal #576 gemini review on PR #512.
+      const firstFollowingRun = (() => {
+        for (let j = i + 1; j < runsForLine.length; j++) {
+          const next = runsForLine[j];
+          if (!next || isTabRun(next) || isLineBreakRun(next)) {
+            return undefined;
+          }
+          if (isTextRun(next) || isFieldRun(next)) {
+            return next;
+          }
+        }
+        return undefined;
+      })();
       const decimalPrefixWidth =
         decimalIndex !== -1
-          ? measureText(followingText.slice(0, decimalIndex))
+          ? measureText(
+              followingText.slice(0, decimalIndex),
+              firstFollowingRun?.fontSize,
+              firstFollowingRun?.fontFamily,
+              firstFollowingRun ? runMeasureStyle(firstFollowingRun) : {},
+            ) *
+            ((firstFollowingRun?.horizontalScale ?? 100) / 100)
           : 0;
 
       const tabResult = calculateTabWidth(currentX, tabContext, {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1155,16 +1155,25 @@ export function renderLine(
     const run = runsForLine[i]!; // SAFETY: i < runsForLine.length
 
     if (isTabRun(run) && tabContext) {
-      // Get text following this tab for alignment calculations
-      const followingText = getTextAfterTab(runsForLine, i, options?.context);
-
-      // Calculate tab width based on current position
-      const tabResult = calculateTabWidth(
-        currentX,
-        tabContext,
-        followingText,
+      // Per-run measurement (not a single-font pass over the joined string)
+      // keeps the tab width accurate when trailing runs differ in font/size.
+      const followingWidth = measureFollowingContentWidth(
+        runsForLine,
+        i,
         measureText,
+        options?.context,
       );
+      const followingText = getTextAfterTab(runsForLine, i, options?.context);
+      const decimalIndex = followingText.indexOf(".");
+      const decimalPrefixWidth =
+        decimalIndex !== -1
+          ? measureText(followingText.slice(0, decimalIndex))
+          : 0;
+
+      const tabResult = calculateTabWidth(currentX, tabContext, {
+        followingWidth,
+        decimalPrefixWidth,
+      });
 
       // Right-tab anchor (TOC pattern): when an end-aligned tab's stop is at
       // (or past) the line's right edge AND no later tab follows on this
@@ -1172,15 +1181,7 @@ export function renderLine(
       // content flush right. This sidesteps canvas-vs-DOM measurement drift
       // that otherwise leaves the page number a pixel short of the margin.
       const lineRightEdgeX = options?.lineRightEdgePx;
-      const followingWidthForCheck =
-        lineRightEdgeX !== undefined
-          ? measureFollowingContentWidth(
-              runsForLine,
-              i,
-              measureText,
-              options?.context,
-            )
-          : 0;
+      const followingWidthForCheck = followingWidth;
       let hasFollowingTab = false;
       for (let j = i + 1; j < runsForLine.length; j++) {
         // SAFETY: j < runsForLine.length

--- a/packages/folio/src/core/prosemirror/utils/tabCalculator.test.ts
+++ b/packages/folio/src/core/prosemirror/utils/tabCalculator.test.ts
@@ -148,48 +148,41 @@ describe("calculateTabWidth", () => {
     expect(result.width).toBeGreaterThan(0);
   });
 
-  it("adjusts for center alignment with following text", () => {
-    const measureText = (text: string) => text.length * 10; // 10px per char
+  it("adjusts for center alignment with following content", () => {
     const result = calculateTabWidth(
       0,
       { explicitStops: [{ val: "center", pos: 1440 }] },
-      "test", // 4 chars = 40px
-      measureText,
+      { followingWidth: 40 }, // e.g. 'test' at 10px/char
     );
 
-    // Center alignment: tab width should account for half of text width
+    // Center alignment: tab width should account for half of the content width
     // 96px (1440 twips) - 0 - 20px (half of 40) = 76px
     expect(result.alignment).toBe("center");
     expect(result.width).toBe(76);
   });
 
-  it("adjusts for end alignment with following text", () => {
-    const measureText = (text: string) => text.length * 10;
+  it("adjusts for end alignment with following content", () => {
     const result = calculateTabWidth(
       0,
       { explicitStops: [{ val: "end", pos: 1440 }] },
-      "test",
-      measureText,
+      { followingWidth: 40 },
     );
 
-    // End alignment: tab width should account for full text width
+    // End alignment: tab width should account for the full content width
     // 96px - 0 - 40px = 56px
     expect(result.alignment).toBe("end");
     expect(result.width).toBe(56);
   });
 
   it("handles decimal alignment", () => {
-    const measureText = (text: string) => text.length * 10;
     const result = calculateTabWidth(
       0,
       { explicitStops: [{ val: "decimal", pos: 1440 }] },
-      "123.45",
-      measureText,
-      ".",
+      { decimalPrefixWidth: 30 }, // e.g. '123' before the separator
     );
 
     // Decimal alignment: aligns the decimal point
-    // Before decimal: "123" = 30px
+    // Before decimal: 30px
     // 96px - 0 - 30px = 66px
     expect(result.alignment).toBe("decimal");
     expect(result.width).toBe(66);

--- a/packages/folio/src/core/prosemirror/utils/tabCalculator.ts
+++ b/packages/folio/src/core/prosemirror/utils/tabCalculator.ts
@@ -190,24 +190,43 @@ export function computeTabStops(context: TabContext): TabStop[] {
 }
 
 /**
- * Calculate the width of a tab character
+ * Pixel widths of the content after a tab, needed to position non-left stops.
  *
- * Finds the next tab stop after the current position and computes
- * the width needed to reach it.
+ * Caller measures its own runs (the painter and the layout measurer have
+ * different run models and measurement paths) and passes the result here, so
+ * this module owns the stop grid + alignment math without owning measurement.
+ */
+export type TabFollowingContent = {
+  /** Total width of the runs after the tab. Used for `end` and `center` stops. */
+  followingWidth?: number;
+  /** Width of the content before the decimal separator. Used for `decimal` stops. */
+  decimalPrefixWidth?: number;
+};
+
+// eigenpal #576: `calculateTabWidth` previously took a `followingText` string
+// plus a `measureText` callback, which forced both call sites to share one
+// measurement path. The painter and the measurer have different run models
+// (DOM-styled spans vs. layout `Run`s) and different font-resolution paths,
+// so each caller now measures its own runs and passes the result via
+// `TabFollowingContent` — this module owns only the stop grid + alignment.
+/**
+ * Calculate the width of a tab character.
  *
- * @param currentXPx - Current horizontal position in pixels
+ * Finds the next tab stop after the current position and computes the width
+ * needed to reach it. For `end`/`center`/`decimal` stops the content after the
+ * tab is anchored against the stop, so the caller supplies its measured width
+ * via {@link TabFollowingContent}.
+ *
+ * @param currentXPx - Current horizontal position in pixels (from the content
+ *   area's left edge — the same origin tab stop positions are measured from)
  * @param context - Tab context with stops and settings
- * @param followingText - Text immediately after the tab (for center/end/decimal alignment)
- * @param measureText - Function to measure text width in pixels
- * @param decimalSeparator - Character used for decimal alignment (default: '.')
+ * @param following - Measured widths of the content after the tab
  * @returns Tab width result with width in pixels
  */
 export function calculateTabWidth(
   currentXPx: number,
   context: TabContext,
-  followingText = "",
-  measureText?: (text: string) => number,
-  decimalSeparator = ".",
+  following: TabFollowingContent = {},
 ): TabWidthResult {
   const { defaultTabInterval = DEFAULT_TAB_INTERVAL_TWIPS } = context;
 
@@ -237,21 +256,14 @@ export function calculateTabWidth(
   const nextStopPx = twipsToPixels(nextStop.pos);
   let width = nextStopPx - currentXPx;
 
-  // Adjust for alignment types
-  if (nextStop.val === "center" || nextStop.val === "end") {
-    const textWidth = measureText ? measureText(followingText) : 0;
-    if (nextStop.val === "center") {
-      width -= textWidth / 2;
-    } else {
-      width -= textWidth;
-    }
+  // Adjust for alignment types — the content after the tab is anchored to the
+  // stop, so the tab only spans the room left of that content.
+  if (nextStop.val === "center") {
+    width -= (following.followingWidth ?? 0) / 2;
+  } else if (nextStop.val === "end") {
+    width -= following.followingWidth ?? 0;
   } else if (nextStop.val === "decimal") {
-    const decimalIndex = followingText.indexOf(decimalSeparator);
-    if (decimalIndex !== -1 && measureText) {
-      const before = followingText.slice(0, decimalIndex);
-      const beforeWidth = measureText(before);
-      width -= beforeWidth;
-    }
+    width -= following.decimalPrefixWidth ?? 0;
   } else if (nextStop.val === "bar") {
     // Bar tabs have zero width but render a vertical line
     return {


### PR DESCRIPTION
## Summary

Ports [eigenpal/docx-editor#576](https://github.com/eigenpal/docx-editor/pull/576) into folio.

The line measurer at `packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts` had a private `computeTabWidth` helper that ignored the tab stop's `val` field, so a right (`end`) or center tab was measured as if it advanced to the stop unconditionally. The painter at `packages/folio/src/core/layout-painter/renderParagraph.ts` already right-/center-anchored the trailing content via `calculateTabWidth`, so a TOC line, signature row, or table-header line could measure wider than the content area and wrap while painting on a single line.

Both call sites now go through the shared `calculateTabWidth` in `tabCalculator.ts`. The signature takes a new `TabFollowingContent` struct with pre-measured widths; the painter and the measurer each measure their own runs (different run models, different font-resolution paths) and the shared function owns only the geometry — `computeTabStops` + alignment math.

- `tabCalculator`: `calculateTabWidth(currentX, context, TabFollowingContent)` — single owner of stop grid + alignment.
- `renderParagraph`: passes accurate per-run `followingWidth` + `decimalPrefixWidth` (computed once instead of per-anchor branch).
- `measureParagraph`: drops the private `computeTabWidth`, calls `calculateTabWidth` in content-area coordinates (indent + first-line offset folded in), measures trailing-run widths per-run via new `measureInlineWidthAfterTab`.

Adopted the upstream struct refactor: the alternative (keeping the positional `followingText` + `measureText` callback) would have forced the measurer to either string-join all trailing runs (loses per-run fonts) or supply a font-aware `measureText` that special-cases `Run` types — both are more code than the struct.

## Test plan

- [x] `bun --filter @stll/folio test` (1005 pass, 0 fail; 3 new regression tests pass)
- [x] `bun --filter @stll/folio typecheck`
- [x] `bun --filter @stll/folio lint`
- [x] Existing `tabCalculator.test.ts` alignment tests updated to the new struct shape (no semantic change)
- [ ] Manual smoke: open a DOCX with right-tab page numbers (TOC) and verify no spurious wrap

## Regression tests added

`packages/folio/src/core/layout-bridge/measuring/measureParagraph-right-tab.test.ts`:
1. Right tab + trailing text does not wrap.
2. Center tab + trailing text does not wrap.
3. Measurer line width agrees with the painter's `calculateTabWidth` within 0.5 px.

CC on behalf of @jan-kubica