### PR TITLE
fix(folio): anchor inline images at line top to prevent clipping

### DIFF
--- a/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts
@@ -107,6 +107,45 @@ describe("renderLine inline image handling", () => {
     expect(imageEl?.style.height).toBe("29px");
   });
 
+  // Regression for eigenpal #409 inline-image clipping sub-fix. Tailwind
+  // preflight sets `img { vertical-align: middle }` globally; the JS literal
+  // must explicitly anchor inline images at line top so they don't sit
+  // half above / half below the baseline (which clips against paragraph
+  // borders or following lines).
+  test("anchors inline images at line top", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 120,
+      height: 40,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-inline-img",
+      runs: [{ kind: "text", text: "Logo: " }, imageRun],
+      pmStart: 0,
+      pmEnd: 8,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 1,
+      width: 162,
+      ascent: 32,
+      descent: 8,
+      lineHeight: 40,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const imageEl = lineEl.children[1] as HTMLElement | undefined;
+
+    expect(imageEl?.tagName).toBe("img");
+    expect(imageEl?.style.verticalAlign).toBe("top");
+  });
+
   // Regression chatgpt-codex on #410: the image+text flex branch fired on
   // `runsForLine.some(isImageRun)`, which also matched FLOATING images. Those
   // render in a page-level layer and `continue` in the main loop, so a line

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -548,7 +548,10 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
 
   // Inline images should flow with text
   img.style.display = "inline";
-  img.style.verticalAlign = "middle";
+  // Anchor at line top regardless of CSS reset (Tailwind preflight sets
+  // `img { vertical-align: middle }`, which clips against paragraph
+  // borders when the image overflows the baseline) — eigenpal #409.
+  img.style.verticalAlign = "top";
 
   // wp:inline distT/distB: the measurer folds these into maxImageHeightPx;
   // applying them as margins here keeps the margin-box footprint consistent


### PR DESCRIPTION
## Summary

Ports the inline-image clipping sub-fix of upstream eigenpal/docx-editor #409 to folio. The layout painter's `renderInlineImageRun` set `img.style.verticalAlign = "middle"`, which sits an inline image half above / half below the text baseline; the top half visually escapes the paragraph's bounding box and clips against borders or the next line. Setting `verticalAlign = "top"` anchors the image at line top regardless of CSS reset (notably Tailwind preflight's `img { vertical-align: middle }` global rule).

Scope is intentionally limited to the verticalAlign literal change. The other two #409 sub-items (top-of-page `spaceBefore`, break-only page break) are already handled in folio and are not touched here.

## Test plan

- [x] Added regression test in `packages/folio/src/core/layout-painter/renderParagraph-inline-image.test.ts` — `anchors inline images at line top` — asserting an `<img>` rendered through `renderLine` ends up with `style.verticalAlign === "top"`. Confirmed RED before the fix, GREEN after.
- [x] `bun --filter @stll/folio test` — 1003 pass / 0 fail (1002 before, +1 regression test).
- [x] `bun --filter @stll/folio lint` — clean.
- [x] `bun --filter @stll/folio typecheck` — clean.