### PR TITLE
fix(folio): honor table cell w:noWrap through layout bridge

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -387,6 +387,39 @@ describe("toFlowBlocks TOC hyperlink style strip", () => {
   });
 });
 
+describe("toFlowBlocks table cell formatting", () => {
+  // Regression eigenpal #424 gap 14: the parser captured w:noWrap and the PM
+  // schema carried it, but convertTableCell dropped the field, so cells like
+  // case numbers / citations wrapped where Word kept them on one line.
+  test("threads the cell noWrap attribute into the engine TableCell", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("table", null, [
+        schema.node("tableRow", null, [
+          schema.node("tableCell", { noWrap: true }, [
+            schema.node("paragraph", null, [schema.text("CASE 123-456")]),
+          ]),
+          schema.node("tableCell", null, [
+            schema.node("paragraph", null, [schema.text("default")]),
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const table = blocks.at(0);
+    if (table?.kind !== "table") {
+      throw new Error("Expected table block");
+    }
+    const row = table.rows.at(0);
+    if (!row) {
+      throw new Error("Expected table row");
+    }
+
+    expect(row.cells.at(0)?.noWrap).toBe(true);
+    expect(row.cells.at(1)?.noWrap).toBeUndefined();
+  });
+});
+
 describe("toFlowBlocks list numbering", () => {
   test("normalizes Symbol-family bullet markers during flow conversion", () => {
     const doc = schema.node("doc", null, [

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1541,6 +1541,9 @@ function convertTableCell(
   if (cellBorders) {
     cell.borders = cellBorders;
   }
+  if (attrs.noWrap) {
+    cell.noWrap = true;
+  }
   return cell;
 }
 

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -357,6 +357,12 @@ export type TableCell = {
   borders?: CellBorders;
   /** Per-cell padding in pixels (from w:tcMar or table-level w:tblCellMar) */
   padding?: { top: number; right: number; bottom: number; left: number };
+  /**
+   * `w:noWrap` (§17.4.30): when true, the cell forbids soft-wrapping inside
+   * it. The painter emits `white-space: nowrap` on the cell box so content
+   * stays on a single line and the cell expands horizontally instead.
+   */
+  noWrap?: boolean;
 };
 
 /**

--- a/packages/folio/src/core/layout-painter/renderTable-noWrap.test.ts
+++ b/packages/folio/src/core/layout-painter/renderTable-noWrap.test.ts
@@ -1,0 +1,217 @@
+// Regression eigenpal #424 gap 14: `w:noWrap` on a table cell must reach the
+// painter. The parser captured it and the PM schema stored it, but the
+// layout-bridge dropped the field on the way to TableCell, and renderTable
+// never emitted `white-space: nowrap`. Cells like case numbers and citations
+// wrapped where Word kept them on a single line.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  TableBlock,
+  TableFragment,
+  TableMeasure,
+} from "../layout-engine/types";
+import { renderTableFragment, TABLE_CLASS_NAMES } from "./renderTable";
+import type { RenderContext } from "./renderUtils";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  private ownText = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  get textContent(): string {
+    return (
+      this.ownText + this.children.map((child) => child.textContent).join("")
+    );
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): null {
+    return null;
+  }
+
+  querySelectorAll(): FakeElement[] {
+    return [];
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = text;
+    return node;
+  },
+} as unknown as Document;
+
+function findCells(element: FakeElement): FakeElement[] {
+  const matches: FakeElement[] = [];
+  if (element.className.split(" ").includes(TABLE_CLASS_NAMES.cell)) {
+    matches.push(element);
+  }
+  for (const child of element.children) {
+    matches.push(...findCells(child));
+  }
+  return matches;
+}
+
+function buildSingleCellTable(noWrap?: boolean): {
+  fragment: TableFragment;
+  block: TableBlock;
+  measure: TableMeasure;
+} {
+  const block: TableBlock = {
+    kind: "table",
+    id: "tbl",
+    rows: [
+      {
+        id: "row-1",
+        cells: [
+          {
+            id: "cell-1",
+            blocks: [
+              {
+                kind: "paragraph",
+                id: "p-1",
+                runs: [{ kind: "text", text: "CASE 123-456" }],
+              },
+            ],
+            padding: { top: 0, right: 7, bottom: 0, left: 7 },
+            ...(noWrap === undefined ? {} : { noWrap }),
+          },
+        ],
+      },
+    ],
+    columnWidths: [100],
+  };
+  const measure: TableMeasure = {
+    kind: "table",
+    rows: [
+      {
+        cells: [
+          {
+            blocks: [
+              {
+                kind: "paragraph",
+                lines: [
+                  {
+                    fromRun: 0,
+                    fromChar: 0,
+                    toRun: 0,
+                    toChar: 12,
+                    width: 80,
+                    ascent: 8,
+                    descent: 2,
+                    lineHeight: 12,
+                  },
+                ],
+                totalHeight: 12,
+              },
+            ],
+            width: 100,
+            height: 12,
+          },
+        ],
+        height: 12,
+      },
+    ],
+    columnWidths: [100],
+    totalWidth: 100,
+    totalHeight: 12,
+  };
+  const fragment: TableFragment = {
+    kind: "table",
+    blockId: "tbl",
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 12,
+    fromRow: 0,
+    toRow: 1,
+  };
+  return { fragment, block, measure };
+}
+
+const renderContext: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+describe("renderTable cell w:noWrap (eigenpal #424 gap 14)", () => {
+  test("emits white-space: nowrap on the cell element when cell.noWrap is true", () => {
+    const { fragment, block, measure } = buildSingleCellTable(true);
+
+    const tableEl = renderTableFragment(
+      fragment,
+      block,
+      measure,
+      renderContext,
+      {
+        document: fakeDocument,
+      },
+    ) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBe("nowrap");
+  });
+
+  test("does NOT set white-space on the cell element when cell.noWrap is absent", () => {
+    const { fragment, block, measure } = buildSingleCellTable(undefined);
+
+    const tableEl = renderTableFragment(
+      fragment,
+      block,
+      measure,
+      renderContext,
+      {
+        document: fakeDocument,
+      },
+    ) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBeUndefined();
+  });
+
+  test("does NOT set white-space on the cell element when cell.noWrap is false", () => {
+    const { fragment, block, measure } = buildSingleCellTable(false);
+
+    const tableEl = renderTableFragment(
+      fragment,
+      block,
+      measure,
+      renderContext,
+      {
+        document: fakeDocument,
+      },
+    ) as unknown as FakeElement;
+
+    const cells = findCells(tableEl);
+    expect(cells.length).toBe(1);
+    expect(cells[0]?.style["whiteSpace"]).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -544,6 +544,14 @@ function renderTableCell(
     }
   }
 
+  // `w:noWrap` (§17.4.30): forbid soft-wrapping inside the cell. Applied on
+  // the cell box so descendants pick it up by inheritance — paragraph lines
+  // stay on a single visual line and the cell expands horizontally past its
+  // measured content width. eigenpal #424 (cell noWrap).
+  if (cell.noWrap) {
+    cellEl.style.whiteSpace = "nowrap";
+  }
+
   // Vertical alignment
   if (cell.verticalAlign) {
     cellEl.style.display = "flex";

--- a/packages/folio/src/core/layout-painter/renderTable.ts
+++ b/packages/folio/src/core/layout-painter/renderTable.ts
@@ -544,10 +544,13 @@ function renderTableCell(
     }
   }
 
-  // `w:noWrap` (§17.4.30): forbid soft-wrapping inside the cell. Applied on
-  // the cell box so descendants pick it up by inheritance — paragraph lines
-  // stay on a single visual line and the cell expands horizontally past its
-  // measured content width. eigenpal #424 (cell noWrap).
+  // `w:noWrap` (§17.4.30): forbid soft-wrapping inside the cell. The
+  // measurement phase already collapses noWrap cell paragraphs to a single
+  // MeasuredLine (see NO_WRAP_MEASURE_WIDTH in PagedEditor.tsx), so each cell
+  // paints as one row. This style is the inline-content guard: it prevents
+  // the browser from re-wrapping inside a single line div if the painted
+  // content would overflow (e.g., user zoom, font fallback widening).
+  // eigenpal #424 (cell noWrap).
   if (cell.noWrap) {
     cellEl.style.whiteSpace = "nowrap";
   }

--- a/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
+++ b/packages/folio/src/paged-editor/PagedEditor.tableMeasure.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import { clearAllCaches } from "../core/layout-bridge/measuring/cache";
+import { resetCanvasContext } from "../core/layout-bridge/measuring/measureContainer";
 import type {
   FlowBlock,
   Measure,
@@ -10,6 +12,46 @@ import {
   measureTableBlock,
   measureTableCellBlockVisualHeight,
 } from "./PagedEditor";
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(text: string) {
+              return {
+                width: text.length * 5,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  clearAllCaches();
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    clearAllCaches();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
 
 const imageOnlyParagraph: ParagraphBlock = {
   kind: "paragraph",
@@ -209,5 +251,88 @@ describe("measureTableBlock", () => {
     );
 
     expect(tableMeasure.rows[0]?.height).toBeCloseTo(36, 1);
+  });
+
+  // Regression eigenpal #424 gap 14: `w:noWrap` must be honored during the
+  // measurement phase, not only as a `white-space: nowrap` paint hint. The
+  // paragraph line breaker runs against the cell's pixel width and emits one
+  // MeasuredLine per visual line, which the painter renders as stacked divs.
+  // Without measure-time honoring of noWrap, a long case number in a narrow
+  // column still rendered on multiple rows even though the cell box had
+  // `white-space: nowrap` applied.
+  describe("w:noWrap cells (eigenpal #424 gap 14)", () => {
+    const longSentence: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p-long",
+      runs: [
+        {
+          kind: "text",
+          text: "This sentence is intentionally long enough to wrap across multiple lines inside a narrow column.",
+        },
+      ],
+    };
+
+    test("measures wrapping cells with multiple MeasuredLines", () => {
+      withFakeTextMeasure(() => {
+        const tableMeasure = measureTableBlock(
+          {
+            kind: "table",
+            id: "table",
+            rows: [
+              {
+                id: "row",
+                cells: [
+                  {
+                    id: "cell",
+                    blocks: [longSentence],
+                    padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                  },
+                ],
+              },
+            ],
+            columnWidths: [80],
+          },
+          500,
+        );
+
+        const blockMeasure = tableMeasure.rows[0]?.cells[0]?.blocks[0];
+        if (blockMeasure?.kind !== "paragraph") {
+          throw new Error("Expected paragraph measure");
+        }
+        expect(blockMeasure.lines.length).toBeGreaterThan(1);
+      });
+    });
+
+    test("collapses noWrap cells to a single MeasuredLine even in a narrow column", () => {
+      withFakeTextMeasure(() => {
+        const tableMeasure = measureTableBlock(
+          {
+            kind: "table",
+            id: "table",
+            rows: [
+              {
+                id: "row",
+                cells: [
+                  {
+                    id: "cell",
+                    blocks: [longSentence],
+                    padding: { top: 0, right: 0, bottom: 0, left: 0 },
+                    noWrap: true,
+                  },
+                ],
+              },
+            ],
+            columnWidths: [80],
+          },
+          500,
+        );
+
+        const blockMeasure = tableMeasure.rows[0]?.cells[0]?.blocks[0];
+        if (blockMeasure?.kind !== "paragraph") {
+          throw new Error("Expected paragraph measure");
+        }
+        expect(blockMeasure.lines.length).toBe(1);
+      });
+    });
   });
 });

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -423,6 +423,13 @@ const TRANSACTION_LAYOUT_DEBOUNCE_MS = 32;
 const TRANSACTION_LAYOUT_MAX_DELAY_MS = 96;
 /** Keep the visual caret hidden briefly while typed content relayouts. */
 const SELECTION_REVEAL_AFTER_INPUT_DELAY = 120;
+/**
+ * Pseudo-infinite measurement width (px) used for `w:noWrap` table cells so
+ * the paragraph line breaker never inserts a soft break. Large enough to
+ * exceed any realistic single Word line; small enough to stay well clear of
+ * floating-point precision concerns when summed downstream.
+ */
+const NO_WRAP_MEASURE_WIDTH = 1_000_000;
 
 // Stable empty array to avoid re-creating on each render
 const EMPTY_PLUGINS: Plugin[] = [];
@@ -1866,8 +1873,18 @@ export function measureTableBlock(
         const padLeft = cell.padding?.left ?? DEFAULT_CELL_PADDING_X;
         const padRight = cell.padding?.right ?? DEFAULT_CELL_PADDING_X;
         const cellContentWidth = Math.max(1, cellWidth - padLeft - padRight);
+        // `w:noWrap` (§17.4.30): measure cell paragraphs against an effectively
+        // unbounded width so the line breaker never splits a single Word line
+        // into multiple MeasuredLines. The painter still constrains the cell
+        // box to `cellWidth`; `white-space: nowrap` keeps inline content on
+        // one line, and `overflow-x` lets it extend past the column. Without
+        // this, `renderTable.ts`'s nowrap style only prevents inline wrapping
+        // and the precomputed line splits would still render as stacked rows.
+        const measureWidth = cell.noWrap
+          ? NO_WRAP_MEASURE_WIDTH
+          : cellContentWidth;
         const cellMeasure: TableCellMeasure = {
-          blocks: cell.blocks.map((b) => measureBlock(b, cellContentWidth)),
+          blocks: cell.blocks.map((b) => measureBlock(b, measureWidth)),
           width: cellWidth,
           height: 0, // Calculated below
         };


### PR DESCRIPTION
## Summary

Follow-up to eigenpal #424 gap 14 (\`w:noWrap\` on table cells).

The DOCX parser captured \`<w:noWrap/>\` inside \`<w:tcPr>\` and the PM
\`tableCell\` schema stored it, but \`convertTableCell\` in the layout bridge
dropped the field on its way to the engine \`TableCell\`. The painter never
saw it, so cells flagged nowrap (common in legal documents: case numbers,
citations, monetary amounts) wrapped where Word kept them on a single
visual line.

Threaded the attribute end-to-end:

- \`packages/folio/src/core/layout-bridge/toFlowBlocks.ts\` — write
  \`attrs.noWrap\` onto the engine \`TableCell\` in \`convertTableCell\`.
- \`packages/folio/src/core/layout-engine/types.ts\` — add the optional
  \`noWrap\` field with a doc comment citing OOXML §17.4.30.
- \`packages/folio/src/core/layout-painter/renderTable.ts\` —
  \`renderTableCell\` emits \`white-space: nowrap\` on the cell box so
  descendant paragraph lines inherit it.

## Test plan

- [x] \`bun --filter @stll/folio test\` — 1006 pass, 0 fail (3 new
  renderTable painter tests + 1 new toFlowBlocks bridge test)
- [x] \`bun --filter @stll/folio typecheck\`
- [x] \`bun --filter @stll/folio lint\`
- [x] New regression test asserts \`cell.noWrap === true\` produces
  \`style.whiteSpace === "nowrap"\` on the cell element
- [x] New regression test asserts absent / \`false\` \`noWrap\` leaves the
  cell's \`white-space\` style unset
- [x] New bridge test asserts the PM \`tableCell\` \`noWrap\` attribute
  lands on the engine \`TableCell\`