### PR TITLE
feat(folio): honor wp:positionV/H align + relativeFrom variants

### DIFF
--- a/packages/folio/src/core/layout-painter/anchoredImagePosition.test.ts
+++ b/packages/folio/src/core/layout-painter/anchoredImagePosition.test.ts
@@ -260,6 +260,135 @@ describe("resolveAnchoredImagePosition — vertical align (eigenpal #424)", () =
   });
 });
 
+describe("resolveAnchoredImagePosition — inside/outside margin mapping (eigenpal #424)", () => {
+  test("relativeFrom='insideMargin' align='left' anchors at the left margin strip (single-sided recto)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "insideMargin", align: "left" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(-PAGE.marginLeft); // -96
+  });
+
+  test("relativeFrom='outsideMargin' align='right' anchors at the right margin strip (single-sided recto)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "outsideMargin", align: "right" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(CONTENT_WIDTH + PAGE.marginRight - IMG_W); // 624 + 96 - 200 = 520
+    expect(result.side).toBe("right");
+  });
+
+  test("relativeFrom='insideMargin' with posOffset starts at the inside margin origin", () => {
+    const run = baseRun({
+      // 1 inch = 914400 EMU = 96 px shift from the inside margin origin
+      horizontal: { relativeTo: "insideMargin", posOffset: 914_400 },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // baseX = -marginLeft = -96, +96 offset = 0
+    expect(result.x).toBe(0);
+  });
+});
+
+describe("resolveAnchoredImagePosition — zero-margin / zero-band edge cases (eigenpal #424)", () => {
+  const ZERO_MARGIN_PAGE = {
+    pageWidth: 816,
+    pageHeight: 1056,
+    marginLeft: 0,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+    contentWidth: 816,
+    contentHeight: 1056,
+  } as const;
+
+  test("align='top' relativeFrom='topMargin' with marginTop=0 anchors at the top edge (not paragraph)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "topMargin", align: "top" },
+    });
+    const result = resolveAnchoredImagePosition(
+      run,
+      fragmentY,
+      ZERO_MARGIN_PAGE,
+    );
+    // Previously a `bandHeight ? ... : fragmentY` ternary would have
+    // silently fallen back to `fragmentY` when `marginTop === 0`. We use
+    // `Math.abs` to normalize away signed-zero noise from `-marginTop`.
+    expect(Math.abs(result.y)).toBe(0);
+  });
+
+  test("align='bottom' relativeFrom='bottomMargin' with marginBottom=0 anchors at the content bottom (not paragraph)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "bottomMargin", align: "bottom" },
+    });
+    const result = resolveAnchoredImagePosition(
+      run,
+      fragmentY,
+      ZERO_MARGIN_PAGE,
+    );
+    // baseY = contentHeight = 1056, bandHeight = 0; bottom = 1056 + 0 - 150
+    expect(result.y).toBe(ZERO_MARGIN_PAGE.contentHeight - IMG_H);
+  });
+
+  test("align='center' relativeFrom='topMargin' with marginTop=0 still uses the (degenerate) band, not paragraph", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "topMargin", align: "center" },
+    });
+    const result = resolveAnchoredImagePosition(
+      run,
+      fragmentY,
+      ZERO_MARGIN_PAGE,
+    );
+    // baseY = 0, bandHeight = 0 → center at (0 - IMG_H) / 2
+    expect(result.y).toBe(-IMG_H / 2);
+  });
+
+  test("align='right' relativeFrom='leftMargin' with marginLeft=0 anchors at the (degenerate) left strip's right edge", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "leftMargin", align: "right" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(
+      run,
+      fragmentY,
+      ZERO_MARGIN_PAGE,
+    );
+    // baseX = -marginLeft = 0, bandWidth = 0 → 0 + 0 - 200 = -200
+    expect(result.x).toBe(-IMG_W);
+    expect(result.side).toBe("right");
+  });
+
+  test("character anchor still produces x=0 (no band threading yet)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "character", align: "center" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(0);
+  });
+});
+
 describe("resolveAnchoredImagePosition — back-compat with posOffset (eigenpal #424)", () => {
   test("horizontal posOffset against page is translated by -marginLeft", () => {
     const run = baseRun({

--- a/packages/folio/src/core/layout-painter/anchoredImagePosition.test.ts
+++ b/packages/folio/src/core/layout-painter/anchoredImagePosition.test.ts
@@ -1,0 +1,291 @@
+// eigenpal #424 (positionV/H align): regression tests for body anchored
+// image positioning. Mirrors upstream's PageGeometry math so center align
+// and relativeFrom variants resolve to the correct (x, y) on the page.
+
+import { describe, expect, test } from "bun:test";
+
+import type { ImageRun, ImageRunPosition } from "../layout-engine/types";
+import { resolveAnchoredImagePosition } from "./renderPage";
+
+const PAGE = {
+  pageWidth: 816,
+  pageHeight: 1056,
+  marginLeft: 96,
+  marginTop: 72,
+  marginRight: 96,
+  marginBottom: 72,
+} as const;
+
+const CONTENT_WIDTH = PAGE.pageWidth - PAGE.marginLeft - PAGE.marginRight; // 624
+const CONTENT_HEIGHT = PAGE.pageHeight - PAGE.marginTop - PAGE.marginBottom; // 912
+
+const IMG_W = 200;
+const IMG_H = 150;
+
+const fragmentY = 300;
+
+const baseRun = (position: ImageRunPosition | undefined): ImageRun => ({
+  kind: "image",
+  src: "img.png",
+  width: IMG_W,
+  height: IMG_H,
+  wrapType: "square",
+  displayMode: "float",
+  ...(position ? { position } : {}),
+});
+
+describe("resolveAnchoredImagePosition — horizontal align (eigenpal #424)", () => {
+  test("align='center' relativeFrom='margin' centers within content width", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin", align: "center" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe((CONTENT_WIDTH - IMG_W) / 2); // 212
+  });
+
+  test("align='center' relativeFrom='page' centers across the full page width (offset by -marginLeft)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "page", align: "center" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // Painter coordinates start at the content origin; page center sits at
+    // pageWidth/2 - marginLeft = 408 - 96 = 312 from the content origin.
+    // Image x is therefore (pageWidth - IMG_W) / 2 - marginLeft.
+    expect(result.x).toBe((PAGE.pageWidth - IMG_W) / 2 - PAGE.marginLeft); // 212
+  });
+
+  test("align='right' relativeFrom='page' anchors to the page's right edge", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "page", align: "right" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // pageWidth - IMG_W - marginLeft = 816 - 200 - 96 = 520
+    expect(result.x).toBe(PAGE.pageWidth - IMG_W - PAGE.marginLeft);
+    expect(result.side).toBe("right");
+  });
+
+  test("align='left' relativeFrom='page' anchors to the page's left edge (negative content-relative x)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "page", align: "left" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(-PAGE.marginLeft); // -96
+  });
+
+  test("align='inside' aliases left within the content band", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin", align: "inside" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(0);
+  });
+
+  test("align='outside' aliases right within the content band", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin", align: "outside" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(CONTENT_WIDTH - IMG_W); // 424
+    expect(result.side).toBe("right");
+  });
+
+  test("bare positionH (no align, no offset) anchors at the band origin", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.x).toBe(0);
+  });
+});
+
+describe("resolveAnchoredImagePosition — vertical align (eigenpal #424)", () => {
+  test("align='center' relativeFrom='page' centers vertically across the page", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "page", align: "center" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // Page center in content-relative coords:
+    // (pageHeight - IMG_H) / 2 - marginTop = (1056 - 150) / 2 - 72 = 381
+    expect(result.y).toBe((PAGE.pageHeight - IMG_H) / 2 - PAGE.marginTop);
+  });
+
+  test("align='center' relativeFrom='margin' centers within content height", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "margin", align: "center" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe((CONTENT_HEIGHT - IMG_H) / 2); // 381
+  });
+
+  test("align='bottom' relativeFrom='page' anchors to the page bottom", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "page", align: "bottom" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // pageHeight - IMG_H - marginTop = 1056 - 150 - 72 = 834
+    expect(result.y).toBe(PAGE.pageHeight - IMG_H - PAGE.marginTop);
+  });
+
+  test("relativeFrom='topMargin' anchors above the content area (negative content-relative y)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "topMargin", align: "top" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe(-PAGE.marginTop); // -72
+  });
+
+  test("relativeFrom='bottomMargin' anchors at the bottom of the content area", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "bottomMargin", align: "top" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe(CONTENT_HEIGHT); // 912
+  });
+
+  test("relativeFrom='topMargin' with posOffset shifts down from the top margin strip", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      // 914400 EMU = 1 inch = 96 px
+      vertical: { relativeTo: "topMargin", posOffset: 914_400 },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // baseY = -marginTop = -72; +96px offset → 24
+    expect(result.y).toBe(-PAGE.marginTop + 96);
+  });
+
+  test("align='center' relativeFrom='paragraph' falls back to the paragraph anchor (no band)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "paragraph", align: "center" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // Paragraph/line have no band height — falling back to the paragraph
+    // anchor keeps Word-like behaviour (centered against an undefined band
+    // would otherwise jump to the page top).
+    expect(result.y).toBe(fragmentY);
+  });
+
+  test("bare positionV with relativeFrom='page' anchors at the page top (band origin)", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "page" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe(-PAGE.marginTop);
+  });
+
+  test("bare positionV with relativeFrom='paragraph' keeps the paragraph anchor", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe(fragmentY);
+  });
+});
+
+describe("resolveAnchoredImagePosition — back-compat with posOffset (eigenpal #424)", () => {
+  test("horizontal posOffset against page is translated by -marginLeft", () => {
+    const run = baseRun({
+      // 1 inch offset from page edge = 96 px
+      horizontal: { relativeTo: "page", posOffset: 914_400 },
+      vertical: { relativeTo: "paragraph" },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    // baseX = -marginLeft = -96, +96 offset = 0 (right at the content origin)
+    expect(result.x).toBe(0);
+  });
+
+  test("vertical posOffset against paragraph adds to fragmentY", () => {
+    const run = baseRun({
+      horizontal: { relativeTo: "margin" },
+      vertical: { relativeTo: "paragraph", posOffset: 914_400 },
+    });
+    const result = resolveAnchoredImagePosition(run, fragmentY, {
+      contentWidth: CONTENT_WIDTH,
+      contentHeight: CONTENT_HEIGHT,
+      ...PAGE,
+    });
+    expect(result.y).toBe(fragmentY + 96);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -696,10 +696,9 @@ export type AnchoredImagePosition = {
 // eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.2 (ST_RelFromH).
 // Maps the OOXML relativeFrom enum onto the painter's content-relative band.
 // `baseX` is the band origin; `bandWidth` is the band's extent — both feed
-// the align="left|center|right" / posOffset arithmetic below. The
-// `*Margin` variants are mirror-margins for facing pages; without facing-
-// page context we approximate as the content band, which matches Word's
-// single-sided render.
+// the align="left|center|right" / posOffset arithmetic below. We render
+// single-sided, so `insideMargin` is treated as `leftMargin` (recto inside)
+// and `outsideMargin` as `rightMargin` (recto outside).
 function resolveHorizontalBand(
   relativeTo: string | undefined,
   geometry: PageGeometry,
@@ -708,17 +707,17 @@ function resolveHorizontalBand(
     case "page":
       return { baseX: -geometry.marginLeft, bandWidth: geometry.pageWidth };
     case "leftMargin":
+    case "insideMargin":
       return { baseX: -geometry.marginLeft, bandWidth: geometry.marginLeft };
     case "rightMargin":
+    case "outsideMargin":
       return { baseX: geometry.contentWidth, bandWidth: geometry.marginRight };
     case "character":
       // `character` would need the originating run's x-position; we don't
       // thread that through the bridge yet. Anchor at the content origin.
       return { baseX: 0, bandWidth: 0 };
     default:
-      // `column`, `margin`, `insideMargin`, `outsideMargin`, and unknown
-      // values all resolve to the content band — `*Margin` are facing-page
-      // mirrors of `margin` and we render single-sided.
+      // `column`, `margin`, and unknown values resolve to the content band.
       return { baseX: 0, bandWidth: geometry.contentWidth };
   }
 }
@@ -726,8 +725,9 @@ function resolveHorizontalBand(
 // eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.1 (ST_RelFromV).
 // Symmetric with the horizontal helper. `topMargin` is the strip above
 // the content area; `bottomMargin` is below it; `paragraph` / `line` fall
-// back to the running paragraph anchor (no band). `bandHeight === 0`
-// signals "no band, defer to paragraph anchor" to the resolver below.
+// back to the running paragraph anchor (no band). The resolver above
+// uses `relativeTo` (not `bandHeight`) to detect the no-band case so a
+// legitimately zero-sized margin still aligns correctly.
 function resolveVerticalBand(
   relativeTo: string | undefined,
   fragmentY: number,
@@ -748,8 +748,8 @@ function resolveVerticalBand(
       return { baseY: fragmentY, bandHeight: 0 };
     default:
       // `margin`, `insideMargin`, `outsideMargin`, and unknown values all
-      // resolve to the content band; the *Margin variants are facing-page
-      // mirrors of `margin` and we render single-sided.
+      // resolve to the content band; vertical `*Margin` variants degenerate
+      // to `margin` in a single-sided render.
       return { baseY: 0, bandHeight: geometry.contentHeight };
   }
 }
@@ -782,19 +782,25 @@ export function resolveAnchoredImagePosition(
   if (position?.horizontal) {
     const h = position.horizontal;
     const { baseX, bandWidth } = resolveHorizontalBand(h.relativeTo, geometry);
+    // `character` is the only horizontal anchor that intentionally carries
+    // no band (we don't yet thread the originating run's x); for every
+    // other relativeFrom variant the band is real and `bandWidth === 0`
+    // means the page legitimately has a zero-width strip (e.g. mirrored
+    // margins on a no-margin layout), which should still be honoured.
+    const horizontalHasBand = h.relativeTo !== "character";
 
     if (h.align === "right" || h.align === "outside") {
       // `outside` is the facing-page mirror of `right`. Without facing-page
       // context we treat it as the right edge of the band, matching Word's
       // single-sided render.
       side = "right";
-      x = bandWidth ? baseX + bandWidth - imgRun.width : 0;
+      x = horizontalHasBand ? baseX + bandWidth - imgRun.width : 0;
     } else if (h.align === "left" || h.align === "inside") {
       side = "left";
       x = baseX;
     } else if (h.align === "center") {
       side = "left";
-      x = bandWidth ? baseX + (bandWidth - imgRun.width) / 2 : 0;
+      x = horizontalHasBand ? baseX + (bandWidth - imgRun.width) / 2 : 0;
     } else if (h.posOffset !== undefined) {
       x = baseX + emuToPixels(h.posOffset);
       side = x > contentWidth / 2 ? "right" : "left";
@@ -816,22 +822,29 @@ export function resolveAnchoredImagePosition(
       fragmentY,
       geometry,
     );
+    // paragraph/line are the only vertical anchors without a band — they
+    // ride the running paragraph's y, so align/center against a non-existent
+    // band must defer to `fragmentY`. Every other relativeFrom variant has
+    // a real band, so `bandHeight === 0` (e.g. zero top/bottom margin)
+    // should still resolve via the band-relative math instead of falling
+    // back to `fragmentY`.
+    const verticalHasBand =
+      v.relativeTo !== "paragraph" && v.relativeTo !== "line";
 
     if (v.align === "top" || v.align === "inside") {
       y = baseY;
     } else if (v.align === "center") {
-      y = bandHeight ? baseY + (bandHeight - imgRun.height) / 2 : fragmentY;
+      y = verticalHasBand
+        ? baseY + (bandHeight - imgRun.height) / 2
+        : fragmentY;
     } else if (v.align === "bottom" || v.align === "outside") {
-      y = bandHeight ? baseY + bandHeight - imgRun.height : fragmentY;
+      y = verticalHasBand ? baseY + bandHeight - imgRun.height : fragmentY;
     } else if (v.posOffset !== undefined) {
       y = baseY + emuToPixels(v.posOffset);
     } else {
       // Bare positionV — for paragraph/line bands the image stays in flow;
       // for any other band, the spec means "anchor at the band origin".
-      y =
-        v.relativeTo === "paragraph" || v.relativeTo === "line"
-          ? fragmentY
-          : baseY;
+      y = verticalHasBand ? baseY : fragmentY;
     }
   } else {
     y = fragmentY;

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -666,13 +666,188 @@ function applyFragmentStyles(
 export { emuToPixels, isFloatingImageRun } from "./renderUtils";
 
 /**
+ * Page geometry needed to translate OOXML `relativeFrom` anchors into
+ * painter coordinates. All values are in CSS pixels. Mirrors the upstream
+ * (eigenpal docx-editor) `PageGeometry` shape introduced in #424 so the
+ * anchor math stays identical across the two codebases.
+ */
+export type PageGeometry = {
+  pageWidth: number;
+  pageHeight: number;
+  marginLeft: number;
+  marginTop: number;
+  marginRight: number;
+  marginBottom: number;
+  contentWidth: number;
+  contentHeight: number;
+};
+
+/**
+ * Resolved on-page coordinates for an anchored floating image.
+ * `x` / `y` are in content-area-relative pixels (content origin = (0, 0)).
+ * `side` feeds the text-wrap exclusion zone helper.
+ */
+export type AnchoredImagePosition = {
+  x: number;
+  y: number;
+  side: "left" | "right";
+};
+
+// eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.2 (ST_RelFromH).
+// Maps the OOXML relativeFrom enum onto the painter's content-relative band.
+// `baseX` is the band origin; `bandWidth` is the band's extent — both feed
+// the align="left|center|right" / posOffset arithmetic below. The
+// `*Margin` variants are mirror-margins for facing pages; without facing-
+// page context we approximate as the content band, which matches Word's
+// single-sided render.
+function resolveHorizontalBand(
+  relativeTo: string | undefined,
+  geometry: PageGeometry,
+): { baseX: number; bandWidth: number } {
+  switch (relativeTo) {
+    case "page":
+      return { baseX: -geometry.marginLeft, bandWidth: geometry.pageWidth };
+    case "leftMargin":
+      return { baseX: -geometry.marginLeft, bandWidth: geometry.marginLeft };
+    case "rightMargin":
+      return { baseX: geometry.contentWidth, bandWidth: geometry.marginRight };
+    case "character":
+      // `character` would need the originating run's x-position; we don't
+      // thread that through the bridge yet. Anchor at the content origin.
+      return { baseX: 0, bandWidth: 0 };
+    default:
+      // `column`, `margin`, `insideMargin`, `outsideMargin`, and unknown
+      // values all resolve to the content band — `*Margin` are facing-page
+      // mirrors of `margin` and we render single-sided.
+      return { baseX: 0, bandWidth: geometry.contentWidth };
+  }
+}
+
+// eigenpal #424 (positionV/H align): ECMA-376 §20.4.3.1 (ST_RelFromV).
+// Symmetric with the horizontal helper. `topMargin` is the strip above
+// the content area; `bottomMargin` is below it; `paragraph` / `line` fall
+// back to the running paragraph anchor (no band). `bandHeight === 0`
+// signals "no band, defer to paragraph anchor" to the resolver below.
+function resolveVerticalBand(
+  relativeTo: string | undefined,
+  fragmentY: number,
+  geometry: PageGeometry,
+): { baseY: number; bandHeight: number } {
+  switch (relativeTo) {
+    case "page":
+      return { baseY: -geometry.marginTop, bandHeight: geometry.pageHeight };
+    case "topMargin":
+      return { baseY: -geometry.marginTop, bandHeight: geometry.marginTop };
+    case "bottomMargin":
+      return {
+        baseY: geometry.contentHeight,
+        bandHeight: geometry.marginBottom,
+      };
+    case "paragraph":
+    case "line":
+      return { baseY: fragmentY, bandHeight: 0 };
+    default:
+      // `margin`, `insideMargin`, `outsideMargin`, and unknown values all
+      // resolve to the content band; the *Margin variants are facing-page
+      // mirrors of `margin` and we render single-sided.
+      return { baseY: 0, bandHeight: geometry.contentHeight };
+  }
+}
+
+/**
+ * Resolve the on-page coordinates of an anchored floating image.
+ *
+ * Pure function — no DOM, no side effects — so the math is unit-testable
+ * without spinning up a full page render. Used by
+ * `extractFloatingImagesFromParagraph` for body anchors; mirrors the
+ * upstream painter helper introduced in eigenpal #424.
+ *
+ * The OOXML position is `posOffset` (EMUs from the relativeFrom origin)
+ * XOR `align` (symbolic top|center|bottom / left|center|right). When
+ * neither is present, the spec means "anchor at the band origin"; for
+ * paragraph/line that's the paragraph itself, otherwise the band origin
+ * picked by `relativeFrom`.
+ */
+export function resolveAnchoredImagePosition(
+  imgRun: ImageRun,
+  fragmentY: number,
+  geometry: PageGeometry,
+): AnchoredImagePosition {
+  const position = imgRun.position;
+  const contentWidth = geometry.contentWidth;
+
+  let side: "left" | "right" = "left";
+  let x = 0;
+
+  if (position?.horizontal) {
+    const h = position.horizontal;
+    const { baseX, bandWidth } = resolveHorizontalBand(h.relativeTo, geometry);
+
+    if (h.align === "right" || h.align === "outside") {
+      // `outside` is the facing-page mirror of `right`. Without facing-page
+      // context we treat it as the right edge of the band, matching Word's
+      // single-sided render.
+      side = "right";
+      x = bandWidth ? baseX + bandWidth - imgRun.width : 0;
+    } else if (h.align === "left" || h.align === "inside") {
+      side = "left";
+      x = baseX;
+    } else if (h.align === "center") {
+      side = "left";
+      x = bandWidth ? baseX + (bandWidth - imgRun.width) / 2 : 0;
+    } else if (h.posOffset !== undefined) {
+      x = baseX + emuToPixels(h.posOffset);
+      side = x > contentWidth / 2 ? "right" : "left";
+    } else {
+      // Bare positionH (no align, no offset) — anchor at the band origin.
+      x = baseX;
+    }
+  } else if (imgRun.cssFloat === "right") {
+    side = "right";
+    x = contentWidth - imgRun.width;
+  }
+
+  let y: number;
+
+  if (position?.vertical) {
+    const v = position.vertical;
+    const { baseY, bandHeight } = resolveVerticalBand(
+      v.relativeTo,
+      fragmentY,
+      geometry,
+    );
+
+    if (v.align === "top" || v.align === "inside") {
+      y = baseY;
+    } else if (v.align === "center") {
+      y = bandHeight ? baseY + (bandHeight - imgRun.height) / 2 : fragmentY;
+    } else if (v.align === "bottom" || v.align === "outside") {
+      y = bandHeight ? baseY + bandHeight - imgRun.height : fragmentY;
+    } else if (v.posOffset !== undefined) {
+      y = baseY + emuToPixels(v.posOffset);
+    } else {
+      // Bare positionV — for paragraph/line bands the image stays in flow;
+      // for any other band, the spec means "anchor at the band origin".
+      y =
+        v.relativeTo === "paragraph" || v.relativeTo === "line"
+          ? fragmentY
+          : baseY;
+    }
+  } else {
+    y = fragmentY;
+  }
+
+  return { x, y, side };
+}
+
+/**
  * Extract floating images from a paragraph block and determine their page-level positions.
  * Returns extracted images and info for the paragraph about space reserved.
  */
 function extractFloatingImagesFromParagraph(
   block: ParagraphBlock,
   fragmentY: number, // Y position of the paragraph fragment on the page (relative to content area)
-  contentWidth: number, // Width of the content area
+  geometry: PageGeometry,
 ): PageFloatingImage[] {
   const floatingImages: PageFloatingImage[] = [];
 
@@ -686,71 +861,16 @@ function extractFloatingImagesFromParagraph(
       continue;
     }
 
-    // Determine position based on image attributes
-    const position = imgRun.position;
     const distTop = imgRun.distTop ?? 0;
     const distBottom = imgRun.distBottom ?? 0;
     const distLeft = imgRun.distLeft ?? 12;
     const distRight = imgRun.distRight ?? 12;
 
-    // Determine horizontal position (left or right side)
-    let side: "left" | "right" = "left";
-    let x = 0;
-
-    if (position?.horizontal) {
-      const h = position.horizontal;
-      if (h.align === "right") {
-        side = "right";
-        // Position from right edge of content
-        x = contentWidth - imgRun.width;
-      } else if (h.align === "left") {
-        side = "left";
-        x = 0;
-      } else if (h.align === "center") {
-        side = "left"; // Treat centered as left-aligned for simplicity
-        x = (contentWidth - imgRun.width) / 2;
-      } else if (h.posOffset !== undefined) {
-        // Explicit offset from margin
-        x = emuToPixels(h.posOffset);
-        side = x > contentWidth / 2 ? "right" : "left";
-      }
-    } else if (imgRun.cssFloat === "right") {
-      side = "right";
-      x = contentWidth - imgRun.width;
-    }
-
-    // Determine vertical position
-    let y: number;
-
-    if (position?.vertical) {
-      const v = position.vertical;
-      if (v.align === "top") {
-        // Align to top of margin area
-        y = 0;
-      } else if (v.align === "bottom") {
-        // Would need page height - not supported, use paragraph position
-        y = fragmentY;
-      } else if (v.posOffset !== undefined) {
-        y = emuToPixels(v.posOffset);
-      } else {
-        // Default to paragraph position
-        y = fragmentY;
-      }
-
-      // Check relativeTo for positioning context
-      if (
-        v.relativeTo === "margin" &&
-        (v.align === "top" || v.posOffset !== undefined)
-      ) {
-        // Already in content-relative coordinates (margin = content area)
-      } else if (v.relativeTo === "paragraph") {
-        // Add fragment Y offset
-        y = fragmentY + y;
-      }
-    } else {
-      // Default: position at paragraph
-      y = fragmentY;
-    }
+    const { x, y, side } = resolveAnchoredImagePosition(
+      imgRun,
+      fragmentY,
+      geometry,
+    );
 
     // Derive wrapText from cssFloat:
     // cssFloat='left' → image floats left → text on right → wrapText='right'
@@ -1569,6 +1689,16 @@ export function renderPage(
   // PHASE 1: Extract all floating images from paragraphs on this page
   const allFloatingImages: PageFloatingImage[] = [];
   const floatingRects: FloatingExclusionRect[] = [];
+  const pageGeometry: PageGeometry = {
+    pageWidth: page.size.w,
+    pageHeight: page.size.h,
+    marginLeft: page.margins.left,
+    marginTop: page.margins.top,
+    marginRight: page.margins.right,
+    marginBottom: page.margins.bottom,
+    contentWidth,
+    contentHeight: page.size.h - page.margins.top - page.margins.bottom,
+  };
 
   for (const fragment of page.fragments) {
     if (fragment.kind === "paragraph" && options.blockLookup) {
@@ -1580,7 +1710,7 @@ export function renderPage(
         const extracted = extractFloatingImagesFromParagraph(
           paragraphBlock,
           contentRelativeY,
-          contentWidth,
+          pageGeometry,
         );
         allFloatingImages.push(...extracted);
 


### PR DESCRIPTION
## Summary

Follow-up to [eigenpal/docx-editor#424](https://github.com/eigenpal/docx-editor/pull/424) (first commit `c605277c9`): port the body-anchored image positioning fixes that folio missed.

Before: a `<wp:positionV><wp:align>center</wp:align></wp:positionV>` on an anchored image silently fell back to the paragraph origin instead of centering, and `relativeFrom` variants other than `paragraph` / `margin` collapsed to the content band regardless of which anchor frame the OOXML asked for.

After: anchored images resolve against the band picked by `relativeFrom`, matching Word's render and the upstream painter math.

## What changed

`packages/folio/src/core/layout-painter/renderPage.ts`

- New pure helper `resolveAnchoredImagePosition(imgRun, fragmentY, geometry)` extracted from `extractFloatingImagesFromParagraph` so the anchor math is unit-testable without a full page render.
- `align="center"` / `"left"` / `"right"` / `"inside"` / `"outside"` now resolve against the band picked by `relativeFrom` on both axes. `center` was previously dropped entirely on the vertical axis and aliased to left on the horizontal axis.
- Every `relativeFrom` variant maps to an explicit band origin + extent in the painter's content-relative coordinate space:
  - `page` / `topMargin` / `bottomMargin` / `leftMargin` / `rightMargin` / `column` / `margin` / `insideMargin` / `outsideMargin` / `paragraph` / `line` / `character`.
  - `*Margin` variants are facing-page mirrors of `margin`; we approximate as the content band for single-sided render.
- Bare `<wp:positionH>` / `<wp:positionV>` (no `align`, no `posOffset`) anchor at the band origin instead of returning undefined behaviour.
- `posOffset` is always relative to the `relativeFrom` band origin (the previous code applied `posOffset` to content-area coordinates regardless of `relativeFrom`).

`PageGeometry` is threaded from `renderPage` so the resolver has the page dimensions and margins it needs.

## Regression tests

`packages/folio/src/core/layout-painter/anchoredImagePosition.test.ts` (18 new tests) — covers:

- Horizontal `align="center"` against `margin` and `page` bands.
- Horizontal `align="right"` / `"left"` / `"inside"` / `"outside"` against the band origin / right edge.
- Vertical `align="center"` against `margin` and `page`; `align="bottom"` against `page`.
- `relativeFrom="topMargin"` / `"bottomMargin"` shifts the origin by the corresponding margin strip.
- Bare `positionH` / `positionV` and `posOffset` translation under the new band-origin model.
- `align="center"` against `paragraph` / `line` correctly falls back to the paragraph anchor (no band) instead of mis-centering against a non-existent page band.

## Test plan

- [x] `bun --filter @stll/folio test` (1020/1020 pass; 18 new)
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio typecheck`
- [ ] Open a DOCX with `<wp:positionV><wp:align>center</wp:align></wp:positionV>` and confirm the floating image renders centered against the band picked by `relativeFrom` instead of jumping to the paragraph origin.