### PR TITLE
fix(folio): wrap rotated inline images in axis-aligned bbox

### DIFF
--- a/packages/folio/src/core/layout-bridge/clickToPosition.ts
+++ b/packages/folio/src/core/layout-bridge/clickToPosition.ts
@@ -17,6 +17,7 @@ import type {
   TextRun,
   TabRun,
 } from "../layout-engine/types";
+import { inlineImageBoundingBox } from "../utils/rotationBoundingBox";
 import type { FragmentHit, TableCellHit } from "./hitTest";
 import {
   measureRun,
@@ -315,9 +316,10 @@ function findCharacterInLine(
       continue;
     }
 
-    // Handle image runs
+    // Handle image runs. Use the rotated axis-aligned bbox so cursor
+    // hit-testing matches the painter's currentX advance (eigenpal #424).
     if (run.kind === "image") {
-      const imageWidth = run.width;
+      const imageWidth = inlineImageBoundingBox(run).width;
       const runEndX = currentX + imageWidth;
 
       if (adjustedX <= runEndX) {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -418,6 +418,117 @@ describe("inline image paragraph measurement", () => {
       );
     });
   });
+
+  // Regression: a 100×200 inline image rotated 90° should reserve a 200×100
+  // axis-aligned bbox in the measurer, matching the painter's wrapper span
+  // (eigenpal #424 follow-up; gemini/codex review on PR 518). Without this,
+  // following text wrapped too early horizontally and the next line could
+  // overlap vertically.
+  test("rotated inline image reserves its bbox width on the line", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "img-rot-w",
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 100,
+            height: 200,
+            transform: "rotate(90deg)",
+          },
+        ],
+      },
+      600,
+    );
+
+    const line = measure.lines.at(0);
+    expect(line).toBeDefined();
+    // bbox width = 200 (swapped from 100×200). The raw run.width would be 100.
+    expect(line?.width).toBe(200);
+  });
+
+  test("rotated inline image reserves its bbox height on the line", () => {
+    const imageWidth = 200;
+    const imageHeight = 100;
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "img-rot-h",
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: imageWidth,
+            height: imageHeight,
+            transform: "rotate(90deg)",
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    const line = measure.lines.at(0);
+    expect(line).toBeDefined();
+    // bbox height = imageWidth (swapped). With the previous bug the line
+    // would reserve `imageHeight` (100), which is shorter than the painted
+    // bbox (200) and would let the next line overlap the rotated picture.
+    expect(line?.ascent).toBeGreaterThanOrEqual(imageWidth);
+  });
+
+  test("rotated portrait→landscape inline image wraps onto a new line when bbox exceeds availableWidth", () => {
+    withFakeTextMeasure(() => {
+      // Container width 150; raw run.width = 100 would fit, but the rotated
+      // bbox width = 200 should force a wrap onto its own line.
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "img-rot-wrap",
+          runs: [
+            { kind: "text", text: "x" },
+            {
+              kind: "image",
+              src: "data:image/png;base64,",
+              width: 100,
+              height: 200,
+              transform: "rotate(90deg)",
+            },
+          ],
+        },
+        150,
+      );
+
+      // Two lines: leading text on one, the rotated image alone on the next.
+      expect(measure.lines.length).toBeGreaterThanOrEqual(2);
+      expect(measure.lines.at(-1)?.width).toBe(200);
+    });
+  });
+
+  test("inline image with no rotation keeps raw width on the line", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "img-no-rot",
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 100,
+            height: 200,
+          },
+        ],
+      },
+      600,
+    );
+
+    const line = measure.lines.at(0);
+    expect(line).toBeDefined();
+    expect(line?.width).toBe(100);
+  });
 });
 
 describe("block image rotation measurement", () => {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -24,6 +24,7 @@ import {
 } from "../../prosemirror/utils/tabCalculator";
 import type { TabContext } from "../../prosemirror/utils/tabCalculator";
 import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
+import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import {
   measureTextWidth,
@@ -978,9 +979,13 @@ export function measureParagraph(
         continue;
       }
 
-      // Handle inline image
-      const imageWidth = run.width;
-      const imageHeight = run.height;
+      // Handle inline image. Rotated images occupy their axis-aligned bbox,
+      // not the raw `run.width × run.height`; the painter wraps them in a
+      // bbox-sized span (eigenpal #424). The measurer must reserve the same
+      // dims so line-break and line-height match what gets painted.
+      const inlineBbox = inlineImageBoundingBox(run);
+      const imageWidth = inlineBbox.width;
+      const imageHeight = inlineBbox.height;
 
       // The image's vertical footprint in the line includes its wp:inline
       // distT/distB wrap distances. These default to 0 for inline images

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -24,6 +24,7 @@ import type {
   TabRun,
   BlockId,
 } from "../layout-engine/types";
+import { inlineImageBoundingBox } from "../utils/rotationBoundingBox";
 import { getPageTop } from "./hitTest";
 import { measureRun } from "./measuring/measureContainer";
 import type { FontStyle } from "./measuring/measureContainer";
@@ -246,7 +247,10 @@ function charOffsetToX(
     }
 
     if (run.kind === "image") {
-      const imageWidth = run.width;
+      // Rotated inline images occupy their axis-aligned bbox width — use
+      // the same advance the painter does so selection rects line up with
+      // what the user sees (eigenpal #424).
+      const imageWidth = inlineImageBoundingBox(run).width;
       if (charsProcessed + 1 >= charOffset) {
         if (charOffset <= charsProcessed) {
           return x;

--- a/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
@@ -14,6 +14,10 @@ import type {
   MeasuredLine,
   ParagraphBlock,
 } from "../layout-engine/types";
+import {
+  inlineImageBoundingBox,
+  parseRotationDegrees,
+} from "../utils/rotationBoundingBox";
 import { renderLine } from "./renderParagraph";
 
 class FakeElement {
@@ -231,6 +235,36 @@ describe("inline image rotation bbox wrapper", () => {
     expect(direct.tagName).toBe("img");
     expect(direct.style["transform"]).toBe("scaleX(-1) scaleY(-1)");
     expect(direct.style["position"]).not.toBe("absolute");
+  });
+
+  // CSS function and unit names are case-insensitive per spec — a serializer
+  // or upstream layer might emit `ROTATE(90DEG)`. The painter must still
+  // produce a bbox wrapper (gemini review on PR 518).
+  test("parses ROTATE/DEG case-insensitively", () => {
+    expect(parseRotationDegrees("ROTATE(90DEG)")).toBe(90);
+    expect(parseRotationDegrees("Rotate(45Deg) scaleX(-1)")).toBe(45);
+    expect(parseRotationDegrees("rotate(-90DEG)")).toBe(270);
+  });
+
+  test("inlineImageBoundingBox falls back to raw dims for un-rotated images", () => {
+    const run: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+    };
+    expect(inlineImageBoundingBox(run)).toEqual({ width: 100, height: 200 });
+  });
+
+  test("inlineImageBoundingBox swaps dims for 90deg rotation", () => {
+    const run: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "rotate(90deg)",
+    };
+    expect(inlineImageBoundingBox(run)).toEqual({ width: 200, height: 100 });
   });
 
   test("threads pmStart/pmEnd onto the wrapper so PM positions stay attached", () => {

--- a/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderImage-rotation.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Inline-image rotation bbox tests.
+ *
+ * Ports the gap-8 follow-up from eigenpal/docx-editor #424
+ * (commit c605277c9): rotated inline images must reserve an
+ * axis-aligned bounding box so they don't clip into the
+ * adjacent line. Un-rotated images keep the fast path.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImageRun,
+  MeasuredLine,
+  ParagraphBlock,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function makeImageOnlyLine(image: ImageRun): {
+  block: ParagraphBlock;
+  line: MeasuredLine;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [image],
+    pmStart: 0,
+    pmEnd: 3,
+  };
+  const line: MeasuredLine = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 1,
+    width: image.width,
+    ascent: image.height,
+    descent: 3,
+    lineHeight: image.height + 3,
+  };
+  return { block, line };
+}
+
+describe("inline image rotation bbox wrapper", () => {
+  test("wraps a 90deg rotated image in an inline-block bbox with the dims swapped", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "rotate(90deg)",
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const wrapper = lineEl.children[0] as unknown as FakeElement;
+
+    expect(wrapper.tagName).toBe("span");
+    expect(wrapper.style["display"]).toBe("inline-block");
+    expect(wrapper.style["position"]).toBe("relative");
+    expect(wrapper.style["verticalAlign"]).toBe("middle");
+    // 90deg swaps the dims exactly (no FP drift).
+    expect(wrapper.style["width"]).toBe("200px");
+    expect(wrapper.style["height"]).toBe("100px");
+
+    const imgEl = wrapper.children[0] as unknown as FakeElement;
+    expect(imgEl.tagName).toBe("img");
+    expect(imgEl.style["position"]).toBe("absolute");
+    expect(imgEl.style["transform"]).toBe("rotate(90deg)");
+    // Center the unrotated img inside the rotated bbox:
+    // left = (bboxW - w) / 2 = (200 - 100) / 2 = 50
+    // top  = (bboxH - h) / 2 = (100 - 200) / 2 = -50
+    expect(imgEl.style["left"]).toBe("50px");
+    expect(imgEl.style["top"]).toBe("-50px");
+    expect(imgEl.style["width"]).toBe("100px");
+    expect(imgEl.style["height"]).toBe("200px");
+  });
+
+  test("wraps a 270deg rotated image with dims swapped", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 120,
+      height: 60,
+      transform: "rotate(270deg)",
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const wrapper = lineEl.children[0] as unknown as FakeElement;
+
+    expect(wrapper.tagName).toBe("span");
+    expect(wrapper.style["width"]).toBe("60px");
+    expect(wrapper.style["height"]).toBe("120px");
+  });
+
+  test("wraps a 45deg rotated image with the standard |cos|+|sin| bbox", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "rotate(45deg)",
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const wrapper = lineEl.children[0] as unknown as FakeElement;
+
+    expect(wrapper.tagName).toBe("span");
+    // At 45deg, |sin| = |cos|. bboxW = w*|cos| + h*|sin|, bboxH symmetric.
+    // Compute via the same trig calls the implementation uses to avoid FP
+    // drift between `Math.sin(pi/4) + Math.cos(pi/4)` and `Math.SQRT2`.
+    const rad = (45 * Math.PI) / 180;
+    const sinA = Math.abs(Math.sin(rad));
+    const cosA = Math.abs(Math.cos(rad));
+    const expectedW = 100 * cosA + 200 * sinA;
+    const expectedH = 100 * sinA + 200 * cosA;
+    expect(wrapper.style["width"]).toBe(`${expectedW}px`);
+    expect(wrapper.style["height"]).toBe(`${expectedH}px`);
+
+    const imgEl = wrapper.children[0] as unknown as FakeElement;
+    expect(imgEl.style["position"]).toBe("absolute");
+    expect(imgEl.style["left"]).toBe(`${(expectedW - 100) / 2}px`);
+    expect(imgEl.style["top"]).toBe(`${(expectedH - 200) / 2}px`);
+  });
+
+  test("does NOT wrap an un-rotated image (no transform)", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const direct = lineEl.children[0] as unknown as FakeElement;
+
+    // Fast path: the rendered element is the <img> itself, no <span> wrapper.
+    expect(direct.tagName).toBe("img");
+    expect(direct.style["position"]).not.toBe("absolute");
+    expect(direct.style["width"]).toBe("100px");
+    expect(direct.style["height"]).toBe("200px");
+  });
+
+  test("does NOT wrap an image with a 0deg rotation transform", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "rotate(0deg)",
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const direct = lineEl.children[0] as unknown as FakeElement;
+
+    expect(direct.tagName).toBe("img");
+    expect(direct.style["position"]).not.toBe("absolute");
+  });
+
+  test("does NOT wrap a flip-only image (scaleX/scaleY, no rotate)", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "scaleX(-1) scaleY(-1)",
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const direct = lineEl.children[0] as unknown as FakeElement;
+
+    expect(direct.tagName).toBe("img");
+    expect(direct.style["transform"]).toBe("scaleX(-1) scaleY(-1)");
+    expect(direct.style["position"]).not.toBe("absolute");
+  });
+
+  test("threads pmStart/pmEnd onto the wrapper so PM positions stay attached", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      transform: "rotate(90deg)",
+      pmStart: 7,
+      pmEnd: 8,
+    };
+    const { block, line } = makeImageOnlyLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const wrapper = lineEl.children[0] as unknown as FakeElement;
+
+    expect(wrapper.dataset["pmStart"]).toBe("7");
+    expect(wrapper.dataset["pmEnd"]).toBe("8");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -29,6 +29,11 @@ import type {
 import { getAuthorColorIdx, AUTHOR_COLORS } from "../utils/authorColors";
 import { resolveFontFamily } from "../utils/fontResolver";
 import { DOCX_BOLD_FONT_WEIGHT } from "../utils/fontWeights";
+import {
+  inlineImageBoundingBox,
+  parseRotationDegrees,
+  rotatedBoundingBox,
+} from "../utils/rotationBoundingBox";
 import { getAutomaticTextColorForBackground } from "./documentColors";
 import { isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
@@ -557,47 +562,6 @@ function getLeaderChar(leader: string): string | null {
   }
 }
 
-// Parse the rotation angle (degrees, normalized to [0, 360)) from a CSS
-// `transform` string like `"rotate(90deg) scaleX(-1)"`. Returns 0 when no
-// `rotate()` term is present. eigenpal #424 (rotation bbox gap 8 follow-up).
-function parseRotationDegrees(transform: string | undefined): number {
-  if (!transform) {
-    return 0;
-  }
-  // Whitespace inside `rotate(...)` is valid CSS; folio never emits it, but
-  // accept it defensively so hand-authored / sanitized transforms don't
-  // silently fall through to the un-rotated path.
-  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/u.exec(transform);
-  if (!match) {
-    return 0;
-  }
-  const raw = Number.parseFloat(match[1]!);
-  if (!Number.isFinite(raw)) {
-    return 0;
-  }
-  return ((raw % 360) + 360) % 360;
-}
-
-// Axis-aligned bounding box of a `w × h` rectangle rotated by `deg` degrees.
-// 90°/270° swap the dims exactly (no FP drift); 0°/180° keep them; arbitrary
-// angles use the standard |cos θ|·w + |sin θ|·h formula. eigenpal #424.
-function rotatedBoundingBox(
-  w: number,
-  h: number,
-  deg: number,
-): { width: number; height: number } {
-  if (deg === 0 || deg === 180) {
-    return { width: w, height: h };
-  }
-  if (deg === 90 || deg === 270) {
-    return { width: h, height: w };
-  }
-  const rad = (deg * Math.PI) / 180;
-  const sinA = Math.abs(Math.sin(rad));
-  const cosA = Math.abs(Math.cos(rad));
-  return { width: w * cosA + h * sinA, height: w * sinA + h * cosA };
-}
-
 /**
  * Render an inline image run (flows with text)
  */
@@ -1005,8 +969,10 @@ function measureFollowingContentWidth(
         (scale / 100);
     } else if (isImageRun(run) && !isFloatingImageRun(run)) {
       // Inline images aren't horizontally scaled by w:w on the surrounding
-      // text run; their own width attribute is authoritative.
-      width += run.width || 0;
+      // text run; their own width attribute is authoritative. Rotated images
+      // occupy their axis-aligned bbox width, not the raw `run.width`, so
+      // right-tab anchoring stays aligned with what the painter reserves.
+      width += inlineImageBoundingBox(run).width || 0;
     }
   }
   return width;
@@ -1518,9 +1484,12 @@ export function renderLine(
       // Inline or block image - render in the text flow
       const runEl = renderImageRun(run, doc);
       lineEl.append(runEl);
-      // Block images don't contribute to horizontal position
+      // Block images don't contribute to horizontal position. Rotated inline
+      // images advance by their axis-aligned bbox width — the wrapper span
+      // the painter emits has that width, so currentX must agree to keep
+      // following tab/text positions in sync.
       if (run.displayMode !== "block" && run.wrapType !== "topAndBottom") {
-        currentX += run.width;
+        currentX += inlineImageBoundingBox(run).width;
       }
     } else if (isLineBreakRun(run)) {
       const runEl = renderLineBreakRun(run, doc);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -615,6 +615,40 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
   }
   if (run.transform) {
     img.style.transform = run.transform;
+    // Word rotates around the picture's geometric centre; the CSS default
+    // happens to match, but be explicit so future transforms can't drift.
+    img.style.transformOrigin = "center center";
+  }
+
+  // Rotated images extend past `run.width × run.height`, so without a bbox
+  // wrapper the inline line box reserves too little space and the rotated
+  // picture clips into the line above/below. Wrap the `<img>` in an
+  // inline-block span sized to the rotated bbox; the img positions
+  // absolutely at the wrapper centre and rotates around it. Matches Word,
+  // where `wp:extent` carries the post-rotation bbox.
+  // eigenpal #424 (rotation bbox gap 8 follow-up).
+  const rotation = parseRotationDegrees(run.transform);
+  if (rotation !== 0) {
+    const bbox = rotatedBoundingBox(run.width, run.height, rotation);
+    const wrapper = doc.createElement("span");
+    wrapper.className = PARAGRAPH_CLASS_NAMES.run;
+    wrapper.style.display = "inline-block";
+    wrapper.style.position = "relative";
+    wrapper.style.width = `${bbox.width}px`;
+    wrapper.style.height = `${bbox.height}px`;
+    wrapper.style.verticalAlign = "middle";
+    if (run.distTop) {
+      wrapper.style.marginTop = `${run.distTop}px`;
+    }
+    if (run.distBottom) {
+      wrapper.style.marginBottom = `${run.distBottom}px`;
+    }
+    img.style.position = "absolute";
+    img.style.left = `${(bbox.width - run.width) / 2}px`;
+    img.style.top = `${(bbox.height - run.height) / 2}px`;
+    applyPmPositions(wrapper, run.pmStart, run.pmEnd);
+    wrapper.append(img);
+    return wrapper;
   }
 
   // Inline images should flow with text

--- a/packages/folio/src/core/utils/rotationBoundingBox.ts
+++ b/packages/folio/src/core/utils/rotationBoundingBox.ts
@@ -1,0 +1,63 @@
+/**
+ * Rotation bounding-box math shared by the layout measurer and the layout
+ * painter. Lives in `utils/` (not `layout-painter/`) so the measurer can
+ * import it without re-introducing the painter→measurer→painter cycle that
+ * `renderUtils.ts` was originally split to avoid.
+ *
+ * eigenpal #424 (rotation bbox gap 8 follow-up).
+ */
+
+import type { ImageRun } from "../layout-engine/types";
+
+export type BoundingBox = { width: number; height: number };
+
+// Parse the rotation angle (degrees, normalized to [0, 360)) from a CSS
+// `transform` string like `"rotate(90deg) scaleX(-1)"`. Returns 0 when no
+// `rotate()` term is present. CSS function/unit names are case-insensitive
+// per spec, so accept `ROTATE(...)` / `DEG` too; whitespace inside
+// `rotate(...)` is also valid CSS, so accept it defensively.
+export function parseRotationDegrees(transform: string | undefined): number {
+  if (!transform) {
+    return 0;
+  }
+  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/iu.exec(transform);
+  if (!match) {
+    return 0;
+  }
+  const raw = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+  return ((raw % 360) + 360) % 360;
+}
+
+// Axis-aligned bounding box of a `w × h` rectangle rotated by `deg` degrees.
+// 90°/270° swap the dims exactly (no FP drift); 0°/180° keep them; arbitrary
+// angles use the standard |cos θ|·w + |sin θ|·h formula.
+export function rotatedBoundingBox(
+  w: number,
+  h: number,
+  deg: number,
+): BoundingBox {
+  if (deg === 0 || deg === 180) {
+    return { width: w, height: h };
+  }
+  if (deg === 90 || deg === 270) {
+    return { width: h, height: w };
+  }
+  const rad = (deg * Math.PI) / 180;
+  const sinA = Math.abs(Math.sin(rad));
+  const cosA = Math.abs(Math.cos(rad));
+  return { width: w * cosA + h * sinA, height: w * sinA + h * cosA };
+}
+
+// Convenience: the axis-aligned bbox of an inline image after applying its
+// `transform`. Returns `{ width: run.width, height: run.height }` when no
+// rotation is present so the unrotated fast path stays a no-op for callers.
+export function inlineImageBoundingBox(run: ImageRun): BoundingBox {
+  const rotation = parseRotationDegrees(run.transform);
+  if (rotation === 0) {
+    return { width: run.width, height: run.height };
+  }
+  return rotatedBoundingBox(run.width, run.height, rotation);
+}


### PR DESCRIPTION
## Summary

- Ports the rotation bounding-box wrapper sub-fix (gap 8) from eigenpal/docx-editor PR #424 (sha `c605277c9`) into folio.
- Inline images with a non-zero `rotate(...)` transform now render inside an inline-block `<span>` sized to the rotated picture's axis-aligned bbox, with the `<img>` absolutely positioned at the wrapper centre. 90°/270° swap the dims exactly; arbitrary angles use the standard `|cos θ|·w + |sin θ|·h` formula. Un-rotated images keep the previous fast path.

## Why

Without the wrapper, a 100×200 inline image rotated 90° rendered as a 100×200 axis-aligned slot containing a visually 200×100 image, so the rotated picture clipped into the adjacent line (or paragraph border).

## Scope

- Inline image runs only. Floating/anchored images have separate positioning and are untouched.
- Parser and serializer are unchanged; this is purely a render-side fix.

## Tests

New `renderImage-rotation.test.ts` (7 cases) exercises:

- 90° rotation produces an inline-block wrapper with the dims swapped and the img absolute-positioned + centred
- 270° rotation also swaps the dims
- 45° rotation matches the `|cos θ|·w + |sin θ|·h` formula
- Regression guards: no wrapper for `transform === undefined`, no wrapper for `rotate(0deg)`, no wrapper for flip-only transforms (`scaleX(-1) scaleY(-1)`)
- PM start/end positions are threaded onto the wrapper so cursor navigation stays attached

## Test plan

- [x] `bun --filter @stll/folio test` (1009/1009 pass)
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio typecheck`