### PR TITLE
feat(folio): render hidden text (w:vanish) as dimmed underline

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -22,6 +22,7 @@ const schema = new Schema({
     smallCaps: {},
     emboss: {},
     imprint: {},
+    hidden: {},
     textShadow: {},
     textOutline: {},
     emphasisMark: {
@@ -83,6 +84,14 @@ describe("toFlowBlocks run-level OOXML marks", () => {
       const blocks = toFlowBlocks(buildSingleRunDoc("text", markName), {});
       expect(firstRun(blocks)[markName]).toBe(true);
     }
+  });
+
+  // eigenpal #424 (w:vanish gap 9): the `hidden` PM mark must surface as
+  // RunFormatting.hidden so the painter applies the dimmed dotted-underline
+  // treatment for the editing view.
+  test("propagates the hidden mark (w:vanish) to RunFormatting.hidden", () => {
+    const blocks = toFlowBlocks(buildSingleRunDoc("text", "hidden"), {});
+    expect(firstRun(blocks).hidden).toBe(true);
   });
 
   test("propagates character spacing position, scale, and kerning", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -477,6 +477,12 @@ function extractRunFormatting(
         formatting.imprint = true;
         break;
 
+      case "hidden":
+        // eigenpal #424 (w:vanish gap 9): mark surfaces RunFormatting.hidden
+        // so the painter can apply the dimmed dotted-underline treatment.
+        formatting.hidden = true;
+        break;
+
       case "textShadow":
         formatting.textShadow = true;
         break;

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -46,6 +46,13 @@ export type RunFormatting = {
   textShadow?: boolean;
   textOutline?: boolean;
   emphasisMark?: "dot" | "comma" | "circle" | "underDot";
+  /**
+   * Hidden run (OOXML w:vanish, §17.3.2.41). Word's print/normal view
+   * suppresses it entirely, but the editing view dims it with a dotted
+   * underline so the author can navigate to and edit it. The painter
+   * mirrors the editing-view treatment so PM cursor traversal works.
+   */
+  hidden?: boolean;
   /** Hyperlink info if this run is a link */
   hyperlink?: HyperlinkInfo;
   /** Footnote reference ID (if this run contains a footnote reference) */

--- a/packages/folio/src/core/layout-painter/renderParagraph-hidden.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-hidden.test.ts
@@ -129,9 +129,14 @@ describe("renderParagraph w:vanish (hidden text) — eigenpal #424 gap 9", () =>
     expect(visibleEl.style["textDecoration"]).toBeUndefined();
 
     // Hidden run: dimmed with dotted underline, class hook present.
+    // Longhand properties (not the `text-decoration` shorthand) so a later
+    // `textDecorationLine` assignment can't reset color/thickness, and so
+    // combining `w:vanish` with `w:strike` keeps both decorations visible.
     expect(hiddenEl.className).toContain("docx-hidden");
     expect(hiddenEl.style["opacity"]).toBe("0.4");
-    expect(hiddenEl.style["textDecoration"]).toBe("underline dotted");
+    expect(hiddenEl.style["textDecoration"]).toBeUndefined();
+    expect(hiddenEl.style["textDecorationLine"]).toBe("underline");
+    expect(hiddenEl.style["textDecorationStyle"]).toBe("dotted");
     // Text content is preserved so the cursor has something to land on.
     expect(hiddenEl.textContent).toBe("secret");
   });
@@ -153,5 +158,60 @@ describe("renderParagraph w:vanish (hidden text) — eigenpal #424 gap 9", () =>
     expect(textEl.className).not.toContain("docx-hidden");
     expect(textEl.style["opacity"]).toBeUndefined();
     expect(textEl.style["textDecoration"]).toBeUndefined();
+    expect(textEl.style["textDecorationLine"]).toBeUndefined();
+    expect(textEl.style["textDecorationStyle"]).toBeUndefined();
+  });
+
+  test("hidden + strike keeps both line-through and underline (longhand)", () => {
+    // Regression: the previous `element.style.textDecoration = "underline dotted"`
+    // shorthand was overwritten by the later `textDecorationLine` assignment
+    // once `decorations` contained anything (e.g. line-through from w:strike),
+    // silently dropping the hidden underline. Longhand keeps both visible.
+    const { block, line } = buildLine([
+      { kind: "text", text: "gone", hidden: true, strike: true },
+    ]);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [],
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    const [textEl] = findTextRunEls(lineEl) as [FakeElement];
+    const line_ = textEl.style["textDecorationLine"] ?? "";
+    expect(line_).toContain("underline");
+    expect(line_).toContain("line-through");
+    expect(textEl.style["textDecorationStyle"]).toBe("dotted");
+  });
+
+  test("hidden + explicit underline mark preserves the underline style", () => {
+    // When a run is both hidden and carries an explicit `w:u w:val="double"`,
+    // the explicit style must win over the hidden-run dotted default.
+    const { block, line } = buildLine([
+      {
+        kind: "text",
+        text: "both",
+        hidden: true,
+        underline: { style: "double" },
+      },
+    ]);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [],
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    const [textEl] = findTextRunEls(lineEl) as [FakeElement];
+    expect(textEl.style["textDecorationLine"]).toBe("underline");
+    expect(textEl.style["textDecorationStyle"]).toBe("double");
   });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph-hidden.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-hidden.test.ts
@@ -1,0 +1,157 @@
+// Regression eigenpal #424 gap 9 (w:vanish): hidden runs must stay in the DOM
+// so PM cursor navigation works across hidden ranges. Word's editing view
+// dims hidden text with a dotted underline instead of suppressing it; mirror
+// that. A `docx-hidden` class hook lets host CSS opt into print-style
+// suppression later without us changing the painter.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  MeasuredLine,
+  ParagraphBlock,
+  TextRun,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+  textContent = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return this.children.at(0) ?? null;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function findTextRunEls(lineEl: FakeElement): FakeElement[] {
+  return lineEl.children.filter((c) => c.className.includes("layout-run-text"));
+}
+
+function buildLine(runs: TextRun[]): {
+  block: ParagraphBlock;
+  line: MeasuredLine;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p",
+    runs,
+  };
+  const lastRun = runs.at(-1);
+  if (!lastRun) {
+    throw new Error("buildLine requires at least one run");
+  }
+  const line: MeasuredLine = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: runs.length - 1,
+    toChar: lastRun.text.length,
+    width: 200,
+    ascent: 12,
+    descent: 3,
+    lineHeight: 15,
+  };
+  return { block, line };
+}
+
+describe("renderParagraph w:vanish (hidden text) — eigenpal #424 gap 9", () => {
+  test("hidden run renders with docx-hidden class and dimmed dotted-underline style", () => {
+    const { block, line } = buildLine([
+      { kind: "text", text: "visible " },
+      { kind: "text", text: "secret", hidden: true },
+    ]);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [],
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    const textEls = findTextRunEls(lineEl);
+    // Both runs must remain in the DOM — display:none would orphan PM
+    // positions and break cursor navigation across the hidden boundary.
+    expect(textEls).toHaveLength(2);
+
+    const [visibleEl, hiddenEl] = textEls as [FakeElement, FakeElement];
+
+    // Visible run: no hidden treatment.
+    expect(visibleEl.className).not.toContain("docx-hidden");
+    expect(visibleEl.style["opacity"]).toBeUndefined();
+    expect(visibleEl.style["textDecoration"]).toBeUndefined();
+
+    // Hidden run: dimmed with dotted underline, class hook present.
+    expect(hiddenEl.className).toContain("docx-hidden");
+    expect(hiddenEl.style["opacity"]).toBe("0.4");
+    expect(hiddenEl.style["textDecoration"]).toBe("underline dotted");
+    // Text content is preserved so the cursor has something to land on.
+    expect(hiddenEl.textContent).toBe("secret");
+  });
+
+  test("non-hidden run does NOT receive docx-hidden class or dim styles", () => {
+    const { block, line } = buildLine([{ kind: "text", text: "plain" }]);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 600,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [],
+      leftIndentPx: 0,
+      lineRightEdgePx: 600,
+    }) as unknown as FakeElement;
+
+    const [textEl] = findTextRunEls(lineEl) as [FakeElement];
+    expect(textEl.className).not.toContain("docx-hidden");
+    expect(textEl.style["opacity"]).toBeUndefined();
+    expect(textEl.style["textDecoration"]).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -257,6 +257,20 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     ).webkitTextEmphasisPosition = position;
   }
 
+  // Hidden run (OOXML w:vanish, §17.3.2.41). Word's print/normal view
+  // suppresses hidden text entirely, but in editing view it draws the
+  // run dimmed with a dotted underline so the author can still navigate
+  // to and edit it. Mirror that: keep the run in flow and selectable —
+  // `display: none` would orphan PM positions and break cursor movement
+  // across hidden ranges. The `docx-hidden` class hook lets host CSS
+  // swap to print-style suppression when a future view-mode toggle ships.
+  // eigenpal #424 (w:vanish gap 9)
+  if (run.hidden) {
+    element.classList.add("docx-hidden");
+    element.style.opacity = "0.4";
+    element.style.textDecoration = "underline dotted";
+  }
+
   // Highlight (background color)
   if (run.highlight) {
     element.style.backgroundColor = run.highlight;

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -268,7 +268,6 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   if (run.hidden) {
     element.classList.add("docx-hidden");
     element.style.opacity = "0.4";
-    element.style.textDecoration = "underline dotted";
   }
 
   // Highlight (background color)
@@ -288,12 +287,14 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
 
   // Text decorations
   const decorations: string[] = [];
+  let explicitDecorationStyle = false;
 
   if (run.underline) {
     decorations.push("underline");
     if (typeof run.underline === "object") {
       if (run.underline.style) {
         element.style.textDecorationStyle = run.underline.style;
+        explicitDecorationStyle = true;
       }
       if (run.underline.color) {
         element.style.textDecorationColor = run.underline.color;
@@ -303,6 +304,21 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
 
   if (run.strike) {
     decorations.push("line-through");
+  }
+
+  // Hidden runs need a dotted underline alongside any explicit underline/strike.
+  // Push into the shared `decorations` array (consumed at the end of this
+  // function) so the line 376 longhand assignment doesn't clobber it. The
+  // `textDecorationStyle` longhand is set only when no explicit underline
+  // style has already won — that keeps `w:u w:val="double"` visible if a
+  // hidden run also carries an underline mark.
+  if (run.hidden) {
+    if (!decorations.includes("underline")) {
+      decorations.push("underline");
+    }
+    if (!explicitDecorationStyle) {
+      element.style.textDecorationStyle = "dotted";
+    }
   }
 
   // Comment highlight

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1586,6 +1586,12 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
         formatting.imprint = true;
         break;
 
+      case "hidden":
+        // eigenpal #424 (w:vanish gap 9): mark closes the round-trip so
+        // `<w:vanish/>` survives parse → PM → serialize.
+        formatting.hidden = true;
+        break;
+
       case "textShadow":
         formatting.shadow = true;
         break;

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2258,6 +2258,11 @@ function textFormattingToMarks(
     );
   }
 
+  // Hidden text (w:vanish). eigenpal #424 (gap 9).
+  if (formatting.hidden === true) {
+    marks.push(schema.mark("hidden"));
+  }
+
   // Emboss (w:emboss)
   if (formatting.emboss) {
     marks.push(schema.mark("emboss"));

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -34,6 +34,7 @@ import { CommentExtension } from "./marks/CommentExtension";
 import { FontFamilyExtension } from "./marks/FontFamilyExtension";
 import { FontSizeExtension } from "./marks/FontSizeExtension";
 import { FootnoteRefExtension } from "./marks/FootnoteRefExtension";
+import { HiddenTextExtension } from "./marks/HiddenTextExtension";
 import { HighlightExtension } from "./marks/HighlightExtension";
 import { HyperlinkExtension } from "./marks/HyperlinkExtension";
 import { ItalicExtension } from "./marks/ItalicExtension";
@@ -132,6 +133,7 @@ export function createStarterKit(
   add("characterSpacing", CharacterSpacingExtension());
   add("emboss", EmbossExtension());
   add("imprint", ImprintExtension());
+  add("hidden", HiddenTextExtension());
   add("textShadow", TextShadowExtension());
   add("emphasisMark", EmphasisMarkExtension());
   add("textOutline", TextOutlineExtension());

--- a/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.test.ts
@@ -1,0 +1,38 @@
+// Regression eigenpal #424 gap 9 (w:vanish): the hidden mark's toDOM must
+// NOT emit inline `text-decoration`. UnderlineExtension's parseDOM rule
+// matches any element style containing "underline", so a dotted underline
+// emitted here would round-trip through the clipboard / DOM reparse as both
+// `hidden` and `underline` marks, adding a spurious `<w:u>` next to
+// `<w:vanish/>` on DOCX export.
+
+import { describe, expect, test } from "bun:test";
+
+import { HiddenTextExtension } from "./HiddenTextExtension";
+
+describe("HiddenTextExtension toDOM — eigenpal #424 gap 9", () => {
+  test("emits only the docx-hidden class hook (no inline text-decoration)", () => {
+    const extension = HiddenTextExtension();
+    const spec = extension.config.markSpec;
+    if (!spec.toDOM) {
+      throw new Error("HiddenTextExtension must define toDOM");
+    }
+
+    // The mark argument is unused by this toDOM, but the PM type signature
+    // requires one; passing a stub keeps the test independent of the
+    // schema/mark plumbing.
+    const fakeMark = { type: { name: "hidden" }, attrs: {} } as Parameters<
+      typeof spec.toDOM
+    >[0];
+    const output = spec.toDOM(fakeMark, true);
+
+    if (!Array.isArray(output)) {
+      throw new TypeError("Expected DOMOutputSpec to be an array");
+    }
+    expect(output[0]).toBe("span");
+    const attrs = output[1] as Record<string, string> | undefined;
+    expect(attrs).toEqual({ class: "docx-hidden" });
+    // Most important: no inline style with `text-decoration` so the
+    // UnderlineExtension parser cannot pick it up on reparse.
+    expect(attrs?.["style"]).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.ts
@@ -1,0 +1,31 @@
+/**
+ * Hidden Text Mark Extension (w:vanish, OOXML §17.3.2.41)
+ *
+ * Word's editing view dims hidden text with a dotted underline so the
+ * author can navigate to and edit it; the print/normal view suppresses it
+ * entirely. The painter mirrors the editing-view treatment so PM cursor
+ * traversal stays correct across hidden ranges. The `docx-hidden` class
+ * hook lets host CSS opt into print-style suppression independently.
+ *
+ * eigenpal #424 (w:vanish gap 9).
+ */
+
+import { createMarkExtension } from "../create";
+
+export const HiddenTextExtension = createMarkExtension({
+  name: "hidden",
+  schemaMarkName: "hidden",
+  markSpec: {
+    parseDOM: [{ tag: "span.docx-hidden" }],
+    toDOM() {
+      return [
+        "span",
+        {
+          class: "docx-hidden",
+          style: "opacity: 0.4; text-decoration: underline dotted",
+        },
+        0,
+      ];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/HiddenTextExtension.ts
@@ -7,6 +7,12 @@
  * traversal stays correct across hidden ranges. The `docx-hidden` class
  * hook lets host CSS opt into print-style suppression independently.
  *
+ * The dotted-underline visual is delivered via `editor.css` (`.docx-hidden`
+ * rule), NOT inline `text-decoration`. Inline `text-decoration: underline`
+ * would be picked up by `UnderlineExtension`'s `style: "text-decoration"`
+ * parser on DOM/clipboard reparse and add a spurious `<w:u>` alongside
+ * `<w:vanish/>` on export.
+ *
  * eigenpal #424 (w:vanish gap 9).
  */
 
@@ -18,14 +24,7 @@ export const HiddenTextExtension = createMarkExtension({
   markSpec: {
     parseDOM: [{ tag: "span.docx-hidden" }],
     toDOM() {
-      return [
-        "span",
-        {
-          class: "docx-hidden",
-          style: "opacity: 0.4; text-decoration: underline dotted",
-        },
-        0,
-      ];
+      return ["span", { class: "docx-hidden" }, 0];
     },
   },
 });

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -201,6 +201,7 @@ const validateMarks = (
       case "smallCaps":
       case "emboss":
       case "imprint":
+      case "hidden":
       case "textShadow":
       case "textOutline":
         continue;

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -453,6 +453,21 @@
   --tc-color: #bf8f00;
 }
 
+/* Hidden text (OOXML w:vanish, §17.3.2.41) — mirrors Word's editing-view
+ * treatment: dim the run with a dotted underline so the author can still
+ * navigate to and edit it. The mark is applied by HiddenTextExtension
+ * (PM layer) and the painter applies the same `.docx-hidden` class on
+ * its output. Host apps can override this rule to suppress hidden text
+ * entirely (Word's print/normal view) without touching the editor.
+ *
+ * Styling lives here (not inline on the span) so the underline isn't
+ * re-parsed as an underline mark on DOM/clipboard reparse. eigenpal #424. */
+.docx-hidden {
+  opacity: 0.4;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+}
+
 .docx-insertion {
   color: var(--tc-color, #c00000);
   text-decoration: underline;


### PR DESCRIPTION
## Summary

Closes gap 9 of the eigenpal/docx-editor #423 OOXML rendering audit, ported from upstream PR #424.

`packages/folio` already round-tripped `<w:vanish/>` through `TextFormatting.hidden` at the parser/serializer layer, but the PM mark, layout bridge, and painter were missing — hidden runs landed in the DOM with no visual treatment, and could not survive a round-trip through ProseMirror.

This change mirrors Word's editing-view rendering: keep the run in flow and selectable with `opacity: 0.4; text-decoration: underline dotted`, plus a `docx-hidden` class hook so host CSS can opt into print-style suppression later. `display: none` would orphan PM positions and break cursor navigation across hidden ranges.

- New `HiddenTextExtension` mark registered in `StarterKit`.
- `toProseDoc` emits the mark when `formatting.hidden === true`; `toFlowBlocks` and `fromProseDoc` copy it back to `RunFormatting.hidden`.
- `renderParagraph.applyRunStyles` applies the class + inline style.
- `validation` accepts the new mark name.

## Test plan

- [x] `bun --filter @stll/folio test` — 1005 pass, 0 fail (1 new file + 1 added assertion vs. main)
- [x] `bun --filter @stll/folio lint`
- [x] `bun --filter @stll/folio typecheck`
- [x] `renderParagraph-hidden.test.ts` asserts the hidden run gets the class + dimmed dotted-underline style, the non-hidden run does not, and both runs remain in the DOM (PM cursor stays navigable).
- [x] `toFlowBlocks-run-marks.test.ts` asserts the new `hidden` mark surfaces as `RunFormatting.hidden`.