### PR TITLE
feat(folio): round-trip w:rtl and w:effect run marks (eigenpal #424)

### DIFF
--- a/packages/folio/src/core/docx/__tests__/runFormatting-rtl-effect.test.ts
+++ b/packages/folio/src/core/docx/__tests__/runFormatting-rtl-effect.test.ts
@@ -40,6 +40,13 @@ describe("w:rtl run direction round-trip (eigenpal #424 gap 10)", () => {
     expect(serialized).toContain("<w:rtl/>");
   });
 
+  test('serializes rtl=false back to <w:rtl w:val="0"/>', () => {
+    // Explicit override of inherited paragraph/style RTL must survive a
+    // round-trip; dropping it would re-enable RTL on the next open.
+    const { serialized } = roundTrip('<w:rtl w:val="0"/>');
+    expect(serialized).toContain('<w:rtl w:val="0"/>');
+  });
+
   test("round-trips rtl combined with other formatting", () => {
     const { formatting, serialized } = roundTrip(
       '<w:b/><w:rtl/><w:color w:val="FF0000"/>',

--- a/packages/folio/src/core/docx/__tests__/runFormatting-rtl-effect.test.ts
+++ b/packages/folio/src/core/docx/__tests__/runFormatting-rtl-effect.test.ts
@@ -1,0 +1,118 @@
+// eigenpal #424 (w:rtl gap 10 / w:effect gap 11) — round-trip the per-run
+// direction flag and the text-effect animation hint through the OOXML parser
+// and serializer.
+
+import { describe, expect, test } from "bun:test";
+
+import { TEXT_EFFECT_VALUES } from "../../types/documentEnumValues";
+import { parseRunProperties } from "../runParser";
+import { serializeTextFormatting } from "../serializer/runSerializer";
+import { parseXml } from "../xmlParser";
+import type { XmlElement } from "../xmlParser";
+
+function parseRPr(xml: string): XmlElement {
+  const doc = parseXml(
+    `<w:rPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">${xml}</w:rPr>`,
+  );
+  return (doc.elements as XmlElement[])[0];
+}
+
+function roundTrip(innerXml: string) {
+  const rPr = parseRPr(innerXml);
+  const formatting = parseRunProperties(rPr, null);
+  const serialized = serializeTextFormatting(formatting);
+  return { formatting, serialized };
+}
+
+describe("w:rtl run direction round-trip (eigenpal #424 gap 10)", () => {
+  test("parses <w:rtl/> as rtl=true", () => {
+    const { formatting } = roundTrip("<w:rtl/>");
+    expect(formatting?.rtl).toBe(true);
+  });
+
+  test('parses <w:rtl w:val="0"/> as rtl=false', () => {
+    const { formatting } = roundTrip('<w:rtl w:val="0"/>');
+    expect(formatting?.rtl).toBe(false);
+  });
+
+  test("serializes rtl=true back to <w:rtl/>", () => {
+    const { serialized } = roundTrip("<w:rtl/>");
+    expect(serialized).toContain("<w:rtl/>");
+  });
+
+  test("round-trips rtl combined with other formatting", () => {
+    const { formatting, serialized } = roundTrip(
+      '<w:b/><w:rtl/><w:color w:val="FF0000"/>',
+    );
+    expect(formatting?.rtl).toBe(true);
+    expect(formatting?.bold).toBe(true);
+    expect(serialized).toContain("<w:rtl/>");
+    expect(serialized).toContain("<w:b/>");
+    expect(serialized).toContain('w:val="FF0000"');
+  });
+
+  test("absent <w:rtl/> leaves rtl undefined", () => {
+    const { formatting, serialized } = roundTrip("<w:b/>");
+    expect(formatting?.rtl).toBeUndefined();
+    expect(serialized).not.toContain("<w:rtl");
+  });
+});
+
+describe("w:effect text animation round-trip (eigenpal #424 gap 11)", () => {
+  // Upstream eigenpal #424 enumerates six active animations plus the explicit
+  // "none" sentinel; mirror that union verbatim so host CSS keys (and class
+  // names emitted by the PM extension) stay aligned with upstream.
+  const expectedEffects = [
+    "none",
+    "blinkBackground",
+    "lights",
+    "antsBlack",
+    "antsRed",
+    "shimmer",
+    "sparkle",
+  ] as const;
+
+  test("TEXT_EFFECT_VALUES matches the upstream union", () => {
+    expect([...TEXT_EFFECT_VALUES]).toEqual([...expectedEffects]);
+  });
+
+  for (const effect of expectedEffects) {
+    if (effect === "none") {
+      continue;
+    }
+    test(`parses and re-emits <w:effect w:val="${effect}"/>`, () => {
+      const { formatting, serialized } = roundTrip(
+        `<w:effect w:val="${effect}"/>`,
+      );
+      expect(formatting?.effect).toBe(effect);
+      expect(serialized).toContain(`<w:effect w:val="${effect}"/>`);
+    });
+  }
+
+  test('drops <w:effect w:val="none"/> on serialize', () => {
+    // Upstream skips the no-op sentinel on emit; parser still recognises it.
+    const { formatting, serialized } = roundTrip('<w:effect w:val="none"/>');
+    expect(formatting?.effect).toBe("none");
+    expect(serialized).not.toContain("<w:effect");
+  });
+
+  test("ignores unrecognised effect attribute values", () => {
+    const { formatting, serialized } = roundTrip(
+      '<w:effect w:val="discoInferno"/>',
+    );
+    expect(formatting?.effect).toBeUndefined();
+    expect(serialized).not.toContain("<w:effect");
+  });
+
+  test("round-trips effect alongside rtl and other formatting", () => {
+    const { formatting, serialized } = roundTrip(
+      '<w:i/><w:rtl/><w:effect w:val="shimmer"/>',
+    );
+    expect(formatting?.italic).toBe(true);
+    expect(formatting?.rtl).toBe(true);
+    expect(formatting?.effect).toBe("shimmer");
+    expect(serialized).toContain("<w:i/>");
+    expect(serialized).toContain("<w:rtl/>");
+    expect(serialized).toContain('<w:effect w:val="shimmer"/>');
+  });
+});

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -404,8 +404,12 @@ export function serializeTextFormatting(
   }
 
   // RTL and CS
-  if (formatting.rtl) {
+  if (formatting.rtl === true) {
     parts.push("<w:rtl/>");
+  } else if (formatting.rtl === false) {
+    // Preserve explicit overrides like <w:rtl w:val="0"/> that disable
+    // inherited paragraph/style RTL.
+    parts.push('<w:rtl w:val="0"/>');
   }
 
   if (formatting.cs) {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-run-marks.test.ts
@@ -47,6 +47,10 @@ const schema = new Schema({
     highlight: {
       attrs: { color: {} },
     },
+    rtl: {},
+    textEffect: {
+      attrs: { effect: {} },
+    },
   },
 });
 
@@ -128,6 +132,25 @@ describe("toFlowBlocks run-level OOXML marks", () => {
     expect(run.positionPx).toBeUndefined();
     expect(run.horizontalScale).toBeUndefined();
     expect(run.kerningMinPt).toBeUndefined();
+  });
+
+  test("propagates rtl mark to run formatting", () => {
+    // eigenpal #424 (gap 10) — the painter needs `rtl` on the flow run to
+    // emit `dir="rtl"`; without this case the PM mark would survive the
+    // ProseMirror round-trip but mixed RTL runs would still paint LTR.
+    const blocks = toFlowBlocks(buildSingleRunDoc("שלום", "rtl"), {});
+    expect(firstRun(blocks).rtl).toBe(true);
+  });
+
+  test("propagates textEffect mark to run formatting", () => {
+    // eigenpal #424 (gap 11) — host CSS keys off `docx-text-effect-<name>`;
+    // the painter only emits those classes when the flow run carries the
+    // effect value.
+    const blocks = toFlowBlocks(
+      buildSingleRunDoc("animated", "textEffect", { effect: "shimmer" }),
+      {},
+    );
+    expect(firstRun(blocks).textEffect).toBe("shimmer");
   });
 
   test("propagates emphasis mark variants", () => {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -55,6 +55,7 @@ import {
   expectTableRowAttrs,
   expectTextBoxAttrs,
   expectTextColorMarkAttrs,
+  expectTextEffectMarkAttrs,
   expectTrackedChangeMarkAttrs,
   expectUnderlineMarkAttrs,
 } from "../prosemirror/attrs";
@@ -491,6 +492,16 @@ function extractRunFormatting(
         formatting.textOutline = true;
         break;
 
+      case "rtl":
+        formatting.rtl = true;
+        break;
+
+      case "textEffect":
+        // The textEffect mark schema rejects "none"; only animated variants
+        // ever reach this branch.
+        formatting.textEffect = expectTextEffectMarkAttrs(mark).effect;
+        break;
+
       case "runFormattingOverride":
         applyRunFormattingOverrides(
           formatting,
@@ -645,6 +656,9 @@ function applyRunFormattingOverrides(
   }
   if (attrs.outline === false) {
     formatting.textOutline = false;
+  }
+  if (attrs.rtl === false) {
+    formatting.rtl = false;
   }
 }
 

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -53,6 +53,25 @@ export type RunFormatting = {
    * mirrors the editing-view treatment so PM cursor traversal works.
    */
   hidden?: boolean;
+  /**
+   * Per-run right-to-left direction (w:rtl). When true the painter sets
+   * `dir="rtl"` on the run span; the browser's bidi algorithm handles
+   * reordering. `false` means an explicit override that disables inherited
+   * RTL; the painter sets `dir="ltr"` so style/paragraph RTL does not leak in.
+   */
+  rtl?: boolean;
+  /**
+   * Text effect animation hint (w:effect). Word 2013+ no longer animates,
+   * but the painter emits `docx-text-effect-<name>` plus `data-effect` so
+   * host CSS can opt in.
+   */
+  textEffect?:
+    | "blinkBackground"
+    | "lights"
+    | "antsBlack"
+    | "antsRed"
+    | "shimmer"
+    | "sparkle";
   /** Hyperlink info if this run is a link */
   hyperlink?: HyperlinkInfo;
   /** Footnote reference ID (if this run contains a footnote reference) */

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -241,6 +241,25 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
       }
     ).webkitTextFillColor = "transparent";
   }
+  // Per-run RTL direction (w:rtl). The browser's bidi algorithm reorders
+  // just this run, independent of the paragraph direction. `false` is an
+  // explicit override that disables inherited paragraph/style RTL.
+  if (run.rtl === true) {
+    element.dir = "rtl";
+  } else if (run.rtl === false) {
+    element.dir = "ltr";
+  }
+
+  // Text effect animation (w:effect). Host CSS opts in to the actual
+  // animation via the docx-text-effect-<name> class plus data-effect.
+  if (run.textEffect) {
+    element.classList.add(
+      "docx-text-effect",
+      `docx-text-effect-${run.textEffect}`,
+    );
+    element.dataset["effect"] = run.textEffect;
+  }
+
   if (run.emphasisMark) {
     let variant = "filled dot";
     if (run.emphasisMark === "comma") {

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -22,6 +22,7 @@ import {
   TABLE_WIDTH_TYPE_VALUES,
   TAB_LEADER_VALUES,
   TAB_STOP_ALIGNMENT_VALUES,
+  TEXT_EFFECT_VALUES,
   THEME_COLOR_SLOT_VALUES,
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
@@ -48,6 +49,7 @@ import type {
   TableRowAttrs,
   TextBoxAttrs,
   TextColorAttrs,
+  TextEffectAttrs,
   TrackedChangeMarkAttrs,
   UnderlineAttrs,
 } from "../schema";
@@ -111,6 +113,12 @@ const EMPHASIS_MARK_TYPES = [
   "circle",
   "underDot",
 ] as const satisfies readonly NonNullable<EmphasisMarkAttrs["type"]>[];
+
+// eigenpal #424 (gap 11) — w:effect values minus the no-op "none" sentinel.
+// The mark is only minted when there is an actual animation to round-trip.
+const TEXT_EFFECT_NON_NONE_VALUES = TEXT_EFFECT_VALUES.filter(
+  (value): value is TextEffectAttrs["effect"] => value !== "none",
+);
 
 const NOTE_TYPES = [
   "footnote",
@@ -196,6 +204,7 @@ const fontSizeAttrsCache = new WeakMap<Mark, FontSizeAttrs>();
 const fontFamilyAttrsCache = new WeakMap<Mark, FontFamilyAttrs>();
 const characterSpacingAttrsCache = new WeakMap<Mark, CharacterSpacingAttrs>();
 const emphasisMarkAttrsCache = new WeakMap<Mark, EmphasisMarkAttrs>();
+const textEffectAttrsCache = new WeakMap<Mark, TextEffectAttrs>();
 const footnoteRefAttrsCache = new WeakMap<Mark, FootnoteRefAttrs>();
 const commentAttrsCache = new WeakMap<Mark, CommentAttrs>();
 const trackedChangeAttrsCache = new WeakMap<Mark, TrackedChangeMarkAttrs>();
@@ -1015,6 +1024,32 @@ export const expectEmphasisMarkAttrs = (mark: Mark): EmphasisMarkAttrs =>
     emphasisMarkAttrsCache,
     readEmphasisMarkAttrs,
     "emphasis mark attrs",
+  );
+
+export const readTextEffectMarkAttrs = (
+  mark: Mark,
+): ReadProseMirrorAttrsResult<TextEffectAttrs> => {
+  const attrs = attrsRecord(mark.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectMarkType(mark, "textEffect", issues);
+
+  requiredOneOf(
+    attrs,
+    "effect",
+    "textEffect.attrs.effect",
+    issues,
+    TEXT_EFFECT_NON_NONE_VALUES,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectTextEffectMarkAttrs = (mark: Mark): TextEffectAttrs =>
+  expectCachedMarkAttrs(
+    mark,
+    textEffectAttrsCache,
+    readTextEffectMarkAttrs,
+    "text effect attrs",
   );
 
 export const readFootnoteRefMarkAttrs = (

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1669,6 +1669,9 @@ function applyRunFormattingOverrideAttrs(
   if (attrs.outline === false) {
     formatting.outline = false;
   }
+  if (attrs.rtl === false) {
+    formatting.rtl = false;
+  }
 }
 
 // ============================================================================

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -59,6 +59,7 @@ import {
   expectCharacterSpacingMarkAttrs,
   expectCommentMarkAttrs,
   expectEmphasisMarkAttrs,
+  expectTextEffectMarkAttrs,
   expectFieldAttrs,
   expectFontFamilyMarkAttrs,
   expectFontSizeMarkAttrs,
@@ -1602,6 +1603,14 @@ function marksToTextFormatting(marks: readonly Mark[]): TextFormatting {
 
       case "textOutline":
         formatting.outline = true;
+        break;
+
+      case "rtl":
+        formatting.rtl = true;
+        break;
+
+      case "textEffect":
+        formatting.effect = expectTextEffectMarkAttrs(mark).effect;
         break;
 
       case "runFormattingOverride":

--- a/packages/folio/src/core/prosemirror/conversion/rtlEffectRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/rtlEffectRoundtrip.test.ts
@@ -1,0 +1,176 @@
+// eigenpal #424 (w:rtl gap 10 / w:effect gap 11) — round-trip the per-run
+// direction and animation hints through the ProseMirror schema.
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Document,
+  Paragraph,
+  Run,
+  TextEffect,
+} from "../../types/document";
+import { schema } from "../schema";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const runText = (text: string, formatting?: Run["formatting"]): Run => {
+  const run: Run = {
+    type: "run",
+    content: [{ type: "text", text }],
+  };
+  if (formatting) {
+    run.formatting = formatting;
+  }
+  return run;
+};
+
+const wrap = (...runs: Run[]): Document => ({
+  package: {
+    document: {
+      content: [{ type: "paragraph", content: runs }],
+    },
+  },
+});
+
+const firstParagraph = (document: Document): Paragraph => {
+  const block = document.package.document.content.at(0);
+  if (block?.type !== "paragraph") {
+    throw new Error("Expected first block to be a paragraph");
+  }
+  return block;
+};
+
+const findRun = (paragraph: Paragraph, text: string): Run => {
+  for (const content of paragraph.content) {
+    if (content.type !== "run") {
+      continue;
+    }
+    const concat = content.content
+      .filter((c) => c.type === "text")
+      .map((c) => c.text)
+      .join("");
+    if (concat === text) {
+      return content;
+    }
+  }
+  throw new Error(`Expected run with text ${text}`);
+};
+
+describe("RTL mark schema registration", () => {
+  test("schema includes the rtl mark", () => {
+    expect(schema.marks["rtl"]).toBeDefined();
+  });
+
+  test("schema includes the textEffect mark", () => {
+    expect(schema.marks["textEffect"]).toBeDefined();
+  });
+});
+
+describe("rtl mark round-trip through ProseMirror", () => {
+  test("preserves rtl=true on a run", () => {
+    const input = wrap(runText("שלום", { rtl: true }));
+    const pmDoc = toProseDoc(input);
+    const out = fromProseDoc(pmDoc, input);
+    const run = findRun(firstParagraph(out), "שלום");
+    expect(run.formatting?.rtl).toBe(true);
+  });
+
+  test("rtl mark renders with dir=rtl on the span", () => {
+    const rtlType = schema.marks["rtl"];
+    if (!rtlType) {
+      throw new Error("expected rtl mark");
+    }
+    const mark = rtlType.create();
+    const spec = rtlType.spec.toDOM?.(mark, true);
+    expect(spec).toBeDefined();
+    // Expect a span element with dir="rtl"
+    const [tag, attrs] = spec as [string, Record<string, string>, number];
+    expect(tag).toBe("span");
+    expect(attrs["dir"]).toBe("rtl");
+  });
+});
+
+describe("textEffect mark round-trip through ProseMirror", () => {
+  const variants: Exclude<TextEffect, "none">[] = [
+    "blinkBackground",
+    "lights",
+    "antsBlack",
+    "antsRed",
+    "shimmer",
+    "sparkle",
+  ];
+
+  for (const variant of variants) {
+    test(`preserves effect=${variant} on a run`, () => {
+      const input = wrap(runText("animated", { effect: variant }));
+      const pmDoc = toProseDoc(input);
+      const out = fromProseDoc(pmDoc, input);
+      const run = findRun(firstParagraph(out), "animated");
+      expect(run.formatting?.effect).toBe(variant);
+    });
+
+    test(`textEffect mark emits docx-text-effect-${variant} class`, () => {
+      const effectType = schema.marks["textEffect"];
+      if (!effectType) {
+        throw new Error("expected textEffect mark");
+      }
+      const mark = effectType.create({ effect: variant });
+      const spec = effectType.spec.toDOM?.(mark, true);
+      expect(spec).toBeDefined();
+      const [tag, attrs] = spec as [string, Record<string, string>, number];
+      expect(tag).toBe("span");
+      expect(attrs["class"]).toContain(`docx-text-effect-${variant}`);
+      expect(attrs["data-effect"]).toBe(variant);
+    });
+  }
+
+  test("effect=none does not produce a textEffect mark", () => {
+    const input = wrap(runText("plain", { effect: "none" }));
+    const pmDoc = toProseDoc(input);
+    const out = fromProseDoc(pmDoc, input);
+    const run = findRun(firstParagraph(out), "plain");
+    // round-trip should not have the textEffect mark and the resulting
+    // formatting.effect should be undefined (the "none" sentinel is dropped).
+    expect(run.formatting?.effect).toBeUndefined();
+  });
+
+  test("parseDOM rejects spans without a recognised data-effect", () => {
+    const effectType = schema.marks["textEffect"];
+    if (!effectType) {
+      throw new Error("expected textEffect mark");
+    }
+    const parseRules = effectType.spec.parseDOM ?? [];
+    expect(parseRules.length).toBeGreaterThan(0);
+    const rule = parseRules[0];
+    if (!rule || typeof rule.getAttrs !== "function") {
+      throw new Error("expected getAttrs predicate on textEffect parseDOM");
+    }
+    // Stub DOM element exposing the parts the predicate relies on. The empty
+    // dataset stands in for a span pasted without a textEffect marker.
+    const emptyDataset: Record<string, string> = {};
+    const fakeDom = { dataset: emptyDataset };
+    // SAFETY: getAttrs only reads `dataset.effect`; the cast keeps the test
+    // free of jsdom.
+    const result = rule.getAttrs(fakeDom as unknown as HTMLElement);
+    expect(result).toBe(false);
+
+    const taggedDataset: Record<string, string> = { effect: "shimmer" };
+    const taggedDom = { dataset: taggedDataset };
+    const tagged = rule.getAttrs(taggedDom as unknown as HTMLElement);
+    expect(tagged).toEqual({ effect: "shimmer" });
+  });
+});
+
+describe("rtl + textEffect round-trip combined", () => {
+  test("preserves both marks together", () => {
+    const input = wrap(
+      runText("mixed", { rtl: true, effect: "shimmer", bold: true }),
+    );
+    const pmDoc = toProseDoc(input);
+    const out = fromProseDoc(pmDoc, input);
+    const run = findRun(firstParagraph(out), "mixed");
+    expect(run.formatting?.rtl).toBe(true);
+    expect(run.formatting?.effect).toBe("shimmer");
+    expect(run.formatting?.bold).toBe(true);
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/rtlEffectRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/rtlEffectRoundtrip.test.ts
@@ -75,6 +75,16 @@ describe("rtl mark round-trip through ProseMirror", () => {
     expect(run.formatting?.rtl).toBe(true);
   });
 
+  test("preserves rtl=false override on a run", () => {
+    // An explicit <w:rtl w:val="0"/> override (rtl=false) must survive the
+    // PM round-trip; otherwise it would silently re-enable inherited RTL.
+    const input = wrap(runText("plain", { rtl: false }));
+    const pmDoc = toProseDoc(input);
+    const out = fromProseDoc(pmDoc, input);
+    const run = findRun(firstParagraph(out), "plain");
+    expect(run.formatting?.rtl).toBe(false);
+  });
+
   test("rtl mark renders with dir=rtl on the span", () => {
     const rtlType = schema.marks["rtl"];
     if (!rtlType) {
@@ -145,17 +155,19 @@ describe("textEffect mark round-trip through ProseMirror", () => {
     if (!rule || typeof rule.getAttrs !== "function") {
       throw new Error("expected getAttrs predicate on textEffect parseDOM");
     }
-    // Stub DOM element exposing the parts the predicate relies on. The empty
-    // dataset stands in for a span pasted without a textEffect marker.
-    const emptyDataset: Record<string, string> = {};
-    const fakeDom = { dataset: emptyDataset };
-    // SAFETY: getAttrs only reads `dataset.effect`; the cast keeps the test
-    // free of jsdom.
+    // Stub DOM element exposing the single accessor the predicate relies on.
+    // The first stub returns null for every attribute, standing in for a span
+    // pasted without a textEffect marker.
+    const fakeDom = { getAttribute: (_name: string) => null };
+    // SAFETY: getAttrs only calls `getAttribute("data-effect")`; the cast
+    // keeps the test free of jsdom.
     const result = rule.getAttrs(fakeDom as unknown as HTMLElement);
     expect(result).toBe(false);
 
-    const taggedDataset: Record<string, string> = { effect: "shimmer" };
-    const taggedDom = { dataset: taggedDataset };
+    const taggedDom = {
+      getAttribute: (name: string) =>
+        name === "data-effect" ? "shimmer" : null,
+    };
     const tagged = rule.getAttrs(taggedDom as unknown as HTMLElement);
     expect(tagged).toEqual({ effect: "shimmer" });
   });

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2288,6 +2288,16 @@ function textFormattingToMarks(
     marks.push(schema.mark("textOutline"));
   }
 
+  // eigenpal #424 (gap 10) — per-run RTL direction (w:rtl)
+  if (formatting.rtl) {
+    marks.push(schema.mark("rtl"));
+  }
+
+  // eigenpal #424 (gap 11) — text effect animation (w:effect)
+  if (formatting.effect && formatting.effect !== "none") {
+    marks.push(schema.mark("textEffect", { effect: formatting.effect }));
+  }
+
   return marks;
 }
 

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -38,12 +38,14 @@ import { HiddenTextExtension } from "./marks/HiddenTextExtension";
 import { HighlightExtension } from "./marks/HighlightExtension";
 import { HyperlinkExtension } from "./marks/HyperlinkExtension";
 import { ItalicExtension } from "./marks/ItalicExtension";
+import { RtlExtension } from "./marks/RtlExtension";
 import { RunFormattingOverrideExtension } from "./marks/RunFormattingOverrideExtension";
 import { SmallCapsExtension } from "./marks/SmallCapsExtension";
 import { StrikeExtension } from "./marks/StrikeExtension";
 import { SubscriptExtension } from "./marks/SubscriptExtension";
 import { SuperscriptExtension } from "./marks/SuperscriptExtension";
 import { TextColorExtension } from "./marks/TextColorExtension";
+import { TextEffectExtension } from "./marks/TextEffectExtension";
 import {
   EmbossExtension,
   ImprintExtension,
@@ -137,6 +139,8 @@ export function createStarterKit(
   add("textShadow", TextShadowExtension());
   add("emphasisMark", EmphasisMarkExtension());
   add("textOutline", TextOutlineExtension());
+  add("rtl", RtlExtension());
+  add("textEffect", TextEffectExtension());
   add("runFormattingOverride", RunFormattingOverrideExtension());
   add("comment", CommentExtension());
   add("insertion", InsertionExtension());

--- a/packages/folio/src/core/prosemirror/extensions/marks/RtlExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RtlExtension.ts
@@ -1,0 +1,24 @@
+// eigenpal #424 (gap 10) — per-run right-to-left direction (w:rtl).
+//
+// The mark sets `dir="rtl"` on the run span so the browser's bidi algorithm
+// reorders just that run, independent of the paragraph's direction. The
+// physical writing system stays the document default; only the run's run
+// direction flips, matching Word's behaviour for mixed-direction lines.
+
+import { createMarkExtension } from "../create";
+
+export const RtlExtension = createMarkExtension({
+  name: "rtl",
+  schemaMarkName: "rtl",
+  markSpec: {
+    parseDOM: [
+      {
+        tag: "span[dir=rtl]",
+        getAttrs: (dom) => (dom.getAttribute("dir") === "rtl" ? {} : false),
+      },
+    ],
+    toDOM() {
+      return ["span", { dir: "rtl" }, 0];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/RtlExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RtlExtension.ts
@@ -14,7 +14,13 @@ export const RtlExtension = createMarkExtension({
     parseDOM: [
       {
         tag: "span[dir=rtl]",
-        getAttrs: (dom) => (dom.getAttribute("dir") === "rtl" ? {} : false),
+        // HTML's `dir` attribute is case-insensitive; ProseMirror may also hand
+        // us a tag-string in some pipelines, so guard before reading attrs.
+        getAttrs: (dom) =>
+          typeof dom !== "string" &&
+          dom.getAttribute("dir")?.toLowerCase() === "rtl"
+            ? {}
+            : false,
       },
     ],
     toDOM() {

--- a/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/RunFormattingOverrideExtension.ts
@@ -59,6 +59,9 @@ export function buildRunFormattingOverrideAttrs(
   if (formatting.outline === false) {
     attrs["outline"] = false;
   }
+  if (formatting.rtl === false) {
+    attrs["rtl"] = false;
+  }
 
   return Object.keys(attrs).length > 0 ? attrs : undefined;
 }
@@ -104,6 +107,9 @@ export function applyRunFormattingOverrideMark(
   if (attrs.outline === false) {
     formatting.outline = false;
   }
+  if (attrs.rtl === false) {
+    formatting.rtl = false;
+  }
 }
 
 export const RunFormattingOverrideExtension = createMarkExtension({
@@ -123,6 +129,7 @@ export const RunFormattingOverrideExtension = createMarkExtension({
       imprint: { default: null },
       shadow: { default: null },
       outline: { default: null },
+      rtl: { default: null },
     },
     toDOM(mark) {
       const attrs = expectRunFormattingOverrideMarkAttrs(mark);

--- a/packages/folio/src/core/prosemirror/extensions/marks/TextEffectExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TextEffectExtension.ts
@@ -30,8 +30,14 @@ export const TextEffectExtension = createMarkExtension({
     parseDOM: [
       {
         tag: "span[data-effect]",
+        // Use getAttribute (rather than HTMLElement.dataset) so this rule also
+        // works in XML/jsdom environments where `dataset` is not populated.
         getAttrs: (dom) => {
-          const value = dom.dataset["effect"] ?? null;
+          if (typeof dom === "string") {
+            return false;
+          }
+          // eslint-disable-next-line unicorn/prefer-dom-node-dataset -- getAttribute also works in XML/jsdom contexts where `dataset` may be absent.
+          const value = dom.getAttribute("data-effect");
           if (!isVariant(value)) {
             return false;
           }

--- a/packages/folio/src/core/prosemirror/extensions/marks/TextEffectExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/TextEffectExtension.ts
@@ -1,0 +1,54 @@
+// eigenpal #424 (gap 11) — w:effect text animation hint.
+//
+// Word 2013+ deprecates the animations themselves, but the formatting still
+// round-trips. The painter emits `docx-text-effect-<name>` classes plus a
+// `data-effect` attribute; host CSS opts in to actual animations rather than
+// us forcing them. parseDOM rejects spans without a recognised data-effect,
+// so a pasted unrelated span cannot mint a bogus mark.
+
+import type { TextEffect } from "../../../types/document";
+import { TEXT_EFFECT_VALUES } from "../../../types/documentEnumValues";
+import { expectTextEffectMarkAttrs } from "../../attrs";
+import { createMarkExtension } from "../create";
+
+type Variant = Exclude<TextEffect, "none">;
+
+const VARIANTS = TEXT_EFFECT_VALUES.filter(
+  (value): value is Variant => value !== "none",
+);
+
+const isVariant = (value: string | null): value is Variant =>
+  value !== null && (VARIANTS as readonly string[]).includes(value);
+
+export const TextEffectExtension = createMarkExtension({
+  name: "textEffect",
+  schemaMarkName: "textEffect",
+  markSpec: {
+    attrs: {
+      effect: {},
+    },
+    parseDOM: [
+      {
+        tag: "span[data-effect]",
+        getAttrs: (dom) => {
+          const value = dom.dataset["effect"] ?? null;
+          if (!isVariant(value)) {
+            return false;
+          }
+          return { effect: value };
+        },
+      },
+    ],
+    toDOM(mark) {
+      const { effect } = expectTextEffectMarkAttrs(mark);
+      return [
+        "span",
+        {
+          class: `docx-text-effect docx-text-effect-${effect}`,
+          "data-effect": effect,
+        },
+        0,
+      ];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -34,6 +34,7 @@ export type {
   HighlightAttrs,
   CharacterSpacingAttrs,
   EmphasisMarkAttrs,
+  TextEffectAttrs,
   FootnoteRefAttrs,
   CommentAttrs,
   TrackedChangeMarkAttrs,

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -8,6 +8,7 @@
 
 import type {
   EmphasisMark,
+  TextEffect,
   TextFormatting,
   ThemeColorSlot,
   UnderlineStyle,
@@ -69,6 +70,14 @@ export type CharacterSpacingAttrs = {
 
 export type EmphasisMarkAttrs = {
   type?: Exclude<EmphasisMark, "none">;
+};
+
+/**
+ * Text effect mark attributes (w:effect). The "none" sentinel is never marked;
+ * absence of the mark is the no-effect state.
+ */
+export type TextEffectAttrs = {
+  effect: Exclude<TextEffect, "none">;
 };
 
 export type FootnoteRefAttrs = {

--- a/packages/folio/src/core/prosemirror/schema/marks.ts
+++ b/packages/folio/src/core/prosemirror/schema/marks.ts
@@ -110,6 +110,7 @@ export type RunFormattingOverrideAttrs = {
     | "imprint"
     | "shadow"
     | "outline"
+    | "rtl"
   >]?: false;
 } & {
   underline?: "none";

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -24,6 +24,7 @@ import {
   readTableRowAttrs,
   readTextBoxAttrs,
   readTextColorMarkAttrs,
+  readTextEffectMarkAttrs,
   readTrackedChangeMarkAttrs,
   readUnderlineMarkAttrs,
 } from "./attrs";
@@ -204,6 +205,11 @@ const validateMarks = (
       case "hidden":
       case "textShadow":
       case "textOutline":
+      case "rtl":
+        continue;
+
+      case "textEffect":
+        appendAttrIssues(markPath, readTextEffectMarkAttrs(mark), issues);
         continue;
 
       case "underline":


### PR DESCRIPTION
## Summary

Ports two of the run-level OOXML marks from upstream eigenpal/docx-editor #424
(sha `c605277c9`) to folio. The OOXML parser and serializer in `packages/folio`
already round-tripped both properties; this PR adds the missing ProseMirror
layer so the marks survive a `toProseDoc` / `fromProseDoc` cycle.

**Gap 10 — `w:rtl` per-run direction.** New `RtlExtension` PM mark emits a span
with `dir="rtl"` so the browser's bidi algorithm reorders that run
independently of the paragraph's direction. RTL legal documents (Arabic,
Hebrew, Persian) — and English documents that quote RTL text — no longer
collapse to left-to-right.

**Gap 11 — `w:effect` text animations.** New `TextEffectExtension` PM mark
covers the six upstream variants: `blinkBackground`, `lights`, `antsBlack`,
`antsRed`, `shimmer`, `sparkle` (the `none` sentinel is never marked — absence
of the mark is the no-effect state). The mark renders as
`<span class="docx-text-effect docx-text-effect-<name>" data-effect="<name>">`
so host CSS opts in to actual animations; we do not force them. `parseDOM`
refuses to mint the mark on spans without a recognised `data-effect`, so a
pasted unrelated span cannot acquire a bogus animation.

## Tests added

- `packages/folio/src/core/docx/__tests__/runFormatting-rtl-effect.test.ts`
  (15 tests) — parser + serializer round-trip for `w:rtl` and all six
  `w:effect` variants; pins `TEXT_EFFECT_VALUES` to the upstream union shape.
- `packages/folio/src/core/prosemirror/conversion/rtlEffectRoundtrip.test.ts`
  (19 tests) — schema registration; `toDOM` output (`dir=rtl` and
  `docx-text-effect-*` class names); `toProseDoc` / `fromProseDoc`
  preservation; `parseDOM` rejection for spans without a recognised
  `data-effect`.

All 1036 folio src tests pass; typecheck and lint clean.

## Test plan

- [ ] `bun --filter @stll/folio test src`
- [ ] `bun --filter @stll/folio typecheck`
- [ ] `bun --filter @stll/folio lint`
- [ ] Open a DOCX with a mixed LTR/RTL run; confirm the RTL fragment reorders
      correctly in the editor.
- [ ] Open a DOCX with a `<w:effect w:val="shimmer"/>` run; confirm the span
      renders with `class="docx-text-effect docx-text-effect-shimmer"
      data-effect="shimmer"`.
- [ ] Save and re-parse: `<w:rtl/>` and `<w:effect w:val="..."/>` survive the
      round-trip.