### PR TITLE
fix(folio): wrap rotated block images in axis-aligned bbox

### DIFF
--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -420,6 +420,76 @@ describe("inline image paragraph measurement", () => {
   });
 });
 
+describe("block image rotation measurement", () => {
+  // The painter wraps a rotated block image in an axis-aligned bbox
+  // (`renderBlockImage`, eigenpal #424). The measurer has to reserve the
+  // same rotated bbox height; otherwise the painter's container overflows
+  // the line box and the next paragraph paints on top of the rotated
+  // landscape image (codex PR #521 review).
+  test("rotated block image reserves the rotated bbox height (270deg landscape)", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "rot-block",
+        pmStart: 0,
+        pmEnd: 1,
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 120,
+            height: 60,
+            displayMode: "block",
+            transform: "rotate(270deg)",
+            distTop: 6,
+            distBottom: 6,
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    // Rotated bbox of 120x60 at 270deg is 60x120: reserve the 120px
+    // rotated height plus the default 6+6 margins, not the intrinsic
+    // 60px height the un-rotated path used.
+    expect(measure.lines[0]?.lineHeight).toBeGreaterThanOrEqual(120 + 12);
+  });
+
+  test("un-rotated block image still reserves the intrinsic height", () => {
+    const measure = measureParagraph(
+      {
+        kind: "paragraph",
+        id: "noop-block",
+        pmStart: 0,
+        pmEnd: 1,
+        runs: [
+          {
+            kind: "image",
+            src: "data:image/png;base64,",
+            width: 120,
+            height: 60,
+            displayMode: "block",
+            distTop: 6,
+            distBottom: 6,
+          },
+        ],
+        attrs: {
+          defaultFontSize: 11,
+          defaultFontFamily: "Calibri",
+        },
+      },
+      600,
+    );
+
+    expect(measure.lines[0]?.lineHeight).toBeGreaterThanOrEqual(60 + 12);
+    expect(measure.lines[0]?.lineHeight).toBeLessThan(120);
+  });
+});
+
 describe("paragraph indentation measurement", () => {
   test("negative side indents widen the measured line box", () => {
     withFakeTextMeasure(() => {

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -262,6 +262,38 @@ function isImageRun(run: Run): run is ImageRun {
   return run.kind === "image";
 }
 
+// Local copies of the painter's rotation helpers (eigenpal #424). Kept in
+// sync with `renderParagraph.parseRotationDegrees` /
+// `rotatedBoundingBox`; will dedupe once PR #518 + PR #521 land.
+function parseRotationDegrees(transform: string | undefined): number {
+  if (!transform) {
+    return 0;
+  }
+  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/u.exec(transform);
+  if (!match) {
+    return 0;
+  }
+  const raw = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+  return ((raw % 360) + 360) % 360;
+}
+
+function rotatedBlockImageHeight(run: ImageRun): number {
+  const deg = parseRotationDegrees(run.transform);
+  if (deg === 0 || deg === 180) {
+    return run.height;
+  }
+  if (deg === 90 || deg === 270) {
+    return run.width;
+  }
+  const rad = (deg * Math.PI) / 180;
+  const sinA = Math.abs(Math.sin(rad));
+  const cosA = Math.abs(Math.cos(rad));
+  return run.width * sinA + run.height * cosA;
+}
+
 /**
  * Check if a run is a line break run
  */
@@ -925,8 +957,13 @@ export function measureParagraph(
           startNewLine(runIndex, 0);
         }
 
-        // The image gets its own line with full image height
-        const imageHeight = run.height;
+        // The image gets its own line. For rotated images, reserve the
+        // axis-aligned bounding-box height so the painter's bbox wrapper
+        // (`renderBlockImage`, eigenpal #424) doesn't overflow the line
+        // and bleed into the next paragraph. Non-rotated images keep
+        // their intrinsic height. Helpers duplicated from the painter
+        // until cross-PR dedupe with #518 lands.
+        const imageHeight = rotatedBlockImageHeight(run);
         const distTop = run.distTop ?? 6;
         const distBottom = run.distBottom ?? 6;
 

--- a/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Block-image rotation bbox tests.
+ *
+ * Ports the gap-8 block path from eigenpal/docx-editor #424
+ * (commit c605277c9): rotated block images must reserve an
+ * axis-aligned bounding box on their container so they don't
+ * bleed into the next paragraph. Un-rotated block images keep
+ * the fast path.
+ *
+ * Companion to the inline path covered in
+ * `renderImage-rotation.test.ts` (folio PR #518).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImageRun,
+  MeasuredLine,
+  ParagraphBlock,
+} from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function makeBlockImageLine(image: ImageRun): {
+  block: ParagraphBlock;
+  line: MeasuredLine;
+} {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: "p1",
+    runs: [image],
+    pmStart: 0,
+    pmEnd: 3,
+  };
+  const line: MeasuredLine = {
+    fromRun: 0,
+    fromChar: 0,
+    toRun: 0,
+    toChar: 1,
+    width: image.width,
+    ascent: image.height,
+    descent: 3,
+    lineHeight: image.height + 3,
+  };
+  return { block, line };
+}
+
+describe("block image rotation bbox container", () => {
+  test("wraps a 90deg rotated block image with bbox height + absolute centering", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "rotate(90deg)",
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.tagName).toBe("div");
+    expect(container.className).toContain("layout-block-image");
+    expect(container.style["position"]).toBe("relative");
+    // 90deg swaps the dims exactly (no FP drift): bboxH = original width.
+    expect(container.style["height"]).toBe("100px");
+
+    const imgEl = container.children[0] as unknown as FakeElement;
+    expect(imgEl.tagName).toBe("img");
+    expect(imgEl.style["transform"]).toBe("rotate(90deg)");
+    expect(imgEl.style["transformOrigin"]).toBe("center center");
+    expect(imgEl.style["position"]).toBe("absolute");
+    expect(imgEl.style["left"]).toBe("50%");
+    expect(imgEl.style["top"]).toBe("50%");
+    expect(imgEl.style["marginLeft"]).toBe(`${-imageRun.width / 2}px`);
+    expect(imgEl.style["marginTop"]).toBe(`${-imageRun.height / 2}px`);
+    expect(imgEl.style["marginRight"]).toBe("0");
+  });
+
+  test("wraps a 270deg rotated block image with the height set to original width", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 120,
+      height: 60,
+      displayMode: "block",
+      transform: "rotate(270deg)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.tagName).toBe("div");
+    expect(container.style["height"]).toBe("120px");
+    expect(container.style["position"]).toBe("relative");
+  });
+
+  test("wraps a 45deg rotated block image with the standard |cos|+|sin| height", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "rotate(45deg)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    // At 45deg, |sin| = |cos|. bboxH = w*|sin| + h*|cos|.
+    // Compute via the same trig calls the implementation uses to avoid FP
+    // drift between `Math.sin(pi/4) + Math.cos(pi/4)` and `Math.SQRT2`.
+    const rad = (45 * Math.PI) / 180;
+    const sinA = Math.abs(Math.sin(rad));
+    const cosA = Math.abs(Math.cos(rad));
+    const expectedH = 100 * sinA + 200 * cosA;
+    expect(container.style["height"]).toBe(`${expectedH}px`);
+    expect(container.style["position"]).toBe("relative");
+
+    const imgEl = container.children[0] as unknown as FakeElement;
+    expect(imgEl.style["position"]).toBe("absolute");
+  });
+
+  test("does NOT add bbox container styles to an un-rotated block image", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.tagName).toBe("div");
+    expect(container.style["position"]).not.toBe("relative");
+    expect(container.style["height"]).toBeUndefined();
+
+    const imgEl = container.children[0] as unknown as FakeElement;
+    expect(imgEl.tagName).toBe("img");
+    expect(imgEl.style["position"]).not.toBe("absolute");
+    // Fast path: centered via auto margins, not absolute positioning.
+    expect(imgEl.style["marginLeft"]).toBe("auto");
+    expect(imgEl.style["marginRight"]).toBe("auto");
+  });
+
+  test("does NOT add bbox container styles to a 0deg rotated block image", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "rotate(0deg)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.tagName).toBe("div");
+    expect(container.style["position"]).not.toBe("relative");
+    expect(container.style["height"]).toBeUndefined();
+  });
+
+  test("does NOT add bbox container styles to a flip-only block image", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "scaleX(-1) scaleY(-1)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.style["position"]).not.toBe("relative");
+    expect(container.style["height"]).toBeUndefined();
+
+    const imgEl = container.children[0] as unknown as FakeElement;
+    expect(imgEl.style["transform"]).toBe("scaleX(-1) scaleY(-1)");
+    expect(imgEl.style["position"]).not.toBe("absolute");
+  });
+
+  test("sets transformOrigin: center center on every block-image transform (rotated or not)", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "scaleX(-1)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+    const imgEl = container.children[0] as unknown as FakeElement;
+
+    expect(imgEl.style["transformOrigin"]).toBe("center center");
+  });
+
+  test("threads pmStart/pmEnd onto the container so PM positions stay attached after wrapping", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "rotate(90deg)",
+      pmStart: 7,
+      pmEnd: 8,
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.dataset["pmStart"]).toBe("7");
+    expect(container.dataset["pmEnd"]).toBe("8");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
@@ -115,19 +115,29 @@ describe("block image rotation bbox container", () => {
     expect(container.tagName).toBe("div");
     expect(container.className).toContain("layout-block-image");
     expect(container.style["position"]).toBe("relative");
-    // 90deg swaps the dims exactly (no FP drift): bboxH = original width.
-    expect(container.style["height"]).toBe("100px");
+    // 90deg swaps the dims exactly (no FP drift): bbox = (h, w).
+    expect(container.style["width"]).toBe(`${imageRun.height}px`);
+    expect(container.style["height"]).toBe(`${imageRun.width}px`);
 
     const imgEl = container.children[0] as unknown as FakeElement;
     expect(imgEl.tagName).toBe("img");
     expect(imgEl.style["transform"]).toBe("rotate(90deg)");
     expect(imgEl.style["transformOrigin"]).toBe("center center");
     expect(imgEl.style["position"]).toBe("absolute");
-    expect(imgEl.style["left"]).toBe("50%");
-    expect(imgEl.style["top"]).toBe("50%");
-    expect(imgEl.style["marginLeft"]).toBe(`${-imageRun.width / 2}px`);
-    expect(imgEl.style["marginTop"]).toBe(`${-imageRun.height / 2}px`);
+    // Centred inside the bbox: (bboxW - w) / 2, (bboxH - h) / 2.
+    expect(imgEl.style["left"]).toBe(
+      `${(imageRun.height - imageRun.width) / 2}px`,
+    );
+    expect(imgEl.style["top"]).toBe(
+      `${(imageRun.width - imageRun.height) / 2}px`,
+    );
+    // Tailwind preflight needs explicit dims on an absolute <img>.
+    expect(imgEl.style["width"]).toBe(`${imageRun.width}px`);
+    expect(imgEl.style["height"]).toBe(`${imageRun.height}px`);
+    // Auto-margin fast path is cleared in the rotated branch.
+    expect(imgEl.style["marginLeft"]).toBe("0");
     expect(imgEl.style["marginRight"]).toBe("0");
+    expect(imgEl.style["marginTop"]).toBe("0");
   });
 
   test("wraps a 270deg rotated block image with the height set to original width", () => {
@@ -145,6 +155,8 @@ describe("block image rotation bbox container", () => {
     const container = lineEl.children[0] as unknown as FakeElement;
 
     expect(container.tagName).toBe("div");
+    // 270deg swaps the dims: bbox = (h, w) = (60, 120).
+    expect(container.style["width"]).toBe("60px");
     expect(container.style["height"]).toBe("120px");
     expect(container.style["position"]).toBe("relative");
   });
@@ -163,18 +175,22 @@ describe("block image rotation bbox container", () => {
     const lineEl = renderLine(block, line, undefined, fakeDocument);
     const container = lineEl.children[0] as unknown as FakeElement;
 
-    // At 45deg, |sin| = |cos|. bboxH = w*|sin| + h*|cos|.
+    // At 45deg, |sin| = |cos|. bboxW = w*|cos| + h*|sin|, bboxH symmetric.
     // Compute via the same trig calls the implementation uses to avoid FP
     // drift between `Math.sin(pi/4) + Math.cos(pi/4)` and `Math.SQRT2`.
     const rad = (45 * Math.PI) / 180;
     const sinA = Math.abs(Math.sin(rad));
     const cosA = Math.abs(Math.cos(rad));
+    const expectedW = 100 * cosA + 200 * sinA;
     const expectedH = 100 * sinA + 200 * cosA;
+    expect(container.style["width"]).toBe(`${expectedW}px`);
     expect(container.style["height"]).toBe(`${expectedH}px`);
     expect(container.style["position"]).toBe("relative");
 
     const imgEl = container.children[0] as unknown as FakeElement;
     expect(imgEl.style["position"]).toBe("absolute");
+    expect(imgEl.style["left"]).toBe(`${(expectedW - 100) / 2}px`);
+    expect(imgEl.style["top"]).toBe(`${(expectedH - 200) / 2}px`);
   });
 
   test("does NOT add bbox container styles to an un-rotated block image", () => {
@@ -281,5 +297,68 @@ describe("block image rotation bbox container", () => {
 
     expect(container.dataset["pmStart"]).toBe("7");
     expect(container.dataset["pmEnd"]).toBe("8");
+  });
+
+  test("tolerates whitespace inside rotate(...) when computing the bbox", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      // CSS permits whitespace around the argument; folio doesn't emit it,
+      // but the regex must still match (gemini PR #521 review).
+      transform: "rotate( 90deg )",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.style["position"]).toBe("relative");
+    expect(container.style["width"]).toBe(`${imageRun.height}px`);
+    expect(container.style["height"]).toBe(`${imageRun.width}px`);
+  });
+
+  test("rotated bbox container has an explicit width so the flex line doesn't collapse it", () => {
+    // `renderLine` switches single-image lines to `display: flex; alignItems:
+    // center`; with `position: absolute` on the <img>, the container would
+    // get 0 width without an explicit one, and centering would land at the
+    // line start (codex PR #521 review).
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 80,
+      height: 40,
+      displayMode: "block",
+      transform: "rotate(90deg)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+
+    expect(container.style["width"]).toBe(`${imageRun.height}px`);
+  });
+
+  test("rotated <img> has explicit width/height so Tailwind preflight can't shrink it", () => {
+    // Tailwind's `img { max-width: 100%; height: auto }` would distort an
+    // absolutely-positioned <img> (gemini PR #521 review).
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      transform: "rotate(90deg)",
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const imgEl = (lineEl.children[0] as unknown as FakeElement)
+      .children[0] as unknown as FakeElement;
+
+    expect(imgEl.style["width"]).toBe(`${imageRun.width}px`);
+    expect(imgEl.style["height"]).toBe(`${imageRun.height}px`);
   });
 });

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -564,7 +564,10 @@ function parseRotationDegrees(transform: string | undefined): number {
   if (!transform) {
     return 0;
   }
-  const match = /rotate\(([-\d.]+)deg\)/u.exec(transform);
+  // Whitespace inside `rotate(...)` is valid CSS; folio never emits it, but
+  // accept it defensively so hand-authored / sanitized transforms don't
+  // silently fall through to the un-rotated path.
+  const match = /rotate\(\s*([-\d.]+)\s*deg\s*\)/u.exec(transform);
   if (!match) {
     return 0;
   }
@@ -663,25 +666,35 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
     img.style.transformOrigin = "center center";
   }
 
-  // Reserve the rotated bbox height on the container so a rotated block
-  // image doesn't bleed into the next paragraph. The container height is
-  // sized to the rotated bbox; the inner `<img>` positions absolutely at
-  // the container's centre and rotates around its own centre, which now
-  // lands inside the wrapper. Non-rotated images keep the fast path (auto
-  // margins for horizontal centering). Mirrors the inline path that PR
-  // #518 added in `renderInlineImageRun`.
+  // Reserve the rotated bbox on the container so a rotated block image
+  // doesn't bleed into the next paragraph. The container is sized to the
+  // rotated bbox; the inner `<img>` positions absolutely at the offset
+  // that centres it inside the wrapper, then rotates around its own
+  // centre. Non-rotated images keep the fast path (auto margins for
+  // horizontal centering). Mirrors the inline path that PR #518 added in
+  // `renderInlineImageRun` — keep the two in sync until they dedupe.
   // eigenpal #424 (rotation bbox gap 8 follow-up).
   const rotation = parseRotationDegrees(run.transform);
   if (rotation !== 0) {
     const bbox = rotatedBoundingBox(run.width, run.height, rotation);
+    // Width must be explicit: `renderLine` wraps a single-image line in a
+    // flex container, and an absolutely-positioned `<img>` provides no
+    // in-flow width, so the wrapper would collapse to 0 and break
+    // centering.
+    container.style.width = `${bbox.width}px`;
     container.style.height = `${bbox.height}px`;
     container.style.position = "relative";
     img.style.position = "absolute";
-    img.style.left = "50%";
-    img.style.top = "50%";
-    img.style.marginLeft = `${-run.width / 2}px`;
+    img.style.left = `${(bbox.width - run.width) / 2}px`;
+    img.style.top = `${(bbox.height - run.height) / 2}px`;
+    // Tailwind preflight applies `img { max-width: 100%; height: auto }`,
+    // which would shrink an absolutely-positioned `<img>`. Pin the
+    // intrinsic dims explicitly, same as the inline path.
+    img.style.width = `${run.width}px`;
+    img.style.height = `${run.height}px`;
+    img.style.marginLeft = "0";
     img.style.marginRight = "0";
-    img.style.marginTop = `${-run.height / 2}px`;
+    img.style.marginTop = "0";
   }
 
   applyPmPositions(container, run.pmStart, run.pmEnd);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -557,6 +557,44 @@ function getLeaderChar(leader: string): string | null {
   }
 }
 
+// Parse the rotation angle (degrees, normalized to [0, 360)) from a CSS
+// `transform` string like `"rotate(90deg) scaleX(-1)"`. Returns 0 when no
+// `rotate()` term is present. eigenpal #424 (rotation bbox gap 8 follow-up).
+function parseRotationDegrees(transform: string | undefined): number {
+  if (!transform) {
+    return 0;
+  }
+  const match = /rotate\(([-\d.]+)deg\)/u.exec(transform);
+  if (!match) {
+    return 0;
+  }
+  const raw = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(raw)) {
+    return 0;
+  }
+  return ((raw % 360) + 360) % 360;
+}
+
+// Axis-aligned bounding box of a `w × h` rectangle rotated by `deg` degrees.
+// 90°/270° swap the dims exactly (no FP drift); 0°/180° keep them; arbitrary
+// angles use the standard |cos θ|·w + |sin θ|·h formula. eigenpal #424.
+function rotatedBoundingBox(
+  w: number,
+  h: number,
+  deg: number,
+): { width: number; height: number } {
+  if (deg === 0 || deg === 180) {
+    return { width: w, height: h };
+  }
+  if (deg === 90 || deg === 270) {
+    return { width: h, height: w };
+  }
+  const rad = (deg * Math.PI) / 180;
+  const sinA = Math.abs(Math.sin(rad));
+  const cosA = Math.abs(Math.cos(rad));
+  return { width: w * cosA + h * sinA, height: w * sinA + h * cosA };
+}
+
 /**
  * Render an inline image run (flows with text)
  */
@@ -620,6 +658,30 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   }
   if (run.transform) {
     img.style.transform = run.transform;
+    // Word rotates around the picture's geometric centre; be explicit so
+    // future stacked transforms can't drift. eigenpal #424.
+    img.style.transformOrigin = "center center";
+  }
+
+  // Reserve the rotated bbox height on the container so a rotated block
+  // image doesn't bleed into the next paragraph. The container height is
+  // sized to the rotated bbox; the inner `<img>` positions absolutely at
+  // the container's centre and rotates around its own centre, which now
+  // lands inside the wrapper. Non-rotated images keep the fast path (auto
+  // margins for horizontal centering). Mirrors the inline path that PR
+  // #518 added in `renderInlineImageRun`.
+  // eigenpal #424 (rotation bbox gap 8 follow-up).
+  const rotation = parseRotationDegrees(run.transform);
+  if (rotation !== 0) {
+    const bbox = rotatedBoundingBox(run.width, run.height, rotation);
+    container.style.height = `${bbox.height}px`;
+    container.style.position = "relative";
+    img.style.position = "absolute";
+    img.style.left = "50%";
+    img.style.top = "50%";
+    img.style.marginLeft = `${-run.width / 2}px`;
+    img.style.marginRight = "0";
+    img.style.marginTop = `${-run.height / 2}px`;
   }
 
   applyPmPositions(container, run.pmStart, run.pmEnd);


### PR DESCRIPTION
## Summary

- Completes the block-image half of the rotation bbox fix that PR #518 started for inline images. Cited reporter flagged that `renderBlockImage` had the same gap as `renderInlineImageRun`.
- Rotated block images previously bled into the next paragraph because the container reserved only the un-rotated picture's height. Now the container is sized to the rotated axis-aligned bbox and the `<img>` is absolutely centered inside it, rotating around its own centre (which now lands inside the wrapper).
- `transformOrigin: center center` is set on every block-image transform (rotated or not) so future stacked transforms cannot drift, matching upstream.

Ports the block-image half of eigenpal/docx-editor commit `c605277c9` (gap 8 of #423/#424).

## Helpers

`parseRotationDegrees` and `rotatedBoundingBox` are duplicated from PR #518's inline-path commit (which is not yet on `main`). They are small (~30 lines) and identical, which keeps this PR reviewable on its own without stacking on #518. Once both land, they can be deduped in a follow-up.

## Regression tests

New file `renderBlockImage-rotation.test.ts` (companion to PR #518's `renderImage-rotation.test.ts`), 8 cases:

- 90°: container height = original width (dim swap, no FP drift); img absolute-centered with negative margins.
- 270°: container height = original width.
- 45°: container height matches the standard `|cos|·w + |sin|·h` formula.
- 0° rotation transform: no bbox styles applied (fast path).
- No transform at all: no bbox styles applied (fast path).
- Flip-only (`scaleX(-1) scaleY(-1)`): no bbox styles applied; transform survives.
- Any transform (rotated or not) gets `transformOrigin: center center`.
- `pmStart`/`pmEnd` thread onto the container so PM positions stay attached.

## Test plan

- [x] `bun --filter @stll/folio test` (1010 pass, 0 fail)
- [x] `bun --filter @stll/folio lint` clean
- [x] `bun --filter @stll/folio typecheck` clean
- [x] `bun --filter @stll/folio format` clean