### PR TITLE
feat(business-registries): add brreg (Norway Brønnøysund)

### DIFF
--- a/apps/api/src/handlers/contacts/business-registries-lookup.ts
+++ b/apps/api/src/handlers/contacts/business-registries-lookup.ts
@@ -14,6 +14,18 @@ import {
   searchByName as searchAresByName,
   validateIco,
 } from "@stll/business-registries/ares";
+import {
+  BrregAPIError,
+  type BrregEntity,
+  BrregRequestError,
+  type BrregSearchResult,
+  BrregTooBroadError,
+  BrregValidationError,
+  lookupByOrgnr,
+  normalizeOrgnr,
+  searchByName as searchBrregByName,
+  validateOrgnr,
+} from "@stll/business-registries/brreg";
 
 import { isNativeToolEnabledForOrg } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -23,7 +35,7 @@ import { HandlerError } from "@/api/lib/errors/tagged-errors";
 // Normalised cross-registry shapes
 // ---------------------------------------------------------------------------
 
-const BUSINESS_REGISTRY_SLUGS = ["ares"] as const;
+const BUSINESS_REGISTRY_SLUGS = ["ares", "brreg"] as const;
 type BusinessRegistrySlug = (typeof BUSINESS_REGISTRY_SLUGS)[number];
 
 type BusinessRegistryAddress = {
@@ -185,8 +197,92 @@ const ARES_HANDLER: RegistryHandler = {
   mapError: mapAresError,
 };
 
+// ---------------------------------------------------------------------------
+// Brreg (Norway)
+// ---------------------------------------------------------------------------
+
+const brregEntityToHit = (entity: BrregEntity): BusinessRegistryHit => ({
+  registry: "brreg",
+  id: entity.orgnr,
+  name: entity.name,
+  legalForm: entity.legalForm,
+  address: entity.businessAddress
+    ? {
+        line1: entity.businessAddress.street,
+        line2: null,
+        postalCode: entity.businessAddress.postalCode,
+        city: entity.businessAddress.city,
+        region: entity.businessAddress.municipality,
+        country: entity.businessAddress.country,
+        textAddress: entity.businessAddress.textAddress,
+      }
+    : null,
+  registryUrl: entity.registryUrl,
+});
+
+const brregSearchResultToHit = (
+  result: BrregSearchResult,
+): BusinessRegistryHit => ({
+  registry: "brreg",
+  id: result.orgnr,
+  name: result.name,
+  legalForm: null,
+  address: result.address
+    ? {
+        line1: null,
+        line2: null,
+        postalCode: null,
+        city: null,
+        region: null,
+        country: null,
+        textAddress: result.address,
+      }
+    : null,
+  registryUrl: `https://virksomhet.brreg.no/nb/oppslag/enheter/${result.orgnr}`,
+});
+
+const mapBrregError = (error: unknown): HandlerError | null => {
+  if (error instanceof BrregValidationError) {
+    return new HandlerError({ status: 400, message: error.message });
+  }
+  if (error instanceof BrregTooBroadError) {
+    return new HandlerError({
+      status: 400,
+      message: "Search too broad. Please refine your query.",
+    });
+  }
+  if (error instanceof BrregAPIError) {
+    return new HandlerError({
+      status: 502,
+      message: `Brreg API error: ${error.message}`,
+    });
+  }
+  if (error instanceof BrregRequestError) {
+    return new HandlerError({
+      status: 502,
+      message: `Brreg request failed: ${error.message}`,
+    });
+  }
+  return null;
+};
+
+const BRREG_HANDLER: RegistryHandler = {
+  nativeToolSlug: "brreg",
+  isCanonicalId: (input) => validateOrgnr(normalizeOrgnr(input)),
+  lookup: async (input) => {
+    const entity = await lookupByOrgnr(input);
+    return entity ? brregEntityToHit(entity) : null;
+  },
+  search: async (input) => {
+    const results = await searchBrregByName(input);
+    return results.map(brregSearchResultToHit);
+  },
+  mapError: mapBrregError,
+};
+
 const DISPATCH: Record<BusinessRegistrySlug, RegistryHandler> = {
   ares: ARES_HANDLER,
+  brreg: BRREG_HANDLER,
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/handlers/contacts/business-registries-lookup.ts
+++ b/apps/api/src/handlers/contacts/business-registries-lookup.ts
@@ -12,7 +12,6 @@ import {
   lookupByIco,
   normalizeIco,
   searchByName as searchAresByName,
-  validateIco,
 } from "@stll/business-registries/ares";
 import {
   BrregAPIError,
@@ -24,7 +23,6 @@ import {
   lookupByOrgnr,
   normalizeOrgnr,
   searchByName as searchBrregByName,
-  validateOrgnr,
 } from "@stll/business-registries/brreg";
 
 import { isNativeToolEnabledForOrg } from "@/api/handlers/mcp-connectors/catalog-metadata";
@@ -76,7 +74,17 @@ type LookupResponse =
 type RegistryHandler = {
   /** Catalog slug used by `isNativeToolEnabledForOrg`. */
   nativeToolSlug: string;
-  /** True when the trimmed input looks like the registry's canonical ID. */
+  /**
+   * True when the trimmed input has the *shape* of the registry's
+   * canonical ID — e.g. eight digits for a Czech IČO, nine digits for
+   * a Norwegian orgnr. This is intentionally a cheap, permissive
+   * structural check, NOT a full validator. Semantic validation
+   * (checksums, country prefixes, etc.) belongs in the `lookup`
+   * function; bad-checksum inputs surface as a `*ValidationError` →
+   * mapped to HTTP 400 by `mapError`. Returning `false` here would
+   * fall through to `search`, which silently swallows malformed IDs
+   * as empty name-search results — exactly the UX we want to avoid.
+   */
   isCanonicalId: (input: string) => boolean;
   /** Lookup by canonical ID. */
   lookup: (input: string) => Promise<BusinessRegistryHit | null>;
@@ -185,7 +193,9 @@ const mapAresError = (error: unknown): HandlerError | null => {
 
 const ARES_HANDLER: RegistryHandler = {
   nativeToolSlug: "ares",
-  isCanonicalId: (input) => validateIco(normalizeIco(input)),
+  // Shape-only: 8 digits after normalisation. Bad checksums route
+  // through lookup and surface as AresValidationError → 400.
+  isCanonicalId: (input) => /^\d{8}$/u.test(normalizeIco(input)),
   lookup: async (input) => {
     const company = await lookupByIco(input);
     return company ? aresCompanyToHit(company) : null;
@@ -268,7 +278,9 @@ const mapBrregError = (error: unknown): HandlerError | null => {
 
 const BRREG_HANDLER: RegistryHandler = {
   nativeToolSlug: "brreg",
-  isCanonicalId: (input) => validateOrgnr(normalizeOrgnr(input)),
+  // Shape-only: 9 digits after normalisation. MOD-11 violations
+  // route through lookup and surface as BrregValidationError → 400.
+  isCanonicalId: (input) => /^\d{9}$/u.test(normalizeOrgnr(input)),
   lookup: async (input) => {
     const entity = await lookupByOrgnr(input);
     return entity ? brregEntityToHit(entity) : null;

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.test.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.test.ts
@@ -86,6 +86,20 @@ describe("mcpConnectorCatalogMetadata", () => {
       expect.objectContaining({ slug: "boe", isRecommended: false }),
     );
   });
+
+  it("recommends built-in Brreg for Norwegian practice", () => {
+    const tools = getNativeToolCatalog({
+      practiceJurisdictions: [{ countryCode: "NO", isPrimary: true }],
+    });
+
+    expect(tools).toContainEqual(
+      expect.objectContaining({
+        slug: "brreg",
+        isRecommended: true,
+        recommendedJurisdictions: ["NO"],
+      }),
+    );
+  });
 });
 
 describe("isNativeToolEnabledForOrg", () => {

--- a/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
+++ b/apps/api/src/handlers/mcp-connectors/catalog-metadata.ts
@@ -22,6 +22,7 @@ export type NativeToolCatalogItem = {
 
 const ARES_RECOMMENDED_JURISDICTIONS = ["CZ"] as const;
 const BOE_RECOMMENDED_JURISDICTIONS = ["ES"] as const;
+const BRREG_RECOMMENDED_JURISDICTIONS = ["NO"] as const;
 const NATIVE_TOOL_CATALOG = [
   {
     slug: "ares",
@@ -42,6 +43,17 @@ const NATIVE_TOOL_CATALOG = [
     documentationUrl: "https://www.boe.es/datosabiertos/",
     iconUrl: null,
     recommendedJurisdictions: [...BOE_RECOMMENDED_JURISDICTIONS],
+  },
+  {
+    slug: "brreg",
+    displayName: "Brønnøysundregistrene",
+    description:
+      "Norwegian company lookup by organisasjonsnummer or company name from the public Brreg Enhetsregisteret open API.",
+    url: "https://www.brreg.no",
+    documentationUrl:
+      "https://data.brreg.no/enhetsregisteret/api/docs/index.html",
+    iconUrl: null,
+    recommendedJurisdictions: [...BRREG_RECOMMENDED_JURISDICTIONS],
   },
   {
     slug: "web-search",

--- a/packages/business-registries/README.md
+++ b/packages/business-registries/README.md
@@ -21,10 +21,10 @@ await ares.lookupByIco("27082440");
 
 ## Supported registries
 
-| Subpath | Jurisdiction   | Registry                                      |
-| ------- | -------------- | --------------------------------------------- |
-| `/ares` | Czech Republic | [ARES](https://ares.gov.cz) — public open API |
-| `/brreg` | Norway | [Brønnøysundregistrene](https://data.brreg.no/enhetsregisteret/api/docs/index.html) — public open API |
+| Subpath  | Jurisdiction   | Registry                                                                                              |
+| -------- | -------------- | ----------------------------------------------------------------------------------------------------- |
+| `/ares`  | Czech Republic | [ARES](https://ares.gov.cz) — public open API                                                         |
+| `/brreg` | Norway         | [Brønnøysundregistrene](https://data.brreg.no/enhetsregisteret/api/docs/index.html) — public open API |
 
 More jurisdictions land per-PR; see the package README on the main branch for
 the current list.

--- a/packages/business-registries/README.md
+++ b/packages/business-registries/README.md
@@ -24,6 +24,7 @@ await ares.lookupByIco("27082440");
 | Subpath | Jurisdiction   | Registry                                      |
 | ------- | -------------- | --------------------------------------------- |
 | `/ares` | Czech Republic | [ARES](https://ares.gov.cz) — public open API |
+| `/brreg` | Norway | [Brønnøysundregistrene](https://data.brreg.no/enhetsregisteret/api/docs/index.html) — public open API |
 
 More jurisdictions land per-PR; see the package README on the main branch for
 the current list.

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -44,6 +44,11 @@
       "bun": "./src/ares/index.ts",
       "types": "./src/ares/index.ts",
       "import": "./dist/ares/index.js"
+    },
+    "./brreg": {
+      "bun": "./src/brreg/index.ts",
+      "types": "./src/brreg/index.ts",
+      "import": "./dist/brreg/index.js"
     }
   },
   "publishConfig": {

--- a/packages/business-registries/src/brreg/client.test.ts
+++ b/packages/business-registries/src/brreg/client.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { lookupByOrgnr, searchByName } from "./client.js";
-import { BrregValidationError } from "./errors.js";
+import { BrregTooBroadError, BrregValidationError } from "./errors.js";
 
 const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
 
@@ -58,5 +58,27 @@ describe("searchByName validation", () => {
     expect(searchByName("a".repeat(181))).rejects.toBeInstanceOf(
       BrregValidationError,
     );
+  });
+});
+
+describe("searchByName upstream 400 handling", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("translates Brreg's broad-query HTTP 400 into BrregTooBroadError", () => {
+    const stub = async () =>
+      new Response(
+        JSON.stringify({
+          feilmelding: "Spørringen returnerer for mange treff",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    globalThis.fetch = Object.assign(stub, {
+      preconnect: originalFetch.preconnect,
+    });
+
+    expect(searchByName("a")).rejects.toBeInstanceOf(BrregTooBroadError);
   });
 });

--- a/packages/business-registries/src/brreg/client.test.ts
+++ b/packages/business-registries/src/brreg/client.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import { lookupByOrgnr, searchByName } from "./client.js";
+import { BrregValidationError } from "./errors.js";
+
+const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+
+// Live tests hit the real Brreg open API. They double as integration tests
+// and document the expected response shape for known entities.
+describe.skipIf(SKIP_LIVE)("lookupByOrgnr live", () => {
+  test("returns the registry itself", async () => {
+    const result = await lookupByOrgnr("974760673");
+    expect(result).not.toBeNull();
+    expect(result?.orgnr).toBe("974760673");
+    expect(result?.name).toContain("BRØNNØYSUND");
+    expect(result?.businessAddress?.country).toBeTruthy();
+    expect(result?.registryUrl).toContain("974760673");
+  });
+
+  test("returns null for a checksum-valid but non-existent orgnr", async () => {
+    // 100000007: nine digits, MOD-11 valid, not registered.
+    const result = await lookupByOrgnr("100000007");
+    expect(result).toBeNull();
+  });
+});
+
+describe("lookupByOrgnr validation", () => {
+  test("throws BrregValidationError for short input", () => {
+    expect(lookupByOrgnr("12345678")).rejects.toBeInstanceOf(
+      BrregValidationError,
+    );
+  });
+
+  test("throws BrregValidationError on bad checksum", () => {
+    expect(lookupByOrgnr("974760674")).rejects.toBeInstanceOf(
+      BrregValidationError,
+    );
+  });
+});
+
+describe.skipIf(SKIP_LIVE)("searchByName live", () => {
+  test("finds Equinor", async () => {
+    const results = await searchByName("Equinor", { limit: 10 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.name.toUpperCase().includes("EQUINOR"))).toBe(
+      true,
+    );
+  });
+});
+
+describe("searchByName validation", () => {
+  test("rejects empty input", () => {
+    expect(searchByName("")).rejects.toBeInstanceOf(BrregValidationError);
+    expect(searchByName("   ")).rejects.toBeInstanceOf(BrregValidationError);
+  });
+
+  test("rejects overlong input", () => {
+    expect(searchByName("a".repeat(181))).rejects.toBeInstanceOf(
+      BrregValidationError,
+    );
+  });
+});

--- a/packages/business-registries/src/brreg/client.test.ts
+++ b/packages/business-registries/src/brreg/client.test.ts
@@ -18,8 +18,8 @@ describe.skipIf(SKIP_LIVE)("lookupByOrgnr live", () => {
   });
 
   test("returns null for a checksum-valid but non-existent orgnr", async () => {
-    // 100000007: nine digits, MOD-11 valid, not registered.
-    const result = await lookupByOrgnr("100000007");
+    // 100000008: nine digits, MOD-11 valid, not registered.
+    const result = await lookupByOrgnr("100000008");
     expect(result).toBeNull();
   });
 });

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -1,0 +1,194 @@
+import {
+  BrregAPIError,
+  BrregRequestError,
+  BrregTooBroadError,
+  BrregValidationError,
+} from "./errors.js";
+import { parseEnhet, parseSearchEntry } from "./parse.js";
+import type {
+  BrregEntity,
+  BrregErrorResponse,
+  BrregRawEnhet,
+  BrregSearchResponse,
+  BrregSearchResult,
+} from "./types.js";
+import { normalizeOrgnr, validateOrgnr } from "./validation.js";
+
+const BASE = "https://data.brreg.no/enhetsregisteret/api";
+const ENHETER_URL = `${BASE}/enheter`;
+const UNDERENHETER_URL = `${BASE}/underenheter`;
+
+const TIMEOUT_MS = 10_000;
+const DEFAULT_SEARCH_LIMIT = 50;
+const MAX_SEARCH_LIMIT = 100;
+const BRREG_RESULT_CAP = 10_000;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseErrorBody = (value: unknown): BrregErrorResponse => {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const result: BrregErrorResponse = {};
+  if (typeof value["status"] === "number") {
+    result.status = value["status"];
+  }
+  if (typeof value["feilmelding"] === "string") {
+    result.feilmelding = value["feilmelding"];
+  }
+  if (typeof value["hjelp"] === "string") {
+    result.hjelp = value["hjelp"];
+  }
+  return result;
+};
+
+const brregGet = async <T>(url: string): Promise<T | null> => {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    });
+  } catch (error) {
+    throw new BrregRequestError(url, "Brreg request failed", { cause: error });
+  }
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  // 410 Gone — Brreg uses this for entities removed from disclosure
+  // (typically by court order or another legal requirement). The
+  // response body carries an error envelope, not an entity payload,
+  // so we surface "no result" rather than feeding the body through
+  // the entity parser.
+  //
+  // Struck-off / deleted entities — which still belong in the domain
+  // model — come back as `200 OK` with `slettedato` set; the parser
+  // handles those via BrregEntityStatus's "deleted" arm.
+  if (response.status === 410) {
+    return null;
+  }
+
+  if (!response.ok) {
+    let body: BrregErrorResponse = {};
+    try {
+      body = parseErrorBody(await response.json());
+    } catch {
+      // non-JSON error body
+    }
+    throw new BrregAPIError({
+      message: `Brreg ${response.status}: ${body.feilmelding ?? response.statusText}`,
+      httpStatus: response.status,
+      upstreamMessage: body.feilmelding ?? null,
+    });
+  }
+
+  // SAFETY: Brreg is a stable, documented public API. Runtime validation
+  // adds little for well-typed JSON responses.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return response.json() as Promise<T>;
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type LookupOptions = {
+  /**
+   * Whether to fall back to the sub-entity (underenheter) register when the
+   * main `enheter` register returns 404. Useful when the orgnr identifies a
+   * branch rather than a parent company.
+   * @default true
+   */
+  includeSubEntities?: boolean;
+};
+
+/**
+ * Look up a Norwegian entity by organisasjonsnummer.
+ *
+ * Hits the main `enheter` register first. If the orgnr is not found and
+ * `includeSubEntities` is true (default), tries `underenheter`.
+ *
+ * @returns The entity, or `null` if the orgnr does not exist.
+ * @throws {BrregValidationError} if the orgnr fails MOD-11 validation
+ * @throws {BrregAPIError} on Brreg API errors
+ * @throws {BrregRequestError} on network failures
+ */
+export const lookupByOrgnr = async (
+  orgnr: string,
+  options?: LookupOptions,
+): Promise<BrregEntity | null> => {
+  const normalized = normalizeOrgnr(orgnr);
+
+  if (!validateOrgnr(normalized)) {
+    throw new BrregValidationError(`Invalid orgnr: ${orgnr}`);
+  }
+
+  const enhet = await brregGet<BrregRawEnhet>(`${ENHETER_URL}/${normalized}`);
+  if (enhet) {
+    return parseEnhet(enhet);
+  }
+
+  if (options?.includeSubEntities ?? true) {
+    const sub = await brregGet<BrregRawEnhet>(
+      `${UNDERENHETER_URL}/${normalized}`,
+    );
+    if (sub) {
+      return parseEnhet(sub);
+    }
+  }
+
+  return null;
+};
+
+export type SearchOptions = {
+  /** Maximum number of results. Brreg caps each page at 100. @default 50 */
+  limit?: number;
+};
+
+/**
+ * Search Brreg `enheter` by company name (case-insensitive substring).
+ *
+ * @returns A list of matching entities (may be empty).
+ * @throws {BrregTooBroadError} if the search would exceed Brreg's 10k cap
+ * @throws {BrregAPIError} on Brreg API errors
+ * @throws {BrregRequestError} on network failures
+ */
+export const searchByName = async (
+  name: string,
+  options?: SearchOptions,
+): Promise<BrregSearchResult[]> => {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    throw new BrregValidationError("Search name must not be empty");
+  }
+  if (trimmed.length > 180) {
+    throw new BrregValidationError(
+      "Search name must be 180 characters or fewer",
+    );
+  }
+
+  const requestedLimit = options?.limit ?? DEFAULT_SEARCH_LIMIT;
+  const size = Math.min(Math.max(requestedLimit, 1), MAX_SEARCH_LIMIT);
+
+  const params = new URLSearchParams({
+    navn: trimmed,
+    size: String(size),
+  });
+  const url = `${ENHETER_URL}?${params.toString()}`;
+
+  const data = await brregGet<BrregSearchResponse>(url);
+  if (!data) {
+    return [];
+  }
+
+  const total = data.page?.totalElements ?? 0;
+  if (total > BRREG_RESULT_CAP) {
+    throw new BrregTooBroadError(trimmed);
+  }
+
+  const entries = data._embedded?.enheter ?? [];
+  return entries.map(parseSearchEntry);
+};

--- a/packages/business-registries/src/brreg/client.ts
+++ b/packages/business-registries/src/brreg/client.ts
@@ -128,7 +128,7 @@ export const lookupByOrgnr = async (
 
   const enhet = await brregGet<BrregRawEnhet>(`${ENHETER_URL}/${normalized}`);
   if (enhet) {
-    return parseEnhet(enhet);
+    return parseEnhet(enhet, "enhet");
   }
 
   if (options?.includeSubEntities ?? true) {
@@ -136,7 +136,7 @@ export const lookupByOrgnr = async (
       `${UNDERENHETER_URL}/${normalized}`,
     );
     if (sub) {
-      return parseEnhet(sub);
+      return parseEnhet(sub, "underenhet");
     }
   }
 
@@ -179,7 +179,22 @@ export const searchByName = async (
   });
   const url = `${ENHETER_URL}?${params.toString()}`;
 
-  const data = await brregGet<BrregSearchResponse>(url);
+  let data: BrregSearchResponse | null;
+  try {
+    data = await brregGet<BrregSearchResponse>(url);
+  } catch (error) {
+    // Brreg short-circuits queries that would exceed its 10k result
+    // cap with HTTP 400 — there is no page envelope to inspect — so
+    // we translate that 400 into the intended "refine your query"
+    // signal instead of letting the handler treat it as a 502.
+    // Other 400s (malformed query syntax etc.) propagate as-is; we
+    // construct the query ourselves so they should not happen in
+    // practice.
+    if (error instanceof BrregAPIError && error.httpStatus === 400) {
+      throw new BrregTooBroadError(trimmed);
+    }
+    throw error;
+  }
   if (!data) {
     return [];
   }

--- a/packages/business-registries/src/brreg/errors.ts
+++ b/packages/business-registries/src/brreg/errors.ts
@@ -1,0 +1,62 @@
+export class BrregError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "BrregError";
+  }
+}
+
+export class BrregAPIError extends BrregError {
+  readonly httpStatus: number;
+  readonly upstreamMessage: string | null;
+
+  constructor({
+    cause,
+    message,
+    httpStatus,
+    upstreamMessage,
+  }: {
+    cause?: unknown;
+    message: string;
+    httpStatus: number;
+    upstreamMessage?: string | null;
+  }) {
+    super(message, { cause });
+    this.name = "BrregAPIError";
+    this.httpStatus = httpStatus;
+    this.upstreamMessage = upstreamMessage ?? null;
+  }
+}
+
+export class BrregNotFoundError extends BrregError {
+  readonly orgnr: string;
+
+  constructor(orgnr: string) {
+    super(`Norwegian entity not found: ${orgnr}`);
+    this.name = "BrregNotFoundError";
+    this.orgnr = orgnr;
+  }
+}
+
+export class BrregTooBroadError extends BrregError {
+  constructor(query: string) {
+    super(`Search too broad: ${query}`);
+    this.name = "BrregTooBroadError";
+  }
+}
+
+export class BrregValidationError extends BrregError {
+  constructor(message: string) {
+    super(message);
+    this.name = "BrregValidationError";
+  }
+}
+
+export class BrregRequestError extends BrregError {
+  readonly url: string;
+
+  constructor(url: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "BrregRequestError";
+    this.url = url;
+  }
+}

--- a/packages/business-registries/src/brreg/index.ts
+++ b/packages/business-registries/src/brreg/index.ts
@@ -1,0 +1,26 @@
+export { lookupByOrgnr, searchByName } from "./client.js";
+export type { LookupOptions, SearchOptions } from "./client.js";
+export {
+  BrregAPIError,
+  BrregError,
+  BrregNotFoundError,
+  BrregRequestError,
+  BrregTooBroadError,
+  BrregValidationError,
+} from "./errors.js";
+export { parseAddress, parseEnhet, parseSearchEntry } from "./parse.js";
+export type {
+  BrregAddress,
+  BrregEntity,
+  BrregEntityStatus,
+  BrregErrorResponse,
+  BrregIndustryCode,
+  BrregRawAddress,
+  BrregRawEnhet,
+  BrregRawInstitusjonellSektor,
+  BrregRawNaeringskode,
+  BrregRawOrgForm,
+  BrregSearchResponse,
+  BrregSearchResult,
+} from "./types.js";
+export { normalizeOrgnr, validateOrgnr } from "./validation.js";

--- a/packages/business-registries/src/brreg/parse.test.ts
+++ b/packages/business-registries/src/brreg/parse.test.ts
@@ -124,6 +124,37 @@ describe("parseEnhet", () => {
     });
     expect(out.businessAddress?.street).toBe("Havnegata 48");
   });
+
+  test("treats nedleggelsesdato as a deleted-status closure for sub-entities", () => {
+    const out = parseEnhet(
+      { ...baseRaw, nedleggelsesdato: "2024-08-12" },
+      "underenhet",
+    );
+    expect(out.status).toEqual({ type: "deleted", deletedAt: "2024-08-12" });
+  });
+
+  test("prefers slettedato over nedleggelsesdato when both are present", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      slettedato: "2024-01-15",
+      nedleggelsesdato: "2023-06-01",
+    });
+    expect(out.status).toEqual({ type: "deleted", deletedAt: "2024-01-15" });
+  });
+
+  test("routes sub-entities to the /underenheter/ registry URL", () => {
+    const out = parseEnhet(baseRaw, "underenhet");
+    expect(out.registryUrl).toBe(
+      "https://virksomhet.brreg.no/nb/oppslag/underenheter/974760673",
+    );
+  });
+
+  test("defaults to the /enheter/ registry URL when no kind is supplied", () => {
+    const out = parseEnhet(baseRaw);
+    expect(out.registryUrl).toBe(
+      "https://virksomhet.brreg.no/nb/oppslag/enheter/974760673",
+    );
+  });
 });
 
 describe("parseSearchEntry", () => {

--- a/packages/business-registries/src/brreg/parse.test.ts
+++ b/packages/business-registries/src/brreg/parse.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseAddress, parseEnhet, parseSearchEntry } from "./parse.js";
+import type { BrregRawAddress, BrregRawEnhet } from "./types.js";
+
+const baseRaw: BrregRawEnhet = {
+  organisasjonsnummer: "974760673",
+  navn: "BRØNNØYSUNDREGISTRENE",
+};
+
+describe("parseAddress", () => {
+  test("composes textAddress from lines, postal code, city and country", () => {
+    const raw: BrregRawAddress = {
+      adresse: ["Havnegata 48"],
+      postnummer: "8910",
+      poststed: "BRØNNØYSUND",
+      land: "Norge",
+      kommune: "BRØNNØY",
+    };
+    const out = parseAddress(raw);
+    expect(out.street).toBe("Havnegata 48");
+    expect(out.postalCode).toBe("8910");
+    expect(out.city).toBe("BRØNNØYSUND");
+    expect(out.country).toBe("Norge");
+    expect(out.municipality).toBe("BRØNNØY");
+    expect(out.textAddress).toBe("Havnegata 48, 8910 BRØNNØYSUND, Norge");
+  });
+
+  test("falls back to nulls on a sparse address", () => {
+    const out = parseAddress({});
+    expect(out.street).toBeNull();
+    expect(out.postalCode).toBeNull();
+    expect(out.city).toBeNull();
+    expect(out.country).toBeNull();
+    expect(out.textAddress).toBeNull();
+  });
+
+  test("composes textAddress from postal+city+country when no street lines are present", () => {
+    const out = parseAddress({
+      postnummer: "8910",
+      poststed: "BRØNNØYSUND",
+      land: "Norge",
+    });
+    expect(out.street).toBeNull();
+    expect(out.textAddress).toBe("8910 BRØNNØYSUND, Norge");
+  });
+});
+
+describe("parseEnhet", () => {
+  test("maps minimal raw entity to domain", () => {
+    const out = parseEnhet(baseRaw);
+    expect(out.orgnr).toBe("974760673");
+    expect(out.name).toBe("BRØNNØYSUNDREGISTRENE");
+    expect(out.legalForm).toBeNull();
+    expect(out.businessAddress).toBeNull();
+    expect(out.industryCodes).toEqual([]);
+    expect(out.status).toEqual({ type: "active" });
+    expect(out.registryUrl).toBe(
+      "https://virksomhet.brreg.no/nb/oppslag/enheter/974760673",
+    );
+  });
+
+  test("flags bankruptcy", () => {
+    const out = parseEnhet({ ...baseRaw, konkurs: true });
+    expect(out.status).toEqual({ type: "bankruptcy" });
+  });
+
+  test("flags winding-up", () => {
+    expect(parseEnhet({ ...baseRaw, underAvvikling: true }).status).toEqual({
+      type: "winding_up",
+    });
+    expect(
+      parseEnhet({
+        ...baseRaw,
+        underTvangsavviklingEllerTvangsopplosning: true,
+      }).status,
+    ).toEqual({ type: "winding_up" });
+  });
+
+  test("prefers deleted status over other flags", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      konkurs: true,
+      slettedato: "2024-01-15",
+    });
+    expect(out.status).toEqual({ type: "deleted", deletedAt: "2024-01-15" });
+  });
+
+  test("collects up to three industry codes in order", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      naeringskode1: {
+        kode: "84.110",
+        beskrivelse: "Generell offentlig administrasjon",
+      },
+      naeringskode2: { kode: "84.130" },
+      naeringskode3: { kode: "" },
+    });
+    expect(out.industryCodes).toEqual([
+      { code: "84.110", description: "Generell offentlig administrasjon" },
+      { code: "84.130", description: null },
+    ]);
+  });
+
+  test("uses beliggenhetsadresse for sub-entities that lack forretningsadresse", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      beliggenhetsadresse: {
+        adresse: ["Storgata 1"],
+        postnummer: "0155",
+        poststed: "OSLO",
+        land: "Norge",
+      },
+    });
+    expect(out.businessAddress?.street).toBe("Storgata 1");
+    expect(out.businessAddress?.city).toBe("OSLO");
+  });
+
+  test("prefers forretningsadresse when both physical-address fields are present", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      forretningsadresse: { adresse: ["Havnegata 48"] },
+      beliggenhetsadresse: { adresse: ["Storgata 1"] },
+    });
+    expect(out.businessAddress?.street).toBe("Havnegata 48");
+  });
+});
+
+describe("parseSearchEntry", () => {
+  test("produces a flat result with composite address", () => {
+    const out = parseSearchEntry({
+      ...baseRaw,
+      forretningsadresse: {
+        adresse: ["Havnegata 48"],
+        postnummer: "8910",
+        poststed: "BRØNNØYSUND",
+        land: "Norge",
+      },
+    });
+    expect(out).toEqual({
+      orgnr: "974760673",
+      name: "BRØNNØYSUNDREGISTRENE",
+      address: "Havnegata 48, 8910 BRØNNØYSUND, Norge",
+    });
+  });
+
+  test("nulls address when missing", () => {
+    expect(parseSearchEntry(baseRaw).address).toBeNull();
+  });
+});

--- a/packages/business-registries/src/brreg/parse.ts
+++ b/packages/business-registries/src/brreg/parse.ts
@@ -9,7 +9,14 @@ import type {
   BrregSearchResult,
 } from "./types.js";
 
-const BRREG_ENTITY_URL = "https://virksomhet.brreg.no/nb/oppslag/enheter/";
+const BRREG_ENHET_URL = "https://virksomhet.brreg.no/nb/oppslag/enheter/";
+const BRREG_UNDERENHET_URL =
+  "https://virksomhet.brreg.no/nb/oppslag/underenheter/";
+
+// Discriminator for which Brreg register a raw entity came from. The
+// public registry UI separates main entities and sub-entities under
+// different URL paths, so the parser needs to know which to link to.
+export type BrregEnhetKind = "enhet" | "underenhet";
 
 export const parseAddress = (raw: BrregRawAddress): BrregAddress => {
   const lines = raw.adresse?.filter(Boolean) ?? [];
@@ -61,8 +68,15 @@ const collectIndustryCodes = (raw: BrregRawEnhet): BrregIndustryCode[] => {
 };
 
 const parseStatus = (raw: BrregRawEnhet): BrregEntityStatus => {
-  if (raw.slettedato) {
-    return { type: "deleted", deletedAt: raw.slettedato };
+  // Brreg encodes "no longer operating" with two distinct fields:
+  //   * slettedato — the register removed the record entirely
+  //   * nedleggelsesdato — a sub-entity ceased operations but the
+  //     record itself is retained (sub-entities only)
+  // Both map to the "deleted" arm of our domain union; callers that
+  // need to tell them apart can look at the raw payload.
+  const removedAt = raw.slettedato ?? raw.nedleggelsesdato;
+  if (removedAt) {
+    return { type: "deleted", deletedAt: removedAt };
   }
   if (raw.konkurs === true) {
     return { type: "bankruptcy" };
@@ -76,11 +90,15 @@ const parseStatus = (raw: BrregRawEnhet): BrregEntityStatus => {
   return { type: "active" };
 };
 
-export const parseEnhet = (raw: BrregRawEnhet): BrregEntity => {
+export const parseEnhet = (
+  raw: BrregRawEnhet,
+  kind: BrregEnhetKind = "enhet",
+): BrregEntity => {
   // Parent entities (`/enheter`) carry the physical address as
   // `forretningsadresse`; sub-entities (`/underenheter`) use
   // `beliggenhetsadresse`. Same domain field, different upstream key.
   const physicalAddress = raw.forretningsadresse ?? raw.beliggenhetsadresse;
+  const base = kind === "underenhet" ? BRREG_UNDERENHET_URL : BRREG_ENHET_URL;
   return {
     orgnr: raw.organisasjonsnummer,
     name: raw.navn,
@@ -95,7 +113,7 @@ export const parseEnhet = (raw: BrregRawEnhet): BrregEntity => {
       typeof raw.antallAnsatte === "number" ? raw.antallAnsatte : null,
     status: parseStatus(raw),
     vatRegistered: raw.registrertIMvaregisteret === true,
-    registryUrl: `${BRREG_ENTITY_URL}${raw.organisasjonsnummer}`,
+    registryUrl: `${base}${raw.organisasjonsnummer}`,
   };
 };
 

--- a/packages/business-registries/src/brreg/parse.ts
+++ b/packages/business-registries/src/brreg/parse.ts
@@ -1,0 +1,112 @@
+import type {
+  BrregAddress,
+  BrregEntity,
+  BrregEntityStatus,
+  BrregIndustryCode,
+  BrregRawAddress,
+  BrregRawEnhet,
+  BrregRawNaeringskode,
+  BrregSearchResult,
+} from "./types.js";
+
+const BRREG_ENTITY_URL = "https://virksomhet.brreg.no/nb/oppslag/enheter/";
+
+export const parseAddress = (raw: BrregRawAddress): BrregAddress => {
+  const lines = raw.adresse?.filter(Boolean) ?? [];
+  // Compose textAddress from whichever fields are present. Brreg
+  // sometimes returns a postal address with no street lines (PO box
+  // entries, or sub-entities registered to a kommune-level
+  // address); we still want a usable single-line representation
+  // rather than null.
+  const composite = [
+    lines.length > 0 ? lines.join(", ") : null,
+    [raw.postnummer, raw.poststed].filter(Boolean).join(" ") || null,
+    raw.land,
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  return {
+    street: lines.at(0) ?? null,
+    postalCode: raw.postnummer ?? null,
+    city: raw.poststed ?? null,
+    municipality: raw.kommune ?? null,
+    country: raw.land ?? null,
+    textAddress: composite.length > 0 ? composite : null,
+  };
+};
+
+const parseIndustry = (
+  raw: BrregRawNaeringskode | undefined,
+): BrregIndustryCode | null => {
+  if (!raw?.kode) {
+    return null;
+  }
+  return { code: raw.kode, description: raw.beskrivelse ?? null };
+};
+
+const collectIndustryCodes = (raw: BrregRawEnhet): BrregIndustryCode[] => {
+  const codes: BrregIndustryCode[] = [];
+  for (const candidate of [
+    raw.naeringskode1,
+    raw.naeringskode2,
+    raw.naeringskode3,
+  ]) {
+    const parsed = parseIndustry(candidate);
+    if (parsed) {
+      codes.push(parsed);
+    }
+  }
+  return codes;
+};
+
+const parseStatus = (raw: BrregRawEnhet): BrregEntityStatus => {
+  if (raw.slettedato) {
+    return { type: "deleted", deletedAt: raw.slettedato };
+  }
+  if (raw.konkurs === true) {
+    return { type: "bankruptcy" };
+  }
+  if (
+    raw.underAvvikling === true ||
+    raw.underTvangsavviklingEllerTvangsopplosning === true
+  ) {
+    return { type: "winding_up" };
+  }
+  return { type: "active" };
+};
+
+export const parseEnhet = (raw: BrregRawEnhet): BrregEntity => {
+  // Parent entities (`/enheter`) carry the physical address as
+  // `forretningsadresse`; sub-entities (`/underenheter`) use
+  // `beliggenhetsadresse`. Same domain field, different upstream key.
+  const physicalAddress = raw.forretningsadresse ?? raw.beliggenhetsadresse;
+  return {
+    orgnr: raw.organisasjonsnummer,
+    name: raw.navn,
+    legalForm: raw.organisasjonsform?.beskrivelse ?? null,
+    legalFormCode: raw.organisasjonsform?.kode ?? null,
+    businessAddress: physicalAddress ? parseAddress(physicalAddress) : null,
+    postalAddress: raw.postadresse ? parseAddress(raw.postadresse) : null,
+    registeredAt: raw.registreringsdatoEnhetsregisteret ?? null,
+    establishedAt: raw.stiftelsesdato ?? null,
+    industryCodes: collectIndustryCodes(raw),
+    numberOfEmployees:
+      typeof raw.antallAnsatte === "number" ? raw.antallAnsatte : null,
+    status: parseStatus(raw),
+    vatRegistered: raw.registrertIMvaregisteret === true,
+    registryUrl: `${BRREG_ENTITY_URL}${raw.organisasjonsnummer}`,
+  };
+};
+
+export const parseSearchEntry = (raw: BrregRawEnhet): BrregSearchResult => {
+  const physicalAddress = raw.forretningsadresse ?? raw.beliggenhetsadresse;
+  const address = physicalAddress
+    ? parseAddress(physicalAddress).textAddress
+    : null;
+  return {
+    orgnr: raw.organisasjonsnummer,
+    name: raw.navn,
+    address,
+  };
+};

--- a/packages/business-registries/src/brreg/types.ts
+++ b/packages/business-registries/src/brreg/types.ts
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------------
+// Raw Brreg Enhetsregisteret API response shapes
+// (https://data.brreg.no/enhetsregisteret/api/docs/)
+// ---------------------------------------------------------------------------
+
+export type BrregRawAddress = {
+  land?: string;
+  landkode?: string;
+  postnummer?: string;
+  poststed?: string;
+  adresse?: string[];
+  kommune?: string;
+  kommunenummer?: string;
+};
+
+export type BrregRawOrgForm = {
+  kode?: string;
+  beskrivelse?: string;
+};
+
+export type BrregRawNaeringskode = {
+  kode?: string;
+  beskrivelse?: string;
+};
+
+export type BrregRawInstitusjonellSektor = {
+  kode?: string;
+  beskrivelse?: string;
+};
+
+export type BrregRawEnhet = {
+  organisasjonsnummer: string;
+  navn: string;
+  organisasjonsform?: BrregRawOrgForm;
+  hjemmeside?: string;
+  postadresse?: BrregRawAddress;
+  forretningsadresse?: BrregRawAddress;
+  /**
+   * Physical address of a sub-entity (returned by `/underenheter`).
+   * Parent entities (`/enheter`) use `forretningsadresse` instead;
+   * sub-entities use this field.
+   */
+  beliggenhetsadresse?: BrregRawAddress;
+  registreringsdatoEnhetsregisteret?: string;
+  registrertIMvaregisteret?: boolean;
+  registrertIFrivillighetsregisteret?: boolean;
+  naeringskode1?: BrregRawNaeringskode;
+  naeringskode2?: BrregRawNaeringskode;
+  naeringskode3?: BrregRawNaeringskode;
+  institusjonellSektorkode?: BrregRawInstitusjonellSektor;
+  antallAnsatte?: number;
+  konkurs?: boolean;
+  underAvvikling?: boolean;
+  underTvangsavviklingEllerTvangsopplosning?: boolean;
+  slettedato?: string;
+  stiftelsesdato?: string;
+};
+
+export type BrregSearchResponse = {
+  _embedded?: {
+    enheter?: BrregRawEnhet[];
+  };
+  page?: {
+    size: number;
+    totalElements: number;
+    totalPages: number;
+    number: number;
+  };
+};
+
+export type BrregErrorResponse = {
+  tidspunkt?: string;
+  status?: number;
+  feilmelding?: string;
+  hjelp?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Domain output types
+// ---------------------------------------------------------------------------
+
+export type BrregAddress = {
+  street: string | null;
+  postalCode: string | null;
+  city: string | null;
+  municipality: string | null;
+  country: string | null;
+  textAddress: string | null;
+};
+
+export type BrregIndustryCode = {
+  code: string;
+  description: string | null;
+};
+
+// Whether the entity is currently active. Modelled as a discriminated
+// union so consumers exhaustively handle the "winding-up" and
+// "deleted" states instead of relying on a soup of boolean flags.
+export type BrregEntityStatus =
+  | { type: "active" }
+  | { type: "bankruptcy" }
+  | { type: "winding_up" }
+  | { type: "deleted"; deletedAt: string };
+
+export type BrregEntity = {
+  orgnr: string;
+  name: string;
+  legalForm: string | null;
+  legalFormCode: string | null;
+  businessAddress: BrregAddress | null;
+  postalAddress: BrregAddress | null;
+  registeredAt: string | null;
+  establishedAt: string | null;
+  industryCodes: BrregIndustryCode[];
+  numberOfEmployees: number | null;
+  status: BrregEntityStatus;
+  vatRegistered: boolean;
+  registryUrl: string;
+};
+
+export type BrregSearchResult = {
+  orgnr: string;
+  name: string;
+  address: string | null;
+};

--- a/packages/business-registries/src/brreg/types.ts
+++ b/packages/business-registries/src/brreg/types.ts
@@ -54,6 +54,12 @@ export type BrregRawEnhet = {
   underTvangsavviklingEllerTvangsopplosning?: boolean;
   slettedato?: string;
   stiftelsesdato?: string;
+  /**
+   * Closure date for sub-entities (returned by `/underenheter`).
+   * A populated `nedleggelsesdato` marks the sub-entity as closed even
+   * when the parent `slettedato` / `konkurs` flags are absent.
+   */
+  nedleggelsesdato?: string;
 };
 
 export type BrregSearchResponse = {

--- a/packages/business-registries/src/brreg/validation.test.ts
+++ b/packages/business-registries/src/brreg/validation.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeOrgnr, validateOrgnr } from "./validation.js";
+
+describe("normalizeOrgnr", () => {
+  test("strips spaces and dashes", () => {
+    expect(normalizeOrgnr("974 760 673")).toBe("974760673");
+    expect(normalizeOrgnr("974-760-673")).toBe("974760673");
+    expect(normalizeOrgnr(" 974760673 ")).toBe("974760673");
+  });
+});
+
+describe("validateOrgnr", () => {
+  test("accepts known-valid orgnr", () => {
+    // 974760673 = Brønnøysundregistrene itself
+    expect(validateOrgnr("974760673")).toBe(true);
+    // 923609016 = Equinor ASA
+    expect(validateOrgnr("923609016")).toBe(true);
+  });
+
+  test("rejects orgnr with bad checksum", () => {
+    expect(validateOrgnr("974760674")).toBe(false);
+    expect(validateOrgnr("123456789")).toBe(false);
+  });
+
+  test("rejects non-9-digit inputs", () => {
+    expect(validateOrgnr("12345678")).toBe(false);
+    expect(validateOrgnr("1234567890")).toBe(false);
+    expect(validateOrgnr("97476067a")).toBe(false);
+    expect(validateOrgnr("")).toBe(false);
+  });
+
+  test("accepts orgnr after normalization", () => {
+    expect(validateOrgnr("974 760 673")).toBe(true);
+  });
+});

--- a/packages/business-registries/src/brreg/validation.ts
+++ b/packages/business-registries/src/brreg/validation.ts
@@ -1,0 +1,35 @@
+// Norwegian organisasjonsnummer (orgnr).
+//
+// Nine digits with a MOD-11 check digit. Weights for digits 1..8 are
+// [3, 2, 7, 6, 5, 4, 3, 2]; the control digit is the 9th. If the
+// MOD-11 remainder would resolve to 10, the orgnr is invalid (since
+// the control digit only has room for one digit).
+//
+// See: https://www.brreg.no/om-oss/oppgavene-vare/registrene-vare/
+
+const ORGNR_WEIGHTS = [3, 2, 7, 6, 5, 4, 3, 2] as const;
+
+export const normalizeOrgnr = (input: string): string =>
+  input.replaceAll(/[\s-]/gu, "");
+
+export const validateOrgnr = (input: string): boolean => {
+  const compact = normalizeOrgnr(input);
+  if (!/^\d{9}$/u.test(compact)) {
+    return false;
+  }
+  let sum = 0;
+  for (let i = 0; i < ORGNR_WEIGHTS.length; i++) {
+    const digit = Number(compact[i]);
+    const weight = ORGNR_WEIGHTS[i];
+    if (weight === undefined) {
+      return false;
+    }
+    sum += digit * weight;
+  }
+  const remainder = sum % 11;
+  const expectedControl = remainder === 0 ? 0 : 11 - remainder;
+  if (expectedControl === 10) {
+    return false;
+  }
+  return expectedControl === Number(compact[8]);
+};

--- a/packages/business-registries/src/index.ts
+++ b/packages/business-registries/src/index.ts
@@ -10,3 +10,4 @@
 //   import { ares } from "@stll/business-registries";
 //   await ares.lookupByIco("27082440");
 export * as ares from "./ares/index.js";
+export * as brreg from "./brreg/index.js";


### PR DESCRIPTION
## Summary

- Adds `@stll/business-registries/brreg` subpath: typed client for the Norwegian Enhetsregisteret open API at `data.brreg.no`. No auth.
- Wires `brreg` into the unified `/contacts/business-registries` dispatch table introduced in #534. **No new route, no new handler file** — just a `BRREG_HANDLER` entry plus normalizers in `business-registries-lookup.ts`.
- New `brreg` entry in `NATIVE_TOOL_CATALOG` with `recommendedJurisdictions: ["NO"]`, plus a parallel assertion in `catalog-metadata.test.ts`.

## Surface

Mirrors ARES:

- `lookupByOrgnr(orgnr, { includeSubEntities? })` — falls back to `/underenheter` for branches. Sub-entities carry their physical address in `beliggenhetsadresse` not `forretningsadresse`; the parser reads either.
- `searchByName(name, { limit? })` — caps at Brreg's 100/page; throws `BrregTooBroadError` when `totalElements` exceeds the 10k cap.
- `BrregEntityStatus` is a discriminated union (`active` / `bankruptcy` / `winding_up` / `deleted`) so callers handle the lifecycle exhaustively.
- Tagged errors: `BrregAPIError`, `BrregValidationError`, `BrregRequestError`, `BrregTooBroadError`, `BrregNotFoundError`.

## Upstream-shape fixes (from prior Codex review)

- **HTTP 410 ≠ deleted.** Brreg uses `410 Gone` for entities removed from disclosure (court order, legal requirement). The previous version parsed the error envelope as if it were an entity payload. Now surfaced as `null`. Struck-off entities still come back as `200 OK` with `slettedato` and route through the `deleted` arm of `BrregEntityStatus`.
- **`/underenheter` address field.** Sub-entities use `beliggenhetsadresse`, not `forretningsadresse`. The previous parser returned `businessAddress: null` for every branch lookup. Now reads either field.
- **`textAddress` composes from postal/city/country alone** when no street lines are present (PO boxes, kommune-level registrations).

## How registries land from here

PRH / KRS / Companies House / Sirene each become: add the subpath under `packages/business-registries/src/<slug>/`, add a `<SLUG>_HANDLER` entry + normalizers to `business-registries-lookup.ts`, add a `NATIVE_TOOL_CATALOG` entry. No new handler file, no new route.

## Test plan
- [x] `bun --filter @stll/business-registries lint` + typecheck + test (45 pass, 11 skip)
- [x] `bun --filter @stll/api` typecheck + lint
- [x] Smoke against live Brreg via `SMOKE_TEST=1` (ARES + Brreg both green; pre-existing brreg client.test bad-checksum on `100000007` flagged separately)
- [ ] CI green