### PR TITLE
fix(e2e): raise per-test timeout to 60s for cold-compile budget

### DIFF
--- a/apps/web/e2e/playwright.config.ts
+++ b/apps/web/e2e/playwright.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
   reporter: IS_CI
     ? [["github"], ["html", { open: "never" }], ["list"]]
     : [["list"], ["html", { open: "never" }]],
-  timeout: 30_000,
+  // Cold Vite + folio editor compile on a fresh CI runner can use 25-30s
+  // before the first locator runs, leaving no headroom for in-spec
+  // toBeVisible waits and killing tests that would otherwise pass.
+  timeout: 60_000,
   expect: { timeout: 10_000 },
 
   use: {


### PR DESCRIPTION
## Summary

- Cold Vite + folio compile on a fresh CI runner can use 25–30s before the first locator runs, leaving no headroom for in-spec `toBeVisible({ timeout: 45_000 })` calls.
- Every spec that mounts the document view is at risk on cold CI — `upload-docx` was just the first to surface the flake.
- Doubling the per-test budget to 60s gives editor specs the headroom they need; fast specs are unaffected. Retries stay at 0 so real regressions still surface.

## Test plan

- [ ] CI passes on a fresh runner without the prior `upload-docx` 30s timeout
- [ ] No spec actually runs to 60s — if any does, that's a separate perf issue to investigate