### PR TITLE
fix(folio): close 3 image OOXML round-trip gaps (eigenpal #424)

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -446,6 +446,25 @@ export type Image = {
   padding?: ImagePadding;
   /** Source-bitmap crop (wp:srcRect), eigenpal #424 */
   crop?: ImageCrop;
+  /**
+   * Opacity in [0, 1] (OOXML `a:alphaModFix amt`). Undefined or `1` means
+   * fully opaque. Mirrors eigenpal docx-editor #424.
+   */
+  opacity?: number;
+  /**
+   * `wp:anchor layoutInCell` — when true (OOXML default), an anchored image
+   * inside a table cell is constrained to the cell. When false, the image
+   * escapes the cell into the page area. Round-tripped on save so the
+   * author's intent survives; undefined means "use the spec default".
+   */
+  layoutInCell?: boolean;
+  /**
+   * `wp:anchor allowOverlap` — when true (OOXML default), anchored objects
+   * may overlap; when false, Word repositions them to avoid collisions. We
+   * don't currently reposition, but we round-trip the flag so saving
+   * preserves the author's intent; undefined means "use the spec default".
+   */
+  allowOverlap?: boolean;
   /** Whether this is a decorative image */
   decorative?: boolean;
   /** Hyperlink URL for clickable image */

--- a/packages/folio/src/core/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
+++ b/packages/folio/src/core/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
@@ -66,9 +66,7 @@ describe("wp:effectExtent stays separate from wp:inline/wp:anchor dist*", () => 
       // image.padding is OOXML's wp:effectExtent reservation (EMUs).
       padding: { top: 100, bottom: 200, left: 300, right: 400 },
     });
-    expect(xml).toContain(
-      '<wp:effectExtent l="300" t="100" r="400" b="200"/>',
-    );
+    expect(xml).toContain('<wp:effectExtent l="300" t="100" r="400" b="200"/>');
     // No wrap distances were set, so dist* on wp:inline must be zero.
     expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
   });
@@ -153,6 +151,22 @@ describe("a:alphaModFix opacity round-trip", () => {
     expect(img?.opacity).toBeUndefined();
   });
 
+  test('non-numeric amt (e.g. amt="oops") parses as undefined, not NaN', () => {
+    const img = parseDrawingFromXml(`
+      <wp:inline>
+        <wp:extent cx="100" cy="100"/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"><a:alphaModFix amt="oops"/></a:blip></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:inline>`);
+    expect(img?.opacity).toBeUndefined();
+  });
+
   test("serialize opacity < 1 emits a:alphaModFix; opacity 1 omits it", () => {
     const opaque = serializeImage({
       type: "image",
@@ -208,6 +222,50 @@ describe("wp:anchor layoutInCell / allowOverlap tri-state round-trip", () => {
       </wp:anchor>`);
     expect(img?.layoutInCell).toBe(false);
     expect(img?.allowOverlap).toBe(false);
+  });
+
+  test('parse "true"/"false" literals (OOXML ST_OnOff full set)', () => {
+    const trueImg = parseDrawingFromXml(`
+      <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"
+                 relativeHeight="0" behindDoc="0" locked="0"
+                 layoutInCell="true" allowOverlap="true">
+        <wp:simplePos x="0" y="0"/>
+        <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+        <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+        <wp:extent cx="100" cy="100"/>
+        <wp:wrapNone/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:anchor>`);
+    expect(trueImg?.layoutInCell).toBe(true);
+    expect(trueImg?.allowOverlap).toBe(true);
+
+    const falseImg = parseDrawingFromXml(`
+      <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"
+                 relativeHeight="0" behindDoc="0" locked="0"
+                 layoutInCell="false" allowOverlap="false">
+        <wp:simplePos x="0" y="0"/>
+        <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+        <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+        <wp:extent cx="100" cy="100"/>
+        <wp:wrapNone/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:anchor>`);
+    expect(falseImg?.layoutInCell).toBe(false);
+    expect(falseImg?.allowOverlap).toBe(false);
   });
 
   test("parse absent attrs → undefined (omit the field entirely)", () => {

--- a/packages/folio/src/core/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
+++ b/packages/folio/src/core/docx/__tests__/image-effect-extent-opacity-overlap.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Round-trip tests for OOXML image attributes that previously round-tripped
+ * incorrectly. Mirrors eigenpal docx-editor PR #424 (sha c605277c9), narrowed
+ * to the three sub-items the folio fork still needed:
+ *   A. wp:effectExtent vs wp:inline/wp:anchor distT/B/L/R separation
+ *   B. a:alphaModFix image opacity (parse + serialize)
+ *   C. wp:anchor layoutInCell / allowOverlap as tri-state
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Image, Run } from "../../types/document";
+import { parseDrawing } from "../imageParser";
+import { serializeRun } from "../serializer/runSerializer";
+import { parseXml } from "../xmlParser";
+import type { XmlElement } from "../xmlParser";
+
+const NS = [
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
+  'xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"',
+  'xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"',
+  'xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"',
+  'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"',
+].join(" ");
+
+function parseDrawingFromXml(innerXml: string): Image | null {
+  const doc = parseXml(`<w:drawing ${NS}>${innerXml}</w:drawing>`);
+  const drawing = (doc.elements as XmlElement[])[0];
+  if (!drawing) {
+    return null;
+  }
+  return parseDrawing(drawing, undefined, undefined);
+}
+
+function serializeImage(image: Image): string {
+  const run: Run = { type: "run", content: [{ type: "drawing", image }] };
+  return serializeRun(run);
+}
+
+/** Parse the `<w:drawing>` payload out of a serialized `<w:r>...</w:r>` blob. */
+function reparseSerializedImage(xml: string): Image | null {
+  const wrapped = `<root ${NS}>${xml}</root>`;
+  const doc = parseXml(wrapped);
+  const root = (doc.elements as XmlElement[])[0];
+  if (!root) {
+    return null;
+  }
+  const wr = (root.elements as XmlElement[])[0]; // <w:r>
+  if (!wr) {
+    return null;
+  }
+  const drawing = (wr.elements as XmlElement[])[0]; // <w:drawing>
+  if (!drawing) {
+    return null;
+  }
+  return parseDrawing(drawing, undefined, undefined);
+}
+
+describe("wp:effectExtent stays separate from wp:inline/wp:anchor dist*", () => {
+  test("inline image padding round-trips through <wp:effectExtent>, not dist*", () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 1_000_000, height: 500_000 },
+      wrap: { type: "inline" },
+      // image.padding is OOXML's wp:effectExtent reservation (EMUs).
+      padding: { top: 100, bottom: 200, left: 300, right: 400 },
+    });
+    expect(xml).toContain(
+      '<wp:effectExtent l="300" t="100" r="400" b="200"/>',
+    );
+    // No wrap distances were set, so dist* on wp:inline must be zero.
+    expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
+  });
+
+  test("inline image wrap.dist* serializes to wp:inline dist* attrs", () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "inline", distT: 1, distB: 2, distL: 3, distR: 4 },
+    });
+    expect(xml).toContain('distT="1" distB="2" distL="3" distR="4"');
+    // No padding set → effectExtent should be all zeros.
+    expect(xml).toContain('<wp:effectExtent l="0" t="0" r="0" b="0"/>');
+  });
+
+  test("floating image keeps padding and wrap.dist* on independent elements", () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "square", distT: 10, distB: 20, distL: 30, distR: 40 },
+      padding: { top: 1, bottom: 2, left: 3, right: 4 },
+      position: {
+        horizontal: { relativeTo: "column", posOffset: 0 },
+        vertical: { relativeTo: "paragraph", posOffset: 0 },
+      },
+    });
+    expect(xml).toContain('distT="10" distB="20" distL="30" distR="40"');
+    expect(xml).toContain('<wp:effectExtent l="3" t="1" r="4" b="2"/>');
+  });
+
+  test("padding survives a full XML round-trip", () => {
+    const original: Image = {
+      type: "image",
+      rId: "rId1",
+      size: { width: 1_000_000, height: 500_000 },
+      wrap: { type: "inline" },
+      padding: { top: 100, bottom: 200, left: 300, right: 400 },
+    };
+    const xml = serializeImage(original);
+    const parsed = reparseSerializedImage(xml);
+    expect(parsed?.padding).toEqual(original.padding);
+  });
+});
+
+describe("a:alphaModFix opacity round-trip", () => {
+  test("parse a:alphaModFix amt as opacity fraction", () => {
+    const img = parseDrawingFromXml(`
+      <wp:inline distT="0" distB="0" distL="0" distR="0">
+        <wp:extent cx="1000000" cy="500000"/>
+        <wp:docPr id="1" name="Picture 1"/>
+        <a:graphic>
+          <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+            <pic:pic>
+              <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+              <pic:blipFill>
+                <a:blip r:embed="rId1"><a:alphaModFix amt="50000"/></a:blip>
+                <a:stretch><a:fillRect/></a:stretch>
+              </pic:blipFill>
+              <pic:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="1000000" cy="500000"/></a:xfrm></pic:spPr>
+            </pic:pic>
+          </a:graphicData>
+        </a:graphic>
+      </wp:inline>`);
+    expect(img?.opacity).toBeCloseTo(0.5, 5);
+  });
+
+  test('amt="100000" (fully opaque) does not produce an opacity field', () => {
+    const img = parseDrawingFromXml(`
+      <wp:inline>
+        <wp:extent cx="100" cy="100"/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"><a:alphaModFix amt="100000"/></a:blip></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:inline>`);
+    expect(img?.opacity).toBeUndefined();
+  });
+
+  test("serialize opacity < 1 emits a:alphaModFix; opacity 1 omits it", () => {
+    const opaque = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "inline" },
+    });
+    expect(opaque).not.toContain("alphaModFix");
+
+    const transparent = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "inline" },
+      opacity: 0.5,
+    });
+    expect(transparent).toContain('<a:alphaModFix amt="50000"/>');
+  });
+
+  test("opacity round-trips through XML", () => {
+    const original: Image = {
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "inline" },
+      opacity: 0.25,
+    };
+    const xml = serializeImage(original);
+    const parsed = reparseSerializedImage(xml);
+    expect(parsed?.opacity).toBeCloseTo(0.25, 5);
+  });
+});
+
+describe("wp:anchor layoutInCell / allowOverlap tri-state round-trip", () => {
+  test('parse explicit "0" → false', () => {
+    const img = parseDrawingFromXml(`
+      <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"
+                 relativeHeight="0" behindDoc="0" locked="0"
+                 layoutInCell="0" allowOverlap="0">
+        <wp:simplePos x="0" y="0"/>
+        <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+        <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+        <wp:extent cx="100" cy="100"/>
+        <wp:wrapNone/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:anchor>`);
+    expect(img?.layoutInCell).toBe(false);
+    expect(img?.allowOverlap).toBe(false);
+  });
+
+  test("parse absent attrs → undefined (omit the field entirely)", () => {
+    const img = parseDrawingFromXml(`
+      <wp:anchor distT="0" distB="0" distL="0" distR="0" simplePos="0"
+                 relativeHeight="0" behindDoc="0" locked="0">
+        <wp:simplePos x="0" y="0"/>
+        <wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH>
+        <wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>
+        <wp:extent cx="100" cy="100"/>
+        <wp:wrapNone/>
+        <wp:docPr id="1" name="img"/>
+        <a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+          <pic:pic>
+            <pic:nvPicPr><pic:cNvPr id="1" name="img"/><pic:cNvPicPr/></pic:nvPicPr>
+            <pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill>
+            <pic:spPr><a:xfrm><a:ext cx="100" cy="100"/></a:xfrm></pic:spPr>
+          </pic:pic>
+        </a:graphicData></a:graphic>
+      </wp:anchor>`);
+    expect(img?.layoutInCell).toBeUndefined();
+    expect(img?.allowOverlap).toBeUndefined();
+  });
+
+  test('serializer emits explicit "0" only when the model says false', () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "square" },
+      position: {
+        horizontal: { relativeTo: "column", posOffset: 0 },
+        vertical: { relativeTo: "paragraph", posOffset: 0 },
+      },
+      layoutInCell: false,
+      allowOverlap: false,
+    });
+    expect(xml).toContain('layoutInCell="0"');
+    expect(xml).toContain('allowOverlap="0"');
+  });
+
+  test('absent or explicit-true folds back to the spec default "1"', () => {
+    const xml = serializeImage({
+      type: "image",
+      rId: "rId1",
+      size: { width: 100, height: 100 },
+      wrap: { type: "square" },
+      position: {
+        horizontal: { relativeTo: "column", posOffset: 0 },
+        vertical: { relativeTo: "paragraph", posOffset: 0 },
+      },
+    });
+    expect(xml).toContain('layoutInCell="1"');
+    expect(xml).toContain('allowOverlap="1"');
+  });
+});

--- a/packages/folio/src/core/docx/imageParser.ts
+++ b/packages/folio/src/core/docx/imageParser.ts
@@ -307,6 +307,29 @@ function parseImageCrop(blipFill: XmlElement | null): ImageCrop | undefined {
 }
 
 /**
+ * Parse `<a:alphaModFix amt="..."/>` inside the `a:blip` element. The
+ * `amt` value is in 1/100000; convert to a fraction in [0, 1] for CSS
+ * `opacity`. Returns undefined when no alpha modifier is present (fully
+ * opaque) or when `amt` >= 100000 (also fully opaque).
+ *
+ * Mirrors eigenpal docx-editor #424.
+ */
+function parseImageOpacity(blip: XmlElement | null): number | undefined {
+  if (!blip) {
+    return undefined;
+  }
+  const alpha = findByFullName(blip, "a:alphaModFix");
+  if (!alpha) {
+    return undefined;
+  }
+  const amt = parseNumericAttribute(alpha, null, "amt");
+  if (amt === undefined || amt >= 100_000) {
+    return undefined;
+  }
+  return Math.max(0, Math.min(1, amt / 100_000));
+}
+
+/**
  * Extract rId from a:blip element
  */
 function extractBlipRId(blip: XmlElement | null): string {
@@ -536,6 +559,7 @@ function parseInline(
   const blip = blipFill ? findByFullName(blipFill, "a:blip") : null;
   const rId = extractBlipRId(blip);
   const crop = parseImageCrop(blipFill);
+  const opacity = parseImageOpacity(blip);
 
   // Resolve image data
   const imageData = resolveImageData(rId, rels, media);
@@ -602,6 +626,9 @@ function parseInline(
   if (crop) {
     image.crop = crop;
   }
+  if (opacity !== undefined) {
+    image.opacity = opacity;
+  }
 
   // Resolve image hyperlink (a:hlinkClick)
   if (props.hlinkRId && rels) {
@@ -642,6 +669,17 @@ function parseAnchor(
   // Check behindDoc attribute
   const behindDoc = getAttribute(anchorEl, null, "behindDoc") === "1";
 
+  // OOXML defaults `layoutInCell` and `allowOverlap` to "1" (true) when the
+  // attributes are absent. We only record the value when the document
+  // deviates from the default so the round-trip preserves author intent
+  // without bloating the serialized XML. Mirrors eigenpal #424.
+  const layoutInCellAttr = getAttribute(anchorEl, null, "layoutInCell");
+  const layoutInCell =
+    layoutInCellAttr === null ? undefined : layoutInCellAttr === "1";
+  const allowOverlapAttr = getAttribute(anchorEl, null, "allowOverlap");
+  const allowOverlap =
+    allowOverlapAttr === null ? undefined : allowOverlapAttr === "1";
+
   // Read distance attributes from the wp:anchor element itself (fallback values)
   const anchorDistT = parseNumericAttribute(anchorEl, null, "distT");
   const anchorDistB = parseNumericAttribute(anchorEl, null, "distB");
@@ -677,6 +715,7 @@ function parseAnchor(
   const blip = blipFill ? findByFullName(blipFill, "a:blip") : null;
   const rId = extractBlipRId(blip);
   const crop = parseImageCrop(blipFill);
+  const opacity = parseImageOpacity(blip);
 
   // Resolve image data
   const imageData = resolveImageData(rId, rels, media);
@@ -725,6 +764,15 @@ function parseAnchor(
   }
   if (crop) {
     image.crop = crop;
+  }
+  if (opacity !== undefined) {
+    image.opacity = opacity;
+  }
+  if (layoutInCell !== undefined) {
+    image.layoutInCell = layoutInCell;
+  }
+  if (allowOverlap !== undefined) {
+    image.allowOverlap = allowOverlap;
   }
 
   // Resolve image hyperlink (a:hlinkClick)

--- a/packages/folio/src/core/docx/imageParser.ts
+++ b/packages/folio/src/core/docx/imageParser.ts
@@ -307,10 +307,37 @@ function parseImageCrop(blipFill: XmlElement | null): ImageCrop | undefined {
 }
 
 /**
+ * Parse an OOXML `ST_OnOff` attribute on an element. Accepts the full
+ * set of literals the spec allows (`"1"`/`"true"`/`"on"` and
+ * `"0"`/`"false"`/`"off"`); anything else (including an absent
+ * attribute) folds back to `undefined` so callers can apply the
+ * spec-defined default.
+ */
+function parseOnOffAttr(
+  element: XmlElement,
+  name: string,
+): boolean | undefined {
+  const raw = getAttribute(element, null, name);
+  if (raw === null) {
+    return undefined;
+  }
+  if (raw === "1" || raw === "true" || raw === "on") {
+    return true;
+  }
+  if (raw === "0" || raw === "false" || raw === "off") {
+    return false;
+  }
+  return undefined;
+}
+
+/**
  * Parse `<a:alphaModFix amt="..."/>` inside the `a:blip` element. The
  * `amt` value is in 1/100000; convert to a fraction in [0, 1] for CSS
  * `opacity`. Returns undefined when no alpha modifier is present (fully
- * opaque) or when `amt` >= 100000 (also fully opaque).
+ * opaque), when `amt` is missing or non-numeric, or when `amt` >= 100000
+ * (also fully opaque). `parseNumericAttribute` already returns
+ * `undefined` (not `NaN`) for non-numeric values, so a downstream NaN
+ * is impossible here.
  *
  * Mirrors eigenpal docx-editor #424.
  */
@@ -326,7 +353,9 @@ function parseImageOpacity(blip: XmlElement | null): number | undefined {
   if (amt === undefined || amt >= 100_000) {
     return undefined;
   }
-  return Math.max(0, Math.min(1, amt / 100_000));
+  // `amt < 100_000` is guaranteed above, so the result is < 1; only
+  // clamp the lower bound.
+  return Math.max(0, amt / 100_000);
 }
 
 /**
@@ -673,12 +702,11 @@ function parseAnchor(
   // attributes are absent. We only record the value when the document
   // deviates from the default so the round-trip preserves author intent
   // without bloating the serialized XML. Mirrors eigenpal #424.
-  const layoutInCellAttr = getAttribute(anchorEl, null, "layoutInCell");
-  const layoutInCell =
-    layoutInCellAttr === null ? undefined : layoutInCellAttr === "1";
-  const allowOverlapAttr = getAttribute(anchorEl, null, "allowOverlap");
-  const allowOverlap =
-    allowOverlapAttr === null ? undefined : allowOverlapAttr === "1";
+  //
+  // `ST_OnOff` accepts "1"/"true"/"on" and "0"/"false"/"off"; anything
+  // unrecognized folds back to `undefined` (default).
+  const layoutInCell = parseOnOffAttr(anchorEl, "layoutInCell");
+  const allowOverlap = parseOnOffAttr(anchorEl, "allowOverlap");
 
   // Read distance attributes from the wp:anchor element itself (fallback values)
   const anchorDistT = parseNumericAttribute(anchorEl, null, "distT");

--- a/packages/folio/src/core/docx/serializer/runSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.test.ts
@@ -128,13 +128,18 @@ const ANY_DECIMAL_IN_EMU_ATTR =
 const POSOFFSET_DECIMAL = /<wp:posOffset>-?\d+\.\d+<\/wp:posOffset>/u;
 
 describe("image EMU attributes are integer-only (issue #417)", () => {
-  test("inline image with float dimensions serializes integer cx/cy/distT/distB", () => {
+  test("inline image with float dimensions serializes integer cx/cy/effectExtent", () => {
     const xml = serializeRun(FLOAT_INLINE_IMAGE);
 
     expect(xml).not.toMatch(ANY_DECIMAL_IN_EMU_ATTR);
     expect(xml).toContain('<wp:extent cx="5610225" cy="495300"/>');
     expect(xml).toContain('<a:ext cx="5610225" cy="495300"/>');
-    expect(xml).toContain('distT="0" distB="1"');
+    // Per ECMA-376 §20.4.2.5 / §20.4.2.8, image.padding (shadow/glow
+    // reservation) belongs in <wp:effectExtent>; it no longer leaks into
+    // wp:inline distT/B/L/R. With padding {top: 0.4, bottom: 0.6},
+    // intAttr rounds → t="0" b="1" on the effectExtent element.
+    expect(xml).toContain('<wp:effectExtent l="0" t="0" r="0" b="1"/>');
+    expect(xml).toContain('distT="0" distB="0" distL="0" distR="0"');
   });
 
   test("floating image with float position/extent serializes integer attrs", () => {

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -771,6 +771,16 @@ function serializePicGraphic(image: Image, sharedId: string): string {
   const srcRectEl =
     cropAttrs.length > 0 ? `<a:srcRect ${cropAttrs.join(" ")}/>` : "";
 
+  // <a:blip> with optional <a:alphaModFix> child for image transparency.
+  // OOXML stores the alpha amount in 1/100000 units. Mirrors eigenpal #424.
+  const alphaChild =
+    image.opacity !== undefined && image.opacity < 1
+      ? `<a:alphaModFix amt="${Math.round(Math.max(0, Math.min(1, image.opacity)) * 100_000)}"/>`
+      : "";
+  const blipEl = alphaChild
+    ? `<a:blip r:embed="${rId}">${alphaChild}</a:blip>`
+    : `<a:blip r:embed="${rId}"/>`;
+
   return [
     '<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">',
     '<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">',
@@ -780,7 +790,7 @@ function serializePicGraphic(image: Image, sharedId: string): string {
     "<pic:cNvPicPr/>",
     "</pic:nvPicPr>",
     "<pic:blipFill>",
-    `<a:blip r:embed="${rId}"/>`,
+    blipEl,
     srcRectEl,
     "<a:stretch><a:fillRect/></a:stretch>",
     "</pic:blipFill>",
@@ -806,10 +816,19 @@ function serializeDrawingContent(content: DrawingContent): string {
   const isFloating = image.wrap.type !== "inline";
   const cx = image.size.width;
   const cy = image.size.height;
-  const distT = image.padding?.top ?? image.wrap.distT ?? 0;
-  const distB = image.padding?.bottom ?? image.wrap.distB ?? 0;
-  const distL = image.padding?.left ?? image.wrap.distL ?? 0;
-  const distR = image.padding?.right ?? image.wrap.distR ?? 0;
+  // ECMA-376 §20.4.2.8: dist* on wp:inline / wp:anchor are text-wrap
+  // distances. Per §20.4.2.5, the visual-effect reservation lives on the
+  // separate <wp:effectExtent> element. Don't fold `image.padding`
+  // (effectExtent) into wrap dist* — that's the eigenpal #424 fix.
+  const distT = image.wrap.distT ?? 0;
+  const distB = image.wrap.distB ?? 0;
+  const distL = image.wrap.distL ?? 0;
+  const distR = image.wrap.distR ?? 0;
+  const effL = image.padding?.left ?? 0;
+  const effT = image.padding?.top ?? 0;
+  const effR = image.padding?.right ?? 0;
+  const effB = image.padding?.bottom ?? 0;
+  const effectExtentEl = `<wp:effectExtent l="${intAttr(effL)}" t="${intAttr(effT)}" r="${intAttr(effR)}" b="${intAttr(effB)}"/>`;
   const docPrId = getUniqueId(image.id);
   const docPrName = image.title || image.filename || `Picture ${docPrId}`;
 
@@ -821,7 +840,7 @@ function serializeDrawingContent(content: DrawingContent): string {
       "<w:drawing>",
       `<wp:inline distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}">`,
       `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
-      '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
+      effectExtentEl,
       `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}${image.decorative ? ' hidden="1"' : ""}/>`,
       '<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/></wp:cNvGraphicFramePr>',
       graphic,
@@ -836,14 +855,18 @@ function serializeDrawingContent(content: DrawingContent): string {
     ? serializePosition(image.position)
     : '<wp:positionH relativeFrom="column"><wp:posOffset>0</wp:posOffset></wp:positionH><wp:positionV relativeFrom="paragraph"><wp:posOffset>0</wp:posOffset></wp:positionV>';
   const wrap = serializeWrap(image.wrap);
+  // Tri-state: explicit `false` → "0"; explicit `true` or absent →
+  // "1" (the OOXML default). Mirrors eigenpal #424.
+  const layoutInCellAttr = image.layoutInCell === false ? "0" : "1";
+  const allowOverlapAttr = image.allowOverlap === false ? "0" : "1";
 
   return [
     "<w:drawing>",
-    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="1" allowOverlap="1">`,
+    `<wp:anchor distT="${intAttr(distT)}" distB="${intAttr(distB)}" distL="${intAttr(distL)}" distR="${intAttr(distR)}" simplePos="0" relativeHeight="251658240" behindDoc="${behindDoc}" locked="0" layoutInCell="${layoutInCellAttr}" allowOverlap="${allowOverlapAttr}">`,
     '<wp:simplePos x="0" y="0"/>',
     position,
     `<wp:extent cx="${intAttr(cx)}" cy="${intAttr(cy)}"/>`,
-    '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
+    effectExtentEl,
     wrap,
     `<wp:docPr id="${docPrId}" name="${escapeXml(docPrName)}"${image.alt ? ` descr="${escapeXml(image.alt)}"` : ""}/>`,
     '<wp:cNvGraphicFramePr><a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/></wp:cNvGraphicFramePr>',

--- a/packages/folio/src/core/docx/serializer/runSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/runSerializer.ts
@@ -773,9 +773,11 @@ function serializePicGraphic(image: Image, sharedId: string): string {
 
   // <a:blip> with optional <a:alphaModFix> child for image transparency.
   // OOXML stores the alpha amount in 1/100000 units. Mirrors eigenpal #424.
+  // `image.opacity < 1` is guaranteed by the branch, so only clamp the
+  // lower bound.
   const alphaChild =
     image.opacity !== undefined && image.opacity < 1
-      ? `<a:alphaModFix amt="${Math.round(Math.max(0, Math.min(1, image.opacity)) * 100_000)}"/>`
+      ? `<a:alphaModFix amt="${Math.round(Math.max(0, image.opacity) * 100_000)}"/>`
       : "";
   const blipEl = alphaChild
     ? `<a:blip r:embed="${rId}">${alphaChild}</a:blip>`


### PR DESCRIPTION
## Summary

Replaces #513 (auto-closed by GitHub after a botched rebase push). Same content. Ports the three remaining image sub-items of eigenpal/docx-editor PR #424:

- `<wp:effectExtent>` vs `<wp:inline>`/`<wp:anchor> distT/B/L/R` — previously folio's serializer folded `image.padding` into `dist*`, mangling wrap distance on round-trip. Now split: `dist*` carries wrap distance only, `<wp:effectExtent>` carries the padding.
- `<a:alphaModFix>` image opacity — `Image.opacity` field, parse, serialize. Render-side wiring is in stacked PR #517.
- `wp:anchor layoutInCell` / `allowOverlap` — tri-state parse + serialize (was hardcoded to `"1"`).

Includes 14 regression tests across A/B/C + bot-review hardening of `parseOnOffAttr` (full `ST_OnOff` literal set).

## Test plan

- [x] Folio + docx-core tests pass locally
- [x] Lint + typecheck clean
- [ ] CI green