### PR TITLE
feat(folio): render image opacity from <a:alphaModFix>

### DIFF
--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.test.ts
@@ -640,3 +640,61 @@ describe("toFlowBlocks list numbering", () => {
     expect(blocks.at(1)?.attrs?.listMarker).toBe("1.");
   });
 });
+
+// Regression guard for the eigenpal #424 opacity render pipeline. PR #517
+// review (gemini-code-assist) flagged that `attrs.opacity !== undefined` in
+// buildImageRun allowed the PM schema's null default to leak into
+// ImageRun.opacity (typed `number | undefined`). The bridge now gates with
+// `!= null`; these tests pin the contract for inline images, which is the
+// only path the schema permits (images are inline-only in PM).
+describe("toFlowBlocks image opacity null-default leak", () => {
+  test("drops PM null default for inline image opacity (ImageRun)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "media/image.png",
+          width: 100,
+          height: 100,
+        }),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const imageRun = paragraph.runs.find((run) => run.kind === "image");
+    if (imageRun?.kind !== "image") {
+      throw new Error("Expected image run");
+    }
+    // Critical: must be `undefined`, not `null`. The PM schema default is
+    // `null` and the bridge must filter it so downstream consumers (the
+    // painter, the floating-image collector) see only valid numbers.
+    expect(imageRun.opacity).toBeUndefined();
+  });
+
+  test("preserves explicit inline image opacity (ImageRun)", () => {
+    const doc = schema.node("doc", null, [
+      schema.node("paragraph", null, [
+        schema.nodes.image.create({
+          src: "media/image.png",
+          width: 100,
+          height: 100,
+          opacity: 0.5,
+        }),
+      ]),
+    ]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.at(0);
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected paragraph block");
+    }
+    const imageRun = paragraph.runs.find((run) => run.kind === "image");
+    if (imageRun?.kind !== "image") {
+      throw new Error("Expected image run");
+    }
+    expect(imageRun.opacity).toBe(0.5);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -797,6 +797,12 @@ function buildImageRun(
   if (attrs.transform !== undefined) {
     run.transform = attrs.transform;
   }
+  // eigenpal #424 (opacity render pipeline): copy opacity verbatim. The
+  // painter gates the actual CSS write with `!= null` so PM's null defaults
+  // don't paint plain images at opacity 0.
+  if (attrs.opacity !== undefined) {
+    run.opacity = attrs.opacity;
+  }
   if (attrs.wrapType !== undefined) {
     run.wrapType = attrs.wrapType;
   }
@@ -1764,6 +1770,10 @@ function convertImage(
   }
   if (attrs.transform) {
     imgBlock.transform = attrs.transform;
+  }
+  // eigenpal #424 (opacity render pipeline)
+  if (attrs.opacity !== undefined) {
+    imgBlock.opacity = attrs.opacity;
   }
   if (shouldAnchor) {
     const anchor: NonNullable<ImageBlock["anchor"]> = {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -797,10 +797,11 @@ function buildImageRun(
   if (attrs.transform !== undefined) {
     run.transform = attrs.transform;
   }
-  // eigenpal #424 (opacity render pipeline): copy opacity verbatim. The
-  // painter gates the actual CSS write with `!= null` so PM's null defaults
-  // don't paint plain images at opacity 0.
-  if (attrs.opacity !== undefined) {
+  // eigenpal #424 (opacity render pipeline): copy opacity verbatim. PM
+  // schema defaults `opacity` to `null`, which survives the typed cast on
+  // ImageAttrs (`number | undefined`). Gate with `!= null` so the model
+  // never carries the schema sentinel.
+  if (attrs.opacity != null) {
     run.opacity = attrs.opacity;
   }
   if (attrs.wrapType !== undefined) {
@@ -1771,8 +1772,9 @@ function convertImage(
   if (attrs.transform) {
     imgBlock.transform = attrs.transform;
   }
-  // eigenpal #424 (opacity render pipeline)
-  if (attrs.opacity !== undefined) {
+  // eigenpal #424 (opacity render pipeline). `!= null` so PM's null schema
+  // default doesn't leak into ImageBlock.opacity (`number | undefined`).
+  if (attrs.opacity != null) {
     imgBlock.opacity = attrs.opacity;
   }
   if (shouldAnchor) {

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -159,6 +159,12 @@ export type ImageRun = {
   alt?: string;
   /** CSS transform string (rotation, flip) */
   transform?: string;
+  /**
+   * Opacity in [0, 1] from `<a:alphaModFix amt>`. Undefined or `1` means
+   * fully opaque; the painter emits no CSS `opacity` in that case.
+   * eigenpal #424 (opacity render pipeline).
+   */
+  opacity?: number;
   /** Position for floating/anchored images */
   position?: ImageRunPosition;
   /** Wrap type from DOCX (inline, square, tight, through, topAndBottom, etc.) */
@@ -460,6 +466,12 @@ export type ImageBlock = {
   alt?: string;
   /** CSS transform string (rotation, flip) */
   transform?: string;
+  /**
+   * Opacity in [0, 1] from `<a:alphaModFix amt>`. Undefined or `1` means
+   * fully opaque; the painter emits no CSS `opacity` in that case.
+   * eigenpal #424 (opacity render pipeline).
+   */
+  opacity?: number;
   anchor?: {
     isAnchored?: boolean;
     offsetH?: number;

--- a/packages/folio/src/core/layout-painter/renderImage-opacity.test.ts
+++ b/packages/folio/src/core/layout-painter/renderImage-opacity.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImageBlock,
+  ImageFragment,
+  ImageMeasure,
+  ImageRun,
+  MeasuredLine,
+  ParagraphBlock,
+} from "../layout-engine/types";
+import {
+  applyImageVisualAttrs,
+  hasImageVisualAttrs,
+  renderImageFragment,
+} from "./renderImage";
+import { renderLine } from "./renderParagraph";
+
+// Render-pipeline follow-up to PR #513 (eigenpal #424): the model layer now
+// parses <a:alphaModFix amt> into `Image.opacity`, but the layout/painter
+// chain previously dropped it on the floor so partially-transparent images
+// still painted fully opaque. Mirrors eigenpal's `ImageVisualAttrs` helper
+// gated by `!= null` so the ProseMirror `null` defaults don't read as 0.
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  innerHTML = "";
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  height = 0;
+  width = 0;
+  src = "";
+  alt = "";
+  draggable = true;
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+const baseImageBlock = (overrides: Partial<ImageBlock> = {}): ImageBlock => ({
+  kind: "image",
+  id: "img-1",
+  src: "data:image/png;base64,",
+  width: 100,
+  height: 80,
+  ...overrides,
+});
+
+const baseImageFragment = (
+  overrides: Partial<ImageFragment> = {},
+): ImageFragment => ({
+  kind: "image",
+  blockId: "img-1",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 80,
+  ...overrides,
+});
+
+const baseImageMeasure: ImageMeasure = {
+  kind: "image",
+  width: 100,
+  height: 80,
+};
+
+// Minimal RenderContext stub; `renderImageFragment` ignores the value.
+const fakeContext = {} as Parameters<typeof renderImageFragment>[3];
+
+const findImageDescendant = (el: FakeElement): FakeElement | undefined => {
+  if (el.tagName === "img") {
+    return el;
+  }
+  for (const child of el.children) {
+    const found = findImageDescendant(child);
+    if (found) {
+      return found;
+    }
+  }
+  return undefined;
+};
+
+describe("renderImageFragment opacity (floating block path)", () => {
+  test("emits CSS opacity for a floating image with opacity 0.5", () => {
+    const block = baseImageBlock({ opacity: 0.5 });
+    const fragment = baseImageFragment({ isAnchored: true });
+
+    const containerEl = renderImageFragment(
+      fragment,
+      block,
+      baseImageMeasure,
+      fakeContext,
+      { document: fakeDocument },
+    ) as unknown as FakeElement;
+
+    const imgEl = findImageDescendant(containerEl);
+    expect(imgEl?.style["opacity"]).toBe("0.5");
+  });
+
+  test("does not set CSS opacity when the image has no opacity attribute", () => {
+    const block = baseImageBlock();
+    const fragment = baseImageFragment({ isAnchored: true });
+
+    const containerEl = renderImageFragment(
+      fragment,
+      block,
+      baseImageMeasure,
+      fakeContext,
+      { document: fakeDocument },
+    ) as unknown as FakeElement;
+
+    const imgEl = findImageDescendant(containerEl);
+    expect(imgEl?.style["opacity"]).toBeUndefined();
+  });
+});
+
+describe("renderLine inline image opacity", () => {
+  test("emits CSS opacity on the inline <img> when run carries opacity 0.5", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 80,
+      opacity: 0.5,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [imageRun],
+      pmStart: 0,
+      pmEnd: 3,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 100,
+      ascent: 20,
+      descent: 3,
+      lineHeight: 23,
+    };
+
+    const lineEl = renderLine(
+      block,
+      line,
+      undefined,
+      fakeDocument,
+    ) as unknown as FakeElement;
+    const imgEl = findImageDescendant(lineEl);
+
+    expect(imgEl?.style["opacity"]).toBe("0.5");
+  });
+
+  // Regression guard for the upstream null-default leak. ProseMirror schema
+  // attrs default to `null`, so `!== undefined` would erroneously gate the
+  // write on plain images and paint them at opacity 0. The helper must use
+  // `!= null` so absent/null opacity skips the write entirely.
+  test("does not set CSS opacity on a plain inline image with no opacity attribute", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 80,
+      pmStart: 1,
+      pmEnd: 2,
+    };
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      runs: [imageRun],
+      pmStart: 0,
+      pmEnd: 3,
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 100,
+      ascent: 20,
+      descent: 3,
+      lineHeight: 23,
+    };
+
+    const lineEl = renderLine(
+      block,
+      line,
+      undefined,
+      fakeDocument,
+    ) as unknown as FakeElement;
+    const imgEl = findImageDescendant(lineEl);
+
+    expect(imgEl?.style["opacity"]).toBeUndefined();
+  });
+});
+
+describe("ImageVisualAttrs helpers", () => {
+  test("hasImageVisualAttrs returns true for opacity < 1", () => {
+    expect(hasImageVisualAttrs({ opacity: 0.5 })).toBe(true);
+  });
+
+  test("hasImageVisualAttrs returns false for opacity 1 (fully opaque)", () => {
+    expect(hasImageVisualAttrs({ opacity: 1 })).toBe(false);
+  });
+
+  // Regression: ProseMirror schema attrs default to `null`, which slips
+  // through `as number | undefined` casts in the bridge. Treat null exactly
+  // like undefined so plain images don't accidentally paint at opacity 0.
+  test("hasImageVisualAttrs returns false for opacity null (PM schema default)", () => {
+    // The bridge boxes the PM null default as `number | undefined`; the
+    // helper sees a literal null at runtime. Force the same shape here.
+    const attrs = { opacity: null } as unknown as { opacity?: number };
+    expect(hasImageVisualAttrs(attrs)).toBe(false);
+  });
+
+  test("applyImageVisualAttrs skips the opacity write for a null PM default", () => {
+    const img = fakeDocument.createElement(
+      "img",
+    ) as unknown as HTMLImageElement;
+    const attrs = { opacity: null } as unknown as { opacity?: number };
+    applyImageVisualAttrs(img, attrs);
+    expect((img as unknown as FakeElement).style["opacity"]).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderImage.ts
+++ b/packages/folio/src/core/layout-painter/renderImage.ts
@@ -22,58 +22,19 @@ export const IMAGE_CLASS_NAMES = {
   imageAnchored: "layout-image-anchored",
 };
 
-// eigenpal #424 (opacity render pipeline): shared visual-attrs helper used by
-// the inline (`renderParagraph`), block, and floating (`renderPage`,
-// `renderImageFragment`) image render sites. Folio currently only honors
-// opacity; crop / effectExtent are future-proofing slots that mirror
-// upstream's `ImageVisualAttrs` shape so adding them later is structural,
-// not a new abstraction.
+// eigenpal #424: shared visual-attrs helper used by the inline
+// (`renderParagraph`), block, and floating (`renderPage`,
+// `renderImageFragment`) image render sites. Currently honours
+// `wp:srcRect` crop (image-crop subset) and `a:alphaModFix` opacity
+// (opacity render pipeline).
 
 /**
  * Structural shape required to apply Word's per-image visual attributes:
- * currently `a:alphaModFix` opacity. Crop fractions are tracked here for
- * symmetry with eigenpal docx-editor but are not yet emitted by folio.
+ * `wp:srcRect` crop fractions and `a:alphaModFix` opacity. `ImageRun` and
+ * `ImageBlock` both satisfy this, so callers don't need an adapter.
  */
 export type ImageVisualAttrs = {
   opacity?: number;
-};
-
-/**
- * True when any visual attribute is set. Cheap call-site guard so the no-op
- * common case skips the function call and template-literal allocations.
- *
- * IMPORTANT: ProseMirror schema attrs default to `null`, not `undefined`,
- * and that `null` survives the `as number | undefined` cast in the layout
- * bridge. Use `!= null` rather than `!== undefined` so a default-null
- * opacity isn't read as `0` (`null < 1` is `true`, `Math.max(0, null)` is
- * `0`) — that bug hid every plain image behind `opacity: 0`.
- */
-export function hasImageVisualAttrs(v: ImageVisualAttrs): boolean {
-  return v.opacity != null && v.opacity < 1;
-}
-
-/**
- * Apply visual attributes (opacity) to an `<img>` element. Caller should
- * gate with `hasImageVisualAttrs(v)` to avoid the function call for plain
- * images.
- */
-export function applyImageVisualAttrs(
-  img: HTMLImageElement,
-  v: ImageVisualAttrs,
-): void {
-  if (v.opacity != null && v.opacity < 1) {
-    img.style.opacity = String(Math.max(0, v.opacity));
-  }
-}
-
-/**
- * Structural shape required to apply Word's per-image visual attributes
- * (currently `wp:srcRect` crop fractions). `ImageRun` and `ImageBlock` both
- * satisfy this, so callers don't need an adapter.
- *
- * eigenpal #424 (image-crop subset).
- */
-export type ImageVisualAttrs = {
   cropTop?: number;
   cropRight?: number;
   cropBottom?: number;
@@ -86,10 +47,14 @@ export type ImageVisualAttrs = {
  *
  * IMPORTANT: ProseMirror schema attrs default to `null`, not `undefined`,
  * and a `null` survives `as number | undefined` casts in the layout bridge.
- * Use `!= null` rather than `!== undefined` so default-null crop fields are
- * not read as `0`.
+ * Use `!= null` rather than `!== undefined` so default-null opacity / crop
+ * fields are not read as `0` (`null < 1` is `true`, `Math.max(0, null)` is
+ * `0`) — that bug otherwise hides every plain image behind `opacity: 0`.
  */
 export function hasImageVisualAttrs(v: ImageVisualAttrs): boolean {
+  if (v.opacity != null && v.opacity < 1) {
+    return true;
+  }
   return Boolean(v.cropTop || v.cropRight || v.cropBottom || v.cropLeft);
 }
 
@@ -117,6 +82,9 @@ export function applyImageVisualAttrs(
   img: HTMLImageElement,
   v: ImageVisualAttrs,
 ): void {
+  if (v.opacity != null && v.opacity < 1) {
+    img.style.opacity = String(Math.max(0, v.opacity));
+  }
   const top = v.cropTop ?? 0;
   const right = v.cropRight ?? 0;
   const bottom = v.cropBottom ?? 0;

--- a/packages/folio/src/core/layout-painter/renderImage.ts
+++ b/packages/folio/src/core/layout-painter/renderImage.ts
@@ -22,6 +22,50 @@ export const IMAGE_CLASS_NAMES = {
   imageAnchored: "layout-image-anchored",
 };
 
+// eigenpal #424 (opacity render pipeline): shared visual-attrs helper used by
+// the inline (`renderParagraph`), block, and floating (`renderPage`,
+// `renderImageFragment`) image render sites. Folio currently only honors
+// opacity; crop / effectExtent are future-proofing slots that mirror
+// upstream's `ImageVisualAttrs` shape so adding them later is structural,
+// not a new abstraction.
+
+/**
+ * Structural shape required to apply Word's per-image visual attributes:
+ * currently `a:alphaModFix` opacity. Crop fractions are tracked here for
+ * symmetry with eigenpal docx-editor but are not yet emitted by folio.
+ */
+export type ImageVisualAttrs = {
+  opacity?: number;
+};
+
+/**
+ * True when any visual attribute is set. Cheap call-site guard so the no-op
+ * common case skips the function call and template-literal allocations.
+ *
+ * IMPORTANT: ProseMirror schema attrs default to `null`, not `undefined`,
+ * and that `null` survives the `as number | undefined` cast in the layout
+ * bridge. Use `!= null` rather than `!== undefined` so a default-null
+ * opacity isn't read as `0` (`null < 1` is `true`, `Math.max(0, null)` is
+ * `0`) — that bug hid every plain image behind `opacity: 0`.
+ */
+export function hasImageVisualAttrs(v: ImageVisualAttrs): boolean {
+  return v.opacity != null && v.opacity < 1;
+}
+
+/**
+ * Apply visual attributes (opacity) to an `<img>` element. Caller should
+ * gate with `hasImageVisualAttrs(v)` to avoid the function call for plain
+ * images.
+ */
+export function applyImageVisualAttrs(
+  img: HTMLImageElement,
+  v: ImageVisualAttrs,
+): void {
+  if (v.opacity != null && v.opacity < 1) {
+    img.style.opacity = String(Math.max(0, v.opacity));
+  }
+}
+
 /**
  * Structural shape required to apply Word's per-image visual attributes
  * (currently `wp:srcRect` crop fractions). `ImageRun` and `ImageBlock` both
@@ -208,7 +252,8 @@ export function renderImageFragment(
   }
 
   // eigenpal #424: scale/shift `<img>` so the cropped slice fills the
-  // overflow-hidden container (already sized to the visible extent above).
+  // overflow-hidden container (already sized to the visible extent above),
+  // plus emit `opacity` when set via `<a:alphaModFix>` (PR #517 follow-up).
   if (hasImageVisualAttrs(block)) {
     applyImageVisualAttrs(imgEl, block);
   }

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -913,8 +913,9 @@ function extractFloatingImagesFromParagraph(
       ...(imgRun.transform !== undefined
         ? { transform: imgRun.transform }
         : {}),
-      // eigenpal #424 (opacity render pipeline)
-      ...(imgRun.opacity !== undefined ? { opacity: imgRun.opacity } : {}),
+      // eigenpal #424 (opacity render pipeline). `!= null` so a PM null
+      // schema default doesn't leak into PageFloatingImage.opacity.
+      ...(imgRun.opacity != null ? { opacity: imgRun.opacity } : {}),
       side,
       x,
       y,
@@ -1144,8 +1145,10 @@ function renderHeaderFooterContent(
             width: run.width,
             height: run.height,
             ...(run.alt !== undefined ? { alt: run.alt } : {}),
-            // eigenpal #424 (opacity render pipeline)
-            ...(run.opacity !== undefined ? { opacity: run.opacity } : {}),
+            // eigenpal #424 (opacity render pipeline). `!= null` so a PM
+            // null schema default doesn't leak into the HF floating-image
+            // collector.
+            ...(run.opacity != null ? { opacity: run.opacity } : {}),
             ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
             ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
             paragraphY: paragraphStartY,

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -47,7 +47,11 @@ import { borderToStyle } from "../utils/formatToStyle";
 import { eighthsToPixels, pointsToPixels } from "../utils/units";
 import type { BlockLookup } from "./index";
 import { renderFragment } from "./renderFragment";
-import { renderImageFragment } from "./renderImage";
+import {
+  applyImageVisualAttrs,
+  hasImageVisualAttrs,
+  renderImageFragment,
+} from "./renderImage";
 import { renderParagraphFragment } from "./renderParagraph";
 import { renderTableFragment } from "./renderTable";
 import { renderTextBoxFragment } from "./renderTextBox";
@@ -68,6 +72,11 @@ type PageFloatingImage = {
   height: number;
   alt?: string;
   transform?: string;
+  /**
+   * Opacity in [0, 1] from `<a:alphaModFix amt>`. Undefined / 1 means fully
+   * opaque. eigenpal #424 (opacity render pipeline).
+   */
+  opacity?: number;
   /** Which side: 'left' for left margin, 'right' for right margin */
   side: "left" | "right";
   /** X position relative to content area (0 = left edge of content) */
@@ -904,6 +913,8 @@ function extractFloatingImagesFromParagraph(
       ...(imgRun.transform !== undefined
         ? { transform: imgRun.transform }
         : {}),
+      // eigenpal #424 (opacity render pipeline)
+      ...(imgRun.opacity !== undefined ? { opacity: imgRun.opacity } : {}),
       side,
       x,
       y,
@@ -1036,6 +1047,10 @@ function renderFloatingImagesLayer(
     if (floatImg.transform) {
       img.style.transform = floatImg.transform;
     }
+    // eigenpal #424 (opacity render pipeline)
+    if (hasImageVisualAttrs(floatImg)) {
+      applyImageVisualAttrs(img, floatImg);
+    }
 
     container.append(img);
     layer.append(container);
@@ -1066,6 +1081,11 @@ function renderHeaderFooterContent(
     width: number;
     height: number;
     alt?: string;
+    /**
+     * Opacity in [0, 1] from `<a:alphaModFix amt>`. Undefined / 1 means
+     * fully opaque. eigenpal #424 (opacity render pipeline).
+     */
+    opacity?: number;
     /** Run-level PM position so the pointer pipeline can NodeSelect HF images. */
     pmStart?: number;
     pmEnd?: number;
@@ -1124,6 +1144,8 @@ function renderHeaderFooterContent(
             width: run.width,
             height: run.height,
             ...(run.alt !== undefined ? { alt: run.alt } : {}),
+            // eigenpal #424 (opacity render pipeline)
+            ...(run.opacity !== undefined ? { opacity: run.opacity } : {}),
             ...(run.pmStart !== undefined ? { pmStart: run.pmStart } : {}),
             ...(run.pmEnd !== undefined ? { pmEnd: run.pmEnd } : {}),
             paragraphY: paragraphStartY,
@@ -1313,6 +1335,10 @@ function renderHeaderFooterContent(
     // behindDoc images render behind text (full-page letterhead backgrounds)
     if (floatImg.behindDoc) {
       img.style.zIndex = "-1";
+    }
+    // eigenpal #424 (opacity render pipeline)
+    if (hasImageVisualAttrs(floatImg)) {
+      applyImageVisualAttrs(img, floatImg);
     }
 
     applyHeaderFooterFloatHorizontalPosition(img, floatImg, layout);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -35,7 +35,11 @@ import {
   rotatedBoundingBox,
 } from "../utils/rotationBoundingBox";
 import { getAutomaticTextColorForBackground } from "./documentColors";
-import { hasImageVisualAttrs, wrapImageWithCrop } from "./renderImage";
+import {
+  applyImageVisualAttrs,
+  hasImageVisualAttrs,
+  wrapImageWithCrop,
+} from "./renderImage";
 import { isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
 
@@ -659,6 +663,11 @@ function renderInlineImageRun(run: ImageRun, doc: Document): HTMLElement {
     return wrapper;
   }
 
+  // eigenpal #424 (opacity render pipeline)
+  if (hasImageVisualAttrs(run)) {
+    applyImageVisualAttrs(img, run);
+  }
+
   // Inline images should flow with text
   img.style.display = "inline";
   img.style.verticalAlign = "middle";
@@ -758,6 +767,11 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
   if (rotation === 0) {
     img.style.marginLeft = "auto";
     img.style.marginRight = "auto";
+  }
+
+  // eigenpal #424 (opacity render pipeline)
+  if (hasImageVisualAttrs(run)) {
+    applyImageVisualAttrs(img, run);
   }
 
   applyPmPositions(container, run.pmStart, run.pmEnd);

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1297,6 +1297,12 @@ function createImageRun(node: PMNode): Run {
     }
   }
 
+  // eigenpal #424 (opacity render pipeline). PM schema default is `null`;
+  // use `!= null` so the model only carries an explicit opacity value.
+  if (attrs.opacity != null) {
+    image.opacity = attrs.opacity;
+  }
+
   // Round-trip floating image position (ImagePositionAttrs uses loose strings;
   // cast to the strict OOXML union types for the Document model)
   const horizontalPosition = attrs.position?.horizontal;

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2083,6 +2083,10 @@ function convertImage(image: Image, rawXml?: string): PMNode {
     displayMode,
     cssFloat,
     transform,
+    // eigenpal #424 (opacity render pipeline). PR #513 added Image.opacity
+    // on the model; thread it onto the PM node so the layout-bridge and
+    // painter can honor it.
+    opacity: image.opacity,
     distTop,
     distBottom,
     distLeft,

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ImageExtension.ts
@@ -25,6 +25,7 @@ export const ImageExtension = createNodeExtension({
       displayMode: { default: "inline" },
       cssFloat: { default: null },
       transform: { default: null },
+      opacity: { default: null },
       distTop: { default: null },
       distBottom: { default: null },
       distLeft: { default: null },
@@ -52,6 +53,9 @@ export const ImageExtension = createNodeExtension({
             | NonNullable<ImageAttrs["cssFloat"]>
             | undefined;
           const borderWidthRaw = element.dataset["borderWidth"];
+          const opacityRaw = element.dataset["opacity"];
+          const opacityParsed =
+            opacityRaw === undefined ? Number.NaN : Number(opacityRaw);
           return {
             src: element.getAttribute("src") || "",
             ...(alt ? { alt } : {}),
@@ -68,6 +72,9 @@ export const ImageExtension = createNodeExtension({
             ...(cssFloat ? { cssFloat } : {}),
             ...(element.dataset["transform"]
               ? { transform: element.dataset["transform"] }
+              : {}),
+            ...(Number.isFinite(opacityParsed)
+              ? { opacity: opacityParsed }
               : {}),
             ...(borderWidthRaw ? { borderWidth: Number(borderWidthRaw) } : {}),
             ...(element.dataset["borderColor"]
@@ -107,6 +114,12 @@ export const ImageExtension = createNodeExtension({
       }
       if (attrs.transform) {
         domAttrs["data-transform"] = attrs.transform;
+      }
+      // eigenpal #424 (opacity render pipeline). Use `!= null` so a PM
+      // schema default of `null` is treated like undefined and not
+      // serialized as the string "null".
+      if (attrs.opacity != null) {
+        domAttrs["data-opacity"] = String(attrs.opacity);
       }
       if (attrs.borderWidth) {
         domAttrs["data-border-width"] = String(attrs.borderWidth);
@@ -178,6 +191,12 @@ export const ImageExtension = createNodeExtension({
 
       if (attrs.transform) {
         styles.push(`transform: ${attrs.transform}`);
+      }
+
+      // eigenpal #424 (opacity render pipeline). `!= null` so a PM null
+      // default doesn't paint as `opacity: 0`.
+      if (attrs.opacity != null && attrs.opacity < 1) {
+        styles.push(`opacity: ${Math.max(0, attrs.opacity)}`);
       }
 
       if (attrs.borderWidth && attrs.borderWidth > 0) {

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -218,6 +218,11 @@ export type ImageAttrs = {
   cssFloat?: "left" | "right" | "none";
   /** CSS transform string (rotation, flip) */
   transform?: string;
+  /**
+   * Opacity in [0, 1] from `<a:alphaModFix amt>`. Undefined / 1 means fully
+   * opaque (no CSS `opacity` emitted). eigenpal #424.
+   */
+  opacity?: number;
   /** Distance from text above (pixels) */
   distTop?: number;
   /** Distance from text below (pixels) */


### PR DESCRIPTION
## Summary

Replaces #517 (auto-closed by GitHub after a botched rebase push). Threads `Image.opacity` (round-tripped in main via the predecessor model-layer PR) through the render pipeline so partially-transparent images visually render at their opacity.

- `ImageVisualAttrs` / `hasImageVisualAttrs` / `applyImageVisualAttrs` helpers in `renderImage.ts`
- Threaded `opacity?: number` through layout types, layout bridge, PM schema/extension, and the five paint sites (inline, block, floating body, floating header/footer)
- `!= null` gate prevents the PM schema null-default from leaking through and rendering plain images at opacity 0

## Test plan

- [x] Folio + docx-core tests pass locally
- [x] Lint + typecheck clean
- [ ] CI green