### PR TITLE
feat(folio): wrap body text around anchored text boxes (eigenpal #474)

### DIFF
--- a/packages/folio/src/core/docx/wrapTypes.ts
+++ b/packages/folio/src/core/docx/wrapTypes.ts
@@ -1,0 +1,46 @@
+/**
+ * Wrap-type predicates shared across the layout pipeline.
+ *
+ * Mirrors eigenpal docx-editor `wrapTypes` so that the new textBoxFlow
+ * predicates (eigenpal #474) and the existing image classifiers agree on
+ * which OOXML wrap variants are floating, which paint over body text, and
+ * which wrap around it.
+ */
+
+const FLOATING_WRAP_TYPES = new Set([
+  "square",
+  "tight",
+  "through",
+  "topAndBottom",
+  "behind",
+  "inFront",
+]);
+
+const TEXT_WRAPPING_TYPES = new Set(["square", "tight", "through"]);
+
+/**
+ * `true` for any wrap type that takes the object out of inline flow.
+ * Includes `topAndBottom` and the wrapNone variants (`behind`/`inFront`):
+ * those are anchored at absolute coordinates even though they don't shrink
+ * line widths.
+ */
+export function isFloatingWrapType(wrapType: string | undefined): boolean {
+  return wrapType !== undefined && FLOATING_WRAP_TYPES.has(wrapType);
+}
+
+/**
+ * `true` for `behind` and `inFront` — wrapNone variants that don't shrink
+ * line widths; text paints over or under the object.
+ */
+export function isWrapNone(wrapType: string | undefined): boolean {
+  return wrapType === "behind" || wrapType === "inFront";
+}
+
+/**
+ * `true` for wrap types that actually divert lines around the object
+ * (`square` / `tight` / `through`). Excludes `topAndBottom` (block flow)
+ * and the wrapNone variants.
+ */
+export function wrapsAroundText(wrapType: string | undefined): boolean {
+  return wrapType !== undefined && TEXT_WRAPPING_TYPES.has(wrapType);
+}

--- a/packages/folio/src/core/layout-bridge/measuring/clampFloatingWrapMargins.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/clampFloatingWrapMargins.ts
@@ -1,0 +1,26 @@
+/**
+ * Guard against wrap margins that exceed the available content width.
+ *
+ * When a float's wrap margins consume the entire content width (or more),
+ * there is no horizontal strip beside it for body text. Word renders the
+ * following lines at full content width instead of collapsing them to a
+ * 1-glyph column. Unchecked margins from near-full-width tables/images can
+ * exceed contentWidth and collapse every wrap line to ~1 character.
+ *
+ * Returned margins are zeroed when either side alone is >= contentWidth or
+ * their sum is >= contentWidth. Otherwise the original (non-negative) values
+ * pass through unchanged.
+ */
+export function clampFloatingWrapMargins(
+  leftMargin: number,
+  rightMargin: number,
+  contentWidth: number,
+): { leftMargin: number; rightMargin: number } {
+  const cw = Math.max(1, contentWidth);
+  const lm = Math.max(0, leftMargin);
+  const rm = Math.max(0, rightMargin);
+  if (lm >= cw || rm >= cw || lm + rm >= cw) {
+    return { leftMargin: 0, rightMargin: 0 };
+  }
+  return { leftMargin: lm, rightMargin: rm };
+}

--- a/packages/folio/src/core/layout-bridge/measuring/floatingZones.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/floatingZones.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, test } from "bun:test";
 import { rectsToFloatingZones } from "./floatingZones";
 
 describe("rectsToFloatingZones", () => {
-  test("splits centered both-sides objects into left and right line segments", () => {
+  test("centered both-sides object falls back to the wider side (split rendering is not yet supported)", () => {
+    // Split-segment rendering requires painter support not yet wired
+    // through `MeasuredLine`. Until then, a centered both-sides box
+    // collapses to the largest single side so text never paints
+    // through the excluded region.
     const [zone] = rectsToFloatingZones(
       [
         {
@@ -26,11 +30,10 @@ describe("rectsToFloatingZones", () => {
       500,
     );
 
-    expect(zone?.segments).toEqual([
-      { leftOffset: 0, availableWidth: 200 },
-      { leftOffset: 300, availableWidth: 200 },
-    ]);
-    expect(zone?.leftMargin).toBe(0);
+    expect(zone?.segments).toBeUndefined();
+    // leftWidth (200) === rightWidth (200) → tied; largestSideMargins
+    // picks the right path, blocking the left side with leftMargin = rectRight.
+    expect(zone?.leftMargin).toBe(300);
     expect(zone?.rightMargin).toBe(0);
   });
 

--- a/packages/folio/src/core/layout-bridge/measuring/floatingZones.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/floatingZones.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Floating exclusion zone unit tests. Mirrors eigenpal #474.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { rectsToFloatingZones } from "./floatingZones";
+
+describe("rectsToFloatingZones", () => {
+  test("splits centered both-sides objects into left and right line segments", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 200,
+          y: 0,
+          width: 100,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 0,
+          wrapText: "bothSides",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.segments).toEqual([
+      { leftOffset: 0, availableWidth: 200 },
+      { leftOffset: 300, availableWidth: 200 },
+    ]);
+    expect(zone?.leftMargin).toBe(0);
+    expect(zone?.rightMargin).toBe(0);
+  });
+
+  test("keeps largest-side wrapping on a single side instead of splitting the line", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 100,
+          y: 0,
+          width: 100,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 0,
+          wrapText: "largest",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.segments).toBeUndefined();
+    expect(zone?.leftMargin).toBe(200);
+    expect(zone?.rightMargin).toBe(0);
+  });
+
+  test("wrapText='right' (text only on right) carves a left margin", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 0,
+          y: 0,
+          width: 150,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 12,
+          wrapText: "right",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.leftMargin).toBe(162);
+    expect(zone?.rightMargin).toBe(0);
+    expect(zone?.segments).toBeUndefined();
+  });
+
+  test("wrapText='left' (text only on left) carves a right margin", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "right",
+          x: 350,
+          y: 0,
+          width: 150,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 12,
+          distRight: 0,
+          wrapText: "left",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.leftMargin).toBe(0);
+    expect(zone?.rightMargin).toBe(162);
+  });
+
+  test("omitted wrapText falls back to rect.side (preserves pre-#474 image wrap)", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 200,
+          y: 0,
+          width: 100,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 0,
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.segments).toBeUndefined();
+    expect(zone?.leftMargin).toBe(300);
+    expect(zone?.rightMargin).toBe(0);
+  });
+
+  test("near-full-width float is clamped so body text does not collapse", () => {
+    const [zone] = rectsToFloatingZones(
+      [
+        {
+          side: "left",
+          x: 0,
+          y: 0,
+          width: 500,
+          height: 40,
+          distTop: 0,
+          distBottom: 0,
+          distLeft: 0,
+          distRight: 0,
+          wrapText: "right",
+        },
+      ],
+      500,
+    );
+
+    expect(zone?.leftMargin).toBe(0);
+    expect(zone?.rightMargin).toBe(0);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/floatingZones.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/floatingZones.ts
@@ -1,0 +1,260 @@
+/**
+ * Floating exclusion zones — shared between floating images and anchored
+ * text boxes. Ported from eigenpal docx-editor #474 to extract per-object
+ * zone construction out of the page renderer so text-box anchors can
+ * contribute exclusion rects through the same pipeline.
+ *
+ * Folio adds `clampFloatingWrapMargins` (near-full-width float guard) on top
+ * of the upstream conversion; without it, body text after a wide float
+ * collapses to ~1 glyph per line.
+ */
+
+import { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
+
+export type WrapTextDirection = "bothSides" | "left" | "right" | "largest";
+
+/**
+ * A single floating object's exclusion rectangle in content-area coordinates.
+ * Produced from images and anchored text boxes; consumed by
+ * `rectsToFloatingZones` to derive per-line wrap margins.
+ */
+export type FloatingExclusionRect = {
+  /** Which side the object is on for simple one-sided wrapping. */
+  side: "left" | "right";
+  /** X position relative to the content area. */
+  x: number;
+  /** Y position relative to the content area. */
+  y: number;
+  width: number;
+  height: number;
+  distTop: number;
+  distBottom: number;
+  distLeft: number;
+  distRight: number;
+  wrapText?: WrapTextDirection;
+  wrapType?: string;
+};
+
+/**
+ * Per-object exclusion zone in the measurement coordinate space. Each rect
+ * becomes its own zone so lines at different Y positions get independently
+ * correct widths.
+ */
+export type FloatingImageZone = {
+  /** Left margin reduction (pixels from left edge). */
+  leftMargin: number;
+  /** Right margin reduction (pixels from right edge). */
+  rightMargin: number;
+  /** Top Y coordinate of the exclusion zone. */
+  topY: number;
+  /** Bottom Y coordinate of the exclusion zone. */
+  bottomY: number;
+  /** Optional split segments for centered both-sides wrapping. */
+  segments?: FloatingLineSegmentZone[];
+};
+
+export type FloatingLineSegmentZone = {
+  leftOffset: number;
+  availableWidth: number;
+};
+
+export type FloatingLineMargins = {
+  leftMargin: number;
+  rightMargin: number;
+  segments?: FloatingLineSegmentZone[];
+};
+
+/**
+ * Convert floating exclusion rectangles to per-object zones for the
+ * measurement system. Mirrors eigenpal #474.
+ *
+ * `wrapText` controls which side(s) text flows on:
+ *   - `right`     → text only on right → object blocks left side (leftMargin)
+ *   - `left`      → text only on left  → object blocks right side (rightMargin)
+ *   - `bothSides` → split the line into two segments when the object is
+ *                   centered in the column; otherwise pick a single side
+ *                   based on `rect.side`.
+ *   - `largest`   → pick whichever side has more remaining room and reduce
+ *                   the line to that single side (no split).
+ */
+export function rectsToFloatingZones(
+  rects: FloatingExclusionRect[],
+  contentWidth: number,
+): FloatingImageZone[] {
+  return rects.map((rect) => {
+    const rectLeft = rect.x - rect.distLeft;
+    const rectRight = rect.x + rect.width + rect.distRight;
+    const rectTop = rect.y - rect.distTop;
+    const rectBottom = rect.y + rect.height + rect.distBottom;
+
+    let leftMargin = 0;
+    let rightMargin = 0;
+    let segments: FloatingLineSegmentZone[] | undefined;
+
+    if (rect.wrapText === "right") {
+      leftMargin = leftObjectMargin(rectRight);
+    } else if (rect.wrapText === "left") {
+      rightMargin = rightObjectMargin(rectLeft, contentWidth);
+    } else if (rect.wrapText === "largest") {
+      ({ leftMargin, rightMargin } = largestSideMargins(
+        rectLeft,
+        rectRight,
+        contentWidth,
+      ));
+    } else if (
+      rect.wrapText === "bothSides" &&
+      canSplitCenteredBothSidesWrap(rectLeft, rectRight, contentWidth)
+    ) {
+      // Eigenpal #474: a centered both-sides object splits the line into two
+      // segments instead of carving a single side. Only applied when the
+      // caller explicitly opts in via `wrapText: 'bothSides'` so legacy
+      // callers (images relying on `rect.side`-driven single-side wrap) keep
+      // their existing behavior.
+      segments = centeredWrapSegments(rectLeft, rectRight, contentWidth);
+    } else if (rect.side === "left") {
+      leftMargin = leftObjectMargin(rectRight);
+    } else {
+      rightMargin = rightObjectMargin(rectLeft, contentWidth);
+    }
+
+    // Near-full-width floats can compute a wrap margin >= contentWidth; if we
+    // let that propagate, body text after the float collapses to ~1 glyph per
+    // line. Word falls back to full content width in that case.
+    const clamped = clampFloatingWrapMargins(
+      leftMargin,
+      rightMargin,
+      contentWidth,
+    );
+
+    const zone: FloatingImageZone = {
+      leftMargin: clamped.leftMargin,
+      rightMargin: clamped.rightMargin,
+      topY: rectTop,
+      bottomY: rectBottom,
+    };
+    if (segments) {
+      zone.segments = segments;
+    }
+    return zone;
+  });
+}
+
+/**
+ * Effective horizontal text width for a line under the given margins.
+ * Uses the sum of segment widths when the zone provides split segments;
+ * otherwise falls back to `baseWidth - leftMargin - rightMargin`.
+ */
+export function getFloatingAvailableWidth(
+  margins: FloatingLineMargins,
+  baseWidth: number,
+): number {
+  const segmentWidth = margins.segments?.reduce(
+    (sum, segment) => sum + segment.availableWidth,
+    0,
+  );
+  return segmentWidth ?? baseWidth - margins.leftMargin - margins.rightMargin;
+}
+
+/**
+ * Calculate width reduction for a line based on floating object zones.
+ * Returns the left and right margins (plus optional segments) that apply
+ * at this vertical position.
+ */
+export function getFloatingMargins(
+  lineY: number,
+  lineHeight: number,
+  zones: FloatingImageZone[] | undefined,
+  paragraphYOffset: number,
+): FloatingLineMargins {
+  if (!zones || zones.length === 0) {
+    return { leftMargin: 0, rightMargin: 0 };
+  }
+
+  let leftMargin = 0;
+  let rightMargin = 0;
+  let segments: FloatingLineSegmentZone[] | undefined;
+
+  const absoluteLineTop = paragraphYOffset + lineY;
+  const absoluteLineBottom = absoluteLineTop + lineHeight;
+
+  for (const zone of zones) {
+    if (absoluteLineBottom <= zone.topY || absoluteLineTop >= zone.bottomY) {
+      continue;
+    }
+    if (zone.segments?.length) {
+      segments = segments
+        ? intersectSegments(segments, zone.segments)
+        : zone.segments;
+      continue;
+    }
+    leftMargin = Math.max(leftMargin, zone.leftMargin);
+    rightMargin = Math.max(rightMargin, zone.rightMargin);
+  }
+
+  if (segments) {
+    return { leftMargin, rightMargin, segments };
+  }
+  return { leftMargin, rightMargin };
+}
+
+function intersectSegments(
+  a: FloatingLineSegmentZone[],
+  b: FloatingLineSegmentZone[],
+): FloatingLineSegmentZone[] {
+  const result: FloatingLineSegmentZone[] = [];
+  for (const left of a) {
+    for (const right of b) {
+      const start = Math.max(left.leftOffset, right.leftOffset);
+      const end = Math.min(
+        left.leftOffset + left.availableWidth,
+        right.leftOffset + right.availableWidth,
+      );
+      if (end > start) {
+        result.push({ leftOffset: start, availableWidth: end - start });
+      }
+    }
+  }
+  return result;
+}
+
+function canSplitCenteredBothSidesWrap(
+  rectLeft: number,
+  rectRight: number,
+  contentWidth: number,
+): boolean {
+  return rectLeft > 0 && rectRight < contentWidth;
+}
+
+function centeredWrapSegments(
+  rectLeft: number,
+  rectRight: number,
+  contentWidth: number,
+): FloatingLineSegmentZone[] {
+  return [
+    { leftOffset: 0, availableWidth: Math.max(0, rectLeft) },
+    {
+      leftOffset: Math.max(0, rectRight),
+      availableWidth: Math.max(0, contentWidth - rectRight),
+    },
+  ].filter((segment) => segment.availableWidth > 1);
+}
+
+function largestSideMargins(
+  rectLeft: number,
+  rectRight: number,
+  contentWidth: number,
+): Pick<FloatingLineMargins, "leftMargin" | "rightMargin"> {
+  const leftWidth = Math.max(0, rectLeft);
+  const rightWidth = Math.max(0, contentWidth - rectRight);
+  return rightWidth >= leftWidth
+    ? { leftMargin: leftObjectMargin(rectRight), rightMargin: 0 }
+    : { leftMargin: 0, rightMargin: rightObjectMargin(rectLeft, contentWidth) };
+}
+
+function leftObjectMargin(rectRight: number): number {
+  return Math.max(0, rectRight);
+}
+
+function rightObjectMargin(rectLeft: number, contentWidth: number): number {
+  return Math.max(0, contentWidth - rectLeft);
+}

--- a/packages/folio/src/core/layout-bridge/measuring/floatingZones.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/floatingZones.ts
@@ -71,9 +71,11 @@ export type FloatingLineMargins = {
  * `wrapText` controls which side(s) text flows on:
  *   - `right`     → text only on right → object blocks left side (leftMargin)
  *   - `left`      → text only on left  → object blocks right side (rightMargin)
- *   - `bothSides` → split the line into two segments when the object is
- *                   centered in the column; otherwise pick a single side
- *                   based on `rect.side`.
+ *   - `bothSides` → ideally splits the line into two segments when the
+ *                   object is centered in the column; folio currently falls
+ *                   back to the wider side because split-segment rendering
+ *                   is not yet plumbed through the painter (see comment in
+ *                   the function body).
  *   - `largest`   → pick whichever side has more remaining room and reduce
  *                   the line to that single side (no split).
  */
@@ -89,28 +91,30 @@ export function rectsToFloatingZones(
 
     let leftMargin = 0;
     let rightMargin = 0;
-    let segments: FloatingLineSegmentZone[] | undefined;
 
     if (rect.wrapText === "right") {
       leftMargin = leftObjectMargin(rectRight);
     } else if (rect.wrapText === "left") {
       rightMargin = rightObjectMargin(rectLeft, contentWidth);
-    } else if (rect.wrapText === "largest") {
+    } else if (
+      rect.wrapText === "largest" ||
+      (rect.wrapText === "bothSides" &&
+        canSplitCenteredBothSidesWrap(rectLeft, rectRight, contentWidth))
+    ) {
+      // `largest` always picks the wider side.
+      //
+      // `bothSides` + centered would split the line into two segments per
+      // eigenpal #474, but split-segment rendering is not yet plumbed
+      // through the painter — `MeasuredLine` carries only
+      // `leftOffset`/`rightOffset`, so a two-segment line would paint as
+      // one contiguous strip through the excluded object. Until the
+      // painter can render two physical line fragments at different x
+      // offsets, fall back to the wider side here too.
       ({ leftMargin, rightMargin } = largestSideMargins(
         rectLeft,
         rectRight,
         contentWidth,
       ));
-    } else if (
-      rect.wrapText === "bothSides" &&
-      canSplitCenteredBothSidesWrap(rectLeft, rectRight, contentWidth)
-    ) {
-      // Eigenpal #474: a centered both-sides object splits the line into two
-      // segments instead of carving a single side. Only applied when the
-      // caller explicitly opts in via `wrapText: 'bothSides'` so legacy
-      // callers (images relying on `rect.side`-driven single-side wrap) keep
-      // their existing behavior.
-      segments = centeredWrapSegments(rectLeft, rectRight, contentWidth);
     } else if (rect.side === "left") {
       leftMargin = leftObjectMargin(rectRight);
     } else {
@@ -126,33 +130,41 @@ export function rectsToFloatingZones(
       contentWidth,
     );
 
-    const zone: FloatingImageZone = {
+    return {
       leftMargin: clamped.leftMargin,
       rightMargin: clamped.rightMargin,
       topY: rectTop,
       bottomY: rectBottom,
     };
-    if (segments) {
-      zone.segments = segments;
-    }
-    return zone;
   });
 }
 
 /**
  * Effective horizontal text width for a line under the given margins.
- * Uses the sum of segment widths when the zone provides split segments;
- * otherwise falls back to `baseWidth - leftMargin - rightMargin`.
+ * When the zone provides split segments (centered both-sides wrap), each
+ * segment is clipped against `leftMargin`/`rightMargin` so a side float
+ * overlapping vertically with the centered float still reduces the budget.
+ * Otherwise falls back to `baseWidth - leftMargin - rightMargin`.
  */
 export function getFloatingAvailableWidth(
   margins: FloatingLineMargins,
   baseWidth: number,
 ): number {
-  const segmentWidth = margins.segments?.reduce(
-    (sum, segment) => sum + segment.availableWidth,
-    0,
-  );
-  return segmentWidth ?? baseWidth - margins.leftMargin - margins.rightMargin;
+  if (margins.segments?.length) {
+    const leftLimit = margins.leftMargin;
+    const rightLimit = baseWidth - margins.rightMargin;
+    let total = 0;
+    for (const segment of margins.segments) {
+      const start = Math.max(segment.leftOffset, leftLimit);
+      const end = Math.min(
+        segment.leftOffset + segment.availableWidth,
+        rightLimit,
+      );
+      total += Math.max(0, end - start);
+    }
+    return total;
+  }
+  return baseWidth - margins.leftMargin - margins.rightMargin;
 }
 
 /**
@@ -223,20 +235,6 @@ function canSplitCenteredBothSidesWrap(
   contentWidth: number,
 ): boolean {
   return rectLeft > 0 && rectRight < contentWidth;
-}
-
-function centeredWrapSegments(
-  rectLeft: number,
-  rectRight: number,
-  contentWidth: number,
-): FloatingLineSegmentZone[] {
-  return [
-    { leftOffset: 0, availableWidth: Math.max(0, rectLeft) },
-    {
-      leftOffset: Math.max(0, rectRight),
-      availableWidth: Math.max(0, contentWidth - rectRight),
-    },
-  ].filter((segment) => segment.availableWidth > 1);
 }
 
 function largestSideMargins(

--- a/packages/folio/src/core/layout-bridge/measuring/index.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/index.ts
@@ -40,6 +40,17 @@ export {
   type MeasureParagraphOptions,
 } from "./measureParagraph";
 
+// Floating exclusion zones (shared by images and anchored text boxes)
+export {
+  rectsToFloatingZones,
+  getFloatingMargins,
+  getFloatingAvailableWidth,
+  type FloatingExclusionRect,
+  type FloatingLineMargins,
+  type FloatingLineSegmentZone,
+  type WrapTextDirection,
+} from "./floatingZones";
+
 // Caching utilities
 export {
   // Text width cache

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-textbox-wrap.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-textbox-wrap.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Body text wraps around an anchored text box (eigenpal #474).
+ *
+ * Mirrors the renderPage pipeline: derives a FloatingExclusionRect from a
+ * TextBoxBlock-shaped input, converts via `rectsToFloatingZones`, then
+ * checks the paragraph's first line shrinks past the box.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  type FloatingExclusionRect,
+  rectsToFloatingZones,
+} from "./floatingZones";
+import { resetCanvasContext } from "./measureContainer";
+import { measureParagraph } from "./measureParagraph";
+
+function withFakeTextMeasure(runTest: () => void): void {
+  const originalDocument = globalThis.document;
+  const fakeDocument = {
+    createElement() {
+      return {
+        getContext() {
+          return {
+            font: "",
+            measureText(_text: string) {
+              return {
+                width: _text.length * 5,
+                actualBoundingBoxAscent: 8,
+                actualBoundingBoxDescent: 2,
+              };
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Document;
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: fakeDocument,
+  });
+  resetCanvasContext();
+
+  try {
+    runTest();
+  } finally {
+    resetCanvasContext();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+  }
+}
+
+describe("body text wraps around floating text box", () => {
+  test("a left-floated text box with wrapType='square' carves a left margin out of the first line", () => {
+    withFakeTextMeasure(() => {
+      const contentWidth = 500;
+      // Anchored text box: 150x60 at top-left, 12px wrap distance on all sides.
+      // wrapText='right' → text flows on the right side of the box only.
+      const textBoxRect: FloatingExclusionRect = {
+        side: "left",
+        x: 0,
+        y: 0,
+        width: 150,
+        height: 60,
+        distTop: 0,
+        distBottom: 0,
+        distLeft: 12,
+        distRight: 12,
+        wrapType: "square",
+        wrapText: "right",
+      };
+
+      const zones = rectsToFloatingZones([textBoxRect], contentWidth);
+      expect(zones[0]?.leftMargin).toBe(162);
+
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "p",
+          runs: [
+            {
+              kind: "text",
+              text: "this is a paragraph that should wrap around the floating text box",
+            },
+          ],
+          attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri" },
+        },
+        contentWidth,
+        { floatingZones: zones },
+      );
+
+      const firstLine = measure.lines.at(0);
+      expect(firstLine).toBeDefined();
+      // First line was reduced past the floating text box.
+      expect(firstLine?.leftOffset).toBe(162);
+    });
+  });
+
+  test("a text box with wrapType='behind' does not reduce line widths", () => {
+    withFakeTextMeasure(() => {
+      const contentWidth = 500;
+      // Even though the rect spans most of the content, wrapType='behind'
+      // means body text paints over the box; line widths are untouched.
+      // Mirroring renderPage's gate (`floatingTextBoxWrapsText`), the rect
+      // never reaches `rectsToFloatingZones` — measurement runs without any
+      // floating zones at all.
+      const measure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "p",
+          runs: [{ kind: "text", text: "body text over a behind box" }],
+          attrs: { defaultFontSize: 11, defaultFontFamily: "Calibri" },
+        },
+        contentWidth,
+        { floatingZones: [] },
+      );
+
+      const firstLine = measure.lines.at(0);
+      expect(firstLine?.leftOffset).toBeUndefined();
+      expect(firstLine?.rightOffset).toBeUndefined();
+    });
+  });
+});

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -25,6 +25,12 @@ import {
 import type { TabContext } from "../../prosemirror/utils/tabCalculator";
 import { DEFAULT_SINGLE_LINE_RATIO } from "../../utils/fontResolver";
 import { inlineImageBoundingBox } from "../../utils/rotationBoundingBox";
+import {
+  getFloatingAvailableWidth,
+  getFloatingMargins,
+  type FloatingImageZone,
+  type FloatingLineSegmentZone,
+} from "./floatingZones";
 import { getListMarkerInlineWidth } from "./listMarkerWidth";
 import {
   measureTextWidth,
@@ -33,12 +39,6 @@ import {
   ptToPx,
 } from "./measureContainer";
 import type { FontStyle, FontMetrics } from "./measureContainer";
-import {
-  getFloatingAvailableWidth,
-  getFloatingMargins,
-  type FloatingImageZone,
-  type FloatingLineSegmentZone,
-} from "./floatingZones";
 
 export { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
 export type { FloatingImageZone } from "./floatingZones";
@@ -439,7 +439,10 @@ export function findClearLineY(
   // happy path O(zones).
   for (let i = 0; i < zones.length + 2; i++) {
     const margins = getFloatingMargins(y, lineHeight, zones, 0);
-    const available = Math.max(0, getFloatingAvailableWidth(margins, contentWidth));
+    const available = Math.max(
+      0,
+      getFloatingAvailableWidth(margins, contentWidth),
+    );
     if (available >= minWidth) {
       return y;
     }

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -33,6 +33,15 @@ import {
   ptToPx,
 } from "./measureContainer";
 import type { FontStyle, FontMetrics } from "./measureContainer";
+import {
+  getFloatingAvailableWidth,
+  getFloatingMargins,
+  type FloatingImageZone,
+  type FloatingLineSegmentZone,
+} from "./floatingZones";
+
+export { clampFloatingWrapMargins } from "./clampFloatingWrapMargins";
+export type { FloatingImageZone } from "./floatingZones";
 
 // Default values - match OOXML spec defaults
 const DEFAULT_FONT_SIZE = 11; // 11pt (Word 2007+ default)
@@ -67,21 +76,6 @@ function findMaxFittingLength(
   }
   return forceMin && best === 0 ? 1 : best;
 }
-
-/**
- * Floating image exclusion zone - describes an area where text cannot flow.
- * Used to calculate reduced line widths for text wrapping around floating images.
- */
-export type FloatingImageZone = {
-  /** Left margin reduction (pixels from left edge) */
-  leftMargin: number;
-  /** Right margin reduction (pixels from right edge) */
-  rightMargin: number;
-  /** Top Y coordinate of the exclusion zone (pixels from paragraph start) */
-  topY: number;
-  /** Bottom Y coordinate of the exclusion zone (pixels from paragraph start) */
-  bottomY: number;
-};
 
 /**
  * Options for paragraph measurement
@@ -120,6 +114,8 @@ type LineState = {
   leftOffset: number;
   /** Right offset from floating images (pixels from content right edge) */
   rightOffset: number;
+  /** Optional split segment zones from centered floating exclusions */
+  segmentZones?: FloatingLineSegmentZone[];
 };
 
 /**
@@ -402,29 +398,9 @@ function findWordBreaks(text: string): number[] {
 }
 
 /**
- * When a float's wrap margins consume the entire content width (or more),
- * there is no horizontal strip beside it for body text. Word renders the
- * following lines at full content width instead of collapsing them to a
- * 1-glyph column. Unchecked margins from near-full-width tables/images can
- * exceed contentWidth and collapse every wrap line to ~1 character.
- *
- * Returned margins are zeroed when either side alone is >= contentWidth or
- * their sum is >= contentWidth. Otherwise the original (non-negative) values
- * pass through unchanged.
+ * Default tab width in pixels (0.5 inch at 96 DPI)
  */
-export function clampFloatingWrapMargins(
-  leftMargin: number,
-  rightMargin: number,
-  contentWidth: number,
-): { leftMargin: number; rightMargin: number } {
-  const cw = Math.max(1, contentWidth);
-  const lm = Math.max(0, leftMargin);
-  const rm = Math.max(0, rightMargin);
-  if (lm >= cw || rm >= cw || lm + rm >= cw) {
-    return { leftMargin: 0, rightMargin: 0 };
-  }
-  return { leftMargin: lm, rightMargin: rm };
-}
+const DEFAULT_TAB_WIDTH = 48;
 
 /**
  * Minimum horizontal room a line must offer before we treat it as usable for
@@ -463,10 +439,7 @@ export function findClearLineY(
   // happy path O(zones).
   for (let i = 0; i < zones.length + 2; i++) {
     const margins = getFloatingMargins(y, lineHeight, zones, 0);
-    const available = Math.max(
-      0,
-      contentWidth - margins.leftMargin - margins.rightMargin,
-    );
+    const available = Math.max(0, getFloatingAvailableWidth(margins, contentWidth));
     if (available >= minWidth) {
       return y;
     }
@@ -488,38 +461,6 @@ export function findClearLineY(
     y = nextY;
   }
   return y;
-}
-
-/**
- * Calculate width reduction for a line based on floating image zones.
- * Returns the left and right margins that need to be applied.
- */
-function getFloatingMargins(
-  lineY: number,
-  lineHeight: number,
-  zones: FloatingImageZone[] | undefined,
-  paragraphYOffset: number,
-): { leftMargin: number; rightMargin: number } {
-  if (!zones || zones.length === 0) {
-    return { leftMargin: 0, rightMargin: 0 };
-  }
-
-  let leftMargin = 0;
-  let rightMargin = 0;
-
-  // Line position relative to exclusion zones
-  const absoluteLineTop = paragraphYOffset + lineY;
-  const absoluteLineBottom = absoluteLineTop + lineHeight;
-
-  for (const zone of zones) {
-    // Check if this line overlaps vertically with the exclusion zone
-    if (absoluteLineBottom > zone.topY && absoluteLineTop < zone.bottomY) {
-      leftMargin = Math.max(leftMargin, zone.leftMargin);
-      rightMargin = Math.max(rightMargin, zone.rightMargin);
-    }
-  }
-
-  return { leftMargin, rightMargin };
 }
 
 /**
@@ -628,9 +569,7 @@ export function measureParagraph(
   );
   const firstLineWidth = Math.max(
     1,
-    baseFirstLineWidth -
-      firstLineFloatingMargins.leftMargin -
-      firstLineFloatingMargins.rightMargin,
+    getFloatingAvailableWidth(firstLineFloatingMargins, baseFirstLineWidth),
   );
 
   const lines: MeasuredLine[] = [];
@@ -742,6 +681,9 @@ export function measureParagraph(
     availableWidth: firstLineWidth,
     leftOffset: firstLineFloatingMargins.leftMargin,
     rightOffset: firstLineFloatingMargins.rightMargin,
+    ...(firstLineFloatingMargins.segments?.length
+      ? { segmentZones: firstLineFloatingMargins.segments }
+      : {}),
   };
 
   /**
@@ -835,9 +777,7 @@ export function measureParagraph(
     // Body content width minus floating image margins
     const adjustedWidth = Math.max(
       1,
-      bodyContentWidth -
-        floatingMargins.leftMargin -
-        floatingMargins.rightMargin,
+      getFloatingAvailableWidth(floatingMargins, bodyContentWidth),
     );
 
     currentLine = {
@@ -852,6 +792,9 @@ export function measureParagraph(
       availableWidth: adjustedWidth,
       leftOffset: floatingMargins.leftMargin,
       rightOffset: floatingMargins.rightMargin,
+      ...(floatingMargins.segments?.length
+        ? { segmentZones: floatingMargins.segments }
+        : {}),
     };
   };
 

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -398,11 +398,6 @@ function findWordBreaks(text: string): number[] {
 }
 
 /**
- * Default tab width in pixels (0.5 inch at 96 DPI)
- */
-const DEFAULT_TAB_WIDTH = 48;
-
-/**
  * Minimum horizontal room a line must offer before we treat it as usable for
  * body text. Below this threshold the line is bumped past obstructing floats
  * via `findClearLineY` instead of being rendered into the unusable sliver.

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1859,6 +1859,32 @@ function convertTextBoxNode(
   if (attrs.outlineStyle !== undefined) {
     textBox.outlineStyle = attrs.outlineStyle;
   }
+  // Carry anchored-textbox wrap attributes through so the page renderer can
+  // build exclusion rects (eigenpal #474).
+  if (attrs.displayMode !== undefined) {
+    textBox.displayMode = attrs.displayMode;
+  }
+  if (attrs.cssFloat !== undefined) {
+    textBox.cssFloat = attrs.cssFloat;
+  }
+  if (attrs.wrapType !== undefined) {
+    textBox.wrapType = attrs.wrapType;
+  }
+  if (attrs.wrapText !== undefined) {
+    textBox.wrapText = attrs.wrapText;
+  }
+  if (attrs.distTop !== undefined) {
+    textBox.distTop = attrs.distTop;
+  }
+  if (attrs.distBottom !== undefined) {
+    textBox.distBottom = attrs.distBottom;
+  }
+  if (attrs.distLeft !== undefined) {
+    textBox.distLeft = attrs.distLeft;
+  }
+  if (attrs.distRight !== undefined) {
+    textBox.distRight = attrs.distRight;
+  }
   return textBox;
 }
 

--- a/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Floating text-box predicate tests. Mirrors eigenpal #474.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  floatingTextBoxWrapsText,
+  isFloatingTextBoxBlock,
+} from "./textBoxFlow";
+
+describe("isFloatingTextBoxBlock", () => {
+  test("recognizes displayMode='float' as floating", () => {
+    expect(isFloatingTextBoxBlock({ displayMode: "float" })).toBe(true);
+  });
+
+  test("recognizes OOXML floating wrap types as floating", () => {
+    expect(isFloatingTextBoxBlock({ wrapType: "square" })).toBe(true);
+    expect(isFloatingTextBoxBlock({ wrapType: "tight" })).toBe(true);
+    expect(isFloatingTextBoxBlock({ wrapType: "through" })).toBe(true);
+    expect(isFloatingTextBoxBlock({ wrapType: "behind" })).toBe(true);
+    expect(isFloatingTextBoxBlock({ wrapType: "inFront" })).toBe(true);
+    expect(isFloatingTextBoxBlock({ wrapType: "topAndBottom" })).toBe(true);
+  });
+
+  test("inline text boxes are not floating", () => {
+    expect(isFloatingTextBoxBlock({ displayMode: "inline" })).toBe(false);
+    expect(isFloatingTextBoxBlock({ wrapType: "inline" })).toBe(false);
+    expect(isFloatingTextBoxBlock({})).toBe(false);
+  });
+});
+
+describe("floatingTextBoxWrapsText", () => {
+  test("wraps text for square/tight/through", () => {
+    expect(
+      floatingTextBoxWrapsText({ displayMode: "float", wrapType: "square" }),
+    ).toBe(true);
+    expect(
+      floatingTextBoxWrapsText({ displayMode: "float", wrapType: "tight" }),
+    ).toBe(true);
+    expect(
+      floatingTextBoxWrapsText({ displayMode: "float", wrapType: "through" }),
+    ).toBe(true);
+  });
+
+  test("does not wrap text for wrapNone (behind/inFront)", () => {
+    expect(floatingTextBoxWrapsText({ wrapType: "behind" })).toBe(false);
+    expect(floatingTextBoxWrapsText({ wrapType: "inFront" })).toBe(false);
+  });
+
+  test("does not wrap text for topAndBottom", () => {
+    expect(floatingTextBoxWrapsText({ wrapType: "topAndBottom" })).toBe(false);
+  });
+
+  test("does not wrap text for non-floating blocks", () => {
+    expect(floatingTextBoxWrapsText({ displayMode: "inline" })).toBe(false);
+    expect(floatingTextBoxWrapsText({})).toBe(false);
+  });
+});

--- a/packages/folio/src/core/layout-engine/textBoxFlow.ts
+++ b/packages/folio/src/core/layout-engine/textBoxFlow.ts
@@ -1,0 +1,29 @@
+/**
+ * Floating text-box predicates. Ported from eigenpal docx-editor #474.
+ */
+
+import { isFloatingWrapType, isWrapNone } from "../docx/wrapTypes";
+import type { TextBoxBlock } from "./types";
+
+export type TextBoxFlowAttrs = Pick<TextBoxBlock, "displayMode" | "wrapType">;
+
+/**
+ * `true` when the text box is anchored outside normal block flow — either
+ * via the `float` display mode or via an OOXML floating wrap type.
+ */
+export function isFloatingTextBoxBlock(block: TextBoxFlowAttrs): boolean {
+  return block.displayMode === "float" || isFloatingWrapType(block.wrapType);
+}
+
+/**
+ * `true` when a floating text box should also reduce surrounding text
+ * line widths. Excludes wrapNone (`behind`/`inFront`) and `topAndBottom`
+ * which are positioned floats but do not carve a horizontal exclusion.
+ */
+export function floatingTextBoxWrapsText(block: TextBoxFlowAttrs): boolean {
+  return (
+    isFloatingTextBoxBlock(block) &&
+    !isWrapNone(block.wrapType) &&
+    block.wrapType !== "topAndBottom"
+  );
+}

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -553,6 +553,21 @@ export type TextBoxBlock = {
   margins?: { top: number; bottom: number; left: number; right: number };
   /** Paragraph blocks inside the text box */
   content: ParagraphBlock[];
+  /** Display mode copied from the ProseMirror text box node. */
+  displayMode?: "inline" | "float" | "block";
+  /** CSS float direction copied from the ProseMirror text box node. */
+  cssFloat?: "left" | "right" | "none";
+  /** OOXML wrap type for anchored text boxes. */
+  wrapType?: string;
+  /** OOXML wrapText direction for anchored text boxes. */
+  wrapText?: "bothSides" | "left" | "right" | "largest";
+  /** Position for floating/anchored text boxes (pixel-converted EMU). */
+  position?: ImageRunPosition;
+  /** Wrap distances in pixels. */
+  distTop?: number;
+  distBottom?: number;
+  distLeft?: number;
+  distRight?: number;
   pmStart?: number;
   pmEnd?: number;
 };

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -13,7 +13,6 @@ import {
   FOOTNOTE_SEPARATOR_HEIGHT,
 } from "../layout-bridge/footnoteLayout";
 import {
-  clampFloatingWrapMargins,
   measureParagraph,
   rectsToFloatingZones,
 } from "../layout-bridge/measuring";

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -21,6 +21,10 @@ import type {
   FloatingExclusionRect,
   FloatingImageZone,
 } from "../layout-bridge/measuring";
+import {
+  floatingTextBoxWrapsText,
+  isFloatingTextBoxBlock,
+} from "../layout-engine/textBoxFlow";
 import type {
   Page,
   Fragment,
@@ -1745,6 +1749,67 @@ export function renderPage(
         distLeft,
         distRight,
       });
+    }
+  }
+
+  // Collect floating text-box exclusion rectangles (eigenpal #474).
+  // The text-box paint already exists; this only adds the measurement-side
+  // contribution so body text wraps around anchored boxes instead of
+  // running underneath them.
+  if (options.blockLookup) {
+    for (const fragment of page.fragments) {
+      if (fragment.kind !== "textBox") {
+        continue;
+      }
+      const blockData = options.blockLookup.get(String(fragment.blockId));
+      if (blockData?.block.kind !== "textBox") {
+        continue;
+      }
+      const textBoxBlock = blockData.block as TextBoxBlock;
+      if (!isFloatingTextBoxBlock(textBoxBlock)) {
+        continue;
+      }
+      if (!floatingTextBoxWrapsText(textBoxBlock)) {
+        continue;
+      }
+
+      const contentX = fragment.x - page.margins.left;
+      const contentY = fragment.y - page.margins.top;
+
+      const distTop = textBoxBlock.distTop ?? 0;
+      const distBottom = textBoxBlock.distBottom ?? 0;
+      const distLeft = textBoxBlock.distLeft ?? 12;
+      const distRight = textBoxBlock.distRight ?? 12;
+
+      // Side hints which margin the rect blocks when `wrapText` falls back to
+      // `rect.side`. Prefer the explicit cssFloat over the X heuristic so a
+      // right-floated box hugging the centre still produces a right-side rect.
+      let side: "left" | "right" =
+        contentX < contentWidth / 2 ? "left" : "right";
+      if (textBoxBlock.cssFloat === "left") {
+        side = "left";
+      } else if (textBoxBlock.cssFloat === "right") {
+        side = "right";
+      }
+
+      const rect: FloatingExclusionRect = {
+        side,
+        x: contentX,
+        y: contentY,
+        width: fragment.width,
+        height: fragment.height,
+        distTop,
+        distBottom,
+        distLeft,
+        distRight,
+      };
+      if (textBoxBlock.wrapText !== undefined) {
+        rect.wrapText = textBoxBlock.wrapText;
+      }
+      if (textBoxBlock.wrapType !== undefined) {
+        rect.wrapType = textBoxBlock.wrapType;
+      }
+      floatingRects.push(rect);
     }
   }
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -15,8 +15,12 @@ import {
 import {
   clampFloatingWrapMargins,
   measureParagraph,
+  rectsToFloatingZones,
 } from "../layout-bridge/measuring";
-import type { FloatingImageZone } from "../layout-bridge/measuring";
+import type {
+  FloatingExclusionRect,
+  FloatingImageZone,
+} from "../layout-bridge/measuring";
 import type {
   Page,
   Fragment,
@@ -107,30 +111,6 @@ type PageFloatingImage = {
    * above-text layer so wrapNone semantics survive in the DOM.
    */
   behindDoc: boolean;
-};
-
-/**
- * Floating object exclusion rectangle used for text wrapping.
- */
-type FloatingExclusionRect = {
-  /** Which side the IMAGE is on (for rendering): 'left' or 'right' */
-  side: "left" | "right";
-  /** X position relative to content area (0 = left edge of content) */
-  x: number;
-  /** Y position relative to content area (0 = top of content) */
-  y: number;
-  /** Object dimensions */
-  width: number;
-  height: number;
-  /** Wrap distances */
-  distTop: number;
-  distBottom: number;
-  distLeft: number;
-  distRight: number;
-  /** OOXML wrapText: which side(s) TEXT flows on */
-  wrapText?: "bothSides" | "left" | "right" | "largest";
-  /** Wrap type from DOCX (square, tight, through, topAndBottom) */
-  wrapType?: string;
 };
 
 /**
@@ -897,8 +877,10 @@ function extractFloatingImagesFromParagraph(
     // Derive wrapText from cssFloat:
     // cssFloat='left' → image floats left → text on right → wrapText='right'
     // cssFloat='right' → image floats right → text on left → wrapText='left'
-    // cssFloat='none' or undefined → wrapText='bothSides' (default)
-    let wrapText: "bothSides" | "left" | "right" | "largest" = "bothSides";
+    // cssFloat='none' or undefined → omit wrapText; rect.side drives the side
+    // (preserves pre-eigenpal-#474 image wrap behavior — text boxes opt in to
+    // the new bothSides splitting separately).
+    let wrapText: "bothSides" | "left" | "right" | "largest" | undefined;
     if (imgRun.cssFloat === "left") {
       wrapText = "right";
     } else if (imgRun.cssFloat === "right") {
@@ -925,7 +907,7 @@ function extractFloatingImagesFromParagraph(
       distRight,
       ...(imgRun.pmStart !== undefined ? { pmStart: imgRun.pmStart } : {}),
       ...(imgRun.pmEnd !== undefined ? { pmEnd: imgRun.pmEnd } : {}),
-      wrapText,
+      ...(wrapText !== undefined ? { wrapText } : {}),
       ...(imgRun.wrapType !== undefined ? { wrapType: imgRun.wrapType } : {}),
       affectsTextWrap: isTextWrappingFloatingImageRun(imgRun),
       behindDoc: imgRun.wrapType === "behind",
@@ -933,65 +915,6 @@ function extractFloatingImagesFromParagraph(
   }
 
   return floatingImages;
-}
-
-/**
- * Convert floating exclusion rectangles to per-image FloatingImageZone[]
- * for the measurement system. Each rect becomes its own zone so
- * lines at different Y positions get independently correct widths.
- *
- * wrapText controls which side(s) TEXT flows on:
- *   'right'    → text only on right → image blocks left side (leftMargin)
- *   'left'     → text only on left  → image blocks right side (rightMargin)
- *   'bothSides'→ text on right of left-side images, left of right-side images
- *   'largest'  → same as bothSides (simplified)
- *
- * topAndBottom → full-width exclusion (leftMargin = contentWidth → forces line skip)
- */
-function rectsToFloatingZones(
-  rects: FloatingExclusionRect[],
-  contentWidth: number,
-): FloatingImageZone[] {
-  return rects.map((rect) => {
-    const rectRight = rect.x + rect.width + rect.distRight;
-    const rectTop = rect.y - rect.distTop;
-    const rectBottom = rect.y + rect.height + rect.distBottom;
-
-    let leftMargin = 0;
-    let rightMargin = 0;
-
-    const wt = rect.wrapText ?? "bothSides";
-
-    if (wt === "right") {
-      // Text flows on RIGHT only → image blocks the left side
-      leftMargin = rectRight;
-    } else if (wt === "left") {
-      // Text flows on LEFT only → image blocks the right side
-      rightMargin = contentWidth - (rect.x - rect.distLeft);
-    } else {
-      // bothSides / largest: use image position to determine which side it blocks
-      if (rect.side === "left") {
-        leftMargin = rectRight;
-      } else {
-        rightMargin = contentWidth - (rect.x - rect.distLeft);
-      }
-    }
-
-    // Near-full-width floats can compute a wrap margin >= contentWidth; if we
-    // let that propagate, body text after the float collapses to ~1 glyph per
-    // line. Word falls back to full content width in that case.
-    const clamped = clampFloatingWrapMargins(
-      leftMargin,
-      rightMargin,
-      contentWidth,
-    );
-    return {
-      leftMargin: clamped.leftMargin,
-      rightMargin: clamped.rightMargin,
-      topY: rectTop,
-      bottomY: rectBottom,
-    };
-  });
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -812,6 +812,17 @@ export const readTextBoxAttrs = (
   optionalString(attrs, "wrapType", "textBox.attrs.wrapType", issues);
   optionalOneOf(
     attrs,
+    "wrapText",
+    "textBox.attrs.wrapText",
+    issues,
+    IMAGE_WRAP_TEXT_VALUES,
+  );
+  optionalNumber(attrs, "distTop", "textBox.attrs.distTop", issues);
+  optionalNumber(attrs, "distBottom", "textBox.attrs.distBottom", issues);
+  optionalNumber(attrs, "distLeft", "textBox.attrs.distLeft", issues);
+  optionalNumber(attrs, "distRight", "textBox.attrs.distRight", issues);
+  optionalOneOf(
+    attrs,
     "_docxPlacement",
     "textBox.attrs._docxPlacement",
     issues,

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-textbox-wrap.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Ensures DOCX-imported text boxes carry their wrap attributes (wrapType,
+ * wrapText, dist*, displayMode, cssFloat) into the PM `textBox` node so the
+ * page renderer can build floating exclusion rects (eigenpal #474). Without
+ * this mapping the imported text box would stay with the schema default
+ * `wrapType: 'inline'` and the renderer would never wrap body text around it.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Document } from "../../types/document";
+import { toProseDoc } from "./toProseDoc";
+
+type TextBoxAttrs = Record<string, unknown>;
+
+function textBoxAttrsFromImport(args: {
+  wrapType:
+    | "inline"
+    | "square"
+    | "tight"
+    | "through"
+    | "topAndBottom"
+    | "behind"
+    | "inFront";
+  wrapText?: "bothSides" | "left" | "right" | "largest";
+  hAlign?: "left" | "right" | "center";
+  distTEmu?: number;
+  distBEmu?: number;
+  distLEmu?: number;
+  distREmu?: number;
+}): TextBoxAttrs {
+  const document: Document = {
+    package: {
+      document: {
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "run",
+                content: [
+                  {
+                    type: "shape",
+                    shape: {
+                      type: "shape",
+                      shapeType: "textBox",
+                      size: { width: 914_400, height: 457_200 },
+                      position: {
+                        horizontal: {
+                          relativeTo: "column",
+                          ...(args.hAlign ? { alignment: args.hAlign } : {}),
+                        },
+                        vertical: { relativeTo: "paragraph" },
+                      },
+                      wrap: {
+                        type: args.wrapType,
+                        ...(args.wrapText ? { wrapText: args.wrapText } : {}),
+                        ...(args.distTEmu !== undefined
+                          ? { distT: args.distTEmu }
+                          : {}),
+                        ...(args.distBEmu !== undefined
+                          ? { distB: args.distBEmu }
+                          : {}),
+                        ...(args.distLEmu !== undefined
+                          ? { distL: args.distLEmu }
+                          : {}),
+                        ...(args.distREmu !== undefined
+                          ? { distR: args.distREmu }
+                          : {}),
+                      },
+                      textBody: {
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [
+                              {
+                                type: "run",
+                                content: [{ type: "text", text: "Body" }],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+
+  const pmDoc = toProseDoc(document);
+  // Standalone text box becomes its own top-level node (the wrapper paragraph
+  // is dropped because it contained only the shape).
+  const textBoxNode = pmDoc.firstChild;
+  if (!textBoxNode || textBoxNode.type.name !== "textBox") {
+    throw new Error(
+      `Expected first child to be textBox, got ${textBoxNode?.type.name}`,
+    );
+  }
+  return textBoxNode.attrs as TextBoxAttrs;
+}
+
+describe("toProseDoc propagates text-box wrap attributes", () => {
+  test("wrap='square' + wrapText='right' becomes a left-floating wrap", () => {
+    const attrs = textBoxAttrsFromImport({
+      wrapType: "square",
+      wrapText: "right",
+      distLEmu: 114_300, // ~12px at 96dpi
+      distREmu: 114_300,
+    });
+
+    expect(attrs["wrapType"]).toBe("square");
+    expect(attrs["wrapText"]).toBe("right");
+    expect(attrs["displayMode"]).toBe("float");
+    expect(attrs["cssFloat"]).toBe("left");
+    expect(attrs["distLeft"]).toBe(12);
+    expect(attrs["distRight"]).toBe(12);
+  });
+
+  test("wrap='tight' + wrapText='left' becomes a right-floating wrap", () => {
+    const attrs = textBoxAttrsFromImport({
+      wrapType: "tight",
+      wrapText: "left",
+    });
+
+    expect(attrs["wrapType"]).toBe("tight");
+    expect(attrs["wrapText"]).toBe("left");
+    expect(attrs["displayMode"]).toBe("float");
+    expect(attrs["cssFloat"]).toBe("right");
+  });
+
+  test("wrap='topAndBottom' becomes a block (no float)", () => {
+    const attrs = textBoxAttrsFromImport({ wrapType: "topAndBottom" });
+
+    expect(attrs["wrapType"]).toBe("topAndBottom");
+    expect(attrs["displayMode"]).toBe("block");
+    expect(attrs["cssFloat"]).toBe("none");
+  });
+
+  test("wrap='behind' becomes a float (anchored, paints over text)", () => {
+    const attrs = textBoxAttrsFromImport({ wrapType: "behind" });
+
+    expect(attrs["wrapType"]).toBe("behind");
+    expect(attrs["displayMode"]).toBe("float");
+  });
+
+  test("wrap='inline' stays inline", () => {
+    const attrs = textBoxAttrsFromImport({ wrapType: "inline" });
+
+    expect(attrs["wrapType"]).toBe("inline");
+    expect(attrs["displayMode"]).toBe("inline");
+    expect(attrs["cssFloat"]).toBe("none");
+  });
+
+  test("wrap='square' without wrapText falls back to position alignment", () => {
+    const attrs = textBoxAttrsFromImport({
+      wrapType: "square",
+      hAlign: "right",
+    });
+
+    expect(attrs["cssFloat"]).toBe("right");
+    expect(attrs["displayMode"]).toBe("float");
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2580,6 +2580,64 @@ function convertTextBox(
     contentNodes.push(schema.node("paragraph", {}, []));
   }
 
+  // Map wrap settings into the PM textBox attrs so the page renderer can
+  // build floating exclusion rects for body text wrapping (eigenpal #474).
+  // Mirrors the float/displayMode derivation used by `convertImage` above.
+  const wrapType = textBox.wrap?.type;
+  const wrapText = textBox.wrap?.wrapText;
+  const hAlign = textBox.position?.horizontal.alignment;
+
+  let cssFloat: "left" | "right" | "none" | undefined;
+  if (wrapType === undefined || wrapType === "inline") {
+    cssFloat = "none";
+  } else if (wrapType === "topAndBottom") {
+    cssFloat = "none";
+  } else if (
+    wrapType === "square" ||
+    wrapType === "tight" ||
+    wrapType === "through"
+  ) {
+    if (wrapText === "left") {
+      cssFloat = "right";
+    } else if (wrapText === "right") {
+      cssFloat = "left";
+    } else if (hAlign === "left") {
+      cssFloat = "left";
+    } else if (hAlign === "right") {
+      cssFloat = "right";
+    } else {
+      cssFloat = "none";
+    }
+  } else {
+    cssFloat = "none";
+  }
+
+  let displayMode: "inline" | "block" | "float";
+  if (wrapType === undefined || wrapType === "inline") {
+    displayMode = "inline";
+  } else if (wrapType === "topAndBottom") {
+    displayMode = "block";
+  } else if (wrapType === "behind" || wrapType === "inFront") {
+    displayMode = "float";
+  } else if (cssFloat !== "none") {
+    displayMode = "float";
+  } else {
+    displayMode = "block";
+  }
+
+  const distTop = textBox.wrap?.distT
+    ? emuToPixels(textBox.wrap.distT)
+    : undefined;
+  const distBottom = textBox.wrap?.distB
+    ? emuToPixels(textBox.wrap.distB)
+    : undefined;
+  const distLeft = textBox.wrap?.distL
+    ? emuToPixels(textBox.wrap.distL)
+    : undefined;
+  const distRight = textBox.wrap?.distR
+    ? emuToPixels(textBox.wrap.distR)
+    : undefined;
+
   return schema.node(
     "textBox",
     {
@@ -2594,6 +2652,14 @@ function convertTextBox(
       marginBottom,
       marginLeft,
       marginRight,
+      displayMode,
+      cssFloat,
+      wrapType: wrapType ?? "inline",
+      wrapText,
+      distTop,
+      distBottom,
+      distLeft,
+      distRight,
       _docxPlacement: options.placement,
       _docxGroupId: options.groupId,
     },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/TextBoxExtension.ts
@@ -40,6 +40,16 @@ export type TextBoxAttrs = {
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
   wrapType?: string;
+  /** OOXML wrapText direction for anchored text boxes (eigenpal #474). */
+  wrapText?: "bothSides" | "left" | "right" | "largest";
+  /** Wrap distance from top edge, in pixels (OOXML distT, EMU-converted). */
+  distTop?: number;
+  /** Wrap distance from bottom edge, in pixels. */
+  distBottom?: number;
+  /** Wrap distance from left edge, in pixels. */
+  distLeft?: number;
+  /** Wrap distance from right edge, in pixels. */
+  distRight?: number;
   /** Original DOCX placement hint for save-path reconstruction. */
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */
@@ -70,6 +80,11 @@ export const TextBoxExtension = createNodeExtension({
       displayMode: { default: "inline" },
       cssFloat: { default: null },
       wrapType: { default: "inline" },
+      wrapText: { default: null },
+      distTop: { default: null },
+      distBottom: { default: null },
+      distLeft: { default: null },
+      distRight: { default: null },
       _docxPlacement: { default: null },
       _docxGroupId: { default: null },
     },
@@ -118,6 +133,17 @@ export const TextBoxExtension = createNodeExtension({
                 }
               : {}),
             ...(d["wrapType"] ? { wrapType: d["wrapType"] } : {}),
+            ...(d["wrapText"]
+              ? {
+                  wrapText: d["wrapText"] as NonNullable<
+                    TextBoxAttrs["wrapText"]
+                  >,
+                }
+              : {}),
+            ...(d["distTop"] ? { distTop: Number(d["distTop"]) } : {}),
+            ...(d["distBottom"] ? { distBottom: Number(d["distBottom"]) } : {}),
+            ...(d["distLeft"] ? { distLeft: Number(d["distLeft"]) } : {}),
+            ...(d["distRight"] ? { distRight: Number(d["distRight"]) } : {}),
           };
         },
       },
@@ -173,6 +199,21 @@ export const TextBoxExtension = createNodeExtension({
       }
       if (attrs.wrapType) {
         domAttrs["data-wrap-type"] = attrs.wrapType;
+      }
+      if (attrs.wrapText) {
+        domAttrs["data-wrap-text"] = attrs.wrapText;
+      }
+      if (typeof attrs.distTop === "number") {
+        domAttrs["data-dist-top"] = String(attrs.distTop);
+      }
+      if (typeof attrs.distBottom === "number") {
+        domAttrs["data-dist-bottom"] = String(attrs.distBottom);
+      }
+      if (typeof attrs.distLeft === "number") {
+        domAttrs["data-dist-left"] = String(attrs.distLeft);
+      }
+      if (typeof attrs.distRight === "number") {
+        domAttrs["data-dist-right"] = String(attrs.distRight);
       }
 
       // Build inline styles

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -394,6 +394,16 @@ export type TextBoxAttrs = {
   cssFloat?: "left" | "right" | "none";
   /** Wrap type */
   wrapType?: string;
+  /** OOXML wrapText direction for anchored text boxes (eigenpal #474). */
+  wrapText?: "bothSides" | "left" | "right" | "largest";
+  /** Wrap distance from top edge, in pixels (OOXML distT, EMU-converted). */
+  distTop?: number;
+  /** Wrap distance from bottom edge, in pixels. */
+  distBottom?: number;
+  /** Wrap distance from left edge, in pixels. */
+  distLeft?: number;
+  /** Wrap distance from right edge, in pixels. */
+  distRight?: number;
   /** Original DOCX placement hint for save-path reconstruction. */
   _docxPlacement?: "standalone" | "inlineWithPrevious";
   /** Original DOCX paragraph group for standalone text-box reconstruction. */


### PR DESCRIPTION
## Summary

Replaces #509 (auto-closed by GitHub after a botched rebase push). Ports the flow/measurement half of eigenpal docx-editor #474 — body text in folio used to render straight through anchored text boxes because `renderPage`'s `extractFloatingImagesFromParagraph` had no text-box analogue.

- Extracts floating-zone helpers (`rectsToFloatingZones`, `getFloatingMargins`, `getFloatingAvailableWidth`, `clampFloatingWrapMargins`) into shared `floatingZones.ts` so anchored text boxes contribute `FloatingExclusionRect`s through the same pipeline as floating images
- Adds `wrapTypes` predicates (shared with image classification) and `textBoxFlow` predicates (gate which boxes contribute exclusions)
- `TextBoxBlock` now carries `wrapType`/`wrapText`/`dist{Top,Bottom,Left,Right}`/`displayMode`/`cssFloat`/`position` end-to-end from PM attrs through the renderer

## Test plan

- [x] Folio tests pass locally
- [x] Lint + typecheck clean
- [ ] CI green