### PR TITLE
chore(api): replace ioredis with Bun's native Redis client

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -82,7 +82,6 @@
     "drizzle-orm": "catalog:",
     "elysia": "catalog:",
     "elysia-rate-limit": "^4.6.2",
-    "ioredis": "^5.10.1",
     "jose": "^6.2.3",
     "jszip": "catalog:",
     "nodemailer": "^8.0.8",

--- a/apps/api/src/lib/file-derivative-queue.ts
+++ b/apps/api/src/lib/file-derivative-queue.ts
@@ -1,11 +1,9 @@
 import { Result } from "better-result";
 import { Queue, Worker } from "bullmq";
 import { and, eq, sql } from "drizzle-orm";
-import Redis from "ioredis";
 
 import { fields } from "@/api/db/schema";
 import type { FieldContent } from "@/api/db/schema-validators";
-import { env } from "@/api/env";
 import {
   convertToPdf,
   shouldGeneratePdfDerivative,
@@ -15,7 +13,7 @@ import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
-import { redisConnectionOptions } from "@/api/lib/redis-options";
+import { createBullMqConnection } from "@/api/lib/redis-client";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import { getS3 } from "@/api/lib/s3";
 import {
@@ -52,19 +50,16 @@ type EnqueuePdfDerivativeArgs = {
 };
 
 let queue: Queue<PdfDerivativeJobData> | null = null;
-let redisClient: Redis | null = null;
+let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
 
-const getRedis = (): Redis => {
-  redisClient ??= new Redis(env.REDIS_URL, {
-    ...redisConnectionOptions(),
-    maxRetriesPerRequest: null,
-  });
-  return redisClient;
+const getQueueConnection = () => {
+  queueConnection ??= createBullMqConnection();
+  return queueConnection;
 };
 
 const getQueue = (): Queue<PdfDerivativeJobData> => {
   queue ??= new Queue<PdfDerivativeJobData>(QUEUE_NAME, {
-    connection: getRedis(),
+    connection: getQueueConnection(),
     defaultJobOptions: {
       attempts: DEFAULT_JOB_ATTEMPTS,
       backoff: { type: "exponential", delay: 30_000 },
@@ -131,10 +126,9 @@ export const enqueuePdfDerivativeOrMarkFailed = async (
 };
 
 export const initFileDerivativeWorker = () => {
-  const workerConnection = new Redis(env.REDIS_URL, {
-    ...redisConnectionOptions(),
-    maxRetriesPerRequest: null,
-  });
+  // BullMQ workers use blocking commands and need a dedicated connection
+  // separate from the queue's. Create a fresh raw client per worker init.
+  const workerConnection = createBullMqConnection();
 
   const worker = new Worker<PdfDerivativeJobData>(
     QUEUE_NAME,

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -1,37 +1,47 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-// A controllable fake of ioredis: `redisDown` toggles whether get/set
-// reject, simulating an unreachable Redis without real I/O.
+// A controllable fake of Bun's RedisClient: `redisDown` toggles whether
+// get/set reject, simulating an unreachable Redis without real I/O.
+// `commandLatencyMs` makes commands hang for the test, exercising the
+// per-command timeout that auth-storage layers on top of the client.
 let redisDown = false;
+let commandLatencyMs = 0;
 const redisStore = new Map<string, string>();
-const redisConstructorOptions: unknown[] = [];
 
-class FakeRedis {
-  constructor(_url: string, options: unknown) {
-    redisConstructorOptions.push(options);
-  }
+class FakeRedisClient {
+  onclose: ((error: Error) => void) | null = null;
+  onconnect: (() => void) | null = null;
 
-  on(): this {
-    return this;
+  private async maybeDelay<T>(value: T): Promise<T> {
+    if (commandLatencyMs > 0) {
+      return new Promise<T>((resolve) => {
+        setTimeout(() => {
+          resolve(value);
+        }, commandLatencyMs);
+      });
+    }
+    return value;
   }
 
   async get(key: string): Promise<string | null> {
     if (redisDown) {
       throw new Error("redis unreachable");
     }
-    return redisStore.get(key) ?? null;
+    return this.maybeDelay(redisStore.get(key) ?? null);
   }
 
-  async set(key: string, value: string): Promise<string> {
+  async set(key: string, value: string): Promise<"OK"> {
     if (redisDown) {
       throw new Error("redis unreachable");
     }
     redisStore.set(key, value);
-    return "OK";
+    return this.maybeDelay("OK" as const);
   }
 }
 
-void mock.module("ioredis", () => ({ default: FakeRedis }));
+void mock.module("@/api/lib/redis-client", () => ({
+  createRedisClient: () => new FakeRedisClient(),
+}));
 
 const { createAuthRateLimitStorage } =
   await import("@/api/lib/rate-limit/auth-storage");
@@ -45,8 +55,8 @@ const value = (count: number, lastRequest = 1000) => ({
 describe("auth rate-limit storage", () => {
   beforeEach(() => {
     redisDown = false;
+    commandLatencyMs = 0;
     redisStore.clear();
-    redisConstructorOptions.length = 0;
   });
 
   test("round-trips through Redis when it is reachable", async () => {
@@ -61,18 +71,6 @@ describe("auth rate-limit storage", () => {
     const storage = createAuthRateLimitStorage(60_000);
 
     expect(await storage.get("ip:9.9.9.9")).toBeNull();
-  });
-
-  test("configures Redis commands to fail fast", () => {
-    createAuthRateLimitStorage(60_000);
-
-    expect(redisConstructorOptions.at(0)).toMatchObject({
-      commandTimeout: 500,
-      connectTimeout: 500,
-      enableOfflineQueue: false,
-      lazyConnect: true,
-      maxRetriesPerRequest: 1,
-    });
   });
 
   test("fails open: a get after Redis goes down reads the fallback", async () => {
@@ -131,5 +129,25 @@ describe("auth rate-limit storage", () => {
     expect(redisStore.get("auth:ratelimit:ip:1.2.3.4")).toBe(
       JSON.stringify(value(6, 2000)),
     );
+  });
+
+  test("fails open when a Redis command hangs past the timeout", async () => {
+    const storage = createAuthRateLimitStorage(60_000);
+
+    // Warm the fallback.
+    await storage.set("ip:1.2.3.4", value(8));
+
+    // Now make Redis "hang" — get() will not resolve. The per-command
+    // timeout must reject internally and the storage must surface the
+    // fallback value within a bounded window.
+    commandLatencyMs = 5000;
+    const start = Date.now();
+    const result = await storage.get("ip:1.2.3.4");
+    const elapsed = Date.now() - start;
+
+    expect(result).toEqual(value(8));
+    // 500ms timeout + scheduler slack. If this fails, the timeout
+    // wrapper has regressed and auth could hang on a slow Redis.
+    expect(elapsed).toBeLessThan(1500);
   });
 });

--- a/apps/api/src/lib/rate-limit/auth-storage.test.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test, vi } from "bun:test";
 
 // A controllable fake of Bun's RedisClient: `redisDown` toggles whether
 // get/set reject, simulating an unreachable Redis without real I/O.
@@ -149,5 +149,20 @@ describe("auth rate-limit storage", () => {
     // 500ms timeout + scheduler slack. If this fails, the timeout
     // wrapper has regressed and auth could hang on a slow Redis.
     expect(elapsed).toBeLessThan(1500);
+  });
+
+  test("clears command timeout timers after Redis resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const storage = createAuthRateLimitStorage(60_000);
+      const baselineTimers = vi.getTimerCount();
+
+      await storage.set("ip:1.2.3.4", value(9));
+
+      expect(vi.getTimerCount()).toBe(baselineTimers);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -54,13 +54,18 @@ const isStricterRateLimitValue = (
     candidate.lastRequest > current.lastRequest);
 
 const withCommandTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_resolve, reject) => {
-    setTimeout(
+    timeoutId = setTimeout(
       () => reject(new Error("redis command timeout")),
       COMMAND_TIMEOUT_MS,
     );
   });
-  return await Promise.race([promise, timeout]);
+  return await Promise.race([promise, timeout]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  });
 };
 
 /**

--- a/apps/api/src/lib/rate-limit/auth-storage.ts
+++ b/apps/api/src/lib/rate-limit/auth-storage.ts
@@ -10,21 +10,16 @@
  * per-process Map (the previous behaviour) instead of blocking auth. A
  * Redis outage must never hard-lock sign-in.
  */
-import Redis from "ioredis";
-
-import { env } from "@/api/env";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
-import { redisConnectionOptions } from "@/api/lib/redis-options";
+import { createRedisClient } from "@/api/lib/redis-client";
 
-/** Value better-auth persists per rate-limit key. */
 type RateLimitValue = {
   key: string;
   count: number;
   lastRequest: number;
 };
 
-/** The get/set contract better-auth's `customStorage` option expects. */
 type AuthRateLimitStorage = {
   get: (key: string) => Promise<RateLimitValue | null>;
   set: (key: string, value: RateLimitValue) => Promise<void>;
@@ -32,6 +27,13 @@ type AuthRateLimitStorage = {
 
 const REDIS_KEY_PREFIX = "auth:ratelimit:";
 const FALLBACK_CLEANUP_INTERVAL_MS = 60_000;
+/**
+ * Bound every Redis command so a slow or unreachable Redis cannot stall
+ * an auth request. Bun's RedisClient has no built-in commandTimeout, so
+ * we race the command against a timer and degrade to the fallback Map
+ * if it does not resolve in time.
+ */
+const COMMAND_TIMEOUT_MS = 500;
 
 const isRateLimitValue = (value: unknown): value is RateLimitValue =>
   typeof value === "object" &&
@@ -51,6 +53,16 @@ const isStricterRateLimitValue = (
   (candidate.count === current.count &&
     candidate.lastRequest > current.lastRequest);
 
+const withCommandTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+  const timeout = new Promise<never>((_resolve, reject) => {
+    setTimeout(
+      () => reject(new Error("redis command timeout")),
+      COMMAND_TIMEOUT_MS,
+    );
+  });
+  return await Promise.race([promise, timeout]);
+};
+
 /**
  * Build the better-auth rate-limit storage. `ttlMs` is the longest
  * rate-limit window; it expires both Redis keys and fallback entries.
@@ -58,21 +70,13 @@ const isStricterRateLimitValue = (
 export const createAuthRateLimitStorage = (
   ttlMs: number,
 ): AuthRateLimitStorage => {
-  const redis = new Redis(env.REDIS_URL, {
-    ...redisConnectionOptions(),
-    lazyConnect: true,
-    // Bound every command so a slow or unreachable Redis cannot stall
-    // an auth request; a timed-out command rejects and falls back.
-    connectTimeout: 500,
-    commandTimeout: 500,
+  const redis = createRedisClient({
+    connectionTimeout: COMMAND_TIMEOUT_MS,
     enableOfflineQueue: false,
-    maxRetriesPerRequest: 1,
   });
-  redis.on("error", () => {
-    // Connection errors are handled per-command below (fail-open to the
-    // fallback Map). This listener only exists so an unhandled 'error'
-    // event cannot crash the process.
-  });
+  // Bun's RedisClient surfaces connection loss via the onclose callback
+  // and exposes errors through rejected commands. Leaving onclose unset
+  // is safe; per-command rejections drive the fail-open path below.
 
   type FallbackEntry = { value: RateLimitValue; expiresAt: number };
   const fallback = new Map<string, FallbackEntry>();
@@ -95,11 +99,13 @@ export const createAuthRateLimitStorage = (
   };
 
   const writeRedis = async (key: string, value: RateLimitValue) => {
-    await redis.set(
-      `${REDIS_KEY_PREFIX}${key}`,
-      JSON.stringify(value),
-      "PX",
-      ttlMs,
+    await withCommandTimeout(
+      redis.set(
+        `${REDIS_KEY_PREFIX}${key}`,
+        JSON.stringify(value),
+        "PX",
+        ttlMs,
+      ),
     );
   };
 
@@ -107,7 +113,9 @@ export const createAuthRateLimitStorage = (
     get: async (key) => {
       try {
         const fallbackValue = readFallback(key);
-        const raw = await redis.get(`${REDIS_KEY_PREFIX}${key}`);
+        const raw = await withCommandTimeout(
+          redis.get(`${REDIS_KEY_PREFIX}${key}`),
+        );
         if (raw === null) {
           return fallbackValue;
         }

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -4,8 +4,22 @@ import { type RedisOptions, RedisClient } from "bun";
 import { env } from "@/api/env";
 import { redisConnectionOptions } from "@/api/lib/redis-options";
 
-export const createRedisClient = (overrides?: RedisOptions): RedisClient =>
-  new RedisClient(env.REDIS_URL, { ...redisConnectionOptions(), ...overrides });
+type StellaRedisClient = RedisClient & {
+  readonly url: string;
+};
+
+class ConfiguredRedisClient extends RedisClient {
+  readonly url: string;
+
+  constructor(url = env.REDIS_URL, overrides?: RedisOptions) {
+    super(url, { ...redisConnectionOptions(url), ...overrides });
+    this.url = url;
+  }
+}
+
+export const createRedisClient = (
+  overrides?: RedisOptions,
+): StellaRedisClient => new ConfiguredRedisClient(env.REDIS_URL, overrides);
 
 /**
  * Build a BullMQ connection wrapped around a freshly-constructed Bun
@@ -18,11 +32,11 @@ export const createBullMqConnection = (): ReturnType<
 > => {
   const raw = createRedisClient();
   // SAFETY: structural mismatch between BullMQ's BunRedisRawClient
-  // (onconnect/onclose typed as non-nullable functions) and Bun's
-  // RedisClient (typed as nullable). At runtime Bun's client satisfies
-  // the interface — BullMQ's adapter only assigns these callbacks, it
-  // never invokes them as non-null functions, so the looser Bun typing
-  // is sound.
+  // (callback properties are optional functions) and Bun's RedisClient
+  // (callback properties may be null). ConfiguredRedisClient also
+  // exposes `url`, which BullMQ's Bun adapter uses when duplicating or
+  // reconnecting raw clients, so TLS/options from redisConnectionOptions
+  // are preserved by the subclass constructor.
   // eslint-disable-next-line typescript/no-unsafe-type-assertion
   return createBunRedisClient(raw as unknown as BunRedisRawClient);
 };

--- a/apps/api/src/lib/redis-client.ts
+++ b/apps/api/src/lib/redis-client.ts
@@ -1,0 +1,28 @@
+import { type BunRedisRawClient, createBunRedisClient } from "bullmq";
+import { type RedisOptions, RedisClient } from "bun";
+
+import { env } from "@/api/env";
+import { redisConnectionOptions } from "@/api/lib/redis-options";
+
+export const createRedisClient = (overrides?: RedisOptions): RedisClient =>
+  new RedisClient(env.REDIS_URL, { ...redisConnectionOptions(), ...overrides });
+
+/**
+ * Build a BullMQ connection wrapped around a freshly-constructed Bun
+ * RedisClient. BullMQ's adapter assigns onconnect/onclose on the raw
+ * client, so a wrapped connection must own its raw client — never share
+ * one with code that uses the client directly.
+ */
+export const createBullMqConnection = (): ReturnType<
+  typeof createBunRedisClient
+> => {
+  const raw = createRedisClient();
+  // SAFETY: structural mismatch between BullMQ's BunRedisRawClient
+  // (onconnect/onclose typed as non-nullable functions) and Bun's
+  // RedisClient (typed as nullable). At runtime Bun's client satisfies
+  // the interface — BullMQ's adapter only assigns these callbacks, it
+  // never invokes them as non-null functions, so the looser Bun typing
+  // is sound.
+  // eslint-disable-next-line typescript/no-unsafe-type-assertion
+  return createBunRedisClient(raw as unknown as BunRedisRawClient);
+};

--- a/apps/api/src/lib/redis-options.ts
+++ b/apps/api/src/lib/redis-options.ts
@@ -11,7 +11,7 @@
  * small enough that a MITM would already be inside the VPC.
  */
 
-import type { RedisOptions } from "ioredis";
+import type { RedisOptions } from "bun";
 
 import { env } from "@/api/env";
 

--- a/apps/api/src/lib/redis-options.ts
+++ b/apps/api/src/lib/redis-options.ts
@@ -15,7 +15,7 @@ import type { RedisOptions } from "bun";
 
 import { env } from "@/api/env";
 
-export const redisConnectionOptions = (): RedisOptions => {
-  const useTls = env.REDIS_URL.toLowerCase().startsWith("rediss://");
+export const redisConnectionOptions = (url = env.REDIS_URL): RedisOptions => {
+  const useTls = url.toLowerCase().startsWith("rediss://");
   return useTls ? { tls: { rejectUnauthorized: false } } : {};
 };

--- a/apps/api/src/lib/scheduler/bullmq.ts
+++ b/apps/api/src/lib/scheduler/bullmq.ts
@@ -1,12 +1,11 @@
 import { Queue } from "bullmq";
-import Redis from "ioredis";
 
-import { env } from "@/api/env";
 import { ConfigurationError } from "@/api/lib/errors/tagged-errors";
+import { createBullMqConnection } from "@/api/lib/redis-client";
 import type { SchedulerTask } from "@/api/lib/scheduler/types";
 
 type QueueCache = {
-  redis: Redis | null;
+  connection: ReturnType<typeof createBullMqConnection> | null;
   queues: Map<string, Queue>;
 };
 
@@ -17,7 +16,7 @@ type BullMqSchedulerPayload = {
 };
 
 const cache: QueueCache = {
-  redis: null,
+  connection: null,
   queues: new Map(),
 };
 
@@ -38,9 +37,9 @@ export const createBullMqDispatchTask =
     });
   };
 
-const getRedis = (): Redis => {
-  cache.redis ??= new Redis(env.REDIS_URL, { maxRetriesPerRequest: null });
-  return cache.redis;
+const getConnection = () => {
+  cache.connection ??= createBullMqConnection();
+  return cache.connection;
 };
 
 const getSchedulerQueue = (queueName: string): Queue => {
@@ -50,7 +49,7 @@ const getSchedulerQueue = (queueName: string): Queue => {
   }
 
   const queue = new Queue(queueName, {
-    connection: getRedis(),
+    connection: getConnection(),
     defaultJobOptions: {
       attempts: 3,
       backoff: { type: "exponential", delay: 30_000 },

--- a/apps/api/src/lib/sse.ts
+++ b/apps/api/src/lib/sse.ts
@@ -1,10 +1,7 @@
-import Redis from "ioredis";
-
-import { env } from "@/api/env";
 import type { SafeId } from "@/api/lib/branded-types";
 import { errorTag } from "@/api/lib/errors/utils";
 import { logger } from "@/api/lib/observability/logger";
-import { redisConnectionOptions } from "@/api/lib/redis-options";
+import { createRedisClient } from "@/api/lib/redis-client";
 import {
   brandPersistedDesktopEditSessionId,
   brandPersistedOrganizationId,
@@ -186,48 +183,43 @@ const parseRedisPayload = (raw: string): RedisPayload | null => {
   };
 };
 
-const publisher = new Redis(env.REDIS_URL, {
-  ...redisConnectionOptions(),
-  lazyConnect: true,
-});
-const subscriber = new Redis(env.REDIS_URL, {
-  ...redisConnectionOptions(),
-  lazyConnect: true,
-});
+// Bun's pub/sub puts a connection into a subscribed mode that monopolises
+// it, so the subscriber must be a separate client from the publisher.
+const publisher = createRedisClient();
+
+const handleMessage = (message: string) => {
+  try {
+    const parsed = parseRedisPayload(message);
+    if (!parsed) {
+      return;
+    }
+    if (parsed.scope === "workspace") {
+      broadcastLocal(brandPersistedWorkspaceId(parsed.id), parsed.event);
+    } else if (parsed.scope === "organization") {
+      broadcastLocalToOrganization(
+        brandPersistedOrganizationId(parsed.id),
+        parsed.event,
+      );
+    } else if (parsed.originInstanceId !== INSTANCE_ID) {
+      sessionDeliveryHandler?.(
+        brandPersistedDesktopEditSessionId(parsed.id),
+        parsed.event,
+      );
+    }
+  } catch (error) {
+    logger.warn("sse.invalid_redis_message", {
+      "error.type": errorTag(error),
+      "payload.bytes": message.length,
+    });
+  }
+};
 
 const initRedis = async () => {
   try {
-    await Promise.all([publisher.connect(), subscriber.connect()]);
-
-    await subscriber.subscribe(REDIS_CHANNEL);
-
-    subscriber.on("message", (_channel: string, message: string) => {
-      try {
-        const parsed = parseRedisPayload(message);
-        if (!parsed) {
-          return;
-        }
-        if (parsed.scope === "workspace") {
-          broadcastLocal(brandPersistedWorkspaceId(parsed.id), parsed.event);
-        } else if (parsed.scope === "organization") {
-          broadcastLocalToOrganization(
-            brandPersistedOrganizationId(parsed.id),
-            parsed.event,
-          );
-        } else if (parsed.originInstanceId !== INSTANCE_ID) {
-          sessionDeliveryHandler?.(
-            brandPersistedDesktopEditSessionId(parsed.id),
-            parsed.event,
-          );
-        }
-      } catch (error) {
-        logger.warn("sse.invalid_redis_message", {
-          "error.type": errorTag(error),
-          "payload.bytes": message.length,
-        });
-      }
+    const subscriber = await publisher.duplicate();
+    await subscriber.subscribe(REDIS_CHANNEL, (message) => {
+      handleMessage(message);
     });
-
     logger.info("sse.redis_connected", { channel: REDIS_CHANNEL });
   } catch (error: unknown) {
     logger.error("sse.redis_connection_failed", {

--- a/apps/api/src/lib/workflow-queue.ts
+++ b/apps/api/src/lib/workflow-queue.ts
@@ -1,8 +1,8 @@
 import { matchError, panic, Result } from "better-result";
 import { Queue, Worker } from "bullmq";
+import type { RedisClient } from "bun";
 import { sleep } from "bun";
 import { and, asc, eq, gt, inArray, or, sql } from "drizzle-orm";
-import Redis from "ioredis";
 
 import { isMockAI } from "@/api/consts";
 import type { ScopedDb } from "@/api/db";
@@ -15,7 +15,6 @@ import {
   properties,
 } from "@/api/db/schema";
 import type { EntityKind, FieldContent } from "@/api/db/schema-validators";
-import { env } from "@/api/env";
 import {
   loadOrgAIConfig,
   loadPromptCachingPreference,
@@ -27,7 +26,10 @@ import { acquireCellLocks } from "@/api/lib/cell-lock";
 import { errorTag } from "@/api/lib/errors/utils";
 import { LIMITS } from "@/api/lib/limits";
 import { logger } from "@/api/lib/observability/logger";
-import { redisConnectionOptions } from "@/api/lib/redis-options";
+import {
+  createBullMqConnection,
+  createRedisClient,
+} from "@/api/lib/redis-client";
 import { createRootScopedDb } from "@/api/lib/root-scoped-db";
 import {
   brandPersistedEntityId,
@@ -102,19 +104,22 @@ type EntityJobData = {
 // ── Public API ─────────────────────────────────────────
 
 let queue: Queue | null = null;
-let redisClient: Redis | null = null;
+let queueConnection: ReturnType<typeof createBullMqConnection> | null = null;
+let redisClient: RedisClient | null = null;
 
-const getRedis = (): Redis => {
-  redisClient ??= new Redis(env.REDIS_URL, {
-    ...redisConnectionOptions(),
-    maxRetriesPerRequest: null,
-  });
+const getQueueConnection = () => {
+  queueConnection ??= createBullMqConnection();
+  return queueConnection;
+};
+
+const getRedis = (): RedisClient => {
+  redisClient ??= createRedisClient();
   return redisClient;
 };
 
 const getQueue = (): Queue => {
   queue ??= new Queue(QUEUE_NAME, {
-    connection: getRedis(),
+    connection: getQueueConnection(),
     defaultJobOptions: {
       removeOnComplete: 100,
       removeOnFail: 500,
@@ -129,7 +134,7 @@ const getQueue = (): Queue => {
 };
 
 const clearWorkflowRunState = async (
-  redis: Redis,
+  redis: RedisClient,
   workspaceId: SafeId<"workspace">,
 ): Promise<void> => {
   await redis.del(
@@ -491,7 +496,7 @@ export const startWorkflow = async ({
     workflowKey(workspaceId, "running"),
     "1",
     "EX",
-    RUNNING_LOCK_TTL_SEC,
+    String(RUNNING_LOCK_TTL_SEC),
     "NX",
   );
   if (!wasSet) {
@@ -672,10 +677,7 @@ export const startWorkflow = async ({
 export const initWorkflowWorker = () => {
   // BullMQ Worker uses blocking commands (BRPOPLPUSH) so it
   // needs a dedicated Redis connection, not the shared one.
-  const workerConnection = new Redis(env.REDIS_URL, {
-    ...redisConnectionOptions(),
-    maxRetriesPerRequest: null,
-  });
+  const workerConnection = createBullMqConnection();
 
   const worker = new Worker<EntityJobData>(
     QUEUE_NAME,

--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,6 @@
         "drizzle-orm": "catalog:",
         "elysia": "catalog:",
         "elysia-rate-limit": "^4.6.2",
-        "ioredis": "^5.10.1",
         "jose": "^6.2.3",
         "jszip": "catalog:",
         "nodemailer": "^8.0.8",


### PR DESCRIPTION
## Summary

- Drops the direct `ioredis` dependency from `@stll/api`. Bun's built-in `RedisClient` now handles raw commands and pub/sub; BullMQ runs on its new `createBunRedisClient` adapter (BullMQ 5.77+).
- `ioredis` remains as a transitive dep of `bullmq` itself; only direct usage is gone.
- `apps/api/src/lib/redis-client.ts` (new) centralises construction: `createRedisClient(overrides?)` for raw use, `createBullMqConnection()` for queues. The structural cast bridging Bun's nullable `onconnect`/`onclose` and BullMQ's `BunRedisRawClient` non-nullable typings lives here with a `SAFETY:` comment.
- Pub/sub in `sse.ts` uses one publisher and `publisher.duplicate()` for the subscriber, matching Bun's subscribe-mode-monopolises-the-connection contract.
- `rate-limit/auth-storage.ts`: Bun has no `commandTimeout`, so every Redis call is wrapped in a 500ms `Promise.race` timeout to preserve the fail-open guarantee documented in the file header. The test mocks the new redis-client helper and adds a regression test asserting the storage falls back within 1.5 s when Redis hangs.
- `workflow-queue.ts` lock acquisition (`SET ... EX ... NX`) passes the TTL as `String(seconds)` to satisfy Bun's typed overloads; Redis itself takes strings on the wire either way.

## Validation

- `tsgo --noEmit`: clean
- `oxlint --deny-warnings --type-aware apps/api`: clean
- `bun test` in `apps/api`: 2065 / 2065 pass (+1 new timeout regression test)
- Manual smoke against the dev Valkey container: raw `set`/`get`/`del`, `SET ... EX ... NX` lock + TTL, multi-arg `del`, pub/sub via `duplicate()`, and BullMQ enqueue/worker drain end-to-end all pass.

## Test plan

- [ ] Staging: confirm workflow jobs enqueue and drain (`workflow-queue.ts`)
- [ ] Staging: confirm PDF-derivative jobs run (`file-derivative-queue.ts`)
- [ ] Staging: confirm cross-instance SSE delivery (`sse.ts` pub/sub)
- [ ] Staging: confirm auth rate-limit storage round-trips
- [ ] Staging: simulate slow Redis (e.g., add latency) and confirm auth requests fall back within ~500 ms instead of stalling