### PR TITLE
refactor(folio): introduce feature-module registry for layout-painter

### DIFF
--- a/packages/folio/src/core/layout-painter/index.ts
+++ b/packages/folio/src/core/layout-painter/index.ts
@@ -14,19 +14,9 @@ import type {
   Fragment,
   FlowBlock,
   Measure,
-  ParagraphBlock,
-  ParagraphMeasure,
-  ParagraphFragment,
-  TableBlock,
-  TableMeasure,
-  TableFragment,
-  ImageBlock,
-  ImageMeasure,
-  ImageFragment,
-  TextBoxBlock,
-  TextBoxMeasure,
-  TextBoxFragment,
 } from "../layout-engine/types";
+import { createDefaultRegistry } from "./registry/modules";
+import type { FeatureRegistry } from "./registry/registry";
 import { renderFragment, FRAGMENT_CLASS_NAMES } from "./renderFragment";
 import { renderImageFragment, IMAGE_CLASS_NAMES } from "./renderImage";
 import { renderPage, renderPages } from "./renderPage";
@@ -57,6 +47,20 @@ export {
   type RenderContext,
 };
 
+// Re-export feature-module registry surface
+export { createFeatureRegistry } from "./registry/registry";
+export type { FeatureRegistry } from "./registry/registry";
+export { createDefaultRegistry } from "./registry/modules";
+export type {
+  FeatureModule,
+  FeatureRenderInput,
+  FeatureDispatchInput,
+  FeatureFallback,
+  BlockFor,
+  MeasureFor,
+  FragmentFor,
+} from "./registry/types";
+
 /**
  * Block lookup entry for painter
  */
@@ -85,6 +89,12 @@ export type PainterOptions = {
   pageBackground?: string;
   /** Container background color */
   containerBackground?: string;
+  /**
+   * Optional custom feature registry. Defaults to `createDefaultRegistry()`.
+   * Pass a custom registry to swap or extend renderers without subclassing
+   * `LayoutPainter`.
+   */
+  registry?: FeatureRegistry;
 };
 
 /**
@@ -109,10 +119,12 @@ export class LayoutPainter {
   private totalPages = 0;
   private options: PainterOptions;
   private doc: Document;
+  private registry: FeatureRegistry;
 
   constructor(options: PainterOptions = {}) {
     this.options = options;
     this.doc = options.document ?? document;
+    this.registry = options.registry ?? createDefaultRegistry();
   }
 
   /**
@@ -239,72 +251,23 @@ export class LayoutPainter {
   }
 
   /**
-   * Render a fragment using block lookup for full content rendering
+   * Render a fragment via the feature-module registry. Dispatch is O(1)
+   * keyed on `fragment.kind`; modules supply the actual render. Fragments
+   * without a resolved block/measure or with an unregistered kind fall
+   * back to the placeholder renderer (`renderFragment`).
    */
   private renderFragmentWithLookup(
     fragment: Fragment,
     context: RenderContext,
   ): HTMLElement {
     const lookup = this.blockLookup.get(String(fragment.blockId));
-
-    if (fragment.kind === "paragraph" && lookup) {
-      const block = lookup.block as ParagraphBlock;
-      const measure = lookup.measure as ParagraphMeasure;
-      return renderParagraphFragment(
-        fragment as ParagraphFragment,
-        block,
-        measure,
-        context,
-        {
-          document: this.doc,
-        },
-      );
-    }
-
-    if (fragment.kind === "table" && lookup) {
-      const block = lookup.block as TableBlock;
-      const measure = lookup.measure as TableMeasure;
-      return renderTableFragment(
-        fragment as TableFragment,
-        block,
-        measure,
-        context,
-        {
-          document: this.doc,
-        },
-      );
-    }
-
-    if (fragment.kind === "image" && lookup) {
-      const block = lookup.block as ImageBlock;
-      const measure = lookup.measure as ImageMeasure;
-      return renderImageFragment(
-        fragment as ImageFragment,
-        block,
-        measure,
-        context,
-        {
-          document: this.doc,
-        },
-      );
-    }
-
-    if (fragment.kind === "textBox" && lookup) {
-      const block = lookup.block as TextBoxBlock;
-      const measure = lookup.measure as TextBoxMeasure;
-      return renderTextBoxFragment(
-        fragment as TextBoxFragment,
-        block,
-        measure,
-        context,
-        {
-          document: this.doc,
-        },
-      );
-    }
-
-    // Fallback to placeholder for other fragment types
-    return renderFragment(fragment, context, { document: this.doc });
+    return this.registry.render({
+      fragment,
+      block: lookup?.block,
+      measure: lookup?.measure,
+      context,
+      doc: this.doc,
+    });
   }
 
   /**

--- a/packages/folio/src/core/layout-painter/registry/modules.test.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Default-registry composition test. Confirms the registry built by
+ * `createDefaultRegistry` knows every Fragment kind. If a new fragment
+ * kind is added to the union without a matching module, this fails fast.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Fragment } from "../../layout-engine/types";
+import { createDefaultRegistry } from "./modules";
+
+describe("createDefaultRegistry", () => {
+  test("registers a module for every Fragment kind", () => {
+    const registry = createDefaultRegistry();
+    const expectedKinds: readonly Fragment["kind"][] = [
+      "paragraph",
+      "table",
+      "image",
+      "textBox",
+    ];
+    for (const kind of expectedKinds) {
+      expect(registry.has(kind)).toBe(true);
+    }
+  });
+});

--- a/packages/folio/src/core/layout-painter/registry/modules.test.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules.test.ts
@@ -12,13 +12,15 @@ import { createDefaultRegistry } from "./modules";
 describe("createDefaultRegistry", () => {
   test("registers a module for every Fragment kind", () => {
     const registry = createDefaultRegistry();
-    const expectedKinds: readonly Fragment["kind"][] = [
-      "paragraph",
-      "table",
-      "image",
-      "textBox",
-    ];
-    for (const kind of expectedKinds) {
+    const expectedKinds = {
+      paragraph: true,
+      table: true,
+      image: true,
+      textBox: true,
+    } satisfies Record<Fragment["kind"], true>;
+
+    for (const kind of ["paragraph", "table", "image", "textBox"] as const) {
+      expect(expectedKinds[kind]).toBe(true);
       expect(registry.has(kind)).toBe(true);
     }
   });

--- a/packages/folio/src/core/layout-painter/registry/modules.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules.ts
@@ -1,0 +1,26 @@
+/**
+ * Default feature-module registry.
+ *
+ * To add a new OOXML renderer:
+ *   1. Create `modules/<kind>.ts` exporting a `FeatureModule<"...">`.
+ *   2. Add one import + `register(...)` line below.
+ *
+ * Discovery is explicit (not glob-based) so register lines are greppable
+ * and tree-shaking stays deterministic.
+ */
+
+import { imageModule } from "./modules/image";
+import { paragraphModule } from "./modules/paragraph";
+import { tableModule } from "./modules/table";
+import { textBoxModule } from "./modules/textBox";
+import { createFeatureRegistry } from "./registry";
+import type { FeatureRegistry } from "./registry";
+
+export function createDefaultRegistry(): FeatureRegistry {
+  const registry = createFeatureRegistry();
+  registry.register(paragraphModule);
+  registry.register(tableModule);
+  registry.register(imageModule);
+  registry.register(textBoxModule);
+  return registry;
+}

--- a/packages/folio/src/core/layout-painter/registry/modules/image.test.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/image.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Image-module contract test. Verifies the module identifies as "image"
+ * and delegates rendering to `renderImageFragment` (anchored class +
+ * z-index propagate through).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  ImageBlock,
+  ImageFragment,
+  ImageMeasure,
+} from "../../../layout-engine/types";
+import { IMAGE_CLASS_NAMES } from "../../renderImage";
+import type { RenderContext } from "../../renderUtils";
+import { imageModule } from "./image";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  src = "";
+  alt = "";
+  draggable = false;
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+}
+
+const fakeDocument = {
+  createElement(tag: string): FakeElement {
+    return new FakeElement(tag);
+  },
+} as unknown as Document;
+
+const ctx: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+const measure: ImageMeasure = { kind: "image", width: 100, height: 80 };
+
+describe("imageModule", () => {
+  test("identifies itself as the image kind", () => {
+    expect(imageModule.kind).toBe("image");
+  });
+
+  test("renders an inline image fragment with the layout-image class", () => {
+    const fragment: ImageFragment = {
+      kind: "image",
+      blockId: "b1",
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 80,
+    };
+    const block: ImageBlock = {
+      kind: "image",
+      id: "b1",
+      src: "img.png",
+      width: 100,
+      height: 80,
+    };
+
+    const el = imageModule.render({
+      fragment,
+      block,
+      measure,
+      context: ctx,
+      doc: fakeDocument,
+    }) as unknown as FakeElement;
+
+    expect(el.className).toContain(IMAGE_CLASS_NAMES.image);
+    expect(el.className).not.toContain(IMAGE_CLASS_NAMES.imageAnchored);
+    expect(el.dataset["blockId"]).toBe("b1");
+  });
+
+  test("propagates anchored flag + z-index from fragment", () => {
+    const fragment: ImageFragment = {
+      kind: "image",
+      blockId: "b1",
+      x: 10,
+      y: 20,
+      width: 50,
+      height: 50,
+      isAnchored: true,
+      zIndex: 5,
+    };
+    const block: ImageBlock = {
+      kind: "image",
+      id: "b1",
+      src: "img.png",
+      width: 50,
+      height: 50,
+    };
+
+    const el = imageModule.render({
+      fragment,
+      block,
+      measure,
+      context: ctx,
+      doc: fakeDocument,
+    }) as unknown as FakeElement;
+
+    expect(el.className).toContain(IMAGE_CLASS_NAMES.imageAnchored);
+    expect(el.style["zIndex"]).toBe("5");
+  });
+});

--- a/packages/folio/src/core/layout-painter/registry/modules/image.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/image.ts
@@ -1,0 +1,19 @@
+/**
+ * Image feature module — renders `ImageFragment`.
+ *
+ * Thin wrapper over `renderImageFragment`. Kept as a module so the
+ * registry can dispatch image fragments uniformly and so future
+ * variants (e.g. SVG, EMF preview) can plug in alongside.
+ */
+
+import { renderImageFragment } from "../../renderImage";
+import type { FeatureModule } from "../types";
+
+export const imageModule: FeatureModule<"image"> = {
+  kind: "image",
+  render({ fragment, block, measure, context, doc }) {
+    return renderImageFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+  },
+};

--- a/packages/folio/src/core/layout-painter/registry/modules/paragraph.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/paragraph.ts
@@ -1,0 +1,20 @@
+/**
+ * Paragraph feature module — wraps `renderParagraphFragment`.
+ *
+ * The paragraph orchestrator is intentionally still monolithic: it dispatches
+ * paragraph-internal kinds (runs, fields, inline images, hyperlinks). Future
+ * work can split that into a sub-registry without changing this module's
+ * external contract.
+ */
+
+import { renderParagraphFragment } from "../../renderParagraph";
+import type { FeatureModule } from "../types";
+
+export const paragraphModule: FeatureModule<"paragraph"> = {
+  kind: "paragraph",
+  render({ fragment, block, measure, context, doc }) {
+    return renderParagraphFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+  },
+};

--- a/packages/folio/src/core/layout-painter/registry/modules/table.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/table.ts
@@ -1,0 +1,18 @@
+/**
+ * Table feature module — wraps `renderTableFragment`.
+ *
+ * Like paragraph, the table orchestrator still owns row/cell rendering.
+ * Splitting cell-level renderers into a sub-registry is future work.
+ */
+
+import { renderTableFragment } from "../../renderTable";
+import type { FeatureModule } from "../types";
+
+export const tableModule: FeatureModule<"table"> = {
+  kind: "table",
+  render({ fragment, block, measure, context, doc }) {
+    return renderTableFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+  },
+};

--- a/packages/folio/src/core/layout-painter/registry/modules/textBox.test.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/textBox.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Text-box module contract test. Verifies kind discriminator and that
+ * style attributes (fill, border, padding) flow through the module.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  TextBoxBlock,
+  TextBoxFragment,
+  TextBoxMeasure,
+} from "../../../layout-engine/types";
+import { TEXTBOX_CLASS_NAMES } from "../../renderTextBox";
+import type { RenderContext } from "../../renderUtils";
+import { textBoxModule } from "./textBox";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+}
+
+const fakeDocument = {
+  createElement(tag: string): FakeElement {
+    return new FakeElement(tag);
+  },
+} as unknown as Document;
+
+const ctx: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+describe("textBoxModule", () => {
+  test("identifies itself as the textBox kind", () => {
+    expect(textBoxModule.kind).toBe("textBox");
+  });
+
+  test("renders a text box fragment with fill, border, and padding", () => {
+    const fragment: TextBoxFragment = {
+      kind: "textBox",
+      blockId: "tb1",
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+    };
+    const block: TextBoxBlock = {
+      kind: "textBox",
+      id: "tb1",
+      width: 200,
+      height: 100,
+      fillColor: "var(--test-fill)",
+      outlineWidth: 2,
+      outlineColor: "var(--test-outline)",
+      outlineStyle: "solid",
+      margins: { top: 4, right: 6, bottom: 4, left: 6 },
+      content: [],
+    };
+    const measure: TextBoxMeasure = {
+      kind: "textBox",
+      width: 200,
+      height: 100,
+      innerMeasures: [],
+    };
+
+    const el = textBoxModule.render({
+      fragment,
+      block,
+      measure,
+      context: ctx,
+      doc: fakeDocument,
+    }) as unknown as FakeElement;
+
+    expect(el.className).toBe(TEXTBOX_CLASS_NAMES.textBox);
+    expect(el.style["backgroundColor"]).toBe("var(--test-fill)");
+    expect(el.style["border"]).toBe("2px solid var(--test-outline)");
+    expect(el.style["padding"]).toBe("4px 6px 4px 6px");
+    expect(el.dataset["blockId"]).toBe("tb1");
+  });
+});

--- a/packages/folio/src/core/layout-painter/registry/modules/textBox.ts
+++ b/packages/folio/src/core/layout-painter/registry/modules/textBox.ts
@@ -1,0 +1,15 @@
+/**
+ * Text-box feature module — renders `TextBoxFragment`.
+ */
+
+import { renderTextBoxFragment } from "../../renderTextBox";
+import type { FeatureModule } from "../types";
+
+export const textBoxModule: FeatureModule<"textBox"> = {
+  kind: "textBox",
+  render({ fragment, block, measure, context, doc }) {
+    return renderTextBoxFragment(fragment, block, measure, context, {
+      document: doc,
+    });
+  },
+};

--- a/packages/folio/src/core/layout-painter/registry/registry.test.ts
+++ b/packages/folio/src/core/layout-painter/registry/registry.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Feature-registry dispatch tests.
+ *
+ * Asserts the core contract:
+ *  - Modules registered by kind are dispatched on matching fragments.
+ *  - Unknown kinds and fragments without block/measure hit the fallback.
+ *  - Duplicate registration panics (prevents silent overrides).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type {
+  Fragment,
+  ImageBlock,
+  ImageFragment,
+  ImageMeasure,
+  TableBlock,
+  TableFragment,
+  TableMeasure,
+} from "../../layout-engine/types";
+import type { RenderContext } from "../renderUtils";
+import { createFeatureRegistry } from "./registry";
+import type { FeatureModule } from "./types";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  src = "";
+  alt = "";
+  draggable = false;
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+}
+
+const fakeDocument = {
+  createElement(tag: string): FakeElement {
+    return new FakeElement(tag);
+  },
+} as unknown as Document;
+
+const ctx: RenderContext = {
+  pageNumber: 1,
+  totalPages: 1,
+  section: "body",
+};
+
+const imageFragment: ImageFragment = {
+  kind: "image",
+  blockId: "b1",
+  x: 0,
+  y: 0,
+  width: 100,
+  height: 80,
+};
+
+const imageBlock: ImageBlock = {
+  kind: "image",
+  id: "b1",
+  src: "img.png",
+  width: 100,
+  height: 80,
+};
+
+const imageMeasure: ImageMeasure = {
+  kind: "image",
+  width: 100,
+  height: 80,
+};
+
+const tableFragment: TableFragment = {
+  kind: "table",
+  blockId: "t1",
+  x: 0,
+  y: 0,
+  width: 400,
+  height: 100,
+  fromRow: 0,
+  toRow: 1,
+};
+
+const tableBlock: TableBlock = {
+  kind: "table",
+  id: "t1",
+  rows: [{ cells: [] }],
+};
+
+const tableMeasure: TableMeasure = {
+  kind: "table",
+  rows: [{ cells: [], height: 0 }],
+  columnWidths: [],
+  totalWidth: 400,
+  totalHeight: 0,
+};
+
+describe("createFeatureRegistry", () => {
+  test("dispatches to the module registered for the fragment's kind", () => {
+    let called = false;
+    const imageMod: FeatureModule<"image"> = {
+      kind: "image",
+      render() {
+        called = true;
+        const el = new FakeElement("div");
+        el.dataset["from"] = "imageMod";
+        return el as unknown as HTMLElement;
+      },
+    };
+    const registry = createFeatureRegistry();
+    registry.register(imageMod);
+
+    const out = registry.render({
+      fragment: imageFragment,
+      block: imageBlock,
+      measure: imageMeasure,
+      context: ctx,
+      doc: fakeDocument,
+    }) as unknown as FakeElement;
+
+    expect(called).toBe(true);
+    expect(out.dataset["from"]).toBe("imageMod");
+  });
+
+  test("routes by kind, not by accident — wrong-kind modules are ignored", () => {
+    const imageMod: FeatureModule<"image"> = {
+      kind: "image",
+      render() {
+        const el = new FakeElement("div");
+        el.dataset["from"] = "imageMod";
+        return el as unknown as HTMLElement;
+      },
+    };
+    const tableMod: FeatureModule<"table"> = {
+      kind: "table",
+      render() {
+        const el = new FakeElement("div");
+        el.dataset["from"] = "tableMod";
+        return el as unknown as HTMLElement;
+      },
+    };
+    const registry = createFeatureRegistry();
+    registry.register(imageMod);
+    registry.register(tableMod);
+
+    const out = registry.render({
+      fragment: tableFragment,
+      block: tableBlock,
+      measure: tableMeasure,
+      context: ctx,
+      doc: fakeDocument,
+    }) as unknown as FakeElement;
+
+    expect(out.dataset["from"]).toBe("tableMod");
+  });
+
+  test("falls back when no module matches the kind", () => {
+    let fallbackCalled = false;
+    const registry = createFeatureRegistry({
+      fallback: ({ doc }) => {
+        fallbackCalled = true;
+        return doc.createElement("div") as unknown as HTMLElement;
+      },
+    });
+
+    const unknownFragment = {
+      kind: "image" as const,
+      blockId: "z",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    } satisfies Fragment;
+
+    registry.render({
+      fragment: unknownFragment,
+      block: imageBlock,
+      measure: imageMeasure,
+      context: ctx,
+      doc: fakeDocument,
+    });
+
+    expect(fallbackCalled).toBe(true);
+  });
+
+  test("falls back when block/measure are missing even if a module is registered", () => {
+    let fallbackCalled = false;
+    let moduleCalled = false;
+    const registry = createFeatureRegistry({
+      fallback: ({ doc }) => {
+        fallbackCalled = true;
+        return doc.createElement("div") as unknown as HTMLElement;
+      },
+    });
+    registry.register({
+      kind: "image",
+      render() {
+        moduleCalled = true;
+        return fakeDocument.createElement("div");
+      },
+    });
+
+    registry.render({
+      fragment: imageFragment,
+      block: undefined,
+      measure: undefined,
+      context: ctx,
+      doc: fakeDocument,
+    });
+
+    expect(fallbackCalled).toBe(true);
+    expect(moduleCalled).toBe(false);
+  });
+
+  test("rejects duplicate registration", () => {
+    const registry = createFeatureRegistry();
+    const mod: FeatureModule<"image"> = {
+      kind: "image",
+      render: () => fakeDocument.createElement("div"),
+    };
+    registry.register(mod);
+    expect(() => registry.register(mod)).toThrow();
+  });
+
+  test("get() returns the registered module, undefined otherwise", () => {
+    const registry = createFeatureRegistry();
+    const mod: FeatureModule<"image"> = {
+      kind: "image",
+      render: () => fakeDocument.createElement("div"),
+    };
+    registry.register(mod);
+    expect(registry.get("image")).toBe(mod);
+    expect(registry.get("table")).toBeUndefined();
+    expect(registry.has("image")).toBe(true);
+    expect(registry.has("textBox")).toBe(false);
+  });
+});

--- a/packages/folio/src/core/layout-painter/registry/registry.ts
+++ b/packages/folio/src/core/layout-painter/registry/registry.ts
@@ -1,0 +1,111 @@
+/**
+ * Feature-module registry for the layout painter.
+ *
+ * O(1) dispatch keyed on `Fragment["kind"]`. Modules self-describe their
+ * kind; the registry routes each fragment to its module's `render()`. A
+ * fallback closes the loop for unknown kinds and for fragments arriving
+ * without a resolved block/measure.
+ */
+
+import { panic } from "better-result";
+
+import type { Fragment, FlowBlock, Measure } from "../../layout-engine/types";
+import { renderFragment } from "../renderFragment";
+import type {
+  BlockFor,
+  FeatureDispatchInput,
+  FeatureFallback,
+  FeatureModule,
+  MeasureFor,
+} from "./types";
+
+export type FeatureRegistry = {
+  register<TKind extends Fragment["kind"]>(mod: FeatureModule<TKind>): void;
+  get<TKind extends Fragment["kind"]>(
+    kind: TKind,
+  ): FeatureModule<TKind> | undefined;
+  has(kind: Fragment["kind"]): boolean;
+  render(input: FeatureDispatchInput): HTMLElement;
+};
+
+export type CreateFeatureRegistryOptions = {
+  /**
+   * Hook for unknown kinds and fragments with no resolved block/measure.
+   * Defaults to the placeholder renderer in `renderFragment.ts`.
+   */
+  fallback?: FeatureFallback;
+};
+
+const defaultFallback: FeatureFallback = ({ fragment, context, doc }) =>
+  renderFragment(fragment, context, { document: doc });
+
+/**
+ * Build a new feature registry. Callers register modules, then dispatch via
+ * `render()`. The registry never mutates module objects.
+ */
+export function createFeatureRegistry(
+  options: CreateFeatureRegistryOptions = {},
+): FeatureRegistry {
+  const modules = new Map<Fragment["kind"], FeatureModule>();
+  const fallback = options.fallback ?? defaultFallback;
+
+  const register: FeatureRegistry["register"] = (mod) => {
+    if (modules.has(mod.kind)) {
+      panic(
+        `FeatureRegistry: module for kind "${mod.kind}" is already registered`,
+      );
+    }
+    // SAFETY: we store as the erased `FeatureModule` and re-narrow on
+    // retrieval; the module's own `kind` is the discriminator that makes
+    // this sound. `as unknown` is required because the parametric module
+    // type and the erased union don't structurally overlap to TS.
+    modules.set(mod.kind, mod as unknown as FeatureModule);
+  };
+
+  const get: FeatureRegistry["get"] = <TKind extends Fragment["kind"]>(
+    kind: TKind,
+  ) => {
+    const found = modules.get(kind);
+    if (!found) {
+      return undefined;
+    }
+    // SAFETY: the map key is the module's `kind`; the value was registered
+    // with a matching TKind. The cast restores the original narrow type.
+    return found as unknown as FeatureModule<TKind>;
+  };
+
+  const has: FeatureRegistry["has"] = (kind) => modules.has(kind);
+
+  const render: FeatureRegistry["render"] = ({
+    fragment,
+    block,
+    measure,
+    context,
+    doc,
+  }) => {
+    const mod = modules.get(fragment.kind);
+    if (!mod || !block || !measure) {
+      return fallback({ fragment, context, doc });
+    }
+    return mod.render({
+      // SAFETY: map key is the fragment's own discriminator; caller is
+      // responsible for supplying a matching block + measure (the painter's
+      // block-lookup map guarantees this for the default registry).
+      fragment: fragment as FragmentInputFor<typeof mod>,
+      block: block as BlockInputFor<typeof mod>,
+      measure: measure as MeasureInputFor<typeof mod>,
+      context,
+      doc,
+    });
+  };
+
+  return { register, get, has, render };
+}
+
+// Helper aliases to keep the cast comments in `render` readable.
+type FragmentInputFor<TMod> =
+  TMod extends FeatureModule<infer K> ? Extract<Fragment, { kind: K }> : never;
+type BlockInputFor<TMod> =
+  TMod extends FeatureModule<infer K> ? BlockFor<K> : FlowBlock;
+type MeasureInputFor<TMod> =
+  TMod extends FeatureModule<infer K> ? MeasureFor<K> : Measure;

--- a/packages/folio/src/core/layout-painter/registry/types.ts
+++ b/packages/folio/src/core/layout-painter/registry/types.ts
@@ -46,7 +46,7 @@ export type BlockFor<TKind extends Fragment["kind"]> = TKind extends "paragraph"
       ? ImageBlock
       : TKind extends "textBox"
         ? TextBoxBlock
-        : never;
+        : FlowBlock;
 
 /**
  * Maps Fragment kind -> concrete Measure subtype. Same intent as `BlockFor`.
@@ -60,7 +60,7 @@ export type MeasureFor<TKind extends Fragment["kind"]> =
         ? ImageMeasure
         : TKind extends "textBox"
           ? TextBoxMeasure
-          : never;
+          : Measure;
 
 /**
  * Inputs handed to a feature module's render function.

--- a/packages/folio/src/core/layout-painter/registry/types.ts
+++ b/packages/folio/src/core/layout-painter/registry/types.ts
@@ -1,0 +1,106 @@
+/**
+ * Feature-module registry types for the layout painter.
+ *
+ * A feature module describes how to render one OOXML fragment kind. The
+ * registry dispatches a Fragment to the module registered for its `kind`.
+ * Each module exports a pure renderer; modules never import the registry.
+ *
+ * Mirrors folio's existing ProseMirror extension idiom
+ * (`createNodeExtension({ name, nodeSpec, ... })`) so contributors find the
+ * pattern familiar.
+ */
+
+import type {
+  Fragment,
+  FlowBlock,
+  Measure,
+  ParagraphBlock,
+  ParagraphMeasure,
+  TableBlock,
+  TableMeasure,
+  ImageBlock,
+  ImageMeasure,
+  TextBoxBlock,
+  TextBoxMeasure,
+} from "../../layout-engine/types";
+import type { RenderContext } from "../renderUtils";
+
+/**
+ * Resolve the concrete Fragment subtype for a given kind discriminator.
+ */
+export type FragmentFor<TKind extends Fragment["kind"]> = Extract<
+  Fragment,
+  { kind: TKind }
+>;
+
+/**
+ * Maps Fragment kind -> concrete Block subtype. The block lookup table
+ * passes a `FlowBlock`; modules use this to narrow to the block they need
+ * without unsafe casts.
+ */
+export type BlockFor<TKind extends Fragment["kind"]> = TKind extends "paragraph"
+  ? ParagraphBlock
+  : TKind extends "table"
+    ? TableBlock
+    : TKind extends "image"
+      ? ImageBlock
+      : TKind extends "textBox"
+        ? TextBoxBlock
+        : never;
+
+/**
+ * Maps Fragment kind -> concrete Measure subtype. Same intent as `BlockFor`.
+ */
+export type MeasureFor<TKind extends Fragment["kind"]> =
+  TKind extends "paragraph"
+    ? ParagraphMeasure
+    : TKind extends "table"
+      ? TableMeasure
+      : TKind extends "image"
+        ? ImageMeasure
+        : TKind extends "textBox"
+          ? TextBoxMeasure
+          : never;
+
+/**
+ * Inputs handed to a feature module's render function.
+ */
+export type FeatureRenderInput<TKind extends Fragment["kind"]> = {
+  fragment: FragmentFor<TKind>;
+  block: BlockFor<TKind>;
+  measure: MeasureFor<TKind>;
+  context: RenderContext;
+  doc: Document;
+};
+
+/**
+ * One renderer for one OOXML fragment kind. Pure — no instance state.
+ */
+export type FeatureModule<TKind extends Fragment["kind"] = Fragment["kind"]> = {
+  readonly kind: TKind;
+  render(input: FeatureRenderInput<TKind>): HTMLElement;
+};
+
+/**
+ * Dispatch input: caller hands the registry the still-untyped fragment plus
+ * its associated block/measure, and the registry narrows by kind.
+ */
+export type FeatureDispatchInput = {
+  fragment: Fragment;
+  block: FlowBlock | undefined;
+  measure: Measure | undefined;
+  context: RenderContext;
+  doc: Document;
+};
+
+/**
+ * Fallback hook invoked when no module matches the fragment's kind (or when
+ * block/measure are missing for a fragment that needs them). Mirrors the
+ * existing `renderFragment` placeholder behaviour so partial registries stay
+ * safe at runtime.
+ */
+export type FeatureFallback = (input: {
+  fragment: Fragment;
+  context: RenderContext;
+  doc: Document;
+}) => HTMLElement;


### PR DESCRIPTION
Adds a typed `FeatureModule` registry under `core/layout-painter/registry/` and migrates `paragraph`, `table`, `image`, `textBox` fragment renderers as proof of concept.

## Test plan
- [ ] CI passes