### PR TITLE
feat(folio): full page-borders coverage (eigenpal parity)

### DIFF
--- a/packages/docx-core/src/model/colors.ts
+++ b/packages/docx-core/src/model/colors.ts
@@ -81,6 +81,12 @@ export type BorderSpec = {
   shadow?: boolean;
   /** Frame effect */
   frame?: boolean;
+  /**
+   * Page-border art ID (`w:id` on `<w:CT_Border>` children of `<w:pgBorders>`).
+   * Numeric token from ECMA-376 §17.18.2 `ST_BorderArt`. Preserved for
+   * round-trip; folio does not paint art-border glyphs.
+   */
+  artId?: number;
 };
 
 /**

--- a/packages/docx-core/src/model/colors.ts
+++ b/packages/docx-core/src/model/colors.ts
@@ -82,11 +82,18 @@ export type BorderSpec = {
   /** Frame effect */
   frame?: boolean;
   /**
-   * Page-border art ID (`w:id` on `<w:CT_Border>` children of `<w:pgBorders>`).
-   * Numeric token from ECMA-376 §17.18.2 `ST_BorderArt`. Preserved for
-   * round-trip; folio does not paint art-border glyphs.
+   * Custom page-border art relationship id (`w:id` on `<w:pgBorders>` side
+   * children). Preserved for round-trip; folio does not paint art glyphs.
    */
-  artId?: number;
+  artRelationshipId?: string;
+  /** Custom page-border art relationship id for the top-left corner. */
+  topLeftArtRelationshipId?: string;
+  /** Custom page-border art relationship id for the top-right corner. */
+  topRightArtRelationshipId?: string;
+  /** Custom page-border art relationship id for the bottom-left corner. */
+  bottomLeftArtRelationshipId?: string;
+  /** Custom page-border art relationship id for the bottom-right corner. */
+  bottomRightArtRelationshipId?: string;
 };
 
 /**

--- a/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
@@ -4,9 +4,9 @@
  * symmetry. Companion to the painter tests in
  * `layout-painter/renderPage-pageBorders.test.ts`.
  *
- * Art borders (`w:id` on a side) are preserved through the round-trip
- * even though folio does not paint art glyphs; see the design doc at
- * `/tmp/folio-page-borders-design.md`.
+ * Custom art-border relationship ids (`w:id` and corner ids on a side) are
+ * preserved through the round-trip even though folio does not paint art
+ * glyphs; see the design doc at `/tmp/folio-page-borders-design.md`.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -110,14 +110,17 @@ describe("pgBorders parser coverage", () => {
     expect(section.pageBorders?.bottom?.frame).toBe(true);
   });
 
-  test("preserves art-border id attribute for round-trip", () => {
+  test("preserves custom art-border relationship ids for round-trip", () => {
     const section = parseSectPr(`
       <w:pgBorders>
-        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto" w:id="11"/>
+        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto"
+               w:id="rId5" w:topLeft="rId6" w:topRight="rId7"/>
       </w:pgBorders>
     `);
 
-    expect(section.pageBorders?.top?.artId).toBe(11);
+    expect(section.pageBorders?.top?.artRelationshipId).toBe("rId5");
+    expect(section.pageBorders?.top?.topLeftArtRelationshipId).toBe("rId6");
+    expect(section.pageBorders?.top?.topRightArtRelationshipId).toBe("rId7");
   });
 
   test("preserves an unknown style as the raw string", () => {
@@ -199,15 +202,23 @@ describe("pgBorders serializer round-trip", () => {
     expect(xml).not.toContain("<w:right");
   });
 
-  test("round-trips the art-border id", () => {
+  test("round-trips custom art-border relationship ids", () => {
     const section = parseSectPr(`
       <w:pgBorders w:offsetFrom="page">
-        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto" w:id="11"/>
+        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto"
+               w:id="rId5" w:topLeft="rId6" w:topRight="rId7"/>
+        <w:bottom w:val="single" w:id="rId8" w:bottomLeft="rId9"
+                  w:bottomRight="rId10"/>
       </w:pgBorders>
     `);
 
     const xml = serializeSectionProperties(section);
-    expect(xml).toContain('w:id="11"');
+    expect(xml).toContain('w:id="rId5"');
+    expect(xml).toContain('w:topLeft="rId6"');
+    expect(xml).toContain('w:topRight="rId7"');
+    expect(xml).toContain('w:id="rId8"');
+    expect(xml).toContain('w:bottomLeft="rId9"');
+    expect(xml).toContain('w:bottomRight="rId10"');
   });
 
   test("round-trips auto color and theme-color attributes", () => {

--- a/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/__tests__/pageBorders-roundtrip.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Round-trip coverage for `<w:pgBorders>` (ECMA-376 §17.6.10) — parser
+ * fidelity for every documented attribute/sub-element plus serializer
+ * symmetry. Companion to the painter tests in
+ * `layout-painter/renderPage-pageBorders.test.ts`.
+ *
+ * Art borders (`w:id` on a side) are preserved through the round-trip
+ * even though folio does not paint art glyphs; see the design doc at
+ * `/tmp/folio-page-borders-design.md`.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseSectionProperties } from "../sectionParser";
+import { serializeSectionProperties } from "../serializer/sectionPropertiesSerializer";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+
+const SECT_PR_NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+
+const parseSectPr = (inner: string) => {
+  const node = parseXmlDocument(
+    `<w:sectPr ${SECT_PR_NS}>${inner}</w:sectPr>`,
+  ) as XmlElement | null;
+  if (!node) {
+    throw new Error("Failed to parse sectPr fixture");
+  }
+  return parseSectionProperties(node);
+};
+
+describe("pgBorders parser coverage", () => {
+  test("parses display, offsetFrom, and zOrder attributes", () => {
+    const section = parseSectPr(`
+      <w:pgBorders w:display="firstPage" w:offsetFrom="page" w:zOrder="back">
+        <w:top w:val="single" w:sz="4" w:space="24" w:color="000000"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.display).toBe("firstPage");
+    expect(section.pageBorders?.offsetFrom).toBe("page");
+    expect(section.pageBorders?.zOrder).toBe("back");
+  });
+
+  test("parses all four sides independently with mixed styles", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="single" w:sz="8" w:space="10" w:color="FF0000"/>
+        <w:bottom w:val="double" w:sz="12" w:space="5" w:color="00FF00"/>
+        <w:left w:val="dashed" w:sz="6" w:space="3" w:color="0000FF"/>
+        <w:right w:val="dotted" w:sz="4" w:space="1" w:color="123456"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top).toEqual({
+      style: "single",
+      size: 8,
+      space: 10,
+      color: { rgb: "FF0000" },
+    });
+    expect(section.pageBorders?.bottom).toEqual({
+      style: "double",
+      size: 12,
+      space: 5,
+      color: { rgb: "00FF00" },
+    });
+    expect(section.pageBorders?.left).toEqual({
+      style: "dashed",
+      size: 6,
+      space: 3,
+      color: { rgb: "0000FF" },
+    });
+    expect(section.pageBorders?.right).toEqual({
+      style: "dotted",
+      size: 4,
+      space: 1,
+      color: { rgb: "123456" },
+    });
+  });
+
+  test("parses auto color and theme color on a side", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="single" w:sz="4" w:color="auto"/>
+        <w:bottom w:val="single" w:sz="4" w:color="000000"
+                  w:themeColor="accent1" w:themeTint="66" w:themeShade="BF"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top?.color).toEqual({ auto: true });
+    expect(section.pageBorders?.bottom?.color).toEqual({
+      rgb: "000000",
+      themeColor: "accent1",
+      themeTint: "66",
+      themeShade: "BF",
+    });
+  });
+
+  test("parses shadow and frame flags from `1` and `true`", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="single" w:shadow="1" w:frame="true"/>
+        <w:bottom w:val="single" w:shadow="true" w:frame="1"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top?.shadow).toBe(true);
+    expect(section.pageBorders?.top?.frame).toBe(true);
+    expect(section.pageBorders?.bottom?.shadow).toBe(true);
+    expect(section.pageBorders?.bottom?.frame).toBe(true);
+  });
+
+  test("preserves art-border id attribute for round-trip", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto" w:id="11"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top?.artId).toBe(11);
+  });
+
+  test("preserves an unknown style as the raw string", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="someExoticArtName" w:sz="4" w:color="000000"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top?.style).toBe("someExoticArtName");
+  });
+
+  test("treats `nil` and `none` styles as preserved no-op values", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="nil"/>
+        <w:bottom w:val="none"/>
+        <w:left w:val="single" w:sz="4"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.top?.style).toBe("nil");
+    expect(section.pageBorders?.bottom?.style).toBe("none");
+    expect(section.pageBorders?.left?.style).toBe("single");
+  });
+
+  test("ignores unknown display/offsetFrom/zOrder values", () => {
+    const section = parseSectPr(`
+      <w:pgBorders w:display="weirdMode" w:offsetFrom="bogus" w:zOrder="sideways">
+        <w:top w:val="single"/>
+      </w:pgBorders>
+    `);
+
+    expect(section.pageBorders?.display).toBeUndefined();
+    expect(section.pageBorders?.offsetFrom).toBeUndefined();
+    expect(section.pageBorders?.zOrder).toBeUndefined();
+  });
+});
+
+describe("pgBorders serializer round-trip", () => {
+  test("round-trips all attributes and one full-coverage side", () => {
+    const section = parseSectPr(`
+      <w:pgBorders w:display="allPages" w:offsetFrom="text" w:zOrder="front">
+        <w:top w:val="single" w:sz="8" w:space="12" w:color="FF8800"
+               w:themeColor="accent2" w:themeTint="40" w:themeShade="80"
+               w:shadow="true" w:frame="true"/>
+      </w:pgBorders>
+    `);
+
+    const xml = serializeSectionProperties(section);
+
+    expect(xml).toContain('w:display="allPages"');
+    expect(xml).toContain('w:offsetFrom="text"');
+    expect(xml).toContain('w:zOrder="front"');
+    expect(xml).toContain('w:val="single"');
+    expect(xml).toContain('w:sz="8"');
+    expect(xml).toContain('w:space="12"');
+    expect(xml).toContain('w:color="FF8800"');
+    expect(xml).toContain('w:themeColor="accent2"');
+    expect(xml).toContain('w:themeTint="40"');
+    expect(xml).toContain('w:themeShade="80"');
+    expect(xml).toContain('w:shadow="true"');
+    expect(xml).toContain('w:frame="true"');
+  });
+
+  test("emits each side once and only when set", () => {
+    const xml = serializeSectionProperties({
+      pageBorders: {
+        top: { style: "single", size: 4 },
+        bottom: { style: "double", size: 12 },
+        left: { style: "none" },
+        right: { style: "nil" },
+      },
+    });
+
+    expect(xml).toContain('<w:top w:val="single"');
+    expect(xml).toContain('<w:bottom w:val="double"');
+    expect(xml).not.toContain("<w:left");
+    expect(xml).not.toContain("<w:right");
+  });
+
+  test("round-trips the art-border id", () => {
+    const section = parseSectPr(`
+      <w:pgBorders w:offsetFrom="page">
+        <w:top w:val="single" w:sz="20" w:space="24" w:color="auto" w:id="11"/>
+      </w:pgBorders>
+    `);
+
+    const xml = serializeSectionProperties(section);
+    expect(xml).toContain('w:id="11"');
+  });
+
+  test("round-trips auto color and theme-color attributes", () => {
+    const section = parseSectPr(`
+      <w:pgBorders>
+        <w:top w:val="single" w:color="auto"/>
+        <w:bottom w:val="single" w:themeColor="accent3"/>
+      </w:pgBorders>
+    `);
+
+    const xml = serializeSectionProperties(section);
+    expect(xml).toContain('w:color="auto"');
+    expect(xml).toContain('w:themeColor="accent3"');
+  });
+
+  test("preserves an attributes-only pgBorders element through round-trip", () => {
+    // Word emits `<w:pgBorders w:offsetFrom="text" w:display="allPages"/>`
+    // with no child sides to signal "remove all page borders, keep the
+    // section-level placement". Dropping the element loses that intent.
+    const section = parseSectPr(`
+      <w:pgBorders w:display="allPages" w:offsetFrom="text"/>
+    `);
+
+    const xml = serializeSectionProperties(section);
+    expect(xml).toContain(
+      '<w:pgBorders w:display="allPages" w:offsetFrom="text"/>',
+    );
+  });
+
+  test("skips pgBorders entirely when neither attributes nor sides are set", () => {
+    const xml = serializeSectionProperties({ pageBorders: {} });
+    expect(xml).not.toContain("pgBorders");
+  });
+});

--- a/packages/folio/src/core/docx/sectionParser.ts
+++ b/packages/folio/src/core/docx/sectionParser.ts
@@ -204,12 +204,44 @@ function parseBorderSpec(element: XmlElement | null): BorderSpec | undefined {
     border.frame = true;
   }
 
-  // Art-border ID (`w:id` on a <w:CT_Border> inside <w:pgBorders>).
-  // Preserved through the round-trip so Word can re-paint the art glyphs
-  // even though folio renders the underlying line style instead.
-  const artId = parseNumericAttribute(element, "w", "id");
-  if (artId !== undefined) {
-    border.artId = artId;
+  // Custom page-border art relationship ids. Preserved through the
+  // round-trip so Word can re-paint art glyphs and corner images even
+  // though folio renders the underlying line style instead.
+  const artRelationshipId = getAttribute(element, "w", "id")?.trim();
+  if (artRelationshipId) {
+    border.artRelationshipId = artRelationshipId;
+  }
+  const topLeftArtRelationshipId = getAttribute(
+    element,
+    "w",
+    "topLeft",
+  )?.trim();
+  if (topLeftArtRelationshipId) {
+    border.topLeftArtRelationshipId = topLeftArtRelationshipId;
+  }
+  const topRightArtRelationshipId = getAttribute(
+    element,
+    "w",
+    "topRight",
+  )?.trim();
+  if (topRightArtRelationshipId) {
+    border.topRightArtRelationshipId = topRightArtRelationshipId;
+  }
+  const bottomLeftArtRelationshipId = getAttribute(
+    element,
+    "w",
+    "bottomLeft",
+  )?.trim();
+  if (bottomLeftArtRelationshipId) {
+    border.bottomLeftArtRelationshipId = bottomLeftArtRelationshipId;
+  }
+  const bottomRightArtRelationshipId = getAttribute(
+    element,
+    "w",
+    "bottomRight",
+  )?.trim();
+  if (bottomRightArtRelationshipId) {
+    border.bottomRightArtRelationshipId = bottomRightArtRelationshipId;
   }
 
   return border;

--- a/packages/folio/src/core/docx/sectionParser.ts
+++ b/packages/folio/src/core/docx/sectionParser.ts
@@ -204,6 +204,14 @@ function parseBorderSpec(element: XmlElement | null): BorderSpec | undefined {
     border.frame = true;
   }
 
+  // Art-border ID (`w:id` on a <w:CT_Border> inside <w:pgBorders>).
+  // Preserved through the round-trip so Word can re-paint the art glyphs
+  // even though folio renders the underlying line style instead.
+  const artId = parseNumericAttribute(element, "w", "id");
+  if (artId !== undefined) {
+    border.artId = artId;
+  }
+
   return border;
 }
 

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -48,8 +48,24 @@ function serializeBorder(
   if (border.frame) {
     attrs.push('w:frame="true"');
   }
-  if (border.artId !== undefined) {
-    attrs.push(`w:id="${intAttr(border.artId)}"`);
+  if (border.artRelationshipId) {
+    attrs.push(`w:id="${escapeXml(border.artRelationshipId)}"`);
+  }
+  if (border.topLeftArtRelationshipId) {
+    attrs.push(`w:topLeft="${escapeXml(border.topLeftArtRelationshipId)}"`);
+  }
+  if (border.topRightArtRelationshipId) {
+    attrs.push(`w:topRight="${escapeXml(border.topRightArtRelationshipId)}"`);
+  }
+  if (border.bottomLeftArtRelationshipId) {
+    attrs.push(
+      `w:bottomLeft="${escapeXml(border.bottomLeftArtRelationshipId)}"`,
+    );
+  }
+  if (border.bottomRightArtRelationshipId) {
+    attrs.push(
+      `w:bottomRight="${escapeXml(border.bottomRightArtRelationshipId)}"`,
+    );
   }
 
   return `<w:${elementName} ${attrs.join(" ")}/>`;

--- a/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/sectionPropertiesSerializer.ts
@@ -48,6 +48,9 @@ function serializeBorder(
   if (border.frame) {
     attrs.push('w:frame="true"');
   }
+  if (border.artId !== undefined) {
+    attrs.push(`w:id="${intAttr(border.artId)}"`);
+  }
 
   return `<w:${elementName} ${attrs.join(" ")}/>`;
 }
@@ -280,11 +283,19 @@ function serializePageBorders(props: SectionProperties): string {
     }
   }
 
-  if (borderElements.length === 0) {
+  // Drop the element entirely when nothing meaningful would be emitted —
+  // an attribute-less, child-less `<w:pgBorders>` carries no information.
+  // Attributes alone (display/offsetFrom/zOrder) on a parsed pgBorders
+  // are still meaningful for round-trip fidelity, so keep the element in
+  // that case even when every side is `none`/`nil`.
+  if (borderElements.length === 0 && attrs.length === 0) {
     return "";
   }
 
   const attrsStr = attrs.length > 0 ? ` ${attrs.join(" ")}` : "";
+  if (borderElements.length === 0) {
+    return `<w:pgBorders${attrsStr}/>`;
+  }
   return `<w:pgBorders${attrsStr}>${borderElements.join("")}</w:pgBorders>`;
 }
 

--- a/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
@@ -98,7 +98,10 @@ const findByClass = (
   className: string,
 ): FakeElement | null => {
   for (const child of root.children) {
-    if (child.className.split(/\s+/u).includes(className)) {
+    if (
+      child.className.split(/\s+/u).includes(className) ||
+      child.tagName === className
+    ) {
       return child;
     }
     const inner = findByClass(child, className);
@@ -115,7 +118,10 @@ const collectByClass = (
   out: FakeElement[],
 ): void => {
   for (const child of root.children) {
-    if (child.className.split(/\s+/u).includes(className)) {
+    if (
+      child.className.split(/\s+/u).includes(className) ||
+      child.tagName === className
+    ) {
       out.push(child);
     }
     collectByClass(child, className, out);

--- a/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage-pageBorders.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Painter coverage for `<w:pgBorders>` rendering (ECMA-376 §17.6.10).
+ *
+ * Verifies the overlay geometry, `display` gating, `offsetFrom`, `zOrder`,
+ * per-side independence, and edge cases (no-op styles, hairline floor,
+ * double-line floor). Mirrors the eigenpal `border-overlay-layout` test
+ * (see `git show eigenpal/main:packages/core/src/layout-painter/__tests__/border-overlay-layout.test.ts`)
+ * but uses folio's lightweight FakeElement harness instead of happy-dom
+ * to keep the suite Bun-native.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Page } from "../layout-engine/types";
+import { eighthsToPixels, pointsToPixels } from "../utils/units";
+import { renderPage } from "./renderPage";
+import type { RenderPageOptions } from "./renderPage";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  parent: FakeElement | null = null;
+  private ownText = "";
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  get textContent(): string {
+    return this.ownText + this.children.map((c) => c.textContent).join("");
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+    this.children = [];
+  }
+
+  append(...children: FakeElement[]): void {
+    for (const child of children) {
+      child.parent = this;
+      this.children.push(child);
+    }
+  }
+
+  prepend(...children: FakeElement[]): void {
+    for (let i = children.length - 1; i >= 0; i--) {
+      const child = children[i]!;
+      child.parent = this;
+      this.children.unshift(child);
+    }
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+
+  remove(): void {
+    if (!this.parent) {
+      return;
+    }
+    const idx = this.parent.children.indexOf(this);
+    if (idx !== -1) {
+      this.parent.children.splice(idx, 1);
+    }
+    this.parent = null;
+  }
+
+  getContext(): null {
+    return null;
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return findByClass(this, classFromSelector(selector));
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const out: FakeElement[] = [];
+    collectByClass(this, classFromSelector(selector), out);
+    return out;
+  }
+}
+
+const CLASS_SELECTOR_RE = /\.([\w-]+)/u;
+
+const classFromSelector = (selector: string): string => {
+  // Tests pass either `.layout-page-border` or `:scope > .layout-page-border`.
+  const match = CLASS_SELECTOR_RE.exec(selector);
+  return match ? (match[1] ?? "") : selector;
+};
+
+const findByClass = (
+  root: FakeElement,
+  className: string,
+): FakeElement | null => {
+  for (const child of root.children) {
+    if (child.className.split(/\s+/u).includes(className)) {
+      return child;
+    }
+    const inner = findByClass(child, className);
+    if (inner) {
+      return inner;
+    }
+  }
+  return null;
+};
+
+const collectByClass = (
+  root: FakeElement,
+  className: string,
+  out: FakeElement[],
+): void => {
+  for (const child of root.children) {
+    if (child.className.split(/\s+/u).includes(className)) {
+      out.push(child);
+    }
+    collectByClass(child, className, out);
+  }
+};
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+  createTextNode(text: string): FakeElement {
+    const node = new FakeElement("#text");
+    node.textContent = text;
+    return node;
+  },
+} as unknown as Document;
+
+const makePage = (overrides: Partial<Page> = {}): Page => ({
+  number: 1,
+  fragments: [],
+  margins: { top: 54, right: 36, bottom: 52, left: 54 },
+  size: { w: 816, h: 1056 },
+  ...overrides,
+});
+
+const renderWithBorders = (
+  page: Page,
+  pageBorders: NonNullable<RenderPageOptions["pageBorders"]>,
+): FakeElement =>
+  renderPage(
+    page,
+    { pageNumber: page.number, totalPages: 1, section: "body" },
+    {
+      document: fakeDocument,
+      pageBorders,
+    },
+  ) as unknown as FakeElement;
+
+const borderOverlay = (pageEl: FakeElement): FakeElement | null =>
+  pageEl.querySelector(".layout-page-border");
+
+describe("renderPageBorderOverlay", () => {
+  test("renders an inset overlay with all four sides applied", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+      bottom: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+      left: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+      right: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl);
+    expect(overlay).not.toBeNull();
+    expect(overlay!.style["borderTopStyle"]).toBe("solid");
+    expect(overlay!.style["borderBottomStyle"]).toBe("solid");
+    expect(overlay!.style["borderLeftStyle"]).toBe("solid");
+    expect(overlay!.style["borderRightStyle"]).toBe("solid");
+  });
+
+  test("offsetFrom='page' positions the overlay from the page edges", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 4, space: 24, color: { rgb: "000000" } },
+      left: { style: "single", size: 4, space: 24, color: { rgb: "000000" } },
+      bottom: { style: "single", size: 4, space: 24, color: { rgb: "000000" } },
+      right: { style: "single", size: 4, space: 24, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    const expected = `${pointsToPixels(24)}px`;
+    expect(overlay.style["top"]).toBe(expected);
+    expect(overlay.style["bottom"]).toBe(expected);
+    expect(overlay.style["left"]).toBe(expected);
+    expect(overlay.style["right"]).toBe(expected);
+  });
+
+  test("offsetFrom='text' shifts the overlay outward by both space and stroke width", () => {
+    // Doubled stroke is forced to >= 3px by the painter so browsers do not
+    // collapse it to a single line; the overlay must shift outward by the
+    // exact stroke that will paint.
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "text",
+      top: { style: "double", size: 4, space: 15, color: { rgb: "000000" } },
+      left: { style: "double", size: 4, space: 15, color: { rgb: "000000" } },
+      bottom: { style: "double", size: 4, space: 11, color: { rgb: "000000" } },
+      right: { style: "double", size: 4, space: 2, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    const stroke = 3; // doubled stroke floor
+    expect(Number.parseFloat(overlay.style["top"] ?? "")).toBeCloseTo(
+      54 - pointsToPixels(15) - stroke,
+      5,
+    );
+    expect(Number.parseFloat(overlay.style["left"] ?? "")).toBeCloseTo(
+      54 - pointsToPixels(15) - stroke,
+      5,
+    );
+    expect(Number.parseFloat(overlay.style["bottom"] ?? "")).toBeCloseTo(
+      52 - pointsToPixels(11) - stroke,
+      5,
+    );
+    expect(Number.parseFloat(overlay.style["right"] ?? "")).toBeCloseTo(
+      36 - pointsToPixels(2) - stroke,
+      5,
+    );
+    expect(overlay.style["borderTopStyle"]).toBe("double");
+    expect(overlay.style["borderTopWidth"]).toBe("3px");
+  });
+
+  test("display='firstPage' renders on page 1 and is skipped on page 2", () => {
+    const onPage1 = renderWithBorders(makePage({ number: 1 }), {
+      display: "firstPage",
+      top: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+    });
+    const onPage2 = renderWithBorders(makePage({ number: 2 }), {
+      display: "firstPage",
+      top: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+    });
+
+    expect(borderOverlay(onPage1)).not.toBeNull();
+    expect(borderOverlay(onPage2)).toBeNull();
+  });
+
+  test("display='notFirstPage' is skipped on page 1 and renders on page 2+", () => {
+    const onPage1 = renderWithBorders(makePage({ number: 1 }), {
+      display: "notFirstPage",
+      top: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+    });
+    const onPage3 = renderWithBorders(makePage({ number: 3 }), {
+      display: "notFirstPage",
+      top: { style: "single", size: 8, space: 24, color: { rgb: "000000" } },
+    });
+
+    expect(borderOverlay(onPage1)).toBeNull();
+    expect(borderOverlay(onPage3)).not.toBeNull();
+  });
+
+  test("display='allPages' (default) renders on every page", () => {
+    const onPage1 = renderWithBorders(makePage({ number: 1 }), {
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+    });
+    const onPage5 = renderWithBorders(makePage({ number: 5 }), {
+      display: "allPages",
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+    });
+
+    expect(borderOverlay(onPage1)).not.toBeNull();
+    expect(borderOverlay(onPage5)).not.toBeNull();
+  });
+
+  test("zOrder='back' inserts the overlay before content; zOrder='front' (default) inserts it after", () => {
+    const backPage = renderWithBorders(makePage(), {
+      zOrder: "back",
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+    });
+    const frontPage = renderWithBorders(makePage(), {
+      zOrder: "front",
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+    });
+
+    const backIdx = backPage.children.findIndex((c) =>
+      c.className.includes("layout-page-border"),
+    );
+    const frontIdx = frontPage.children.findIndex((c) =>
+      c.className.includes("layout-page-border"),
+    );
+    expect(backIdx).toBe(0);
+    expect(frontIdx).toBe(frontPage.children.length - 1);
+
+    // z-index also encodes the layering for browsers that compute stacking
+    // contexts (back behind content, front above content).
+    const backOverlay = borderOverlay(backPage)!;
+    const frontOverlay = borderOverlay(frontPage)!;
+    expect(backOverlay.style["zIndex"]).toBe("0");
+    expect(frontOverlay.style["zIndex"]).toBe("20");
+  });
+
+  test("per-side independence — each side keeps its own style/size/color/space", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 16, space: 4, color: { rgb: "FF0000" } },
+      bottom: { style: "dashed", size: 8, space: 8, color: { rgb: "00FF00" } },
+      left: { style: "double", size: 24, space: 12, color: { rgb: "0000FF" } },
+      right: { style: "dotted", size: 4, space: 2, color: { rgb: "123456" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    expect(overlay.style["borderTopStyle"]).toBe("solid");
+    expect(overlay.style["borderBottomStyle"]).toBe("dashed");
+    expect(overlay.style["borderLeftStyle"]).toBe("double");
+    expect(overlay.style["borderRightStyle"]).toBe("dotted");
+    expect(overlay.style["borderTopColor"]?.toUpperCase()).toContain("FF0000");
+    expect(overlay.style["borderBottomColor"]?.toUpperCase()).toContain(
+      "00FF00",
+    );
+    expect(overlay.style["borderLeftColor"]?.toUpperCase()).toContain("0000FF");
+    expect(overlay.style["borderRightColor"]?.toUpperCase()).toContain(
+      "123456",
+    );
+  });
+
+  test("none/nil sides are no-ops and do not contribute CSS", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+      bottom: { style: "none" },
+      left: { style: "nil" },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    expect(overlay.style["borderTopStyle"]).toBe("solid");
+    expect(overlay.style["borderBottomStyle"]).toBeUndefined();
+    expect(overlay.style["borderLeftStyle"]).toBeUndefined();
+    expect(overlay.style["borderRightStyle"]).toBeUndefined();
+  });
+
+  test("returns no overlay when every side is none/nil", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      display: "allPages",
+      top: { style: "none" },
+      bottom: { style: "nil" },
+      left: { style: "none" },
+      right: { style: "nil" },
+    });
+
+    expect(borderOverlay(pageEl)).toBeNull();
+  });
+
+  test("hairline (sz=2 = 0.25pt) is floored to a 1px stroke so it stays visible", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 2, space: 12, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    expect(overlay.style["borderTopWidth"]).toBe("1px");
+    expect(overlay.style["borderTopStyle"]).toBe("solid");
+  });
+
+  test("sz=0 with a printable style still emits a 1px hairline (Word fallback)", () => {
+    // OOXML allows w:sz="0" to coexist with a non-nil style; matching the
+    // existing `borderToStyle` behavior keeps these visible at common zoom
+    // levels rather than collapsing them to nothing.
+    const pageEl = renderWithBorders(makePage(), {
+      offsetFrom: "page",
+      top: { style: "single", size: 0, space: 12, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    expect(overlay.style["borderTopWidth"]).toBe("1px");
+  });
+
+  test("respects offsetFrom default 'text' when offsetFrom is omitted", () => {
+    const pageEl = renderWithBorders(makePage(), {
+      top: { style: "single", size: 8, space: 12, color: { rgb: "000000" } },
+    });
+
+    const overlay = borderOverlay(pageEl)!;
+    // top should be `max(0, margins.top - space - widthPx)` =
+    // `54 - pointsToPixels(12) - eighthsToPixels(8)` (sz=8 = 1pt ≈ 1.333px).
+    const strokeWidth = Math.max(1, eighthsToPixels(8));
+    const expected = Math.max(0, 54 - pointsToPixels(12) - strokeWidth);
+    expect(Number.parseFloat(overlay.style["top"] ?? "")).toBeCloseTo(
+      expected,
+      5,
+    );
+  });
+});


### PR DESCRIPTION
Closes folio's `<w:pgBorders>` coverage: per-side fidelity, `offsetFrom`, `display=firstPage/notFirstPage/allPages`, per-section overrides. Art borders out of scope.

## Test plan
- [ ] CI passes