### PR TITLE
refactor(folio): consolidate style cascade into style-engine module

### DIFF
--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -14,6 +14,8 @@
 
 import type { MarkType, Node as PMNode } from "prosemirror-model";
 
+import { createStyleEngine } from "../../style-engine";
+import type { StyleEngine } from "../../style-engine";
 import type {
   Document,
   Paragraph,
@@ -52,8 +54,6 @@ import type {
   TableRowAttrs,
   TableCellAttrs,
 } from "../schema/nodes";
-import { createStyleResolver } from "../styles";
-import type { StyleResolver } from "../styles";
 import { assertValidProseMirrorDocument } from "../validation";
 
 /**
@@ -83,7 +83,7 @@ export function toProseDoc(
   const paragraphs = document.package.document.content;
   const nodes: PMNode[] = [];
 
-  const styleResolver = createStyleResolver(options?.styles);
+  const styleResolver = createStyleEngine(options?.styles);
   const theme = options?.theme ?? document.package.theme ?? null;
   let textBoxGroupIndex = 0;
 
@@ -135,7 +135,7 @@ export function toProseDoc(
  */
 function convertParagraph(
   paragraph: Paragraph,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   activeCommentIds?: Set<number>,
   extraRunFormatting?: TextFormatting,
 ): PMNode {
@@ -336,7 +336,7 @@ function convertTrackedChange(
   change: Insertion | Deletion | MoveFrom | MoveTo,
   markType: "insertion" | "deletion",
   getInheritedRunFormatting: RunFormattingResolver,
-  styleResolver?: StyleResolver | null,
+  styleResolver?: StyleEngine | null,
   moveKind: "moveFrom" | "moveTo" | null = null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
@@ -400,7 +400,7 @@ function canCarryTrackedRunMark(node: PMNode, markType: MarkType): boolean {
  */
 function paragraphFormattingToAttrs(
   paragraph: Paragraph,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
 ): ParagraphAttrs {
   const formatting = paragraph.formatting;
   const styleId = formatting?.styleId;
@@ -601,7 +601,7 @@ function paragraphFormattingToAttrs(
  * Resolve table style conditional formatting
  */
 function resolveTableStyleConditional(
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   tableStyleId: string | undefined,
   conditionType: string,
 ): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
@@ -638,7 +638,7 @@ function resolveTableStyleConditional(
 }
 
 function resolveTableBaseStyle(
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   tableStyleId: string | undefined,
 ): { tcPr?: TableCellFormatting; rPr?: TextFormatting } | undefined {
   if (!styleResolver || !tableStyleId) {
@@ -739,7 +739,7 @@ function hasDirectRunFormatting(
 
 function resolveTextFormatting(
   formatting: TextFormatting | undefined,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
 ): TextFormatting | undefined {
   if (!formatting) {
     return styleResolver?.resolveRunStyle(null);
@@ -755,7 +755,7 @@ function resolveTextFormatting(
 function resolveParagraphDefaultTextFormatting(
   styleId: string | undefined,
   formatting: Paragraph["formatting"] | undefined,
-  styleResolver: StyleResolver,
+  styleResolver: StyleEngine,
 ): TextFormatting | undefined {
   const style = styleId
     ? (styleResolver.getStyle(styleId) ??
@@ -936,7 +936,7 @@ function paragraphContentHasMeaningfulContent(
 
 function convertTable(
   table: Table,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   theme: Theme | null | undefined,
 ): PMNode {
   // Calculate rowSpan values from vMerge
@@ -1136,7 +1136,7 @@ function countTableColumns(rows: TableRow[]): number {
  */
 function convertTableRow(
   row: TableRow,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   isHeaderRow: boolean,
   columnWidths?: number[],
   totalWidth?: number,
@@ -1448,7 +1448,7 @@ function resolveThemedBorderColors(
  */
 function convertTableCell(
   cell: TableCell,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   isHeader: boolean,
   gridWidthPercent?: number,
   conditionalStyle?: { tcPr?: TableCellFormatting; rPr?: TextFormatting },
@@ -1678,7 +1678,7 @@ function convertMathEquation(math: MathEquation): PMNode | null {
 function convertInlineSdt(
   sdt: InlineSdt,
   getInheritedRunFormatting: RunFormattingResolver,
-  styleResolver?: StyleResolver | null,
+  styleResolver?: StyleEngine | null,
 ): PMNode | null {
   const props = sdt.properties;
   const inlineNodes: PMNode[] = [];
@@ -1755,7 +1755,7 @@ function convertInlineSdt(
 function convertRun(
   run: Run,
   styleFormatting?: TextFormatting,
-  styleResolver?: StyleResolver | null,
+  styleResolver?: StyleEngine | null,
 ): PMNode[] {
   const nodes: PMNode[] = [];
 
@@ -2115,7 +2115,7 @@ function convertImage(image: Image, rawXml?: string): PMNode {
 function convertHyperlink(
   hyperlink: Hyperlink,
   getInheritedRunFormatting: RunFormattingResolver,
-  styleResolver?: StyleResolver | null,
+  styleResolver?: StyleEngine | null,
   hyperlinkIndex?: number,
 ): PMNode[] {
   const nodes: PMNode[] = [];
@@ -2431,7 +2431,7 @@ function convertShape(shape: Shape): PMNode {
  */
 function convertParagraphWithTextBoxes(
   block: Paragraph,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   textBoxGroupId: string,
 ): PMNode[] {
   const textBoxes = extractTextBoxesFromParagraph(block);
@@ -2523,7 +2523,7 @@ function extractTextBoxesFromParagraph(paragraph: Paragraph): TextBox[] {
  */
 function convertTextBox(
   textBox: TextBox,
-  styleResolver: StyleResolver | null,
+  styleResolver: StyleEngine | null,
   options: {
     placement?: "standalone" | "inlineWithPrevious";
     groupId?: string;
@@ -2681,7 +2681,7 @@ export function headerFooterToProseDoc(
 ): PMNode {
   const nodes: PMNode[] = [];
   const styleResolver = options?.styles
-    ? createStyleResolver(options.styles)
+    ? createStyleEngine(options.styles)
     : null;
   const theme = options?.theme ?? null;
   let textBoxGroupIndex = 0;

--- a/packages/folio/src/core/style-engine/index.ts
+++ b/packages/folio/src/core/style-engine/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Style Engine — explicit cached OOXML style cascade.
+ *
+ * See {@link createStyleEngine} for the public entry point.
+ */
+
+export {
+  createStyleEngine,
+  type StyleEngine,
+  type StyleEngineCacheStats,
+  type StyleEngineOptions,
+} from "./styleEngine";
+export type { ResolvedParagraphStyle } from "../prosemirror/styles/styleResolver";

--- a/packages/folio/src/core/style-engine/styleEngine.test.ts
+++ b/packages/folio/src/core/style-engine/styleEngine.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Tests for the style engine.
+ *
+ * Covers public API surface, cascade-order parity with the underlying
+ * resolver, and cache semantics (hits, misses, invalidation, toggle).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { StyleDefinitions } from "../types/document";
+import { createStyleEngine } from "./styleEngine";
+
+const normalOnly: StyleDefinitions = {
+  styles: [
+    {
+      styleId: "Normal",
+      type: "paragraph",
+      name: "Normal",
+      default: true,
+      pPr: { spaceAfter: 200 },
+      rPr: { fontSize: 22 },
+    },
+  ],
+};
+
+const withHeading: StyleDefinitions = {
+  styles: [
+    {
+      styleId: "Normal",
+      type: "paragraph",
+      name: "Normal",
+      default: true,
+      rPr: { fontSize: 22 },
+    },
+    {
+      styleId: "Heading1",
+      type: "paragraph",
+      name: "Heading 1",
+      basedOn: "Normal",
+      pPr: { alignment: "center" },
+      rPr: { fontSize: 36, bold: true },
+    },
+  ],
+};
+
+const withCharacter: StyleDefinitions = {
+  docDefaults: {
+    rPr: { fontFamily: { ascii: "Calibri", hAnsi: "Calibri" } },
+  },
+  styles: [
+    {
+      styleId: "Emphasis",
+      type: "character",
+      name: "Emphasis",
+      rPr: { italic: true },
+    },
+  ],
+};
+
+describe("styleEngine — public API", () => {
+  test("createStyleEngine accepts undefined definitions", () => {
+    const engine = createStyleEngine(undefined);
+    expect(engine.hasStyle("Normal")).toBe(false);
+    expect(engine.getStyle("Normal")).toBeUndefined();
+  });
+
+  test("exposes pass-through accessors", () => {
+    const engine = createStyleEngine(withHeading);
+    expect(engine.hasStyle("Heading1")).toBe(true);
+    expect(engine.getStyle("Heading1")?.name).toBe("Heading 1");
+    expect(engine.getDefaultParagraphStyle()?.styleId).toBe("Normal");
+    expect(engine.getDefaultCharacterStyle()).toBeUndefined();
+    expect(engine.getDefaultTableStyle()).toBeUndefined();
+    expect(
+      engine
+        .getParagraphStyles()
+        .map((s) => s.styleId)
+        .sort(),
+    ).toEqual(["Heading1", "Normal"]);
+    expect(engine.getTableStyles()).toEqual([]);
+  });
+
+  test("getDocDefaults reflects underlying definitions", () => {
+    const engine = createStyleEngine(withCharacter);
+    expect(engine.getDocDefaults()?.rPr?.fontFamily?.ascii).toBe("Calibri");
+  });
+});
+
+describe("styleEngine — cascade resolution", () => {
+  test("resolveParagraphStyle applies basedOn chain", () => {
+    const engine = createStyleEngine(withHeading);
+    const resolved = engine.resolveParagraphStyle("Heading1");
+    expect(resolved.paragraphFormatting?.alignment).toBe("center");
+    expect(resolved.runFormatting?.fontSize).toBe(36);
+    expect(resolved.runFormatting?.bold).toBe(true);
+  });
+
+  test("resolveParagraphStyle falls back to default for unknown styleId", () => {
+    const engine = createStyleEngine(normalOnly);
+    const resolved = engine.resolveParagraphStyle("DoesNotExist");
+    expect(resolved.paragraphFormatting?.spaceAfter).toBe(200);
+    expect(resolved.runFormatting?.fontSize).toBe(22);
+  });
+
+  test("resolveParagraphStyle uses default when styleId is null", () => {
+    const engine = createStyleEngine(normalOnly);
+    const fromNull = engine.resolveParagraphStyle(null);
+    const fromUndef = engine.resolveParagraphStyle(undefined);
+    expect(fromNull.runFormatting?.fontSize).toBe(22);
+    expect(fromUndef.runFormatting?.fontSize).toBe(22);
+  });
+
+  test("resolveRunStyle merges docDefaults under character style", () => {
+    const engine = createStyleEngine(withCharacter);
+    const resolved = engine.resolveRunStyle("Emphasis");
+    expect(resolved?.italic).toBe(true);
+    expect(resolved?.fontFamily?.ascii).toBe("Calibri");
+  });
+
+  test("resolveRunStyle returns undefined when nothing applies", () => {
+    const engine = createStyleEngine({ styles: [] });
+    expect(engine.resolveRunStyle(null)).toBeUndefined();
+  });
+
+  test("getRunStyleOwnProperties skips docDefaults", () => {
+    const engine = createStyleEngine(withCharacter);
+    const own = engine.getRunStyleOwnProperties("Emphasis");
+    expect(own?.italic).toBe(true);
+    // docDefault font intentionally NOT included
+    expect(own?.fontFamily).toBeUndefined();
+  });
+
+  test("getRunStyleOwnProperties returns undefined for null styleId", () => {
+    const engine = createStyleEngine(withCharacter);
+    expect(engine.getRunStyleOwnProperties(null)).toBeUndefined();
+  });
+});
+
+describe("styleEngine — cache semantics", () => {
+  test("repeated resolveParagraphStyle calls hit the cache", () => {
+    const engine = createStyleEngine(withHeading);
+    engine.resolveParagraphStyle("Heading1");
+    engine.resolveParagraphStyle("Heading1");
+    engine.resolveParagraphStyle("Heading1");
+    const stats = engine.stats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(2);
+    expect(stats.size).toBe(1);
+  });
+
+  test("distinct styleIds occupy distinct cache slots", () => {
+    const engine = createStyleEngine(withHeading);
+    engine.resolveParagraphStyle("Heading1");
+    engine.resolveParagraphStyle("Normal");
+    expect(engine.stats().size).toBe(2);
+  });
+
+  test("null and undefined styleIds share the default cache slot", () => {
+    const engine = createStyleEngine(normalOnly);
+    engine.resolveParagraphStyle(null);
+    engine.resolveParagraphStyle(undefined);
+    const stats = engine.stats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+  });
+
+  test("cache returns the same object reference on subsequent hits", () => {
+    const engine = createStyleEngine(withHeading);
+    const first = engine.resolveParagraphStyle("Heading1");
+    const second = engine.resolveParagraphStyle("Heading1");
+    expect(first).toBe(second);
+  });
+
+  test("cached result matches uncached result for parity", () => {
+    const cached = createStyleEngine(withHeading);
+    const uncached = createStyleEngine(withHeading, { cache: false });
+    expect(cached.resolveParagraphStyle("Heading1")).toEqual(
+      uncached.resolveParagraphStyle("Heading1"),
+    );
+    expect(cached.resolveRunStyle("Heading1")).toEqual(
+      uncached.resolveRunStyle("Heading1"),
+    );
+  });
+
+  test("invalidate clears every cache and resets counters", () => {
+    const engine = createStyleEngine(withHeading);
+    engine.resolveParagraphStyle("Heading1");
+    engine.resolveRunStyle("Heading1");
+    engine.getRunStyleOwnProperties("Heading1");
+    expect(engine.stats().size).toBeGreaterThan(0);
+    engine.invalidate();
+    const after = engine.stats();
+    expect(after.size).toBe(0);
+    expect(after.hits).toBe(0);
+    expect(after.misses).toBe(0);
+  });
+
+  test("cache:false disables memoization but preserves correctness", () => {
+    const engine = createStyleEngine(withHeading, { cache: false });
+    const first = engine.resolveParagraphStyle("Heading1");
+    const second = engine.resolveParagraphStyle("Heading1");
+    expect(first).not.toBe(second);
+    expect(first).toEqual(second);
+    const stats = engine.stats();
+    expect(stats.misses).toBe(2);
+    expect(stats.hits).toBe(0);
+    expect(stats.size).toBe(0);
+  });
+
+  test("resolveRunStyle cache stores undefined results", () => {
+    const engine = createStyleEngine({ styles: [] });
+    engine.resolveRunStyle("NoSuchStyle");
+    engine.resolveRunStyle("NoSuchStyle");
+    const stats = engine.stats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(1);
+  });
+
+  test("getRunStyleOwnProperties is memoized independently", () => {
+    const engine = createStyleEngine(withCharacter);
+    engine.getRunStyleOwnProperties("Emphasis");
+    engine.resolveRunStyle("Emphasis");
+    engine.getRunStyleOwnProperties("Emphasis");
+    const stats = engine.stats();
+    // Two distinct caches populated once each, plus one repeat hit.
+    expect(stats.hits).toBe(1);
+    expect(stats.misses).toBe(2);
+    expect(stats.size).toBe(2);
+  });
+});
+
+describe("styleEngine — ECMA-376 cascade precedence", () => {
+  // Direct < named-style < default-of-type < docDefaults is the
+  // *reverse* of precedence; the engine merges low→high so direct
+  // overrides win at the call site (toProseDoc layers direct
+  // formatting on top of the resolved style result).
+  test("docDefaults are dominated by default-of-type style", () => {
+    const defs: StyleDefinitions = {
+      docDefaults: { rPr: { fontSize: 20 } },
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          name: "Normal",
+          default: true,
+          rPr: { fontSize: 24 },
+        },
+      ],
+    };
+    const engine = createStyleEngine(defs);
+    expect(engine.resolveParagraphStyle(null).runFormatting?.fontSize).toBe(24);
+  });
+
+  test("named style dominates default-of-type style", () => {
+    const defs: StyleDefinitions = {
+      styles: [
+        {
+          styleId: "Normal",
+          type: "paragraph",
+          name: "Normal",
+          default: true,
+          rPr: { fontSize: 22 },
+        },
+        {
+          styleId: "Heading1",
+          type: "paragraph",
+          name: "Heading 1",
+          basedOn: "Normal",
+          rPr: { fontSize: 36 },
+        },
+      ],
+    };
+    const engine = createStyleEngine(defs);
+    expect(
+      engine.resolveParagraphStyle("Heading1").runFormatting?.fontSize,
+    ).toBe(36);
+  });
+
+  test("character-style cascade layers docDefaults below own props", () => {
+    const defs: StyleDefinitions = {
+      docDefaults: { rPr: { fontSize: 22, bold: false } },
+      styles: [
+        {
+          styleId: "Strong",
+          type: "character",
+          name: "Strong",
+          rPr: { bold: true },
+        },
+      ],
+    };
+    const engine = createStyleEngine(defs);
+    const resolved = engine.resolveRunStyle("Strong");
+    expect(resolved?.bold).toBe(true);
+    expect(resolved?.fontSize).toBe(22);
+  });
+});

--- a/packages/folio/src/core/style-engine/styleEngine.ts
+++ b/packages/folio/src/core/style-engine/styleEngine.ts
@@ -1,0 +1,203 @@
+/**
+ * Style Engine
+ *
+ * Explicit, cached cascade resolution over OOXML style definitions.
+ * Wraps the existing {@link StyleResolver} (which encodes the cascade
+ * order per ECMA-376 §17.7) with per-method memoization so that callers
+ * walking many paragraphs that reference the same handful of styleIds
+ * pay the resolution cost once per distinct key.
+ *
+ * Cascade order (lowest → highest precedence, per ECMA-376 §17.7.2):
+ *   docDefaults → default-of-type style → linked character style →
+ *   named style chain (basedOn) → direct formatting.
+ *
+ * The engine does not change cascade semantics; it is a pure cache in
+ * front of the legacy resolver, kept additive so callers can be migrated
+ * one at a time.
+ */
+
+import type {
+  ResolvedParagraphStyle,
+  StyleResolver,
+} from "../prosemirror/styles/styleResolver";
+import { createStyleResolver } from "../prosemirror/styles/styleResolver";
+import type {
+  DocDefaults,
+  Style,
+  StyleDefinitions,
+  TextFormatting,
+} from "../types/document";
+
+/**
+ * Sentinel key used for null / undefined styleId queries so that
+ * {@link Map} lookups distinguish "cached an undefined result" from
+ * "never queried" without storing JS `undefined` as a key.
+ */
+const DEFAULT_KEY = "\0__default__";
+
+function cacheKey(styleId: string | undefined | null): string {
+  if (styleId === undefined || styleId === null || styleId === "") {
+    return DEFAULT_KEY;
+  }
+  return styleId;
+}
+
+/** Engine construction options. */
+export type StyleEngineOptions = {
+  /**
+   * Toggle the memoization layer.
+   *
+   * Defaults to `true`. Set to `false` to force every call through the
+   * underlying {@link StyleResolver}; useful in tests where stale-cache
+   * bugs could mask real regressions, and for diagnosing cache-related
+   * behaviour without rebuilding the engine.
+   */
+  cache?: boolean;
+};
+
+/** Lightweight observability for cache effectiveness. */
+export type StyleEngineCacheStats = {
+  hits: number;
+  misses: number;
+  /** Total entries across all internal caches. */
+  size: number;
+};
+
+/**
+ * Cached, explicit style cascade engine.
+ *
+ * The engine exposes the same surface as {@link StyleResolver} for the
+ * methods folio currently consumes, plus cache controls. Returned
+ * objects are shared between cache hits — treat them as immutable.
+ */
+export type StyleEngine = {
+  /** Look up a single named style by id. */
+  getStyle(styleId: string): Style | undefined;
+  /** True if a style with the given id is registered. */
+  hasStyle(styleId: string): boolean;
+  /** Return the document-wide defaults (`w:docDefaults`). */
+  getDocDefaults(): DocDefaults | undefined;
+  /** The style flagged `w:default="1"` for paragraphs, else "Normal". */
+  getDefaultParagraphStyle(): Style | undefined;
+  /** The style flagged `w:default="1"` for character styles. */
+  getDefaultCharacterStyle(): Style | undefined;
+  /** The style flagged `w:default="1"` for tables. */
+  getDefaultTableStyle(): Style | undefined;
+  /** All visible paragraph styles, sorted for toolbar use. */
+  getParagraphStyles(): Style[];
+  /** All visible table styles, sorted for the table-style gallery. */
+  getTableStyles(): Style[];
+
+  /**
+   * Resolve the full paragraph cascade for a given styleId.
+   * Returned object is cached and must not be mutated.
+   */
+  resolveParagraphStyle(
+    styleId: string | undefined | null,
+  ): ResolvedParagraphStyle;
+  /**
+   * Resolve a run/character style with docDefaults applied.
+   * Returns `undefined` when the cascade yields nothing.
+   */
+  resolveRunStyle(
+    styleId: string | undefined | null,
+  ): TextFormatting | undefined;
+  /**
+   * Return a run style's own properties without docDefaults applied —
+   * used when the caller has already merged docDefaults via the
+   * paragraph cascade and would otherwise double-apply font defaults.
+   */
+  getRunStyleOwnProperties(
+    styleId: string | undefined | null,
+  ): TextFormatting | undefined;
+
+  /** Drop every memoized cascade result. */
+  invalidate(): void;
+  /** Inspect cache effectiveness (hits, misses, current size). */
+  stats(): StyleEngineCacheStats;
+};
+
+/**
+ * Build a {@link StyleEngine} from parsed style definitions.
+ *
+ * @param styleDefinitions - The parsed `styles.xml` package, or `undefined`
+ *   for documents without a styles part.
+ * @param options - Engine-level toggles, see {@link StyleEngineOptions}.
+ */
+export function createStyleEngine(
+  styleDefinitions: StyleDefinitions | undefined,
+  options?: StyleEngineOptions,
+): StyleEngine {
+  const resolver: StyleResolver = createStyleResolver(styleDefinitions);
+  const cacheEnabled = options?.cache ?? true;
+
+  // Wrap values in a single-property record so that `Map.get` returning
+  // `undefined` unambiguously means "not cached" — even when the cached
+  // value itself is `undefined` (e.g., resolveRunStyle for a styleId
+  // whose cascade resolves to nothing). Avoids the unsafe `as T` cast
+  // we would otherwise need on the `has` / `get` boundary.
+  type Cached<T> = { value: T };
+  const paragraphCache = new Map<string, Cached<ResolvedParagraphStyle>>();
+  const runCache = new Map<string, Cached<TextFormatting | undefined>>();
+  const ownPropsCache = new Map<string, Cached<TextFormatting | undefined>>();
+
+  let hits = 0;
+  let misses = 0;
+
+  const memoize = <T>(
+    cache: Map<string, Cached<T>>,
+    key: string,
+    compute: () => T,
+  ): T => {
+    if (!cacheEnabled) {
+      misses += 1;
+      return compute();
+    }
+    const cached = cache.get(key);
+    if (cached !== undefined) {
+      hits += 1;
+      return cached.value;
+    }
+    misses += 1;
+    const value = compute();
+    cache.set(key, { value });
+    return value;
+  };
+
+  return {
+    getStyle: (styleId) => resolver.getStyle(styleId),
+    hasStyle: (styleId) => resolver.hasStyle(styleId),
+    getDocDefaults: () => resolver.getDocDefaults(),
+    getDefaultParagraphStyle: () => resolver.getDefaultParagraphStyle(),
+    getDefaultCharacterStyle: () => resolver.getDefaultCharacterStyle(),
+    getDefaultTableStyle: () => resolver.getDefaultTableStyle(),
+    getParagraphStyles: () => resolver.getParagraphStyles(),
+    getTableStyles: () => resolver.getTableStyles(),
+
+    resolveParagraphStyle: (styleId) =>
+      memoize(paragraphCache, cacheKey(styleId), () =>
+        resolver.resolveParagraphStyle(styleId),
+      ),
+    resolveRunStyle: (styleId) =>
+      memoize(runCache, cacheKey(styleId), () =>
+        resolver.resolveRunStyle(styleId),
+      ),
+    getRunStyleOwnProperties: (styleId) =>
+      memoize(ownPropsCache, cacheKey(styleId), () =>
+        resolver.getRunStyleOwnProperties(styleId),
+      ),
+
+    invalidate: () => {
+      paragraphCache.clear();
+      runCache.clear();
+      ownPropsCache.clear();
+      hits = 0;
+      misses = 0;
+    },
+    stats: () => ({
+      hits,
+      misses,
+      size: paragraphCache.size + runCache.size + ownPropsCache.size,
+    }),
+  };
+}


### PR DESCRIPTION
Consolidates style cascade resolution into `core/style-engine/` with optional memoization. `toProseDoc` migrated; legacy `createStyleResolver` kept as re-export.

## Test plan
- [ ] CI passes