### PR TITLE
feat(folio): gate selective save behind a feature flag with tripwire

### DIFF
--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -11,6 +11,8 @@ import type {
   FolioAIEditSnapshot,
 } from "../core/ai-edits";
 import type { DocxCompatibility } from "../core/docx/compatibility";
+import type { FolioSelectiveSaveFlags } from "../core/docx/selectiveSaveFlags";
+import type { TripwireResult } from "../core/docx/selectiveSaveTripwire";
 import type { SelectionState, TableContextInfo } from "../core/prosemirror";
 import type { AnonymizationMatch } from "../core/prosemirror/plugins/anonymizationDecorations";
 import type { Document, Theme, TabStop } from "../core/types/document";
@@ -164,7 +166,20 @@ export type DocxEditorProps = {
   selectedAnonymizationCanonical?: string | null | undefined;
   /** Monotonic counter from the bridge store; drives the re-scroll. */
   anonymizationSelectionSeq?: number | undefined;
+  /**
+   * Operational flags for save-path features. Selective save and its tripwire
+   * mode are OFF by default; hosts opt in once their rollout pipeline is ready.
+   */
+  featureFlags?: FolioSelectiveSaveFlags;
+  /**
+   * Receives the structured comparison between selective save and full repack
+   * whenever {@link FolioSelectiveSaveFlags.selectiveSaveTripwire} is enabled.
+   * Saves are never blocked by the tripwire; this is observability only.
+   */
+  onSelectiveSaveTripwire?: (result: TripwireResult) => void;
 };
+
+export type { FolioSelectiveSaveFlags, TripwireResult };
 
 export type DocxEditorCollaboration = {
   awareness?:

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2561,10 +2561,8 @@ export function DocxEditor({
         // The tripwire observes the selective path independently from the
         // user-visible save mode. Only `useSelectiveForSave` is allowed to
         // choose the returned bytes.
-        const explicitSelectiveSave = options?.selective === true;
         const useSelectiveForSave =
-          (flags.selectiveSave || explicitSelectiveSave) &&
-          options?.selective !== false;
+          flags.selectiveSave && options?.selective !== false;
         const shouldAttemptSelective =
           useSelectiveForSave || flags.selectiveSaveTripwire;
         const view = pagedEditorRef.current?.getView();

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2556,8 +2556,10 @@ export function DocxEditor({
         // The tripwire observes the selective path independently from the
         // user-visible save mode. Only `useSelectiveForSave` is allowed to
         // choose the returned bytes.
+        const explicitSelectiveSave = options?.selective === true;
         const useSelectiveForSave =
-          flags.selectiveSave && options?.selective !== false;
+          (flags.selectiveSave || explicitSelectiveSave) &&
+          options?.selective !== false;
         const shouldAttemptSelective =
           useSelectiveForSave || flags.selectiveSaveTripwire;
         const view = pagedEditorRef.current?.getView();
@@ -2604,16 +2606,21 @@ export function DocxEditor({
         ) {
           // Tripwire compares selective vs full bytes but never blocks the save.
           // The host decides whether to log, alert, or fail CI.
+          let tripwireResult:
+            | Parameters<NonNullable<typeof onSelectiveSaveTripwire>>[0]
+            | null = null;
           try {
             const { compareSelectiveVsFull } =
               await import("../core/docx/selectiveSaveTripwire");
-            const result = await compareSelectiveVsFull(
+            tripwireResult = await compareSelectiveVsFull(
               selectiveBuffer,
               fullBuffer,
             );
-            onSelectiveSaveTripwire(result);
           } catch {
-            // Tripwire failures must never poison the save path.
+            // Comparison failures must never poison the save path.
+          }
+          if (tripwireResult) {
+            onSelectiveSaveTripwire(tripwireResult);
           }
         }
 

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -456,6 +456,8 @@ export function DocxEditor({
   selectedAnonymizationCanonical = null,
   anonymizationSelectionSeq,
   collaboration,
+  featureFlags,
+  onSelectiveSaveTripwire,
 }: DocxEditorProps & { ref?: Ref<DocxEditorRef> }) {
   const t = useTranslations("folio");
 
@@ -2547,26 +2549,64 @@ export function DocxEditor({
           return null;
         }
 
-        // Try selective save first (patches only changed paragraphs). If the
-        // edit cannot be patched, fall back to guarded repack: repackDocx now
-        // validates section/header/footer references before returning bytes.
-        const useSelective = options?.selective !== false;
+        const { resolveSelectiveSaveFlags } = await import(
+          "../core/docx/selectiveSaveFlags"
+        );
+        const flags = resolveSelectiveSaveFlags(featureFlags);
+
+        // Selective save runs only when the feature flag is on AND the
+        // per-call override hasn't disabled it. Otherwise the full repack is
+        // the single, documented save path.
+        const useSelective =
+          flags.selectiveSave && options?.selective !== false;
         const view = pagedEditorRef.current?.getView();
-        let buffer: ArrayBuffer | null = null;
+        let selectiveBuffer: ArrayBuffer | null = null;
 
         if (useSelective && view && originalBufferRef.current) {
           const editorState = view.state;
           const attemptSelectiveSave = await loadAttemptSelectiveSave();
-          buffer = await attemptSelectiveSave(doc, originalBufferRef.current, {
-            changedParaIds: getChangedParagraphIds(editorState),
-            structuralChange: hasStructuralChanges(editorState),
-            hasUntrackedChanges: hasUntrackedChanges(editorState),
-          });
+          selectiveBuffer = await attemptSelectiveSave(
+            doc,
+            originalBufferRef.current,
+            {
+              changedParaIds: getChangedParagraphIds(editorState),
+              structuralChange: hasStructuralChanges(editorState),
+              hasUntrackedChanges: hasUntrackedChanges(editorState),
+              maxBytes: flags.selectiveSaveMaxBytes,
+            },
+          );
         }
 
-        if (!buffer) {
+        let buffer: ArrayBuffer | null = selectiveBuffer;
+        let fullBuffer: ArrayBuffer | null = null;
+
+        if (!buffer || flags.selectiveSaveTripwire) {
           const repackDocx = await loadRepackDocx();
-          buffer = await repackDocx(doc);
+          fullBuffer = await repackDocx(doc);
+          if (!buffer) {
+            buffer = fullBuffer;
+          }
+        }
+
+        if (
+          flags.selectiveSaveTripwire &&
+          fullBuffer &&
+          onSelectiveSaveTripwire
+        ) {
+          // Tripwire compares selective vs full bytes but never blocks the save.
+          // The host decides whether to log, alert, or fail CI.
+          try {
+            const { compareSelectiveVsFull } = await import(
+              "../core/docx/selectiveSaveTripwire"
+            );
+            const result = await compareSelectiveVsFull(
+              selectiveBuffer,
+              fullBuffer,
+            );
+            onSelectiveSaveTripwire(result);
+          } catch {
+            // Tripwire failures must never poison the save path.
+          }
         }
 
         // Clear change tracker after successful save
@@ -2585,7 +2625,14 @@ export function DocxEditor({
         return null;
       }
     },
-    [buildCurrentDocument, onSave, onError, originalBufferRef],
+    [
+      buildCurrentDocument,
+      onSave,
+      onError,
+      originalBufferRef,
+      featureFlags,
+      onSelectiveSaveTripwire,
+    ],
   );
 
   // Handle error from editor

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2566,36 +2566,36 @@ export function DocxEditor({
         const shouldAttemptSelective =
           useSelectiveForSave || flags.selectiveSaveTripwire;
         const view = pagedEditorRef.current?.getView();
+        const baselineBuffer = originalBufferRef.current;
         let selectiveBuffer: ArrayBuffer | null = null;
 
-        if (shouldAttemptSelective && view && originalBufferRef.current) {
+        if (shouldAttemptSelective && view && baselineBuffer) {
           const editorState = view.state;
           const attemptSelectiveSave = await loadAttemptSelectiveSave();
-          selectiveBuffer = await attemptSelectiveSave(
-            doc,
-            originalBufferRef.current,
-            {
-              changedParaIds: getChangedParagraphIds(editorState),
-              structuralChange: hasStructuralChanges(editorState),
-              hasUntrackedChanges: hasUntrackedChanges(editorState),
-              maxBytes: flags.selectiveSaveMaxBytes,
-            },
-          );
+          selectiveBuffer = await attemptSelectiveSave(doc, baselineBuffer, {
+            changedParaIds: getChangedParagraphIds(editorState),
+            structuralChange: hasStructuralChanges(editorState),
+            hasUntrackedChanges: hasUntrackedChanges(editorState),
+            maxBytes: flags.selectiveSaveMaxBytes,
+          });
         }
 
         let buffer: ArrayBuffer | null = useSelectiveForSave
           ? selectiveBuffer
           : null;
         let fullBuffer: ArrayBuffer | null = null;
+        const repackSourceDoc = baselineBuffer
+          ? { ...doc, originalBuffer: baselineBuffer }
+          : doc;
 
         if (!buffer) {
           const repackDocx = await loadRepackDocx();
-          fullBuffer = await repackDocx(doc);
+          fullBuffer = await repackDocx(repackSourceDoc);
           buffer = fullBuffer;
         } else if (flags.selectiveSaveTripwire) {
           try {
             const repackDocx = await loadRepackDocx();
-            fullBuffer = await repackDocx(doc);
+            fullBuffer = await repackDocx(repackSourceDoc);
           } catch {
             // Tripwire-only full repack failures must never poison a
             // successful selective save.

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2553,15 +2553,17 @@ export function DocxEditor({
           await import("../core/docx/selectiveSaveFlags");
         const flags = resolveSelectiveSaveFlags(featureFlags);
 
-        // Selective save runs only when the feature flag is on AND the
-        // per-call override hasn't disabled it. Otherwise the full repack is
-        // the single, documented save path.
-        const useSelective =
+        // The tripwire observes the selective path independently from the
+        // user-visible save mode. Only `useSelectiveForSave` is allowed to
+        // choose the returned bytes.
+        const useSelectiveForSave =
           flags.selectiveSave && options?.selective !== false;
+        const shouldAttemptSelective =
+          useSelectiveForSave || flags.selectiveSaveTripwire;
         const view = pagedEditorRef.current?.getView();
         let selectiveBuffer: ArrayBuffer | null = null;
 
-        if (useSelective && view && originalBufferRef.current) {
+        if (shouldAttemptSelective && view && originalBufferRef.current) {
           const editorState = view.state;
           const attemptSelectiveSave = await loadAttemptSelectiveSave();
           selectiveBuffer = await attemptSelectiveSave(
@@ -2576,7 +2578,9 @@ export function DocxEditor({
           );
         }
 
-        let buffer: ArrayBuffer | null = selectiveBuffer;
+        let buffer: ArrayBuffer | null = useSelectiveForSave
+          ? selectiveBuffer
+          : null;
         let fullBuffer: ArrayBuffer | null = null;
 
         if (!buffer || flags.selectiveSaveTripwire) {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2549,9 +2549,8 @@ export function DocxEditor({
           return null;
         }
 
-        const { resolveSelectiveSaveFlags } = await import(
-          "../core/docx/selectiveSaveFlags"
-        );
+        const { resolveSelectiveSaveFlags } =
+          await import("../core/docx/selectiveSaveFlags");
         const flags = resolveSelectiveSaveFlags(featureFlags);
 
         // Selective save runs only when the feature flag is on AND the
@@ -2596,9 +2595,8 @@ export function DocxEditor({
           // Tripwire compares selective vs full bytes but never blocks the save.
           // The host decides whether to log, alert, or fail CI.
           try {
-            const { compareSelectiveVsFull } = await import(
-              "../core/docx/selectiveSaveTripwire"
-            );
+            const { compareSelectiveVsFull } =
+              await import("../core/docx/selectiveSaveTripwire");
             const result = await compareSelectiveVsFull(
               selectiveBuffer,
               fullBuffer,

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2583,11 +2583,17 @@ export function DocxEditor({
           : null;
         let fullBuffer: ArrayBuffer | null = null;
 
-        if (!buffer || flags.selectiveSaveTripwire) {
+        if (!buffer) {
           const repackDocx = await loadRepackDocx();
           fullBuffer = await repackDocx(doc);
-          if (!buffer) {
-            buffer = fullBuffer;
+          buffer = fullBuffer;
+        } else if (flags.selectiveSaveTripwire) {
+          try {
+            const repackDocx = await loadRepackDocx();
+            fullBuffer = await repackDocx(doc);
+          } catch {
+            // Tripwire-only full repack failures must never poison a
+            // successful selective save.
           }
         }
 

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2542,6 +2542,11 @@ export function DocxEditor({
   // Handle save
   const handleSave = useCallback(
     async (options?: { selective?: boolean }): Promise<ArrayBuffer | null> => {
+      let tripwireResult:
+        | Parameters<NonNullable<typeof onSelectiveSaveTripwire>>[0]
+        | null = null;
+      let savedBuffer: ArrayBuffer | null = null;
+
       try {
         // Build current document from PM editor state
         const doc = buildCurrentDocument();
@@ -2604,11 +2609,9 @@ export function DocxEditor({
           fullBuffer &&
           onSelectiveSaveTripwire
         ) {
-          // Tripwire compares selective vs full bytes but never blocks the save.
-          // The host decides whether to log, alert, or fail CI.
-          let tripwireResult:
-            | Parameters<NonNullable<typeof onSelectiveSaveTripwire>>[0]
-            | null = null;
+          // The comparison itself never blocks the save path. The host
+          // callback runs after the save try/catch so test harnesses may fail
+          // on mismatches by throwing.
           try {
             const { compareSelectiveVsFull } =
               await import("../core/docx/selectiveSaveTripwire");
@@ -2618,9 +2621,6 @@ export function DocxEditor({
             );
           } catch {
             // Comparison failures must never poison the save path.
-          }
-          if (tripwireResult) {
-            onSelectiveSaveTripwire(tripwireResult);
           }
         }
 
@@ -2632,13 +2632,18 @@ export function DocxEditor({
         commentsDirtyRef.current = false;
 
         onSave?.(buffer);
-        return buffer;
+        savedBuffer = buffer;
       } catch (error) {
         onError?.(
           error instanceof Error ? error : new Error("Failed to save document"),
         );
         return null;
       }
+
+      if (tripwireResult && onSelectiveSaveTripwire) {
+        onSelectiveSaveTripwire(tripwireResult);
+      }
+      return savedBuffer;
     },
     [
       buildCurrentDocument,

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -18,6 +18,7 @@ import {
   collectHeaderFooterUpdates,
   COMMENTS_CONTENT_TYPE,
 } from "./rezip";
+import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
 import { buildPatchedDocumentXml } from "./selectiveXmlPatch";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
@@ -91,6 +92,12 @@ export type SelectiveSaveOptions = {
   structuralChange: boolean;
   /** Whether any changes affected paragraphs without paraId */
   hasUntrackedChanges: boolean;
+  /**
+   * Maximum allowed `originalBuffer.byteLength` for the selective path. Above
+   * this size the function returns null and the caller falls back to full
+   * repack. Defaults to {@link DEFAULT_SELECTIVE_SAVE_MAX_BYTES}.
+   */
+  maxBytes?: number;
 };
 
 /**
@@ -107,12 +114,18 @@ export async function attemptSelectiveSave(
   options: SelectiveSaveOptions,
 ): Promise<ArrayBuffer | null> {
   const { changedParaIds, structuralChange, hasUntrackedChanges } = options;
+  const maxBytes = options.maxBytes ?? DEFAULT_SELECTIVE_SAVE_MAX_BYTES;
 
   // Bail out conditions — fall back to full repack
   if (structuralChange) {
     return null;
   }
   if (hasUntrackedChanges) {
+    return null;
+  }
+  // Refuse very large inputs: the JSZip overhead on top of the original buffer
+  // dominates memory cost, and full repack is the safer path at that scale.
+  if (originalBuffer.byteLength > maxBytes) {
     return null;
   }
   // Check for new images/hyperlinks that need relationship management

--- a/packages/folio/src/core/docx/selectiveSaveFlags.test.ts
+++ b/packages/folio/src/core/docx/selectiveSaveFlags.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for selective save feature flag resolution.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  DEFAULT_SELECTIVE_SAVE_MAX_BYTES,
+  resolveSelectiveSaveFlags,
+} from "./selectiveSaveFlags";
+
+describe("resolveSelectiveSaveFlags", () => {
+  test("defaults all flags to safe values when input is undefined", () => {
+    const resolved = resolveSelectiveSaveFlags(undefined);
+    expect(resolved.selectiveSave).toBe(false);
+    expect(resolved.selectiveSaveTripwire).toBe(false);
+    expect(resolved.selectiveSaveMaxBytes).toBe(
+      DEFAULT_SELECTIVE_SAVE_MAX_BYTES,
+    );
+  });
+
+  test("defaults all flags to safe values when input is an empty object", () => {
+    const resolved = resolveSelectiveSaveFlags({});
+    expect(resolved.selectiveSave).toBe(false);
+    expect(resolved.selectiveSaveTripwire).toBe(false);
+    expect(resolved.selectiveSaveMaxBytes).toBe(
+      DEFAULT_SELECTIVE_SAVE_MAX_BYTES,
+    );
+  });
+
+  test("honours an explicit `selectiveSave: true`", () => {
+    const resolved = resolveSelectiveSaveFlags({ selectiveSave: true });
+    expect(resolved.selectiveSave).toBe(true);
+    expect(resolved.selectiveSaveTripwire).toBe(false);
+  });
+
+  test("tripwire is independent from selectiveSave", () => {
+    const resolved = resolveSelectiveSaveFlags({
+      selectiveSaveTripwire: true,
+    });
+    expect(resolved.selectiveSave).toBe(false);
+    expect(resolved.selectiveSaveTripwire).toBe(true);
+  });
+
+  test("custom selectiveSaveMaxBytes overrides the default ceiling", () => {
+    const resolved = resolveSelectiveSaveFlags({
+      selectiveSaveMaxBytes: 4096,
+    });
+    expect(resolved.selectiveSaveMaxBytes).toBe(4096);
+  });
+
+  test("default ceiling is 100 MiB so legal docs with embedded scans fit", () => {
+    expect(DEFAULT_SELECTIVE_SAVE_MAX_BYTES).toBe(100 * 1024 * 1024);
+  });
+});

--- a/packages/folio/src/core/docx/selectiveSaveFlags.ts
+++ b/packages/folio/src/core/docx/selectiveSaveFlags.ts
@@ -1,0 +1,45 @@
+/**
+ * Selective Save Feature Flags
+ *
+ * Operational controls for the selective save path. Default values keep the
+ * existing full-repack behavior in place so hosts opt in explicitly.
+ *
+ * - `selectiveSave` — gate the selective branch entirely.
+ * - `selectiveSaveTripwire` — run selective + full and compare bytes for CI
+ *   observability. Never blocks the user-visible save.
+ * - `selectiveSaveMaxBytes` — refuse the selective path for original buffers
+ *   above this size, since holding them in memory plus the JSZip overhead is
+ *   the dominant cost.
+ */
+
+export type FolioSelectiveSaveFlags = {
+  /** Enable the selective save path. Default: false (full repack only). */
+  selectiveSave?: boolean;
+  /**
+   * Run selective save and full repack on every save, compare bytes, and emit
+   * a `TripwireResult` via `onSelectiveSaveTripwire`. Independent of
+   * `selectiveSave`: the tripwire always observes both paths.
+   */
+  selectiveSaveTripwire?: boolean;
+  /** Maximum original buffer size, in bytes, for which selective save is allowed. */
+  selectiveSaveMaxBytes?: number;
+};
+
+export const DEFAULT_SELECTIVE_SAVE_MAX_BYTES = 100 * 1024 * 1024;
+
+export type ResolvedSelectiveSaveFlags = {
+  selectiveSave: boolean;
+  selectiveSaveTripwire: boolean;
+  selectiveSaveMaxBytes: number;
+};
+
+export function resolveSelectiveSaveFlags(
+  flags: FolioSelectiveSaveFlags | undefined,
+): ResolvedSelectiveSaveFlags {
+  return {
+    selectiveSave: flags?.selectiveSave ?? false,
+    selectiveSaveTripwire: flags?.selectiveSaveTripwire ?? false,
+    selectiveSaveMaxBytes:
+      flags?.selectiveSaveMaxBytes ?? DEFAULT_SELECTIVE_SAVE_MAX_BYTES,
+  };
+}

--- a/packages/folio/src/core/docx/selectiveSaveGuards.test.ts
+++ b/packages/folio/src/core/docx/selectiveSaveGuards.test.ts
@@ -215,9 +215,7 @@ describe("fallback contract", () => {
         {
           type: "hyperlink",
           href: "https://example.com",
-          content: [
-            { type: "run", content: [{ type: "text", text: "link" }] },
-          ],
+          content: [{ type: "run", content: [{ type: "text", text: "link" }] }],
         },
       ],
     });

--- a/packages/folio/src/core/docx/selectiveSaveGuards.test.ts
+++ b/packages/folio/src/core/docx/selectiveSaveGuards.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for selective-save guard rails added to harden the rollout:
+ *   - memory ceiling (originalBuffer.byteLength > maxBytes → null)
+ *   - structural-change fallback
+ *   - untracked-change fallback
+ *   - invalid model fallback
+ *   - new image / new hyperlink fallback
+ *   - feature-flag resolution at the call site
+ *
+ * Existing selective-save behaviour (patch application, cross-reference
+ * invariants, comments/headers/footers handling) is covered in
+ * `selectiveSave.test.ts`. These tests focus exclusively on the new code
+ * paths landed alongside the feature flag.
+ */
+
+import { describe, test, expect } from "bun:test";
+import JSZip from "jszip";
+
+import { parseDocx } from "./parser";
+import { attemptSelectiveSave } from "./selectiveSave";
+import {
+  DEFAULT_SELECTIVE_SAVE_MAX_BYTES,
+  resolveSelectiveSaveFlags,
+} from "./selectiveSaveFlags";
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const PARAGRAPH = (id: string, text: string): string =>
+  `<w:p w14:paraId="${id}"><w:r><w:t>${text}</w:t></w:r></w:p>`;
+
+const DOCUMENT_XML = `${XML_DECL}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    ${PARAGRAPH("P0000001", "Hello world")}
+    ${PARAGRAPH("P0000002", "Second paragraph")}
+    <w:sectPr><w:pgSz w:w="11906" w:h="16838"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440"/></w:sectPr>
+  </w:body>
+</w:document>`;
+
+const CONTENT_TYPES = `${XML_DECL}<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/><Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/></Types>`;
+
+const PACKAGE_RELS = `${XML_DECL}<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties" Target="docProps/core.xml"/></Relationships>`;
+
+const DOC_RELS = `${XML_DECL}<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`;
+
+const STYLES = `${XML_DECL}<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/></w:style></w:styles>`;
+
+const CORE_PROPS = `${XML_DECL}<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><dc:title>fx</dc:title><dcterms:modified xsi:type="dcterms:W3CDTF">2024-01-01T00:00:00.000Z</dcterms:modified></cp:coreProperties>`;
+
+async function makeFixture(extraPaddingBytes = 0): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file("[Content_Types].xml", CONTENT_TYPES);
+  zip.file("_rels/.rels", PACKAGE_RELS);
+  zip.file("word/_rels/document.xml.rels", DOC_RELS);
+  zip.file("word/document.xml", DOCUMENT_XML);
+  zip.file("word/styles.xml", STYLES);
+  zip.file("docProps/core.xml", CORE_PROPS);
+  if (extraPaddingBytes > 0) {
+    // Synthetic large binary so we can drive the memory-threshold guard
+    // without inflating the test runner with multi-MB fixtures.
+    zip.file("word/media/padding.bin", new Uint8Array(extraPaddingBytes), {
+      compression: "STORE",
+    });
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+describe("memory threshold guard", () => {
+  test("allows the selective path when the buffer is under the ceiling", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      maxBytes: buffer.byteLength + 1,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  test("returns null when the buffer is over the configured ceiling", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      maxBytes: buffer.byteLength - 1,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("allows the selective path when the buffer is exactly at the ceiling", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    // The guard refuses strictly greater than maxBytes.
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      maxBytes: buffer.byteLength,
+    });
+
+    expect(result).not.toBeNull();
+  });
+
+  test("default ceiling (100 MiB) is large enough for typical legal documents", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      // omit maxBytes → DEFAULT_SELECTIVE_SAVE_MAX_BYTES applies
+    });
+
+    expect(result).not.toBeNull();
+    expect(buffer.byteLength).toBeLessThan(DEFAULT_SELECTIVE_SAVE_MAX_BYTES);
+  });
+
+  test("crosses the threshold cleanly when padding pushes the buffer over", async () => {
+    const padded = await makeFixture(8 * 1024);
+    const doc = await parseDocx(padded, { preloadFonts: false });
+
+    const tooSmall = await attemptSelectiveSave(doc, padded, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      maxBytes: 4 * 1024,
+    });
+
+    const allowed = await attemptSelectiveSave(doc, padded, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+      maxBytes: padded.byteLength,
+    });
+
+    expect(tooSmall).toBeNull();
+    expect(allowed).not.toBeNull();
+  });
+});
+
+describe("fallback contract", () => {
+  test("structural change → null", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(["P0000001"]),
+      structuralChange: true,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("untracked changes → null", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(["P0000001"]),
+      structuralChange: false,
+      hasUntrackedChanges: true,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("new image (data: URL without rId) → null", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    doc.package.document.content.unshift({
+      type: "paragraph",
+      content: [
+        {
+          type: "run",
+          content: [
+            {
+              type: "drawing",
+              wrap: { type: "inline" },
+              image: {
+                src: "data:image/png;base64,AAAA",
+                width: 100,
+                height: 100,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("new hyperlink (href without rId / anchor) → null", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    doc.package.document.content.unshift({
+      type: "paragraph",
+      content: [
+        {
+          type: "hyperlink",
+          href: "https://example.com",
+          content: [
+            { type: "run", content: [{ type: "text", text: "link" }] },
+          ],
+        },
+      ],
+    });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("invalid model → null (orphaned commentReference triggers validator)", async () => {
+    const buffer = await makeFixture();
+    const doc = await parseDocx(buffer, { preloadFonts: false });
+    doc.package.document.content.unshift({
+      type: "paragraph",
+      content: [{ type: "commentReference", id: 9999 }],
+    });
+
+    const result = await attemptSelectiveSave(doc, buffer, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("flag resolution at the call boundary", () => {
+  test("when flags are absent, selective save is OFF", () => {
+    const resolved = resolveSelectiveSaveFlags(undefined);
+    expect(resolved.selectiveSave).toBe(false);
+  });
+
+  test("a host that opts in still gets the tripwire off by default", () => {
+    const resolved = resolveSelectiveSaveFlags({ selectiveSave: true });
+    expect(resolved.selectiveSave).toBe(true);
+    expect(resolved.selectiveSaveTripwire).toBe(false);
+  });
+
+  test("a host enabling only the tripwire keeps selective save off", () => {
+    const resolved = resolveSelectiveSaveFlags({
+      selectiveSaveTripwire: true,
+    });
+    expect(resolved.selectiveSave).toBe(false);
+    expect(resolved.selectiveSaveTripwire).toBe(true);
+  });
+});

--- a/packages/folio/src/core/docx/selectiveSaveTripwire.test.ts
+++ b/packages/folio/src/core/docx/selectiveSaveTripwire.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the selective-save tripwire byte comparison.
+ *
+ * The tripwire only observes — it never blocks a save. Its job is to flag
+ * divergence between the selective and full save paths so CI / observability
+ * can act on it.
+ */
+
+import { describe, test, expect } from "bun:test";
+import JSZip from "jszip";
+
+import { compareSelectiveVsFull } from "./selectiveSaveTripwire";
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+async function makeZip(
+  entries: Record<string, string | Uint8Array>,
+): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  for (const [path, data] of Object.entries(entries)) {
+    zip.file(path, data);
+  }
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+const SHARED_ENTRIES = {
+  "[Content_Types].xml": `${XML_DECL}<Types/>`,
+  "_rels/.rels": `${XML_DECL}<Relationships/>`,
+  "word/document.xml": `${XML_DECL}<doc>same</doc>`,
+};
+
+describe("compareSelectiveVsFull", () => {
+  test("returns `selective-skipped` when selective bytes are null", async () => {
+    const full = await makeZip(SHARED_ENTRIES);
+    const result = await compareSelectiveVsFull(null, full);
+    expect(result.kind).toBe("selective-skipped");
+    if (result.kind === "selective-skipped") {
+      expect(result.reason).toBe("selective-returned-null");
+    }
+  });
+
+  test("returns `match` for two zips with identical entry sets and bytes", async () => {
+    const a = await makeZip(SHARED_ENTRIES);
+    const b = await makeZip(SHARED_ENTRIES);
+    const result = await compareSelectiveVsFull(a, b);
+    expect(result.kind).toBe("match");
+  });
+
+  test("ignores `docProps/core.xml` differences (both paths refresh dcterms:modified)", async () => {
+    const a = await makeZip({
+      ...SHARED_ENTRIES,
+      "docProps/core.xml": `${XML_DECL}<core><modified>A</modified></core>`,
+    });
+    const b = await makeZip({
+      ...SHARED_ENTRIES,
+      "docProps/core.xml": `${XML_DECL}<core><modified>B</modified></core>`,
+    });
+    const result = await compareSelectiveVsFull(a, b);
+    expect(result.kind).toBe("match");
+  });
+
+  test("reports `entry-set-diff` when paths only appear in one side", async () => {
+    const a = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/comments.xml": "<comments/>",
+    });
+    const b = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/footnotes.xml": "<footnotes/>",
+    });
+    const result = await compareSelectiveVsFull(a, b);
+    expect(result.kind).toBe("entry-set-diff");
+    if (result.kind === "entry-set-diff") {
+      expect(result.onlyInSelective).toContain("word/comments.xml");
+      expect(result.onlyInFull).toContain("word/footnotes.xml");
+    }
+  });
+
+  test("reports `entry-byte-diff` when a shared entry's bytes differ", async () => {
+    const a = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/document.xml": `${XML_DECL}<doc>alpha</doc>`,
+    });
+    const b = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/document.xml": `${XML_DECL}<doc>beta_____</doc>`,
+    });
+    const result = await compareSelectiveVsFull(a, b);
+    expect(result.kind).toBe("entry-byte-diff");
+    if (result.kind === "entry-byte-diff") {
+      expect(result.path).toBe("word/document.xml");
+      expect(result.selectiveSize).not.toBe(result.fullSize);
+    }
+  });
+
+  test("`match` survives different file insertion order in the zip", async () => {
+    const a = new JSZip();
+    a.file("[Content_Types].xml", SHARED_ENTRIES["[Content_Types].xml"]);
+    a.file("_rels/.rels", SHARED_ENTRIES["_rels/.rels"]);
+    a.file("word/document.xml", SHARED_ENTRIES["word/document.xml"]);
+    const aBuf = await a.generateAsync({ type: "arraybuffer" });
+
+    const b = new JSZip();
+    b.file("word/document.xml", SHARED_ENTRIES["word/document.xml"]);
+    b.file("_rels/.rels", SHARED_ENTRIES["_rels/.rels"]);
+    b.file("[Content_Types].xml", SHARED_ENTRIES["[Content_Types].xml"]);
+    const bBuf = await b.generateAsync({ type: "arraybuffer" });
+
+    const result = await compareSelectiveVsFull(aBuf, bBuf);
+    expect(result.kind).toBe("match");
+  });
+
+  test("detects byte-level mismatch on a binary entry", async () => {
+    const a = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/media/image1.png": new Uint8Array([1, 2, 3, 4]),
+    });
+    const b = await makeZip({
+      ...SHARED_ENTRIES,
+      "word/media/image1.png": new Uint8Array([1, 2, 3, 5]),
+    });
+    const result = await compareSelectiveVsFull(a, b);
+    expect(result.kind).toBe("entry-byte-diff");
+    if (result.kind === "entry-byte-diff") {
+      expect(result.path).toBe("word/media/image1.png");
+    }
+  });
+});

--- a/packages/folio/src/core/docx/selectiveSaveTripwire.ts
+++ b/packages/folio/src/core/docx/selectiveSaveTripwire.ts
@@ -1,0 +1,120 @@
+/**
+ * Selective Save Tripwire
+ *
+ * Compares the bytes produced by selective save against a full repack of the
+ * same document, so CI and local soak can detect divergence between the two
+ * paths before it reaches a user's `.docx`.
+ *
+ * Tripwire NEVER blocks a save. The host receives a structured `TripwireResult`
+ * via callback and decides what to do (log, surface as observability event,
+ * fail a CI assertion, etc.).
+ *
+ * The diff ignores `docProps/core.xml` because both paths refresh
+ * `dcterms:modified` with the current wall clock and would always disagree.
+ */
+
+const IGNORED_PATHS = new Set<string>(["docProps/core.xml"]);
+
+export type TripwireResult =
+  | { kind: "match" }
+  | { kind: "selective-skipped"; reason: string }
+  | {
+      kind: "entry-set-diff";
+      onlyInSelective: readonly string[];
+      onlyInFull: readonly string[];
+    }
+  | {
+      kind: "entry-byte-diff";
+      path: string;
+      selectiveSize: number;
+      fullSize: number;
+    };
+
+type ZipLike = {
+  files: Record<string, { dir: boolean }>;
+  file(path: string): { async(type: "uint8array"): Promise<Uint8Array> } | null;
+};
+
+async function listEntries(buffer: ArrayBuffer): Promise<{
+  zip: ZipLike;
+  paths: string[];
+}> {
+  const JSZip = (await import("jszip")).default;
+  const zip = (await JSZip.loadAsync(buffer)) as unknown as ZipLike;
+  const paths: string[] = [];
+  for (const [path, entry] of Object.entries(zip.files)) {
+    if (entry.dir) {
+      continue;
+    }
+    if (IGNORED_PATHS.has(path)) {
+      continue;
+    }
+    paths.push(path);
+  }
+  paths.sort();
+  return { zip, paths };
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function compareSelectiveVsFull(
+  selective: ArrayBuffer | null,
+  full: ArrayBuffer,
+): Promise<TripwireResult> {
+  if (selective === null) {
+    return { kind: "selective-skipped", reason: "selective-returned-null" };
+  }
+
+  const [selectiveZip, fullZip] = await Promise.all([
+    listEntries(selective),
+    listEntries(full),
+  ]);
+
+  const selectiveSet = new Set(selectiveZip.paths);
+  const fullSet = new Set(fullZip.paths);
+
+  const onlyInSelective: string[] = [];
+  const onlyInFull: string[] = [];
+  for (const path of selectiveSet) {
+    if (!fullSet.has(path)) {
+      onlyInSelective.push(path);
+    }
+  }
+  for (const path of fullSet) {
+    if (!selectiveSet.has(path)) {
+      onlyInFull.push(path);
+    }
+  }
+
+  if (onlyInSelective.length > 0 || onlyInFull.length > 0) {
+    return { kind: "entry-set-diff", onlyInSelective, onlyInFull };
+  }
+
+  for (const path of selectiveZip.paths) {
+    const a = await selectiveZip.zip.file(path)?.async("uint8array");
+    const b = await fullZip.zip.file(path)?.async("uint8array");
+    if (!a || !b) {
+      continue;
+    }
+    if (!bytesEqual(a, b)) {
+      return {
+        kind: "entry-byte-diff",
+        path,
+        selectiveSize: a.length,
+        fullSize: b.length,
+      };
+    }
+  }
+
+  return { kind: "match" };
+}

--- a/packages/folio/src/core/docx/selectiveSaveTripwire.ts
+++ b/packages/folio/src/core/docx/selectiveSaveTripwire.ts
@@ -13,6 +13,7 @@
  * `dcterms:modified` with the current wall clock and would always disagree.
  */
 
+import { panic } from "better-result";
 import type JSZipType from "jszip";
 
 const IGNORED_PATHS = new Set<string>(["docProps/core.xml"]);
@@ -35,6 +36,12 @@ export type TripwireResult =
 type LoadedEntries = {
   zip: JSZipType;
   paths: string[];
+};
+
+type EntryBytes = {
+  path: string;
+  selective: Uint8Array;
+  full: Uint8Array;
 };
 
 async function listEntries(buffer: ArrayBuffer): Promise<LoadedEntries> {
@@ -64,6 +71,33 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
     }
   }
   return true;
+}
+
+function readEntryBytes(
+  zip: JSZipType,
+  path: string,
+  side: "selective" | "full",
+): Promise<Uint8Array> {
+  const entry = zip.file(path);
+  if (!entry) {
+    panic(`Missing ${side} zip entry: ${path}`);
+  }
+  return entry.async("uint8array");
+}
+
+function readCommonEntryBytes(
+  selectiveZip: LoadedEntries,
+  fullZip: LoadedEntries,
+): Promise<EntryBytes[]> {
+  return Promise.all(
+    selectiveZip.paths.map(async (path) => {
+      const [selective, full] = await Promise.all([
+        readEntryBytes(selectiveZip.zip, path, "selective"),
+        readEntryBytes(fullZip.zip, path, "full"),
+      ]);
+      return { path, selective, full };
+    }),
+  );
 }
 
 export async function compareSelectiveVsFull(
@@ -99,18 +133,15 @@ export async function compareSelectiveVsFull(
     return { kind: "entry-set-diff", onlyInSelective, onlyInFull };
   }
 
-  for (const path of selectiveZip.paths) {
-    const a = await selectiveZip.zip.file(path)?.async("uint8array");
-    const b = await fullZip.zip.file(path)?.async("uint8array");
-    if (!a || !b) {
-      continue;
-    }
-    if (!bytesEqual(a, b)) {
+  const entries = await readCommonEntryBytes(selectiveZip, fullZip);
+
+  for (const { path, selective: selectiveBytes, full: fullBytes } of entries) {
+    if (!bytesEqual(selectiveBytes, fullBytes)) {
       return {
         kind: "entry-byte-diff",
         path,
-        selectiveSize: a.length,
-        fullSize: b.length,
+        selectiveSize: selectiveBytes.length,
+        fullSize: fullBytes.length,
       };
     }
   }

--- a/packages/folio/src/core/docx/selectiveSaveTripwire.ts
+++ b/packages/folio/src/core/docx/selectiveSaveTripwire.ts
@@ -13,6 +13,8 @@
  * `dcterms:modified` with the current wall clock and would always disagree.
  */
 
+import type JSZipType from "jszip";
+
 const IGNORED_PATHS = new Set<string>(["docProps/core.xml"]);
 
 export type TripwireResult =
@@ -30,17 +32,14 @@ export type TripwireResult =
       fullSize: number;
     };
 
-type ZipLike = {
-  files: Record<string, { dir: boolean }>;
-  file(path: string): { async(type: "uint8array"): Promise<Uint8Array> } | null;
+type LoadedEntries = {
+  zip: JSZipType;
+  paths: string[];
 };
 
-async function listEntries(buffer: ArrayBuffer): Promise<{
-  zip: ZipLike;
-  paths: string[];
-}> {
+async function listEntries(buffer: ArrayBuffer): Promise<LoadedEntries> {
   const JSZip = (await import("jszip")).default;
-  const zip = (await JSZip.loadAsync(buffer)) as unknown as ZipLike;
+  const zip = await JSZip.loadAsync(buffer);
   const paths: string[] = [];
   for (const [path, entry] of Object.entries(zip.files)) {
     if (entry.dir) {

--- a/packages/folio/src/core/docx/selectiveXmlPatch.property.test.ts
+++ b/packages/folio/src/core/docx/selectiveXmlPatch.property.test.ts
@@ -26,10 +26,10 @@ import {
 const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 
 const paraIdArb = fc
-  .stringMatching(/^[A-Z]{3}[0-9]{4}$/)
+  .stringMatching(/^[A-Z]{3}[0-9]{4}$/u)
   .map((id) => id.toUpperCase());
 
-const paraTextArb = fc.stringMatching(/^[A-Za-z0-9 ]{1,40}$/);
+const paraTextArb = fc.stringMatching(/^[A-Za-z0-9 ]{1,40}$/u);
 
 type Para = { id: string; text: string };
 

--- a/packages/folio/src/core/docx/selectiveXmlPatch.property.test.ts
+++ b/packages/folio/src/core/docx/selectiveXmlPatch.property.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Property tests for `buildPatchedDocumentXml` and helpers.
+ *
+ * The selective patcher mutates raw OOXML strings. We use fast-check to fuzz
+ * the structural invariants that the patcher must preserve regardless of the
+ * actual paragraph content:
+ *
+ *   1. An empty change set is the identity.
+ *   2. Patching with the same serialized XML is the identity.
+ *   3. Patching one paragraph only mutates that paragraph's slice.
+ *   4. Patch order does not matter (the user-visible result must not depend
+ *      on Set iteration order).
+ *   5. Paragraph count must be invariant across patch.
+ *   6. `findParagraphOffsets` returns a well-formed span.
+ */
+
+import { describe, test, expect } from "bun:test";
+import fc from "fast-check";
+
+import {
+  buildPatchedDocumentXml,
+  countParagraphElements,
+  findParagraphOffsets,
+} from "./selectiveXmlPatch";
+
+const XML_DECL = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+
+const paraIdArb = fc
+  .stringMatching(/^[A-Z]{3}[0-9]{4}$/)
+  .map((id) => id.toUpperCase());
+
+const paraTextArb = fc.stringMatching(/^[A-Za-z0-9 ]{1,40}$/);
+
+type Para = { id: string; text: string };
+
+const paragraphsArb: fc.Arbitrary<Para[]> = fc.uniqueArray(
+  fc.record({ id: paraIdArb, text: paraTextArb }),
+  {
+    selector: (p) => p.id,
+    minLength: 2,
+    maxLength: 8,
+  },
+);
+
+function renderParagraph(p: Para): string {
+  return `<w:p w14:paraId="${p.id}"><w:r><w:t>${p.text}</w:t></w:r></w:p>`;
+}
+
+function renderDoc(paras: Para[]): string {
+  return `${XML_DECL}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml">
+<w:body>
+${paras.map(renderParagraph).join("\n")}
+<w:sectPr><w:pgSz w:w="11906" w:h="16838"/></w:sectPr>
+</w:body>
+</w:document>`;
+}
+
+describe("buildPatchedDocumentXml property invariants", () => {
+  test("empty change set returns the original XML unchanged", () => {
+    fc.assert(
+      fc.property(paragraphsArb, (paras) => {
+        const xml = renderDoc(paras);
+        const result = buildPatchedDocumentXml(xml, xml, new Set());
+        expect(result).toBe(xml);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("patching against identical serialized XML is the identity", () => {
+    fc.assert(
+      fc.property(paragraphsArb, (paras) => {
+        const xml = renderDoc(paras);
+        const ids = new Set(paras.map((p) => p.id));
+        const result = buildPatchedDocumentXml(xml, xml, ids);
+        expect(result).toBe(xml);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("paragraph count is preserved after a patch", () => {
+    fc.assert(
+      fc.property(paragraphsArb, fc.integer({ min: 0 }), (paras, seed) => {
+        const idx = seed % paras.length;
+        const original = renderDoc(paras);
+        const edited = paras.map((p, i) =>
+          i === idx ? { ...p, text: `${p.text}_NEW` } : p,
+        );
+        const serialized = renderDoc(edited);
+        const ids = new Set([edited[idx]!.id]);
+        const result = buildPatchedDocumentXml(original, serialized, ids);
+        expect(result).not.toBeNull();
+        if (result) {
+          expect(countParagraphElements(result)).toBe(
+            countParagraphElements(original),
+          );
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("bytes outside the changed paragraph remain byte-identical", () => {
+    fc.assert(
+      fc.property(paragraphsArb, fc.integer({ min: 0 }), (paras, seed) => {
+        const idx = seed % paras.length;
+        const target = paras[idx]!;
+        const original = renderDoc(paras);
+        const edited = paras.map((p, i) =>
+          i === idx ? { ...p, text: `${p.text}_X` } : p,
+        );
+        const serialized = renderDoc(edited);
+        const result = buildPatchedDocumentXml(
+          original,
+          serialized,
+          new Set([target.id]),
+        );
+        if (!result) {
+          return;
+        }
+
+        const originalOffsets = findParagraphOffsets(original, target.id);
+        const resultOffsets = findParagraphOffsets(result, target.id);
+        expect(originalOffsets).not.toBeNull();
+        expect(resultOffsets).not.toBeNull();
+        if (originalOffsets && resultOffsets) {
+          expect(result.slice(0, resultOffsets.start)).toBe(
+            original.slice(0, originalOffsets.start),
+          );
+          expect(result.slice(resultOffsets.end)).toBe(
+            original.slice(originalOffsets.end),
+          );
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("patch result is independent of Set iteration order over changed ids", () => {
+    fc.assert(
+      fc.property(paragraphsArb, (paras) => {
+        if (paras.length < 2) {
+          return;
+        }
+        const original = renderDoc(paras);
+        const edited = paras.map((p, i) =>
+          i < 2 ? { ...p, text: `${p.text}_X` } : p,
+        );
+        const serialized = renderDoc(edited);
+
+        const orderA = new Set([paras[0]!.id, paras[1]!.id]);
+        const orderB = new Set([paras[1]!.id, paras[0]!.id]);
+        const a = buildPatchedDocumentXml(original, serialized, orderA);
+        const b = buildPatchedDocumentXml(original, serialized, orderB);
+        expect(a).toBe(b);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("findParagraphOffsets returns a well-formed span", () => {
+    fc.assert(
+      fc.property(paragraphsArb, (paras) => {
+        const xml = renderDoc(paras);
+        for (const p of paras) {
+          const offsets = findParagraphOffsets(xml, p.id);
+          expect(offsets).not.toBeNull();
+          if (offsets) {
+            expect(offsets.end).toBeGreaterThan(offsets.start);
+            const slice = xml.slice(offsets.start, offsets.end);
+            expect(slice.startsWith("<w:p")).toBe(true);
+            expect(slice.endsWith("</w:p>")).toBe(true);
+          }
+        }
+      }),
+      { numRuns: 50 },
+    );
+  });
+});


### PR DESCRIPTION
Adds operational controls on top of the existing selective-save core:
- `featureFlags.selectiveSave` — default off
- `featureFlags.selectiveSaveTripwire` — byte-diffs selective vs full save when enabled
- `featureFlags.selectiveSaveMaxBytes` — refuses selective path above this size (default 100 MiB)

## Test plan
- [ ] CI passes