### PR TITLE
feat(folio): render OMML math via MathML

### DIFF
--- a/packages/folio/src/core/docx/mathToMathml.test.ts
+++ b/packages/folio/src/core/docx/mathToMathml.test.ts
@@ -90,6 +90,15 @@ describe("ommlToMathml — run tokenisation", () => {
     const omml = parse(`<m:oMath ${MATH_NS}><m:r><m:t>α</m:t></m:r></m:oMath>`);
     expect(ommlToMathml(omml)).toContain("<mi>α</mi>");
   });
+
+  test("handles Letterlike and Mathematical Alphanumeric Symbols as identifiers", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>ℏ𝑥</m:t></m:r></m:oMath>`,
+    );
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mi>ℏ</mi>");
+    expect(mml).toContain("<mi>𝑥</mi>");
+  });
 });
 
 describe("ommlToMathml — fractions and scripts", () => {
@@ -106,6 +115,19 @@ describe("ommlToMathml — fractions and scripts", () => {
     expect(mml).toContain("<mfrac>");
     expect(mml).toContain("<mn>1</mn>");
     expect(mml).toContain("<mn>2</mn>");
+  });
+
+  test("converts no-bar fractions into mfrac linethickness=0", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:f>
+          <m:fPr><m:type m:val="noBar"/></m:fPr>
+          <m:num><m:r><m:t>1</m:t></m:r></m:num>
+          <m:den><m:r><m:t>2</m:t></m:r></m:den>
+        </m:f>
+      </m:oMath>
+    `);
+    expect(ommlToMathml(omml)).toContain('<mfrac linethickness="0">');
   });
 
   test("converts <m:sSup> into <msup>", () => {
@@ -258,6 +280,20 @@ describe("ommlToMathml — delimiters, matrices, accents", () => {
     `);
     const mml = ommlToMathml(omml);
     expect(mml).toContain('<mover accent="true">');
+  });
+
+  test("defaults top group characters to the overbrace glyph", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:groupChr>
+          <m:groupChrPr><m:pos m:val="top"/></m:groupChrPr>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+        </m:groupChr>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mover>");
+    expect(mml).toContain('<mo stretchy="true">⏞</mo>');
   });
 });
 

--- a/packages/folio/src/core/docx/mathToMathml.test.ts
+++ b/packages/folio/src/core/docx/mathToMathml.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, test } from "bun:test";
+
+import { ommlToMathml } from "./mathToMathml";
+import { parseXmlDocument } from "./xmlParser";
+
+const MATH_NS =
+  'xmlns="http://schemas.openxmlformats.org/officeDocument/2006/math"';
+
+function parse(xml: string) {
+  const root = parseXmlDocument(xml);
+  if (!root) {
+    throw new Error("Failed to parse OMML fixture");
+  }
+  return root;
+}
+
+describe("ommlToMathml — root + display", () => {
+  test("returns null for a non-OMML element", () => {
+    const root = parse(`<w:p xmlns:w="urn"/>`);
+    expect(ommlToMathml(root)).toBeNull();
+  });
+
+  test("emits inline <math> for <m:oMath>", () => {
+    const omml = parse(`<m:oMath ${MATH_NS}><m:r><m:t>x</m:t></m:r></m:oMath>`);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain('<math xmlns="http://www.w3.org/1998/Math/MathML">');
+    expect(mml).not.toContain('display="block"');
+    expect(mml).toContain("<mi>x</mi>");
+  });
+
+  test("emits display=block for <m:oMathPara>", () => {
+    const omml = parse(
+      `<m:oMathPara ${MATH_NS}><m:oMath><m:r><m:t>y</m:t></m:r></m:oMath></m:oMathPara>`,
+    );
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain('display="block"');
+    expect(mml).toContain("<mi>y</mi>");
+  });
+
+  test("returns null when conversion yields no body content", () => {
+    const omml = parse(`<m:oMath ${MATH_NS}/>`);
+    expect(ommlToMathml(omml)).toBeNull();
+  });
+});
+
+describe("ommlToMathml — run tokenisation", () => {
+  test("classifies digits into <mn>", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>123</m:t></m:r></m:oMath>`,
+    );
+    expect(ommlToMathml(omml)).toContain("<mn>123</mn>");
+  });
+
+  test("classifies letters into per-character <mi>", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>ab</m:t></m:r></m:oMath>`,
+    );
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mi>a</mi>");
+    expect(mml).toContain("<mi>b</mi>");
+  });
+
+  test("classifies operators into <mo>", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>x+1</m:t></m:r></m:oMath>`,
+    );
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mi>x</mi>");
+    expect(mml).toContain("<mo>+</mo>");
+    expect(mml).toContain("<mn>1</mn>");
+  });
+
+  test("treats decimal points as part of the digit cluster", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>3.14</m:t></m:r></m:oMath>`,
+    );
+    expect(ommlToMathml(omml)).toContain("<mn>3.14</mn>");
+  });
+
+  test("escapes XML metacharacters in math text", () => {
+    const omml = parse(
+      `<m:oMath ${MATH_NS}><m:r><m:t>a&lt;b</m:t></m:r></m:oMath>`,
+    );
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("&lt;");
+    expect(mml).not.toContain("<b>");
+  });
+
+  test("handles Greek letters as identifiers", () => {
+    const omml = parse(`<m:oMath ${MATH_NS}><m:r><m:t>α</m:t></m:r></m:oMath>`);
+    expect(ommlToMathml(omml)).toContain("<mi>α</mi>");
+  });
+});
+
+describe("ommlToMathml — fractions and scripts", () => {
+  test("converts <m:f> into <mfrac>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:f>
+          <m:num><m:r><m:t>1</m:t></m:r></m:num>
+          <m:den><m:r><m:t>2</m:t></m:r></m:den>
+        </m:f>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mfrac>");
+    expect(mml).toContain("<mn>1</mn>");
+    expect(mml).toContain("<mn>2</mn>");
+  });
+
+  test("converts <m:sSup> into <msup>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:sSup>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+          <m:sup><m:r><m:t>2</m:t></m:r></m:sup>
+        </m:sSup>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<msup>");
+    expect(mml).toContain("<mi>x</mi>");
+    expect(mml).toContain("<mn>2</mn>");
+  });
+
+  test("converts <m:sSub> into <msub>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:sSub>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+          <m:sub><m:r><m:t>i</m:t></m:r></m:sub>
+        </m:sSub>
+      </m:oMath>
+    `);
+    expect(ommlToMathml(omml)).toContain("<msub>");
+  });
+
+  test("converts <m:sSubSup> into <msubsup>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:sSubSup>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+          <m:sub><m:r><m:t>i</m:t></m:r></m:sub>
+          <m:sup><m:r><m:t>2</m:t></m:r></m:sup>
+        </m:sSubSup>
+      </m:oMath>
+    `);
+    expect(ommlToMathml(omml)).toContain("<msubsup>");
+  });
+});
+
+describe("ommlToMathml — radicals", () => {
+  test("converts a degree-less <m:rad> into <msqrt>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:rad>
+          <m:deg/>
+          <m:e><m:r><m:t>2</m:t></m:r></m:e>
+        </m:rad>
+      </m:oMath>
+    `);
+    expect(ommlToMathml(omml)).toContain("<msqrt>");
+  });
+
+  test("converts a <m:rad> with explicit degree into <mroot>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:rad>
+          <m:deg><m:r><m:t>3</m:t></m:r></m:deg>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+        </m:rad>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mroot>");
+    expect(mml).toContain("<mn>3</mn>");
+  });
+});
+
+describe("ommlToMathml — n-ary operators", () => {
+  test("converts a summation with sub+sup into <msubsup>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:nary>
+          <m:naryPr><m:chr m:val="∑"/></m:naryPr>
+          <m:sub><m:r><m:t>i=1</m:t></m:r></m:sub>
+          <m:sup><m:r><m:t>n</m:t></m:r></m:sup>
+          <m:e><m:r><m:t>i</m:t></m:r></m:e>
+        </m:nary>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mo>∑</mo>");
+    expect(mml).toContain("<msubsup>");
+  });
+
+  test("converts an integral using limLoc=undOvr into <munderover>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:nary>
+          <m:naryPr><m:chr m:val="∫"/><m:limLoc m:val="undOvr"/></m:naryPr>
+          <m:sub><m:r><m:t>0</m:t></m:r></m:sub>
+          <m:sup><m:r><m:t>1</m:t></m:r></m:sup>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+        </m:nary>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mo>∫</mo>");
+    expect(mml).toContain("<munderover>");
+  });
+});
+
+describe("ommlToMathml — delimiters, matrices, accents", () => {
+  test("wraps <m:d> children in begChr/endChr operators", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:d>
+          <m:dPr><m:begChr m:val="["/><m:endChr m:val="]"/></m:dPr>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+        </m:d>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mo>[</mo>");
+    expect(mml).toContain("<mo>]</mo>");
+  });
+
+  test("converts <m:m>/<m:mr>/<m:e> into <mtable>/<mtr>/<mtd>", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:m>
+          <m:mr>
+            <m:e><m:r><m:t>a</m:t></m:r></m:e>
+            <m:e><m:r><m:t>b</m:t></m:r></m:e>
+          </m:mr>
+          <m:mr>
+            <m:e><m:r><m:t>c</m:t></m:r></m:e>
+            <m:e><m:r><m:t>d</m:t></m:r></m:e>
+          </m:mr>
+        </m:m>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mtable>");
+    expect((mml ?? "").match(/<mtr>/gu)?.length).toBe(2);
+    expect((mml ?? "").match(/<mtd>/gu)?.length).toBe(4);
+  });
+
+  test('converts <m:acc> into <mover accent="true">', () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:acc>
+          <m:accPr><m:chr m:val="̂"/></m:accPr>
+          <m:e><m:r><m:t>x</m:t></m:r></m:e>
+        </m:acc>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain('<mover accent="true">');
+  });
+});
+
+describe("ommlToMathml — graceful degradation", () => {
+  test("degrades unknown OMML elements to their children", () => {
+    // `<m:unknownThing>` isn't an OMML element we model — wrap the run
+    // anyway so its text survives.
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:unknownThing>
+          <m:r><m:t>z</m:t></m:r>
+        </m:unknownThing>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    expect(mml).toContain("<mi>z</mi>");
+  });
+
+  test("drops property-only elements without emitting output", () => {
+    const omml = parse(`
+      <m:oMath ${MATH_NS}>
+        <m:r><m:rPr><m:nor/></m:rPr><m:t>k</m:t></m:r>
+      </m:oMath>
+    `);
+    const mml = ommlToMathml(omml);
+    // `<m:rPr>` should not bleed into MathML output.
+    expect(mml).not.toContain("rPr");
+    expect(mml).not.toContain("<nor");
+    expect(mml).toContain("<mi>k</mi>");
+  });
+});

--- a/packages/folio/src/core/docx/mathToMathml.ts
+++ b/packages/folio/src/core/docx/mathToMathml.ts
@@ -316,7 +316,9 @@ function classifyChar(ch: string): "letter" | "digit" | "operator" {
     (code >= 0x00_61 && code <= 0x00_7a) || // a-z
     (code >= 0x03_91 && code <= 0x03_a9) || // Greek capital
     (code >= 0x03_b1 && code <= 0x03_c9) || // Greek small
-    (code >= 0x05_d0 && code <= 0x05_ea) // Hebrew letters
+    (code >= 0x05_d0 && code <= 0x05_ea) || // Hebrew letters
+    (code >= 0x21_00 && code <= 0x21_4f) || // Letterlike Symbols
+    (code >= 0x01_d4_00 && code <= 0x01_d7_ff) // Mathematical Alphanumeric Symbols
   ) {
     return "letter";
   }
@@ -329,7 +331,11 @@ function renderFraction(el: XmlElement): string {
   const den = findChildByLocalName(el, "den");
   const numMml = num ? wrapMrow(renderChildren(num)) : "<mrow/>";
   const denMml = den ? wrapMrow(renderChildren(den)) : "<mrow/>";
-  return `<mfrac>${numMml}${denMml}</mfrac>`;
+  const fPr = findChildByLocalName(el, "fPr");
+  const typeEl = fPr ? findChildByLocalName(fPr, "type") : null;
+  const type = typeEl ? getAttrValue(typeEl, "val") : null;
+  const attrs = type === "noBar" ? ' linethickness="0"' : "";
+  return `<mfrac${attrs}>${numMml}${denMml}</mfrac>`;
 }
 
 function renderScript(el: XmlElement, tag: "msup" | "msub"): string {
@@ -471,10 +477,11 @@ function renderBar(el: XmlElement): string {
 
 function renderGroupChr(el: XmlElement): string {
   const groupChrPr = findChildByLocalName(el, "groupChrPr");
-  const chrEl = groupChrPr ? findChildByLocalName(groupChrPr, "chr") : null;
-  const chr = chrEl ? (getAttrValue(chrEl, "val") ?? "⏟") : "⏟";
   const posEl = groupChrPr ? findChildByLocalName(groupChrPr, "pos") : null;
   const pos = posEl ? (getAttrValue(posEl, "val") ?? "bot") : "bot";
+  const chrEl = groupChrPr ? findChildByLocalName(groupChrPr, "chr") : null;
+  const defaultChr = pos === "top" ? "⏞" : "⏟";
+  const chr = chrEl ? (getAttrValue(chrEl, "val") ?? defaultChr) : defaultChr;
   const base = findChildByLocalName(el, "e");
   const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
   const grouper = `<mo stretchy="true">${escapeXml(chr)}</mo>`;

--- a/packages/folio/src/core/docx/mathToMathml.ts
+++ b/packages/folio/src/core/docx/mathToMathml.ts
@@ -1,0 +1,567 @@
+/**
+ * OMML → MathML conversion.
+ *
+ * Office Math Markup Language (OMML, namespace
+ * `http://schemas.openxmlformats.org/officeDocument/2006/math`) is what
+ * `<m:oMath>` / `<m:oMathPara>` carry inside `.docx`. OMML and MathML cover
+ * the same equation primitives, and Microsoft ships an XSLT
+ * (`OMML2MML.XSL`) that maps the two for Office's "save as MathML" feature.
+ *
+ * This module is a focused TypeScript implementation that walks the parsed
+ * XML tree produced by folio's parser (`XmlElement` from `./xmlParser`) and
+ * emits a MathML XML string suitable for direct injection into the DOM via
+ * `innerHTML` on a `<math>` host element. All Tier 1 desktop browsers
+ * render MathML Core natively (Firefox, Safari, Chromium ≥ 24 — Igalia's
+ * MathML revival shipped in Chrome 109, 2023), so the painter does not need
+ * KaTeX or MathJax on top.
+ *
+ * Coverage targets the OMML elements that appear in legal-doc and
+ * expert-report use cases: fractions, sub/superscripts, n-ary operators
+ * (Σ ∫ ∏ ⋃), radicals, delimiters, matrices, accents, plus the run/text
+ * primitives. Unknown OMML elements degrade to a `<mrow>` of their
+ * children rather than dropping content.
+ *
+ * Structural mapping is informed by Microsoft's public OMML2MML.XSL
+ * (BSD-style licence) — we borrow the element correspondence table but
+ * implement against folio's own `XmlElement` rather than vendoring the
+ * stylesheet.
+ */
+
+import {
+  type XmlElement,
+  findChildByLocalName,
+  getLocalName,
+} from "./xmlParser";
+
+/**
+ * Convert an OMML element (`<m:oMath>` or `<m:oMathPara>`) into a MathML
+ * XML string.
+ *
+ * The returned string is the full `<math>...</math>` element including the
+ * MathML namespace, ready to set via `Element.innerHTML` or
+ * `Range.createContextualFragment`. Returns `null` if `omml` is not an
+ * OMML root element or contains no convertible children.
+ */
+export function ommlToMathml(omml: XmlElement): string | null {
+  const local = omml.name ? getLocalName(omml.name) : "";
+  if (local !== "oMath" && local !== "oMathPara") {
+    return null;
+  }
+
+  const isBlock = local === "oMathPara";
+
+  // `<m:oMathPara>` wraps one or more `<m:oMath>` children plus
+  // paragraph properties (`<m:oMathParaPr>`). Convert every contained
+  // oMath child; if none exist, fall through to the generic mrow path.
+  let bodyMathml: string;
+  if (isBlock) {
+    const oMathChildren = (omml.elements ?? []).filter(
+      (child) =>
+        child.type === "element" && getLocalName(child.name ?? "") === "oMath",
+    );
+    if (oMathChildren.length > 0) {
+      bodyMathml = oMathChildren.map((child) => renderChildren(child)).join("");
+    } else {
+      bodyMathml = renderChildren(omml);
+    }
+  } else {
+    bodyMathml = renderChildren(omml);
+  }
+
+  if (!bodyMathml) {
+    return null;
+  }
+
+  const displayAttr = isBlock ? ' display="block"' : "";
+  return `<math xmlns="http://www.w3.org/1998/Math/MathML"${displayAttr}>${bodyMathml}</math>`;
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+const MATH_OPERATOR_HINT = new Set<string>([
+  "+",
+  "-",
+  "=",
+  "<",
+  ">",
+  "≤",
+  "≥",
+  "≠",
+  "±",
+  "×",
+  "÷",
+  "·",
+  "∙",
+  "/",
+  "*",
+  "(",
+  ")",
+  "[",
+  "]",
+  "{",
+  "}",
+  "|",
+  ",",
+  ";",
+  ":",
+  "→",
+  "←",
+  "↔",
+  "⇒",
+  "⇐",
+  "∈",
+  "∉",
+  "⊂",
+  "⊃",
+  "∪",
+  "∩",
+  "∀",
+  "∃",
+  "∂",
+  "∇",
+  "∞",
+  "…",
+]);
+
+function renderElement(el: XmlElement): string {
+  if (el.type === "text") {
+    return escapeXml(textValue(el));
+  }
+  if (el.type !== "element") {
+    return "";
+  }
+
+  const local = el.name ? getLocalName(el.name) : "";
+  switch (local) {
+    case "oMath":
+    case "oMathPara":
+      return renderChildren(el);
+    case "r":
+      return renderRun(el);
+    case "t":
+      return escapeXml(extractText(el));
+    case "f":
+      return renderFraction(el);
+    case "num":
+    case "den":
+      return wrapMrow(renderChildren(el));
+    case "sSup":
+      return renderScript(el, "msup");
+    case "sSub":
+      return renderScript(el, "msub");
+    case "sSubSup":
+      return renderSubSup(el);
+    case "sPre":
+      return renderPreScript(el);
+    case "rad":
+      return renderRadical(el);
+    case "deg":
+    case "e":
+    case "sup":
+    case "sub":
+    case "fName":
+    case "lim":
+      return wrapMrow(renderChildren(el));
+    case "nary":
+      return renderNary(el);
+    case "d":
+      return renderDelimiter(el);
+    case "m":
+      return renderMatrix(el);
+    case "mr":
+      return renderMatrixRow(el);
+    case "acc":
+      return renderAccent(el);
+    case "bar":
+      return renderBar(el);
+    case "groupChr":
+      return renderGroupChr(el);
+    case "limLow":
+      return renderLimLow(el);
+    case "limUpp":
+      return renderLimUpp(el);
+    case "func":
+      return renderChildren(el);
+    case "box":
+    case "borderBox":
+    case "eqArr":
+      // Best-effort: render children inline; no first-class MathML for these.
+      return wrapMrow(renderChildren(el));
+    case "rPr":
+    case "ctrlPr":
+    case "fPr":
+    case "naryPr":
+    case "dPr":
+    case "rPrChange":
+    case "mPr":
+    case "accPr":
+    case "barPr":
+    case "groupChrPr":
+    case "limLowPr":
+    case "limUppPr":
+    case "sSupPr":
+    case "sSubPr":
+    case "sSubSupPr":
+    case "sPrePr":
+    case "radPr":
+    case "boxPr":
+    case "borderBoxPr":
+    case "eqArrPr":
+    case "oMathParaPr":
+    case "funcPr":
+      // Property elements carry presentation hints we ignore today.
+      return "";
+    default:
+      // Unknown OMML elements degrade to their children so content is not
+      // silently dropped.
+      return renderChildren(el);
+  }
+}
+
+function renderChildren(el: XmlElement): string {
+  if (!el.elements) {
+    return "";
+  }
+  let out = "";
+  for (const child of el.elements) {
+    out += renderElement(child);
+  }
+  return out;
+}
+
+/**
+ * Convert an `<m:r>` run into a sequence of `<mi>` / `<mn>` / `<mo>`
+ * tokens. OMML stores math text in `<m:t>`; we tokenise on
+ * letter/digit/operator transitions to mirror MathML's per-token model.
+ */
+function renderRun(run: XmlElement): string {
+  const tElems = (run.elements ?? []).filter(
+    (c) => c.type === "element" && getLocalName(c.name ?? "") === "t",
+  );
+  if (tElems.length === 0) {
+    return "";
+  }
+  let out = "";
+  for (const tEl of tElems) {
+    out += tokenizeMathText(extractText(tEl));
+  }
+  return out;
+}
+
+function tokenizeMathText(text: string): string {
+  if (!text) {
+    return "";
+  }
+  let out = "";
+  let buf = "";
+  let bufKind: "letter" | "digit" | null = null;
+  const flush = () => {
+    if (!buf) {
+      return;
+    }
+    if (bufKind === "digit") {
+      out += `<mn>${escapeXml(buf)}</mn>`;
+    } else {
+      out += `<mi>${escapeXml(buf)}</mi>`;
+    }
+    buf = "";
+    bufKind = null;
+  };
+  for (const ch of text) {
+    if (ch === " " || ch === "\t" || ch === "\n") {
+      flush();
+      out += '<mspace width="0.2em"/>';
+      continue;
+    }
+    const kind = classifyChar(ch);
+    if (kind === "operator") {
+      flush();
+      out += `<mo>${escapeXml(ch)}</mo>`;
+      continue;
+    }
+    if (kind === "digit") {
+      // No mixed letter/digit buffer to flush — letters are emitted
+      // immediately below, so when we get here bufKind is either null
+      // or already "digit".
+      bufKind = "digit";
+      buf += ch;
+      continue;
+    }
+    // letter / identifier: each letter is its own <mi> token per MathML
+    // convention (variables are single-letter).
+    flush();
+    out += `<mi>${escapeXml(ch)}</mi>`;
+  }
+  flush();
+  return out;
+}
+
+function classifyChar(ch: string): "letter" | "digit" | "operator" {
+  if (ch >= "0" && ch <= "9") {
+    return "digit";
+  }
+  if (ch === ".") {
+    // Decimal point — sticks to surrounding numerals so "3.14" stays one <mn>.
+    return "digit";
+  }
+  if (MATH_OPERATOR_HINT.has(ch)) {
+    return "operator";
+  }
+  // Letter (Latin + Greek + Hebrew + other identifier-ish Unicode).
+  const code = ch.codePointAt(0) ?? 0;
+  if (
+    (code >= 0x00_41 && code <= 0x00_5a) || // A-Z
+    (code >= 0x00_61 && code <= 0x00_7a) || // a-z
+    (code >= 0x03_91 && code <= 0x03_a9) || // Greek capital
+    (code >= 0x03_b1 && code <= 0x03_c9) || // Greek small
+    (code >= 0x05_d0 && code <= 0x05_ea) // Hebrew letters
+  ) {
+    return "letter";
+  }
+  // Default: treat as operator (covers punctuation, arrows, set symbols).
+  return "operator";
+}
+
+function renderFraction(el: XmlElement): string {
+  const num = findChildByLocalName(el, "num");
+  const den = findChildByLocalName(el, "den");
+  const numMml = num ? wrapMrow(renderChildren(num)) : "<mrow/>";
+  const denMml = den ? wrapMrow(renderChildren(den)) : "<mrow/>";
+  return `<mfrac>${numMml}${denMml}</mfrac>`;
+}
+
+function renderScript(el: XmlElement, tag: "msup" | "msub"): string {
+  const base = findChildByLocalName(el, "e");
+  const script = findChildByLocalName(el, tag === "msup" ? "sup" : "sub");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const scriptMml = script ? wrapMrow(renderChildren(script)) : "<mrow/>";
+  return `<${tag}>${baseMml}${scriptMml}</${tag}>`;
+}
+
+function renderSubSup(el: XmlElement): string {
+  const base = findChildByLocalName(el, "e");
+  const sub = findChildByLocalName(el, "sub");
+  const sup = findChildByLocalName(el, "sup");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const subMml = sub ? wrapMrow(renderChildren(sub)) : "<mrow/>";
+  const supMml = sup ? wrapMrow(renderChildren(sup)) : "<mrow/>";
+  return `<msubsup>${baseMml}${subMml}${supMml}</msubsup>`;
+}
+
+function renderPreScript(el: XmlElement): string {
+  const base = findChildByLocalName(el, "e");
+  const sub = findChildByLocalName(el, "sub");
+  const sup = findChildByLocalName(el, "sup");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const subMml = sub ? wrapMrow(renderChildren(sub)) : "<none/>";
+  const supMml = sup ? wrapMrow(renderChildren(sup)) : "<none/>";
+  return `<mmultiscripts>${baseMml}<mprescripts/>${subMml}${supMml}</mmultiscripts>`;
+}
+
+function renderRadical(el: XmlElement): string {
+  const deg = findChildByLocalName(el, "deg");
+  const radicand = findChildByLocalName(el, "e");
+  const radMml = radicand ? wrapMrow(renderChildren(radicand)) : "<mrow/>";
+  // OMML uses `<m:radPr><m:degHide m:val="1"/></m:radPr>` or an empty
+  // `<m:deg/>` to mean "no degree" — render `<msqrt>` in that case.
+  const degText = deg ? renderChildren(deg) : "";
+  if (!deg || !degText) {
+    return `<msqrt>${radMml}</msqrt>`;
+  }
+  return `<mroot>${radMml}${wrapMrow(degText)}</mroot>`;
+}
+
+function renderNary(el: XmlElement): string {
+  const sub = findChildByLocalName(el, "sub");
+  const sup = findChildByLocalName(el, "sup");
+  const body = findChildByLocalName(el, "e");
+
+  // The operator character lives in `<m:naryPr><m:chr m:val="∑"/>`. Default
+  // to ∫ per OMML spec (the implicit char when chr is absent).
+  const naryPr = findChildByLocalName(el, "naryPr");
+  const chrEl = naryPr ? findChildByLocalName(naryPr, "chr") : null;
+  const chr = (chrEl ? getAttrValue(chrEl, "val") : null) || "∫";
+  const limLocEl = naryPr ? findChildByLocalName(naryPr, "limLoc") : null;
+  const limLoc = (limLocEl ? getAttrValue(limLocEl, "val") : null) || "subSup";
+
+  const opMml = `<mo>${escapeXml(chr)}</mo>`;
+  const subMml = sub ? wrapMrow(renderChildren(sub)) : "";
+  const supMml = sup ? wrapMrow(renderChildren(sup)) : "";
+  const bodyMml = body ? wrapMrow(renderChildren(body)) : "<mrow/>";
+
+  let nary: string;
+  if (subMml && supMml) {
+    nary =
+      limLoc === "undOvr"
+        ? `<munderover>${opMml}${subMml}${supMml}</munderover>`
+        : `<msubsup>${opMml}${subMml}${supMml}</msubsup>`;
+  } else if (subMml) {
+    nary =
+      limLoc === "undOvr"
+        ? `<munder>${opMml}${subMml}</munder>`
+        : `<msub>${opMml}${subMml}</msub>`;
+  } else if (supMml) {
+    nary =
+      limLoc === "undOvr"
+        ? `<mover>${opMml}${supMml}</mover>`
+        : `<msup>${opMml}${supMml}</msup>`;
+  } else {
+    nary = opMml;
+  }
+
+  return `<mrow>${nary}${bodyMml}</mrow>`;
+}
+
+function renderDelimiter(el: XmlElement): string {
+  const dPr = findChildByLocalName(el, "dPr");
+  const begChrEl = dPr ? findChildByLocalName(dPr, "begChr") : null;
+  const endChrEl = dPr ? findChildByLocalName(dPr, "endChr") : null;
+  const sepChrEl = dPr ? findChildByLocalName(dPr, "sepChr") : null;
+  const begChr = begChrEl ? (getAttrValue(begChrEl, "val") ?? "(") : "(";
+  const endChr = endChrEl ? (getAttrValue(endChrEl, "val") ?? ")") : ")";
+  const sepChr = sepChrEl ? (getAttrValue(sepChrEl, "val") ?? "|") : "|";
+
+  const children = (el.elements ?? []).filter(
+    (c) => c.type === "element" && getLocalName(c.name ?? "") === "e",
+  );
+  const parts = children.map((c) => wrapMrow(renderChildren(c)));
+  const inner = parts.join(`<mo>${escapeXml(sepChr)}</mo>`);
+
+  return `<mrow><mo>${escapeXml(begChr)}</mo>${inner}<mo>${escapeXml(endChr)}</mo></mrow>`;
+}
+
+function renderMatrix(el: XmlElement): string {
+  const rows = (el.elements ?? []).filter(
+    (c) => c.type === "element" && getLocalName(c.name ?? "") === "mr",
+  );
+  const body = rows.map(renderMatrixRow).join("");
+  return `<mtable>${body}</mtable>`;
+}
+
+function renderMatrixRow(row: XmlElement): string {
+  const cells = (row.elements ?? []).filter(
+    (c) => c.type === "element" && getLocalName(c.name ?? "") === "e",
+  );
+  const body = cells.map((c) => `<mtd>${renderChildren(c)}</mtd>`).join("");
+  return `<mtr>${body}</mtr>`;
+}
+
+function renderAccent(el: XmlElement): string {
+  const accPr = findChildByLocalName(el, "accPr");
+  const chrEl = accPr ? findChildByLocalName(accPr, "chr") : null;
+  const chr = chrEl ? (getAttrValue(chrEl, "val") ?? "̂") : "̂";
+  const base = findChildByLocalName(el, "e");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  return `<mover accent="true">${baseMml}<mo>${escapeXml(chr)}</mo></mover>`;
+}
+
+function renderBar(el: XmlElement): string {
+  const barPr = findChildByLocalName(el, "barPr");
+  const posEl = barPr ? findChildByLocalName(barPr, "pos") : null;
+  const pos = posEl ? (getAttrValue(posEl, "val") ?? "top") : "top";
+  const base = findChildByLocalName(el, "e");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const bar = '<mo stretchy="true">¯</mo>';
+  return pos === "bot"
+    ? `<munder>${baseMml}${bar}</munder>`
+    : `<mover>${baseMml}${bar}</mover>`;
+}
+
+function renderGroupChr(el: XmlElement): string {
+  const groupChrPr = findChildByLocalName(el, "groupChrPr");
+  const chrEl = groupChrPr ? findChildByLocalName(groupChrPr, "chr") : null;
+  const chr = chrEl ? (getAttrValue(chrEl, "val") ?? "⏟") : "⏟";
+  const posEl = groupChrPr ? findChildByLocalName(groupChrPr, "pos") : null;
+  const pos = posEl ? (getAttrValue(posEl, "val") ?? "bot") : "bot";
+  const base = findChildByLocalName(el, "e");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const grouper = `<mo stretchy="true">${escapeXml(chr)}</mo>`;
+  return pos === "top"
+    ? `<mover>${baseMml}${grouper}</mover>`
+    : `<munder>${baseMml}${grouper}</munder>`;
+}
+
+function renderLimLow(el: XmlElement): string {
+  const base = findChildByLocalName(el, "e");
+  const lim = findChildByLocalName(el, "lim");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const limMml = lim ? wrapMrow(renderChildren(lim)) : "<mrow/>";
+  return `<munder>${baseMml}${limMml}</munder>`;
+}
+
+function renderLimUpp(el: XmlElement): string {
+  const base = findChildByLocalName(el, "e");
+  const lim = findChildByLocalName(el, "lim");
+  const baseMml = base ? wrapMrow(renderChildren(base)) : "<mrow/>";
+  const limMml = lim ? wrapMrow(renderChildren(lim)) : "<mrow/>";
+  return `<mover>${baseMml}${limMml}</mover>`;
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function wrapMrow(body: string): string {
+  if (!body) {
+    return "<mrow/>";
+  }
+  return `<mrow>${body}</mrow>`;
+}
+
+function extractText(el: XmlElement): string {
+  if (el.type === "text") {
+    return textValue(el);
+  }
+  if (!el.elements) {
+    return "";
+  }
+  let out = "";
+  for (const child of el.elements) {
+    if (child.type === "text") {
+      out += textValue(child);
+    } else {
+      out += extractText(child);
+    }
+  }
+  return out;
+}
+
+function textValue(el: XmlElement): string {
+  const v = el.text;
+  if (typeof v === "string") {
+    return v;
+  }
+  if (typeof v === "number" || typeof v === "boolean") {
+    return String(v);
+  }
+  return "";
+}
+
+function getAttrValue(el: XmlElement, localAttr: string): string | undefined {
+  if (!el.attributes) {
+    return undefined;
+  }
+  for (const [k, v] of Object.entries(el.attributes)) {
+    if (k === localAttr || k.endsWith(`:${localAttr}`)) {
+      if (typeof v === "string") {
+        return v;
+      }
+      if (v === undefined) {
+        return undefined;
+      }
+      return String(v);
+    }
+  }
+  return undefined;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/packages/folio/src/core/docx/serializer/math-roundtrip.test.ts
+++ b/packages/folio/src/core/docx/serializer/math-roundtrip.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { fromProseDoc } from "../../prosemirror/conversion/fromProseDoc";
+import { toProseDoc } from "../../prosemirror/conversion/toProseDoc";
+import type { Document, Paragraph } from "../../types/document";
+import { parseParagraph } from "../paragraphParser";
+import { parseXmlDocument } from "../xmlParser";
+import { serializeParagraph } from "./paragraphSerializer";
+
+function parseParagraphXml(xml: string): Paragraph {
+  const root = parseXmlDocument(xml);
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" ' +
+  'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"';
+
+/**
+ * Math equation round-trip safety. The renderer derives MathML from
+ * `ommlXml` only at paint time; the document model must keep the OMML
+ * unchanged so save side stays byte-stable for the equation chunk.
+ */
+describe("math equation round-trip", () => {
+  test("preserves inline <m:oMath> through parse → serialize", () => {
+    const xml = `
+      <w:p ${NS}>
+        <m:oMath><m:r><m:t>x+1</m:t></m:r></m:oMath>
+      </w:p>
+    `;
+    const paragraph = parseParagraphXml(xml);
+    expect(paragraph.content[0]?.type).toBe("mathEquation");
+
+    const serialized = serializeParagraph(paragraph);
+    expect(serialized).toContain("<m:oMath");
+    expect(serialized).toContain("x+1");
+    expect(serialized).toContain("</m:oMath>");
+  });
+
+  test("preserves <m:oMathPara> display equations", () => {
+    const xml = `
+      <w:p ${NS}>
+        <m:oMathPara>
+          <m:oMath><m:r><m:t>n</m:t></m:r></m:oMath>
+        </m:oMathPara>
+      </w:p>
+    `;
+    const paragraph = parseParagraphXml(xml);
+    const first = paragraph.content[0];
+    expect(first?.type).toBe("mathEquation");
+    if (first?.type === "mathEquation") {
+      expect(first.display).toBe("block");
+    }
+    const serialized = serializeParagraph(paragraph);
+    expect(serialized).toContain("<m:oMathPara");
+  });
+
+  test("preserves a fraction structure verbatim", () => {
+    const xml = `<w:p ${NS}><m:oMath><m:f><m:num><m:r><m:t>1</m:t></m:r></m:num><m:den><m:r><m:t>2</m:t></m:r></m:den></m:f></m:oMath></w:p>`;
+    const paragraph = parseParagraphXml(xml);
+    const first = paragraph.content[0];
+    expect(first?.type).toBe("mathEquation");
+    const serialized = serializeParagraph(paragraph);
+    expect(serialized).toContain("<m:f>");
+    expect(serialized).toContain("<m:num>");
+    expect(serialized).toContain("<m:den>");
+    expect(serialized).toContain("</m:f>");
+  });
+
+  test("OMML survives the full ProseMirror round-trip", () => {
+    const xml = `<w:p ${NS}><m:oMath><m:r><m:t>a+b</m:t></m:r></m:oMath></w:p>`;
+    const paragraph = parseParagraphXml(xml);
+    // SAFETY: minimal document shape — `toProseDoc`/`fromProseDoc` only
+    // touch `package.document.content` in this test path. Building a full
+    // `Document` would obscure what we're actually round-tripping.
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+    const doc = {
+      package: {
+        document: {
+          content: [paragraph],
+        },
+      },
+    } as unknown as Document;
+
+    const pmDoc = toProseDoc(doc);
+    const docAgain = fromProseDoc(pmDoc, doc);
+    const para2 = docAgain.package.document.content.at(0);
+    expect(para2?.type).toBe("paragraph");
+    if (para2?.type !== "paragraph") {
+      return;
+    }
+    const mathItem = para2.content.find((c) => c.type === "mathEquation");
+    expect(mathItem).toBeDefined();
+    if (mathItem?.type === "mathEquation") {
+      expect(mathItem.ommlXml).toContain("<m:oMath");
+      expect(mathItem.ommlXml).toContain("a+b");
+    }
+  });
+});

--- a/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
+++ b/packages/folio/src/core/layout-bridge/headerFooterLayout.ts
@@ -750,6 +750,11 @@ function blockSig(b: FlowBlock): string {
         text +=
           `[i${r.width}x${r.height}|${r.src}|` +
           `${r.transform ?? ""}|${r.wrapType ?? ""}];`;
+      } else if (r.kind === "math") {
+        // OMML XML uniquely identifies the rendered MathML output;
+        // changes to the equation must invalidate the HF cache so the
+        // painter re-injects the updated `<math>` element.
+        text += `M:${r.display}|${r.ommlXml};`;
       } else {
         // field run
         text += `F:${r.fieldType}|${serializeRunFmt(r)};`;

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph-decimal-tab.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph-decimal-tab.test.ts
@@ -115,6 +115,49 @@ describe("measureParagraph — decimal tab stop (PR #512 gemini HIGH)", () => {
     });
   });
 
+  test("decimal prefix includes math runs after the tab", () => {
+    withFakeTextMeasure(() => {
+      const block = {
+        kind: "paragraph" as const,
+        id: "decimal-tab-math",
+        runs: [
+          { kind: "text" as const, text: "x", fontSize: 11 },
+          { kind: "tab" as const },
+          {
+            kind: "math" as const,
+            display: "inline" as const,
+            ommlXml: "<m:oMath />",
+            plainText: "12.34",
+            fontSize: 11,
+          },
+        ],
+        attrs: {
+          tabs: [{ val: "decimal" as const, pos: 3000 }],
+        },
+      };
+
+      const measure = measureParagraph(block, 400);
+      const line = measure.lines.at(0);
+      expect(line).toBeDefined();
+
+      const leadingWidth = 5;
+      const followingWidth = 25;
+      const decimalPrefixWidth = 10;
+      const tabContext: TabContext = {
+        explicitStops: [{ val: "decimal", pos: 3000 }],
+      };
+      const tabResult = calculateTabWidth(leadingWidth, tabContext, {
+        followingWidth,
+        decimalPrefixWidth,
+      });
+      const painterLineWidth = leadingWidth + tabResult.width + followingWidth;
+
+      expect(
+        Math.abs((line?.width ?? 0) - painterLineWidth),
+      ).toBeLessThanOrEqual(0.5);
+    });
+  });
+
   test("decimal tab without a decimal point falls back to left-tab math", () => {
     // No "." in the trailing content → `decimalPrefixWidth` is 0, so the
     // tab advances to the stop and the line width is leading + (stop -

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.test.ts
@@ -531,6 +531,50 @@ describe("inline image paragraph measurement", () => {
   });
 });
 
+describe("math paragraph measurement", () => {
+  test("stacked inline math reserves extra line height", () => {
+    withFakeTextMeasure(() => {
+      const inlineMeasure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "math-inline",
+          runs: [
+            {
+              kind: "math",
+              display: "inline",
+              ommlXml: "<m:oMath><m:r><m:t>x</m:t></m:r></m:oMath>",
+              plainText: "x",
+              fontSize: 11,
+            },
+          ],
+        },
+        600,
+      );
+      const stackedMeasure = measureParagraph(
+        {
+          kind: "paragraph",
+          id: "math-stacked",
+          runs: [
+            {
+              kind: "math",
+              display: "inline",
+              ommlXml:
+                "<m:oMath><m:f><m:num><m:r><m:t>a</m:t></m:r></m:num><m:den><m:r><m:t>b</m:t></m:r></m:den></m:f></m:oMath>",
+              plainText: "a/b",
+              fontSize: 11,
+            },
+          ],
+        },
+        600,
+      );
+
+      const inlineLineHeight = inlineMeasure.lines.at(0)?.lineHeight ?? 0;
+      const stackedLineHeight = stackedMeasure.lines.at(0)?.lineHeight ?? 0;
+      expect(stackedLineHeight).toBeGreaterThan(inlineLineHeight + 10);
+    });
+  });
+});
+
 describe("block image rotation measurement", () => {
   // The painter wraps a rotated block image in an axis-aligned bbox
   // (`renderBlockImage`, eigenpal #424). The measurer has to reserve the

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -15,6 +15,7 @@ import type {
   ImageRun,
   LineBreakRun,
   FieldRun,
+  MathRun,
   ParagraphSpacing,
 } from "../../layout-engine/types";
 import { isFloatingImageRun } from "../../layout-painter/renderUtils";
@@ -124,7 +125,7 @@ type LineState = {
  * same way; widening the parameter keeps tab-following measurement
  * (FieldRun page numbers, etc.) consistent with TextRun handling.
  */
-function runToFontStyle(run: TextRun | TabRun | FieldRun): FontStyle {
+function runToFontStyle(run: TextRun | TabRun | FieldRun | MathRun): FontStyle {
   return {
     fontFamily: run.fontFamily ?? DEFAULT_FONT_FAMILY,
     fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
@@ -306,6 +307,13 @@ function isFieldRun(run: Run): run is FieldRun {
 }
 
 /**
+ * Check if a run is a math equation run
+ */
+function isMathRun(run: Run): run is MathRun {
+  return run.kind === "math";
+}
+
+/**
  * Check if text run is empty (only whitespace or no text)
  */
 function isEmptyTextRun(run: TextRun): boolean {
@@ -336,6 +344,11 @@ function measureInlineWidthAfterTab(runs: Run[], tabIndex: number): number {
       width += measureTextWidth(next.fallback || "1", runToFontStyle(next));
     } else if (isImageRun(next) && !isFloatingImageRun(next)) {
       width += next.width || 0;
+    } else if (isMathRun(next)) {
+      width += measureTextWidth(
+        next.plainText || "[equation]",
+        runToFontStyle(next),
+      );
     }
   }
   return width;
@@ -983,6 +996,35 @@ export function measureParagraph(
       }
 
       currentLine.width += fieldWidth;
+      currentLine.toRun = runIndex;
+      currentLine.toChar = 1;
+      continue;
+    }
+
+    if (isMathRun(run)) {
+      // Math is opaque to the line breaker: it can't wrap mid-equation.
+      // Reserve the rendered MathML's approximate inline width using the
+      // plain-text fallback measured in Cambria Math at the run's font
+      // size — this matches what the browser actually puts on screen
+      // closely enough for line-wrap decisions. The painter then injects
+      // the real `<math>` element, which the browser sizes natively.
+      const style: FontStyle = {
+        fontFamily: run.fontFamily ?? "Cambria Math",
+        fontSize: run.fontSize ?? DEFAULT_FONT_SIZE,
+        ...(run.bold !== undefined ? { bold: run.bold } : {}),
+        ...(run.italic !== undefined ? { italic: run.italic } : {}),
+      };
+      updateMaxFont(style);
+      const mathWidth = measureTextWidth(run.plainText || "[equation]", style);
+      if (
+        currentLine.width > 0 &&
+        currentLine.width + mathWidth >
+          currentLine.availableWidth + WIDTH_TOLERANCE
+      ) {
+        startNewLine(runIndex, 0);
+        updateMaxFont(style);
+      }
+      currentLine.width += mathWidth;
       currentLine.toRun = runIndex;
       currentLine.toChar = 1;
       continue;

--- a/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
+++ b/packages/folio/src/core/layout-bridge/measuring/measureParagraph.ts
@@ -110,6 +110,8 @@ type LineState = {
   maxFontMetrics: FontMetrics | null;
   /** Maximum inline image height in pixels (already in px, not points) */
   maxImageHeightPx: number;
+  /** Maximum inline math height in pixels (already in px, not points) */
+  maxMathHeightPx: number;
   availableWidth: number;
   /** Left offset from floating images (pixels from content left edge) */
   leftOffset: number;
@@ -313,6 +315,51 @@ function isMathRun(run: Run): run is MathRun {
   return run.kind === "math";
 }
 
+function isStackedMathLocalName(localName: string): boolean {
+  switch (localName) {
+    case "bar":
+    case "d":
+    case "eqArr":
+    case "f":
+    case "groupChr":
+    case "limLow":
+    case "limUpp":
+    case "m":
+    case "nary":
+    case "rad":
+    case "sPre":
+    case "sSubSup":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function hasStackedMathLayout(run: MathRun): boolean {
+  if (run.display === "block") {
+    return true;
+  }
+  const tagPattern = /<([A-Za-z_][\w.-]*(?::[A-Za-z_][\w.-]*)?)(?:\s|\/|>)/gu;
+  for (const match of run.ommlXml.matchAll(tagPattern)) {
+    const tagName = match[1];
+    if (!tagName) {
+      continue;
+    }
+    const colonIndex = tagName.indexOf(":");
+    const localName =
+      colonIndex === -1 ? tagName : tagName.slice(colonIndex + 1);
+    if (isStackedMathLocalName(localName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function estimateMathFootprintPx(run: MathRun): number {
+  const fontSizePx = ptToPx(run.fontSize ?? DEFAULT_FONT_SIZE);
+  return fontSizePx * (hasStackedMathLayout(run) ? 2.4 : 1.25);
+}
+
 /**
  * Check if text run is empty (only whitespace or no text)
  */
@@ -368,7 +415,7 @@ function measureDecimalPrefixWidthAfterTab(
   tabIndex: number,
 ): number {
   let text = "";
-  let firstRun: TextRun | FieldRun | undefined;
+  let firstRun: TextRun | FieldRun | MathRun | undefined;
   for (let i = tabIndex + 1; i < runs.length; i++) {
     const next = runs[i];
     if (!next || isTabRun(next) || isLineBreakRun(next)) {
@@ -379,6 +426,9 @@ function measureDecimalPrefixWidthAfterTab(
       firstRun ??= next;
     } else if (isFieldRun(next)) {
       text += next.fallback || "1";
+      firstRun ??= next;
+    } else if (isMathRun(next)) {
+      text += next.plainText || "[equation]";
       firstRun ??= next;
     }
   }
@@ -689,6 +739,7 @@ export function measureParagraph(
     maxFontSize: DEFAULT_FONT_SIZE,
     maxFontMetrics: null,
     maxImageHeightPx: 0,
+    maxMathHeightPx: 0,
     availableWidth: firstLineWidth,
     leftOffset: firstLineFloatingMargins.leftMargin,
     rightOffset: firstLineFloatingMargins.rightMargin,
@@ -707,33 +758,36 @@ export function measureParagraph(
       currentLine.maxFontMetrics,
     );
 
-    // If an inline image is taller than the text-based line height, the line
-    // grows to fit the image. Word seats an inline image as a tall glyph on
-    // the text baseline.
+    // If an inline image or stacked equation is taller than the text-based
+    // line height, the line grows to fit it. Word seats these inline objects
+    // as tall glyphs on the text baseline.
     const finalTypography = { ...typography };
-    if (currentLine.maxImageHeightPx > finalTypography.lineHeight) {
-      const imageHeight = currentLine.maxImageHeightPx;
+    const inlineObjectHeight = Math.max(
+      currentLine.maxImageHeightPx,
+      currentLine.maxMathHeightPx,
+    );
+    if (inlineObjectHeight > finalTypography.lineHeight) {
+      const objectHeight = inlineObjectHeight;
       const buffer = finalTypography.descent;
-      // `fromRun === toRun` with a tall image present means the line holds
-      // exactly that one image (no flowing text/tabs). Must stay paired with
-      // the painter's image-only `runsForLine.length === 1 && isImageRun(...)`
+      // `fromRun === toRun` with a tall inline object present means the line
+      // holds exactly that one object (no flowing text/tabs). Must stay paired
+      // with the painter's image-only `runsForLine.length === 1 && isImageRun(...)`
       // test in renderLine — the two pick paired line-height + alignment
       // strategies and disagreeing reintroduces the floating-label bug.
       if (currentLine.fromRun === currentLine.toRun) {
-        // Image alone on the line: grow to the image height plus the parent
-        // font's descent on BOTH sides so the row has visible breathing room
-        // above and below the image (Word's render gives a few px of cell
-        // padding even with tcMar=0).
-        finalTypography.lineHeight = imageHeight + buffer * 2;
-        finalTypography.ascent = imageHeight + buffer;
+        // Object alone on the line: grow to the object height plus the
+        // parent font's descent on BOTH sides so the row has visible
+        // breathing room above and below it.
+        finalTypography.lineHeight = objectHeight + buffer * 2;
+        finalTypography.ascent = objectHeight + buffer;
       } else {
-        // Image flowing with text/tabs (e.g. a logo + label header line):
-        // the full image height sits above the baseline and only the text
-        // descent is reserved below — no extra leading above the image. The
-        // painter baseline-aligns the row so the image bottom lands on the
-        // text baseline.
-        finalTypography.lineHeight = imageHeight + buffer;
-        finalTypography.ascent = imageHeight;
+        // Object flowing with text/tabs (e.g. a logo + label header line):
+        // the full object height sits above the baseline and only the text
+        // descent is reserved below — no extra leading above it. The painter
+        // baseline-aligns the row so the object bottom lands on the text
+        // baseline.
+        finalTypography.lineHeight = objectHeight + buffer;
+        finalTypography.ascent = objectHeight;
       }
     }
 
@@ -800,6 +854,7 @@ export function measureParagraph(
       maxFontSize: DEFAULT_FONT_SIZE,
       maxFontMetrics: null,
       maxImageHeightPx: 0,
+      maxMathHeightPx: 0,
       availableWidth: adjustedWidth,
       leftOffset: floatingMargins.leftMargin,
       rightOffset: floatingMargins.rightMargin,
@@ -1016,6 +1071,7 @@ export function measureParagraph(
       };
       updateMaxFont(style);
       const mathWidth = measureTextWidth(run.plainText || "[equation]", style);
+      const mathFootprintPx = estimateMathFootprintPx(run);
       if (
         currentLine.width > 0 &&
         currentLine.width + mathWidth >
@@ -1023,6 +1079,9 @@ export function measureParagraph(
       ) {
         startNewLine(runIndex, 0);
         updateMaxFont(style);
+      }
+      if (mathFootprintPx > currentLine.maxMathHeightPx) {
+        currentLine.maxMathHeightPx = mathFootprintPx;
       }
       currentLine.width += mathWidth;
       currentLine.toRun = runIndex;

--- a/packages/folio/src/core/layout-bridge/selectionRects.test.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { Layout, Measure, ParagraphBlock } from "../layout-engine/types";
+import { resetCanvasContext } from "./measuring/measureContainer";
+import { getCaretPosition } from "./selectionRects";
+
+const originalDocument = globalThis.document;
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      createElement(tagName: string) {
+        if (tagName !== "canvas") {
+          return {};
+        }
+        return {
+          getContext() {
+            return {
+              font: "",
+              measureText(text: string) {
+                return { width: text.length * 7 };
+              },
+            };
+          },
+        };
+      },
+    },
+  });
+  resetCanvasContext();
+});
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: originalDocument,
+  });
+  resetCanvasContext();
+});
+
+describe("selection rect geometry", () => {
+  test("caret positions advance over atomic math runs", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "p1",
+      pmStart: 0,
+      pmEnd: 5,
+      runs: [
+        {
+          kind: "math",
+          display: "inline",
+          ommlXml: "<m:oMath />",
+          plainText: "xx",
+          fontFamily: "Cambria Math",
+          fontSize: 11,
+          pmStart: 1,
+          pmEnd: 2,
+        },
+        {
+          kind: "text",
+          text: "abc",
+          fontFamily: "Calibri",
+          fontSize: 11,
+          pmStart: 2,
+          pmEnd: 5,
+        },
+      ],
+    };
+    const measures: Measure[] = [
+      {
+        kind: "paragraph",
+        lines: [
+          {
+            fromRun: 0,
+            toRun: 1,
+            fromChar: 0,
+            toChar: 3,
+            width: 35,
+            lineHeight: 16,
+            ascent: 12,
+            descent: 4,
+          },
+        ],
+        width: 35,
+        height: 16,
+      },
+    ];
+    const layout: Layout = {
+      pageGap: 0,
+      pages: [
+        {
+          number: 1,
+          size: { w: 600, h: 800 },
+          margins: { top: 0, right: 0, bottom: 0, left: 0 },
+          fragments: [
+            {
+              kind: "paragraph",
+              blockId: "p1",
+              x: 0,
+              y: 0,
+              width: 500,
+              height: 16,
+              fromLine: 0,
+              toLine: 1,
+            },
+          ],
+        },
+      ],
+    };
+
+    const caret = getCaretPosition(layout, [block], measures, 2);
+
+    expect(caret?.x).toBe(14);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/selectionRects.ts
+++ b/packages/folio/src/core/layout-bridge/selectionRects.ts
@@ -22,6 +22,7 @@ import type {
   TableMeasure,
   TextRun,
   TabRun,
+  MathRun,
   BlockId,
 } from "../layout-engine/types";
 import { inlineImageBoundingBox } from "../utils/rotationBoundingBox";
@@ -81,6 +82,21 @@ function runToFontStyle(run: TextRun | TabRun): FontStyle {
       : {}),
     ...(run.allCaps ? { textTransform: "uppercase" as const } : {}),
     ...(run.smallCaps ? { fontVariant: "small-caps" as const } : {}),
+    ...(run.horizontalScale !== undefined
+      ? { horizontalScale: run.horizontalScale }
+      : {}),
+  };
+}
+
+function mathRunToFontStyle(run: MathRun): FontStyle {
+  return {
+    fontFamily: run.fontFamily ?? "Cambria Math",
+    fontSize: run.fontSize ?? 11,
+    ...(run.bold !== undefined ? { bold: run.bold } : {}),
+    ...(run.italic !== undefined ? { italic: run.italic } : {}),
+    ...(run.letterSpacing !== undefined
+      ? { letterSpacing: run.letterSpacing }
+      : {}),
     ...(run.horizontalScale !== undefined
       ? { horizontalScale: run.horizontalScale }
       : {}),
@@ -266,6 +282,22 @@ function charOffsetToX(
       if (charOffset <= charsProcessed) {
         return x;
       }
+      charsProcessed += 1;
+      continue;
+    }
+
+    if (run.kind === "math") {
+      const mathWidth = measureRun(
+        run.plainText,
+        mathRunToFontStyle(run),
+      ).width;
+      if (charsProcessed + 1 >= charOffset) {
+        if (charOffset <= charsProcessed) {
+          return x;
+        }
+        return x + mathWidth;
+      }
+      x += mathWidth;
       charsProcessed += 1;
       continue;
     }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -1013,10 +1013,13 @@ function paragraphToRuns(
       return;
     }
     if (child.type.name === "math") {
-      const text = expectMathAttrs(child).plainText || "[equation]";
+      const attrs = expectMathAttrs(child);
+      const plainText = attrs.plainText || "[equation]";
       runs.push({
-        kind: "text",
-        text,
+        kind: "math",
+        display: attrs.display ?? "inline",
+        ommlXml: attrs.ommlXml,
+        plainText,
         italic: true,
         fontFamily: "Cambria Math",
         pmStart: childPos,

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -222,9 +222,36 @@ export type FieldRun = RunFormatting & {
 };
 
 /**
+ * A native math equation run. The painter converts `ommlXml` to MathML
+ * and injects a `<math>` element inline; `plainText` is the screen-reader
+ * fallback and the measurer's width estimate.
+ *
+ * The raw OMML XML lives on the run so the painter can re-convert when
+ * markup changes; it is never modified on save (round-trip happens via
+ * the document model, not the layout layer).
+ */
+export type MathRun = RunFormatting & {
+  kind: "math";
+  /** `inline` = `<m:oMath>`, `block` = `<m:oMathPara>`. */
+  display: "inline" | "block";
+  /** Raw OMML XML for conversion + round-trip. */
+  ommlXml: string;
+  /** Plain-text fallback used when MathML rendering is unavailable. */
+  plainText: string;
+  pmStart?: number;
+  pmEnd?: number;
+};
+
+/**
  * Union of all run types.
  */
-export type Run = TextRun | TabRun | ImageRun | LineBreakRun | FieldRun;
+export type Run =
+  | TextRun
+  | TabRun
+  | ImageRun
+  | LineBreakRun
+  | FieldRun
+  | MathRun;
 
 /**
  * Paragraph spacing configuration.

--- a/packages/folio/src/core/layout-painter/renderMath.test.ts
+++ b/packages/folio/src/core/layout-painter/renderMath.test.ts
@@ -1,0 +1,428 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MathRun } from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+// Render-side tests for OMML math runs (`feat/folio-omml-math-render`).
+// The painter converts OMML XML to MathML at paint time and injects a
+// native `<math>` element. These tests exercise the painter's run
+// dispatch using a minimal fake Document so we don't pull in jsdom /
+// happy-dom for one feature.
+
+class FakeStyle {
+  private values: Record<string, string> = {};
+  setProperty(name: string, value: string): void {
+    this.values[name] = value;
+  }
+  getPropertyValue(name: string): string {
+    return this.values[name] ?? "";
+  }
+}
+
+type StyleProxy = FakeStyle & Record<string, string>;
+
+function makeStyle(): StyleProxy {
+  const fake = new FakeStyle();
+  return new Proxy(fake, {
+    get(target, prop) {
+      if (prop in target) {
+        const v = (target as unknown as Record<PropertyKey, unknown>)[prop];
+        if (typeof v === "function") {
+          return (v as (...a: unknown[]) => unknown).bind(target);
+        }
+        return v;
+      }
+      return target.getPropertyValue(String(prop));
+    },
+    set(target, prop, value) {
+      target.setProperty(String(prop), String(value));
+      return true;
+    },
+  }) as StyleProxy;
+}
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  textContent = "";
+  title = "";
+  style: StyleProxy = makeStyle();
+  children: FakeElement[] = [];
+  attributes: Record<string, string> = {};
+  height = 0;
+  width = 0;
+  src = "";
+  alt = "";
+  draggable = true;
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+  #innerHTML = "";
+
+  constructor(tagName: string) {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  get innerHTML(): string {
+    return this.#innerHTML;
+  }
+
+  set innerHTML(value: string) {
+    this.#innerHTML = value;
+    // Minimal HTML tokeniser: extract top-level open tags so
+    // `firstElementChild`/tag walks work for tests that inspect injected
+    // MathML. Sufficient for the render tests; not a full HTML parser.
+    this.children = parseTopLevelChildren(value);
+  }
+
+  get firstElementChild(): FakeElement | null {
+    return this.children[0] ?? null;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes[name] = value;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "CANVAS") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+/**
+ * Tokenise a serialised HTML string into a flat list of top-level
+ * children sufficient for tests that inspect tag names and attributes.
+ * Nested children are parsed recursively so `findElement` can recurse
+ * through the MathML tree.
+ */
+function parseTopLevelChildren(html: string): FakeElement[] {
+  const children: FakeElement[] = [];
+  let i = 0;
+  while (i < html.length) {
+    const openIdx = html.indexOf("<", i);
+    if (openIdx === -1) {
+      break;
+    }
+    if (html.startsWith("</", openIdx)) {
+      // Stray close tag — skip.
+      const closeEnd = html.indexOf(">", openIdx);
+      if (closeEnd === -1) {
+        break;
+      }
+      i = closeEnd + 1;
+      continue;
+    }
+    const tagEnd = html.indexOf(">", openIdx);
+    if (tagEnd === -1) {
+      break;
+    }
+    const isSelfClose = html[tagEnd - 1] === "/";
+    const tagBody = html.slice(openIdx + 1, isSelfClose ? tagEnd - 1 : tagEnd);
+    const spaceIdx = tagBody.search(/\s/u);
+    const tagName = (
+      spaceIdx === -1 ? tagBody : tagBody.slice(0, spaceIdx)
+    ).trim();
+    const attrText = spaceIdx === -1 ? "" : tagBody.slice(spaceIdx);
+    const el = new FakeElement(tagName);
+    // Linear-time attribute extraction: walk the text instead of using a
+    // regex with alternation that sonarjs flags as super-linear.
+    let attrPos = 0;
+    while (attrPos < attrText.length) {
+      while (attrPos < attrText.length && /\s/u.test(attrText[attrPos] ?? "")) {
+        attrPos += 1;
+      }
+      const eqIdx = attrText.indexOf("=", attrPos);
+      if (eqIdx === -1) {
+        break;
+      }
+      const name = attrText.slice(attrPos, eqIdx).trim();
+      const quote = attrText[eqIdx + 1];
+      if (quote !== '"' && quote !== "'") {
+        break;
+      }
+      const valueEnd = attrText.indexOf(quote, eqIdx + 2);
+      if (valueEnd === -1) {
+        break;
+      }
+      el.attributes[name] = attrText.slice(eqIdx + 2, valueEnd);
+      attrPos = valueEnd + 1;
+    }
+
+    if (isSelfClose) {
+      children.push(el);
+      i = tagEnd + 1;
+      continue;
+    }
+
+    // Find matching close tag, tracking depth so nested same-name tags
+    // don't terminate prematurely.
+    const closeTag = `</${tagName}>`;
+    const openTagRe = new RegExp(`<${tagName}(?=[\\s>/])`, "gu");
+    let depth = 1;
+    let cursor = tagEnd + 1;
+    let closeIdx = -1;
+    while (cursor < html.length && depth > 0) {
+      const nextClose = html.indexOf(closeTag, cursor);
+      if (nextClose === -1) {
+        break;
+      }
+      openTagRe.lastIndex = cursor;
+      let opensBetween = 0;
+      let m: RegExpExecArray | null;
+      while ((m = openTagRe.exec(html)) !== null && m.index < nextClose) {
+        // Self-close in between counts as 0 net depth — but our simple
+        // tokeniser treats them the same; tests don't hit nested self-close
+        // for the same name.
+        opensBetween += 1;
+      }
+      depth += opensBetween - 1;
+      if (depth === 0) {
+        closeIdx = nextClose;
+        break;
+      }
+      cursor = nextClose + closeTag.length;
+    }
+    if (closeIdx === -1) {
+      // No matching close tag — push as leaf and advance past the open tag.
+      children.push(el);
+      i = tagEnd + 1;
+      continue;
+    }
+    const inner = html.slice(tagEnd + 1, closeIdx);
+    el.children = parseTopLevelChildren(inner);
+    children.push(el);
+    i = closeIdx + closeTag.length;
+  }
+  return children;
+}
+
+function findElement(
+  root: FakeElement,
+  predicate: (el: FakeElement) => boolean,
+): FakeElement | null {
+  if (predicate(root)) {
+    return root;
+  }
+  for (const child of root.children) {
+    const hit = findElement(child, predicate);
+    if (hit) {
+      return hit;
+    }
+  }
+  return null;
+}
+
+function findAll(
+  root: FakeElement,
+  predicate: (el: FakeElement) => boolean,
+): FakeElement[] {
+  const hits: FakeElement[] = [];
+  const walk = (el: FakeElement) => {
+    if (predicate(el)) {
+      hits.push(el);
+    }
+    for (const child of el.children) {
+      walk(child);
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+const MATH_NS =
+  'xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math"';
+
+function mathRun(overrides: Partial<MathRun>): MathRun {
+  return {
+    kind: "math",
+    display: "inline",
+    ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>x</m:t></m:r></m:oMath>`,
+    plainText: "x",
+    fontFamily: "Cambria Math",
+    fontSize: 12,
+    italic: true,
+    ...overrides,
+  };
+}
+
+function renderMathRunOnce(run: MathRun): FakeElement {
+  const block = {
+    kind: "paragraph",
+    runs: [run],
+    attrs: {},
+    styleId: undefined,
+  } as unknown as Parameters<typeof renderLine>[0];
+
+  const line = {
+    fromRun: 0,
+    toRun: 0,
+    fromChar: 0,
+    toChar: 1,
+    lineHeight: 16,
+    maxAscent: 12,
+    maxDescent: 4,
+    maxImageHeightPx: 0,
+  } as unknown as Parameters<typeof renderLine>[1];
+
+  return renderLine(block, line, "left", fakeDocument, {
+    availableWidth: 500,
+    isLastLine: true,
+    isFirstLine: true,
+    paragraphEndsWithLineBreak: false,
+  }) as unknown as FakeElement;
+}
+
+describe("painter — OMML math run", () => {
+  test("renders an inline `<math>` element with the MathML namespace", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>a+b</m:t></m:r></m:oMath>`,
+        plainText: "a+b",
+      }),
+    );
+
+    const host = findElement(line, (el) =>
+      el.className.includes("docx-math-inline"),
+    );
+    expect(host).not.toBeNull();
+    expect(host?.dataset["ommlRender"]).toBe("mathml");
+    // `innerHTML` carries the MathML root element.
+    expect(host?.innerHTML).toContain(
+      'xmlns="http://www.w3.org/1998/Math/MathML"',
+    );
+    expect(host?.innerHTML).toContain("<mi>a</mi>");
+    expect(host?.innerHTML).toContain("<mo>+</mo>");
+    expect(host?.innerHTML).toContain("<mi>b</mi>");
+  });
+
+  test("marks block math with display=block class + dataset flag", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        display: "block",
+        ommlXml: `<m:oMathPara ${MATH_NS}><m:oMath><m:r><m:t>n</m:t></m:r></m:oMath></m:oMathPara>`,
+        plainText: "n",
+      }),
+    );
+
+    const host = findElement(line, (el) =>
+      el.className.includes("docx-math-block"),
+    );
+    expect(host).not.toBeNull();
+    expect(host?.dataset["display"]).toBe("block");
+    expect(host?.innerHTML).toContain('display="block"');
+  });
+
+  test("falls back to italic plain-text span when OMML XML is malformed", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: "<not-actually-omml>",
+        plainText: "broken",
+      }),
+    );
+
+    const fallback = findElement(line, (el) =>
+      el.className.includes("docx-math-fallback"),
+    );
+    expect(fallback).not.toBeNull();
+    expect(fallback?.dataset["ommlRender"]).toBe("fallback");
+    expect(fallback?.dataset["ommlRenderError"]).toBe("1");
+    expect(fallback?.textContent).toBe("broken");
+  });
+
+  test("falls back when OMML element parses but has no math children", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}/>`,
+        plainText: "empty",
+      }),
+    );
+
+    const fallback = findElement(line, (el) =>
+      el.className.includes("docx-math-fallback"),
+    );
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toBe("empty");
+  });
+
+  test("sets alttext on the <math> root for screen readers", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>z</m:t></m:r></m:oMath>`,
+        plainText: "the variable z",
+      }),
+    );
+
+    const mathEl = findElement(line, (el) => el.tagName === "MATH");
+    expect(mathEl).not.toBeNull();
+    expect(mathEl?.getAttribute("alttext")).toBe("the variable z");
+  });
+
+  test("renders the same MathML when the same OMML is rendered twice", () => {
+    const run = mathRun({
+      ommlXml: `<m:oMath ${MATH_NS}><m:f><m:num><m:r><m:t>1</m:t></m:r></m:num><m:den><m:r><m:t>2</m:t></m:r></m:den></m:f></m:oMath>`,
+      plainText: "1/2",
+    });
+    const first = renderMathRunOnce(run);
+    const second = renderMathRunOnce(run);
+    const a = findElement(first, (el) => el.className.includes("docx-math"));
+    const b = findElement(second, (el) => el.className.includes("docx-math"));
+    expect(a?.innerHTML).toBe(b?.innerHTML ?? "");
+    expect(a?.innerHTML).toContain("<mfrac>");
+  });
+
+  test("does not emit OMML property elements into the MathML tree", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}><m:r><m:rPr><m:nor/></m:rPr><m:t>k</m:t></m:r></m:oMath>`,
+        plainText: "k",
+      }),
+    );
+    const host = findElement(line, (el) => el.className.includes("docx-math"));
+    expect(host?.innerHTML).not.toContain("rPr");
+    // The plain text k still made it through.
+    expect(host?.innerHTML).toContain("<mi>k</mi>");
+  });
+
+  test("only one `<math>` root per inline run", () => {
+    const line = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>q</m:t></m:r></m:oMath>`,
+        plainText: "q",
+      }),
+    );
+    const mathRoots = findAll(line, (el) => el.tagName === "MATH");
+    expect(mathRoots.length).toBe(1);
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderMath.test.ts
+++ b/packages/folio/src/core/layout-painter/renderMath.test.ts
@@ -389,6 +389,36 @@ describe("painter — OMML math run", () => {
     expect(mathEl?.getAttribute("alttext")).toBe("the variable z");
   });
 
+  test("threads PM anchors onto MathML and fallback hosts", () => {
+    const mathLine = renderMathRunOnce(
+      mathRun({
+        ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>q</m:t></m:r></m:oMath>`,
+        pmStart: 4,
+        pmEnd: 5,
+      }),
+    );
+    const mathHost = findElement(mathLine, (el) =>
+      el.className.includes("docx-math-inline"),
+    );
+
+    const fallbackLine = renderMathRunOnce(
+      mathRun({
+        ommlXml: "<not-actually-omml>",
+        plainText: "broken",
+        pmStart: 8,
+        pmEnd: 9,
+      }),
+    );
+    const fallbackHost = findElement(fallbackLine, (el) =>
+      el.className.includes("docx-math-fallback"),
+    );
+
+    expect(mathHost?.dataset["pmStart"]).toBe("4");
+    expect(mathHost?.dataset["pmEnd"]).toBe("5");
+    expect(fallbackHost?.dataset["pmStart"]).toBe("8");
+    expect(fallbackHost?.dataset["pmEnd"]).toBe("9");
+  });
+
   test("renders the same MathML when the same OMML is rendered twice", () => {
     const run = mathRun({
       ommlXml: `<m:oMath ${MATH_NS}><m:f><m:num><m:r><m:t>1</m:t></m:r></m:num><m:den><m:r><m:t>2</m:t></m:r></m:den></m:f></m:oMath>`,

--- a/packages/folio/src/core/layout-painter/renderMath.test.ts
+++ b/packages/folio/src/core/layout-painter/renderMath.test.ts
@@ -425,4 +425,43 @@ describe("painter — OMML math run", () => {
     const mathRoots = findAll(line, (el) => el.tagName === "MATH");
     expect(mathRoots.length).toBe(1);
   });
+
+  test("right tabs reserve width for following math runs", () => {
+    const block = {
+      kind: "paragraph",
+      runs: [
+        { kind: "tab" },
+        mathRun({
+          plainText: "ABCDE",
+          ommlXml: `<m:oMath ${MATH_NS}><m:r><m:t>ABCDE</m:t></m:r></m:oMath>`,
+        }),
+      ],
+      attrs: {},
+      styleId: undefined,
+    } as unknown as Parameters<typeof renderLine>[0];
+
+    const line = {
+      fromRun: 0,
+      toRun: 1,
+      fromChar: 0,
+      toChar: 1,
+      lineHeight: 16,
+      maxAscent: 12,
+      maxDescent: 4,
+      maxImageHeightPx: 0,
+    } as unknown as Parameters<typeof renderLine>[1];
+
+    const rendered = renderLine(block, line, "left", fakeDocument, {
+      availableWidth: 300,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      tabStops: [{ val: "end", pos: 4500 }],
+    }) as unknown as FakeElement;
+
+    const tab = findElement(rendered, (el) =>
+      el.className.includes("layout-run-tab"),
+    );
+    expect(tab?.style.width).toBe("265px");
+  });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -2473,7 +2473,7 @@ function runContentKey(run: Run): string {
     return `img:${run.src}|${run.width}x${run.height}${run.transform ? `|tr:${run.transform}` : ""}`;
   }
 
-  // Remaining kinds (text, tab, field) all carry RunFormatting.
+  // Remaining kinds (text, tab, field, math) all carry RunFormatting.
   const parts: string[] = [run.kind];
   if (run.kind === "text") {
     parts.push(`t:${run.text}`);
@@ -2481,6 +2481,11 @@ function runContentKey(run: Run): string {
     if (run.width !== undefined) {
       parts.push(`w:${run.width}`);
     }
+  } else if (run.kind === "math") {
+    // The OMML XML uniquely identifies the rendered MathML output;
+    // include `display` so swapping inline ↔ block also re-fingerprints.
+    parts.push(`md:${run.display}`);
+    parts.push(`mx:${run.ommlXml}`);
   } else {
     parts.push(`ft:${run.fieldType}`);
     if (run.fallback !== undefined) {

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -5,6 +5,8 @@
  * Handles text formatting, alignment, and positioning.
  */
 
+import { ommlToMathml } from "../docx/mathToMathml";
+import { parseXmlDocument } from "../docx/xmlParser";
 import { getListMarkerInlineWidth } from "../layout-bridge/measuring/listMarkerWidth";
 import type {
   ParagraphBlock,
@@ -19,6 +21,7 @@ import type {
   ImageRun,
   LineBreakRun,
   FieldRun,
+  MathRun,
   TabStop,
 } from "../layout-engine/types";
 import { calculateTabWidth } from "../prosemirror/utils/tabCalculator";
@@ -109,6 +112,13 @@ function isLineBreakRun(run: Run): run is LineBreakRun {
  */
 function isFieldRun(run: Run): run is FieldRun {
   return run.kind === "field";
+}
+
+/**
+ * Check if run is a math equation run
+ */
+function isMathRun(run: Run): run is MathRun {
+  return run.kind === "math";
 }
 
 const AUTOMATIC_TEXT_COLOR_VALUES = new Set(["auto", "windowtext"]);
@@ -909,6 +919,87 @@ function renderFieldRun(
 }
 
 /**
+ * Render an OMML math run by converting it to MathML and injecting a
+ * native `<math>` element. Browsers (Firefox, Safari, Chromium ≥ 109)
+ * render MathML Core natively, so no JS typesetting engine is required.
+ *
+ * The raw OMML XML stays on the model — only the rendered DOM is derived
+ * from it. If conversion fails we fall back to the existing italic
+ * plain-text span so the user always sees something and the underlying
+ * OMML is preserved for save.
+ */
+function renderMathRun(run: MathRun, doc: Document): HTMLElement {
+  const fallbackText = run.plainText || "[equation]";
+
+  let mathml: string | null = null;
+  try {
+    const ommlEl = parseXmlDocument(run.ommlXml);
+    if (ommlEl) {
+      mathml = ommlToMathml(ommlEl);
+    }
+  } catch {
+    // Conversion-time errors land on the fallback span below.
+  }
+
+  if (!mathml) {
+    return renderMathFallback(run, doc, fallbackText, "1");
+  }
+
+  // Inject the MathML via a sandbox span (`innerHTML` parses MathML in
+  // HTML documents per the HTML spec). Browsers without MathML support
+  // still render the inner `<mtext>` text content, so layout is preserved.
+  const host = doc.createElement("span");
+  host.className = `${PARAGRAPH_CLASS_NAMES.run} docx-math docx-math-${run.display}`;
+  host.dataset["display"] = run.display;
+  host.dataset["ommlRender"] = "mathml";
+
+  if (run.display === "block") {
+    host.style.display = "inline-block";
+    host.style.verticalAlign = "middle";
+  }
+
+  // Cambria Math fallback chain for browsers that don't ship a math font.
+  host.style.fontFamily =
+    '"Cambria Math", "Latin Modern Math", "STIX Two Math", serif';
+
+  try {
+    host.innerHTML = mathml;
+  } catch {
+    return renderMathFallback(run, doc, fallbackText, "1");
+  }
+
+  // Add an `alttext` attribute on the <math> root for screen-reader
+  // resilience even when the engine ignores MathML structure.
+  const mathRoot = host.firstElementChild;
+  if (mathRoot && mathRoot.tagName.toLowerCase() === "math") {
+    mathRoot.setAttribute("alttext", fallbackText);
+  }
+
+  return host;
+}
+
+function renderMathFallback(
+  run: MathRun,
+  doc: Document,
+  fallbackText: string,
+  errorFlag: "1" | "0",
+): HTMLElement {
+  const span = doc.createElement("span");
+  span.className = `${PARAGRAPH_CLASS_NAMES.run} docx-math docx-math-${run.display} docx-math-fallback`;
+  span.dataset["display"] = run.display;
+  span.dataset["ommlRender"] = "fallback";
+  if (errorFlag === "1") {
+    span.dataset["ommlRenderError"] = "1";
+    span.title = "[equation render failed]";
+  }
+  span.style.fontStyle = "italic";
+  span.style.fontFamily =
+    '"Cambria Math", "Latin Modern Math", "STIX Two Math", serif';
+  span.textContent = fallbackText;
+  return span;
+}
+
+/**
  * Render a single run (for non-tab runs)
  */
 function renderRun(
@@ -932,6 +1023,9 @@ function renderRun(
   }
   if (isFieldRun(run) && context) {
     return renderFieldRun(run, doc, context);
+  }
+  if (isMathRun(run)) {
+    return renderMathRun(run, doc);
   }
 
   // Fallback for unknown run types

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -1125,7 +1125,7 @@ const RIGHT_EDGE_EPSILON_PX = 0.5;
 /**
  * Build a TextMeasureStyle from a TextRun or FieldRun's relevant fields.
  */
-function runMeasureStyle(run: TextRun | FieldRun): TextMeasureStyle {
+function runMeasureStyle(run: TextRun | FieldRun | MathRun): TextMeasureStyle {
   return {
     ...(run.bold !== undefined ? { bold: run.bold } : {}),
     ...(run.italic !== undefined ? { italic: run.italic } : {}),
@@ -1198,6 +1198,15 @@ function measureFollowingContentWidth(
       // occupy their axis-aligned bbox width, not the raw `run.width`, so
       // right-tab anchoring stays aligned with what the painter reserves.
       width += inlineImageBoundingBox(run).width || 0;
+    } else if (isMathRun(run)) {
+      width +=
+        measureText(
+          run.plainText,
+          run.fontSize ?? 11,
+          run.fontFamily ?? "Cambria Math",
+          runMeasureStyle(run),
+        ) *
+        (scale / 100);
     }
   }
   return width;
@@ -1258,6 +1267,8 @@ function getTextAfterTab(
     } else if (isTabRun(run) || isLineBreakRun(run)) {
       // Stop at next tab or line break
       break;
+    } else if (isMathRun(run)) {
+      text += run.plainText;
     }
   }
   return text;
@@ -1508,6 +1519,9 @@ export function renderLine(
           if (isTextRun(next) || isFieldRun(next)) {
             return next;
           }
+          if (isMathRun(next)) {
+            return next;
+          }
         }
         return undefined;
       })();
@@ -1744,6 +1758,17 @@ export function renderLine(
             : {}),
           ...(run.smallCaps !== undefined ? { smallCaps: run.smallCaps } : {}),
         },
+      );
+      reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
+      currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);
+    } else if (isMathRun(run)) {
+      const runEl = renderMathRun(run, doc);
+      lineEl.append(runEl);
+      const measuredWidth = measureText(
+        run.plainText,
+        run.fontSize ?? 11,
+        run.fontFamily ?? "Cambria Math",
+        runMeasureStyle(run),
       );
       reserveScaledAdvance(runEl, measuredWidth, run.horizontalScale);
       currentX += measuredWidth * ((run.horizontalScale ?? 100) / 100);

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -975,6 +975,7 @@ function renderMathRun(run: MathRun, doc: Document): HTMLElement {
     mathRoot.setAttribute("alttext", fallbackText);
   }
 
+  applyPmPositions(host, run.pmStart, run.pmEnd);
   return host;
 }
 
@@ -996,6 +997,7 @@ function renderMathFallback(
   span.style.fontFamily =
     '"Cambria Math", "Latin Modern Math", "STIX Two Math", serif';
   span.textContent = fallbackText;
+  applyPmPositions(span, run.pmStart, run.pmEnd);
   return span;
 }
 


### PR DESCRIPTION
Renders `<m:oMath>` / `<m:oMathPara>` via native browser MathML Core. In-tree OMML→MathML converter (~430 LOC); no new runtime dependencies. OMML stays the source of truth on save.

## Test plan
- [ ] CI passes