### PR TITLE
feat(folio): track image insertions and deletions (eigenpal #641)

### DIFF
--- a/packages/folio/src/core/docx/imageTrackedChangeSave.test.ts
+++ b/packages/folio/src/core/docx/imageTrackedChangeSave.test.ts
@@ -15,8 +15,9 @@ import type { Insertion, Paragraph } from "../types/document";
 import { attemptSelectiveSave } from "./selectiveSave";
 
 const PNG_DATA_URL = "data:image/png;base64,AA==";
+const SYNTHETIC_RID = "rId_img_123";
 
-function trackedNewImageParagraph(): Paragraph {
+function trackedNewImageParagraph(rId?: string): Paragraph {
   const insertion: Insertion = {
     type: "insertion",
     info: {
@@ -32,7 +33,9 @@ function trackedNewImageParagraph(): Paragraph {
             type: "drawing",
             image: {
               type: "image",
-              // No rId → this is a fresh image needing media write.
+              // No rId or a synthetic editor rId means this is a fresh image
+              // needing media write.
+              rId,
               src: PNG_DATA_URL,
               size: { width: 914_400, height: 457_200 },
               wrap: { type: "inline" },
@@ -59,6 +62,22 @@ describe("selectiveSave bails out on a tracked-new image (eigenpal #641)", () =>
     };
     // Buffer content isn't read on the bail path — selectiveSave checks the
     // model first and returns null on detection.
+    const result = await attemptSelectiveSave(doc, new ArrayBuffer(0), {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null for a tracked image with a synthetic editor rId", async () => {
+    const doc = {
+      package: {
+        document: {
+          content: [trackedNewImageParagraph(SYNTHETIC_RID)],
+        },
+      },
+    };
     const result = await attemptSelectiveSave(doc, new ArrayBuffer(0), {
       changedParaIds: new Set(),
       structuralChange: false,

--- a/packages/folio/src/core/docx/imageTrackedChangeSave.test.ts
+++ b/packages/folio/src/core/docx/imageTrackedChangeSave.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Save-path coverage for a picture that is itself a tracked change.
+ *
+ * `selectiveSave` and `rezip` collect new image media so a freshly inserted
+ * picture's bytes land in `word/media` and a rId is allocated. A tracked
+ * picture lives inside an `<w:ins>` / `<w:del>` / `<w:moveFrom>` / `<w:moveTo>`
+ * wrapper; without the wrapper-descent fix, the freshly tracked image is
+ * skipped, the rels file references no media for it, and Word renders a
+ * broken image. Port of eigenpal docx-editor #641 reviewer-fix commit.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Insertion, Paragraph } from "../types/document";
+import { attemptSelectiveSave } from "./selectiveSave";
+
+const PNG_DATA_URL = "data:image/png;base64,AA==";
+
+function trackedNewImageParagraph(): Paragraph {
+  const insertion: Insertion = {
+    type: "insertion",
+    info: {
+      id: 99,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    },
+    content: [
+      {
+        type: "run",
+        content: [
+          {
+            type: "drawing",
+            image: {
+              type: "image",
+              // No rId → this is a fresh image needing media write.
+              src: PNG_DATA_URL,
+              size: { width: 914_400, height: 457_200 },
+              wrap: { type: "inline" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+  return { type: "paragraph", content: [insertion] };
+}
+
+describe("selectiveSave bails out on a tracked-new image (eigenpal #641)", () => {
+  test("returns null so the full repack writes the media for the wrapped picture", async () => {
+    // The selective path can't allocate fresh rIds — its job is to delegate
+    // back to the full repack path when new media is present. The wrapper-
+    // descent fix is exactly so this gate fires for tracked-new pictures.
+    const doc = {
+      package: {
+        document: {
+          content: [trackedNewImageParagraph()],
+        },
+      },
+    };
+    // Buffer content isn't read on the bail path — selectiveSave checks the
+    // model first and returns null on detection.
+    const result = await attemptSelectiveSave(doc, new ArrayBuffer(0), {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("returns null on a tracked-DELETED new image (deletion wrapper variant)", async () => {
+    const para: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "deletion",
+          info: {
+            id: 100,
+            author: "Reviewer",
+            date: "2026-05-30T00:00:00Z",
+          },
+          content: [
+            {
+              type: "run",
+              content: [
+                {
+                  type: "drawing",
+                  image: {
+                    type: "image",
+                    src: PNG_DATA_URL,
+                    size: { width: 914_400, height: 457_200 },
+                    wrap: { type: "inline" },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const doc = {
+      package: {
+        document: {
+          content: [para],
+        },
+      },
+    };
+    const result = await attemptSelectiveSave(doc, new ArrayBuffer(0), {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("does NOT bail out for an unrelated paragraph without new images", async () => {
+    // Baseline guard: the wrapper-descent guard must not over-fire. A
+    // paragraph that contains only text in an insertion wrapper has no
+    // new media, so the selective path is still eligible.
+    const para: Paragraph = {
+      type: "paragraph",
+      content: [
+        {
+          type: "insertion",
+          info: {
+            id: 101,
+            author: "Reviewer",
+            date: "2026-05-30T00:00:00Z",
+          },
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "added" }],
+            },
+          ],
+        },
+      ],
+    };
+    const doc = {
+      package: {
+        document: {
+          content: [para],
+        },
+      },
+    };
+    // Other guards (model validation, missing zip, etc.) will return null,
+    // but the new-images gate specifically must NOT fire. We catch null
+    // here only because the unrelated bail path lands there too — the
+    // important assertion is that this call doesn't throw on the wrapper-
+    // descent path.
+    await attemptSelectiveSave(doc, new ArrayBuffer(0), {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    // Reaching here without an exception is the assertion: the wrapper
+    // descent doesn't crash on a text-only insertion wrapper.
+    expect(true).toBe(true);
+  });
+});

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -304,13 +304,33 @@ const isNewDataUrlImage = (image: Image) =>
 function collectNewImages(blocks: BlockContent[]): Image[] {
   const images: Image[] = [];
 
+  const collectFromRun = (run: {
+    content: { type: string; image?: Image }[];
+  }): void => {
+    for (const c of run.content) {
+      if (c.type === "drawing" && c.image && isNewDataUrlImage(c.image)) {
+        images.push(c.image);
+      }
+    }
+  };
+
   for (const block of blocks) {
     if (block.type === "paragraph") {
       for (const item of block.content) {
         if (item.type === "run") {
-          for (const c of item.content) {
-            if (c.type === "drawing" && isNewDataUrlImage(c.image)) {
-              images.push(c.image);
+          collectFromRun(item);
+        } else if (
+          // A picture inserted/deleted/moved under track changes lives inside
+          // an ins/del/moveFrom/moveTo wrapper. Descend so its media part
+          // still gets written. eigenpal #641.
+          item.type === "insertion" ||
+          item.type === "deletion" ||
+          item.type === "moveFrom" ||
+          item.type === "moveTo"
+        ) {
+          for (const sub of item.content) {
+            if (sub.type === "run") {
+              collectFromRun(sub);
             }
           }
         }

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -28,18 +28,22 @@ import { serializeDocument } from "./serializer/documentSerializer";
  * to avoid walking the block tree twice.
  */
 function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
+  const runHasNewImage = (run: {
+    content: { type: string; image?: { src?: string; rId?: string } }[];
+  }): boolean =>
+    run.content.some(
+      (c) =>
+        c.type === "drawing" &&
+        c.image?.src?.startsWith("data:") === true &&
+        !c.image.rId,
+    );
+
   for (const block of blocks) {
     if (block.type === "paragraph") {
       for (const item of block.content) {
         if (item.type === "run") {
-          for (const c of item.content) {
-            if (
-              c.type === "drawing" &&
-              c.image.src?.startsWith("data:") &&
-              !c.image.rId
-            ) {
-              return true;
-            }
+          if (runHasNewImage(item)) {
+            return true;
           }
         } else if (
           item.type === "hyperlink" &&
@@ -48,6 +52,21 @@ function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
           !item.anchor
         ) {
           return true;
+        } else if (
+          // A picture inserted/deleted/moved under track changes lives inside
+          // an ins/del/moveFrom/moveTo wrapper. Without descending into them,
+          // a freshly tracked image gets no rId allocated and the saved DOCX
+          // references missing media. eigenpal #641.
+          item.type === "insertion" ||
+          item.type === "deletion" ||
+          item.type === "moveFrom" ||
+          item.type === "moveTo"
+        ) {
+          for (const sub of item.content) {
+            if (sub.type === "run" && runHasNewImage(sub)) {
+              return true;
+            }
+          }
         }
       }
     } else if (block.type === "table") {

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -22,6 +22,8 @@ import { buildPatchedDocumentXml } from "./selectiveXmlPatch";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 
+const SYNTHETIC_IMAGE_RID_PREFIX = "rId_img_";
+
 /**
  * Check if document content has new images (data: URL without rId) or
  * new hyperlinks (href without rId). Combined into a single traversal
@@ -35,7 +37,7 @@ function hasNewImagesOrHyperlinks(blocks: BlockContent[]): boolean {
       (c) =>
         c.type === "drawing" &&
         c.image?.src?.startsWith("data:") === true &&
-        !c.image.rId,
+        (!c.image.rId || c.image.rId.startsWith(SYNTHETIC_IMAGE_RID_PREFIX)),
     );
 
   for (const block of blocks) {

--- a/packages/folio/src/core/docx/serializer/imageTrackedChangeSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/imageTrackedChangeSerializer.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Serializer guard: a deleted drawing/shape run keeps its content verbatim
+ * inside a `<w:del>` wrapper. The `<w:t>` → `<w:delText>` rewrite must skip
+ * drawing runs because:
+ *
+ * - a picture has no `<w:t>` anyway, and
+ * - a shape's nested textbox text (`<w:txbxContent><w:t>`) belongs to a
+ *   nested textbox document, NOT to the run's own deleted text. Rewriting
+ *   it to `<w:delText>` produces invalid OOXML markup.
+ *
+ * The fix is conservative — it only suppresses the rewrite for runs that
+ * carry a drawing or shape, so the normal text-deletion path is unchanged.
+ * Port of eigenpal docx-editor #641 reviewer-fix commit.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Deletion, Insertion, Paragraph } from "../../types/document";
+import { serializeParagraph } from "./paragraphSerializer";
+
+const PNG_DATA_URL = "data:image/png;base64,AA==";
+
+function deletedDrawingParagraph(): Paragraph {
+  const deletion: Deletion = {
+    type: "deletion",
+    info: {
+      id: 1,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    },
+    content: [
+      {
+        type: "run",
+        content: [
+          {
+            type: "drawing",
+            image: {
+              type: "image",
+              rId: "rIdImg1",
+              src: PNG_DATA_URL,
+              size: { width: 914_400, height: 457_200 },
+              wrap: { type: "inline" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+  return { type: "paragraph", content: [deletion] };
+}
+
+function deletedTextParagraph(): Paragraph {
+  const deletion: Deletion = {
+    type: "deletion",
+    info: {
+      id: 2,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    },
+    content: [
+      {
+        type: "run",
+        content: [{ type: "text", text: "gone" }],
+      },
+    ],
+  };
+  return { type: "paragraph", content: [deletion] };
+}
+
+function insertedDrawingParagraph(): Paragraph {
+  const insertion: Insertion = {
+    type: "insertion",
+    info: {
+      id: 3,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    },
+    content: [
+      {
+        type: "run",
+        content: [
+          {
+            type: "drawing",
+            image: {
+              type: "image",
+              rId: "rIdImg2",
+              src: PNG_DATA_URL,
+              size: { width: 914_400, height: 457_200 },
+              wrap: { type: "inline" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+  return { type: "paragraph", content: [insertion] };
+}
+
+describe("serializeParagraph — tracked image (eigenpal #641)", () => {
+  test("deleted drawing run does NOT rewrite <w:t> to <w:delText>", () => {
+    const xml = serializeParagraph(deletedDrawingParagraph());
+    expect(xml).toContain("<w:del ");
+    expect(xml).toContain("<w:drawing>");
+    // The drawing-run gate: the rewrite must not fire for a drawing-bearing
+    // run. A nested textbox would surface `<w:t>` inside `<w:txbxContent>`,
+    // which must remain `<w:t>`, not become `<w:delText>`.
+    expect(xml).not.toContain("<w:delText");
+  });
+
+  test("deleted text run STILL rewrites <w:t> to <w:delText> (gate is conservative)", () => {
+    const xml = serializeParagraph(deletedTextParagraph());
+    expect(xml).toContain("<w:del ");
+    expect(xml).toContain("<w:delText");
+    expect(xml).toContain("gone</w:delText>");
+  });
+
+  test("inserted drawing run serializes inside <w:ins> with a <w:drawing>", () => {
+    const xml = serializeParagraph(insertedDrawingParagraph());
+    expect(xml).toContain("<w:ins ");
+    expect(xml).toContain('w:author="Reviewer"');
+    expect(xml).toContain("<w:drawing>");
+  });
+});

--- a/packages/folio/src/core/docx/serializer/imageTrackedChangeSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/imageTrackedChangeSerializer.test.ts
@@ -67,6 +67,36 @@ function deletedTextParagraph(): Paragraph {
   return { type: "paragraph", content: [deletion] };
 }
 
+function deletedMixedTextAndDrawingParagraph(): Paragraph {
+  const deletion: Deletion = {
+    type: "deletion",
+    info: {
+      id: 4,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    },
+    content: [
+      {
+        type: "run",
+        content: [
+          { type: "text", text: "gone" },
+          {
+            type: "drawing",
+            image: {
+              type: "image",
+              rId: "rIdImg3",
+              src: PNG_DATA_URL,
+              size: { width: 914_400, height: 457_200 },
+              wrap: { type: "inline" },
+            },
+          },
+        ],
+      },
+    ],
+  };
+  return { type: "paragraph", content: [deletion] };
+}
+
 function insertedDrawingParagraph(): Paragraph {
   const insertion: Insertion = {
     type: "insertion",
@@ -112,6 +142,15 @@ describe("serializeParagraph — tracked image (eigenpal #641)", () => {
     expect(xml).toContain("<w:del ");
     expect(xml).toContain("<w:delText");
     expect(xml).toContain("gone</w:delText>");
+  });
+
+  test("deleted mixed text and drawing run rewrites only the top-level text", () => {
+    const xml = serializeParagraph(deletedMixedTextAndDrawingParagraph());
+    expect(xml).toContain("<w:del ");
+    expect(xml).toContain("<w:delText");
+    expect(xml).toContain("gone</w:delText>");
+    expect(xml).toContain("<w:drawing>");
+    expect(xml).not.toContain("gone</w:t>");
   });
 
   test("inserted drawing run serializes inside <w:ins> with a <w:drawing>", () => {

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -914,6 +914,14 @@ function serializeMoveRangeStart(
 /**
  * Serialize a tracked change wrapper (ins/del/moveFrom/moveTo)
  */
+function rewriteRunTextAsDeleted(xml: string): string {
+  return xml
+    .replace(/<w:t\b/gu, "<w:delText")
+    .replace(/<\/w:t>/gu, "</w:delText>")
+    .replace(/<w:instrText\b/gu, "<w:delInstrText")
+    .replace(/<\/w:instrText>/gu, "</w:delInstrText>");
+}
+
 function serializeTrackedChange(
   tag: "ins" | "del" | "moveFrom" | "moveTo",
   change: Insertion | Deletion | MoveFrom | MoveTo,
@@ -934,26 +942,45 @@ function serializeTrackedChange(
     attrs.push(`w:date="${escapeXml(normalizedDate)}"`);
   }
 
+  const serializeDeletedRun = (run: Run): string => {
+    const xml = serializeRun(run);
+    const hasDrawingContent = run.content.some(
+      (c) => c.type === "drawing" || c.type === "shape",
+    );
+    if (!hasDrawingContent) {
+      return rewriteRunTextAsDeleted(xml);
+    }
+
+    const hasTextualContent = run.content.some(
+      (c) => c.type !== "drawing" && c.type !== "shape",
+    );
+    if (!hasTextualContent) {
+      return xml;
+    }
+
+    return run.content
+      .map((content) => {
+        const contentXml = serializeRun({ ...run, content: [content] });
+        if (content.type === "drawing" || content.type === "shape") {
+          return contentXml;
+        }
+        return rewriteRunTextAsDeleted(contentXml);
+      })
+      .join("");
+  };
+
   const contentXml = change.content
     .map((item) => {
       if (item.type === "run") {
-        const xml = serializeRun(item);
         // A deleted drawing/shape run keeps its content verbatim: a picture
         // has no `<w:t>`, and a shape's nested textbox text
         // (`<w:txbxContent><w:t>`) must NOT be rewritten to `<w:delText>` —
         // that markup belongs only to a run's own deleted text, not to a
         // nested textbox document. eigenpal #641.
-        const isDrawingRun = item.content.some(
-          (c) => c.type === "drawing" || c.type === "shape",
-        );
-        if ((tag === "del" || tag === "moveFrom") && !isDrawingRun) {
-          return xml
-            .replace(/<w:t\b/gu, "<w:delText")
-            .replace(/<\/w:t>/gu, "</w:delText>")
-            .replace(/<w:instrText\b/gu, "<w:delInstrText")
-            .replace(/<\/w:instrText>/gu, "</w:delInstrText>");
+        if (tag === "del" || tag === "moveFrom") {
+          return serializeDeletedRun(item);
         }
-        return xml;
+        return serializeRun(item);
       }
       return serializeHyperlink(item);
     })

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -937,14 +937,23 @@ function serializeTrackedChange(
   const contentXml = change.content
     .map((item) => {
       if (item.type === "run") {
-        if (tag === "del" || tag === "moveFrom") {
-          return serializeRun(item)
+        const xml = serializeRun(item);
+        // A deleted drawing/shape run keeps its content verbatim: a picture
+        // has no `<w:t>`, and a shape's nested textbox text
+        // (`<w:txbxContent><w:t>`) must NOT be rewritten to `<w:delText>` —
+        // that markup belongs only to a run's own deleted text, not to a
+        // nested textbox document. eigenpal #641.
+        const isDrawingRun = item.content.some(
+          (c) => c.type === "drawing" || c.type === "shape",
+        );
+        if ((tag === "del" || tag === "moveFrom") && !isDrawingRun) {
+          return xml
             .replace(/<w:t\b/gu, "<w:delText")
             .replace(/<\/w:t>/gu, "</w:delText>")
             .replace(/<w:instrText\b/gu, "<w:delInstrText")
             .replace(/<\/w:instrText>/gu, "</w:delInstrText>");
         }
-        return serializeRun(item);
+        return xml;
       }
       return serializeHyperlink(item);
     })

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -782,6 +782,15 @@ function buildImageRun(
   constrained: { width: number; height: number },
   pmStart: number,
   pmEnd: number,
+  // Tracked-change attrs lifted off the image node's PM marks. eigenpal #641.
+  trackedChange?: Pick<
+    RunFormatting,
+    | "isInsertion"
+    | "isDeletion"
+    | "changeAuthor"
+    | "changeDate"
+    | "changeRevisionId"
+  >,
 ): ImageRun {
   const run: ImageRun = {
     kind: "image",
@@ -841,6 +850,21 @@ function buildImageRun(
   }
   if (attrs.position !== undefined) {
     run.position = attrs.position;
+  }
+  if (trackedChange?.isInsertion) {
+    run.isInsertion = true;
+  }
+  if (trackedChange?.isDeletion) {
+    run.isDeletion = true;
+  }
+  if (trackedChange?.changeAuthor !== undefined) {
+    run.changeAuthor = trackedChange.changeAuthor;
+  }
+  if (trackedChange?.changeDate !== undefined) {
+    run.changeDate = trackedChange.changeDate;
+  }
+  if (trackedChange?.changeRevisionId !== undefined) {
+    run.changeRevisionId = trackedChange.changeRevisionId;
   }
   return run;
 }
@@ -935,11 +959,16 @@ function paragraphToRuns(
         attrs.height || 100,
         _options.pageContentHeight,
       );
+      // Lift tracked-change marks off the image node so an inserted/deleted
+      // picture paints in the revision colour and resolves with the rest of
+      // the change. eigenpal #641.
+      const trackedFmt = extractRunFormatting(child.marks, theme);
       const run = buildImageRun(
         attrs,
         constrained,
         childPos,
         childPos + child.nodeSize,
+        trackedFmt,
       );
       runs.push(run);
       return;

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -186,6 +186,16 @@ export type ImageRun = {
   cropRight?: number;
   cropBottom?: number;
   cropLeft?: number;
+  /** Whether this picture is itself a tracked insertion (`<w:ins>`). eigenpal #641. */
+  isInsertion?: boolean;
+  /** Whether this picture is itself a tracked deletion (`<w:del>`). eigenpal #641. */
+  isDeletion?: boolean;
+  /** Author of the tracked change wrapping the picture. eigenpal #641. */
+  changeAuthor?: string;
+  /** Date of the tracked change wrapping the picture. eigenpal #641. */
+  changeDate?: string;
+  /** Revision id of the tracked change wrapping the picture. eigenpal #641. */
+  changeRevisionId?: number;
   pmStart?: number;
   pmEnd?: number;
 };

--- a/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
+++ b/packages/folio/src/core/layout-painter/renderBlockImage-rotation.test.ts
@@ -220,6 +220,30 @@ describe("block image rotation bbox container", () => {
     expect(imgEl.style["marginRight"]).toBe("auto");
   });
 
+  test("applies tracked-change outline to the block image, not the full-width container", () => {
+    const imageRun: ImageRun = {
+      kind: "image",
+      src: "data:image/png;base64,",
+      width: 100,
+      height: 200,
+      displayMode: "block",
+      isInsertion: true,
+      changeAuthor: "Reviewer",
+      changeRevisionId: 321,
+    };
+    const { block, line } = makeBlockImageLine(imageRun);
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument);
+    const container = lineEl.children[0] as unknown as FakeElement;
+    const imgEl = container.children[0] as unknown as FakeElement;
+
+    expect(container.className).toContain("layout-block-image");
+    expect(container.style["outline"]).toBeUndefined();
+    expect(imgEl.style["outline"]).toBe("2px solid #2e7d32");
+    expect(imgEl.dataset["changeAuthor"]).toBe("Reviewer");
+    expect(imgEl.dataset["revisionId"]).toBe("321");
+  });
+
   test("does NOT add bbox container styles to a 0deg rotated block image", () => {
     const imageRun: ImageRun = {
       kind: "image",

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -798,7 +798,26 @@ function renderImageRun(run: ImageRun, doc: Document): HTMLElement {
   } else {
     el = renderInlineImageRun(run, doc);
   }
-  applyImageRevisionStyle(el, run);
+  applyImageRevisionStyle(getImageRevisionStyleTarget(el), run);
+  return el;
+}
+
+function isStyleableHTMLElement(
+  value: Element | undefined,
+): value is HTMLElement {
+  return typeof value === "object" && "style" in value;
+}
+
+function getImageRevisionStyleTarget(el: HTMLElement): HTMLElement {
+  if (!el.className.split(/\s+/u).includes("layout-block-image")) {
+    return el;
+  }
+
+  const firstChild = el.children[0];
+  if (isStyleableHTMLElement(firstChild)) {
+    return firstChild;
+  }
+
   return el;
 }
 

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -788,15 +788,48 @@ function renderBlockImage(run: ImageRun, doc: Document): HTMLElement {
 function renderImageRun(run: ImageRun, doc: Document): HTMLElement {
   // Floating images should be handled at paragraph level, not here
   // If they reach here (e.g., inside table cells), render as block
+  let el: HTMLElement;
   if (
     isFloatingImageRun(run) ||
     run.displayMode === "block" ||
     run.wrapType === "topAndBottom"
   ) {
-    return renderBlockImage(run, doc);
+    el = renderBlockImage(run, doc);
+  } else {
+    el = renderInlineImageRun(run, doc);
   }
-  // Default: inline
-  return renderInlineImageRun(run, doc);
+  applyImageRevisionStyle(el, run);
+  return el;
+}
+
+/**
+ * A picture that is itself a tracked change gets a coloured outline (green for
+ * an insertion, red + faded for a deletion), mirroring the text-run treatment.
+ * `outline` is used over `border` so the image's box size is unchanged and
+ * line metrics stay stable. eigenpal #641.
+ */
+function applyImageRevisionStyle(el: HTMLElement, run: ImageRun): void {
+  if (run.isInsertion) {
+    el.style.outline = "2px solid #2e7d32";
+    el.style.outlineOffset = "1px";
+    el.classList.add("docx-insertion");
+  } else if (run.isDeletion) {
+    el.style.outline = "2px solid #c62828";
+    el.style.outlineOffset = "1px";
+    el.style.opacity = "0.6";
+    el.classList.add("docx-deletion");
+  } else {
+    return;
+  }
+  if (run.changeAuthor !== undefined) {
+    el.dataset["changeAuthor"] = run.changeAuthor;
+  }
+  if (run.changeDate !== undefined) {
+    el.dataset["changeDate"] = run.changeDate;
+  }
+  if (run.changeRevisionId !== undefined) {
+    el.dataset["revisionId"] = String(run.changeRevisionId);
+  }
 }
 
 /**

--- a/packages/folio/src/core/prosemirror/commands/comments.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.test.ts
@@ -14,8 +14,15 @@ import {
 const schema = new Schema({
   nodes: {
     doc: { content: "block+" },
-    paragraph: { content: "text*", group: "block" },
-    text: { marks: "_" },
+    paragraph: { content: "inline*", group: "block" },
+    text: { group: "inline", marks: "_" },
+    image: {
+      group: "inline",
+      inline: true,
+      atom: true,
+      marks: "_",
+      toDOM: () => ["img"],
+    },
   },
   marks: {
     // `bold` is here so a single tracked-change span can be split into
@@ -315,6 +322,27 @@ describe("tracked change navigation", () => {
     expect(findNextChange(state, 8)).toMatchObject({
       from: 6,
       to: 15,
+      type: "insertion",
+    });
+  });
+
+  test("findNextChange expands across marked inline atoms in the same revision", () => {
+    const insertion = schema.marks["insertion"]!.create(REV_A_ATTRS);
+    const image = schema.nodes["image"]!.create(null, null, [insertion]);
+    const state = EditorState.create({
+      schema,
+      doc: schema.node("doc", null, [
+        schema.node("paragraph", null, [
+          schema.text("text", [insertion]),
+          image,
+          schema.text("tail", [insertion]),
+        ]),
+      ]),
+    });
+
+    expect(findNextChange(state, 0)).toMatchObject({
+      from: 1,
+      to: 10,
       type: "insertion",
     });
   });

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -4,7 +4,7 @@
  * PM commands for adding/removing comments and accepting/rejecting tracked changes.
  */
 
-import type { Mark } from "prosemirror-model";
+import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { Command, EditorState } from "prosemirror-state";
 
 /**
@@ -482,25 +482,29 @@ function expandTrackedChangeRange(
   fromHint: number,
   toHint: number,
 ): { from: number; to: number } {
+  const carriesSameInlineMark = (node: PMNode | null): node is PMNode =>
+    node?.isInline === true && node.marks.some((m) => m.eq(mark));
+
   // Resolve the boundary positions and hop outward through `nodeBefore`
-  // / `nodeAfter` while the neighbouring text node still carries the
+  // / `nodeAfter` while the neighbouring inline node still carries the
   // same mark instance. O(K) in the number of text nodes that make up
   // the span — `nodesBetween`-based fixed-point expansion is O(K²) and
   // re-walks the same subtree on every iteration.
   let from = fromHint;
   let to = toHint;
   let $from = state.doc.resolve(from);
-  while (
-    $from.nodeBefore?.isText &&
-    $from.nodeBefore.marks.some((m) => m.eq(mark))
-  ) {
-    from -= $from.nodeBefore.nodeSize;
+  let nodeBefore = $from.nodeBefore;
+  while (carriesSameInlineMark(nodeBefore)) {
+    from -= nodeBefore.nodeSize;
     $from = state.doc.resolve(from);
+    nodeBefore = $from.nodeBefore;
   }
   let $to = state.doc.resolve(to);
-  while ($to.nodeAfter?.isText && $to.nodeAfter.marks.some((m) => m.eq(mark))) {
-    to += $to.nodeAfter.nodeSize;
+  let nodeAfter = $to.nodeAfter;
+  while (carriesSameInlineMark(nodeAfter)) {
+    to += nodeAfter.nodeSize;
     $to = state.doc.resolve(to);
+    nodeAfter = $to.nodeAfter;
   }
   return { from, to };
 }

--- a/packages/folio/src/core/prosemirror/commands/comments.ts
+++ b/packages/folio/src/core/prosemirror/commands/comments.ts
@@ -108,7 +108,10 @@ function resolveChange(
           }
           return true;
         }
-        if (!node.isText) {
+        // Text AND inline atoms (image, shape, hardBreak, tab) can carry
+        // tracked-change marks; widen the visitor so rejecting an inserted
+        // picture removes it like inserted text. eigenpal #641.
+        if (!node.isInline) {
           return true;
         }
         const nodeEnd = pos + node.nodeSize;
@@ -291,7 +294,9 @@ export function findAIEditRevisionRange(
   const range = { from: null as number | null, to: null as number | null };
 
   state.doc.descendants((node, pos) => {
-    if (!node.isText) {
+    // Widen from `isText` to `isInline` so an AI-edit revision on an inline
+    // atom (image, shape) shows up in the matched range. eigenpal #641.
+    if (!node.isInline) {
       return;
     }
     for (const mark of node.marks) {
@@ -521,7 +526,10 @@ export function findNextChange(
     if (result.value) {
       return false;
     }
-    if (!node.isText) {
+    // Widen from `isText` to `isInline` so an image-only insertion / deletion
+    // appears in the find-next walk (an atomic image carries the mark itself,
+    // not as a text-node sibling). eigenpal #641.
+    if (!node.isInline) {
       return;
     }
     if (pos + node.nodeSize <= startPos) {
@@ -586,7 +594,9 @@ export function findPreviousChange(
   let resultMark: Mark | null = null;
 
   state.doc.descendants((node, pos) => {
-    if (!node.isText) {
+    // Widen from `isText` to `isInline` so an image-only change appears in
+    // the find-previous walk. eigenpal #641.
+    if (!node.isInline) {
       return;
     }
     if (pos >= startPos) {

--- a/packages/folio/src/core/prosemirror/conversion/imageTrackedChanges.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/imageTrackedChanges.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Image-insertion / -deletion tracked-change round-trip tests.
+ *
+ * Port of eigenpal docx-editor #641 ("track inserted/deleted images as tracked
+ * changes"). A picture that is itself a tracked change must:
+ *
+ * 1. carry the `insertion` / `deletion` mark on the atomic image PM node
+ *    (the image schema has `marks: "_"` so the leaf atom accepts marks);
+ * 2. serialize back into a `<w:ins>` / `<w:del>` wrapper around the
+ *    drawing-bearing run;
+ * 3. reload on the next parse with the mark re-applied.
+ *
+ * Background: folio's tracked-change model previously surfaced only on text
+ * runs, so an inserted picture round-tripped as untracked content.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+
+import type { Document, Paragraph } from "../../types/document";
+import { schema } from "../schema";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const PNG_DATA_URL = "data:image/png;base64,AA==";
+
+function makeMarkedImageDoc(
+  markName: "insertion" | "deletion",
+  revisionId: number,
+): PMNode {
+  // SAFETY: real editor schema has both insertion and deletion marks.
+  const mark = schema.marks[markName]!.create({
+    revisionId,
+    author: "Reviewer",
+    date: "2026-05-30T00:00:00Z",
+  });
+  // SAFETY: real editor schema has the image node.
+  const image = schema.nodes["image"]!.create({
+    src: PNG_DATA_URL,
+    width: 80,
+    height: 60,
+  });
+  const markedImage = image.mark(mark.addToSet(image.marks));
+  // SAFETY: real editor schema has the paragraph node.
+  const paragraph = schema.nodes["paragraph"]!.create({}, [markedImage]);
+  // SAFETY: real editor schema has the doc node.
+  return schema.nodes["doc"]!.create({}, [paragraph]);
+}
+
+function firstParagraph(doc: Document): Paragraph | undefined {
+  const block = doc.package.document.content.at(0);
+  return block?.type === "paragraph" ? block : undefined;
+}
+
+describe("tracked image insertion round-trip", () => {
+  test("inserted image serializes inside a <w:ins> wrapper", () => {
+    const pmDoc = makeMarkedImageDoc("insertion", 200);
+    const result = fromProseDoc(pmDoc);
+    const paragraph = firstParagraph(result);
+    expect(paragraph).toBeDefined();
+
+    const insertion = paragraph?.content.find(
+      (item) => item.type === "insertion",
+    );
+    expect(insertion).toBeDefined();
+    if (insertion?.type !== "insertion") {
+      return;
+    }
+    expect(insertion.info.id).toBe(200);
+    expect(insertion.info.author).toBe("Reviewer");
+
+    const innerRun = insertion.content.at(0);
+    expect(innerRun?.type).toBe("run");
+    if (innerRun?.type !== "run") {
+      return;
+    }
+    expect(innerRun.content.at(0)?.type).toBe("drawing");
+  });
+
+  test("inserted image reloads with the insertion mark re-applied", () => {
+    const pmDoc = makeMarkedImageDoc("insertion", 201);
+    const result = fromProseDoc(pmDoc);
+    const reloaded = toProseDoc(result);
+
+    let markedImages = 0;
+    reloaded.descendants((node) => {
+      if (
+        node.type.name === "image" &&
+        node.marks.some((m) => m.type.name === "insertion")
+      ) {
+        markedImages += 1;
+      }
+      return true;
+    });
+    expect(markedImages).toBe(1);
+  });
+
+  test("deleted image serializes inside a <w:del> wrapper", () => {
+    const pmDoc = makeMarkedImageDoc("deletion", 300);
+    const result = fromProseDoc(pmDoc);
+    const paragraph = firstParagraph(result);
+    expect(paragraph).toBeDefined();
+
+    const deletion = paragraph?.content.find(
+      (item) => item.type === "deletion",
+    );
+    expect(deletion).toBeDefined();
+    if (deletion?.type !== "deletion") {
+      return;
+    }
+    expect(deletion.info.id).toBe(300);
+
+    const innerRun = deletion.content.at(0);
+    expect(innerRun?.type).toBe("run");
+    if (innerRun?.type !== "run") {
+      return;
+    }
+    expect(innerRun.content.at(0)?.type).toBe("drawing");
+  });
+
+  test("deleted image reloads with the deletion mark re-applied", () => {
+    const pmDoc = makeMarkedImageDoc("deletion", 301);
+    const result = fromProseDoc(pmDoc);
+    const reloaded = toProseDoc(result);
+
+    let markedImages = 0;
+    reloaded.descendants((node) => {
+      if (
+        node.type.name === "image" &&
+        node.marks.some((m) => m.type.name === "deletion")
+      ) {
+        markedImages += 1;
+      }
+      return true;
+    });
+    expect(markedImages).toBe(1);
+  });
+
+  test("parses <w:ins><w:r><w:drawing>...</w:drawing></w:r></w:ins>", () => {
+    // Regression guard: the parser path that constructs this Document and the
+    // toProseDoc mapping must re-apply the insertion mark on the atomic image
+    // node — a leaf atom whose schema doesn't list `marks: "_"` would lose
+    // the mark silently.
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "insertion",
+                  info: {
+                    id: 42,
+                    author: "Reviewer",
+                    date: "2026-05-30T00:00:00Z",
+                  },
+                  content: [
+                    {
+                      type: "run",
+                      content: [
+                        {
+                          type: "drawing",
+                          image: {
+                            type: "image",
+                            rId: "rIdImg1",
+                            src: PNG_DATA_URL,
+                            size: { width: 914_400, height: 457_200 },
+                            wrap: { type: "inline" },
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const pmDoc = toProseDoc(document);
+    let imageMark: { name: string; revisionId: unknown } | null = null;
+    pmDoc.descendants((node) => {
+      if (node.type.name === "image") {
+        const m = node.marks.at(0);
+        if (m) {
+          imageMark = {
+            name: m.type.name,
+            revisionId: m.attrs["revisionId"],
+          };
+        }
+      }
+      return true;
+    });
+    expect(imageMark).not.toBeNull();
+    expect(imageMark!.name).toBe("insertion");
+    expect(imageMark!.revisionId).toBe(42);
+  });
+
+  test("tracked text still round-trips (regression: do not gate on allowsMarkType alone)", () => {
+    // A leaf text node's own markSet is empty, so
+    // `text.allowsMarkType(insertion) === false` even though the paragraph
+    // permits the mark. The `node.isText` short-circuit must stay or every
+    // tracked text load/round-trip collapses to plain text.
+    // SAFETY: real editor schema has the insertion mark and paragraph/doc.
+    const insertionMark = schema.marks["insertion"]!.create({
+      revisionId: 500,
+      author: "Reviewer",
+      date: "2026-05-30T00:00:00Z",
+    });
+    const paragraph = schema.nodes["paragraph"]!.create({}, [
+      schema.text("added text", [insertionMark]),
+    ]);
+    const pmDoc = schema.nodes["doc"]!.create({}, [paragraph]);
+
+    const result = fromProseDoc(pmDoc);
+    const reloaded = toProseDoc(result);
+
+    let markedTextRuns = 0;
+    reloaded.descendants((node) => {
+      if (node.isText && node.marks.some((m) => m.type.name === "insertion")) {
+        markedTextRuns += 1;
+      }
+      return true;
+    });
+    expect(markedTextRuns).toBeGreaterThan(0);
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/semanticRoundtrip.test.ts
@@ -219,6 +219,10 @@ describe("semantic ProseMirror round-trip fixture", () => {
     const paragraph = firstParagraph(roundtripped);
 
     expect(pmValidation.valid).toBe(true);
+    // The shape now carries marks (eigenpal #641 — `Shape.nodeSpec.marks = "_"`
+    // so a tracked or commented shape survives the round-trip), so the
+    // comment range correctly re-opens around the shape-bearing run too. The
+    // mid-paragraph atom inserts split it from `mathEquation`.
     expect(paragraph.content.map((content) => content.type)).toEqual([
       "commentRangeStart",
       "run",
@@ -228,7 +232,9 @@ describe("semantic ProseMirror round-trip fixture", () => {
       "inlineSdt",
       "commentRangeEnd",
       "mathEquation",
+      "commentRangeStart",
       "run",
+      "commentRangeEnd",
     ]);
     expect(findRunText(paragraph, "Clause ").formatting).toMatchObject({
       bold: true,

--- a/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/ShapeExtension.ts
@@ -323,6 +323,10 @@ export const ShapeExtension = createNodeExtension({
   nodeSpec: {
     inline: true,
     group: "inline",
+    // Allow marks so an inserted/deleted shape can carry the tracked-change
+    // mark (see ImageExtension — leaf inline atoms disallow marks by default).
+    // eigenpal #641.
+    marks: "_",
     draggable: true,
     atom: true,
     attrs: {

--- a/packages/folio/src/core/prosemirror/plugins/imageSuggestionMode.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/imageSuggestionMode.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Image-tracked-change behaviour in suggesting mode and the accept/reject
+ * resolver. Port of eigenpal docx-editor #641.
+ *
+ * Uses the real folio schema (not a minimal local one) because the new
+ * behaviour hinges on `Image.nodeSpec.marks = "_"` and the schema's
+ * `allowsMarkType` checks — a minimal schema can't exercise either.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState } from "prosemirror-state";
+
+import {
+  acceptAIEditRevision,
+  findNextChange,
+  rejectAIEditRevision,
+} from "../commands/comments";
+import { schema } from "../schema";
+import { createSuggestionModePlugin } from "./suggestionMode";
+
+const PNG_DATA_URL = "data:image/png;base64,AA==";
+
+function makeImageDoc(markName?: "insertion" | "deletion"): PMNode {
+  // SAFETY: real editor schema has image, paragraph, and doc nodes.
+  const image = schema.nodes["image"]!.create({
+    src: PNG_DATA_URL,
+    width: 80,
+    height: 60,
+  });
+  const node = markName
+    ? image.mark(
+        schema.marks[markName]!.create({
+          revisionId: 700,
+          author: "Reviewer",
+          date: "2026-05-30T00:00:00Z",
+        }).addToSet(image.marks),
+      )
+    : image;
+  const paragraph = schema.nodes["paragraph"]!.create({}, [node]);
+  return schema.nodes["doc"]!.create({}, [paragraph]);
+}
+
+function countMarkedImages(
+  state: EditorState,
+  markName: "insertion" | "deletion",
+): number {
+  let count = 0;
+  state.doc.descendants((node) => {
+    if (
+      node.type.name === "image" &&
+      node.marks.some((m) => m.type.name === markName)
+    ) {
+      count += 1;
+    }
+    return true;
+  });
+  return count;
+}
+
+function countImages(state: EditorState): number {
+  let count = 0;
+  state.doc.descendants((node) => {
+    if (node.type.name === "image") {
+      count += 1;
+    }
+    return true;
+  });
+  return count;
+}
+
+describe("suggesting-mode catch-all marks pasted/dropped image (eigenpal #641)", () => {
+  test("a plain insertText-style transaction in suggesting mode marks text", () => {
+    // Regression guard for the dual `isText || allowsMarkType` arm: dropping
+    // the text short-circuit would silently stop tracking pasted text.
+    const plugin = createSuggestionModePlugin(true, "Jane");
+    const doc = schema.nodes["doc"]!.create({}, [
+      schema.nodes["paragraph"]!.create({}, [schema.text("hi")]),
+    ]);
+    let state = EditorState.create({ doc, plugins: [plugin] });
+
+    // Plain insertion transaction — not via the suggestionMode handler.
+    state = state.apply(state.tr.insertText("XY", 3));
+
+    let xyMarked = false;
+    state.doc.descendants((node) => {
+      if (node.isText && node.text === "XY") {
+        xyMarked = node.marks.some((m) => m.type.name === "insertion");
+      }
+      return true;
+    });
+    expect(xyMarked).toBe(true);
+  });
+
+  test("a programmatic image insert in suggesting mode auto-marks the image as inserted", () => {
+    const plugin = createSuggestionModePlugin(true, "Jane");
+    const doc = schema.nodes["doc"]!.create({}, [
+      schema.nodes["paragraph"]!.create({}, [schema.text("hi")]),
+    ]);
+    let state = EditorState.create({ doc, plugins: [plugin] });
+
+    const image = schema.nodes["image"]!.create({
+      src: PNG_DATA_URL,
+      width: 40,
+      height: 40,
+    });
+    state = state.apply(state.tr.insert(3, image));
+
+    expect(countMarkedImages(state, "insertion")).toBe(1);
+  });
+});
+
+describe("accept / reject on a tracked image (eigenpal #641)", () => {
+  test("accept on an inserted image keeps the image and strips the mark", () => {
+    const doc = makeImageDoc("insertion");
+    const state = EditorState.create({ doc });
+
+    let nextState = state;
+    acceptAIEditRevision(700)(state, (tr) => {
+      nextState = state.apply(tr);
+    });
+
+    expect(countImages(nextState)).toBe(1);
+    expect(countMarkedImages(nextState, "insertion")).toBe(0);
+  });
+
+  test("reject on an inserted image removes the image entirely", () => {
+    const doc = makeImageDoc("insertion");
+    const state = EditorState.create({ doc });
+
+    let nextState = state;
+    rejectAIEditRevision(700)(state, (tr) => {
+      nextState = state.apply(tr);
+    });
+
+    expect(countImages(nextState)).toBe(0);
+  });
+
+  test("accept on a deleted image removes the image entirely", () => {
+    const doc = makeImageDoc("deletion");
+    const state = EditorState.create({ doc });
+
+    let nextState = state;
+    acceptAIEditRevision(700)(state, (tr) => {
+      nextState = state.apply(tr);
+    });
+
+    expect(countImages(nextState)).toBe(0);
+  });
+
+  test("reject on a deleted image keeps the image and strips the mark", () => {
+    const doc = makeImageDoc("deletion");
+    const state = EditorState.create({ doc });
+
+    let nextState = state;
+    rejectAIEditRevision(700)(state, (tr) => {
+      nextState = state.apply(tr);
+    });
+
+    expect(countImages(nextState)).toBe(1);
+    expect(countMarkedImages(nextState, "deletion")).toBe(0);
+  });
+
+  test("findNextChange finds an image-only insertion (currently skipped pre-#641)", () => {
+    // An atomic image carrying an insertion mark must surface in the
+    // find-next walk; widening the visitor from isText to isInline is the
+    // entire fix.
+    const doc = makeImageDoc("insertion");
+    const state = EditorState.create({ doc });
+    const range = findNextChange(state, 0);
+    expect(range).not.toBeNull();
+    expect(range?.type).toBe("insertion");
+  });
+
+  test("findNextChange surfaces a deleted image too", () => {
+    const doc = makeImageDoc("deletion");
+    const state = EditorState.create({ doc });
+    const range = findNextChange(state, 0);
+    expect(range).not.toBeNull();
+    expect(range?.type).toBe("deletion");
+  });
+});

--- a/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
+++ b/packages/folio/src/core/prosemirror/plugins/suggestionMode.ts
@@ -117,7 +117,16 @@ function markRangeAsDeleted(
   const ranges: { from: number; to: number; isOwnInsert: boolean }[] = [];
 
   doc.nodesBetween(from, to, (node, pos) => {
-    if (!node.isText) {
+    // Text AND inline atoms (image, shape) that accept the deletion mark go
+    // through the strike-through path so a selection that includes a picture
+    // marks it as deleted (or retracts an own-insert) like text. The text
+    // short-circuit stays because a leaf text node's own `markSet` is empty —
+    // `allowsMarkType` is false even though the paragraph permits the mark.
+    // eigenpal #641.
+    if (
+      !node.isText &&
+      !(node.isInline && node.type.allowsMarkType(deletionType))
+    ) {
       return;
     }
     const start = Math.max(pos, from);
@@ -449,8 +458,17 @@ function handleSuggestionDelete(
   const $deletePos = state.doc.resolve(deletePos);
   const nodeAfter = $deletePos.nodeAfter;
 
-  // At block boundary — let default behavior handle (e.g. join paragraphs)
-  if (!nodeAfter?.isText) {
+  // At a block boundary — let default behavior handle (e.g. join paragraphs).
+  // Text and inline atoms (image, shape) that accept the deletion mark fall
+  // through to the strike-through path; other inline nodes use the default
+  // delete. eigenpal #641.
+  if (
+    !nodeAfter ||
+    !(
+      nodeAfter.isText ||
+      (nodeAfter.isInline && nodeAfter.type.allowsMarkType(deletionType))
+    )
+  ) {
     return false;
   }
 
@@ -608,10 +626,21 @@ export function createSuggestionModePlugin(
         // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror StepMap.forEach
         stepMap.forEach((_oldFrom, _oldTo, newFrom, newTo) => {
           if (newTo > newFrom) {
-            // Only mark text nodes that don't already have tracked change marks.
-            // Marking the entire range would overwrite existing marks from other authors.
+            // Mark text AND inline atoms (image, shape) that accept the
+            // insertion mark and don't already carry a tracked-change mark,
+            // so a pasted/dropped picture becomes a tracked insertion just
+            // like typed text. Marking the entire range would overwrite
+            // other authors' marks, so we go node by node and skip any the
+            // schema disallows marks on. eigenpal #641.
             newState.doc.nodesBetween(newFrom, newTo, (node, pos) => {
-              if (!node.isText) {
+              // Text is the short-circuit: a leaf text node's own `markSet`
+              // is empty, so `allowsMarkType` is false even though the
+              // paragraph permits the mark — dropping the `isText` arm
+              // would silently stop tracking pasted text.
+              if (
+                !node.isText &&
+                !(node.isInline && node.type.allowsMarkType(insertionType))
+              ) {
                 return;
               }
               const hasTrackedMark = node.marks.some(


### PR DESCRIPTION
Adds insertion / deletion mark support to atomic image and shape nodes. Round-trips `<w:ins>` / `<w:del>` wrapped drawings; accept/reject and suggesting mode work. Also fixes a pre-existing serializer bug where the unconditional `<w:t>` → `<w:delText>` rewrite corrupted deleted shapes containing nested textbox text.

## Test plan
- [ ] CI passes