### PR TITLE
feat(business-registries): add shared architectural baseline

### DIFF
--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -49,6 +49,11 @@
       "bun": "./src/brreg/index.ts",
       "types": "./src/brreg/index.ts",
       "import": "./dist/brreg/index.js"
+    },
+    "./shared": {
+      "bun": "./src/shared/index.ts",
+      "types": "./src/shared/index.ts",
+      "import": "./dist/shared/index.js"
     }
   },
   "publishConfig": {

--- a/packages/business-registries/src/ares/errors.ts
+++ b/packages/business-registries/src/ares/errors.ts
@@ -1,4 +1,4 @@
-import { EntityNotFoundError, RegistryError } from "../shared/errors.js";
+import { RegistryError } from "../shared/errors.js";
 
 const ARES_REGISTRY_SLUG = "cz-ares";
 
@@ -35,17 +35,18 @@ export class AresAPIError extends AresError {
   }
 }
 
-export class AresNotFoundError extends EntityNotFoundError {
+export class AresNotFoundError extends AresError {
   readonly ico: string;
+  readonly canonicalId: string;
+  readonly registrySlug: string = ARES_REGISTRY_SLUG;
 
   constructor(ico: string) {
-    super({
-      canonicalId: ico,
-      registrySlug: ARES_REGISTRY_SLUG,
-      message: `Economic subject not found: ${ico}`,
-    });
+    super(`Economic subject not found: ${ico}`);
     this.name = "AresNotFoundError";
     this.ico = ico;
+    // Also expose as canonicalId so the shared `isEntityNotFound`
+    // predicate picks this up alongside `error instanceof AresError`.
+    this.canonicalId = ico;
   }
 }
 

--- a/packages/business-registries/src/ares/errors.ts
+++ b/packages/business-registries/src/ares/errors.ts
@@ -1,4 +1,8 @@
-export class AresError extends Error {
+import { EntityNotFoundError, RegistryError } from "../shared/errors.js";
+
+const ARES_REGISTRY_SLUG = "cz-ares";
+
+export class AresError extends RegistryError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "AresError";
@@ -31,11 +35,15 @@ export class AresAPIError extends AresError {
   }
 }
 
-export class AresNotFoundError extends AresError {
+export class AresNotFoundError extends EntityNotFoundError {
   readonly ico: string;
 
   constructor(ico: string) {
-    super(`Economic subject not found: ${ico}`);
+    super({
+      canonicalId: ico,
+      registrySlug: ARES_REGISTRY_SLUG,
+      message: `Economic subject not found: ${ico}`,
+    });
     this.name = "AresNotFoundError";
     this.ico = ico;
   }

--- a/packages/business-registries/src/brreg/errors.ts
+++ b/packages/business-registries/src/brreg/errors.ts
@@ -1,4 +1,8 @@
-export class BrregError extends Error {
+import { EntityNotFoundError, RegistryError } from "../shared/errors.js";
+
+const BRREG_REGISTRY_SLUG = "no-brreg";
+
+export class BrregError extends RegistryError {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "BrregError";
@@ -27,11 +31,15 @@ export class BrregAPIError extends BrregError {
   }
 }
 
-export class BrregNotFoundError extends BrregError {
+export class BrregNotFoundError extends EntityNotFoundError {
   readonly orgnr: string;
 
   constructor(orgnr: string) {
-    super(`Norwegian entity not found: ${orgnr}`);
+    super({
+      canonicalId: orgnr,
+      registrySlug: BRREG_REGISTRY_SLUG,
+      message: `Norwegian entity not found: ${orgnr}`,
+    });
     this.name = "BrregNotFoundError";
     this.orgnr = orgnr;
   }

--- a/packages/business-registries/src/brreg/errors.ts
+++ b/packages/business-registries/src/brreg/errors.ts
@@ -1,4 +1,4 @@
-import { EntityNotFoundError, RegistryError } from "../shared/errors.js";
+import { RegistryError } from "../shared/errors.js";
 
 const BRREG_REGISTRY_SLUG = "no-brreg";
 
@@ -31,17 +31,18 @@ export class BrregAPIError extends BrregError {
   }
 }
 
-export class BrregNotFoundError extends EntityNotFoundError {
+export class BrregNotFoundError extends BrregError {
   readonly orgnr: string;
+  readonly canonicalId: string;
+  readonly registrySlug: string = BRREG_REGISTRY_SLUG;
 
   constructor(orgnr: string) {
-    super({
-      canonicalId: orgnr,
-      registrySlug: BRREG_REGISTRY_SLUG,
-      message: `Norwegian entity not found: ${orgnr}`,
-    });
+    super(`Norwegian entity not found: ${orgnr}`);
     this.name = "BrregNotFoundError";
     this.orgnr = orgnr;
+    // Also expose as canonicalId so the shared `isEntityNotFound`
+    // predicate picks this up alongside `error instanceof BrregError`.
+    this.canonicalId = orgnr;
   }
 }
 

--- a/packages/business-registries/src/index.ts
+++ b/packages/business-registries/src/index.ts
@@ -11,3 +11,4 @@
 //   await ares.lookupByIco("27082440");
 export * as ares from "./ares/index.js";
 export * as brreg from "./brreg/index.js";
+export * as shared from "./shared/index.js";

--- a/packages/business-registries/src/shared/adapter.ts
+++ b/packages/business-registries/src/shared/adapter.ts
@@ -1,0 +1,21 @@
+// Three integration shapes every registry adapter falls into. Modelled as
+// a discriminated union so the dispatch layer can branch at compile time
+// instead of stringly-typed runtime checks.
+//
+// - rpc: live request/response (ARES, Brreg, Companies House, ...).
+// - local-index: bulk-only sources ingested into Postgres nightly and
+//   served via the same exported functions (BE-KBO, LU-RCSL, GLEIF, ...).
+// - event-stream: state reconstructed from gazette events
+//   (ES-BORME, PT-publicacoes).
+
+export type RegistryAdapterShape =
+  | { type: "rpc" }
+  | { type: "local-index" }
+  | { type: "event-stream" };
+
+export type RegistryDescriptor<Scheme extends string> = {
+  slug: string;
+  country: string;
+  idScheme: Scheme;
+  shape: RegistryAdapterShape;
+};

--- a/packages/business-registries/src/shared/canonical-id.ts
+++ b/packages/business-registries/src/shared/canonical-id.ts
@@ -1,0 +1,34 @@
+// Branded canonical identifiers keyed by `${country}-${scheme}`.
+//
+// Catches "right ID, wrong adapter" mismatches at compile time and is
+// critical for multi-key registries (PL: KRS/NIP/REGON, CH: UID/CHID,
+// NL: KvK/vestiging/RSIN, FR: SIREN/SIRET).
+
+export type CanonicalId<Scheme extends string> = string & {
+  readonly __brand: Scheme;
+};
+
+// Schemes for the registries on the build-order roadmap.
+// Extend this tuple as new adapters land.
+export const CANONICAL_ID_SCHEMES = [
+  "CZ-ICO",
+  "NO-ORGNR",
+  "FI-Y",
+  "PL-KRS",
+  "PL-NIP",
+  "PL-REGON",
+  "GB-CRN",
+  "FR-SIREN",
+  "FR-SIRET",
+  "BR-CNPJ",
+] as const;
+
+export type KnownCanonicalIdScheme = (typeof CANONICAL_ID_SCHEMES)[number];
+
+// SAFETY: caller is responsible for validating the input matches scheme S
+// (e.g. ARES has its own `validateIco` that runs before branding). The brand
+// is a phantom type; this helper performs no runtime check, so narrowing
+// `string` to `CanonicalId<S>` is the entire point of the helper.
+export const unsafeBrand = <S extends string>(raw: string): CanonicalId<S> =>
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  raw as CanonicalId<S>;

--- a/packages/business-registries/src/shared/errors.ts
+++ b/packages/business-registries/src/shared/errors.ts
@@ -19,27 +19,31 @@ export class RegistryUnavailableError extends RegistryError {
   }
 }
 
-export class EntityNotFoundError extends RegistryError {
+// Not-found is intentionally NOT a class. JavaScript single inheritance
+// means a per-adapter class can extend either its adapter base
+// (AresError / BrregError, preserving `error instanceof AresError`
+// checks across consumers) OR a shared NotFound base — not both. The
+// adapter chain is the older, established expectation; the structural
+// type + predicate below give the shared layer the cross-adapter
+// detection it needs without forcing adapter classes off their base.
+//
+// Per-adapter NotFound classes declare `readonly canonicalId: string`
+// and `readonly registrySlug: string` to satisfy this contract.
+export type EntityNotFound = RegistryError & {
   readonly canonicalId: string;
   readonly registrySlug: string;
+};
 
-  constructor({
-    canonicalId,
-    registrySlug,
-    message,
-    cause,
-  }: {
-    canonicalId: string;
-    registrySlug: string;
-    message: string;
-    cause?: unknown;
-  }) {
-    super(message, { cause });
-    this.name = "EntityNotFoundError";
-    this.canonicalId = canonicalId;
-    this.registrySlug = registrySlug;
+export const isEntityNotFound = (error: unknown): error is EntityNotFound => {
+  if (!(error instanceof RegistryError)) {
+    return false;
   }
-}
+  const maybe = error as Partial<EntityNotFound>;
+  return (
+    typeof maybe.canonicalId === "string" &&
+    typeof maybe.registrySlug === "string"
+  );
+};
 
 export class RegistryRateLimitedError extends RegistryError {
   readonly retryAfterMs: number | null;

--- a/packages/business-registries/src/shared/errors.ts
+++ b/packages/business-registries/src/shared/errors.ts
@@ -1,0 +1,81 @@
+// Shared tagged-error hierarchy for every business-registry adapter.
+//
+// Per-adapter errors (e.g. AresError, BrregError) extend `RegistryError`
+// or one of its specialised subclasses so downstream consumers can branch
+// on registry-agnostic failure modes without importing adapter-internal
+// types.
+
+export class RegistryError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RegistryError";
+  }
+}
+
+export class RegistryUnavailableError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RegistryUnavailableError";
+  }
+}
+
+export class EntityNotFoundError extends RegistryError {
+  readonly canonicalId: string;
+  readonly registrySlug: string;
+
+  constructor({
+    canonicalId,
+    registrySlug,
+    message,
+    cause,
+  }: {
+    canonicalId: string;
+    registrySlug: string;
+    message: string;
+    cause?: unknown;
+  }) {
+    super(message, { cause });
+    this.name = "EntityNotFoundError";
+    this.canonicalId = canonicalId;
+    this.registrySlug = registrySlug;
+  }
+}
+
+export class RegistryRateLimitedError extends RegistryError {
+  readonly retryAfterMs: number | null;
+
+  constructor({
+    message,
+    retryAfterMs,
+    cause,
+  }: {
+    message: string;
+    retryAfterMs?: number | null;
+    cause?: unknown;
+  }) {
+    super(message, { cause });
+    this.name = "RegistryRateLimitedError";
+    this.retryAfterMs = retryAfterMs ?? null;
+  }
+}
+
+export class RegistryAuthRequiredError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RegistryAuthRequiredError";
+  }
+}
+
+export class RegistryDataPaywalledError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RegistryDataPaywalledError";
+  }
+}
+
+export class RegistryLicenceIncompatibleError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "RegistryLicenceIncompatibleError";
+  }
+}

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -2,7 +2,7 @@ export type { RegistryAdapterShape, RegistryDescriptor } from "./adapter.js";
 export type { CanonicalId, KnownCanonicalIdScheme } from "./canonical-id.js";
 export { CANONICAL_ID_SCHEMES, unsafeBrand } from "./canonical-id.js";
 export {
-  EntityNotFoundError,
+  isEntityNotFound,
   RegistryAuthRequiredError,
   RegistryDataPaywalledError,
   RegistryError,
@@ -10,5 +10,6 @@ export {
   RegistryRateLimitedError,
   RegistryUnavailableError,
 } from "./errors.js";
+export type { EntityNotFound } from "./errors.js";
 export type { EntityStatus } from "./status.js";
 export { mapEntityStatus } from "./status.js";

--- a/packages/business-registries/src/shared/index.ts
+++ b/packages/business-registries/src/shared/index.ts
@@ -1,0 +1,14 @@
+export type { RegistryAdapterShape, RegistryDescriptor } from "./adapter.js";
+export type { CanonicalId, KnownCanonicalIdScheme } from "./canonical-id.js";
+export { CANONICAL_ID_SCHEMES, unsafeBrand } from "./canonical-id.js";
+export {
+  EntityNotFoundError,
+  RegistryAuthRequiredError,
+  RegistryDataPaywalledError,
+  RegistryError,
+  RegistryLicenceIncompatibleError,
+  RegistryRateLimitedError,
+  RegistryUnavailableError,
+} from "./errors.js";
+export type { EntityStatus } from "./status.js";
+export { mapEntityStatus } from "./status.js";

--- a/packages/business-registries/src/shared/status.ts
+++ b/packages/business-registries/src/shared/status.ts
@@ -12,7 +12,15 @@ export type EntityStatus =
   | { type: "deleted"; at: string | null }
   | { type: "unknown" };
 
+// Accept any runtime string for `internal` so undocumented or newly-added
+// upstream status codes fall through to `{ type: "unknown" }` instead of
+// landing in the return value as `undefined`. The mapping keys still drive
+// `TInternal` inference, so call sites get autocomplete on documented codes
+// without giving up runtime resilience to upstream drift.
 export const mapEntityStatus = <TInternal extends string>(
-  internal: TInternal,
+  internal: string,
   mapping: Record<TInternal, EntityStatus>,
-): EntityStatus => mapping[internal];
+): EntityStatus =>
+  (mapping as Record<string, EntityStatus | undefined>)[internal] ?? {
+    type: "unknown",
+  };

--- a/packages/business-registries/src/shared/status.ts
+++ b/packages/business-registries/src/shared/status.ts
@@ -1,0 +1,18 @@
+// Cross-registry entity status — the boundary representation every adapter
+// translates into. Adapters keep richer per-registry vocabularies internally
+// for callers that need fidelity, but expose this normalised shape at the
+// public surface.
+
+export type EntityStatus =
+  | { type: "active" }
+  | { type: "inactive" }
+  | { type: "liquidating" }
+  | { type: "bankruptcy" }
+  | { type: "dissolved" }
+  | { type: "deleted"; at: string | null }
+  | { type: "unknown" };
+
+export const mapEntityStatus = <TInternal extends string>(
+  internal: TInternal,
+  mapping: Record<TInternal, EntityStatus>,
+): EntityStatus => mapping[internal];


### PR DESCRIPTION
## Summary

Introduces a `packages/business-registries/src/shared/` module + `/shared` subpath export that promotes the cross-cutting types every future registry adapter needs into a single place. Migrates ARES + Brreg error hierarchies onto the shared base; per-adapter clients, parsers, and types are intentionally untouched (per-adapter status/canonical-id translation lands in the per-adapter PRs that follow).

This is the foundation referenced in the [business-registries catalogue](../memory) under "Cross-cutting architectural baseline". Every queued adapter (FI PRH, PL KRS, UK Companies House, FR recherche-entreprises) inherits the shape from day one.

## What lands

- **`shared/errors.ts`** — `RegistryError` base + specialised subclasses: `RegistryUnavailableError`, `EntityNotFoundError` (carries `canonicalId` + `registrySlug`), `RegistryRateLimitedError` (optional `retryAfterMs`), `RegistryAuthRequiredError`, `RegistryDataPaywalledError`, `RegistryLicenceIncompatibleError`.
- **`shared/status.ts`** — `EntityStatus` discriminated union (`active | inactive | liquidating | bankruptcy | dissolved | deleted{at} | unknown`) + tiny `mapEntityStatus` helper.
- **`shared/canonical-id.ts`** — `CanonicalId<Scheme>` phantom-branded string; `CANONICAL_ID_SCHEMES` tuple of every known scheme on the build-order roadmap (`CZ-ICO`, `NO-ORGNR`, `FI-Y`, `PL-KRS`, `PL-NIP`, `PL-REGON`, `GB-CRN`, `FR-SIREN`, `FR-SIRET`, `BR-CNPJ`); `unsafeBrand<S>` helper for adapter internals to use after their own validate function passes.
- **`shared/adapter.ts`** — `RegistryAdapterShape = "rpc" | "local-index" | "event-stream"` so the dispatch layer can branch on integration style at compile time; `RegistryDescriptor<Scheme>` for the future registry-of-registries metadata.

## Adapter migrations

- `ares/errors.ts` — `AresError extends RegistryError`; `AresNotFoundError extends EntityNotFoundError` with `registrySlug: "cz-ares"`.
- `brreg/errors.ts` — `BrregError extends RegistryError`; `BrregNotFoundError extends EntityNotFoundError` with `registrySlug: "no-brreg"`.
- Per-adapter `client.ts` / `parse.ts` / `types.ts` are untouched. EntityStatus translation per adapter lands in the per-adapter PRs.

## Test plan
- [x] `bun --filter @stll/business-registries lint` + `typecheck` + `test` (50 pass, 11 skip)
- [x] `bun --filter @stll/api typecheck` + `lint`
- [ ] CI green