### PR TITLE
refactor(api): adopt Bun-native APIs for markdown, hashing, and HTML sanitization

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -85,7 +85,6 @@
     "ioredis": "^5.10.1",
     "jose": "^6.2.3",
     "jszip": "catalog:",
-    "marked": "^18.0.4",
     "nodemailer": "^8.0.8",
     "posthog-node": "^5.35.2",
     "quickjs-emscripten": "^0.32.0",

--- a/apps/api/src/handlers/mcp-connectors/oauth.ts
+++ b/apps/api/src/handlers/mcp-connectors/oauth.ts
@@ -1,5 +1,4 @@
 import { Result, TaggedError } from "better-result";
-import { createHash, randomBytes } from "node:crypto";
 import * as v from "valibot";
 
 import type { McpOAuthRegistrationResponse } from "@/api/db/schema";
@@ -227,17 +226,22 @@ export const discoverOAuthMetadata = async (
   return Result.ok({ authorizationServer, protectedResource });
 };
 
+const randomBase64Url = (byteLength: number): string => {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return Buffer.from(bytes).toString("base64url");
+};
+
 export const createPkce = () => {
-  const codeVerifier = randomBytes(PKCE_VERIFIER_BYTES).toString("base64url");
-  const codeChallenge = createHash("sha256")
+  const codeVerifier = randomBase64Url(PKCE_VERIFIER_BYTES);
+  const codeChallenge = new Bun.CryptoHasher("sha256")
     .update(codeVerifier)
     .digest("base64url");
 
   return { codeChallenge, codeVerifier };
 };
 
-export const createOAuthState = (): string =>
-  randomBytes(32).toString("base64url");
+export const createOAuthState = (): string => randomBase64Url(32);
 
 export const getMcpOAuthRedirectUri = (): string => {
   const publicUrl = env.PUBLIC_URL ?? env.BETTER_AUTH_URL;

--- a/apps/api/src/lib/db/assert-migrations-applied.ts
+++ b/apps/api/src/lib/db/assert-migrations-applied.ts
@@ -1,7 +1,6 @@
 import { panic } from "better-result";
 import { sql } from "drizzle-orm";
-import { createHash } from "node:crypto";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import { rootDb } from "@/api/db/root";
@@ -13,17 +12,23 @@ const ESCAPE_HATCH_ENV = "SKIP_MIGRATION_CHECK";
 type LocalMigration = { name: string; hash: string };
 type AppliedMigrationRow = { hash: string };
 
-const hashMigrationFile = (path: string): string =>
-  createHash("sha256").update(readFileSync(path)).digest("hex");
+const hashMigrationFile = async (path: string): Promise<string> =>
+  new Bun.CryptoHasher("sha256")
+    .update(await Bun.file(path).bytes())
+    .digest("hex");
 
-const listLocalMigrations = (): LocalMigration[] =>
-  readdirSync(MIGRATIONS_DIR)
-    .filter((name) => existsSync(join(MIGRATIONS_DIR, name, "migration.sql")))
-    .sort()
-    .map((name) => ({
-      name,
-      hash: hashMigrationFile(join(MIGRATIONS_DIR, name, "migration.sql")),
-    }));
+const listLocalMigrations = async (): Promise<LocalMigration[]> =>
+  await Promise.all(
+    readdirSync(MIGRATIONS_DIR)
+      .filter((name) => existsSync(join(MIGRATIONS_DIR, name, "migration.sql")))
+      .sort()
+      .map(async (name) => ({
+        name,
+        hash: await hashMigrationFile(
+          join(MIGRATIONS_DIR, name, "migration.sql"),
+        ),
+      })),
+  );
 
 const queryAppliedHashes = async (): Promise<Set<string>> => {
   // Compare on `hash` (always populated) rather than `name` (NULL
@@ -44,7 +49,7 @@ export const assertMigrationsApplied = async (): Promise<void> => {
     return;
   }
 
-  const local = listLocalMigrations();
+  const local = await listLocalMigrations();
   if (local.length === 0) {
     panic(
       `[startup] No migration files at ${MIGRATIONS_DIR}; refusing to start. ` +

--- a/apps/api/src/lib/markdown/ai-tool.test.ts
+++ b/apps/api/src/lib/markdown/ai-tool.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import * as cheerio from "cheerio";
 
 import { deserializeAITool, serializeAITool } from "@/api/lib/markdown/ai-tool";
 import type { AITool } from "@/api/lib/markdown/ai-tool";
@@ -75,6 +76,24 @@ describe("ai tool", () => {
     expect(deserialized.prompt).not.toContain(
       '<mention-component data-id="https://example.com"',
     );
+  });
+
+  test("deserialize escapes generated mention-component attributes", () => {
+    const toolWithHostileLinkText: AITool = {
+      version: 1,
+      type: "ai-model",
+      prompt: '[@" onmouseover="alert(1)](dep)',
+      dependencies: [{ dependsOnPropertyId: "dep", condition: null }],
+    };
+
+    const deserialized = deserializeAITool(toolWithHostileLinkText);
+    const $ = cheerio.load(deserialized.prompt, undefined, false);
+    const mention = $("mention-component");
+
+    expect(mention.attr("data-id")).toBe("dep");
+    expect(mention.attr("data-label")).toBe('" onmouseover="alert(1)');
+    expect(mention.attr("data-mention-suggestion-char")).toBe("@");
+    expect(mention.attr("onmouseover")).toBeUndefined();
   });
 
   test("serialize handles prompt with no mention-component tags", () => {

--- a/apps/api/src/lib/markdown/ai-tool.ts
+++ b/apps/api/src/lib/markdown/ai-tool.ts
@@ -130,7 +130,10 @@ const replaceMentionsWithAnchors = (html: string): string => {
         if (!id || !label || !char) {
           return;
         }
-        el.replace(`<a href="${id}">${char}${label}</a>`, { html: true });
+        el.replace(
+          `<a href="${Bun.escapeHTML(id)}">${Bun.escapeHTML(`${char}${label}`)}</a>`,
+          { html: true },
+        );
       },
     })
     .transform(html);
@@ -168,9 +171,11 @@ export const deserializeAITool = (data: AITool): AITool => {
     const text = $(el).text();
     const mentionChar = text.charAt(0);
     const label = text.slice(1);
-    $(el).replaceWith(
-      `<${MENTION_TAG} ${ATTR_ID}="${href}" ${ATTR_LABEL}="${label}" ${ATTR_SUGGESTION_CHAR}="${mentionChar}"></${MENTION_TAG}>`,
-    );
+    const mention = $(`<${MENTION_TAG}></${MENTION_TAG}>`)
+      .attr(ATTR_ID, href)
+      .attr(ATTR_LABEL, label)
+      .attr(ATTR_SUGGESTION_CHAR, mentionChar);
+    $(el).replaceWith(mention);
   });
 
   return { ...data, prompt: $.html().trimEnd() };

--- a/apps/api/src/lib/markdown/ai-tool.ts
+++ b/apps/api/src/lib/markdown/ai-tool.ts
@@ -1,11 +1,10 @@
 import * as cheerio from "cheerio";
-import { marked } from "marked";
 
 import type { PropertyCondition } from "@/api/db/schema-validators";
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
 
 /**
- * Allowlist-based HTML sanitizer using cheerio.
+ * Allowlist-based HTML sanitizer using HTMLRewriter.
  * Strips all tags and attributes not explicitly listed.
  */
 const ALLOWED_TAGS = new Set([
@@ -52,49 +51,59 @@ const ALLOWED_ATTRS: Record<string, Set<string>> = {
   th: new Set(["colspan", "rowspan"]),
 };
 
+const REMOVE_ENTIRELY = new Set([
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "textarea",
+]);
+
 const ALLOWED_HREF_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
 
-const sanitizeHtml = (html: string): string => {
-  const $ = cheerio.load(html, undefined, false);
-
-  $("script, style, iframe, object, embed, form, textarea").remove();
-
-  // Walk bottom-up so that unwrapping a disallowed parent
-  // never leaves unvisited disallowed children behind.
-  // `$("*").get().reverse()` gives us a leaf-first order.
-  for (const el of $("*").get().toReversed()) {
-    if (!("tagName" in el)) {
-      continue;
-    }
-    const tagName = el.tagName.toLowerCase();
-
-    if (!ALLOWED_TAGS.has(tagName)) {
-      $(el).replaceWith($(el).contents());
-      continue;
-    }
-
-    const allowed = ALLOWED_ATTRS[tagName];
-    for (const attr of Object.keys(el.attribs)) {
-      if (!allowed?.has(attr)) {
-        $(el).removeAttr(attr);
-      }
-    }
-
-    if (tagName === "a" && el.attribs["href"]) {
-      if (!URL.canParse(el.attribs["href"], "https://placeholder.invalid")) {
-        $(el).removeAttr("href");
-        continue;
-      }
-
-      const url = new URL(el.attribs["href"], "https://placeholder.invalid");
-      if (!ALLOWED_HREF_SCHEMES.has(url.protocol)) {
-        $(el).removeAttr("href");
-      }
-    }
-  }
-
-  return $.html();
-};
+const sanitizeHtml = (html: string): string =>
+  new HTMLRewriter()
+    .on("*", {
+      element(el) {
+        const tagName = el.tagName;
+        if (REMOVE_ENTIRELY.has(tagName)) {
+          el.remove();
+          return;
+        }
+        if (!ALLOWED_TAGS.has(tagName)) {
+          el.removeAndKeepContent();
+          return;
+        }
+        const allowed = ALLOWED_ATTRS[tagName];
+        const toRemove: string[] = [];
+        for (const [name] of el.attributes) {
+          if (!allowed?.has(name)) {
+            toRemove.push(name);
+          }
+        }
+        for (const name of toRemove) {
+          el.removeAttribute(name);
+        }
+        if (tagName !== "a") {
+          return;
+        }
+        const href = el.getAttribute("href");
+        if (!href) {
+          return;
+        }
+        if (!URL.canParse(href, "https://placeholder.invalid")) {
+          el.removeAttribute("href");
+          return;
+        }
+        const url = new URL(href, "https://placeholder.invalid");
+        if (!ALLOWED_HREF_SCHEMES.has(url.protocol)) {
+          el.removeAttribute("href");
+        }
+      },
+    })
+    .transform(html);
 
 export type AITool = {
   version: 1;
@@ -144,19 +153,25 @@ export const deserializeAITool = (data: AITool): AITool => {
     data.dependencies.map((d) => d.dependsOnPropertyId),
   );
 
-  const renderer = new marked.Renderer();
-  renderer.link = ({ href, text, tokens }) => {
+  const html = Bun.markdown.html(data.prompt);
+  const $ = cheerio.load(html, undefined, false);
+
+  $("a").each((_, el) => {
+    const href = $(el).attr("href") ?? "";
     if (!dependencyIds.has(href)) {
-      return renderer.parser.parseInline(tokens);
+      // Non-dependency links render as inline content (no anchor wrapper),
+      // mirroring marked's parseInline fallback.
+      $(el).replaceWith($(el).contents());
+      return;
     }
 
+    const text = $(el).text();
     const mentionChar = text.charAt(0);
     const label = text.slice(1);
+    $(el).replaceWith(
+      `<${MENTION_TAG} ${ATTR_ID}="${href}" ${ATTR_LABEL}="${label}" ${ATTR_SUGGESTION_CHAR}="${mentionChar}"></${MENTION_TAG}>`,
+    );
+  });
 
-    return `<${MENTION_TAG} ${ATTR_ID}="${href}" ${ATTR_LABEL}="${label}" ${ATTR_SUGGESTION_CHAR}="${mentionChar}"></${MENTION_TAG}>`;
-  };
-
-  const html = marked.parse(data.prompt, { renderer, async: false });
-
-  return { ...data, prompt: html.trimEnd() };
+  return { ...data, prompt: $.html().trimEnd() };
 };

--- a/apps/api/src/lib/markdown/chat-message.ts
+++ b/apps/api/src/lib/markdown/chat-message.ts
@@ -48,55 +48,64 @@ const ALLOWED_ATTRS: Record<string, Set<string>> = {
 const ALLOWED_HREF_SCHEMES = new Set(["https:", "mailto:", "tel:"]);
 const SKILL_REF_HREF_PREFIX = "#stella-skill-ref=";
 
+const REMOVE_ENTIRELY = new Set([
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "textarea",
+]);
+
 const isAllowedLocalHref = (href: string): boolean =>
   href.startsWith(SKILL_REF_HREF_PREFIX) &&
   href.length > SKILL_REF_HREF_PREFIX.length;
 
-const sanitizeHtml = (html: string): string => {
-  const $ = cheerio.load(html, undefined, false);
-
-  $("script, style, iframe, object, embed, form, textarea").remove();
-
-  for (const el of $("*").get().toReversed()) {
-    if (!("tagName" in el)) {
-      continue;
-    }
-
-    const tagName = el.tagName.toLowerCase();
-    if (!ALLOWED_TAGS.has(tagName)) {
-      $(el).replaceWith($(el).contents());
-      continue;
-    }
-
-    const allowed = ALLOWED_ATTRS[tagName];
-    for (const attr of Object.keys(el.attribs)) {
-      if (!allowed?.has(attr)) {
-        $(el).removeAttr(attr);
-      }
-    }
-
-    if (tagName !== "a" || !el.attribs["href"]) {
-      continue;
-    }
-
-    const href = el.attribs["href"];
-    if (isAllowedLocalHref(href)) {
-      continue;
-    }
-
-    if (!URL.canParse(href, "https://placeholder.invalid")) {
-      $(el).removeAttr("href");
-      continue;
-    }
-
-    const url = new URL(href, "https://placeholder.invalid");
-    if (!ALLOWED_HREF_SCHEMES.has(url.protocol)) {
-      $(el).removeAttr("href");
-    }
-  }
-
-  return $.html();
-};
+const sanitizeHtml = (html: string): string =>
+  new HTMLRewriter()
+    .on("*", {
+      element(el) {
+        const tagName = el.tagName;
+        if (REMOVE_ENTIRELY.has(tagName)) {
+          el.remove();
+          return;
+        }
+        if (!ALLOWED_TAGS.has(tagName)) {
+          el.removeAndKeepContent();
+          return;
+        }
+        const allowed = ALLOWED_ATTRS[tagName];
+        const toRemove: string[] = [];
+        for (const [name] of el.attributes) {
+          if (!allowed?.has(name)) {
+            toRemove.push(name);
+          }
+        }
+        for (const name of toRemove) {
+          el.removeAttribute(name);
+        }
+        if (tagName !== "a") {
+          return;
+        }
+        const href = el.getAttribute("href");
+        if (!href) {
+          return;
+        }
+        if (isAllowedLocalHref(href)) {
+          return;
+        }
+        if (!URL.canParse(href, "https://placeholder.invalid")) {
+          el.removeAttribute("href");
+          return;
+        }
+        const url = new URL(href, "https://placeholder.invalid");
+        if (!ALLOWED_HREF_SCHEMES.has(url.protocol)) {
+          el.removeAttribute("href");
+        }
+      },
+    })
+    .transform(html);
 
 const parseMentionCategory = (value: string): ChatMentionCategory | null => {
   for (const [category] of typedEntries(CHAT_MENTION_HREF_PREFIXES)) {

--- a/apps/api/src/lib/markdown/html-to-markdown.test.ts
+++ b/apps/api/src/lib/markdown/html-to-markdown.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { marked } from "marked";
 
 import { htmlToMarkdown } from "@/api/lib/markdown/html-to-markdown";
 
@@ -144,18 +143,18 @@ describe("htmlToMarkdown", () => {
     );
   });
 
-  test("paragraph→link round-trips through marked back to the same HTML", () => {
+  test("paragraph→link round-trips through Bun.markdown back to the same HTML", () => {
     const html = '<p>see <a href="https://example.com">here</a> for more</p>';
     const md = htmlToMarkdown(html);
-    const reHtml = marked.parse(md, { async: false });
+    const reHtml = Bun.markdown.html(md);
     expect(reHtml).toContain('<a href="https://example.com">here</a>');
     expect(reHtml).toContain("see");
     expect(reHtml).toContain("for more");
   });
 
-  test("escaped specials round-trip through marked without becoming formatting", () => {
+  test("escaped specials round-trip through Bun.markdown without becoming formatting", () => {
     const md = htmlToMarkdown("<p>5 * 3 = 15</p>");
-    const reHtml = marked.parse(md, { async: false });
+    const reHtml = Bun.markdown.html(md);
     expect(reHtml).toContain("5 * 3 = 15");
     expect(reHtml).not.toContain("<em>");
     expect(reHtml).not.toContain("<strong>");
@@ -166,7 +165,7 @@ describe("htmlToMarkdown", () => {
       "literal \\~\\~text\\~\\~ here\n",
     );
     const md = htmlToMarkdown("<p>~~not strike~~</p>");
-    const reHtml = marked.parse(md, { async: false, gfm: true });
+    const reHtml = Bun.markdown.html(md);
     expect(reHtml).not.toContain("<del>");
     expect(reHtml).not.toContain("<s>");
   });

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,6 @@
         "ioredis": "^5.10.1",
         "jose": "^6.2.3",
         "jszip": "catalog:",
-        "marked": "^18.0.4",
         "nodemailer": "^8.0.8",
         "posthog-node": "^5.35.2",
         "quickjs-emscripten": "^0.32.0",
@@ -2881,7 +2880,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@18.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA=="],
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -3873,8 +3872,6 @@
 
     "@react-email/components/@react-email/render": ["@react-email/render@2.0.6", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog=="],
 
-    "@react-email/markdown/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
-
     "@react-email/tailwind/tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
 
     "@react-email/ui/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
@@ -4108,8 +4105,6 @@
     "react-email/esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "react-email/jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
-
-    "react-email/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.132.0", "", {}, "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ=="],
 


### PR DESCRIPTION
## Summary

- Replace `marked` with `Bun.markdown.html()` in AI-tool deserialization; drop the `marked` dependency.
- Swap `node:crypto` `createHash` / `randomBytes` for `Bun.CryptoHasher` and `crypto.getRandomValues` in the startup migration-hash check, PKCE code-challenge, and OAuth state generation.
- Read migration files via `Bun.file().bytes()`; the listing path becomes async.
- Migrate the allowlist HTML sanitizers in `markdown/ai-tool.ts` and `markdown/chat-message.ts` from a cheerio bottom-up walk to a single `HTMLRewriter` `on("*")` handler. Cheerio is kept for the anchor / entity-mention rewrites where DOM random access is still needed.

Cross-verified all 45 drizzle migration hashes match byte-for-byte between `node:crypto.createHash` and `Bun.CryptoHasher` so the startup check stays stable.