### PR TITLE
feat(business-registries): brreg officers + richer status union

### DIFF
--- a/packages/business-registries/src/brreg/__fixtures__/roles-bankrupt.json
+++ b/packages/business-registries/src/brreg/__fixtures__/roles-bankrupt.json
@@ -1,0 +1,122 @@
+{
+  "rollegrupper": [
+    {
+      "type": {
+        "kode": "DAGL",
+        "beskrivelse": "Daglig leder",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/DAGL"
+          }
+        }
+      },
+      "sistEndret": "2025-10-03",
+      "roller": [
+        {
+          "type": {
+            "kode": "DAGL",
+            "beskrivelse": "Daglig leder",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/DAGL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1990-10-11",
+            "navn": {
+              "fornavn": "Morten",
+              "etternavn": "Drange"
+            },
+            "erDoed": false
+          },
+          "fratraadt": true,
+          "avregistrert": true,
+          "rekkefolge": 0
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "BOBE",
+        "beskrivelse": "Bostyrer",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/BOBE"
+          }
+        }
+      },
+      "sistEndret": "2026-04-07",
+      "roller": [
+        {
+          "type": {
+            "kode": "BOBE",
+            "beskrivelse": "Bostyrer",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/BOBE"
+              }
+            }
+          },
+          "bostyrer": {
+            "navn": "Adv. Odd Valland Bovim",
+            "postadresse": {
+              "landkode": "NO",
+              "postnummer": "5819",
+              "poststed": "BERGEN",
+              "adresse": ["Postboks 54 Kronstad"]
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "STYR",
+        "beskrivelse": "Styre",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/STYR"
+          }
+        }
+      },
+      "sistEndret": "2025-10-03",
+      "roller": [
+        {
+          "type": {
+            "kode": "LEDE",
+            "beskrivelse": "Styrets leder",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/LEDE"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1990-10-11",
+            "navn": {
+              "fornavn": "Morten",
+              "etternavn": "Drange"
+            },
+            "erDoed": false
+          },
+          "fratraadt": true,
+          "avregistrert": true,
+          "rekkefolge": 0
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/934955404/roller"
+    },
+    "enhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/934955404"
+    }
+  }
+}

--- a/packages/business-registries/src/brreg/__fixtures__/roles-brreg.json
+++ b/packages/business-registries/src/brreg/__fixtures__/roles-brreg.json
@@ -1,0 +1,143 @@
+{
+  "rollegrupper": [
+    {
+      "type": {
+        "kode": "DAGL",
+        "beskrivelse": "Daglig leder",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/DAGL"
+          }
+        }
+      },
+      "sistEndret": "2026-04-13",
+      "roller": [
+        {
+          "type": {
+            "kode": "DAGL",
+            "beskrivelse": "Daglig leder",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/DAGL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1971-05-11",
+            "navn": {
+              "fornavn": "Inger Lise",
+              "etternavn": "Str\u00f8m"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "REVI",
+        "beskrivelse": "Revisor",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/REVI"
+          }
+        }
+      },
+      "sistEndret": "2020-02-26",
+      "roller": [
+        {
+          "type": {
+            "kode": "REVI",
+            "beskrivelse": "Revisor",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/REVI"
+              }
+            }
+          },
+          "enhet": {
+            "organisasjonsnummer": "974760843",
+            "organisasjonsform": {
+              "kode": "ORGL",
+              "beskrivelse": "Organisasjonsledd",
+              "_links": {
+                "self": {
+                  "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/ORGL"
+                }
+              }
+            },
+            "navn": ["RIKSREVISJONEN"],
+            "godkjenningsstatus": "Godkjent revisjonsforetak",
+            "erSlettet": false,
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/enheter/974760843"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "ORGL",
+        "beskrivelse": "Org.ledd i offentlig sektor",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/ORGL"
+          }
+        }
+      },
+      "sistEndret": "2014-01-14",
+      "roller": [
+        {
+          "type": {
+            "kode": "ORGL",
+            "beskrivelse": "Org.ledd i offentlig sektor",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/ORGL"
+              }
+            }
+          },
+          "enhet": {
+            "organisasjonsnummer": "912660680",
+            "organisasjonsform": {
+              "kode": "STAT",
+              "beskrivelse": "Staten",
+              "_links": {
+                "self": {
+                  "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/STAT"
+                }
+              }
+            },
+            "navn": ["N\u00c6RINGS- OG FISKERIDEPARTEMENTET"],
+            "erSlettet": false,
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/enheter/912660680"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/974760673/roller"
+    },
+    "enhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/974760673"
+    }
+  }
+}

--- a/packages/business-registries/src/brreg/__fixtures__/roles-equinor.json
+++ b/packages/business-registries/src/brreg/__fixtures__/roles-equinor.json
@@ -1,0 +1,473 @@
+{
+  "rollegrupper": [
+    {
+      "type": {
+        "kode": "DAGL",
+        "beskrivelse": "Daglig leder",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/DAGL"
+          }
+        }
+      },
+      "sistEndret": "2020-11-02",
+      "roller": [
+        {
+          "type": {
+            "kode": "DAGL",
+            "beskrivelse": "Daglig leder",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/DAGL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1968-05-04",
+            "navn": {
+              "fornavn": "Anders",
+              "etternavn": "Opedal"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "STYR",
+        "beskrivelse": "Styre",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/STYR"
+          }
+        }
+      },
+      "sistEndret": "2026-02-17",
+      "roller": [
+        {
+          "type": {
+            "kode": "LEDE",
+            "beskrivelse": "Styrets leder",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/LEDE"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1956-11-30",
+            "navn": {
+              "fornavn": "Jon Erik",
+              "etternavn": "Reinhardsen"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1956-01-14",
+            "navn": {
+              "fornavn": "Anne",
+              "etternavn": "Drinkwater"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 1
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1964-02-15",
+            "navn": {
+              "fornavn": "Finn Bj\u00f8rn",
+              "etternavn": "Ruyter"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 2
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1960-07-08",
+            "navn": {
+              "fornavn": "Haakon Stephen",
+              "etternavn": "Bruun-Hanssen"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 3
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1960-04-26",
+            "navn": {
+              "fornavn": "Jarle Kjell",
+              "etternavn": "Roth"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 4
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1961-08-14",
+            "navn": {
+              "fornavn": "Mikael Roland",
+              "etternavn": "Karlsson"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 5
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1973-09-17",
+            "navn": {
+              "fornavn": "Dawn",
+              "etternavn": "Summers"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 6
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1974-04-09",
+            "navn": {
+              "fornavn": "Fernanda",
+              "etternavn": "Lopes Larsen"
+            },
+            "erDoed": false
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 7
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1966-11-14",
+            "navn": {
+              "fornavn": "Hilde",
+              "etternavn": "M\u00f8llerstad"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 8
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1990-03-05",
+            "navn": {
+              "fornavn": "Frank",
+              "mellomnavn": "Indreland",
+              "etternavn": "Gundersen"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 9
+        },
+        {
+          "type": {
+            "kode": "MEDL",
+            "beskrivelse": "Styremedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/MEDL"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1962-06-19",
+            "navn": {
+              "fornavn": "Geir Leon",
+              "etternavn": "Vadheim"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 10
+        },
+        {
+          "type": {
+            "kode": "VARA",
+            "beskrivelse": "Varamedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/VARA"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1966-12-23",
+            "navn": {
+              "fornavn": "Hans Einar",
+              "etternavn": "Haldorsen"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 11
+        },
+        {
+          "type": {
+            "kode": "VARA",
+            "beskrivelse": "Varamedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/VARA"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1978-03-06",
+            "navn": {
+              "fornavn": "Anette",
+              "etternavn": "Heggholmen"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 12
+        },
+        {
+          "type": {
+            "kode": "VARA",
+            "beskrivelse": "Varamedlem",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/VARA"
+              }
+            }
+          },
+          "person": {
+            "fodselsdato": "1968-09-10",
+            "navn": {
+              "fornavn": "Terje Werner",
+              "etternavn": "Hansen"
+            },
+            "erDoed": false
+          },
+          "valgtAv": {
+            "kode": "AREP",
+            "beskrivelse": "Representant for de ansatte",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/representanter/AREP"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 13
+        }
+      ]
+    },
+    {
+      "type": {
+        "kode": "REVI",
+        "beskrivelse": "Revisor",
+        "_links": {
+          "self": {
+            "href": "https://data.brreg.no/enhetsregisteret/api/roller/rollegruppetyper/REVI"
+          }
+        }
+      },
+      "sistEndret": "2019-07-12",
+      "roller": [
+        {
+          "type": {
+            "kode": "REVI",
+            "beskrivelse": "Revisor",
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/roller/rolletyper/REVI"
+              }
+            }
+          },
+          "enhet": {
+            "organisasjonsnummer": "976389387",
+            "organisasjonsform": {
+              "kode": "AS",
+              "beskrivelse": "Aksjeselskap",
+              "_links": {
+                "self": {
+                  "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/AS"
+                }
+              }
+            },
+            "navn": ["ERNST & YOUNG AS"],
+            "godkjenningsstatus": "Godkjent revisjonsforetak",
+            "erSlettet": false,
+            "_links": {
+              "self": {
+                "href": "https://data.brreg.no/enhetsregisteret/api/enheter/976389387"
+              }
+            }
+          },
+          "fratraadt": false,
+          "avregistrert": false,
+          "rekkefolge": 0
+        }
+      ]
+    }
+  ],
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/923609016/roller"
+    },
+    "enhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/923609016"
+    }
+  }
+}

--- a/packages/business-registries/src/brreg/index.ts
+++ b/packages/business-registries/src/brreg/index.ts
@@ -9,6 +9,18 @@ export {
   BrregValidationError,
 } from "./errors.js";
 export { parseAddress, parseEnhet, parseSearchEntry } from "./parse.js";
+export {
+  lookupOfficersByOrgnr,
+  parseOfficer,
+  parseRolesResponse,
+} from "./roles.js";
+export type {
+  BrregOfficer,
+  BrregOfficerEntity,
+  BrregOfficerPerson,
+  BrregOfficerTrustee,
+  BrregRawRolesResponse,
+} from "./roles.js";
 export type {
   BrregAddress,
   BrregEntity,

--- a/packages/business-registries/src/brreg/parse.test.ts
+++ b/packages/business-registries/src/brreg/parse.test.ts
@@ -99,6 +99,15 @@ describe("parseEnhet", () => {
         tvangsopplostPgaMangelfulltStyreDato: "2026-04-07",
       }).status,
     ).toEqual({ type: "compulsory_liquidation", openedAt: "2026-04-07" });
+    // The "missing general manager" reason — Brreg ships it as the
+    // separate `tvangsopplostPgaManglendeDagligLederDato` field.
+    expect(
+      parseEnhet({
+        ...baseRaw,
+        underTvangsavviklingEllerTvangsopplosning: true,
+        tvangsopplostPgaManglendeDagligLederDato: "2026-03-02",
+      }).status,
+    ).toEqual({ type: "compulsory_liquidation", openedAt: "2026-03-02" });
     expect(
       parseEnhet({
         ...baseRaw,

--- a/packages/business-registries/src/brreg/parse.test.ts
+++ b/packages/business-registries/src/brreg/parse.test.ts
@@ -60,21 +60,65 @@ describe("parseEnhet", () => {
     );
   });
 
-  test("flags bankruptcy", () => {
-    const out = parseEnhet({ ...baseRaw, konkurs: true });
-    expect(out.status).toEqual({ type: "bankruptcy" });
+  test("flags bankruptcy with opening date when present", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      konkurs: true,
+      konkursdato: "2026-05-05",
+    });
+    expect(out.status).toEqual({ type: "bankruptcy", openedAt: "2026-05-05" });
   });
 
-  test("flags winding-up", () => {
-    expect(parseEnhet({ ...baseRaw, underAvvikling: true }).status).toEqual({
-      type: "winding_up",
-    });
+  test("flags bankruptcy with null openedAt when date is missing", () => {
+    const out = parseEnhet({ ...baseRaw, konkurs: true });
+    expect(out.status).toEqual({ type: "bankruptcy", openedAt: null });
+  });
+
+  test("flags voluntary liquidation with opening date", () => {
+    expect(
+      parseEnhet({
+        ...baseRaw,
+        underAvvikling: true,
+        underAvviklingDato: "2025-08-08",
+      }).status,
+    ).toEqual({ type: "voluntary_liquidation", openedAt: "2025-08-08" });
+  });
+
+  test("flags compulsory liquidation and selects the first populated date field", () => {
+    expect(
+      parseEnhet({
+        ...baseRaw,
+        underTvangsavviklingEllerTvangsopplosning: true,
+        tvangsopplostPgaManglendeRegnskapDato: "2026-05-11",
+      }).status,
+    ).toEqual({ type: "compulsory_liquidation", openedAt: "2026-05-11" });
+    expect(
+      parseEnhet({
+        ...baseRaw,
+        underTvangsavviklingEllerTvangsopplosning: true,
+        tvangsopplostPgaMangelfulltStyreDato: "2026-04-07",
+      }).status,
+    ).toEqual({ type: "compulsory_liquidation", openedAt: "2026-04-07" });
     expect(
       parseEnhet({
         ...baseRaw,
         underTvangsavviklingEllerTvangsopplosning: true,
       }).status,
-    ).toEqual({ type: "winding_up" });
+    ).toEqual({ type: "compulsory_liquidation", openedAt: null });
+  });
+
+  test("prefers compulsory liquidation over voluntary when both flags are set", () => {
+    const out = parseEnhet({
+      ...baseRaw,
+      underAvvikling: true,
+      underAvviklingDato: "2025-08-08",
+      underTvangsavviklingEllerTvangsopplosning: true,
+      tvangsopplostPgaManglendeRegnskapDato: "2026-05-11",
+    });
+    expect(out.status).toEqual({
+      type: "compulsory_liquidation",
+      openedAt: "2026-05-11",
+    });
   });
 
   test("prefers deleted status over other flags", () => {

--- a/packages/business-registries/src/brreg/parse.ts
+++ b/packages/business-registries/src/brreg/parse.ts
@@ -79,13 +79,29 @@ const parseStatus = (raw: BrregRawEnhet): BrregEntityStatus => {
     return { type: "deleted", deletedAt: removedAt };
   }
   if (raw.konkurs === true) {
-    return { type: "bankruptcy" };
+    return { type: "bankruptcy", openedAt: raw.konkursdato ?? null };
   }
-  if (
-    raw.underAvvikling === true ||
-    raw.underTvangsavviklingEllerTvangsopplosning === true
-  ) {
-    return { type: "winding_up" };
+  // Compulsory liquidation precedes voluntary liquidation on purpose:
+  // Brreg can set both flags during a transition, and the compulsory
+  // proceeding is the more material legal regime.
+  if (raw.underTvangsavviklingEllerTvangsopplosning === true) {
+    // Brreg has no single "compulsory liquidation date" field; the
+    // opening date lives on whichever reason-specific column applies
+    // (failure to file accounts, missing auditor, defective board,
+    // failure to delete). Pick the first populated one.
+    const openedAt =
+      raw.tvangsopplostPgaManglendeRegnskapDato ??
+      raw.tvangsopplostPgaManglendeRevisorDato ??
+      raw.tvangsopplostPgaMangelfulltStyreDato ??
+      raw.tvangsavvikletPgaManglendeSlettingDato ??
+      null;
+    return { type: "compulsory_liquidation", openedAt };
+  }
+  if (raw.underAvvikling === true) {
+    return {
+      type: "voluntary_liquidation",
+      openedAt: raw.underAvviklingDato ?? null,
+    };
   }
   return { type: "active" };
 };

--- a/packages/business-registries/src/brreg/parse.ts
+++ b/packages/business-registries/src/brreg/parse.ts
@@ -93,6 +93,7 @@ const parseStatus = (raw: BrregRawEnhet): BrregEntityStatus => {
       raw.tvangsopplostPgaManglendeRegnskapDato ??
       raw.tvangsopplostPgaManglendeRevisorDato ??
       raw.tvangsopplostPgaMangelfulltStyreDato ??
+      raw.tvangsopplostPgaManglendeDagligLederDato ??
       raw.tvangsavvikletPgaManglendeSlettingDato ??
       null;
     return { type: "compulsory_liquidation", openedAt };

--- a/packages/business-registries/src/brreg/roles.test.ts
+++ b/packages/business-registries/src/brreg/roles.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import bankruptFixture from "./__fixtures__/roles-bankrupt.json" with { type: "json" };
 import brregFixture from "./__fixtures__/roles-brreg.json" with { type: "json" };
 import equinorFixture from "./__fixtures__/roles-equinor.json" with { type: "json" };
-import { BrregValidationError } from "./errors.js";
+import { BrregAPIError, BrregValidationError } from "./errors.js";
 import {
   type BrregRawRolesResponse,
   lookupOfficersByOrgnr,
@@ -63,6 +63,44 @@ describe("parseRolesResponse", () => {
     expect(ceo?.person?.isDeceased).toBe(false);
     expect(ceo?.entity).toBeUndefined();
     expect(ceo?.trustee).toBeUndefined();
+  });
+
+  test("rejects malformed and future birth years", () => {
+    const officers = parseRolesResponse({
+      rollegrupper: [
+        {
+          type: { kode: "STYR" },
+          roller: [
+            {
+              type: { kode: "LEDE" },
+              person: {
+                fodselsdato: "95",
+                navn: { fornavn: "Short", etternavn: "Value" },
+              },
+            },
+            {
+              type: { kode: "LEDE" },
+              person: {
+                fodselsdato: "2999-01-01",
+                navn: { fornavn: "Future", etternavn: "Value" },
+              },
+            },
+            {
+              type: { kode: "LEDE" },
+              person: {
+                fodselsdato: "197x-01-01",
+                navn: { fornavn: "Partial", etternavn: "Value" },
+              },
+            },
+          ],
+        },
+      ],
+    });
+    expect(officers.map((officer) => officer.person?.birthYear)).toEqual([
+      null,
+      null,
+      null,
+    ]);
   });
 
   test("populates `entity` for corporate role holders", () => {
@@ -158,6 +196,34 @@ describe("lookupOfficersByOrgnr fetch", () => {
   test("returns [] when the upstream returns 410 Gone", async () => {
     restore = installFetchStub(async () => new Response(null, { status: 410 }));
     expect(await lookupOfficersByOrgnr("974760673")).toEqual([]);
+  });
+
+  test("preserves API status when non-JSON error bodies are returned", () => {
+    restore = installFetchStub(
+      async () =>
+        new Response("<html>bad gateway</html>", {
+          status: 502,
+          headers: { "Content-Type": "text/html" },
+        }),
+    );
+    expect(lookupOfficersByOrgnr("974760673")).rejects.toMatchObject({
+      name: "BrregAPIError",
+      httpStatus: 502,
+      upstreamMessage: null,
+    });
+  });
+
+  test("surfaces malformed 200 JSON as BrregAPIError", () => {
+    restore = installFetchStub(
+      async () =>
+        new Response("{", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    expect(lookupOfficersByOrgnr("974760673")).rejects.toBeInstanceOf(
+      BrregAPIError,
+    );
   });
 
   test("normalises spaces and dashes before hitting the API", async () => {

--- a/packages/business-registries/src/brreg/roles.test.ts
+++ b/packages/business-registries/src/brreg/roles.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import bankruptFixture from "./__fixtures__/roles-bankrupt.json" with { type: "json" };
+import brregFixture from "./__fixtures__/roles-brreg.json" with { type: "json" };
+import equinorFixture from "./__fixtures__/roles-equinor.json" with { type: "json" };
+import { BrregValidationError } from "./errors.js";
+import {
+  type BrregRawRolesResponse,
+  lookupOfficersByOrgnr,
+  parseRolesResponse,
+} from "./roles.js";
+
+const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+
+// SAFETY: the fixtures are static JSON captured from the live API and
+// the runtime types match the file shape; the assertion narrows the
+// `unknown` inferred from JSON import attributes.
+// eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+const asResponse = (value: unknown) => value as BrregRawRolesResponse;
+
+const stringifyFetchInput = (input: Parameters<typeof fetch>[0]): string => {
+  if (typeof input === "string") {
+    return input;
+  }
+  if (input instanceof URL) {
+    return input.href;
+  }
+  return input.url;
+};
+
+const installFetchStub = (
+  stub: (url: string) => Promise<Response>,
+): (() => void) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (input: Parameters<typeof fetch>[0]) =>
+      stub(stringifyFetchInput(input)),
+    { preconnect: original.preconnect },
+  );
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+describe("parseRolesResponse", () => {
+  test("flattens role groups and labels roles structurally", () => {
+    const officers = parseRolesResponse(asResponse(brregFixture));
+    // Brreg's own roster: CEO + auditor entity + public-sector parent.
+    expect(officers).toHaveLength(3);
+    expect(officers.every((o) => !o.isResigned)).toBe(true);
+    expect(officers.map((o) => o.role.code).sort()).toEqual([
+      "DAGL",
+      "ORGL",
+      "REVI",
+    ]);
+  });
+
+  test("populates `person` for natural persons with a composed name", () => {
+    const officers = parseRolesResponse(asResponse(brregFixture));
+    const ceo = officers.find((o) => o.role.code === "DAGL");
+    expect(ceo?.person?.name).toBe("Inger Lise Strøm");
+    expect(ceo?.person?.birthYear).toBe(1971);
+    expect(ceo?.person?.isDeceased).toBe(false);
+    expect(ceo?.entity).toBeUndefined();
+    expect(ceo?.trustee).toBeUndefined();
+  });
+
+  test("populates `entity` for corporate role holders", () => {
+    const officers = parseRolesResponse(asResponse(brregFixture));
+    const auditor = officers.find((o) => o.role.code === "REVI");
+    expect(auditor?.entity?.orgnr).toBe("974760843");
+    expect(auditor?.entity?.name).toBe("RIKSREVISJONEN");
+    expect(auditor?.person).toBeUndefined();
+  });
+
+  test("includes mellomnavn in composed person name when present", () => {
+    const officers = parseRolesResponse(asResponse(equinorFixture));
+    const employeeRep = officers.find(
+      (o) => o.person?.name === "Frank Indreland Gundersen",
+    );
+    expect(employeeRep).toBeDefined();
+  });
+
+  test("propagates the role group's sistEndret as changedAt", () => {
+    const officers = parseRolesResponse(asResponse(brregFixture));
+    const ceo = officers.find((o) => o.role.code === "DAGL");
+    expect(ceo?.changedAt).toBe("2026-04-13");
+  });
+
+  test("marks resigned officers via isResigned and keeps them in the list", () => {
+    const officers = parseRolesResponse(asResponse(bankruptFixture));
+    // Bankrupt entity: one trustee (active) + two resigned officers.
+    const resigned = officers.filter((o) => o.isResigned);
+    const active = officers.filter((o) => !o.isResigned);
+    expect(resigned.length).toBeGreaterThan(0);
+    expect(active.length).toBeGreaterThan(0);
+    // Resigned officers are NOT silently dropped — they remain in the
+    // payload labelled with isResigned so callers can render "former".
+    expect(officers.length).toBe(resigned.length + active.length);
+  });
+
+  test("populates `trustee` for bostyrer roles", () => {
+    const officers = parseRolesResponse(asResponse(bankruptFixture));
+    const trustee = officers.find((o) => o.role.code === "BOBE");
+    expect(trustee?.trustee?.name).toContain("Bovim");
+    expect(trustee?.trustee?.postalAddress).toContain("BERGEN");
+    expect(trustee?.person).toBeUndefined();
+    expect(trustee?.entity).toBeUndefined();
+  });
+
+  test("returns an empty list for a payload with no role groups", () => {
+    expect(parseRolesResponse({})).toEqual([]);
+    expect(parseRolesResponse({ rollegrupper: [] })).toEqual([]);
+  });
+});
+
+describe("lookupOfficersByOrgnr validation", () => {
+  test("throws BrregValidationError for malformed input", () => {
+    expect(lookupOfficersByOrgnr("12345678")).rejects.toBeInstanceOf(
+      BrregValidationError,
+    );
+  });
+
+  test("throws BrregValidationError for bad checksum", () => {
+    expect(lookupOfficersByOrgnr("974760674")).rejects.toBeInstanceOf(
+      BrregValidationError,
+    );
+  });
+});
+
+describe("lookupOfficersByOrgnr fetch", () => {
+  let restore: (() => void) | undefined;
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  test("returns the parsed officer roster for a 200 response", async () => {
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify(brregFixture), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const officers = await lookupOfficersByOrgnr("974760673");
+    expect(officers).toHaveLength(3);
+    expect(officers.find((o) => o.role.code === "DAGL")?.person?.name).toBe(
+      "Inger Lise Strøm",
+    );
+  });
+
+  test("returns [] when the orgnr is unknown (404)", async () => {
+    restore = installFetchStub(async () => new Response(null, { status: 404 }));
+    expect(await lookupOfficersByOrgnr("974760673")).toEqual([]);
+  });
+
+  test("returns [] when the upstream returns 410 Gone", async () => {
+    restore = installFetchStub(async () => new Response(null, { status: 410 }));
+    expect(await lookupOfficersByOrgnr("974760673")).toEqual([]);
+  });
+
+  test("normalises spaces and dashes before hitting the API", async () => {
+    let observedUrl = "";
+    restore = installFetchStub(async (url) => {
+      observedUrl = url;
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    await lookupOfficersByOrgnr("974 760 673");
+    expect(observedUrl).toBe(
+      "https://data.brreg.no/enhetsregisteret/api/enheter/974760673/roller",
+    );
+  });
+});
+
+// Live tests hit the real Brreg open API. They double as integration tests
+// and document the expected response shape for known entities.
+describe.skipIf(SKIP_LIVE)("lookupOfficersByOrgnr live", () => {
+  test("returns the registry's own officer roster", async () => {
+    const officers = await lookupOfficersByOrgnr("974760673");
+    expect(officers.length).toBeGreaterThan(0);
+    expect(officers.some((o) => o.role.code === "DAGL")).toBe(true);
+  });
+
+  test("returns [] for a checksum-valid but non-existent orgnr", async () => {
+    const officers = await lookupOfficersByOrgnr("100000008");
+    expect(officers).toEqual([]);
+  });
+});

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -160,12 +160,14 @@ const composeTrusteeAddress = (raw: BrregRawRoleTrustee): string | null => {
 };
 
 const parseBirthYear = (fodselsdato: string | undefined): number | null => {
-  if (!fodselsdato) {
+  if (!fodselsdato || fodselsdato.length < 4) {
     return null;
   }
-  // Brreg returns ISO-style YYYY-MM-DD; take the first four characters.
+  // Brreg returns ISO-style YYYY-MM-DD; take the first four
+  // characters. Reject obviously-bogus values — a stray `"95"` would
+  // otherwise parse to 95 AD.
   const year = Number.parseInt(fodselsdato.slice(0, 4), 10);
-  return Number.isFinite(year) ? year : null;
+  return Number.isFinite(year) && year >= 1000 ? year : null;
 };
 
 export const parseOfficer = (
@@ -256,13 +258,20 @@ const brregGetRoles = async (
 
   if (!response.ok) {
     let upstreamMessage: string | null = null;
-    try {
-      upstreamMessage = parseUpstreamMessage(await response.json());
-    } catch {
-      // non-JSON error body
+    // Brreg's error envelope is JSON, but upstream proxies
+    // (Cloudflare / nginx) can intercept and return HTML error pages
+    // — feeding those to `response.json()` throws a SyntaxError that
+    // would mask the real status. Guard on Content-Type. The
+    // statusText fallback covers HTTP/2 (where it is typically empty).
+    if (response.headers.get("content-type")?.includes("application/json")) {
+      try {
+        upstreamMessage = parseUpstreamMessage(await response.json());
+      } catch {
+        // non-JSON body despite the header — ignore
+      }
     }
     throw new BrregAPIError({
-      message: `Brreg ${response.status}: ${upstreamMessage ?? response.statusText}`,
+      message: `Brreg ${response.status}: ${upstreamMessage ?? (response.statusText || "API error")}`,
       httpStatus: response.status,
       upstreamMessage,
     });

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -24,6 +24,7 @@ import { normalizeOrgnr, validateOrgnr } from "./validation.js";
 
 const BASE = "https://data.brreg.no/enhetsregisteret/api";
 const TIMEOUT_MS = 10_000;
+const MIN_BIRTH_YEAR = 1900;
 
 // ---------------------------------------------------------------------------
 // Raw Brreg roles response shapes
@@ -160,14 +161,16 @@ const composeTrusteeAddress = (raw: BrregRawRoleTrustee): string | null => {
 };
 
 const parseBirthYear = (fodselsdato: string | undefined): number | null => {
-  if (!fodselsdato || fodselsdato.length < 4) {
+  if (!fodselsdato || !/^\d{4}/u.test(fodselsdato)) {
     return null;
   }
   // Brreg returns ISO-style YYYY-MM-DD; take the first four
   // characters. Reject obviously-bogus values — a stray `"95"` would
-  // otherwise parse to 95 AD.
+  // otherwise parse to 95 AD, and a future year is not a valid birth
+  // year for a current registry actor.
   const year = Number.parseInt(fodselsdato.slice(0, 4), 10);
-  return Number.isFinite(year) && year >= 1000 ? year : null;
+  const currentYear = new Date().getUTCFullYear();
+  return year >= MIN_BIRTH_YEAR && year <= currentYear ? year : null;
 };
 
 export const parseOfficer = (
@@ -277,10 +280,19 @@ const brregGetRoles = async (
     });
   }
 
-  // SAFETY: Brreg is a stable, documented public API. Runtime validation
-  // adds little for well-typed JSON responses.
-  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
-  return response.json() as Promise<BrregRawRolesResponse>;
+  try {
+    // SAFETY: Brreg is a stable, documented public API. Runtime validation
+    // adds little for well-typed JSON responses.
+    // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+    return (await response.json()) as BrregRawRolesResponse;
+  } catch (error) {
+    throw new BrregAPIError({
+      message: `Brreg ${response.status}: invalid JSON payload`,
+      httpStatus: response.status,
+      upstreamMessage: null,
+      cause: error,
+    });
+  }
 };
 
 /**

--- a/packages/business-registries/src/brreg/roles.ts
+++ b/packages/business-registries/src/brreg/roles.ts
@@ -1,0 +1,302 @@
+// Brreg "roles" endpoint — the entity's officer roster (CEO, board
+// members, deputy members, auditors, bankruptcy trustees, …) returned
+// from `/api/enheter/{orgnr}/roller`.
+//
+// The upstream response is a list of role groups (`rollegrupper`),
+// each grouping together related roles (e.g. the whole board sits in
+// one group). The actor in each row is one of three shapes:
+//   * person — a natural person (board members, CEO).
+//   * enhet  — another registered entity (corporate auditor, public
+//              sector parent).
+//   * bostyrer — a court-appointed trustee, returned with a single
+//              `navn` string and a postal address.
+//
+// We surface all three, label resigned/de-registered officers
+// (`fratraadt` / `avregistrert`) instead of dropping them, and keep
+// the role group's `sistEndret` as the change date.
+
+import {
+  BrregAPIError,
+  BrregRequestError,
+  BrregValidationError,
+} from "./errors.js";
+import { normalizeOrgnr, validateOrgnr } from "./validation.js";
+
+const BASE = "https://data.brreg.no/enhetsregisteret/api";
+const TIMEOUT_MS = 10_000;
+
+// ---------------------------------------------------------------------------
+// Raw Brreg roles response shapes
+// ---------------------------------------------------------------------------
+
+type BrregRawRoleType = {
+  kode: string;
+  beskrivelse?: string;
+};
+
+type BrregRawRolePerson = {
+  fodselsdato?: string;
+  navn?: {
+    fornavn?: string;
+    mellomnavn?: string;
+    etternavn?: string;
+  };
+  erDoed?: boolean;
+};
+
+type BrregRawRoleEntity = {
+  organisasjonsnummer: string;
+  navn?: string[];
+  organisasjonsform?: BrregRawRoleType;
+  erSlettet?: boolean;
+};
+
+type BrregRawRoleTrustee = {
+  navn: string;
+  postadresse?: {
+    adresse?: string[];
+    postnummer?: string;
+    poststed?: string;
+    landkode?: string;
+  };
+  erDoed?: boolean;
+};
+
+type BrregRawRole = {
+  type: BrregRawRoleType;
+  person?: BrregRawRolePerson;
+  enhet?: BrregRawRoleEntity;
+  bostyrer?: BrregRawRoleTrustee;
+  fratraadt?: boolean;
+  avregistrert?: boolean;
+  rekkefolge?: number;
+};
+
+type BrregRawRoleGroup = {
+  type: BrregRawRoleType;
+  sistEndret?: string;
+  roller?: BrregRawRole[];
+};
+
+export type BrregRawRolesResponse = {
+  rollegrupper?: BrregRawRoleGroup[];
+};
+
+// ---------------------------------------------------------------------------
+// Domain output
+// ---------------------------------------------------------------------------
+
+export type BrregOfficerPerson = {
+  name: string;
+  /**
+   * Birth year only — Brreg returns the full `fodselsdato`, but we
+   * trim to the year on the way out so the domain shape never carries
+   * the full birth date of a private individual.
+   */
+  birthYear: number | null;
+  isDeceased: boolean;
+};
+
+export type BrregOfficerEntity = {
+  orgnr: string;
+  name: string;
+};
+
+export type BrregOfficerTrustee = {
+  name: string;
+  postalAddress: string | null;
+};
+
+export type BrregOfficer = {
+  role: { code: string; description: string | null };
+  /** Set when the actor is a natural person. */
+  person?: BrregOfficerPerson;
+  /** Set when the actor is another registered entity. */
+  entity?: BrregOfficerEntity;
+  /** Set when the actor is a court-appointed trustee (bostyrer). */
+  trustee?: BrregOfficerTrustee;
+  /**
+   * Date the role group was last changed in the register. Useful for
+   * dating a resignation in the absence of a per-officer `to` field.
+   */
+  changedAt: string | null;
+  /**
+   * `true` when the officer has resigned (`fratraadt`) or been
+   * de-registered (`avregistrert`). Brreg returns terminated rows in
+   * the same payload — we keep them so callers can show "former CEO"
+   * etc. instead of silently dropping records.
+   */
+  isResigned: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+const composePersonName = (raw: BrregRawRolePerson): string => {
+  const navn = raw.navn;
+  if (!navn) {
+    return "";
+  }
+  return [navn.fornavn, navn.mellomnavn, navn.etternavn]
+    .filter(Boolean)
+    .join(" ");
+};
+
+const composeTrusteeAddress = (raw: BrregRawRoleTrustee): string | null => {
+  const post = raw.postadresse;
+  if (!post) {
+    return null;
+  }
+  const lines = post.adresse?.filter(Boolean) ?? [];
+  const composite = [
+    lines.length > 0 ? lines.join(", ") : null,
+    [post.postnummer, post.poststed].filter(Boolean).join(" ") || null,
+    post.landkode ?? null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  return composite.length > 0 ? composite : null;
+};
+
+const parseBirthYear = (fodselsdato: string | undefined): number | null => {
+  if (!fodselsdato) {
+    return null;
+  }
+  // Brreg returns ISO-style YYYY-MM-DD; take the first four characters.
+  const year = Number.parseInt(fodselsdato.slice(0, 4), 10);
+  return Number.isFinite(year) ? year : null;
+};
+
+export const parseOfficer = (
+  raw: BrregRawRole,
+  changedAt: string | null,
+): BrregOfficer => {
+  const isResigned = raw.fratraadt === true || raw.avregistrert === true;
+  const officer: BrregOfficer = {
+    role: {
+      code: raw.type.kode,
+      description: raw.type.beskrivelse ?? null,
+    },
+    changedAt,
+    isResigned,
+  };
+  if (raw.person) {
+    officer.person = {
+      name: composePersonName(raw.person),
+      birthYear: parseBirthYear(raw.person.fodselsdato),
+      isDeceased: raw.person.erDoed === true,
+    };
+  }
+  if (raw.enhet) {
+    officer.entity = {
+      orgnr: raw.enhet.organisasjonsnummer,
+      // Brreg returns the entity name as an array (multi-line legal
+      // names are rare but possible); join on spaces to keep one string.
+      name: (raw.enhet.navn ?? []).filter(Boolean).join(" "),
+    };
+  }
+  if (raw.bostyrer) {
+    officer.trustee = {
+      name: raw.bostyrer.navn,
+      postalAddress: composeTrusteeAddress(raw.bostyrer),
+    };
+  }
+  return officer;
+};
+
+export const parseRolesResponse = (
+  raw: BrregRawRolesResponse,
+): BrregOfficer[] => {
+  const officers: BrregOfficer[] = [];
+  for (const group of raw.rollegrupper ?? []) {
+    const changedAt = group.sistEndret ?? null;
+    for (const role of group.roller ?? []) {
+      officers.push(parseOfficer(role, changedAt));
+    }
+  }
+  return officers;
+};
+
+// ---------------------------------------------------------------------------
+// HTTP client
+// ---------------------------------------------------------------------------
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseUpstreamMessage = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (typeof value["feilmelding"] === "string") {
+    return value["feilmelding"];
+  }
+  return null;
+};
+
+const brregGetRoles = async (
+  url: string,
+): Promise<BrregRawRolesResponse | null> => {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    });
+  } catch (error) {
+    throw new BrregRequestError(url, "Brreg roles request failed", {
+      cause: error,
+    });
+  }
+
+  if (response.status === 404 || response.status === 410) {
+    return null;
+  }
+
+  if (!response.ok) {
+    let upstreamMessage: string | null = null;
+    try {
+      upstreamMessage = parseUpstreamMessage(await response.json());
+    } catch {
+      // non-JSON error body
+    }
+    throw new BrregAPIError({
+      message: `Brreg ${response.status}: ${upstreamMessage ?? response.statusText}`,
+      httpStatus: response.status,
+      upstreamMessage,
+    });
+  }
+
+  // SAFETY: Brreg is a stable, documented public API. Runtime validation
+  // adds little for well-typed JSON responses.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return response.json() as Promise<BrregRawRolesResponse>;
+};
+
+/**
+ * Look up the officer roster for a Norwegian entity by orgnr.
+ *
+ * Hits `/api/enheter/{orgnr}/roller`. Returns every officer the API
+ * surfaces, including resigned / de-registered ones (flagged via
+ * `isResigned`) so callers can render "former CEO" etc. rather than
+ * silently dropping records.
+ *
+ * @returns The officer list, or `[]` if the orgnr is unknown.
+ * @throws {BrregValidationError} if the orgnr fails MOD-11 validation
+ * @throws {BrregAPIError} on Brreg API errors
+ * @throws {BrregRequestError} on network failures
+ */
+export const lookupOfficersByOrgnr = async (
+  orgnr: string,
+): Promise<BrregOfficer[]> => {
+  const normalized = normalizeOrgnr(orgnr);
+  if (!validateOrgnr(normalized)) {
+    throw new BrregValidationError(`Invalid orgnr: ${orgnr}`);
+  }
+  const data = await brregGetRoles(`${BASE}/enheter/${normalized}/roller`);
+  if (!data) {
+    return [];
+  }
+  return parseRolesResponse(data);
+};

--- a/packages/business-registries/src/brreg/types.ts
+++ b/packages/business-registries/src/brreg/types.ts
@@ -50,8 +50,17 @@ export type BrregRawEnhet = {
   institusjonellSektorkode?: BrregRawInstitusjonellSektor;
   antallAnsatte?: number;
   konkurs?: boolean;
+  konkursdato?: string;
   underAvvikling?: boolean;
+  underAvviklingDato?: string;
   underTvangsavviklingEllerTvangsopplosning?: boolean;
+  // Brreg splits "compulsory liquidation" into four reason-specific
+  // date fields rather than a single `tvangsopplosningDato`. We treat
+  // the first populated one as the opening date of the proceeding.
+  tvangsopplostPgaManglendeRegnskapDato?: string;
+  tvangsopplostPgaManglendeRevisorDato?: string;
+  tvangsopplostPgaMangelfulltStyreDato?: string;
+  tvangsavvikletPgaManglendeSlettingDato?: string;
   slettedato?: string;
   stiftelsesdato?: string;
   /**
@@ -100,12 +109,23 @@ export type BrregIndustryCode = {
 };
 
 // Whether the entity is currently active. Modelled as a discriminated
-// union so consumers exhaustively handle the "winding-up" and
-// "deleted" states instead of relying on a soup of boolean flags.
+// union so consumers exhaustively handle the wind-down states instead
+// of relying on a soup of boolean flags.
+//
+// Brreg differentiates voluntary liquidation (`underAvvikling`,
+// initiated by the shareholders) from compulsory liquidation
+// (`underTvangsavviklingEllerTvangsopplosning`, initiated by the
+// register or a court for failure-to-file accounts / missing auditor
+// / etc.) — both surfaces as separate union arms so legal callers can
+// tell the two regimes apart. `openedAt` carries the proceeding's
+// start date when the upstream payload includes one (Brreg has no
+// dedicated `/konkursdetaljer` endpoint; the date lives on the entity
+// payload itself).
 export type BrregEntityStatus =
   | { type: "active" }
-  | { type: "bankruptcy" }
-  | { type: "winding_up" }
+  | { type: "bankruptcy"; openedAt: string | null }
+  | { type: "voluntary_liquidation"; openedAt: string | null }
+  | { type: "compulsory_liquidation"; openedAt: string | null }
   | { type: "deleted"; deletedAt: string };
 
 export type BrregEntity = {

--- a/packages/business-registries/src/brreg/types.ts
+++ b/packages/business-registries/src/brreg/types.ts
@@ -54,12 +54,13 @@ export type BrregRawEnhet = {
   underAvvikling?: boolean;
   underAvviklingDato?: string;
   underTvangsavviklingEllerTvangsopplosning?: boolean;
-  // Brreg splits "compulsory liquidation" into four reason-specific
+  // Brreg splits "compulsory liquidation" into five reason-specific
   // date fields rather than a single `tvangsopplosningDato`. We treat
   // the first populated one as the opening date of the proceeding.
   tvangsopplostPgaManglendeRegnskapDato?: string;
   tvangsopplostPgaManglendeRevisorDato?: string;
   tvangsopplostPgaMangelfulltStyreDato?: string;
+  tvangsopplostPgaManglendeDagligLederDato?: string;
   tvangsavvikletPgaManglendeSlettingDato?: string;
   slettedato?: string;
   stiftelsesdato?: string;


### PR DESCRIPTION
## Summary

Extends `@stll/business-registries/brreg` with a new `lookupOfficersByOrgnr` hitting `/api/enheter/{orgnr}/roller`, returning CEO, board members, deputies, auditors, and bankruptcy trustees as a flat `BrregOfficer[]` with `person` / `entity` / `trustee` arms. Resigned and de-registered officers are surfaced with `isResigned: true` rather than dropped, so callers can render "former CEO" without losing history.

Also refines `BrregEntityStatus`: the single `winding_up` arm splits into `voluntary_liquidation` (shareholder-initiated, `underAvvikling`) and `compulsory_liquidation` (court/register-initiated, `underTvangsavviklingEllerTvangsopplosning`); `bankruptcy`, `voluntary_liquidation`, and `compulsory_liquidation` all carry an `openedAt: string | null` sourced from the date fields on the entity payload (`konkursdato`, `underAvviklingDato`, and the reason-specific `tvangsopplostPga*Dato` family — Brreg has no `/konkursdetaljer` endpoint).

Prior-art note: the existing `brreg` npm package (zrrrzzt/brreg) is unmaintained (last release 2022, basic entity lookup only, no `/roller`), and there is no other maintained TS client; this adapter is the only path to the officer roster.

## Test plan
- [x] `bun --filter @stll/business-registries test src/brreg` (43 pass, 5 skip)
- [x] `SMOKE_TEST=1 bun --filter @stll/business-registries test src/brreg/client.test.ts src/brreg/roles.test.ts` (24 pass against live API)
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run i18n:check`