### PR TITLE
feat(business-registries): add EU VIES VAT validation adapter

### DIFF
--- a/apps/api/src/handlers/chat/tools/business-registry-tools.test.ts
+++ b/apps/api/src/handlers/chat/tools/business-registry-tools.test.ts
@@ -24,4 +24,11 @@ describe("createBusinessRegistryTools", () => {
     });
     expect(tools[BUSINESS_REGISTRY_LOOKUP_TOOL_NAME]).toBeDefined();
   });
+
+  test("accepts the EU pseudo-jurisdiction (VIES)", () => {
+    const tools = createBusinessRegistryTools({
+      enabledJurisdictions: ["EU"],
+    });
+    expect(tools[BUSINESS_REGISTRY_LOOKUP_TOOL_NAME]).toBeDefined();
+  });
 });

--- a/apps/api/src/handlers/chat/tools/business-registry-tools.ts
+++ b/apps/api/src/handlers/chat/tools/business-registry-tools.ts
@@ -2,11 +2,10 @@ import { valibotSchema } from "@ai-sdk/valibot";
 import { tool } from "ai";
 import * as v from "valibot";
 
-import type { CountryCode } from "@stll/country-codes";
-
 import {
   executeRegistryLookup,
   getRegistryHandlerByCountry,
+  type RegistryJurisdictionCode,
 } from "@/api/lib/business-registries/dispatch";
 
 const BUSINESS_REGISTRY_LOOKUP_TOOL_NAME = "business_registry_lookup" as const;
@@ -17,21 +16,28 @@ const TOOL_DESCRIPTION =
   "Look up companies in official national business registries. " +
   "Use jurisdiction for the country whose registry should be searched, " +
   "for example CZ for the Czech ARES register or NO for " +
-  "Brønnøysundregistrene in Norway. Search by company registration " +
-  "number or company name.";
+  "Brønnøysundregistrene in Norway. Pass EU to validate an EU VAT " +
+  "number against VIES (the VAT Information Exchange System); the " +
+  "query must then be a fully-qualified VAT number including the " +
+  "2-letter country prefix, e.g. DE143593636. Search by company " +
+  "registration number or company name; name search is not supported " +
+  "for VIES.";
 
 type CreateBusinessRegistryToolsArgs = {
   /**
-   * Country codes for the registry adapters the org is permitted to
-   * call on this chat turn. Computed by the caller from the existing
-   * native-tool enablement logic (practice-jurisdiction defaults +
-   * `nativeToolOverrides`). Pass only countries we actually ship an
-   * adapter for.
+   * Jurisdiction codes for the registry adapters the org is permitted
+   * to call on this chat turn. Computed by the caller from the
+   * existing native-tool enablement logic (practice-jurisdiction
+   * defaults + `nativeToolOverrides`). Pass only jurisdictions we
+   * actually ship an adapter for.
+   *
+   * Accepts the special "EU" pseudo-jurisdiction for EU-wide adapters
+   * such as VIES; see `RegistryJurisdictionCode`.
    *
    * Empty array → the tool is not registered (do not surface a
    * jurisdiction picker the model cannot use).
    */
-  enabledJurisdictions: readonly CountryCode[];
+  enabledJurisdictions: readonly RegistryJurisdictionCode[];
 };
 
 /**
@@ -50,28 +56,35 @@ export const createBusinessRegistryTools = ({
   }
 
   // valibot's `picklist` requires a tuple of literals. We can safely
-  // narrow `enabledJurisdictions` (a runtime array of CountryCode) to
-  // a non-empty readonly tuple here because we just checked length.
+  // narrow `enabledJurisdictions` (a runtime array of
+  // RegistryJurisdictionCode) to a non-empty readonly tuple here
+  // because we just checked length.
   const [first, ...rest] = enabledJurisdictions;
   if (first === undefined) {
     return {};
   }
-  const picklistOptions = [first, ...rest] as [CountryCode, ...CountryCode[]];
+  const picklistOptions = [first, ...rest] as [
+    RegistryJurisdictionCode,
+    ...RegistryJurisdictionCode[],
+  ];
 
   const inputSchema = v.strictObject({
     jurisdiction: v.pipe(
       v.picklist(picklistOptions),
       v.description(
-        "ISO 3166-1 alpha-2 country code for the registry to query.",
+        "ISO 3166-1 alpha-2 country code for the registry to query, or " +
+          "the special 'EU' code for the EU-wide VIES VAT-validation " +
+          "service.",
       ),
     ),
     query: v.pipe(
       v.string(),
       v.description(
-        "Company registration number (e.g. Czech IČO, Norwegian orgnr) " +
-          "or company name. Numeric inputs that match the registry's " +
-          "canonical ID format route to a direct lookup; everything " +
-          "else is treated as a name search.",
+        "Company registration number (e.g. Czech IČO, Norwegian orgnr, " +
+          "fully-qualified EU VAT such as DE143593636) or company name. " +
+          "Numeric inputs that match the registry's canonical ID format " +
+          "route to a direct lookup; everything else is treated as a " +
+          "name search (where supported).",
       ),
     ),
     limit: v.optional(

--- a/apps/api/src/lib/business-registries/dispatch.test.ts
+++ b/apps/api/src/lib/business-registries/dispatch.test.ts
@@ -5,6 +5,7 @@ import type { AresCompany } from "@stll/business-registries/ares";
 import {
   BUSINESS_REGISTRY_DISPATCH,
   executeRegistryLookup,
+  getRegistryHandlerByCountry,
   type RegistryHandler,
 } from "@/api/lib/business-registries/dispatch";
 
@@ -90,5 +91,43 @@ describe("executeRegistryLookup — details channel", () => {
       throw new Error(`expected search result, got ${result.type}`);
     }
     expect(result.hits[0]?.details).toBeUndefined();
+  });
+});
+
+describe("VIES handler wiring", () => {
+  test("is registered under the EU pseudo-jurisdiction", () => {
+    const handler = getRegistryHandlerByCountry("EU");
+    expect(handler).toBeDefined();
+    expect(handler?.slug).toBe("vies");
+  });
+
+  test("isCanonicalId accepts well-formed EU VAT numbers", () => {
+    const handler = BUSINESS_REGISTRY_DISPATCH.vies;
+    expect(handler.isCanonicalId("DE143593636")).toBe(true);
+    expect(handler.isCanonicalId(" ie 6388047v ")).toBe(true);
+    expect(handler.isCanonicalId("IT00159560366")).toBe(true);
+  });
+
+  test("isCanonicalId rejects inputs without a known prefix or with GB", () => {
+    const handler = BUSINESS_REGISTRY_DISPATCH.vies;
+    expect(handler.isCanonicalId("143593636")).toBe(false);
+    expect(handler.isCanonicalId("ZZ12345")).toBe(false);
+    // GB was removed from VIES post-Brexit.
+    expect(handler.isCanonicalId("GB123456789")).toBe(false);
+  });
+
+  test("search is null — VIES has no name-search endpoint", () => {
+    expect(BUSINESS_REGISTRY_DISPATCH.vies.search).toBeNull();
+  });
+
+  test("name search is rejected with a useful error", async () => {
+    const result = await executeRegistryLookup({
+      handler: BUSINESS_REGISTRY_DISPATCH.vies,
+      query: "Acme Corp",
+    });
+    expect(result).toBeInstanceOf(Error);
+    if (result instanceof Error) {
+      expect(result.message).toContain("does not support name search");
+    }
   });
 });

--- a/apps/api/src/lib/business-registries/dispatch.test.ts
+++ b/apps/api/src/lib/business-registries/dispatch.test.ts
@@ -106,12 +106,23 @@ describe("VIES handler wiring", () => {
     expect(handler.isCanonicalId("DE143593636")).toBe(true);
     expect(handler.isCanonicalId(" ie 6388047v ")).toBe(true);
     expect(handler.isCanonicalId("IT00159560366")).toBe(true);
+    expect(handler.isCanonicalId("RO12")).toBe(true);
   });
 
   test("isCanonicalId rejects inputs without a known VAT prefix", () => {
     const handler = BUSINESS_REGISTRY_DISPATCH.vies;
     expect(handler.isCanonicalId("143593636")).toBe(false);
     expect(handler.isCanonicalId("ZZ12345")).toBe(false);
+  });
+
+  test("isCanonicalId rejects ordinary names that start with VAT prefixes", () => {
+    const handler = BUSINESS_REGISTRY_DISPATCH.vies;
+    expect(handler.isCanonicalId("Deutsche Bank")).toBe(false);
+  });
+
+  test("isCanonicalId routes malformed numeric VATs to validation", () => {
+    const handler = BUSINESS_REGISTRY_DISPATCH.vies;
+    expect(handler.isCanonicalId("DE123")).toBe(true);
   });
 
   test("isCanonicalId accepts removed prefixes so lookup can give a tailored error", () => {

--- a/apps/api/src/lib/business-registries/dispatch.test.ts
+++ b/apps/api/src/lib/business-registries/dispatch.test.ts
@@ -108,12 +108,21 @@ describe("VIES handler wiring", () => {
     expect(handler.isCanonicalId("IT00159560366")).toBe(true);
   });
 
-  test("isCanonicalId rejects inputs without a known prefix or with GB", () => {
+  test("isCanonicalId rejects inputs without a known VAT prefix", () => {
     const handler = BUSINESS_REGISTRY_DISPATCH.vies;
     expect(handler.isCanonicalId("143593636")).toBe(false);
     expect(handler.isCanonicalId("ZZ12345")).toBe(false);
-    // GB was removed from VIES post-Brexit.
-    expect(handler.isCanonicalId("GB123456789")).toBe(false);
+  });
+
+  test("isCanonicalId accepts removed prefixes so lookup can give a tailored error", () => {
+    // GB was removed from VIES after Brexit, but the prefix is still
+    // a known VAT country — `isCanonicalId` must let it through to the
+    // lookup path so `validateVat()` can raise the dedicated
+    // "removed after Brexit" ViesValidationError. Returning false
+    // here would instead surface the generic "name search not
+    // supported" 400.
+    const handler = BUSINESS_REGISTRY_DISPATCH.vies;
+    expect(handler.isCanonicalId("GB123456789")).toBe(true);
   });
 
   test("search is null — VIES has no name-search endpoint", () => {

--- a/apps/api/src/lib/business-registries/dispatch.ts
+++ b/apps/api/src/lib/business-registries/dispatch.ts
@@ -83,9 +83,32 @@ import {
   RechercheEntreprisesValidationError,
   searchByName as searchRechercheEntreprisesByName,
 } from "@stll/business-registries/recherche-entreprises";
+import {
+  isKnownVatCountry,
+  parseVatNumber,
+  validateVat,
+  type ViesValidation,
+  ViesAPIError,
+  ViesRequestError,
+  ViesValidationError,
+} from "@stll/business-registries/vies";
 import type { CountryCode } from "@stll/country-codes";
 
 import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+// ---------------------------------------------------------------------------
+// Jurisdiction codes
+//
+// VIES is an EU-wide pseudo-jurisdiction, not a real country. We widen
+// the registry jurisdiction type to `CountryCode | "EU"` so the unified
+// dispatch + chat tool can route to the VIES adapter without polluting
+// `CountryCode` (which is structurally the ISO 3166-1 alpha-2 set).
+// ---------------------------------------------------------------------------
+
+export const EU_PSEUDO_JURISDICTION = "EU" as const;
+export type RegistryJurisdictionCode =
+  | CountryCode
+  | typeof EU_PSEUDO_JURISDICTION;
 
 // ---------------------------------------------------------------------------
 // Normalised cross-registry shapes
@@ -99,6 +122,7 @@ export const BUSINESS_REGISTRY_SLUGS = [
   "orsr",
   "prh",
   "recherche-entreprises",
+  "vies",
 ] as const;
 export type BusinessRegistrySlug = (typeof BUSINESS_REGISTRY_SLUGS)[number];
 
@@ -143,7 +167,8 @@ export type BusinessRegistryHitDetails =
   | { registry: "krs"; entity: KrsEntity }
   | { registry: "orsr"; company: OrsrCompany }
   | { registry: "prh"; company: PrhCompany }
-  | { registry: "recherche-entreprises"; company: RechercheEntreprisesCompany };
+  | { registry: "recherche-entreprises"; company: RechercheEntreprisesCompany }
+  | { registry: "vies"; validation: ViesValidation };
 
 export type RegistryLookupResponse =
   | {
@@ -165,11 +190,16 @@ export type RegistryHandler = {
   /** Slug as it appears in the catalogue + the REST `?registry=` param. */
   slug: BusinessRegistrySlug;
   /**
-   * ISO country code the registry covers. The chat tool uses this to
+   * Jurisdiction the registry covers. The chat tool uses this to
    * route a user-supplied jurisdiction to the right adapter
-   * (CZ → ares, NO → brreg, ...).
+   * (CZ → ares, NO → brreg, EU → vies, ...).
+   *
+   * Normally an ISO 3166-1 alpha-2 country code. The special "EU"
+   * value is reserved for EU-wide pseudo-jurisdictions (currently
+   * just VIES, which validates VAT numbers across all member states
+   * from a single endpoint).
    */
-  country: CountryCode;
+  country: RegistryJurisdictionCode;
   /** Catalog slug used by `isNativeToolEnabledForOrg`. */
   nativeToolSlug: string;
   /**
@@ -756,6 +786,72 @@ const mapPrhError = (error: unknown): HandlerError | null => {
   return null;
 };
 
+// ---------------------------------------------------------------------------
+// VIES (EU-wide VAT validation)
+//
+// Special-case: VIES is not a per-country business registry. The input
+// already carries the 2-letter country prefix (e.g. "DE143593636"),
+// so the handler's jurisdiction is the synthetic "EU" pseudo-code and
+// `isCanonicalId` accepts any VAT-shaped input.
+//
+// There is no name-search endpoint: VIES validates a fully-qualified
+// VAT number and that is it. The handler's `search` is null so the
+// dispatch layer surfaces a 400 with a useful message rather than
+// silently returning an empty list.
+// ---------------------------------------------------------------------------
+
+const VIES_HOMEPAGE = "https://ec.europa.eu/taxation_customs/vies/";
+
+const viesValidationToHit = (
+  validation: ViesValidation,
+): BusinessRegistryHit => {
+  const fullVat = `${validation.vatNumber.country}${validation.vatNumber.vat}`;
+  return {
+    registry: "vies",
+    id: fullVat,
+    // Fall back to the VAT itself when the member state suppresses
+    // trader data (DE, ES, AT, …) so callers always have something
+    // to render in the name slot.
+    name: validation.name ?? fullVat,
+    legalForm: null,
+    address: validation.address
+      ? {
+          line1: null,
+          line2: null,
+          postalCode: null,
+          city: null,
+          region: null,
+          country: validation.vatNumber.country,
+          textAddress: validation.address,
+        }
+      : null,
+    registryUrl: VIES_HOMEPAGE,
+    // Carry the structured validation so the chat model can answer
+    // "is VAT DE143593636 valid?" with the registered name + address
+    // and the timestamp VIES stamped.
+    details: { registry: "vies", validation },
+  };
+};
+
+const mapViesError = (error: unknown): HandlerError | null => {
+  if (error instanceof ViesValidationError) {
+    return new HandlerError({ status: 400, message: error.message });
+  }
+  if (error instanceof ViesAPIError) {
+    return new HandlerError({
+      status: 502,
+      message: `VIES API error: ${error.message}`,
+    });
+  }
+  if (error instanceof ViesRequestError) {
+    return new HandlerError({
+      status: 502,
+      message: `VIES request failed: ${error.message}`,
+    });
+  }
+  return null;
+};
+
 const PRH_HANDLER: RegistryHandler = {
   slug: "prh",
   country: "FI",
@@ -774,6 +870,40 @@ const PRH_HANDLER: RegistryHandler = {
     return results.map(prhSearchResultToHit);
   },
   mapError: mapPrhError,
+};
+
+const VIES_HANDLER: RegistryHandler = {
+  slug: "vies",
+  country: EU_PSEUDO_JURISDICTION,
+  nativeToolSlug: "vies",
+  // Shape check only — accept inputs whose prefix matches a known
+  // VAT country (`isKnownVatCountry` includes historical members
+  // like GB) followed by ≥2 alphanumerics. Without the prefix
+  // whitelist a plain name like `Acme Corp` would parse as prefix
+  // `AC` + VAT `MECORP` and route to the lookup path, surfacing a
+  // confusing "unknown country" error instead of the intended
+  // "name search not supported" 400. Removed participants (GB) still
+  // pass the shape check; the lookup handler owns their tailored
+  // `ViesValidationError`.
+  isCanonicalId: (input) => {
+    const parsed = parseVatNumber(input);
+    if (!parsed) {
+      return false;
+    }
+    if (!isKnownVatCountry(parsed.country)) {
+      return false;
+    }
+    return /^[A-Z0-9+*]{2,}$/u.test(parsed.vat);
+  },
+  lookup: async (input) => {
+    const validation = await validateVat(input);
+    return viesValidationToHit(validation);
+  },
+  // VIES has no name-search endpoint — VAT-only validation. Returning
+  // `null` lets `executeRegistryLookup` produce the standard
+  // "name-search not supported" 400 instead of guessing.
+  search: null,
+  mapError: mapViesError,
 };
 
 // ---------------------------------------------------------------------------
@@ -895,9 +1025,13 @@ export const BUSINESS_REGISTRY_DISPATCH: Record<
   orsr: ORSR_HANDLER,
   prh: PRH_HANDLER,
   "recherche-entreprises": RECHERCHE_ENTREPRISES_HANDLER,
+  vies: VIES_HANDLER,
 };
 
-const HANDLERS_BY_COUNTRY: ReadonlyMap<CountryCode, RegistryHandler> = new Map(
+const HANDLERS_BY_JURISDICTION: ReadonlyMap<
+  RegistryJurisdictionCode,
+  RegistryHandler
+> = new Map(
   Object.values(BUSINESS_REGISTRY_DISPATCH).map((handler) => [
     handler.country,
     handler,
@@ -905,13 +1039,17 @@ const HANDLERS_BY_COUNTRY: ReadonlyMap<CountryCode, RegistryHandler> = new Map(
 );
 
 /**
- * Look up the registry handler for a given country code, if Stella
- * has an adapter shipped for it. The chat tool uses this to dispatch
- * from a user-facing jurisdiction (CZ, NO) to the underlying adapter.
+ * Look up the registry handler for a given jurisdiction code, if
+ * Stella has an adapter shipped for it. The chat tool uses this to
+ * dispatch from a user-facing jurisdiction (CZ, NO, EU, …) to the
+ * underlying adapter.
+ *
+ * Accepts the special "EU" pseudo-jurisdiction for EU-wide adapters
+ * (currently just VIES); see `RegistryJurisdictionCode`.
  */
 export const getRegistryHandlerByCountry = (
-  country: CountryCode,
-): RegistryHandler | undefined => HANDLERS_BY_COUNTRY.get(country);
+  country: RegistryJurisdictionCode,
+): RegistryHandler | undefined => HANDLERS_BY_JURISDICTION.get(country);
 
 /**
  * Run the dispatch flow for a registry handler: detect lookup vs.

--- a/apps/api/src/lib/business-registries/dispatch.ts
+++ b/apps/api/src/lib/business-registries/dispatch.ts
@@ -878,14 +878,14 @@ const VIES_HANDLER: RegistryHandler = {
   nativeToolSlug: "vies",
   // Shape check only — accept inputs whose prefix matches a known
   // VAT country (`isKnownVatCountry` includes historical members
-  // like GB) followed by ≥2 alphanumerics (Romanian VAT numbers can
-  // be as short as 2 digits, e.g. `RO12`). Without the prefix
-  // whitelist a plain name like `Acme Corp` would parse as prefix
-  // `AC` + VAT `MECORP` and route to the lookup path, surfacing a
-  // confusing "unknown country" error instead of the intended
-  // "name search not supported" 400. Removed participants (GB) still
-  // pass the shape check; the lookup handler owns their tailored
-  // `ViesValidationError`.
+  // like GB) followed by ≥2 VAT characters and at least one digit
+  // (Romanian VAT numbers can be as short as 2 digits, e.g. `RO12`).
+  // Without the prefix whitelist and digit check, a plain name like
+  // `Deutsche Bank` would parse as prefix `DE` + VAT `UTSCHEBANK`
+  // and route to the lookup path, surfacing a confusing VAT-format
+  // error instead of the intended "name search not supported" 400.
+  // Removed participants (GB) still pass the shape check; the lookup
+  // handler owns their tailored `ViesValidationError`.
   isCanonicalId: (input) => {
     const parsed = parseVatNumber(input);
     if (!parsed) {
@@ -894,7 +894,7 @@ const VIES_HANDLER: RegistryHandler = {
     if (!isKnownVatCountry(parsed.country)) {
       return false;
     }
-    return /^[A-Z0-9+*]{2,}$/u.test(parsed.vat);
+    return /[0-9]/u.test(parsed.vat) && /^[A-Z0-9+*]{2,}$/u.test(parsed.vat);
   },
   lookup: async (input) => {
     const validation = await validateVat(input);

--- a/apps/api/src/lib/business-registries/dispatch.ts
+++ b/apps/api/src/lib/business-registries/dispatch.ts
@@ -878,7 +878,8 @@ const VIES_HANDLER: RegistryHandler = {
   nativeToolSlug: "vies",
   // Shape check only — accept inputs whose prefix matches a known
   // VAT country (`isKnownVatCountry` includes historical members
-  // like GB) followed by ≥2 alphanumerics. Without the prefix
+  // like GB) followed by ≥2 alphanumerics (Romanian VAT numbers can
+  // be as short as 2 digits, e.g. `RO12`). Without the prefix
   // whitelist a plain name like `Acme Corp` would parse as prefix
   // `AC` + VAT `MECORP` and route to the lookup path, surfacing a
   // confusing "unknown country" error instead of the intended

--- a/packages/business-registries/package.json
+++ b/packages/business-registries/package.json
@@ -16,7 +16,9 @@
     "orsr",
     "prh",
     "registry",
-    "sirene"
+    "sirene",
+    "vat",
+    "vies"
   ],
   "homepage": "https://github.com/stella/stella/tree/main/packages/business-registries",
   "bugs": {
@@ -77,6 +79,11 @@
       "bun": "./src/recherche-entreprises/index.ts",
       "types": "./src/recherche-entreprises/index.ts",
       "import": "./dist/recherche-entreprises/index.js"
+    },
+    "./vies": {
+      "bun": "./src/vies/index.ts",
+      "types": "./src/vies/index.ts",
+      "import": "./dist/vies/index.js"
     },
     "./shared": {
       "bun": "./src/shared/index.ts",

--- a/packages/business-registries/src/index.ts
+++ b/packages/business-registries/src/index.ts
@@ -17,3 +17,4 @@ export * as orsr from "./orsr/index.js";
 export * as prh from "./prh/index.js";
 export * as rechercheEntreprises from "./recherche-entreprises/index.js";
 export * as shared from "./shared/index.js";
+export * as vies from "./vies/index.js";

--- a/packages/business-registries/src/vies/__fixtures__/check-de-data-protected.json
+++ b/packages/business-registries/src/vies/__fixtures__/check-de-data-protected.json
@@ -1,0 +1,22 @@
+{
+  "isValid": true,
+  "requestDate": "2026-05-31T07:43:05.714Z",
+  "userError": "VALID",
+  "name": "---",
+  "address": "---",
+  "requestIdentifier": "",
+  "originalVatNumber": "811569869",
+  "vatNumber": "811569869",
+  "viesApproximate": {
+    "name": "---",
+    "street": "---",
+    "postalCode": "---",
+    "city": "---",
+    "companyType": "---",
+    "matchName": 3,
+    "matchStreet": 3,
+    "matchPostalCode": 3,
+    "matchCity": 3,
+    "matchCompanyType": 3
+  }
+}

--- a/packages/business-registries/src/vies/__fixtures__/check-de-not-found.json
+++ b/packages/business-registries/src/vies/__fixtures__/check-de-not-found.json
@@ -1,0 +1,22 @@
+{
+  "isValid": false,
+  "requestDate": "2026-05-31T07:43:06.807Z",
+  "userError": "INVALID",
+  "name": "---",
+  "address": "---",
+  "requestIdentifier": "",
+  "originalVatNumber": "000000000",
+  "vatNumber": "000000000",
+  "viesApproximate": {
+    "name": "---",
+    "street": "---",
+    "postalCode": "---",
+    "city": "---",
+    "companyType": "---",
+    "matchName": 3,
+    "matchStreet": 3,
+    "matchPostalCode": 3,
+    "matchCity": 3,
+    "matchCompanyType": 3
+  }
+}

--- a/packages/business-registries/src/vies/__fixtures__/check-ie-google.json
+++ b/packages/business-registries/src/vies/__fixtures__/check-ie-google.json
@@ -1,0 +1,22 @@
+{
+  "isValid": true,
+  "requestDate": "2026-05-31T07:43:04.734Z",
+  "userError": "VALID",
+  "name": "GOOGLE IRELAND LIMITED",
+  "address": "3RD FLOOR, GORDON HOUSE, BARROW STREET, DUBLIN 4",
+  "requestIdentifier": "",
+  "originalVatNumber": "6388047V",
+  "vatNumber": "6388047V",
+  "viesApproximate": {
+    "name": "---",
+    "street": "---",
+    "postalCode": "---",
+    "city": "---",
+    "companyType": "---",
+    "matchName": 3,
+    "matchStreet": 3,
+    "matchPostalCode": 3,
+    "matchCity": 3,
+    "matchCompanyType": 3
+  }
+}

--- a/packages/business-registries/src/vies/__fixtures__/check-invalid-short.json
+++ b/packages/business-registries/src/vies/__fixtures__/check-invalid-short.json
@@ -1,0 +1,22 @@
+{
+  "isValid": false,
+  "requestDate": "2026-05-31T07:43:06.985Z",
+  "userError": "INVALID",
+  "name": "---",
+  "address": "---",
+  "requestIdentifier": "",
+  "originalVatNumber": "ABC",
+  "vatNumber": "ABC",
+  "viesApproximate": {
+    "name": "---",
+    "street": "---",
+    "postalCode": "---",
+    "city": "---",
+    "companyType": "---",
+    "matchName": 3,
+    "matchStreet": 3,
+    "matchPostalCode": 3,
+    "matchCity": 3,
+    "matchCompanyType": 3
+  }
+}

--- a/packages/business-registries/src/vies/__fixtures__/check-it-ferrari.json
+++ b/packages/business-registries/src/vies/__fixtures__/check-it-ferrari.json
@@ -1,0 +1,22 @@
+{
+  "isValid": true,
+  "requestDate": "2026-05-31T07:43:04.377Z",
+  "userError": "VALID",
+  "name": "FERRARI S.P.A.",
+  "address": "VIA EMILIA EST 1163 \n41122 MODENA MO\n",
+  "requestIdentifier": "",
+  "originalVatNumber": "00159560366",
+  "vatNumber": "00159560366",
+  "viesApproximate": {
+    "name": "---",
+    "street": "---",
+    "postalCode": "---",
+    "city": "---",
+    "companyType": "---",
+    "matchName": 3,
+    "matchStreet": 3,
+    "matchPostalCode": 3,
+    "matchCity": 3,
+    "matchCompanyType": 3
+  }
+}

--- a/packages/business-registries/src/vies/client.test.ts
+++ b/packages/business-registries/src/vies/client.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { validateVat } from "./client.js";
+import { ViesAPIError, ViesValidationError } from "./errors.js";
+import type { ViesRawResponse } from "./types.js";
+
+const SKIP_LIVE = process.env["SMOKE_TEST"] !== "1";
+
+const FIXTURE_DIR = new URL("__fixtures__/", import.meta.url);
+const readFixture = async (name: string): Promise<ViesRawResponse> => {
+  const value: unknown = await Bun.file(new URL(name, FIXTURE_DIR)).json();
+  // SAFETY: fixtures are captured directly from the live VIES REST
+  // API and committed alongside the tests; runtime validation would
+  // only catch drift between the upstream payload and the committed
+  // JSON, which the assertions below cover.
+  // eslint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+  return value as ViesRawResponse;
+};
+
+const installFetchStub = (
+  handler: (input: URL | Request | string) => Promise<Response>,
+) => {
+  const original = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    async (input: URL | Request | string) => handler(input),
+    { preconnect: original.preconnect },
+  );
+  return () => {
+    globalThis.fetch = original;
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Live tests — opt-in. Mirror the brreg / prh patterns.
+// ---------------------------------------------------------------------------
+describe.skipIf(SKIP_LIVE)("validateVat live", () => {
+  test("returns valid for Google Ireland (IE6388047V)", async () => {
+    const result = await validateVat("IE6388047V");
+    expect(result.valid).toBe(true);
+    expect(result.status).toEqual({ type: "valid" });
+    expect(result.vatNumber).toEqual({ country: "IE", vat: "6388047V" });
+    expect(result.name?.toUpperCase()).toContain("GOOGLE");
+  });
+
+  test("returns not-registered for an unregistered DE number", async () => {
+    const result = await validateVat("DE000000000");
+    expect(result.valid).toBe(false);
+    expect(result.status.type).not.toBe("valid");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mocked fetch tests using captured upstream fixtures.
+// ---------------------------------------------------------------------------
+describe("validateVat (fixture)", () => {
+  let restore: () => void = () => {
+    // noop until installFetchStub assigns a real teardown
+  };
+  afterEach(() => {
+    restore();
+    restore = () => {
+      // noop
+    };
+  });
+
+  test("parses a VALID Italian record (Ferrari S.p.A.)", async () => {
+    const body = await readFixture("check-it-ferrari.json");
+    restore = installFetchStub(async (input) => {
+      let url: string;
+      if (typeof input === "string") {
+        url = input;
+      } else if (input instanceof URL) {
+        url = input.href;
+      } else {
+        url = input.url;
+      }
+      expect(url).toContain("/ms/IT/vat/00159560366");
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await validateVat("IT00159560366");
+    expect(result.valid).toBe(true);
+    expect(result.status).toEqual({ type: "valid" });
+    expect(result.name).toBe("FERRARI S.P.A.");
+    expect(result.address).toContain("MODENA");
+    expect(result.vatNumber).toEqual({ country: "IT", vat: "00159560366" });
+  });
+
+  test("parses a VALID Irish record (Google Ireland)", async () => {
+    const body = await readFixture("check-ie-google.json");
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await validateVat("IE6388047V");
+    expect(result.valid).toBe(true);
+    expect(result.name).toBe("GOOGLE IRELAND LIMITED");
+    expect(result.address).toContain("DUBLIN");
+  });
+
+  test("normalises '---' name/address for data-protected member states (DE)", async () => {
+    const body = await readFixture("check-de-data-protected.json");
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await validateVat("DE811569869");
+    expect(result.valid).toBe(true);
+    expect(result.name).toBeNull();
+    expect(result.address).toBeNull();
+  });
+
+  test("maps INVALID (well-formed but unregistered) to not-registered", async () => {
+    const body = await readFixture("check-de-not-found.json");
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await validateVat("DE000000000");
+    expect(result.valid).toBe(false);
+    expect(result.status).toEqual({ type: "not-registered" });
+  });
+
+  test("maps short / malformed inputs that upstream rejects to not-registered", async () => {
+    // The REST endpoint rolls all rejection variants (well-formed but
+    // unregistered, non-numeric, too-short, …) into `userError:
+    // "INVALID"`. The fixture below was captured from a literal "ABC"
+    // submitted to the DE endpoint; the structured outcome we surface
+    // is `not-registered`, since the VIES POST endpoint's separate
+    // `INVALID_INPUT` flavour does not appear here. The `invalid-format`
+    // branch is still exercised through parse.test.ts using a
+    // hand-built upstream payload, since it remains a documented
+    // upstream verdict.
+    const body = await readFixture("check-invalid-short.json");
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await validateVat("DE123456789");
+    expect(result.valid).toBe(false);
+    expect(result.status).toEqual({ type: "not-registered" });
+  });
+
+  test("surfaces upstream non-2xx as ViesAPIError", async () => {
+    restore = installFetchStub(
+      async () => new Response("Bad Gateway", { status: 502 }),
+    );
+
+    expect(validateVat("IE6388047V")).rejects.toMatchObject({
+      name: "ViesAPIError",
+      httpStatus: 502,
+    });
+  });
+
+  test("rejects responses that fail shape detection", async () => {
+    restore = installFetchStub(
+      async () =>
+        new Response(JSON.stringify({ unexpected: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    expect(validateVat("IE6388047V")).rejects.toMatchObject({
+      name: "ViesAPIError",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-flight validation
+// ---------------------------------------------------------------------------
+describe("validateVat pre-flight validation", () => {
+  test("throws ViesValidationError when no country prefix is present", () => {
+    expect(validateVat("143593636")).rejects.toBeInstanceOf(
+      ViesValidationError,
+    );
+  });
+
+  test("throws ViesValidationError for unknown country prefix", () => {
+    expect(validateVat("ZZ123456789")).rejects.toBeInstanceOf(
+      ViesValidationError,
+    );
+  });
+
+  test("throws ViesValidationError for GB (removed from VIES)", () => {
+    expect(validateVat("GB123456789")).rejects.toBeInstanceOf(
+      ViesValidationError,
+    );
+  });
+});
+
+// Smoke: ViesAPIError reachable via barrel for consumers that only
+// import from the package root.
+test("exports ViesAPIError", () => {
+  expect(ViesAPIError).toBeDefined();
+});

--- a/packages/business-registries/src/vies/client.test.ts
+++ b/packages/business-registries/src/vies/client.test.ts
@@ -207,6 +207,18 @@ describe("validateVat pre-flight validation", () => {
       ViesValidationError,
     );
   });
+
+  test("short-circuits malformed national part before fetching VIES", () => {
+    // The REST endpoint reports `userError: "INVALID"` for malformed
+    // input, which would otherwise be mapped to `not-registered` —
+    // a misleading "VAT exists but isn't registered" verdict for
+    // what is actually a format violation. Pre-flight the per-
+    // country rule and surface the format error directly.
+    expect(validateVat("DE123")).rejects.toBeInstanceOf(ViesValidationError);
+    expect(validateVat("DEABCDEFGHI")).rejects.toBeInstanceOf(
+      ViesValidationError,
+    );
+  });
 });
 
 // Smoke: ViesAPIError reachable via barrel for consumers that only

--- a/packages/business-registries/src/vies/client.ts
+++ b/packages/business-registries/src/vies/client.ts
@@ -1,0 +1,121 @@
+import {
+  ViesAPIError,
+  ViesRequestError,
+  ViesValidationError,
+} from "./errors.js";
+import { parseValidation } from "./parse.js";
+import type { ViesRawResponse, ViesValidation } from "./types.js";
+import {
+  isViesParticipant,
+  normalizeVatNumber,
+  parseVatNumber,
+  validateVatFormat,
+  VAT_FORMAT_RULES,
+} from "./validation.js";
+
+const BASE = "https://ec.europa.eu/taxation_customs/vies/rest-api";
+const TIMEOUT_MS = 10_000;
+
+/**
+ * Validate an EU VAT number against the VIES (VAT Information
+ * Exchange System) REST API.
+ *
+ * The input must carry the 2-letter country prefix (e.g.
+ * "DE143593636"). Spaces, dots, dashes, and slashes inside the
+ * string are stripped before the call.
+ *
+ * @returns The structured validation result. `valid` will be `false`
+ *   when the VAT is not registered, when the upstream member-state
+ *   service is unavailable, or when the per-country format rule
+ *   rejects the input.
+ * @throws {ViesValidationError} for inputs missing the country prefix,
+ *   for unknown country prefixes, and for prefixes no longer in VIES
+ *   (currently only GB after Brexit).
+ * @throws {ViesAPIError} on a non-2xx HTTP response.
+ * @throws {ViesRequestError} on a network/transport failure.
+ */
+export const validateVat = async (input: string): Promise<ViesValidation> => {
+  const parsed = parseVatNumber(input);
+  if (!parsed) {
+    throw new ViesValidationError(
+      `Invalid VAT number: ${input}. Expected a 2-letter country prefix followed by national VAT digits.`,
+    );
+  }
+  const rule = VAT_FORMAT_RULES[parsed.country];
+  if (!rule) {
+    throw new ViesValidationError(
+      `Unknown VAT country prefix: ${parsed.country}.`,
+    );
+  }
+  if (!isViesParticipant(parsed.country)) {
+    throw new ViesValidationError(
+      `${parsed.country} VAT numbers are not in VIES (removed after Brexit on 2021-01-01).`,
+    );
+  }
+  // Format check is best-effort upstream-mirror; the authoritative
+  // response is still the VIES call below. We forward malformed inputs
+  // to VIES anyway so the upstream's INVALID_INPUT verdict comes back
+  // through the structured status rather than as a thrown error.
+  const url = `${BASE}/ms/${parsed.country}/vat/${encodeURIComponent(parsed.vat)}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+      headers: { Accept: "application/json" },
+    });
+  } catch (error) {
+    throw new ViesRequestError(url, "VIES request failed", { cause: error });
+  }
+
+  if (!response.ok) {
+    throw new ViesAPIError({
+      message: `VIES ${response.status}: ${response.statusText}`,
+      httpStatus: response.status,
+    });
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (error) {
+    throw new ViesAPIError({
+      message: "VIES returned a non-JSON body",
+      httpStatus: response.status,
+      cause: error,
+    });
+  }
+
+  if (!isViesRawResponse(body)) {
+    throw new ViesAPIError({
+      message: "VIES response did not match the expected shape",
+      httpStatus: response.status,
+    });
+  }
+
+  return parseValidation(body, parsed);
+};
+
+const isViesRawResponse = (value: unknown): value is ViesRawResponse => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  return (
+    "isValid" in value &&
+    typeof value.isValid === "boolean" &&
+    "userError" in value &&
+    typeof value.userError === "string" &&
+    "requestDate" in value &&
+    typeof value.requestDate === "string" &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    "address" in value &&
+    typeof value.address === "string"
+  );
+};
+
+/**
+ * Convenience re-export: cheap format check. Useful when callers want
+ * to short-circuit before incurring a round-trip to VIES.
+ */
+export { normalizeVatNumber, validateVatFormat };

--- a/packages/business-registries/src/vies/client.ts
+++ b/packages/business-registries/src/vies/client.ts
@@ -52,10 +52,18 @@ export const validateVat = async (input: string): Promise<ViesValidation> => {
       `${parsed.country} VAT numbers are not in VIES (removed after Brexit on 2021-01-01).`,
     );
   }
-  // Format check is best-effort upstream-mirror; the authoritative
-  // response is still the VIES call below. We forward malformed inputs
-  // to VIES anyway so the upstream's INVALID_INPUT verdict comes back
-  // through the structured status rather than as a thrown error.
+  if (!rule.pattern.test(parsed.vat)) {
+    // Short-circuit malformed national parts before the network
+    // round-trip. The REST endpoint returns `userError: "INVALID"`
+    // for malformed input, and `parseValidation` maps that to
+    // `not-registered` — a misleading "VAT exists but isn't
+    // registered" result for what is actually a format violation.
+    // Throwing here lets the dispatch layer surface a 400 with a
+    // useful message instead.
+    throw new ViesValidationError(
+      `Invalid VAT format for ${parsed.country}: ${parsed.vat}.`,
+    );
+  }
   const url = `${BASE}/ms/${parsed.country}/vat/${encodeURIComponent(parsed.vat)}`;
 
   let response: Response;

--- a/packages/business-registries/src/vies/errors.ts
+++ b/packages/business-registries/src/vies/errors.ts
@@ -1,0 +1,53 @@
+import { RegistryError } from "../shared/errors.js";
+
+// Note: no `ViesNotFoundError`. VIES does not distinguish "not on file"
+// from a bad-format input via 404; both come back as HTTP 200 with a
+// `userError` discriminator in the body. The dispatch layer surfaces
+// the unregistered case via `ViesValidation.valid === false`, not as
+// an `isEntityNotFound` error.
+
+export class ViesError extends RegistryError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ViesError";
+  }
+}
+
+export class ViesAPIError extends ViesError {
+  readonly httpStatus: number;
+  readonly upstreamUserError: string | null;
+
+  constructor({
+    cause,
+    message,
+    httpStatus,
+    upstreamUserError,
+  }: {
+    cause?: unknown;
+    message: string;
+    httpStatus: number;
+    upstreamUserError?: string | null;
+  }) {
+    super(message, { cause });
+    this.name = "ViesAPIError";
+    this.httpStatus = httpStatus;
+    this.upstreamUserError = upstreamUserError ?? null;
+  }
+}
+
+export class ViesValidationError extends ViesError {
+  constructor(message: string) {
+    super(message);
+    this.name = "ViesValidationError";
+  }
+}
+
+export class ViesRequestError extends ViesError {
+  readonly url: string;
+
+  constructor(url: string, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ViesRequestError";
+    this.url = url;
+  }
+}

--- a/packages/business-registries/src/vies/index.ts
+++ b/packages/business-registries/src/vies/index.ts
@@ -1,0 +1,28 @@
+export {
+  normalizeVatNumber,
+  validateVat,
+  validateVatFormat,
+} from "./client.js";
+export {
+  ViesAPIError,
+  ViesError,
+  ViesRequestError,
+  ViesValidationError,
+} from "./errors.js";
+export { parseValidation } from "./parse.js";
+export type {
+  ViesApproximate,
+  ViesRawResponse,
+  ViesUserError,
+  ViesValidation,
+  ViesValidationStatus,
+  ViesVatNumber,
+} from "./types.js";
+export {
+  isKnownVatCountry,
+  isViesParticipant,
+  knownVatCountries,
+  parseVatNumber,
+  VAT_FORMAT_RULES,
+} from "./validation.js";
+export type { ParsedVatNumber, VatFormatRule } from "./validation.js";

--- a/packages/business-registries/src/vies/parse.test.ts
+++ b/packages/business-registries/src/vies/parse.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseValidation } from "./parse.js";
+import type { ViesRawResponse, ViesVatNumber } from "./types.js";
+
+const VAT_NUMBER: ViesVatNumber = { country: "IE", vat: "6388047V" };
+
+const baseRaw = (overrides: Partial<ViesRawResponse>): ViesRawResponse => ({
+  isValid: false,
+  requestDate: "2026-05-31T00:00:00.000Z",
+  userError: "INVALID",
+  name: "---",
+  address: "---",
+  requestIdentifier: "",
+  originalVatNumber: "6388047V",
+  vatNumber: "6388047V",
+  ...overrides,
+});
+
+describe("parseValidation", () => {
+  test("maps a VALID response to status.valid", () => {
+    const out = parseValidation(
+      baseRaw({
+        isValid: true,
+        userError: "VALID",
+        name: "GOOGLE IRELAND LIMITED",
+        address: "3RD FLOOR, GORDON HOUSE, BARROW STREET, DUBLIN 4",
+      }),
+      VAT_NUMBER,
+    );
+    expect(out.valid).toBe(true);
+    expect(out.status).toEqual({ type: "valid" });
+    expect(out.name).toBe("GOOGLE IRELAND LIMITED");
+    expect(out.address).toBe(
+      "3RD FLOOR, GORDON HOUSE, BARROW STREET, DUBLIN 4",
+    );
+    expect(out.vatNumber).toEqual(VAT_NUMBER);
+  });
+
+  test("collapses '---' sentinel name/address to null", () => {
+    const out = parseValidation(
+      baseRaw({ isValid: true, userError: "VALID" }),
+      VAT_NUMBER,
+    );
+    expect(out.valid).toBe(true);
+    expect(out.name).toBeNull();
+    expect(out.address).toBeNull();
+  });
+
+  test("INVALID maps to not-registered", () => {
+    const out = parseValidation(baseRaw({ userError: "INVALID" }), VAT_NUMBER);
+    expect(out.valid).toBe(false);
+    expect(out.status).toEqual({ type: "not-registered" });
+  });
+
+  test("INVALID_INPUT maps to invalid-format", () => {
+    const out = parseValidation(
+      baseRaw({ userError: "INVALID_INPUT" }),
+      VAT_NUMBER,
+    );
+    expect(out.valid).toBe(false);
+    expect(out.status).toEqual({ type: "invalid-format" });
+  });
+
+  test("SERVICE_UNAVAILABLE family maps to service-unavailable", () => {
+    for (const userError of [
+      "SERVICE_UNAVAILABLE",
+      "MS_UNAVAILABLE",
+      "TIMEOUT",
+      "MS_MAX_CONCURRENT_REQ",
+    ]) {
+      const out = parseValidation(baseRaw({ userError }), VAT_NUMBER);
+      expect(out.valid).toBe(false);
+      expect(out.status).toEqual({ type: "service-unavailable", userError });
+    }
+  });
+
+  test("unknown userError values collapse to not-registered (safe default)", () => {
+    const out = parseValidation(
+      baseRaw({ userError: "SOMETHING_NEW_FROM_UPSTREAM" }),
+      VAT_NUMBER,
+    );
+    expect(out.valid).toBe(false);
+    expect(out.status).toEqual({ type: "not-registered" });
+  });
+
+  test("preserves requestDate", () => {
+    const out = parseValidation(
+      baseRaw({ requestDate: "2026-01-15T10:30:00.000Z" }),
+      VAT_NUMBER,
+    );
+    expect(out.requestDate).toBe("2026-01-15T10:30:00.000Z");
+  });
+});

--- a/packages/business-registries/src/vies/parse.test.ts
+++ b/packages/business-registries/src/vies/parse.test.ts
@@ -62,11 +62,13 @@ describe("parseValidation", () => {
     expect(out.status).toEqual({ type: "invalid-format" });
   });
 
-  test("SERVICE_UNAVAILABLE family maps to service-unavailable", () => {
+  test("SERVICE_UNAVAILABLE family (incl. SERVER_BUSY) maps to service-unavailable", () => {
     for (const userError of [
       "SERVICE_UNAVAILABLE",
       "MS_UNAVAILABLE",
       "TIMEOUT",
+      "SERVER_BUSY",
+      "GLOBAL_MAX_CONCURRENT_REQ",
       "MS_MAX_CONCURRENT_REQ",
     ]) {
       const out = parseValidation(baseRaw({ userError }), VAT_NUMBER);
@@ -75,11 +77,24 @@ describe("parseValidation", () => {
     }
   });
 
-  test("unknown userError values collapse to not-registered (safe default)", () => {
+  test("unknown userError values map to service-unavailable, NOT not-registered", () => {
+    // A new transient fault we have not enumerated yet would
+    // otherwise be reported as "VAT does not exist", falsely killing
+    // a real B2B counterparty's compliance check during an outage.
+    // Safer default: surface it as a retryable upstream issue.
     const out = parseValidation(
       baseRaw({ userError: "SOMETHING_NEW_FROM_UPSTREAM" }),
       VAT_NUMBER,
     );
+    expect(out.valid).toBe(false);
+    expect(out.status).toEqual({
+      type: "service-unavailable",
+      userError: "SOMETHING_NEW_FROM_UPSTREAM",
+    });
+  });
+
+  test("only the explicit INVALID userError maps to not-registered", () => {
+    const out = parseValidation(baseRaw({ userError: "INVALID" }), VAT_NUMBER);
     expect(out.valid).toBe(false);
     expect(out.status).toEqual({ type: "not-registered" });
   });

--- a/packages/business-registries/src/vies/parse.ts
+++ b/packages/business-registries/src/vies/parse.ts
@@ -1,0 +1,59 @@
+import type {
+  ViesRawResponse,
+  ViesValidation,
+  ViesValidationStatus,
+  ViesVatNumber,
+} from "./types.js";
+
+// Several VIES member-state services suppress trader data even for
+// valid records. Those responses come back with the literal "---" in
+// `name`/`address`. Normalise to null so downstream consumers do not
+// have to handle the sentinel.
+const VIES_BLANK_SENTINEL = "---";
+
+const normalizeBlank = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed === VIES_BLANK_SENTINEL) {
+    return null;
+  }
+  return trimmed;
+};
+
+const SERVICE_UNAVAILABLE_USER_ERRORS = new Set<string>([
+  "SERVICE_UNAVAILABLE",
+  "MS_UNAVAILABLE",
+  "TIMEOUT",
+  "GLOBAL_MAX_CONCURRENT_REQ",
+  "MS_MAX_CONCURRENT_REQ",
+]);
+
+const deriveStatus = (raw: ViesRawResponse): ViesValidationStatus => {
+  if (raw.isValid && raw.userError === "VALID") {
+    return { type: "valid" };
+  }
+  if (raw.userError === "INVALID_INPUT") {
+    return { type: "invalid-format" };
+  }
+  if (SERVICE_UNAVAILABLE_USER_ERRORS.has(raw.userError)) {
+    return { type: "service-unavailable", userError: raw.userError };
+  }
+  // `INVALID` plus any uncatalogued non-success userError collapses to
+  // not-registered; the upstream `isValid` flag is the authoritative
+  // signal and is already false in those cases.
+  return { type: "not-registered" };
+};
+
+export const parseValidation = (
+  raw: ViesRawResponse,
+  vatNumber: ViesVatNumber,
+): ViesValidation => {
+  const status = deriveStatus(raw);
+  return {
+    vatNumber,
+    valid: status.type === "valid",
+    status,
+    requestDate: raw.requestDate,
+    name: normalizeBlank(raw.name),
+    address: normalizeBlank(raw.address),
+  };
+};

--- a/packages/business-registries/src/vies/parse.ts
+++ b/packages/business-registries/src/vies/parse.ts
@@ -23,6 +23,7 @@ const SERVICE_UNAVAILABLE_USER_ERRORS = new Set<string>([
   "SERVICE_UNAVAILABLE",
   "MS_UNAVAILABLE",
   "TIMEOUT",
+  "SERVER_BUSY",
   "GLOBAL_MAX_CONCURRENT_REQ",
   "MS_MAX_CONCURRENT_REQ",
 ]);
@@ -37,10 +38,17 @@ const deriveStatus = (raw: ViesRawResponse): ViesValidationStatus => {
   if (SERVICE_UNAVAILABLE_USER_ERRORS.has(raw.userError)) {
     return { type: "service-unavailable", userError: raw.userError };
   }
-  // `INVALID` plus any uncatalogued non-success userError collapses to
-  // not-registered; the upstream `isValid` flag is the authoritative
-  // signal and is already false in those cases.
-  return { type: "not-registered" };
+  // Only the explicit `INVALID` user-error is a real negative
+  // validation. Any uncatalogued non-success value (a new transient
+  // fault we haven't enumerated yet, an `MS_*` variant the upstream
+  // adds in future) is conservatively classified as
+  // service-unavailable — surfacing an unknown outage as
+  // "not-registered" would falsely tell users their counterparty's
+  // VAT is dead.
+  if (raw.userError === "INVALID") {
+    return { type: "not-registered" };
+  }
+  return { type: "service-unavailable", userError: raw.userError };
 };
 
 export const parseValidation = (

--- a/packages/business-registries/src/vies/types.ts
+++ b/packages/business-registries/src/vies/types.ts
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------
+// Raw VIES REST API response shapes
+// (https://ec.europa.eu/taxation_customs/vies/rest-api/ms/{COUNTRY}/vat/{VAT})
+//
+// VIES is the EU-wide VAT Information Exchange System. The REST endpoint
+// always responds with HTTP 200 and a JSON body whose `userError` field
+// is the real discriminator:
+//
+//   VALID         → the VAT is registered and validation succeeded
+//   INVALID       → the VAT is well-formed but not registered
+//   INVALID_INPUT → the input did not match the country's format rules
+//   SERVICE_UNAVAILABLE / MS_UNAVAILABLE / TIMEOUT → upstream member-state
+//     service was unreachable (validation could not be performed)
+// ---------------------------------------------------------------------------
+
+export type ViesUserError =
+  | "VALID"
+  | "INVALID"
+  | "INVALID_INPUT"
+  | "SERVICE_UNAVAILABLE"
+  | "MS_UNAVAILABLE"
+  | "TIMEOUT"
+  | "GLOBAL_MAX_CONCURRENT_REQ"
+  | "MS_MAX_CONCURRENT_REQ";
+
+export type ViesApproximate = {
+  name: string;
+  street: string;
+  postalCode: string;
+  city: string;
+  companyType: string;
+  matchName: number;
+  matchStreet: number;
+  matchPostalCode: number;
+  matchCity: number;
+  matchCompanyType: number;
+};
+
+export type ViesRawResponse = {
+  isValid: boolean;
+  requestDate: string;
+  userError: string;
+  name: string;
+  address: string;
+  requestIdentifier: string;
+  originalVatNumber: string;
+  vatNumber: string;
+  viesApproximate?: ViesApproximate;
+};
+
+// ---------------------------------------------------------------------------
+// Domain output types
+// ---------------------------------------------------------------------------
+
+export type ViesVatNumber = {
+  /** ISO 3166-1 alpha-2 country prefix (e.g. "DE", "IE"). VIES uses
+   *  "EL" rather than ISO "GR" for Greece — we surface what the user
+   *  passed in (after normalisation to uppercase) so they can map back
+   *  to their input. */
+  country: string;
+  /** National VAT digits without the country prefix. */
+  vat: string;
+};
+
+// Discriminated union over the request outcome.
+//
+//   valid               → registered VAT, member state returned a record
+//   not-registered      → format ok, member state has no record
+//   invalid-format      → input did not match the country's format rules
+//   service-unavailable → member state's validation service was down
+export type ViesValidationStatus =
+  | { type: "valid" }
+  | { type: "not-registered" }
+  | { type: "invalid-format" }
+  | { type: "service-unavailable"; userError: string };
+
+export type ViesValidation = {
+  vatNumber: ViesVatNumber;
+  /** Convenience boolean — `true` iff status.type === "valid". */
+  valid: boolean;
+  status: ViesValidationStatus;
+  /** ISO timestamp the upstream stamped on the validation. */
+  requestDate: string;
+  /**
+   * Registered name as held by the member state. Several countries
+   * (notably DE, ES, AT) suppress trader data even on valid records;
+   * those responses come back as the literal "---" upstream, which we
+   * normalise to `null` for callers that want to display the name.
+   */
+  name: string | null;
+  /** Same null-on-"---" normalisation as `name`. */
+  address: string | null;
+};

--- a/packages/business-registries/src/vies/validation.test.ts
+++ b/packages/business-registries/src/vies/validation.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isKnownVatCountry,
+  isViesParticipant,
+  knownVatCountries,
+  normalizeVatNumber,
+  parseVatNumber,
+  validateVatFormat,
+} from "./validation.js";
+
+describe("normalizeVatNumber", () => {
+  test("strips whitespace, dots, slashes and dashes; uppercases", () => {
+    expect(normalizeVatNumber("de 143.593.636")).toBe("DE143593636");
+    expect(normalizeVatNumber("IE-6388047V")).toBe("IE6388047V");
+    expect(normalizeVatNumber("  fr 12 345678901 ")).toBe("FR12345678901");
+  });
+});
+
+describe("parseVatNumber", () => {
+  test("splits country prefix from national digits", () => {
+    expect(parseVatNumber("DE143593636")).toEqual({
+      country: "DE",
+      vat: "143593636",
+    });
+    expect(parseVatNumber("ie 6388047v")).toEqual({
+      country: "IE",
+      vat: "6388047V",
+    });
+  });
+
+  test("returns null when no 2-letter prefix is present", () => {
+    expect(parseVatNumber("143593636")).toBeNull();
+    expect(parseVatNumber("D143593636")).toBeNull();
+    expect(parseVatNumber("")).toBeNull();
+  });
+});
+
+describe("validateVatFormat", () => {
+  test("accepts well-formed VATs across countries", () => {
+    expect(validateVatFormat("DE143593636")).toBe(true);
+    expect(validateVatFormat("IE6388047V")).toBe(true);
+    expect(validateVatFormat("IT00159560366")).toBe(true);
+    expect(validateVatFormat("FRXX123456789")).toBe(true);
+    expect(validateVatFormat("ATU12345678")).toBe(true);
+  });
+
+  test("normalises punctuation before checking", () => {
+    expect(validateVatFormat("DE 143.593.636")).toBe(true);
+    expect(validateVatFormat(" ie-6388047v ")).toBe(true);
+  });
+
+  test("rejects unknown country prefix", () => {
+    expect(validateVatFormat("ZZ123456789")).toBe(false);
+  });
+
+  test("rejects GB (removed from VIES post-Brexit)", () => {
+    expect(validateVatFormat("GB123456789")).toBe(false);
+  });
+
+  test("accepts XI (Northern Ireland, still in VIES)", () => {
+    expect(validateVatFormat("XI123456789")).toBe(true);
+  });
+
+  test("rejects malformed national digits per country", () => {
+    // DE wants exactly 9 digits.
+    expect(validateVatFormat("DE12345")).toBe(false);
+    expect(validateVatFormat("DE1435936361")).toBe(false);
+    // IT wants exactly 11.
+    expect(validateVatFormat("IT12345")).toBe(false);
+  });
+});
+
+describe("isKnownVatCountry / isViesParticipant", () => {
+  test("known prefixes include all EU-27 + XI", () => {
+    for (const code of ["AT", "BE", "DE", "FR", "IE", "IT", "XI"]) {
+      expect(isKnownVatCountry(code)).toBe(true);
+      expect(isViesParticipant(code)).toBe(true);
+    }
+  });
+
+  test("GB is known but not a current participant", () => {
+    expect(isKnownVatCountry("GB")).toBe(true);
+    expect(isViesParticipant("GB")).toBe(false);
+  });
+
+  test("unknown codes fail both checks", () => {
+    expect(isKnownVatCountry("ZZ")).toBe(false);
+    expect(isViesParticipant("ZZ")).toBe(false);
+  });
+});
+
+describe("knownVatCountries", () => {
+  test("returns at least the 27 EU members + XI + GB", () => {
+    const codes = knownVatCountries();
+    // 27 current EU members, plus EL (Greece's VAT prefix), plus XI
+    // and GB — 29 codes total when EL replaces GR (Greece is only
+    // present as EL in the VAT scheme).
+    expect(codes.length).toBeGreaterThanOrEqual(29);
+    for (const code of ["AT", "BE", "BG", "CY", "CZ", "DE", "EL", "XI", "GB"]) {
+      expect(codes).toContain(code);
+    }
+  });
+});

--- a/packages/business-registries/src/vies/validation.ts
+++ b/packages/business-registries/src/vies/validation.ts
@@ -1,0 +1,141 @@
+// EU VAT identification numbers.
+//
+// Each member state defines its own VAT format. This module covers the
+// FORMAT check (length + character class) for every current EU member
+// state plus the special cases below. Per-country checksum algorithms
+// (MOD-11, MOD-97, Luhn variants, etc.) are NOT implemented here — VIES
+// itself performs the authoritative check upstream, and adding per-country
+// checksums is queued as a separate follow-up (see README note).
+//
+// Special prefixes:
+//   - EL: Greece (ISO 3166 says GR; the EU VAT register uses EL).
+//   - XI: Northern Ireland — post-Brexit, NI VATs are validated by
+//     VIES under the XI prefix.
+//   - GB: removed from VIES on 2021-01-01 after Brexit. Retained here
+//     with `removed: true` so the dispatch layer can produce a useful
+//     error rather than a generic "unknown country" reject.
+//
+// Reference:
+//   https://taxation-customs.ec.europa.eu/online-services/online-services-and-databases-taxation/vies-vat-information-exchange-system_en
+
+export type VatFormatRule = {
+  /** Regex against the national digits (NO country prefix). */
+  pattern: RegExp;
+  /** True iff the country no longer participates in VIES. */
+  removed?: boolean;
+};
+
+// Patterns drawn from the EU's published format list. The match runs
+// against the national portion only — the dispatch layer splits off
+// the leading 2-letter prefix before looking the country up.
+export const VAT_FORMAT_RULES: Readonly<Record<string, VatFormatRule>> = {
+  AT: { pattern: /^U\d{8}$/u },
+  BE: { pattern: /^[01]\d{9}$/u },
+  BG: { pattern: /^\d{9,10}$/u },
+  CY: { pattern: /^\d{8}[A-Z]$/u },
+  CZ: { pattern: /^\d{8,10}$/u },
+  DE: { pattern: /^\d{9}$/u },
+  DK: { pattern: /^\d{8}$/u },
+  EE: { pattern: /^\d{9}$/u },
+  EL: { pattern: /^\d{9}$/u },
+  ES: { pattern: /^[A-Z0-9]\d{7}[A-Z0-9]$/u },
+  FI: { pattern: /^\d{8}$/u },
+  FR: { pattern: /^[A-HJ-NP-Z0-9]{2}\d{9}$/u },
+  HR: { pattern: /^\d{11}$/u },
+  HU: { pattern: /^\d{8}$/u },
+  IE: { pattern: /^(?:\d[A-Z0-9*+]\d{5}[A-W]|\d{7}[A-W][A-I])$/u },
+  IT: { pattern: /^\d{11}$/u },
+  LT: { pattern: /^(?:\d{9}|\d{12})$/u },
+  LU: { pattern: /^\d{8}$/u },
+  LV: { pattern: /^\d{11}$/u },
+  MT: { pattern: /^\d{8}$/u },
+  NL: { pattern: /^[A-Z0-9+*]{10}\d{2}$/u },
+  PL: { pattern: /^\d{10}$/u },
+  PT: { pattern: /^\d{9}$/u },
+  RO: { pattern: /^\d{2,10}$/u },
+  SE: { pattern: /^\d{12}$/u },
+  SI: { pattern: /^\d{8}$/u },
+  SK: { pattern: /^\d{10}$/u },
+  XI: { pattern: /^(?:\d{9}|\d{12}|GD\d{3}|HA\d{3})$/u },
+  // Removed from VIES on 2021-01-01 (Brexit). Pattern retained for
+  // diagnostic messages; the dispatch layer rejects with a dedicated
+  // "GB no longer in VIES" error before reaching the upstream call.
+  GB: { pattern: /^(?:\d{9}|\d{12}|GD\d{3}|HA\d{3})$/u, removed: true },
+} as const;
+
+const COUNTRY_PREFIXES = Object.freeze(Object.keys(VAT_FORMAT_RULES));
+
+/**
+ * Strip spaces, dots, dashes, then uppercase. VAT numbers are
+ * frequently quoted with thousand-separator dots or hyphens, e.g.
+ * "DE 143.593.636" or "FR 12-345678901".
+ */
+export const normalizeVatNumber = (input: string): string =>
+  input.replaceAll(/[\s.\-/]/gu, "").toUpperCase();
+
+export type ParsedVatNumber = {
+  country: string;
+  vat: string;
+};
+
+/**
+ * Split a VAT string into `{country, vat}`. Returns `null` if the input
+ * does not start with two letters followed by at least one VAT character.
+ */
+export const parseVatNumber = (input: string): ParsedVatNumber | null => {
+  const compact = normalizeVatNumber(input);
+  const match = /^([A-Z]{2})([A-Z0-9+*]+)$/u.exec(compact);
+  if (!match) {
+    return null;
+  }
+  const [, country, vat] = match;
+  if (country === undefined || vat === undefined) {
+    return null;
+  }
+  return { country, vat };
+};
+
+/**
+ * Whether `prefix` is a 2-letter code we have a VAT format rule for.
+ */
+export const isKnownVatCountry = (prefix: string): boolean =>
+  Object.hasOwn(VAT_FORMAT_RULES, prefix);
+
+/**
+ * Whether the country still participates in VIES (GB does not).
+ */
+export const isViesParticipant = (prefix: string): boolean => {
+  const rule = VAT_FORMAT_RULES[prefix];
+  return rule !== undefined && rule.removed !== true;
+};
+
+/**
+ * Format-only validity check for a VAT number string.
+ *
+ * Returns `false` for unknown country prefixes, removed-from-VIES
+ * prefixes (GB), and inputs that fail the per-country format rule.
+ * Does NOT perform per-country checksum validation — VIES does that
+ * upstream and is the source of truth for whether a number is
+ * actually registered.
+ */
+export const validateVatFormat = (input: string): boolean => {
+  const parsed = parseVatNumber(input);
+  if (!parsed) {
+    return false;
+  }
+  if (!isViesParticipant(parsed.country)) {
+    return false;
+  }
+  const rule = VAT_FORMAT_RULES[parsed.country];
+  if (!rule) {
+    return false;
+  }
+  return rule.pattern.test(parsed.vat);
+};
+
+/**
+ * All country prefixes the validator knows about (including GB,
+ * which is marked `removed`). Exposed so callers can build picklists
+ * or surface "supported countries" UI.
+ */
+export const knownVatCountries = (): readonly string[] => COUNTRY_PREFIXES;

--- a/packages/business-registries/src/vies/validation.ts
+++ b/packages/business-registries/src/vies/validation.ts
@@ -43,7 +43,12 @@ export const VAT_FORMAT_RULES: Readonly<Record<string, VatFormatRule>> = {
   FR: { pattern: /^[A-HJ-NP-Z0-9]{2}\d{9}$/u },
   HR: { pattern: /^\d{11}$/u },
   HU: { pattern: /^\d{8}$/u },
-  IE: { pattern: /^(?:\d[A-Z0-9*+]\d{5}[A-W]|\d{7}[A-W][A-I])$/u },
+  // Ireland: legacy 8-char `\d[A-Z0-9*+]\d{5}[A-W]` plus the
+  // 7-digit-then-letter format that Revenue issues at either 8 or 9
+  // chars (the trailing letter is optional). Without the `?`, the
+  // second alternative rejects every 8-char number that doesn't
+  // happen to overlap with the first.
+  IE: { pattern: /^(?:\d[A-Z0-9*+]\d{5}[A-W]|\d{7}[A-W][A-I]?)$/u },
   IT: { pattern: /^\d{11}$/u },
   LT: { pattern: /^(?:\d{9}|\d{12})$/u },
   LU: { pattern: /^\d{8}$/u },

--- a/packages/business-registries/src/vies/validation.ts
+++ b/packages/business-registries/src/vies/validation.ts
@@ -54,7 +54,12 @@ export const VAT_FORMAT_RULES: Readonly<Record<string, VatFormatRule>> = {
   LU: { pattern: /^\d{8}$/u },
   LV: { pattern: /^\d{11}$/u },
   MT: { pattern: /^\d{8}$/u },
-  NL: { pattern: /^[A-Z0-9+*]{10}\d{2}$/u },
+  // Netherlands: 9 digits, the literal `B`, then 2 digits
+  // (e.g. `123456789B01`). The Belastingdienst's published format is
+  // strict — the `B` separator is mandatory and not an arbitrary
+  // alphanumeric, so the catch-all `{10}` pattern would have leaked
+  // malformed inputs to VIES.
+  NL: { pattern: /^\d{9}B\d{2}$/u },
   PL: { pattern: /^\d{10}$/u },
   PT: { pattern: /^\d{9}$/u },
   RO: { pattern: /^\d{2,10}$/u },

--- a/packages/catalogue/entries/native-tools/vies/manifest.json
+++ b/packages/catalogue/entries/native-tools/vies/manifest.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../schema.json",
+  "kind": "native-tool",
+  "slug": "vies",
+  "displayName": "EU VIES VAT validation",
+  "description": "EU-wide VAT identification number validation via the European Commission's VAT Information Exchange System (VIES) REST API. Confirms whether a VAT number is registered in the supplier's member state and returns the registered trader name and address where the member state discloses them.",
+  "author": "stella",
+  "authorUrl": "https://github.com/stella",
+  "license": "Apache-2.0",
+  "cost": "free",
+  "setup": "none",
+  "homepage": "https://ec.europa.eu/taxation_customs/vies/",
+  "tags": ["tax", "regulatory", "corporate"],
+  "jurisdictions": ["EU"],
+  "backendSlug": "vies",
+  "url": "https://ec.europa.eu/taxation_customs/vies/",
+  "documentationUrl": "https://ec.europa.eu/taxation_customs/vies/#/technical-information"
+}

--- a/packages/catalogue/entries/recommended.json
+++ b/packages/catalogue/entries/recommended.json
@@ -1,6 +1,7 @@
 {
   "CZ": ["ares", "infosoud"],
   "ES": ["boe"],
+  "EU": ["vies"],
   "FI": ["prh"],
   "FR": ["recherche-entreprises"],
   "NO": ["brreg"],

--- a/packages/catalogue/src/catalogue.gen.ts
+++ b/packages/catalogue/src/catalogue.gen.ts
@@ -11,6 +11,7 @@ import nativeToolKrs from "../entries/native-tools/krs/manifest.json" with { typ
 import nativeToolOrsr from "../entries/native-tools/orsr/manifest.json" with { type: "json" };
 import nativeToolPrh from "../entries/native-tools/prh/manifest.json" with { type: "json" };
 import nativeToolRechercheEntreprises from "../entries/native-tools/recherche-entreprises/manifest.json" with { type: "json" };
+import nativeToolVies from "../entries/native-tools/vies/manifest.json" with { type: "json" };
 import nativeToolWebSearch from "../entries/native-tools/web-search/manifest.json" with { type: "json" };
 import recommended from "../entries/recommended.json" with { type: "json" };
 
@@ -26,6 +27,7 @@ export const GENERATED_ENTRIES = [
   { manifest: nativeToolOrsr, icon: null },
   { manifest: nativeToolPrh, icon: null },
   { manifest: nativeToolRechercheEntreprises, icon: null },
+  { manifest: nativeToolVies, icon: null },
   { manifest: nativeToolWebSearch, icon: null },
 ] as const;
 

--- a/packages/catalogue/src/loader.test.ts
+++ b/packages/catalogue/src/loader.test.ts
@@ -100,6 +100,26 @@ describe("recommendedSlugsForJurisdictions", () => {
     const slugs = recommendedSlugsForJurisdictions(new Set(["JP"]));
     expect(slugs.size).toBe(0);
   });
+
+  it("activates the EU wildcard tier (VIES) for any EU member practice", () => {
+    // FR is a member but has no per-country entry in recommended.json;
+    // the EU wildcard should still surface VIES.
+    expect(recommendedSlugsForJurisdictions(new Set(["FR"])).has("vies")).toBe(
+      true,
+    );
+    expect(recommendedSlugsForJurisdictions(new Set(["CZ"])).has("vies")).toBe(
+      true,
+    );
+  });
+
+  it("does not surface the EU wildcard tier for non-EU practices", () => {
+    expect(recommendedSlugsForJurisdictions(new Set(["JP"])).has("vies")).toBe(
+      false,
+    );
+    expect(recommendedSlugsForJurisdictions(new Set(["NO"])).has("vies")).toBe(
+      false,
+    );
+  });
 });
 
 describe("loadRecommended", () => {

--- a/packages/catalogue/src/loader.ts
+++ b/packages/catalogue/src/loader.ts
@@ -59,6 +59,7 @@ export const TOGGLEABLE_NATIVE_TOOL_BACKEND_SLUGS = [
   "orsr",
   "prh",
   "recherche-entreprises",
+  "vies",
   "web-search",
 ] as const;
 export type ToggleableNativeToolBackendSlug =


### PR DESCRIPTION
Adds `@stll/business-registries/vies` — EU VAT-number validation against the VIES REST API (no auth, public). Inputs carry the country prefix (e.g. `DE143593636`), so the unified `business_registry_lookup` tool surfaces VIES under a pseudo-jurisdiction `EU`; the handler dispatches internally on the prefix.

Per-country format checks ship for all current EU members; full per-country checksum algorithms are deferred (out of scope for this PR — flagged in code). Live tests gated on `SMOKE_TEST=1`; unit tests use captured real-VIES responses. Prior art on npm is sparse and stale (most predate the REST endpoint).