### PR TITLE
fix(web): wait for file metadata before preview fetch

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/$viewId.document.tsx
@@ -44,7 +44,7 @@ import { cn } from "@stll/ui/lib/utils";
 
 import { api } from "@/lib/api";
 import { TOOLBAR_ROW_HEIGHT } from "@/lib/consts";
-import { toAPIError } from "@/lib/errors";
+import { ClientOperationError, toAPIError } from "@/lib/errors";
 import {
   PDFProvider,
   getPDFPageIdByNumber,
@@ -242,9 +242,10 @@ function RouteComponentInner({
   const { data: entity } = useSuspenseQuery(
     entityOptions(workspaceId, entityId),
   );
-  const { data: versionData } = useQuery(
+  const versionDataQuery = useQuery(
     entityVersionsOptions({ workspaceId, entityId }),
   );
+  const versionData = versionDataQuery.data;
   const setActiveJustification = useWorkspaceStore(
     (s) => s.setActiveJustification,
   );
@@ -338,6 +339,18 @@ function RouteComponentInner({
     hasFilePropertyId: filePropertyId !== undefined,
     isComparing,
   });
+  const filePreviewState = (() => {
+    if (activeMimeType !== undefined) {
+      return "ready";
+    }
+    if (versionDataQuery.isError) {
+      return "error";
+    }
+    if (versionDataQuery.isPending) {
+      return "loading";
+    }
+    return "missing";
+  })();
   const shouldRenderDocxBrowserShell =
     isDocxFile &&
     filePropertyId !== undefined &&
@@ -452,6 +465,31 @@ function RouteComponentInner({
           )}
           <div className="relative min-h-0 flex-1">
             {(() => {
+              if (filePreviewState === "error") {
+                const error = versionDataQuery.error;
+                if (error instanceof Error) {
+                  throw error;
+                }
+                throw new ClientOperationError({
+                  action: "load_document_version_metadata",
+                  message: "Failed to load document version metadata",
+                  cause: error,
+                });
+              }
+
+              if (filePreviewState === "loading") {
+                return <DocxLoadingShell scaleOffset={scaleOffset} />;
+              }
+
+              if (filePreviewState === "missing") {
+                return (
+                  <Navigate
+                    params={{ workspaceId }}
+                    to="/workspaces/$workspaceId"
+                  />
+                );
+              }
+
               if (shouldRenderDocxBrowserShell && filePropertyId) {
                 return (
                   <VersionDropZone


### PR DESCRIPTION
## Summary
- wait for entity/version metadata before selecting the PDF or native DOCX preview path
- avoid the transient 404 caused by fetching a display URL before the file field is resolved

## Verification
- bun --filter @stll/web lint
- bun --filter @stll/web typecheck
- E2E_WEB_URL=http://localhost:3313 E2E_API_URL=http://localhost:3314 bun --filter @stll/web test:e2e
- pre-push hook: format, i18n, typecheck