### PR TITLE
feat: add chat history compaction

### DIFF
--- a/apps/api/src/handlers/chat/compaction.test.ts
+++ b/apps/api/src/handlers/chat/compaction.test.ts
@@ -10,6 +10,7 @@ import {
   planChatCompaction,
   planModelCompaction,
   renderChatMessagesForCompaction,
+  renderModelMessagesForCompaction,
 } from "./compaction";
 
 const textMessage = ({
@@ -70,12 +71,49 @@ describe("chat history compaction", () => {
     }
 
     expect(compacted.value).toHaveLength(2);
-    expect(compacted.value.at(0)?.role).toBe("system");
+    expect(compacted.value.at(0)?.role).toBe("user");
     expect(compacted.value.at(0)?.parts.at(0)).toEqual({
       type: "text",
       text: "Earlier conversation compacted from 2 message(s).\n\nold work summary",
     });
     expect(compacted.value.at(1)?.id).toBe("msg_3");
+  });
+
+  test("preserves chat history from the latest user turn boundary", () => {
+    const messages = [
+      textMessage({ id: "msg_1", role: "user", text: "old fact ".repeat(80) }),
+      textMessage({
+        id: "msg_2",
+        role: "assistant",
+        text: "old answer ".repeat(80),
+      }),
+      textMessage({
+        id: "msg_3",
+        role: "user",
+        text: "latest question ".repeat(20),
+      }),
+      textMessage({ id: "msg_4", role: "assistant", text: "working on it" }),
+    ];
+
+    const plan = planChatCompaction({
+      messages,
+      preserveTokens: 20,
+      triggerTokens: 50,
+    });
+
+    expect(plan.type).toBe("compact");
+    if (plan.type === "none") {
+      return;
+    }
+
+    expect(plan.messagesToSummarize.map((message) => message.id)).toEqual([
+      "msg_1",
+      "msg_2",
+    ]);
+    expect(plan.recentMessages.map((message) => message.id)).toEqual([
+      "msg_3",
+      "msg_4",
+    ]);
   });
 
   test("anonymizes the compaction transcript before summarizing", async () => {
@@ -184,11 +222,62 @@ describe("chat history compaction", () => {
 
     expect(compacted.value).toEqual([
       {
-        role: "system",
+        role: "user",
         content:
           "Earlier model-step history compacted from 2 message(s).\n\nstep summary",
       },
       { role: "user", content: "latest request" },
+    ]);
+  });
+
+  test("preserves model history from the latest user turn boundary", () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "old request ".repeat(80) },
+      { role: "assistant", content: "old answer ".repeat(80) },
+      { role: "user", content: "latest request ".repeat(20) },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "searchMatter",
+            input: { query: "termination" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "searchMatter",
+            output: { type: "json", value: { finding: "survives" } },
+          },
+        ],
+      },
+    ];
+
+    const plan = planModelCompaction({
+      messages,
+      preserveTokens: 20,
+      triggerTokens: 50,
+    });
+
+    expect(plan.type).toBe("compact");
+    if (plan.type === "none") {
+      return;
+    }
+
+    expect(plan.messagesToSummarize.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+    expect(plan.recentMessages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "tool",
     ]);
   });
 
@@ -199,5 +288,23 @@ describe("chat history compaction", () => {
     });
 
     expect(plan.type).toBe("none");
+  });
+
+  test("renders non-json structured parts without failing compaction", () => {
+    const transcript = renderModelMessagesForCompaction([
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "searchMatter",
+            input: { value: 1n },
+          },
+        ],
+      },
+    ]);
+
+    expect(transcript).toContain("[unserializable]");
   });
 });

--- a/apps/api/src/handlers/chat/compaction.test.ts
+++ b/apps/api/src/handlers/chat/compaction.test.ts
@@ -1,0 +1,203 @@
+import type { ModelMessage } from "ai";
+import { Result } from "better-result";
+import { describe, expect, test } from "bun:test";
+
+import type { ChatMessage } from "@/api/handlers/chat/types";
+
+import {
+  compactChatMessages,
+  compactModelMessages,
+  planChatCompaction,
+  planModelCompaction,
+  renderChatMessagesForCompaction,
+} from "./compaction";
+
+const textMessage = ({
+  id,
+  role,
+  text,
+}: {
+  id: string;
+  role: ChatMessage["role"];
+  text: string;
+}): ChatMessage => ({
+  id,
+  role,
+  parts: [{ type: "text", text }],
+});
+
+describe("chat history compaction", () => {
+  test("keeps full history below the token trigger", () => {
+    const messages = [
+      textMessage({ id: "msg_1", role: "user", text: "hello" }),
+      textMessage({ id: "msg_2", role: "assistant", text: "hi" }),
+    ];
+
+    const plan = planChatCompaction({
+      messages,
+      triggerTokens: 1000,
+    });
+
+    expect(plan.type).toBe("none");
+  });
+
+  test("summarizes older messages and preserves the recent tail", async () => {
+    const messages = [
+      textMessage({ id: "msg_1", role: "user", text: "old fact ".repeat(80) }),
+      textMessage({
+        id: "msg_2",
+        role: "assistant",
+        text: "old answer ".repeat(80),
+      }),
+      textMessage({
+        id: "msg_3",
+        role: "user",
+        text: "latest question",
+      }),
+    ];
+
+    const compacted = await compactChatMessages({
+      messages,
+      preserveTokens: 20,
+      summarizeTranscript: async (transcript) =>
+        transcript.includes("old fact") ? "old work summary" : "",
+      triggerTokens: 50,
+    });
+
+    expect(Result.isOk(compacted)).toBe(true);
+    if (Result.isError(compacted)) {
+      return;
+    }
+
+    expect(compacted.value).toHaveLength(2);
+    expect(compacted.value.at(0)?.role).toBe("system");
+    expect(compacted.value.at(0)?.parts.at(0)).toEqual({
+      type: "text",
+      text: "Earlier conversation compacted from 2 message(s).\n\nold work summary",
+    });
+    expect(compacted.value.at(1)?.id).toBe("msg_3");
+  });
+
+  test("anonymizes the compaction transcript before summarizing", async () => {
+    const messages = [
+      textMessage({
+        id: "msg_1",
+        role: "user",
+        text: "Acme s.r.o. signed the NDA.",
+      }),
+      textMessage({
+        id: "msg_2",
+        role: "user",
+        text: "What obligations survive termination?",
+      }),
+    ];
+    let transcriptSeenBySummarizer = "";
+
+    const compacted = await compactChatMessages({
+      messages,
+      prepareTranscript: async (transcript) =>
+        Result.ok(transcript.replaceAll("Acme s.r.o.", "[ORG_1]")),
+      preserveTokens: 10,
+      summarizeTranscript: async (transcript) => {
+        transcriptSeenBySummarizer = transcript;
+        return "summary";
+      },
+      triggerTokens: 20,
+    });
+
+    expect(Result.isOk(compacted)).toBe(true);
+    expect(transcriptSeenBySummarizer).toContain("[ORG_1]");
+    expect(transcriptSeenBySummarizer).not.toContain("Acme s.r.o.");
+  });
+
+  test("masks bulky file attachments in the transcript", () => {
+    const transcript = renderChatMessagesForCompaction([
+      {
+        id: "msg_1",
+        role: "user",
+        parts: [
+          {
+            type: "file",
+            filename: "contract.pdf",
+            mediaType: "application/pdf",
+            url: "stella-user-file://file_1",
+          },
+        ],
+      },
+    ]);
+
+    expect(transcript).toContain("contract.pdf");
+    expect(transcript).toContain("old file attachments are not rehydrated");
+    expect(transcript).not.toContain("stella-user-file://file_1");
+  });
+
+  test("falls back to the recent tail when summary generation fails", async () => {
+    const messages = [
+      textMessage({ id: "msg_1", role: "user", text: "old fact ".repeat(80) }),
+      textMessage({ id: "msg_2", role: "user", text: "latest question" }),
+    ];
+    let observedSummaryError = false;
+
+    const compacted = await compactChatMessages({
+      messages,
+      onSummaryError: () => {
+        observedSummaryError = true;
+      },
+      preserveTokens: 20,
+      summarizeTranscript: async () => {
+        throw new Error("provider unavailable");
+      },
+      triggerTokens: 50,
+    });
+
+    expect(Result.isOk(compacted)).toBe(true);
+    if (Result.isError(compacted)) {
+      return;
+    }
+
+    expect(observedSummaryError).toBe(true);
+    expect(compacted.value.map((message) => message.id)).toEqual(["msg_2"]);
+  });
+
+  test("compacts model messages for step-level tool loops", async () => {
+    const messages: ModelMessage[] = [
+      { role: "user", content: "old request ".repeat(80) },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "old tool finding ".repeat(80) }],
+      },
+      { role: "user", content: "latest request" },
+    ];
+
+    const compacted = await compactModelMessages({
+      messages,
+      preserveTokens: 20,
+      summarizeTranscript: async (transcript) =>
+        transcript.includes("old request") ? "step summary" : "",
+      triggerTokens: 50,
+    });
+
+    expect(Result.isOk(compacted)).toBe(true);
+    if (Result.isError(compacted)) {
+      return;
+    }
+
+    expect(compacted.value).toEqual([
+      {
+        role: "system",
+        content:
+          "Earlier model-step history compacted from 2 message(s).\n\nstep summary",
+      },
+      { role: "user", content: "latest request" },
+    ]);
+  });
+
+  test("skips model-message compaction below the token trigger", () => {
+    const plan = planModelCompaction({
+      messages: [{ role: "user", content: "small" }],
+      triggerTokens: 1000,
+    });
+
+    expect(plan.type).toBe("none");
+  });
+});

--- a/apps/api/src/handlers/chat/compaction.ts
+++ b/apps/api/src/handlers/chat/compaction.ts
@@ -1,0 +1,514 @@
+import { generateText, isFileUIPart, isTextUIPart, isToolUIPart } from "ai";
+import type { LanguageModel, ModelMessage } from "ai";
+import { Result } from "better-result";
+
+import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
+import { prepareTextForThirdParty } from "@/api/handlers/chat/third-party-boundary";
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+const MESSAGE_OVERHEAD_TOKENS = 12;
+const FILE_PART_ESTIMATED_TOKENS = 8000;
+const DEFAULT_TRIGGER_TOKENS = 64_000;
+const DEFAULT_PRESERVE_TOKENS = 38_000;
+const MAX_TEXT_PART_CHARS = 8000;
+const MAX_STRUCTURED_PART_CHARS = 4000;
+const MAX_SUMMARY_OUTPUT_TOKENS = 1800;
+
+const COMPACTION_SUMMARY_MESSAGE_ID = "stella-chat-compaction-summary";
+
+const COMPACTION_SYSTEM_PROMPT = [
+  "You compact chat history for stella, a legal workspace.",
+  "Write a concise checkpoint that lets the next assistant continue the work without rereading the earlier messages.",
+  "Preserve concrete facts, parties, dates, jurisdictions, source documents, cited law, tool findings, decisions already made, open tasks, user preferences, and unresolved questions.",
+  "Do not invent facts. Keep placeholder tokens, IDs, citations, and quoted legal terms exactly as provided.",
+].join("\n");
+
+type ChatCompactionPlan =
+  | {
+      totalTokens: number;
+      type: "none";
+    }
+  | {
+      messagesToSummarize: ChatMessage[];
+      preservedTokens: number;
+      recentMessages: ChatMessage[];
+      totalTokens: number;
+      type: "compact";
+    };
+
+type ModelCompactionPlan =
+  | {
+      totalTokens: number;
+      type: "none";
+    }
+  | {
+      messagesToSummarize: ModelMessage[];
+      preservedTokens: number;
+      recentMessages: ModelMessage[];
+      totalTokens: number;
+      type: "compact";
+    };
+
+type PlanChatCompactionOptions = {
+  messages: ChatMessage[];
+  preserveTokens?: number | undefined;
+  triggerTokens?: number | undefined;
+};
+
+export const planChatCompaction = ({
+  messages,
+  preserveTokens = DEFAULT_PRESERVE_TOKENS,
+  triggerTokens = DEFAULT_TRIGGER_TOKENS,
+}: PlanChatCompactionOptions): ChatCompactionPlan => {
+  const totalTokens = estimateMessagesTokens(messages);
+  if (totalTokens <= triggerTokens) {
+    return { totalTokens, type: "none" };
+  }
+
+  const recentMessages: ChatMessage[] = [];
+  let preservedTokens = 0;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages.at(index);
+    if (!message) {
+      continue;
+    }
+
+    const messageTokens = estimateMessageTokens(message);
+    if (
+      recentMessages.length > 0 &&
+      preservedTokens + messageTokens > preserveTokens
+    ) {
+      break;
+    }
+
+    preservedTokens += messageTokens;
+    recentMessages.unshift(message);
+  }
+
+  const messagesToSummarize = messages.slice(
+    0,
+    messages.length - recentMessages.length,
+  );
+  if (messagesToSummarize.length === 0) {
+    return { totalTokens, type: "none" };
+  }
+
+  return {
+    messagesToSummarize,
+    preservedTokens,
+    recentMessages,
+    totalTokens,
+    type: "compact",
+  };
+};
+
+export const planModelCompaction = ({
+  messages,
+  preserveTokens = DEFAULT_PRESERVE_TOKENS,
+  triggerTokens = DEFAULT_TRIGGER_TOKENS,
+}: {
+  messages: ModelMessage[];
+  preserveTokens?: number | undefined;
+  triggerTokens?: number | undefined;
+}): ModelCompactionPlan => {
+  const totalTokens = estimateModelMessagesTokens(messages);
+  if (totalTokens <= triggerTokens) {
+    return { totalTokens, type: "none" };
+  }
+
+  const recentMessages: ModelMessage[] = [];
+  let preservedTokens = 0;
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages.at(index);
+    if (!message) {
+      continue;
+    }
+
+    const messageTokens = estimateModelMessageTokens(message);
+    if (
+      recentMessages.length > 0 &&
+      preservedTokens + messageTokens > preserveTokens
+    ) {
+      break;
+    }
+
+    preservedTokens += messageTokens;
+    recentMessages.unshift(message);
+  }
+
+  const messagesToSummarize = messages.slice(
+    0,
+    messages.length - recentMessages.length,
+  );
+  if (messagesToSummarize.length === 0) {
+    return { totalTokens, type: "none" };
+  }
+
+  return {
+    messagesToSummarize,
+    preservedTokens,
+    recentMessages,
+    totalTokens,
+    type: "compact",
+  };
+};
+
+type CompactChatMessagesOptions = PlanChatCompactionOptions & {
+  onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
+  prepareTranscript?:
+    | ((transcript: string) => Promise<Result<string, HandlerError<422 | 500>>>)
+    | undefined;
+  summarizeTranscript: (transcript: string) => Promise<string>;
+};
+
+type CompactModelMessagesOptions = {
+  messages: ModelMessage[];
+  onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
+  preserveTokens?: number | undefined;
+  summarizeTranscript: (transcript: string) => Promise<string>;
+  triggerTokens?: number | undefined;
+};
+
+export const compactChatMessages = async ({
+  messages,
+  onSummaryError,
+  prepareTranscript,
+  preserveTokens,
+  summarizeTranscript,
+  triggerTokens,
+}: CompactChatMessagesOptions): Promise<
+  Result<ChatMessage[], HandlerError<422 | 500>>
+> => {
+  const plan = planChatCompaction({ messages, preserveTokens, triggerTokens });
+  if (plan.type === "none") {
+    return Result.ok(messages);
+  }
+
+  const transcript = renderChatMessagesForCompaction(plan.messagesToSummarize);
+  const preparedTranscript = prepareTranscript
+    ? await prepareTranscript(transcript)
+    : Result.ok(transcript);
+  if (Result.isError(preparedTranscript)) {
+    return Result.err(preparedTranscript.error);
+  }
+
+  const summaryResult = await Result.tryPromise({
+    try: async () => await summarizeTranscript(preparedTranscript.value),
+    catch: (cause) =>
+      new HandlerError({
+        status: 500,
+        message: "Failed to compact chat history",
+        cause,
+      }),
+  });
+  if (Result.isError(summaryResult)) {
+    onSummaryError?.(summaryResult.error);
+    return Result.ok(plan.recentMessages);
+  }
+
+  const summary = summaryResult.value.trim();
+  if (summary.length === 0) {
+    return Result.ok(plan.recentMessages);
+  }
+
+  return Result.ok([
+    createCompactionSummaryMessage({
+      summarizedMessageCount: plan.messagesToSummarize.length,
+      summary,
+    }),
+    ...plan.recentMessages,
+  ]);
+};
+
+export const compactModelMessages = async ({
+  messages,
+  onSummaryError,
+  preserveTokens,
+  summarizeTranscript,
+  triggerTokens,
+}: CompactModelMessagesOptions): Promise<
+  Result<ModelMessage[], HandlerError<500>>
+> => {
+  const plan = planModelCompaction({ messages, preserveTokens, triggerTokens });
+  if (plan.type === "none") {
+    return Result.ok(messages);
+  }
+
+  const transcript = renderModelMessagesForCompaction(plan.messagesToSummarize);
+  const summaryResult = await Result.tryPromise({
+    try: async () => await summarizeTranscript(transcript),
+    catch: (cause) =>
+      new HandlerError({
+        status: 500,
+        message: "Failed to compact model step history",
+        cause,
+      }),
+  });
+  if (Result.isError(summaryResult)) {
+    onSummaryError?.(summaryResult.error);
+    return Result.ok(plan.recentMessages);
+  }
+
+  const summary = summaryResult.value.trim();
+  if (summary.length === 0) {
+    return Result.ok(plan.recentMessages);
+  }
+
+  return Result.ok([
+    createModelCompactionSummaryMessage({
+      summarizedMessageCount: plan.messagesToSummarize.length,
+      summary,
+    }),
+    ...plan.recentMessages,
+  ]);
+};
+
+type CompactChatMessagesForModelOptions = PlanChatCompactionOptions & {
+  abortSignal: AbortSignal;
+  boundary: ChatThirdPartyBoundary;
+  model: LanguageModel;
+  onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
+};
+
+type CompactModelMessagesForModelOptions = {
+  abortSignal: AbortSignal;
+  messages: ModelMessage[];
+  model: LanguageModel;
+  onSummaryError?: ((error: HandlerError<500>) => void) | undefined;
+};
+
+export const compactChatMessagesForModel = async ({
+  abortSignal,
+  boundary,
+  messages,
+  model,
+  onSummaryError,
+  preserveTokens,
+  triggerTokens,
+}: CompactChatMessagesForModelOptions): Promise<
+  Result<ChatMessage[], HandlerError<422 | 500>>
+> =>
+  await compactChatMessages({
+    messages,
+    onSummaryError,
+    preserveTokens,
+    triggerTokens,
+    prepareTranscript: async (transcript) =>
+      await prepareTextForThirdParty({ boundary, text: transcript }),
+    summarizeTranscript: async (transcript) => {
+      const result = await generateText({
+        abortSignal,
+        maxOutputTokens: MAX_SUMMARY_OUTPUT_TOKENS,
+        model,
+        prompt: [
+          "Compact the earlier conversation transcript below.",
+          "Return only the checkpoint summary.",
+          "",
+          transcript,
+        ].join("\n"),
+        system: COMPACTION_SYSTEM_PROMPT,
+        temperature: 0,
+      });
+
+      return result.text;
+    },
+  });
+
+export const compactModelMessagesForModel = async ({
+  abortSignal,
+  messages,
+  model,
+  onSummaryError,
+}: CompactModelMessagesForModelOptions): Promise<
+  Result<ModelMessage[], HandlerError<500>>
+> =>
+  await compactModelMessages({
+    messages,
+    onSummaryError,
+    summarizeTranscript: async (transcript) => {
+      const result = await generateText({
+        abortSignal,
+        maxOutputTokens: MAX_SUMMARY_OUTPUT_TOKENS,
+        model,
+        prompt: [
+          "Compact the earlier model-step transcript below.",
+          "Return only the checkpoint summary.",
+          "",
+          transcript,
+        ].join("\n"),
+        system: COMPACTION_SYSTEM_PROMPT,
+        temperature: 0,
+      });
+
+      return result.text;
+    },
+  });
+
+export const renderChatMessagesForCompaction = (
+  messages: readonly ChatMessage[],
+): string =>
+  messages
+    .map((message, index) =>
+      [
+        `<message index="${index + 1}" role="${message.role}" id="${message.id}">`,
+        ...message.parts.map(renderPartForCompaction),
+        "</message>",
+      ].join("\n"),
+    )
+    .join("\n\n");
+
+export const renderModelMessagesForCompaction = (
+  messages: readonly ModelMessage[],
+): string =>
+  messages
+    .map((message, index) =>
+      [
+        `<message index="${index + 1}" role="${message.role}">`,
+        renderTaggedValue(
+          "content",
+          truncateForCompaction(
+            renderModelMessageContent(message),
+            MAX_STRUCTURED_PART_CHARS,
+          ),
+        ),
+        "</message>",
+      ].join("\n"),
+    )
+    .join("\n\n");
+
+const createCompactionSummaryMessage = ({
+  summarizedMessageCount,
+  summary,
+}: {
+  summarizedMessageCount: number;
+  summary: string;
+}): ChatMessage => ({
+  id: COMPACTION_SUMMARY_MESSAGE_ID,
+  role: "system",
+  parts: [
+    {
+      type: "text",
+      text: [
+        `Earlier conversation compacted from ${summarizedMessageCount} message(s).`,
+        summary,
+      ].join("\n\n"),
+    },
+  ],
+});
+
+const createModelCompactionSummaryMessage = ({
+  summarizedMessageCount,
+  summary,
+}: {
+  summarizedMessageCount: number;
+  summary: string;
+}): ModelMessage => ({
+  role: "system",
+  content: [
+    `Earlier model-step history compacted from ${summarizedMessageCount} message(s).`,
+    summary,
+  ].join("\n\n"),
+});
+
+const estimateMessagesTokens = (messages: readonly ChatMessage[]): number =>
+  messages.reduce(
+    (total, message) => total + estimateMessageTokens(message),
+    0,
+  );
+
+const estimateMessageTokens = (message: ChatMessage): number =>
+  message.parts.reduce(
+    (total, part) => total + estimatePartTokens(part),
+    MESSAGE_OVERHEAD_TOKENS,
+  );
+
+const estimatePartTokens = (part: ChatMessage["parts"][number]): number => {
+  if (isTextUIPart(part)) {
+    return estimateTextTokens(part.text);
+  }
+
+  if (isFileUIPart(part)) {
+    return FILE_PART_ESTIMATED_TOKENS;
+  }
+
+  return estimateTextTokens(safeStringify(part));
+};
+
+const estimateTextTokens = (text: string): number =>
+  Math.ceil(text.length / ESTIMATED_CHARS_PER_TOKEN);
+
+const estimateModelMessagesTokens = (
+  messages: readonly ModelMessage[],
+): number =>
+  messages.reduce(
+    (total, message) => total + estimateModelMessageTokens(message),
+    0,
+  );
+
+const estimateModelMessageTokens = (message: ModelMessage): number =>
+  MESSAGE_OVERHEAD_TOKENS + estimateTextTokens(safeStringify(message));
+
+const renderPartForCompaction = (
+  part: ChatMessage["parts"][number],
+): string => {
+  if (isTextUIPart(part)) {
+    return renderTaggedValue(
+      "text",
+      truncateForCompaction(part.text, MAX_TEXT_PART_CHARS),
+    );
+  }
+
+  if (isFileUIPart(part)) {
+    return renderTaggedValue(
+      "file",
+      [
+        `name: ${part.filename ?? "unnamed"}`,
+        `mediaType: ${part.mediaType}`,
+        "content: omitted; old file attachments are not rehydrated during compaction",
+      ].join("\n"),
+    );
+  }
+
+  if (isToolUIPart(part)) {
+    return renderTaggedValue(
+      "tool",
+      truncateForCompaction(safeStringify(part), MAX_STRUCTURED_PART_CHARS),
+    );
+  }
+
+  return renderTaggedValue(
+    part.type,
+    truncateForCompaction(safeStringify(part), MAX_STRUCTURED_PART_CHARS),
+  );
+};
+
+const renderModelMessageContent = (message: ModelMessage): string => {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+
+  return safeStringify(message.content);
+};
+
+const renderTaggedValue = (tag: string, value: string): string =>
+  `<${tag}>\n${value}\n</${tag}>`;
+
+const truncateForCompaction = (value: string, maxChars: number): string => {
+  if (value.length <= maxChars) {
+    return value;
+  }
+
+  return `${value.slice(0, maxChars)}\n[truncated ${value.length - maxChars} chars]`;
+};
+
+const safeStringify = (value: unknown): string => {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return JSON.stringify(value);
+};

--- a/apps/api/src/handlers/chat/compaction.ts
+++ b/apps/api/src/handlers/chat/compaction.ts
@@ -79,7 +79,8 @@ export const planChatCompaction = ({
     const messageTokens = estimateMessageTokens(message);
     if (
       recentMessages.length > 0 &&
-      preservedTokens + messageTokens > preserveTokens
+      preservedTokens + messageTokens > preserveTokens &&
+      startsWithUserMessage(recentMessages)
     ) {
       break;
     }
@@ -131,7 +132,8 @@ export const planModelCompaction = ({
     const messageTokens = estimateModelMessageTokens(message);
     if (
       recentMessages.length > 0 &&
-      preservedTokens + messageTokens > preserveTokens
+      preservedTokens + messageTokens > preserveTokens &&
+      startsWithUserMessage(recentMessages)
     ) {
       break;
     }
@@ -388,7 +390,7 @@ const createCompactionSummaryMessage = ({
   summary: string;
 }): ChatMessage => ({
   id: COMPACTION_SUMMARY_MESSAGE_ID,
-  role: "system",
+  role: "user",
   parts: [
     {
       type: "text",
@@ -407,7 +409,7 @@ const createModelCompactionSummaryMessage = ({
   summarizedMessageCount: number;
   summary: string;
 }): ModelMessage => ({
-  role: "system",
+  role: "user",
   content: [
     `Earlier model-step history compacted from ${summarizedMessageCount} message(s).`,
     summary,
@@ -440,6 +442,10 @@ const estimatePartTokens = (part: ChatMessage["parts"][number]): number => {
 
 const estimateTextTokens = (text: string): number =>
   Math.ceil(text.length / ESTIMATED_CHARS_PER_TOKEN);
+
+const startsWithUserMessage = (
+  messages: readonly { role: string }[],
+): boolean => messages.at(0)?.role === "user";
 
 const estimateModelMessagesTokens = (
   messages: readonly ModelMessage[],
@@ -510,5 +516,10 @@ const safeStringify = (value: unknown): string => {
     return value;
   }
 
-  return JSON.stringify(value);
+  try {
+    const serialized: unknown = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized : "[unserializable]";
+  } catch {
+    return "[unserializable]";
+  }
 };

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -27,6 +27,7 @@ import {
   validateMessage,
 } from "@/api/handlers/chat/chat-schema";
 import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import { compactChatMessagesForModel } from "@/api/handlers/chat/compaction";
 import {
   expandThreadDataScope,
   extractAssistantWorkspaceIds,
@@ -70,9 +71,12 @@ import type { UploadedChatFile } from "@/api/handlers/chat/upload-files";
 import { createFileKey } from "@/api/handlers/files/utils";
 import { getDisabledNativeToolSlugs } from "@/api/handlers/mcp-connectors/catalog-metadata";
 import {
+  getModelById,
+  getModelForRole,
   requireAIAvailable,
   validateDevModelOverride,
 } from "@/api/lib/ai-models";
+import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import type { HandlerConfig } from "@/api/lib/api-handlers";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -90,8 +94,6 @@ const config = {
   permissions: { chat: ["create"] },
   body: sendMessageBodySchema,
 } satisfies HandlerConfig;
-
-const MESSAGE_WINDOW = 20;
 
 const sendMessage = createSafeRootHandler(
   config,
@@ -361,13 +363,40 @@ const sendMessage = createSafeRootHandler(
           })
         : null;
 
-    const messageWindow = latestMessagePlan.messages.slice(-MESSAGE_WINDOW);
+    const messagesForContextResult = await compactMessagesForContext({
+      abortSignal: request.signal,
+      boundary: thirdPartyBoundary,
+      devModelId: body.devModelId,
+      messages: latestMessagePlan.messages,
+      organizationId: session.activeOrganizationId,
+      orgAIConfig,
+      threadId: body.threadId,
+    });
+    if (Result.isError(messagesForContextResult)) {
+      const rollbackResult = await rollbackUnpersistedChatSideEffects({
+        recordAuditEvent,
+        safeDb,
+        threadId: body.threadId,
+        threadState: thread,
+        uploadedFiles: uploadResult.uploadedFiles,
+        userId: user.id,
+      });
+      if (Result.isError(rollbackResult)) {
+        captureError(messagesForContextResult.error, {
+          threadId: body.threadId,
+        });
+        return yield* Result.err(rollbackResult.error);
+      }
+
+      return yield* Result.err(messagesForContextResult.error);
+    }
+
     const chatContextResult = await prepareChatContext({
       activeDecision: body.activeDecision,
       activeExternal: body.activeExternal,
       activeFile: body.activeFile,
       contextMatterIds: effectiveContextMatterIds,
-      messageWindow,
+      messageWindow: messagesForContextResult.value,
       organizationId: session.activeOrganizationId,
       safeDb,
       sendMode: body.sendMode,
@@ -647,6 +676,82 @@ const sendMessage = createSafeRootHandler(
 );
 
 export default sendMessage;
+
+type ResolveChatCompactionModelProps = {
+  devModelId: string | undefined;
+  organizationId: SafeId<"organization">;
+  orgAIConfig: OrgAIConfig | null;
+};
+
+type CompactMessagesForContextProps = ResolveChatCompactionModelProps & {
+  abortSignal: AbortSignal;
+  boundary: ReturnType<typeof createChatThirdPartyBoundary>;
+  messages: ChatMessage[];
+  threadId: SafeId<"chatThread">;
+};
+
+const compactMessagesForContext = async ({
+  abortSignal,
+  boundary,
+  devModelId,
+  messages,
+  organizationId,
+  orgAIConfig,
+  threadId,
+}: CompactMessagesForContextProps): Promise<
+  Result<ChatMessage[], HandlerError>
+> => {
+  const modelResult = resolveChatCompactionModel({
+    devModelId,
+    organizationId,
+    orgAIConfig,
+  });
+  if (Result.isError(modelResult)) {
+    return Result.err(modelResult.error);
+  }
+
+  return await compactChatMessagesForModel({
+    abortSignal,
+    boundary,
+    messages,
+    model: modelResult.value,
+    onSummaryError: (error) => {
+      captureError(error, {
+        threadId,
+        feature: "chat.compaction",
+      });
+    },
+  });
+};
+
+const resolveChatCompactionModel = ({
+  devModelId,
+  organizationId,
+  orgAIConfig,
+}: ResolveChatCompactionModelProps) =>
+  Result.try({
+    try: () =>
+      devModelId
+        ? getModelById(devModelId, orgAIConfig, {
+            organizationId,
+            promptCachingEnabled: false,
+            role: "chat",
+            scopeKey: null,
+          })
+        : getModelForRole("chat", orgAIConfig, {
+            organizationId,
+            promptCachingEnabled: false,
+            scopeKey: null,
+          }),
+    catch: (cause) =>
+      HandlerError.is(cause)
+        ? cause
+        : new HandlerError({
+            status: 500,
+            message: "Failed to initialize chat compaction model",
+            cause,
+          }),
+  });
 
 const isChatStreamResponse = (response: Response): boolean => {
   const contentType = response.headers.get("content-type");

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -23,6 +23,7 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 
 import type { SafeDb, SafeDbError } from "@/api/db";
 import { getUserFileIdFromPart } from "@/api/handlers/chat/attachment-validation";
+import { compactModelMessagesForModel } from "@/api/handlers/chat/compaction";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import {
   deanonymizeFromBoundary,
@@ -175,6 +176,29 @@ const runChatStream = async ({
     tools,
     experimental_repairToolCall: async ({ toolCall }) =>
       await Promise.resolve(repairActiveDocxEditToolCall(toolCall)),
+    prepareStep: async ({ messages }) => {
+      const compactedMessages = await compactModelMessagesForModel({
+        abortSignal,
+        messages,
+        model,
+        onSummaryError: (error) => {
+          captureError(error, {
+            threadId,
+            provider: modelInfo.provider,
+            modelId: modelInfo.modelId,
+            feature: "chat.step-compaction",
+          });
+        },
+      });
+      if (Result.isError(compactedMessages)) {
+        throw compactedMessages.error;
+      }
+      if (compactedMessages.value === messages) {
+        return undefined;
+      }
+
+      return { messages: compactedMessages.value };
+    },
     stopWhen: [stepCountIs(MAX_TOOL_STEPS), hasToolCall("ask-user")],
     messages: modelMessages,
     onFinish: ({ finishReason, totalUsage }) => {


### PR DESCRIPTION
## Summary
- add token-estimated chat history compaction before preparing model context
- compact step-level model messages through `prepareStep` so long tool loops can keep recent state
- mask old file attachment bodies in compaction transcripts and cover the behavior with unit tests

## Tests
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`