### PR TITLE
feat: add chat loop detection

### DIFF
--- a/apps/api/src/handlers/chat/loop-detector.test.ts
+++ b/apps/api/src/handlers/chat/loop-detector.test.ts
@@ -2,9 +2,11 @@ import type { ModelMessage } from "ai";
 import { describe, expect, test } from "bun:test";
 
 import {
-  createLoopRecoveryMessage,
+  createLoopRecoverySystemPrompt,
   detectModelLoop,
+  getLoopRecoveryKey,
   shouldInjectLoopRecovery,
+  shouldSurfaceFinalContentLoop,
   shouldStopLoopRecovery,
 } from "./loop-detector";
 
@@ -34,11 +36,12 @@ describe("model loop detection", () => {
 
     const detection = detectModelLoop(messages);
 
-    expect(detection).toEqual({
-      repetitionCount: 5,
-      toolName: "searchMatter",
-      type: "tool-call-loop",
-    });
+    expect(detection.type).toBe("tool-call-loop");
+    if (detection.type === "tool-call-loop") {
+      expect(detection.repetitionCount).toBe(5);
+      expect(detection.signature).toHaveLength(64);
+      expect(detection.toolName).toBe("searchMatter");
+    }
     expect(shouldInjectLoopRecovery(detection)).toBe(true);
   });
 
@@ -64,6 +67,21 @@ describe("model loop detection", () => {
     expect(detectModelLoop(messages).type).toBe("tool-call-loop");
   });
 
+  test("handles structured values that JSON.stringify cannot serialize", () => {
+    const messages = Array.from({ length: 5 }, () =>
+      toolCallMessage({ input: { amount: 10n } }),
+    );
+
+    const detection = detectModelLoop(messages);
+
+    expect(detection.type).toBe("tool-call-loop");
+    if (detection.type === "tool-call-loop") {
+      expect(detection.repetitionCount).toBe(5);
+      expect(detection.signature).toHaveLength(64);
+      expect(detection.toolName).toBe("searchMatter");
+    }
+  });
+
   test("does not flag batch work with different tool inputs", () => {
     const messages = Array.from({ length: 8 }, (_, index) =>
       toolCallMessage({ input: { documentId: `doc_${index}` } }),
@@ -81,11 +99,37 @@ describe("model loop detection", () => {
       toolCallMessage({ input: { query: "termination" } }),
     ]).flat();
 
-    expect(detectModelLoop(messages)).toEqual({
-      repetitionCount: 5,
-      toolName: "searchMatter",
-      type: "tool-call-loop",
-    });
+    const detection = detectModelLoop(messages);
+
+    expect(detection.type).toBe("tool-call-loop");
+    if (detection.type === "tool-call-loop") {
+      expect(detection.repetitionCount).toBe(5);
+      expect(detection.signature).toHaveLength(64);
+      expect(detection.toolName).toBe("searchMatter");
+    }
+  });
+
+  test("uses tool input identity in the internal recovery key", () => {
+    const firstDetection = detectModelLoop(
+      Array.from({ length: 5 }, () =>
+        toolCallMessage({ input: { query: "termination" } }),
+      ),
+    );
+    const nextDetection = detectModelLoop(
+      Array.from({ length: 5 }, () =>
+        toolCallMessage({ input: { query: "force majeure" } }),
+      ),
+    );
+    if (firstDetection.type !== "tool-call-loop") {
+      throw new Error("Expected first tool loop detection");
+    }
+    if (nextDetection.type !== "tool-call-loop") {
+      throw new Error("Expected next tool loop detection");
+    }
+
+    expect(getLoopRecoveryKey(nextDetection)).not.toBe(
+      getLoopRecoveryKey(firstDetection),
+    );
   });
 
   test("does not count repeated tool calls across separate user turns", () => {
@@ -132,7 +176,116 @@ describe("model loop detection", () => {
     ]);
 
     expect(detection.type).toBe("content-loop");
+    if (detection.type === "content-loop") {
+      expect(detection.repetitionCount).toBeGreaterThanOrEqual(10);
+      expect(detection.signature).toHaveLength(64);
+    }
+  });
+
+  test("hard-stops content loops that keep repeating past recovery", () => {
+    const repeated = "No progress was made on this exact same line. ";
+    const detection = detectModelLoop([
+      {
+        role: "assistant",
+        content: repeated.repeat(24),
+      },
+    ]);
+
+    expect(detection.type).toBe("content-loop");
+    expect(shouldStopLoopRecovery(detection)).toBe(true);
+  });
+
+  test("surfaces final content loops without treating tool loops as final text", () => {
+    const contentLoop = detectModelLoop([
+      {
+        role: "assistant",
+        content: "No progress was made on this exact same line. ".repeat(14),
+      },
+    ]);
+    const toolLoop = detectModelLoop(
+      Array.from({ length: 5 }, () =>
+        toolCallMessage({ input: { query: "termination" } }),
+      ),
+    );
+
+    expect(shouldSurfaceFinalContentLoop(contentLoop)).toBe(true);
+    expect(shouldSurfaceFinalContentLoop(toolLoop)).toBe(false);
+  });
+
+  test("uses repeated content identity in the internal recovery key", () => {
+    const firstDetection = detectModelLoop([
+      {
+        role: "assistant",
+        content: "No progress was made on this exact same line. ".repeat(14),
+      },
+    ]);
+    const nextDetection = detectModelLoop([
+      {
+        role: "assistant",
+        content: "Still repeating a different exact same line. ".repeat(14),
+      },
+    ]);
+    if (firstDetection.type !== "content-loop") {
+      throw new Error("Expected first content loop detection");
+    }
+    if (nextDetection.type !== "content-loop") {
+      throw new Error("Expected next content loop detection");
+    }
+
+    expect(getLoopRecoveryKey(nextDetection)).not.toBe(
+      getLoopRecoveryKey(firstDetection),
+    );
+  });
+
+  test("prefers the active content loop over stale repeated text", () => {
+    const staleChunk = "Earlier repeated text ".padEnd(50, "s");
+    const activeChunk = "New repeated text ".padEnd(50, "n");
+    const staleDetection = detectModelLoop([
+      {
+        role: "assistant",
+        content: staleChunk.repeat(20),
+      },
+    ]);
+    const detection = detectModelLoop([
+      {
+        role: "assistant",
+        content: `${staleChunk.repeat(20)}\n${activeChunk.repeat(10)}`,
+      },
+    ]);
+
+    expect(staleDetection.type).toBe("content-loop");
+    expect(detection.type).toBe("content-loop");
+    if (staleDetection.type === "none" || detection.type === "none") {
+      throw new Error("Expected content loop detection");
+    }
+
+    expect(detection.signature).not.toBe(staleDetection.signature);
+    expect(detection.repetitionCount).toBe(10);
     expect(shouldInjectLoopRecovery(detection)).toBe(true);
+  });
+
+  test("keeps the same recovery key when stale repeated text has not changed", () => {
+    const repeated = "No progress was made on this exact same line. ";
+    const firstDetection = detectModelLoop([
+      {
+        role: "assistant",
+        content: repeated.repeat(14),
+      },
+    ]);
+    const nextDetection = detectModelLoop([
+      {
+        role: "assistant",
+        content: repeated.repeat(14),
+      },
+      toolCallMessage({ input: { documentId: "doc_1" } }),
+    ]);
+    if (firstDetection.type === "none" || nextDetection.type === "none") {
+      throw new Error("Expected loop detection");
+    }
+
+    expect(getLoopRecoveryKey(nextDetection)).toBe(
+      getLoopRecoveryKey(firstDetection),
+    );
   });
 
   test("recovery message does not echo sensitive tool arguments", () => {
@@ -147,10 +300,14 @@ describe("model loop detection", () => {
       throw new Error("Expected loop detection");
     }
 
-    const recovery = createLoopRecoveryMessage(detection);
+    const recovery = createLoopRecoverySystemPrompt({
+      baseSystem: "Base system prompt.",
+      detection,
+    });
 
-    expect(recovery.content).not.toContain("Jan Novak");
-    expect(recovery.content).not.toContain("confidential dispute");
-    expect(recovery.content).toContain("searchMatter");
+    expect(recovery).not.toContain("Jan Novak");
+    expect(recovery).not.toContain("confidential dispute");
+    expect(recovery).toContain("Base system prompt.");
+    expect(recovery).toContain("searchMatter");
   });
 });

--- a/apps/api/src/handlers/chat/loop-detector.test.ts
+++ b/apps/api/src/handlers/chat/loop-detector.test.ts
@@ -5,6 +5,7 @@ import {
   createLoopRecoveryMessage,
   detectModelLoop,
   shouldInjectLoopRecovery,
+  shouldStopLoopRecovery,
 } from "./loop-detector";
 
 const toolCallMessage = ({
@@ -71,6 +72,22 @@ describe("model loop detection", () => {
     expect(detectModelLoop(messages)).toEqual({ type: "none" });
   });
 
+  test("detects repeated tool calls even when the model alternates tools", () => {
+    const messages = Array.from({ length: 5 }, (_, index) => [
+      toolCallMessage({
+        input: { documentId: `doc_${index}` },
+        toolName: "readDocument",
+      }),
+      toolCallMessage({ input: { query: "termination" } }),
+    ]).flat();
+
+    expect(detectModelLoop(messages)).toEqual({
+      repetitionCount: 5,
+      toolName: "searchMatter",
+      type: "tool-call-loop",
+    });
+  });
+
   test("does not count repeated tool calls across separate user turns", () => {
     const messages = Array.from({ length: 6 }, () => [
       {
@@ -93,6 +110,16 @@ describe("model loop detection", () => {
 
     expect(shouldInjectLoopRecovery(detectModelLoop(sixCalls))).toBe(false);
     expect(shouldInjectLoopRecovery(detectModelLoop(tenCalls))).toBe(true);
+  });
+
+  test("hard-stops persistent loops after repeated recovery attempts", () => {
+    const detection = detectModelLoop(
+      Array.from({ length: 15 }, () =>
+        toolCallMessage({ input: { query: "termination" } }),
+      ),
+    );
+
+    expect(shouldStopLoopRecovery(detection)).toBe(true);
   });
 
   test("detects repeated assistant text chunks", () => {

--- a/apps/api/src/handlers/chat/loop-detector.test.ts
+++ b/apps/api/src/handlers/chat/loop-detector.test.ts
@@ -1,0 +1,129 @@
+import type { ModelMessage } from "ai";
+import { describe, expect, test } from "bun:test";
+
+import {
+  createLoopRecoveryMessage,
+  detectModelLoop,
+  shouldInjectLoopRecovery,
+} from "./loop-detector";
+
+const toolCallMessage = ({
+  input,
+  toolName = "searchMatter",
+}: {
+  input: unknown;
+  toolName?: string | undefined;
+}): ModelMessage => ({
+  role: "assistant",
+  content: [
+    {
+      type: "tool-call",
+      toolCallId: Bun.randomUUIDv7(),
+      toolName,
+      input,
+    },
+  ],
+});
+
+describe("model loop detection", () => {
+  test("detects five consecutive identical tool calls", () => {
+    const messages = Array.from({ length: 5 }, () =>
+      toolCallMessage({ input: { query: "force majeure" } }),
+    );
+
+    const detection = detectModelLoop(messages);
+
+    expect(detection).toEqual({
+      repetitionCount: 5,
+      toolName: "searchMatter",
+      type: "tool-call-loop",
+    });
+    expect(shouldInjectLoopRecovery(detection)).toBe(true);
+  });
+
+  test("treats reordered object keys as the same tool input", () => {
+    const messages = [
+      toolCallMessage({
+        input: { filters: { jurisdiction: "CZ", type: "contract" } },
+      }),
+      toolCallMessage({
+        input: { filters: { type: "contract", jurisdiction: "CZ" } },
+      }),
+      toolCallMessage({
+        input: { filters: { jurisdiction: "CZ", type: "contract" } },
+      }),
+      toolCallMessage({
+        input: { filters: { type: "contract", jurisdiction: "CZ" } },
+      }),
+      toolCallMessage({
+        input: { filters: { jurisdiction: "CZ", type: "contract" } },
+      }),
+    ];
+
+    expect(detectModelLoop(messages).type).toBe("tool-call-loop");
+  });
+
+  test("does not flag batch work with different tool inputs", () => {
+    const messages = Array.from({ length: 8 }, (_, index) =>
+      toolCallMessage({ input: { documentId: `doc_${index}` } }),
+    );
+
+    expect(detectModelLoop(messages)).toEqual({ type: "none" });
+  });
+
+  test("does not count repeated tool calls across separate user turns", () => {
+    const messages = Array.from({ length: 6 }, () => [
+      {
+        role: "user" as const,
+        content: "Run the same search again.",
+      },
+      toolCallMessage({ input: { query: "termination" } }),
+    ]).flat();
+
+    expect(detectModelLoop(messages)).toEqual({ type: "none" });
+  });
+
+  test("injects recovery periodically instead of on every repeated call", () => {
+    const sixCalls = Array.from({ length: 6 }, () =>
+      toolCallMessage({ input: { query: "termination" } }),
+    );
+    const tenCalls = Array.from({ length: 10 }, () =>
+      toolCallMessage({ input: { query: "termination" } }),
+    );
+
+    expect(shouldInjectLoopRecovery(detectModelLoop(sixCalls))).toBe(false);
+    expect(shouldInjectLoopRecovery(detectModelLoop(tenCalls))).toBe(true);
+  });
+
+  test("detects repeated assistant text chunks", () => {
+    const repeated = "No progress was made on this exact same line. ";
+    const detection = detectModelLoop([
+      {
+        role: "assistant",
+        content: repeated.repeat(14),
+      },
+    ]);
+
+    expect(detection.type).toBe("content-loop");
+    expect(shouldInjectLoopRecovery(detection)).toBe(true);
+  });
+
+  test("recovery message does not echo sensitive tool arguments", () => {
+    const detection = detectModelLoop(
+      Array.from({ length: 5 }, () =>
+        toolCallMessage({
+          input: { party: "Jan Novak", query: "confidential dispute" },
+        }),
+      ),
+    );
+    if (detection.type === "none") {
+      throw new Error("Expected loop detection");
+    }
+
+    const recovery = createLoopRecoveryMessage(detection);
+
+    expect(recovery.content).not.toContain("Jan Novak");
+    expect(recovery.content).not.toContain("confidential dispute");
+    expect(recovery.content).toContain("searchMatter");
+  });
+});

--- a/apps/api/src/handlers/chat/loop-detector.ts
+++ b/apps/api/src/handlers/chat/loop-detector.ts
@@ -1,0 +1,369 @@
+import type { ModelMessage } from "ai";
+
+const codePointOf = (value: string): number => {
+  const code = value.codePointAt(0);
+  if (code === undefined) {
+    return 0;
+  }
+  return code;
+};
+
+const TOOL_CALL_LOOP_THRESHOLD = 5;
+const LOOP_RECOVERY_INTERVAL = 5;
+const CONTENT_CHUNK_SIZE = 50;
+const CONTENT_LOOP_THRESHOLD = 10;
+const CONTENT_HISTORY_CHARS = 5000;
+const BOX_DRAWING_START_CODE_POINT = codePointOf("\u2500");
+const BOX_DRAWING_END_CODE_POINT = codePointOf("\u257f");
+const DIGIT_ZERO_CODE_POINT = 48;
+const DIGIT_NINE_CODE_POINT = 57;
+
+type AssistantMessage = Extract<ModelMessage, { role: "assistant" }>;
+type AssistantContentPart = Exclude<
+  AssistantMessage["content"],
+  string
+>[number];
+type ToolCallPart = Extract<AssistantContentPart, { type: "tool-call" }>;
+
+type ToolCallLoopDetection = {
+  repetitionCount: number;
+  toolName: string;
+  type: "tool-call-loop";
+};
+
+type ContentLoopDetection = {
+  repetitionCount: number;
+  type: "content-loop";
+};
+
+export type ModelLoopDetection =
+  | {
+      type: "none";
+    }
+  | ToolCallLoopDetection
+  | ContentLoopDetection;
+
+export const detectModelLoop = (
+  messages: readonly ModelMessage[],
+): ModelLoopDetection => {
+  const currentTurnMessages = getCurrentTurnMessages(messages);
+  const toolCallLoop = detectToolCallLoop(currentTurnMessages);
+  if (toolCallLoop.type !== "none") {
+    return toolCallLoop;
+  }
+
+  return detectContentLoop(currentTurnMessages);
+};
+
+export const shouldInjectLoopRecovery = (
+  detection: ModelLoopDetection,
+): detection is Exclude<ModelLoopDetection, { type: "none" }> => {
+  if (detection.type === "none") {
+    return false;
+  }
+
+  return detection.repetitionCount % LOOP_RECOVERY_INTERVAL === 0;
+};
+
+export const createLoopRecoveryMessage = (
+  detection: Exclude<ModelLoopDetection, { type: "none" }>,
+): ModelMessage => ({
+  role: "system",
+  content: [
+    "System: Potential loop detected.",
+    `Signal: ${describeLoopDetection(detection)}.`,
+    "Take a step back before continuing. Confirm what has changed, choose a different approach, or ask the user a focused clarification if you are blocked. Do not repeat the same tool call or response without new information.",
+  ].join("\n"),
+});
+
+const detectToolCallLoop = (
+  messages: readonly ModelMessage[],
+): ModelLoopDetection => {
+  const signatures = collectToolCallSignatures(messages);
+  const latest = signatures.at(-1);
+  if (!latest) {
+    return { type: "none" };
+  }
+
+  let repetitionCount = 0;
+  for (let index = signatures.length - 1; index >= 0; index -= 1) {
+    const signature = signatures.at(index);
+    if (!signature || signature.key !== latest.key) {
+      break;
+    }
+    repetitionCount += 1;
+  }
+
+  if (repetitionCount < TOOL_CALL_LOOP_THRESHOLD) {
+    return { type: "none" };
+  }
+
+  return {
+    repetitionCount,
+    toolName: latest.toolName,
+    type: "tool-call-loop",
+  };
+};
+
+const getCurrentTurnMessages = (
+  messages: readonly ModelMessage[],
+): readonly ModelMessage[] => {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages.at(index);
+    if (message?.role === "user") {
+      return messages.slice(index + 1);
+    }
+  }
+
+  return messages;
+};
+
+const collectToolCallSignatures = (
+  messages: readonly ModelMessage[],
+): { key: string; toolName: string }[] => {
+  const signatures: { key: string; toolName: string }[] = [];
+
+  for (const message of messages) {
+    if (message.role !== "assistant" || typeof message.content === "string") {
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (!isToolCallPart(part)) {
+        continue;
+      }
+
+      const serializedInput = stableStringify(part.input);
+      signatures.push({
+        key: hashString(`${part.toolName}:${serializedInput}`),
+        toolName: part.toolName,
+      });
+    }
+  }
+
+  return signatures;
+};
+
+const detectContentLoop = (
+  messages: readonly ModelMessage[],
+): ModelLoopDetection => {
+  const assistantText = collectAssistantText(messages)
+    .join("\n")
+    .slice(-CONTENT_HISTORY_CHARS);
+  if (assistantText.length < CONTENT_CHUNK_SIZE * CONTENT_LOOP_THRESHOLD) {
+    return { type: "none" };
+  }
+
+  const chunkIndicesByHash = new Map<string, number[]>();
+  for (
+    let index = 0;
+    index + CONTENT_CHUNK_SIZE <= assistantText.length;
+    index += 1
+  ) {
+    const chunk = assistantText.slice(index, index + CONTENT_CHUNK_SIZE);
+    if (isStructuredMarkdownChunk(chunk)) {
+      continue;
+    }
+
+    const chunkHash = hashString(chunk);
+    const indices = chunkIndicesByHash.get(chunkHash);
+    if (!indices) {
+      chunkIndicesByHash.set(chunkHash, [index]);
+      continue;
+    }
+
+    indices.push(index);
+    const recent = indices.slice(-CONTENT_LOOP_THRESHOLD);
+    if (
+      recent.length >= CONTENT_LOOP_THRESHOLD &&
+      isClusteredContentLoop(assistantText, recent)
+    ) {
+      return {
+        repetitionCount: indices.length,
+        type: "content-loop",
+      };
+    }
+  }
+
+  return { type: "none" };
+};
+
+const collectAssistantText = (
+  messages: readonly ModelMessage[],
+): readonly string[] => {
+  const texts: string[] = [];
+
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+    if (typeof message.content === "string") {
+      texts.push(message.content);
+      continue;
+    }
+
+    for (const part of message.content) {
+      if (part.type === "text") {
+        texts.push(part.text);
+      }
+    }
+  }
+
+  return texts;
+};
+
+const isClusteredContentLoop = (
+  content: string,
+  indices: readonly number[],
+): boolean => {
+  const firstIndex = indices.at(0);
+  const lastIndex = indices.at(-1);
+  if (firstIndex === undefined || lastIndex === undefined) {
+    return false;
+  }
+
+  const averageDistance = (lastIndex - firstIndex) / (indices.length - 1);
+  if (averageDistance > CONTENT_CHUNK_SIZE * 5) {
+    return false;
+  }
+
+  const periods = new Set<string>();
+  for (let index = 0; index < indices.length - 1; index += 1) {
+    const start = indices.at(index);
+    const end = indices.at(index + 1);
+    if (start === undefined || end === undefined) {
+      continue;
+    }
+    periods.add(content.slice(start, end));
+  }
+
+  return periods.size <= Math.floor(CONTENT_LOOP_THRESHOLD / 2);
+};
+
+const isStructuredMarkdownChunk = (chunk: string): boolean => {
+  if (chunk.includes("```")) {
+    return true;
+  }
+
+  for (const line of chunk.split("\n")) {
+    const trimmedLine = line.trimStart();
+    if (trimmedLine.startsWith("|")) {
+      return true;
+    }
+    if (isMarkdownRuleLine(trimmedLine.trim())) {
+      return true;
+    }
+    if (isMarkdownListItemLine(trimmedLine)) {
+      return true;
+    }
+    if (isMarkdownHeadingLine(trimmedLine)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isMarkdownRuleLine = (value: string): boolean => {
+  if (value.length < 3) {
+    return false;
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value.at(index);
+    const code = value.codePointAt(index);
+    if (
+      char !== "+" &&
+      char !== "-" &&
+      char !== "_" &&
+      char !== "=" &&
+      char !== "*" &&
+      (code === undefined ||
+        code < BOX_DRAWING_START_CODE_POINT ||
+        code > BOX_DRAWING_END_CODE_POINT)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isMarkdownListItemLine = (value: string): boolean => {
+  const first = value.at(0);
+  if (
+    (first === "*" || first === "+" || first === "-") &&
+    value.at(1) === " "
+  ) {
+    return true;
+  }
+
+  const dotIndex = value.indexOf(".");
+  if (dotIndex <= 0 || dotIndex > 4 || value.at(dotIndex + 1) !== " ") {
+    return false;
+  }
+
+  for (let index = 0; index < dotIndex; index += 1) {
+    const code = value.codePointAt(index);
+    if (
+      code === undefined ||
+      code < DIGIT_ZERO_CODE_POINT ||
+      code > DIGIT_NINE_CODE_POINT
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isMarkdownHeadingLine = (value: string): boolean => {
+  let headingMarks = 0;
+  while (value.at(headingMarks) === "#") {
+    headingMarks += 1;
+  }
+
+  return (
+    headingMarks >= 1 && headingMarks <= 6 && value.at(headingMarks) === " "
+  );
+};
+
+const isToolCallPart = (part: AssistantContentPart): part is ToolCallPart =>
+  part.type === "tool-call";
+
+const describeLoopDetection = (
+  detection: Exclude<ModelLoopDetection, { type: "none" }>,
+): string => {
+  if (detection.type === "tool-call-loop") {
+    return `${detection.repetitionCount} identical calls to ${detection.toolName}`;
+  }
+
+  return `${detection.repetitionCount} repeated assistant text chunks`;
+};
+
+const stableStringify = (value: unknown): string => {
+  if (value === undefined) {
+    return "undefined";
+  }
+  if (value === null || typeof value !== "object") {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized : "undefined";
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+
+  const serializedEntries: string[] = [];
+  for (const [key, entryValue] of Object.entries(value).sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    serializedEntries.push(
+      `${JSON.stringify(key)}:${stableStringify(entryValue)}`,
+    );
+  }
+
+  return `{${serializedEntries.join(",")}}`;
+};
+
+const hashString = (value: string): string =>
+  new Bun.CryptoHasher("sha256").update(value).digest("hex");

--- a/apps/api/src/handlers/chat/loop-detector.ts
+++ b/apps/api/src/handlers/chat/loop-detector.ts
@@ -28,13 +28,21 @@ type ToolCallPart = Extract<AssistantContentPart, { type: "tool-call" }>;
 
 type ToolCallLoopDetection = {
   repetitionCount: number;
+  signature: string;
   toolName: string;
   type: "tool-call-loop";
 };
 
 type ContentLoopDetection = {
   repetitionCount: number;
+  signature: string;
   type: "content-loop";
+};
+
+type ContentLoopCandidate = {
+  lastIndex: number;
+  repetitionCount: number;
+  signature: string;
 };
 
 export type ModelLoopDetection =
@@ -76,16 +84,34 @@ export const shouldStopLoopRecovery = (
   return detection.repetitionCount >= PERSISTENT_LOOP_REPETITION_LIMIT;
 };
 
-export const createLoopRecoveryMessage = (
-  detection: Exclude<ModelLoopDetection, { type: "none" }>,
-): ModelMessage => ({
-  role: "system",
-  content: [
-    "System: Potential loop detected.",
+export const shouldSurfaceFinalContentLoop = (
+  detection: ModelLoopDetection,
+): detection is ContentLoopDetection => detection.type === "content-loop";
+
+export const createLoopRecoverySystemPrompt = ({
+  baseSystem,
+  detection,
+}: {
+  baseSystem: string;
+  detection: Exclude<ModelLoopDetection, { type: "none" }>;
+}): string =>
+  [
+    baseSystem,
+    "",
+    "Potential loop detected.",
     `Signal: ${describeLoopDetection(detection)}.`,
     "Take a step back before continuing. Confirm what has changed, choose a different approach, or ask the user a focused clarification if you are blocked. Do not repeat the same tool call or response without new information.",
-  ].join("\n"),
-});
+  ].join("\n");
+
+export const getLoopRecoveryKey = (
+  detection: Exclude<ModelLoopDetection, { type: "none" }>,
+): string => {
+  if (detection.type === "tool-call-loop") {
+    return `${detection.type}:${detection.signature}:${detection.repetitionCount}`;
+  }
+
+  return `${detection.type}:${detection.signature}:${detection.repetitionCount}`;
+};
 
 const detectToolCallLoop = (
   messages: readonly ModelMessage[],
@@ -109,6 +135,7 @@ const detectToolCallLoop = (
 
   return {
     repetitionCount,
+    signature: latest.key,
     toolName: latest.toolName,
     type: "tool-call-loop",
   };
@@ -164,6 +191,7 @@ const detectContentLoop = (
   }
 
   const chunkIndices = new Map<string, number[]>();
+  let candidate: ContentLoopCandidate | null = null;
   for (
     let index = 0;
     index + CONTENT_CHUNK_SIZE <= assistantText.length;
@@ -182,18 +210,46 @@ const detectContentLoop = (
 
     indices.push(index);
     const recent = indices.slice(-CONTENT_LOOP_THRESHOLD);
+    const lastIndex = recent.at(-1);
     if (
+      lastIndex !== undefined &&
       recent.length >= CONTENT_LOOP_THRESHOLD &&
       isClusteredContentLoop(assistantText, recent)
     ) {
-      return {
+      const nextCandidate = {
+        lastIndex,
         repetitionCount: indices.length,
-        type: "content-loop",
+        signature: hashString(chunk),
       };
+      if (isPreferredContentLoopCandidate(candidate, nextCandidate)) {
+        candidate = nextCandidate;
+      }
     }
   }
 
-  return { type: "none" };
+  if (!candidate) {
+    return { type: "none" };
+  }
+
+  return {
+    repetitionCount: candidate.repetitionCount,
+    signature: candidate.signature,
+    type: "content-loop",
+  };
+};
+
+const isPreferredContentLoopCandidate = (
+  current: ContentLoopCandidate | null,
+  next: ContentLoopCandidate,
+): boolean => {
+  if (!current) {
+    return true;
+  }
+  if (next.lastIndex !== current.lastIndex) {
+    return next.lastIndex > current.lastIndex;
+  }
+
+  return next.repetitionCount > current.repetitionCount;
 };
 
 const collectAssistantText = (
@@ -349,16 +405,46 @@ const describeLoopDetection = (
   return `${detection.repetitionCount} repeated assistant text chunks`;
 };
 
-const stableStringify = (value: unknown): string => {
+const stableStringify = (
+  value: unknown,
+  seen = new WeakSet<object>(),
+): string => {
+  if (value === null) {
+    return "null";
+  }
+
+  if (
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string"
+  ) {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized : String(value);
+  }
+
+  if (typeof value === "bigint") {
+    return `${value.toString()}n`;
+  }
+
   if (value === undefined) {
     return "undefined";
   }
-  if (value === null || typeof value !== "object") {
-    const serialized = JSON.stringify(value);
-    return typeof serialized === "string" ? serialized : "undefined";
+
+  if (typeof value === "symbol") {
+    return value.toString();
   }
+
+  if (typeof value === "function") {
+    return `[function ${value.name || "anonymous"}]`;
+  }
+
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+
+  seen.add(value);
   if (Array.isArray(value)) {
-    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+    return `[${value.map((item) => stableStringify(item, seen)).join(",")}]`;
   }
 
   const serializedEntries: string[] = [];
@@ -366,7 +452,7 @@ const stableStringify = (value: unknown): string => {
     ([left], [right]) => left.localeCompare(right),
   )) {
     serializedEntries.push(
-      `${JSON.stringify(key)}:${stableStringify(entryValue)}`,
+      `${JSON.stringify(key)}:${stableStringify(entryValue, seen)}`,
     );
   }
 

--- a/apps/api/src/handlers/chat/loop-detector.ts
+++ b/apps/api/src/handlers/chat/loop-detector.ts
@@ -10,6 +10,7 @@ const codePointOf = (value: string): number => {
 
 const TOOL_CALL_LOOP_THRESHOLD = 5;
 const LOOP_RECOVERY_INTERVAL = 5;
+const PERSISTENT_LOOP_REPETITION_LIMIT = 15;
 const CONTENT_CHUNK_SIZE = 50;
 const CONTENT_LOOP_THRESHOLD = 10;
 const CONTENT_HISTORY_CHARS = 5000;
@@ -65,6 +66,16 @@ export const shouldInjectLoopRecovery = (
   return detection.repetitionCount % LOOP_RECOVERY_INTERVAL === 0;
 };
 
+export const shouldStopLoopRecovery = (
+  detection: ModelLoopDetection,
+): detection is Exclude<ModelLoopDetection, { type: "none" }> => {
+  if (detection.type === "none") {
+    return false;
+  }
+
+  return detection.repetitionCount >= PERSISTENT_LOOP_REPETITION_LIMIT;
+};
+
 export const createLoopRecoveryMessage = (
   detection: Exclude<ModelLoopDetection, { type: "none" }>,
 ): ModelMessage => ({
@@ -86,12 +97,10 @@ const detectToolCallLoop = (
   }
 
   let repetitionCount = 0;
-  for (let index = signatures.length - 1; index >= 0; index -= 1) {
-    const signature = signatures.at(index);
-    if (!signature || signature.key !== latest.key) {
-      break;
+  for (const signature of signatures) {
+    if (signature.key === latest.key) {
+      repetitionCount += 1;
     }
-    repetitionCount += 1;
   }
 
   if (repetitionCount < TOOL_CALL_LOOP_THRESHOLD) {
@@ -154,7 +163,7 @@ const detectContentLoop = (
     return { type: "none" };
   }
 
-  const chunkIndicesByHash = new Map<string, number[]>();
+  const chunkIndices = new Map<string, number[]>();
   for (
     let index = 0;
     index + CONTENT_CHUNK_SIZE <= assistantText.length;
@@ -165,10 +174,9 @@ const detectContentLoop = (
       continue;
     }
 
-    const chunkHash = hashString(chunk);
-    const indices = chunkIndicesByHash.get(chunkHash);
+    const indices = chunkIndices.get(chunk);
     if (!indices) {
-      chunkIndicesByHash.set(chunkHash, [index]);
+      chunkIndices.set(chunk, [index]);
       continue;
     }
 

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -24,6 +24,11 @@ import type { ChatSendMode } from "@stll/anonymize-chat";
 import type { SafeDb, SafeDbError } from "@/api/db";
 import { getUserFileIdFromPart } from "@/api/handlers/chat/attachment-validation";
 import { compactModelMessagesForModel } from "@/api/handlers/chat/compaction";
+import {
+  createLoopRecoveryMessage,
+  detectModelLoop,
+  shouldInjectLoopRecovery,
+} from "@/api/handlers/chat/loop-detector";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import {
   deanonymizeFromBoundary,
@@ -52,7 +57,7 @@ import {
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
 
-const MAX_TOOL_STEPS = 8;
+const MAX_TOOL_STEPS = 100;
 const CHAT_TOOL_ERROR_UNWRAP_DEPTH = 8;
 
 const unwrapChatToolError = (error: unknown): ChatToolError | null => {
@@ -177,9 +182,13 @@ const runChatStream = async ({
     experimental_repairToolCall: async ({ toolCall }) =>
       await Promise.resolve(repairActiveDocxEditToolCall(toolCall)),
     prepareStep: async ({ messages }) => {
+      const loopDetection = detectModelLoop(messages);
+      const messagesWithLoopRecovery = shouldInjectLoopRecovery(loopDetection)
+        ? [...messages, createLoopRecoveryMessage(loopDetection)]
+        : messages;
       const compactedMessages = await compactModelMessagesForModel({
         abortSignal,
-        messages,
+        messages: messagesWithLoopRecovery,
         model,
         onSummaryError: (error) => {
           captureError(error, {

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -28,6 +28,7 @@ import {
   createLoopRecoveryMessage,
   detectModelLoop,
   shouldInjectLoopRecovery,
+  shouldStopLoopRecovery,
 } from "@/api/handlers/chat/loop-detector";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
 import {
@@ -183,6 +184,14 @@ const runChatStream = async ({
       await Promise.resolve(repairActiveDocxEditToolCall(toolCall)),
     prepareStep: async ({ messages }) => {
       const loopDetection = detectModelLoop(messages);
+      if (shouldStopLoopRecovery(loopDetection)) {
+        throw new HandlerError({
+          status: 502,
+          message:
+            "The AI model is repeating itself and could not recover. Please try again with a narrower request.",
+        });
+      }
+
       const messagesWithLoopRecovery = shouldInjectLoopRecovery(loopDetection)
         ? [...messages, createLoopRecoveryMessage(loopDetection)]
         : messages;

--- a/apps/api/src/handlers/chat/stream-chat.ts
+++ b/apps/api/src/handlers/chat/stream-chat.ts
@@ -25,9 +25,11 @@ import type { SafeDb, SafeDbError } from "@/api/db";
 import { getUserFileIdFromPart } from "@/api/handlers/chat/attachment-validation";
 import { compactModelMessagesForModel } from "@/api/handlers/chat/compaction";
 import {
-  createLoopRecoveryMessage,
+  createLoopRecoverySystemPrompt,
   detectModelLoop,
+  getLoopRecoveryKey,
   shouldInjectLoopRecovery,
+  shouldSurfaceFinalContentLoop,
   shouldStopLoopRecovery,
 } from "@/api/handlers/chat/loop-detector";
 import type { ChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
@@ -54,6 +56,7 @@ import { captureError } from "@/api/lib/analytics";
 import type { SafeId } from "@/api/lib/branded-types";
 import {
   ChatEmptyCompletionError,
+  ChatLoopDetectedError,
   ChatToolError,
   HandlerError,
 } from "@/api/lib/errors/tagged-errors";
@@ -171,6 +174,8 @@ const runChatStream = async ({
   onAiError,
 }: RunChatStreamArgs): Promise<boolean> => {
   let emptyCompletion: ChatEmptyCompletionError | null = null;
+  let finalLoopDetection: ChatLoopDetectedError | null = null;
+  let lastLoopRecoveryKey: string | null = null;
   let flushResolve: (() => void) | null = null;
   const flushed = new Promise<void>((resolve) => {
     flushResolve = resolve;
@@ -185,19 +190,27 @@ const runChatStream = async ({
     prepareStep: async ({ messages }) => {
       const loopDetection = detectModelLoop(messages);
       if (shouldStopLoopRecovery(loopDetection)) {
-        throw new HandlerError({
-          status: 502,
+        throw new ChatLoopDetectedError({
           message:
-            "The AI model is repeating itself and could not recover. Please try again with a narrower request.",
+            "The AI model repeated the same work and could not recover. Please try again with a narrower request.",
         });
       }
 
-      const messagesWithLoopRecovery = shouldInjectLoopRecovery(loopDetection)
-        ? [...messages, createLoopRecoveryMessage(loopDetection)]
-        : messages;
+      let nextSystem = system;
+      if (shouldInjectLoopRecovery(loopDetection)) {
+        const recoveryKey = getLoopRecoveryKey(loopDetection);
+        if (recoveryKey !== lastLoopRecoveryKey) {
+          lastLoopRecoveryKey = recoveryKey;
+          nextSystem = createLoopRecoverySystemPrompt({
+            baseSystem: system,
+            detection: loopDetection,
+          });
+        }
+      }
+
       const compactedMessages = await compactModelMessagesForModel({
         abortSignal,
-        messages: messagesWithLoopRecovery,
+        messages,
         model,
         onSummaryError: (error) => {
           captureError(error, {
@@ -211,14 +224,32 @@ const runChatStream = async ({
       if (Result.isError(compactedMessages)) {
         throw compactedMessages.error;
       }
-      if (compactedMessages.value === messages) {
+      if (compactedMessages.value === messages && nextSystem === system) {
         return undefined;
       }
 
-      return { messages: compactedMessages.value };
+      return {
+        messages: compactedMessages.value,
+        system: nextSystem,
+      };
     },
     stopWhen: [stepCountIs(MAX_TOOL_STEPS), hasToolCall("ask-user")],
     messages: modelMessages,
+    onStepFinish: ({ response, toolCalls }) => {
+      if (toolCalls.length > 0) {
+        return;
+      }
+
+      const loopDetection = detectModelLoop(response.messages);
+      if (!shouldSurfaceFinalContentLoop(loopDetection)) {
+        return;
+      }
+
+      finalLoopDetection = new ChatLoopDetectedError({
+        message:
+          "The AI model repeated the same work and could not recover. Please try again with a narrower request.",
+      });
+    },
     onFinish: ({ finishReason, totalUsage }) => {
       // `outputTokens` is `number | undefined` — only fire when
       // explicitly zero, otherwise providers that omit usage
@@ -265,6 +296,12 @@ const runChatStream = async ({
         controller.enqueue(chunk);
       },
       flush(controller) {
+        if (finalLoopDetection) {
+          controller.enqueue({
+            type: "error",
+            errorText: onAiError(finalLoopDetection),
+          });
+        }
         if (emptyCompletion && emitErrorOnEmpty) {
           controller.enqueue({
             type: "error",

--- a/apps/api/src/lib/ai-error.test.ts
+++ b/apps/api/src/lib/ai-error.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { classifyAIError } from "@/api/lib/ai-error";
+import { ChatLoopDetectedError } from "@/api/lib/errors/tagged-errors";
+
+describe("classifyAIError", () => {
+  test("maps chat loop stops to a stable stream error kind", () => {
+    const error = new ChatLoopDetectedError({
+      message:
+        "The AI model repeated the same work and could not recover. Please try again with a narrower request.",
+    });
+
+    expect(classifyAIError(error)).toBe("loop_detected");
+  });
+
+  test("finds chat loop stops through wrapped causes", () => {
+    const error = new Error("stream failed", {
+      cause: new ChatLoopDetectedError({
+        message:
+          "The AI model repeated the same work and could not recover. Please try again with a narrower request.",
+      }),
+    });
+
+    expect(classifyAIError(error)).toBe("loop_detected");
+  });
+});

--- a/apps/api/src/lib/ai-error.ts
+++ b/apps/api/src/lib/ai-error.ts
@@ -8,13 +8,17 @@
  */
 import { APICallError, RetryError } from "ai";
 
-import { HandlerError } from "@/api/lib/errors/tagged-errors";
+import {
+  ChatLoopDetectedError,
+  HandlerError,
+} from "@/api/lib/errors/tagged-errors";
 import type { HandlerErrorStatusCode } from "@/api/lib/errors/tagged-errors";
 
 export const AI_ERROR_KINDS = [
   "quota_exhausted",
   "insufficient_credits",
   "provider_unavailable",
+  "loop_detected",
   "unknown",
 ] as const;
 
@@ -23,6 +27,9 @@ export type AIErrorKind = (typeof AI_ERROR_KINDS)[number];
 export const classifyAIError = (error: unknown): AIErrorKind => {
   if (RetryError.isInstance(error)) {
     return classifyAIError(error.lastError);
+  }
+  if (ChatLoopDetectedError.is(error)) {
+    return "loop_detected";
   }
   if (APICallError.isInstance(error)) {
     if (error.statusCode === 429) {
@@ -89,6 +96,13 @@ export const aiHandlerError = (
         status: 502,
         message:
           "The AI provider is temporarily unavailable. Please try again in a moment.",
+        cause: error,
+      });
+    case "loop_detected":
+      return new HandlerError({
+        status: 502,
+        message:
+          "The AI model repeated the same work and could not recover. Please try again with a narrower request.",
         cause: error,
       });
     case "unknown":

--- a/apps/api/src/lib/errors/tagged-errors.ts
+++ b/apps/api/src/lib/errors/tagged-errors.ts
@@ -117,6 +117,13 @@ export class ChatEmptyCompletionError extends TaggedError(
   message: string;
 }>() {}
 
+/** Chat agent looped past the recovery budget. */
+export class ChatLoopDetectedError extends TaggedError(
+  "ChatLoopDetectedError",
+)<{
+  message: string;
+}>() {}
+
 /** Sandbox execution failure: transpile, runtime, limit, or marshalling. */
 export class SandboxError extends TaggedError("SandboxError")<{
   reason:

--- a/apps/web/src/components/chat/chat-thread-messages.tsx
+++ b/apps/web/src/components/chat/chat-thread-messages.tsx
@@ -243,6 +243,7 @@ const ThinkingIndicator = () => {
 // copy.
 const CHAT_ERROR_TRANSLATION_KEYS = {
   insufficient_credits: "chat.sendErrorInsufficientCredits",
+  loop_detected: "chat.sendErrorLoopDetected",
   provider_unavailable: "chat.sendErrorProviderUnavailable",
   quota_exhausted: "chat.sendErrorQuotaExhausted",
 } as const satisfies Record<string, TranslationKey>;

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -475,6 +475,7 @@
     "sendError": "Při odesílání zprávy došlo k problému. Pokud chyba přetrvává, kontaktujte podporu.",
     "sendErrorAnonymizationBlocked": "stella nedokázala anonymizovat jednu přílohu, takže se nic neodeslalo. Odeberte soubor, nebo odešlete zprávu bez anonymizace.",
     "sendErrorInsufficientCredits": "AI poskytovatel potřebuje doplnit kredity. Požádejte správce pracovního prostoru o navýšení zůstatku.",
+    "sendErrorLoopDetected": "Odpověď AI se příliš opakovala. Zkuste to znovu s užším požadavkem.",
     "sendErrorProviderUnavailable": "AI poskytovatel je dočasně nedostupný. Zkuste to prosím za chvíli znovu.",
     "sendErrorQuotaExhausted": "Kvóta AI poskytovatele je vyčerpaná. Zkuste to za chvíli znovu nebo požádejte správce pracovního prostoru o navýšení plánu.",
     "sendPrompt": "Odeslat zprávu",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -475,6 +475,7 @@
     "sendError": "Beim Senden deiner Nachricht ist ein Problem aufgetreten. Wende dich an den Support, wenn der Fehler weiterhin auftritt.",
     "sendErrorAnonymizationBlocked": "stella konnte einen Anhang nicht anonymisieren, daher wurde nichts gesendet. Entferne die Datei oder sende diese Nachricht ohne Anonymisierung.",
     "sendErrorInsufficientCredits": "Der KI-Provider benötigt mehr Guthaben. Bitte deinen Workspace-Admin, das Konto aufzuladen.",
+    "sendErrorLoopDetected": "Die KI-Antwort hat sich zu oft wiederholt. Versuche es mit einer enger gefassten Anfrage erneut.",
     "sendErrorProviderUnavailable": "Der KI-Provider ist vorübergehend nicht verfügbar. Bitte versuche es gleich noch einmal.",
     "sendErrorQuotaExhausted": "Das Kontingent des KI-Providers ist aufgebraucht. Versuche es gleich noch einmal oder bitte deinen Workspace-Admin, das Paket zu erweitern.",
     "sendPrompt": "Nachricht senden",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -475,6 +475,7 @@
     "sendError": "There was an issue sending your message. Contact support if the error persists.",
     "sendErrorAnonymizationBlocked": "stella could not anonymize one attachment, so nothing was sent. Remove the file or send this message without anonymization.",
     "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.",
+    "sendErrorLoopDetected": "The AI response repeated too many times. Try again with a narrower request.",
     "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.",
     "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.",
     "sendPrompt": "Send message",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -475,6 +475,7 @@
     "sendError": "Hubo un problema al enviar tu mensaje. Contacta con soporte si el error persiste.",
     "sendErrorAnonymizationBlocked": "stella no pudo anonimizar un archivo adjunto, así que no se envió nada. Quita el archivo o envía este mensaje sin anonimización.",
     "sendErrorInsufficientCredits": "El proveedor de IA necesita más créditos. Pídele al administrador del espacio de trabajo que recargue la cuenta.",
+    "sendErrorLoopDetected": "La respuesta de IA se repitió demasiadas veces. Inténtalo de nuevo con una solicitud más concreta.",
     "sendErrorProviderUnavailable": "El proveedor de IA no está disponible temporalmente. Inténtalo de nuevo en un momento.",
     "sendErrorQuotaExhausted": "Se ha agotado la cuota del proveedor de IA. Inténtalo de nuevo en un minuto o pídele al administrador del espacio de trabajo que mejore el plan.",
     "sendPrompt": "Enviar mensaje",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -475,6 +475,7 @@
     "sendError": "Sõnumi saatmisel tekkis probleem. Kui viga püsib, võta ühendust toega.",
     "sendErrorAnonymizationBlocked": "stella ei saanud üht manust anonüümida, seega midagi ei saadetud. Eemalda fail või saada see sõnum anonüümimiseta.",
     "sendErrorInsufficientCredits": "AI-teenusepakkujal on vaja rohkem krediiti. Palu töökoha administraatoril kontot täiendada.",
+    "sendErrorLoopDetected": "AI vastus kordus liiga palju. Proovi uuesti kitsama päringuga.",
     "sendErrorProviderUnavailable": "AI-teenusepakkuja pole hetkel saadaval. Proovi hetke pärast uuesti.",
     "sendErrorQuotaExhausted": "AI-teenusepakkuja kvoot on otsas. Proovi minuti pärast uuesti või palu töökoha administraatoril paketti uuendada.",
     "sendPrompt": "Saada sõnum",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -475,6 +475,7 @@
     "sendError": "Un problème est survenu lors de l’envoi de ton message. Contacte le support si l’erreur persiste.",
     "sendErrorAnonymizationBlocked": "stella n’a pas pu anonymiser une pièce jointe, donc rien n’a été envoyé. Retire le fichier ou envoie ce message sans anonymisation.",
     "sendErrorInsufficientCredits": "Le fournisseur d’IA a besoin de crédits supplémentaires. Demande à l’administrateur de l’espace de travail de recharger le compte.",
+    "sendErrorLoopDetected": "La réponse de l’IA s’est trop répétée. Réessaie avec une demande plus ciblée.",
     "sendErrorProviderUnavailable": "Le fournisseur d’IA est temporairement indisponible. Réessaie dans un instant.",
     "sendErrorQuotaExhausted": "Le quota du fournisseur d’IA est épuisé. Réessaie dans une minute, ou demande à l’administrateur de l’espace de travail de passer à un plan supérieur.",
     "sendPrompt": "Envoyer le message",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -475,6 +475,7 @@
     "sendError": "Probléma történt az üzenet elküldésekor. Ha a hiba továbbra is fennáll, vedd fel a kapcsolatot a támogatással.",
     "sendErrorAnonymizationBlocked": "A stella nem tudta anonimizálni az egyik mellékletet, ezért semmi sem lett elküldve. Távolítsd el a fájlt, vagy küldd el az üzenetet anonimizálás nélkül.",
     "sendErrorInsufficientCredits": "Az AI-szolgáltatónak további kreditre van szüksége. Kérd a munkaterület adminisztrátorát, hogy töltse fel a fiókot.",
+    "sendErrorLoopDetected": "Az AI-válasz túl sokszor ismétlődött. Próbáld újra szűkebb kéréssel.",
     "sendErrorProviderUnavailable": "Az AI-szolgáltató átmenetileg nem elérhető. Próbáld újra egy pillanat múlva.",
     "sendErrorQuotaExhausted": "Az AI-szolgáltató kvótája kimerült. Próbáld újra egy perc múlva, vagy kérd a munkaterület adminisztrátorát, hogy bővítse a csomagot.",
     "sendPrompt": "Üzenet küldése",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -475,6 +475,7 @@
     "sendError": "Siunčiant žinutę kilo problema. Jei klaida kartojasi, susisiekite su palaikymo komanda.",
     "sendErrorAnonymizationBlocked": "stella nepavyko anonimizuoti vieno priedo, todėl niekas nebuvo išsiųsta. Pašalinkite failą arba siųskite šią žinutę be anonimizavimo.",
     "sendErrorInsufficientCredits": "AI teikėjui reikia daugiau kreditų. Paprašykite darbo srities administratoriaus papildyti sąskaitą.",
+    "sendErrorLoopDetected": "AI atsakymas kartojosi per daug kartų. Bandykite dar kartą su siauresne užklausa.",
     "sendErrorProviderUnavailable": "AI teikėjas laikinai nepasiekiamas. Pabandykite po akimirkos dar kartą.",
     "sendErrorQuotaExhausted": "AI teikėjo kvota išnaudota. Pabandykite po minutės dar kartą arba paprašykite darbo srities administratoriaus atnaujinti planą.",
     "sendPrompt": "Siųsti pranešimą",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -475,6 +475,7 @@
     "sendError": "Nosūtot ziņu, radās problēma. Ja kļūda nepazūd, sazinieties ar atbalsta dienestu.",
     "sendErrorAnonymizationBlocked": "stella nevarēja anonimizēt vienu pielikumu, tāpēc nekas netika nosūtīts. Noņemiet failu vai nosūtiet šo ziņu bez anonimizācijas.",
     "sendErrorInsufficientCredits": "AI pakalpojumu sniedzējam ir vajadzīgi papildu kredīti. Sazinieties ar darba telpas administratoru, lai papildinātu kontu.",
+    "sendErrorLoopDetected": "AI atbilde atkārtojās pārāk daudz reižu. Mēģiniet vēlreiz ar šaurāku pieprasījumu.",
     "sendErrorProviderUnavailable": "AI pakalpojumu sniedzējs uz laiku nav pieejams. Mēģiniet vēlreiz pēc brīža.",
     "sendErrorQuotaExhausted": "AI pakalpojumu sniedzēja kvota ir izsmelta. Mēģiniet vēlreiz pēc minūtes vai sazinieties ar darba telpas administratoru, lai uzlabotu plānu.",
     "sendPrompt": "Sūtīt ziņojumu",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -478,6 +478,7 @@ type Messages = {
     "sendError": "There was an issue sending your message. Contact support if the error persists.";
     "sendErrorAnonymizationBlocked": "stella could not anonymize one attachment, so nothing was sent. Remove the file or send this message without anonymization.";
     "sendErrorInsufficientCredits": "The AI provider needs more credits. Contact your workspace admin to top up the account.";
+    "sendErrorLoopDetected": "The AI response repeated too many times. Try again with a narrower request.";
     "sendErrorProviderUnavailable": "The AI provider is temporarily unavailable. Please try again in a moment.";
     "sendErrorQuotaExhausted": "The AI provider's quota is exhausted. Try again in a minute, or contact your workspace admin to upgrade the plan.";
     "sendPrompt": "Send message";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -475,6 +475,7 @@
     "sendError": "Wystąpił problem podczas wysyłania wiadomości. Jeśli błąd będzie się powtarzał, skontaktuj się z pomocą techniczną.",
     "sendErrorAnonymizationBlocked": "stella nie mogła zanonimizować jednego załącznika, więc nic nie wysłano. Usuń plik albo wyślij tę wiadomość bez anonimizacji.",
     "sendErrorInsufficientCredits": "Dostawca AI potrzebuje więcej środków. Poproś administratora obszaru roboczego o doładowanie konta.",
+    "sendErrorLoopDetected": "Odpowiedź AI powtórzyła się zbyt wiele razy. Spróbuj ponownie z węższą prośbą.",
     "sendErrorProviderUnavailable": "Dostawca AI jest tymczasowo niedostępny. Spróbuj ponownie za chwilę.",
     "sendErrorQuotaExhausted": "Limit dostawcy AI został wyczerpany. Spróbuj za chwilę ponownie lub poproś administratora obszaru roboczego o ulepszenie planu.",
     "sendPrompt": "Wyślij wiadomość",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -475,6 +475,7 @@
     "sendError": "Ocorreu um problema ao enviar sua mensagem. Entre em contato com o suporte se o erro persistir.",
     "sendErrorAnonymizationBlocked": "A stella não conseguiu anonimizar um anexo, então nada foi enviado. Remova o arquivo ou envie esta mensagem sem anonimização.",
     "sendErrorInsufficientCredits": "O provedor de IA precisa de mais créditos. Peça ao administrador do espaço de trabalho para recarregar a conta.",
+    "sendErrorLoopDetected": "A resposta da IA se repetiu muitas vezes. Tente novamente com uma solicitação mais específica.",
     "sendErrorProviderUnavailable": "O provedor de IA está temporariamente indisponível. Tente novamente em instantes.",
     "sendErrorQuotaExhausted": "A cota do provedor de IA foi esgotada. Tente novamente em um minuto ou peça ao administrador do espaço de trabalho para atualizar o plano.",
     "sendPrompt": "Enviar mensagem",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -475,6 +475,7 @@
     "sendError": "Pri odosielaní správy nastal problém. Ak chyba pretrváva, kontaktujte podporu.",
     "sendErrorAnonymizationBlocked": "stella nedokázala anonymizovať jednu prílohu, takže sa nič neodoslalo. Odstráňte súbor alebo odošlite správu bez anonymizácie.",
     "sendErrorInsufficientCredits": "AI poskytovateľ potrebuje doplniť kredity. Požiadajte správcu pracovného priestoru o navýšenie zostatku.",
+    "sendErrorLoopDetected": "Odpoveď AI sa príliš opakovala. Skúste to znova s užšou požiadavkou.",
     "sendErrorProviderUnavailable": "AI poskytovateľ je dočasne nedostupný. Skúste to prosím o chvíľu znova.",
     "sendErrorQuotaExhausted": "Kvóta AI poskytovateľa je vyčerpaná. Skúste to o chvíľu znova alebo požiadajte správcu pracovného priestoru o navýšenie plánu.",
     "sendPrompt": "Odoslať správu",


### PR DESCRIPTION
## Summary
- add hash-based detection for repeated assistant tool calls and repeated assistant text chunks
- inject a concise recovery system message when a loop signature recurs
- raise the chat tool-step emergency cap from 8 to 100

Stacked on #570.

## Validation
- `bun run lint`
- `bun run format`
- `bun run typecheck`
- `bun run test`
- targeted security pass for secrets and recovery-message leakage