### PR TITLE
fix: improve Folio DOCX rendering fidelity

### DIFF
--- a/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
+++ b/apps/api/src/handlers/chat/tools/execute/sandbox/run-sandbox.test.ts
@@ -570,6 +570,7 @@ describe("runSandbox", () => {
   });
 
   it("serializes runs for the same concurrency key", async () => {
+    const concurrencyKey = nextSandboxConcurrencyKey();
     const startedLabels: string[] = [];
     const holds = new Map<string, DeferredPromise>();
     const hold = createToolFunction(
@@ -592,7 +593,7 @@ describe("runSandbox", () => {
     const firstPromise = runSandbox({
       source: `return await read.hold({ label: "first" });`,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
     });
     await waitForCondition({
       condition: () => startedLabels.length === 1,
@@ -601,7 +602,7 @@ describe("runSandbox", () => {
     const secondPromise = runSandbox({
       source: `return await read.hold({ label: "second" });`,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
     });
 
     await new Promise<void>((resolve) => {
@@ -623,6 +624,7 @@ describe("runSandbox", () => {
   });
 
   it("allows different concurrency keys to run concurrently up to the global cap", async () => {
+    const concurrencyKeyPrefix = nextSandboxConcurrencyKey();
     const startedLabels: string[] = [];
     const holds = new Map<string, DeferredPromise>();
     const hold = createToolFunction(
@@ -647,7 +649,7 @@ describe("runSandbox", () => {
         await runSandbox({
           source: `return await read.hold({ label: "${label}" });`,
           registry,
-          concurrencyKey: `user-${label}`,
+          concurrencyKey: `${concurrencyKeyPrefix}-${label}`,
         }),
     );
 
@@ -665,6 +667,7 @@ describe("runSandbox", () => {
   });
 
   it("queues a fifth distinct key until a global slot opens", async () => {
+    const concurrencyKeyPrefix = nextSandboxConcurrencyKey();
     const startedLabels: string[] = [];
     const holds = new Map<string, DeferredPromise>();
     const hold = createToolFunction(
@@ -689,7 +692,7 @@ describe("runSandbox", () => {
         await runSandbox({
           source: `return await read.hold({ label: "${label}" });`,
           registry,
-          concurrencyKey: `user-${label}`,
+          concurrencyKey: `${concurrencyKeyPrefix}-${label}`,
         }),
     );
 
@@ -714,6 +717,7 @@ describe("runSandbox", () => {
   });
 
   it("does not count queue wait time against maxDurationMs", async () => {
+    const concurrencyKey = nextSandboxConcurrencyKey();
     const holds = new Map<string, DeferredPromise>();
     const hold = createToolFunction(
       {
@@ -734,7 +738,7 @@ describe("runSandbox", () => {
     const firstPromise = runSandbox({
       source: `return await read.hold({ label: "first" });`,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
       limits: { maxDurationMs: 2000 },
     });
     await waitForCondition({
@@ -744,7 +748,7 @@ describe("runSandbox", () => {
     const secondPromise = runSandbox({
       source: `return 42;`,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
       limits: { maxDurationMs: 1000 },
     });
 
@@ -763,10 +767,11 @@ describe("runSandbox", () => {
   });
 
   it("releases keyed and global slots after a timeout", async () => {
+    const concurrencyKey = nextSandboxConcurrencyKey();
     const firstPromise = runSandbox({
       source: `await read.slow({ ms: 150 }); return "late";`,
       registry: baseRegistry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
       limits: { maxDurationMs: 50 },
     });
 
@@ -777,7 +782,7 @@ describe("runSandbox", () => {
     const secondPromise = runSandbox({
       source: `return 42;`,
       registry: baseRegistry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
     });
 
     const [first, second] = await Promise.all([firstPromise, secondPromise]);
@@ -792,6 +797,7 @@ describe("runSandbox", () => {
   });
 
   it("releases keyed and global slots after a runtime failure", async () => {
+    const concurrencyKey = nextSandboxConcurrencyKey();
     const holds = new Map<string, DeferredPromise>();
     const hold = createToolFunction(
       {
@@ -815,7 +821,7 @@ describe("runSandbox", () => {
         throw new Error("boom");
       `,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
     });
     await waitForCondition({
       condition: () => holds.has("first"),
@@ -824,7 +830,7 @@ describe("runSandbox", () => {
     const secondPromise = runSandbox({
       source: `return 42;`,
       registry,
-      concurrencyKey: "user-a",
+      concurrencyKey,
     });
 
     holds.get("first")?.resolve();

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -65,6 +65,7 @@ function createLargeDocument(paragraphCount: number): FolioDocument {
 
 export function App() {
   const editorRef = useRef<DocxEditorRef>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [currentDocument, setCurrentDocument] = useState<FolioDocument | null>(
     null,
   );
@@ -120,6 +121,7 @@ export function App() {
 
   const handleFileSelect = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const input = event.currentTarget;
       const file = event.target.files?.[0];
       if (!file) {
         return;
@@ -130,13 +132,26 @@ export function App() {
         setCurrentDocument(null);
         setDocumentBuffer(buffer);
         setFileName(file.name);
-        setStatus("");
+        setStatus(`Loaded ${file.name}`);
       } catch {
         setStatus("Error loading file");
+      } finally {
+        input.value = "";
       }
     },
     [],
   );
+
+  const handleOpenDocument = useCallback(() => {
+    const input = fileInputRef.current;
+    if (!input) {
+      setStatus("File picker unavailable");
+      return;
+    }
+
+    input.value = "";
+    input.click();
+  }, []);
 
   const handleSave = useCallback(async () => {
     if (!editorRef.current) {
@@ -243,16 +258,11 @@ export function App() {
 
         <Separator orientation="vertical" className="h-5" />
 
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() =>
-            document.querySelector<HTMLInputElement>("#file-input")?.click()
-          }
-        >
+        <Button variant="ghost" size="sm" onClick={handleOpenDocument}>
           Open
         </Button>
         <input
+          ref={fileInputRef}
           aria-label="Open .docx file"
           id="file-input"
           type="file"

--- a/packages/folio/src/core/__tests__/footnoteOverflow.integration.test.ts
+++ b/packages/folio/src/core/__tests__/footnoteOverflow.integration.test.ts
@@ -131,7 +131,7 @@ const basePage: Page = {
 // Painter constants mirrored in `calculateFootnoteAreaRenderHeight`. Kept
 // local to the test so a drift between painter/helper fails here before it
 // fails in production. See `renderPage.ts` for the source values.
-const PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
+const PAINTER_FOOTNOTE_ENTRY_MARGIN_BOTTOM = 0;
 const PAINTER_FOOTNOTE_FALLBACK_LINE_HEIGHT = 13;
 
 describe("calculateFootnoteAreaRenderHeight", () => {
@@ -141,7 +141,7 @@ describe("calculateFootnoteAreaRenderHeight", () => {
     );
   });
 
-  test("sums each footnote content height plus per-entry margin and a single separator", () => {
+  test("sums each footnote content height plus any wrapper margin and a single separator", () => {
     const footnotes: FootnoteRenderItem[] = [
       makeParagraphFootnote(20),
       makeParagraphFootnote(35),
@@ -236,10 +236,10 @@ describe("renderFootnoteArea overflow clamp", () => {
 });
 
 describe("footnote separator height parity", () => {
-  test("painter render height covers paginator reservation plus per-entry margin for 1, 3, and 10 footnotes", () => {
-    // Paginator reserves separator + sum(content). Painter additionally
-    // draws a `marginBottom` between entries, so the clamp helper must
-    // exceed the paginator reservation by exactly `count * margin`.
+  test("painter render height matches paginator reservation for 1, 3, and 10 footnotes", () => {
+    // Paginator reserves separator + sum(content) + any wrapper margin. The
+    // wrapper margin is zero for Word-like footnote spacing, but keep the
+    // parity assertion so a future nonzero value stays accounted for.
     for (const count of [1, 3, 10]) {
       const heights = Array.from({ length: count }, (_, index) => 10 + index);
       const footnotes = heights.map(makeParagraphFootnote);

--- a/packages/folio/src/core/__tests__/layout-pipeline.integration.test.ts
+++ b/packages/folio/src/core/__tests__/layout-pipeline.integration.test.ts
@@ -905,6 +905,34 @@ describe("Section Breaks", () => {
     expect(layout.pages[1].fragments.some((f) => f.blockId === 2)).toBe(true);
   });
 
+  test("coalesced blank section page gets the next section header and footer refs", () => {
+    const blocks: FlowBlock[] = [
+      { kind: "sectionBreak", id: 1, type: "nextPage" },
+      makeParagraphBlock(2, "After section", 18),
+    ];
+    const measures: Measure[] = [
+      { kind: "sectionBreak" },
+      makeParagraphMeasure([makeLine(0, 0, 0, 13, 110, 24)]),
+    ];
+
+    const layout = layoutDocument(
+      blocks,
+      measures,
+      makeLayoutOptions({
+        sectionHeaderFooterRefs: [
+          { footerDefault: "previous-footer" },
+          { footerDefault: "next-footer" },
+        ],
+      }),
+    );
+
+    expect(layout.pages.length).toBe(1);
+    expect(layout.pages[0].sectionIndex).toBe(1);
+    expect(layout.pages[0].sectionPageNumber).toBe(1);
+    expect(layout.pages[0].headerFooterRefs?.footerDefault).toBe("next-footer");
+    expect(layout.pages[0].fragments.some((f) => f.blockId === 2)).toBe(true);
+  });
+
   test("continuous section break does not force new page", () => {
     const blocks: FlowBlock[] = [
       makeParagraphBlock(0, "Before section", 1),

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -295,4 +295,70 @@ describe("footnote layout", () => {
     expect(paragraph.runs.at(0)?.fontSize).toBe(8);
     expect(paragraph.runs.at(1)?.fontSize).toBe(8);
   });
+
+  test("matches footnote number typography to the first footnote text run", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "footnote-text",
+        runs: [
+          {
+            kind: "text",
+            text: " Insert the name of the legal entity.",
+            fontFamily: "Times New Roman",
+            fontSize: 10,
+          },
+        ],
+        attrs: {
+          defaultFontFamily: "Times New Roman",
+          defaultFontSize: 10,
+        },
+      },
+    ];
+
+    const paragraph = applyFootnotePresentation(blocks, 8).at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected a paragraph block");
+    }
+
+    expect(paragraph.runs.at(0)).toMatchObject({
+      kind: "text",
+      text: "8",
+      fontFamily: "Times New Roman",
+      fontSize: 10,
+      superscript: true,
+    });
+  });
+
+  test("adds one separator space when footnote text has no leading space", () => {
+    const blocks: FlowBlock[] = [
+      {
+        kind: "paragraph",
+        id: "footnote-text",
+        runs: [
+          {
+            kind: "text",
+            text: "Footnote text",
+            fontFamily: "Times New Roman",
+            fontSize: 10,
+          },
+        ],
+      },
+    ];
+
+    const paragraph = applyFootnotePresentation(blocks, 8).at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected a paragraph block");
+    }
+
+    expect(paragraph.runs.at(0)).toMatchObject({
+      kind: "text",
+      text: "8 ",
+      fontFamily: "Times New Roman",
+      fontSize: 10,
+      superscript: true,
+    });
+  });
 });

--- a/packages/folio/src/core/layout-bridge/footnoteLayout.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout.ts
@@ -438,15 +438,9 @@ export function applyFootnotePresentation(
 
   const first = output[0];
   if (first?.kind === "paragraph") {
-    const numberRun: TextRun = {
-      kind: "text",
-      text: `${displayNumber}  `,
-      fontSize: FOOTNOTE_FONT_SIZE,
-      superscript: true,
-    };
     output[0] = {
       ...first,
-      runs: [numberRun, ...first.runs],
+      runs: [createFootnoteNumberRun(displayNumber, first), ...first.runs],
     };
   } else {
     output.unshift({
@@ -464,6 +458,34 @@ export function applyFootnotePresentation(
   }
 
   return output;
+}
+
+function createFootnoteNumberRun(
+  displayNumber: number,
+  paragraph: ParagraphBlock,
+): TextRun {
+  const firstTextRun = paragraph.runs.find((run) => run.kind === "text");
+  const firstFormattedRun = paragraph.runs.find(
+    (run) => run.kind === "text" || run.kind === "tab" || run.kind === "field",
+  );
+  const text = firstTextRun?.text.match(/^\s/u)
+    ? `${displayNumber}`
+    : `${displayNumber} `;
+  const numberRun: TextRun = {
+    kind: "text",
+    text,
+    fontSize:
+      firstFormattedRun?.fontSize ??
+      paragraph.attrs?.defaultFontSize ??
+      FOOTNOTE_FONT_SIZE,
+    superscript: true,
+  };
+  const fontFamily =
+    firstFormattedRun?.fontFamily ?? paragraph.attrs?.defaultFontFamily;
+  if (fontFamily) {
+    numberRun.fontFamily = fontFamily;
+  }
+  return numberRun;
 }
 
 function applyFootnoteBlockPresentation(block: FlowBlock): FlowBlock {
@@ -582,12 +604,10 @@ export function calculateFootnoteReservedHeights(
     }
 
     if (totalHeight > 0) {
-      // Add separator + per-entry margin so the static reservation
-      // matches what `renderFootnoteArea` actually paints (4px
-      // `marginBottom` per fn wrapper). Without this, the painter's
-      // clamp would shift the area upward by `count × margin` and
-      // overlap the body lines the engine laid out against the
-      // smaller reservation.
+      // Add separator + any wrapper margin so the static reservation matches
+      // what `renderFootnoteArea` actually paints. In Word-like rendering the
+      // wrapper margin is zero; paragraph spacing inside each footnote content
+      // carries the source DOCX spacing.
       totalHeight += FOOTNOTE_SEPARATOR_HEIGHT;
       totalHeight += footnoteIds.length * FOOTNOTE_ENTRY_MARGIN_BOTTOM;
       reserved.set(pageNumber, totalHeight);

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2010,6 +2010,16 @@ export function toFlowBlocks(
                 left: twipsToPixels(lastSectionMarginsTwips.left),
                 right: twipsToPixels(lastSectionMarginsTwips.right),
               };
+              if (secProps.headerDistance !== undefined) {
+                sectionBreak.margins.header = twipsToPixels(
+                  secProps.headerDistance,
+                );
+              }
+              if (secProps.footerDistance !== undefined) {
+                sectionBreak.margins.footer = twipsToPixels(
+                  secProps.footerDistance,
+                );
+              }
             }
             // Populate columns
             const colCount = secProps.columnCount ?? 1;

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -245,6 +245,9 @@ export function layoutDocument(
     ...(options.footnoteReservedHeights !== undefined
       ? { footnoteReservedHeights: options.footnoteReservedHeights }
       : {}),
+    ...(options.sectionHeaderFooterRefs !== undefined
+      ? { sectionHeaderFooterRefs: options.sectionHeaderFooterRefs }
+      : {}),
   });
 
   // Apply contextual spacing: suppress spaceBefore/spaceAfter between
@@ -342,6 +345,7 @@ export function layoutDocument(
           paginator,
           sectionConfigs[sectionIdx + 1] ?? initialConfig,
           nextType,
+          sectionIdx + 1,
         );
         sectionIdx++;
         break;
@@ -916,6 +920,7 @@ function handleSectionBreak(
   paginator: ReturnType<typeof createPaginator>,
   nextSectionConfig: SectionLayoutConfig,
   nextSectionType: SectionBreakBlock["type"] = "nextPage",
+  nextSectionIndex?: number,
 ): void {
   switch (nextSectionType) {
     case "nextPage":
@@ -923,6 +928,9 @@ function handleSectionBreak(
         nextSectionConfig.pageSize,
         nextSectionConfig.margins,
       );
+      if (nextSectionIndex !== undefined) {
+        paginator.startSection(nextSectionIndex);
+      }
       paginator.forcePageBreak({ coalesceBlankPage: true });
       break;
 
@@ -931,6 +939,9 @@ function handleSectionBreak(
         nextSectionConfig.pageSize,
         nextSectionConfig.margins,
       );
+      if (nextSectionIndex !== undefined) {
+        paginator.startSection(nextSectionIndex);
+      }
       const state = paginator.forcePageBreak({ coalesceBlankPage: true });
       // If landed on odd page, add another page
       if (state.page.number % 2 !== 0) {
@@ -944,6 +955,9 @@ function handleSectionBreak(
         nextSectionConfig.pageSize,
         nextSectionConfig.margins,
       );
+      if (nextSectionIndex !== undefined) {
+        paginator.startSection(nextSectionIndex);
+      }
       const state = paginator.forcePageBreak({ coalesceBlankPage: true });
       // If landed on even page, add another page
       if (state.page.number % 2 === 0) {

--- a/packages/folio/src/core/layout-engine/paginator.ts
+++ b/packages/folio/src/core/layout-engine/paginator.ts
@@ -7,7 +7,13 @@
 
 import { panic } from "better-result";
 
-import type { Page, PageMargins, Fragment, ColumnLayout } from "./types";
+import type {
+  Page,
+  PageMargins,
+  Fragment,
+  ColumnLayout,
+  PageHeaderFooterRefs,
+} from "./types";
 import { FOOTNOTE_SEPARATOR_HEIGHT } from "./types";
 
 /**
@@ -64,6 +70,8 @@ export type PaginatorOptions = {
   columns?: ColumnLayout;
   /** Per-page footnote reserved heights (pageNumber → height in pixels). */
   footnoteReservedHeights?: Map<number, number>;
+  /** Header/footer refs by section index. */
+  sectionHeaderFooterRefs?: PageHeaderFooterRefs[];
   /** Callback when a new page is created. */
   onNewPage?: (state: PageState) => void;
 };
@@ -113,6 +121,8 @@ export function createPaginator(options: PaginatorOptions) {
   let columns: ColumnLayout = options.columns ?? { count: 1, gap: 0 };
   let pendingPageSize: { w: number; h: number } | undefined;
   let pendingMargins: PageMargins | undefined;
+  let currentSectionIndex = 0;
+  let currentSectionPageNumber = 0;
 
   const pages: Page[] = [];
   const states: PageState[] = [];
@@ -186,6 +196,7 @@ export function createPaginator(options: PaginatorOptions) {
     }
 
     const pageNumber = pages.length + 1;
+    currentSectionPageNumber += 1;
     // Page 1 of the document may use first-page margins (extended top to
     // clear an overflowing first-page header on a titlePg section) while
     // pages 2+ use the regular section margins. Without this distinction
@@ -217,6 +228,7 @@ export function createPaginator(options: PaginatorOptions) {
       // Set initial columns; may be overwritten by updateColumns() for continuous section breaks
       ...(columns.count > 1 ? { columns: { ...columns } } : {}),
     };
+    applySectionMetadata(page);
 
     const state: PageState = {
       page,
@@ -420,6 +432,10 @@ export function createPaginator(options: PaginatorOptions) {
       current.cursorY === current.topMargin &&
       currentPageUsesActiveLayout(current)
     ) {
+      if (current.page.sectionIndex !== currentSectionIndex) {
+        currentSectionPageNumber = 1;
+        applySectionMetadata(current.page);
+      }
       return current;
     }
     return createNewPage();
@@ -495,6 +511,22 @@ export function createPaginator(options: PaginatorOptions) {
     pendingMargins = undefined;
   }
 
+  function startSection(sectionIndex: number): void {
+    currentSectionIndex = sectionIndex;
+    currentSectionPageNumber = 0;
+  }
+
+  function applySectionMetadata(page: Page): void {
+    page.sectionIndex = currentSectionIndex;
+    page.sectionPageNumber = currentSectionPageNumber;
+    const refs = options.sectionHeaderFooterRefs?.[currentSectionIndex];
+    if (refs) {
+      page.headerFooterRefs = refs;
+    } else {
+      delete page.headerFooterRefs;
+    }
+  }
+
   return {
     /** All pages created so far. */
     pages,
@@ -532,6 +564,8 @@ export function createPaginator(options: PaginatorOptions) {
     updateColumns,
     /** Update page size/margins for subsequent pages. */
     updatePageLayout,
+    /** Mark the next created page as the first page of a new section. */
+    startSection,
   };
 }
 

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -542,6 +542,16 @@ export type SectionBreakBlock = {
   columns?: ColumnLayout;
 };
 
+export type PageHeaderFooterRefs = {
+  titlePg?: boolean;
+  headerDefault?: string;
+  headerFirst?: string;
+  headerEven?: string;
+  footerDefault?: string;
+  footerFirst?: string;
+  footerEven?: string;
+};
+
 /**
  * Explicit page break block.
  */
@@ -876,15 +886,10 @@ export type Page = {
   orientation?: "portrait" | "landscape";
   /** Section index this page belongs to. */
   sectionIndex?: number;
+  /** 1-based page number within the active section. */
+  sectionPageNumber?: number;
   /** Header/footer references for this page. */
-  headerFooterRefs?: {
-    headerDefault?: string;
-    headerFirst?: string;
-    headerEven?: string;
-    footerDefault?: string;
-    footerFirst?: string;
-    footerEven?: string;
-  };
+  headerFooterRefs?: PageHeaderFooterRefs;
   /** Footnote IDs that appear on this page (for rendering). */
   footnoteIds?: number[];
   /** Height reserved for the footnote area at page bottom (pixels). */
@@ -1006,6 +1011,8 @@ export type LayoutOptions = {
   footnoteHeightById?: Map<number, number>;
   /** Section break type for the body-level (final) section (for section transition logic). */
   bodyBreakType?: "continuous" | "nextPage" | "evenPage" | "oddPage";
+  /** Header/footer references for each document section, by section index. */
+  sectionHeaderFooterRefs?: PageHeaderFooterRefs[];
 };
 
 // =============================================================================
@@ -1058,11 +1065,14 @@ export type DocumentPosition = {
 export const FOOTNOTE_SEPARATOR_HEIGHT = 12;
 
 /**
- * Bottom margin applied to every rendered footnote entry, in CSS pixels.
- * Counted by the bridge when computing the reserved footnote height and by
- * the painter when stacking entries.
+ * Extra bottom margin applied to every rendered footnote entry, in CSS pixels.
+ *
+ * Word footnotes are separate paragraphs in the footnote story, so their
+ * own paragraph spacing already describes the vertical gap between notes.
+ * Keep the wrapper margin at zero to avoid adding whitespace that is not
+ * present in the source DOCX.
  */
-export const FOOTNOTE_ENTRY_MARGIN_BOTTOM = 4;
+export const FOOTNOTE_ENTRY_MARGIN_BOTTOM = 0;
 
 /**
  * Line height used when a footnote entry has no measured line height yet.

--- a/packages/folio/src/core/layout-painter/renderPage.test.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import type {
   Page,
+  HeaderFooterContent,
   ParagraphBlock,
   ParagraphMeasure,
   TableBlock,
@@ -9,6 +10,7 @@ import type {
 } from "../layout-engine/types";
 import type { BlockLookup } from "./index";
 import {
+  applySectionHeaderFooterOptions,
   computePageFingerprint,
   getDefaultPageFontFamily,
   renderPage,
@@ -143,6 +145,35 @@ function lookup(block: ParagraphBlock): BlockLookup {
   ]);
 }
 
+function headerFooterTextContent(text: string): HeaderFooterContent {
+  const block: ParagraphBlock = {
+    kind: "paragraph",
+    id: `hf-${text}`,
+    runs: [{ kind: "text", text }],
+  };
+  const measure: ParagraphMeasure = {
+    kind: "paragraph",
+    lines: [
+      {
+        fromRun: 0,
+        fromChar: 0,
+        toRun: 0,
+        toChar: text.length,
+        width: text.length * 5,
+        ascent: 8,
+        descent: 2,
+        lineHeight: 12,
+      },
+    ],
+    totalHeight: 12,
+  };
+  return {
+    blocks: [block],
+    measures: [measure],
+    height: 12,
+  };
+}
+
 describe("render page fingerprint", () => {
   test("changes when comment annotations change without layout geometry changing", () => {
     expect(computePageFingerprint(page, lookup(blockWithComment()))).not.toBe(
@@ -207,6 +238,34 @@ describe("header and footer rendering", () => {
       findByClass(pageElement as unknown as FakeElement, "layout-page-footer")
         ?.style.opacity,
     ).toBe("0.62");
+  });
+
+  test("resolves even headers and footers from the section page number", () => {
+    const pageOptions = {};
+    const applied = applySectionHeaderFooterOptions(
+      {
+        ...page,
+        number: 2,
+        sectionPageNumber: 1,
+        headerFooterRefs: {
+          footerDefault: "default-footer",
+          footerEven: "even-footer",
+        },
+        fragments: [],
+      },
+      pageOptions,
+      {
+        footerContentByRId: new Map([
+          ["default-footer", headerFooterTextContent("Default footer")],
+          ["even-footer", headerFooterTextContent("Even footer")],
+        ]),
+      },
+    );
+
+    expect(applied).toBe(true);
+    expect(pageOptions).toEqual({
+      footerContent: headerFooterTextContent("Default footer"),
+    });
   });
 });
 

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -166,6 +166,10 @@ export type RenderPageOptions = {
   headerContent?: HeaderFooterContent;
   /** Footer content to render (used for all pages, or pages 2+ when titlePg is set). */
   footerContent?: HeaderFooterContent;
+  /** Header content by part relationship id, used for section-scoped rendering. */
+  headerContentByRId?: ReadonlyMap<string, HeaderFooterContent>;
+  /** Footer content by part relationship id, used for section-scoped rendering. */
+  footerContentByRId?: ReadonlyMap<string, HeaderFooterContent>;
   /** Header content for the first page only (when titlePg is set). */
   firstPageHeaderContent?: HeaderFooterContent;
   /** Footer content for the first page only (when titlePg is set). */
@@ -1251,7 +1255,7 @@ function renderHeaderFooterContent(
  * to clamp the paginator's reservation if it under-estimated, so dense
  * stacks never overflow past the page bottom. Mirrors the upstream helper
  * from eigenpal/docx-editor#485, extended for folio's fallback rendering
- * and inter-footnote margin so the helper matches the painted stack.
+ * and any wrapper margin so the helper matches the painted stack.
  */
 export function calculateFootnoteAreaRenderHeight(
   footnotes: FootnoteRenderItem[],
@@ -2171,6 +2175,65 @@ type FullPageOptions = RenderPageOptions & {
   footnotesByPage?: Map<number, FootnoteRenderItem[]>;
 };
 
+export function applySectionHeaderFooterOptions(
+  page: Page,
+  pageOptions: RenderPageOptions,
+  options: RenderPageOptions,
+): boolean {
+  const refs = page.headerFooterRefs;
+  if (!refs) {
+    return false;
+  }
+
+  const isFirstSectionPage = page.sectionPageNumber === 1;
+  const useFirst = refs.titlePg === true && isFirstSectionPage;
+  const sectionPageNumber = page.sectionPageNumber ?? page.number;
+  const useEven = sectionPageNumber % 2 === 0;
+
+  const headerRId = (() => {
+    if (useFirst) {
+      return refs.headerFirst;
+    }
+    if (useEven && refs.headerEven) {
+      return refs.headerEven;
+    }
+    return refs.headerDefault;
+  })();
+  const footerRId = (() => {
+    if (useFirst) {
+      return refs.footerFirst;
+    }
+    if (useEven && refs.footerEven) {
+      return refs.footerEven;
+    }
+    return refs.footerDefault;
+  })();
+
+  if (headerRId) {
+    const content = options.headerContentByRId?.get(headerRId);
+    if (content) {
+      pageOptions.headerContent = content;
+    } else {
+      delete pageOptions.headerContent;
+    }
+  } else {
+    delete pageOptions.headerContent;
+  }
+
+  if (footerRId) {
+    const content = options.footerContentByRId?.get(footerRId);
+    if (content) {
+      pageOptions.footerContent = content;
+    } else {
+      delete pageOptions.footerContent;
+    }
+  } else {
+    delete pageOptions.footerContent;
+  }
+
+  return true;
+}
+
 /**
  * Build a RenderContext and resolved page options (with footnotes) for a page.
  * Centralises logic shared by populatePageShell, repopulatePageContent, and the eager render path.
@@ -2186,8 +2249,13 @@ function buildPageRenderArgs(
     section: "body",
   };
   const pageOptions: RenderPageOptions = { ...options };
+  const hasSectionHeaderFooter = applySectionHeaderFooterOptions(
+    page,
+    pageOptions,
+    options,
+  );
   // Per-page header/footer selection when titlePg is enabled
-  if (options.titlePg && page.number === 1) {
+  if (!hasSectionHeaderFooter && options.titlePg && page.number === 1) {
     if (options.firstPageHeaderContent !== undefined) {
       pageOptions.headerContent = options.firstPageHeaderContent;
     } else {
@@ -2279,6 +2347,15 @@ function computePageFingerprintInternal(
     `m:${page.margins.top},${page.margins.right},${page.margins.bottom},${page.margins.left}`,
   );
   parts.push(`n:${page.number}`);
+  if (page.sectionIndex !== undefined) {
+    parts.push(`si:${page.sectionIndex}`);
+  }
+  if (page.sectionPageNumber !== undefined) {
+    parts.push(`sp:${page.sectionPageNumber}`);
+  }
+  if (page.headerFooterRefs) {
+    parts.push(`hf:${JSON.stringify(page.headerFooterRefs)}`);
+  }
   if (page.footnoteReservedHeight) {
     parts.push(`fn:${page.footnoteReservedHeight}`);
   }
@@ -2530,6 +2607,23 @@ function runContentKey(run: Run): string {
   return parts.join("|");
 }
 
+function headerFooterContentFingerprint(
+  prefix: string,
+  entries: ReadonlyMap<string, HeaderFooterContent> | undefined,
+): string[] {
+  if (!entries) {
+    return [];
+  }
+  return Array.from(entries.entries())
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(
+      ([rId, content]) =>
+        `${prefix}:${rId},${content.blocks.length},${content.height},${
+          content.visualTop ?? 0
+        },${content.visualBottom ?? content.height},${content.textSig ?? ""}`,
+    );
+}
+
 /**
  * Compute a hash for render options that affect all pages globally.
  * When this changes, all pages need a full re-render.
@@ -2562,6 +2656,12 @@ function computeOptionsHash(options: RenderPageOptions): string {
       },${options.footerContent.textSig ?? ""}`,
     );
   }
+  parts.push(
+    ...headerFooterContentFingerprint("hdr-map", options.headerContentByRId),
+  );
+  parts.push(
+    ...headerFooterContentFingerprint("ftr-map", options.footerContentByRId),
+  );
 
   if (options.firstPageHeaderContent) {
     parts.push(

--- a/packages/folio/src/core/layout-painter/renderParagraph-line-box.test.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph-line-box.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from "bun:test";
+
+import type { MeasuredLine, ParagraphBlock } from "../layout-engine/types";
+import { renderLine } from "./renderParagraph";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  textContent = "";
+  classList = {
+    add: (...tokens: string[]) => {
+      this.className = [this.className, ...tokens].filter(Boolean).join(" ");
+    },
+  };
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    this.children.push(child);
+    return child;
+  }
+
+  getContext(): {
+    font: string;
+    measureText: (text: string) => { width: number };
+  } | null {
+    if (this.tagName !== "canvas") {
+      return null;
+    }
+    return {
+      font: "",
+      measureText(text: string) {
+        return { width: text.length * 7 };
+      },
+    };
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function findTabEl(lineEl: FakeElement): FakeElement | undefined {
+  return lineEl.children.find((child) =>
+    child.className.includes("layout-run-tab"),
+  );
+}
+
+describe("renderLine box model", () => {
+  test("uses content-box and visible overflow so highlighted text is not clipped", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "highlighted-placeholder",
+      runs: [
+        {
+          kind: "text",
+          text: "COMPANY NAME",
+          highlight: "yellow",
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: "COMPANY NAME".length,
+      width: 100,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 288,
+    }) as unknown as FakeElement;
+
+    expect(lineEl.style["boxSizing"]).toBe("content-box");
+    expect(lineEl.style["overflow"]).toBe("visible");
+  });
+
+  test("renders underlined tabs as a continuous rule without a text underline mark", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "signature-line",
+      runs: [
+        { kind: "text", text: "By:" },
+        { kind: "tab", underline: { style: "single" } },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 1,
+      toChar: 1,
+      width: 200,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+
+    const tabEl = findTabEl(lineEl);
+    expect(tabEl).toBeDefined();
+    expect(tabEl?.style["borderBottom"]).toBe("1px solid currentColor");
+    expect(tabEl?.style["textDecorationLine"]).toBe("");
+  });
+
+  test("does not underline raised footnote reference markers", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "footnote-marker",
+      runs: [
+        {
+          kind: "text",
+          text: "9",
+          footnoteRefId: 9,
+          superscript: true,
+          underline: { style: "single" },
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 10,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const noteMarker = lineEl.children.at(0);
+
+    expect(noteMarker?.style["verticalAlign"]).toBe("super");
+    expect(noteMarker?.style["textDecorationLine"]).toBeUndefined();
+  });
+
+  test("sizes superscript markers from the run font instead of the parent line", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "footnote-marker",
+      runs: [
+        {
+          kind: "text",
+          text: "8",
+          fontFamily: "Times New Roman",
+          fontSize: 10,
+          superscript: true,
+        },
+      ],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 1,
+      width: 10,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const noteMarker = lineEl.children.at(0);
+
+    expect(noteMarker?.style["verticalAlign"]).toBe("super");
+    expect(noteMarker?.style["fontFamily"]).toContain("Times New Roman");
+    expect(noteMarker?.style["fontSize"]).toBe("10px");
+  });
+
+  test("renders underlined whitespace as a rule segment", () => {
+    const block: ParagraphBlock = {
+      kind: "paragraph",
+      id: "underlined-space",
+      runs: [{ kind: "text", text: "  ", underline: { style: "single" } }],
+    };
+    const line: MeasuredLine = {
+      fromRun: 0,
+      fromChar: 0,
+      toRun: 0,
+      toChar: 2,
+      width: 20,
+      ascent: 12,
+      descent: 3,
+      lineHeight: 15,
+    };
+
+    const lineEl = renderLine(block, line, undefined, fakeDocument, {
+      availableWidth: 360,
+      isLastLine: true,
+      isFirstLine: true,
+      paragraphEndsWithLineBreak: false,
+      leftIndentPx: 0,
+    }) as unknown as FakeElement;
+    const space = lineEl.children.at(0);
+
+    expect(space?.style["borderBottom"]).toBe("1px solid currentColor");
+    expect(space?.style["textDecorationLine"]).toBe("");
+  });
+});

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -123,6 +123,7 @@ function isMathRun(run: Run): run is MathRun {
 
 const AUTOMATIC_TEXT_COLOR_VALUES = new Set(["auto", "windowtext"]);
 const DEFAULT_BLACK_TEXT_COLOR_VALUES = new Set(["000000", "000"]);
+const DOCX_SUPERSCRIPT_SCALE = 0.75;
 
 function normalizeTextColorValue(color: string): string {
   return color.trim().toLowerCase().replace(/^#/u, "");
@@ -180,6 +181,17 @@ function getHyperlinkTextColor(run: TextRun, inheritedColor: string): string {
   return getRenderableTextColor(run) || inheritedColor || "#0563c1";
 }
 
+function fontSizePtToPx(fontSizePt: number): number {
+  return (fontSizePt * 96) / 72;
+}
+
+function getRaisedRunFontSize(run: TextRun | TabRun): string {
+  if (run.fontSize) {
+    return `${fontSizePtToPx(run.fontSize) * DOCX_SUPERSCRIPT_SCALE}px`;
+  }
+  return `${DOCX_SUPERSCRIPT_SCALE}em`;
+}
+
 /**
  * Apply text run styles to an element
  */
@@ -194,8 +206,7 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
     // fontSize is in points - convert to pixels to match Canvas measurement
     // (1pt = 96/72 px at standard web DPI)
     // Using px ensures consistent rendering with Canvas-based measurements
-    const fontSizePx = (run.fontSize * 96) / 72;
-    element.style.fontSize = `${fontSizePx}px`;
+    element.style.fontSize = `${fontSizePtToPx(run.fontSize)}px`;
   }
   if (run.bold) {
     element.style.fontWeight = DOCX_BOLD_FONT_WEIGHT;
@@ -329,7 +340,9 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   let explicitDecorationStyle = false;
 
   if (run.underline) {
-    decorations.push("underline");
+    if (!isNoteReferenceRun(run)) {
+      decorations.push("underline");
+    }
     if (typeof run.underline === "object") {
       if (run.underline.style) {
         element.style.textDecorationStyle = run.underline.style;
@@ -434,11 +447,11 @@ function applyRunStyles(element: HTMLElement, run: TextRun | TabRun): void {
   // Superscript/subscript
   if (run.superscript) {
     element.style.verticalAlign = "super";
-    element.style.fontSize = "0.75em";
+    element.style.fontSize = getRaisedRunFontSize(run);
   }
   if (run.subscript) {
     element.style.verticalAlign = "sub";
-    element.style.fontSize = "0.75em";
+    element.style.fontSize = getRaisedRunFontSize(run);
   }
 }
 
@@ -510,8 +523,31 @@ function renderTextRun(run: TextRun, doc: Document): HTMLElement {
     // Set text content
     span.textContent = run.text;
   }
+  applyWhitespaceUnderline(span, run);
 
   return span;
+}
+
+function isNoteReferenceRun(run: TextRun | TabRun): boolean {
+  return run.footnoteRefId !== undefined || run.endnoteRefId !== undefined;
+}
+
+function removeUnderlineTextDecoration(element: HTMLElement): void {
+  const textDecorationLines = element.style.textDecorationLine
+    .split(/\s+/u)
+    .filter((line) => line && line !== "underline");
+  element.style.textDecorationLine = textDecorationLines.join(" ");
+}
+
+function applyWhitespaceUnderline(element: HTMLElement, run: TextRun): void {
+  if (!run.underline || run.text.trim().length > 0) {
+    return;
+  }
+  removeUnderlineTextDecoration(element);
+  element.style.borderBottom = "1px solid currentColor";
+  if (typeof run.underline === "object" && run.underline.color) {
+    element.style.borderBottomColor = run.underline.color;
+  }
 }
 
 /**
@@ -545,6 +581,8 @@ function renderTabRun(
 
   span.style.display = "inline-block";
   span.style.width = `${width}px`;
+  applyRunStyles(span, run);
+  applyTabUnderline(span, run);
 
   applyPmPositions(span, run.pmStart, run.pmEnd);
 
@@ -574,6 +612,17 @@ function renderTabRun(
   }
 
   return span;
+}
+
+function applyTabUnderline(element: HTMLElement, run: TabRun): void {
+  if (!run.underline) {
+    return;
+  }
+  removeUnderlineTextDecoration(element);
+  element.style.borderBottom = "1px solid currentColor";
+  if (typeof run.underline === "object" && run.underline.color) {
+    element.style.borderBottomColor = run.underline.color;
+  }
 }
 
 /**
@@ -1367,6 +1416,7 @@ export function renderLine(
 ): HTMLElement {
   const lineEl = doc.createElement("div");
   lineEl.className = PARAGRAPH_CLASS_NAMES.line;
+  lineEl.style.boxSizing = "content-box";
 
   // Apply line height
   lineEl.style.height = `${line.lineHeight}px`;
@@ -1442,10 +1492,7 @@ export function renderLine(
   // are rendered visually (unlike 'nowrap' which collapses them).
   lineEl.style.whiteSpace = "pre";
 
-  // Check if any run in this line has a highlight. If so, we need overflow:hidden
-  // to prevent the padding-extended background from bleeding into adjacent lines.
-  const hasHighlight = runsForLine.some((r) => isTextRun(r) && r.highlight);
-  lineEl.style.overflow = hasHighlight ? "hidden" : "visible";
+  lineEl.style.overflow = "visible";
 
   // Per-line floating margins (leftOffset/rightOffset) are now applied by
   // renderParagraphFragment via MeasuredLine offsets from re-measurement.
@@ -1673,21 +1720,6 @@ export function renderLine(
       currentX += tabWidth;
     } else if (isTextRun(run)) {
       const runEl = renderTextRun(run, doc);
-
-      // For highlighted runs, extend background to fill the full line height.
-      // Inline elements' background only covers the content area (font ascent+descent),
-      // which differs by font size. Vertical padding on inline elements extends the
-      // background without affecting line box calculations.
-      if (run.highlight) {
-        const fontSizePx = run.fontSize ? (run.fontSize * 96) / 72 : 14.67;
-        const contentHeight = fontSizePx * 1.2; // approximate content area
-        const gap = Math.max(0, line.lineHeight - contentHeight);
-        if (gap > 0) {
-          const pad = gap / 2;
-          runEl.style.paddingTop = `${pad}px`;
-          runEl.style.paddingBottom = `${pad}px`;
-        }
-      }
 
       lineEl.append(runEl);
 

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -533,7 +533,7 @@ function isNoteReferenceRun(run: TextRun | TabRun): boolean {
 }
 
 function removeUnderlineTextDecoration(element: HTMLElement): void {
-  const textDecorationLines = element.style.textDecorationLine
+  const textDecorationLines = (element.style.textDecorationLine || "")
     .split(/\s+/u)
     .filter((line) => line && line !== "underline");
   element.style.textDecorationLine = textDecorationLines.join(" ");

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.test.ts
@@ -122,6 +122,124 @@ describe("toProseDoc", () => {
     ).toBe(20);
   });
 
+  test("preserves direct run marks on tab nodes", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    underline: { style: "single" },
+                  },
+                  content: [{ type: "tab" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const tab = doc.firstChild?.firstChild;
+
+    expect(tab?.type.name).toBe("tab");
+    expect(
+      tab?.marks.find((mark) => mark.type.name === "underline")?.attrs.style,
+    ).toBe("single");
+  });
+
+  test("does not leak paragraph mark underline onto directly formatted text runs", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  underline: { style: "single" },
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: { fontSize: 22 },
+                  content: [{ type: "text", text: "By:" }],
+                },
+                {
+                  type: "run",
+                  formatting: {
+                    underline: { style: "single" },
+                    fontSize: 22,
+                  },
+                  content: [{ type: "tab" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const label = doc.firstChild?.child(0);
+    const tab = doc.firstChild?.child(1);
+
+    expect(label?.marks.some((mark) => mark.type.name === "underline")).toBe(
+      false,
+    );
+    expect(
+      label?.marks.find((mark) => mark.type.name === "runFormattingOverride")
+        ?.attrs.underline,
+    ).toBe("none");
+    expect(
+      tab?.marks.find((mark) => mark.type.name === "underline")?.attrs.style,
+    ).toBe("single");
+  });
+
+  test("does not leak paragraph mark bold onto directly formatted highlighted text", () => {
+    const document: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              formatting: {
+                runProperties: {
+                  bold: true,
+                },
+              },
+              content: [
+                {
+                  type: "run",
+                  formatting: {
+                    fontSize: 22,
+                    highlight: "yellow",
+                  },
+                  content: [{ type: "text", text: "COMPANY NAME" }],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const doc = toProseDoc(document);
+    const text = doc.firstChild?.firstChild;
+
+    expect(text?.marks.some((mark) => mark.type.name === "bold")).toBe(false);
+    expect(
+      text?.marks.find((mark) => mark.type.name === "runFormattingOverride")
+        ?.attrs.bold,
+    ).toBe(false);
+  });
+
   test("applies oneNDA table style run properties before direct run properties", () => {
     const document: Document = {
       package: {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -190,10 +190,16 @@ function convertParagraph(
   );
   const getInheritedRunFormatting = (
     formatting: TextFormatting | undefined,
-  ): TextFormatting | undefined =>
-    hasDirectRunFormatting(formatting)
-      ? baseRunFormatting
-      : defaultRunFormatting;
+  ): TextFormatting | undefined => {
+    if (!hasDirectRunFormatting(formatting)) {
+      return defaultRunFormatting;
+    }
+    return suppressParagraphMarkFormatting(
+      baseRunFormatting,
+      paragraphRunFormatting,
+      formatting,
+    );
+  };
   const emitTrackedChange = (
     change: Insertion | Deletion | MoveFrom | MoveTo,
     markType: "insertion" | "deletion",
@@ -736,6 +742,65 @@ function hasDirectRunFormatting(
   return entries.some(
     ([key, value]) => key !== "styleId" && value !== undefined,
   );
+}
+
+function suppressParagraphMarkFormatting(
+  base: TextFormatting | undefined,
+  paragraphMark: TextFormatting | undefined,
+  direct: TextFormatting | undefined,
+): TextFormatting | undefined {
+  if (!paragraphMark) {
+    return base;
+  }
+
+  const result: TextFormatting = { ...base };
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "bold");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "italic");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "strike");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "doubleStrike");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "allCaps");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "smallCaps");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "hidden");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "emboss");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "imprint");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "shadow");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "outline");
+  suppressBooleanParagraphMark(result, paragraphMark, direct, "rtl");
+
+  if (
+    paragraphMark.underline !== undefined &&
+    direct?.underline === undefined
+  ) {
+    result.underline = { style: "none" };
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function suppressBooleanParagraphMark(
+  result: TextFormatting,
+  paragraphMark: TextFormatting,
+  direct: TextFormatting | undefined,
+  key: keyof Pick<
+    TextFormatting,
+    | "bold"
+    | "italic"
+    | "strike"
+    | "doubleStrike"
+    | "allCaps"
+    | "smallCaps"
+    | "hidden"
+    | "emboss"
+    | "imprint"
+    | "shadow"
+    | "outline"
+    | "rtl"
+  >,
+): void {
+  if (paragraphMark[key] === undefined || direct?.[key] !== undefined) {
+    return;
+  }
+  result[key] = false;
 }
 
 function resolveTextFormatting(
@@ -1814,8 +1879,9 @@ function convertRunContent(
       return [];
 
     case "tab":
-      // Convert to tab node for proper rendering
-      return [withHyperlinkBoundaryMarks(schema.node("tab"), marks)];
+      // Convert to tab node for proper rendering. Keep the run marks because
+      // Word commonly represents signature blanks as underlined tab runs.
+      return [schema.node("tab").mark(marks)];
 
     case "drawing":
       return [

--- a/packages/folio/src/paged-editor/PagedEditor.tsx
+++ b/packages/folio/src/paged-editor/PagedEditor.tsx
@@ -100,6 +100,7 @@ import type {
   SectionBreakBlock,
   TextBoxBlock,
   FootnoteContent,
+  PageHeaderFooterRefs,
 } from "../core/layout-engine/types";
 import { DEFAULT_TEXTBOX_MARGINS } from "../core/layout-engine/types";
 // Layout painter
@@ -902,6 +903,81 @@ function renderHfFromContentOrPm(
   return convertHeaderFooterToContent(hf, contentWidth, metrics, optsWithRId);
 }
 
+function renderHeaderFooterContentByRId(
+  source: Map<string, HeaderFooter> | undefined,
+  hfPMs: HiddenHeaderFooterPMsRef | null,
+  contentWidth: number,
+  metrics: HeaderFooterMetrics,
+  options: ConvertHeaderFooterOptions,
+): Map<string, HeaderFooterContent> | undefined {
+  if (!source || source.size === 0) {
+    return undefined;
+  }
+  const rendered = new Map<string, HeaderFooterContent>();
+  for (const [rId, hf] of source) {
+    const content = renderHfFromContentOrPm(
+      hf,
+      rId,
+      hfPMs,
+      contentWidth,
+      metrics,
+      options,
+    );
+    if (content) {
+      rendered.set(rId, content);
+    }
+  }
+  return rendered.size > 0 ? rendered : undefined;
+}
+
+function getSectionHeaderFooterRefs(
+  documentModel: Document | null | undefined,
+): PageHeaderFooterRefs[] | undefined {
+  const body = documentModel?.package.document;
+  if (!body) {
+    return undefined;
+  }
+  const sections = body.sections;
+  if (sections && sections.length > 0) {
+    return sections.map((section) =>
+      getHeaderFooterRefsFromSectionProperties(section.properties),
+    );
+  }
+  const finalProps = body.finalSectionProperties;
+  if (!finalProps) {
+    return undefined;
+  }
+  return [getHeaderFooterRefsFromSectionProperties(finalProps)];
+}
+
+function getHeaderFooterRefsFromSectionProperties(
+  props: SectionProperties,
+): PageHeaderFooterRefs {
+  const refs: PageHeaderFooterRefs = {};
+  if (props.titlePg !== undefined) {
+    refs.titlePg = props.titlePg;
+  }
+  for (const ref of props.headerReferences ?? []) {
+    if (ref.type === "default") {
+      refs.headerDefault = ref.rId;
+    } else if (ref.type === "first") {
+      refs.headerFirst = ref.rId;
+    } else {
+      refs.headerEven = ref.rId;
+    }
+  }
+  for (const ref of props.footerReferences ?? []) {
+    if (ref.type === "default") {
+      refs.footerDefault = ref.rId;
+    } else if (ref.type === "first") {
+      refs.footerFirst = ref.rId;
+    } else {
+      refs.footerEven = ref.rId;
+    }
+  }
+  return refs;
+}
+
 type LayoutInputSignatureOptions = {
   columns: ColumnLayout | undefined;
   contentWidth: number;
@@ -921,6 +997,7 @@ type LayoutInputSignatureOptions = {
   footerContentRId: string | null | undefined;
   firstPageHeaderContentRId: string | null | undefined;
   firstPageFooterContentRId: string | null | undefined;
+  sectionHeaderFooterRefs: PageHeaderFooterRefs[] | undefined;
   margins: PageMargins;
   pageGap: number;
   pageSize: { h: number; w: number };
@@ -2779,6 +2856,10 @@ export function PagedEditor(
   );
   const contentWidth = pageSize.w - margins.left - margins.right;
   const defaultTabStop = document?.package.settings?.defaultTabStop;
+  const sectionHeaderFooterRefs = useMemo(
+    () => getSectionHeaderFooterRefs(document),
+    [document],
+  );
   const layoutInputSignature = useMemo(
     () =>
       buildLayoutInputSignature({
@@ -2793,6 +2874,7 @@ export function PagedEditor(
         footerContentRId,
         firstPageHeaderContentRId,
         firstPageFooterContentRId,
+        sectionHeaderFooterRefs,
         margins,
         pageGap,
         pageSize,
@@ -2812,6 +2894,7 @@ export function PagedEditor(
       footerContentRId,
       firstPageHeaderContentRId,
       firstPageFooterContentRId,
+      sectionHeaderFooterRefs,
       margins,
       pageGap,
       pageSize,
@@ -2988,6 +3071,20 @@ export function PagedEditor(
               hfOptions,
             )
           : undefined;
+        const headerContentByRId = renderHeaderFooterContentByRId(
+          document?.package.headers,
+          hfPMsRef.current,
+          contentWidth,
+          hfMetricsHeader,
+          hfOptions,
+        );
+        const footerContentByRId = renderHeaderFooterContentByRId(
+          document?.package.footers,
+          hfPMsRef.current,
+          contentWidth,
+          hfMetricsFooter,
+          hfOptions,
+        );
 
         // Default extender — applied to pages 2+ of every section. It
         // ignores firstPage H/F so a `<w:titlePg/>` section's
@@ -3055,6 +3152,9 @@ export function PagedEditor(
         if (bodyBreakType !== undefined) {
           layoutOpts.bodyBreakType = bodyBreakType;
         }
+        if (sectionHeaderFooterRefs !== undefined) {
+          layoutOpts.sectionHeaderFooterRefs = sectionHeaderFooterRefs;
+        }
 
         if (hasFootnotes) {
           // Build footnote content and measure heights up front. The
@@ -3083,21 +3183,19 @@ export function PagedEditor(
           );
 
           const footnoteHeightById = new Map<number, number>();
-          // Per-fn vertical margin applied by the painter
-          // (`renderFootnoteArea` sets `marginBottom` on each fn
-          // entry). Reserved alongside content height so the page
-          // accounts for inter-fn whitespace; constant is owned by
-          // `footnoteLayout` so painter, dynamic, and static paths
-          // stay in lockstep.
+          // Any per-fn wrapper margin applied by the painter is reserved
+          // alongside content height. The value is zero for Word-like footnote
+          // spacing; source paragraph spacing inside each note carries the
+          // visible gaps.
           for (const [id, content] of footnoteContentMap) {
             footnoteHeightById.set(
               id,
               content.height + FOOTNOTE_ENTRY_MARGIN_BOTTOM,
             );
           }
-          // Note: the layout engine adds the divider's height once
-          // per fn-bearing page (in paginator.addFootnoteHeight); we
-          // pass per-fn (content + entry margin) here.
+          // Note: the layout engine adds the divider's height once per
+          // fn-bearing page (in paginator.addFootnoteHeight); we pass per-fn
+          // content plus any wrapper margin here.
 
           newLayout = layoutDocument(newBlocks, newMeasures, {
             ...layoutOpts,
@@ -3176,12 +3274,24 @@ export function PagedEditor(
           if (firstPageFooterForRender) {
             renderOpts.firstPageFooterContent = firstPageFooterForRender;
           }
-          if (sectionProperties?.headerDistance) {
+          if (headerContentByRId) {
+            renderOpts.headerContentByRId = headerContentByRId;
+          }
+          if (footerContentByRId) {
+            renderOpts.footerContentByRId = footerContentByRId;
+          }
+          if (
+            sectionHeaderFooterRefs === undefined &&
+            sectionProperties?.headerDistance
+          ) {
             renderOpts.headerDistance = twipsToPixels(
               sectionProperties.headerDistance,
             );
           }
-          if (sectionProperties?.footerDistance) {
+          if (
+            sectionHeaderFooterRefs === undefined &&
+            sectionProperties?.footerDistance
+          ) {
             renderOpts.footerDistance = twipsToPixels(
               sectionProperties.footerDistance,
             );
@@ -3237,6 +3347,7 @@ export function PagedEditor(
       footerContentRId,
       firstPageHeaderContentRId,
       firstPageFooterContentRId,
+      sectionHeaderFooterRefs,
       _theme,
       sectionProperties,
       document,


### PR DESCRIPTION
## Summary
- Improve Folio DOCX rendering fidelity for SAFE-style signature pages: section-scoped footers, underlined tab blanks, paragraph-mark formatting leakage, highlight clipping, and footnote typography/spacing.
- Make the playground Open flow reliable when reselecting the same DOCX file.
- Isolate sandbox concurrency test keys so queue tests do not couple to suite scheduling.

## Verification
- bun run lint && bun run format && bun run typecheck && bun run test