### PR TITLE
fix: cancel timed-out critical queries

### DIFF
--- a/apps/web/src/components/route-components.tsx
+++ b/apps/web/src/components/route-components.tsx
@@ -19,6 +19,7 @@ import { StellaMark } from "@/components/stella-mark";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { useAnalytics } from "@/lib/analytics/provider";
 import { isMemberError, isUnauthorizedError } from "@/lib/errors";
+import { CriticalQueryTimeoutError } from "@/lib/react-query";
 
 type DefaultErrorComponentProps = ErrorComponentProps & {
   className?: string;
@@ -37,7 +38,8 @@ const NETWORK_ERROR_MESSAGES = new Set([
 ]);
 
 const isNetworkError = (error: unknown): boolean =>
-  error instanceof TypeError && NETWORK_ERROR_MESSAGES.has(error.message);
+  CriticalQueryTimeoutError.is(error) ||
+  (error instanceof TypeError && NETWORK_ERROR_MESSAGES.has(error.message));
 
 /** Max number of automatic recovery attempts before
  *  falling back to the manual "Try again" button.

--- a/apps/web/src/lib/react-query.test.ts
+++ b/apps/web/src/lib/react-query.test.ts
@@ -1,7 +1,93 @@
 import { QueryClient } from "@tanstack/react-query";
 import { describe, expect, mock, test } from "bun:test";
 
-import { prefetchNonCriticalQuery } from "@/lib/react-query";
+import {
+  CriticalQueryTimeoutError,
+  ensureCriticalQueryData,
+  prefetchNonCriticalQuery,
+} from "@/lib/react-query";
+
+const wait = async (ms: number) =>
+  await new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("ensureCriticalQueryData", () => {
+  test("cancels timed-out critical queries and reports the query key", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = ["workspaces", "ws_1"] as const;
+    let abortReceived = false;
+    let fetchStarted = false;
+
+    const result = ensureCriticalQueryData(
+      queryClient,
+      {
+        queryKey,
+        queryFn: async ({ signal }) => {
+          fetchStarted = true;
+          return await new Promise<string>((_resolve, reject) => {
+            signal.addEventListener(
+              "abort",
+              () => {
+                abortReceived = true;
+                reject(signal.reason);
+              },
+              { once: true },
+            );
+          });
+        },
+      },
+      { timeoutMs: 1 },
+    );
+
+    let caughtError: unknown;
+    try {
+      await result;
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(fetchStarted).toBe(true);
+    expect(CriticalQueryTimeoutError.is(caughtError)).toBe(true);
+    if (!CriticalQueryTimeoutError.is(caughtError)) {
+      throw new Error("Expected CriticalQueryTimeoutError");
+    }
+
+    expect(caughtError.queryKey).toEqual(queryKey);
+    expect(caughtError.message).toContain(JSON.stringify(queryKey));
+
+    await wait(0);
+
+    expect(abortReceived).toBe(true);
+    expect(
+      queryClient.getQueryCache().find({ queryKey })?.state.fetchStatus,
+    ).toBe("idle");
+  });
+
+  test("does not cancel queries that resolve before the timeout", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = ["workspaces", "ws_2"] as const;
+    let abortReceived = false;
+
+    const result = await ensureCriticalQueryData(
+      queryClient,
+      {
+        queryKey,
+        queryFn: async ({ signal }) => {
+          signal.addEventListener("abort", () => {
+            abortReceived = true;
+          });
+          return "ok";
+        },
+      },
+      { timeoutMs: 1 },
+    );
+
+    await wait(5);
+
+    expect(result).toBe("ok");
+    expect(abortReceived).toBe(false);
+    expect(queryClient.getQueryData<string>(queryKey)).toBe("ok");
+  });
+});
 
 describe("prefetchNonCriticalQuery", () => {
   test("reports errors through onError", async () => {

--- a/apps/web/src/lib/react-query.test.ts
+++ b/apps/web/src/lib/react-query.test.ts
@@ -8,7 +8,9 @@ import {
 } from "@/lib/react-query";
 
 const wait = async (ms: number) =>
-  await new Promise((resolve) => setTimeout(resolve, ms));
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 describe("ensureCriticalQueryData", () => {
   test("cancels timed-out critical queries and reports the query key", async () => {
@@ -28,7 +30,7 @@ describe("ensureCriticalQueryData", () => {
               "abort",
               () => {
                 abortReceived = true;
-                reject(signal.reason);
+                reject(new Error("Query aborted", { cause: signal.reason }));
               },
               { once: true },
             );
@@ -57,9 +59,12 @@ describe("ensureCriticalQueryData", () => {
     await wait(0);
 
     expect(abortReceived).toBe(true);
-    expect(
-      queryClient.getQueryCache().find({ queryKey })?.state.fetchStatus,
-    ).toBe("idle");
+    expect(queryClient.getQueryCache().find({ queryKey })?.state).toMatchObject(
+      {
+        fetchStatus: "idle",
+        status: "error",
+      },
+    );
   });
 
   test("does not cancel queries that resolve before the timeout", async () => {

--- a/apps/web/src/lib/react-query.ts
+++ b/apps/web/src/lib/react-query.ts
@@ -60,10 +60,13 @@ export const ensureCriticalQueryData = async <
       queryClient.ensureQueryData(options),
       new Promise<never>((_resolve, reject) => {
         timeoutId = setTimeout(() => {
-          void queryClient.cancelQueries({
-            exact: true,
-            queryKey: options.queryKey,
-          });
+          void queryClient.cancelQueries(
+            {
+              exact: true,
+              queryKey: options.queryKey,
+            },
+            { revert: false },
+          );
           reject(
             new CriticalQueryTimeoutError({
               message: `Critical query timed out after ${timeoutMs}ms: ${formatQueryKey(options.queryKey)}`,

--- a/apps/web/src/lib/react-query.ts
+++ b/apps/web/src/lib/react-query.ts
@@ -4,6 +4,7 @@ import type {
   QueryClient,
   QueryKey,
 } from "@tanstack/react-query";
+import { TaggedError } from "better-result";
 
 /**
  * Typed input shape for query option factories.
@@ -21,6 +22,26 @@ export type QueryOptionsInput<
 
 const CRITICAL_QUERY_TIMEOUT_MS = 10_000;
 
+export class CriticalQueryTimeoutError extends TaggedError(
+  "CriticalQueryTimeoutError",
+)<{
+  message: string;
+  queryKey: QueryKey;
+  timeoutMs: number;
+}>() {}
+
+type EnsureCriticalQueryDataConfig = {
+  timeoutMs?: number;
+};
+
+const formatQueryKey = (queryKey: QueryKey): string => {
+  try {
+    return JSON.stringify(queryKey);
+  } catch {
+    return "[unserializable query key]";
+  }
+};
+
 export const ensureCriticalQueryData = async <
   TQueryFnData,
   TError = Error,
@@ -29,19 +50,35 @@ export const ensureCriticalQueryData = async <
 >(
   queryClient: QueryClient,
   options: EnsureQueryDataOptions<TQueryFnData, TError, TData, TQueryKey>,
+  config: EnsureCriticalQueryDataConfig = {},
 ): Promise<TData> => {
-  const signal = AbortSignal.timeout(CRITICAL_QUERY_TIMEOUT_MS);
+  const timeoutMs = config.timeoutMs ?? CRITICAL_QUERY_TIMEOUT_MS;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-  return await Promise.race([
-    queryClient.ensureQueryData(options),
-    new Promise<never>((_resolve, reject) => {
-      signal.addEventListener(
-        "abort",
-        () => reject(new Error("Query timed out", { cause: signal.reason })),
-        { once: true },
-      );
-    }),
-  ]);
+  try {
+    return await Promise.race([
+      queryClient.ensureQueryData(options),
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          void queryClient.cancelQueries({
+            exact: true,
+            queryKey: options.queryKey,
+          });
+          reject(
+            new CriticalQueryTimeoutError({
+              message: `Critical query timed out after ${timeoutMs}ms: ${formatQueryKey(options.queryKey)}`,
+              queryKey: options.queryKey,
+              timeoutMs,
+            }),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
 };
 
 export const prefetchNonCriticalQuery = async <


### PR DESCRIPTION
Cancel timed-out critical queries and include the query key in timeout errors.