### PR TITLE
fix(folio): style empty-paragraph headings and drop to body on Enter

### DIFF
--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -39,6 +39,7 @@ import { EditorView } from "prosemirror-view";
 import { headerFooterToProseDoc } from "../core/prosemirror/conversion/toProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
+import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
 import { schema } from "../core/prosemirror/schema";
 import type {
   Document,
@@ -145,10 +146,13 @@ function buildInitialState(
     proseDocOptions.theme = theme;
   }
   const pmDoc = headerFooterToProseDoc(hf.content, proseDocOptions);
+  // Header/footer paragraphs share the document's style table, so they get
+  // the same style-aware behavior (e.g. Enter after a heading → body text).
+  const styleResolverPlugin = createDocumentStylesPlugin(styles);
   return EditorState.create({
     doc: pmDoc,
     schema,
-    plugins: mgr.getPlugins(),
+    plugins: [...mgr.getPlugins(), styleResolverPlugin],
   });
 }
 

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -18,6 +18,7 @@ import { BaseKeymapExtension } from "./features/BaseKeymapExtension";
 // oxlint-disable-next-line import/no-cycle
 import { BidiShortcutExtension } from "./features/BidiShortcutExtension";
 import { DropCursorExtension } from "./features/DropCursorExtension";
+import { EmptyParagraphFormatExtension } from "./features/EmptyParagraphFormatExtension";
 import { ImageDragExtension } from "./features/ImageDragExtension";
 import { ImagePasteExtension } from "./features/ImagePasteExtension";
 // Features
@@ -170,6 +171,7 @@ export function createStarterKit(
   add("pasteStyleInliner", PasteStyleInlinerExtension());
   add("list", ListExtension());
   add("baseKeymap", BaseKeymapExtension());
+  add("emptyParagraphFormat", EmptyParagraphFormatExtension());
   add(
     "selectionTracker",
     options.onSelectionChange === undefined

--- a/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/ParagraphExtension.ts
@@ -24,6 +24,7 @@ import { paragraphToStyle } from "../../../utils/formatToStyle";
 import { collectHeadings } from "../../../utils/headingCollector";
 import { expectParagraphAttrs } from "../../attrs";
 import type { ParagraphAttrs } from "../../schema/nodes";
+import { paragraphAttrsFromResolvedStyle } from "../../styles/resolvedStyleAttrs";
 import { createNodeExtension } from "../create";
 import type { ExtensionContext, ExtensionRuntime } from "../types";
 
@@ -707,22 +708,15 @@ function makeApplyStyle(schema: Schema) {
             // When applying a style, explicitly reset all style-controlled
             // paragraph attrs to the new style's values (or null to clear).
             // This prevents old style properties (e.g. heading line spacing)
-            // from persisting when switching to a different style.
-            const ppr = resolvedAttrs.paragraphFormatting;
-            newAttrs["alignment"] = ppr?.alignment ?? null;
-            newAttrs["spaceBefore"] = ppr?.spaceBefore ?? null;
-            newAttrs["spaceAfter"] = ppr?.spaceAfter ?? null;
-            newAttrs["lineSpacing"] = ppr?.lineSpacing ?? null;
-            newAttrs["lineSpacingRule"] = ppr?.lineSpacingRule ?? null;
-            newAttrs["indentLeft"] = ppr?.indentLeft ?? null;
-            newAttrs["indentRight"] = ppr?.indentRight ?? null;
-            newAttrs["indentFirstLine"] = ppr?.indentFirstLine ?? null;
-            newAttrs["hangingIndent"] = ppr?.hangingIndent ?? null;
-            newAttrs["contextualSpacing"] = ppr?.contextualSpacing ?? null;
-            newAttrs["keepNext"] = ppr?.keepNext ?? null;
-            newAttrs["keepLines"] = ppr?.keepLines ?? null;
-            newAttrs["pageBreakBefore"] = ppr?.pageBreakBefore ?? null;
-            newAttrs["outlineLevel"] = ppr?.outlineLevel ?? null;
+            // from persisting when switching to a different style. The same
+            // projection drives the Enter handler's next-style switch, so
+            // both paths produce identical paragraph attrs — and the resulting
+            // `defaultTextFormatting` lets EmptyParagraphFormatExtension keep
+            // typed text styled after the style picker steals focus.
+            Object.assign(
+              newAttrs,
+              paragraphAttrsFromResolvedStyle(resolvedAttrs),
+            );
           }
 
           tr = tr.setNodeMarkup(pos, undefined, newAttrs);

--- a/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -13,11 +13,14 @@ import {
   selectAll,
   selectParentNode,
 } from "prosemirror-commands";
-import type { Mark } from "prosemirror-model";
+import type { Mark, Node as PMNode } from "prosemirror-model";
 import type { Command, Transaction } from "prosemirror-state";
 
 import type { TextFormatting } from "../../../types/document";
 import { mergeFontFamily } from "../../../utils/fontFamilyMerge";
+import { getDocumentStyleResolver } from "../../plugins/documentStyles";
+import { paragraphAttrsFromResolvedStyle } from "../../styles/resolvedStyleAttrs";
+import type { StyleResolver } from "../../styles/styleResolver";
 import { createExtension } from "../create";
 import { textFormattingToMarks } from "../marks/markUtils";
 import { Priority } from "../types";
@@ -105,6 +108,44 @@ const INHERITED_PARA_ATTRS = [
 /** Mark types that represent style-inherited formatting (font, size, color). */
 const STYLE_MARK_NAMES = new Set(["fontFamily", "fontSize", "textColor"]);
 
+/**
+ * If `sourcePara`'s style defines a `w:next`, replace the empty `newPara`
+ * with that style's resolved attrs and seed stored marks from its run
+ * formatting. Returns true when a switch happened (caller should dispatch
+ * the transaction as-is), false when the source style has no `w:next` and
+ * the caller should fall back to the regular inheritance path.
+ */
+function applyNextParagraphStyle(
+  tr: Transaction,
+  sourcePara: PMNode,
+  newPara: PMNode,
+  resolver: StyleResolver,
+): boolean {
+  const nextStyleId = resolver.getNextStyleId(
+    sourcePara.attrs["styleId"] as string | null | undefined,
+  );
+  if (!nextStyleId) {
+    return false;
+  }
+
+  const resolved = resolver.resolveParagraphStyle(nextStyleId);
+  const { $from } = tr.selection;
+  tr.setNodeMarkup($from.before(), undefined, {
+    ...newPara.attrs,
+    styleId: nextStyleId,
+    ...paragraphAttrsFromResolvedStyle(resolved),
+    borders: null,
+  });
+
+  // setStoredMarks MUST come after setNodeMarkup — every step clears it.
+  tr.setStoredMarks(
+    resolved.runFormatting
+      ? textFormattingToMarks(resolved.runFormatting, tr.doc.type.schema)
+      : [],
+  );
+  return true;
+}
+
 export const splitBlockClearBorders: Command = (state, dispatch, view) => {
   // Capture source paragraph info BEFORE split (splitBlock resets everything)
   const { $from: preSplitFrom } = state.selection;
@@ -138,6 +179,21 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
     const newPara = $from.parent;
 
     if (newPara.type.name === "paragraph") {
+      // Word's `w:next`: pressing Enter at the end of a paragraph (the new
+      // paragraph is empty) switches it to the style's follow-on style — e.g.
+      // a heading drops to body text. Only applies to an empty trailing
+      // paragraph; splitting mid-paragraph keeps the style on both halves.
+      const resolver = getDocumentStyleResolver(state);
+      if (
+        resolver !== null &&
+        sourcePara !== null &&
+        newPara.textContent.length === 0 &&
+        applyNextParagraphStyle(tr, sourcePara, newPara, resolver)
+      ) {
+        dispatch(tr.scrollIntoView());
+        return true;
+      }
+
       const newAttrs = { ...newPara.attrs };
       let attrsChanged = false;
 

--- a/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -130,11 +130,13 @@ function applyNextParagraphStyle(
 
   const resolved = resolver.resolveParagraphStyle(nextStyleId);
   const { $from } = tr.selection;
+  // `paragraphAttrsFromResolvedStyle` already projects the next style's
+  // borders (or null), which both clears the source paragraph's leftover
+  // border and applies a bordered next style (callouts, etc.).
   tr.setNodeMarkup($from.before(), undefined, {
     ...newPara.attrs,
     styleId: nextStyleId,
     ...paragraphAttrsFromResolvedStyle(resolved),
-    borders: null,
   });
 
   // setStoredMarks MUST come after setNodeMarkup — every step clears it.

--- a/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/BaseKeymapExtension.ts
@@ -183,11 +183,14 @@ export const splitBlockClearBorders: Command = (state, dispatch, view) => {
       // paragraph is empty) switches it to the style's follow-on style — e.g.
       // a heading drops to body text. Only applies to an empty trailing
       // paragraph; splitting mid-paragraph keeps the style on both halves.
+      // Use `content.size === 0` rather than `textContent.length` so a
+      // mid-paragraph split before an inline atom (image, equation, field,
+      // sdt, shape) is not mistaken for an empty trailing paragraph.
       const resolver = getDocumentStyleResolver(state);
       if (
         resolver !== null &&
         sourcePara !== null &&
-        newPara.textContent.length === 0 &&
+        newPara.content.size === 0 &&
         applyNextParagraphStyle(tr, sourcePara, newPara, resolver)
       ) {
         dispatch(tr.scrollIntoView());

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for the empty-paragraph formatting fix (eigenpal #657).
+ *
+ * Bug 1: applying a heading to an empty paragraph then typing produced
+ *        unstyled text — the style picker's refocus cleared the stored
+ *        marks before the first keystroke. EmptyParagraphFormatExtension
+ *        re-derives them from the paragraph's `defaultTextFormatting`.
+ *
+ * Bug 2: pressing Enter at the end of a heading kept the heading style;
+ *        it should drop to the style's `w:next` (body text).
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Node as PMNode } from "prosemirror-model";
+import { EditorState, TextSelection } from "prosemirror-state";
+import type { Transaction } from "prosemirror-state";
+
+import { createEmptyDocument } from "../../../utils/createDocument";
+import { createDocumentStylesPlugin } from "../../plugins/documentStyles";
+import { singletonManager, schema } from "../../schema";
+import { createStyleResolver } from "../../styles/styleResolver";
+import { splitBlockClearBorders } from "./BaseKeymapExtension";
+
+const resolver = createStyleResolver(createEmptyDocument().package.styles);
+
+function markNames(
+  marks: readonly { type: { name: string } }[] | null,
+): string[] {
+  return (marks ?? []).map((m) => m.type.name);
+}
+
+function stateWith(doc: PMNode, withResolver = true): EditorState {
+  const plugins = [...singletonManager.getPlugins()];
+  if (withResolver) {
+    plugins.push(createDocumentStylesPlugin(resolver));
+  }
+  return EditorState.create({ doc, schema, plugins });
+}
+
+describe("EmptyParagraphFormatExtension", () => {
+  test("re-derives stored marks from a heading paragraph defaultTextFormatting", () => {
+    const heading = schema.node("paragraph", {
+      styleId: "Heading1",
+      defaultTextFormatting: {
+        fontSize: 40,
+        bold: true,
+        fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+      },
+    });
+    let state = stateWith(schema.node("doc", null, [heading]));
+
+    // A selection change (mimicking the dropdown refocus) clears stored
+    // marks; the plugin must put them back so typed text inherits the
+    // heading.
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1)),
+    );
+
+    expect(markNames(state.storedMarks)).toContain("bold");
+    expect(markNames(state.storedMarks)).toContain("fontSize");
+  });
+
+  test("leaves a plain body paragraph mark-free (font/size handled by the painter)", () => {
+    const body = schema.node("paragraph", {
+      defaultTextFormatting: {
+        fontSize: 22,
+        fontFamily: { ascii: "Arial", hAnsi: "Arial" },
+      },
+    });
+    let state = stateWith(schema.node("doc", null, [body]));
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 1)),
+    );
+
+    // No bold/color/etc. → no stored marks forced onto ordinary typed text.
+    expect(state.storedMarks).toBeNull();
+  });
+});
+
+describe("splitBlockClearBorders — w:next style switch", () => {
+  // Build a heading paragraph with text, place the cursor at its end, run
+  // the editor's Enter handler (`splitBlockClearBorders`), and capture the
+  // transaction. The new (second) paragraph should now carry the heading
+  // style's `w:next` style.
+  function splitAtEndOfHeading(withResolver: boolean): Transaction {
+    const heading = schema.node(
+      "paragraph",
+      {
+        styleId: "Heading1",
+        defaultTextFormatting: { fontSize: 40, bold: true },
+      },
+      [schema.text("Heading One")],
+    );
+    let state = stateWith(schema.node("doc", null, [heading]), withResolver);
+    const headingNode = state.doc.firstChild;
+    if (!headingNode) {
+      throw new Error("Expected heading paragraph");
+    }
+    const endOfHeading = headingNode.nodeSize - 1;
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, endOfHeading)),
+    );
+
+    const captured: { tr: Transaction | null } = { tr: null };
+    splitBlockClearBorders(state, (tr) => {
+      captured.tr = tr;
+    });
+    if (!captured.tr) {
+      throw new Error("Enter handler did not produce a transaction");
+    }
+    return captured.tr;
+  }
+
+  test("Enter after a heading switches the new paragraph to the next style", () => {
+    const tr = splitAtEndOfHeading(true);
+    const newPara = tr.doc.child(1);
+    expect(newPara.attrs["styleId"]).toBe("Normal");
+    // Heading spacing should be dropped (Normal has no spaceBefore).
+    expect(newPara.attrs["spaceBefore"]).toBeNull();
+    // Stored marks should come from Normal's run formatting (no bold).
+    expect(markNames(tr.storedMarks)).not.toContain("bold");
+  });
+
+  test("without a resolver the new paragraph inherits the source heading style", () => {
+    const tr = splitAtEndOfHeading(false);
+    expect(tr.doc.child(1).attrs["styleId"]).toBe("Heading1");
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
@@ -125,4 +125,40 @@ describe("splitBlockClearBorders — w:next style switch", () => {
     const tr = splitAtEndOfHeading(false);
     expect(tr.doc.child(1).attrs["styleId"]).toBe("Heading1");
   });
+
+  test("mid-paragraph split before an inline atom keeps the heading style", () => {
+    // Regression: textContent.length === 0 was incorrectly true for a
+    // paragraph carrying only an inline atom (image/equation/field/etc.),
+    // which made a mid-paragraph split apply w:next and silently demote the
+    // atom-bearing half to Normal. Use a hard_break as the simplest inline
+    // non-text node to reproduce the condition.
+    const heading = schema.node(
+      "paragraph",
+      {
+        styleId: "Heading1",
+        defaultTextFormatting: { fontSize: 40, bold: true },
+      },
+      [schema.text("Title"), schema.node("hardBreak")],
+    );
+    let state = stateWith(schema.node("doc", null, [heading]));
+    // Cursor between "Title" and the hard_break (offset 6 inside the doc:
+    // 1 for paragraph open + 5 text chars).
+    state = state.apply(
+      state.tr.setSelection(TextSelection.create(state.doc, 6)),
+    );
+
+    const captured: { tr: Transaction | null } = { tr: null };
+    splitBlockClearBorders(state, (tr) => {
+      captured.tr = tr;
+    });
+    if (!captured.tr) {
+      throw new Error("Enter handler did not produce a transaction");
+    }
+
+    const trailingPara = captured.tr.doc.child(1);
+    expect(trailingPara.content.size).toBeGreaterThan(0);
+    // Old buggy behavior would set this to "Normal"; w:next must not fire
+    // for a mid-paragraph split.
+    expect(trailingPara.attrs["styleId"]).toBe("Heading1");
+  });
 });

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.test.ts
@@ -126,6 +126,68 @@ describe("splitBlockClearBorders — w:next style switch", () => {
     expect(tr.doc.child(1).attrs["styleId"]).toBe("Heading1");
   });
 
+  test("applies the next style's own borders (callout / bordered next style)", () => {
+    // Regression: the handler used to hardcode `borders: null` on the new
+    // paragraph, dropping the legitimate borders of a w:next that defines its
+    // own pBdr (e.g. a heading whose follow-on is a bordered callout).
+    const calloutBorder = {
+      top: { style: "single", size: 4, color: { auto: true } },
+      bottom: { style: "single", size: 4, color: { auto: true } },
+      left: { style: "single", size: 4, color: { auto: true } },
+      right: { style: "single", size: 4, color: { auto: true } },
+    };
+    const customResolver = createStyleResolver({
+      styles: [
+        { styleId: "Normal", type: "paragraph", name: "Normal", default: true },
+        {
+          styleId: "BorderedHeading",
+          type: "paragraph",
+          name: "Bordered Heading",
+          next: "Callout",
+        },
+        {
+          styleId: "Callout",
+          type: "paragraph",
+          name: "Callout",
+          pPr: { borders: calloutBorder },
+        },
+      ],
+    });
+    const heading = schema.node("paragraph", { styleId: "BorderedHeading" }, [
+      schema.text("Heading"),
+    ]);
+    const plugins = [
+      ...singletonManager.getPlugins(),
+      createDocumentStylesPlugin(customResolver),
+    ];
+    let state = EditorState.create({
+      doc: schema.node("doc", null, [heading]),
+      schema,
+      plugins,
+    });
+    const headingNode = state.doc.firstChild;
+    if (!headingNode) {
+      throw new Error("Expected heading paragraph");
+    }
+    state = state.apply(
+      state.tr.setSelection(
+        TextSelection.create(state.doc, headingNode.nodeSize - 1),
+      ),
+    );
+
+    const captured: { tr: Transaction | null } = { tr: null };
+    splitBlockClearBorders(state, (tr) => {
+      captured.tr = tr;
+    });
+    if (!captured.tr) {
+      throw new Error("Enter handler did not produce a transaction");
+    }
+
+    const newPara = captured.tr.doc.child(1);
+    expect(newPara.attrs["styleId"]).toBe("Callout");
+    expect(newPara.attrs["borders"]).toEqual(calloutBorder);
+  });
+
   test("mid-paragraph split before an inline atom keeps the heading style", () => {
     // Regression: textContent.length === 0 was incorrectly true for a
     // paragraph carrying only an inline atom (image/equation/field/etc.),

--- a/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/EmptyParagraphFormatExtension.ts
@@ -1,0 +1,105 @@
+/**
+ * EmptyParagraphFormat — re-establishes stored marks for an empty styled
+ * paragraph so typed text inherits the style's run formatting (bold, color,
+ * size, font).
+ *
+ * Why this exists:
+ * An empty paragraph carries its run defaults in the `defaultTextFormatting`
+ * attr (set at load by `toProseDoc`, and when a style is applied via
+ * `applyStyle`). The visible painter only derives font/size from that attr,
+ * so an empty heading renders a correctly sized caret — but typed text only
+ * becomes bold/colored if it carries real marks. Those marks live in
+ * `storedMarks`, which ProseMirror clears on the next selection change
+ * (e.g. when the style picker dropdown returns focus to the editor).
+ *
+ * This plugin watches for the caret sitting in an empty paragraph with no
+ * stored marks and re-derives them from `defaultTextFormatting`, but only
+ * when the defaults carry formatting the painter can't reproduce on its own
+ * (bold/italic/color/…). Plain body paragraphs (font + size only) are left
+ * untouched so ordinary typed text stays mark-free and serializes cleanly.
+ */
+
+import type { Schema } from "prosemirror-model";
+import { Plugin, PluginKey } from "prosemirror-state";
+
+import type { TextFormatting } from "../../../types/document";
+import { createExtension } from "../create";
+import { textFormattingToMarks } from "../marks/markUtils";
+import type { ExtensionContext, ExtensionRuntime } from "../types";
+
+export const emptyParagraphFormatKey = new PluginKey("emptyParagraphFormat");
+
+/**
+ * Run-formatting properties the painter does NOT reproduce from
+ * `defaultTextFormatting` on its own (it forwards only font family + size).
+ * When an empty paragraph's defaults carry any of these, typed text must
+ * acquire real marks or it would render unstyled. Kept in sync with the
+ * properties `textFormattingToMarks` can turn into marks — listing one it
+ * can't (e.g. allCaps) would gate work that produces nothing.
+ */
+function hasNonFontDefaults(dtf: TextFormatting): boolean {
+  return !!(
+    dtf.bold ||
+    dtf.italic ||
+    dtf.underline ||
+    dtf.strike ||
+    dtf.doubleStrike ||
+    dtf.color ||
+    dtf.highlight ||
+    dtf.vertAlign
+  );
+}
+
+function createEmptyParagraphFormatPlugin(schema: Schema): Plugin {
+  return new Plugin({
+    key: emptyParagraphFormatKey,
+    appendTransaction(transactions, _oldState, newState) {
+      // Only react when the caret may have moved into an empty paragraph.
+      if (!transactions.some((t) => t.selectionSet || t.docChanged)) {
+        return null;
+      }
+
+      const { selection } = newState;
+      if (!selection.empty) {
+        return null;
+      }
+
+      // A format command (bold button, applyStyle, clearFormatting) already
+      // set stored marks — never override an explicit choice.
+      if (newState.storedMarks !== null) {
+        return null;
+      }
+
+      const para = selection.$from.parent;
+      if (para.type.name !== "paragraph" || para.content.size !== 0) {
+        return null;
+      }
+
+      const dtf = para.attrs["defaultTextFormatting"] as
+        | TextFormatting
+        | null
+        | undefined;
+      if (!dtf || !hasNonFontDefaults(dtf)) {
+        return null;
+      }
+
+      const marks = textFormattingToMarks(dtf, schema);
+      if (marks.length === 0) {
+        return null;
+      }
+
+      const tr = newState.tr.setStoredMarks(marks);
+      tr.setMeta("addToHistory", false);
+      return tr;
+    },
+  });
+}
+
+export const EmptyParagraphFormatExtension = createExtension({
+  name: "emptyParagraphFormat",
+  onSchemaReady(ctx: ExtensionContext): ExtensionRuntime {
+    return {
+      plugins: [createEmptyParagraphFormatPlugin(ctx.schema)],
+    };
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
+++ b/packages/folio/src/core/prosemirror/extensions/marks/markUtils.ts
@@ -375,7 +375,11 @@ export const clearFormatting: Command = (state, dispatch) => {
 
   if (empty) {
     if (dispatch) {
-      dispatch(state.tr.setStoredMarks([]));
+      // Clear the paragraph's run defaults too, so EmptyParagraphFormatExtension
+      // doesn't re-derive stored marks from them right after the clear.
+      const tr = saveStoredMarksToParagraph(state, state.tr, []);
+      tr.setStoredMarks([]);
+      dispatch(tr);
     }
     return true;
   }

--- a/packages/folio/src/core/prosemirror/index.ts
+++ b/packages/folio/src/core/prosemirror/index.ts
@@ -59,6 +59,9 @@ export {
   extractSelectionContext,
   getSelectionContext,
   selectionTrackerKey,
+  createDocumentStylesPlugin,
+  getDocumentStyleResolver,
+  documentStylesKey,
 } from "./plugins";
 export type { SelectionContext, SelectionChangeCallback } from "./plugins";
 

--- a/packages/folio/src/core/prosemirror/plugins/documentStyles.ts
+++ b/packages/folio/src/core/prosemirror/plugins/documentStyles.ts
@@ -1,0 +1,59 @@
+/**
+ * documentStyles plugin — makes the document's StyleResolver reachable from
+ * ProseMirror commands.
+ *
+ * Styles otherwise flow one way (Document → PM) at load time: `toProseDoc`
+ * bakes resolved formatting into nodes and discards the resolver. Some
+ * commands need the live style table though — the Enter handler looks up a
+ * paragraph style's `w:next` to switch to body text after a heading. This
+ * plugin parks the resolver in plugin state so those commands can read it
+ * via `getDocumentStyleResolver(state)`.
+ *
+ * The host (HiddenProseMirror / HiddenHeaderFooterPMs) passes the same
+ * styles it hands to `toProseDoc` and adds this plugin when creating the
+ * EditorState. When absent, style-aware commands fall back to their
+ * style-agnostic behavior.
+ */
+
+import { Plugin, PluginKey, type EditorState } from "prosemirror-state";
+
+import type { StyleDefinitions } from "../../types/document";
+import { StyleResolver, createStyleResolver } from "../styles/styleResolver";
+
+export const documentStylesKey = new PluginKey<StyleResolver | null>(
+  "documentStyles",
+);
+
+/**
+ * Create the plugin holding a StyleResolver for the document's `styles` for
+ * the lifetime of the EditorState. The resolver is fixed per document load;
+ * loading a new document recreates the state (and thus this plugin) with a
+ * fresh resolver. Accepts a pre-built resolver too, for callers that already
+ * have one.
+ */
+export function createDocumentStylesPlugin(
+  styles: StyleDefinitions | StyleResolver | null | undefined,
+): Plugin {
+  let resolver: StyleResolver | null;
+  if (styles instanceof StyleResolver) {
+    resolver = styles;
+  } else if (styles) {
+    resolver = createStyleResolver(styles);
+  } else {
+    resolver = null;
+  }
+  return new Plugin<StyleResolver | null>({
+    key: documentStylesKey,
+    state: {
+      init: () => resolver,
+      apply: (_tr, value) => value,
+    },
+  });
+}
+
+/** Read the document's StyleResolver, or null when the plugin isn't installed. */
+export function getDocumentStyleResolver(
+  state: EditorState,
+): StyleResolver | null {
+  return documentStylesKey.getState(state) ?? null;
+}

--- a/packages/folio/src/core/prosemirror/plugins/index.ts
+++ b/packages/folio/src/core/prosemirror/plugins/index.ts
@@ -16,3 +16,9 @@ export type {
   SelectionContext,
   SelectionChangeCallback,
 } from "./selectionTracker";
+
+export {
+  documentStylesKey,
+  createDocumentStylesPlugin,
+  getDocumentStyleResolver,
+} from "./documentStyles";

--- a/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helper for projecting a resolved paragraph style onto ProseMirror
+ * paragraph node attrs.
+ *
+ * Both `applyStyle` (toolbar style picker) and the Enter handler's
+ * next-style switch need to write the same set of style-controlled attrs.
+ * Keeping the projection in one place ensures the two paths stay in sync —
+ * a style applied via the picker and a style applied on Enter produce
+ * identical paragraph attrs.
+ */
+
+import type { ResolvedParagraphStyle } from "./styleResolver";
+
+/**
+ * The paragraph attrs a style definition controls. Applying a style resets
+ * every one of these to the style's value (or `null` to clear), so a prior
+ * style's properties (e.g. a heading's spacing) never leak through. Returns
+ * a partial attrs object to merge over the paragraph's existing attrs.
+ */
+export function paragraphAttrsFromResolvedStyle(
+  resolved: ResolvedParagraphStyle,
+): Record<string, unknown> {
+  const ppr = resolved.paragraphFormatting;
+  const runFormatting = resolved.runFormatting;
+  const hasRunFormatting =
+    !!runFormatting && Object.keys(runFormatting).length > 0;
+
+  return {
+    alignment: ppr?.alignment ?? null,
+    spaceBefore: ppr?.spaceBefore ?? null,
+    spaceAfter: ppr?.spaceAfter ?? null,
+    lineSpacing: ppr?.lineSpacing ?? null,
+    lineSpacingRule: ppr?.lineSpacingRule ?? null,
+    indentLeft: ppr?.indentLeft ?? null,
+    indentRight: ppr?.indentRight ?? null,
+    indentFirstLine: ppr?.indentFirstLine ?? null,
+    hangingIndent: ppr?.hangingIndent ?? null,
+    contextualSpacing: ppr?.contextualSpacing ?? null,
+    keepNext: ppr?.keepNext ?? null,
+    keepLines: ppr?.keepLines ?? null,
+    pageBreakBefore: ppr?.pageBreakBefore ?? null,
+    outlineLevel: ppr?.outlineLevel ?? null,
+    // The style's run defaults drive the caret height in an empty paragraph
+    // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
+    defaultTextFormatting: hasRunFormatting ? runFormatting : null,
+  };
+}

--- a/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
+++ b/packages/folio/src/core/prosemirror/styles/resolvedStyleAttrs.ts
@@ -40,6 +40,11 @@ export function paragraphAttrsFromResolvedStyle(
     keepLines: ppr?.keepLines ?? null,
     pageBreakBefore: ppr?.pageBreakBefore ?? null,
     outlineLevel: ppr?.outlineLevel ?? null,
+    // Custom paragraph styles (callouts, bordered headings) carry their own
+    // `w:pBdr`; the picker and the Enter-into-w:next path both need to apply
+    // them, while clearing any source paragraph's leftover borders when the
+    // new style has none.
+    borders: ppr?.borders ?? null,
     // The style's run defaults drive the caret height in an empty paragraph
     // and the formatting typed text inherits (see EmptyParagraphFormatExtension).
     defaultTextFormatting: hasRunFormatting ? runFormatting : null,

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
@@ -476,6 +476,22 @@ describe("StyleResolver", () => {
       expect(resolver.getNextStyleId("Normal")).toBeNull();
     });
 
+    test("returns null when next references a non-paragraph style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "Heading1",
+            type: "paragraph",
+            name: "Heading 1",
+            next: "Strong",
+          },
+          { styleId: "Strong", type: "character", name: "Strong" },
+        ],
+      };
+      const resolver = createStyleResolver(styleDefinitions);
+      expect(resolver.getNextStyleId("Heading1")).toBeNull();
+    });
+
     test("returns null when next references a style that does not exist", () => {
       const styleDefinitions: StyleDefinitions = {
         styles: [

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.test.ts
@@ -443,4 +443,63 @@ describe("StyleResolver", () => {
       expect(result.runFormatting?.fontFamily?.eastAsia).toBe("SimSun"); // Preserved from docDefaults
     });
   });
+
+  describe("getNextStyleId", () => {
+    test("returns next styleId when it points to an existing style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "Heading1",
+            type: "paragraph",
+            name: "Heading 1",
+            next: "Normal",
+          },
+          { styleId: "Normal", type: "paragraph", name: "Normal" },
+        ],
+      };
+      const resolver = createStyleResolver(styleDefinitions);
+      expect(resolver.getNextStyleId("Heading1")).toBe("Normal");
+    });
+
+    test("returns null when next points back at the same style", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "Normal",
+            type: "paragraph",
+            name: "Normal",
+            next: "Normal",
+          },
+        ],
+      };
+      const resolver = createStyleResolver(styleDefinitions);
+      expect(resolver.getNextStyleId("Normal")).toBeNull();
+    });
+
+    test("returns null when next references a style that does not exist", () => {
+      const styleDefinitions: StyleDefinitions = {
+        styles: [
+          {
+            styleId: "Heading1",
+            type: "paragraph",
+            name: "Heading 1",
+            next: "MissingStyle",
+          },
+        ],
+      };
+      const resolver = createStyleResolver(styleDefinitions);
+      expect(resolver.getNextStyleId("Heading1")).toBeNull();
+    });
+
+    test("returns null for unknown source style", () => {
+      const resolver = createStyleResolver({ styles: [] });
+      expect(resolver.getNextStyleId("Heading1")).toBeNull();
+    });
+
+    test("returns null for nullish input", () => {
+      const resolver = createStyleResolver({ styles: [] });
+      expect(resolver.getNextStyleId(null)).toBeNull();
+      expect(resolver.getNextStyleId(undefined)).toBeNull();
+    });
+  });
 });

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -148,6 +148,22 @@ export class StyleResolver {
   }
 
   /**
+   * Resolve the style applied to the paragraph that follows one styled with
+   * `styleId` when the user presses Enter (OOXML `w:next`, §17.7.4.10).
+   *
+   * Returns null when the style has no `w:next`, when `next` points back at
+   * the same style (the common heading-stays-heading case is handled by the
+   * caller), or when the style is unknown.
+   */
+  getNextStyleId(styleId: string | undefined | null): string | null {
+    if (!styleId) {
+      return null;
+    }
+    const next = this.stylesById.get(styleId)?.next;
+    return next && next !== styleId ? next : null;
+  }
+
+  /**
    * Get all available table styles (for style gallery)
    */
   getTableStyles(): Style[] {

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -153,14 +153,19 @@ export class StyleResolver {
    *
    * Returns null when the style has no `w:next`, when `next` points back at
    * the same style (the common heading-stays-heading case is handled by the
-   * caller), or when the style is unknown.
+   * caller), when the style is unknown, or when `next` is a dangling
+   * reference to a style that does not exist (OOXML allows this; treat it as
+   * absent so we do not write a non-resolvable styleId into the document).
    */
   getNextStyleId(styleId: string | undefined | null): string | null {
     if (!styleId) {
       return null;
     }
     const next = this.stylesById.get(styleId)?.next;
-    return next && next !== styleId ? next : null;
+    if (!next || next === styleId || !this.stylesById.has(next)) {
+      return null;
+    }
+    return next;
   }
 
   /**

--- a/packages/folio/src/core/prosemirror/styles/styleResolver.ts
+++ b/packages/folio/src/core/prosemirror/styles/styleResolver.ts
@@ -153,16 +153,22 @@ export class StyleResolver {
    *
    * Returns null when the style has no `w:next`, when `next` points back at
    * the same style (the common heading-stays-heading case is handled by the
-   * caller), when the style is unknown, or when `next` is a dangling
-   * reference to a style that does not exist (OOXML allows this; treat it as
-   * absent so we do not write a non-resolvable styleId into the document).
+   * caller), when the style is unknown, when `next` is a dangling reference
+   * to a style that does not exist, or when the target is not a paragraph
+   * style (malformed DOCX may point `w:next` at a character or table style;
+   * writing such an ID into a paragraph's `styleId` would create an invalid
+   * reference).
    */
   getNextStyleId(styleId: string | undefined | null): string | null {
     if (!styleId) {
       return null;
     }
     const next = this.stylesById.get(styleId)?.next;
-    if (!next || next === styleId || !this.stylesById.has(next)) {
+    if (!next || next === styleId) {
+      return null;
+    }
+    const target = this.stylesById.get(next);
+    if (!target || target.type !== "paragraph") {
       return null;
     }
     return next;

--- a/packages/folio/src/paged-editor/HiddenProseMirror.tsx
+++ b/packages/folio/src/paged-editor/HiddenProseMirror.tsx
@@ -44,6 +44,7 @@ import type * as Yjs from "yjs";
 import { toProseDoc, createEmptyDoc } from "../core/prosemirror/conversion";
 import { fromProseDoc } from "../core/prosemirror/conversion/fromProseDoc";
 import type { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
+import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
 import { schema } from "../core/prosemirror/schema";
 import type { Document, Theme, StyleDefinitions } from "../core/types/document";
 import { suppressHiddenEditorScrollToSelection } from "./hiddenEditorScroll";
@@ -390,6 +391,13 @@ export function createHiddenEditorState(
     );
   }
 
+  // Expose the document's styles to style-aware commands (e.g. the Enter
+  // handler's `w:next` switch from heading to body text). Same resolver for
+  // collab and non-collab paths.
+  const styleResolverPlugin = createDocumentStylesPlugin(
+    styles ?? document?.package.styles,
+  );
+
   if (collaboration) {
     if (!collaborationModules) {
       panic(
@@ -414,7 +422,11 @@ export function createHiddenEditorState(
     const state = EditorState.create({
       doc,
       schema: activeSchema,
-      plugins: [...externalPlugins, ...(manager?.getPlugins() ?? [])],
+      plugins: [
+        ...externalPlugins,
+        ...(manager?.getPlugins() ?? []),
+        styleResolverPlugin,
+      ],
     });
     recordHiddenEditorPhase(
       reason,
@@ -429,6 +441,7 @@ export function createHiddenEditorState(
   const plugins: Plugin[] = [
     ...externalPlugins,
     ...(manager?.getPlugins() ?? []),
+    styleResolverPlugin,
   ];
 
   const startedAt = performance.now();


### PR DESCRIPTION
## Summary

Ports the two-bug fix from upstream [eigenpal/docx-editor#657](https://github.com/eigenpal/docx-editor/pull/657) to folio:

1. **Empty styled paragraph loses formatting on first keystroke.** Applying a heading to an empty paragraph then typing produced unstyled text — the style picker's refocus discarded the stored marks. `applyStyle` now writes the style's run defaults to the paragraph's `defaultTextFormatting`, and a new `EmptyParagraphFormatExtension` re-derives stored marks from those defaults when the caret sits in an empty styled paragraph.
2. **Enter at end of a heading kept the heading style.** A new `documentStyles` plugin exposes the live `StyleResolver` to PM commands so `splitBlockClearBorders` can look up the OOXML `w:next` (already parsed) and switch the empty new paragraph to that style (typically Normal / body text).

`clearFormatting` for an empty selection also clears the paragraph's run defaults so the new extension does not re-derive marks right after the user clears them.

The plugin is wired into both the body editor (`HiddenProseMirror`) and the header/footer editors (`HiddenHeaderFooterPMs`) so the behavior is consistent across all editable regions.

## Test plan

- [x] New regression tests in `EmptyParagraphFormatExtension.test.ts` (4 tests, all pass) cover: empty heading paragraph re-derives stored marks; plain body paragraph stays mark-free; Enter at end of heading switches to `w:next`; falls back to source style without a resolver.
- [x] `bun run lint` clean
- [x] `bun run typecheck` clean
- [x] Full `bun run test` clean apart from 9 pre-existing `roundtrip.property.test.ts` timeouts that reproduce on `main`.
- [ ] Manual smoke test in the playground: apply Heading 1 to an empty paragraph, type → text is bold and large; press Enter → next paragraph is Normal.