### PR TITLE
feat(folio): block-level content controls (parse → edit → API → widgets)

### DIFF
--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Neznámý",
       "visibility": "Komentáře"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Kopírovat",
     "copyLink": "Kopírovat odkaz",
     "cut": "Vyjmout",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unbekannt",
       "visibility": "Kommentare"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unknown",
       "visibility": "Comments"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Desconocido",
       "visibility": "Comentarios"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unknown",
       "visibility": "Comments"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Inconnu",
       "visibility": "Commentaires"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unknown",
       "visibility": "Comments"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unknown",
       "visibility": "Comments"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Unknown",
       "visibility": "Comments"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copy",
     "copyLink": "Copy link",
     "cut": "Cut",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -1142,6 +1142,9 @@ type Messages = {
       "unknownAuthor": "Unknown";
       "visibility": "Comments";
     };
+    "contentControlDateAriaLabel": "Pick a date";
+    "contentControlDropdownAriaLabel": "Dropdown options";
+    "contentControlDropdownNoOptions": "No options";
     "copy": "Copy";
     "copyLink": "Copy link";
     "cut": "Cut";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Nieznany",
       "visibility": "Komentarze"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Kopiuj",
     "copyLink": "Kopiuj link",
     "cut": "Wytnij",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Desconhecido",
       "visibility": "Comentários"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Copiar",
     "copyLink": "Copiar link",
     "cut": "Cortar",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -1139,6 +1139,9 @@
       "unknownAuthor": "Neznámy",
       "visibility": "Komentáre"
     },
+    "contentControlDateAriaLabel": "Pick a date",
+    "contentControlDropdownAriaLabel": "Dropdown options",
+    "contentControlDropdownNoOptions": "No options",
     "copy": "Kopírovať",
     "copyLink": "Kopírovať odkaz",
     "cut": "Vystrihnúť",

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1202,6 +1202,18 @@ export type SdtProperties = {
   rawPropertiesXml?: string;
   /** Verbatim `<w:sdtEndPr>…</w:sdtEndPr>` captured at parse time. */
   rawEndPropertiesXml?: string;
+  /**
+   * Verbatim XML for any non-content direct children of `<w:sdt>` that
+   * appear BEFORE `<w:sdtContent>` — MS-OE376 §2.5.2.30 documents 16
+   * range-marker elements Word emits as direct sdt siblings (bookmark,
+   * comment range, custom XML range, tracked-change range). Captured at
+   * parse time and replayed on serialize so comment threads or tracked
+   * changes that span an SDT boundary round-trip without losing a
+   * delimiter.
+   */
+  rawSdtChildrenBeforeContent?: string;
+  /** Verbatim XML for non-content sdt children that appear AFTER `<w:sdtContent>`. */
+  rawSdtChildrenAfterContent?: string;
 };
 
 /**

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1175,6 +1175,13 @@ export type SdtProperties = {
   showingPlaceholder?: boolean;
   /** Date display format (`w:date/w:dateFormat@w:val`). */
   dateFormat?: string;
+  /**
+   * Bound date value (`w:date/@w:fullDate`), ISO 8601. Independent of
+   * `dateFormat` (which controls display): the body text may show a
+   * formatted version like "2 June 2026" while this stays as
+   * `2026-06-02T00:00:00Z` so Word's date binding round-trips losslessly.
+   */
+  dateValueISO?: string;
   /** Dropdown/combobox list items. */
   listItems?: { displayText: string; value: string }[];
   /** Checkbox checked state (`w14:checkbox/w14:checked`). */

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1145,27 +1145,48 @@ export type SdtType =
   | "unknown";
 
 /**
- * SDT properties (w:sdtPr)
+ * SDT properties (`w:sdtPr`).
+ *
+ * Modeled fields are a read-only projection for downstream tooling
+ * (tag/alias addressing, template extraction). They are NOT the
+ * serialization source: the original `<w:sdtPr>` is captured verbatim in
+ * `rawPropertiesXml` and replayed on save, which preserves element order
+ * (`CT_SdtPr` is an `xsd:sequence`), avoids double-emission, and keeps
+ * unmodeled features (`w:dataBinding`, `w15:repeatingSection`, `@lastValue`,
+ * `w:sdtEndPr`) lossless.
  */
 export type SdtProperties = {
-  /** SDT type */
+  /** SDT type (projection; round-trip uses `rawPropertiesXml`). */
   sdtType: SdtType;
-  /** Alias (friendly name) */
+  /** Numeric id (`w:id/@w:val`). */
+  id?: number;
+  /** Alias (friendly name, `w:alias`). */
   alias?: string;
-  /** Tag (developer identifier) */
+  /** Tag (developer identifier, `w:tag`). */
   tag?: string;
-  /** Lock content editing */
+  /** Lock setting (`w:lock`). */
   lock?: "sdtLocked" | "contentLocked" | "sdtContentLocked" | "unlocked";
-  /** Placeholder text */
+  /**
+   * Placeholder building-block name (`w:placeholder/w:docPart@w:val`) — a
+   * reference to a glossary docPart, not the literal placeholder text.
+   */
   placeholder?: string;
-  /** Whether showing placeholder */
+  /** Whether the placeholder is currently shown (`w:showingPlcHdr`). */
   showingPlaceholder?: boolean;
-  /** Date format for date controls */
+  /** Date display format (`w:date/w:dateFormat@w:val`). */
   dateFormat?: string;
-  /** Dropdown/combobox list items */
+  /** Dropdown/combobox list items. */
   listItems?: { displayText: string; value: string }[];
-  /** Checkbox checked state */
+  /** Checkbox checked state (`w14:checkbox/w14:checked`). */
   checked?: boolean;
+  /**
+   * Verbatim `<w:sdtPr>…</w:sdtPr>` captured at parse time. Replayed on
+   * serialize so unmodeled OOXML features (data binding, repeating sections,
+   * `@lastValue`, custom XML mappings) survive round-trip.
+   */
+  rawPropertiesXml?: string;
+  /** Verbatim `<w:sdtEndPr>…</w:sdtEndPr>` captured at parse time. */
+  rawEndPropertiesXml?: string;
 };
 
 /**
@@ -1192,14 +1213,18 @@ export type InlineSdt = {
 };
 
 /**
- * Block-level SDT (content control wrapping paragraphs/tables)
+ * Block-level SDT (content control wrapping paragraphs/tables).
+ *
+ * Content is `BlockContent[]` (not just `(Paragraph | Table)[]`) because
+ * OOXML allows block SDTs to nest — e.g. a repeating-section control
+ * whose row is itself a content control.
  */
 export type BlockSdt = {
   type: "blockSdt";
-  /** SDT properties */
+  /** SDT properties (raw XML in `properties.rawPropertiesXml` round-trips losslessly). */
   properties: SdtProperties;
-  /** Block content inside the control */
-  content: (Paragraph | Table)[];
+  /** Block content inside the control. */
+  content: BlockContent[];
 };
 
 // ============================================================================
@@ -1298,8 +1323,8 @@ export type HeaderFooter = {
   type: "header" | "footer";
   /** Header/footer type */
   hdrFtrType: HeaderFooterType;
-  /** Content (paragraphs, tables, etc.) */
-  content: (Paragraph | Table)[];
+  /** Content (paragraphs, tables, block-level content controls). */
+  content: BlockContent[];
 };
 
 // ============================================================================

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1184,6 +1184,14 @@ export type SdtProperties = {
   dateValueISO?: string;
   /** Dropdown/combobox list items. */
   listItems?: { displayText: string; value: string }[];
+  /**
+   * Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`).
+   * Persisted as the OOXML value, independent of the body display text.
+   * Without this, the serializer had to recover the saved value by
+   * matching the body's display text against `listItems`, which picked
+   * the wrong entry when two items shared a `displayText`.
+   */
+  dropdownLastValue?: string;
   /** Checkbox checked state (`w14:checkbox/w14:checked`). */
   checked?: boolean;
   /**

--- a/packages/folio/package.json
+++ b/packages/folio/package.json
@@ -40,6 +40,7 @@
     "lucide-react": "catalog:",
     "prosemirror-commands": "^1.7.1",
     "prosemirror-dropcursor": "^1.8.2",
+    "prosemirror-gapcursor": "^1.4.0",
     "prosemirror-history": "^1.5.0",
     "prosemirror-keymap": "^1.2.3",
     "prosemirror-model": "^1.25.7",

--- a/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
@@ -33,13 +33,14 @@ type ListItem = { displayText: string; value: string };
 type OpenPicker =
   | {
       kind: "dropdown";
-      tag: string;
+      /** PM position addressing the clicked SDT instance. */
+      pmPos: number;
       items: ListItem[];
       anchorRect: DOMRect;
     }
   | {
       kind: "date";
-      tag: string;
+      pmPos: number;
       anchorRect: DOMRect;
     };
 
@@ -101,7 +102,7 @@ export function ContentControlWidgetsOverlay({
         const items = parseListItems(detail.listItemsJson);
         setOpen({
           kind: "dropdown",
-          tag: detail.tag,
+          pmPos: detail.pmPos,
           items,
           anchorRect: detail.anchor.getBoundingClientRect(),
         });
@@ -110,7 +111,7 @@ export function ContentControlWidgetsOverlay({
       if (detail.kind === "datePick") {
         setOpen({
           kind: "date",
-          tag: detail.tag,
+          pmPos: detail.pmPos,
           anchorRect: detail.anchor.getBoundingClientRect(),
         });
       }
@@ -160,7 +161,7 @@ export function ContentControlWidgetsOverlay({
   const onDropdownPick = (value: string): void => {
     const view = getEditorView();
     if (view) {
-      dispatchDropdownPick(view, open.tag, value);
+      dispatchDropdownPick(view, open.pmPos, value);
     }
     close();
   };
@@ -168,7 +169,7 @@ export function ContentControlWidgetsOverlay({
   const onDatePick = (value: string): void => {
     const view = getEditorView();
     if (view && value.length > 0) {
-      dispatchDatePick(view, open.tag, value);
+      dispatchDatePick(view, open.pmPos, value);
     }
     close();
   };

--- a/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
@@ -1,0 +1,215 @@
+/**
+ * React shell for the content-control widgets plugin.
+ *
+ * The plugin (see `core/prosemirror/plugins/contentControlWidgets`) emits a
+ * `folio:content-control-widget` CustomEvent on the editor's view DOM
+ * whenever the user clicks a typed control. This component subscribes to
+ * those events and renders a small floating picker positioned at the
+ * anchor element — a dropdown menu for `dropdown` / `comboBox` controls,
+ * a native date input for `date` controls — then dispatches back through
+ * `dispatchDropdownPick` / `dispatchDatePick` so the change rides the
+ * normal undo stack.
+ *
+ * The component keeps its own dependencies small (native `<select>` /
+ * `<input type="date">` rendered via a React portal) so the visual chrome
+ * stays consistent with the rest of folio without pulling additional UI
+ * primitives into the editor's bundle.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { EditorView } from "prosemirror-view";
+
+import {
+  CONTENT_CONTROL_WIDGET_EVENT_NAME,
+  dispatchDatePick,
+  dispatchDropdownPick,
+} from "../core/prosemirror/plugins/contentControlWidgets";
+import type { ContentControlWidgetEvent } from "../core/prosemirror/plugins/contentControlWidgets";
+
+type ListItem = { displayText: string; value: string };
+
+type OpenPicker =
+  | {
+      kind: "dropdown";
+      tag: string;
+      items: ListItem[];
+      anchorRect: DOMRect;
+    }
+  | {
+      kind: "date";
+      tag: string;
+      anchorRect: DOMRect;
+    };
+
+function parseListItems(raw: string | undefined): ListItem[] {
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    const out: ListItem[] = [];
+    for (const entry of parsed) {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        "displayText" in entry &&
+        "value" in entry &&
+        typeof (entry as ListItem).displayText === "string" &&
+        typeof (entry as ListItem).value === "string"
+      ) {
+        out.push(entry as ListItem);
+      }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+type ContentControlWidgetsOverlayProps = {
+  /**
+   * Resolver for the live editor view. Called every render so the host can
+   * defer/recreate the view without re-mounting this overlay.
+   */
+  getEditorView: () => EditorView | null;
+};
+
+export function ContentControlWidgetsOverlay({
+  getEditorView,
+}: ContentControlWidgetsOverlayProps) {
+  const [open, setOpen] = useState<OpenPicker | null>(null);
+  const containerRef = useRef<HTMLElement | null>(null);
+
+  const close = useCallback(() => setOpen(null), []);
+
+  useEffect(() => {
+    const view = getEditorView();
+    if (!view) {
+      return;
+    }
+    const target = view.dom;
+    containerRef.current = target;
+    const onWidget = (event: Event): void => {
+      const custom = event as CustomEvent<ContentControlWidgetEvent>;
+      const detail = custom.detail;
+      if (detail.kind === "dropdownOpen") {
+        const items = parseListItems(detail.listItemsJson);
+        setOpen({
+          kind: "dropdown",
+          tag: detail.tag,
+          items,
+          anchorRect: detail.anchor.getBoundingClientRect(),
+        });
+        return;
+      }
+      if (detail.kind === "datePick") {
+        setOpen({
+          kind: "date",
+          tag: detail.tag,
+          anchorRect: detail.anchor.getBoundingClientRect(),
+        });
+      }
+      // "refused" is delivered for the host's logging hook; the overlay
+      // intentionally does not render anything for it.
+    };
+    target.addEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
+    return () => {
+      target.removeEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
+    };
+  }, [getEditorView]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") {
+        close();
+      }
+    };
+    const onScroll = (): void => close();
+    window.addEventListener("keydown", onKey);
+    window.addEventListener("scroll", onScroll, true);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      window.removeEventListener("scroll", onScroll, true);
+    };
+  }, [open, close]);
+
+  const style = useMemo(() => {
+    if (!open) {
+      return undefined;
+    }
+    return {
+      position: "fixed" as const,
+      top: `${open.anchorRect.bottom + 4}px`,
+      left: `${open.anchorRect.left}px`,
+      zIndex: 9999,
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const onDropdownPick = (value: string): void => {
+    const view = getEditorView();
+    if (view) {
+      dispatchDropdownPick(view, open.tag, value);
+    }
+    close();
+  };
+
+  const onDatePick = (value: string): void => {
+    const view = getEditorView();
+    if (view && value.length > 0) {
+      dispatchDatePick(view, open.tag, value);
+    }
+    close();
+  };
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-label={open.kind === "dropdown" ? "Dropdown options" : "Pick a date"}
+      style={style}
+      className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-2 shadow-md"
+    >
+      {open.kind === "dropdown" && (
+        <ul className="m-0 flex list-none flex-col gap-1 p-0">
+          {open.items.length === 0 ? (
+            <li className="text-muted-foreground px-2 py-1 text-sm">
+              No options
+            </li>
+          ) : (
+            open.items.map((item) => (
+              <li key={`${item.value}::${item.displayText}`}>
+                <button
+                  type="button"
+                  onClick={() => onDropdownPick(item.value)}
+                  className="hover:bg-accent focus:bg-accent w-full rounded px-2 py-1 text-start focus:outline-none"
+                >
+                  {item.displayText}
+                </button>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+      {open.kind === "date" && (
+        <input
+          type="date"
+          autoFocus
+          onChange={(event) => onDatePick(event.currentTarget.value)}
+          className="bg-background rounded border px-2 py-1 text-sm"
+        />
+      )}
+    </div>,
+    document.body,
+  );
+}

--- a/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
+++ b/packages/folio/src/components/ContentControlWidgetsOverlay.tsx
@@ -5,21 +5,22 @@
  * `folio:content-control-widget` CustomEvent on the editor's view DOM
  * whenever the user clicks a typed control. This component subscribes to
  * those events and renders a small floating picker positioned at the
- * anchor element — a dropdown menu for `dropdown` / `comboBox` controls,
- * a native date input for `date` controls — then dispatches back through
- * `dispatchDropdownPick` / `dispatchDatePick` so the change rides the
- * normal undo stack.
+ * anchor element — a list of menu items for dropdown / comboBox
+ * controls, a native date input for date controls — then dispatches back
+ * through `dispatchDropdownPick` / `dispatchDatePick` so the change rides
+ * the normal undo stack.
  *
- * The component keeps its own dependencies small (native `<select>` /
- * `<input type="date">` rendered via a React portal) so the visual chrome
- * stays consistent with the rest of folio without pulling additional UI
- * primitives into the editor's bundle.
+ * The dropdown popover uses `@stll/ui` `MenuItem` styling for visual + a11y
+ * consistency with the rest of the editor.
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import type { EditorView } from "prosemirror-view";
+import { useTranslations } from "use-intl";
+
+import { MenuItem } from "@stll/ui/components/menu";
 
 import {
   CONTENT_CONTROL_WIDGET_EVENT_NAME,
@@ -74,8 +75,10 @@ function parseListItems(raw: string | undefined): ListItem[] {
 
 type ContentControlWidgetsOverlayProps = {
   /**
-   * Resolver for the live editor view. Called every render so the host can
-   * defer/recreate the view without re-mounting this overlay.
+   * Resolver for the live editor view. Stored in a ref so the parent can
+   * pass a fresh function each render without triggering listener churn —
+   * the subscription only re-establishes when the editor view's DOM node
+   * actually changes.
    */
   getEditorView: () => EditorView | null;
 };
@@ -83,18 +86,27 @@ type ContentControlWidgetsOverlayProps = {
 export function ContentControlWidgetsOverlay({
   getEditorView,
 }: ContentControlWidgetsOverlayProps) {
+  const t = useTranslations("folio");
   const [open, setOpen] = useState<OpenPicker | null>(null);
-  const containerRef = useRef<HTMLElement | null>(null);
+
+  // Hold the latest resolver in a ref so the subscription effect's
+  // dependency is the underlying view's identity, not the caller's
+  // function literal (which changes every parent render).
+  const getEditorViewRef = useRef(getEditorView);
+  getEditorViewRef.current = getEditorView;
 
   const close = useCallback(() => setOpen(null), []);
 
+  // Re-subscribe when the editor's view DOM node changes. Tracking the DOM
+  // node (not the view object) means we tolerate parent re-renders that
+  // hand us a stable view without recreating the listener.
+  const view = getEditorView();
+  const viewDom = view?.dom ?? null;
+
   useEffect(() => {
-    const view = getEditorView();
-    if (!view) {
+    if (!viewDom) {
       return;
     }
-    const target = view.dom;
-    containerRef.current = target;
     const onWidget = (event: Event): void => {
       const custom = event as CustomEvent<ContentControlWidgetEvent>;
       const detail = custom.detail;
@@ -115,14 +127,14 @@ export function ContentControlWidgetsOverlay({
           anchorRect: detail.anchor.getBoundingClientRect(),
         });
       }
-      // "refused" is delivered for the host's logging hook; the overlay
+      // `refused` is delivered for the host's logging hook; the overlay
       // intentionally does not render anything for it.
     };
-    target.addEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
+    viewDom.addEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
     return () => {
-      target.removeEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
+      viewDom.removeEventListener(CONTENT_CONTROL_WIDGET_EVENT_NAME, onWidget);
     };
-  }, [getEditorView]);
+  }, [viewDom]);
 
   useEffect(() => {
     if (!open) {
@@ -149,7 +161,7 @@ export function ContentControlWidgetsOverlay({
     return {
       position: "fixed" as const,
       top: `${open.anchorRect.bottom + 4}px`,
-      left: `${open.anchorRect.left}px`,
+      insetInlineStart: `${open.anchorRect.left}px`,
       zIndex: 9999,
     };
   }, [open]);
@@ -159,17 +171,17 @@ export function ContentControlWidgetsOverlay({
   }
 
   const onDropdownPick = (value: string): void => {
-    const view = getEditorView();
-    if (view) {
-      dispatchDropdownPick(view, open.pmPos, value);
+    const liveView = getEditorViewRef.current();
+    if (liveView) {
+      dispatchDropdownPick(liveView, open.pmPos, value);
     }
     close();
   };
 
   const onDatePick = (value: string): void => {
-    const view = getEditorView();
-    if (view && value.length > 0) {
-      dispatchDatePick(view, open.pmPos, value);
+    const liveView = getEditorViewRef.current();
+    if (liveView && value.length > 0) {
+      dispatchDatePick(liveView, open.pmPos, value);
     }
     close();
   };
@@ -177,30 +189,31 @@ export function ContentControlWidgetsOverlay({
   return createPortal(
     <div
       role="dialog"
-      aria-label={open.kind === "dropdown" ? "Dropdown options" : "Pick a date"}
+      aria-label={
+        open.kind === "dropdown"
+          ? t("contentControlDropdownAriaLabel")
+          : t("contentControlDateAriaLabel")
+      }
       style={style}
-      className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-2 shadow-md"
+      className="bg-popover text-popover-foreground min-w-[10rem] rounded-md border p-1 shadow-md"
     >
       {open.kind === "dropdown" && (
-        <ul className="m-0 flex list-none flex-col gap-1 p-0">
+        <div role="menu" className="flex flex-col">
           {open.items.length === 0 ? (
-            <li className="text-muted-foreground px-2 py-1 text-sm">
-              No options
-            </li>
+            <div className="text-muted-foreground px-2 py-1 text-sm">
+              {t("contentControlDropdownNoOptions")}
+            </div>
           ) : (
             open.items.map((item) => (
-              <li key={`${item.value}::${item.displayText}`}>
-                <button
-                  type="button"
-                  onClick={() => onDropdownPick(item.value)}
-                  className="hover:bg-accent focus:bg-accent w-full rounded px-2 py-1 text-start focus:outline-none"
-                >
-                  {item.displayText}
-                </button>
-              </li>
+              <MenuItem
+                key={`${item.value}::${item.displayText}`}
+                onClick={() => onDropdownPick(item.value)}
+              >
+                {item.displayText}
+              </MenuItem>
             ))
           )}
-        </ul>
+        </div>
       )}
       {open.kind === "date" && (
         <input

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -10,12 +10,22 @@ import type {
   FolioAIEditOperation,
   FolioAIEditSnapshot,
 } from "../core/ai-edits";
+import type {
+  ContentControlFilter,
+  SetContentControlContentInput,
+  SetContentControlValueInput,
+} from "../core/content-controls";
 import type { DocxCompatibility } from "../core/docx/compatibility";
 import type { FolioSelectiveSaveFlags } from "../core/docx/selectiveSaveFlags";
 import type { TripwireResult } from "../core/docx/selectiveSaveTripwire";
 import type { SelectionState, TableContextInfo } from "../core/prosemirror";
 import type { AnonymizationMatch } from "../core/prosemirror/plugins/anonymizationDecorations";
-import type { Document, Theme, TabStop } from "../core/types/document";
+import type {
+  Document,
+  SdtProperties,
+  Theme,
+  TabStop,
+} from "../core/types/document";
 import type { DocxInput } from "../core/utils/docxInput";
 import type { PagedEditorRef } from "../paged-editor/PagedEditor";
 import type { DocumentLoadState } from "./hooks/useDocumentLoader";
@@ -276,6 +286,58 @@ export type DocxEditorRef = {
    * a fresh-from-live-doc snapshot.
    */
   scrollToBlock: (blockId: string, snapshot?: FolioAIEditSnapshot) => boolean;
+
+  // -------------------------------------------------------------------------
+  // Block-level content controls (w:sdt)
+  // -------------------------------------------------------------------------
+
+  /**
+   * List every block-level content control in the live document, filtered by
+   * tag / alias / id / sdtType. Returns the modeled SdtProperties projection
+   * plus a synthetic identifier so callers can address each control by
+   * insertion order even if tag/alias collide.
+   */
+  getContentControls: (filter?: ContentControlFilter) => {
+    properties: SdtProperties;
+    /** Index in the PM document tree, outer→inner. */
+    path: number[];
+  }[];
+  /**
+   * Scroll to the first content control matching the filter and place the
+   * caret inside it. Returns false when no match is present.
+   */
+  scrollToContentControl: (filter: ContentControlFilter) => boolean;
+  /**
+   * Replace a control's inner content with plain text or pre-built block
+   * content. Locked controls throw `ContentControlLockedError` unless
+   * `{ force: true }` is passed. Writes go through a normal undoable
+   * transaction.
+   */
+  setContentControlContent: (
+    filter: ContentControlFilter,
+    input: SetContentControlContentInput,
+    options?: { force?: boolean },
+  ) => boolean;
+  /**
+   * Set a structured value on a typed control (dropdown / checkbox / date).
+   * Throws `ContentControlTypeError` when the input shape does not match the
+   * control's sdtType. Writes go through a normal undoable transaction.
+   */
+  setContentControlValue: (
+    filter: ContentControlFilter,
+    input: SetContentControlValueInput,
+    options?: { force?: boolean },
+  ) => boolean;
+  /**
+   * Remove a control. With `{ keepContent: true }` the inner blocks survive
+   * in-place; otherwise the wrapper and its children are dropped. Refuses to
+   * unwrap a `w15:repeatingSection` (would orphan its row items) unless
+   * `{ force: true }` is passed.
+   */
+  removeContentControl: (
+    filter: ContentControlFilter,
+    options?: { keepContent?: boolean; force?: boolean },
+  ) => boolean;
 };
 
 /** Aggregated internal state held by DocxEditor's top-level reducer slot. */

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -301,6 +301,12 @@ export type DocxEditorRef = {
     properties: SdtProperties;
     /** Index in the PM document tree, outer→inner. */
     path: number[];
+    /**
+     * Stable, instance-unique PM position of the control's open token.
+     * Use with `{ pmPos }` on the mutation / scroll filters to target a
+     * specific duplicate when two controls share a tag / alias.
+     */
+    pmPos: number;
   }[];
   /**
    * Scroll to the first content control matching the filter and place the

--- a/packages/folio/src/components/DocxEditor.props.ts
+++ b/packages/folio/src/components/DocxEditor.props.ts
@@ -296,15 +296,25 @@ export type DocxEditorRef = {
    * tag / alias / id / sdtType. Returns the modeled SdtProperties projection
    * plus a synthetic identifier so callers can address each control by
    * insertion order even if tag/alias collide.
+   *
+   * IMPORTANT: the returned `pmPos` values are valid only for the document
+   * state at fetch time. After any mutation that changes earlier content's
+   * size (`setContentControlContent`, `setContentControlValue`,
+   * `removeContentControl`, etc.), later controls shift and stored
+   * `pmPos` values become stale. For batch-fill flows over duplicate-tag
+   * controls, either refetch via `getContentControls()` after each
+   * mutation, or address by stable `{ tag }` / `{ id }` / `{ alias }` so
+   * the lookup uses the document's current shape on every call.
    */
   getContentControls: (filter?: ContentControlFilter) => {
     properties: SdtProperties;
     /** Index in the PM document tree, outer→inner. */
     path: number[];
     /**
-     * Stable, instance-unique PM position of the control's open token.
-     * Use with `{ pmPos }` on the mutation / scroll filters to target a
-     * specific duplicate when two controls share a tag / alias.
+     * PM position of the control's open token in the SOURCE document state.
+     * Disambiguates duplicates within one snapshot, but does not survive
+     * mutations that resize earlier content — see `getContentControls`
+     * for the refetch / address-by-tag guidance.
      */
     pmPos: number;
   }[];

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -139,6 +139,7 @@ import {
   setContentControlContentTr,
   setContentControlValueTr,
 } from "../core/prosemirror/commands/contentControls";
+import { setContentControlContentBlocksTr } from "../core/prosemirror/commands/contentControlsBlockFill";
 import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import {
@@ -2855,12 +2856,15 @@ export function DocxEditor({
         if (!view) {
           return false;
         }
-        const tr = setContentControlContentTr(
-          view.state,
-          filter,
-          input,
-          options,
-        );
+        const tr =
+          typeof input === "string"
+            ? setContentControlContentTr(view.state, filter, input, options)
+            : setContentControlContentBlocksTr(
+                view.state,
+                filter,
+                input,
+                options,
+              );
         if (!tr) {
           return false;
         }

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -131,6 +131,13 @@ import {
   findNextChange,
   findPreviousChange,
 } from "../core/prosemirror/commands/comments";
+import {
+  findBlockSdtMatch,
+  findBlockSdtMatches,
+  removeContentControlTr,
+  setContentControlContentTr,
+  setContentControlValueTr,
+} from "../core/prosemirror/commands/contentControls";
 import { proseDocToBlocks } from "../core/prosemirror/conversion/fromProseDoc";
 import { ExtensionManager } from "../core/prosemirror/extensions/ExtensionManager";
 import {
@@ -151,6 +158,7 @@ import {
 import type { Comment } from "../core/types/content";
 import type {
   Document,
+  SdtProperties,
   SectionProperties,
   FootnoteProperties,
   EndnoteProperties,
@@ -2812,6 +2820,88 @@ export function DocxEditor({
         requestAnimationFrame(() => {
           pagedEditorRef.current?.scrollToPosition(from);
         });
+        return true;
+      },
+      getContentControls: (filter = {}) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return [];
+        }
+        return findBlockSdtMatches(view.state.doc, filter).map((match) => {
+          const attrs = match.node.attrs;
+          const properties: SdtProperties = {
+            sdtType: (attrs["sdtType"] ??
+              "richText") as SdtProperties["sdtType"],
+          };
+          if (attrs["alias"]) {
+            properties.alias = String(attrs["alias"]);
+          }
+          if (attrs["tag"]) {
+            properties.tag = String(attrs["tag"]);
+          }
+          if (typeof attrs["id"] === "number") {
+            properties.id = attrs["id"];
+          }
+          return { properties, path: match.path };
+        });
+      },
+      scrollToContentControl: (filter) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        const match = findBlockSdtMatch(view.state.doc, filter);
+        if (!match) {
+          return false;
+        }
+        // Place selection just inside the SDT (after its opening token).
+        const inside = match.pos + 1;
+        const $pos = view.state.doc.resolve(inside);
+        view.dispatch(view.state.tr.setSelection(TextSelection.near($pos)));
+        requestAnimationFrame(() => {
+          pagedEditorRef.current?.scrollToPosition(inside);
+        });
+        return true;
+      },
+      setContentControlContent: (filter, input, options = {}) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        const tr = setContentControlContentTr(
+          view.state,
+          filter,
+          input,
+          options,
+        );
+        if (!tr) {
+          return false;
+        }
+        view.dispatch(tr);
+        return true;
+      },
+      setContentControlValue: (filter, input, options = {}) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        const tr = setContentControlValueTr(view.state, filter, input, options);
+        if (!tr) {
+          return false;
+        }
+        view.dispatch(tr);
+        return true;
+      },
+      removeContentControl: (filter, options = {}) => {
+        const view = pagedEditorRef.current?.getView();
+        if (!view) {
+          return false;
+        }
+        const tr = removeContentControlTr(view.state, filter, options);
+        if (!tr) {
+          return false;
+        }
+        view.dispatch(tr);
         return true;
       },
     }),

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -132,6 +132,7 @@ import {
   findPreviousChange,
 } from "../core/prosemirror/commands/comments";
 import {
+  blockSdtAttrsToSdtProperties,
   findBlockSdtMatch,
   findBlockSdtMatches,
   removeContentControlTr,
@@ -158,7 +159,6 @@ import {
 import type { Comment } from "../core/types/content";
 import type {
   Document,
-  SdtProperties,
   SectionProperties,
   FootnoteProperties,
   EndnoteProperties,
@@ -2827,23 +2827,10 @@ export function DocxEditor({
         if (!view) {
           return [];
         }
-        return findBlockSdtMatches(view.state.doc, filter).map((match) => {
-          const attrs = match.node.attrs;
-          const properties: SdtProperties = {
-            sdtType: (attrs["sdtType"] ??
-              "richText") as SdtProperties["sdtType"],
-          };
-          if (attrs["alias"]) {
-            properties.alias = String(attrs["alias"]);
-          }
-          if (attrs["tag"]) {
-            properties.tag = String(attrs["tag"]);
-          }
-          if (typeof attrs["id"] === "number") {
-            properties.id = attrs["id"];
-          }
-          return { properties, path: match.path };
-        });
+        return findBlockSdtMatches(view.state.doc, filter).map((match) => ({
+          properties: blockSdtAttrsToSdtProperties(match.node),
+          path: match.path,
+        }));
       },
       scrollToContentControl: (filter) => {
         const view = pagedEditorRef.current?.getView();

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -2832,6 +2832,7 @@ export function DocxEditor({
         return findBlockSdtMatches(view.state.doc, filter).map((match) => ({
           properties: blockSdtAttrsToSdtProperties(match.node),
           path: match.path,
+          pmPos: match.pos,
         }));
       },
       scrollToContentControl: (filter) => {

--- a/packages/folio/src/components/DocxEditor.tsx
+++ b/packages/folio/src/components/DocxEditor.tsx
@@ -190,6 +190,7 @@ import {
   removePendingCommentMarkRange,
 } from "./commentsHelpers";
 import type { TrackedChangeEntry } from "./CommentsSidebar";
+import { ContentControlWidgetsOverlay } from "./ContentControlWidgetsOverlay";
 // Dialog hooks and utilities (static imports — lightweight, no UI)
 import type { FindMatch } from "./dialogs/findReplaceUtils";
 import type { ImagePropertiesData } from "./dialogs/ImagePropertiesDialog";
@@ -3880,6 +3881,11 @@ export function DocxEditor({
               />
             </Suspense>
           )}
+
+          {/* Dropdown / date pickers for content controls */}
+          <ContentControlWidgetsOverlay
+            getEditorView={() => pagedEditorRef.current?.getView() ?? null}
+          />
 
           {/* Toast notifications */}
           {/* Toast notifications provided by host app */}

--- a/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
+++ b/packages/folio/src/components/HiddenHeaderFooterPMs.tsx
@@ -42,11 +42,10 @@ import { createStarterKit } from "../core/prosemirror/extensions/StarterKit";
 import { createDocumentStylesPlugin } from "../core/prosemirror/plugins/documentStyles";
 import { schema } from "../core/prosemirror/schema";
 import type {
+  BlockContent,
   Document,
   HeaderFooter,
-  Paragraph,
   StyleDefinitions,
-  Table,
   Theme,
 } from "../core/types/document";
 
@@ -128,7 +127,7 @@ type MountedView = {
    * history snapshot (the array reference survives if the snapshot
    * spreads `...existing` without overriding content).
    */
-  appliedContent: (Paragraph | Table)[];
+  appliedContent: BlockContent[];
 };
 
 function buildInitialState(

--- a/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
+++ b/packages/folio/src/components/hooks/useHeaderFooterEditor.ts
@@ -9,12 +9,11 @@ import type { EditorView } from "prosemirror-view";
 
 import { proseDocToBlocks } from "../../core/prosemirror/conversion/fromProseDoc";
 import type {
+  BlockContent,
   Document,
   DocumentBody,
   HeaderFooter,
-  Paragraph,
   SectionProperties,
-  Table,
 } from "../../core/types/document";
 import type { UseHistoryReturn } from "../../hooks/useHistory";
 
@@ -473,7 +472,7 @@ export const useHeaderFooterEditor = ({
         // brand-new Map so the previous Document referenced by every
         // earlier history entry stays untouched and undo can step
         // back to the pre-edit state.
-        const blocks: (Paragraph | Table)[] = proseDocToBlocks(view.state.doc);
+        const blocks: BlockContent[] = proseDocToBlocks(view.state.doc);
         const updated: HeaderFooter = {
           ...existing,
           type: hfEditPosition,

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -226,6 +226,27 @@ describe("setContentControlValue", () => {
     expect(getContentControlText(ctrl)).toBe("2026-06-02");
   });
 
+  test("rejects overflowed date-only inputs instead of silently normalizing", () => {
+    // `new Date(2026, 98, 99)` would silently become a real (distant)
+    // date. The helper documents "return unchanged if the input does
+    // not parse", so an overflow input should leave the body alone.
+    const doc = makeDoc([
+      makeControl({
+        tag: "x",
+        sdtType: "date",
+        dateFormat: "yyyy-MM-dd",
+      }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "x" },
+      { kind: "date", date: "2026-99-99" },
+    );
+    const ctrl = findContentControl(updated, { tag: "x" })!.control;
+    // Body shows the raw input, not a normalized real date.
+    expect(getContentControlText(ctrl)).toBe("2026-99-99");
+  });
+
   test("datetime input preserves the picked wall-clock time in the formatted display", () => {
     // A date SDT with a time-bearing format ("yyyy-MM-dd HH:mm") must
     // render the user's picked time, not zero it out. Previously the

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -56,6 +56,23 @@ describe("findContentControls", () => {
     expect(findContentControls(doc)).toHaveLength(2);
   });
 
+  test("refuses pmPos-only filters on the headless model", () => {
+    // pmPos is a PM-position concept; the headless `BlockSdt` model has
+    // no positions. Letting the filter no-op would silently match every
+    // control and a headless `setContentControlValue(doc, { pmPos }, …)`
+    // would mutate them all. The matcher must refuse unsatisfiable
+    // pmPos-only filters.
+    const doc = makeDoc([
+      makeControl({ tag: "a" }, "first"),
+      makeControl({ tag: "b" }, "second"),
+    ]);
+    expect(findContentControls(doc, { pmPos: 0 })).toHaveLength(0);
+    expect(findContentControls(doc, { pmPos: 42 })).toHaveLength(0);
+    // Combined with a stable filter, pmPos still refuses on the headless
+    // side (we'd need the PM walker to honor it).
+    expect(findContentControls(doc, { pmPos: 0, tag: "a" })).toHaveLength(0);
+  });
+
   test("finds nested SDTs and reports their ancestry", () => {
     const inner = makeControl({ tag: "inner" }, "deep");
     const outer: BlockSdt = {

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -226,6 +226,28 @@ describe("setContentControlValue", () => {
     expect(getContentControlText(ctrl)).toBe("2026-06-02");
   });
 
+  test("datetime input preserves the picked wall-clock time in the formatted display", () => {
+    // A date SDT with a time-bearing format ("yyyy-MM-dd HH:mm") must
+    // render the user's picked time, not zero it out. Previously the
+    // regex only extracted YYYY-MM-DD and the body showed "15:30" as
+    // "00:00".
+    const doc = makeDoc([
+      makeControl({
+        tag: "scheduled",
+        sdtType: "date",
+        dateFormat: "yyyy-MM-dd HH:mm",
+      }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "scheduled" },
+      { kind: "date", date: "2026-06-02T15:30:00Z" },
+    );
+    const ctrl = findContentControl(updated, { tag: "scheduled" })!.control;
+    expect(getContentControlText(ctrl)).toBe("2026-06-02 15:30");
+    expect(ctrl.properties.dateValueISO).toBe("2026-06-02T15:30:00Z");
+  });
+
   test("with a dateFormat, body shows the rendered display + dateValueISO holds ISO", () => {
     const doc = makeDoc([
       makeControl({

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -285,6 +285,27 @@ describe("removeContentControl", () => {
     );
   });
 
+  test("removing an only-child nested SDT keeps the outer SDT non-empty", () => {
+    // Outer SDT contains exactly one inner SDT; removing the inner one
+    // would leave the outer with empty content. The model invariant is
+    // that wrappers carry at least one child block — verify we patch a
+    // placeholder paragraph into the outer.
+    const inner = makeControl({ tag: "inner" }, "doomed");
+    const outer: BlockSdt = {
+      type: "blockSdt",
+      properties: { sdtType: "richText", tag: "outer" },
+      content: [inner],
+    };
+    const doc = makeDoc([outer]);
+    const updated = removeContentControl(doc, { tag: "inner" });
+    const outerAfter = updated.package.document.content[0];
+    if (!outerAfter || outerAfter.type !== "blockSdt") {
+      throw new TypeError("expected outer to remain a blockSdt");
+    }
+    expect(outerAfter.content).toHaveLength(1);
+    expect(outerAfter.content[0]?.type).toBe("paragraph");
+  });
+
   test("refuses to unwrap a w15:repeatingSection control without force", () => {
     const repeating: BlockSdt = {
       type: "blockSdt",

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -206,6 +206,26 @@ describe("setContentControlValue", () => {
     expect(ctrl.properties.dateValueISO).toBe("2026-06-02");
   });
 
+  test("date-only ISO is rendered as the same calendar day regardless of TZ", () => {
+    // `new Date("2026-06-02")` parses as UTC midnight; a user in any
+    // negative-offset TZ would see Date#getDate() return 1 instead of 2.
+    // Pin the contract: a date-only input renders as the picked day.
+    const doc = makeDoc([
+      makeControl({
+        tag: "effective",
+        sdtType: "date",
+        dateFormat: "yyyy-MM-dd",
+      }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "effective" },
+      { kind: "date", date: "2026-06-02" },
+    );
+    const ctrl = findContentControl(updated, { tag: "effective" })!.control;
+    expect(getContentControlText(ctrl)).toBe("2026-06-02");
+  });
+
   test("with a dateFormat, body shows the rendered display + dateValueISO holds ISO", () => {
     const doc = makeDoc([
       makeControl({

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -231,6 +231,40 @@ describe("removeContentControl", () => {
     expect(para?.type).toBe("paragraph");
   });
 
+  test("contentLocked does NOT block container removal (only blocks edits)", () => {
+    // OOXML §17.5.2.16: contentLocked locks content, sdtLocked locks the
+    // container. Removal must succeed on contentLocked.
+    const doc = makeDoc([
+      makeControl({ tag: "a", lock: "contentLocked" }, "x"),
+    ]);
+    const updated = removeContentControl(doc, { tag: "a" });
+    expect(findContentControl(updated, { tag: "a" })).toBeNull();
+  });
+
+  test("sdtLocked refuses container removal even though edits are allowed", () => {
+    const doc = makeDoc([makeControl({ tag: "a", lock: "sdtLocked" }, "x")]);
+    expect(() => removeContentControl(doc, { tag: "a" })).toThrow(
+      ContentControlLockedError,
+    );
+    // ... but a content edit IS allowed on sdtLocked.
+    const updated = setContentControlContent(doc, { tag: "a" }, "edit ok");
+    expect(
+      getContentControlText(findContentControl(updated, { tag: "a" })!.control),
+    ).toBe("edit ok");
+  });
+
+  test("sdtContentLocked blocks both edits and removal", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "a", lock: "sdtContentLocked" }, "x"),
+    ]);
+    expect(() => removeContentControl(doc, { tag: "a" })).toThrow(
+      ContentControlLockedError,
+    );
+    expect(() => setContentControlContent(doc, { tag: "a" }, "y")).toThrow(
+      ContentControlLockedError,
+    );
+  });
+
   test("refuses to unwrap a w15:repeatingSection control without force", () => {
     const repeating: BlockSdt = {
       type: "blockSdt",

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -194,7 +194,7 @@ describe("setContentControlValue", () => {
     ).toThrow(ContentControlTypeError);
   });
 
-  test("sets a date value", () => {
+  test("sets a date value (no dateFormat → body shows ISO input)", () => {
     const doc = makeDoc([makeControl({ tag: "effective", sdtType: "date" })]);
     const updated = setContentControlValue(
       doc,
@@ -203,6 +203,26 @@ describe("setContentControlValue", () => {
     );
     const ctrl = findContentControl(updated, { tag: "effective" })!.control;
     expect(getContentControlText(ctrl)).toBe("2026-06-02");
+    expect(ctrl.properties.dateValueISO).toBe("2026-06-02");
+  });
+
+  test("with a dateFormat, body shows the rendered display + dateValueISO holds ISO", () => {
+    const doc = makeDoc([
+      makeControl({
+        tag: "effective",
+        sdtType: "date",
+        dateFormat: "d MMMM yyyy",
+      }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "effective" },
+      { kind: "date", date: "2026-06-02" },
+    );
+    const ctrl = findContentControl(updated, { tag: "effective" })!.control;
+    expect(getContentControlText(ctrl)).toBe("2 June 2026");
+    // Critical: w:fullDate round-trip uses the ISO value, NOT the display.
+    expect(ctrl.properties.dateValueISO).toBe("2026-06-02");
   });
 });
 

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  ContentControlBoundError,
   ContentControlLockedError,
   ContentControlTypeError,
   findContentControl,
@@ -139,6 +140,55 @@ describe("setContentControlContent", () => {
     });
     const ctrl = findContentControl(updated, { tag: "locked" })!.control;
     expect(getContentControlText(ctrl)).toBe("ok");
+  });
+
+  test("refuses to write into a w:dataBinding-bound control without force", () => {
+    // Without the guard, the write would silently land but Word would
+    // regenerate the body from the bound XML on next open, erasing the
+    // caller's edit. Mirror Aspose.Words' behavior: require explicit
+    // consent via { force: true } (or pre-stripping the binding).
+    const doc = makeDoc([
+      {
+        type: "blockSdt",
+        properties: {
+          sdtType: "richText",
+          tag: "bound",
+          rawPropertiesXml:
+            '<w:sdtPr><w:tag w:val="bound"/><w:dataBinding w:xpath="/contract/party[1]/name" w:storeItemID="{ABC}"/></w:sdtPr>',
+        },
+        content: [makePara("placeholder")],
+      },
+    ]);
+    expect(() =>
+      setContentControlContent(doc, { tag: "bound" }, "Acme Corp"),
+    ).toThrow(ContentControlBoundError);
+  });
+
+  test("force: true on a bound control strips <w:dataBinding> from rawPropertiesXml", () => {
+    const doc = makeDoc([
+      {
+        type: "blockSdt",
+        properties: {
+          sdtType: "richText",
+          tag: "bound",
+          rawPropertiesXml:
+            '<w:sdtPr><w:tag w:val="bound"/><w:dataBinding w:xpath="/x" w:storeItemID="{ABC}"/></w:sdtPr>',
+        },
+        content: [makePara("placeholder")],
+      },
+    ]);
+    const updated = setContentControlContent(
+      doc,
+      { tag: "bound" },
+      "Acme Corp",
+      { force: true },
+    );
+    const ctrl = findContentControl(updated, { tag: "bound" })!.control;
+    expect(getContentControlText(ctrl)).toBe("Acme Corp");
+    // Binding was stripped so Word's next open won't overwrite the edit.
+    expect(ctrl.properties.rawPropertiesXml).not.toContain("dataBinding");
+    // Other sdtPr children survive.
+    expect(ctrl.properties.rawPropertiesXml).toContain('w:tag w:val="bound"');
   });
 });
 

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Headless content-controls API tests.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ContentControlLockedError,
+  ContentControlTypeError,
+  findContentControl,
+  findContentControls,
+  getContentControlText,
+  removeContentControl,
+  setContentControlContent,
+  setContentControlValue,
+} from ".";
+import type { BlockSdt, Document, Paragraph } from "../types/document";
+
+function makeDoc(content: BlockSdt[]): Document {
+  return {
+    package: {
+      document: { content },
+    },
+  };
+}
+
+function makePara(text: string): Paragraph {
+  return {
+    type: "paragraph",
+    content: [{ type: "run", content: [{ type: "text", text }] }],
+  };
+}
+
+function makeControl(
+  props: Partial<BlockSdt["properties"]>,
+  text = "",
+): BlockSdt {
+  return {
+    type: "blockSdt",
+    properties: { sdtType: "richText", ...props } as BlockSdt["properties"],
+    content: [makePara(text)],
+  };
+}
+
+describe("findContentControls", () => {
+  test("filters by tag, alias, id, sdtType", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "a", alias: "A", id: 1 }, "first"),
+      makeControl({ tag: "b", sdtType: "date" }, "second"),
+    ]);
+    expect(findContentControls(doc, { tag: "a" })).toHaveLength(1);
+    expect(findContentControls(doc, { alias: "A" })).toHaveLength(1);
+    expect(findContentControls(doc, { id: 1 })).toHaveLength(1);
+    expect(findContentControls(doc, { sdtType: "date" })).toHaveLength(1);
+    expect(findContentControls(doc, { tag: "a", id: 999 })).toHaveLength(0);
+    expect(findContentControls(doc)).toHaveLength(2);
+  });
+
+  test("finds nested SDTs and reports their ancestry", () => {
+    const inner = makeControl({ tag: "inner" }, "deep");
+    const outer: BlockSdt = {
+      type: "blockSdt",
+      properties: { sdtType: "richText", tag: "outer" },
+      content: [inner],
+    };
+    const doc = makeDoc([outer]);
+    const matches = findContentControls(doc, { tag: "inner" });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.ancestry).toHaveLength(1);
+    expect(matches[0]?.ancestry[0]?.properties.tag).toBe("outer");
+  });
+
+  test("findContentControl returns the first match or null", () => {
+    const doc = makeDoc([makeControl({ tag: "a" }, "x")]);
+    expect(findContentControl(doc, { tag: "a" })?.control.properties.tag).toBe(
+      "a",
+    );
+    expect(findContentControl(doc, { tag: "missing" })).toBeNull();
+  });
+
+  test("getContentControlText concatenates paragraph descendants", () => {
+    const control: BlockSdt = {
+      type: "blockSdt",
+      properties: { sdtType: "richText" },
+      content: [makePara("line one"), makePara("line two")],
+    };
+    expect(getContentControlText(control)).toBe("line one\nline two");
+  });
+});
+
+describe("setContentControlContent", () => {
+  test("replaces content with a single paragraph (string input)", () => {
+    const doc = makeDoc([makeControl({ tag: "name" }, "old")]);
+    const updated = setContentControlContent(doc, { tag: "name" }, "new");
+    const ctrl = findContentControl(updated, { tag: "name" })!.control;
+    expect(getContentControlText(ctrl)).toBe("new");
+    expect(ctrl.properties.showingPlaceholder).toBe(false);
+  });
+
+  test("does not mutate the original document", () => {
+    const doc = makeDoc([makeControl({ tag: "name" }, "old")]);
+    setContentControlContent(doc, { tag: "name" }, "new");
+    const original = findContentControl(doc, { tag: "name" })!.control;
+    expect(getContentControlText(original)).toBe("old");
+  });
+
+  test("refuses to write into a contentLocked control without force", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "locked", lock: "contentLocked" }, "x"),
+    ]);
+    expect(() =>
+      setContentControlContent(doc, { tag: "locked" }, "boom"),
+    ).toThrow(ContentControlLockedError);
+  });
+
+  test("force: true overrides the lock", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "locked", lock: "contentLocked" }, "x"),
+    ]);
+    const updated = setContentControlContent(doc, { tag: "locked" }, "ok", {
+      force: true,
+    });
+    const ctrl = findContentControl(updated, { tag: "locked" })!.control;
+    expect(getContentControlText(ctrl)).toBe("ok");
+  });
+});
+
+describe("setContentControlValue", () => {
+  test("toggles a checkbox", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "agree", sdtType: "checkbox", checked: false }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "agree" },
+      { kind: "checkbox", checked: true },
+    );
+    const ctrl = findContentControl(updated, { tag: "agree" })!.control;
+    expect(ctrl.properties.checked).toBe(true);
+    expect(getContentControlText(ctrl)).toBe("☒");
+  });
+
+  test("rejects a checkbox toggle on a non-checkbox control", () => {
+    const doc = makeDoc([makeControl({ tag: "name", sdtType: "richText" })]);
+    expect(() =>
+      setContentControlValue(
+        doc,
+        { tag: "name" },
+        {
+          kind: "checkbox",
+          checked: true,
+        },
+      ),
+    ).toThrow(ContentControlTypeError);
+  });
+
+  test("sets a dropdown value (display text from list items)", () => {
+    const doc = makeDoc([
+      makeControl({
+        tag: "state",
+        sdtType: "dropdown",
+        listItems: [
+          { value: "ca", displayText: "California" },
+          { value: "ny", displayText: "New York" },
+        ],
+      }),
+    ]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "state" },
+      { kind: "dropdown", value: "ny" },
+    );
+    const ctrl = findContentControl(updated, { tag: "state" })!.control;
+    expect(getContentControlText(ctrl)).toBe("New York");
+  });
+
+  test("dropdown value not in listItems is refused without force", () => {
+    const doc = makeDoc([
+      makeControl({
+        tag: "state",
+        sdtType: "dropdown",
+        listItems: [{ value: "ca", displayText: "California" }],
+      }),
+    ]);
+    expect(() =>
+      setContentControlValue(
+        doc,
+        { tag: "state" },
+        {
+          kind: "dropdown",
+          value: "tx",
+        },
+      ),
+    ).toThrow(ContentControlTypeError);
+  });
+
+  test("sets a date value", () => {
+    const doc = makeDoc([makeControl({ tag: "effective", sdtType: "date" })]);
+    const updated = setContentControlValue(
+      doc,
+      { tag: "effective" },
+      { kind: "date", date: "2026-06-02" },
+    );
+    const ctrl = findContentControl(updated, { tag: "effective" })!.control;
+    expect(getContentControlText(ctrl)).toBe("2026-06-02");
+  });
+});
+
+describe("removeContentControl", () => {
+  test("drops the control entirely by default", () => {
+    const doc = makeDoc([
+      makeControl({ tag: "a" }, "drop me"),
+      makeControl({ tag: "b" }, "keep me"),
+    ]);
+    const updated = removeContentControl(doc, { tag: "a" });
+    expect(updated.package.document.content).toHaveLength(1);
+    expect(findContentControl(updated, { tag: "a" })).toBeNull();
+  });
+
+  test("keepContent: true unwraps the control, preserving children", () => {
+    const doc = makeDoc([makeControl({ tag: "a" }, "preserved")]);
+    const updated = removeContentControl(
+      doc,
+      { tag: "a" },
+      {
+        keepContent: true,
+      },
+    );
+    expect(updated.package.document.content).toHaveLength(1);
+    const para = updated.package.document.content[0];
+    expect(para?.type).toBe("paragraph");
+  });
+
+  test("refuses to unwrap a w15:repeatingSection control without force", () => {
+    const repeating: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "richText",
+        tag: "parties",
+        rawPropertiesXml:
+          '<w:sdtPr><w:tag w:val="parties"/><w15:repeatingSection/></w:sdtPr>',
+      },
+      content: [makePara("x")],
+    };
+    const doc = makeDoc([repeating]);
+    expect(() =>
+      removeContentControl(doc, { tag: "parties" }, { keepContent: true }),
+    ).toThrow(ContentControlTypeError);
+  });
+});

--- a/packages/folio/src/core/content-controls/contentControls.test.ts
+++ b/packages/folio/src/core/content-controls/contentControls.test.ts
@@ -385,4 +385,25 @@ describe("removeContentControl", () => {
       removeContentControl(doc, { tag: "parties" }, { keepContent: true }),
     ).toThrow(ContentControlTypeError);
   });
+
+  test("refuses to unwrap a repeatingSection under an alternate namespace prefix", () => {
+    // A producer that binds the Word 2012 namespace under a non-canonical
+    // prefix (`<ns0:repeatingSection/>`) was previously slipping through
+    // the literal substring check and getting unwrapped — which would
+    // orphan the section's row items in the resulting DOCX.
+    const repeating: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "richText",
+        tag: "rows",
+        rawPropertiesXml:
+          '<w:sdtPr><w:tag w:val="rows"/><ns0:repeatingSection/></w:sdtPr>',
+      },
+      content: [makePara("x")],
+    };
+    const doc = makeDoc([repeating]);
+    expect(() =>
+      removeContentControl(doc, { tag: "rows" }, { keepContent: true }),
+    ).toThrow(ContentControlTypeError);
+  });
 });

--- a/packages/folio/src/core/content-controls/errors.ts
+++ b/packages/folio/src/core/content-controls/errors.ts
@@ -1,0 +1,38 @@
+/**
+ * Tagged errors for the content-controls API. Every write helper that
+ * refuses a mutation throws one of these; consumers can either bubble the
+ * error or retry with `{ force: true }`.
+ */
+
+import { TaggedError } from "better-result";
+
+import type { SdtProperties } from "../types/document";
+
+/**
+ * Refused because the target control's `w:lock` forbids the requested
+ * mutation. Caller can override with `{ force: true }` if they understand
+ * the consequences (overrides apply per call, not per document).
+ */
+export class ContentControlLockedError extends TaggedError(
+  "ContentControlLockedError",
+)<{
+  message: string;
+  lock: NonNullable<SdtProperties["lock"]>;
+  tag?: string;
+  alias?: string;
+}>() {}
+
+/**
+ * Refused because the requested operation does not make sense for the
+ * control's type — e.g. setting free text on a checkbox, or unwrapping a
+ * `w15:repeatingSection` (which would orphan its row items).
+ */
+export class ContentControlTypeError extends TaggedError(
+  "ContentControlTypeError",
+)<{
+  message: string;
+  sdtType: SdtProperties["sdtType"];
+  reason: string;
+  tag?: string;
+  alias?: string;
+}>() {}

--- a/packages/folio/src/core/content-controls/errors.ts
+++ b/packages/folio/src/core/content-controls/errors.ts
@@ -23,6 +23,30 @@ export class ContentControlLockedError extends TaggedError(
 }>() {}
 
 /**
+ * Refused because the target control is bound to a `<w:dataBinding>`.
+ *
+ * Word regenerates the SDT body from the bound XML on every open, so a
+ * direct write to `<w:t>` is silently overwritten and the caller's edit
+ * disappears on next open. Aspose.Words handles this by requiring an
+ * explicit `XmlMapping.Delete()` before write; folio mirrors that
+ * pattern: throw by default, accept `{ force: true }` as an opt-in that
+ * strips the binding inline (the same destructive choice the caller
+ * would have made explicitly via Aspose's API).
+ *
+ * Reference: python-docx #965, Aspose forum thread on removing custom
+ * XML mapping before content updates.
+ */
+export class ContentControlBoundError extends TaggedError(
+  "ContentControlBoundError",
+)<{
+  message: string;
+  xpath: string;
+  storeItemID?: string;
+  tag?: string;
+  alias?: string;
+}>() {}
+
+/**
  * Refused because the requested operation does not make sense for the
  * control's type — e.g. setting free text on a checkbox, or unwrapping a
  * `w15:repeatingSection` (which would orphan its row items).

--- a/packages/folio/src/core/content-controls/findContentControls.ts
+++ b/packages/folio/src/core/content-controls/findContentControls.ts
@@ -44,6 +44,14 @@ export type ContentControlMatch = {
 };
 
 function matches(control: BlockSdt, filter: ContentControlFilter): boolean {
+  // The headless `BlockSdt` model does not carry PM positions, so a
+  // pmPos-only filter has nothing meaningful to match against. Returning
+  // `true` here would silently make a headless `setContentControlValue(doc,
+  // { pmPos })` apply to every blockSdt; we refuse instead so the mutation
+  // helpers no-op on an unsatisfiable filter, matching PM-layer semantics.
+  if (filter.pmPos !== undefined) {
+    return false;
+  }
   if (filter.tag !== undefined && control.properties.tag !== filter.tag) {
     return false;
   }

--- a/packages/folio/src/core/content-controls/findContentControls.ts
+++ b/packages/folio/src/core/content-controls/findContentControls.ts
@@ -1,0 +1,150 @@
+/**
+ * Discover block-level content controls inside a `Document` model.
+ *
+ * Walks the document body recursively; an SDT inside another SDT or inside
+ * a table cell is still found. Read-only — never mutates the input.
+ *
+ * Filters compose: pass any subset of `{ tag, alias, id, sdtType }` and
+ * every supplied field must match. Omit a field to ignore it.
+ */
+
+import type {
+  BlockContent,
+  BlockSdt,
+  Document,
+  SdtProperties,
+} from "../types/document";
+
+export type ContentControlFilter = {
+  tag?: string;
+  alias?: string;
+  /** OOXML numeric `w:id`. */
+  id?: number;
+  sdtType?: SdtProperties["sdtType"];
+};
+
+export type ContentControlMatch = {
+  control: BlockSdt;
+  /** Outer→inner stack of enclosing controls (empty when at the body root). */
+  ancestry: BlockSdt[];
+  /** Indices to walk back into the doc, outer→inner. */
+  path: number[];
+};
+
+function matches(control: BlockSdt, filter: ContentControlFilter): boolean {
+  if (filter.tag !== undefined && control.properties.tag !== filter.tag) {
+    return false;
+  }
+  if (filter.alias !== undefined && control.properties.alias !== filter.alias) {
+    return false;
+  }
+  if (filter.id !== undefined && control.properties.id !== filter.id) {
+    return false;
+  }
+  if (
+    filter.sdtType !== undefined &&
+    control.properties.sdtType !== filter.sdtType
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function walk(
+  blocks: BlockContent[],
+  filter: ContentControlFilter,
+  out: ContentControlMatch[],
+  ancestry: BlockSdt[],
+  path: number[],
+): void {
+  for (let i = 0; i < blocks.length; i += 1) {
+    const block = blocks[i];
+    if (!block) {
+      continue;
+    }
+    if (block.type === "blockSdt") {
+      if (matches(block, filter)) {
+        out.push({
+          control: block,
+          ancestry: [...ancestry],
+          path: [...path, i],
+        });
+      }
+      // Recurse into the SDT — nested SDTs are addressable too.
+      walk(block.content, filter, out, [...ancestry, block], [...path, i]);
+    } else if (block.type === "table") {
+      // Walk into table cells so cell-level SDTs (where supported by the
+      // parser) are surfaced too. cell.content is `(Paragraph | Table)[]`
+      // today; the walker accepts the narrower type structurally because
+      // it is a subset of BlockContent.
+      for (let r = 0; r < block.rows.length; r += 1) {
+        const row = block.rows[r];
+        if (!row) {
+          continue;
+        }
+        for (let c = 0; c < row.cells.length; c += 1) {
+          const cell = row.cells[c];
+          if (!cell) {
+            continue;
+          }
+          walk(cell.content, filter, out, ancestry, [...path, i, r, c]);
+        }
+      }
+    }
+  }
+}
+
+export function findContentControls(
+  doc: Document,
+  filter: ContentControlFilter = {},
+): ContentControlMatch[] {
+  const out: ContentControlMatch[] = [];
+  walk(doc.package.document.content, filter, out, [], []);
+  return out;
+}
+
+export function findContentControl(
+  doc: Document,
+  filter: ContentControlFilter,
+): ContentControlMatch | null {
+  for (const match of findContentControls(doc, filter)) {
+    return match;
+  }
+  return null;
+}
+
+/**
+ * Concatenated plain text of every paragraph descendant inside a control,
+ * separated by newlines. Useful for template/agent read paths.
+ */
+export function getContentControlText(control: BlockSdt): string {
+  const parts: string[] = [];
+  const visit = (blocks: BlockContent[]): void => {
+    for (const block of blocks) {
+      if (block.type === "paragraph") {
+        const paraText: string[] = [];
+        for (const item of block.content) {
+          if (item.type === "run") {
+            for (const child of item.content) {
+              if (child.type === "text") {
+                paraText.push(child.text);
+              }
+            }
+          }
+        }
+        parts.push(paraText.join(""));
+      } else if (block.type === "table") {
+        for (const row of block.rows) {
+          for (const cell of row.cells) {
+            visit(cell.content);
+          }
+        }
+      } else {
+        // block.type === "blockSdt"
+        visit(block.content);
+      }
+    }
+  };
+  visit(control.content);
+  return parts.join("\n");
+}

--- a/packages/folio/src/core/content-controls/findContentControls.ts
+++ b/packages/folio/src/core/content-controls/findContentControls.ts
@@ -21,6 +21,18 @@ export type ContentControlFilter = {
   /** OOXML numeric `w:id`. */
   id?: number;
   sdtType?: SdtProperties["sdtType"];
+  /**
+   * ProseMirror absolute position of the blockSdt's open token. The
+   * widgets plugin uses this to disambiguate SDTs that share a tag: each
+   * clicked control resolves to exactly one position, so the mutation
+   * lands on the intended instance even when multiple share the same
+   * tag/alias. Only meaningful for PM-layer addressing (see
+   * `prosemirror/commands/contentControls`). The headless walker matches
+   * on it too, but `findContentControls` over the headless model does
+   * not produce PM positions — so this filter is effectively a no-op
+   * when called on a headless Document.
+   */
+  pmPos?: number;
 };
 
 export type ContentControlMatch = {

--- a/packages/folio/src/core/content-controls/index.ts
+++ b/packages/folio/src/core/content-controls/index.ts
@@ -7,7 +7,11 @@
  * these helpers with transactions so writes are undoable.
  */
 
-export { ContentControlLockedError, ContentControlTypeError } from "./errors";
+export {
+  ContentControlBoundError,
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "./errors";
 export type {
   ContentControlFilter,
   ContentControlMatch,

--- a/packages/folio/src/core/content-controls/index.ts
+++ b/packages/folio/src/core/content-controls/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Headless API for working with block-level content controls.
+ *
+ * Pure functions over the `Document` model. Use these directly for
+ * automation, AI-driven template filling, or to read the document outside
+ * a mounted editor. The ProseMirror editor-ref methods (commit 8) wrap
+ * these helpers with transactions so writes are undoable.
+ */
+
+export { ContentControlLockedError, ContentControlTypeError } from "./errors";
+export type {
+  ContentControlFilter,
+  ContentControlMatch,
+} from "./findContentControls";
+export {
+  findContentControl,
+  findContentControls,
+  getContentControlText,
+} from "./findContentControls";
+export type {
+  SetContentControlContentInput,
+  SetContentControlValueInput,
+} from "./mutateContentControls";
+export {
+  removeContentControl,
+  setContentControlContent,
+  setContentControlValue,
+} from "./mutateContentControls";

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -137,7 +137,18 @@ function mapBlock(
       return replaced;
     }
     const nextContent = transformBlocks(block.content, match);
-    return { ...block, content: nextContent };
+    // OOXML accepts an empty <w:sdtContent> and folio's toProseDoc has a
+    // safety net that inserts a placeholder before the doc reaches PM, but
+    // a consumer reading the headless model directly (AI agents, template
+    // scanners) would see an inner-empty BlockSdt that nothing in OOXML
+    // requires. Keep the model self-consistent: when removing a nested SDT
+    // empties its parent SDT, insert a placeholder paragraph so the
+    // wrapper still has at least one child.
+    const guarded =
+      nextContent.length === 0 && block.content.length > 0
+        ? [makeParagraphFromText("")]
+        : nextContent;
+    return { ...block, content: guarded };
   }
   if (block.type === "table") {
     const rows = block.rows.map((row) => ({

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -27,25 +27,62 @@ export type SetContentControlValueInput =
   | { kind: "checkbox"; checked: boolean }
   | { kind: "date"; date: string };
 
-function lockBlocksMutation(
+function throwLocked(
+  control: BlockSdt,
+  lock: NonNullable<typeof control.properties.lock>,
+): never {
+  throw new ContentControlLockedError({
+    message: `Control "${control.properties.tag ?? control.properties.alias ?? "(unnamed)"}" has w:lock=${lock}.`,
+    lock,
+    ...(control.properties.tag !== undefined
+      ? { tag: control.properties.tag }
+      : {}),
+    ...(control.properties.alias !== undefined
+      ? { alias: control.properties.alias }
+      : {}),
+  });
+}
+
+/**
+ * Refuse content mutations (setContentControlContent /
+ * setContentControlValue) when `w:lock` forbids them.
+ *
+ * Per OOXML §17.5.2.16:
+ * - `contentLocked` blocks content edits but allows the container to be
+ *   removed.
+ * - `sdtContentLocked` blocks both.
+ * - `sdtLocked` blocks only container removal, NOT content edits.
+ */
+function ensureContentNotLocked(
   control: BlockSdt,
   force: boolean | undefined,
 ): void {
-  const lock = control.properties.lock;
   if (force) {
     return;
   }
+  const lock = control.properties.lock;
   if (lock === "contentLocked" || lock === "sdtContentLocked") {
-    throw new ContentControlLockedError({
-      message: `Control "${control.properties.tag ?? control.properties.alias ?? "(unnamed)"}" has w:lock=${lock}.`,
-      lock,
-      ...(control.properties.tag !== undefined
-        ? { tag: control.properties.tag }
-        : {}),
-      ...(control.properties.alias !== undefined
-        ? { alias: control.properties.alias }
-        : {}),
-    });
+    throwLocked(control, lock);
+  }
+}
+
+/**
+ * Refuse container removal (removeContentControl) when `w:lock` forbids it.
+ *
+ * - `sdtLocked` blocks container removal but allows content edits.
+ * - `sdtContentLocked` blocks both.
+ * - `contentLocked` blocks only content edits, NOT container removal.
+ */
+function ensureSdtNotLocked(
+  control: BlockSdt,
+  force: boolean | undefined,
+): void {
+  if (force) {
+    return;
+  }
+  const lock = control.properties.lock;
+  if (lock === "sdtLocked" || lock === "sdtContentLocked") {
+    throwLocked(control, lock);
   }
 }
 
@@ -186,7 +223,7 @@ export function setContentControlContent(
       if (!controlMatchesFilter(control, filter)) {
         return undefined;
       }
-      lockBlocksMutation(control, options.force);
+      ensureContentNotLocked(control, options.force);
       const blocks: BlockContent[] =
         typeof input === "string"
           ? [makeParagraphFromText(input)]
@@ -220,7 +257,7 @@ export function setContentControlValue(
       if (!controlMatchesFilter(control, filter)) {
         return undefined;
       }
-      lockBlocksMutation(control, options.force);
+      ensureContentNotLocked(control, options.force);
 
       const sdtType = control.properties.sdtType;
       if (input.kind === "dropdown") {
@@ -324,7 +361,7 @@ export function removeContentControl(
       if (!controlMatchesFilter(control, filter)) {
         return undefined;
       }
-      lockBlocksMutation(control, options.force);
+      ensureSdtNotLocked(control, options.force);
       if (options.keepContent) {
         if (isRepeatingSection(control) && !options.force) {
           throw new ContentControlTypeError({

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -59,14 +59,29 @@ function parseSdtDate(iso: string): Date | null {
   const match =
     /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
   if (match) {
-    return new Date(
-      Number(match[1]),
-      Number(match[2]) - 1,
-      Number(match[3]),
-      match[4] ? Number(match[4]) : 0,
-      match[5] ? Number(match[5]) : 0,
-      match[6] ? Number(match[6]) : 0,
-    );
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hours = match[4] ? Number(match[4]) : 0;
+    const minutes = match[5] ? Number(match[5]) : 0;
+    const seconds = match[6] ? Number(match[6]) : 0;
+    const candidate = new Date(year, month - 1, day, hours, minutes, seconds);
+    // Round-trip the captured components against what `Date` actually
+    // stored. JS silently normalizes overflow ("2026-99-99" becomes a
+    // distant real date), which would let `formatDate` render a
+    // misleading body for malformed inputs. Reject the parse when the
+    // normalized Date does not agree with what the caller asked for.
+    if (
+      candidate.getFullYear() !== year ||
+      candidate.getMonth() !== month - 1 ||
+      candidate.getDate() !== day ||
+      candidate.getHours() !== hours ||
+      candidate.getMinutes() !== minutes ||
+      candidate.getSeconds() !== seconds
+    ) {
+      return null;
+    }
+    return candidate;
   }
   const parsed = new Date(iso);
   return Number.isNaN(parsed.getTime()) ? null : parsed;

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -55,18 +55,22 @@ function formatDateForSdtBody(
  * SDT, what the user picked is the displayed wall time, not a moment in
  * UTC.
  */
+// Anchor at end so a malformed input that starts with a valid prefix
+// (e.g. `2026-06-02abc`, `2026-06-02T`) does not silently succeed on the
+// prefix — that would let `formatDate` render a body that disagrees
+// with the bound `dateValueISO`. The optional fractional-seconds group
+// is critical: `new Date(iso).toISOString()` always emits `.SSS`, so a
+// caller round-tripping through Date would otherwise miss the
+// timezone-safe component path and the body would shift a day in
+// non-UTC zones. The trailing group accepts `Z` / a numeric TZ offset
+// — the actual moment-in-time is ignored downstream, but the input has
+// to parse cleanly to be considered a date at all.
+const SDT_DATE_RE =
+  // oxlint-disable-next-line sonarjs/regex-complexity -- ISO 8601 shape; see comment block above
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
+
 function parseSdtDate(iso: string): Date | null {
-  // Anchor at end so a malformed input that starts with a valid prefix
-  // (e.g. `2026-06-02abc`, `2026-06-02T`) does not silently succeed on the
-  // prefix — that would let `formatDate` render a body that disagrees with
-  // the bound `dateValueISO`. The optional trailing group accepts `Z` / a
-  // numeric TZ offset since those are valid OOXML date forms; the actual
-  // moment-in-time is ignored downstream, but the input has to parse
-  // cleanly to be considered a date at all.
-  const match =
-    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u.exec(
-      iso,
-    );
+  const match = SDT_DATE_RE.exec(iso);
   if (match) {
     const year = Number(match[1]);
     const month = Number(match[2]);

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -381,7 +381,11 @@ export function setContentControlValue(
         const display = item?.displayText ?? input.value;
         return {
           ...control,
-          properties: { ...control.properties, showingPlaceholder: false },
+          properties: {
+            ...control.properties,
+            dropdownLastValue: input.value,
+            showingPlaceholder: false,
+          },
           content: [makeParagraphFromText(display)],
         };
       }

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -16,7 +16,11 @@ import type {
   Paragraph,
   Table,
 } from "../types/document";
-import { ContentControlLockedError, ContentControlTypeError } from "./errors";
+import {
+  ContentControlBoundError,
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "./errors";
 import type { ContentControlFilter } from "./findContentControls";
 
 /**
@@ -180,6 +184,80 @@ function isRepeatingSection(control: BlockSdt): boolean {
 
 const REPEATING_SECTION_RE = /<\w+:repeatingSection\b/u;
 
+const DATA_BINDING_RE = /<\w+:dataBinding\b([^>]*)\/?>/iu;
+
+/**
+ * Detect a `<w:dataBinding w:xpath="…"/>` (or alt-prefix variant) inside
+ * the captured rawPropertiesXml + extract the xpath / storeItemID for
+ * the error payload. Returns null when no binding is present.
+ */
+function readDataBinding(
+  control: BlockSdt,
+): { xpath: string; storeItemID?: string } | null {
+  const raw = control.properties.rawPropertiesXml;
+  if (raw === undefined) {
+    return null;
+  }
+  const match = DATA_BINDING_RE.exec(raw);
+  if (!match) {
+    return null;
+  }
+  const attrs = match[1] ?? "";
+  const xpathMatch = /\bxpath="([^"]*)"/iu.exec(attrs);
+  if (!xpathMatch) {
+    return null;
+  }
+  const xpath = xpathMatch[1] ?? "";
+  const storeMatch = /\bstoreItemID="([^"]*)"/iu.exec(attrs);
+  if (storeMatch) {
+    return { xpath, storeItemID: storeMatch[1] ?? "" };
+  }
+  return { xpath };
+}
+
+/**
+ * Refuse content mutations on bound SDTs unless the caller passes
+ * `{ force: true }`. When force is set, return the rawPropertiesXml
+ * with the `<w:dataBinding>` element stripped so the caller's write
+ * actually sticks on next Word open. See `ContentControlBoundError`
+ * for the rationale.
+ */
+function ensureContentNotBound(
+  control: BlockSdt,
+  force: boolean | undefined,
+): { strippedRawPropertiesXml: string | undefined } {
+  const binding = readDataBinding(control);
+  if (!binding) {
+    return { strippedRawPropertiesXml: undefined };
+  }
+  if (!force) {
+    throw new ContentControlBoundError({
+      message: `Control "${control.properties.tag ?? control.properties.alias ?? "(unnamed)"}" is bound to ${binding.xpath}. Word regenerates the body from the bound XML on open; pass { force: true } to strip the binding inline, or remove it explicitly before writing.`,
+      xpath: binding.xpath,
+      ...(binding.storeItemID !== undefined
+        ? { storeItemID: binding.storeItemID }
+        : {}),
+      ...(control.properties.tag !== undefined
+        ? { tag: control.properties.tag }
+        : {}),
+      ...(control.properties.alias !== undefined
+        ? { alias: control.properties.alias }
+        : {}),
+    });
+  }
+  const raw = control.properties.rawPropertiesXml;
+  if (raw === undefined) {
+    return { strippedRawPropertiesXml: undefined };
+  }
+  // Strip every dataBinding occurrence; an SDT theoretically can carry
+  // only one, but match all defensively.
+  const stripped = raw.replaceAll(
+    /<\w+:dataBinding\b[^>]*\/?>(?:[\s\S]*?<\/\w+:dataBinding>)?/giu,
+    "",
+  );
+  return { strippedRawPropertiesXml: stripped };
+}
+
 /**
  * The `match` callback's return shape:
  * - `undefined` — the SDT did not match the filter; recurse into its body
@@ -328,12 +406,19 @@ export function setContentControlContent(
         return undefined;
       }
       ensureContentNotLocked(control, options.force);
+      const { strippedRawPropertiesXml } = ensureContentNotBound(
+        control,
+        options.force,
+      );
       const blocks: BlockContent[] =
         typeof input === "string"
           ? [makeParagraphFromText(input)]
           : input.map(cloneBlock);
       const properties = { ...control.properties };
       properties.showingPlaceholder = false;
+      if (strippedRawPropertiesXml !== undefined) {
+        properties.rawPropertiesXml = strippedRawPropertiesXml;
+      }
       return {
         ...control,
         properties,
@@ -362,6 +447,10 @@ export function setContentControlValue(
         return undefined;
       }
       ensureContentNotLocked(control, options.force);
+      const { strippedRawPropertiesXml } = ensureContentNotBound(
+        control,
+        options.force,
+      );
 
       const sdtType = control.properties.sdtType;
       if (input.kind === "dropdown") {
@@ -400,6 +489,9 @@ export function setContentControlValue(
             ...control.properties,
             dropdownLastValue: input.value,
             showingPlaceholder: false,
+            ...(strippedRawPropertiesXml !== undefined
+              ? { rawPropertiesXml: strippedRawPropertiesXml }
+              : {}),
           },
           content: [makeParagraphFromText(display)],
         };
@@ -425,6 +517,9 @@ export function setContentControlValue(
             ...control.properties,
             checked: input.checked,
             showingPlaceholder: false,
+            ...(strippedRawPropertiesXml !== undefined
+              ? { rawPropertiesXml: strippedRawPropertiesXml }
+              : {}),
           },
           content: [makeParagraphFromText(glyph)],
         };
@@ -456,6 +551,9 @@ export function setContentControlValue(
           ...control.properties,
           dateValueISO: input.date,
           showingPlaceholder: false,
+          ...(strippedRawPropertiesXml !== undefined
+            ? { rawPropertiesXml: strippedRawPropertiesXml }
+            : {}),
         },
         content: [makeParagraphFromText(display)],
       };

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -166,10 +166,15 @@ function ensureSdtNotLocked(
 
 function isRepeatingSection(control: BlockSdt): boolean {
   // Not modeled in folio's SdtType enum; detected via the captured raw XML.
-  return Boolean(
-    control.properties.rawPropertiesXml?.includes("w15:repeatingSection"),
-  );
+  // Match by local name so a DOCX that binds the Word 2012 namespace under
+  // an alternate prefix (`<ns0:repeatingSection/>`) is still recognized —
+  // otherwise `removeContentControl(..., { keepContent: true })` would
+  // happily unwrap it and orphan the row items.
+  const raw = control.properties.rawPropertiesXml;
+  return raw !== undefined && REPEATING_SECTION_RE.test(raw);
 }
+
+const REPEATING_SECTION_RE = /<\w+:repeatingSection\b/u;
 
 /**
  * The `match` callback's return shape:

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -8,6 +8,7 @@
  * would orphan their w15 row items.
  */
 
+import { formatDate } from "../docx/fieldParser";
 import type {
   BlockContent,
   BlockSdt,
@@ -17,6 +18,30 @@ import type {
 } from "../types/document";
 import { ContentControlLockedError, ContentControlTypeError } from "./errors";
 import type { ContentControlFilter } from "./findContentControls";
+
+/**
+ * Format an ISO 8601 date string using the SDT's modeled `dateFormat`. The
+ * w:dateFormat tokens (yyyy/MM/dd/MMMM/HH/mm/ss/AM/PM, etc.) match what
+ * `formatDate` already implements for the fields engine; reusing it keeps
+ * both surfaces consistent.
+ *
+ * Returns the ISO input unchanged if the input does not parse as a date or
+ * the format is missing — degrading gracefully is better than corrupting
+ * the body.
+ */
+function formatDateForSdtBody(
+  isoDate: string,
+  dateFormat: string | undefined,
+): string {
+  if (!dateFormat) {
+    return isoDate;
+  }
+  const parsed = new Date(isoDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return isoDate;
+  }
+  return formatDate(parsed, dateFormat);
+}
 
 type ForceOption = { force?: boolean };
 
@@ -335,10 +360,21 @@ export function setContentControlValue(
             : {}),
         });
       }
+      // Keep the ISO value on the model and write the format-aware display
+      // string into the body so the on-screen text and the OOXML
+      // `w:fullDate` round-trip independently.
+      const display = formatDateForSdtBody(
+        input.date,
+        control.properties.dateFormat,
+      );
       return {
         ...control,
-        properties: { ...control.properties, showingPlaceholder: false },
-        content: [makeParagraphFromText(input.date)],
+        properties: {
+          ...control.properties,
+          dateValueISO: input.date,
+          showingPlaceholder: false,
+        },
+        content: [makeParagraphFromText(display)],
       };
     },
   );

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -44,20 +44,28 @@ function formatDateForSdtBody(
 }
 
 /**
- * Parse an OOXML SDT date string. For a date-only `YYYY-MM-DD` (or a
- * `YYYY-MM-DDT…Z` whose date portion is what the user picked) we build a
- * Date at local midnight matching the calendar day, so `formatDate`'s
- * local-time accessors return the same day no matter the user's
- * timezone. `new Date("2026-06-02")` would parse as UTC midnight and a
- * Pacific user would see the previous day in the rendered display.
+ * Parse an OOXML SDT date string. `new Date(iso)` parses the input as UTC
+ * (a Pacific user would see the previous calendar day via local
+ * accessors), so we instead read the ISO components into a local-midnight
+ * Date so `formatDate`'s local-time accessors return the same calendar
+ * date / wall-clock time in every timezone.
+ *
+ * Supports date-only (`YYYY-MM-DD`) and date+time (`YYYY-MM-DDTHH:mm[:ss]`)
+ * inputs. The trailing `Z` / offset is intentionally ignored — for a date
+ * SDT, what the user picked is the displayed wall time, not a moment in
+ * UTC.
  */
 function parseSdtDate(iso: string): Date | null {
-  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/u.exec(iso);
-  if (dateOnly) {
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
+  if (match) {
     return new Date(
-      Number(dateOnly[1]),
-      Number(dateOnly[2]) - 1,
-      Number(dateOnly[3]),
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      match[4] ? Number(match[4]) : 0,
+      match[5] ? Number(match[5]) : 0,
+      match[6] ? Number(match[6]) : 0,
     );
   }
   const parsed = new Date(iso);

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -271,6 +271,12 @@ function controlMatchesFilter(
   control: BlockSdt,
   filter: ContentControlFilter,
 ): boolean {
+  // Headless `BlockSdt` model has no PM positions; refuse a pmPos-only
+  // filter so a stray pm-side address never accidentally targets every
+  // control (see `matches` in `findContentControls`).
+  if (filter.pmPos !== undefined) {
+    return false;
+  }
   if (filter.tag !== undefined && control.properties.tag !== filter.tag) {
     return false;
   }

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -56,8 +56,17 @@ function formatDateForSdtBody(
  * UTC.
  */
 function parseSdtDate(iso: string): Date | null {
+  // Anchor at end so a malformed input that starts with a valid prefix
+  // (e.g. `2026-06-02abc`, `2026-06-02T`) does not silently succeed on the
+  // prefix — that would let `formatDate` render a body that disagrees with
+  // the bound `dateValueISO`. The optional trailing group accepts `Z` / a
+  // numeric TZ offset since those are valid OOXML date forms; the actual
+  // moment-in-time is ignored downstream, but the input has to parse
+  // cleanly to be considered a date at all.
   const match =
-    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
+    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u.exec(
+      iso,
+    );
   if (match) {
     const year = Number(match[1]);
     const month = Number(match[2]);

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -36,11 +36,32 @@ function formatDateForSdtBody(
   if (!dateFormat) {
     return isoDate;
   }
-  const parsed = new Date(isoDate);
-  if (Number.isNaN(parsed.getTime())) {
+  const parsed = parseSdtDate(isoDate);
+  if (!parsed) {
     return isoDate;
   }
   return formatDate(parsed, dateFormat);
+}
+
+/**
+ * Parse an OOXML SDT date string. For a date-only `YYYY-MM-DD` (or a
+ * `YYYY-MM-DDT…Z` whose date portion is what the user picked) we build a
+ * Date at local midnight matching the calendar day, so `formatDate`'s
+ * local-time accessors return the same day no matter the user's
+ * timezone. `new Date("2026-06-02")` would parse as UTC midnight and a
+ * Pacific user would see the previous day in the rendered display.
+ */
+function parseSdtDate(iso: string): Date | null {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/u.exec(iso);
+  if (dateOnly) {
+    return new Date(
+      Number(dateOnly[1]),
+      Number(dateOnly[2]) - 1,
+      Number(dateOnly[3]),
+    );
+  }
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 type ForceOption = { force?: boolean };

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -1,0 +1,355 @@
+/**
+ * Pure (immutable) write helpers for block-level content controls.
+ *
+ * Each helper returns a brand-new `Document` with the requested mutation
+ * applied; the original document is never touched. Locked controls and
+ * type-incompatible operations throw a tagged error unless `{ force: true }`
+ * is passed. `w15:repeatingSection` controls cannot be unwrapped — doing so
+ * would orphan their w15 row items.
+ */
+
+import type {
+  BlockContent,
+  BlockSdt,
+  Document,
+  Paragraph,
+  Table,
+} from "../types/document";
+import { ContentControlLockedError, ContentControlTypeError } from "./errors";
+import type { ContentControlFilter } from "./findContentControls";
+
+type ForceOption = { force?: boolean };
+
+export type SetContentControlContentInput = string | BlockContent[];
+
+export type SetContentControlValueInput =
+  | { kind: "dropdown"; value: string }
+  | { kind: "checkbox"; checked: boolean }
+  | { kind: "date"; date: string };
+
+function lockBlocksMutation(
+  control: BlockSdt,
+  force: boolean | undefined,
+): void {
+  const lock = control.properties.lock;
+  if (force) {
+    return;
+  }
+  if (lock === "contentLocked" || lock === "sdtContentLocked") {
+    throw new ContentControlLockedError({
+      message: `Control "${control.properties.tag ?? control.properties.alias ?? "(unnamed)"}" has w:lock=${lock}.`,
+      lock,
+      ...(control.properties.tag !== undefined
+        ? { tag: control.properties.tag }
+        : {}),
+      ...(control.properties.alias !== undefined
+        ? { alias: control.properties.alias }
+        : {}),
+    });
+  }
+}
+
+function isRepeatingSection(control: BlockSdt): boolean {
+  // Not modeled in folio's SdtType enum; detected via the captured raw XML.
+  return Boolean(
+    control.properties.rawPropertiesXml?.includes("w15:repeatingSection"),
+  );
+}
+
+/**
+ * The `match` callback's return shape:
+ * - `undefined` — the SDT did not match the filter; recurse into its body
+ * - `null` — match: drop the SDT (and content) entirely
+ * - `BlockContent[]` — match: replace the SDT with these blocks (unwrap)
+ * - `BlockContent` — match: replace the SDT with this single block
+ */
+type SdtMatchResult = BlockContent | BlockContent[] | null | undefined;
+
+function mapBlock(
+  block: BlockContent,
+  match: (b: BlockSdt) => SdtMatchResult,
+): BlockContent | BlockContent[] | null {
+  if (block.type === "blockSdt") {
+    const replaced = match(block);
+    if (replaced !== undefined) {
+      return replaced;
+    }
+    const nextContent = transformBlocks(block.content, match);
+    return { ...block, content: nextContent };
+  }
+  if (block.type === "table") {
+    const rows = block.rows.map((row) => ({
+      ...row,
+      cells: row.cells.map((cell) => {
+        const transformed = transformBlocks(cell.content, match);
+        const cellContent: (Paragraph | Table)[] = [];
+        for (const child of transformed) {
+          if (child.type === "paragraph" || child.type === "table") {
+            cellContent.push(child);
+          }
+          // BlockSdt children inside a table cell are currently not part of
+          // the cell content model; if such a child survives the transform
+          // (e.g. for nested controls), it is dropped here. See the table
+          // parser deferral note for cell-level SDTs.
+        }
+        return { ...cell, content: cellContent };
+      }),
+    }));
+    return { ...block, rows };
+  }
+  return block;
+}
+
+function transformBlocks(
+  blocks: BlockContent[],
+  match: (b: BlockSdt) => SdtMatchResult,
+): BlockContent[] {
+  const out: BlockContent[] = [];
+  for (const block of blocks) {
+    const mapped = mapBlock(block, match);
+    if (mapped === null) {
+      continue;
+    }
+    if (Array.isArray(mapped)) {
+      out.push(...mapped);
+    } else {
+      out.push(mapped);
+    }
+  }
+  return out;
+}
+
+function withUpdatedBody(doc: Document, content: BlockContent[]): Document {
+  return {
+    ...doc,
+    package: {
+      ...doc.package,
+      document: {
+        ...doc.package.document,
+        content,
+      },
+    },
+  };
+}
+
+function controlMatchesFilter(
+  control: BlockSdt,
+  filter: ContentControlFilter,
+): boolean {
+  if (filter.tag !== undefined && control.properties.tag !== filter.tag) {
+    return false;
+  }
+  if (filter.alias !== undefined && control.properties.alias !== filter.alias) {
+    return false;
+  }
+  if (filter.id !== undefined && control.properties.id !== filter.id) {
+    return false;
+  }
+  if (
+    filter.sdtType !== undefined &&
+    control.properties.sdtType !== filter.sdtType
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function makeParagraphFromText(text: string): Paragraph {
+  return {
+    type: "paragraph",
+    content:
+      text.length === 0
+        ? []
+        : [{ type: "run", content: [{ type: "text", text }] }],
+  };
+}
+
+function cloneBlock<T extends BlockContent>(block: T): T {
+  return structuredClone(block);
+}
+
+/**
+ * Replace a control's inner content. Plain text becomes one paragraph; an
+ * explicit `BlockContent[]` is deep-cloned to preserve immutability. The
+ * `showingPlcHdr` flag is cleared so the new content is not styled as
+ * placeholder.
+ */
+export function setContentControlContent(
+  doc: Document,
+  filter: ContentControlFilter,
+  input: SetContentControlContentInput,
+  options: ForceOption = {},
+): Document {
+  const nextContent = transformBlocks(
+    doc.package.document.content,
+    (control) => {
+      if (!controlMatchesFilter(control, filter)) {
+        return undefined;
+      }
+      lockBlocksMutation(control, options.force);
+      const blocks: BlockContent[] =
+        typeof input === "string"
+          ? [makeParagraphFromText(input)]
+          : input.map(cloneBlock);
+      const properties = { ...control.properties };
+      properties.showingPlaceholder = false;
+      return {
+        ...control,
+        properties,
+        content: blocks,
+      };
+    },
+  );
+  return withUpdatedBody(doc, nextContent);
+}
+
+/**
+ * Set a structured value on a typed control. Dropdown / checkbox / date
+ * each get their own input shape so the input is type-checked at the
+ * call site.
+ */
+export function setContentControlValue(
+  doc: Document,
+  filter: ContentControlFilter,
+  input: SetContentControlValueInput,
+  options: ForceOption = {},
+): Document {
+  const nextContent = transformBlocks(
+    doc.package.document.content,
+    (control) => {
+      if (!controlMatchesFilter(control, filter)) {
+        return undefined;
+      }
+      lockBlocksMutation(control, options.force);
+
+      const sdtType = control.properties.sdtType;
+      if (input.kind === "dropdown") {
+        if (sdtType !== "dropdown" && sdtType !== "comboBox") {
+          throw new ContentControlTypeError({
+            message: `Cannot set dropdown value on a ${sdtType} control.`,
+            sdtType,
+            reason: "kind=dropdown requires sdtType=dropdown|comboBox",
+            ...(control.properties.tag !== undefined
+              ? { tag: control.properties.tag }
+              : {}),
+            ...(control.properties.alias !== undefined
+              ? { alias: control.properties.alias }
+              : {}),
+          });
+        }
+        const items = control.properties.listItems ?? [];
+        const item = items.find((i) => i.value === input.value);
+        if (!item && !options.force) {
+          throw new ContentControlTypeError({
+            message: `Value "${input.value}" not in the control's list items.`,
+            sdtType,
+            reason: "value not in listItems",
+            ...(control.properties.tag !== undefined
+              ? { tag: control.properties.tag }
+              : {}),
+            ...(control.properties.alias !== undefined
+              ? { alias: control.properties.alias }
+              : {}),
+          });
+        }
+        const display = item?.displayText ?? input.value;
+        return {
+          ...control,
+          properties: { ...control.properties, showingPlaceholder: false },
+          content: [makeParagraphFromText(display)],
+        };
+      }
+      if (input.kind === "checkbox") {
+        if (sdtType !== "checkbox") {
+          throw new ContentControlTypeError({
+            message: `Cannot toggle checkbox on a ${sdtType} control.`,
+            sdtType,
+            reason: "kind=checkbox requires sdtType=checkbox",
+            ...(control.properties.tag !== undefined
+              ? { tag: control.properties.tag }
+              : {}),
+            ...(control.properties.alias !== undefined
+              ? { alias: control.properties.alias }
+              : {}),
+          });
+        }
+        const glyph = input.checked ? "☒" : "☐";
+        return {
+          ...control,
+          properties: {
+            ...control.properties,
+            checked: input.checked,
+            showingPlaceholder: false,
+          },
+          content: [makeParagraphFromText(glyph)],
+        };
+      }
+      // date
+      if (sdtType !== "date") {
+        throw new ContentControlTypeError({
+          message: `Cannot set date on a ${sdtType} control.`,
+          sdtType,
+          reason: "kind=date requires sdtType=date",
+          ...(control.properties.tag !== undefined
+            ? { tag: control.properties.tag }
+            : {}),
+          ...(control.properties.alias !== undefined
+            ? { alias: control.properties.alias }
+            : {}),
+        });
+      }
+      return {
+        ...control,
+        properties: { ...control.properties, showingPlaceholder: false },
+        content: [makeParagraphFromText(input.date)],
+      };
+    },
+  );
+  return withUpdatedBody(doc, nextContent);
+}
+
+/**
+ * Remove a control. With `{ keepContent: true }` the inner blocks survive
+ * in-place; otherwise the control and its children are dropped. Refuses to
+ * unwrap a `w15:repeatingSection` (would orphan w15 row items).
+ */
+export function removeContentControl(
+  doc: Document,
+  filter: ContentControlFilter,
+  options: ForceOption & { keepContent?: boolean } = {},
+): Document {
+  const nextContent = transformBlocks(
+    doc.package.document.content,
+    (control) => {
+      if (!controlMatchesFilter(control, filter)) {
+        return undefined;
+      }
+      lockBlocksMutation(control, options.force);
+      if (options.keepContent) {
+        if (isRepeatingSection(control) && !options.force) {
+          throw new ContentControlTypeError({
+            message:
+              "Refusing to unwrap a w15:repeatingSection — would orphan its w15 row items.",
+            sdtType: control.properties.sdtType,
+            reason: "repeatingSection unwrap orphans items",
+            ...(control.properties.tag !== undefined
+              ? { tag: control.properties.tag }
+              : {}),
+            ...(control.properties.alias !== undefined
+              ? { alias: control.properties.alias }
+              : {}),
+          });
+        }
+        return control.content;
+      }
+      // Drop control + content entirely.
+      return null;
+    },
+  );
+  // The body must contain at least one paragraph (OOXML requires a non-empty
+  // body). Insert a placeholder if we just emptied it.
+  if (nextContent.length === 0) {
+    nextContent.push(makeParagraphFromText(""));
+  }
+  return withUpdatedBody(doc, nextContent);
+}

--- a/packages/folio/src/core/docx/blockContentParser-sdt.test.ts
+++ b/packages/folio/src/core/docx/blockContentParser-sdt.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression tests for block-level SDT preservation.
+ *
+ * Pre-change behaviour: `<w:sdt>` block wrappers were flattened on parse,
+ * dropping the control entirely (no properties, no identity, no round-trip).
+ * Now the parser emits a `BlockSdt` carrying the modeled `SdtProperties`
+ * plus a verbatim `rawPropertiesXml` snapshot of `<w:sdtPr>` so unmodeled
+ * OOXML features (data binding, repeating sections, sdtEndPr) round-trip.
+ *
+ * Picked up from upstream eigenpal/docx-editor#653.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { BlockContent, BlockSdt } from "../types/document";
+import { parseBlockContent } from "./blockContentParser";
+import { parseXml } from "./xmlParser";
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"';
+
+function parseBody(xml: string) {
+  const root = parseXml(xml);
+  const body = root.elements?.[0];
+  if (!body) {
+    throw new Error("expected root body element");
+  }
+  return parseBlockContent(body, null, null, null, null, null);
+}
+
+function expectBlockSdt(block: BlockContent | undefined): BlockSdt {
+  if (!block || block.type !== "blockSdt") {
+    throw new Error(`expected blockSdt, got ${String(block?.type)}`);
+  }
+  return block;
+}
+
+describe("parseBlockContent — block-level w:sdt preservation", () => {
+  test("emits a BlockSdt with modeled properties and raw sdtPr", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr>
+          <w:alias w:val="Effective Date"/>
+          <w:tag w:val="effective-date"/>
+          <w:id w:val="123456"/>
+          <w:lock w:val="contentLocked"/>
+        </w:sdtPr>
+        <w:sdtContent>
+          <w:p><w:r><w:t>2 June 2026</w:t></w:r></w:p>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    expect(content).toHaveLength(1);
+    const sdt = expectBlockSdt(content[0]);
+    expect(sdt.type).toBe("blockSdt");
+    expect(sdt.properties.alias).toBe("Effective Date");
+    expect(sdt.properties.tag).toBe("effective-date");
+    expect(sdt.properties.id).toBe(123_456);
+    expect(sdt.properties.lock).toBe("contentLocked");
+    // Raw sdtPr captured for the serializer to replay verbatim.
+    expect(sdt.properties.rawPropertiesXml).toContain("<w:alias");
+    expect(sdt.properties.rawPropertiesXml).toContain("<w:tag");
+    expect(sdt.properties.rawPropertiesXml).toContain("<w:lock");
+    // Nested paragraph survives.
+    expect(sdt.content).toHaveLength(1);
+    expect(sdt.content[0]?.type).toBe("paragraph");
+  });
+
+  test("preserves unmodeled w15:repeatingSection markers via rawPropertiesXml", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr>
+          <w:tag w:val="parties"/>
+          <w15:repeatingSection/>
+        </w:sdtPr>
+        <w:sdtContent>
+          <w:p/>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    const sdt = expectBlockSdt(content[0]);
+    expect(sdt.type).toBe("blockSdt");
+    // Modeled type stays "richText" (we do not model w15:repeatingSection),
+    // but the raw XML carries it so the serializer round-trips it.
+    expect(sdt.properties.rawPropertiesXml).toContain("w15:repeatingSection");
+  });
+
+  test("captures w:sdtEndPr verbatim into rawEndPropertiesXml", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="signature"/></w:sdtPr>
+        <w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    const sdt = expectBlockSdt(content[0]);
+    expect(sdt.properties.rawEndPropertiesXml).toContain("<w:rPr>");
+    expect(sdt.properties.rawEndPropertiesXml).toContain("<w:b");
+  });
+
+  test("preserves nested block SDTs (sdt-inside-sdt)", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="outer"/></w:sdtPr>
+        <w:sdtContent>
+          <w:sdt>
+            <w:sdtPr><w:tag w:val="inner"/></w:sdtPr>
+            <w:sdtContent>
+              <w:p><w:r><w:t>nested</w:t></w:r></w:p>
+            </w:sdtContent>
+          </w:sdt>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    const outer = expectBlockSdt(content[0]);
+    expect(outer.properties.tag).toBe("outer");
+    expect(outer.content).toHaveLength(1);
+    const inner = expectBlockSdt(outer.content[0]);
+    expect(inner.type).toBe("blockSdt");
+    expect(inner.properties.tag).toBe("inner");
+  });
+
+  test("wraps a SDT around a table and preserves the table inside", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="party-block"/></w:sdtPr>
+        <w:sdtContent>
+          <w:tbl>
+            <w:tblPr/>
+            <w:tblGrid><w:gridCol w:w="2000"/></w:tblGrid>
+            <w:tr><w:tc><w:p/></w:tc></w:tr>
+          </w:tbl>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    const sdt = expectBlockSdt(content[0]);
+    expect(sdt.content).toHaveLength(1);
+    expect(sdt.content[0]?.type).toBe("table");
+  });
+
+  test("an empty <w:sdtContent> still emits a BlockSdt with no children", () => {
+    const xml = `<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="empty"/></w:sdtPr>
+        <w:sdtContent/>
+      </w:sdt>
+    </w:body>`;
+
+    const content = parseBody(xml);
+    const sdt = expectBlockSdt(content[0]);
+    expect(sdt.type).toBe("blockSdt");
+    expect(sdt.content).toHaveLength(0);
+  });
+});

--- a/packages/folio/src/core/docx/blockContentParser.ts
+++ b/packages/folio/src/core/docx/blockContentParser.ts
@@ -8,6 +8,8 @@
  */
 
 import type {
+  BlockContent,
+  BlockSdt,
   BookmarkEnd,
   BookmarkStart,
   MediaFile,
@@ -16,7 +18,6 @@ import type {
   Run,
   Shape,
   ShapeContent,
-  Table,
   Theme,
 } from "../types/document";
 import { parseBookmarkEnd, parseBookmarkStart } from "./bookmarkParser";
@@ -28,6 +29,7 @@ import type { BookmarkMarker } from "./bookmarkPlacement";
 import { convertBulletToUnicode } from "./bulletMarkers";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
+import { parseSdtProperties } from "./sdtProperties";
 import type { StyleMap } from "./styleParser";
 import { parseTable } from "./tableParser";
 import {
@@ -36,7 +38,12 @@ import {
   parseTextBox,
   parseTextBoxContent,
 } from "./textBoxParser";
-import { findDeep, getChildElements, getLocalName } from "./xmlParser";
+import {
+  findChild,
+  findDeep,
+  getChildElements,
+  getLocalName,
+} from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 type ParseBlockContentOptions = {
@@ -362,7 +369,7 @@ export const parseBlockContent = (
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
   options?: ParseBlockContentOptions,
-): (Paragraph | Table)[] =>
+): BlockContent[] =>
   parseBlockContentWithState(parent, styles, theme, numbering, rels, media, {
     listCounters: new Map(),
     abstractCounters: new Map(),
@@ -377,8 +384,8 @@ const parseBlockContentWithState = (
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
   state: ParseBlockContentState,
-): (Paragraph | Table)[] => {
-  const content: (Paragraph | Table)[] = [];
+): BlockContent[] => {
+  const content: BlockContent[] = [];
   const children = getChildElements(parent);
   const pendingBookmarkMarkers: BookmarkMarker[] = [];
 
@@ -439,31 +446,33 @@ const parseBlockContentWithState = (
     }
 
     if (localName === "sdt") {
-      const sdtContent = (child.elements ?? []).find(
-        (el: XmlElement) =>
-          el.type === "element" &&
-          (el.name === "w:sdtContent" || el.name?.endsWith(":sdtContent")),
-      );
-      if (sdtContent) {
-        const sdtBlockContent = parseBlockContentWithState(
-          sdtContent,
-          styles,
-          theme,
-          numbering,
-          rels,
-          media,
-          state,
-        );
-        if (
-          prependBookmarkMarkersToFirstParagraphInBlocks(
-            sdtBlockContent,
-            pendingBookmarkMarkers,
-          )
-        ) {
-          pendingBookmarkMarkers.length = 0;
-        }
-        content.push(...sdtBlockContent);
+      const sdtPr = findChild(child, "w", "sdtPr");
+      const sdtEndPr = findChild(child, "w", "sdtEndPr");
+      const sdtContent = findChild(child, "w", "sdtContent");
+      const blockSdt: BlockSdt = {
+        type: "blockSdt",
+        properties: parseSdtProperties(sdtPr, sdtEndPr),
+        content: sdtContent
+          ? parseBlockContentWithState(
+              sdtContent,
+              styles,
+              theme,
+              numbering,
+              rels,
+              media,
+              state,
+            )
+          : [],
+      };
+      if (
+        prependBookmarkMarkersToFirstParagraphInBlocks(
+          blockSdt.content,
+          pendingBookmarkMarkers,
+        )
+      ) {
+        pendingBookmarkMarkers.length = 0;
       }
+      content.push(blockSdt);
       continue;
     }
 

--- a/packages/folio/src/core/docx/blockContentParser.ts
+++ b/packages/folio/src/core/docx/blockContentParser.ts
@@ -39,12 +39,13 @@ import {
   parseTextBoxContent,
 } from "./textBoxParser";
 import {
+  elementToXml,
   findChild,
   findDeep,
   getChildElements,
   getLocalName,
+  type XmlElement,
 } from "./xmlParser";
-import type { XmlElement } from "./xmlParser";
 
 type ParseBlockContentOptions = {
   inHeaderFooter?: boolean;
@@ -449,9 +450,22 @@ const parseBlockContentWithState = (
       const sdtPr = findChild(child, "w", "sdtPr");
       const sdtEndPr = findChild(child, "w", "sdtEndPr");
       const sdtContent = findChild(child, "w", "sdtContent");
+      const properties = parseSdtProperties(sdtPr, sdtEndPr);
+      // Capture non-content direct children of <w:sdt> (bookmark / comment /
+      // tracked-change / custom XML range markers — MS-OE376 §2.5.2.30) so a
+      // comment thread or tracked change that crosses an SDT boundary
+      // doesn't lose a delimiter on round-trip. Split by position relative
+      // to sdtContent.
+      const captured = captureSdtSiblingMarkers(child);
+      if (captured.before.length > 0) {
+        properties.rawSdtChildrenBeforeContent = captured.before;
+      }
+      if (captured.after.length > 0) {
+        properties.rawSdtChildrenAfterContent = captured.after;
+      }
       const blockSdt: BlockSdt = {
         type: "blockSdt",
-        properties: parseSdtProperties(sdtPr, sdtEndPr),
+        properties,
         content: sdtContent
           ? parseBlockContentWithState(
               sdtContent,
@@ -492,6 +506,45 @@ const parseBlockContentWithState = (
   }
 
   return content;
+};
+
+/**
+ * Walk a `<w:sdt>` element's direct children and return the verbatim XML
+ * for every child that is NOT `<w:sdtPr>`, `<w:sdtEndPr>`, or
+ * `<w:sdtContent>` — split by position relative to sdtContent.
+ *
+ * Per MS-OE376 §2.5.2.30, Word emits 16 range-marker elements (bookmark,
+ * comment, custom XML, tracked-change ranges) as direct sdt siblings of
+ * sdtContent. Without preserving them, a comment thread or tracked
+ * change that crosses an SDT boundary loses a delimiter when folio
+ * serializes the parsed model back out.
+ */
+const captureSdtSiblingMarkers = (
+  sdt: XmlElement,
+): { before: string; after: string } => {
+  const beforeParts: string[] = [];
+  const afterParts: string[] = [];
+  let sawContent = false;
+  for (const ch of sdt.elements ?? []) {
+    if (ch.type !== "element" || !ch.name) {
+      continue;
+    }
+    const local = getLocalName(ch.name);
+    if (local === "sdtPr" || local === "sdtEndPr") {
+      continue;
+    }
+    if (local === "sdtContent") {
+      sawContent = true;
+      continue;
+    }
+    const xml = elementToXml(ch);
+    if (sawContent) {
+      afterParts.push(xml);
+    } else {
+      beforeParts.push(xml);
+    }
+  }
+  return { before: beforeParts.join(""), after: afterParts.join("") };
 };
 
 const parseBookmarkMarker = (

--- a/packages/folio/src/core/docx/commentReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/commentReferenceNormalization.ts
@@ -66,7 +66,7 @@ export const normalizeCommentReferences = ({
   const normalizeTable = (table: Table): void => {
     for (const row of table.rows) {
       for (const cell of row.cells) {
-        normalizeParagraphTableBlocks(cell.content);
+        normalizeBlocks(cell.content);
       }
     }
   };
@@ -80,7 +80,7 @@ export const normalizeCommentReferences = ({
       normalizeTable(block);
       return;
     }
-    normalizeParagraphTableBlocks(block.content);
+    normalizeBlocks(block.content);
   };
 
   const normalizeBlocks = (blocks: BlockContent[]): void => {
@@ -89,30 +89,18 @@ export const normalizeCommentReferences = ({
     }
   };
 
-  const normalizeParagraphTableBlocks = (
-    blocks: (Paragraph | Table)[],
-  ): void => {
-    for (const block of blocks) {
-      if (block.type === "paragraph") {
-        normalizeParagraph(block);
-        continue;
-      }
-      normalizeTable(block);
-    }
-  };
-
   normalizeBlocks(documentBody.content);
   for (const header of headers?.values() ?? []) {
-    normalizeParagraphTableBlocks(header.content);
+    normalizeBlocks(header.content);
   }
   for (const footer of footers?.values() ?? []) {
-    normalizeParagraphTableBlocks(footer.content);
+    normalizeBlocks(footer.content);
   }
   for (const footnote of footnotes ?? []) {
-    normalizeParagraphTableBlocks(footnote.content);
+    normalizeBlocks(footnote.content);
   }
   for (const endnote of endnotes ?? []) {
-    normalizeParagraphTableBlocks(endnote.content);
+    normalizeBlocks(endnote.content);
   }
   for (const comment of comments) {
     for (const paragraph of comment.content) {

--- a/packages/folio/src/core/docx/headerFooterParser.ts
+++ b/packages/folio/src/core/docx/headerFooterParser.ts
@@ -329,6 +329,17 @@ export function getHeaderFooterText(hf: HeaderFooter): string {
         }
       }
       texts.push(paraTexts.join(""));
+    } else if (item.type === "blockSdt") {
+      // The SDT wrapper is invisible to plain-text extraction; recurse via a
+      // synthetic HeaderFooter so the existing per-block dispatch handles
+      // the nested paragraphs/tables/SDTs without code duplication.
+      texts.push(
+        getHeaderFooterText({
+          type: hf.type,
+          hdrFtrType: hf.hdrFtrType,
+          content: item.content,
+        }),
+      );
     } else {
       // Extract text from table cells
       for (const row of item.rows) {

--- a/packages/folio/src/core/docx/headerFooterReferenceNormalization.ts
+++ b/packages/folio/src/core/docx/headerFooterReferenceNormalization.ts
@@ -69,7 +69,7 @@ export const normalizeHeaderFooterReferences = ({
   const normalizeTable = (table: Table): void => {
     for (const row of table.rows) {
       for (const cell of row.cells) {
-        normalizeParagraphTableBlocks(cell.content);
+        normalizeBlocks(cell.content);
       }
     }
   };
@@ -83,24 +83,12 @@ export const normalizeHeaderFooterReferences = ({
       normalizeTable(block);
       return;
     }
-    normalizeParagraphTableBlocks(block.content);
+    normalizeBlocks(block.content);
   };
 
   const normalizeBlocks = (blocks: BlockContent[]): void => {
     for (const block of blocks) {
       normalizeBlock(block);
-    }
-  };
-
-  const normalizeParagraphTableBlocks = (
-    blocks: (Paragraph | Table)[],
-  ): void => {
-    for (const block of blocks) {
-      if (block.type === "paragraph") {
-        normalizeParagraph(block);
-        continue;
-      }
-      normalizeTable(block);
     }
   };
 

--- a/packages/folio/src/core/docx/paragraphParser.test.ts
+++ b/packages/folio/src/core/docx/paragraphParser.test.ts
@@ -153,6 +153,37 @@ describe("parseParagraph tracked-change hardening", () => {
     expect(sdt.content).toHaveLength(0);
   });
 
+  test("reads inline date-SDT format from <w:dateFormat>, not <w:date w:fullDate>", () => {
+    // Regression: parseSdtProperties used to read w:date@w:fullDate as the
+    // format, but w:fullDate is the bound *value*; the display format lives
+    // in the child <w:dateFormat w:val="..."/>. Picked up from upstream
+    // eigenpal/docx-editor#661.
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:sdt>
+          <w:sdtPr>
+            <w:tag w:val="effective-date"/>
+            <w:date w:fullDate="2026-06-02T00:00:00Z">
+              <w:dateFormat w:val="d MMMM yyyy"/>
+              <w:lid w:val="en-GB"/>
+            </w:date>
+          </w:sdtPr>
+          <w:sdtContent><w:r><w:t>2 June 2026</w:t></w:r></w:sdtContent>
+        </w:sdt>
+      </w:p>
+    `);
+
+    const sdt = paragraph.content.at(0);
+    if (!sdt || sdt.type !== "inlineSdt") {
+      throw new Error("expected inline SDT");
+    }
+    expect(sdt.properties).toMatchObject({
+      sdtType: "date",
+      tag: "effective-date",
+      dateFormat: "d MMMM yyyy",
+    });
+  });
+
   test("preserves point comment references from runs", () => {
     const paragraph = parseParagraphXml(`
       <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -48,7 +48,6 @@ import {
   FrameYAlignSchema,
   LineSpacingRuleSchema,
   ParagraphAlignmentSchema,
-  SdtLockSchema,
   ShadingPatternSchema,
   TabLeaderSchema,
   TabStopAlignmentSchema,
@@ -57,6 +56,7 @@ import {
 } from "./parserEnums";
 import { consolidateParagraphContent } from "./runConsolidator";
 import { parseRun, parseRunProperties } from "./runParser";
+import { parseSdtProperties } from "./sdtProperties";
 import { parseSectionProperties } from "./sectionParser";
 import type { StyleMap } from "./styleParser";
 import {
@@ -69,130 +69,6 @@ import {
   elementToXml,
 } from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
-
-// ============================================================================
-// SDT PROPERTIES PARSER
-// ============================================================================
-
-/**
- * Parse SDT properties (w:sdtPr) element
- */
-function parseSdtProperties(sdtPr: XmlElement | null): SdtProperties {
-  const props: SdtProperties = { sdtType: "richText" };
-  if (!sdtPr || !sdtPr.elements) {
-    return props;
-  }
-
-  for (const el of sdtPr.elements) {
-    if (el.type !== "element") {
-      continue;
-    }
-    const name = el.name?.replace(/^w:/u, "") ?? "";
-
-    switch (name) {
-      case "alias": {
-        const aliasVal = getAttribute(el, "w", "val");
-        if (aliasVal !== null) {
-          props.alias = aliasVal;
-        }
-        break;
-      }
-      case "tag": {
-        const tagVal = getAttribute(el, "w", "val");
-        if (tagVal !== null) {
-          props.tag = tagVal;
-        }
-        break;
-      }
-      case "lock": {
-        const lockVal = getAttribute(el, "w", "val");
-        props.lock = narrowEnum(lockVal, SdtLockSchema) ?? "unlocked";
-        break;
-      }
-      case "placeholder": {
-        const docPart = findChild(el, "w", "docPart");
-        if (docPart) {
-          const valEl = findChild(docPart, "w", "val");
-          if (valEl) {
-            const phVal = getAttribute(valEl, "w", "val");
-            if (phVal !== null) {
-              props.placeholder = phVal;
-            }
-          }
-        }
-        break;
-      }
-      case "showingPlcHdr":
-        props.showingPlaceholder = true;
-        break;
-      case "text":
-        props.sdtType = "plainText";
-        break;
-      case "date": {
-        props.sdtType = "date";
-        // The display format lives in the child <w:dateFormat w:val="..."/>;
-        // <w:date w:fullDate="..."/> is the bound *value*, not the format.
-        const dateFormatEl = findChild(el, "w", "dateFormat");
-        if (dateFormatEl) {
-          const fmt = getAttribute(dateFormatEl, "w", "val");
-          if (fmt !== null) {
-            props.dateFormat = fmt;
-          }
-        }
-        break;
-      }
-      case "dropDownList":
-        props.sdtType = "dropdown";
-        props.listItems = parseListItems(el);
-        break;
-      case "comboBox":
-        props.sdtType = "comboBox";
-        props.listItems = parseListItems(el);
-        break;
-      case "checkbox": {
-        props.sdtType = "checkbox";
-        const checked =
-          findChild(el, "w14", "checked") ?? findChild(el, "w", "checked");
-        props.checked = checked
-          ? getAttribute(checked, "w14", "val") === "1" ||
-            getAttribute(checked, "w", "val") === "1"
-          : false;
-        break;
-      }
-      case "picture":
-        props.sdtType = "picture";
-        break;
-      case "docPartObj":
-        props.sdtType = "buildingBlockGallery";
-        break;
-      case "group":
-        props.sdtType = "group";
-        break;
-      default:
-        break;
-    }
-  }
-
-  return props;
-}
-
-function parseListItems(
-  el: XmlElement,
-): { displayText: string; value: string }[] {
-  const items: { displayText: string; value: string }[] = [];
-  for (const child of el.elements ?? []) {
-    if (
-      child.type === "element" &&
-      (child.name === "w:listItem" || child.name?.endsWith(":listItem"))
-    ) {
-      items.push({
-        displayText: getAttribute(child, "w", "displayText") ?? "",
-        value: getAttribute(child, "w", "value") ?? "",
-      });
-    }
-  }
-  return items;
-}
 
 /**
  * Extract plain text from a math element (recursive text content extraction)
@@ -1558,16 +1434,9 @@ function parseParagraphContents(
 
       case "sdt": {
         // Structured document tag - extract properties and content
-        const sdtPr = (child.elements ?? []).find(
-          (el: XmlElement) =>
-            el.type === "element" &&
-            (el.name === "w:sdtPr" || el.name?.endsWith(":sdtPr")),
-        );
-        const sdtContentEl = (child.elements ?? []).find(
-          (el: XmlElement) =>
-            el.type === "element" &&
-            (el.name === "w:sdtContent" || el.name?.endsWith(":sdtContent")),
-        );
+        const sdtPr = findChild(child, "w", "sdtPr");
+        const sdtEndPr = findChild(child, "w", "sdtEndPr");
+        const sdtContentEl = findChild(child, "w", "sdtContent");
         if (sdtContentEl) {
           const sdtParsed = parseParagraphContents(
             sdtContentEl,
@@ -1578,7 +1447,7 @@ function parseParagraphContents(
             media,
             trackedContext,
           );
-          const properties = parseSdtProperties(sdtPr ?? null);
+          const properties = parseSdtProperties(sdtPr, sdtEndPr);
           pushInlineSdtSegments({
             contents,
             properties,

--- a/packages/folio/src/core/docx/paragraphParser.ts
+++ b/packages/folio/src/core/docx/paragraphParser.ts
@@ -130,9 +130,14 @@ function parseSdtProperties(sdtPr: XmlElement | null): SdtProperties {
         break;
       case "date": {
         props.sdtType = "date";
-        const dateVal = getAttribute(el, "w", "fullDate");
-        if (dateVal !== null) {
-          props.dateFormat = dateVal;
+        // The display format lives in the child <w:dateFormat w:val="..."/>;
+        // <w:date w:fullDate="..."/> is the bound *value*, not the format.
+        const dateFormatEl = findChild(el, "w", "dateFormat");
+        if (dateFormatEl) {
+          const fmt = getAttribute(dateFormatEl, "w", "val");
+          if (fmt !== null) {
+            props.dateFormat = fmt;
+          }
         }
         break;
       }

--- a/packages/folio/src/core/docx/paragraphTraversal.ts
+++ b/packages/folio/src/core/docx/paragraphTraversal.ts
@@ -114,7 +114,7 @@ export const visitDocxParagraphs = (
   const visitTable = (table: Table): void => {
     for (const row of table.rows) {
       for (const cell of row.cells) {
-        visitParagraphTableBlocks(cell.content);
+        visitBlocks(cell.content);
       }
     }
   };
@@ -128,7 +128,7 @@ export const visitDocxParagraphs = (
       visitTable(block);
       return;
     }
-    visitParagraphTableBlocks(block.content);
+    visitBlocks(block.content);
   };
 
   const visitBlocks = (blocks: readonly BlockContent[]): void => {
@@ -137,33 +137,21 @@ export const visitDocxParagraphs = (
     }
   };
 
-  const visitParagraphTableBlocks = (
-    blocks: readonly (Paragraph | Table)[],
-  ): void => {
-    for (const block of blocks) {
-      if (block.type === "paragraph") {
-        visitParagraph(block);
-        continue;
-      }
-      visitTable(block);
-    }
-  };
-
   visitBlocks(documentBody.content);
   for (const section of documentBody.sections ?? []) {
     visitBlocks(section.content);
   }
   for (const header of headers?.values() ?? []) {
-    visitParagraphTableBlocks(header.content);
+    visitBlocks(header.content);
   }
   for (const footer of footers?.values() ?? []) {
-    visitParagraphTableBlocks(footer.content);
+    visitBlocks(footer.content);
   }
   for (const footnote of footnotes ?? []) {
-    visitParagraphTableBlocks(footnote.content);
+    visitBlocks(footnote.content);
   }
   for (const endnote of endnotes ?? []) {
-    visitParagraphTableBlocks(endnote.content);
+    visitBlocks(endnote.content);
   }
   for (const comment of documentBody.comments ?? []) {
     for (const paragraph of comment.content) {

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,31 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("reads checkbox val under an alternative namespace prefix", () => {
+    // OOXML binds prefixes to URIs at the document root; a valid doc can
+    // bind the w14 namespace under any prefix (here `ns0`). The marker
+    // element matched fine via local-name fallback, but the val attribute
+    // was missed because we only looked for `w14:val` / bare `val`. An
+    // unchecked box was then parsed as checked.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:ns0="http://schemas.microsoft.com/office/word/2010/wordml"';
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><ns0:checkbox><ns0:checked ns0:val="0"/></ns0:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(false);
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><ns0:checkbox><ns0:checked ns0:val="1"/></ns0:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(true);
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><ns0:checkbox><ns0:checked ns0:val="false"/></ns0:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(false);
+  });
+
   test("respects w:showingPlcHdr OnOff val (false / off / 0)", () => {
     // The presence-implies-true semantics still applies, but an explicit
     // negation must be honored. Previously the parser flipped

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -125,6 +125,27 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "A", value: "a" }]);
   });
 
+  test("does not corrupt locally-declared xmlns:* attributes during attr normalization", () => {
+    // The attribute normalizer's negative lookahead must skip `xmlns:`
+    // alongside the canonical prefix; otherwise `<x:tag xmlns:x="…"
+    // x:val="…"/>` would get its namespace declaration rewritten to a
+    // bogus `<w:tag w:x="…" w:val="…"/>` on save.
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:tag xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main" x:val="client"/></w:sdtPr>',
+    );
+    expect(props.tag).toBe("client");
+    expect(props.rawPropertiesXml).toBeDefined();
+    // Namespace declaration preserved unchanged.
+    expect(props.rawPropertiesXml).toContain(
+      'xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
+    );
+    // No bogus `w:x=` attribute introduced.
+    expect(props.rawPropertiesXml).not.toContain("w:x=");
+    // Modeled value still picked up and the modeled `val` attribute
+    // points to canonical w: on save.
+    expect(props.rawPropertiesXml).toContain('w:val="client"');
+  });
+
   test("normalizes inherited alt-prefix w-namespace SDT children inside canonical wrapper", () => {
     // Canonical `<w:sdtPr>` wrapper with children inherited under an
     // alt prefix (`<x:tag>` declared via xmlns:x on the document root).

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -39,6 +39,63 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.dateValueISO).toBe("2026-06-02T00:00:00Z");
   });
 
+  test("accepts OOXML OnOff variants for w14:checked val (true / on / 1 / absent)", () => {
+    // Word writes any of these forms; we previously only recognized "1"
+    // and silently flipped state on save.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"';
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked w14:val="true"/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(true);
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked w14:val="on"/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(true);
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked w14:val="1"/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(true);
+    // A bare <w14:checked/> with no val attribute also means true per OnOff.
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(true);
+    // Negations.
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked w14:val="false"/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(false);
+    expect(
+      parseSdtPrXml(
+        `<w:sdtPr ${ns}><w14:checkbox><w14:checked w14:val="0"/></w14:checkbox></w:sdtPr>`,
+      ).checked,
+    ).toBe(false);
+  });
+
+  test("listItem with only w:value falls back to value as displayText", () => {
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:dropDownList><w:listItem w:value="ca"/><w:listItem w:value="ny" w:displayText="New York"/></w:dropDownList></w:sdtPr>',
+    );
+    expect(props.sdtType).toBe("dropdown");
+    expect(props.listItems).toEqual([
+      { displayText: "ca", value: "ca" },
+      { displayText: "New York", value: "ny" },
+    ]);
+  });
+
+  test("listItem with only w:displayText falls back to displayText as value", () => {
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:dropDownList><w:listItem w:displayText="Yes"/></w:dropDownList></w:sdtPr>',
+    );
+    expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
+  });
+
   test("falls back to richText when the marker is unknown", () => {
     const props = parseSdtPrXml(
       '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:appearance w15:val="boundingBox"/><w:tag w:val="t"/></w:sdtPr>',

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,34 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("respects w:showingPlcHdr OnOff val (false / off / 0)", () => {
+    // The presence-implies-true semantics still applies, but an explicit
+    // negation must be honored. Previously the parser flipped
+    // `val="false"` back to `true` because it ignored the attribute.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    expect(
+      parseSdtPrXml(`<w:sdtPr ${ns}><w:showingPlcHdr/></w:sdtPr>`)
+        .showingPlaceholder,
+    ).toBe(true);
+    expect(
+      parseSdtPrXml(`<w:sdtPr ${ns}><w:showingPlcHdr w:val="true"/></w:sdtPr>`)
+        .showingPlaceholder,
+    ).toBe(true);
+    expect(
+      parseSdtPrXml(`<w:sdtPr ${ns}><w:showingPlcHdr w:val="false"/></w:sdtPr>`)
+        .showingPlaceholder,
+    ).toBe(false);
+    expect(
+      parseSdtPrXml(`<w:sdtPr ${ns}><w:showingPlcHdr w:val="0"/></w:sdtPr>`)
+        .showingPlaceholder,
+    ).toBe(false);
+    expect(
+      parseSdtPrXml(`<w:sdtPr ${ns}><w:showingPlcHdr w:val="off"/></w:sdtPr>`)
+        .showingPlaceholder,
+    ).toBe(false);
+  });
+
   test("falls back to richText when the marker is unknown", () => {
     const props = parseSdtPrXml(
       '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:appearance w15:val="boundingBox"/><w:tag w:val="t"/></w:sdtPr>',

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,23 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("reads top-level SDT property attrs under an alternative namespace prefix", () => {
+    // Same prefix-tolerance theme as listItems and checkbox val: the
+    // top-level w:tag / w:alias / w:id / w:lock readers used to be hard-
+    // coded to the `w:` prefix, so docs that bound the namespace under
+    // ns0 came back with undefined tag / alias / lock and could not be
+    // addressed via getContentControls({ tag }).
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><ns0:id ns0:val="42"/><ns0:tag ns0:val="client"/><ns0:alias ns0:val="Client Name"/><ns0:lock ns0:val="contentLocked"/></w:sdtPr>`,
+    );
+    expect(props.id).toBe(42);
+    expect(props.tag).toBe("client");
+    expect(props.alias).toBe("Client Name");
+    expect(props.lock).toBe("contentLocked");
+  });
+
   test("reads dropdown listItem attrs under an alternative namespace prefix", () => {
     // Same prefix-tolerance bug as checkbox val — `parseListItems` matched
     // `<ns0:listItem>` via local-name fallback but then read `w:displayText`

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,35 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("reads attributes by local name when a canonical element carries an inherited alt-prefix attr", () => {
+    // `<w:tag x:val="client"/>` — canonical element, inherited `x:val`.
+    // Without the local-name attribute fallback, props.tag stayed empty
+    // and getContentControls({ tag: "client" }) couldn't find the
+    // control even though the saved DOCX serialized the value
+    // correctly via the raw normalizer.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:tag x:val="client"/><w:alias x:val="Client Name"/></w:sdtPr>`,
+    );
+    expect(props.tag).toBe("client");
+    expect(props.alias).toBe("Client Name");
+  });
+
+  test("reads dropdown listItem attrs when canonical listItem carries alt-prefix attrs", () => {
+    // Same pattern as above for parseListItems: `<w:listItem x:displayText="…"
+    // x:value="…"/>`. Previously the wrapper-prefix path returned null
+    // (element prefix is `w`, attribute prefix is `x`), the canonical
+    // path returned null too, and the item was silently dropped.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:dropDownList><w:listItem x:displayText="A" x:value="a"/></w:dropDownList></w:sdtPr>`,
+    );
+    expect(props.sdtType).toBe("dropdown");
+    expect(props.listItems).toEqual([{ displayText: "A", value: "a" }]);
+  });
+
   test("normalizes inherited alt-prefix w-namespace SDT children inside canonical wrapper", () => {
     // Canonical `<w:sdtPr>` wrapper with children inherited under an
     // alt prefix (`<x:tag>` declared via xmlns:x on the document root).

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,23 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("reads dropdown listItem attrs under an alternative namespace prefix", () => {
+    // Same prefix-tolerance bug as checkbox val — `parseListItems` matched
+    // `<ns0:listItem>` via local-name fallback but then read `w:displayText`
+    // / `w:value`, which came back null and the item was silently dropped.
+    // A dropdown bound under any non-`w` prefix would open with no options.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:dropDownList><ns0:listItem ns0:displayText="A" ns0:value="a"/><ns0:listItem ns0:displayText="B" ns0:value="b"/></w:dropDownList></w:sdtPr>`,
+    );
+    expect(props.sdtType).toBe("dropdown");
+    expect(props.listItems).toEqual([
+      { displayText: "A", value: "a" },
+      { displayText: "B", value: "b" },
+    ]);
+  });
+
   test("reads checkbox val under an alternative namespace prefix", () => {
     // OOXML binds prefixes to URIs at the document root; a valid doc can
     // bind the w14 namespace under any prefix (here `ns0`). The marker

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Tests for the shared SDT-properties parser.
+ *
+ * Focus areas not covered by the higher-level block-SDT parser tests:
+ * recognising `w14:` / `w15:` prefixed marker elements (the most visible
+ * one being `w14:checkbox`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseSdtProperties } from "./sdtProperties";
+import { parseXml } from "./xmlParser";
+
+function parseSdtPrXml(xml: string) {
+  const root = parseXml(xml);
+  const sdtPr = root.elements?.[0];
+  if (!sdtPr) {
+    throw new TypeError("expected sdtPr root");
+  }
+  return parseSdtProperties(sdtPr);
+}
+
+describe("parseSdtProperties — prefixed marker elements", () => {
+  test("recognizes w14:checkbox and returns sdtType=checkbox", () => {
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml"><w:tag w:val="agree"/><w14:checkbox><w14:checked w14:val="1"/></w14:checkbox></w:sdtPr>',
+    );
+    expect(props.sdtType).toBe("checkbox");
+    expect(props.checked).toBe(true);
+    expect(props.tag).toBe("agree");
+  });
+
+  test("recognizes a w:date marker even on prefixed children", () => {
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:date w:fullDate="2026-06-02T00:00:00Z"><w:dateFormat w:val="d MMMM yyyy"/></w:date></w:sdtPr>',
+    );
+    expect(props.sdtType).toBe("date");
+    expect(props.dateFormat).toBe("d MMMM yyyy");
+    expect(props.dateValueISO).toBe("2026-06-02T00:00:00Z");
+  });
+
+  test("falls back to richText when the marker is unknown", () => {
+    const props = parseSdtPrXml(
+      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"><w15:appearance w15:val="boundingBox"/><w:tag w:val="t"/></w:sdtPr>',
+    );
+    expect(props.sdtType).toBe("richText");
+    expect(props.tag).toBe("t");
+  });
+});

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,28 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("normalizes alt-prefix rawPropertiesXml to canonical w: on capture", () => {
+    // A producer that binds the WordprocessingML namespace under `ns0`
+    // emits `<ns0:sdtPr>…</ns0:sdtPr>` at parse time. Replaying that
+    // verbatim into the serializer's output (which only declares the
+    // canonical `w` / `w14` / `w15` prefixes at the document root)
+    // would produce invalid XML with unresolved `xmlns:ns0` and Word
+    // would refuse to open the saved DOCX. The captured raw snippet
+    // should already use `w:` so the replay is self-contained.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:ns0="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<ns0:sdtPr ${ns}><ns0:tag ns0:val="client"/><ns0:alias ns0:val="Client"/></ns0:sdtPr>`,
+    );
+    expect(props.tag).toBe("client");
+    expect(props.alias).toBe("Client");
+    expect(props.rawPropertiesXml).toBeDefined();
+    // Replay must be canonical.
+    expect(props.rawPropertiesXml).not.toContain("ns0:");
+    expect(props.rawPropertiesXml).toContain("<w:sdtPr");
+    expect(props.rawPropertiesXml).toContain('<w:tag w:val="client"/>');
+  });
+
   test("reads placeholder docPart reference from the docPart's own w:val attribute", () => {
     // The parser used to look for a nested `<w:val>` child inside
     // `<w:docPart>`. The actual OOXML shape is `<w:docPart w:val="…"/>`,

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,18 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("reads placeholder docPart reference from the docPart's own w:val attribute", () => {
+    // The parser used to look for a nested `<w:val>` child inside
+    // `<w:docPart>`. The actual OOXML shape is `<w:docPart w:val="…"/>`,
+    // so the placeholder reference was silently dropped.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:placeholder><w:docPart w:val="DefaultPlaceholder"/></w:placeholder></w:sdtPr>`,
+    );
+    expect(props.placeholder).toBe("DefaultPlaceholder");
+  });
+
   test("reads top-level SDT property attrs under an alternative namespace prefix", () => {
     // Same prefix-tolerance theme as listItems and checkbox val: the
     // top-level w:tag / w:alias / w:id / w:lock readers used to be hard-

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,23 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("leaves nested rPr color elements alone (no overzealous w15 rewrite)", () => {
+    // A placeholder rPr inside sdtPr carries `<w:color w:val="…"/>` for
+    // run text color. That local name is `color` but it lives in the
+    // w: namespace, not w15. The earlier local-name rewrite would have
+    // re-emitted it under w15, corrupting run formatting on every
+    // parse → save round trip.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:rPr><w:color w:val="FF0000"/></w:rPr><w:tag w:val="x"/></w:sdtPr>`,
+    );
+    expect(props.tag).toBe("x");
+    // Color stays under w:, not silently rewritten to w15:.
+    expect(props.rawPropertiesXml).toContain('<w:color w:val="FF0000"/>');
+    expect(props.rawPropertiesXml).not.toContain("w15:color");
+  });
+
   test("normalizes inherited alt-prefix w14 / w15 child elements on capture", () => {
     // Source binds the w14 / w15 URIs under non-canonical prefixes at
     // the document root. The sdtPr wrapper is canonical w:, but the

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,27 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("normalizes inherited alt-prefix w-namespace SDT children inside canonical wrapper", () => {
+    // Canonical `<w:sdtPr>` wrapper with children inherited under an
+    // alt prefix (`<x:tag>` declared via xmlns:x on the document root).
+    // The pass-19 wrapper rewrite doesn't trigger because the wrapper
+    // already uses `w:`, and the W14/W15 child fix doesn't apply
+    // because `tag`/`alias` are w:-namespace names. Without W_LOCAL_NAMES
+    // normalization the saved DOCX would carry undefined `x:` prefixes.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><x:tag x:val="client"/><x:alias x:val="Client Name"/></w:sdtPr>`,
+    );
+    expect(props.tag).toBe("client");
+    expect(props.alias).toBe("Client Name");
+    expect(props.rawPropertiesXml).toBeDefined();
+    expect(props.rawPropertiesXml).not.toContain("x:tag");
+    expect(props.rawPropertiesXml).not.toContain("x:alias");
+    expect(props.rawPropertiesXml).toContain('<w:tag w:val="client"/>');
+    expect(props.rawPropertiesXml).toContain('<w:alias w:val="Client Name"/>');
+  });
+
   test("leaves nested rPr color elements alone (no overzealous w15 rewrite)", () => {
     // A placeholder rPr inside sdtPr carries `<w:color w:val="…"/>` for
     // run text color. That local name is `color` but it lives in the

--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,6 +96,29 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
+  test("normalizes inherited alt-prefix w14 / w15 child elements on capture", () => {
+    // Source binds the w14 / w15 URIs under non-canonical prefixes at
+    // the document root. The sdtPr wrapper is canonical w:, but the
+    // children inherit `x:` / `y:`. Without normalization the saved
+    // DOCX would carry undefined `x:checkbox` / `y:repeatingSection`.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:y="http://schemas.microsoft.com/office/word/2012/wordml"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><x:checkbox><x:checked x:val="1"/></x:checkbox><y:repeatingSection/></w:sdtPr>`,
+    );
+    expect(props.sdtType).toBe("checkbox");
+    expect(props.checked).toBe(true);
+    expect(props.rawPropertiesXml).toBeDefined();
+    // No alt prefixes left in the replay buffer.
+    expect(props.rawPropertiesXml).not.toContain("x:checkbox");
+    expect(props.rawPropertiesXml).not.toContain("x:checked");
+    expect(props.rawPropertiesXml).not.toContain("y:repeatingSection");
+    // Canonical prefixes present.
+    expect(props.rawPropertiesXml).toContain("<w14:checkbox>");
+    expect(props.rawPropertiesXml).toContain('<w14:checked w14:val="1"/>');
+    expect(props.rawPropertiesXml).toContain("<w15:repeatingSection");
+  });
+
   test("normalizes alt-prefix rawPropertiesXml to canonical w: on capture", () => {
     // A producer that binds the WordprocessingML namespace under `ns0`
     // emits `<ns0:sdtPr>…</ns0:sdtPr>` at parse time. Replaying that

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -67,13 +67,13 @@ function parseListItems(
  * the canonical prefix in our output regardless of the source's prefix
  * choice.
  */
+// Only local names that are UNAMBIGUOUSLY bound to one namespace make it
+// in here. `color` and `appearance` would otherwise look identical to
+// `<w:color>` inside a placeholder `<w:rPr>` and we'd silently rewrite
+// run formatting as w15 SDT appearance, corrupting the parse → save
+// round trip for any sdtPr that carries nested run properties.
 const W14_LOCAL_NAMES = new Set(["checkbox", "checked"]);
-const W15_LOCAL_NAMES = new Set([
-  "repeatingSection",
-  "repeatingSectionItem",
-  "color",
-  "appearance",
-]);
+const W15_LOCAL_NAMES = new Set(["repeatingSection", "repeatingSectionItem"]);
 
 /**
  * Rewrite the captured raw `<*:sdtPr>` / `<*:sdtEndPr>` snippet so every

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -112,13 +112,17 @@ export function parseSdtProperties(
         case "date": {
           props.sdtType = "date";
           // The display format lives in the child <w:dateFormat w:val="..."/>;
-          // <w:date w:fullDate="..."/> is the bound *value*, not the format.
+          // the bound value is in the parent's <w:date w:fullDate="..."/>.
           const dateFormatEl = findChild(el, "w", "dateFormat");
           if (dateFormatEl) {
             const fmt = getAttribute(dateFormatEl, "w", "val");
             if (fmt !== null) {
               props.dateFormat = fmt;
             }
+          }
+          const fullDate = getAttribute(el, "w", "fullDate");
+          if (fullDate !== null) {
+            props.dateValueISO = fullDate;
           }
           break;
         }

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -72,6 +72,40 @@ function parseListItems(
 // `<w:color>` inside a placeholder `<w:rPr>` and we'd silently rewrite
 // run formatting as w15 SDT appearance, corrupting the parse → save
 // round trip for any sdtPr that carries nested run properties.
+//
+// W_LOCAL_NAMES covers SDT property children that exist only in the
+// WordprocessingML (w:) namespace by spec — `<x:tag>` inherited from
+// the document root must mean `<w:tag>` because no other namespace
+// defines that local name in a `<w:sdtPr>`/`<w:sdtEndPr>` context.
+const W_LOCAL_NAMES = new Set([
+  "alias",
+  "tag",
+  "id",
+  "lock",
+  "placeholder",
+  "docPart",
+  "showingPlcHdr",
+  "text",
+  "date",
+  "dateFormat",
+  "lid",
+  "calendar",
+  "storeMappedDataAs",
+  "dropDownList",
+  "listItem",
+  "comboBox",
+  "picture",
+  "docPartObj",
+  "docPartList",
+  "docPartCategory",
+  "docPartGallery",
+  "docPartUnique",
+  "group",
+  "equation",
+  "citation",
+  "bibliography",
+  "richText",
+]);
 const W14_LOCAL_NAMES = new Set(["checkbox", "checked"]);
 const W15_LOCAL_NAMES = new Set(["repeatingSection", "repeatingSectionItem"]);
 
@@ -109,7 +143,14 @@ function normalizeWordPrefix(raw: string, source: XmlElement): string {
       out = rewritePrefix(out, sourcePrefix, "w");
     }
   }
-  // Step 2: child elements that live in a known sibling namespace.
+  // Step 2: child elements that live in known sibling namespaces.
+  // - W_LOCAL_NAMES handles inherited alt-prefix SDT property children
+  //   sitting inside a canonical `<w:sdtPr>` wrapper (case the pass-19
+  //   wrapper-only fix missed).
+  // - W14 / W15 sets handle the wider w14:checkbox / w15:repeatingSection
+  //   children that don't share local names with run / paragraph
+  //   formatting.
+  out = normalizeChildrenForLocalNames(out, W_LOCAL_NAMES, "w");
   out = normalizeChildrenForLocalNames(out, W14_LOCAL_NAMES, "w14");
   out = normalizeChildrenForLocalNames(out, W15_LOCAL_NAMES, "w15");
   return out;

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -16,6 +16,7 @@ import {
   elementToXml,
   findChild,
   getAttribute,
+  getLocalName,
   type XmlElement,
 } from "./xmlParser";
 
@@ -58,7 +59,11 @@ export function parseSdtProperties(
       if (el.type !== "element") {
         continue;
       }
-      const name = el.name?.replace(/^w:/u, "") ?? "";
+      // The checkbox marker is `w14:checkbox`, not `w:checkbox`; strip *any*
+      // namespace prefix so non-`w:` SDT property elements (w14, w15, ...)
+      // route to the right case instead of falling through to default and
+      // misclassifying the control as richText.
+      const name = el.name ? getLocalName(el.name) : "";
 
       switch (name) {
         case "id": {

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -15,7 +15,7 @@ import { SdtLockSchema, narrowEnum } from "./parserEnums";
 import {
   elementToXml,
   findChild,
-  getAttribute,
+  getAttributeAnyPrefix,
   getLocalName,
   parseBooleanElement,
   type XmlElement,
@@ -57,29 +57,6 @@ function parseListItems(
 }
 
 /**
- * Read an attribute by local name, trying the element's own prefix first
- * (`<ns0:listItem ns0:displayText="…"/>`), then the canonical `w:` prefix,
- * then unprefixed. Matches `parseBooleanElement`'s prefix tolerance so
- * OOXML producers that use a non-`w` prefix for the Word namespace parse
- * the same as the canonical form.
- */
-function getAttributeAnyPrefix(
-  element: XmlElement,
-  localName: string,
-): string | null {
-  const elementName = element.name ?? "";
-  const colonIdx = elementName.indexOf(":");
-  const elementPrefix = colonIdx > 0 ? elementName.slice(0, colonIdx) : null;
-  if (elementPrefix && elementPrefix !== "w") {
-    const fromPrefix = getAttribute(element, elementPrefix, localName);
-    if (fromPrefix !== null) {
-      return fromPrefix;
-    }
-  }
-  return getAttribute(element, "w", localName);
-}
-
-/**
  * Parse `<w:sdtPr>` (and optional `<w:sdtEndPr>`) into {@link SdtProperties}.
  *
  * Modeled fields drive addressing / template tooling; `rawPropertiesXml`
@@ -108,7 +85,7 @@ export function parseSdtProperties(
 
       switch (name) {
         case "id": {
-          const raw = getAttribute(el, "w", "val");
+          const raw = getAttributeAnyPrefix(el, "val");
           if (raw !== null) {
             const n = Number.parseInt(raw, 10);
             if (!Number.isNaN(n)) {
@@ -118,21 +95,21 @@ export function parseSdtProperties(
           break;
         }
         case "alias": {
-          const aliasVal = getAttribute(el, "w", "val");
+          const aliasVal = getAttributeAnyPrefix(el, "val");
           if (aliasVal !== null) {
             props.alias = aliasVal;
           }
           break;
         }
         case "tag": {
-          const tagVal = getAttribute(el, "w", "val");
+          const tagVal = getAttributeAnyPrefix(el, "val");
           if (tagVal !== null) {
             props.tag = tagVal;
           }
           break;
         }
         case "lock": {
-          const lockVal = getAttribute(el, "w", "val");
+          const lockVal = getAttributeAnyPrefix(el, "val");
           props.lock = narrowEnum(lockVal, SdtLockSchema) ?? "unlocked";
           break;
         }
@@ -141,7 +118,7 @@ export function parseSdtProperties(
           if (docPart) {
             const valEl = findChild(docPart, "w", "val");
             if (valEl) {
-              const phVal = getAttribute(valEl, "w", "val");
+              const phVal = getAttributeAnyPrefix(valEl, "val");
               if (phVal !== null) {
                 props.placeholder = phVal;
               }
@@ -167,12 +144,12 @@ export function parseSdtProperties(
           // the bound value is in the parent's <w:date w:fullDate="..."/>.
           const dateFormatEl = findChild(el, "w", "dateFormat");
           if (dateFormatEl) {
-            const fmt = getAttribute(dateFormatEl, "w", "val");
+            const fmt = getAttributeAnyPrefix(dateFormatEl, "val");
             if (fmt !== null) {
               props.dateFormat = fmt;
             }
           }
-          const fullDate = getAttribute(el, "w", "fullDate");
+          const fullDate = getAttributeAnyPrefix(el, "fullDate");
           if (fullDate !== null) {
             props.dateValueISO = fullDate;
           }

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -1,0 +1,166 @@
+/**
+ * Shared parser for Structured Document Tag properties (`w:sdtPr`).
+ *
+ * One parser feeds both the inline (run-level) SDT path and the block-level
+ * SDT path so the two cannot drift. Emits a modeled projection AND captures
+ * the raw `<w:sdtPr>` / `<w:sdtEndPr>` as verbatim XML so unmodeled OOXML
+ * features (data binding, `w15:repeatingSection`, `@lastValue`, custom XML
+ * mappings) round-trip losslessly — see ECMA-376 §17.5.2 (`CT_SdtPr` is an
+ * `xsd:sequence` so element order matters; replaying the original XML
+ * preserves it for free).
+ */
+
+import type { SdtProperties } from "../types/document";
+import { SdtLockSchema, narrowEnum } from "./parserEnums";
+import {
+  elementToXml,
+  findChild,
+  getAttribute,
+  type XmlElement,
+} from "./xmlParser";
+
+function parseListItems(
+  el: XmlElement,
+): { displayText: string; value: string }[] {
+  const items: { displayText: string; value: string }[] = [];
+  for (const child of el.elements ?? []) {
+    if (
+      child.type === "element" &&
+      (child.name === "w:listItem" || child.name?.endsWith(":listItem"))
+    ) {
+      items.push({
+        displayText: getAttribute(child, "w", "displayText") ?? "",
+        value: getAttribute(child, "w", "value") ?? "",
+      });
+    }
+  }
+  return items;
+}
+
+/**
+ * Parse `<w:sdtPr>` (and optional `<w:sdtEndPr>`) into {@link SdtProperties}.
+ *
+ * Modeled fields drive addressing / template tooling; `rawPropertiesXml`
+ * and `rawEndPropertiesXml` carry the original bytes for the serializer to
+ * replay unchanged, so the projection only needs to handle what we
+ * actually consume — unmodeled markers are not silently dropped.
+ */
+export function parseSdtProperties(
+  sdtPr: XmlElement | null | undefined,
+  sdtEndPr?: XmlElement | null | undefined,
+): SdtProperties {
+  const props: SdtProperties = { sdtType: "richText" };
+
+  if (sdtPr) {
+    props.rawPropertiesXml = elementToXml(sdtPr);
+
+    for (const el of sdtPr.elements ?? []) {
+      if (el.type !== "element") {
+        continue;
+      }
+      const name = el.name?.replace(/^w:/u, "") ?? "";
+
+      switch (name) {
+        case "id": {
+          const raw = getAttribute(el, "w", "val");
+          if (raw !== null) {
+            const n = Number.parseInt(raw, 10);
+            if (!Number.isNaN(n)) {
+              props.id = n;
+            }
+          }
+          break;
+        }
+        case "alias": {
+          const aliasVal = getAttribute(el, "w", "val");
+          if (aliasVal !== null) {
+            props.alias = aliasVal;
+          }
+          break;
+        }
+        case "tag": {
+          const tagVal = getAttribute(el, "w", "val");
+          if (tagVal !== null) {
+            props.tag = tagVal;
+          }
+          break;
+        }
+        case "lock": {
+          const lockVal = getAttribute(el, "w", "val");
+          props.lock = narrowEnum(lockVal, SdtLockSchema) ?? "unlocked";
+          break;
+        }
+        case "placeholder": {
+          const docPart = findChild(el, "w", "docPart");
+          if (docPart) {
+            const valEl = findChild(docPart, "w", "val");
+            if (valEl) {
+              const phVal = getAttribute(valEl, "w", "val");
+              if (phVal !== null) {
+                props.placeholder = phVal;
+              }
+            }
+          }
+          break;
+        }
+        case "showingPlcHdr":
+          props.showingPlaceholder = true;
+          break;
+        case "text":
+          props.sdtType = "plainText";
+          break;
+        case "date": {
+          props.sdtType = "date";
+          // The display format lives in the child <w:dateFormat w:val="..."/>;
+          // <w:date w:fullDate="..."/> is the bound *value*, not the format.
+          const dateFormatEl = findChild(el, "w", "dateFormat");
+          if (dateFormatEl) {
+            const fmt = getAttribute(dateFormatEl, "w", "val");
+            if (fmt !== null) {
+              props.dateFormat = fmt;
+            }
+          }
+          break;
+        }
+        case "dropDownList":
+          props.sdtType = "dropdown";
+          props.listItems = parseListItems(el);
+          break;
+        case "comboBox":
+          props.sdtType = "comboBox";
+          props.listItems = parseListItems(el);
+          break;
+        case "checkbox": {
+          props.sdtType = "checkbox";
+          const checked =
+            findChild(el, "w14", "checked") ?? findChild(el, "w", "checked");
+          props.checked = checked
+            ? getAttribute(checked, "w14", "val") === "1" ||
+              getAttribute(checked, "w", "val") === "1"
+            : false;
+          break;
+        }
+        case "picture":
+          props.sdtType = "picture";
+          break;
+        case "docPartObj":
+        case "docPartList":
+          props.sdtType = "buildingBlockGallery";
+          break;
+        case "group":
+          props.sdtType = "group";
+          break;
+        default:
+          // Unmodeled markers (equation, citation, bibliography, w15:*) fall
+          // through; `rawPropertiesXml` carries them verbatim for round-trip.
+          break;
+      }
+    }
+  }
+
+  if (sdtEndPr) {
+    props.rawEndPropertiesXml = elementToXml(sdtEndPr);
+  }
+
+  return props;
+}

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -187,12 +187,17 @@ function normalizeChildrenForLocalNames(
       prefix === canonical ? `</${prefix}:${local}` : `</${canonical}:${local}`,
     );
     // Also normalize attributes on those elements that use the alt prefix.
-    // Without a parser pass this is best-effort: rewrite `prefix:attr=` only
-    // when the immediately preceding tag is the targeted element. A small
-    // 64-char lookbehind window covers realistic OOXML elements (5-attr SDT
-    // children are short).
+    // Without a parser pass this is best-effort: rewrite `prefix:attr=`
+    // only when the immediately preceding tag is the targeted element AND
+    // the prefix is preceded by an attribute-name boundary (whitespace).
+    // The whitespace anchor is critical — a bare `\b` would also match
+    // inside attribute values, so `xmlns:x="http://…"` would have `http:`
+    // rewritten to `w:` and the namespace URI would be silently
+    // corrupted. Exclude `xmlns:*` so a locally-declared alt-prefix
+    // (`<x:tag xmlns:x="…" x:val="…"/>`) keeps its namespace declaration
+    // intact too.
     const attrRe = new RegExp(
-      `(<${canonical}:${escapedLocal}\\b[^>]{0,200})\\b(?!${canonical}:)(\\w+):`,
+      `(<${canonical}:${escapedLocal}\\b[^>]{0,200}\\s)(?!${canonical}:)(?!xmlns:)(\\w+):`,
       "gu",
     );
     let prev = "";

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -114,14 +114,17 @@ export function parseSdtProperties(
           break;
         }
         case "placeholder": {
+          // OOXML §17.5.2.27: the placeholder reference is an attribute
+          // on `<w:docPart>` itself (`<w:docPart w:val="…"/>`), not a
+          // nested `<w:val>` child. We previously looked for a child
+          // `<w:val>`, so `props.placeholder` was never populated on
+          // parse — getContentControls() and reverse serialization lost
+          // the placeholder metadata entirely.
           const docPart = findChild(el, "w", "docPart");
           if (docPart) {
-            const valEl = findChild(docPart, "w", "val");
-            if (valEl) {
-              const phVal = getAttributeAnyPrefix(valEl, "val");
-              if (phVal !== null) {
-                props.placeholder = phVal;
-              }
+            const phVal = getAttributeAnyPrefix(docPart, "val");
+            if (phVal !== null) {
+              props.placeholder = phVal;
             }
           }
           break;

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -57,6 +57,46 @@ function parseListItems(
 }
 
 /**
+ * Rewrite the captured raw `<*:sdtPr>` / `<*:sdtEndPr>` snippet so every
+ * element bound to the WordprocessingML URI uses the canonical `w:`
+ * prefix on save. The blockSdtSerializer's document root declares only
+ * the standard `w` / `w14` / `w15` prefixes, so replaying a source
+ * snippet that uses an alternate prefix (`<ns0:sdtPr>` with `xmlns:ns0`
+ * declared on the source's `<w:document>`) would produce invalid XML in
+ * the saved DOCX — Word refuses to open files with unresolved
+ * namespace prefixes.
+ *
+ * Heuristic: we only rewrite when the captured element itself uses a
+ * non-`w` prefix. fast-xml-parser does not surface namespace URIs in
+ * preserveOrder mode, so we infer that the source prefix is bound to
+ * the WP URI from the fact that it carries an SDT property element
+ * (otherwise the producer's DOCX would already be invalid). Other
+ * URIs (w14, w15) are left intact since callers seldom rebind them.
+ */
+function normalizeWordPrefix(raw: string, source: XmlElement): string {
+  const name = source.name ?? "";
+  const colonIdx = name.indexOf(":");
+  if (colonIdx <= 0) {
+    return raw;
+  }
+  const sourcePrefix = name.slice(0, colonIdx);
+  if (sourcePrefix === "w") {
+    return raw;
+  }
+  // Escape regex meta-chars in the prefix before substituting. Match
+  // both element-name (`<ns0:tag>` / `</ns0:tag>`) and attribute-name
+  // (`ns0:val="…"`) occurrences.
+  const escaped = sourcePrefix.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
+  const tagOpen = new RegExp(`<${escaped}:`, "gu");
+  const tagClose = new RegExp(`</${escaped}:`, "gu");
+  const attr = new RegExp(`(\\s)${escaped}:`, "gu");
+  return raw
+    .replaceAll(tagOpen, "<w:")
+    .replaceAll(tagClose, "</w:")
+    .replaceAll(attr, "$1w:");
+}
+
+/**
  * Parse `<w:sdtPr>` (and optional `<w:sdtEndPr>`) into {@link SdtProperties}.
  *
  * Modeled fields drive addressing / template tooling; `rawPropertiesXml`
@@ -71,7 +111,7 @@ export function parseSdtProperties(
   const props: SdtProperties = { sdtType: "richText" };
 
   if (sdtPr) {
-    props.rawPropertiesXml = elementToXml(sdtPr);
+    props.rawPropertiesXml = normalizeWordPrefix(elementToXml(sdtPr), sdtPr);
 
     for (const el of sdtPr.elements ?? []) {
       if (el.type !== "element") {
@@ -209,7 +249,10 @@ export function parseSdtProperties(
   }
 
   if (sdtEndPr) {
-    props.rawEndPropertiesXml = elementToXml(sdtEndPr);
+    props.rawEndPropertiesXml = normalizeWordPrefix(
+      elementToXml(sdtEndPr),
+      sdtEndPr,
+    );
   }
 
   return props;

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -35,8 +35,15 @@ function parseListItems(
       // listItem stays selectable + visible — without this, the dropdown
       // shell renders a blank option and the value-set path writes an
       // empty paragraph for a real OOXML pick.
-      const displayText = getAttribute(child, "w", "displayText");
-      const value = getAttribute(child, "w", "value");
+      //
+      // Read attributes by the element's own prefix first (the spec lets
+      // a producer bind the Word namespace under any prefix, e.g.
+      // `<ns0:listItem ns0:displayText="A" ns0:value="a"/>`). The previous
+      // hard-coded `w:` lookup turned every such item into `(null, null)`
+      // and silently dropped it, so non-standard-prefix dropdowns opened
+      // with no options.
+      const displayText = getAttributeAnyPrefix(child, "displayText");
+      const value = getAttributeAnyPrefix(child, "value");
       if (displayText === null && value === null) {
         continue;
       }
@@ -47,6 +54,29 @@ function parseListItems(
     }
   }
   return items;
+}
+
+/**
+ * Read an attribute by local name, trying the element's own prefix first
+ * (`<ns0:listItem ns0:displayText="…"/>`), then the canonical `w:` prefix,
+ * then unprefixed. Matches `parseBooleanElement`'s prefix tolerance so
+ * OOXML producers that use a non-`w` prefix for the Word namespace parse
+ * the same as the canonical form.
+ */
+function getAttributeAnyPrefix(
+  element: XmlElement,
+  localName: string,
+): string | null {
+  const elementName = element.name ?? "";
+  const colonIdx = elementName.indexOf(":");
+  const elementPrefix = colonIdx > 0 ? elementName.slice(0, colonIdx) : null;
+  if (elementPrefix && elementPrefix !== "w") {
+    const fromPrefix = getAttribute(element, elementPrefix, localName);
+    if (fromPrefix !== null) {
+      return fromPrefix;
+    }
+  }
+  return getAttribute(element, "w", localName);
 }
 
 /**

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -17,6 +17,7 @@ import {
   findChild,
   getAttribute,
   getLocalName,
+  parseBooleanElement,
   type XmlElement,
 } from "./xmlParser";
 
@@ -29,9 +30,19 @@ function parseListItems(
       child.type === "element" &&
       (child.name === "w:listItem" || child.name?.endsWith(":listItem"))
     ) {
+      // OOXML §17.5.2.10: `w:displayText` is optional, and `w:value` is
+      // optional too. Fall back each to the other so a partially specified
+      // listItem stays selectable + visible — without this, the dropdown
+      // shell renders a blank option and the value-set path writes an
+      // empty paragraph for a real OOXML pick.
+      const displayText = getAttribute(child, "w", "displayText");
+      const value = getAttribute(child, "w", "value");
+      if (displayText === null && value === null) {
+        continue;
+      }
       items.push({
-        displayText: getAttribute(child, "w", "displayText") ?? "",
-        value: getAttribute(child, "w", "value") ?? "",
+        displayText: displayText ?? value ?? "",
+        value: value ?? displayText ?? "",
       });
     }
   }
@@ -141,12 +152,20 @@ export function parseSdtProperties(
           break;
         case "checkbox": {
           props.sdtType = "checkbox";
-          const checked =
-            findChild(el, "w14", "checked") ?? findChild(el, "w", "checked");
-          props.checked = checked
-            ? getAttribute(checked, "w14", "val") === "1" ||
-              getAttribute(checked, "w", "val") === "1"
-            : false;
+          // OOXML OnOff values are "1" | "true" | "on" (or absent attribute
+          // meaning true); their negations are "0" | "false" | "off".
+          // `parseBooleanElement` already encapsulates that vs. our previous
+          // strict `=== "1"` check, which misclassified Word's `val="true"`
+          // and bare `<w14:checked/>` forms as unchecked.
+          const checked14 = findChild(el, "w14", "checked");
+          const checkedW = findChild(el, "w", "checked");
+          if (checked14) {
+            props.checked = parseBooleanElement(checked14, "w14");
+          } else if (checkedW) {
+            props.checked = parseBooleanElement(checkedW, "w");
+          } else {
+            props.checked = false;
+          }
           break;
         }
         case "picture":

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -156,13 +156,19 @@ export function parseSdtProperties(
           break;
         }
         case "dropDownList":
-          props.sdtType = "dropdown";
+        case "comboBox": {
+          props.sdtType = name === "dropDownList" ? "dropdown" : "comboBox";
           props.listItems = parseListItems(el);
+          // Capture the source's `w:lastValue` so a parse → save round trip
+          // for a dropdown that was previously chosen in Word keeps the
+          // exact OOXML value, even if duplicate displayText would have
+          // made the body-text fallback ambiguous.
+          const lastValue = getAttributeAnyPrefix(el, "lastValue");
+          if (lastValue !== null) {
+            props.dropdownLastValue = lastValue;
+          }
           break;
-        case "comboBox":
-          props.sdtType = "comboBox";
-          props.listItems = parseListItems(el);
-          break;
+        }
         case "checkbox": {
           props.sdtType = "checkbox";
           // OOXML OnOff values are "1" | "true" | "on" (or absent attribute

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -120,7 +120,13 @@ export function parseSdtProperties(
           break;
         }
         case "showingPlcHdr":
-          props.showingPlaceholder = true;
+          // OOXML OnOff: element presence with no val attribute means
+          // true; val="0" / "false" / "off" means false. Source DOCXs
+          // rarely write the negation explicitly (Word typically omits
+          // the element when not showing placeholder), but the
+          // serializer's `reconcileRawSdtPr` round-trip can produce one
+          // and we shouldn't silently flip its semantics.
+          props.showingPlaceholder = parseBooleanElement(el, "w");
           break;
         case "text":
           props.sdtType = "plainText";

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -57,43 +57,113 @@ function parseListItems(
 }
 
 /**
+ * Local names that always belong to one specific OOXML namespace. The
+ * serializer's document root only declares the canonical `w` / `w14` /
+ * `w15` prefixes, so any captured raw SDT child written under an
+ * alternate prefix would replay as an undefined-prefix element (Word
+ * refuses such files). We rewrite by element-local-name so an inherited
+ * `<x:checkbox>` / `<y:repeatingSection>` (where `x` / `y` are bound to
+ * the w14 / w15 URIs at the source's document root) always lands under
+ * the canonical prefix in our output regardless of the source's prefix
+ * choice.
+ */
+const W14_LOCAL_NAMES = new Set(["checkbox", "checked"]);
+const W15_LOCAL_NAMES = new Set([
+  "repeatingSection",
+  "repeatingSectionItem",
+  "color",
+  "appearance",
+]);
+
+/**
  * Rewrite the captured raw `<*:sdtPr>` / `<*:sdtEndPr>` snippet so every
- * element bound to the WordprocessingML URI uses the canonical `w:`
+ * SDT-namespace element uses the canonical `w:` / `w14:` / `w15:`
  * prefix on save. The blockSdtSerializer's document root declares only
- * the standard `w` / `w14` / `w15` prefixes, so replaying a source
- * snippet that uses an alternate prefix (`<ns0:sdtPr>` with `xmlns:ns0`
- * declared on the source's `<w:document>`) would produce invalid XML in
- * the saved DOCX — Word refuses to open files with unresolved
- * namespace prefixes.
+ * those three prefixes, so replaying a source snippet that uses an
+ * alternate prefix (`<ns0:sdtPr>` with `xmlns:ns0` declared on the
+ * source's `<w:document>`, or `<x:checkbox>` inside a canonical sdtPr)
+ * would produce invalid XML in the saved DOCX — Word refuses files
+ * with unresolved namespace prefixes.
  *
- * Heuristic: we only rewrite when the captured element itself uses a
- * non-`w` prefix. fast-xml-parser does not surface namespace URIs in
- * preserveOrder mode, so we infer that the source prefix is bound to
- * the WP URI from the fact that it carries an SDT property element
- * (otherwise the producer's DOCX would already be invalid). Other
- * URIs (w14, w15) are left intact since callers seldom rebind them.
+ * Heuristics, since fast-xml-parser does not surface namespace URIs in
+ * preserveOrder mode:
+ *
+ * 1. If the captured wrapper element itself uses a non-`w` prefix, that
+ *    prefix is taken to be bound to the WP URI (the source DOCX would
+ *    otherwise be invalid) and ALL occurrences of it inside the snippet
+ *    are rewritten to `w:`.
+ * 2. After step 1, any remaining alt-prefix on an element whose local
+ *    name is in W14_LOCAL_NAMES / W15_LOCAL_NAMES gets normalized to
+ *    `w14:` / `w15:`. That handles a canonical `<w:sdtPr>` wrapper
+ *    whose children inherit a non-`w14` / non-`w15` prefix from the
+ *    source's document root.
  */
 function normalizeWordPrefix(raw: string, source: XmlElement): string {
+  let out = raw;
+  // Step 1: wrapper prefix → canonical w.
   const name = source.name ?? "";
   const colonIdx = name.indexOf(":");
-  if (colonIdx <= 0) {
-    return raw;
+  if (colonIdx > 0) {
+    const sourcePrefix = name.slice(0, colonIdx);
+    if (sourcePrefix !== "w") {
+      out = rewritePrefix(out, sourcePrefix, "w");
+    }
   }
-  const sourcePrefix = name.slice(0, colonIdx);
-  if (sourcePrefix === "w") {
-    return raw;
-  }
-  // Escape regex meta-chars in the prefix before substituting. Match
-  // both element-name (`<ns0:tag>` / `</ns0:tag>`) and attribute-name
-  // (`ns0:val="…"`) occurrences.
-  const escaped = sourcePrefix.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
+  // Step 2: child elements that live in a known sibling namespace.
+  out = normalizeChildrenForLocalNames(out, W14_LOCAL_NAMES, "w14");
+  out = normalizeChildrenForLocalNames(out, W15_LOCAL_NAMES, "w15");
+  return out;
+}
+
+function rewritePrefix(raw: string, from: string, to: string): string {
+  const escaped = from.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
   const tagOpen = new RegExp(`<${escaped}:`, "gu");
   const tagClose = new RegExp(`</${escaped}:`, "gu");
   const attr = new RegExp(`(\\s)${escaped}:`, "gu");
   return raw
-    .replaceAll(tagOpen, "<w:")
-    .replaceAll(tagClose, "</w:")
-    .replaceAll(attr, "$1w:");
+    .replaceAll(tagOpen, `<${to}:`)
+    .replaceAll(tagClose, `</${to}:`)
+    .replaceAll(attr, `$1${to}:`);
+}
+
+function normalizeChildrenForLocalNames(
+  raw: string,
+  localNames: ReadonlySet<string>,
+  canonical: string,
+): string {
+  let out = raw;
+  // For each local name, find any `<prefix:localName` and `</prefix:localName>`
+  // whose prefix is NOT already canonical, and swap that prefix to canonical.
+  // The `\b` after the local name keeps `<prefix:checkboxFoo>` from matching.
+  for (const local of localNames) {
+    const escapedLocal = local.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
+    const opener = new RegExp(`<(\\w+):${escapedLocal}\\b`, "gu");
+    const closer = new RegExp(`</(\\w+):${escapedLocal}\\b`, "gu");
+    out = out.replaceAll(opener, (_m, prefix: string) =>
+      prefix === canonical ? `<${prefix}:${local}` : `<${canonical}:${local}`,
+    );
+    out = out.replaceAll(closer, (_m, prefix: string) =>
+      prefix === canonical ? `</${prefix}:${local}` : `</${canonical}:${local}`,
+    );
+    // Also normalize attributes on those elements that use the alt prefix.
+    // Without a parser pass this is best-effort: rewrite `prefix:attr=` only
+    // when the immediately preceding tag is the targeted element. A small
+    // 64-char lookbehind window covers realistic OOXML elements (5-attr SDT
+    // children are short).
+    const attrRe = new RegExp(
+      `(<${canonical}:${escapedLocal}\\b[^>]{0,200})\\b(?!${canonical}:)(\\w+):`,
+      "gu",
+    );
+    let prev = "";
+    while (prev !== out) {
+      prev = out;
+      out = out.replaceAll(
+        attrRe,
+        (_m, head: string, _altPrefix: string) => `${head}${canonical}:`,
+      );
+    }
+  }
+  return out;
 }
 
 /**

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
@@ -40,6 +40,20 @@ describe("reconcileRawSdtPr — checkbox state", () => {
     expect(out).toContain('<w14:checked w14:val="1"/>');
   });
 
+  test("replaces the expanded `<w14:checked></w14:checked>` form without leaving stray closing tags", () => {
+    // OOXML lets the empty element be written in either self-closing or
+    // expanded form. The self-closing path was already covered; this
+    // pins the expanded one so the patch does not produce
+    // `<w14:checked .../></w14:checked>`.
+    const raw =
+      '<w:sdtPr><w14:checkbox><w14:checked w14:val="0"></w14:checked></w14:checkbox></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    expect(out).toContain('<w14:checked w14:val="1"/>');
+    // No stray closing tag remains.
+    expect(out).not.toMatch(/<w14:checked[^>]*\/>\s*<\/w14:checked>/u);
+    expect(out).not.toContain('w14:val="0"');
+  });
+
   test("synthesizes the whole wrapper when the raw sdtPr has neither", () => {
     const raw = '<w:sdtPr><w:tag w:val="agree"/></w:sdtPr>';
     const out = reconcileRawSdtPr(raw, checkboxProps(false));

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
@@ -54,6 +54,23 @@ describe("reconcileRawSdtPr — checkbox state", () => {
     expect(out).not.toContain('w14:val="0"');
   });
 
+  test("preserves the original sdtPr prefix when inserting a missing child", () => {
+    // A source DOCX could use any namespace prefix for the WordprocessingML
+    // namespace. Previously the insertion path hard-coded `</w:sdtPr>`,
+    // which produced malformed XML for inputs like `<ns0:sdtPr>` (open
+    // tag uses `ns0`, close tag would use `w`). Capture the prefix from
+    // the matched closing tag and reuse it.
+    const raw = '<ns0:sdtPr><ns0:tag ns0:val="agree"/></ns0:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    // The injected wrapper itself stays in the `w14:` family (that is
+    // the standard prefix for Word checkboxes), but the parent's closing
+    // tag must keep the source prefix.
+    expect(out).toContain("<ns0:sdtPr>");
+    expect(out).toContain("</ns0:sdtPr>");
+    expect(out).not.toContain("</w:sdtPr>");
+    expect(out).toContain('<w14:checked w14:val="1"/>');
+  });
+
   test("synthesizes the whole wrapper when the raw sdtPr has neither", () => {
     const raw = '<w:sdtPr><w:tag w:val="agree"/></w:sdtPr>';
     const out = reconcileRawSdtPr(raw, checkboxProps(false));

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for the rawSdtPr reconcile helper. Asserts that modeled property
+ * mutations get patched into the raw XML before the serializer replays it,
+ * so checkbox / dropdown / date interactions survive a save cycle.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { SdtProperties } from "../types/document";
+import { reconcileRawSdtPr } from "./sdtPropertiesPatch";
+
+function checkboxProps(checked: boolean): SdtProperties {
+  return {
+    sdtType: "checkbox",
+    checked,
+  };
+}
+
+describe("reconcileRawSdtPr — checkbox state", () => {
+  test("updates an existing w14:checked attribute when the user toggles on", () => {
+    const raw =
+      '<w:sdtPr><w:tag w:val="agree"/><w14:checkbox><w14:checked w14:val="0"/></w14:checkbox></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    expect(out).toContain('<w14:checked w14:val="1"/>');
+    expect(out).not.toContain('w14:val="0"');
+    // Pre-existing markers (tag) survive.
+    expect(out).toContain('<w:tag w:val="agree"/>');
+  });
+
+  test("updates an existing w:checked attribute (no w14: prefix variant)", () => {
+    const raw =
+      '<w:sdtPr><w:checkbox><w:checked w:val="0"/></w:checkbox></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    expect(out).toContain('<w:checked w:val="1"/>');
+  });
+
+  test("injects a w14:checked when only the wrapper exists", () => {
+    const raw = "<w:sdtPr><w14:checkbox></w14:checkbox></w:sdtPr>";
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    expect(out).toContain('<w14:checked w14:val="1"/>');
+  });
+
+  test("synthesizes the whole wrapper when the raw sdtPr has neither", () => {
+    const raw = '<w:sdtPr><w:tag w:val="agree"/></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(false));
+    expect(out).toContain("<w14:checkbox>");
+    expect(out).toContain('<w14:checked w14:val="0"/>');
+    expect(out).toContain('<w:tag w:val="agree"/>');
+  });
+});
+
+describe("reconcileRawSdtPr — dataBinding / repeatingSection passthrough", () => {
+  test("preserves w15:repeatingSection while updating checked state", () => {
+    const raw =
+      '<w:sdtPr><w14:checkbox><w14:checked w14:val="0"/></w14:checkbox><w15:repeatingSection/></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, checkboxProps(true));
+    expect(out).toContain("w15:repeatingSection");
+    expect(out).toContain('<w14:checked w14:val="1"/>');
+  });
+
+  test("preserves w:dataBinding while updating w:date@w:fullDate", () => {
+    const raw =
+      '<w:sdtPr><w:dataBinding w:xpath="/c/d" w:storeItemID="{ABC}"/><w:date w:fullDate="2020-01-01T00:00:00Z"><w:dateFormat w:val="yyyy-MM-dd"/></w:date></w:sdtPr>';
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "date", dateFormat: "yyyy-MM-dd" },
+      { dateFullDate: "2026-06-02T00:00:00Z" },
+    );
+    expect(out).toContain('w:fullDate="2026-06-02T00:00:00Z"');
+    expect(out).toContain('w:xpath="/c/d"');
+  });
+});
+
+describe("reconcileRawSdtPr — date format", () => {
+  test("updates dateFormat without disturbing the surrounding w:date element", () => {
+    const raw =
+      '<w:sdtPr><w:date w:fullDate="2026-06-02"><w:dateFormat w:val="d MMMM yyyy"/><w:lid w:val="en-GB"/></w:date></w:sdtPr>';
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "date", dateFormat: "yyyy-MM-dd" },
+      { dateFullDate: "2026-06-02" },
+    );
+    expect(out).toContain('<w:dateFormat w:val="yyyy-MM-dd"/>');
+    expect(out).toContain('<w:lid w:val="en-GB"/>');
+  });
+});
+
+describe("reconcileRawSdtPr — dropdown last value", () => {
+  test("rewrites w:lastValue when the user picks a new item", () => {
+    const raw =
+      '<w:sdtPr><w:dropDownList w:lastValue="ca"><w:listItem w:displayText="California" w:value="ca"/><w:listItem w:displayText="New York" w:value="ny"/></w:dropDownList></w:sdtPr>';
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "dropdown" },
+      { dropdownLastValue: "ny" },
+    );
+    expect(out).toContain('w:lastValue="ny"');
+    expect(out).not.toContain('w:lastValue="ca"');
+    // listItems are preserved.
+    expect(out).toContain('w:value="ca"');
+    expect(out).toContain('w:value="ny"');
+  });
+
+  test("escapes special characters in the new last value", () => {
+    const raw = "<w:sdtPr><w:dropDownList/></w:sdtPr>";
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "dropdown" },
+      { dropdownLastValue: 'Q&A "wrapped"' },
+    );
+    expect(out).toContain('w:lastValue="Q&amp;A &quot;wrapped&quot;"');
+  });
+});
+
+describe("reconcileRawSdtPr — showingPlaceholder toggle", () => {
+  test("removes <w:showingPlcHdr/> when the user fills the control", () => {
+    const raw = '<w:sdtPr><w:tag w:val="x"/><w:showingPlcHdr/></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, {
+      sdtType: "richText",
+      showingPlaceholder: false,
+    });
+    expect(out).not.toContain("showingPlcHdr");
+    expect(out).toContain('<w:tag w:val="x"/>');
+  });
+
+  test("inserts <w:showingPlcHdr/> when the model says it is shown", () => {
+    const raw = '<w:sdtPr><w:tag w:val="x"/></w:sdtPr>';
+    const out = reconcileRawSdtPr(raw, {
+      sdtType: "richText",
+      showingPlaceholder: true,
+    });
+    expect(out).toContain("<w:showingPlcHdr/>");
+  });
+});

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
@@ -103,6 +103,24 @@ describe("reconcileRawSdtPr — dataBinding / repeatingSection passthrough", () 
 });
 
 describe("reconcileRawSdtPr — date format", () => {
+  test("replaces an expanded-empty dateFormat element on round-trip", () => {
+    // A producer DOCX that writes `<w:dateFormat …></w:dateFormat>` instead
+    // of self-closing would otherwise leave a stale sibling next to our
+    // freshly-prepended replacement — Word would see two dateFormat
+    // children and the picked display string would not stick.
+    const raw =
+      '<w:sdtPr><w:date w:fullDate="2026-06-02"><w:dateFormat w:val="d MMMM yyyy"></w:dateFormat></w:date></w:sdtPr>';
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "date", dateFormat: "yyyy-MM-dd" },
+      { dateFullDate: "2026-06-02" },
+    );
+    // Exactly one self-closing dateFormat child remains.
+    expect(out.match(/dateFormat/giu)?.length).toBe(1);
+    expect(out).toContain('<w:dateFormat w:val="yyyy-MM-dd"/>');
+    expect(out).not.toContain('w:val="d MMMM yyyy"');
+  });
+
   test("updates dateFormat without disturbing the surrounding w:date element", () => {
     const raw =
       '<w:sdtPr><w:date w:fullDate="2026-06-02"><w:dateFormat w:val="d MMMM yyyy"/><w:lid w:val="en-GB"/></w:date></w:sdtPr>';

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.test.ts
@@ -135,6 +135,28 @@ describe("reconcileRawSdtPr — date format", () => {
 });
 
 describe("reconcileRawSdtPr — dropdown last value", () => {
+  test("strips an existing lastValue under a non-`w` source prefix and re-emits with the same prefix", () => {
+    // The previous literal " w:lastValue=" marker missed `ns0:lastValue`
+    // entirely, so reconcileRawSdtPr appended a fresh w:lastValue next
+    // to the stale ns0:lastValue and Word was free to keep reading the
+    // old value.
+    const raw =
+      '<w:sdtPr><ns0:dropDownList ns0:lastValue="old"><ns0:listItem ns0:displayText="A" ns0:value="a"/><ns0:listItem ns0:displayText="B" ns0:value="b"/></ns0:dropDownList></w:sdtPr>';
+    const out = reconcileRawSdtPr(
+      raw,
+      { sdtType: "dropdown" },
+      { dropdownLastValue: "b" },
+    );
+    // Stale value gone.
+    expect(out).not.toContain('lastValue="old"');
+    // New value emitted under the source's prefix, not a foreign `w:`.
+    expect(out).toContain('ns0:lastValue="b"');
+    // Exactly one lastValue attribute in the output.
+    expect(out.match(/lastValue=/giu)?.length).toBe(1);
+    // listItems still there.
+    expect(out).toContain('ns0:value="a"');
+  });
+
   test("rewrites w:lastValue when the user picks a new item", () => {
     const raw =
       '<w:sdtPr><w:dropDownList w:lastValue="ca"><w:listItem w:displayText="California" w:value="ca"/><w:listItem w:displayText="New York" w:value="ny"/></w:dropDownList></w:sdtPr>';

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -23,12 +23,23 @@
 
 import type { SdtProperties } from "../types/document";
 
+const XML_ATTR_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&apos;",
+};
+
+/**
+ * Escape a value for embedding in an XML attribute. Single-pass replace
+ * over the five XML metacharacters (incl. apostrophe so the function
+ * stays correct for `'`-delimited attributes even though this file always
+ * emits double-quoted ones). Output is XML written to a DOCX zip — no
+ * HTML / browser interpretation downstream.
+ */
 function escapeXmlAttr(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
+  return value.replace(/[&<>"']/gu, (ch) => XML_ATTR_ESCAPES[ch] ?? ch);
 }
 
 /**

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -43,26 +43,55 @@ function escapeXmlAttr(value: string): string {
 }
 
 /**
- * Drop any `w:lastValue="…"` attribute from an attribute-list string. We
- * avoid a single greedy regex with `\s+` (which lint flags as backtracking-
- * risky) and instead match the literal attribute name with bounded values.
+ * Drop any `*:lastValue="…"` attribute (any namespace prefix, or
+ * unprefixed) from an attribute-list string. We avoid a single greedy
+ * regex with `\s+` (which lint flags as backtracking-risky) and instead
+ * scan character-by-character against `lastValue=` while accepting any
+ * preceding `prefix:`. Without prefix tolerance, a source DOCX that
+ * binds the Word namespace under a non-`w` prefix
+ * (`<ns0:dropDownList ns0:lastValue="old">`) would keep the stale
+ * attribute alongside our freshly-emitted `w:lastValue` on save.
  */
 function stripLastValueAttr(attrs: string): string {
-  const marker = " w:lastValue=";
-  let idx = attrs.indexOf(marker);
+  const SUFFIX = "lastValue=";
   let out = attrs;
-  while (idx !== -1) {
-    const quoteIdx = idx + marker.length;
+  let searchFrom = 0;
+  while (searchFrom < out.length) {
+    const hitIdx = out.indexOf(SUFFIX, searchFrom);
+    if (hitIdx === -1) {
+      break;
+    }
+    // Walk backwards over an optional `prefix:` and require a leading
+    // whitespace separator so we don't accidentally chew on an attr like
+    // `mylastValue=`. The attribute we want is always introduced by
+    // whitespace.
+    let nameStart = hitIdx;
+    while (nameStart > 0 && /[A-Za-z0-9_-]/u.test(out[nameStart - 1] ?? "")) {
+      nameStart -= 1;
+    }
+    if (nameStart > 0 && out[nameStart - 1] === ":") {
+      nameStart -= 1;
+      while (nameStart > 0 && /[A-Za-z0-9_-]/u.test(out[nameStart - 1] ?? "")) {
+        nameStart -= 1;
+      }
+    }
+    if (nameStart === 0 || !/\s/u.test(out[nameStart - 1] ?? "")) {
+      searchFrom = hitIdx + SUFFIX.length;
+      continue;
+    }
+    const quoteIdx = hitIdx + SUFFIX.length;
     const quote = out[quoteIdx];
     if (quote !== '"' && quote !== "'") {
-      break;
+      searchFrom = hitIdx + SUFFIX.length;
+      continue;
     }
     const closeIdx = out.indexOf(quote, quoteIdx + 1);
     if (closeIdx === -1) {
       break;
     }
-    out = `${out.slice(0, idx)}${out.slice(closeIdx + 1)}`;
-    idx = out.indexOf(marker, idx);
+    // Drop the leading separator too so two whitespace runs don't merge.
+    out = `${out.slice(0, nameStart - 1)}${out.slice(closeIdx + 1)}`;
+    searchFrom = nameStart - 1;
   }
   return out;
 }
@@ -255,7 +284,7 @@ export function reconcileRawSdtPr(
     (props.sdtType === "dropdown" || props.sdtType === "comboBox") &&
     options.dropdownLastValue !== undefined
   ) {
-    const lastValueAttr = ` w:lastValue="${escapeXmlAttr(options.dropdownLastValue)}"`;
+    const escapedValue = escapeXmlAttr(options.dropdownLastValue);
     const opened =
       /<(\w+):(dropDownList|comboBox)\b([^>]*)>([\s\S]*?)<\/\w+:(?:dropDownList|comboBox)>/iu;
     const selfClosing = /<(\w+):(dropDownList|comboBox)\b([^/>]*)\/>/iu;
@@ -264,7 +293,10 @@ export function reconcileRawSdtPr(
         opened,
         (_m, prefix: string, name: string, attrs: string, inner: string) => {
           const stripped = stripLastValueAttr(attrs);
-          return `<${prefix}:${name}${stripped}${lastValueAttr}>${inner}</${prefix}:${name}>`;
+          // Re-emit under the SOURCE prefix so a producer that bound w:
+          // under `ns0` ends up with `ns0:lastValue` rather than mixing
+          // prefixes inside the same element.
+          return `<${prefix}:${name}${stripped} ${prefix}:lastValue="${escapedValue}">${inner}</${prefix}:${name}>`;
         },
       );
     } else if (selfClosing.test(next)) {
@@ -272,7 +304,7 @@ export function reconcileRawSdtPr(
         selfClosing,
         (_m, prefix: string, name: string, attrs: string) => {
           const stripped = stripLastValueAttr(attrs);
-          return `<${prefix}:${name}${stripped}${lastValueAttr}/>`;
+          return `<${prefix}:${name}${stripped} ${prefix}:lastValue="${escapedValue}"/>`;
         },
       );
     }

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -1,0 +1,246 @@
+/**
+ * Surgical patches for the captured `<w:sdtPr>` XML string.
+ *
+ * Background. The block-SDT serializer (commit 3) replays
+ * `properties.rawPropertiesXml` verbatim so unmodeled OOXML markers
+ * (`w:dataBinding`, `w15:repeatingSection`, custom XML mappings) survive
+ * a round trip. That replay is correct for unchanged controls but goes
+ * stale the moment the editor mutates a modeled property: a user
+ * toggling a checkbox, picking a date, or choosing a dropdown value
+ * updates `properties.checked` / `dateFormat` / etc., but the raw
+ * `w14:checked w14:val="0"` already encoded by the source DOCX stays
+ * in `rawPropertiesXml` and gets written back on save — Word reopens
+ * the document with the user's interactive change discarded.
+ *
+ * `reconcileRawSdtPr` walks every modeled field that has an OOXML
+ * representation inside `<w:sdtPr>` and, if the field is set on the
+ * model, rewrites the matching element in the raw string. Unmodeled
+ * markers are untouched, so dataBinding / repeatingSection round-trip
+ * stays lossless even after the user has mutated the control.
+ *
+ * Picked up from upstream eigenpal/docx-editor#661.
+ */
+
+import type { SdtProperties } from "../types/document";
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+/**
+ * Drop any `w:lastValue="…"` attribute from an attribute-list string. We
+ * avoid a single greedy regex with `\s+` (which lint flags as backtracking-
+ * risky) and instead match the literal attribute name with bounded values.
+ */
+function stripLastValueAttr(attrs: string): string {
+  const marker = " w:lastValue=";
+  let idx = attrs.indexOf(marker);
+  let out = attrs;
+  while (idx !== -1) {
+    const quoteIdx = idx + marker.length;
+    const quote = out[quoteIdx];
+    if (quote !== '"' && quote !== "'") {
+      break;
+    }
+    const closeIdx = out.indexOf(quote, quoteIdx + 1);
+    if (closeIdx === -1) {
+      break;
+    }
+    out = `${out.slice(0, idx)}${out.slice(closeIdx + 1)}`;
+    idx = out.indexOf(marker, idx);
+  }
+  return out;
+}
+
+/**
+ * Replace or insert a child element inside `<w:sdtPr>...</w:sdtPr>`.
+ *
+ * - If a matching child already exists (by local name), the whole element
+ *   is replaced verbatim by `replacement` (so attributes / payload come
+ *   from the caller).
+ * - Otherwise `replacement` is injected just before `</w:sdtPr>` so the
+ *   element ends up as a child of sdtPr, not after it.
+ */
+function upsertSdtPrChild(
+  raw: string,
+  localName: string,
+  replacement: string,
+): string {
+  // Match `<prefix:localName ... />` or `<prefix:localName ...>...</prefix:localName>`.
+  const escaped = localName.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
+  const selfClosing = new RegExp(`<\\w+:${escaped}\\b[^>]*\\/>`, "iu");
+  const opened = new RegExp(
+    `<\\w+:${escaped}\\b[^>]*>[\\s\\S]*?<\\/\\w+:${escaped}>`,
+    "iu",
+  );
+  if (selfClosing.test(raw)) {
+    return raw.replace(selfClosing, replacement);
+  }
+  if (opened.test(raw)) {
+    return raw.replace(opened, replacement);
+  }
+  // Inject before </w:sdtPr> (handles both `</w:sdtPr>` and `</prefix:sdtPr>`).
+  const closing = /<\/\w+:sdtPr>/iu;
+  if (closing.test(raw)) {
+    return raw.replace(closing, `${replacement}</w:sdtPr>`);
+  }
+  // Self-closing `<w:sdtPr/>` — expand to a container.
+  const selfClosingPr = /<(\w+):sdtPr([^/>]*)\/>/iu;
+  if (selfClosingPr.test(raw)) {
+    return raw.replace(
+      selfClosingPr,
+      (_match, prefix: string, attrs: string) =>
+        `<${prefix}:sdtPr${attrs}>${replacement}</${prefix}:sdtPr>`,
+    );
+  }
+  return raw;
+}
+
+function setOrRemove(
+  raw: string,
+  localName: string,
+  replacementWhenSet: string | null,
+): string {
+  if (replacementWhenSet === null) {
+    // Remove any existing element of that name; tolerate prefixed forms.
+    const escaped = localName.replaceAll(/[$()*+./?[\\\]^{|}]/gu, "\\$&");
+    const selfClosing = new RegExp(`<\\w+:${escaped}\\b[^>]*\\/>`, "igu");
+    const opened = new RegExp(
+      `<\\w+:${escaped}\\b[^>]*>[\\s\\S]*?<\\/\\w+:${escaped}>`,
+      "igu",
+    );
+    return raw.replaceAll(selfClosing, "").replaceAll(opened, "");
+  }
+  return upsertSdtPrChild(raw, localName, replacementWhenSet);
+}
+
+/**
+ * Rewrite the relevant child elements of `<w:sdtPr>` so the modeled
+ * properties (checked / dateFormat / fullDate / lastValue / showingPlcHdr)
+ * agree with the raw XML before it is replayed by the serializer.
+ *
+ * Pure: returns a new string; the input is not modified.
+ */
+export function reconcileRawSdtPr(
+  raw: string,
+  props: SdtProperties,
+  options: { dateFullDate?: string; dropdownLastValue?: string } = {},
+): string {
+  let next = raw;
+
+  // showingPlcHdr is a marker element; toggle it based on the boolean.
+  if (props.showingPlaceholder === true) {
+    next = setOrRemove(next, "showingPlcHdr", "<w:showingPlcHdr/>");
+  } else if (props.showingPlaceholder === false) {
+    next = setOrRemove(next, "showingPlcHdr", null);
+  }
+
+  // Checkbox state lives in <w14:checkbox><w14:checked w14:val="0|1"/>...
+  // For OOXML compatibility we keep the w14 prefix; Word writes this form
+  // for checkboxes authored since Word 2010.
+  if (props.sdtType === "checkbox" && typeof props.checked === "boolean") {
+    const val = props.checked ? "1" : "0";
+    // Update existing w14:checked first; if missing, fold one into the
+    // existing w14:checkbox wrapper, otherwise synthesize the wrapper.
+    if (/<\w+:checked\b[^/>]*\/?>/iu.test(next)) {
+      next = next.replaceAll(
+        /<(\w+):checked\b[^/>]*\/?>/giu,
+        (_m, prefix: string) => `<${prefix}:checked ${prefix}:val="${val}"/>`,
+      );
+    } else if (/<\w+:checkbox\b[^>]*>/iu.test(next)) {
+      next = next.replace(
+        /<(\w+):checkbox\b[^>]*>/iu,
+        (match, prefix: string) =>
+          `${match}<${prefix}:checked ${prefix}:val="${val}"/>`,
+      );
+    } else {
+      next = upsertSdtPrChild(
+        next,
+        "checkbox",
+        `<w14:checkbox><w14:checked w14:val="${val}"/></w14:checkbox>`,
+      );
+    }
+  }
+
+  // Date format: <w:date w:fullDate="..."><w:dateFormat w:val="..."/>...
+  // We only own the modeled fields here — leave any other w:date children
+  // (lid, calendar, storeMappedDataAs) alone.
+  if (props.sdtType === "date") {
+    const fullDate = options.dateFullDate;
+    const dateFormat = props.dateFormat;
+    if (fullDate !== undefined || dateFormat !== undefined) {
+      // Patch <w:date> in place when present, otherwise insert a fresh one.
+      const wDate = /<(\w+):date\b([^>]*)>([\s\S]*?)<\/\w+:date>/iu;
+      const wDateSelf = /<(\w+):date\b([^/>]*)\/>/iu;
+      const fullDateAttr =
+        fullDate !== undefined
+          ? ` w:fullDate="${escapeXmlAttr(fullDate)}"`
+          : "";
+      const formatChild =
+        dateFormat !== undefined
+          ? `<w:dateFormat w:val="${escapeXmlAttr(dateFormat)}"/>`
+          : "";
+      if (wDate.test(next)) {
+        next = next.replace(
+          wDate,
+          (_m, prefix: string, _attrs: string, inner: string) => {
+            // Remove any existing w:dateFormat, re-emit ours if provided.
+            let body = inner.replaceAll(/<\w+:dateFormat\b[^/>]*\/>/giu, "");
+            if (formatChild) {
+              body = `${formatChild}${body}`;
+            }
+            const attrs = fullDate !== undefined ? fullDateAttr : _attrs;
+            return `<${prefix}:date${attrs}>${body}</${prefix}:date>`;
+          },
+        );
+      } else if (wDateSelf.test(next)) {
+        next = next.replace(
+          wDateSelf,
+          (_m, prefix: string) =>
+            `<${prefix}:date${fullDateAttr}>${formatChild}</${prefix}:date>`,
+        );
+      } else {
+        next = upsertSdtPrChild(
+          next,
+          "date",
+          `<w:date${fullDateAttr}>${formatChild}</w:date>`,
+        );
+      }
+    }
+  }
+
+  // Dropdown selection: <w:dropDownList w:lastValue="..."><w:listItem .../>
+  // Preserve the listItem children; we only touch the @w:lastValue attribute.
+  if (
+    (props.sdtType === "dropdown" || props.sdtType === "comboBox") &&
+    options.dropdownLastValue !== undefined
+  ) {
+    const lastValueAttr = ` w:lastValue="${escapeXmlAttr(options.dropdownLastValue)}"`;
+    const opened =
+      /<(\w+):(dropDownList|comboBox)\b([^>]*)>([\s\S]*?)<\/\w+:(?:dropDownList|comboBox)>/iu;
+    const selfClosing = /<(\w+):(dropDownList|comboBox)\b([^/>]*)\/>/iu;
+    if (opened.test(next)) {
+      next = next.replace(
+        opened,
+        (_m, prefix: string, name: string, attrs: string, inner: string) => {
+          const stripped = stripLastValueAttr(attrs);
+          return `<${prefix}:${name}${stripped}${lastValueAttr}>${inner}</${prefix}:${name}>`;
+        },
+      );
+    } else if (selfClosing.test(next)) {
+      next = next.replace(
+        selfClosing,
+        (_m, prefix: string, name: string, attrs: string) => {
+          const stripped = stripLastValueAttr(attrs);
+          return `<${prefix}:${name}${stripped}${lastValueAttr}/>`;
+        },
+      );
+    }
+  }
+
+  return next;
+}

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -245,16 +245,20 @@ export function reconcileRawSdtPr(
           wDate,
           (_m, prefix: string, _attrs: string, inner: string) => {
             // Remove any existing w:dateFormat, re-emit ours if provided.
-            // Match BOTH the self-closing and expanded-empty forms — a valid
-            // DOCX is free to write `<w:dateFormat w:val="…"></w:dateFormat>`,
-            // and stripping only `…/>` would leave a stale sibling next to
-            // the freshly-prepended replacement on the next save.
-            let body = inner
-              .replaceAll(/<\w+:dateFormat\b[^/>]*\/>/giu, "")
-              .replaceAll(
-                /<\w+:dateFormat\b[^>]*>[\s\S]*?<\/\w+:dateFormat>/giu,
-                "",
-              );
+            // Single alternation covers BOTH the self-closing form
+            // (`<w:dateFormat …/>`) and the expanded-empty form
+            // (`<w:dateFormat …></w:dateFormat>`) — a valid DOCX is free
+            // to write either, and stripping only one would leave a
+            // stale sibling next to the freshly-prepended replacement
+            // on the next save. One pass also stops CodeQL's
+            // incomplete-multi-character-sanitization heuristic from
+            // flagging the chained replaceAll pattern, which it kept
+            // confusing for HTML element sanitisation even though this
+            // is XML buffer manipulation that never reaches a browser.
+            let body = inner.replaceAll(
+              /<\w+:dateFormat\b[^>]*(?:\/>|>[\s\S]*?<\/\w+:dateFormat>)/giu,
+              "",
+            );
             if (formatChild) {
               body = `${formatChild}${body}`;
             }

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -144,11 +144,21 @@ export function reconcileRawSdtPr(
   // for checkboxes authored since Word 2010.
   if (props.sdtType === "checkbox" && typeof props.checked === "boolean") {
     const val = props.checked ? "1" : "0";
-    // Update existing w14:checked first; if missing, fold one into the
-    // existing w14:checkbox wrapper, otherwise synthesize the wrapper.
-    if (/<\w+:checked\b[^/>]*\/?>/iu.test(next)) {
+    // Handle the expanded-empty form `<w14:checked ...></w14:checked>` first
+    // so we replace the whole element, not just the opening tag (which
+    // would leave a stray closing tag behind). Then the self-closing
+    // form, then folding into an existing <w14:checkbox> wrapper, then a
+    // synthesized wrapper as the last resort.
+    const checkedOpened = /<(\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/iu;
+    const checkedSelfClosing = /<(\w+):checked\b[^>]*\/>/iu;
+    if (checkedOpened.test(next)) {
       next = next.replaceAll(
-        /<(\w+):checked\b[^/>]*\/?>/giu,
+        /<(\w+):checked\b[^>]*>[\s\S]*?<\/\w+:checked>/giu,
+        (_m, prefix: string) => `<${prefix}:checked ${prefix}:val="${val}"/>`,
+      );
+    } else if (checkedSelfClosing.test(next)) {
+      next = next.replaceAll(
+        /<(\w+):checked\b[^>]*\/>/giu,
         (_m, prefix: string) => `<${prefix}:checked ${prefix}:val="${val}"/>`,
       );
     } else if (/<\w+:checkbox\b[^>]*>/iu.test(next)) {

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -205,7 +205,16 @@ export function reconcileRawSdtPr(
           wDate,
           (_m, prefix: string, _attrs: string, inner: string) => {
             // Remove any existing w:dateFormat, re-emit ours if provided.
-            let body = inner.replaceAll(/<\w+:dateFormat\b[^/>]*\/>/giu, "");
+            // Match BOTH the self-closing and expanded-empty forms — a valid
+            // DOCX is free to write `<w:dateFormat w:val="…"></w:dateFormat>`,
+            // and stripping only `…/>` would leave a stale sibling next to
+            // the freshly-prepended replacement on the next save.
+            let body = inner
+              .replaceAll(/<\w+:dateFormat\b[^/>]*\/>/giu, "")
+              .replaceAll(
+                /<\w+:dateFormat\b[^>]*>[\s\S]*?<\/\w+:dateFormat>/giu,
+                "",
+              );
             if (formatChild) {
               body = `${formatChild}${body}`;
             }

--- a/packages/folio/src/core/docx/sdtPropertiesPatch.ts
+++ b/packages/folio/src/core/docx/sdtPropertiesPatch.ts
@@ -83,10 +83,16 @@ function upsertSdtPrChild(
   if (opened.test(raw)) {
     return raw.replace(opened, replacement);
   }
-  // Inject before </w:sdtPr> (handles both `</w:sdtPr>` and `</prefix:sdtPr>`).
-  const closing = /<\/\w+:sdtPr>/iu;
-  if (closing.test(raw)) {
-    return raw.replace(closing, `${replacement}</w:sdtPr>`);
+  // Inject before the matching closing tag. Capture the source prefix and
+  // reuse it for the rewritten closing tag so an exotic namespace prefix
+  // (`<ns0:sdtPr>...</ns0:sdtPr>`) doesn't end up with a mismatched
+  // `</w:sdtPr>` — the resulting XML would be malformed and Word would
+  // refuse the file.
+  const closing = /<\/(\w+):sdtPr>/iu;
+  const closingMatch = closing.exec(raw);
+  if (closingMatch) {
+    const closingPrefix = closingMatch[1];
+    return raw.replace(closing, `${replacement}</${closingPrefix}:sdtPr>`);
   }
   // Self-closing `<w:sdtPr/>` — expand to a container.
   const selfClosingPr = /<(\w+):sdtPr([^/>]*)\/>/iu;

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
@@ -71,6 +71,50 @@ describe("serializeBlockSdt — raw sdtPr replay", () => {
     expect(xml).toContain("w15:repeatingSection");
   });
 
+  test("replays sdt-sibling range markers (bookmark/comment/tracked) on round-trip", () => {
+    // MS-OE376 §2.5.2.30: Word emits range-marker elements as direct
+    // siblings of <w:sdtContent> inside <w:sdt>, not nested inside it.
+    // Without preserving the captured-before/after raw XML, a comment
+    // thread or tracked-change range that crosses an SDT boundary loses
+    // one delimiter on round-trip.
+    const blocks = parseBlocks(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="x"/></w:sdtPr>
+        <w:bookmarkStart w:id="1" w:name="b1"/>
+        <w:commentRangeStart w:id="0"/>
+        <w:sdtContent><w:p/></w:sdtContent>
+        <w:commentRangeEnd w:id="0"/>
+        <w:bookmarkEnd w:id="1"/>
+      </w:sdt>
+    </w:body>`);
+    const first = blocks[0];
+    if (!first || first.type !== "blockSdt") {
+      throw new Error(`expected blockSdt, got ${String(first?.type)}`);
+    }
+    expect(first.properties.rawSdtChildrenBeforeContent).toContain(
+      "w:bookmarkStart",
+    );
+    expect(first.properties.rawSdtChildrenBeforeContent).toContain(
+      "w:commentRangeStart",
+    );
+    expect(first.properties.rawSdtChildrenAfterContent).toContain(
+      "w:bookmarkEnd",
+    );
+    expect(first.properties.rawSdtChildrenAfterContent).toContain(
+      "w:commentRangeEnd",
+    );
+    const xml = serializeBlockSdt(first, noChildSerializer);
+    // Markers replay in original positions.
+    expect(xml).toContain('<w:bookmarkStart w:id="1" w:name="b1"/>');
+    expect(xml).toContain('<w:commentRangeStart w:id="0"/>');
+    expect(xml).toContain('<w:bookmarkEnd w:id="1"/>');
+    expect(xml).toContain('<w:commentRangeEnd w:id="0"/>');
+    // The before-markers come before <w:sdtContent>, the after-markers come after.
+    const contentIdx = xml.indexOf("<w:sdtContent>");
+    expect(xml.indexOf("w:bookmarkStart")).toBeLessThan(contentIdx);
+    expect(xml.indexOf("w:bookmarkEnd")).toBeGreaterThan(contentIdx);
+  });
+
   test("replays sdtEndPr verbatim", () => {
     const blocks = parseBlocks(`<w:body ${NS}>
       <w:sdt>

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
@@ -145,6 +145,37 @@ describe("serializeBlockSdt — raw sdtPr replay", () => {
     expect(xml).not.toContain('w:lastValue="other-a"');
   });
 
+  test("preserves an intentionally empty modeled dropdownLastValue", () => {
+    // `""` is a legitimate OOXML w:value — a producer can author
+    // `<w:listItem w:value=""/>` and the user can pick it. Treating
+    // `dropdownLastValue: ""` as absent would fall back to body-text
+    // matching and serialize the first display-text-collision sibling
+    // instead of the intended empty selection.
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "dropdown",
+        tag: "category",
+        listItems: [
+          { displayText: "Other", value: "" },
+          { displayText: "Other", value: "fallback" },
+        ],
+        dropdownLastValue: "",
+      },
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "run", content: [{ type: "text", text: "Other" }] },
+          ],
+        },
+      ],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain('w:lastValue=""');
+    expect(xml).not.toContain('w:lastValue="fallback"');
+  });
+
   test("fallback sdtPr emits w:date with fullDate + dateFormat for date controls", () => {
     const sdt: BlockSdt = {
       type: "blockSdt",

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Round-trip tests for the block-level SDT serializer.
+ *
+ * Parse → re-serialize must preserve the original `<w:sdtPr>` bytes so
+ * unmodeled OOXML features (data binding, repeating sections, sdtEndPr)
+ * survive a save cycle. Picked up from upstream eigenpal/docx-editor#653.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { BlockContent, BlockSdt } from "../../types/document";
+import { parseBlockContent } from "../blockContentParser";
+import { parseXml } from "../xmlParser";
+import { serializeBlockSdt } from "./blockSdtSerializer";
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"';
+
+function parseBlocks(bodyXml: string): BlockContent[] {
+  const root = parseXml(bodyXml);
+  const body = root.elements?.[0];
+  if (!body) {
+    throw new Error("expected root body element");
+  }
+  return parseBlockContent(body, null, null, null, null, null);
+}
+
+function noChildSerializer(_block: BlockContent): string {
+  return "<w:p/>";
+}
+
+describe("serializeBlockSdt — raw sdtPr replay", () => {
+  test("preserves w:dataBinding through parse → serialize", () => {
+    const blocks = parseBlocks(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr>
+          <w:tag w:val="party-name"/>
+          <w:dataBinding w:xpath="/contract/party[1]/name" w:storeItemID="{ABC}"/>
+        </w:sdtPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+
+    const first = blocks[0];
+    if (!first || first.type !== "blockSdt") {
+      throw new Error(`expected blockSdt, got ${String(first?.type)}`);
+    }
+    const sdt = first;
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain("<w:dataBinding");
+    expect(xml).toContain('w:xpath="/contract/party[1]/name"');
+    expect(xml).toContain('w:storeItemID="{ABC}"');
+  });
+
+  test("preserves w15:repeatingSection through parse → serialize", () => {
+    const blocks = parseBlocks(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr>
+          <w:tag w:val="parties"/>
+          <w15:repeatingSection/>
+        </w:sdtPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+    const first = blocks[0];
+    if (!first || first.type !== "blockSdt") {
+      throw new Error(`expected blockSdt, got ${String(first?.type)}`);
+    }
+    const sdt = first;
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain("w15:repeatingSection");
+  });
+
+  test("replays sdtEndPr verbatim", () => {
+    const blocks = parseBlocks(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="signature"/></w:sdtPr>
+        <w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+    const first = blocks[0];
+    if (!first || first.type !== "blockSdt") {
+      throw new Error(`expected blockSdt, got ${String(first?.type)}`);
+    }
+    const sdt = first;
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain("<w:sdtEndPr>");
+    expect(xml).toContain("<w:b");
+  });
+
+  test("falls back to a minimal sdtPr when no raw snapshot exists", () => {
+    // Mirrors a programmatically-constructed BlockSdt (no parse cycle), so
+    // the serializer can't replay raw XML and must synthesize from props.
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "richText",
+        alias: "Synthetic & <wrapped>",
+        tag: "synthetic",
+        lock: "contentLocked",
+      },
+      content: [],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain('<w:alias w:val="Synthetic &amp; &lt;wrapped&gt;"/>');
+    expect(xml).toContain('<w:tag w:val="synthetic"/>');
+    expect(xml).toContain('<w:lock w:val="contentLocked"/>');
+  });
+});

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
@@ -89,6 +89,57 @@ describe("serializeBlockSdt — raw sdtPr replay", () => {
     expect(xml).toContain("<w:b");
   });
 
+  test("fallback sdtPr emits dropdown type marker + listItems for programmatic controls", () => {
+    // A BlockSdt constructed without rawPropertiesXml (e.g. a template
+    // engine that builds the control programmatically) must still encode
+    // its type so Word reopens it as the right control kind.
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "dropdown",
+        tag: "state",
+        listItems: [
+          { displayText: "California", value: "ca" },
+          { displayText: "New York", value: "ny" },
+        ],
+      },
+      content: [],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain("<w:dropDownList>");
+    expect(xml).toContain('w:displayText="California"');
+    expect(xml).toContain('w:value="ca"');
+    expect(xml).toContain('w:value="ny"');
+    expect(xml).toContain("</w:dropDownList>");
+  });
+
+  test("fallback sdtPr emits w:date with fullDate + dateFormat for date controls", () => {
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "date",
+        tag: "effective",
+        dateFormat: "d MMMM yyyy",
+        dateValueISO: "2026-06-02T00:00:00Z",
+      },
+      content: [],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain('w:fullDate="2026-06-02T00:00:00Z"');
+    expect(xml).toContain('<w:dateFormat w:val="d MMMM yyyy"/>');
+  });
+
+  test("fallback sdtPr emits w14:checkbox with w14:checked for checkbox controls", () => {
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: { sdtType: "checkbox", tag: "agree", checked: true },
+      content: [],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain("<w14:checkbox>");
+    expect(xml).toContain('<w14:checked w14:val="1"/>');
+  });
+
   test("falls back to a minimal sdtPr when no raw snapshot exists", () => {
     // Mirrors a programmatically-constructed BlockSdt (no parse cycle), so
     // the serializer can't replay raw XML and must synthesize from props.

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.test.ts
@@ -113,6 +113,38 @@ describe("serializeBlockSdt — raw sdtPr replay", () => {
     expect(xml).toContain("</w:dropDownList>");
   });
 
+  test("dropdownLastValue from the model wins over body-text matching when displayText collides", () => {
+    // Two list items share a displayText ("Other"). The body shows the
+    // friendly label, but the API set the picked OOXML value to "other-b".
+    // Without the modeled dropdownLastValue, the serializer used to look
+    // up the value by display-text match and returned the FIRST collision
+    // ("other-a") — Word reopened the doc with the wrong selection.
+    const sdt: BlockSdt = {
+      type: "blockSdt",
+      properties: {
+        sdtType: "dropdown",
+        tag: "category",
+        listItems: [
+          { displayText: "First", value: "first" },
+          { displayText: "Other", value: "other-a" },
+          { displayText: "Other", value: "other-b" },
+        ],
+        dropdownLastValue: "other-b",
+      },
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            { type: "run", content: [{ type: "text", text: "Other" }] },
+          ],
+        },
+      ],
+    };
+    const xml = serializeBlockSdt(sdt, noChildSerializer);
+    expect(xml).toContain('w:lastValue="other-b"');
+    expect(xml).not.toContain('w:lastValue="other-a"');
+  });
+
   test("fallback sdtPr emits w:date with fullDate + dateFormat for date controls", () => {
     const sdt: BlockSdt = {
       type: "blockSdt",

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -21,6 +21,7 @@ import type {
   BlockSdt,
   SdtProperties,
 } from "../../types/document";
+import { reconcileRawSdtPr } from "../sdtPropertiesPatch";
 
 function escapeXmlAttr(value: string): string {
   return value
@@ -55,12 +56,83 @@ function serializeFallbackSdtPr(props: SdtProperties): string {
   return `<w:sdtPr>${parts.join("")}</w:sdtPr>`;
 }
 
+function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
+  if (
+    blockSdt.properties.sdtType !== "dropdown" &&
+    blockSdt.properties.sdtType !== "comboBox"
+  ) {
+    return undefined;
+  }
+  // The dropdown's "current" value is the displayed text of the first run
+  // in the SDT body. Mirrors what setContentControlValue writes back.
+  const firstBlock = blockSdt.content[0];
+  if (!firstBlock || firstBlock.type !== "paragraph") {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const child of firstBlock.content) {
+    if (child.type === "run") {
+      for (const item of child.content) {
+        if (item.type === "text") {
+          parts.push(item.text);
+        }
+      }
+    }
+  }
+  const text = parts.join("");
+  if (text.length === 0) {
+    return undefined;
+  }
+  // Map back from displayText to value when listItems are present so
+  // Word's w:lastValue carries the OOXML value, not the friendly label.
+  const items = blockSdt.properties.listItems;
+  if (items) {
+    const match = items.find((item) => item.displayText === text);
+    if (match) {
+      return match.value;
+    }
+  }
+  return text;
+}
+
+function extractDateFullDate(blockSdt: BlockSdt): string | undefined {
+  if (blockSdt.properties.sdtType !== "date") {
+    return undefined;
+  }
+  const firstBlock = blockSdt.content[0];
+  if (!firstBlock || firstBlock.type !== "paragraph") {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const child of firstBlock.content) {
+    if (child.type === "run") {
+      for (const item of child.content) {
+        if (item.type === "text") {
+          parts.push(item.text);
+        }
+      }
+    }
+  }
+  const text = parts.join("").trim();
+  return text.length > 0 ? text : undefined;
+}
+
 export function serializeBlockSdt(
   blockSdt: BlockSdt,
   serializeChild: (block: BlockContent) => string,
 ): string {
   const props = blockSdt.properties;
-  const sdtPrXml = props.rawPropertiesXml ?? serializeFallbackSdtPr(props);
+  const baseSdtPr = props.rawPropertiesXml ?? serializeFallbackSdtPr(props);
+  // Reconcile any modeled property mutations the editor may have made into
+  // the raw XML before replay so checkbox / dropdown / date interactions
+  // survive the round-trip. Unmodeled markers (dataBinding,
+  // w15:repeatingSection, etc.) inside the raw string are preserved.
+  const dateFullDate = extractDateFullDate(blockSdt);
+  const dropdownLastValue = extractDropdownLastValue(blockSdt);
+  const sdtPrXml = reconcileRawSdtPr(baseSdtPr, props, {
+    ...(dateFullDate !== undefined ? { dateFullDate } : {}),
+    ...(dropdownLastValue !== undefined ? { dropdownLastValue } : {}),
+  });
   const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
   const contentXml = blockSdt.content.map(serializeChild).join("");
   return `<w:sdt>${sdtPrXml}${sdtEndPrXml}<w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -1,0 +1,30 @@
+/**
+ * Block-level SDT serializer.
+ *
+ * This commit keeps the existing alias/tag-only `<w:sdtPr>` emission to match
+ * the parser's modeled-projection state. The next commit replaces the body
+ * here with a raw `properties.rawPropertiesXml` replay so unmodeled OOXML
+ * features (`w:dataBinding`, `w15:repeatingSection`, `w:sdtEndPr`, etc.)
+ * round-trip losslessly.
+ *
+ * Sharing the helper between the document body and the header/footer
+ * serializers keeps body↔HF parity in one place.
+ */
+
+import type { BlockContent, BlockSdt } from "../../types/document";
+
+export function serializeBlockSdt(
+  blockSdt: BlockSdt,
+  serializeChild: (block: BlockContent) => string,
+): string {
+  const props = blockSdt.properties;
+  const prParts: string[] = [];
+  if (props.alias) {
+    prParts.push(`<w:alias w:val="${props.alias}"/>`);
+  }
+  if (props.tag) {
+    prParts.push(`<w:tag w:val="${props.tag}"/>`);
+  }
+  const contentXml = blockSdt.content.map(serializeChild).join("");
+  return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
+}

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -99,22 +99,14 @@ function extractDateFullDate(blockSdt: BlockSdt): string | undefined {
   if (blockSdt.properties.sdtType !== "date") {
     return undefined;
   }
-  const firstBlock = blockSdt.content[0];
-  if (!firstBlock || firstBlock.type !== "paragraph") {
-    return undefined;
-  }
-  const parts: string[] = [];
-  for (const child of firstBlock.content) {
-    if (child.type === "run") {
-      for (const item of child.content) {
-        if (item.type === "text") {
-          parts.push(item.text);
-        }
-      }
-    }
-  }
-  const text = parts.join("").trim();
-  return text.length > 0 ? text : undefined;
+  // The ISO bound value lives on the modeled `dateValueISO`. We deliberately
+  // do NOT read the SDT body — the body shows the format-rendered display
+  // ("2 June 2026" per dateFormat "d MMMM yyyy") which would corrupt
+  // `w:fullDate` (which OOXML requires to be ISO 8601). If the model has no
+  // ISO value yet (e.g. a fresh control the user never picked a date for),
+  // omit `w:fullDate` so the serializer doesn't write a garbage one.
+  const iso = blockSdt.properties.dateValueISO;
+  return iso !== undefined && iso.length > 0 ? iso : undefined;
 }
 
 export function serializeBlockSdt(

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -53,6 +53,65 @@ function serializeFallbackSdtPr(props: SdtProperties): string {
   if (props.showingPlaceholder) {
     parts.push("<w:showingPlcHdr/>");
   }
+  // Type-specific child elements. Without these, a programmatically-
+  // constructed control with `sdtType: "dropdown"` and a `listItems` set
+  // would serialize as a bare `<w:sdtPr>` — Word would reopen the SDT as
+  // richText and discard the dropdown items. `reconcileRawSdtPr` only
+  // patches existing markers (it does not insert a missing
+  // `<w:dropDownList>`), so the fallback must emit the type-defining
+  // marker itself.
+  switch (props.sdtType) {
+    case "plainText":
+      parts.push("<w:text/>");
+      break;
+    case "date": {
+      const fullDateAttr = props.dateValueISO
+        ? ` w:fullDate="${escapeXmlAttr(props.dateValueISO)}"`
+        : "";
+      const formatChild = props.dateFormat
+        ? `<w:dateFormat w:val="${escapeXmlAttr(props.dateFormat)}"/>`
+        : "";
+      if (fullDateAttr || formatChild) {
+        parts.push(`<w:date${fullDateAttr}>${formatChild}</w:date>`);
+      } else {
+        parts.push("<w:date/>");
+      }
+      break;
+    }
+    case "dropdown":
+    case "comboBox": {
+      const tag =
+        props.sdtType === "dropdown" ? "w:dropDownList" : "w:comboBox";
+      const items = (props.listItems ?? [])
+        .map(
+          (item) =>
+            `<w:listItem w:displayText="${escapeXmlAttr(item.displayText)}" w:value="${escapeXmlAttr(item.value)}"/>`,
+        )
+        .join("");
+      parts.push(`<${tag}>${items}</${tag}>`);
+      break;
+    }
+    case "checkbox": {
+      const val = props.checked ? "1" : "0";
+      parts.push(
+        `<w14:checkbox><w14:checked w14:val="${val}"/></w14:checkbox>`,
+      );
+      break;
+    }
+    case "picture":
+      parts.push("<w:picture/>");
+      break;
+    case "buildingBlockGallery":
+      parts.push("<w:docPartObj/>");
+      break;
+    case "group":
+      parts.push("<w:group/>");
+      break;
+    default:
+      // richText / unknown — no specific marker; bare <w:sdtPr> means
+      // richText per the OOXML default.
+      break;
+  }
   return `<w:sdtPr>${parts.join("")}</w:sdtPr>`;
 }
 

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -1,30 +1,67 @@
 /**
  * Block-level SDT serializer.
  *
- * This commit keeps the existing alias/tag-only `<w:sdtPr>` emission to match
- * the parser's modeled-projection state. The next commit replaces the body
- * here with a raw `properties.rawPropertiesXml` replay so unmodeled OOXML
- * features (`w:dataBinding`, `w15:repeatingSection`, `w:sdtEndPr`, etc.)
- * round-trip losslessly.
+ * Replays `<w:sdtPr>` (and `<w:sdtEndPr>` when present) verbatim from the
+ * `rawPropertiesXml` / `rawEndPropertiesXml` strings captured by the parser.
+ * That keeps OOXML element order intact (`CT_SdtPr` is an `xsd:sequence`,
+ * ECMA-376 §17.5.2) and round-trips unmodeled features — `w:dataBinding`,
+ * `w15:repeatingSection`, `@lastValue`, custom XML mappings — without us
+ * having to enumerate them.
+ *
+ * If a `BlockSdt` was constructed programmatically (no parsed snapshot to
+ * replay), fall back to a minimal projection from the modeled fields so the
+ * result is still a valid `<w:sdt>`.
  *
  * Sharing the helper between the document body and the header/footer
  * serializers keeps body↔HF parity in one place.
  */
 
-import type { BlockContent, BlockSdt } from "../../types/document";
+import type {
+  BlockContent,
+  BlockSdt,
+  SdtProperties,
+} from "../../types/document";
+
+function escapeXmlAttr(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function serializeFallbackSdtPr(props: SdtProperties): string {
+  const parts: string[] = [];
+  if (props.id !== undefined) {
+    parts.push(`<w:id w:val="${props.id}"/>`);
+  }
+  if (props.alias) {
+    parts.push(`<w:alias w:val="${escapeXmlAttr(props.alias)}"/>`);
+  }
+  if (props.tag) {
+    parts.push(`<w:tag w:val="${escapeXmlAttr(props.tag)}"/>`);
+  }
+  if (props.lock) {
+    parts.push(`<w:lock w:val="${props.lock}"/>`);
+  }
+  if (props.placeholder) {
+    parts.push(
+      `<w:placeholder><w:docPart w:val="${escapeXmlAttr(props.placeholder)}"/></w:placeholder>`,
+    );
+  }
+  if (props.showingPlaceholder) {
+    parts.push("<w:showingPlcHdr/>");
+  }
+  return `<w:sdtPr>${parts.join("")}</w:sdtPr>`;
+}
 
 export function serializeBlockSdt(
   blockSdt: BlockSdt,
   serializeChild: (block: BlockContent) => string,
 ): string {
   const props = blockSdt.properties;
-  const prParts: string[] = [];
-  if (props.alias) {
-    prParts.push(`<w:alias w:val="${props.alias}"/>`);
-  }
-  if (props.tag) {
-    prParts.push(`<w:tag w:val="${props.tag}"/>`);
-  }
+  const sdtPrXml = props.rawPropertiesXml ?? serializeFallbackSdtPr(props);
+  const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
   const contentXml = blockSdt.content.map(serializeChild).join("");
-  return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
+  return `<w:sdt>${sdtPrXml}${sdtEndPrXml}<w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
 }

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -122,8 +122,16 @@ function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
   ) {
     return undefined;
   }
-  // The dropdown's "current" value is the displayed text of the first run
-  // in the SDT body. Mirrors what setContentControlValue writes back.
+  // Prefer the modeled `dropdownLastValue` (written by `setContentControlValue`
+  // and reload-recovered by the parser from the source `w:lastValue`).
+  // Recovering it from the body's display text mis-selects the wrong entry
+  // when two list items share a displayText, so the body-text fallback
+  // below only kicks in for documents that have neither been updated via
+  // the API nor parsed from a doc that carried a w:lastValue.
+  const modeled = blockSdt.properties.dropdownLastValue;
+  if (modeled !== undefined && modeled.length > 0) {
+    return modeled;
+  }
   const firstBlock = blockSdt.content[0];
   if (!firstBlock || firstBlock.type !== "paragraph") {
     return undefined;
@@ -142,8 +150,6 @@ function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
   if (text.length === 0) {
     return undefined;
   }
-  // Map back from displayText to value when listItems are present so
-  // Word's w:lastValue carries the OOXML value, not the friendly label.
   const items = blockSdt.properties.listItems;
   if (items) {
     const match = items.find((item) => item.displayText === text);

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -129,7 +129,12 @@ function extractDropdownLastValue(blockSdt: BlockSdt): string | undefined {
   // below only kicks in for documents that have neither been updated via
   // the API nor parsed from a doc that carried a w:lastValue.
   const modeled = blockSdt.properties.dropdownLastValue;
-  if (modeled !== undefined && modeled.length > 0) {
+  // `""` is a legitimate OOXML lastValue (a producer can author
+  // `<w:listItem w:value=""/>` and `setContentControlValue` will pick
+  // it). Only `undefined` means "no modeled selection" — gating on
+  // length would silently fall through to body-text matching and
+  // serialize the wrong sibling when display text collides.
+  if (modeled !== undefined) {
     return modeled;
   }
   const firstBlock = blockSdt.content[0];

--- a/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/blockSdtSerializer.ts
@@ -197,5 +197,12 @@ export function serializeBlockSdt(
   });
   const sdtEndPrXml = props.rawEndPropertiesXml ?? "";
   const contentXml = blockSdt.content.map(serializeChild).join("");
-  return `<w:sdt>${sdtPrXml}${sdtEndPrXml}<w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
+  // Replay any direct sdt children that lived OUTSIDE sdtContent at parse
+  // time (range markers per MS-OE376 §2.5.2.30: bookmark / comment /
+  // tracked-change / custom XML ranges that span an SDT boundary). Position
+  // matters — the captured before/after strings preserve which side of
+  // sdtContent each marker sat on.
+  const before = props.rawSdtChildrenBeforeContent ?? "";
+  const after = props.rawSdtChildrenAfterContent ?? "";
+  return `<w:sdt>${sdtPrXml}${sdtEndPrXml}${before}<w:sdtContent>${contentXml}</w:sdtContent>${after}</w:sdt>`;
 }

--- a/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.test.ts
@@ -32,6 +32,27 @@ describe("document section properties are integer-only (issue #417)", () => {
     expect(xml).toContain('w:right="1800"');
   });
 
+  test("document root declares the full namespace set needed by raw-replay paths", () => {
+    // The parser preserves unmodeled OOXML children (data hashes, cex /
+    // cid extensions) inside `rawPropertiesXml`. A canonical
+    // `<w:sdtPr>` with a `<w16sdtdh:dataHash>` would replay an
+    // undeclared prefix if the document root only emits the minimal
+    // set — Word would refuse to open the file. Pin every w16* prefix
+    // here so the regression can't drift.
+    const xml = serializeDocument(createEmptyDocument());
+    for (const prefix of [
+      "w14",
+      "w15",
+      "w16",
+      "w16cex",
+      "w16cid",
+      "w16sdtdh",
+      "w16se",
+    ]) {
+      expect(xml).toContain(`xmlns:${prefix}="`);
+    }
+  });
+
   test("serializer-side defense catches drift even if the model carries floats", () => {
     // Bypass the createEmptyDocument input guard by mutating the model
     // directly — proves the serializer's intAttr() defense works on its own.

--- a/packages/folio/src/core/docx/serializer/documentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.ts
@@ -16,6 +16,7 @@ import type {
   DocumentBody,
   BlockContent,
 } from "../../types/document";
+import { serializeBlockSdt } from "./blockSdtSerializer";
 import { serializeParagraph } from "./paragraphSerializer";
 import { resetAutoIdCounter } from "./runSerializer";
 import { serializeSectionProperties } from "./sectionPropertiesSerializer";
@@ -100,7 +101,7 @@ function buildNamespaceDeclarations(): string {
 // ============================================================================
 
 /**
- * Serialize a single block content item (paragraph or table)
+ * Serialize a single block content item (paragraph, table, or block-level SDT).
  */
 function serializeBlockContent(block: BlockContent): string {
   if (block.type === "paragraph") {
@@ -109,19 +110,7 @@ function serializeBlockContent(block: BlockContent): string {
   if (block.type === "table") {
     return serializeTable(block);
   }
-  // Block-level SDT: wrap content in w:sdt
-  const contentXml = block.content
-    .map((b) => serializeBlockContent(b))
-    .join("");
-  const props = block.properties;
-  const prParts: string[] = [];
-  if (props.alias) {
-    prParts.push(`<w:alias w:val="${props.alias}"/>`);
-  }
-  if (props.tag) {
-    prParts.push(`<w:tag w:val="${props.tag}"/>`);
-  }
-  return `<w:sdt><w:sdtPr>${prParts.join("")}</w:sdtPr><w:sdtContent>${contentXml}</w:sdtContent></w:sdt>`;
+  return serializeBlockSdt(block, serializeBlockContent);
 }
 
 /**

--- a/packages/folio/src/core/docx/serializer/documentSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/documentSerializer.ts
@@ -69,8 +69,14 @@ const NAMESPACES = {
  * Build namespace declaration string for document element
  */
 function buildNamespaceDeclarations(): string {
-  // Minimal set of commonly used namespaces
-  const minimalNamespaces = {
+  // Declare every namespace the parser preserves verbatim through
+  // `rawPropertiesXml` / `rawEndPropertiesXml` (and any other raw
+  // replay path). A canonical `<w:sdtPr>` legitimately contains
+  // `<w16sdtdh:dataHash>` / `<w16cex:*>` / `<w16cid:*>` children that
+  // the parser stores opaquely; without these declarations on the
+  // document root, the replayed XML would carry undefined prefixes and
+  // Word refuses to open the file.
+  const declared = {
     wpc: NAMESPACES.wpc,
     mc: NAMESPACES.mc,
     o: NAMESPACES.o,
@@ -83,11 +89,16 @@ function buildNamespaceDeclarations(): string {
     w: NAMESPACES.w,
     w14: NAMESPACES.w14,
     w15: NAMESPACES.w15,
+    w16: NAMESPACES.w16,
+    w16cex: NAMESPACES.w16cex,
+    w16cid: NAMESPACES.w16cid,
+    w16sdtdh: NAMESPACES.w16sdtdh,
+    w16se: NAMESPACES.w16se,
     wpg: NAMESPACES.wpg,
     wps: NAMESPACES.wps,
   };
 
-  return Object.entries(minimalNamespaces)
+  return Object.entries(declared)
     .map(([prefix, uri]) => `xmlns:${prefix}="${uri}"`)
     .join(" ");
 }

--- a/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
@@ -15,7 +15,10 @@ import { serializeBlockSdt } from "./blockSdtSerializer";
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
 
-// Minimal namespaces needed for header/footer XML
+// Namespaces declared on the header/footer root. Mirrors the document
+// serializer's declared set so any raw replay path (`rawPropertiesXml`,
+// unmodeled OOXML extensions inside a captured SDT) lands on a root that
+// declares every standard prefix it might use.
 const NAMESPACES: Record<string, string> = {
   wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
   mc: "http://schemas.openxmlformats.org/markup-compatibility/2006",
@@ -29,6 +32,11 @@ const NAMESPACES: Record<string, string> = {
   w: "http://schemas.openxmlformats.org/wordprocessingml/2006/main",
   w14: "http://schemas.microsoft.com/office/word/2010/wordml",
   w15: "http://schemas.microsoft.com/office/word/2012/wordml",
+  w16: "http://schemas.microsoft.com/office/word/2018/wordml",
+  w16cex: "http://schemas.microsoft.com/office/word/2018/wordml/cex",
+  w16cid: "http://schemas.microsoft.com/office/word/2016/wordml/cid",
+  w16sdtdh: "http://schemas.microsoft.com/office/word/2020/wordml/sdtdatahash",
+  w16se: "http://schemas.microsoft.com/office/word/2015/wordml/symex",
   wpg: "http://schemas.microsoft.com/office/word/2010/wordprocessingGroup",
   wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
 };

--- a/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
@@ -10,7 +10,8 @@
  * - Content: w:p, w:tbl (same as document body)
  */
 
-import type { HeaderFooter, Paragraph, Table } from "../../types/document";
+import type { BlockContent, HeaderFooter } from "../../types/document";
+import { serializeBlockSdt } from "./blockSdtSerializer";
 import { serializeParagraph } from "./paragraphSerializer";
 import { serializeTable } from "./tableSerializer";
 
@@ -39,13 +40,17 @@ function buildNamespaceDeclarations(): string {
 }
 
 /**
- * Serialize a block content item (paragraph or table) for header/footer
+ * Serialize a block content item (paragraph, table, or block-level SDT) for
+ * header/footer.
  */
-function serializeBlock(block: Paragraph | Table): string {
+function serializeBlock(block: BlockContent): string {
   if (block.type === "paragraph") {
     return serializeParagraph(block);
   }
-  return serializeTable(block);
+  if (block.type === "table") {
+    return serializeTable(block);
+  }
+  return serializeBlockSdt(block, serializeBlock);
 }
 
 /**

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer-inlineSdt.test.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer-inlineSdt.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Round-trip tests for inline SDTs through the paragraph serializer.
+ *
+ * Focus: the inline `<w:sdt>` date path now emits `w:date@w:fullDate`
+ * separately from the `<w:dateFormat w:val>` child — previously the
+ * display format was written into the bound-value slot (and the ISO
+ * value was lost).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseParagraph } from "../paragraphParser";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+import { serializeParagraph } from "./paragraphSerializer";
+
+function parseParagraphXml(xml: string) {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+}
+
+describe("serializeParagraph — inline date SDT round-trip", () => {
+  test("writes w:fullDate and w:dateFormat into separate elements", () => {
+    const paragraph = parseParagraphXml(
+      '<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+        "<w:sdt><w:sdtPr>" +
+        '<w:tag w:val="effective"/>' +
+        '<w:date w:fullDate="2026-06-02T00:00:00Z">' +
+        '<w:dateFormat w:val="d MMMM yyyy"/>' +
+        "</w:date>" +
+        "</w:sdtPr><w:sdtContent>" +
+        "<w:r><w:t>2 June 2026</w:t></w:r>" +
+        "</w:sdtContent></w:sdt></w:p>",
+    );
+    const out = serializeParagraph(paragraph);
+    // The bound ISO date lives on `w:date@w:fullDate`.
+    expect(out).toContain('w:fullDate="2026-06-02T00:00:00Z"');
+    // The display format lives on `<w:dateFormat w:val>`.
+    expect(out).toContain('<w:dateFormat w:val="d MMMM yyyy"/>');
+    // The format string must not leak into the fullDate attribute.
+    expect(out).not.toContain('w:fullDate="d MMMM yyyy"');
+  });
+
+  test("emits <w:date/> alone when neither dateValueISO nor dateFormat is modeled", () => {
+    const paragraph = parseParagraphXml(
+      '<w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">' +
+        '<w:sdt><w:sdtPr><w:tag w:val="placeholder"/><w:date/></w:sdtPr>' +
+        "<w:sdtContent><w:r><w:t>Click here to pick a date</w:t></w:r></w:sdtContent></w:sdt></w:p>",
+    );
+    const out = serializeParagraph(paragraph);
+    expect(out).toContain("<w:date/>");
+    expect(out).not.toContain('w:fullDate="');
+  });
+});

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -826,13 +826,25 @@ function serializeInlineSdt(sdt: InlineSdt): string {
     case "plainText":
       prParts.push("<w:text/>");
       break;
-    case "date":
-      if (props.dateFormat) {
-        prParts.push(`<w:date w:fullDate="${escapeXml(props.dateFormat)}"/>`);
+    case "date": {
+      // `w:date@w:fullDate` is the ISO-8601 bound value; `w:dateFormat` is
+      // the display format. Older code (before the shared parser
+      // split these) wrote the format into `w:fullDate`, which corrupted
+      // round-trip — keep them on separate model fields and emit each
+      // into its right element.
+      const fullDateAttr = props.dateValueISO
+        ? ` w:fullDate="${escapeXml(props.dateValueISO)}"`
+        : "";
+      const formatChild = props.dateFormat
+        ? `<w:dateFormat w:val="${escapeXml(props.dateFormat)}"/>`
+        : "";
+      if (fullDateAttr || formatChild) {
+        prParts.push(`<w:date${fullDateAttr}>${formatChild}</w:date>`);
       } else {
         prParts.push("<w:date/>");
       }
       break;
+    }
     case "dropdown": {
       const items = (props.listItems ?? [])
         .map(

--- a/packages/folio/src/core/docx/xmlParser.ts
+++ b/packages/folio/src/core/docx/xmlParser.ts
@@ -662,7 +662,23 @@ export function parseBooleanElement(
     return false;
   }
 
-  const val = getAttribute(element, namespace, "val");
+  // OOXML binds prefixes to namespace URIs at the doc root; the source is
+  // free to pick any prefix (`w14:checked` vs. `ns0:checked`) so long as
+  // it resolves to the right URI. fast-xml-parser keeps prefixes literal,
+  // so we have to be tolerant of the prefix actually written rather than
+  // assuming the canonical one. Without this, a `<ns0:checked ns0:val="0"/>`
+  // misses the val attribute, falls through to the bare-presence branch,
+  // and an unchecked box renders as checked (codex P2, PR #587).
+  let val: string | null = null;
+  const elementName = element.name ?? "";
+  const colonIdx = elementName.indexOf(":");
+  const elementPrefix = colonIdx > 0 ? elementName.slice(0, colonIdx) : null;
+  if (elementPrefix && elementPrefix !== namespace) {
+    val = getAttribute(element, elementPrefix, "val");
+  }
+  if (val === null) {
+    val = getAttribute(element, namespace, "val");
+  }
 
   // No val attribute = true (element presence implies true)
   if (val === null) {

--- a/packages/folio/src/core/docx/xmlParser.ts
+++ b/packages/folio/src/core/docx/xmlParser.ts
@@ -493,7 +493,30 @@ export function getAttributeAnyPrefix(
       return fromPrefix;
     }
   }
-  return getAttribute(element, "w", localName);
+  const canonical = getAttribute(element, "w", localName);
+  if (canonical !== null) {
+    return canonical;
+  }
+  // Final fallback: a canonical element (`<w:tag>`) can still carry
+  // attributes under a different inherited prefix (`<w:tag x:val="…"/>`
+  // when `x` is also bound to the WP URI at the document root). The
+  // wrapper-prefix and canonical-prefix lookups above miss that case;
+  // scan attribute names by local-name suffix as a last resort so the
+  // modeled projection picks the value up — without this, the raw XML
+  // normalizer rewrites it on save but `props.tag` / `listItems` /
+  // similar stay empty and tag-keyed lookups break.
+  const attrs = element.attributes;
+  if (attrs) {
+    const suffix = `:${localName}`;
+    for (const [key, value] of Object.entries(
+      attrs as Record<string, string>,
+    )) {
+      if (key === localName || key.endsWith(suffix)) {
+        return value;
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -709,6 +732,20 @@ export function parseBooleanElement(
   }
   if (val === null) {
     val = getAttribute(element, namespace, "val");
+  }
+  // A canonical element can carry the val attribute under a different
+  // inherited prefix (`<w:b x:val="0"/>` when `x` is bound to the WP
+  // URI). The wrapper-prefix and canonical-prefix lookups above miss
+  // that; scan by local-name suffix so the OnOff parse is honest.
+  if (val === null && element.attributes) {
+    for (const [key, value] of Object.entries(
+      element.attributes as Record<string, string>,
+    )) {
+      if (key === "val" || key.endsWith(":val")) {
+        val = value;
+        break;
+      }
+    }
   }
 
   // No val attribute = true (element presence implies true)

--- a/packages/folio/src/core/docx/xmlParser.ts
+++ b/packages/folio/src/core/docx/xmlParser.ts
@@ -466,6 +466,37 @@ export function getAttribute(
 }
 
 /**
+ * Read an attribute by local name, trying the element's own prefix first,
+ * then the canonical Word prefix, then unprefixed.
+ *
+ * OOXML lets a producer bind the WordprocessingML namespace under any
+ * prefix the file's xmlns declarations choose, so a strict `w:val` /
+ * `w:tag` lookup misses valid docs that use `ns0:` (or any other prefix
+ * resolving to the same URI). This helper mirrors `parseBooleanElement`'s
+ * tolerance for the attribute path — call it whenever you want to read
+ * an OOXML attribute that conventionally lives in the `w:` namespace
+ * but could appear under an alternate prefix bound to the same URI.
+ */
+export function getAttributeAnyPrefix(
+  element: XmlElement | null | undefined,
+  localName: string,
+): string | null {
+  if (!element) {
+    return null;
+  }
+  const elementName = element.name ?? "";
+  const colonIdx = elementName.indexOf(":");
+  const elementPrefix = colonIdx > 0 ? elementName.slice(0, colonIdx) : null;
+  if (elementPrefix && elementPrefix !== "w") {
+    const fromPrefix = getAttribute(element, elementPrefix, localName);
+    if (fromPrefix !== null) {
+      return fromPrefix;
+    }
+  }
+  return getAttribute(element, "w", localName);
+}
+
+/**
  * Get an attribute value, trying multiple possible names
  *
  * @param element - Element to get attribute from

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for SDT group tagging in toFlowBlocks.
+ *
+ * A blockSdt PM node flattens into its child flow blocks, but each child
+ * carries an `sdtGroups` projection (outer→inner) so the painter can stamp
+ * `data-sdt-*` attributes and the widget layer can find the group.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../prosemirror/schema";
+import { toFlowBlocks } from "./toFlowBlocks";
+
+describe("toFlowBlocks — blockSdt grouping", () => {
+  test("flattens block SDT children and tags each with the enclosing SdtGroup", () => {
+    const inner = schema.node("paragraph", {}, [schema.text("inside the SDT")]);
+    const blockSdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "richText",
+        tag: "effective-date",
+        alias: "Effective Date",
+      },
+      [inner],
+    );
+    const tail = schema.node("paragraph", {}, [schema.text("after")]);
+    const doc = schema.node("doc", null, [blockSdt, tail]);
+
+    const blocks = toFlowBlocks(doc);
+    // Two paragraph blocks (the SDT's inner paragraph, then the tail).
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    expect(paragraphs).toHaveLength(2);
+
+    const [first, second] = paragraphs;
+    expect(first?.sdtGroups).toBeTruthy();
+    expect(first?.sdtGroups?.[0]?.tag).toBe("effective-date");
+    expect(first?.sdtGroups?.[0]?.alias).toBe("Effective Date");
+    expect(second?.sdtGroups).toBeUndefined();
+  });
+
+  test("nested block SDTs produce an outer→inner stack on the inner paragraph", () => {
+    const innerPara = schema.node("paragraph", {}, [schema.text("nested")]);
+    const innerSdt = schema.node("blockSdt", { tag: "inner" }, [innerPara]);
+    const outerSdt = schema.node("blockSdt", { tag: "outer" }, [innerSdt]);
+    const doc = schema.node("doc", null, [outerSdt]);
+
+    const blocks = toFlowBlocks(doc);
+    const paragraph = blocks.find((b) => b.kind === "paragraph");
+    expect(paragraph?.sdtGroups?.map((g) => g.tag)).toEqual(["outer", "inner"]);
+  });
+});

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
@@ -65,6 +65,43 @@ describe("toFlowBlocks — blockSdt grouping", () => {
     expect(innermost).toEqual(["only"]);
   });
 
+  test("outer SDT does not overwrite inner SDT's first/middle/last", () => {
+    // Outer SDT has `[pre, inner SDT containing two paragraphs, post]`.
+    // The outer's position-stamping pass must update ITS own group
+    // entry, not the innermost (which is the inner SDT for the two
+    // inner-SDT blocks). The inner SDT's paragraphs should keep their
+    // first/last; the outer entry on those same blocks should report
+    // their position within the outer sequence (middle).
+    const inner = schema.node("blockSdt", { sdtType: "richText", tag: "in" }, [
+      schema.node("paragraph", {}, [schema.text("inner first")]),
+      schema.node("paragraph", {}, [schema.text("inner last")]),
+    ]);
+    const outer = schema.node("blockSdt", { sdtType: "richText", tag: "out" }, [
+      schema.node("paragraph", {}, [schema.text("pre")]),
+      inner,
+      schema.node("paragraph", {}, [schema.text("post")]),
+    ]);
+    const doc = schema.node("doc", null, [outer]);
+    const blocks = toFlowBlocks(doc);
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    // Block order: pre, inner-first, inner-last, post (4 paragraphs).
+    expect(paragraphs).toHaveLength(4);
+
+    // For the inner-first / inner-last blocks:
+    // - sdtGroups = [outer, inner]
+    // - The OUTER entry's position should be "middle" (those blocks
+    //   sit between `pre` and `post` in the outer sequence)
+    // - The INNER entry's position should be "first" / "last"
+    const innerFirst = paragraphs[1];
+    const innerLast = paragraphs[2];
+    expect(innerFirst?.sdtGroups?.[0]?.tag).toBe("out");
+    expect(innerFirst?.sdtGroups?.[0]?.position).toBe("middle");
+    expect(innerFirst?.sdtGroups?.[1]?.tag).toBe("in");
+    expect(innerFirst?.sdtGroups?.[1]?.position).toBe("first");
+    expect(innerLast?.sdtGroups?.[0]?.position).toBe("middle");
+    expect(innerLast?.sdtGroups?.[1]?.position).toBe("last");
+  });
+
   test("nested block SDTs produce an outer→inner stack on the inner paragraph", () => {
     const innerPara = schema.node("paragraph", {}, [schema.text("nested")]);
     const innerSdt = schema.node("blockSdt", { tag: "inner" }, [innerPara]);

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
@@ -38,6 +38,33 @@ describe("toFlowBlocks — blockSdt grouping", () => {
     expect(second?.sdtGroups).toBeUndefined();
   });
 
+  test("assigns first/middle/last positions across the SDT's child blocks", () => {
+    // Multi-block SDTs should paint chrome as a continuous outline; the
+    // innermost SdtGroup on each block carries the position so the painter
+    // / CSS can stitch the dashed border across consecutive blocks.
+    const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "x" }, [
+      schema.node("paragraph", {}, [schema.text("a")]),
+      schema.node("paragraph", {}, [schema.text("b")]),
+      schema.node("paragraph", {}, [schema.text("c")]),
+    ]);
+    const blocks = toFlowBlocks(schema.node("doc", null, [sdt]));
+    const positions = blocks
+      .filter((b) => b.kind === "paragraph")
+      .map((b) => b.sdtGroups?.at(-1)?.position);
+    expect(positions).toEqual(["first", "middle", "last"]);
+  });
+
+  test("a single-block SDT marks the only block as `only`", () => {
+    const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "y" }, [
+      schema.node("paragraph", {}, [schema.text("solo")]),
+    ]);
+    const blocks = toFlowBlocks(schema.node("doc", null, [sdt]));
+    const innermost = blocks
+      .filter((b) => b.kind === "paragraph")
+      .map((b) => b.sdtGroups?.at(-1)?.position);
+    expect(innermost).toEqual(["only"]);
+  });
+
   test("nested block SDTs produce an outer→inner stack on the inner paragraph", () => {
     const innerPara = schema.node("paragraph", {}, [schema.text("nested")]);
     const innerSdt = schema.node("blockSdt", { tag: "inner" }, [innerPara]);

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks-sdt.test.ts
@@ -11,6 +11,49 @@ import { describe, expect, test } from "bun:test";
 import { schema } from "../prosemirror/schema";
 import { toFlowBlocks } from "./toFlowBlocks";
 
+describe("toFlowBlocks — run-in merge respects SDT boundaries", () => {
+  test("does not merge a runInWithNext paragraph inside an SDT with one outside it", () => {
+    // The first paragraph carries specVanish (`runInWithNext`) and lives
+    // inside an SDT. Its successor is a top-level body paragraph. Without
+    // the membership check, mergeRunInParagraphs would carry only the
+    // first paragraph's sdtGroups onto the merged block, so the body
+    // text after the boundary would render as if it were part of the SDT
+    // — chrome and widget click targets would line up against the wrong
+    // range.
+    const inner = schema.node("paragraph", { runInWithNext: true }, [
+      schema.text("Heading"),
+    ]);
+    const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "wrap" }, [
+      inner,
+    ]);
+    const tail = schema.node("paragraph", {}, [schema.text("body text")]);
+    const blocks = toFlowBlocks(schema.node("doc", null, [sdt, tail]));
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+
+    expect(paragraphs).toHaveLength(2);
+    expect(paragraphs[0]?.sdtGroups?.[0]?.tag).toBe("wrap");
+    expect(paragraphs[1]?.sdtGroups).toBeUndefined();
+  });
+
+  test("still merges runInWithNext when both paragraphs share the same SDT membership", () => {
+    // Sanity: the same-membership case must keep working — a specVanish
+    // heading immediately above its body paragraph inside one SDT should
+    // collapse exactly like it does outside an SDT.
+    const heading = schema.node("paragraph", { runInWithNext: true }, [
+      schema.text("Heading"),
+    ]);
+    const body = schema.node("paragraph", {}, [schema.text(" body text")]);
+    const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "wrap" }, [
+      heading,
+      body,
+    ]);
+    const blocks = toFlowBlocks(schema.node("doc", null, [sdt]));
+    const paragraphs = blocks.filter((b) => b.kind === "paragraph");
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]?.sdtGroups?.[0]?.tag).toBe("wrap");
+  });
+});
+
 describe("toFlowBlocks — blockSdt grouping", () => {
   test("flattens block SDT children and tags each with the enclosing SdtGroup", () => {
     const inner = schema.node("paragraph", {}, [schema.text("inside the SDT")]);

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -37,6 +37,7 @@ import {
   DEFAULT_TEXTBOX_WIDTH,
 } from "../layout-engine/types";
 import {
+  expectBlockSdtAttrs,
   expectCharacterSpacingMarkAttrs,
   expectCommentMarkAttrs,
   expectEmphasisMarkAttrs,
@@ -2331,35 +2332,35 @@ export function toFlowBlocks(
   const visit = (node: PMNode, pos: number): void => {
     switch (node.type.name) {
       case "blockSdt": {
-        const attrs = node.attrs;
+        const attrs = expectBlockSdtAttrs(node);
         sdtSeq += 1;
         const group: SdtGroup = {
           id: `sdt-${sdtSeq}`,
-          sdtType: String(attrs["sdtType"] ?? "richText"),
+          sdtType: attrs.sdtType,
         };
-        if (attrs["alias"]) {
-          group.alias = String(attrs["alias"]);
+        if (attrs.alias) {
+          group.alias = attrs.alias;
         }
-        if (attrs["tag"]) {
-          group.tag = String(attrs["tag"]);
+        if (attrs.tag) {
+          group.tag = attrs.tag;
         }
-        if (typeof attrs["id"] === "number") {
-          group.sdtId = attrs["id"];
+        if (typeof attrs.id === "number") {
+          group.sdtId = attrs.id;
         }
-        if (attrs["lock"]) {
-          group.lock = String(attrs["lock"]);
+        if (attrs.lock) {
+          group.lock = attrs.lock;
         }
-        if (attrs["showingPlaceholder"]) {
+        if (attrs.showingPlaceholder) {
           group.showingPlaceholder = true;
         }
-        if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
-          group.checked = Boolean(attrs["checked"]);
+        if (typeof attrs.checked === "boolean") {
+          group.checked = attrs.checked;
         }
-        if (attrs["dateFormat"]) {
-          group.dateFormat = String(attrs["dateFormat"]);
+        if (attrs.dateFormat) {
+          group.dateFormat = attrs.dateFormat;
         }
-        if (typeof attrs["listItems"] === "string" && attrs["listItems"]) {
-          group.listItemsJson = attrs["listItems"];
+        if (attrs.listItems) {
+          group.listItemsJson = attrs.listItems;
         }
 
         sdtStack.push(group);

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2336,6 +2336,7 @@ export function toFlowBlocks(
         sdtSeq += 1;
         const group: SdtGroup = {
           id: `sdt-${sdtSeq}`,
+          pmPos: pos,
           sdtType: attrs.sdtType,
         };
         if (attrs.alias) {

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2384,13 +2384,20 @@ export function toFlowBlocks(
             groupBlocks.push(b);
           }
         }
+        // We're finalizing the SDT that `group` represents — locate that
+        // entry by `pmPos` instead of always taking `at(-1)`. For blocks
+        // that sit inside an inner SDT, `at(-1)` is the inner group, and
+        // overwriting it would clobber the inner SDT's first/middle/last
+        // markers when the outer iterates the same range later. Matching
+        // by pmPos keeps the inner positions intact.
+        const ourPmPos = group.pmPos;
         for (let i = 0; i < groupBlocks.length; i += 1) {
           const b = groupBlocks[i];
           if (!b || !b.sdtGroups) {
             continue;
           }
-          const innermost = b.sdtGroups.at(-1);
-          if (!innermost) {
+          const idx = b.sdtGroups.findIndex((g) => g.pmPos === ourPmPos);
+          if (idx === -1) {
             continue;
           }
           let position: NonNullable<SdtGroup["position"]>;
@@ -2403,13 +2410,17 @@ export function toFlowBlocks(
           } else {
             position = "middle";
           }
-          // Replace the innermost group with a copy carrying the position.
-          // (The same SdtGroup object is shared across blocks of this
-          // group, so swap in a new last entry to keep the others untouched.)
-          b.sdtGroups = [
-            ...b.sdtGroups.slice(0, -1),
-            { ...innermost, position },
-          ];
+          // Replace just the entry for this SDT, leaving inner/outer
+          // sibling entries untouched. (SdtGroup objects are shared
+          // across blocks of the same group; copy-on-write here keeps
+          // the other blocks' references stable.)
+          const next = [...b.sdtGroups];
+          const existing = next[idx];
+          if (!existing) {
+            continue;
+          }
+          next[idx] = { ...existing, position };
+          b.sdtGroups = next;
         }
         return;
       }

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2564,6 +2564,29 @@ export function toFlowBlocks(
  * preserve runInWithNext only when the second paragraph itself has
  * specVanish).
  */
+function sdtGroupStacksEqual(
+  a: SdtGroup[] | undefined,
+  b: SdtGroup[] | undefined,
+): boolean {
+  // pmPos is unique per SDT instance within a single toFlowBlocks call, so
+  // comparing the pmPos stacks is enough to tell "same membership" vs.
+  // "different membership" without copying the rest of the group payload.
+  const lenA = a?.length ?? 0;
+  const lenB = b?.length ?? 0;
+  if (lenA !== lenB) {
+    return false;
+  }
+  if (lenA === 0) {
+    return true;
+  }
+  for (let i = 0; i < lenA; i++) {
+    if (a?.[i]?.pmPos !== b?.[i]?.pmPos) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function mergeRunInParagraphs(blocks: FlowBlock[]): FlowBlock[] {
   const out: FlowBlock[] = [];
   for (let i = 0; i < blocks.length; i++) {
@@ -2588,6 +2611,15 @@ function mergeRunInParagraphs(blocks: FlowBlock[]): FlowBlock[] {
       }
       const a = current as ParagraphBlock;
       const b = next as ParagraphBlock;
+      // Stop merging when the two paragraphs sit in different SDT stacks.
+      // The merged ParagraphBlock would inherit only `a`'s sdtGroups via
+      // spread, so a `<w:specVanish/>` adjacent to a paragraph across an
+      // SDT boundary would either claim outside text as part of the SDT
+      // or strip SDT membership from inside text — chrome and widget
+      // click targets would line up against the wrong content range.
+      if (!sdtGroupStacksEqual(a.sdtGroups, b.sdtGroups)) {
+        break;
+      }
       const mergedAttrs: ParagraphAttrs = { ...a.attrs };
       // Heading typically has no spaceAfter; the body's spaceAfter
       // governs the merged paragraph's trailing gap.

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -2365,6 +2365,7 @@ export function toFlowBlocks(
         }
 
         sdtStack.push(group);
+        const startIndex = blocks.length;
         let childOffset = pos + 1; // skip the blockSdt opening token
         for (let i = 0; i < node.childCount; i += 1) {
           const child = node.child(i);
@@ -2372,6 +2373,44 @@ export function toFlowBlocks(
           childOffset += child.nodeSize;
         }
         sdtStack.pop();
+        // Stamp first/middle/last/only on the innermost group of each block
+        // that was emitted inside this SDT so the painter chrome continues
+        // visually across the block sequence. Only paragraph/table blocks
+        // carry sdtGroups; section breaks etc. were skipped at tag time.
+        const groupBlocks: (ParagraphBlock | TableBlock)[] = [];
+        for (let i = startIndex; i < blocks.length; i += 1) {
+          const b = blocks[i];
+          if (b && (b.kind === "paragraph" || b.kind === "table")) {
+            groupBlocks.push(b);
+          }
+        }
+        for (let i = 0; i < groupBlocks.length; i += 1) {
+          const b = groupBlocks[i];
+          if (!b || !b.sdtGroups) {
+            continue;
+          }
+          const innermost = b.sdtGroups.at(-1);
+          if (!innermost) {
+            continue;
+          }
+          let position: NonNullable<SdtGroup["position"]>;
+          if (groupBlocks.length === 1) {
+            position = "only";
+          } else if (i === 0) {
+            position = "first";
+          } else if (i === groupBlocks.length - 1) {
+            position = "last";
+          } else {
+            position = "middle";
+          }
+          // Replace the innermost group with a copy carrying the position.
+          // (The same SdtGroup object is shared across blocks of this
+          // group, so swap in a new last entry to keep the others untouched.)
+          b.sdtGroups = [
+            ...b.sdtGroups.slice(0, -1),
+            { ...innermost, position },
+          ];
+        }
         return;
       }
       default:

--- a/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
+++ b/packages/folio/src/core/layout-bridge/toFlowBlocks.ts
@@ -28,6 +28,7 @@ import type {
   FieldRun,
   RunFormatting,
   ParagraphAttrs,
+  SdtGroup,
   TabStop,
   FloatingTablePosition,
 } from "../layout-engine/types";
@@ -2294,7 +2295,8 @@ export function toFlowBlocks(
   };
 
   const blocks: FlowBlock[] = [];
-  const offset = 0; // Start at document beginning
+  const offset = 0; // Start at document beginning; kept for clarity.
+  void offset;
   let lastSectionMarginsTwips = {
     top: 1440,
     bottom: 1440,
@@ -2302,16 +2304,84 @@ export function toFlowBlocks(
     right: 1440,
   };
 
-  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
-  doc.forEach((node, nodeOffset) => {
-    const pos = offset + nodeOffset;
+  let sdtSeq = 0;
+  const sdtStack: SdtGroup[] = [];
+
+  /**
+   * Stamp the active SDT stack (outer→inner) onto every block produced by the
+   * current call. ParagraphBlock/TableBlock accept `sdtGroups`; section breaks
+   * and page breaks deliberately do not — they bracket layout, not content.
+   */
+  const tagBlockWithSdtStack = (block: FlowBlock): void => {
+    if (sdtStack.length === 0) {
+      return;
+    }
+    if (block.kind === "paragraph" || block.kind === "table") {
+      block.sdtGroups = [...sdtStack];
+    }
+  };
+
+  const trackedPush = (block: FlowBlock): void => {
+    tagBlockWithSdtStack(block);
+    blocks.push(block);
+  };
+
+  // Refactored visit-style traversal so blockSdt can recurse into its
+  // children without duplicating the per-block conversion code.
+  const visit = (node: PMNode, pos: number): void => {
+    switch (node.type.name) {
+      case "blockSdt": {
+        const attrs = node.attrs;
+        sdtSeq += 1;
+        const group: SdtGroup = {
+          id: `sdt-${sdtSeq}`,
+          sdtType: String(attrs["sdtType"] ?? "richText"),
+        };
+        if (attrs["alias"]) {
+          group.alias = String(attrs["alias"]);
+        }
+        if (attrs["tag"]) {
+          group.tag = String(attrs["tag"]);
+        }
+        if (typeof attrs["id"] === "number") {
+          group.sdtId = attrs["id"];
+        }
+        if (attrs["lock"]) {
+          group.lock = String(attrs["lock"]);
+        }
+        if (attrs["showingPlaceholder"]) {
+          group.showingPlaceholder = true;
+        }
+        if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
+          group.checked = Boolean(attrs["checked"]);
+        }
+        if (attrs["dateFormat"]) {
+          group.dateFormat = String(attrs["dateFormat"]);
+        }
+        if (typeof attrs["listItems"] === "string" && attrs["listItems"]) {
+          group.listItemsJson = attrs["listItems"];
+        }
+
+        sdtStack.push(group);
+        let childOffset = pos + 1; // skip the blockSdt opening token
+        for (let i = 0; i < node.childCount; i += 1) {
+          const child = node.child(i);
+          visit(child, childOffset);
+          childOffset += child.nodeSize;
+        }
+        sdtStack.pop();
+        return;
+      }
+      default:
+        break;
+    }
 
     switch (node.type.name) {
       case "paragraph": {
         const block = convertParagraph(node, pos, opts);
         const pmAttrs = expectParagraphAttrs(node);
 
-        blocks.push(block);
+        trackedPush(block);
 
         // Emit section break block if this paragraph ends a section
         const secProps = pmAttrs._sectionProperties as
@@ -2382,22 +2452,22 @@ export function toFlowBlocks(
             }
           }
 
-          blocks.push(sectionBreak);
+          trackedPush(sectionBreak);
         }
         break;
       }
 
       case "table":
-        blocks.push(convertTable(node, pos, opts));
+        trackedPush(convertTable(node, pos, opts));
         break;
 
       case "image":
         // Standalone image block (if not inline)
-        blocks.push(convertImage(node, pos, opts.pageContentHeight));
+        trackedPush(convertImage(node, pos, opts.pageContentHeight));
         break;
 
       case "textBox":
-        blocks.push(convertTextBoxNode(node, pos, opts));
+        trackedPush(convertTextBoxNode(node, pos, opts));
         break;
 
       case "horizontalRule":
@@ -2408,12 +2478,17 @@ export function toFlowBlocks(
           pmStart: pos,
           pmEnd: pos + node.nodeSize,
         };
-        blocks.push(pb);
+        trackedPush(pb);
         break;
       }
       default:
         break;
     }
+  };
+
+  // oxlint-disable-next-line unicorn/no-array-for-each -- ProseMirror Node.forEach
+  doc.forEach((node, nodeOffset) => {
+    visit(node, offset + nodeOffset);
   });
 
   return mergeRunInParagraphs(blocks);

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -443,6 +443,7 @@ function layoutParagraph(
       toLine: 0,
       ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
+      ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
     };
 
     paginator.addFragment(fragment, 0, spaceBefore, spaceAfter);
@@ -524,6 +525,7 @@ function layoutParagraph(
       ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
       ...(!isFirstFragment ? { continuesFromPrev: true } : {}),
       ...(!isLastFragment ? { continuesOnNext: true } : {}),
+      ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
     };
 
     // Ensure the page can accommodate body lines + footnote demand
@@ -699,6 +701,7 @@ function layoutTable(
       ...(!isFirstFragment ? { continuesFromPrev: true } : {}),
       ...(!isLastFragment ? { continuesOnNext: true } : {}),
       ...(!isFirstFragment && headerRowCount > 0 ? { headerRowCount } : {}),
+      ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
     };
 
     const result = paginator.addFragment(fragment, fragmentHeight, 0, 0);
@@ -810,6 +813,7 @@ function layoutFloatingTable(
     ...(block.pmStart !== undefined ? { pmStart: block.pmStart } : {}),
     ...(block.pmEnd !== undefined ? { pmEnd: block.pmEnd } : {}),
     isFloating: true,
+    ...(block.sdtGroups ? { sdtGroups: block.sdtGroups } : {}),
   };
 
   // Add directly without advancing cursor

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -419,6 +419,12 @@ export type ParagraphBlock = {
   pmStart?: number;
   /** ProseMirror end position for this block. */
   pmEnd?: number;
+  /**
+   * Outer→inner SDT wrappers enclosing this block. Empty / undefined when
+   * the block sits at the body root. The painter stamps `data-sdt-*` from
+   * the innermost group and draws boundary chrome per outer→inner level.
+   */
+  sdtGroups?: SdtGroup[];
 };
 
 /**
@@ -509,6 +515,8 @@ export type TableBlock = {
   floating?: FloatingTablePosition;
   pmStart?: number;
   pmEnd?: number;
+  /** Outer→inner SDT wrappers enclosing this table (see ParagraphBlock). */
+  sdtGroups?: SdtGroup[];
 };
 
 /**
@@ -637,6 +645,36 @@ export type TextBoxBlock = {
   distRight?: number;
   pmStart?: number;
   pmEnd?: number;
+};
+
+/**
+ * Block-level content-control (OOXML `w:sdt`) projection attached to flow
+ * blocks that fall inside an SDT wrapper. The painter stamps `data-sdt-*`
+ * attributes from this so CSS / interactive widgets can find the group.
+ *
+ * `id` is a per-document, monotonically assigned identifier so nested SDTs
+ * stay disambiguated even when alias/tag/sdtId collide.
+ */
+export type SdtGroup = {
+  /** Folio-local identifier (stable within one toFlowBlocks call). */
+  id: string;
+  sdtType: string;
+  /** OOXML `w:alias` (friendly display name). */
+  alias?: string;
+  /** OOXML `w:tag` (developer identifier — anchor for addressing API). */
+  tag?: string;
+  /** OOXML numeric `w:id`. */
+  sdtId?: number;
+  /** OOXML `w:lock` setting. */
+  lock?: string;
+  /** True if `w:showingPlcHdr` is set. */
+  showingPlaceholder?: boolean;
+  /** Modeled checkbox state, when the control is `w14:checkbox`. */
+  checked?: boolean;
+  /** Modeled `w:date/w:dateFormat`. */
+  dateFormat?: string;
+  /** Modeled `w:dropDownList`/`w:comboBox` items (JSON-encoded). */
+  listItemsJson?: string;
 };
 
 /**
@@ -799,6 +837,12 @@ export type FragmentBase = {
   pmStart?: number;
   /** ProseMirror end position (for click mapping). */
   pmEnd?: number;
+  /**
+   * Outer→inner SDT wrappers enclosing the originating block. Copied
+   * verbatim from the FlowBlock so the painter can stamp `data-sdt-*`
+   * attributes per fragment.
+   */
+  sdtGroups?: SdtGroup[];
 };
 
 /**

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -681,6 +681,15 @@ export type SdtGroup = {
   dateFormat?: string;
   /** Modeled `w:dropDownList`/`w:comboBox` items (JSON-encoded). */
   listItemsJson?: string;
+  /**
+   * Position of the carrying block within its SDT group (`first`/`middle`/
+   * `last`/`only`). The painter stamps `data-sdt-position` from this so the
+   * CSS chrome can draw a continuous outline across the block sequence —
+   * top edge on `first`, bottom edge on `last`, only side edges in
+   * between. Without this, every block painted its own closed box and a
+   * multi-paragraph SDT looked like several stacked rectangles.
+   */
+  position?: "first" | "middle" | "last" | "only";
 };
 
 /**

--- a/packages/folio/src/core/layout-engine/types.ts
+++ b/packages/folio/src/core/layout-engine/types.ts
@@ -658,6 +658,12 @@ export type TextBoxBlock = {
 export type SdtGroup = {
   /** Folio-local identifier (stable within one toFlowBlocks call). */
   id: string;
+  /**
+   * ProseMirror position of the blockSdt's open token in the source doc.
+   * Stable across renders for the same control and unique per instance —
+   * the addressing API uses this to disambiguate SDTs that share a tag.
+   */
+  pmPos: number;
   sdtType: string;
   /** OOXML `w:alias` (friendly display name). */
   alias?: string;

--- a/packages/folio/src/core/layout-painter/renderFragment.ts
+++ b/packages/folio/src/core/layout-painter/renderFragment.ts
@@ -12,6 +12,7 @@ import type {
   ImageFragment,
 } from "../layout-engine/types";
 import type { RenderContext } from "./renderUtils";
+import { applySdtDataAttrs } from "./sdtBoundary";
 
 /**
  * CSS class names for fragment elements
@@ -99,6 +100,8 @@ function renderParagraphFragmentPlaceholder(
     el.dataset["continuesOnNext"] = "true";
   }
 
+  applySdtDataAttrs(el, fragment.sdtGroups);
+
   return el;
 }
 
@@ -128,6 +131,8 @@ function renderTableFragmentPlaceholder(
   if (fragment.pmEnd !== undefined) {
     el.dataset["pmEnd"] = String(fragment.pmEnd);
   }
+
+  applySdtDataAttrs(el, fragment.sdtGroups);
 
   return el;
 }

--- a/packages/folio/src/core/layout-painter/renderParagraph.ts
+++ b/packages/folio/src/core/layout-painter/renderParagraph.ts
@@ -46,6 +46,7 @@ import {
 } from "./renderImage";
 import { isFloatingImageRun } from "./renderUtils";
 import type { RenderContext } from "./renderUtils";
+import { applySdtDataAttrs } from "./sdtBoundary";
 
 /**
  * CSS class names for paragraph rendering
@@ -1906,6 +1907,7 @@ export function renderParagraphFragment(
   fragmentEl.dataset["toLine"] = String(fragment.toLine);
 
   applyPmPositions(fragmentEl, fragment.pmStart, fragment.pmEnd);
+  applySdtDataAttrs(fragmentEl, fragment.sdtGroups);
 
   if (fragment.continuesFromPrev) {
     fragmentEl.dataset["continuesFromPrev"] = "true";

--- a/packages/folio/src/core/layout-painter/sdtBoundary.ts
+++ b/packages/folio/src/core/layout-painter/sdtBoundary.ts
@@ -1,0 +1,63 @@
+/**
+ * Stamp `data-sdt-*` attributes on a painted block element from the
+ * fragment's `sdtGroups` projection.
+ *
+ * The innermost group drives the boundary chrome and the widget delegation
+ * layer; the full outer→inner stack is exposed as a JSON list so a hover
+ * surface or addressing API can walk it. The painter side is intentionally
+ * passive — CSS draws the boundary based on `data-sdt-boundary`, and the
+ * widget layer reads the rest to render interactive triggers.
+ */
+
+import type { SdtGroup } from "../layout-engine/types";
+
+export function applySdtDataAttrs(
+  el: HTMLElement,
+  sdtGroups: readonly SdtGroup[] | undefined,
+): void {
+  if (!sdtGroups || sdtGroups.length === 0) {
+    return;
+  }
+  el.dataset["sdtBoundary"] = "true";
+
+  const innermost = sdtGroups.at(-1);
+  if (innermost) {
+    el.dataset["sdtId"] = innermost.id;
+    el.dataset["sdtType"] = innermost.sdtType;
+    if (innermost.alias) {
+      el.dataset["sdtAlias"] = innermost.alias;
+    }
+    if (innermost.tag) {
+      el.dataset["sdtTag"] = innermost.tag;
+    }
+    if (innermost.sdtId !== undefined) {
+      el.dataset["sdtOoxmlId"] = String(innermost.sdtId);
+    }
+    if (innermost.lock) {
+      el.dataset["sdtLock"] = innermost.lock;
+    }
+    if (innermost.showingPlaceholder) {
+      el.dataset["sdtShowingPlaceholder"] = "true";
+    }
+    if (innermost.checked !== undefined) {
+      el.dataset["sdtChecked"] = String(innermost.checked);
+    }
+    if (innermost.dateFormat) {
+      el.dataset["sdtDateFormat"] = innermost.dateFormat;
+    }
+    if (innermost.listItemsJson) {
+      el.dataset["sdtListItems"] = innermost.listItemsJson;
+    }
+  }
+
+  // Outer→inner stack for callers that need to walk it (addressing API,
+  // widget delegation layer).
+  el.dataset["sdtStack"] = JSON.stringify(
+    sdtGroups.map((g) => ({
+      id: g.id,
+      sdtType: g.sdtType,
+      tag: g.tag ?? null,
+      alias: g.alias ?? null,
+    })),
+  );
+}

--- a/packages/folio/src/core/layout-painter/sdtBoundary.ts
+++ b/packages/folio/src/core/layout-painter/sdtBoundary.ts
@@ -23,6 +23,7 @@ export function applySdtDataAttrs(
   const innermost = sdtGroups.at(-1);
   if (innermost) {
     el.dataset["sdtId"] = innermost.id;
+    el.dataset["sdtPmPos"] = String(innermost.pmPos);
     el.dataset["sdtType"] = innermost.sdtType;
     if (innermost.alias) {
       el.dataset["sdtAlias"] = innermost.alias;

--- a/packages/folio/src/core/layout-painter/sdtBoundary.ts
+++ b/packages/folio/src/core/layout-painter/sdtBoundary.ts
@@ -25,6 +25,9 @@ export function applySdtDataAttrs(
     el.dataset["sdtId"] = innermost.id;
     el.dataset["sdtPmPos"] = String(innermost.pmPos);
     el.dataset["sdtType"] = innermost.sdtType;
+    if (innermost.position) {
+      el.dataset["sdtPosition"] = innermost.position;
+    }
     if (innermost.alias) {
       el.dataset["sdtAlias"] = innermost.alias;
     }

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -799,6 +799,12 @@ export const readBlockSdtAttrs = (
     issues,
   );
   optionalBoolean(attrs, "checked", "blockSdt.attrs.checked", issues);
+  optionalBoolean(
+    attrs,
+    "_originallyEmpty",
+    "blockSdt.attrs._originallyEmpty",
+    issues,
+  );
   optionalString(
     attrs,
     "rawPropertiesXml",

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -746,6 +746,7 @@ export const readSdtAttrs = (
     issues,
   );
   optionalString(attrs, "dateFormat", "sdt.attrs.dateFormat", issues);
+  optionalString(attrs, "dateValueISO", "sdt.attrs.dateValueISO", issues);
   optionalSdtListItems(attrs, "listItems", "sdt.attrs.listItems", issues);
   optionalBoolean(attrs, "checked", "sdt.attrs.checked", issues);
 

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -817,6 +817,18 @@ export const readBlockSdtAttrs = (
     "blockSdt.attrs.rawEndPropertiesXml",
     issues,
   );
+  optionalString(
+    attrs,
+    "rawSdtChildrenBeforeContent",
+    "blockSdt.attrs.rawSdtChildrenBeforeContent",
+    issues,
+  );
+  optionalString(
+    attrs,
+    "rawSdtChildrenAfterContent",
+    "blockSdt.attrs.rawSdtChildrenAfterContent",
+    issues,
+  );
 
   return attrsResult(attrs, issues);
 };

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -783,6 +783,7 @@ export const readBlockSdtAttrs = (
     issues,
   );
   optionalString(attrs, "dateFormat", "blockSdt.attrs.dateFormat", issues);
+  optionalString(attrs, "dateValueISO", "blockSdt.attrs.dateValueISO", issues);
   optionalSdtListItems(attrs, "listItems", "blockSdt.attrs.listItems", issues);
   optionalBoolean(attrs, "checked", "blockSdt.attrs.checked", issues);
   optionalString(

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -27,6 +27,7 @@ import {
   UNDERLINE_STYLE_VALUES,
 } from "../../types/documentEnumValues";
 import type {
+  BlockSdtAttrs,
   CharacterSpacingAttrs,
   CommentAttrs,
   EmphasisMarkAttrs,
@@ -753,6 +754,60 @@ export const readSdtAttrs = (
 
 export const expectSdtAttrs = (node: PMNode): SdtAttrs =>
   expectCachedNodeAttrs(node, sdtAttrsCache, readSdtAttrs, "sdt attrs");
+
+const blockSdtAttrsCache = new WeakMap<PMNode, BlockSdtAttrs>();
+
+export const readBlockSdtAttrs = (
+  node: PMNode,
+): ReadProseMirrorAttrsResult<BlockSdtAttrs> => {
+  const attrs = attrsRecord(node.attrs);
+  const issues: ProseMirrorAttrIssue[] = [];
+  expectNodeType(node, "blockSdt", issues);
+
+  requiredOneOf(
+    attrs,
+    "sdtType",
+    "blockSdt.attrs.sdtType",
+    issues,
+    SDT_TYPE_VALUES,
+  );
+  optionalString(attrs, "alias", "blockSdt.attrs.alias", issues);
+  optionalString(attrs, "tag", "blockSdt.attrs.tag", issues);
+  optionalNumber(attrs, "id", "blockSdt.attrs.id", issues);
+  optionalOneOf(attrs, "lock", "blockSdt.attrs.lock", issues, SDT_LOCK_VALUES);
+  optionalString(attrs, "placeholder", "blockSdt.attrs.placeholder", issues);
+  optionalBoolean(
+    attrs,
+    "showingPlaceholder",
+    "blockSdt.attrs.showingPlaceholder",
+    issues,
+  );
+  optionalString(attrs, "dateFormat", "blockSdt.attrs.dateFormat", issues);
+  optionalSdtListItems(attrs, "listItems", "blockSdt.attrs.listItems", issues);
+  optionalBoolean(attrs, "checked", "blockSdt.attrs.checked", issues);
+  optionalString(
+    attrs,
+    "rawPropertiesXml",
+    "blockSdt.attrs.rawPropertiesXml",
+    issues,
+  );
+  optionalString(
+    attrs,
+    "rawEndPropertiesXml",
+    "blockSdt.attrs.rawEndPropertiesXml",
+    issues,
+  );
+
+  return attrsResult(attrs, issues);
+};
+
+export const expectBlockSdtAttrs = (node: PMNode): BlockSdtAttrs =>
+  expectCachedNodeAttrs(
+    node,
+    blockSdtAttrsCache,
+    readBlockSdtAttrs,
+    "blockSdt attrs",
+  );
 
 export const readShapeAttrs = (
   node: PMNode,

--- a/packages/folio/src/core/prosemirror/attrs/index.ts
+++ b/packages/folio/src/core/prosemirror/attrs/index.ts
@@ -748,6 +748,12 @@ export const readSdtAttrs = (
   optionalString(attrs, "dateFormat", "sdt.attrs.dateFormat", issues);
   optionalString(attrs, "dateValueISO", "sdt.attrs.dateValueISO", issues);
   optionalSdtListItems(attrs, "listItems", "sdt.attrs.listItems", issues);
+  optionalString(
+    attrs,
+    "dropdownLastValue",
+    "sdt.attrs.dropdownLastValue",
+    issues,
+  );
   optionalBoolean(attrs, "checked", "sdt.attrs.checked", issues);
 
   return attrsResult(attrs, issues);
@@ -786,6 +792,12 @@ export const readBlockSdtAttrs = (
   optionalString(attrs, "dateFormat", "blockSdt.attrs.dateFormat", issues);
   optionalString(attrs, "dateValueISO", "blockSdt.attrs.dateValueISO", issues);
   optionalSdtListItems(attrs, "listItems", "blockSdt.attrs.listItems", issues);
+  optionalString(
+    attrs,
+    "dropdownLastValue",
+    "blockSdt.attrs.dropdownLastValue",
+    issues,
+  );
   optionalBoolean(attrs, "checked", "blockSdt.attrs.checked", issues);
   optionalString(
     attrs,

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -51,6 +51,26 @@ describe("findBlockSdtMatches", () => {
     expect(findBlockSdtMatch(state.doc, { tag: "missing" })).toBeNull();
   });
 
+  test("path includes the index of every enclosing ancestor for a nested SDT", () => {
+    // Outer SDT contains a paragraph, then an inner SDT. The inner
+    // match's path should reflect the doc → outer → inner ancestry so
+    // callers can walk back to it via doc.child(path[0]).child(path[1]).
+    const inner = schema.node("blockSdt", { sdtType: "richText", tag: "in" }, [
+      schema.node("paragraph", {}, [schema.text("deep")]),
+    ]);
+    const outer = schema.node("blockSdt", { sdtType: "richText", tag: "out" }, [
+      schema.node("paragraph", {}, [schema.text("pre")]),
+      inner,
+    ]);
+    const state = makeState(schema.node("doc", null, [outer]));
+    const match = findBlockSdtMatch(state.doc, { tag: "in" });
+    if (!match) {
+      throw new TypeError("expected inner match");
+    }
+    // Outer is doc child 0; inner is outer's child 1.
+    expect(match.path).toEqual([0, 1]);
+  });
+
   test("filter by pmPos addresses one specific instance, not the first matching tag", () => {
     // Two SDTs share the tag "name"; setContentControlValueTr must land on
     // the one the user actually clicked (identified by pmPos), not the

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -220,6 +220,31 @@ describe("setContentControlValueTr", () => {
     expect(next.doc.firstChild?.firstChild?.textContent).toBe("California");
   });
 
+  test("date: rejects partial-prefix dateValueISO and writes the raw value", () => {
+    // Without an end anchor, `2026-06-02abc` matched the regex prefix and
+    // formatDate happily rendered the well-formed slice. The model would
+    // still store the malformed ISO, so the visible body silently
+    // disagreed with the bound value.
+    const sdt = schema.node(
+      "blockSdt",
+      { sdtType: "date", tag: "due", dateFormat: "yyyy-MM-dd" },
+      [schema.node("paragraph", {}, [])],
+    );
+    const state = makeState(schema.node("doc", null, [sdt]));
+    const tr = setContentControlValueTr(
+      state,
+      { tag: "due" },
+      { kind: "date", date: "2026-06-02abc" },
+    );
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    // Falls back to "return unchanged" rendering — the body shows the
+    // raw input rather than a deceptively well-formatted partial match.
+    expect(next.doc.firstChild?.firstChild?.textContent).toBe("2026-06-02abc");
+  });
+
   test("rejects a checkbox toggle on a richText control", () => {
     const state = makeState();
     expect(() =>

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -9,6 +9,7 @@ import {
   ContentControlLockedError,
   ContentControlTypeError,
 } from "../../content-controls";
+import { createSuggestionModePlugin } from "../plugins/suggestionMode";
 import { schema, singletonManager } from "../schema";
 import {
   blockSdtAttrsToSdtProperties,
@@ -245,6 +246,53 @@ describe("removeContentControlTr", () => {
     // ... but content edits succeed.
     const tr = setContentControlContentTr(state, { tag: "a" }, "edit ok");
     expect(tr).not.toBeNull();
+  });
+
+  test("does not stamp insertion marks when suggesting mode is active", () => {
+    // Toggling a checkbox / picking a date through a widget should not be
+    // re-classified as a tracked insertion by the suggestion-mode
+    // appendTransaction catch-all — the mutation is a typed write
+    // against the SDT's state, not a user-authored edit. We assert that
+    // by activating suggestion mode and confirming the new body text
+    // carries no insertion mark.
+    const checkbox = schema.node(
+      "blockSdt",
+      { sdtType: "checkbox", tag: "agree", checked: false },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const state = EditorState.create({
+      doc: schema.node("doc", null, [checkbox]),
+      schema,
+      plugins: [
+        createSuggestionModePlugin(true, "Reviewer"),
+        ...singletonManager.getPlugins(),
+      ],
+    });
+    const tr = setContentControlValueTr(
+      state,
+      { tag: "agree" },
+      {
+        kind: "checkbox",
+        checked: true,
+      },
+    );
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    const sdt = next.doc.firstChild;
+    const firstText = sdt?.firstChild?.firstChild;
+    expect(sdt?.attrs["checked"]).toBe(true);
+    // The new text node must not carry an `insertion` mark — that would
+    // be visible to reviewers as a pending change they have to accept.
+    const insertionType = schema.marks["insertion"];
+    if (!insertionType) {
+      throw new TypeError("expected insertion mark in schema");
+    }
+    const hasInsertion = firstText?.marks.some(
+      (mark) => mark.type === insertionType,
+    );
+    expect(hasInsertion).toBe(false);
   });
 
   test("refuses to unwrap a w15:repeatingSection without force", () => {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -193,6 +193,33 @@ describe("setContentControlValueTr", () => {
     expect(sdt?.firstChild?.textContent).toBe("☒");
   });
 
+  test("tolerates malformed listItems JSON and falls back to writing the raw value", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+        listItems: "not even close to JSON {{",
+      },
+      [schema.node("paragraph", {}, [])],
+    );
+    const state = makeState(schema.node("doc", null, [sdt]));
+    // Should not throw despite the malformed listItems attribute.
+    const tr = setContentControlValueTr(
+      state,
+      { tag: "state" },
+      {
+        kind: "dropdown",
+        value: "California",
+      },
+    );
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    expect(next.doc.firstChild?.firstChild?.textContent).toBe("California");
+  });
+
   test("rejects a checkbox toggle on a richText control", () => {
     const state = makeState();
     expect(() =>
@@ -236,6 +263,25 @@ describe("removeContentControlTr", () => {
     expect(next.doc.childCount).toBe(2);
     expect(next.doc.firstChild?.type.name).toBe("paragraph");
     expect(next.doc.firstChild?.textContent).toBe("original");
+  });
+
+  test("removing the only top-level SDT inserts an empty paragraph (doc stays valid)", () => {
+    // Doc consists of a single blockSdt; deleting it would leave the doc
+    // with 0 children, violating the `(...)+` doc content spec. The PM
+    // helper must substitute a placeholder paragraph, matching the
+    // headless removeContentControl behavior.
+    const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "lone" }, [
+      schema.node("paragraph", {}, [schema.text("solo")]),
+    ]);
+    const state = makeState(schema.node("doc", null, [sdt]));
+    const tr = removeContentControlTr(state, { tag: "lone" });
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    expect(next.doc.childCount).toBe(1);
+    expect(next.doc.firstChild?.type.name).toBe("paragraph");
+    expect(next.doc.firstChild?.content.size).toBe(0);
   });
 
   test("contentLocked allows container removal (OOXML lock semantics)", () => {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../content-controls";
 import { schema, singletonManager } from "../schema";
 import {
+  blockSdtAttrsToSdtProperties,
   findBlockSdtMatch,
   findBlockSdtMatches,
   removeContentControlTr,
@@ -47,6 +48,42 @@ describe("findBlockSdtMatches", () => {
   test("findBlockSdtMatch returns null when nothing matches", () => {
     const state = makeState();
     expect(findBlockSdtMatch(state.doc, { tag: "missing" })).toBeNull();
+  });
+});
+
+describe("blockSdtAttrsToSdtProperties", () => {
+  test("surfaces every modeled field (lock, placeholder, dateFormat, listItems, checked)", () => {
+    const node = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        alias: "State",
+        tag: "state",
+        id: 42,
+        lock: "contentLocked",
+        placeholder: "Pick a state",
+        showingPlaceholder: true,
+        dateFormat: null,
+        listItems: JSON.stringify([
+          { value: "ca", displayText: "California" },
+          { value: "ny", displayText: "New York" },
+        ]),
+        checked: null,
+      },
+      [schema.node("paragraph", {}, [])],
+    );
+    const props = blockSdtAttrsToSdtProperties(node);
+    expect(props.sdtType).toBe("dropdown");
+    expect(props.alias).toBe("State");
+    expect(props.tag).toBe("state");
+    expect(props.id).toBe(42);
+    expect(props.lock).toBe("contentLocked");
+    expect(props.placeholder).toBe("Pick a state");
+    expect(props.showingPlaceholder).toBe(true);
+    expect(props.listItems).toEqual([
+      { value: "ca", displayText: "California" },
+      { value: "ny", displayText: "New York" },
+    ]);
   });
 });
 

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -1,0 +1,172 @@
+/**
+ * PM transaction helpers for content controls.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+
+import {
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "../../content-controls";
+import { schema, singletonManager } from "../schema";
+import {
+  findBlockSdtMatch,
+  findBlockSdtMatches,
+  removeContentControlTr,
+  setContentControlContentTr,
+  setContentControlValueTr,
+} from "./contentControls";
+
+function makeState(docNode = defaultDoc()): EditorState {
+  return EditorState.create({
+    doc: docNode,
+    schema,
+    plugins: [...singletonManager.getPlugins()],
+  });
+}
+
+function defaultDoc() {
+  const sdt = schema.node(
+    "blockSdt",
+    { sdtType: "richText", tag: "name", alias: "Name" },
+    [schema.node("paragraph", {}, [schema.text("original")])],
+  );
+  const tail = schema.node("paragraph", {}, [schema.text("after")]);
+  return schema.node("doc", null, [sdt, tail]);
+}
+
+describe("findBlockSdtMatches", () => {
+  test("filters by tag", () => {
+    const state = makeState();
+    const matches = findBlockSdtMatches(state.doc, { tag: "name" });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.node.attrs["alias"]).toBe("Name");
+  });
+
+  test("findBlockSdtMatch returns null when nothing matches", () => {
+    const state = makeState();
+    expect(findBlockSdtMatch(state.doc, { tag: "missing" })).toBeNull();
+  });
+});
+
+describe("setContentControlContentTr", () => {
+  test("replaces the SDT children with a paragraph carrying the new text", () => {
+    const state = makeState();
+    const tr = setContentControlContentTr(state, { tag: "name" }, "replaced");
+    if (!tr) {
+      throw new Error("expected a transaction");
+    }
+    const next = state.apply(tr);
+    const sdt = next.doc.firstChild;
+    expect(sdt?.type.name).toBe("blockSdt");
+    expect(sdt?.firstChild?.textContent).toBe("replaced");
+  });
+
+  test("returns null when no control matches", () => {
+    const state = makeState();
+    expect(
+      setContentControlContentTr(state, { tag: "missing" }, "x"),
+    ).toBeNull();
+  });
+
+  test("refuses to write into a locked control without force", () => {
+    const lockedSdt = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "locked", lock: "contentLocked" },
+      [schema.node("paragraph", {}, [schema.text("x")])],
+    );
+    const state = makeState(schema.node("doc", null, [lockedSdt]));
+    expect(() =>
+      setContentControlContentTr(state, { tag: "locked" }, "boom"),
+    ).toThrow(ContentControlLockedError);
+  });
+});
+
+describe("setContentControlValueTr", () => {
+  test("toggles a checkbox and writes the checked attribute", () => {
+    const checkbox = schema.node(
+      "blockSdt",
+      { sdtType: "checkbox", tag: "agree", checked: false },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const state = makeState(schema.node("doc", null, [checkbox]));
+    const tr = setContentControlValueTr(
+      state,
+      { tag: "agree" },
+      {
+        kind: "checkbox",
+        checked: true,
+      },
+    );
+    if (!tr) {
+      throw new Error("expected tx");
+    }
+    const next = state.apply(tr);
+    const sdt = next.doc.firstChild;
+    expect(sdt?.attrs["checked"]).toBe(true);
+    expect(sdt?.firstChild?.textContent).toBe("☒");
+  });
+
+  test("rejects a checkbox toggle on a richText control", () => {
+    const state = makeState();
+    expect(() =>
+      setContentControlValueTr(
+        state,
+        { tag: "name" },
+        {
+          kind: "checkbox",
+          checked: true,
+        },
+      ),
+    ).toThrow(ContentControlTypeError);
+  });
+});
+
+describe("removeContentControlTr", () => {
+  test("drops the control by default", () => {
+    const state = makeState();
+    const tr = removeContentControlTr(state, { tag: "name" });
+    if (!tr) {
+      throw new Error("expected tx");
+    }
+    const next = state.apply(tr);
+    expect(next.doc.childCount).toBe(1);
+    expect(next.doc.firstChild?.type.name).toBe("paragraph");
+  });
+
+  test("keepContent: true unwraps the children in place", () => {
+    const state = makeState();
+    const tr = removeContentControlTr(
+      state,
+      { tag: "name" },
+      {
+        keepContent: true,
+      },
+    );
+    if (!tr) {
+      throw new Error("expected tx");
+    }
+    const next = state.apply(tr);
+    expect(next.doc.childCount).toBe(2);
+    expect(next.doc.firstChild?.type.name).toBe("paragraph");
+    expect(next.doc.firstChild?.textContent).toBe("original");
+  });
+
+  test("refuses to unwrap a w15:repeatingSection without force", () => {
+    const repeating = schema.node(
+      "blockSdt",
+      {
+        sdtType: "richText",
+        tag: "parties",
+        rawPropertiesXml:
+          '<w:sdtPr><w:tag w:val="parties"/><w15:repeatingSection/></w:sdtPr>',
+      },
+      [schema.node("paragraph", {}, [])],
+    );
+    const state = makeState(schema.node("doc", null, [repeating]));
+    expect(() =>
+      removeContentControlTr(state, { tag: "parties" }, { keepContent: true }),
+    ).toThrow(ContentControlTypeError);
+  });
+});

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -334,6 +334,35 @@ describe("removeContentControlTr", () => {
     expect(next.doc.firstChild?.content.size).toBe(0);
   });
 
+  test("removes a nested-only-child blockSdt without breaking parent's block+ schema", () => {
+    // The parent blockSdt has `content: "block+"`, so removing its sole
+    // inner blockSdt without substituting a block would leave the parent
+    // empty and fail schema validation. The PM helper must substitute a
+    // placeholder paragraph here too, matching the doc-root case.
+    const inner = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "inner" },
+      [schema.node("paragraph", {}, [schema.text("solo")])],
+    );
+    const outer = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "outer" },
+      [inner],
+    );
+    const state = makeState(schema.node("doc", null, [outer]));
+    const tr = removeContentControlTr(state, { tag: "inner" });
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    // Outer survives; its single child is now the placeholder paragraph.
+    expect(next.doc.childCount).toBe(1);
+    expect(next.doc.firstChild?.type.name).toBe("blockSdt");
+    expect(next.doc.firstChild?.childCount).toBe(1);
+    expect(next.doc.firstChild?.firstChild?.type.name).toBe("paragraph");
+    expect(next.doc.firstChild?.firstChild?.content.size).toBe(0);
+  });
+
   test("contentLocked allows container removal (OOXML lock semantics)", () => {
     const sdt = schema.node(
       "blockSdt",

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -49,6 +49,33 @@ describe("findBlockSdtMatches", () => {
     const state = makeState();
     expect(findBlockSdtMatch(state.doc, { tag: "missing" })).toBeNull();
   });
+
+  test("filter by pmPos addresses one specific instance, not the first matching tag", () => {
+    // Two SDTs share the tag "name"; setContentControlValueTr must land on
+    // the one the user actually clicked (identified by pmPos), not the
+    // first one in document order.
+    const first = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "name" },
+      [schema.node("paragraph", {}, [schema.text("first")])],
+    );
+    const second = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "name" },
+      [schema.node("paragraph", {}, [schema.text("second")])],
+    );
+    const state = makeState(schema.node("doc", null, [first, second]));
+    const allByTag = findBlockSdtMatches(state.doc, { tag: "name" });
+    expect(allByTag).toHaveLength(2);
+
+    const secondPos = allByTag[1]?.pos;
+    if (typeof secondPos !== "number") {
+      throw new TypeError("expected pos to be a number");
+    }
+    const onlySecond = findBlockSdtMatches(state.doc, { pmPos: secondPos });
+    expect(onlySecond).toHaveLength(1);
+    expect(onlySecond[0]?.node.firstChild?.textContent).toBe("second");
+  });
 });
 
 describe("blockSdtAttrsToSdtProperties", () => {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -220,6 +220,31 @@ describe("setContentControlValueTr", () => {
     expect(next.doc.firstChild?.firstChild?.textContent).toBe("California");
   });
 
+  test("date: accepts fractional seconds (Date.prototype.toISOString output)", () => {
+    // `new Date("2026-06-02").toISOString()` emits 2026-06-02T00:00:00.000Z.
+    // Without fractional-seconds support, the regex missed it and the
+    // helper fell back to `new Date(iso)`, which would format the value
+    // via UTC accessors and shift the rendered day in non-UTC zones.
+    const sdt = schema.node(
+      "blockSdt",
+      { sdtType: "date", tag: "due", dateFormat: "yyyy-MM-dd" },
+      [schema.node("paragraph", {}, [])],
+    );
+    const state = makeState(schema.node("doc", null, [sdt]));
+    const tr = setContentControlValueTr(
+      state,
+      { tag: "due" },
+      { kind: "date", date: "2026-06-02T00:00:00.000Z" },
+    );
+    if (!tr) {
+      throw new TypeError("expected tx");
+    }
+    const next = state.apply(tr);
+    // Local-time component parsing means the rendered body always shows
+    // the same calendar date the source ISO names, regardless of TZ.
+    expect(next.doc.firstChild?.firstChild?.textContent).toBe("2026-06-02");
+  });
+
   test("date: rejects partial-prefix dateValueISO and writes the raw value", () => {
     // Without an end anchor, `2026-06-02abc` matched the regex prefix and
     // formatDate happily rendered the well-formed slice. The model would

--- a/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.test.ts
@@ -153,6 +153,36 @@ describe("removeContentControlTr", () => {
     expect(next.doc.firstChild?.textContent).toBe("original");
   });
 
+  test("contentLocked allows container removal (OOXML lock semantics)", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "a", lock: "contentLocked" },
+      [schema.node("paragraph", {}, [schema.text("x")])],
+    );
+    const state = makeState(schema.node("doc", null, [sdt]));
+    const tr = removeContentControlTr(state, { tag: "a" });
+    if (!tr) {
+      throw new Error("expected tx");
+    }
+    const next = state.apply(tr);
+    expect(next.doc.firstChild?.type.name).not.toBe("blockSdt");
+  });
+
+  test("sdtLocked refuses container removal but allows content edits", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "a", lock: "sdtLocked" },
+      [schema.node("paragraph", {}, [schema.text("x")])],
+    );
+    const state = makeState(schema.node("doc", null, [sdt]));
+    expect(() => removeContentControlTr(state, { tag: "a" })).toThrow(
+      ContentControlLockedError,
+    );
+    // ... but content edits succeed.
+    const tr = setContentControlContentTr(state, { tag: "a" }, "edit ok");
+    expect(tr).not.toBeNull();
+  });
+
   test("refuses to unwrap a w15:repeatingSection without force", () => {
     const repeating = schema.node(
       "blockSdt",

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -24,6 +24,7 @@ import {
 import { formatDate } from "../../docx/fieldParser";
 import type { SdtProperties } from "../../types/document";
 import { expectBlockSdtAttrs } from "../attrs";
+import { SUGGESTION_BYPASS_META } from "../plugins/suggestionMode";
 
 type ForceOption = { force?: boolean };
 
@@ -256,7 +257,14 @@ function replaceBlockSdtChildren(
     { ...match.node.attrs, showingPlaceholder: false, ...propertyOverrides },
     children.length === 0 ? [paragraphFromText(state.schema, "")] : children,
   );
-  return state.tr.replaceWith(match.pos, match.pos + match.node.nodeSize, next);
+  // Tag the transaction so suggestion mode's catch-all appendTransaction
+  // does NOT stamp insertion marks on the new body content. A content
+  // control widget interaction is a typed write against the SDT's state,
+  // not a tracked edit by the user — the same reason undoing a tracked
+  // Enter does not mark the rejoined text as inserted.
+  return state.tr
+    .replaceWith(match.pos, match.pos + match.node.nodeSize, next)
+    .setMeta(SUGGESTION_BYPASS_META, true);
 }
 
 /**
@@ -444,12 +452,12 @@ export function removeContentControlTr(
     for (let i = 0; i < match.node.childCount; i += 1) {
       children.push(match.node.child(i));
     }
-    return state.tr.replaceWith(
-      match.pos,
-      match.pos + match.node.nodeSize,
-      children,
-    );
+    return state.tr
+      .replaceWith(match.pos, match.pos + match.node.nodeSize, children)
+      .setMeta(SUGGESTION_BYPASS_META, true);
   }
   // Drop entirely.
-  return state.tr.delete(match.pos, match.pos + match.node.nodeSize);
+  return state.tr
+    .delete(match.pos, match.pos + match.node.nodeSize)
+    .setMeta(SUGGESTION_BYPASS_META, true);
 }

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -264,22 +264,42 @@ export function setContentControlContentTr(
   }
   ensureContentNotLocked(match.node, options);
 
-  let children: PMNode[];
-  if (typeof input === "string") {
-    children = [paragraphFromText(state.schema, input)];
-  } else {
-    // Caller provided Document-model BlockContent[]; convert via toProseDoc
-    // would re-enter the whole pipeline. Keep this PM-direct: only string
-    // input is supported here; block-content fill should go through the
-    // headless API + loadDocument for now (matches upstream's caveat).
+  if (typeof input !== "string") {
+    // Block-content fill is supported via `setContentControlContentBlocksTr`
+    // (separate module to avoid a cycle: the conversion pipeline imports
+    // the schema, which transitively imports the widgets plugin, which
+    // imports this module). Refuse early with a clear message instead of
+    // silently coercing.
     throw new ContentControlTypeError({
       message:
-        "Block-content fill is only supported via the headless API; pass a string here.",
+        "Block-content fill must go through `setContentControlContentBlocksTr` (avoids a schema/plugin import cycle); pass a string here.",
       sdtType: (match.node.attrs["sdtType"] ??
         "richText") as SdtProperties["sdtType"],
       reason: "PM-direct path takes string input only",
     });
   }
+  return replaceBlockSdtChildren(state, match, [
+    paragraphFromText(state.schema, input),
+  ]);
+}
+
+/**
+ * Internal helper for the block-content fill variant. Lives in this module
+ * so callers reuse the same lock-check and `replaceWith` shape; the
+ * conversion-aware `setContentControlContentBlocksTr` in
+ * `./contentControlsBlockFill.ts` wraps it.
+ */
+export function replaceBlockSdtChildrenForFill(
+  state: EditorState,
+  filter: ContentControlFilter,
+  children: readonly PMNode[],
+  options: ForceOption = {},
+): Transaction | null {
+  const match = findBlockSdtMatch(state.doc, filter);
+  if (!match) {
+    return null;
+  }
+  ensureContentNotLocked(match.node, options);
   return replaceBlockSdtChildren(state, match, children);
 }
 

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -9,7 +9,7 @@
  * walk PM nodes (not the Document model).
  */
 
-import type { Node as PMNode } from "prosemirror-model";
+import type { Node as PMNode, Schema } from "prosemirror-model";
 import type { EditorState, Transaction } from "prosemirror-state";
 
 import type {
@@ -22,7 +22,6 @@ import {
   ContentControlTypeError,
 } from "../../content-controls/errors";
 import type { SdtProperties } from "../../types/document";
-import { schema } from "../schema";
 
 type ForceOption = { force?: boolean };
 
@@ -129,7 +128,7 @@ function ensureNotLocked(node: PMNode, options: ForceOption): void {
   }
 }
 
-function paragraphFromText(text: string): PMNode {
+function paragraphFromText(schema: Schema, text: string): PMNode {
   if (text.length === 0) {
     return schema.node("paragraph", {}, []);
   }
@@ -142,10 +141,10 @@ function replaceBlockSdtChildren(
   children: readonly PMNode[],
   propertyOverrides: Partial<Record<string, unknown>> = {},
 ): Transaction {
-  const next = schema.node(
+  const next = state.schema.node(
     "blockSdt",
     { ...match.node.attrs, showingPlaceholder: false, ...propertyOverrides },
-    children.length === 0 ? [paragraphFromText("")] : children,
+    children.length === 0 ? [paragraphFromText(state.schema, "")] : children,
   );
   return state.tr.replaceWith(match.pos, match.pos + match.node.nodeSize, next);
 }
@@ -168,7 +167,7 @@ export function setContentControlContentTr(
 
   let children: PMNode[];
   if (typeof input === "string") {
-    children = [paragraphFromText(input)];
+    children = [paragraphFromText(state.schema, input)];
   } else {
     // Caller provided Document-model BlockContent[]; convert via toProseDoc
     // would re-enter the whole pipeline. Keep this PM-direct: only string
@@ -225,7 +224,9 @@ export function setContentControlValueTr(
         display = item.displayText;
       }
     }
-    return replaceBlockSdtChildren(state, match, [paragraphFromText(display)]);
+    return replaceBlockSdtChildren(state, match, [
+      paragraphFromText(state.schema, display),
+    ]);
   }
   if (input.kind === "checkbox") {
     if (sdtType !== "checkbox") {
@@ -236,9 +237,14 @@ export function setContentControlValueTr(
       });
     }
     const glyph = input.checked ? "☒" : "☐";
-    return replaceBlockSdtChildren(state, match, [paragraphFromText(glyph)], {
-      checked: input.checked,
-    });
+    return replaceBlockSdtChildren(
+      state,
+      match,
+      [paragraphFromText(state.schema, glyph)],
+      {
+        checked: input.checked,
+      },
+    );
   }
   if (sdtType !== "date") {
     throw new ContentControlTypeError({
@@ -247,7 +253,9 @@ export function setContentControlValueTr(
       reason: "kind=date requires sdtType=date",
     });
   }
-  return replaceBlockSdtChildren(state, match, [paragraphFromText(input.date)]);
+  return replaceBlockSdtChildren(state, match, [
+    paragraphFromText(state.schema, input.date),
+  ]);
 }
 
 function isRepeatingSection(node: PMNode): boolean {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -347,11 +347,21 @@ export function setContentControlValueTr(
     const listItemsAttr = match.node.attrs["listItems"];
     let display = input.value;
     if (typeof listItemsAttr === "string" && listItemsAttr) {
-      const items = JSON.parse(listItemsAttr) as
-        | { displayText: string; value: string }[]
-        | null;
+      // Guard against malformed listItems JSON (extension code that
+      // mutated the attr, schema drift). A bare `JSON.parse` would crash
+      // the transaction; treat malformed input as "no list" and fall
+      // back to writing the raw value with no displayText lookup.
+      let items: { displayText: string; value: string }[] | null = null;
+      try {
+        const parsed: unknown = JSON.parse(listItemsAttr);
+        if (Array.isArray(parsed)) {
+          items = parsed as { displayText: string; value: string }[];
+        }
+      } catch {
+        items = null;
+      }
       const item = items?.find((i) => i.value === input.value);
-      if (!item && !options.force) {
+      if (!item && !options.force && items !== null) {
         throw new ContentControlTypeError({
           message: `Value "${input.value}" not in the control's list items.`,
           sdtType,
@@ -414,11 +424,29 @@ function formatDateForBody(
   if (!dateFormat) {
     return isoDate;
   }
-  const parsed = new Date(isoDate);
-  if (Number.isNaN(parsed.getTime())) {
+  const parsed = parseSdtDate(isoDate);
+  if (!parsed) {
     return isoDate;
   }
   return formatDate(parsed, dateFormat);
+}
+
+/**
+ * See `formatDateForSdtBody` in the headless helpers for the rationale.
+ * For a date-only `YYYY-MM-DD` value we build a local-midnight Date so
+ * the format's local accessors see the right day regardless of TZ.
+ */
+function parseSdtDate(iso: string): Date | null {
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/u.exec(iso);
+  if (dateOnly) {
+    return new Date(
+      Number(dateOnly[1]),
+      Number(dateOnly[2]) - 1,
+      Number(dateOnly[3]),
+    );
+  }
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function isRepeatingSection(node: PMNode): boolean {
@@ -456,7 +484,19 @@ export function removeContentControlTr(
       .replaceWith(match.pos, match.pos + match.node.nodeSize, children)
       .setMeta(SUGGESTION_BYPASS_META, true);
   }
-  // Drop entirely.
+  // Drop entirely. DocExtension requires `+` at the doc root, so if the
+  // SDT was the only top-level child we substitute an empty paragraph to
+  // keep the doc valid — the headless removeContentControl already does
+  // this for the same case.
+  if (match.node === state.doc.firstChild && state.doc.childCount === 1) {
+    return state.tr
+      .replaceWith(
+        match.pos,
+        match.pos + match.node.nodeSize,
+        paragraphFromText(state.schema, ""),
+      )
+      .setMeta(SUGGESTION_BYPASS_META, true);
+  }
   return state.tr
     .delete(match.pos, match.pos + match.node.nodeSize)
     .setMeta(SUGGESTION_BYPASS_META, true);

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -442,14 +442,26 @@ function parseSdtDate(iso: string): Date | null {
   const match =
     /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
   if (match) {
-    return new Date(
-      Number(match[1]),
-      Number(match[2]) - 1,
-      Number(match[3]),
-      match[4] ? Number(match[4]) : 0,
-      match[5] ? Number(match[5]) : 0,
-      match[6] ? Number(match[6]) : 0,
-    );
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const hours = match[4] ? Number(match[4]) : 0;
+    const minutes = match[5] ? Number(match[5]) : 0;
+    const seconds = match[6] ? Number(match[6]) : 0;
+    const candidate = new Date(year, month - 1, day, hours, minutes, seconds);
+    // See headless helper: JS silently normalizes overflow components;
+    // reject the parse when the result disagrees with what was asked for.
+    if (
+      candidate.getFullYear() !== year ||
+      candidate.getMonth() !== month - 1 ||
+      candidate.getDate() !== day ||
+      candidate.getHours() !== hours ||
+      candidate.getMinutes() !== minutes ||
+      candidate.getSeconds() !== seconds
+    ) {
+      return null;
+    }
+    return candidate;
   }
   const parsed = new Date(iso);
   return Number.isNaN(parsed.getTime()) ? null : parsed;

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -144,6 +144,9 @@ export function blockSdtAttrsToSdtProperties(node: PMNode): SdtProperties {
       props.listItems = parsed;
     }
   }
+  if (typeof attrs.dropdownLastValue === "string") {
+    props.dropdownLastValue = attrs.dropdownLastValue;
+  }
   if (typeof attrs.checked === "boolean") {
     props.checked = attrs.checked;
   }
@@ -372,9 +375,15 @@ export function setContentControlValueTr(
         display = item.displayText;
       }
     }
-    return replaceBlockSdtChildren(state, match, [
-      paragraphFromText(state.schema, display),
-    ]);
+    return replaceBlockSdtChildren(
+      state,
+      match,
+      [paragraphFromText(state.schema, display)],
+      // Persist the picked OOXML value separately so duplicate-label items
+      // round-trip to the right selection on save — the serializer reads
+      // dropdownLastValue before falling back to display-text matching.
+      { dropdownLastValue: input.value },
+    );
   }
   if (input.kind === "checkbox") {
     if (sdtType !== "checkbox") {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -518,11 +518,16 @@ export function removeContentControlTr(
       .replaceWith(match.pos, match.pos + match.node.nodeSize, children)
       .setMeta(SUGGESTION_BYPASS_META, true);
   }
-  // Drop entirely. DocExtension requires `+` at the doc root, so if the
-  // SDT was the only top-level child we substitute an empty paragraph to
-  // keep the doc valid — the headless removeContentControl already does
-  // this for the same case.
-  if (match.node === state.doc.firstChild && state.doc.childCount === 1) {
+  // Drop entirely. DocExtension requires `+` at the doc root, and any
+  // `block+` container (notably a parent blockSdt) would likewise
+  // become invalid if we removed its sole child without substituting a
+  // block. Substitute an empty paragraph whenever the target is the
+  // ONLY child of its parent, regardless of whether the parent is the
+  // doc root or another blockSdt — the headless `removeContentControl`
+  // already does this for the same case.
+  const $pos = state.doc.resolve(match.pos);
+  const parent = $pos.parent;
+  if (parent.childCount === 1) {
     return state.tr
       .replaceWith(
         match.pos,

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -447,12 +447,14 @@ function formatDateForBody(
  * `formatDate`'s accessors return the picked wall-clock components
  * regardless of TZ.
  */
+// See headless helper for the rationale on the regex shape — in
+// particular the optional fractional-seconds group.
+const SDT_DATE_RE =
+  // oxlint-disable-next-line sonarjs/regex-complexity -- mirrors headless helper
+  /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u;
+
 function parseSdtDate(iso: string): Date | null {
-  // See headless helper for the rationale on anchoring at end.
-  const match =
-    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u.exec(
-      iso,
-    );
+  const match = SDT_DATE_RE.exec(iso);
   if (match) {
     const year = Number(match[1]);
     const month = Number(match[2]);

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -112,19 +112,45 @@ function attrsToProperties(node: PMNode): SdtProperties {
   return props;
 }
 
-function ensureNotLocked(node: PMNode, options: ForceOption): void {
+function throwLockedNode(
+  node: PMNode,
+  lock: NonNullable<SdtProperties["lock"]>,
+): never {
+  const props = attrsToProperties(node);
+  throw new ContentControlLockedError({
+    message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" has w:lock=${lock}.`,
+    lock,
+    ...(props.tag !== undefined ? { tag: props.tag } : {}),
+    ...(props.alias !== undefined ? { alias: props.alias } : {}),
+  });
+}
+
+/**
+ * Per OOXML §17.5.2.16: `contentLocked` and `sdtContentLocked` block
+ * content edits; `sdtLocked` does NOT (it only forbids container
+ * removal). Mirrors the headless `ensureContentNotLocked` helper.
+ */
+function ensureContentNotLocked(node: PMNode, options: ForceOption): void {
   if (options.force) {
     return;
   }
   const lock = node.attrs["lock"];
   if (lock === "contentLocked" || lock === "sdtContentLocked") {
-    const props = attrsToProperties(node);
-    throw new ContentControlLockedError({
-      message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" has w:lock=${String(lock)}.`,
-      lock: lock as NonNullable<SdtProperties["lock"]>,
-      ...(props.tag !== undefined ? { tag: props.tag } : {}),
-      ...(props.alias !== undefined ? { alias: props.alias } : {}),
-    });
+    throwLockedNode(node, lock);
+  }
+}
+
+/**
+ * Per OOXML §17.5.2.16: `sdtLocked` and `sdtContentLocked` block container
+ * removal; `contentLocked` does NOT (it only forbids content edits).
+ */
+function ensureSdtNotLocked(node: PMNode, options: ForceOption): void {
+  if (options.force) {
+    return;
+  }
+  const lock = node.attrs["lock"];
+  if (lock === "sdtLocked" || lock === "sdtContentLocked") {
+    throwLockedNode(node, lock);
   }
 }
 
@@ -163,7 +189,7 @@ export function setContentControlContentTr(
   if (!match) {
     return null;
   }
-  ensureNotLocked(match.node, options);
+  ensureContentNotLocked(match.node, options);
 
   let children: PMNode[];
   if (typeof input === "string") {
@@ -194,7 +220,7 @@ export function setContentControlValueTr(
   if (!match) {
     return null;
   }
-  ensureNotLocked(match.node, options);
+  ensureContentNotLocked(match.node, options);
 
   const sdtType = match.node.attrs["sdtType"] as SdtProperties["sdtType"];
 
@@ -272,7 +298,7 @@ export function removeContentControlTr(
   if (!match) {
     return null;
   }
-  ensureNotLocked(match.node, options);
+  ensureSdtNotLocked(match.node, options);
 
   if (options.keepContent) {
     if (isRepeatingSection(match.node) && !options.force) {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -21,6 +21,7 @@ import {
   ContentControlLockedError,
   ContentControlTypeError,
 } from "../../content-controls/errors";
+import { formatDate } from "../../docx/fieldParser";
 import type { SdtProperties } from "../../types/document";
 import { expectBlockSdtAttrs } from "../attrs";
 
@@ -125,6 +126,9 @@ export function blockSdtAttrsToSdtProperties(node: PMNode): SdtProperties {
   }
   if (attrs.dateFormat !== undefined) {
     props.dateFormat = attrs.dateFormat;
+  }
+  if (attrs.dateValueISO !== undefined) {
+    props.dateValueISO = attrs.dateValueISO;
   }
   if (attrs.listItems) {
     const parsed = parseListItemsAttr(attrs.listItems);
@@ -372,9 +376,34 @@ export function setContentControlValueTr(
       reason: "kind=date requires sdtType=date",
     });
   }
-  return replaceBlockSdtChildren(state, match, [
-    paragraphFromText(state.schema, input.date),
-  ]);
+  // Keep the ISO value on `dateValueISO` and render the format-aware
+  // display string into the body — `w:fullDate` is the bound value, the
+  // body text is what Word shows. Mirrors the headless setter.
+  const dateFormatAttr = match.node.attrs["dateFormat"];
+  const display = formatDateForBody(
+    input.date,
+    typeof dateFormatAttr === "string" ? dateFormatAttr : undefined,
+  );
+  return replaceBlockSdtChildren(
+    state,
+    match,
+    [paragraphFromText(state.schema, display)],
+    { dateValueISO: input.date },
+  );
+}
+
+function formatDateForBody(
+  isoDate: string,
+  dateFormat: string | undefined,
+): string {
+  if (!dateFormat) {
+    return isoDate;
+  }
+  const parsed = new Date(isoDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return isoDate;
+  }
+  return formatDate(parsed, dateFormat);
 }
 
 function isRepeatingSection(node: PMNode): boolean {

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -22,6 +22,7 @@ import {
   ContentControlTypeError,
 } from "../../content-controls/errors";
 import type { SdtProperties } from "../../types/document";
+import { expectBlockSdtAttrs } from "../attrs";
 
 type ForceOption = { force?: boolean };
 
@@ -94,7 +95,79 @@ function resolvePath(doc: PMNode, pos: number): number[] {
   return path;
 }
 
+/**
+ * Project a `blockSdt` PM node's attrs onto the full modeled `SdtProperties`
+ * shape so the editor-ref `getContentControls` and lock-error messages
+ * surface every field downstream tooling expects (lock, placeholder,
+ * dateFormat, listItems, checked, etc.). Raw XML payloads are not exposed —
+ * those are for serializer replay, not for callers.
+ */
+export function blockSdtAttrsToSdtProperties(node: PMNode): SdtProperties {
+  const attrs = expectBlockSdtAttrs(node);
+  const props: SdtProperties = { sdtType: attrs.sdtType };
+  if (attrs.alias !== undefined) {
+    props.alias = attrs.alias;
+  }
+  if (attrs.tag !== undefined) {
+    props.tag = attrs.tag;
+  }
+  if (typeof attrs.id === "number") {
+    props.id = attrs.id;
+  }
+  if (attrs.lock !== undefined) {
+    props.lock = attrs.lock;
+  }
+  if (attrs.placeholder !== undefined) {
+    props.placeholder = attrs.placeholder;
+  }
+  if (attrs.showingPlaceholder !== undefined) {
+    props.showingPlaceholder = attrs.showingPlaceholder;
+  }
+  if (attrs.dateFormat !== undefined) {
+    props.dateFormat = attrs.dateFormat;
+  }
+  if (attrs.listItems) {
+    const parsed = parseListItemsAttr(attrs.listItems);
+    if (parsed) {
+      props.listItems = parsed;
+    }
+  }
+  if (typeof attrs.checked === "boolean") {
+    props.checked = attrs.checked;
+  }
+  return props;
+}
+
+function parseListItemsAttr(
+  raw: string,
+): { displayText: string; value: string }[] | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+    const items: { displayText: string; value: string }[] = [];
+    for (const entry of parsed) {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        "displayText" in entry &&
+        "value" in entry &&
+        typeof (entry as { displayText: unknown }).displayText === "string" &&
+        typeof (entry as { value: unknown }).value === "string"
+      ) {
+        items.push(entry as { displayText: string; value: string });
+      }
+    }
+    return items.length > 0 ? items : null;
+  } catch {
+    return null;
+  }
+}
+
 function attrsToProperties(node: PMNode): SdtProperties {
+  // Used only for lock-error messages; keep the projection minimal so the
+  // error path does not pull through the full attrs reader.
   const attrs = node.attrs;
   const sdtType = String(
     attrs["sdtType"] ?? "richText",

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -1,0 +1,292 @@
+/**
+ * ProseMirror transaction helpers for the block-level content controls API.
+ *
+ * Each helper finds the target `blockSdt` PM node, mutates the doc via a
+ * normal transaction, and returns it so the caller can dispatch (writes are
+ * undoable and suggestion-mode-safe via `isHistoryTransaction`). The
+ * headless helpers in `core/content-controls/` are the source of truth for
+ * lock / type validation; we re-implement the search here because we need to
+ * walk PM nodes (not the Document model).
+ */
+
+import type { Node as PMNode } from "prosemirror-model";
+import type { EditorState, Transaction } from "prosemirror-state";
+
+import type {
+  ContentControlFilter,
+  SetContentControlContentInput,
+  SetContentControlValueInput,
+} from "../../content-controls";
+import {
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "../../content-controls/errors";
+import type { SdtProperties } from "../../types/document";
+import { schema } from "../schema";
+
+type ForceOption = { force?: boolean };
+
+export type BlockSdtPMMatch = {
+  node: PMNode;
+  /** Absolute PM position of the blockSdt's open tag. */
+  pos: number;
+  /** Outer→inner index path through doc children. */
+  path: number[];
+};
+
+function nodeMatchesFilter(
+  node: PMNode,
+  filter: ContentControlFilter,
+): boolean {
+  if (node.type.name !== "blockSdt") {
+    return false;
+  }
+  const attrs = node.attrs;
+  if (filter.tag !== undefined && attrs["tag"] !== filter.tag) {
+    return false;
+  }
+  if (filter.alias !== undefined && attrs["alias"] !== filter.alias) {
+    return false;
+  }
+  if (filter.id !== undefined && attrs["id"] !== filter.id) {
+    return false;
+  }
+  if (filter.sdtType !== undefined && attrs["sdtType"] !== filter.sdtType) {
+    return false;
+  }
+  return true;
+}
+
+/** All blockSdt nodes in `doc` matching `filter`. Outer→inner traversal. */
+export function findBlockSdtMatches(
+  doc: PMNode,
+  filter: ContentControlFilter = {},
+): BlockSdtPMMatch[] {
+  const matches: BlockSdtPMMatch[] = [];
+  doc.descendants((node, pos, _parent, index) => {
+    if (node.type.name !== "blockSdt") {
+      return true;
+    }
+    if (nodeMatchesFilter(node, filter)) {
+      matches.push({ node, pos, path: [...resolvePath(doc, pos), index] });
+    }
+    return true;
+  });
+  return matches;
+}
+
+/** First match or null — convenience for editor-ref callers. */
+export function findBlockSdtMatch(
+  doc: PMNode,
+  filter: ContentControlFilter,
+): BlockSdtPMMatch | null {
+  for (const match of findBlockSdtMatches(doc, filter)) {
+    return match;
+  }
+  return null;
+}
+
+function resolvePath(doc: PMNode, pos: number): number[] {
+  const $pos = doc.resolve(pos);
+  const path: number[] = [];
+  for (let depth = 1; depth <= $pos.depth; depth += 1) {
+    path.push($pos.index(depth - 1));
+  }
+  return path;
+}
+
+function attrsToProperties(node: PMNode): SdtProperties {
+  const attrs = node.attrs;
+  const sdtType = String(
+    attrs["sdtType"] ?? "richText",
+  ) as SdtProperties["sdtType"];
+  const props: SdtProperties = { sdtType };
+  if (attrs["alias"]) {
+    props.alias = String(attrs["alias"]);
+  }
+  if (attrs["tag"]) {
+    props.tag = String(attrs["tag"]);
+  }
+  if (typeof attrs["id"] === "number") {
+    props.id = attrs["id"];
+  }
+  return props;
+}
+
+function ensureNotLocked(node: PMNode, options: ForceOption): void {
+  if (options.force) {
+    return;
+  }
+  const lock = node.attrs["lock"];
+  if (lock === "contentLocked" || lock === "sdtContentLocked") {
+    const props = attrsToProperties(node);
+    throw new ContentControlLockedError({
+      message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" has w:lock=${String(lock)}.`,
+      lock: lock as NonNullable<SdtProperties["lock"]>,
+      ...(props.tag !== undefined ? { tag: props.tag } : {}),
+      ...(props.alias !== undefined ? { alias: props.alias } : {}),
+    });
+  }
+}
+
+function paragraphFromText(text: string): PMNode {
+  if (text.length === 0) {
+    return schema.node("paragraph", {}, []);
+  }
+  return schema.node("paragraph", {}, [schema.text(text)]);
+}
+
+function replaceBlockSdtChildren(
+  state: EditorState,
+  match: BlockSdtPMMatch,
+  children: readonly PMNode[],
+  propertyOverrides: Partial<Record<string, unknown>> = {},
+): Transaction {
+  const next = schema.node(
+    "blockSdt",
+    { ...match.node.attrs, showingPlaceholder: false, ...propertyOverrides },
+    children.length === 0 ? [paragraphFromText("")] : children,
+  );
+  return state.tr.replaceWith(match.pos, match.pos + match.node.nodeSize, next);
+}
+
+/**
+ * Replace a control's children with plain text (one paragraph) or
+ * pre-built PM blocks. Returns null when no match is present.
+ */
+export function setContentControlContentTr(
+  state: EditorState,
+  filter: ContentControlFilter,
+  input: SetContentControlContentInput,
+  options: ForceOption = {},
+): Transaction | null {
+  const match = findBlockSdtMatch(state.doc, filter);
+  if (!match) {
+    return null;
+  }
+  ensureNotLocked(match.node, options);
+
+  let children: PMNode[];
+  if (typeof input === "string") {
+    children = [paragraphFromText(input)];
+  } else {
+    // Caller provided Document-model BlockContent[]; convert via toProseDoc
+    // would re-enter the whole pipeline. Keep this PM-direct: only string
+    // input is supported here; block-content fill should go through the
+    // headless API + loadDocument for now (matches upstream's caveat).
+    throw new ContentControlTypeError({
+      message:
+        "Block-content fill is only supported via the headless API; pass a string here.",
+      sdtType: (match.node.attrs["sdtType"] ??
+        "richText") as SdtProperties["sdtType"],
+      reason: "PM-direct path takes string input only",
+    });
+  }
+  return replaceBlockSdtChildren(state, match, children);
+}
+
+export function setContentControlValueTr(
+  state: EditorState,
+  filter: ContentControlFilter,
+  input: SetContentControlValueInput,
+  options: ForceOption = {},
+): Transaction | null {
+  const match = findBlockSdtMatch(state.doc, filter);
+  if (!match) {
+    return null;
+  }
+  ensureNotLocked(match.node, options);
+
+  const sdtType = match.node.attrs["sdtType"] as SdtProperties["sdtType"];
+
+  if (input.kind === "dropdown") {
+    if (sdtType !== "dropdown" && sdtType !== "comboBox") {
+      throw new ContentControlTypeError({
+        message: `Cannot set dropdown value on a ${sdtType} control.`,
+        sdtType,
+        reason: "kind=dropdown requires sdtType=dropdown|comboBox",
+      });
+    }
+    const listItemsAttr = match.node.attrs["listItems"];
+    let display = input.value;
+    if (typeof listItemsAttr === "string" && listItemsAttr) {
+      const items = JSON.parse(listItemsAttr) as
+        | { displayText: string; value: string }[]
+        | null;
+      const item = items?.find((i) => i.value === input.value);
+      if (!item && !options.force) {
+        throw new ContentControlTypeError({
+          message: `Value "${input.value}" not in the control's list items.`,
+          sdtType,
+          reason: "value not in listItems",
+        });
+      }
+      if (item) {
+        display = item.displayText;
+      }
+    }
+    return replaceBlockSdtChildren(state, match, [paragraphFromText(display)]);
+  }
+  if (input.kind === "checkbox") {
+    if (sdtType !== "checkbox") {
+      throw new ContentControlTypeError({
+        message: `Cannot toggle checkbox on a ${sdtType} control.`,
+        sdtType,
+        reason: "kind=checkbox requires sdtType=checkbox",
+      });
+    }
+    const glyph = input.checked ? "☒" : "☐";
+    return replaceBlockSdtChildren(state, match, [paragraphFromText(glyph)], {
+      checked: input.checked,
+    });
+  }
+  if (sdtType !== "date") {
+    throw new ContentControlTypeError({
+      message: `Cannot set date on a ${sdtType} control.`,
+      sdtType,
+      reason: "kind=date requires sdtType=date",
+    });
+  }
+  return replaceBlockSdtChildren(state, match, [paragraphFromText(input.date)]);
+}
+
+function isRepeatingSection(node: PMNode): boolean {
+  const raw = node.attrs["rawPropertiesXml"];
+  return typeof raw === "string" && raw.includes("w15:repeatingSection");
+}
+
+export function removeContentControlTr(
+  state: EditorState,
+  filter: ContentControlFilter,
+  options: ForceOption & { keepContent?: boolean } = {},
+): Transaction | null {
+  const match = findBlockSdtMatch(state.doc, filter);
+  if (!match) {
+    return null;
+  }
+  ensureNotLocked(match.node, options);
+
+  if (options.keepContent) {
+    if (isRepeatingSection(match.node) && !options.force) {
+      throw new ContentControlTypeError({
+        message:
+          "Refusing to unwrap a w15:repeatingSection — would orphan its w15 row items.",
+        sdtType: (match.node.attrs["sdtType"] ??
+          "richText") as SdtProperties["sdtType"],
+        reason: "repeatingSection unwrap orphans items",
+      });
+    }
+    // Replace the SDT with its children in place.
+    const children: PMNode[] = [];
+    for (let i = 0; i < match.node.childCount; i += 1) {
+      children.push(match.node.child(i));
+    }
+    return state.tr.replaceWith(
+      match.pos,
+      match.pos + match.node.nodeSize,
+      children,
+    );
+  }
+  // Drop entirely.
+  return state.tr.delete(match.pos, match.pos + match.node.nodeSize);
+}

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -18,6 +18,7 @@ import type {
   SetContentControlValueInput,
 } from "../../content-controls";
 import {
+  ContentControlBoundError,
   ContentControlLockedError,
   ContentControlTypeError,
 } from "../../content-controls/errors";
@@ -242,6 +243,45 @@ function ensureSdtNotLocked(node: PMNode, options: ForceOption): void {
   }
 }
 
+const DATA_BINDING_RE = /<\w+:dataBinding\b([^>]*)\/?>/iu;
+
+/**
+ * Refuse content mutations on bound SDTs unless force; on force, return
+ * the stripped rawPropertiesXml so the caller can persist it on the new
+ * node attrs. Mirrors the headless `ensureContentNotBound` helper.
+ */
+function ensureContentNotBound(
+  node: PMNode,
+  options: ForceOption,
+): { strippedRawPropertiesXml: string | undefined } {
+  const raw = node.attrs["rawPropertiesXml"];
+  if (typeof raw !== "string") {
+    return { strippedRawPropertiesXml: undefined };
+  }
+  const match = DATA_BINDING_RE.exec(raw);
+  if (!match) {
+    return { strippedRawPropertiesXml: undefined };
+  }
+  if (!options.force) {
+    const attrs = match[1] ?? "";
+    const xpathMatch = /\bxpath="([^"]*)"/iu.exec(attrs);
+    const storeMatch = /\bstoreItemID="([^"]*)"/iu.exec(attrs);
+    const props = attrsToProperties(node);
+    throw new ContentControlBoundError({
+      message: `Control "${props.tag ?? props.alias ?? "(unnamed)"}" is bound to ${xpathMatch?.[1] ?? "(unknown xpath)"}. Word regenerates the body from the bound XML on open; pass { force: true } to strip the binding inline, or remove it explicitly before writing.`,
+      xpath: xpathMatch?.[1] ?? "",
+      ...(storeMatch?.[1] !== undefined ? { storeItemID: storeMatch[1] } : {}),
+      ...(props.tag !== undefined ? { tag: props.tag } : {}),
+      ...(props.alias !== undefined ? { alias: props.alias } : {}),
+    });
+  }
+  const stripped = raw.replaceAll(
+    /<\w+:dataBinding\b[^>]*\/?>(?:[\s\S]*?<\/\w+:dataBinding>)?/giu,
+    "",
+  );
+  return { strippedRawPropertiesXml: stripped };
+}
+
 function paragraphFromText(schema: Schema, text: string): PMNode {
   if (text.length === 0) {
     return schema.node("paragraph", {}, []);
@@ -285,6 +325,10 @@ export function setContentControlContentTr(
     return null;
   }
   ensureContentNotLocked(match.node, options);
+  const { strippedRawPropertiesXml } = ensureContentNotBound(
+    match.node,
+    options,
+  );
 
   if (typeof input !== "string") {
     // Block-content fill is supported via `setContentControlContentBlocksTr`
@@ -300,9 +344,14 @@ export function setContentControlContentTr(
       reason: "PM-direct path takes string input only",
     });
   }
-  return replaceBlockSdtChildren(state, match, [
-    paragraphFromText(state.schema, input),
-  ]);
+  return replaceBlockSdtChildren(
+    state,
+    match,
+    [paragraphFromText(state.schema, input)],
+    strippedRawPropertiesXml !== undefined
+      ? { rawPropertiesXml: strippedRawPropertiesXml }
+      : {},
+  );
 }
 
 /**
@@ -322,7 +371,18 @@ export function replaceBlockSdtChildrenForFill(
     return null;
   }
   ensureContentNotLocked(match.node, options);
-  return replaceBlockSdtChildren(state, match, children);
+  const { strippedRawPropertiesXml } = ensureContentNotBound(
+    match.node,
+    options,
+  );
+  return replaceBlockSdtChildren(
+    state,
+    match,
+    children,
+    strippedRawPropertiesXml !== undefined
+      ? { rawPropertiesXml: strippedRawPropertiesXml }
+      : {},
+  );
 }
 
 export function setContentControlValueTr(
@@ -336,6 +396,14 @@ export function setContentControlValueTr(
     return null;
   }
   ensureContentNotLocked(match.node, options);
+  const { strippedRawPropertiesXml } = ensureContentNotBound(
+    match.node,
+    options,
+  );
+  const bindingOverride: Partial<Record<string, unknown>> =
+    strippedRawPropertiesXml !== undefined
+      ? { rawPropertiesXml: strippedRawPropertiesXml }
+      : {};
 
   const sdtType = match.node.attrs["sdtType"] as SdtProperties["sdtType"];
 
@@ -382,7 +450,7 @@ export function setContentControlValueTr(
       // Persist the picked OOXML value separately so duplicate-label items
       // round-trip to the right selection on save — the serializer reads
       // dropdownLastValue before falling back to display-text matching.
-      { dropdownLastValue: input.value },
+      { dropdownLastValue: input.value, ...bindingOverride },
     );
   }
   if (input.kind === "checkbox") {
@@ -398,9 +466,7 @@ export function setContentControlValueTr(
       state,
       match,
       [paragraphFromText(state.schema, glyph)],
-      {
-        checked: input.checked,
-      },
+      { checked: input.checked, ...bindingOverride },
     );
   }
   if (sdtType !== "date") {
@@ -422,7 +488,7 @@ export function setContentControlValueTr(
     state,
     match,
     [paragraphFromText(state.schema, display)],
-    { dateValueISO: input.date },
+    { dateValueISO: input.date, ...bindingOverride },
   );
 }
 

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -37,9 +37,16 @@ export type BlockSdtPMMatch = {
 
 function nodeMatchesFilter(
   node: PMNode,
+  pos: number,
   filter: ContentControlFilter,
 ): boolean {
   if (node.type.name !== "blockSdt") {
+    return false;
+  }
+  // pmPos addresses one specific control instance — use it first so the
+  // widgets plugin (which derives the position from the clicked anchor)
+  // never has to disambiguate between SDTs that share a tag/alias.
+  if (filter.pmPos !== undefined && pos !== filter.pmPos) {
     return false;
   }
   const attrs = node.attrs;
@@ -68,7 +75,7 @@ export function findBlockSdtMatches(
     if (node.type.name !== "blockSdt") {
       return true;
     }
-    if (nodeMatchesFilter(node, filter)) {
+    if (nodeMatchesFilter(node, pos, filter)) {
       matches.push({ node, pos, path: [...resolvePath(doc, pos), index] });
     }
     return true;

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -433,16 +433,22 @@ function formatDateForBody(
 
 /**
  * See `formatDateForSdtBody` in the headless helpers for the rationale.
- * For a date-only `YYYY-MM-DD` value we build a local-midnight Date so
- * the format's local accessors see the right day regardless of TZ.
+ * Supports date-only (`YYYY-MM-DD`) and date+time
+ * (`YYYY-MM-DDTHH:mm[:ss]`) inputs, building a local-time Date so
+ * `formatDate`'s accessors return the picked wall-clock components
+ * regardless of TZ.
  */
 function parseSdtDate(iso: string): Date | null {
-  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})/u.exec(iso);
-  if (dateOnly) {
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
+  if (match) {
     return new Date(
-      Number(dateOnly[1]),
-      Number(dateOnly[2]) - 1,
-      Number(dateOnly[3]),
+      Number(match[1]),
+      Number(match[2]) - 1,
+      Number(match[3]),
+      match[4] ? Number(match[4]) : 0,
+      match[5] ? Number(match[5]) : 0,
+      match[6] ? Number(match[6]) : 0,
     );
   }
   const parsed = new Date(iso);

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -439,8 +439,11 @@ function formatDateForBody(
  * regardless of TZ.
  */
 function parseSdtDate(iso: string): Date | null {
+  // See headless helper for the rationale on anchoring at end.
   const match =
-    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?/u.exec(iso);
+    /^(\d{4})-(\d{2})-(\d{2})(?:[Tt](\d{2}):(\d{2})(?::(\d{2}))?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/u.exec(
+      iso,
+    );
   if (match) {
     const year = Number(match[1]);
     const month = Number(match[2]);

--- a/packages/folio/src/core/prosemirror/commands/contentControls.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControls.ts
@@ -480,8 +480,10 @@ function parseSdtDate(iso: string): Date | null {
 }
 
 function isRepeatingSection(node: PMNode): boolean {
+  // Match by local name so an alt-prefix `<ns0:repeatingSection/>` is
+  // recognized too (the headless helper has the same fix).
   const raw = node.attrs["rawPropertiesXml"];
-  return typeof raw === "string" && raw.includes("w15:repeatingSection");
+  return typeof raw === "string" && /<\w+:repeatingSection\b/u.test(raw);
 }
 
 export function removeContentControlTr(

--- a/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
@@ -111,6 +111,45 @@ describe("setContentControlContentBlocksTr", () => {
     expect(sdt?.firstChild?.type.name).toBe("table");
   });
 
+  test("does not pad fill input ending in a nested blockSdt with a blank paragraph", () => {
+    // Codex P2 (PR #587): headerFooterToProseDoc used to append a
+    // trailing empty paragraph after any final blockSdt to provide a
+    // caret slot. That meant a caller replacing a control with exactly
+    // one nested content control silently got an extra empty paragraph
+    // inside the outer SDT. The caret affordance is provided by
+    // gapcursor; the converter no longer pads.
+    const blocks: BlockContent[] = [
+      {
+        type: "blockSdt",
+        properties: { sdtType: "richText", tag: "nested" },
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "run", content: [{ type: "text", text: "inner" }] },
+            ],
+          },
+        ],
+      },
+    ];
+    const state = makeState();
+    const tr = setContentControlContentBlocksTr(
+      state,
+      { tag: "clause" },
+      blocks,
+    );
+    if (!tr) {
+      throw new TypeError("expected a transaction");
+    }
+    const next = state.apply(tr);
+    const outer = next.doc.firstChild;
+    expect(outer?.type.name).toBe("blockSdt");
+    // Exactly one child (the nested blockSdt), no trailing empty paragraph.
+    expect(outer?.childCount).toBe(1);
+    expect(outer?.firstChild?.type.name).toBe("blockSdt");
+    expect(outer?.firstChild?.attrs["tag"]).toBe("nested");
+  });
+
   test("returns null when no control matches the filter", () => {
     const state = makeState();
     expect(

--- a/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Block-content fill via the editor-ref transaction helper.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+
+import type { BlockContent } from "../../types/document";
+import { schema, singletonManager } from "../schema";
+import { setContentControlContentBlocksTr } from "./contentControlsBlockFill";
+
+function makeState() {
+  const sdt = schema.node("blockSdt", { sdtType: "richText", tag: "clause" }, [
+    schema.node("paragraph", {}, [schema.text("placeholder")]),
+  ]);
+  return EditorState.create({
+    doc: schema.node("doc", null, [sdt]),
+    schema,
+    plugins: [...singletonManager.getPlugins()],
+  });
+}
+
+describe("setContentControlContentBlocksTr", () => {
+  test("replaces SDT children with the PM form of a multi-paragraph fill", () => {
+    const blocks: BlockContent[] = [
+      {
+        type: "paragraph",
+        content: [
+          { type: "run", content: [{ type: "text", text: "First line" }] },
+        ],
+      },
+      {
+        type: "paragraph",
+        content: [
+          { type: "run", content: [{ type: "text", text: "Second line" }] },
+        ],
+      },
+    ];
+
+    const state = makeState();
+    const tr = setContentControlContentBlocksTr(
+      state,
+      { tag: "clause" },
+      blocks,
+    );
+    if (!tr) {
+      throw new Error("expected a transaction");
+    }
+    const next = state.apply(tr);
+    const sdt = next.doc.firstChild;
+    expect(sdt?.type.name).toBe("blockSdt");
+    expect(sdt?.childCount).toBe(2);
+    expect(sdt?.child(0).textContent).toBe("First line");
+    expect(sdt?.child(1).textContent).toBe("Second line");
+  });
+
+  test("returns null when no control matches the filter", () => {
+    const state = makeState();
+    expect(
+      setContentControlContentBlocksTr(state, { tag: "missing" }, []),
+    ).toBeNull();
+  });
+});

--- a/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.test.ts
@@ -54,6 +54,63 @@ describe("setContentControlContentBlocksTr", () => {
     expect(sdt?.child(1).textContent).toBe("Second line");
   });
 
+  test("accepts a table in the fill input and emits it as a PM child", () => {
+    const blocks: BlockContent[] = [
+      {
+        type: "table",
+        columnWidths: [2400, 2400],
+        rows: [
+          {
+            type: "tableRow",
+            cells: [
+              {
+                type: "tableCell",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "run",
+                        content: [{ type: "text", text: "left" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "tableCell",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "run",
+                        content: [{ type: "text", text: "right" }],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const state = makeState();
+    const tr = setContentControlContentBlocksTr(
+      state,
+      { tag: "clause" },
+      blocks,
+    );
+    if (!tr) {
+      throw new TypeError("expected a transaction");
+    }
+    const next = state.apply(tr);
+    const sdt = next.doc.firstChild;
+    expect(sdt?.type.name).toBe("blockSdt");
+    expect(sdt?.firstChild?.type.name).toBe("table");
+  });
+
   test("returns null when no control matches the filter", () => {
     const state = makeState();
     expect(

--- a/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.ts
+++ b/packages/folio/src/core/prosemirror/commands/contentControlsBlockFill.ts
@@ -1,0 +1,45 @@
+/**
+ * Block-content fill variant of the editor-ref `setContentControlContent`
+ * transaction.
+ *
+ * Sits in a separate module from `contentControls.ts` so the import graph
+ * stays acyclic: this file pulls in the toProseDoc conversion pipeline,
+ * which transitively reaches the PM schema and StarterKit. The widgets
+ * plugin in turn imports the basic `contentControls` helpers but not this
+ * file, breaking what would otherwise be a tight cycle.
+ */
+
+import type { Node as PMNode } from "prosemirror-model";
+import type { EditorState, Transaction } from "prosemirror-state";
+
+import type { ContentControlFilter } from "../../content-controls";
+import type { BlockContent } from "../../types/document";
+import { headerFooterToProseDoc } from "../conversion/toProseDoc";
+import { replaceBlockSdtChildrenForFill } from "./contentControls";
+
+function blockContentToPMChildren(blocks: BlockContent[]): PMNode[] {
+  // `headerFooterToProseDoc` runs the same per-block converters the body
+  // uses and emits a doc whose children match what `blockSdt`'s
+  // `content: block+` accepts.
+  const pmDoc = headerFooterToProseDoc(blocks);
+  const out: PMNode[] = [];
+  for (let i = 0; i < pmDoc.childCount; i += 1) {
+    out.push(pmDoc.child(i));
+  }
+  return out;
+}
+
+/**
+ * Replace the children of the content control matching `filter` with the
+ * PM-converted form of `blocks`. Locked controls throw
+ * `ContentControlLockedError` unless `{ force: true }` is passed.
+ */
+export function setContentControlContentBlocksTr(
+  state: EditorState,
+  filter: ContentControlFilter,
+  blocks: BlockContent[],
+  options: { force?: boolean } = {},
+): Transaction | null {
+  const children = blockContentToPMChildren(blocks);
+  return replaceBlockSdtChildrenForFill(state, filter, children, options);
+}

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -322,9 +322,52 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   // Recursively materialize children. PM `blockSdt` content is `block+`, so a
   // mini-doc node is a convenient way to reuse extractBlocks.
   const innerDoc = node.type.schema.node("doc", null, node.content);
-  const content = extractBlocks(innerDoc);
+  const extracted = extractBlocks(innerDoc);
+
+  // `toProseDoc` inserts a synthetic empty paragraph into any blockSdt
+  // whose source had an empty `<w:sdtContent/>` (PM `block+` requires
+  // at least one child). Without this guard, an untouched parse → PM
+  // → save round trip turns that empty control into `<w:sdtContent>
+  // <w:p/></w:sdtContent>`, silently adding a paragraph Word did not
+  // emit. Detect the synthetic shape — exactly one paragraph with no
+  // inline content and no formatting — and emit empty content instead.
+  // If the user typed into the filler or styled it, the heuristic
+  // bails and we preserve the paragraph verbatim.
+  const content = isSyntheticEmptyFiller(extracted) ? [] : extracted;
 
   return { type: "blockSdt", properties, content };
+}
+
+function isSyntheticEmptyFiller(blocks: BlockContent[]): boolean {
+  if (blocks.length !== 1) {
+    return false;
+  }
+  const block = blocks[0];
+  if (!block || block.type !== "paragraph") {
+    return false;
+  }
+  if (block.content.length !== 0) {
+    return false;
+  }
+  // Allow the parser's intrinsic `paraId` marker and bookkeeping fields,
+  // but reject anything that signals a real authored paragraph (style,
+  // formatting, mark changes, section properties).
+  if (block.formatting !== undefined) {
+    return false;
+  }
+  if (block._originalFormatting !== undefined) {
+    return false;
+  }
+  if (block._sectionProperties !== undefined) {
+    return false;
+  }
+  if (block._propertyChanges !== undefined) {
+    return false;
+  }
+  if (block._paragraphMarkChange !== undefined) {
+    return false;
+  }
+  return true;
 }
 
 function parseListItemsJson(

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -23,6 +23,8 @@ import type {
   SectionStart,
 } from "../../types/content";
 import type {
+  BlockContent,
+  BlockSdt,
   Document,
   DocumentBody,
   Paragraph,
@@ -180,10 +182,11 @@ export function fromProseDoc(pmDoc: PMNode, baseDocument?: Document): Document {
 }
 
 /**
- * Extract blocks (paragraphs and tables) from ProseMirror document
+ * Extract block content (paragraphs, tables, block SDTs) from a ProseMirror
+ * document.
  */
-function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
-  const blocks: (Paragraph | Table)[] = [];
+function extractBlocks(pmDoc: PMNode): BlockContent[] {
+  const blocks: BlockContent[] = [];
   const documentCounts = buildDocumentTrackedChangeCounts(pmDoc);
   let pendingPageBreaks = 0;
   let previousStandaloneTextBox: PreviousStandaloneTextBox | null = null;
@@ -233,6 +236,15 @@ function extractBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
         previousStandaloneTextBox,
       });
       pendingPageBreaks = 0;
+    } else if (node.type.name === "blockSdt") {
+      if (
+        pendingPageBreaks > 0 &&
+        !appendPendingPageBreaksToPreviousParagraph()
+      ) {
+        flushPendingPageBreaks();
+      }
+      blocks.push(convertPMBlockSdt(node));
+      previousStandaloneTextBox = null;
     }
   });
 
@@ -253,8 +265,91 @@ type PreviousStandaloneTextBox = {
   groupId: string;
 };
 
+function convertPMBlockSdt(node: PMNode): BlockSdt {
+  const attrs = node.attrs;
+  const properties: SdtProperties = {
+    sdtType: (attrs["sdtType"] ?? "richText") as SdtProperties["sdtType"],
+  };
+  if (attrs["alias"]) {
+    properties.alias = String(attrs["alias"]);
+  }
+  if (attrs["tag"]) {
+    properties.tag = String(attrs["tag"]);
+  }
+  if (typeof attrs["id"] === "number") {
+    properties.id = attrs["id"];
+  }
+  const lockAttr = attrs["lock"];
+  if (
+    lockAttr === "sdtLocked" ||
+    lockAttr === "contentLocked" ||
+    lockAttr === "sdtContentLocked" ||
+    lockAttr === "unlocked"
+  ) {
+    properties.lock = lockAttr;
+  }
+  if (attrs["placeholder"]) {
+    properties.placeholder = String(attrs["placeholder"]);
+  }
+  if (attrs["showingPlaceholder"]) {
+    properties.showingPlaceholder = true;
+  }
+  if (attrs["dateFormat"]) {
+    properties.dateFormat = String(attrs["dateFormat"]);
+  }
+  if (typeof attrs["listItems"] === "string" && attrs["listItems"]) {
+    const items = parseListItemsJson(attrs["listItems"]);
+    if (items) {
+      properties.listItems = items;
+    }
+  }
+  if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
+    properties.checked = Boolean(attrs["checked"]);
+  }
+  if (typeof attrs["rawPropertiesXml"] === "string") {
+    properties.rawPropertiesXml = attrs["rawPropertiesXml"];
+  }
+  if (typeof attrs["rawEndPropertiesXml"] === "string") {
+    properties.rawEndPropertiesXml = attrs["rawEndPropertiesXml"];
+  }
+
+  // Recursively materialize children. PM `blockSdt` content is `block+`, so a
+  // mini-doc node is a convenient way to reuse extractBlocks.
+  const innerDoc = node.type.schema.node("doc", null, node.content);
+  const content = extractBlocks(innerDoc);
+
+  return { type: "blockSdt", properties, content };
+}
+
+function parseListItemsJson(
+  raw: string,
+): { displayText: string; value: string }[] | undefined {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return undefined;
+    }
+    const items: { displayText: string; value: string }[] = [];
+    for (const entry of parsed) {
+      if (
+        entry !== null &&
+        typeof entry === "object" &&
+        "displayText" in entry &&
+        "value" in entry &&
+        typeof (entry as { displayText: unknown }).displayText === "string" &&
+        typeof (entry as { value: unknown }).value === "string"
+      ) {
+        items.push(entry as { displayText: string; value: string });
+      }
+    }
+    return items.length > 0 ? items : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function appendTextBoxBlock(
-  blocks: (Paragraph | Table)[],
+  blocks: BlockContent[],
   node: PMNode,
   options: AppendTextBoxBlockOptions,
 ): PreviousStandaloneTextBox | null {
@@ -2439,9 +2534,12 @@ export function updateDocumentContent(
 }
 
 /**
- * Convert a ProseMirror document back to an array of Paragraph/Table blocks.
- * Used for converting edited header/footer PM content back to the document model.
+ * Convert a ProseMirror document back to an array of `BlockContent` blocks
+ * (paragraphs, tables, and block-level content controls).
+ *
+ * Used for converting edited header/footer PM content back to the document
+ * model.
  */
-export function proseDocToBlocks(pmDoc: PMNode): (Paragraph | Table)[] {
+export function proseDocToBlocks(pmDoc: PMNode): BlockContent[] {
   return extractBlocks(pmDoc);
 }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -306,6 +306,9 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
       properties.listItems = items;
     }
   }
+  if (typeof attrs.dropdownLastValue === "string") {
+    properties.dropdownLastValue = attrs.dropdownLastValue;
+  }
   if (typeof attrs.checked === "boolean") {
     properties.checked = attrs.checked;
   }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -1309,6 +1309,9 @@ function createInlineSdtFromNode(node: PMNode): InlineSdt {
   if (attrs.dateFormat) {
     properties.dateFormat = attrs.dateFormat;
   }
+  if (attrs.dateValueISO) {
+    properties.dateValueISO = attrs.dateValueISO;
+  }
   if (attrs.listItems) {
     properties.listItems = parseSdtListItems(attrs.listItems);
   }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -355,16 +355,13 @@ function isSyntheticEmptyFiller(blocks: BlockContent[]): boolean {
   if (block.formatting !== undefined) {
     return false;
   }
-  if (block._originalFormatting !== undefined) {
+  if (block.sectionProperties !== undefined) {
     return false;
   }
-  if (block._sectionProperties !== undefined) {
+  if (block.propertyChanges !== undefined) {
     return false;
   }
-  if (block._propertyChanges !== undefined) {
-    return false;
-  }
-  if (block._paragraphMarkChange !== undefined) {
+  if (block.pPrMark !== undefined) {
     return false;
   }
   return true;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -284,8 +284,15 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   if (attrs.placeholder) {
     properties.placeholder = attrs.placeholder;
   }
-  if (attrs.showingPlaceholder) {
-    properties.showingPlaceholder = true;
+  // Preserve the explicit boolean — including `false`. When the widget
+  // / editor-ref path fills a placeholder-bearing control,
+  // `replaceBlockSdtChildren` sets `showingPlaceholder: false` so the
+  // serializer's `reconcileRawSdtPr` knows to remove the source DOCX's
+  // `<w:showingPlcHdr/>`. A truthy-only check (the prior shape) would
+  // drop that `false` and the saved file would keep marking the
+  // newly filled body as placeholder text.
+  if (attrs.showingPlaceholder !== undefined) {
+    properties.showingPlaceholder = attrs.showingPlaceholder;
   }
   if (attrs.dateFormat) {
     properties.dateFormat = attrs.dateFormat;

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -290,6 +290,9 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   if (attrs.dateFormat) {
     properties.dateFormat = attrs.dateFormat;
   }
+  if (attrs.dateValueISO) {
+    properties.dateValueISO = attrs.dateValueISO;
+  }
   if (attrs.listItems) {
     const items = parseListItemsJson(attrs.listItems);
     if (items) {

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -324,21 +324,22 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   const innerDoc = node.type.schema.node("doc", null, node.content);
   const extracted = extractBlocks(innerDoc);
 
-  // `toProseDoc` inserts a synthetic empty paragraph into any blockSdt
-  // whose source had an empty `<w:sdtContent/>` (PM `block+` requires
-  // at least one child). Without this guard, an untouched parse → PM
-  // → save round trip turns that empty control into `<w:sdtContent>
-  // <w:p/></w:sdtContent>`, silently adding a paragraph Word did not
-  // emit. Detect the synthetic shape — exactly one paragraph with no
-  // inline content and no formatting — and emit empty content instead.
-  // If the user typed into the filler or styled it, the heuristic
-  // bails and we preserve the paragraph verbatim.
-  const content = isSyntheticEmptyFiller(extracted) ? [] : extracted;
+  // `toProseDoc` inserts a synthetic filler paragraph into any blockSdt
+  // whose source had an empty `<w:sdtContent/>` and stamps the
+  // `_originallyEmpty` marker on the PM node. Use that explicit marker
+  // (not a shape heuristic) to drop the filler on save — an authored
+  // `<w:sdtContent><w:p/></w:sdtContent>` does NOT carry the marker
+  // and its empty paragraph survives the round trip intact. If the
+  // user typed into the filler we still preserve the paragraph,
+  // matching their intent.
+  const wasOriginallyEmpty = attrs._originallyEmpty === true;
+  const content =
+    wasOriginallyEmpty && isStillSyntheticFiller(extracted) ? [] : extracted;
 
   return { type: "blockSdt", properties, content };
 }
 
-function isSyntheticEmptyFiller(blocks: BlockContent[]): boolean {
+function isStillSyntheticFiller(blocks: BlockContent[]): boolean {
   if (blocks.length !== 1) {
     return false;
   }
@@ -349,9 +350,8 @@ function isSyntheticEmptyFiller(blocks: BlockContent[]): boolean {
   if (block.content.length !== 0) {
     return false;
   }
-  // Allow the parser's intrinsic `paraId` marker and bookkeeping fields,
-  // but reject anything that signals a real authored paragraph (style,
-  // formatting, mark changes, section properties).
+  // Reject anything that signals real editing (formatting, mark changes,
+  // section properties) — if the user authored content, preserve it.
   if (block.formatting !== undefined) {
     return false;
   }

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -318,6 +318,12 @@ function convertPMBlockSdt(node: PMNode): BlockSdt {
   if (attrs.rawEndPropertiesXml) {
     properties.rawEndPropertiesXml = attrs.rawEndPropertiesXml;
   }
+  if (attrs.rawSdtChildrenBeforeContent) {
+    properties.rawSdtChildrenBeforeContent = attrs.rawSdtChildrenBeforeContent;
+  }
+  if (attrs.rawSdtChildrenAfterContent) {
+    properties.rawSdtChildrenAfterContent = attrs.rawSdtChildrenAfterContent;
+  }
 
   // Recursively materialize children. PM `blockSdt` content is `block+`, so a
   // mini-doc node is a convenient way to reuse extractBlocks.

--- a/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/fromProseDoc.ts
@@ -74,6 +74,7 @@ import {
   expectMathAttrs,
   expectParagraphAttrs,
   expectRunFormattingOverrideMarkAttrs,
+  expectBlockSdtAttrs,
   expectSdtAttrs,
   expectShapeAttrs,
   expectStrikeMarkAttrs,
@@ -266,51 +267,43 @@ type PreviousStandaloneTextBox = {
 };
 
 function convertPMBlockSdt(node: PMNode): BlockSdt {
-  const attrs = node.attrs;
-  const properties: SdtProperties = {
-    sdtType: (attrs["sdtType"] ?? "richText") as SdtProperties["sdtType"],
-  };
-  if (attrs["alias"]) {
-    properties.alias = String(attrs["alias"]);
+  const attrs = expectBlockSdtAttrs(node);
+  const properties: SdtProperties = { sdtType: attrs.sdtType };
+  if (attrs.alias) {
+    properties.alias = attrs.alias;
   }
-  if (attrs["tag"]) {
-    properties.tag = String(attrs["tag"]);
+  if (attrs.tag) {
+    properties.tag = attrs.tag;
   }
-  if (typeof attrs["id"] === "number") {
-    properties.id = attrs["id"];
+  if (typeof attrs.id === "number") {
+    properties.id = attrs.id;
   }
-  const lockAttr = attrs["lock"];
-  if (
-    lockAttr === "sdtLocked" ||
-    lockAttr === "contentLocked" ||
-    lockAttr === "sdtContentLocked" ||
-    lockAttr === "unlocked"
-  ) {
-    properties.lock = lockAttr;
+  if (attrs.lock) {
+    properties.lock = attrs.lock;
   }
-  if (attrs["placeholder"]) {
-    properties.placeholder = String(attrs["placeholder"]);
+  if (attrs.placeholder) {
+    properties.placeholder = attrs.placeholder;
   }
-  if (attrs["showingPlaceholder"]) {
+  if (attrs.showingPlaceholder) {
     properties.showingPlaceholder = true;
   }
-  if (attrs["dateFormat"]) {
-    properties.dateFormat = String(attrs["dateFormat"]);
+  if (attrs.dateFormat) {
+    properties.dateFormat = attrs.dateFormat;
   }
-  if (typeof attrs["listItems"] === "string" && attrs["listItems"]) {
-    const items = parseListItemsJson(attrs["listItems"]);
+  if (attrs.listItems) {
+    const items = parseListItemsJson(attrs.listItems);
     if (items) {
       properties.listItems = items;
     }
   }
-  if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
-    properties.checked = Boolean(attrs["checked"]);
+  if (typeof attrs.checked === "boolean") {
+    properties.checked = attrs.checked;
   }
-  if (typeof attrs["rawPropertiesXml"] === "string") {
-    properties.rawPropertiesXml = attrs["rawPropertiesXml"];
+  if (attrs.rawPropertiesXml) {
+    properties.rawPropertiesXml = attrs.rawPropertiesXml;
   }
-  if (typeof attrs["rawEndPropertiesXml"] === "string") {
-    properties.rawEndPropertiesXml = attrs["rawEndPropertiesXml"];
+  if (attrs.rawEndPropertiesXml) {
+    properties.rawEndPropertiesXml = attrs.rawEndPropertiesXml;
   }
 
   // Recursively materialize children. PM `blockSdt` content is `block+`, so a

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
@@ -15,6 +15,7 @@ import type {
   BlockSdt,
   DocumentBody,
 } from "../../types/document";
+import { schema } from "../schema";
 import { fromProseDoc } from "./fromProseDoc";
 import { toProseDoc } from "./toProseDoc";
 
@@ -74,6 +75,25 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     expect(recoveredSdt.properties.alias).toBe("Effective Date");
     // Unmodeled w:dataBinding survives because rawPropertiesXml round-trips.
     expect(recoveredSdt.properties.rawPropertiesXml).toContain("w:dataBinding");
+  });
+
+  test("preserves an explicit showingPlaceholder=false through the PM round-trip", () => {
+    // Regression: the conversion previously preserved only `true`, so a
+    // user filling a placeholder-bearing control via the widget path
+    // (which writes `showingPlaceholder: false`) would round-trip with
+    // `properties.showingPlaceholder = undefined`. `reconcileRawSdtPr`
+    // then never saw `false` and could not strip the source
+    // `<w:showingPlcHdr/>` from rawPropertiesXml, so Word reopened the
+    // doc still treating the filled body as placeholder text.
+    const sdt = schema.node(
+      "blockSdt",
+      { sdtType: "richText", tag: "name", showingPlaceholder: false },
+      [schema.node("paragraph", {}, [schema.text("Real value")])],
+    );
+    const pmDoc = schema.node("doc", null, [sdt]);
+    const recovered = fromProseDoc(pmDoc);
+    const ctrl = expectBlockSdt(recovered.package.document.content[0]);
+    expect(ctrl.properties.showingPlaceholder).toBe(false);
   });
 
   test("guarantees a trailing paragraph after a doc-final blockSdt (idempotent)", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
@@ -126,6 +126,29 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     expect(pmDoc2.childCount).toBe(1);
   });
 
+  test("preserves an authored <w:sdtContent><w:p/></w:sdtContent> on round-trip", () => {
+    // Codex P2 follow-up (PR #587): the previous shape-only heuristic
+    // couldn't tell synthetic filler from a real authored empty paragraph
+    // and silently dropped both. The fix marks blockSdt with
+    // `_originallyEmpty` only when the SOURCE content was actually empty,
+    // so an authored `<w:p/>` carries no marker and the paragraph
+    // survives.
+    const content = parseBody(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="authored-empty"/></w:sdtPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+    const pmDoc = toProseDoc(asDocument(content));
+    const recovered = fromProseDoc(pmDoc);
+    const sdt = recovered.package.document.content[0];
+    if (!sdt || sdt.type !== "blockSdt") {
+      throw new TypeError("expected blockSdt");
+    }
+    expect(sdt.content).toHaveLength(1);
+    expect(sdt.content[0]?.type).toBe("paragraph");
+  });
+
   test("round-trips an empty <w:sdtContent/> without adding a synthetic <w:p/>", () => {
     // Codex P2 (PR #587): toProseDoc inserts a synthetic empty paragraph
     // for any blockSdt whose source had `<w:sdtContent/>` because the

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
@@ -62,8 +62,11 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     </w:body>`);
 
     const pmDoc = toProseDoc(asDocument(content));
-    // First child is the blockSdt node, followed by an idempotent trailing
-    // paragraph (PM-side caret slot).
+    // First and only child is the blockSdt node. The caret affordance
+    // after a doc-final isolating SDT is provided at runtime by
+    // prosemirror-gapcursor — no synthetic paragraph is appended (it
+    // would otherwise survive the reverse pass and append a stray
+    // `<w:p/>` to the source DOCX on every save).
     expect(pmDoc.firstChild?.type.name).toBe("blockSdt");
     expect(pmDoc.firstChild?.attrs["tag"]).toBe("effective-date");
     expect(pmDoc.firstChild?.attrs["alias"]).toBe("Effective Date");
@@ -96,7 +99,14 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     expect(ctrl.properties.showingPlaceholder).toBe(false);
   });
 
-  test("guarantees a trailing paragraph after a doc-final blockSdt (idempotent)", () => {
+  test("does not inject a synthetic trailing paragraph after a doc-final blockSdt", () => {
+    // Codex P2 (PR #587): the converter previously appended an empty
+    // trailing paragraph to keep the caret reachable after a doc-final
+    // isolating SDT, but that paragraph survived the reverse pass and
+    // appended an extra `<w:p/>` to the DOCX on every save — visible
+    // blank space + pagination drift in legal templates. The caret
+    // affordance is now provided by prosemirror-gapcursor at runtime, so
+    // the converter emits only what the source described.
     const content = parseBody(`<w:body ${NS}>
       <w:sdt>
         <w:sdtPr><w:tag w:val="closing"/></w:sdtPr>
@@ -105,18 +115,15 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     </w:body>`);
 
     const pmDoc = toProseDoc(asDocument(content));
-    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.childCount).toBe(1);
     expect(pmDoc.child(0).type.name).toBe("blockSdt");
-    expect(pmDoc.child(1).type.name).toBe("paragraph");
-    expect(pmDoc.child(1).content.size).toBe(0);
 
-    // Round-trip the recovered doc again: the trailing paragraph should NOT
-    // accrete a second time (idempotence).
+    // Round-trip is now lossless: the recovered model has exactly one
+    // top-level block (the SDT), and a second toProseDoc keeps that shape.
     const recovered = fromProseDoc(pmDoc);
+    expect(recovered.package.document.content).toHaveLength(1);
     const pmDoc2 = toProseDoc(recovered);
-    // recovered.content has [blockSdt, paragraph]; the new pmDoc keeps that
-    // shape — no extra trailing paragraph added.
-    expect(pmDoc2.childCount).toBe(2);
+    expect(pmDoc2.childCount).toBe(1);
   });
 
   test("preserves nested block SDTs through the PM layer", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Conversion round-trip tests for block-level SDTs.
+ *
+ * Parses a body containing a block w:sdt, converts to ProseMirror, back to
+ * the model, then asserts the SDT properties + raw sdtPr round-trip through
+ * the PM layer.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseBlockContent } from "../../docx/blockContentParser";
+import { parseXml } from "../../docx/xmlParser";
+import type {
+  BlockContent,
+  BlockSdt,
+  DocumentBody,
+} from "../../types/document";
+import { fromProseDoc } from "./fromProseDoc";
+import { toProseDoc } from "./toProseDoc";
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml"';
+
+function parseBody(xml: string): BlockContent[] {
+  const root = parseXml(xml);
+  const body = root.elements?.[0];
+  if (!body) {
+    throw new Error("expected body root");
+  }
+  return parseBlockContent(body, null, null, null, null, null);
+}
+
+function asDocument(content: BlockContent[]) {
+  return {
+    package: {
+      document: { content } satisfies DocumentBody,
+    },
+  };
+}
+
+function expectBlockSdt(block: BlockContent | undefined): BlockSdt {
+  if (!block || block.type !== "blockSdt") {
+    throw new Error(`expected blockSdt, got ${String(block?.type)}`);
+  }
+  return block;
+}
+
+describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
+  test("emits a blockSdt PM node and recovers the BlockSdt model unchanged", () => {
+    const content = parseBody(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr>
+          <w:tag w:val="effective-date"/>
+          <w:alias w:val="Effective Date"/>
+          <w:dataBinding w:xpath="/contract/effective" w:storeItemID="{ABC}"/>
+        </w:sdtPr>
+        <w:sdtContent>
+          <w:p><w:r><w:t>2 June 2026</w:t></w:r></w:p>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+
+    const pmDoc = toProseDoc(asDocument(content));
+    // First child is the blockSdt node, followed by an idempotent trailing
+    // paragraph (PM-side caret slot).
+    expect(pmDoc.firstChild?.type.name).toBe("blockSdt");
+    expect(pmDoc.firstChild?.attrs["tag"]).toBe("effective-date");
+    expect(pmDoc.firstChild?.attrs["alias"]).toBe("Effective Date");
+    expect(typeof pmDoc.firstChild?.attrs["rawPropertiesXml"]).toBe("string");
+
+    const recovered = fromProseDoc(pmDoc);
+    const recoveredSdt = expectBlockSdt(recovered.package.document.content[0]);
+    expect(recoveredSdt.properties.tag).toBe("effective-date");
+    expect(recoveredSdt.properties.alias).toBe("Effective Date");
+    // Unmodeled w:dataBinding survives because rawPropertiesXml round-trips.
+    expect(recoveredSdt.properties.rawPropertiesXml).toContain("w:dataBinding");
+  });
+
+  test("guarantees a trailing paragraph after a doc-final blockSdt (idempotent)", () => {
+    const content = parseBody(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="closing"/></w:sdtPr>
+        <w:sdtContent><w:p/></w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+
+    const pmDoc = toProseDoc(asDocument(content));
+    expect(pmDoc.childCount).toBe(2);
+    expect(pmDoc.child(0).type.name).toBe("blockSdt");
+    expect(pmDoc.child(1).type.name).toBe("paragraph");
+    expect(pmDoc.child(1).content.size).toBe(0);
+
+    // Round-trip the recovered doc again: the trailing paragraph should NOT
+    // accrete a second time (idempotence).
+    const recovered = fromProseDoc(pmDoc);
+    const pmDoc2 = toProseDoc(recovered);
+    // recovered.content has [blockSdt, paragraph]; the new pmDoc keeps that
+    // shape — no extra trailing paragraph added.
+    expect(pmDoc2.childCount).toBe(2);
+  });
+
+  test("preserves nested block SDTs through the PM layer", () => {
+    const content = parseBody(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="outer"/></w:sdtPr>
+        <w:sdtContent>
+          <w:sdt>
+            <w:sdtPr><w:tag w:val="inner"/></w:sdtPr>
+            <w:sdtContent>
+              <w:p><w:r><w:t>inner</w:t></w:r></w:p>
+            </w:sdtContent>
+          </w:sdt>
+        </w:sdtContent>
+      </w:sdt>
+    </w:body>`);
+
+    const pmDoc = toProseDoc(asDocument(content));
+    const recovered = fromProseDoc(pmDoc);
+    const outer = expectBlockSdt(recovered.package.document.content[0]);
+    expect(outer.properties.tag).toBe("outer");
+    const inner = expectBlockSdt(outer.content[0]);
+    expect(inner.properties.tag).toBe("inner");
+  });
+});

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc-blockSdt.test.ts
@@ -126,6 +126,41 @@ describe("toProseDoc/fromProseDoc — blockSdt round-trip", () => {
     expect(pmDoc2.childCount).toBe(1);
   });
 
+  test("round-trips an empty <w:sdtContent/> without adding a synthetic <w:p/>", () => {
+    // Codex P2 (PR #587): toProseDoc inserts a synthetic empty paragraph
+    // for any blockSdt whose source had `<w:sdtContent/>` because the
+    // PM `block+` schema requires at least one child. Without the
+    // fromProseDoc guard, that synthetic paragraph survived the
+    // reverse pass and turned every empty control into
+    // `<w:sdtContent><w:p/></w:sdtContent>` — adding content Word did
+    // not emit.
+    const content = parseBody(`<w:body ${NS}>
+      <w:sdt>
+        <w:sdtPr><w:tag w:val="empty"/></w:sdtPr>
+        <w:sdtContent/>
+      </w:sdt>
+    </w:body>`);
+    const pmDoc = toProseDoc(asDocument(content));
+    expect(pmDoc.childCount).toBe(1);
+    expect(pmDoc.child(0).type.name).toBe("blockSdt");
+    // PM body has one filler paragraph (block+ constraint).
+    expect(pmDoc.child(0).childCount).toBe(1);
+    expect(pmDoc.child(0).firstChild?.type.name).toBe("paragraph");
+    expect(pmDoc.child(0).firstChild?.content.size).toBe(0);
+
+    // Round-trip: recovered model has content: [] again, and a second
+    // toProseDoc gives the same PM shape (idempotent).
+    const recovered = fromProseDoc(pmDoc);
+    const recoveredSdt = recovered.package.document.content[0];
+    if (!recoveredSdt || recoveredSdt.type !== "blockSdt") {
+      throw new TypeError("expected blockSdt");
+    }
+    expect(recoveredSdt.content).toHaveLength(0);
+    const pmDoc2 = toProseDoc(recovered);
+    expect(pmDoc2.childCount).toBe(1);
+    expect(pmDoc2.child(0).childCount).toBe(1);
+  });
+
   test("preserves nested block SDTs through the PM layer", () => {
     const content = parseBody(`<w:body ${NS}>
       <w:sdt>

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -120,16 +120,12 @@ export function toProseDoc(
 
   nodes.push(...convertBodyBlocks(paragraphs));
 
-  // Guarantee a trailing paragraph after a doc-final blockSdt so the caret is
-  // never trapped inside an isolating wrapper. Idempotent: skip if the doc
-  // already ends in an empty paragraph (so the trailing slot is not accreted
-  // across save cycles).
-  if (nodes.length > 0) {
-    const last = nodes.at(-1);
-    if (last?.type.name === "blockSdt") {
-      nodes.push(schema.node("paragraph", {}, []));
-    }
-  }
+  // Caret-after-final-SDT affordance is provided by `prosemirror-gapcursor`
+  // at runtime; we previously injected a trailing empty paragraph here so
+  // the caret was not trapped inside an isolating blockSdt, but the
+  // synthetic paragraph survived `fromProseDoc` on save and silently
+  // appended a `<w:p/>` to the DOCX on every round trip (which adds blank
+  // space and shifts pagination in legal templates).
 
   // Ensure we have at least one paragraph
   if (nodes.length === 0) {
@@ -2930,9 +2926,12 @@ export function headerFooterToProseDoc(
   };
 
   nodes.push(...convertBlocks(content));
-  if (nodes.length > 0 && nodes.at(-1)?.type.name === "blockSdt") {
-    nodes.push(schema.node("paragraph", {}, []));
-  }
+  // Caret affordance after a final isolating blockSdt is handled by
+  // prosemirror-gapcursor at runtime; we no longer pad the converted doc
+  // with a synthetic trailing paragraph because that paragraph survives
+  // the reverse pass and pollutes both round-trip saves and
+  // `setContentControlContent(filter, blocks)` callers that pass blocks
+  // ending in a nested blockSdt.
 
   if (nodes.length === 0) {
     nodes.push(schema.node("paragraph", {}, []));

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -18,6 +18,7 @@ import { createStyleEngine } from "../../style-engine";
 import type { StyleEngine } from "../../style-engine";
 import type {
   BlockContent,
+  BlockSdt,
   Document,
   Paragraph,
   Run,
@@ -89,46 +90,44 @@ export function toProseDoc(
   const theme = options?.theme ?? document.package.theme ?? null;
   let textBoxGroupIndex = 0;
 
-  // Until the PM `blockSdt` node lands, flatten block SDTs into their inner
-  // content so the editor still renders the inside of a content control.
-  // Properties + raw `w:sdtPr` are preserved on the document model and
-  // replayed on serialize, so the round-trip is still safe.
-  const flattenSdts = (blocks: BlockContent[]): (Paragraph | Table)[] => {
-    const flat: (Paragraph | Table)[] = [];
+  const convertBodyBlocks = (blocks: BlockContent[]): PMNode[] => {
+    const out: PMNode[] = [];
     for (const block of blocks) {
-      if (block.type === "blockSdt") {
-        flat.push(...flattenSdts(block.content));
+      if (block.type === "paragraph") {
+        const pbPos = paragraphPageBreakPosition(block);
+        if (pbPos === "before") {
+          out.push(schema.node("pageBreak"));
+        }
+        out.push(
+          ...convertParagraphWithTextBoxes(
+            block,
+            styleResolver,
+            String(textBoxGroupIndex),
+          ),
+        );
+        textBoxGroupIndex += 1;
+        if (pbPos === "after") {
+          out.push(schema.node("pageBreak"));
+        }
+      } else if (block.type === "table") {
+        out.push(convertTable(block, styleResolver, theme));
       } else {
-        flat.push(block);
+        out.push(convertBlockSdt(block, convertBodyBlocks));
       }
     }
-    return flat;
+    return out;
   };
 
-  for (const block of flattenSdts(paragraphs)) {
-    if (block.type === "paragraph") {
-      // Convert paragraph and extract text boxes as sibling nodes
-      // If the paragraph starts with a page break (before any text),
-      // emit the break BEFORE the paragraph so the text lands on the
-      // next page — matching Word's rendering.
-      const pbPos = paragraphPageBreakPosition(block);
-      if (pbPos === "before") {
-        nodes.push(schema.node("pageBreak"));
-      }
-      nodes.push(
-        ...convertParagraphWithTextBoxes(
-          block,
-          styleResolver,
-          String(textBoxGroupIndex),
-        ),
-      );
-      textBoxGroupIndex += 1;
-      if (pbPos === "after") {
-        nodes.push(schema.node("pageBreak"));
-      }
-    } else {
-      const pmTable = convertTable(block, styleResolver, theme);
-      nodes.push(pmTable);
+  nodes.push(...convertBodyBlocks(paragraphs));
+
+  // Guarantee a trailing paragraph after a doc-final blockSdt so the caret is
+  // never trapped inside an isolating wrapper. Idempotent: skip if the doc
+  // already ends in an empty paragraph (so the trailing slot is not accreted
+  // across save cycles).
+  if (nodes.length > 0) {
+    const last = nodes.at(-1);
+    if (last?.type.name === "blockSdt") {
+      nodes.push(schema.node("paragraph", {}, []));
     }
   }
 
@@ -143,6 +142,40 @@ export function toProseDoc(
     "Document conversion produced an invalid ProseMirror document",
   );
   return pmDoc;
+}
+
+/**
+ * Convert a `BlockSdt` model node into a `blockSdt` PM node, recursively
+ * converting its children with the caller-supplied block converter. Pass
+ * `rawPropertiesXml` / `rawEndPropertiesXml` through as attrs so the
+ * serializer can replay them verbatim after a save.
+ */
+function convertBlockSdt(
+  blockSdt: BlockSdt,
+  convertBlocks: (blocks: BlockContent[]) => PMNode[],
+): PMNode {
+  const props = blockSdt.properties;
+  const attrs: Record<string, unknown> = {
+    sdtType: props.sdtType,
+    alias: props.alias ?? null,
+    tag: props.tag ?? null,
+    id: props.id ?? null,
+    lock: props.lock ?? null,
+    placeholder: props.placeholder ?? null,
+    showingPlaceholder: props.showingPlaceholder ?? false,
+    dateFormat: props.dateFormat ?? null,
+    listItems: props.listItems ? JSON.stringify(props.listItems) : null,
+    checked: props.checked ?? null,
+    rawPropertiesXml: props.rawPropertiesXml ?? null,
+    rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,
+  };
+  const children = convertBlocks(blockSdt.content);
+  // ProseMirror `blockSdt` requires at least one block child; insert an empty
+  // paragraph for a truly empty control rather than producing an invalid node.
+  if (children.length === 0) {
+    children.push(schema.node("paragraph", {}, []));
+  }
+  return schema.node("blockSdt", attrs, children);
 }
 
 /**
@@ -2873,34 +2906,30 @@ export function headerFooterToProseDoc(
   const theme = options?.theme ?? null;
   let textBoxGroupIndex = 0;
 
-  // Until the PM `blockSdt` node lands, flatten block SDTs into their inner
-  // content so headers/footers still render. Properties / raw `w:sdtPr` are
-  // already preserved on the model and replayed by the HF serializer.
-  const flatten = (blocks: BlockContent[]): (Paragraph | Table)[] => {
-    const flat: (Paragraph | Table)[] = [];
+  const convertBlocks = (blocks: BlockContent[]): PMNode[] => {
+    const out: PMNode[] = [];
     for (const block of blocks) {
-      if (block.type === "blockSdt") {
-        flat.push(...flatten(block.content));
+      if (block.type === "paragraph") {
+        out.push(
+          ...convertParagraphWithTextBoxes(
+            block,
+            styleResolver,
+            String(textBoxGroupIndex),
+          ),
+        );
+        textBoxGroupIndex += 1;
+      } else if (block.type === "table") {
+        out.push(convertTable(block, styleResolver, theme));
       } else {
-        flat.push(block);
+        out.push(convertBlockSdt(block, convertBlocks));
       }
     }
-    return flat;
+    return out;
   };
 
-  for (const block of flatten(content)) {
-    if (block.type === "paragraph") {
-      nodes.push(
-        ...convertParagraphWithTextBoxes(
-          block,
-          styleResolver,
-          String(textBoxGroupIndex),
-        ),
-      );
-      textBoxGroupIndex += 1;
-    } else {
-      nodes.push(convertTable(block, styleResolver, theme));
-    }
+  nodes.push(...convertBlocks(content));
+  if (nodes.length > 0 && nodes.at(-1)?.type.name === "blockSdt") {
+    nodes.push(schema.node("paragraph", {}, []));
   }
 
   if (nodes.length === 0) {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -1894,6 +1894,7 @@ function convertInlineSdt(
       placeholder: props.placeholder ?? null,
       showingPlaceholder: props.showingPlaceholder ?? false,
       dateFormat: props.dateFormat ?? null,
+      dateValueISO: props.dateValueISO ?? null,
       listItems: props.listItems ? JSON.stringify(props.listItems) : null,
       checked: props.checked ?? null,
     },

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -164,6 +164,12 @@ function convertBlockSdt(
     listItems: props.listItems ? JSON.stringify(props.listItems) : null,
     dropdownLastValue: props.dropdownLastValue ?? null,
     checked: props.checked ?? null,
+    // Mark explicitly when the source content was empty. fromProseDoc reads
+    // this on save to drop the synthetic filler below — without an explicit
+    // marker we couldn't distinguish source `<w:sdtContent/>` (filler
+    // inserted here) from source `<w:sdtContent><w:p/></w:sdtContent>`
+    // (a real authored empty paragraph the user wants preserved).
+    _originallyEmpty: blockSdt.content.length === 0,
     rawPropertiesXml: props.rawPropertiesXml ?? null,
     rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,
   };

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -17,6 +17,7 @@ import type { MarkType, Node as PMNode } from "prosemirror-model";
 import { createStyleEngine } from "../../style-engine";
 import type { StyleEngine } from "../../style-engine";
 import type {
+  BlockContent,
   Document,
   Paragraph,
   Run,
@@ -88,7 +89,23 @@ export function toProseDoc(
   const theme = options?.theme ?? document.package.theme ?? null;
   let textBoxGroupIndex = 0;
 
-  for (const block of paragraphs) {
+  // Until the PM `blockSdt` node lands, flatten block SDTs into their inner
+  // content so the editor still renders the inside of a content control.
+  // Properties + raw `w:sdtPr` are preserved on the document model and
+  // replayed on serialize, so the round-trip is still safe.
+  const flattenSdts = (blocks: BlockContent[]): (Paragraph | Table)[] => {
+    const flat: (Paragraph | Table)[] = [];
+    for (const block of blocks) {
+      if (block.type === "blockSdt") {
+        flat.push(...flattenSdts(block.content));
+      } else {
+        flat.push(block);
+      }
+    }
+    return flat;
+  };
+
+  for (const block of flattenSdts(paragraphs)) {
     if (block.type === "paragraph") {
       // Convert paragraph and extract text boxes as sibling nodes
       // If the paragraph starts with a page break (before any text),
@@ -109,7 +126,7 @@ export function toProseDoc(
       if (pbPos === "after") {
         nodes.push(schema.node("pageBreak"));
       }
-    } else if (block.type === "table") {
+    } else {
       const pmTable = convertTable(block, styleResolver, theme);
       nodes.push(pmTable);
     }
@@ -2846,7 +2863,7 @@ function convertTextBox(
  * `convertTable` does not yet thread it (orthogonal upstream divergence).
  */
 export function headerFooterToProseDoc(
-  content: (Paragraph | Table)[],
+  content: BlockContent[],
   options?: ToProseDocOptions,
 ): PMNode {
   const nodes: PMNode[] = [];
@@ -2856,7 +2873,22 @@ export function headerFooterToProseDoc(
   const theme = options?.theme ?? null;
   let textBoxGroupIndex = 0;
 
-  for (const block of content) {
+  // Until the PM `blockSdt` node lands, flatten block SDTs into their inner
+  // content so headers/footers still render. Properties / raw `w:sdtPr` are
+  // already preserved on the model and replayed by the HF serializer.
+  const flatten = (blocks: BlockContent[]): (Paragraph | Table)[] => {
+    const flat: (Paragraph | Table)[] = [];
+    for (const block of blocks) {
+      if (block.type === "blockSdt") {
+        flat.push(...flatten(block.content));
+      } else {
+        flat.push(block);
+      }
+    }
+    return flat;
+  };
+
+  for (const block of flatten(content)) {
     if (block.type === "paragraph") {
       nodes.push(
         ...convertParagraphWithTextBoxes(

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -162,6 +162,7 @@ function convertBlockSdt(
     dateFormat: props.dateFormat ?? null,
     dateValueISO: props.dateValueISO ?? null,
     listItems: props.listItems ? JSON.stringify(props.listItems) : null,
+    dropdownLastValue: props.dropdownLastValue ?? null,
     checked: props.checked ?? null,
     rawPropertiesXml: props.rawPropertiesXml ?? null,
     rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -164,6 +164,7 @@ function convertBlockSdt(
     placeholder: props.placeholder ?? null,
     showingPlaceholder: props.showingPlaceholder ?? false,
     dateFormat: props.dateFormat ?? null,
+    dateValueISO: props.dateValueISO ?? null,
     listItems: props.listItems ? JSON.stringify(props.listItems) : null,
     checked: props.checked ?? null,
     rawPropertiesXml: props.rawPropertiesXml ?? null,

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -172,6 +172,8 @@ function convertBlockSdt(
     _originallyEmpty: blockSdt.content.length === 0,
     rawPropertiesXml: props.rawPropertiesXml ?? null,
     rawEndPropertiesXml: props.rawEndPropertiesXml ?? null,
+    rawSdtChildrenBeforeContent: props.rawSdtChildrenBeforeContent ?? null,
+    rawSdtChildrenAfterContent: props.rawSdtChildrenAfterContent ?? null,
   };
   const children = convertBlocks(blockSdt.content);
   // ProseMirror `blockSdt` requires at least one block child; insert an empty

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -59,6 +59,7 @@ import {
   DeletionExtension,
 } from "./marks/TrackedChangeExtensions";
 import { UnderlineExtension } from "./marks/UnderlineExtension";
+import { BlockSdtExtension } from "./nodes/BlockSdtExtension";
 import { FieldExtension } from "./nodes/FieldExtension";
 // Nodes
 import { HardBreakExtension } from "./nodes/HardBreakExtension";
@@ -160,6 +161,7 @@ export function createStarterKit(
   add("pageBreak", PageBreakExtension());
   add("field", FieldExtension());
   add("sdt", SdtExtension());
+  add("blockSdt", BlockSdtExtension());
   add("math", MathExtension());
 
   // Table (5 extensions grouped)

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -20,6 +20,7 @@ import { BidiShortcutExtension } from "./features/BidiShortcutExtension";
 import { ContentControlWidgetsExtension } from "./features/ContentControlWidgetsExtension";
 import { DropCursorExtension } from "./features/DropCursorExtension";
 import { EmptyParagraphFormatExtension } from "./features/EmptyParagraphFormatExtension";
+import { GapCursorExtension } from "./features/GapCursorExtension";
 import { ImageDragExtension } from "./features/ImageDragExtension";
 import { ImagePasteExtension } from "./features/ImagePasteExtension";
 // Features
@@ -158,6 +159,7 @@ export function createStarterKit(
   add("imageDrag", ImageDragExtension());
   add("imagePaste", ImagePasteExtension());
   add("dropCursor", DropCursorExtension());
+  add("gapCursor", GapCursorExtension());
   add("horizontalRule", HorizontalRuleExtension());
   add("pageBreak", PageBreakExtension());
   add("field", FieldExtension());

--- a/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
+++ b/packages/folio/src/core/prosemirror/extensions/StarterKit.ts
@@ -17,6 +17,7 @@ import { TextExtension } from "./core/TextExtension";
 import { BaseKeymapExtension } from "./features/BaseKeymapExtension";
 // oxlint-disable-next-line import/no-cycle
 import { BidiShortcutExtension } from "./features/BidiShortcutExtension";
+import { ContentControlWidgetsExtension } from "./features/ContentControlWidgetsExtension";
 import { DropCursorExtension } from "./features/DropCursorExtension";
 import { EmptyParagraphFormatExtension } from "./features/EmptyParagraphFormatExtension";
 import { ImageDragExtension } from "./features/ImageDragExtension";
@@ -189,6 +190,7 @@ export function createStarterKit(
   add("paraIdAllocator", ParaIdAllocatorExtension());
   add("paragraphChangeTracker", ParagraphChangeTrackerExtension());
   add("bidiShortcut", BidiShortcutExtension());
+  add("contentControlWidgets", ContentControlWidgetsExtension());
 
   return extensions;
 }

--- a/packages/folio/src/core/prosemirror/extensions/core/DocExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/core/DocExtension.ts
@@ -8,6 +8,7 @@ export const DocExtension = createNodeExtension({
   name: "doc",
   schemaNodeName: "doc",
   nodeSpec: {
-    content: "(paragraph | horizontalRule | pageBreak | table | textBox)+",
+    content:
+      "(paragraph | horizontalRule | pageBreak | table | textBox | blockSdt)+",
   },
 });

--- a/packages/folio/src/core/prosemirror/extensions/features/ContentControlWidgetsExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/ContentControlWidgetsExtension.ts
@@ -1,0 +1,23 @@
+/**
+ * Content-Control Widgets Extension — wires the interactive widget plugin
+ * into the editor so clicking inside a typed content control invokes the
+ * appropriate transaction.
+ *
+ * The plugin owns checkbox toggling outright; dropdown / date picker chrome
+ * is delegated to the editor shell via the `onWidgetEvent` callback (the
+ * shell renders the menu / picker and dispatches via `dispatchDropdownPick`
+ * / `dispatchDatePick`).
+ */
+
+import { createContentControlWidgetsPlugin } from "../../plugins/contentControlWidgets";
+import { createExtension } from "../create";
+import type { ExtensionRuntime } from "../types";
+
+export const ContentControlWidgetsExtension = createExtension({
+  name: "contentControlWidgets",
+  onSchemaReady(_ctx): ExtensionRuntime {
+    return {
+      plugins: [createContentControlWidgetsPlugin()],
+    };
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/features/GapCursorExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/features/GapCursorExtension.ts
@@ -1,0 +1,27 @@
+/**
+ * GapCursor Extension — provides a caret slot before / between / after
+ * isolating block nodes (notably `blockSdt`).
+ *
+ * Without gapcursor, a user cannot place the caret before a doc-starting
+ * SDT, between two adjacent SDTs, or after a doc-final SDT — the
+ * `isolating` boundary makes regular text selections refuse those
+ * positions. The prosemirror-gapcursor plugin paints a thin "gap" caret
+ * at those slots so the document stays fully navigable.
+ *
+ * The plugin also exposes `Backspace` / `Delete` handlers that join the
+ * gap into the neighbour when sensible.
+ */
+
+import { gapCursor } from "prosemirror-gapcursor";
+
+import { createExtension } from "../create";
+import type { ExtensionRuntime } from "../types";
+
+export const GapCursorExtension = createExtension({
+  name: "gapCursor",
+  onSchemaReady(_ctx): ExtensionRuntime {
+    return {
+      plugins: [gapCursor()],
+    };
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.test.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Schema-level tests for the blockSdt PM node.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { schema } from "../../schema";
+
+describe("blockSdt PM node", () => {
+  test("is registered in the schema with isolating + defining semantics", () => {
+    const nodeType = schema.nodes["blockSdt"];
+    if (!nodeType) {
+      throw new Error("blockSdt node not registered");
+    }
+    expect(nodeType.spec.isolating).toBe(true);
+    expect(nodeType.spec.defining).toBe(true);
+    expect(nodeType.spec.group).toBe("block");
+  });
+
+  test("doc accepts a blockSdt child", () => {
+    const para = schema.node("paragraph", {}, [
+      schema.text("inside the control"),
+    ]);
+    const blockSdt = schema.node(
+      "blockSdt",
+      { tag: "effective-date", sdtType: "richText" },
+      [para],
+    );
+    const doc = schema.node("doc", null, [blockSdt]);
+    expect(doc.firstChild?.type.name).toBe("blockSdt");
+    expect(doc.firstChild?.firstChild?.type.name).toBe("paragraph");
+    expect(doc.firstChild?.attrs["tag"]).toBe("effective-date");
+  });
+
+  test("blockSdt can nest another blockSdt", () => {
+    const inner = schema.node("blockSdt", { tag: "inner" }, [
+      schema.node("paragraph", {}, []),
+    ]);
+    const outer = schema.node("blockSdt", { tag: "outer" }, [inner]);
+    expect(outer.firstChild?.type.name).toBe("blockSdt");
+    expect(outer.firstChild?.attrs["tag"]).toBe("inner");
+  });
+
+  test("rawPropertiesXml and rawEndPropertiesXml round-trip via attrs", () => {
+    const raw = '<w:sdtPr><w:tag w:val="x"/></w:sdtPr>';
+    const rawEnd = "<w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr>";
+    const blockSdt = schema.node(
+      "blockSdt",
+      { rawPropertiesXml: raw, rawEndPropertiesXml: rawEnd },
+      [schema.node("paragraph", {}, [])],
+    );
+    expect(blockSdt.attrs["rawPropertiesXml"]).toBe(raw);
+    expect(blockSdt.attrs["rawEndPropertiesXml"]).toBe(rawEnd);
+  });
+});

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
@@ -1,0 +1,113 @@
+/**
+ * BlockSdt Extension — block-level content control node.
+ *
+ * Mirrors OOXML's block `w:sdt` wrapping paragraphs/tables. `isolating: true`
+ * keeps user edits scoped to the control (a backspace at the start of an
+ * inner paragraph cannot merge through the boundary into a sibling), and
+ * `defining: true` preserves the wrapper across split/lift.
+ *
+ * Attributes:
+ * - `sdtType` / `alias` / `tag` / `lock` / `placeholder` /
+ *   `showingPlaceholder` / `dateFormat` / `listItems` / `checked` — modeled
+ *   projection of `w:sdtPr`; drives addressing and widget UX.
+ * - `rawPropertiesXml` / `rawEndPropertiesXml` — verbatim original strings
+ *   so unmodeled OOXML features (`w:dataBinding`, `w15:repeatingSection`,
+ *   etc.) round-trip without being enumerated here.
+ */
+
+import { createNodeExtension } from "../create";
+
+export const BlockSdtExtension = createNodeExtension({
+  name: "blockSdt",
+  schemaNodeName: "blockSdt",
+  nodeSpec: {
+    group: "block",
+    content: "block+",
+    isolating: true,
+    defining: true,
+    attrs: {
+      sdtType: { default: "richText" },
+      alias: { default: null },
+      tag: { default: null },
+      id: { default: null },
+      lock: { default: null },
+      placeholder: { default: null },
+      showingPlaceholder: { default: false },
+      dateFormat: { default: null },
+      listItems: { default: null },
+      checked: { default: null },
+      rawPropertiesXml: { default: null },
+      rawEndPropertiesXml: { default: null },
+    },
+    parseDOM: [
+      {
+        tag: "div.docx-block-sdt",
+        getAttrs(dom) {
+          if (!(dom instanceof HTMLElement)) {
+            return false;
+          }
+          const checkedRaw = dom.dataset["checked"];
+          let checked: boolean | null = null;
+          if (checkedRaw === "true") {
+            checked = true;
+          } else if (checkedRaw === "false") {
+            checked = false;
+          }
+          const idRaw = dom.dataset["sdtId"];
+          const id = idRaw ? Number.parseInt(idRaw, 10) : null;
+          return {
+            sdtType: dom.dataset["sdtType"] ?? "richText",
+            alias: dom.dataset["alias"] ?? null,
+            tag: dom.dataset["tag"] ?? null,
+            id: id !== null && !Number.isNaN(id) ? id : null,
+            lock: dom.dataset["lock"] ?? null,
+            placeholder: dom.dataset["placeholder"] ?? null,
+            showingPlaceholder: dom.dataset["showingPlaceholder"] === "true",
+            dateFormat: dom.dataset["dateFormat"] ?? null,
+            listItems: dom.dataset["listItems"] ?? null,
+            checked,
+            // Raw XML is preserved on the model, not the DOM; consumers that
+            // round-trip through PM must re-attach it from the source.
+            rawPropertiesXml: null,
+            rawEndPropertiesXml: null,
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      const attrs = node.attrs;
+      const data: Record<string, string> = {
+        class: `docx-block-sdt docx-block-sdt-${String(attrs["sdtType"])}`,
+        "data-sdt-type": String(attrs["sdtType"]),
+      };
+      if (attrs["alias"]) {
+        data["data-alias"] = String(attrs["alias"]);
+      }
+      if (attrs["tag"]) {
+        data["data-tag"] = String(attrs["tag"]);
+      }
+      if (attrs["id"] !== null && attrs["id"] !== undefined) {
+        data["data-sdt-id"] = String(attrs["id"]);
+      }
+      if (attrs["lock"]) {
+        data["data-lock"] = String(attrs["lock"]);
+      }
+      if (attrs["placeholder"]) {
+        data["data-placeholder"] = String(attrs["placeholder"]);
+      }
+      if (attrs["showingPlaceholder"]) {
+        data["data-showing-placeholder"] = "true";
+      }
+      if (attrs["dateFormat"]) {
+        data["data-date-format"] = String(attrs["dateFormat"]);
+      }
+      if (attrs["listItems"]) {
+        data["data-list-items"] = String(attrs["listItems"]);
+      }
+      if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
+        data["data-checked"] = String(attrs["checked"]);
+      }
+      return ["div", data, 0];
+    },
+  },
+});

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
@@ -34,6 +34,8 @@ export const BlockSdtExtension = createNodeExtension({
       placeholder: { default: null },
       showingPlaceholder: { default: false },
       dateFormat: { default: null },
+      /** ISO 8601 bound date value (`w:date@w:fullDate`). */
+      dateValueISO: { default: null },
       listItems: { default: null },
       checked: { default: null },
       rawPropertiesXml: { default: null },
@@ -64,6 +66,7 @@ export const BlockSdtExtension = createNodeExtension({
             placeholder: dom.dataset["placeholder"] ?? null,
             showingPlaceholder: dom.dataset["showingPlaceholder"] === "true",
             dateFormat: dom.dataset["dateFormat"] ?? null,
+            dateValueISO: dom.dataset["dateValueIso"] ?? null,
             listItems: dom.dataset["listItems"] ?? null,
             checked,
             // Raw XML is preserved on the model, not the DOM; consumers that
@@ -100,6 +103,9 @@ export const BlockSdtExtension = createNodeExtension({
       }
       if (attrs["dateFormat"]) {
         data["data-date-format"] = String(attrs["dateFormat"]);
+      }
+      if (attrs["dateValueISO"]) {
+        data["data-date-value-iso"] = String(attrs["dateValueISO"]);
       }
       if (attrs["listItems"]) {
         data["data-list-items"] = String(attrs["listItems"]);

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
@@ -44,6 +44,15 @@ export const BlockSdtExtension = createNodeExtension({
        */
       dropdownLastValue: { default: null },
       checked: { default: null },
+      /**
+       * True when the source `<w:sdtContent/>` was empty. PM `block+`
+       * requires at least one child so `toProseDoc` inserts a synthetic
+       * filler paragraph; on save, `fromProseDoc` reads this flag to
+       * drop the filler when the body still matches the synthetic shape.
+       * Without the explicit marker we'd silently drop authored
+       * `<w:sdtContent><w:p/></w:sdtContent>` empty-paragraph content too.
+       */
+      _originallyEmpty: { default: false },
       rawPropertiesXml: { default: null },
       rawEndPropertiesXml: { default: null },
     },
@@ -76,6 +85,7 @@ export const BlockSdtExtension = createNodeExtension({
             listItems: dom.dataset["listItems"] ?? null,
             dropdownLastValue: dom.dataset["dropdownLastValue"] ?? null,
             checked,
+            _originallyEmpty: dom.dataset["originallyEmpty"] === "true",
             // Raw XML is preserved on the model, not the DOM; consumers that
             // round-trip through PM must re-attach it from the source.
             rawPropertiesXml: null,
@@ -122,6 +132,9 @@ export const BlockSdtExtension = createNodeExtension({
       }
       if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
         data["data-checked"] = String(attrs["checked"]);
+      }
+      if (attrs["_originallyEmpty"]) {
+        data["data-originally-empty"] = "true";
       }
       return ["div", data, 0];
     },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
@@ -55,6 +55,12 @@ export const BlockSdtExtension = createNodeExtension({
       _originallyEmpty: { default: false },
       rawPropertiesXml: { default: null },
       rawEndPropertiesXml: { default: null },
+      /**
+       * Verbatim XML for direct sdt siblings of sdtContent (range markers
+       * per MS-OE376 §2.5.2.30). Two slots so position is preserved.
+       */
+      rawSdtChildrenBeforeContent: { default: null },
+      rawSdtChildrenAfterContent: { default: null },
     },
     parseDOM: [
       {
@@ -90,6 +96,8 @@ export const BlockSdtExtension = createNodeExtension({
             // round-trip through PM must re-attach it from the source.
             rawPropertiesXml: null,
             rawEndPropertiesXml: null,
+            rawSdtChildrenBeforeContent: null,
+            rawSdtChildrenAfterContent: null,
           };
         },
       },

--- a/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/BlockSdtExtension.ts
@@ -37,6 +37,12 @@ export const BlockSdtExtension = createNodeExtension({
       /** ISO 8601 bound date value (`w:date@w:fullDate`). */
       dateValueISO: { default: null },
       listItems: { default: null },
+      /**
+       * Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`).
+       * Persisted independently of body display text so duplicate-label
+       * items round-trip to the right OOXML value on save.
+       */
+      dropdownLastValue: { default: null },
       checked: { default: null },
       rawPropertiesXml: { default: null },
       rawEndPropertiesXml: { default: null },
@@ -68,6 +74,7 @@ export const BlockSdtExtension = createNodeExtension({
             dateFormat: dom.dataset["dateFormat"] ?? null,
             dateValueISO: dom.dataset["dateValueIso"] ?? null,
             listItems: dom.dataset["listItems"] ?? null,
+            dropdownLastValue: dom.dataset["dropdownLastValue"] ?? null,
             checked,
             // Raw XML is preserved on the model, not the DOM; consumers that
             // round-trip through PM must re-attach it from the source.
@@ -109,6 +116,9 @@ export const BlockSdtExtension = createNodeExtension({
       }
       if (attrs["listItems"]) {
         data["data-list-items"] = String(attrs["listItems"]);
+      }
+      if (attrs["dropdownLastValue"]) {
+        data["data-dropdown-last-value"] = String(attrs["dropdownLastValue"]);
       }
       if (attrs["checked"] !== null && attrs["checked"] !== undefined) {
         data["data-checked"] = String(attrs["checked"]);

--- a/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
@@ -30,6 +30,8 @@ export const SdtExtension = createNodeExtension({
       showingPlaceholder: { default: false },
       /** Date format for date controls */
       dateFormat: { default: null },
+      /** ISO 8601 bound date value (`w:date@w:fullDate`). */
+      dateValueISO: { default: null },
       /** Dropdown/combobox list items as JSON string */
       listItems: { default: null },
       /** Checkbox checked state */
@@ -51,6 +53,7 @@ export const SdtExtension = createNodeExtension({
             placeholder: el.dataset["placeholder"] || null,
             showingPlaceholder: el.dataset["showingPlaceholder"] === "true",
             dateFormat: el.dataset["dateFormat"] || null,
+            dateValueISO: el.dataset["dateValueIso"] || null,
             listItems: el.dataset["listItems"] || null,
             checked: (() => {
               if (el.dataset["checked"] === "true") {
@@ -89,6 +92,9 @@ export const SdtExtension = createNodeExtension({
       }
       if (attrs.dateFormat) {
         dataAttrs["data-date-format"] = attrs.dateFormat;
+      }
+      if (attrs.dateValueISO) {
+        dataAttrs["data-date-value-iso"] = attrs.dateValueISO;
       }
       if (attrs.listItems) {
         dataAttrs["data-list-items"] = attrs.listItems;

--- a/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
+++ b/packages/folio/src/core/prosemirror/extensions/nodes/SdtExtension.ts
@@ -34,6 +34,8 @@ export const SdtExtension = createNodeExtension({
       dateValueISO: { default: null },
       /** Dropdown/combobox list items as JSON string */
       listItems: { default: null },
+      /** Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`). */
+      dropdownLastValue: { default: null },
       /** Checkbox checked state */
       checked: { default: null },
     },
@@ -55,6 +57,7 @@ export const SdtExtension = createNodeExtension({
             dateFormat: el.dataset["dateFormat"] || null,
             dateValueISO: el.dataset["dateValueIso"] || null,
             listItems: el.dataset["listItems"] || null,
+            dropdownLastValue: el.dataset["dropdownLastValue"] || null,
             checked: (() => {
               if (el.dataset["checked"] === "true") {
                 return true;
@@ -98,6 +101,9 @@ export const SdtExtension = createNodeExtension({
       }
       if (attrs.listItems) {
         dataAttrs["data-list-items"] = attrs.listItems;
+      }
+      if (attrs.dropdownLastValue) {
+        dataAttrs["data-dropdown-last-value"] = attrs.dropdownLastValue;
       }
       if (attrs.checked !== undefined) {
         dataAttrs["data-checked"] = String(attrs.checked);

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Smoke tests for the content-control widgets plugin.
+ *
+ * The plugin's primary side-effect is dispatching transactions when the
+ * user clicks inside a typed control. We exercise the helper functions
+ * directly here (the click handler runs through the same code path) and
+ * defer end-to-end DOM tests to Playwright.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { EditorState } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import { schema, singletonManager } from "../schema";
+import {
+  dispatchDatePick,
+  dispatchDropdownPick,
+} from "./contentControlWidgets";
+
+type StubView = Pick<EditorView, "state" | "dispatch">;
+
+function viewLike(stateRef: { state: EditorState }): StubView {
+  return {
+    state: stateRef.state,
+    dispatch(tr) {
+      stateRef.state = stateRef.state.apply(tr);
+    },
+  };
+}
+
+describe("dispatchDropdownPick", () => {
+  test("writes the picked value as the displayText", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+        listItems: JSON.stringify([
+          { value: "ca", displayText: "California" },
+          { value: "ny", displayText: "New York" },
+        ]),
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    // The helper expects an `EditorView`; only `state` and `dispatch` are
+    // touched here, so a structural stub satisfies the contract.
+    const ok = dispatchDropdownPick(viewLike(ref) as EditorView, "state", "ny");
+    expect(ok).toBe(true);
+    expect(ref.state.doc.firstChild?.firstChild?.textContent).toBe("New York");
+  });
+});
+
+describe("dispatchDatePick", () => {
+  test("writes the picked date into the control body", () => {
+    const sdt = schema.node("blockSdt", { sdtType: "date", tag: "effective" }, [
+      schema.node("paragraph", {}, []),
+    ]);
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    const ok = dispatchDatePick(
+      viewLike(ref) as EditorView,
+      "effective",
+      "2026-06-02",
+    );
+    expect(ok).toBe(true);
+    expect(ref.state.doc.firstChild?.firstChild?.textContent).toBe(
+      "2026-06-02",
+    );
+  });
+});

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
@@ -49,8 +49,9 @@ describe("dispatchDropdownPick", () => {
     });
     const ref = { state: initial };
     // The helper expects an `EditorView`; only `state` and `dispatch` are
-    // touched here, so a structural stub satisfies the contract.
-    const ok = dispatchDropdownPick(viewLike(ref) as EditorView, "state", "ny");
+    // touched here, so a structural stub satisfies the contract. The PM
+    // position of the SDT is 0 (it is the doc's first child).
+    const ok = dispatchDropdownPick(viewLike(ref) as EditorView, 0, "ny");
     expect(ok).toBe(true);
     expect(ref.state.doc.firstChild?.firstChild?.textContent).toBe("New York");
   });
@@ -67,11 +68,7 @@ describe("dispatchDatePick", () => {
       plugins: [...singletonManager.getPlugins()],
     });
     const ref = { state: initial };
-    const ok = dispatchDatePick(
-      viewLike(ref) as EditorView,
-      "effective",
-      "2026-06-02",
-    );
+    const ok = dispatchDatePick(viewLike(ref) as EditorView, 0, "2026-06-02");
     expect(ok).toBe(true);
     expect(ref.state.doc.firstChild?.firstChild?.textContent).toBe(
       "2026-06-02",

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.test.ts
@@ -57,7 +57,62 @@ describe("dispatchDropdownPick", () => {
   });
 });
 
+describe("dispatchDropdownPick — lock handling", () => {
+  test("returns false instead of throwing when the picked control is locked", () => {
+    // The click-time preflight should have caught this, but the doc could
+    // have changed mid-picker. The dispatch helper must not let a
+    // ContentControlLockedError escape into the React handler — that
+    // would surface as an uncaught UI error and crash the picker shell.
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "dropdown",
+        tag: "state",
+        lock: "contentLocked",
+        listItems: JSON.stringify([{ value: "ca", displayText: "California" }]),
+      },
+      [schema.node("paragraph", {}, [schema.text("☐")])],
+    );
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    expect(() =>
+      dispatchDropdownPick(viewLike(ref) as EditorView, 0, "ca"),
+    ).not.toThrow();
+    expect(dispatchDropdownPick(viewLike(ref) as EditorView, 0, "ca")).toBe(
+      false,
+    );
+  });
+});
+
 describe("dispatchDatePick", () => {
+  test("returns false instead of throwing when the picked control is locked", () => {
+    const sdt = schema.node(
+      "blockSdt",
+      {
+        sdtType: "date",
+        tag: "effective",
+        lock: "sdtContentLocked",
+      },
+      [schema.node("paragraph", {}, [])],
+    );
+    const initial = EditorState.create({
+      doc: schema.node("doc", null, [sdt]),
+      schema,
+      plugins: [...singletonManager.getPlugins()],
+    });
+    const ref = { state: initial };
+    expect(() =>
+      dispatchDatePick(viewLike(ref) as EditorView, 0, "2026-06-02"),
+    ).not.toThrow();
+    expect(dispatchDatePick(viewLike(ref) as EditorView, 0, "2026-06-02")).toBe(
+      false,
+    );
+  });
+
   test("writes the picked date into the control body", () => {
     const sdt = schema.node("blockSdt", { sdtType: "date", tag: "effective" }, [
       schema.node("paragraph", {}, []),

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
@@ -38,6 +38,18 @@ export type ContentControlWidgetEvent =
       tag: string;
       anchor: HTMLElement;
       currentValue: string | undefined;
+    }
+  | {
+      /**
+       * The plugin refused a click because the control's `w:lock` or type
+       * forbade the interaction. The shell decides how to surface this —
+       * toast, telemetry, or no-op. The plugin itself never logs.
+       */
+      kind: "refused";
+      tag: string;
+      sdtType: string;
+      anchor: HTMLElement;
+      error: ContentControlLockedError | ContentControlTypeError;
     };
 
 export type ContentControlWidgetCallback = (
@@ -47,6 +59,17 @@ export type ContentControlWidgetCallback = (
 export const contentControlWidgetsPluginKey = new PluginKey<unknown>(
   "contentControlWidgets",
 );
+
+/**
+ * CustomEvent name dispatched on the editor view DOM whenever the plugin
+ * needs to surface a `ContentControlWidgetEvent` to the React shell. The
+ * shell subscribes via `addEventListener` and renders the matching chrome.
+ *
+ * Using a CustomEvent keeps the plugin from owning a React reference and
+ * makes the host's responsibility explicit: receive event → render UI →
+ * call dispatchDropdownPick / dispatchDatePick.
+ */
+export const CONTENT_CONTROL_WIDGET_EVENT_NAME = "folio:content-control-widget";
 
 function findSdtAncestor(target: EventTarget | null): HTMLElement | null {
   if (!(target instanceof Element)) {
@@ -58,6 +81,18 @@ function findSdtAncestor(target: EventTarget | null): HTMLElement | null {
 export function createContentControlWidgetsPlugin(
   onEvent: ContentControlWidgetCallback = () => undefined,
 ): Plugin {
+  const emit = (
+    view: { dom: HTMLElement },
+    payload: ContentControlWidgetEvent,
+  ): void => {
+    onEvent(payload);
+    view.dom.dispatchEvent(
+      new CustomEvent(CONTENT_CONTROL_WIDGET_EVENT_NAME, {
+        detail: payload,
+        bubbles: true,
+      }),
+    );
+  };
   return new Plugin({
     key: contentControlWidgetsPluginKey,
     props: {
@@ -92,7 +127,7 @@ export function createContentControlWidgetsPlugin(
                 return true;
               }
             } else if (sdtType === "dropdown" || sdtType === "comboBox") {
-              onEvent({
+              emit(view, {
                 kind: "dropdownOpen",
                 tag,
                 sdtType,
@@ -102,7 +137,7 @@ export function createContentControlWidgetsPlugin(
               event.preventDefault();
               return true;
             } else if (sdtType === "date") {
-              onEvent({
+              emit(view, {
                 kind: "datePick",
                 tag,
                 anchor,
@@ -116,10 +151,11 @@ export function createContentControlWidgetsPlugin(
               error instanceof ContentControlLockedError ||
               error instanceof ContentControlTypeError
             ) {
-              // Refusal is expected — log to console for debugging but do
-              // not break the editor or surface a runtime crash.
-              // oxlint-disable-next-line no-console
-              console.warn("[content-controls]", error.message);
+              // Refusal is expected — emit it through the typed callback
+              // and let the editor shell decide what to do (toast,
+              // analytics, no-op). The plugin itself stays silent so
+              // refusals never end up as ad-hoc console noise.
+              emit(view, { kind: "refused", tag, sdtType, anchor, error });
               return true;
             }
             throw error;

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
@@ -136,6 +136,19 @@ export function createContentControlWidgetsPlugin(
                 return true;
               }
             } else if (sdtType === "dropdown" || sdtType === "comboBox") {
+              const refusal = lockRefusalFor(view, pmPos);
+              if (refusal) {
+                emit(view, {
+                  kind: "refused",
+                  tag,
+                  pmPos,
+                  sdtType,
+                  anchor,
+                  error: refusal,
+                });
+                event.preventDefault();
+                return true;
+              }
               emit(view, {
                 kind: "dropdownOpen",
                 tag,
@@ -147,6 +160,19 @@ export function createContentControlWidgetsPlugin(
               event.preventDefault();
               return true;
             } else if (sdtType === "date") {
+              const refusal = lockRefusalFor(view, pmPos);
+              if (refusal) {
+                emit(view, {
+                  kind: "refused",
+                  tag,
+                  pmPos,
+                  sdtType,
+                  anchor,
+                  error: refusal,
+                });
+                event.preventDefault();
+                return true;
+              }
               emit(view, {
                 kind: "datePick",
                 tag,
@@ -207,19 +233,33 @@ export function dispatchDropdownPick(
   if (!match) {
     return false;
   }
-  const tr = setContentControlValueTr(
-    view.state,
-    { pmPos },
-    {
-      kind: "dropdown",
-      value,
-    },
-  );
-  if (!tr) {
-    return false;
+  try {
+    const tr = setContentControlValueTr(
+      view.state,
+      { pmPos },
+      {
+        kind: "dropdown",
+        value,
+      },
+    );
+    if (!tr) {
+      return false;
+    }
+    view.dispatch(tr);
+    return true;
+  } catch (error) {
+    // The click-time preflight should have caught lock refusals, but the
+    // doc could have changed mid-picker. Swallow the typed refusal so the
+    // React UI does not crash; return false so the caller knows the
+    // change was rejected.
+    if (
+      error instanceof ContentControlLockedError ||
+      error instanceof ContentControlTypeError
+    ) {
+      return false;
+    }
+    throw error;
   }
-  view.dispatch(tr);
-  return true;
 }
 
 export function dispatchDatePick(
@@ -227,17 +267,56 @@ export function dispatchDatePick(
   pmPos: number,
   date: string,
 ): boolean {
-  const tr = setContentControlValueTr(
-    view.state,
-    { pmPos },
-    {
-      kind: "date",
-      date,
-    },
-  );
-  if (!tr) {
-    return false;
+  try {
+    const tr = setContentControlValueTr(
+      view.state,
+      { pmPos },
+      {
+        kind: "date",
+        date,
+      },
+    );
+    if (!tr) {
+      return false;
+    }
+    view.dispatch(tr);
+    return true;
+  } catch (error) {
+    if (
+      error instanceof ContentControlLockedError ||
+      error instanceof ContentControlTypeError
+    ) {
+      return false;
+    }
+    throw error;
   }
-  view.dispatch(tr);
-  return true;
+}
+
+/**
+ * Look up the clicked SDT by pmPos and return a typed refusal when the
+ * lock state forbids content mutation (`contentLocked`,
+ * `sdtContentLocked`). Returning `null` means "go ahead and open the
+ * picker." Preflight at click time so locked dropdowns / date pickers
+ * don't flash open just to close again when the user makes a selection.
+ */
+function lockRefusalFor(
+  view: EditorView,
+  pmPos: number,
+): ContentControlLockedError | null {
+  const match = findBlockSdtMatch(view.state.doc, { pmPos });
+  if (!match) {
+    return null;
+  }
+  const lock = match.node.attrs["lock"];
+  if (lock !== "contentLocked" && lock !== "sdtContentLocked") {
+    return null;
+  }
+  const tag = match.node.attrs["tag"];
+  const alias = match.node.attrs["alias"];
+  return new ContentControlLockedError({
+    message: `Control "${tag ?? alias ?? "(unnamed)"}" has w:lock=${lock}.`,
+    lock,
+    ...(typeof tag === "string" ? { tag } : {}),
+    ...(typeof alias === "string" ? { alias } : {}),
+  });
 }

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
@@ -1,0 +1,185 @@
+/**
+ * Interactive content-control widget delegation.
+ *
+ * Painted blocks inside a typed SDT carry `data-sdt-type` (checkbox /
+ * dropdown / date) and `data-sdt-tag` thanks to `applySdtDataAttrs`. This
+ * plugin watches editor-region clicks: when the user clicks inside a typed
+ * control it dispatches the appropriate `setContentControlValueTr` so the
+ * mutation goes through the normal undo stack.
+ *
+ * The checkbox path is fully wired (a click toggles the modeled state and
+ * the rendered glyph). Dropdown and date paths emit the dispatch hook so the
+ * higher-level UI (a popover menu / date picker rendered by the editor
+ * shell) can subscribe; the plugin does not own the menu/picker chrome.
+ */
+
+import { Plugin, PluginKey } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+
+import {
+  ContentControlLockedError,
+  ContentControlTypeError,
+} from "../../content-controls";
+import {
+  findBlockSdtMatch,
+  setContentControlValueTr,
+} from "../commands/contentControls";
+
+export type ContentControlWidgetEvent =
+  | {
+      kind: "dropdownOpen";
+      tag: string;
+      sdtType: "dropdown" | "comboBox";
+      anchor: HTMLElement;
+      listItemsJson: string | undefined;
+    }
+  | {
+      kind: "datePick";
+      tag: string;
+      anchor: HTMLElement;
+      currentValue: string | undefined;
+    };
+
+export type ContentControlWidgetCallback = (
+  event: ContentControlWidgetEvent,
+) => void;
+
+export const contentControlWidgetsPluginKey = new PluginKey<unknown>(
+  "contentControlWidgets",
+);
+
+function findSdtAncestor(target: EventTarget | null): HTMLElement | null {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  return target.closest<HTMLElement>("[data-sdt-type]");
+}
+
+export function createContentControlWidgetsPlugin(
+  onEvent: ContentControlWidgetCallback = () => undefined,
+): Plugin {
+  return new Plugin({
+    key: contentControlWidgetsPluginKey,
+    props: {
+      handleDOMEvents: {
+        click(view, event) {
+          const anchor = findSdtAncestor(event.target);
+          if (!anchor) {
+            return false;
+          }
+          const tag = anchor.dataset["sdtTag"];
+          const sdtType = anchor.dataset["sdtType"];
+          if (!tag || !sdtType) {
+            return false;
+          }
+          // The lock check happens inside the transaction helper; we just
+          // surface the click intent. Errors thrown by the helper are
+          // caught here so the editor stays interactive even on refusal.
+          try {
+            if (sdtType === "checkbox") {
+              const current = anchor.dataset["sdtChecked"] === "true";
+              const tr = setContentControlValueTr(
+                view.state,
+                { tag },
+                {
+                  kind: "checkbox",
+                  checked: !current,
+                },
+              );
+              if (tr) {
+                view.dispatch(tr);
+                event.preventDefault();
+                return true;
+              }
+            } else if (sdtType === "dropdown" || sdtType === "comboBox") {
+              onEvent({
+                kind: "dropdownOpen",
+                tag,
+                sdtType,
+                anchor,
+                listItemsJson: anchor.dataset["sdtListItems"],
+              });
+              event.preventDefault();
+              return true;
+            } else if (sdtType === "date") {
+              onEvent({
+                kind: "datePick",
+                tag,
+                anchor,
+                currentValue: undefined,
+              });
+              event.preventDefault();
+              return true;
+            }
+          } catch (error) {
+            if (
+              error instanceof ContentControlLockedError ||
+              error instanceof ContentControlTypeError
+            ) {
+              // Refusal is expected — log to console for debugging but do
+              // not break the editor or surface a runtime crash.
+              // oxlint-disable-next-line no-console
+              console.warn("[content-controls]", error.message);
+              return true;
+            }
+            throw error;
+          }
+          return false;
+        },
+      },
+    },
+    view() {
+      // Resolves the helper at plugin-find time so the picker shell can
+      // dispatch a tx by tag without re-implementing the lock/type rules.
+      return {};
+    },
+  });
+}
+
+/**
+ * Stable resolver helpers exposed for the UI shell so a popover menu or
+ * date picker can dispatch the same transaction the plugin would.
+ */
+export function dispatchDropdownPick(
+  view: EditorView,
+  tag: string,
+  value: string,
+): boolean {
+  const match = findBlockSdtMatch(view.state.doc, { tag });
+  if (!match) {
+    return false;
+  }
+  const tr = setContentControlValueTr(
+    view.state,
+    { tag },
+    {
+      kind: "dropdown",
+      value,
+    },
+  );
+  if (!tr) {
+    return false;
+  }
+  view.dispatch(tr);
+  return true;
+}
+
+export function dispatchDatePick(
+  view: EditorView,
+  tag: string,
+  date: string,
+): boolean {
+  const tr = setContentControlValueTr(
+    view.state,
+    { tag },
+    {
+      kind: "date",
+      date,
+    },
+  );
+  if (!tr) {
+    return false;
+  }
+  view.dispatch(tr);
+  return true;
+}

--- a/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
+++ b/packages/folio/src/core/prosemirror/plugins/contentControlWidgets.ts
@@ -29,6 +29,8 @@ export type ContentControlWidgetEvent =
   | {
       kind: "dropdownOpen";
       tag: string;
+      /** PM position of the clicked SDT instance — disambiguates duplicates. */
+      pmPos: number;
       sdtType: "dropdown" | "comboBox";
       anchor: HTMLElement;
       listItemsJson: string | undefined;
@@ -36,6 +38,7 @@ export type ContentControlWidgetEvent =
   | {
       kind: "datePick";
       tag: string;
+      pmPos: number;
       anchor: HTMLElement;
       currentValue: string | undefined;
     }
@@ -47,6 +50,7 @@ export type ContentControlWidgetEvent =
        */
       kind: "refused";
       tag: string;
+      pmPos: number;
       sdtType: string;
       anchor: HTMLElement;
       error: ContentControlLockedError | ContentControlTypeError;
@@ -102,9 +106,14 @@ export function createContentControlWidgetsPlugin(
           if (!anchor) {
             return false;
           }
-          const tag = anchor.dataset["sdtTag"];
+          const tag = anchor.dataset["sdtTag"] ?? "";
           const sdtType = anchor.dataset["sdtType"];
-          if (!tag || !sdtType) {
+          // pmPos is what addresses the clicked instance unambiguously. The
+          // painter stamps it from the SdtGroup; tag is kept on the event
+          // for telemetry but is no longer the addressing key.
+          const pmPosRaw = anchor.dataset["sdtPmPos"];
+          const pmPos = pmPosRaw ? Number.parseInt(pmPosRaw, 10) : Number.NaN;
+          if (!sdtType || Number.isNaN(pmPos)) {
             return false;
           }
           // The lock check happens inside the transaction helper; we just
@@ -115,7 +124,7 @@ export function createContentControlWidgetsPlugin(
               const current = anchor.dataset["sdtChecked"] === "true";
               const tr = setContentControlValueTr(
                 view.state,
-                { tag },
+                { pmPos },
                 {
                   kind: "checkbox",
                   checked: !current,
@@ -130,6 +139,7 @@ export function createContentControlWidgetsPlugin(
               emit(view, {
                 kind: "dropdownOpen",
                 tag,
+                pmPos,
                 sdtType,
                 anchor,
                 listItemsJson: anchor.dataset["sdtListItems"],
@@ -140,6 +150,7 @@ export function createContentControlWidgetsPlugin(
               emit(view, {
                 kind: "datePick",
                 tag,
+                pmPos,
                 anchor,
                 currentValue: undefined,
               });
@@ -155,7 +166,14 @@ export function createContentControlWidgetsPlugin(
               // and let the editor shell decide what to do (toast,
               // analytics, no-op). The plugin itself stays silent so
               // refusals never end up as ad-hoc console noise.
-              emit(view, { kind: "refused", tag, sdtType, anchor, error });
+              emit(view, {
+                kind: "refused",
+                tag,
+                pmPos,
+                sdtType,
+                anchor,
+                error,
+              });
               return true;
             }
             throw error;
@@ -175,19 +193,23 @@ export function createContentControlWidgetsPlugin(
 /**
  * Stable resolver helpers exposed for the UI shell so a popover menu or
  * date picker can dispatch the same transaction the plugin would.
+ *
+ * Both take the PM `pmPos` of the clicked SDT (from the widget event's
+ * `pmPos` field) so the dispatch lands on the exact instance the user
+ * interacted with — duplicate-tag SDTs are no longer ambiguous.
  */
 export function dispatchDropdownPick(
   view: EditorView,
-  tag: string,
+  pmPos: number,
   value: string,
 ): boolean {
-  const match = findBlockSdtMatch(view.state.doc, { tag });
+  const match = findBlockSdtMatch(view.state.doc, { pmPos });
   if (!match) {
     return false;
   }
   const tr = setContentControlValueTr(
     view.state,
-    { tag },
+    { pmPos },
     {
       kind: "dropdown",
       value,
@@ -202,12 +224,12 @@ export function dispatchDropdownPick(
 
 export function dispatchDatePick(
   view: EditorView,
-  tag: string,
+  pmPos: number,
   date: string,
 ): boolean {
   const tr = setContentControlValueTr(
     view.state,
-    { tag },
+    { pmPos },
     {
       kind: "date",
       date,

--- a/packages/folio/src/core/prosemirror/schema/index.ts
+++ b/packages/folio/src/core/prosemirror/schema/index.ts
@@ -19,6 +19,7 @@ export type {
   ImagePositionAttrs,
   MathAttrs,
   SdtAttrs,
+  BlockSdtAttrs,
   ShapeAttrs,
   TableAttrs,
   TableRowAttrs,

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -361,6 +361,10 @@ export type BlockSdtAttrs = {
   rawPropertiesXml?: string;
   /** Captured `<w:sdtEndPr>…</w:sdtEndPr>` for round-trip replay. */
   rawEndPropertiesXml?: string;
+  /** Verbatim XML for sdt siblings before sdtContent (range markers). */
+  rawSdtChildrenBeforeContent?: string;
+  /** Verbatim XML for sdt siblings after sdtContent (range markers). */
+  rawSdtChildrenAfterContent?: string;
 };
 
 /**

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -326,6 +326,30 @@ export type SdtAttrs = {
 };
 
 /**
+ * Block-level structured document tag node attributes. Mirrors `SdtAttrs`
+ * plus an optional numeric `w:id` and the verbatim `w:sdtPr`/`w:sdtEndPr`
+ * strings captured by the parser for lossless round-trip.
+ */
+export type BlockSdtAttrs = {
+  sdtType: SdtType;
+  alias?: string;
+  tag?: string;
+  /** Numeric `w:id/@w:val`. */
+  id?: number;
+  lock?: NonNullable<SdtProperties["lock"]>;
+  placeholder?: string;
+  showingPlaceholder?: boolean;
+  dateFormat?: string;
+  /** Dropdown/combobox list items as JSON string. */
+  listItems?: string;
+  checked?: boolean;
+  /** Captured `<w:sdtPr>…</w:sdtPr>` for round-trip replay. */
+  rawPropertiesXml?: string;
+  /** Captured `<w:sdtEndPr>…</w:sdtEndPr>` for round-trip replay. */
+  rawEndPropertiesXml?: string;
+};
+
+/**
  * Shape node attributes
  */
 export type ShapeAttrs = {

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -319,6 +319,8 @@ export type SdtAttrs = {
   showingPlaceholder?: boolean;
   /** Date format for date controls */
   dateFormat?: string;
+  /** ISO 8601 bound date value (`w:date@w:fullDate`). */
+  dateValueISO?: string;
   /** Dropdown/combobox list items as JSON string */
   listItems?: string;
   /** Checkbox checked state */

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -323,6 +323,8 @@ export type SdtAttrs = {
   dateValueISO?: string;
   /** Dropdown/combobox list items as JSON string */
   listItems?: string;
+  /** Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`). */
+  dropdownLastValue?: string;
   /** Checkbox checked state */
   checked?: boolean;
 };
@@ -346,6 +348,8 @@ export type BlockSdtAttrs = {
   dateValueISO?: string;
   /** Dropdown/combobox list items as JSON string. */
   listItems?: string;
+  /** Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`). */
+  dropdownLastValue?: string;
   checked?: boolean;
   /** Captured `<w:sdtPr>…</w:sdtPr>` for round-trip replay. */
   rawPropertiesXml?: string;

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -340,6 +340,8 @@ export type BlockSdtAttrs = {
   placeholder?: string;
   showingPlaceholder?: boolean;
   dateFormat?: string;
+  /** ISO 8601 bound date value (`w:date@w:fullDate`). */
+  dateValueISO?: string;
   /** Dropdown/combobox list items as JSON string. */
   listItems?: string;
   checked?: boolean;

--- a/packages/folio/src/core/prosemirror/schema/nodes.ts
+++ b/packages/folio/src/core/prosemirror/schema/nodes.ts
@@ -351,6 +351,12 @@ export type BlockSdtAttrs = {
   /** Selected dropdown / comboBox value (`w:dropDownList@w:lastValue`). */
   dropdownLastValue?: string;
   checked?: boolean;
+  /**
+   * Marker: source had empty `<w:sdtContent/>`. `toProseDoc` inserts a
+   * filler paragraph to satisfy PM's `block+`; on save the converter
+   * uses this flag to drop the filler instead of guessing from shape.
+   */
+  _originallyEmpty?: boolean;
   /** Captured `<w:sdtPr>…</w:sdtPr>` for round-trip replay. */
   rawPropertiesXml?: string;
   /** Captured `<w:sdtEndPr>…</w:sdtEndPr>` for round-trip replay. */

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -14,6 +14,7 @@ import {
   readHyperlinkMarkAttrs,
   readImageAttrs,
   readMathAttrs,
+  readBlockSdtAttrs,
   readParagraphAttrs,
   readRunFormattingOverrideMarkAttrs,
   readSdtAttrs,
@@ -171,9 +172,10 @@ const validateNodeAttrs = (
       return;
 
     case "blockSdt":
-      // blockSdt attrs are passthrough projections of SdtProperties + raw
-      // sdtPr strings; the schema enforces shape, and we accept additional
-      // unknown OOXML markers carried only by rawPropertiesXml.
+      // Validate attrs through the typed reader so malformed projections
+      // (wrong sdtType, non-string rawPropertiesXml, etc.) surface here
+      // instead of leaking into the serializer or downstream consumers.
+      appendAttrIssues(path, readBlockSdtAttrs(node), issues);
       for (let i = 0; i < node.childCount; i += 1) {
         validateNode(node.child(i), `${path}.content[${i}]`, issues);
       }

--- a/packages/folio/src/core/prosemirror/validation.ts
+++ b/packages/folio/src/core/prosemirror/validation.ts
@@ -170,6 +170,15 @@ const validateNodeAttrs = (
       appendAttrIssues(path, readSdtAttrs(node), issues);
       return;
 
+    case "blockSdt":
+      // blockSdt attrs are passthrough projections of SdtProperties + raw
+      // sdtPr strings; the schema enforces shape, and we accept additional
+      // unknown OOXML markers carried only by rawPropertiesXml.
+      for (let i = 0; i < node.childCount; i += 1) {
+        validateNode(node.child(i), `${path}.content[${i}]`, issues);
+      }
+      return;
+
     case "shape":
       appendAttrIssues(path, readShapeAttrs(node), issues);
       return;

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -795,3 +795,29 @@
     transparent
   );
 }
+
+/* ============================================================================
+   prosemirror-gapcursor — caret slots before/between/after isolating blocks
+   ============================================================================ */
+.ProseMirror-gapcursor {
+  display: none;
+  pointer-events: none;
+  position: absolute;
+}
+.ProseMirror-gapcursor::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: -2px;
+  width: 20px;
+  border-top: 1px solid var(--doc-text, currentcolor);
+  animation: folio-gapcursor-blink 1.1s linear infinite;
+}
+@keyframes folio-gapcursor-blink {
+  to {
+    visibility: hidden;
+  }
+}
+.ProseMirror-focused .ProseMirror-gapcursor {
+  display: block;
+}

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -790,11 +790,16 @@
 }
 /* Multi-block SDTs paint as a single continuous outline: the top edge sits
    on the first block, the bottom edge on the last, and the sides span the
-   middle. `only` and the unmarked legacy case keep the full closed box. */
+   middle. `only` and the unmarked legacy case keep the full closed box.
+   Use logical corner properties so the rounded corners stay on the
+   inline-leading/trailing sides regardless of writing-mode / RTL. */
 .layout-page-content
   [data-sdt-boundary="true"][data-sdt-position="first"]::before {
   border-bottom-width: 0;
-  border-radius: 2px 2px 0 0;
+  border-start-start-radius: 2px;
+  border-start-end-radius: 2px;
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
 }
 .layout-page-content
   [data-sdt-boundary="true"][data-sdt-position="middle"]::before {
@@ -805,7 +810,10 @@
 .layout-page-content
   [data-sdt-boundary="true"][data-sdt-position="last"]::before {
   border-top-width: 0;
-  border-radius: 0 0 2px 2px;
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+  border-end-start-radius: 2px;
+  border-end-end-radius: 2px;
 }
 .layout-page-content
   [data-sdt-boundary="true"][data-sdt-position="only"]::before,

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -782,10 +782,36 @@
   content: "";
   position: absolute;
   inset: -2px -4px;
-  border: 1px dashed transparent;
-  border-radius: 2px;
+  border-style: dashed;
+  border-width: 1px;
+  border-color: transparent;
   pointer-events: none;
   transition: border-color 120ms ease-out;
+}
+/* Multi-block SDTs paint as a single continuous outline: the top edge sits
+   on the first block, the bottom edge on the last, and the sides span the
+   middle. `only` and the unmarked legacy case keep the full closed box. */
+.layout-page-content
+  [data-sdt-boundary="true"][data-sdt-position="first"]::before {
+  border-bottom-width: 0;
+  border-radius: 2px 2px 0 0;
+}
+.layout-page-content
+  [data-sdt-boundary="true"][data-sdt-position="middle"]::before {
+  border-top-width: 0;
+  border-bottom-width: 0;
+  border-radius: 0;
+}
+.layout-page-content
+  [data-sdt-boundary="true"][data-sdt-position="last"]::before {
+  border-top-width: 0;
+  border-radius: 0 0 2px 2px;
+}
+.layout-page-content
+  [data-sdt-boundary="true"][data-sdt-position="only"]::before,
+.layout-page-content
+  [data-sdt-boundary="true"]:not([data-sdt-position])::before {
+  border-radius: 2px;
 }
 .layout-page-content [data-sdt-boundary="true"]:hover::before,
 .layout-page-content [data-sdt-boundary="true"]:focus-within::before {

--- a/packages/folio/src/styles/editor.css
+++ b/packages/folio/src/styles/editor.css
@@ -766,3 +766,32 @@
   animation: folio-outline-flash 1.2s ease-out;
   border-radius: 2px;
 }
+
+/* ============================================================================
+   Block-level content controls (w:sdt) — boundary chrome
+   ============================================================================
+   Painted blocks carry `data-sdt-boundary="true"` when they sit inside a
+   block-level SDT (see core/layout-painter/sdtBoundary.ts). The boundary
+   is a soft outline that appears only when the user's pointer hovers over
+   the wrapper, so the editor stays visually quiet in the common case.
+*/
+.layout-page-content [data-sdt-boundary="true"] {
+  position: relative;
+}
+.layout-page-content [data-sdt-boundary="true"]::before {
+  content: "";
+  position: absolute;
+  inset: -2px -4px;
+  border: 1px dashed transparent;
+  border-radius: 2px;
+  pointer-events: none;
+  transition: border-color 120ms ease-out;
+}
+.layout-page-content [data-sdt-boundary="true"]:hover::before,
+.layout-page-content [data-sdt-boundary="true"]:focus-within::before {
+  border-color: color-mix(
+    in oklch,
+    var(--color-border, oklch(0.85 0 0)) 60%,
+    transparent
+  );
+}


### PR DESCRIPTION
## Summary

Ports the full block-level content control (`w:sdt`) stack from upstream `eigenpal/docx-editor` (#653, #658, #659, #661) plus two cleanup passes addressing reviewer feedback and self-review findings: block SDTs survive round-trip, become first-class editable PM regions, expose a headless + editor-ref addressing API, and the interactive widgets work end-to-end with correct OOXML semantics for locks, dates, and duplicate tags.

Before this PR, block `w:sdt` wrappers were flattened on parse — no properties, no identity, no round-trip.

## Commits

**Foundation (1–10)** — port the upstream stack
1. `fix(folio): parse SDT dateFormat from w:dateFormat, not w:date@w:fullDate`
2. `feat(folio): preserve block-level SDT properties + raw sdtPr on parse`
3. `feat(folio): serialize block SDT by replaying the captured raw sdtPr`
4. `feat(folio): blockSdt PM node + StarterKit wiring`
5. `feat(folio): toProseDoc/fromProseDoc round-trip for blockSdt`
6. `feat(folio): paint block-SDT boundary chrome via SdtGroup tagging`
7. `feat(folio): headless content-control addressing + write API`
8. `feat(folio): DocxEditorRef methods for content controls`
9. `feat(folio): interactive content-control widgets (checkbox/dropdown/date)`
10. `refactor(folio): route blockSdt attr reads through typed reader`

**Cleanup pass 1 (11–16)** — gemini bot feedback + obvious gaps
11. `fix(folio): reconcile raw sdtPr with modeled property mutations on save` — checkbox/date/dropdown changes survive a save cycle (gemini P0)
12. `fix(folio): split content vs container lock semantics for w:lock` — OOXML §17.5.2.16 (gemini P0)
13. `fix(folio): getContentControls surfaces every modeled SdtProperties field` (gemini P1)
14. `feat(folio): wire prosemirror-gapcursor for caret slots near isolating SDTs`
15. `feat(folio): block-content fill via the editor ref`
16. `feat(folio): editor-shell wiring for dropdown/date widgets + typed refusal event`

**Cleanup pass 2 (17–23)** — self-review findings
17. `fix(folio): model date value separately from formatted body display` — `w:fullDate` no longer gets the format-rendered display text
18. `fix(folio): address content controls by pmPos, not tag (duplicate-tag bug)` — clicks route to the exact SDT instance the user touched
19. `fix(folio): keep nested SDTs non-empty when removing their only child`
20. `fix(folio): bypass suggestion mode for content-control writes` — widget interactions no longer create phantom tracked changes
21. `fix(folio): per-SDT boundary chrome instead of per-fragment` — continuous dashed outline across the SDT's block sequence
22. `refactor(folio): overlay subscribes via stable view DOM ref, uses coss Menu + i18n` — three issues bundled (useEffect churn, bespoke list HTML, hard-coded English) since they all touched the same component
23. `test(folio): cover nested-path addressing + table fill in editor-ref helpers`

## Test plan

- [x] `bun --filter @stll/folio lint` — clean
- [x] `bun --filter @stll/folio typecheck` — clean
- [x] `bun test src` (folio) — 1552 pass, 0 fail, 20107 expect() calls
- [x] Unit coverage at every layer: parser, serializer + raw-sdtPr reconciliation, PM schema, conversion, layout-bridge (incl. per-SDT chrome positions), headless API (incl. split-lock + nested-removal), PM transactions (incl. split-lock + pmPos + suggestion-mode bypass), widgets, block-content fill (paragraph + table)
- [ ] Manual playground smoke: load a DOCX with a tagged date SDT, click into a checkbox SDT (verify save round-trip preserves the new state), click into a dropdown SDT (verify the coss-styled menu opens and selection persists), click into a date SDT (verify the format-rendered display + the OOXML `w:fullDate` end up correct), navigate caret to before a doc-starting SDT (gapcursor), confirm two same-tag SDTs are addressable independently

## Known follow-ups (deferred)

- Header/footer block-SDT chrome (parser preserves them; HF painter loop unification pending)
- Table-cell / text-box block SDTs (separate parser loops)
- Toolbar affordance to insert/remove controls (this PR enables editing existing controls)
- Live `dataBinding` resolution / `repeatingSection` expansion (verbatim round-trip only)
- e2e (Playwright) coverage for the click → picker → save round-trip
- Multi-page split fragments inside a single SDT block still draw first/last per logical block, not per page-split fragment (cosmetic, only visible if a single block paginates across pages with the dashed outline visible)