### PR TITLE
chore: scope pre-push typecheck to packages affected vs origin/main

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,7 +36,7 @@ pre-push:
       # (turbo `...[ref]` filter). tsgo itself still runs project-wide
       # within each selected package, but unaffected packages are skipped
       # entirely instead of being walked for cache decisions.
-      run: bun run typecheck '--filter=...[origin/main]' --concurrency=2
+      run: bun run typecheck "--filter=...[origin/main]" --concurrency=2
     # Lint runs in CI on every push (~10-15 min full-monorepo). Keeping
     # it on pre-push too added another ~15-18 min of waiting that
     # duplicated the CI signal, so the local hook drops it. The

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,10 +32,11 @@ pre-push:
   parallel: false
   commands:
     typecheck:
-      # Project-wide. tsgo/tsc can't be scoped per file and the type
-      # graph spans the whole monorepo (eden, shared packages), so the
-      # full run is the only honest pre-push gate for type errors.
-      run: bun run typecheck --concurrency=2
+      # Scoped to packages changed vs. origin/main plus their dependents
+      # (turbo `...[ref]` filter). tsgo itself still runs project-wide
+      # within each selected package, but unaffected packages are skipped
+      # entirely instead of being walked for cache decisions.
+      run: bun run typecheck '--filter=...[origin/main]' --concurrency=2
     # Lint runs in CI on every push (~10-15 min full-monorepo). Keeping
     # it on pre-push too added another ~15-18 min of waiting that
     # duplicated the CI signal, so the local hook drops it. The


### PR DESCRIPTION
## Summary
- Replace the project-wide pre-push tsgo run with a turbo `--filter=...[origin/main]` invocation so only changed packages and their dependents are typechecked locally.
- PR CI already runs the same scoped check via turbo `--affected`, and `nightly-typecheck.yml` keeps full-monorepo coverage, so this only trims the local hook.
- On a clean branch, the hook now finishes in ~2 s instead of multi-minute tsgo. On a branch that touches one shared package, dry-run shows ~4 of ~25 typecheck tasks scheduled (changed package + dependents).

## Trade-offs
- Stale `origin/main` (no recent `git fetch`) means the local filter compares against an older base. PR CI uses the live merge base, so any miss is caught upstream.
- A type-only import that isn't declared as a workspace dependency would not light up the dependent. Same blind spot exists for CI `--affected`; nightly catches it.
- Root `tsconfig.base.json` is not in `turbo.json` `globalDependencies`, so editing it does not invalidate every package's typecheck input hash. Same caveat as today; nightly is the safety net.

## Test plan
- [x] Touched `packages/errors/src/index.ts` and ran `bun run typecheck '--filter=...[origin/main]' --dry-run` — saw `@stll/errors`, `@stll/api`, `@stll/collab`, `@stll/web` scheduled, no other workspaces.
- [x] Reverted the fake change; dry-run scheduled zero tasks (matches "nothing affected vs. main").
- [x] Verified shell quoting on zsh: bare `[origin/main]` triggers `no matches found`; quoted form passes through to turbo correctly.
- [x] Pre-push hook executed the new command end-to-end on this branch (lefthook output, 1.93 s).