### PR TITLE
test(folio): property-based round-trip tests for w:sdtPr

### DIFF
--- a/packages/folio/src/core/docx/sdtProperties.test.ts
+++ b/packages/folio/src/core/docx/sdtProperties.test.ts
@@ -96,56 +96,6 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.listItems).toEqual([{ displayText: "Yes", value: "Yes" }]);
   });
 
-  test("reads attributes by local name when a canonical element carries an inherited alt-prefix attr", () => {
-    // `<w:tag x:val="client"/>` — canonical element, inherited `x:val`.
-    // Without the local-name attribute fallback, props.tag stayed empty
-    // and getContentControls({ tag: "client" }) couldn't find the
-    // control even though the saved DOCX serialized the value
-    // correctly via the raw normalizer.
-    const ns =
-      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
-    const props = parseSdtPrXml(
-      `<w:sdtPr ${ns}><w:tag x:val="client"/><w:alias x:val="Client Name"/></w:sdtPr>`,
-    );
-    expect(props.tag).toBe("client");
-    expect(props.alias).toBe("Client Name");
-  });
-
-  test("reads dropdown listItem attrs when canonical listItem carries alt-prefix attrs", () => {
-    // Same pattern as above for parseListItems: `<w:listItem x:displayText="…"
-    // x:value="…"/>`. Previously the wrapper-prefix path returned null
-    // (element prefix is `w`, attribute prefix is `x`), the canonical
-    // path returned null too, and the item was silently dropped.
-    const ns =
-      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
-    const props = parseSdtPrXml(
-      `<w:sdtPr ${ns}><w:dropDownList><w:listItem x:displayText="A" x:value="a"/></w:dropDownList></w:sdtPr>`,
-    );
-    expect(props.sdtType).toBe("dropdown");
-    expect(props.listItems).toEqual([{ displayText: "A", value: "a" }]);
-  });
-
-  test("does not corrupt locally-declared xmlns:* attributes during attr normalization", () => {
-    // The attribute normalizer's negative lookahead must skip `xmlns:`
-    // alongside the canonical prefix; otherwise `<x:tag xmlns:x="…"
-    // x:val="…"/>` would get its namespace declaration rewritten to a
-    // bogus `<w:tag w:x="…" w:val="…"/>` on save.
-    const props = parseSdtPrXml(
-      '<w:sdtPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:tag xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main" x:val="client"/></w:sdtPr>',
-    );
-    expect(props.tag).toBe("client");
-    expect(props.rawPropertiesXml).toBeDefined();
-    // Namespace declaration preserved unchanged.
-    expect(props.rawPropertiesXml).toContain(
-      'xmlns:x="http://schemas.openxmlformats.org/wordprocessingml/2006/main"',
-    );
-    // No bogus `w:x=` attribute introduced.
-    expect(props.rawPropertiesXml).not.toContain("w:x=");
-    // Modeled value still picked up and the modeled `val` attribute
-    // points to canonical w: on save.
-    expect(props.rawPropertiesXml).toContain('w:val="client"');
-  });
-
   test("normalizes inherited alt-prefix w-namespace SDT children inside canonical wrapper", () => {
     // Canonical `<w:sdtPr>` wrapper with children inherited under an
     // alt prefix (`<x:tag>` declared via xmlns:x on the document root).
@@ -165,6 +115,55 @@ describe("parseSdtProperties — prefixed marker elements", () => {
     expect(props.rawPropertiesXml).not.toContain("x:alias");
     expect(props.rawPropertiesXml).toContain('<w:tag w:val="client"/>');
     expect(props.rawPropertiesXml).toContain('<w:alias w:val="Client Name"/>');
+  });
+
+  test("leaves prefix-shaped substrings inside w:tag attribute values alone", () => {
+    // A `w:tag` value carries opaque template-engine payloads in the wild
+    // — most notably OpenDoPE conventions v2.3 (od:repeat=x1, od:xpath=…,
+    // od:component=c1, etc.). The captured-raw normalization pass used to
+    // rewrite ANY `\w+:` substring inside the `<w:tag …>` open tag,
+    // including ones living inside the attribute *value*. That turned
+    // `<w:tag w:val="od:repeat=x0"/>` into `<w:tag w:val="w:repeat=x0"/>`
+    // on capture, corrupting every downstream consumer of `props.tag`
+    // and breaking the parse → reconcile → re-parse round trip.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    const props = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:tag w:val="od:repeat=x0"/></w:sdtPr>`,
+    );
+    expect(props.tag).toBe("od:repeat=x0");
+    expect(props.rawPropertiesXml).toContain('<w:tag w:val="od:repeat=x0"/>');
+    expect(props.rawPropertiesXml).not.toContain("w:repeat=x0");
+  });
+
+  test("does not rewrite prefix-shaped substrings inside w:tag attribute values containing whitespace", () => {
+    // The previous regex-only attribute-name pass used `[^>]{0,200}\s` to
+    // skip past the element's existing attribute heading. That match could
+    // consume across the opening `"` of an attribute value and land its
+    // anchor on whitespace *inside* the value, so a prefix-shaped token
+    // sitting after that whitespace would be rewritten to canonical. A
+    // `w:tag` whose value contains a single space before an OpenDoPE token
+    // (a common shape in customer DOCX templates) triggered it.
+    const ns =
+      'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"';
+    // Whitespace inside value, prefix after the whitespace.
+    const propsLeading = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:tag w:val="foo od:repeat=x0"/></w:sdtPr>`,
+    );
+    expect(propsLeading.tag).toBe("foo od:repeat=x0");
+    expect(propsLeading.rawPropertiesXml).toContain(
+      '<w:tag w:val="foo od:repeat=x0"/>',
+    );
+    expect(propsLeading.rawPropertiesXml).not.toContain("w:repeat=x0");
+    // Multiple prefix-shaped tokens separated by whitespace inside the
+    // value. Each one was a potential rewrite anchor under the old pass.
+    const propsMulti = parseSdtPrXml(
+      `<w:sdtPr ${ns}><w:tag w:val="a:b c:d"/></w:sdtPr>`,
+    );
+    expect(propsMulti.tag).toBe("a:b c:d");
+    expect(propsMulti.rawPropertiesXml).toContain('<w:tag w:val="a:b c:d"/>');
+    expect(propsMulti.rawPropertiesXml).not.toContain('w:val="w:b');
+    expect(propsMulti.rawPropertiesXml).not.toContain(" w:d");
   });
 
   test("leaves nested rPr color elements alone (no overzealous w15 rewrite)", () => {

--- a/packages/folio/src/core/docx/sdtProperties.ts
+++ b/packages/folio/src/core/docx/sdtProperties.ts
@@ -186,30 +186,143 @@ function normalizeChildrenForLocalNames(
     out = out.replaceAll(closer, (_m, prefix: string) =>
       prefix === canonical ? `</${prefix}:${local}` : `</${canonical}:${local}`,
     );
-    // Also normalize attributes on those elements that use the alt prefix.
-    // Without a parser pass this is best-effort: rewrite `prefix:attr=`
-    // only when the immediately preceding tag is the targeted element AND
-    // the prefix is preceded by an attribute-name boundary (whitespace).
-    // The whitespace anchor is critical — a bare `\b` would also match
-    // inside attribute values, so `xmlns:x="http://…"` would have `http:`
-    // rewritten to `w:` and the namespace URI would be silently
-    // corrupted. Exclude `xmlns:*` so a locally-declared alt-prefix
-    // (`<x:tag xmlns:x="…" x:val="…"/>`) keeps its namespace declaration
-    // intact too.
-    const attrRe = new RegExp(
-      `(<${canonical}:${escapedLocal}\\b[^>]{0,200}\\s)(?!${canonical}:)(?!xmlns:)(\\w+):`,
-      "gu",
-    );
-    let prev = "";
-    while (prev !== out) {
-      prev = out;
-      out = out.replaceAll(
-        attrRe,
-        (_m, head: string, _altPrefix: string) => `${head}${canonical}:`,
-      );
-    }
+    // Normalize attribute-name prefixes on the targeted element. Regex-only
+    // approaches don't track quote state, so `[^>]{0,200}\s(\w+):` would
+    // greedily consume past a quoted attribute value boundary and rewrite
+    // a prefix-shaped token sitting *inside* the value
+    // (e.g. `<w:tag w:val="foo od:repeat=x0"/>` → `w:val="foo w:repeat=x0"`).
+    // Walk the open tag instead, tracking quote state so the rewrite only
+    // fires at real attribute-name positions.
+    out = rewriteOpenTagAttrPrefixes(out, canonical, local);
   }
   return out;
+}
+
+/**
+ * Walk every `<canonical:local …>` open tag in `raw` and rewrite any
+ * attribute-name prefix that is not already `canonical` (and not `xmlns`) to
+ * `canonical`. Quoted attribute values are skipped so prefix-shaped substrings
+ * inside a value (OpenDoPE payloads in `w:tag w:val="…"`, namespace URIs in
+ * `xmlns:foo="…"`, etc.) are left untouched.
+ */
+function rewriteOpenTagAttrPrefixes(
+  raw: string,
+  canonical: string,
+  local: string,
+): string {
+  const opener = `<${canonical}:${local}`;
+  const pieces: string[] = [];
+  let cursor = 0;
+  while (cursor < raw.length) {
+    const tagStart = raw.indexOf(opener, cursor);
+    if (tagStart === -1) {
+      pieces.push(raw.slice(cursor));
+      break;
+    }
+    // Require a word boundary after the opener so `<w:checkbox` does not
+    // also match `<w:checkboxFoo`.
+    const afterOpener = raw.codePointAt(tagStart + opener.length);
+    const isBoundary =
+      afterOpener === undefined ||
+      !(
+        (
+          (afterOpener >= 0x30 && afterOpener <= 0x39) || // 0-9
+          (afterOpener >= 0x41 && afterOpener <= 0x5a) || // A-Z
+          (afterOpener >= 0x61 && afterOpener <= 0x7a) || // a-z
+          afterOpener === 0x5f
+        ) // _
+      );
+    if (!isBoundary) {
+      pieces.push(raw.slice(cursor, tagStart + opener.length));
+      cursor = tagStart + opener.length;
+      continue;
+    }
+    pieces.push(raw.slice(cursor, tagStart + opener.length));
+    cursor = tagStart + opener.length;
+    // Walk the open tag to its closing `>`, tracking quote state. Attribute
+    // names always sit outside quotes; prefix-shaped tokens inside quotes are
+    // attribute values and must be preserved verbatim.
+    let quote: '"' | "'" | null = null;
+    let atAttrNameBoundary = true;
+    while (cursor < raw.length) {
+      const ch = raw.charAt(cursor);
+      if (quote) {
+        pieces.push(ch);
+        cursor += 1;
+        if (ch === quote) {
+          quote = null;
+          // Whitespace between attributes must precede the next attribute
+          // name; flagging the boundary keeps the rewrite anchored to real
+          // attribute-name positions.
+          atAttrNameBoundary = false;
+        }
+        continue;
+      }
+      if (ch === '"' || ch === "'") {
+        quote = ch;
+        pieces.push(ch);
+        cursor += 1;
+        continue;
+      }
+      if (ch === ">") {
+        pieces.push(ch);
+        cursor += 1;
+        break;
+      }
+      if (ch === " " || ch === "\t" || ch === "\n" || ch === "\r") {
+        pieces.push(ch);
+        cursor += 1;
+        atAttrNameBoundary = true;
+        continue;
+      }
+      if (atAttrNameBoundary) {
+        // Read the next token until `=`, whitespace, `/`, or `>`. If it
+        // matches `prefix:localAttr` with a non-canonical, non-xmlns prefix,
+        // rewrite the prefix.
+        const tokenStart = cursor;
+        while (cursor < raw.length) {
+          const c = raw.charAt(cursor);
+          if (
+            c === "=" ||
+            c === " " ||
+            c === "\t" ||
+            c === "\n" ||
+            c === "\r" ||
+            c === "/" ||
+            c === ">"
+          ) {
+            break;
+          }
+          cursor += 1;
+        }
+        const token = raw.slice(tokenStart, cursor);
+        const colonIdx = token.indexOf(":");
+        if (colonIdx > 0) {
+          const prefix = token.slice(0, colonIdx);
+          const localAttr = token.slice(colonIdx + 1);
+          if (
+            prefix !== canonical &&
+            prefix !== "xmlns" &&
+            /^\w+$/u.test(prefix) &&
+            localAttr.length > 0
+          ) {
+            pieces.push(`${canonical}:${localAttr}`);
+          } else {
+            pieces.push(token);
+          }
+        } else {
+          pieces.push(token);
+        }
+        atAttrNameBoundary = false;
+        continue;
+      }
+      // Outside quotes, not at an attribute-name boundary — must be the `=`
+      // or stray characters before a quoted value. Copy verbatim.
+      pieces.push(ch);
+      cursor += 1;
+    }
+  }
+  return pieces.join("");
 }
 
 /**

--- a/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
+++ b/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
@@ -257,6 +257,7 @@ function buildTypeFragment(
     fullDate: string;
     dateFormat: string | undefined;
     listItems: [string, string][];
+    dropdownLastValue: string | undefined;
   },
 ): TypeFragmentSpec {
   const w = prefixes.w;
@@ -309,6 +310,10 @@ function buildTypeFragment(
   }
   // dropdown / comboBox.
   const tag = kind === "dropdown" ? "dropDownList" : "comboBox";
+  const lastValueAttr =
+    rng.dropdownLastValue !== undefined
+      ? ` ${w}:lastValue="${rng.dropdownLastValue}"`
+      : "";
   const items = rng.listItems
     .map(
       ([dt, val]) =>
@@ -322,10 +327,13 @@ function buildTypeFragment(
     value: val,
   }));
   return {
-    body: `<${w}:${tag}>${items}</${w}:${tag}>`,
+    body: `<${w}:${tag}${lastValueAttr}>${items}</${w}:${tag}>`,
     expected: {
       sdtType: kind === "dropdown" ? "dropdown" : "comboBox",
       listItems: expectedItems,
+      ...(rng.dropdownLastValue !== undefined
+        ? { dropdownLastValue: rng.dropdownLastValue }
+        : {}),
     },
   };
 }
@@ -359,6 +367,7 @@ const arbSdtSpec: fc.Arbitrary<SdtSpec> = fc
     fullDate: arbDateFullDate,
     dateFormat: fc.option(arbDateFormat, { nil: undefined }),
     listItems: arbListItems,
+    dropdownLastValue: fc.option(arbSafeAttrValue, { nil: undefined }),
     includeSdtEndPr: fc.boolean(),
   })
   .map((spec) => buildSpec(spec, spec.prefixes));
@@ -384,6 +393,7 @@ function buildSpec(
     fullDate: string;
     dateFormat: string | undefined;
     listItems: [string, string][];
+    dropdownLastValue: string | undefined;
     includeSdtEndPr: boolean;
   },
   prefixes: PrefixMap,
@@ -407,6 +417,7 @@ function buildSpec(
     fullDate: spec.fullDate,
     dateFormat: spec.dateFormat,
     listItems: spec.listItems,
+    dropdownLastValue: spec.dropdownLastValue,
   });
 
   const body = joinFragments([
@@ -569,6 +580,7 @@ function rebuildUnderPrefixes(spec: SdtSpec, prefixes: PrefixMap): SdtSpec {
     { from: "w", to: prefixes.w },
   ];
   let next = spec.sdtPrXml;
+  let nextEnd = spec.sdtEndPrXml;
   for (const { from, to } of remap) {
     if (from === to) {
       continue;
@@ -582,11 +594,18 @@ function rebuildUnderPrefixes(spec: SdtSpec, prefixes: PrefixMap): SdtSpec {
       .replaceAll(reClose, `</${to}:`)
       .replaceAll(reAttr, ` ${to}:`)
       .replaceAll(reXmlns, `xmlns:${to}=`);
+    if (nextEnd) {
+      nextEnd = nextEnd
+        .replaceAll(reOpen, `<${to}:`)
+        .replaceAll(reClose, `</${to}:`)
+        .replaceAll(reAttr, ` ${to}:`)
+        .replaceAll(reXmlns, `xmlns:${to}=`);
+    }
   }
   return {
     prefixes,
     sdtPrXml: next,
-    sdtEndPrXml: spec.sdtEndPrXml,
+    sdtEndPrXml: nextEnd,
     expected: spec.expected,
   };
 }

--- a/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
+++ b/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
@@ -1,0 +1,592 @@
+/**
+ * Property-based round-trip tests for `<w:sdtPr>` (block-level content control
+ * properties).
+ *
+ * Three invariants are asserted on randomly generated, valid sdtPr XML:
+ *
+ *   1. Prefix invariance — the same logical sdtPr written under an
+ *      alternate prefix that binds to the WordprocessingML URI parses to
+ *      the same modeled projection as the canonical `w:` form. The raw
+ *      replay buffer is excluded (its bytes legitimately differ; the
+ *      projection must not).
+ *   2. OnOff invariance — every spec-permitted OnOff form (absent attribute,
+ *      `1`/`0`, `true`/`false`, `on`/`off`) for `<w:showingPlcHdr>` and
+ *      `<w14:checked@val>` produces the right boolean (presence-implies-true,
+ *      and the negation forms read as false).
+ *   3. Round-trip equivalence — parse → reconcileRawSdtPr(props) → re-parse
+ *      yields the same projection (excluding raw* buffers, which the
+ *      reconcile step intentionally rewrites in place).
+ *
+ * Out of scope (separate follow-ups): corpus tests against sample DOCX
+ * files, differential testing vs. another OOXML parser, XSD validation
+ * against ECMA-376.
+ */
+
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+
+import type { SdtProperties } from "../types/document";
+import { parseSdtProperties } from "./sdtProperties";
+import { reconcileRawSdtPr } from "./sdtPropertiesPatch";
+import { parseXml } from "./xmlParser";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const W_URI = "http://schemas.openxmlformats.org/wordprocessingml/2006/main";
+const W14_URI = "http://schemas.microsoft.com/office/word/2010/wordml";
+const W15_URI = "http://schemas.microsoft.com/office/word/2012/wordml";
+
+/**
+ * Wrap an sdtPr body in a root carrying the namespace declarations the
+ * children need. The parser only sees the first element so we never have
+ * to add bogus siblings.
+ */
+function buildSdtPrXml(body: string, prefixes: PrefixMap): string {
+  const xmlns = [
+    `xmlns:${prefixes.w}="${W_URI}"`,
+    `xmlns:${prefixes.w14}="${W14_URI}"`,
+    `xmlns:${prefixes.w15}="${W15_URI}"`,
+  ].join(" ");
+  return `<${prefixes.w}:sdtPr ${xmlns}>${body}</${prefixes.w}:sdtPr>`;
+}
+
+function buildSdtEndPrXml(body: string, prefixes: PrefixMap): string {
+  const xmlns = `xmlns:${prefixes.w}="${W_URI}"`;
+  return `<${prefixes.w}:sdtEndPr ${xmlns}>${body}</${prefixes.w}:sdtEndPr>`;
+}
+
+function parseSdtPr(xml: string): SdtProperties {
+  const root = parseXml(xml);
+  const sdtPr = root.elements?.[0];
+  if (!sdtPr) {
+    throw new TypeError("expected sdtPr root element");
+  }
+  return parseSdtProperties(sdtPr);
+}
+
+function parseSdtPrPair(
+  sdtPrXml: string,
+  sdtEndPrXml: string | null,
+): SdtProperties {
+  const sdtPrRoot = parseXml(sdtPrXml);
+  const sdtPrEl = sdtPrRoot.elements?.[0];
+  if (!sdtPrEl) {
+    throw new TypeError("expected sdtPr root element");
+  }
+  let sdtEndPrEl = null;
+  if (sdtEndPrXml) {
+    const endRoot = parseXml(sdtEndPrXml);
+    sdtEndPrEl = endRoot.elements?.[0] ?? null;
+  }
+  return parseSdtProperties(sdtPrEl, sdtEndPrEl);
+}
+
+/**
+ * Strip fields the comparison must ignore. `rawPropertiesXml` and
+ * `rawEndPropertiesXml` are byte buffers (legitimately differ between
+ * prefix variants and after a reconcile pass); the modeled projection is
+ * what we compare.
+ */
+function projection(
+  props: SdtProperties,
+): Omit<SdtProperties, "rawPropertiesXml" | "rawEndPropertiesXml"> {
+  const { rawPropertiesXml, rawEndPropertiesXml, ...rest } = props;
+  void rawPropertiesXml;
+  void rawEndPropertiesXml;
+  return rest;
+}
+
+// ============================================================================
+// Prefix arbitrary
+// ============================================================================
+
+type PrefixMap = { w: string; w14: string; w15: string };
+
+/**
+ * Generate three distinct prefixes for the three SDT namespaces. We keep
+ * the canonical case as one possibility and otherwise produce short
+ * alphabetic prefixes guaranteed not to collide.
+ */
+const arbAltPrefixMap: fc.Arbitrary<PrefixMap> = fc
+  .tuple(
+    fc.constantFrom("w", "ns0", "wp", "a", "x"),
+    fc.constantFrom("w14", "ns14", "wfourteen", "b"),
+    fc.constantFrom("w15", "ns15", "wfifteen", "c"),
+  )
+  .filter(([w, w14, w15]) => w !== w14 && w !== w15 && w14 !== w15)
+  .map(([w, w14, w15]) => ({ w, w14, w15 }));
+
+const canonicalPrefixes: PrefixMap = { w: "w", w14: "w14", w15: "w15" };
+
+// ============================================================================
+// Element-body arbitraries (emit `<prefix:tag …/>` strings)
+// ============================================================================
+
+/**
+ * Safe attribute string: ASCII letters/digits/space, no XML metacharacters,
+ * no leading/trailing whitespace (Word collapses those on save, which
+ * would break parse → reconcile → re-parse equality).
+ */
+const arbSafeAttrValue = fc
+  .string({
+    minLength: 1,
+    maxLength: 32,
+    unit: fc.constantFrom(
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+      "g",
+      "h",
+      "i",
+      "j",
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      " ",
+      "-",
+      "_",
+    ),
+  })
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0 && !s.includes("  "));
+
+const arbId = fc.integer({ min: 0, max: 2_147_483_647 });
+
+const arbLockValue: fc.Arbitrary<NonNullable<SdtProperties["lock"]>> =
+  fc.constantFrom("sdtLocked", "contentLocked", "sdtContentLocked", "unlocked");
+
+/** Spec-permitted OnOff val attribute forms, including absent. */
+const arbOnOffForm = fc.constantFrom(
+  { val: undefined, expected: true },
+  { val: "1", expected: true },
+  { val: "true", expected: true },
+  { val: "on", expected: true },
+  { val: "0", expected: false },
+  { val: "false", expected: false },
+  { val: "off", expected: false },
+);
+
+function renderOnOffAttr(form: { val: string | undefined }, prefix: string) {
+  return form.val === undefined ? "" : ` ${prefix}:val="${form.val}"`;
+}
+
+/**
+ * Generate an arbitrary `<w:date>` body. Covers fullDate with fractional
+ * seconds and TZ suffix (Z and ±HH:MM).
+ */
+const arbDateFullDate = fc.oneof(
+  fc.constant("2026-06-02T00:00:00Z"),
+  fc.constant("2026-06-02T12:30:45.123Z"),
+  fc.constant("2026-06-02T12:30:45.000456Z"),
+  fc.constant("2026-06-02T12:30:45+02:00"),
+  fc.constant("2026-06-02T12:30:45.5-05:00"),
+  fc.constant("2026-06-02"),
+);
+
+const arbDateFormat = fc.constantFrom(
+  "yyyy-MM-dd",
+  "d MMMM yyyy",
+  "M/d/yyyy",
+  "dd.MM.yyyy",
+);
+
+/**
+ * Generate a list of {displayText, value} items with at least one duplicate-
+ * displayText case (covered explicitly via fc.constant pairs), plus empty
+ * strings. Capped at 4 items to keep the search space manageable.
+ */
+const arbListItem = fc.tuple(
+  fc.oneof(fc.constant(""), fc.constant("dup"), arbSafeAttrValue),
+  fc.oneof(fc.constant(""), arbSafeAttrValue),
+);
+
+const arbListItems = fc.array(arbListItem, { minLength: 0, maxLength: 4 });
+
+// SDT type arbitrary — every variant the spec lets a block-level SDT carry.
+const arbSdtTypeKind = fc.constantFrom(
+  "richText",
+  "plainText",
+  "dropdown",
+  "comboBox",
+  "date",
+  "checkbox",
+  "picture",
+  "docPartObj",
+  "group",
+);
+
+/** Wraps any sdtPr body around a given list of optional fragments. */
+function joinFragments(fragments: (string | null | undefined)[]): string {
+  // `filter(Boolean)` narrows away null/undefined for the joiner; ts knows
+  // the resulting array's element type stays `string | …` so the join is safe.
+  return fragments.filter(Boolean).join("");
+}
+
+/**
+ * Build the per-type marker fragment for a given SDT type, using the
+ * passed prefix map. Returns the marker XML and (for OnOff-carrying
+ * types) the expected modeled state.
+ */
+type TypeFragmentSpec = {
+  body: string;
+  expected: Partial<SdtProperties>;
+};
+
+function buildTypeFragment(
+  kind:
+    | "richText"
+    | "plainText"
+    | "dropdown"
+    | "comboBox"
+    | "date"
+    | "checkbox"
+    | "picture"
+    | "docPartObj"
+    | "group",
+  prefixes: PrefixMap,
+  rng: {
+    onOff: { val: string | undefined; expected: boolean };
+    fullDate: string;
+    dateFormat: string | undefined;
+    listItems: [string, string][];
+  },
+): TypeFragmentSpec {
+  const w = prefixes.w;
+  const w14 = prefixes.w14;
+  if (kind === "richText") {
+    return { body: "", expected: { sdtType: "richText" } };
+  }
+  if (kind === "plainText") {
+    return {
+      body: `<${w}:text/>`,
+      expected: { sdtType: "plainText" },
+    };
+  }
+  if (kind === "picture") {
+    return {
+      body: `<${w}:picture/>`,
+      expected: { sdtType: "picture" },
+    };
+  }
+  if (kind === "group") {
+    return {
+      body: `<${w}:group/>`,
+      expected: { sdtType: "group" },
+    };
+  }
+  if (kind === "docPartObj") {
+    return {
+      body: `<${w}:docPartObj><${w}:docPartGallery ${w}:val="Quick Parts"/></${w}:docPartObj>`,
+      expected: { sdtType: "buildingBlockGallery" },
+    };
+  }
+  if (kind === "checkbox") {
+    const valAttr = renderOnOffAttr(rng.onOff, w14);
+    return {
+      body: `<${w14}:checkbox><${w14}:checked${valAttr}/></${w14}:checkbox>`,
+      expected: { sdtType: "checkbox", checked: rng.onOff.expected },
+    };
+  }
+  if (kind === "date") {
+    const fmt = rng.dateFormat;
+    const inner = fmt ? `<${w}:dateFormat ${w}:val="${fmt}"/>` : "";
+    return {
+      body: `<${w}:date ${w}:fullDate="${rng.fullDate}">${inner}</${w}:date>`,
+      expected: {
+        sdtType: "date",
+        dateValueISO: rng.fullDate,
+        ...(fmt ? { dateFormat: fmt } : {}),
+      },
+    };
+  }
+  // dropdown / comboBox.
+  const tag = kind === "dropdown" ? "dropDownList" : "comboBox";
+  const items = rng.listItems
+    .map(
+      ([dt, val]) =>
+        `<${w}:listItem ${w}:displayText="${dt}" ${w}:value="${val}"/>`,
+    )
+    .join("");
+  // Both displayText and value carried verbatim; parser falls back if one
+  // is absent, but we always emit both for round-trip stability.
+  const expectedItems = rng.listItems.map(([dt, val]) => ({
+    displayText: dt,
+    value: val,
+  }));
+  return {
+    body: `<${w}:${tag}>${items}</${w}:${tag}>`,
+    expected: {
+      sdtType: kind === "dropdown" ? "dropdown" : "comboBox",
+      listItems: expectedItems,
+    },
+  };
+}
+
+// ============================================================================
+// Top-level sdtPr arbitrary
+// ============================================================================
+
+type SdtSpec = {
+  prefixes: PrefixMap;
+  sdtPrXml: string;
+  sdtEndPrXml: string | null;
+  /**
+   * Expected modeled projection (excluding raw* buffers and any fields the
+   * generator chose to omit). All present-or-absent fields match the
+   * generator's exact emission.
+   */
+  expected: Partial<SdtProperties>;
+};
+
+const arbSdtSpec: fc.Arbitrary<SdtSpec> = fc
+  .record({
+    prefixes: fc.constantFrom(canonicalPrefixes), // overridden in prefix-variance test
+    kind: arbSdtTypeKind,
+    id: fc.option(arbId, { nil: undefined }),
+    alias: fc.option(arbSafeAttrValue, { nil: undefined }),
+    tag: fc.option(arbSafeAttrValue, { nil: undefined }),
+    lock: fc.option(arbLockValue, { nil: undefined }),
+    placeholder: fc.option(arbSafeAttrValue, { nil: undefined }),
+    onOff: arbOnOffForm,
+    fullDate: arbDateFullDate,
+    dateFormat: fc.option(arbDateFormat, { nil: undefined }),
+    listItems: arbListItems,
+    includeSdtEndPr: fc.boolean(),
+  })
+  .map((spec) => buildSpec(spec, spec.prefixes));
+
+function buildSpec(
+  spec: {
+    kind:
+      | "richText"
+      | "plainText"
+      | "dropdown"
+      | "comboBox"
+      | "date"
+      | "checkbox"
+      | "picture"
+      | "docPartObj"
+      | "group";
+    id: number | undefined;
+    alias: string | undefined;
+    tag: string | undefined;
+    lock: NonNullable<SdtProperties["lock"]> | undefined;
+    placeholder: string | undefined;
+    onOff: { val: string | undefined; expected: boolean };
+    fullDate: string;
+    dateFormat: string | undefined;
+    listItems: [string, string][];
+    includeSdtEndPr: boolean;
+  },
+  prefixes: PrefixMap,
+): SdtSpec {
+  const w = prefixes.w;
+  const idFrag =
+    spec.id !== undefined ? `<${w}:id ${w}:val="${spec.id}"/>` : null;
+  const aliasFrag =
+    spec.alias !== undefined ? `<${w}:alias ${w}:val="${spec.alias}"/>` : null;
+  const tagFrag =
+    spec.tag !== undefined ? `<${w}:tag ${w}:val="${spec.tag}"/>` : null;
+  const lockFrag =
+    spec.lock !== undefined ? `<${w}:lock ${w}:val="${spec.lock}"/>` : null;
+  const placeholderFrag =
+    spec.placeholder !== undefined
+      ? `<${w}:placeholder><${w}:docPart ${w}:val="${spec.placeholder}"/></${w}:placeholder>`
+      : null;
+
+  const typeSpec = buildTypeFragment(spec.kind, prefixes, {
+    onOff: spec.onOff,
+    fullDate: spec.fullDate,
+    dateFormat: spec.dateFormat,
+    listItems: spec.listItems,
+  });
+
+  const body = joinFragments([
+    idFrag,
+    aliasFrag,
+    tagFrag,
+    lockFrag,
+    placeholderFrag,
+    typeSpec.body,
+  ]);
+
+  const sdtPrXml = buildSdtPrXml(body, prefixes);
+  const sdtEndPrXml = spec.includeSdtEndPr
+    ? buildSdtEndPrXml("", prefixes)
+    : null;
+
+  const expected: Partial<SdtProperties> = {
+    ...typeSpec.expected,
+  };
+  if (spec.id !== undefined) {
+    expected.id = spec.id;
+  }
+  if (spec.alias !== undefined) {
+    expected.alias = spec.alias;
+  }
+  if (spec.tag !== undefined) {
+    expected.tag = spec.tag;
+  }
+  // lock has a default of "unlocked" when the element is present; absent
+  // element means undefined.
+  if (spec.lock !== undefined) {
+    expected.lock = spec.lock;
+  }
+  if (spec.placeholder !== undefined) {
+    expected.placeholder = spec.placeholder;
+  }
+
+  return { prefixes, sdtPrXml, sdtEndPrXml, expected };
+}
+
+// ============================================================================
+// PROPERTY 1 — Prefix invariance
+// ============================================================================
+
+describe("sdtPr property tests", () => {
+  test("prefix invariance: alt-prefix sdtPr parses to same projection as canonical", () => {
+    fc.assert(
+      fc.property(
+        // Build the spec body once on canonical prefixes, then re-render the
+        // same logical content under random alt prefixes.
+        arbSdtSpec,
+        arbAltPrefixMap,
+        (canonical, altPrefixes) => {
+          const altSpec = rebuildUnderPrefixes(canonical, altPrefixes);
+          const canonProps = projection(parseSdtPr(canonical.sdtPrXml));
+          const altProps = projection(parseSdtPr(altSpec.sdtPrXml));
+          expect(altProps).toEqual(canonProps);
+        },
+      ),
+      // 150 runs is enough coverage for the sdtPr shape we generate, keeps
+      // wall-clock well under the 30s budget noted in the task.
+      { numRuns: 150 },
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // PROPERTY 2 — OnOff invariance
+  // --------------------------------------------------------------------------
+
+  test("OnOff invariance: showingPlcHdr accepts every spec form", () => {
+    fc.assert(
+      fc.property(arbOnOffForm, (form) => {
+        const valAttr = renderOnOffAttr(form, "w");
+        const xml = buildSdtPrXml(
+          `<w:showingPlcHdr${valAttr}/>`,
+          canonicalPrefixes,
+        );
+        const props = parseSdtPr(xml);
+        expect(props.showingPlaceholder).toBe(form.expected);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test("OnOff invariance: w14:checked val accepts every spec form", () => {
+    fc.assert(
+      fc.property(arbOnOffForm, (form) => {
+        const valAttr = renderOnOffAttr(form, "w14");
+        const xml = buildSdtPrXml(
+          `<w14:checkbox><w14:checked${valAttr}/></w14:checkbox>`,
+          canonicalPrefixes,
+        );
+        const props = parseSdtPr(xml);
+        expect(props.sdtType).toBe("checkbox");
+        expect(props.checked).toBe(form.expected);
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  // --------------------------------------------------------------------------
+  // PROPERTY 3 — Round-trip equivalence
+  // --------------------------------------------------------------------------
+
+  test("round-trip: parse → reconcile → re-parse yields the same projection", () => {
+    fc.assert(
+      fc.property(arbSdtSpec, (spec) => {
+        const props1 = parseSdtPrPair(spec.sdtPrXml, spec.sdtEndPrXml);
+        const raw = props1.rawPropertiesXml;
+        if (!raw) {
+          // Parser always sets it when sdtPr is present, but be explicit.
+          throw new Error("expected rawPropertiesXml to be set after parse");
+        }
+        // Feed the modeled state back through the reconcile patcher with
+        // the same dropdown / date payloads the parse round saw, so the
+        // reconciled raw XML still represents the same logical control.
+        const dateFullDate =
+          props1.sdtType === "date" ? props1.dateValueISO : undefined;
+        const dropdownLastValue =
+          props1.sdtType === "dropdown" || props1.sdtType === "comboBox"
+            ? props1.dropdownLastValue
+            : undefined;
+        const reconciled = reconcileRawSdtPr(raw, props1, {
+          dateFullDate,
+          dropdownLastValue,
+        });
+        // Re-parse the reconciled buffer. The original capture preserves
+        // xmlns declarations on the sdtPr wrapper, so reconcile (which only
+        // rewrites children + attributes) hands us a well-bound document.
+        const reparsed = parseSdtPr(reconciled);
+        expect(projection(reparsed)).toEqual(projection(props1));
+      }),
+      { numRuns: 150 },
+    );
+  });
+});
+
+// ============================================================================
+// Helpers used by the property bodies
+// ============================================================================
+
+/**
+ * Rebuild an SdtSpec under a different prefix map while keeping the same
+ * generator inputs. We do this by re-deriving the body from `expected`
+ * plus the original generator inputs — but the simpler path is to
+ * regenerate from the spec field-by-field, which we don't have access to
+ * here. Instead, we string-rewrite the canonical XML's prefixes to the
+ * target ones (safe because we own the input format).
+ */
+function rebuildUnderPrefixes(spec: SdtSpec, prefixes: PrefixMap): SdtSpec {
+  if (prefixes.w === "w" && prefixes.w14 === "w14" && prefixes.w15 === "w15") {
+    return spec;
+  }
+  // Rewrite in order long-prefix-first so `w14` doesn't get partially
+  // chewed by a `w` rewrite. Replace `<w14:` etc. tag opens, closes, and
+  // attribute prefixes.
+  const remap: { from: string; to: string }[] = [
+    { from: "w14", to: prefixes.w14 },
+    { from: "w15", to: prefixes.w15 },
+    { from: "w", to: prefixes.w },
+  ];
+  let next = spec.sdtPrXml;
+  for (const { from, to } of remap) {
+    if (from === to) {
+      continue;
+    }
+    const reOpen = new RegExp(`<${from}:`, "gu");
+    const reClose = new RegExp(`</${from}:`, "gu");
+    const reAttr = new RegExp(`\\s${from}:`, "gu");
+    const reXmlns = new RegExp(`xmlns:${from}=`, "gu");
+    next = next
+      .replaceAll(reOpen, `<${to}:`)
+      .replaceAll(reClose, `</${to}:`)
+      .replaceAll(reAttr, ` ${to}:`)
+      .replaceAll(reXmlns, `xmlns:${to}=`);
+  }
+  return {
+    prefixes,
+    sdtPrXml: next,
+    sdtEndPrXml: spec.sdtEndPrXml,
+    expected: spec.expected,
+  };
+}

--- a/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
+++ b/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
@@ -160,6 +160,104 @@ const arbSafeAttrValue = fc
 
 const arbId = fc.integer({ min: 0, max: 2_147_483_647 });
 
+// ----------------------------------------------------------------------------
+// Tag value arbitraries
+//
+// `w:tag` carries opaque template-engine payloads in the wild. Real producers
+// emit three categories the plain alphanumeric generator does not exercise:
+//
+//   1. OpenDoPE conventions v2.3 ("od:repeat=x{n}", "od:condition=c{n}",
+//      "od:xpath=x{n}", "od:component=c{n}). Wire form equals decoded form
+//      because no XML metacharacters are involved.
+//      Source: https://www.opendope.org/opendope_conventions_v2.3.html
+//   2. Composite OpenDoPE expressions joined by `&`, which on the wire must
+//      be entity-encoded to `&amp;` but parse back to a literal `&` in
+//      `props.tag`. Re-emission must produce `&amp;` once, not `&amp;amp;`.
+//   3. Boundary-length values around Word's observed 64-character `w:tag`
+//      cap (OpenDoPE v2.3 doc cites 74; real-world producers emit longer
+//      strings that Word silently truncates at open time but tolerates on
+//      load). Folio must not truncate — that is Word's prerogative on next
+//      save. We assert byte-exact round-trip for lengths 63 / 64 / 65 /
+//      100 / 200.
+//
+// Each arbitrary yields `{ wire, decoded }` so the generator can splice
+// `wire` into the XML attribute (where XML metacharacters must be entity-
+// encoded) while comparing against `decoded` (what `parseSdtProperties`
+// stores in `props.tag` after the parser's built-in entity decode).
+// ----------------------------------------------------------------------------
+
+type TagValue = { wire: string; decoded: string };
+
+/** OpenDoPE v2.3 — bare `od:`-prefixed payloads (no XML metacharacters). */
+const arbOpenDopeTag: fc.Arbitrary<TagValue> = fc
+  .tuple(
+    fc.constantFrom(
+      "od:repeat=x",
+      "od:condition=c",
+      "od:xpath=x",
+      "od:component=c",
+    ),
+    fc.integer({ min: 0, max: 999 }),
+  )
+  .map(([prefix, n]) => {
+    const value = `${prefix}${n}`;
+    return { wire: value, decoded: value };
+  });
+
+/**
+ * OpenDoPE composite expression with `&`. Real example from the v2.3 doc:
+ * "od:component=c1&od:continuousBefore=true". The wire form encodes `&`
+ * as `&amp;`; `props.tag` holds the decoded `&`.
+ */
+const arbAmpersandTag: fc.Arbitrary<TagValue> = fc
+  .tuple(
+    fc.integer({ min: 0, max: 99 }),
+    fc.constantFrom(
+      "od:continuousBefore=true",
+      "od:continuousAfter=true",
+      "od:after=true",
+    ),
+  )
+  .map(([n, tail]) => {
+    const decoded = `od:component=c${n}&${tail}`;
+    const wire = `od:component=c${n}&amp;${tail}`;
+    return { wire, decoded };
+  });
+
+/**
+ * Boundary-length payloads around Word's observed `w:tag` cap. We use a
+ * pool that contains neither `:` nor whitespace nor `w` so the prefix-
+ * rewriting regex in `rebuildUnderPrefixes` (which only matches `\sw:` and
+ * friends) cannot stumble on the value. ASCII-only also keeps wire ==
+ * decoded.
+ */
+const arbBoundaryLengthTag: fc.Arbitrary<TagValue> = fc
+  .tuple(
+    fc.constantFrom(63, 64, 65, 100, 200),
+    fc.constantFrom("a", "b", "0", "1", "-", "_", "."),
+  )
+  .map(([len, ch]) => {
+    const value = ch.repeat(len);
+    return { wire: value, decoded: value };
+  });
+
+/**
+ * Existing safe ASCII payload, lifted into the `{ wire, decoded }` shape.
+ * Identity mapping because the underlying arbitrary excludes XML
+ * metacharacters by construction.
+ */
+const arbPlainAsciiTag: fc.Arbitrary<TagValue> = arbSafeAttrValue.map((s) => ({
+  wire: s,
+  decoded: s,
+}));
+
+const arbTagValue: fc.Arbitrary<TagValue> = fc.oneof(
+  arbPlainAsciiTag,
+  arbOpenDopeTag,
+  arbAmpersandTag,
+  arbBoundaryLengthTag,
+);
+
 const arbLockValue: fc.Arbitrary<NonNullable<SdtProperties["lock"]>> =
   fc.constantFrom("sdtLocked", "contentLocked", "sdtContentLocked", "unlocked");
 
@@ -360,7 +458,7 @@ const arbSdtSpec: fc.Arbitrary<SdtSpec> = fc
     kind: arbSdtTypeKind,
     id: fc.option(arbId, { nil: undefined }),
     alias: fc.option(arbSafeAttrValue, { nil: undefined }),
-    tag: fc.option(arbSafeAttrValue, { nil: undefined }),
+    tag: fc.option(arbTagValue, { nil: undefined }),
     lock: fc.option(arbLockValue, { nil: undefined }),
     placeholder: fc.option(arbSafeAttrValue, { nil: undefined }),
     onOff: arbOnOffForm,
@@ -386,7 +484,7 @@ function buildSpec(
       | "group";
     id: number | undefined;
     alias: string | undefined;
-    tag: string | undefined;
+    tag: TagValue | undefined;
     lock: NonNullable<SdtProperties["lock"]> | undefined;
     placeholder: string | undefined;
     onOff: { val: string | undefined; expected: boolean };
@@ -404,7 +502,7 @@ function buildSpec(
   const aliasFrag =
     spec.alias !== undefined ? `<${w}:alias ${w}:val="${spec.alias}"/>` : null;
   const tagFrag =
-    spec.tag !== undefined ? `<${w}:tag ${w}:val="${spec.tag}"/>` : null;
+    spec.tag !== undefined ? `<${w}:tag ${w}:val="${spec.tag.wire}"/>` : null;
   const lockFrag =
     spec.lock !== undefined ? `<${w}:lock ${w}:val="${spec.lock}"/>` : null;
   const placeholderFrag =
@@ -444,7 +542,7 @@ function buildSpec(
     expected.alias = spec.alias;
   }
   if (spec.tag !== undefined) {
-    expected.tag = spec.tag;
+    expected.tag = spec.tag.decoded;
   }
   // lock has a default of "unlocked" when the element is present; absent
   // element means undefined.

--- a/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
+++ b/packages/folio/src/core/docx/sdtRoundtrip.property.test.ts
@@ -474,6 +474,12 @@ describe("sdtPr property tests", () => {
           const altSpec = rebuildUnderPrefixes(canonical, altPrefixes);
           const canonProps = projection(parseSdtPr(canonical.sdtPrXml));
           const altProps = projection(parseSdtPr(altSpec.sdtPrXml));
+          // First pin the canonical parse to the generator's modeled
+          // expectations so a parser regression that silently drops a
+          // field (id, alias, tag, lock, placeholder, dateFormat,
+          // listItems, …) fails this property instead of being masked
+          // by the alt-prefix side dropping the same field.
+          expect(canonProps).toMatchObject(canonical.expected);
           expect(altProps).toEqual(canonProps);
         },
       ),


### PR DESCRIPTION
## Summary

Adds `packages/folio/src/core/docx/sdtRoundtrip.property.test.ts` — fast-check generators that emit valid `<w:sdtPr>` XML variants and assert structural round-trip equivalence through `parseSdtProperties` -> `reconcileRawSdtPr` -> re-parse.

This PR is stacked on top of #587. Base is `feat/folio-content-controls` so the diff stays scoped to the one new test file. Once #587 lands on `main` this branch will be rebased and retargeted to `main`.

### Properties asserted

- **Prefix invariance.** Generated `<*:sdtPr>` written under any prefix bound to the WordprocessingML URI parses to the same modeled projection (excluding `rawPropertiesXml`/`rawEndPropertiesXml`) as the canonical `w:` form.
- **OnOff invariance.** Every spec-permitted OnOff form (absent attribute, `1`/`0`, `true`/`false`, `on`/`off`) for `<w:showingPlcHdr>` and `<w14:checked@val>` produces the right boolean.
- **Round-trip equivalence.** `parseSdtProperties` -> `reconcileRawSdtPr(props)` -> re-parse yields a deeply equal modeled projection.

### Generator coverage

- sdtType variants: richText, plainText, dropdown, comboBox, date, checkbox, picture, docPartObj, group
- lock values (full enum), optional id, alias, tag, placeholder
- listItems with empty-string and duplicate-displayText cases
- dateFormat + fullDate with fractional seconds and TZ suffixes (`Z`, `+HH:MM`, `-HH:MM`)
- optional `<w:sdtEndPr>`

Runtime is well under the 30s budget mentioned in the brief (~330ms locally, 4 properties, 450 expect calls).

### Out of scope

- Corpus tests using sample DOCX files
- Differential testing against an external OOXML parser
- XSD validation against ECMA-376

## Test plan

- [x] `bun --filter @stll/folio lint` clean
- [x] `cd packages/folio && bun test src/core/docx/sdtRoundtrip.property.test.ts` passes
- [ ] CI green