### PR TITLE
chore(folio): differential testing scaffold against python-docx

### DIFF
--- a/packages/folio/scripts/differential/README.md
+++ b/packages/folio/scripts/differential/README.md
@@ -1,0 +1,132 @@
+# Differential parser testing (folio vs python-docx)
+
+This directory holds a small scaffold for cross-checking folio's DOCX
+parser against an established reference parser. PR #587 (block-level
+content controls) surfaced a handful of prefix / namespace / OnOff edge
+cases where a spec-faithful implementation still disagreed with how
+mature parsers actually interpret the wire format. Differential testing
+catches that class of issue directly.
+
+The scaffold is intentionally minimal: one orchestrator script, one
+projection helper per side, one smoke test. Scaling to a fixture corpus,
+property-based generators, or CI integration is a follow-up.
+
+## Why python-docx (and not docx4j)
+
+- **No JVM.** Runs in well under a second per small fixture; trivial to
+  shell out from a Bun script.
+- **Already on the dev image.** Python 3.x is preinstalled on macOS dev
+  machines and most CI runners; the only extra step is
+  `pip install python-docx`.
+- **Wire-format-friendly API.** python-docx exposes the underlying
+  `lxml` element tree (`document.element.body`), so the projector can
+  count `w:p` / `w:r` / `w:tbl` / `w:sdt` directly against the OOXML
+  XPath — closer to "what the file actually says" than the high-level
+  `paragraphs`/`tables` API.
+
+docx4j was considered as an alternative but it requires a JVM in CI and
+a much larger install footprint. We can revisit it later if there is a
+specific behaviour python-docx cannot model (e.g., advanced field
+resolution).
+
+## Setup
+
+```bash
+# One-time, on dev or CI image:
+pip install --user python-docx
+```
+
+The smoke test (`packages/folio/src/core/docx/__tests__/differential.test.ts`)
+auto-skips if `python3 -c "import docx"` fails, so contributors without
+python-docx see a clean local test run rather than a hard failure.
+
+## Running
+
+Against a single DOCX:
+
+```bash
+bun packages/folio/scripts/differential/diff.ts path/to/file.docx
+```
+
+Exit codes:
+
+- `0` — projections are equivalent.
+- `1` — at least one structural divergence (printed to stderr).
+- `2` — infrastructure error (python missing, fixture missing, parse
+  exception).
+
+The smoke test runs the same harness against
+`__fixtures__/regressions/repack-paragraph-sectpr.docx` to prove the
+wiring works end-to-end without committing the project to a full corpus
+sweep.
+
+## Projection shape
+
+Both projectors emit the same normalised JSON shape (see
+`StructuralProjection` in `projection.ts`):
+
+- `totalParagraphs` — all `w:p` elements reachable from the body
+  subtree, including paragraphs nested in tables and block SDTs.
+- `totalTables` — all `w:tbl` elements reachable from the body subtree.
+- `topLevelBlocks` — direct paragraph/table/SDT children of `w:body`.
+- `sdts[]` — `{ scope, sdtType, alias?, tag?, lock?, childCount }` for
+  each `w:sdt` in document order.
+- `sdtCountsByType` — quick eyeball summary of the SDT inventory.
+
+### What we do not project (and why)
+
+- **Run count.** folio applies a run consolidator: adjacent
+  identically-formatted `w:r` elements collapse into one. Wire-format
+  run counts will therefore always diverge from python-docx on real
+  documents. Adding `totalRuns` back would make every interesting
+  fixture diverge for an uninteresting reason. If run-level parity
+  becomes interesting, compare _consolidated_ runs on both sides
+  instead of raw `w:r`.
+- **Textbox content.** folio models drawing-anchored paragraphs and
+  tables as run-level shape content, not block content. The python
+  projector excludes paragraphs/tables/SDTs inside `w:txbxContent` to
+  keep the body-block comparison apples-to-apples. Textbox parity is
+  tracked as a separate concern.
+
+## Extending to a corpus
+
+A future PR can scale this to a full corpus loop. Sketch:
+
+1. Drop additional fixtures under
+   `packages/folio/src/core/docx/__tests__/__fixtures__/differential/`.
+2. Add a `differential-corpus.ts` script that globs the directory, runs
+   `runDifferential` per file, accumulates results, and prints a
+   summary.
+3. Triage each new divergence: either fix folio, document it as an
+   intentional shape difference (and filter in the projection), or
+   record it as a known divergence with a tracking issue.
+4. Decide whether to wire the corpus into CI. Start as opt-in / nightly
+   — the harness is not meant to be a blocking signal until divergence
+   triage is complete.
+
+## What python-docx covers (and doesn't)
+
+Covers cleanly:
+
+- Block structure (`w:p`, `w:tbl`, `w:sdt`) at any depth.
+- SDT properties recoverable from `w:sdtPr` (alias, tag, lock, type).
+- Headers/footers/footnotes (via `doc.part.related_parts` — not used
+  yet by this projection; would extend cleanly).
+
+Does not cover:
+
+- Run consolidation semantics (it preserves wire-format runs as-is).
+- Anything below `w:r` (text content, breaks, tabs) without bespoke
+  walking — fine for our needs, but would expand if we projected
+  run-level content.
+- Advanced field/complex-field resolution.
+- Drawing/SmartArt internals.
+
+## Files
+
+- `projection.ts` — folio-side structural projection.
+- `python_docx_project.py` — python-docx-side structural projection.
+- `diff.ts` — orchestrator CLI; exported `runDifferential` is reused by
+  the smoke test.
+- `../../src/core/docx/__tests__/differential.test.ts` — single smoke
+  test that proves the harness works on a known-good fixture.

--- a/packages/folio/scripts/differential/README.md
+++ b/packages/folio/scripts/differential/README.md
@@ -90,6 +90,18 @@ Both projectors emit the same normalised JSON shape (see
   `childCount`) so it matches the python projector's one-entry-per-
   `w:sdt` view; otherwise every bookmarked or comment-marked control
   would diverge on `sdts` length for an uninteresting reason.
+- **Complex field runs are collapsed.** folio represents a `w:fldChar`
+  begin/separate/end span (plus its `w:instrText` and result runs) as a
+  single `complexField` `ParagraphContent` item, so an inline SDT
+  containing a PAGE / REF / etc. field reports `childCount: 1` for the
+  whole field. The python projector applies the same collapse rule when
+  computing `childCount` for inline SDTs: every `w:r` from a `begin`
+  fldChar through the matching `end` fldChar counts as one logical
+  child. Nested complex fields (e.g. PAGEREF inside a TOC entry) are
+  tracked with a depth counter so an inner pair does not close the outer
+  span early. Without this rule any fixture with a complex field inside
+  an inline content control would diverge on `childCount` even when
+  folio's parse is structurally correct.
 - **Textbox content.** folio models drawing-anchored paragraphs and
   tables as run-level shape content, not block content. The python
   projector excludes paragraphs/tables/SDTs inside `w:txbxContent` to

--- a/packages/folio/scripts/differential/README.md
+++ b/packages/folio/scripts/differential/README.md
@@ -82,6 +82,14 @@ Both projectors emit the same normalised JSON shape (see
   fixture diverge for an uninteresting reason. If run-level parity
   becomes interesting, compare _consolidated_ runs on both sides
   instead of raw `w:r`.
+- **Split inline SDT segments are coalesced.** Folio splits a wire
+  `w:sdt` whose inline content straddles a lifted marker (bookmark /
+  comment range / tracked-change boundary) into multiple `InlineSdt`
+  segments that share one `SdtProperties` reference. The folio
+  projector merges those segments back into a single entry (summing
+  `childCount`) so it matches the python projector's one-entry-per-
+  `w:sdt` view; otherwise every bookmarked or comment-marked control
+  would diverge on `sdts` length for an uninteresting reason.
 - **Textbox content.** folio models drawing-anchored paragraphs and
   tables as run-level shape content, not block content. The python
   projector excludes paragraphs/tables/SDTs inside `w:txbxContent` to

--- a/packages/folio/scripts/differential/diff.ts
+++ b/packages/folio/scripts/differential/diff.ts
@@ -1,0 +1,160 @@
+/**
+ * Differential testing harness — folio parser vs. python-docx.
+ *
+ * Parses a single DOCX both with folio (in-process) and python-docx
+ * (subprocess), projects both into a normalised structural shape, and
+ * prints any divergences. Exits 0 on equivalence, 1 on any divergence,
+ * 2 on infrastructure failure (python missing, fixture missing, parse
+ * error).
+ *
+ * Usage:
+ *   bun packages/folio/scripts/differential/diff.ts <docx-path>
+ *
+ * See README.md in this directory for setup and rationale.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+import { parseDocx } from "../../src/core/docx/parser";
+import {
+  diffProjections,
+  projectFolioDocument,
+  type Divergence,
+  type StructuralProjection,
+} from "./projection";
+
+const HERE = import.meta.dirname;
+const PYTHON_SCRIPT = join(HERE, "python_docx_project.py");
+
+const EXIT_OK = 0;
+const EXIT_DIVERGED = 1;
+const EXIT_INFRA = 2;
+
+export type DifferentialResult =
+  | { ok: true; folio: StructuralProjection; reference: unknown }
+  | {
+      ok: false;
+      reason: "diverged";
+      folio: StructuralProjection;
+      reference: unknown;
+      divergences: Divergence[];
+    }
+  | { ok: false; reason: "infra"; message: string };
+
+/**
+ * Run the differential comparison without exiting the process. Returns
+ * a structured result so callers (the smoke test, future corpus runners)
+ * can decide how to fail.
+ */
+export async function runDifferential(
+  docxPath: string,
+  options: { pythonBin?: string } = {},
+): Promise<DifferentialResult> {
+  const pythonBin = options.pythonBin ?? "python3";
+  const resolved = resolve(docxPath);
+  if (!existsSync(resolved)) {
+    return {
+      ok: false,
+      reason: "infra",
+      message: `Fixture not found: ${resolved}`,
+    };
+  }
+
+  const bytes = readFileSync(resolved);
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  );
+
+  let folioProjection: StructuralProjection;
+  try {
+    const doc = await parseDocx(buffer);
+    folioProjection = projectFolioDocument(doc);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      reason: "infra",
+      message: `folio parseDocx failed: ${message}`,
+    };
+  }
+
+  const pythonResult = spawnSync(pythonBin, [PYTHON_SCRIPT, resolved], {
+    encoding: "utf-8",
+    timeout: 30_000,
+  });
+  if (pythonResult.error || pythonResult.status !== 0) {
+    const stderr = pythonResult.stderr.trim();
+    return {
+      ok: false,
+      reason: "infra",
+      message: [
+        `python-docx projection failed (exit ${pythonResult.status ?? "?"}).`,
+        stderr ? `stderr: ${stderr}` : "",
+        "Hint: pip install python-docx",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    };
+  }
+
+  let reference: unknown;
+  try {
+    reference = JSON.parse(pythonResult.stdout);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      reason: "infra",
+      message: `Failed to parse python projector JSON: ${message}`,
+    };
+  }
+
+  const divergences = diffProjections(folioProjection, reference);
+  if (divergences.length === 0) {
+    return { ok: true, folio: folioProjection, reference };
+  }
+  return {
+    ok: false,
+    reason: "diverged",
+    folio: folioProjection,
+    reference,
+    divergences,
+  };
+}
+
+const formatDivergences = (divergences: readonly Divergence[]): string =>
+  divergences
+    .map(
+      (d) =>
+        `  ${d.path}: folio=${JSON.stringify(d.folio)} reference=${JSON.stringify(d.reference)}`,
+    )
+    .join("\n");
+
+const isMain = import.meta.path === Bun.main;
+if (isMain) {
+  const docxPath = process.argv[2];
+  if (!docxPath) {
+    console.error("usage: bun diff.ts <docx-path>");
+    process.exit(EXIT_INFRA);
+  }
+  const result = await runDifferential(docxPath);
+  if (result.ok) {
+    console.log(`OK ${docxPath}`);
+    console.log(JSON.stringify(result.folio, null, 2));
+    process.exit(EXIT_OK);
+  }
+  if (result.reason === "infra") {
+    console.error(result.message);
+    process.exit(EXIT_INFRA);
+  }
+  console.error(`DIVERGED ${docxPath}`);
+  console.error(formatDivergences(result.divergences));
+  console.error("\nfolio projection:");
+  console.error(JSON.stringify(result.folio, null, 2));
+  console.error("\nreference projection:");
+  console.error(JSON.stringify(result.reference, null, 2));
+  process.exit(EXIT_DIVERGED);
+}

--- a/packages/folio/scripts/differential/diff.ts
+++ b/packages/folio/scripts/differential/diff.ts
@@ -62,11 +62,7 @@ export async function runDifferential(
     };
   }
 
-  const bytes = readFileSync(resolved);
-  const buffer = bytes.buffer.slice(
-    bytes.byteOffset,
-    bytes.byteOffset + bytes.byteLength,
-  );
+  const buffer = readFileSync(resolved);
 
   let folioProjection: StructuralProjection;
   try {
@@ -86,12 +82,17 @@ export async function runDifferential(
     timeout: 30_000,
   });
   if (pythonResult.error || pythonResult.status !== 0) {
-    const stderr = pythonResult.stderr.trim();
+    // `stderr` is null when spawn itself fails (python3 missing from PATH);
+    // guard so the harness still surfaces a clean infra error instead of
+    // crashing on `null.trim()`.
+    const stderr = pythonResult.stderr ? pythonResult.stderr.trim() : "";
+    const spawnError = pythonResult.error?.message ?? "";
     return {
       ok: false,
       reason: "infra",
       message: [
         `python-docx projection failed (exit ${pythonResult.status ?? "?"}).`,
+        spawnError ? `error: ${spawnError}` : "",
         stderr ? `stderr: ${stderr}` : "",
         "Hint: pip install python-docx",
       ]

--- a/packages/folio/scripts/differential/projection.ts
+++ b/packages/folio/scripts/differential/projection.ts
@@ -100,20 +100,70 @@ export function projectFolioDocument(doc: Document): StructuralProjection {
 
   const visitParagraph = (p: Paragraph): void => {
     totalParagraphs += 1;
-    for (const item of p.content) {
-      visitParagraphContent(item);
-    }
+    visitInlineSequence(p.content);
   };
 
-  const visitParagraphContent = (c: ParagraphContent): void => {
-    if (c.type === "inlineSdt") {
-      visitInlineSdt(c);
+  /**
+   * Walk a sequence of inline content (paragraph body or another inline
+   * SDT's children), emitting one SDT projection per *wire* `w:sdt`.
+   *
+   * Folio's `pushInlineSdtSegments` deliberately splits a single wire
+   * `w:sdt` whose content straddles a lifted marker (bookmark / comment
+   * range / tracked-change boundary) into multiple `InlineSdt` records
+   * that all share the same `SdtProperties` object reference. The python
+   * projector walks the XML and emits one entry per wire `w:sdt`, so to
+   * keep the differential signal honest we coalesce those split segments
+   * back into a single projection here (summing their `childCount`).
+   *
+   * Reference identity is sufficient: `parseSdtProperties` is called
+   * exactly once per wire `w:sdt`, and the resulting object is passed
+   * unchanged to every segment. Two distinct `w:sdt`s — even with
+   * identical alias/tag/lock — produce two distinct property objects.
+   *
+   * Runs, fields, comment markers, tracked-change markers, math: we walk
+   * into inline SDTs (they carry alias/tag/lock we want to compare),
+   * but otherwise the projection does not count paragraph-content
+   * items — see the run-count comment near `StructuralProjection`.
+   */
+  const visitInlineSequence = (items: readonly ParagraphContent[]): void => {
+    let pendingProps: SdtProperties | null = null;
+    let pendingChildCount = 0;
+    let pendingNested: InlineSdt[] = [];
+
+    const flush = (): void => {
+      if (pendingProps === null) {
+        return;
+      }
+      sdts.push({
+        scope: "inline",
+        sdtType: pendingProps.sdtType,
+        alias: pendingProps.alias,
+        tag: pendingProps.tag,
+        lock: pendingProps.lock,
+        childCount: pendingChildCount,
+      });
+      const nested = pendingNested;
+      pendingProps = null;
+      pendingChildCount = 0;
+      pendingNested = [];
+      for (const child of nested) {
+        visitInlineSequence(child.content);
+      }
+    };
+
+    for (const item of items) {
+      if (item.type !== "inlineSdt") {
+        flush();
+        continue;
+      }
+      if (pendingProps !== null && pendingProps !== item.properties) {
+        flush();
+      }
+      pendingProps = item.properties;
+      pendingChildCount += item.content.length;
+      pendingNested.push(item);
     }
-    // Runs, fields, comment markers, tracked-change markers, math: we
-    // walk into inline SDTs (because they carry alias/tag/lock we want
-    // to compare), but otherwise the projection does not count
-    // paragraph-content items — see the run-count comment near the
-    // StructuralProjection type for why.
+    flush();
   };
 
   const visitTable = (t: Table): void => {
@@ -153,22 +203,6 @@ export function projectFolioDocument(doc: Document): StructuralProjection {
         visitParagraph(child);
       } else {
         visitTable(child);
-      }
-    }
-  };
-
-  const visitInlineSdt = (sdt: InlineSdt): void => {
-    sdts.push({
-      scope: "inline",
-      sdtType: sdt.properties.sdtType,
-      alias: sdt.properties.alias,
-      tag: sdt.properties.tag,
-      lock: sdt.properties.lock,
-      childCount: sdt.content.length,
-    });
-    for (const child of sdt.content) {
-      if (child.type === "inlineSdt") {
-        visitInlineSdt(child);
       }
     }
   };

--- a/packages/folio/scripts/differential/projection.ts
+++ b/packages/folio/scripts/differential/projection.ts
@@ -153,7 +153,12 @@ export function projectFolioDocument(doc: Document): StructuralProjection {
 
     for (const item of items) {
       if (item.type !== "inlineSdt") {
-        flush();
+        // Lifted markers (bookmarks, comment ranges, tracked-change
+        // boundaries) appear as non-inlineSdt siblings between segments
+        // of the same wire `w:sdt`. Don't flush on them: keep the
+        // pending SDT alive so a later same-reference segment coalesces
+        // into one projection, matching python-docx's one entry per
+        // `w:sdt`.
         continue;
       }
       if (pendingProps !== null && pendingProps !== item.properties) {

--- a/packages/folio/scripts/differential/projection.ts
+++ b/packages/folio/scripts/differential/projection.ts
@@ -1,0 +1,247 @@
+/**
+ * Structural projection of a folio-parsed Document into a normalised JSON
+ * shape that can be compared against the equivalent projection produced
+ * by an external OOXML parser (currently python-docx). The two
+ * projections are intentionally narrow: they only cover fields that both
+ * sides expose and that map cleanly across parser ASTs.
+ *
+ * Adding a field here means: extend the python projector in the same
+ * directory in lockstep, and update README.md.
+ */
+
+import type {
+  BlockContent,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  ParagraphContent,
+  BlockSdt,
+  InlineSdt,
+  SdtProperties,
+  SdtType,
+} from "../../src/core/types/content";
+import type { Document } from "../../src/core/types/document";
+
+/**
+ * Normalised SDT projection. Keys are deliberately ordered and only
+ * include fields python-docx can recover from the wire format.
+ */
+export type SdtProjection = {
+  scope: "block" | "inline";
+  sdtType: SdtType;
+  alias?: string;
+  tag?: string;
+  lock?: NonNullable<SdtProperties["lock"]>;
+  /** Number of direct child elements inside the SDT (paragraphs/tables for
+   *  block scope, runs/fields/etc. for inline scope). */
+  childCount: number;
+};
+
+export type StructuralProjection = {
+  /** Schema version so a future python projector and this projector can
+   *  detect drift loudly instead of silently diffing different shapes. */
+  schemaVersion: 1;
+  /** All paragraphs reachable from the body subtree (top level + nested
+   *  in tables and block SDTs). Mirrors python-docx counting against the
+   *  `w:p` element set. */
+  totalParagraphs: number;
+  /** All tables reachable from the body subtree (`w:tbl`). */
+  totalTables: number;
+  /** Top-level block content count (paragraph | table | blockSdt). */
+  topLevelBlocks: number;
+  /** SDT inventory in document order. */
+  sdts: SdtProjection[];
+  /** SDT count by type. Useful for a quick eyeball diff. */
+  sdtCountsByType: Partial<Record<SdtType | "block" | "inline", number>>;
+};
+
+/**
+ * Run counts intentionally omitted from the projection: folio applies a
+ * run consolidator (adjacent identically-formatted `w:r` elements collapse
+ * into one), so wire-format run counts will always diverge from
+ * python-docx's `w:r` count on real documents. Adding it back would make
+ * every interesting fixture diverge for an uninteresting reason. If
+ * future work needs run-level parity, compare *consolidated* runs on both
+ * sides (e.g., post-process python-docx output through the same merge
+ * rules) rather than raw `w:r` count.
+ */
+
+/**
+ * Project a folio Document into the normalised structural shape.
+ */
+export function projectFolioDocument(doc: Document): StructuralProjection {
+  const body = doc.package.document;
+  const sdts: SdtProjection[] = [];
+  let totalParagraphs = 0;
+  let totalTables = 0;
+
+  const visitBlock = (block: BlockContent): void => {
+    if (block.type === "paragraph") {
+      visitParagraph(block);
+      return;
+    }
+    if (block.type === "table") {
+      visitTable(block);
+      return;
+    }
+    visitBlockSdt(block);
+  };
+
+  const visitParagraph = (p: Paragraph): void => {
+    totalParagraphs += 1;
+    for (const item of p.content) {
+      visitParagraphContent(item);
+    }
+  };
+
+  const visitParagraphContent = (c: ParagraphContent): void => {
+    if (c.type === "inlineSdt") {
+      visitInlineSdt(c);
+    }
+    // Runs, fields, comment markers, tracked-change markers, math: we
+    // walk into inline SDTs (because they carry alias/tag/lock we want
+    // to compare), but otherwise the projection does not count
+    // paragraph-content items — see the run-count comment near the
+    // StructuralProjection type for why.
+  };
+
+  const visitTable = (t: Table): void => {
+    totalTables += 1;
+    for (const row of t.rows) {
+      visitRow(row);
+    }
+  };
+
+  const visitRow = (row: TableRow): void => {
+    for (const cell of row.cells) {
+      visitCell(cell);
+    }
+  };
+
+  const visitCell = (cell: TableCell): void => {
+    for (const child of cell.content) {
+      if (child.type === "paragraph") {
+        visitParagraph(child);
+      } else {
+        visitTable(child);
+      }
+    }
+  };
+
+  const visitBlockSdt = (sdt: BlockSdt): void => {
+    sdts.push({
+      scope: "block",
+      sdtType: sdt.properties.sdtType,
+      alias: sdt.properties.alias,
+      tag: sdt.properties.tag,
+      lock: sdt.properties.lock,
+      childCount: sdt.content.length,
+    });
+    for (const child of sdt.content) {
+      if (child.type === "paragraph") {
+        visitParagraph(child);
+      } else {
+        visitTable(child);
+      }
+    }
+  };
+
+  const visitInlineSdt = (sdt: InlineSdt): void => {
+    sdts.push({
+      scope: "inline",
+      sdtType: sdt.properties.sdtType,
+      alias: sdt.properties.alias,
+      tag: sdt.properties.tag,
+      lock: sdt.properties.lock,
+      childCount: sdt.content.length,
+    });
+    for (const child of sdt.content) {
+      if (child.type === "inlineSdt") {
+        visitInlineSdt(child);
+      }
+    }
+  };
+
+  for (const block of body.content) {
+    visitBlock(block);
+  }
+
+  return {
+    schemaVersion: 1,
+    totalParagraphs,
+    totalTables,
+    topLevelBlocks: body.content.length,
+    sdts,
+    sdtCountsByType: summariseSdts(sdts),
+  };
+}
+
+const summariseSdts = (
+  sdts: readonly SdtProjection[],
+): StructuralProjection["sdtCountsByType"] => {
+  const out: StructuralProjection["sdtCountsByType"] = {};
+  for (const s of sdts) {
+    out[s.sdtType] = (out[s.sdtType] ?? 0) + 1;
+    out[s.scope] = (out[s.scope] ?? 0) + 1;
+  }
+  return out;
+};
+
+/**
+ * Diff two structural projections. Returns the empty array on equivalence.
+ *
+ * The differential test ignores absolute values and only reports field-by-
+ * field divergences. python-docx returns a vanilla shape so unknown keys
+ * are not expected; if a future python projector emits unknown fields they
+ * will show up as `extraField`/`missingField` diffs and surface the drift.
+ */
+export type Divergence = {
+  path: string;
+  folio: unknown;
+  reference: unknown;
+};
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+export function diffProjections(
+  folio: StructuralProjection,
+  reference: unknown,
+): Divergence[] {
+  const out: Divergence[] = [];
+  walk("", folio, reference, out);
+  return out;
+}
+
+const walk = (
+  path: string,
+  folio: unknown,
+  reference: unknown,
+  out: Divergence[],
+): void => {
+  if (Array.isArray(folio)) {
+    if (!Array.isArray(reference) || folio.length !== reference.length) {
+      out.push({ path: path || "$", folio, reference });
+      return;
+    }
+    for (const [i, item] of folio.entries()) {
+      walk(`${path}[${i}]`, item, reference[i], out);
+    }
+    return;
+  }
+  if (isPlainObject(folio)) {
+    if (!isPlainObject(reference)) {
+      out.push({ path: path || "$", folio, reference });
+      return;
+    }
+    const keys = new Set([...Object.keys(folio), ...Object.keys(reference)]);
+    for (const k of keys) {
+      walk(path ? `${path}.${k}` : k, folio[k], reference[k], out);
+    }
+    return;
+  }
+  if (folio !== reference) {
+    out.push({ path: path || "$", folio, reference });
+  }
+};

--- a/packages/folio/scripts/differential/projection.ts
+++ b/packages/folio/scripts/differential/projection.ts
@@ -26,13 +26,19 @@ import type { Document } from "../../src/core/types/document";
 /**
  * Normalised SDT projection. Keys are deliberately ordered and only
  * include fields python-docx can recover from the wire format.
+ *
+ * Optional fields use `string | undefined` (not bare `string?`) so that
+ * with `exactOptionalPropertyTypes: true` callers can assign the source
+ * value directly without first narrowing away `undefined`. The python
+ * projector omits the key when the wire format has no value, so the
+ * structural diff already treats `missing` and `undefined` identically.
  */
 export type SdtProjection = {
   scope: "block" | "inline";
   sdtType: SdtType;
-  alias?: string;
-  tag?: string;
-  lock?: NonNullable<SdtProperties["lock"]>;
+  alias: string | undefined;
+  tag: string | undefined;
+  lock: NonNullable<SdtProperties["lock"]> | undefined;
   /** Number of direct child elements inside the SDT (paragraphs/tables for
    *  block scope, runs/fields/etc. for inline scope). */
   childCount: number;
@@ -85,6 +91,10 @@ export function projectFolioDocument(doc: Document): StructuralProjection {
       visitTable(block);
       return;
     }
+    // BlockContent = Paragraph | Table | BlockSdt — the remaining branch
+    // is structurally guaranteed to be a BlockSdt. An explicit
+    // `block.type === "blockSdt"` check trips no-unnecessary-condition
+    // because the comparison is between two literal types.
     visitBlockSdt(block);
   };
 

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -46,6 +46,11 @@ SDT_TYPE_ELEMENTS = (
     ("w:group", "group"),
 )
 
+# Pre-resolve the qualified-name lookup so detect_sdt_type does not pay the
+# `qn()` cost on every traversal step (it is called once per `w:sdt` in the
+# document).
+SDT_TYPE_MAP = tuple((qn(tag), normalised) for tag, normalised in SDT_TYPE_ELEMENTS)
+
 # python-docx exposes w14 namespace via the same qn helper if the element
 # is declared. We probe both namespaces for the checkbox case which lives
 # under w14 in real-world templates.
@@ -54,13 +59,33 @@ W14_CHECKBOX = "{http://schemas.microsoft.com/office/word/2010/wordml}checkbox"
 
 LOCK_VALUES = {"sdtLocked", "contentLocked", "sdtContentLocked", "unlocked"}
 
+# Tags that can appear directly inside an inline `w:sdtContent`. Defined at
+# module scope so project_sdt does not rebuild the set per call.
+INLINE_TAGS = frozenset(
+    {
+        qn("w:r"),
+        qn("w:hyperlink"),
+        qn("w:fldSimple"),
+        qn("w:sdt"),
+        "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMath",
+        "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMathPara",
+    }
+)
+
+# Parent tags that mark an SDT as inline-scoped. `w:sdtContent` itself is
+# transparent in OOXML — when an inline SDT is nested inside another inline
+# SDT, the direct parent in the XML tree is the outer `w:sdtContent`, so we
+# walk past sdtContent ancestors when classifying scope.
+INLINE_PARENT_TAGS = frozenset({qn("w:p"), qn("w:hyperlink"), qn("w:smartTag")})
+SDT_CONTENT_TAG = qn("w:sdtContent")
+
 
 def detect_sdt_type(sdt_pr: Any) -> str:
     """Map a w:sdtPr element to a normalised SdtType."""
     if sdt_pr is None:
         return "unknown"
-    for tag, normalised in SDT_TYPE_ELEMENTS:
-        if sdt_pr.find(qn(tag)) is not None:
+    for qn_tag, normalised in SDT_TYPE_MAP:
+        if sdt_pr.find(qn_tag) is not None:
             return normalised
     if sdt_pr.find(W14_CHECKBOX) is not None:
         return "checkbox"
@@ -82,12 +107,19 @@ def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     inside `w:p` it is inline.
     """
     sdt_pr = sdt_elem.find(qn("w:sdtPr"))
-    sdt_content = sdt_elem.find(qn("w:sdtContent"))
+    sdt_content = sdt_elem.find(SDT_CONTENT_TAG)
 
-    parent = sdt_elem.getparent()
-    parent_tag = parent.tag if parent is not None else ""
-    inline_parents = {qn("w:p"), qn("w:hyperlink"), qn("w:smartTag")}
-    scope = "inline" if parent_tag in inline_parents else "block"
+    # Walk up past any `w:sdtContent` ancestors so a nested inline SDT
+    # (whose direct parent is the outer SDT's content wrapper) is still
+    # classified by the surrounding `w:p`/`w:hyperlink`/`w:smartTag`. Folio
+    # preserves nested inline SDTs as `InlineSdt`, so misclassifying them
+    # as block here would produce a false `scope`/`childCount` divergence
+    # on every fixture with nested controls.
+    scope_parent = sdt_elem.getparent()
+    while scope_parent is not None and scope_parent.tag == SDT_CONTENT_TAG:
+        scope_parent = scope_parent.getparent()
+    scope_parent_tag = scope_parent.tag if scope_parent is not None else ""
+    scope = "inline" if scope_parent_tag in INLINE_PARENT_TAGS else "block"
 
     alias = text_attr(sdt_pr, "w:alias") if sdt_pr is not None else None
     tag_val = text_attr(sdt_pr, "w:tag") if sdt_pr is not None else None
@@ -107,15 +139,7 @@ def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     else:
         # Direct inline children: runs, hyperlinks, fields, nested SDTs,
         # math. Match the union in InlineSdt.content in content.ts.
-        inline_tags = {
-            qn("w:r"),
-            qn("w:hyperlink"),
-            qn("w:fldSimple"),
-            qn("w:sdt"),
-            "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMath",
-            "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMathPara",
-        }
-        child_count = sum(1 for child in sdt_content if child.tag in inline_tags)
+        child_count = sum(1 for child in sdt_content if child.tag in INLINE_TAGS)
 
     out: dict[str, Any] = {
         "scope": scope,

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -31,8 +31,11 @@ SCHEMA_VERSION = 1
 
 
 # OOXML SDT-type element -> normalised SdtType matching folio's union in
-# packages/docx-core/src/model/content.ts. Names without a w:sdtPr child of
-# any recognised type fall back to "unknown" (matches folio's default).
+# packages/docx-core/src/model/content.ts. SDTs without an explicit type
+# child fall back to "richText" — that mirrors folio's `parseSdtProperties`
+# default (a rich-text content control is the OOXML default when no type
+# element is present, so a w:sdtPr containing only w:alias/w:tag is still
+# a rich-text control).
 SDT_TYPE_ELEMENTS = (
     ("w:richText", "richText"),
     ("w:text", "plainText"),
@@ -81,15 +84,19 @@ SDT_CONTENT_TAG = qn("w:sdtContent")
 
 
 def detect_sdt_type(sdt_pr: Any) -> str:
-    """Map a w:sdtPr element to a normalised SdtType."""
+    """Map a w:sdtPr element to a normalised SdtType.
+
+    Mirrors folio's `parseSdtProperties`: a content control without an
+    explicit type child is a rich-text control by default.
+    """
     if sdt_pr is None:
-        return "unknown"
+        return "richText"
     for qn_tag, normalised in SDT_TYPE_MAP:
         if sdt_pr.find(qn_tag) is not None:
             return normalised
     if sdt_pr.find(W14_CHECKBOX) is not None:
         return "checkbox"
-    return "unknown"
+    return "richText"
 
 
 def text_attr(elem: Any, tag: str, attr: str = "w:val") -> str | None:

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -125,6 +125,51 @@ def text_attr(elem: Any, tag: str, attr: str = "w:val") -> str | None:
     return child.get(qn(attr))
 
 
+RUN_TAG = qn("w:r")
+FLD_CHAR_TAG = qn("w:fldChar")
+FLD_CHAR_TYPE_ATTR = qn("w:fldCharType")
+
+
+def run_field_char_type(run_elem: Any) -> str | None:
+    """Return the fldCharType of the first w:fldChar inside this w:r, or None."""
+    fld_char = run_elem.find(FLD_CHAR_TAG)
+    if fld_char is None:
+        return None
+    return fld_char.get(FLD_CHAR_TYPE_ATTR)
+
+
+def count_inline_children(sdt_content: Any) -> int:
+    """Count direct inline children, collapsing complex fields to one item.
+
+    A complex field is a `begin` fldChar w:r through the matching `end`
+    fldChar w:r (with separator and result runs in between). Folio models
+    the whole span as a single `complexField` `ParagraphContent` item, so
+    we match that by counting the entire span as 1. Nested complex fields
+    are common (e.g. PAGEREF inside a TOC entry) and tracked with a depth
+    counter.
+    """
+    count = 0
+    field_depth = 0
+    for child in sdt_content:
+        if child.tag != RUN_TAG:
+            if field_depth == 0 and child.tag in INLINE_TAGS:
+                count += 1
+            continue
+        char_type = run_field_char_type(child)
+        if char_type == "begin":
+            if field_depth == 0:
+                count += 1
+            field_depth += 1
+            continue
+        if char_type == "end":
+            if field_depth > 0:
+                field_depth -= 1
+            continue
+        if field_depth == 0:
+            count += 1
+    return count
+
+
 def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     """Project one w:sdt element into the normalised shape.
 
@@ -166,7 +211,19 @@ def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     else:
         # Direct inline children: runs, hyperlinks, fields, nested SDTs,
         # math. Match the union in InlineSdt.content in content.ts.
-        child_count = sum(1 for child in sdt_content if child.tag in INLINE_TAGS)
+        #
+        # Complex fields span multiple direct `w:r` children
+        # (`fldChar begin` … `instrText` … `fldChar separate` … result …
+        # `fldChar end`), but folio collapses them into a single
+        # `complexField` `ParagraphContent` item — see `ComplexField` in
+        # `docx-core/src/model/content.ts` and the inline-SDT parser test
+        # at `paragraphParser.test.ts:337`. To keep `childCount` aligned
+        # we collapse the same range here: every `w:r` from a `begin`
+        # fldChar up to and including the matching `end` fldChar counts
+        # as one logical item. Nested complex fields are tracked with a
+        # depth counter so an inner `begin`/`end` pair doesn't close the
+        # outer field early.
+        child_count = count_inline_children(sdt_content)
 
     out: dict[str, Any] = {
         "scope": scope,

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -1,0 +1,197 @@
+"""Structural projection of a DOCX file as parsed by python-docx.
+
+Emits JSON on stdout matching the shape produced by `projection.ts` so the
+two can be diffed structurally. Counters walk the OOXML element tree
+(`w:p`, `w:r`, `w:tbl`, `w:sdt`) rather than python-docx's high-level
+API, because the high-level API drops paragraphs nested in tables and
+content controls — and the point of the differential test is to compare
+all paragraphs/runs/SDTs in the body subtree against folio's parse.
+
+Usage:
+    python3 python_docx_project.py path/to/file.docx
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+try:
+    import docx
+    from docx.oxml.ns import qn
+except ImportError:  # pragma: no cover — surfaces an install hint
+    sys.stderr.write(
+        "python-docx not installed. Install with: pip install python-docx\n"
+    )
+    sys.exit(2)
+
+
+SCHEMA_VERSION = 1
+
+
+# OOXML SDT-type element -> normalised SdtType matching folio's union in
+# packages/docx-core/src/model/content.ts. Names without a w:sdtPr child of
+# any recognised type fall back to "unknown" (matches folio's default).
+SDT_TYPE_ELEMENTS = (
+    ("w:richText", "richText"),
+    ("w:text", "plainText"),
+    ("w:date", "date"),
+    ("w:dropDownList", "dropdown"),
+    ("w:comboBox", "comboBox"),
+    ("w:checkbox", "checkbox"),  # w14:checkbox in practice; see below
+    ("w:picture", "picture"),
+    ("w:docPartObj", "buildingBlockGallery"),
+    ("w:docPartList", "buildingBlockGallery"),
+    ("w:group", "group"),
+)
+
+# python-docx exposes w14 namespace via the same qn helper if the element
+# is declared. We probe both namespaces for the checkbox case which lives
+# under w14 in real-world templates.
+W14_CHECKBOX = "{http://schemas.microsoft.com/office/word/2010/wordml}checkbox"
+
+
+LOCK_VALUES = {"sdtLocked", "contentLocked", "sdtContentLocked", "unlocked"}
+
+
+def detect_sdt_type(sdt_pr: Any) -> str:
+    """Map a w:sdtPr element to a normalised SdtType."""
+    if sdt_pr is None:
+        return "unknown"
+    for tag, normalised in SDT_TYPE_ELEMENTS:
+        if sdt_pr.find(qn(tag)) is not None:
+            return normalised
+    if sdt_pr.find(W14_CHECKBOX) is not None:
+        return "checkbox"
+    return "unknown"
+
+
+def text_attr(elem: Any, tag: str, attr: str = "w:val") -> str | None:
+    child = elem.find(qn(tag))
+    if child is None:
+        return None
+    return child.get(qn(attr))
+
+
+def project_sdt(sdt_elem: Any) -> dict[str, Any]:
+    """Project one w:sdt element into the normalised shape.
+
+    `scope` is inferred from the parent element: an `sdt` inside `w:body`,
+    `w:tc`, or another `w:sdtContent` of block scope is block-scoped;
+    inside `w:p` it is inline.
+    """
+    sdt_pr = sdt_elem.find(qn("w:sdtPr"))
+    sdt_content = sdt_elem.find(qn("w:sdtContent"))
+
+    parent = sdt_elem.getparent()
+    parent_tag = parent.tag if parent is not None else ""
+    inline_parents = {qn("w:p"), qn("w:hyperlink"), qn("w:smartTag")}
+    scope = "inline" if parent_tag in inline_parents else "block"
+
+    alias = text_attr(sdt_pr, "w:alias") if sdt_pr is not None else None
+    tag_val = text_attr(sdt_pr, "w:tag") if sdt_pr is not None else None
+    lock = text_attr(sdt_pr, "w:lock") if sdt_pr is not None else None
+    if lock not in LOCK_VALUES:
+        lock = None
+
+    if sdt_content is None:
+        child_count = 0
+    elif scope == "block":
+        # Direct paragraph/table children.
+        child_count = sum(
+            1
+            for child in sdt_content
+            if child.tag in (qn("w:p"), qn("w:tbl"), qn("w:sdt"))
+        )
+    else:
+        # Direct inline children: runs, hyperlinks, fields, nested SDTs,
+        # math. Match the union in InlineSdt.content in content.ts.
+        inline_tags = {
+            qn("w:r"),
+            qn("w:hyperlink"),
+            qn("w:fldSimple"),
+            qn("w:sdt"),
+            "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMath",
+            "{http://schemas.openxmlformats.org/officeDocument/2006/math}oMathPara",
+        }
+        child_count = sum(1 for child in sdt_content if child.tag in inline_tags)
+
+    out: dict[str, Any] = {
+        "scope": scope,
+        "sdtType": detect_sdt_type(sdt_pr),
+        "childCount": child_count,
+    }
+    if alias is not None:
+        out["alias"] = alias
+    if tag_val is not None:
+        out["tag"] = tag_val
+    if lock is not None:
+        out["lock"] = lock
+    return out
+
+
+def project(path: str) -> dict[str, Any]:
+    doc = docx.Document(path)
+    body = doc.element.body
+
+    # Top-level blocks: direct children of <w:body> that are
+    # paragraph/table/sdt. `w:sectPr` at the end of the body is metadata,
+    # not a block.
+    top_level_tags = {qn("w:p"), qn("w:tbl"), qn("w:sdt")}
+    top_level_blocks = sum(1 for child in body if child.tag in top_level_tags)
+
+    # Exclude paragraphs/tables nested inside textbox drawing content
+    # (`w:txbxContent`). folio models drawing-anchored text as run-level
+    # shape content rather than block content, so counting textbox paras
+    # here would always diverge for an uninteresting reason. The
+    # divergence on textbox-heavy fixtures is a known structural shape
+    # difference, not a parse bug; track it separately if textbox parity
+    # becomes interesting.
+    def in_textbox(elem: Any) -> bool:
+        parent = elem.getparent()
+        while parent is not None:
+            if parent.tag == qn("w:txbxContent"):
+                return True
+            parent = parent.getparent()
+        return False
+
+    total_paragraphs = sum(
+        1 for p in body.findall(".//" + qn("w:p")) if not in_textbox(p)
+    )
+    total_tables = sum(
+        1 for t in body.findall(".//" + qn("w:tbl")) if not in_textbox(t)
+    )
+
+    sdts = [
+        project_sdt(elem)
+        for elem in body.findall(".//" + qn("w:sdt"))
+        if not in_textbox(elem)
+    ]
+
+    counts: dict[str, int] = {}
+    for s in sdts:
+        counts[s["sdtType"]] = counts.get(s["sdtType"], 0) + 1
+        counts[s["scope"]] = counts.get(s["scope"], 0) + 1
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "totalParagraphs": total_paragraphs,
+        "totalTables": total_tables,
+        "topLevelBlocks": top_level_blocks,
+        "sdts": sdts,
+        "sdtCountsByType": counts,
+    }
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: python_docx_project.py <docx-path>\n")
+        return 2
+    sys.stdout.write(json.dumps(project(sys.argv[1]), indent=2))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -75,12 +75,18 @@ INLINE_TAGS = frozenset(
     }
 )
 
-# Parent tags that mark an SDT as inline-scoped. `w:sdtContent` itself is
-# transparent in OOXML — when an inline SDT is nested inside another inline
-# SDT, the direct parent in the XML tree is the outer `w:sdtContent`, so we
-# walk past sdtContent ancestors when classifying scope.
+# Parent tags that mark an SDT as inline-scoped. `w:sdtContent` and the
+# enclosing `w:sdt` are transparent for scope classification: when an inline
+# SDT is nested inside another inline SDT the parent chain is
+# `inner sdt → outer sdtContent → outer sdt → outer sdtContent → w:p`, so we
+# walk past both `w:sdtContent` and `w:sdt` ancestors to find the surrounding
+# paragraph/hyperlink/smartTag that decides scope. Folio preserves nested
+# inline SDTs as `InlineSdt`, so missing this step would misclassify them as
+# `block` and produce false `scope`/`childCount` divergences.
 INLINE_PARENT_TAGS = frozenset({qn("w:p"), qn("w:hyperlink"), qn("w:smartTag")})
 SDT_CONTENT_TAG = qn("w:sdtContent")
+SDT_TAG = qn("w:sdt")
+SCOPE_TRANSPARENT_TAGS = frozenset({SDT_CONTENT_TAG, SDT_TAG})
 
 
 def detect_sdt_type(sdt_pr: Any) -> str:
@@ -116,14 +122,15 @@ def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     sdt_pr = sdt_elem.find(qn("w:sdtPr"))
     sdt_content = sdt_elem.find(SDT_CONTENT_TAG)
 
-    # Walk up past any `w:sdtContent` ancestors so a nested inline SDT
-    # (whose direct parent is the outer SDT's content wrapper) is still
-    # classified by the surrounding `w:p`/`w:hyperlink`/`w:smartTag`. Folio
-    # preserves nested inline SDTs as `InlineSdt`, so misclassifying them
-    # as block here would produce a false `scope`/`childCount` divergence
-    # on every fixture with nested controls.
+    # Walk up past any `w:sdtContent` and `w:sdt` ancestors so a nested
+    # inline SDT (whose direct parent is the outer SDT's content wrapper,
+    # itself wrapped by an outer `w:sdt`) is still classified by the
+    # surrounding `w:p`/`w:hyperlink`/`w:smartTag`. Folio preserves nested
+    # inline SDTs as `InlineSdt`, so misclassifying them as block here
+    # would produce a false `scope`/`childCount` divergence on every
+    # fixture with nested controls.
     scope_parent = sdt_elem.getparent()
-    while scope_parent is not None and scope_parent.tag == SDT_CONTENT_TAG:
+    while scope_parent is not None and scope_parent.tag in SCOPE_TRANSPARENT_TAGS:
         scope_parent = scope_parent.getparent()
     scope_parent_tag = scope_parent.tag if scope_parent is not None else ""
     scope = "inline" if scope_parent_tag in INLINE_PARENT_TAGS else "block"

--- a/packages/folio/scripts/differential/python_docx_project.py
+++ b/packages/folio/scripts/differential/python_docx_project.py
@@ -75,18 +75,31 @@ INLINE_TAGS = frozenset(
     }
 )
 
-# Parent tags that mark an SDT as inline-scoped. `w:sdtContent` and the
-# enclosing `w:sdt` are transparent for scope classification: when an inline
-# SDT is nested inside another inline SDT the parent chain is
-# `inner sdt → outer sdtContent → outer sdt → outer sdtContent → w:p`, so we
-# walk past both `w:sdtContent` and `w:sdt` ancestors to find the surrounding
-# paragraph/hyperlink/smartTag that decides scope. Folio preserves nested
-# inline SDTs as `InlineSdt`, so missing this step would misclassify them as
-# `block` and produce false `scope`/`childCount` divergences.
+# Parent tags that mark an SDT as inline-scoped. `w:sdtContent`, the enclosing
+# `w:sdt`, and the tracked-change wrappers `w:ins`/`w:del`/`w:moveFrom`/
+# `w:moveTo` are transparent for scope classification: when an inline SDT is
+# nested inside another inline SDT or wrapped by a tracked change, its direct
+# XML parent is one of these wrappers rather than `w:p`/`w:hyperlink`/
+# `w:smartTag`. Folio parses tracked-change wrappers through
+# `parseParagraphContents` and lifts non-run SDTs back into paragraph-level
+# inline content, so we walk past these ancestors to find the enclosing
+# paragraph/hyperlink/smartTag that decides scope. Missing this step would
+# misclassify wrapped inline SDTs as `block` and produce false
+# `scope`/`childCount` divergences on fixtures with inserted/deleted/moved
+# content controls.
 INLINE_PARENT_TAGS = frozenset({qn("w:p"), qn("w:hyperlink"), qn("w:smartTag")})
 SDT_CONTENT_TAG = qn("w:sdtContent")
 SDT_TAG = qn("w:sdt")
-SCOPE_TRANSPARENT_TAGS = frozenset({SDT_CONTENT_TAG, SDT_TAG})
+SCOPE_TRANSPARENT_TAGS = frozenset(
+    {
+        SDT_CONTENT_TAG,
+        SDT_TAG,
+        qn("w:ins"),
+        qn("w:del"),
+        qn("w:moveFrom"),
+        qn("w:moveTo"),
+    }
+)
 
 
 def detect_sdt_type(sdt_pr: Any) -> str:
@@ -122,13 +135,13 @@ def project_sdt(sdt_elem: Any) -> dict[str, Any]:
     sdt_pr = sdt_elem.find(qn("w:sdtPr"))
     sdt_content = sdt_elem.find(SDT_CONTENT_TAG)
 
-    # Walk up past any `w:sdtContent` and `w:sdt` ancestors so a nested
-    # inline SDT (whose direct parent is the outer SDT's content wrapper,
-    # itself wrapped by an outer `w:sdt`) is still classified by the
-    # surrounding `w:p`/`w:hyperlink`/`w:smartTag`. Folio preserves nested
-    # inline SDTs as `InlineSdt`, so misclassifying them as block here
-    # would produce a false `scope`/`childCount` divergence on every
-    # fixture with nested controls.
+    # Walk up past any `w:sdtContent`, `w:sdt`, or tracked-change wrappers
+    # (`w:ins`/`w:del`/`w:moveFrom`/`w:moveTo`) so a nested or
+    # tracked-change-wrapped inline SDT is still classified by the
+    # surrounding `w:p`/`w:hyperlink`/`w:smartTag`. Folio preserves these
+    # SDTs as `InlineSdt`, so misclassifying them as block here would
+    # produce a false `scope`/`childCount` divergence on every fixture
+    # with nested controls or inserted/deleted/moved content controls.
     scope_parent = sdt_elem.getparent()
     while scope_parent is not None and scope_parent.tag in SCOPE_TRANSPARENT_TAGS:
         scope_parent = scope_parent.getparent()

--- a/packages/folio/src/core/docx/__tests__/differential.test.ts
+++ b/packages/folio/src/core/docx/__tests__/differential.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Smoke test for the differential testing harness.
+ *
+ * Proves the harness wired in `packages/folio/scripts/differential/`
+ * runs end-to-end against a real fixture and surfaces zero divergences
+ * for a parse the team already considers correct. The smoke test does
+ * NOT lock in equivalence for the whole corpus — adding more fixtures
+ * is intentionally a follow-up so a single PR does not commit the
+ * project to maintaining differential parity across the entire fixture
+ * suite.
+ *
+ * If python-docx is not installed on the host (or python3 is missing),
+ * the test is skipped rather than failing. This lets contributors
+ * without the optional Python dependency run `bun test` cleanly. See
+ * `packages/folio/scripts/differential/README.md` for setup.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+import { runDifferential } from "../../../../scripts/differential/diff";
+
+const FIXTURE_PATH = join(
+  import.meta.dir,
+  "__fixtures__",
+  "regressions",
+  "repack-paragraph-sectpr.docx",
+);
+
+const isPythonDocxAvailable = (): boolean => {
+  const result = spawnSync("python3", ["-c", "import docx"], {
+    encoding: "utf-8",
+    timeout: 5000,
+  });
+  return !result.error && result.status === 0;
+};
+
+describe("differential parser harness (folio vs python-docx)", () => {
+  if (!isPythonDocxAvailable()) {
+    test.skip("python-docx not installed; see scripts/differential/README.md", () => {});
+    return;
+  }
+
+  test("structural projection matches python-docx for a known-good fixture", async () => {
+    const result = await runDifferential(FIXTURE_PATH);
+    if (!result.ok) {
+      if (result.reason === "infra") {
+        throw new Error(`harness infrastructure failure: ${result.message}`);
+      }
+      throw new Error(
+        `unexpected divergence on smoke fixture:\n${JSON.stringify(result.divergences, null, 2)}\n\nfolio: ${JSON.stringify(result.folio, null, 2)}\nreference: ${JSON.stringify(result.reference, null, 2)}`,
+      );
+    }
+    expect(result.ok).toBe(true);
+    // Sanity: confirm the projection actually walked the document
+    // rather than returning trivial zeroes that would also match.
+    expect(result.folio.totalParagraphs).toBeGreaterThan(0);
+    expect(result.folio.totalTables).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Set up a small scaffold for cross-checking folio's DOCX parser against an
established reference parser (`python-docx`). Both sides emit the same
normalised JSON projection (paragraph / table / SDT counts + per-SDT
alias/tag/lock/type); the harness diffs them structurally and exits
non-zero on divergence.

Scope is the scaffold only — one orchestrator script, one projection
helper per side, one smoke test on an existing fixture. The smoke test
auto-skips when `python-docx` is not installed so contributors without
the optional Python dependency still see a clean local test run.

## Why this matters

PR #587 (block-level content controls / `w:sdt`) surfaced a handful of
prefix / namespace / OnOff edge cases where a spec-faithful
implementation still disagreed with how mature parsers actually
interpret the wire format. Running real DOCX inputs through both
parsers and diffing structural projections catches that class of
divergence directly, instead of waiting for each individual edge case
to land as a user-reported bug.

## Why python-docx (over docx4j)

- **No JVM** — runs in under a second per small fixture; trivial to
  shell out from Bun.
- **Already on the dev image** — Python 3.x is preinstalled on macOS
  dev machines and most CI runners; the only extra step is
  `pip install python-docx`.
- **Wire-format-friendly** — python-docx exposes the underlying `lxml`
  element tree, so the projector counts `w:p` / `w:tbl` / `w:sdt`
  directly against XPath rather than relying on python-docx's
  high-level API (which silently drops paragraphs nested in tables and
  content controls).

docx4j was considered but requires a JVM in CI and a much larger
install footprint. Revisit if there's a specific behaviour python-docx
cannot model (e.g., advanced field resolution).

## Files

- `packages/folio/scripts/differential/projection.ts` — folio-side
  projection.
- `packages/folio/scripts/differential/python_docx_project.py` —
  python-docx-side projection, emitting identical JSON shape.
- `packages/folio/scripts/differential/diff.ts` — orchestrator CLI;
  exports `runDifferential()` reused by the smoke test.
- `packages/folio/scripts/differential/README.md` — setup, projection
  shape, and follow-up sketch.
- `packages/folio/src/core/docx/__tests__/differential.test.ts` — single
  smoke test on `repack-paragraph-sectpr.docx`, skips if python-docx is
  not installed.

## What the projection includes (and why some fields are excluded)

Included: `totalParagraphs`, `totalTables`, `topLevelBlocks`, an `sdts`
inventory (`scope`, `sdtType`, `alias`, `tag`, `lock`, `childCount`),
and a `sdtCountsByType` summary.

Excluded by design:

- **Run count.** folio applies a run consolidator (adjacent identically-
  formatted `w:r` collapse into one). Wire-format run counts will
  therefore always diverge from python-docx on real documents; keeping
  the field would make every interesting fixture diverge for an
  uninteresting reason. Documented in `projection.ts`; revisit by
  comparing *consolidated* runs on both sides.
- **Textbox content (`w:txbxContent`).** folio models drawing-anchored
  paragraphs/tables as run-level shape content, not block content. The
  python projector excludes paragraphs/tables/SDTs inside
  `w:txbxContent` to keep the body-block comparison apples-to-apples.

## Divergences surfaced during scaffolding

Running the harness against the existing folio fixtures while building
this scaffold turned up two real issues worth noting:

- **Run-count divergence** (`podily-bps.docx`): folio reports 779 runs
  vs. python-docx's 3863. Confirmed to be the run consolidator
  behaviour; led to the design decision above.
- **Textbox paragraph divergence** (`repack-image-count.docx`): 100
  body-block paragraphs in folio vs. 106 in python-docx; the 6
  paragraphs live inside `w:txbxContent`. folio's data model treats
  drawing content separately; led to the textbox filter in the python
  projector.

Both are intentional structural differences, not parser bugs. They are
documented in the projection rationale so the next person to extend the
projection does not re-discover them.

## How to extend (follow-up PRs)

1. Drop additional fixtures under
   `packages/folio/src/core/docx/__tests__/__fixtures__/differential/`
   (none in this PR — the smoke test reuses an existing fixture).
2. Add a `differential-corpus.ts` script that globs the directory and
   accumulates results.
3. Triage each new divergence: fix folio, document an intentional shape
   difference, or record as a known divergence with a tracking issue.
4. Decide whether to wire the corpus into CI. Start opt-in / nightly;
   not a blocking signal until divergence triage is complete.
5. Add property-based generators (separate PR) once the corpus loop is
   in place.

Explicitly out of scope here: full corpus loop, generator-driven
property tests, CI wiring, installing docx4j / Java in CI.

## Test plan

- [x] `bun packages/folio/scripts/differential/diff.ts <fixture>`
      exits 0 on equivalence, prints the projection.
- [x] CLI exits non-zero with a readable divergence report on a
      diverging fixture (verified against `podily-bps.docx` before the
      run-count exclusion landed).
- [x] `bun --filter @stll/folio test src/core/docx/__tests__/differential.test.ts`
      passes locally.
- [x] `bun --filter @stll/folio test src/core/docx` — all 424 docx tests
      pass.
- [x] `bun --filter @stll/folio lint` clean.