### PR TITLE
fix(folio): preserve block-level SDTs inside footnote and endnote bodies

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1410,8 +1410,14 @@ export type Footnote = {
     | "separator"
     | "continuationSeparator"
     | "continuationNotice";
-  /** Content */
-  content: (Paragraph | Table)[];
+  /**
+   * Content. Note bodies may carry block-level `<w:sdt>` content
+   * controls (citation slots, bound metadata fields) — preserved as
+   * `BlockSdt` so the rest of folio's SDT round-trip + mutate APIs
+   * work in notes the same as they do in the main body. Mirrors the
+   * shape upstream eigenpal/docx-editor#678 fixed for the same case.
+   */
+  content: (Paragraph | Table | BlockSdt)[];
 };
 
 /**
@@ -1427,8 +1433,11 @@ export type Endnote = {
     | "separator"
     | "continuationSeparator"
     | "continuationNotice";
-  /** Content */
-  content: (Paragraph | Table)[];
+  /**
+   * Content. Like `Footnote.content`, may carry block-level `<w:sdt>`
+   * preserved as `BlockSdt` so SDT round-trip works inside endnotes.
+   */
+  content: (Paragraph | Table | BlockSdt)[];
 };
 
 // ============================================================================

--- a/packages/folio/src/core/content-controls/findContentControls.ts
+++ b/packages/folio/src/core/content-controls/findContentControls.ts
@@ -35,12 +35,28 @@ export type ContentControlFilter = {
   pmPos?: number;
 };
 
+/**
+ * Source location of a matched content control. Main-body matches stay
+ * the silent default; matches inside a footnote or endnote carry the
+ * note's numeric id so callers can route the right mutate API at it.
+ */
+export type ContentControlLocation =
+  | { kind: "body" }
+  | { kind: "footnote"; noteId: number }
+  | { kind: "endnote"; noteId: number };
+
 export type ContentControlMatch = {
   control: BlockSdt;
   /** Outer→inner stack of enclosing controls (empty when at the body root). */
   ancestry: BlockSdt[];
   /** Indices to walk back into the doc, outer→inner. */
   path: number[];
+  /**
+   * Where in the document this match was found. Defaults to the main
+   * body; populated for matches in `doc.package.footnotes` /
+   * `doc.package.endnotes`.
+   */
+  location: ContentControlLocation;
 };
 
 function matches(control: BlockSdt, filter: ContentControlFilter): boolean {
@@ -76,6 +92,7 @@ function walk(
   out: ContentControlMatch[],
   ancestry: BlockSdt[],
   path: number[],
+  location: ContentControlLocation,
 ): void {
   for (let i = 0; i < blocks.length; i += 1) {
     const block = blocks[i];
@@ -88,10 +105,18 @@ function walk(
           control: block,
           ancestry: [...ancestry],
           path: [...path, i],
+          location,
         });
       }
       // Recurse into the SDT — nested SDTs are addressable too.
-      walk(block.content, filter, out, [...ancestry, block], [...path, i]);
+      walk(
+        block.content,
+        filter,
+        out,
+        [...ancestry, block],
+        [...path, i],
+        location,
+      );
     } else if (block.type === "table") {
       // Walk into table cells so cell-level SDTs (where supported by the
       // parser) are surfaced too. cell.content is `(Paragraph | Table)[]`
@@ -107,7 +132,14 @@ function walk(
           if (!cell) {
             continue;
           }
-          walk(cell.content, filter, out, ancestry, [...path, i, r, c]);
+          walk(
+            cell.content,
+            filter,
+            out,
+            ancestry,
+            [...path, i, r, c],
+            location,
+          );
         }
       }
     }
@@ -119,7 +151,21 @@ export function findContentControls(
   filter: ContentControlFilter = {},
 ): ContentControlMatch[] {
   const out: ContentControlMatch[] = [];
-  walk(doc.package.document.content, filter, out, [], []);
+  walk(doc.package.document.content, filter, out, [], [], { kind: "body" });
+  // Also walk notes — citation slots and bound metadata live there too.
+  // Match objects carry a `location` so callers can route the mutate API.
+  for (const footnote of doc.package.footnotes ?? []) {
+    walk(footnote.content, filter, out, [], [], {
+      kind: "footnote",
+      noteId: footnote.id,
+    });
+  }
+  for (const endnote of doc.package.endnotes ?? []) {
+    walk(endnote.content, filter, out, [], [], {
+      kind: "endnote",
+      noteId: endnote.id,
+    });
+  }
   return out;
 }
 

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -13,6 +13,8 @@ import type {
   BlockContent,
   BlockSdt,
   Document,
+  Endnote,
+  Footnote,
   Paragraph,
   Table,
 } from "../types/document";
@@ -332,7 +334,37 @@ function transformBlocks(
   return out;
 }
 
-function withUpdatedBody(doc: Document, content: BlockContent[]): Document {
+/**
+ * Apply the same SDT match callback to every footnote and endnote body
+ * and return the updated note arrays. Without this, citation slots and
+ * bound metadata inside notes can't be reached through `setContentControl*`
+ * by tag / alias / id even though `findContentControls` surfaces them.
+ */
+function applyMatchToNotes(
+  doc: Document,
+  match: (b: BlockSdt) => SdtMatchResult,
+): { footnotes?: Footnote[]; endnotes?: Endnote[] } {
+  const result: { footnotes?: Footnote[]; endnotes?: Endnote[] } = {};
+  if (doc.package.footnotes) {
+    result.footnotes = doc.package.footnotes.map((note) => ({
+      ...note,
+      content: transformBlocks(note.content, match),
+    }));
+  }
+  if (doc.package.endnotes) {
+    result.endnotes = doc.package.endnotes.map((note) => ({
+      ...note,
+      content: transformBlocks(note.content, match),
+    }));
+  }
+  return result;
+}
+
+function withUpdatedBodyAndNotes(
+  doc: Document,
+  content: BlockContent[],
+  notes: { footnotes?: Footnote[]; endnotes?: Endnote[] },
+): Document {
   return {
     ...doc,
     package: {
@@ -341,6 +373,8 @@ function withUpdatedBody(doc: Document, content: BlockContent[]): Document {
         ...doc.package.document,
         content,
       },
+      ...(notes.footnotes !== undefined ? { footnotes: notes.footnotes } : {}),
+      ...(notes.endnotes !== undefined ? { endnotes: notes.endnotes } : {}),
     },
   };
 }
@@ -399,34 +433,33 @@ export function setContentControlContent(
   input: SetContentControlContentInput,
   options: ForceOption = {},
 ): Document {
-  const nextContent = transformBlocks(
-    doc.package.document.content,
-    (control) => {
-      if (!controlMatchesFilter(control, filter)) {
-        return undefined;
-      }
-      ensureContentNotLocked(control, options.force);
-      const { strippedRawPropertiesXml } = ensureContentNotBound(
-        control,
-        options.force,
-      );
-      const blocks: BlockContent[] =
-        typeof input === "string"
-          ? [makeParagraphFromText(input)]
-          : input.map(cloneBlock);
-      const properties = { ...control.properties };
-      properties.showingPlaceholder = false;
-      if (strippedRawPropertiesXml !== undefined) {
-        properties.rawPropertiesXml = strippedRawPropertiesXml;
-      }
-      return {
-        ...control,
-        properties,
-        content: blocks,
-      };
-    },
-  );
-  return withUpdatedBody(doc, nextContent);
+  const match = (control: BlockSdt): SdtMatchResult => {
+    if (!controlMatchesFilter(control, filter)) {
+      return undefined;
+    }
+    ensureContentNotLocked(control, options.force);
+    const { strippedRawPropertiesXml } = ensureContentNotBound(
+      control,
+      options.force,
+    );
+    const blocks: BlockContent[] =
+      typeof input === "string"
+        ? [makeParagraphFromText(input)]
+        : input.map(cloneBlock);
+    const properties = { ...control.properties };
+    properties.showingPlaceholder = false;
+    if (strippedRawPropertiesXml !== undefined) {
+      properties.rawPropertiesXml = strippedRawPropertiesXml;
+    }
+    return {
+      ...control,
+      properties,
+      content: blocks,
+    };
+  };
+  const nextContent = transformBlocks(doc.package.document.content, match);
+  const notes = applyMatchToNotes(doc, match);
+  return withUpdatedBodyAndNotes(doc, nextContent, notes);
 }
 
 /**
@@ -440,96 +473,23 @@ export function setContentControlValue(
   input: SetContentControlValueInput,
   options: ForceOption = {},
 ): Document {
-  const nextContent = transformBlocks(
-    doc.package.document.content,
-    (control) => {
-      if (!controlMatchesFilter(control, filter)) {
-        return undefined;
-      }
-      ensureContentNotLocked(control, options.force);
-      const { strippedRawPropertiesXml } = ensureContentNotBound(
-        control,
-        options.force,
-      );
+  const match = (control: BlockSdt): SdtMatchResult => {
+    if (!controlMatchesFilter(control, filter)) {
+      return undefined;
+    }
+    ensureContentNotLocked(control, options.force);
+    const { strippedRawPropertiesXml } = ensureContentNotBound(
+      control,
+      options.force,
+    );
 
-      const sdtType = control.properties.sdtType;
-      if (input.kind === "dropdown") {
-        if (sdtType !== "dropdown" && sdtType !== "comboBox") {
-          throw new ContentControlTypeError({
-            message: `Cannot set dropdown value on a ${sdtType} control.`,
-            sdtType,
-            reason: "kind=dropdown requires sdtType=dropdown|comboBox",
-            ...(control.properties.tag !== undefined
-              ? { tag: control.properties.tag }
-              : {}),
-            ...(control.properties.alias !== undefined
-              ? { alias: control.properties.alias }
-              : {}),
-          });
-        }
-        const items = control.properties.listItems ?? [];
-        const item = items.find((i) => i.value === input.value);
-        if (!item && !options.force) {
-          throw new ContentControlTypeError({
-            message: `Value "${input.value}" not in the control's list items.`,
-            sdtType,
-            reason: "value not in listItems",
-            ...(control.properties.tag !== undefined
-              ? { tag: control.properties.tag }
-              : {}),
-            ...(control.properties.alias !== undefined
-              ? { alias: control.properties.alias }
-              : {}),
-          });
-        }
-        const display = item?.displayText ?? input.value;
-        return {
-          ...control,
-          properties: {
-            ...control.properties,
-            dropdownLastValue: input.value,
-            showingPlaceholder: false,
-            ...(strippedRawPropertiesXml !== undefined
-              ? { rawPropertiesXml: strippedRawPropertiesXml }
-              : {}),
-          },
-          content: [makeParagraphFromText(display)],
-        };
-      }
-      if (input.kind === "checkbox") {
-        if (sdtType !== "checkbox") {
-          throw new ContentControlTypeError({
-            message: `Cannot toggle checkbox on a ${sdtType} control.`,
-            sdtType,
-            reason: "kind=checkbox requires sdtType=checkbox",
-            ...(control.properties.tag !== undefined
-              ? { tag: control.properties.tag }
-              : {}),
-            ...(control.properties.alias !== undefined
-              ? { alias: control.properties.alias }
-              : {}),
-          });
-        }
-        const glyph = input.checked ? "☒" : "☐";
-        return {
-          ...control,
-          properties: {
-            ...control.properties,
-            checked: input.checked,
-            showingPlaceholder: false,
-            ...(strippedRawPropertiesXml !== undefined
-              ? { rawPropertiesXml: strippedRawPropertiesXml }
-              : {}),
-          },
-          content: [makeParagraphFromText(glyph)],
-        };
-      }
-      // date
-      if (sdtType !== "date") {
+    const sdtType = control.properties.sdtType;
+    if (input.kind === "dropdown") {
+      if (sdtType !== "dropdown" && sdtType !== "comboBox") {
         throw new ContentControlTypeError({
-          message: `Cannot set date on a ${sdtType} control.`,
+          message: `Cannot set dropdown value on a ${sdtType} control.`,
           sdtType,
-          reason: "kind=date requires sdtType=date",
+          reason: "kind=dropdown requires sdtType=dropdown|comboBox",
           ...(control.properties.tag !== undefined
             ? { tag: control.properties.tag }
             : {}),
@@ -538,18 +498,27 @@ export function setContentControlValue(
             : {}),
         });
       }
-      // Keep the ISO value on the model and write the format-aware display
-      // string into the body so the on-screen text and the OOXML
-      // `w:fullDate` round-trip independently.
-      const display = formatDateForSdtBody(
-        input.date,
-        control.properties.dateFormat,
-      );
+      const items = control.properties.listItems ?? [];
+      const item = items.find((i) => i.value === input.value);
+      if (!item && !options.force) {
+        throw new ContentControlTypeError({
+          message: `Value "${input.value}" not in the control's list items.`,
+          sdtType,
+          reason: "value not in listItems",
+          ...(control.properties.tag !== undefined
+            ? { tag: control.properties.tag }
+            : {}),
+          ...(control.properties.alias !== undefined
+            ? { alias: control.properties.alias }
+            : {}),
+        });
+      }
+      const display = item?.displayText ?? input.value;
       return {
         ...control,
         properties: {
           ...control.properties,
-          dateValueISO: input.date,
+          dropdownLastValue: input.value,
           showingPlaceholder: false,
           ...(strippedRawPropertiesXml !== undefined
             ? { rawPropertiesXml: strippedRawPropertiesXml }
@@ -557,9 +526,72 @@ export function setContentControlValue(
         },
         content: [makeParagraphFromText(display)],
       };
-    },
-  );
-  return withUpdatedBody(doc, nextContent);
+    }
+    if (input.kind === "checkbox") {
+      if (sdtType !== "checkbox") {
+        throw new ContentControlTypeError({
+          message: `Cannot toggle checkbox on a ${sdtType} control.`,
+          sdtType,
+          reason: "kind=checkbox requires sdtType=checkbox",
+          ...(control.properties.tag !== undefined
+            ? { tag: control.properties.tag }
+            : {}),
+          ...(control.properties.alias !== undefined
+            ? { alias: control.properties.alias }
+            : {}),
+        });
+      }
+      const glyph = input.checked ? "☒" : "☐";
+      return {
+        ...control,
+        properties: {
+          ...control.properties,
+          checked: input.checked,
+          showingPlaceholder: false,
+          ...(strippedRawPropertiesXml !== undefined
+            ? { rawPropertiesXml: strippedRawPropertiesXml }
+            : {}),
+        },
+        content: [makeParagraphFromText(glyph)],
+      };
+    }
+    // date
+    if (sdtType !== "date") {
+      throw new ContentControlTypeError({
+        message: `Cannot set date on a ${sdtType} control.`,
+        sdtType,
+        reason: "kind=date requires sdtType=date",
+        ...(control.properties.tag !== undefined
+          ? { tag: control.properties.tag }
+          : {}),
+        ...(control.properties.alias !== undefined
+          ? { alias: control.properties.alias }
+          : {}),
+      });
+    }
+    // Keep the ISO value on the model and write the format-aware display
+    // string into the body so the on-screen text and the OOXML
+    // `w:fullDate` round-trip independently.
+    const display = formatDateForSdtBody(
+      input.date,
+      control.properties.dateFormat,
+    );
+    return {
+      ...control,
+      properties: {
+        ...control.properties,
+        dateValueISO: input.date,
+        showingPlaceholder: false,
+        ...(strippedRawPropertiesXml !== undefined
+          ? { rawPropertiesXml: strippedRawPropertiesXml }
+          : {}),
+      },
+      content: [makeParagraphFromText(display)],
+    };
+  };
+  const nextContent = transformBlocks(doc.package.document.content, match);
+  const notes = applyMatchToNotes(doc, match);
+  return withUpdatedBodyAndNotes(doc, nextContent, notes);
 }
 
 /**
@@ -572,38 +604,37 @@ export function removeContentControl(
   filter: ContentControlFilter,
   options: ForceOption & { keepContent?: boolean } = {},
 ): Document {
-  const nextContent = transformBlocks(
-    doc.package.document.content,
-    (control) => {
-      if (!controlMatchesFilter(control, filter)) {
-        return undefined;
+  const match = (control: BlockSdt): SdtMatchResult => {
+    if (!controlMatchesFilter(control, filter)) {
+      return undefined;
+    }
+    ensureSdtNotLocked(control, options.force);
+    if (options.keepContent) {
+      if (isRepeatingSection(control) && !options.force) {
+        throw new ContentControlTypeError({
+          message:
+            "Refusing to unwrap a w15:repeatingSection — would orphan its w15 row items.",
+          sdtType: control.properties.sdtType,
+          reason: "repeatingSection unwrap orphans items",
+          ...(control.properties.tag !== undefined
+            ? { tag: control.properties.tag }
+            : {}),
+          ...(control.properties.alias !== undefined
+            ? { alias: control.properties.alias }
+            : {}),
+        });
       }
-      ensureSdtNotLocked(control, options.force);
-      if (options.keepContent) {
-        if (isRepeatingSection(control) && !options.force) {
-          throw new ContentControlTypeError({
-            message:
-              "Refusing to unwrap a w15:repeatingSection — would orphan its w15 row items.",
-            sdtType: control.properties.sdtType,
-            reason: "repeatingSection unwrap orphans items",
-            ...(control.properties.tag !== undefined
-              ? { tag: control.properties.tag }
-              : {}),
-            ...(control.properties.alias !== undefined
-              ? { alias: control.properties.alias }
-              : {}),
-          });
-        }
-        return control.content;
-      }
-      // Drop control + content entirely.
-      return null;
-    },
-  );
+      return control.content;
+    }
+    // Drop control + content entirely.
+    return null;
+  };
+  const nextContent = transformBlocks(doc.package.document.content, match);
   // The body must contain at least one paragraph (OOXML requires a non-empty
   // body). Insert a placeholder if we just emptied it.
   if (nextContent.length === 0) {
     nextContent.push(makeParagraphFromText(""));
   }
-  return withUpdatedBody(doc, nextContent);
+  const notes = applyMatchToNotes(doc, match);
+  return withUpdatedBodyAndNotes(doc, nextContent, notes);
 }

--- a/packages/folio/src/core/content-controls/mutateContentControls.ts
+++ b/packages/folio/src/core/content-controls/mutateContentControls.ts
@@ -426,6 +426,16 @@ function cloneBlock<T extends BlockContent>(block: T): T {
  * explicit `BlockContent[]` is deep-cloned to preserve immutability. The
  * `showingPlcHdr` flag is cleared so the new content is not styled as
  * placeholder.
+ *
+ * Applies to SDTs in the main body AND inside `doc.package.footnotes` /
+ * `doc.package.endnotes`. NOTE: save-path propagation for note SDTs is a
+ * known follow-up — `repackDocxFromRaw` currently replays
+ * `word/footnotes.xml` and `word/endnotes.xml` verbatim from the source
+ * zip, so changes to note SDTs land on the in-memory model but the
+ * saved DOCX still contains the original note text. Read APIs
+ * (`findContentControls`, `getFootnoteText`) reflect the update in the
+ * same session; persisting requires extending the selective-save layer
+ * to re-serialize note parts.
  */
 export function setContentControlContent(
   doc: Document,

--- a/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
+++ b/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
@@ -6,7 +6,12 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { parseEndnotes, parseFootnotes } from "./footnoteParser";
+import {
+  getEndnoteText,
+  getFootnoteText,
+  parseEndnotes,
+  parseFootnotes,
+} from "./footnoteParser";
 
 const FOOTNOTE_WITH_SDT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
@@ -75,5 +80,28 @@ describe("footnote / endnote bodies preserve block-level w:sdt", () => {
     // PR #587 then guards mutations on the bound control).
     expect(sdt.properties.rawPropertiesXml).toContain("w:dataBinding");
     expect(sdt.properties.rawPropertiesXml).toContain('w:xpath="/cite/source"');
+  });
+
+  test("getFootnoteText recurses into block SDTs so citation slot text survives", () => {
+    // Without the recursion, BlockSdt children added by the parser fix
+    // would silently hide their inner paragraphs from text extraction.
+    const map = parseFootnotes(FOOTNOTE_WITH_SDT);
+    const footnote = map.byId.get(1);
+    if (!footnote) {
+      throw new TypeError("expected footnote");
+    }
+    const text = getFootnoteText(footnote);
+    expect(text).toContain("before");
+    expect(text).toContain("cited source");
+    expect(text).toContain("after");
+  });
+
+  test("getEndnoteText recurses into block SDTs", () => {
+    const map = parseEndnotes(ENDNOTE_WITH_SDT);
+    const endnote = map.byId.get(2);
+    if (!endnote) {
+      throw new TypeError("expected endnote");
+    }
+    expect(getEndnoteText(endnote)).toBe("bound endnote");
   });
 });

--- a/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
+++ b/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
@@ -7,6 +7,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  findContentControls,
+  setContentControlContent,
+} from "../content-controls";
+import {
   getEndnoteText,
   getFootnoteText,
   parseEndnotes,
@@ -103,5 +107,74 @@ describe("footnote / endnote bodies preserve block-level w:sdt", () => {
       throw new TypeError("expected endnote");
     }
     expect(getEndnoteText(endnote)).toBe("bound endnote");
+  });
+});
+
+describe("findContentControls / mutators reach SDTs in notes", () => {
+  test("findContentControls walks footnote and endnote bodies", () => {
+    // Test setup intentionally crosses parser → headless API; this is
+    // the round-trip codex flagged as silently missing.
+    const footnote = parseFootnotes(FOOTNOTE_WITH_SDT).byId.get(1);
+    const endnote = parseEndnotes(ENDNOTE_WITH_SDT).byId.get(2);
+    if (!footnote || !endnote) {
+      throw new TypeError("expected fixtures to parse");
+    }
+    const doc = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph" as const,
+              content: [
+                {
+                  type: "run" as const,
+                  content: [{ type: "text" as const, text: "body" }],
+                },
+              ],
+            },
+          ],
+        },
+        footnotes: [footnote],
+        endnotes: [endnote],
+      },
+    };
+    const matches = findContentControls(doc, {});
+    // Two SDTs total: one in the footnote, one in the endnote.
+    expect(matches).toHaveLength(2);
+    const locations = matches.map((m) => m.location);
+    expect(locations).toContainEqual({ kind: "footnote", noteId: 1 });
+    expect(locations).toContainEqual({ kind: "endnote", noteId: 2 });
+    // Filter by tag still works across notes.
+    expect(findContentControls(doc, { tag: "cite" })).toHaveLength(1);
+    expect(findContentControls(doc, { tag: "bound" })).toHaveLength(1);
+  });
+
+  test("setContentControlContent mutates SDTs in footnote bodies", () => {
+    const footnote = parseFootnotes(FOOTNOTE_WITH_SDT).byId.get(1);
+    if (!footnote) {
+      throw new TypeError("expected fixture");
+    }
+    const doc = {
+      package: {
+        document: { content: [] },
+        footnotes: [footnote],
+      },
+    };
+    const updated = setContentControlContent(
+      doc,
+      { tag: "cite" },
+      "Smith v Jones",
+    );
+    const sdt = updated.package.footnotes?.[0]?.content[1];
+    if (!sdt || sdt.type !== "blockSdt") {
+      throw new TypeError("expected blockSdt in updated footnote");
+    }
+    const firstBlock = sdt.content[0];
+    if (!firstBlock || firstBlock.type !== "paragraph") {
+      throw new TypeError("expected paragraph inside updated SDT");
+    }
+    expect(getFootnoteText(updated.package.footnotes![0]!)).toContain(
+      "Smith v Jones",
+    );
   });
 });

--- a/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
+++ b/packages/folio/src/core/docx/footnoteParser-sdt.test.ts
@@ -1,0 +1,79 @@
+/**
+ * SDT inside a footnote/endnote body must round-trip as BlockSdt so
+ * getContentControls + headless mutate APIs see citation slots and
+ * bound metadata in notes the same way they see them in the main body.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseEndnotes, parseFootnotes } from "./footnoteParser";
+
+const FOOTNOTE_WITH_SDT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:footnote w:id="1">
+    <w:p><w:r><w:t>before</w:t></w:r></w:p>
+    <w:sdt>
+      <w:sdtPr><w:tag w:val="cite"/><w:alias w:val="Citation"/></w:sdtPr>
+      <w:sdtContent>
+        <w:p><w:r><w:t>cited source</w:t></w:r></w:p>
+      </w:sdtContent>
+    </w:sdt>
+    <w:p><w:r><w:t>after</w:t></w:r></w:p>
+  </w:footnote>
+</w:footnotes>`;
+
+const ENDNOTE_WITH_SDT = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:endnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:endnote w:id="2">
+    <w:sdt>
+      <w:sdtPr><w:tag w:val="bound"/><w:dataBinding w:xpath="/cite/source"/></w:sdtPr>
+      <w:sdtContent>
+        <w:p><w:r><w:t>bound endnote</w:t></w:r></w:p>
+      </w:sdtContent>
+    </w:sdt>
+  </w:endnote>
+</w:endnotes>`;
+
+describe("footnote / endnote bodies preserve block-level w:sdt", () => {
+  test("footnote with a block SDT recovers the BlockSdt in document order", () => {
+    const map = parseFootnotes(FOOTNOTE_WITH_SDT);
+    const footnote = map.byId.get(1);
+    expect(footnote).toBeDefined();
+    if (!footnote) {
+      return;
+    }
+    expect(footnote.content.map((block) => block.type)).toEqual([
+      "paragraph",
+      "blockSdt",
+      "paragraph",
+    ]);
+    const sdt = footnote.content[1];
+    if (!sdt || sdt.type !== "blockSdt") {
+      throw new TypeError("expected blockSdt at index 1");
+    }
+    expect(sdt.properties.tag).toBe("cite");
+    expect(sdt.properties.alias).toBe("Citation");
+    // Inner content is parsed, not frozen.
+    expect(sdt.content[0]?.type).toBe("paragraph");
+  });
+
+  test("endnote with a bound SDT preserves the w:dataBinding in rawPropertiesXml", () => {
+    const map = parseEndnotes(ENDNOTE_WITH_SDT);
+    const endnote = map.byId.get(2);
+    expect(endnote).toBeDefined();
+    if (!endnote) {
+      return;
+    }
+    expect(endnote.content).toHaveLength(1);
+    const sdt = endnote.content[0];
+    if (!sdt || sdt.type !== "blockSdt") {
+      throw new TypeError("expected blockSdt at index 0");
+    }
+    expect(sdt.properties.tag).toBe("bound");
+    // Data binding round-trips verbatim through rawPropertiesXml so a
+    // later save replays it (the ContentControlBoundError contract from
+    // PR #587 then guards mutations on the bound control).
+    expect(sdt.properties.rawPropertiesXml).toContain("w:dataBinding");
+    expect(sdt.properties.rawPropertiesXml).toContain('w:xpath="/cite/source"');
+  });
+});

--- a/packages/folio/src/core/docx/footnoteParser.ts
+++ b/packages/folio/src/core/docx/footnoteParser.ts
@@ -19,6 +19,7 @@
  */
 
 import type {
+  BlockSdt,
   Footnote,
   Endnote,
   Paragraph,
@@ -29,16 +30,18 @@ import type {
 } from "../types/document";
 import type { NumberingMap } from "./numberingParser";
 import { parseParagraph } from "./paragraphParser";
+import { parseSdtProperties } from "./sdtProperties";
 import type { StyleMap } from "./styleParser";
 import { parseTable } from "./tableParser";
 import {
-  parseXml,
+  findChild,
   findChildren,
-  getChildElements,
   getAttributes,
+  getChildElements,
   getLocalName,
+  parseXml,
+  type XmlElement,
 } from "./xmlParser";
-import type { XmlElement } from "./xmlParser";
 
 // ============================================================================
 // FOOTNOTE MAP INTERFACE
@@ -152,8 +155,8 @@ function parseNoteBlockContent(
   numbering: NumberingMap | null,
   rels: RelationshipMap | null,
   media: Map<string, MediaFile> | null,
-): (Paragraph | Table)[] {
-  const blocks: (Paragraph | Table)[] = [];
+): (Paragraph | Table | BlockSdt)[] {
+  const blocks: (Paragraph | Table | BlockSdt)[] = [];
 
   for (const child of getChildElements(element)) {
     const localName = getLocalName(child.name ?? "");
@@ -161,6 +164,27 @@ function parseNoteBlockContent(
       blocks.push(parseParagraph(child, styles, theme, numbering, rels));
     } else if (localName === "tbl") {
       blocks.push(parseTable(child, styles, theme, numbering, rels, media));
+    } else if (localName === "sdt") {
+      // Recurse into sdtContent so SDT children inside notes are
+      // recognized; otherwise the note body silently drops citation
+      // slots and bound metadata controls.
+      const sdtPr = findChild(child, "w", "sdtPr");
+      const sdtEndPr = findChild(child, "w", "sdtEndPr");
+      const sdtContent = findChild(child, "w", "sdtContent");
+      blocks.push({
+        type: "blockSdt",
+        properties: parseSdtProperties(sdtPr, sdtEndPr),
+        content: sdtContent
+          ? parseNoteBlockContent(
+              sdtContent,
+              styles,
+              theme,
+              numbering,
+              rels,
+              media,
+            )
+          : [],
+      });
     }
   }
 

--- a/packages/folio/src/core/docx/footnoteParser.ts
+++ b/packages/folio/src/core/docx/footnoteParser.ts
@@ -438,56 +438,48 @@ export {
 // ============================================================================
 
 /**
- * Get plain text content of a footnote
+ * Get plain text content of a footnote.
+ *
+ * Recurses into block-level SDTs so a citation slot inside a note still
+ * contributes its text; without recursion, the BlockSdt addition from
+ * the previous commit would silently hide the slot's body from this
+ * helper.
  */
 export function getFootnoteText(footnote: Footnote): string {
-  // Import getParagraphText dynamically to avoid circular dependency
-  const texts: string[] = [];
-
-  for (const para of footnote.content) {
-    if (para.type !== "paragraph") {
-      continue;
-    }
-    const paraTexts: string[] = [];
-    for (const content of para.content) {
-      if (content.type === "run") {
-        for (const runContent of content.content) {
-          if (runContent.type === "text") {
-            paraTexts.push(runContent.text);
-          }
-        }
-      }
-    }
-    texts.push(paraTexts.join(""));
-  }
-
-  return texts.join("\n");
+  return collectNoteBlockTexts(footnote.content).join("\n");
 }
 
 /**
- * Get plain text content of an endnote
+ * Get plain text content of an endnote.
  */
 export function getEndnoteText(endnote: Endnote): string {
-  const texts: string[] = [];
+  return collectNoteBlockTexts(endnote.content).join("\n");
+}
 
-  for (const para of endnote.content) {
-    if (para.type !== "paragraph") {
-      continue;
-    }
-    const paraTexts: string[] = [];
-    for (const content of para.content) {
-      if (content.type === "run") {
-        for (const runContent of content.content) {
-          if (runContent.type === "text") {
-            paraTexts.push(runContent.text);
+function collectNoteBlockTexts(
+  blocks: readonly (Paragraph | Table | BlockSdt)[],
+): string[] {
+  const texts: string[] = [];
+  for (const block of blocks) {
+    if (block.type === "paragraph") {
+      const paraTexts: string[] = [];
+      for (const content of block.content) {
+        if (content.type === "run") {
+          for (const runContent of content.content) {
+            if (runContent.type === "text") {
+              paraTexts.push(runContent.text);
+            }
           }
         }
       }
+      texts.push(paraTexts.join(""));
+    } else if (block.type === "blockSdt") {
+      texts.push(...collectNoteBlockTexts(block.content));
     }
-    texts.push(paraTexts.join(""));
+    // Table cells aren't surfaced by this helper today; pre-existing
+    // limitation, leaving out of scope.
   }
-
-  return texts.join("\n");
+  return texts;
 }
 
 /**

--- a/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
+++ b/packages/folio/src/core/layout-bridge/footnoteLayout-table.test.ts
@@ -66,6 +66,32 @@ const emptyFootnoteWithTable: Footnote = {
   ],
 };
 
+const footnoteWithBlockSdt: Footnote = {
+  type: "footnote",
+  id: 10,
+  noteType: "normal",
+  content: [
+    {
+      type: "blockSdt",
+      properties: {
+        tag: "cite",
+        alias: "Citation",
+      },
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [{ type: "text", text: "Smith v Jones" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 const footnoteWithRowSpanTable: Footnote = {
   type: "footnote",
   id: 9,
@@ -199,6 +225,34 @@ describe("footnote layout", () => {
       "table",
     ]);
     expect(content.height).toBe(36);
+  });
+
+  test("renders paragraphs nested inside footnote block SDTs", () => {
+    const content = convertFootnoteToContent(footnoteWithBlockSdt, 10, 400, {
+      measureBlocks(blocks) {
+        return blocks.map(() => ({
+          kind: "paragraph",
+          lines: [],
+          totalHeight: 12,
+        }));
+      },
+    });
+
+    expect(content.blocks).toHaveLength(1);
+    const paragraph = content.blocks.at(0);
+    expect(paragraph?.kind).toBe("paragraph");
+    if (paragraph?.kind !== "paragraph") {
+      throw new Error("Expected footnote SDT to produce a paragraph");
+    }
+
+    expect(paragraph.runs.at(1)).toMatchObject({
+      kind: "text",
+      text: "Smith v Jones",
+    });
+    expect(paragraph.sdtGroups?.at(0)).toMatchObject({
+      tag: "cite",
+      alias: "Citation",
+    });
   });
 
   test("measures table footnotes without a caller-provided measurement hook", () => {

--- a/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
+++ b/packages/folio/src/core/prosemirror/conversion/toProseDoc.ts
@@ -2955,7 +2955,7 @@ export function headerFooterToProseDoc(
 }
 
 export function footnoteToProseDoc(
-  content: (Paragraph | Table)[],
+  content: BlockContent[],
   options?: ToProseDocOptions,
 ): PMNode {
   return headerFooterToProseDoc(content, options);


### PR DESCRIPTION
## Summary

- Picked up upstream eigenpal/docx-editor#678. Folio's parser dropped block-level `<w:sdt>` children of `<w:footnote>` / `<w:endnote>` entirely (worse than upstream's verbatim-XML freeze), so `getContentControls()` and the headless mutate API couldn't see citation slots or bound metadata inside notes.
- Recognise the `<w:sdt>` element in the note-body walker and emit a `BlockSdt` with the same `sdtPr` / `sdtEndPr` raw-replay treatment the main body uses. Widen `Footnote.content` / `Endnote.content` to `(Paragraph | Table | BlockSdt)[]`.

## Improvement over upstream

Upstream had a freeze-gate around note bodies (verbatim XML for SDT cases) and #678 narrowed the gate. Folio has no freeze-gate — it just dropped SDTs — so the right fix is to recognise the SDT inline instead of routing through the main body parser (which would pull in body-only constructs like floating drawings that don't belong in notes).

## Test plan

- [x] `bun test src/core/docx/footnoteParser-sdt.test.ts` — 2 new regression tests fail on `main`, pass on this branch
- [x] `bun test src/core/docx/footnoteParser-table.test.ts` — existing 4 tests still pass
- [x] `bun --filter @stll/folio lint` clean