### PR TITLE
fix: batch MCP search title processing

### DIFF
--- a/apps/api/src/mcp/anonymization.ts
+++ b/apps/api/src/mcp/anonymization.ts
@@ -6,6 +6,7 @@ import {
   redactText,
   runPipeline,
 } from "@stll/anonymize-wasm";
+import type { PipelineContext } from "@stll/anonymize-wasm";
 
 import { loadAnonymizationAllowlistCanonicals } from "@/api/lib/anonymization-allowlist";
 import { loadAnonymizationGazetteerEntries } from "@/api/lib/anonymization-blacklist";
@@ -13,10 +14,24 @@ import type { AnonymizeTextFieldsInput } from "@/api/mcp/anonymization-core";
 import { anonymizeTextFieldsWithDependencies } from "@/api/mcp/anonymization-core";
 
 let dictionariesPromise: ReturnType<typeof loadNameDictionaries> | null = null;
+let pipelineQueue: Promise<void> = Promise.resolve();
+
+const pipelineContext: PipelineContext = createPipelineContext();
 
 const getNameDictionaries = async () => {
   dictionariesPromise ??= loadNameDictionaries();
   return await dictionariesPromise;
+};
+
+const runWithPipelineContext = async <T>(
+  task: () => Promise<T>,
+): Promise<T> => {
+  const run = pipelineQueue.then(task, task);
+  pipelineQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return await run;
 };
 
 const anonymizeTextFieldsDependencies = {
@@ -30,8 +45,20 @@ const anonymizeTextFieldsDependencies = {
   runPipeline,
 };
 
-export const anonymizeTextFields = async (input: AnonymizeTextFieldsInput) =>
-  await anonymizeTextFieldsWithDependencies({
-    ...input,
-    dependencies: anonymizeTextFieldsDependencies,
+export const anonymizeTextFields = async (input: AnonymizeTextFieldsInput) => {
+  if (input.context !== undefined) {
+    return await anonymizeTextFieldsWithDependencies({
+      ...input,
+      dependencies: anonymizeTextFieldsDependencies,
+    });
+  }
+
+  return await runWithPipelineContext(async () => {
+    pipelineContext.corefSourceMap.clear();
+    return await anonymizeTextFieldsWithDependencies({
+      ...input,
+      context: pipelineContext,
+      dependencies: anonymizeTextFieldsDependencies,
+    });
   });
+};

--- a/apps/api/src/mcp/compat-tools.ts
+++ b/apps/api/src/mcp/compat-tools.ts
@@ -123,27 +123,62 @@ const anonymizeCompatSearchResults = async ({
     scopedDb: context.scopedDb,
   });
 
-  return await Promise.all(
-    results.map(async ({ workspaceId, ...result }) => {
-      const anonymized = await anonymizeTextFields({
-        fields: [result.title],
-        gazetteerEntries,
-        organizationId: context.organizationId,
-        scopedDb: context.scopedDb,
-        workspaceId,
-      });
+  const byWorkspace = new Map<
+    string,
+    { indexes: number[]; titles: string[] }
+  >();
+  for (const [index, result] of results.entries()) {
+    const group = byWorkspace.get(result.workspaceId);
+    if (group) {
+      group.indexes.push(index);
+      group.titles.push(result.title);
+      continue;
+    }
+    byWorkspace.set(result.workspaceId, {
+      indexes: [index],
+      titles: [result.title],
+    });
+  }
 
-      return {
-        ...result,
+  const output: (Omit<CompatSearchResult, "workspaceId"> | undefined)[] =
+    Array.from({ length: results.length });
+
+  for (const [workspaceId, group] of byWorkspace) {
+    const anonymized = await anonymizeTextFields({
+      fields: group.titles,
+      gazetteerEntries,
+      organizationId: context.organizationId,
+      scopedDb: context.scopedDb,
+      workspaceId,
+    });
+
+    for (const [groupIndex, resultIndex] of group.indexes.entries()) {
+      const result = results[resultIndex];
+      if (result === undefined) {
+        continue;
+      }
+      output[resultIndex] = {
+        id: result.id,
         title: normalizeTextField({
           allowEmptyFallback: false,
           fallback: result.title,
           missingFallback: ANONYMIZED_FIELD_MISSING_FALLBACK,
-          value: anonymized.fields[0],
+          value: anonymized.fields[groupIndex],
         }),
+        url: result.url,
       };
-    }),
-  );
+    }
+  }
+
+  const normalizedResults: Omit<CompatSearchResult, "workspaceId">[] = [];
+  for (const result of output) {
+    if (result === undefined) {
+      continue;
+    }
+    normalizedResults.push(result);
+  }
+
+  return normalizedResults;
 };
 
 const anonymizeCompatFetchPayload = async ({

--- a/apps/api/src/mcp/tools.test.ts
+++ b/apps/api/src/mcp/tools.test.ts
@@ -940,6 +940,67 @@ describe("OpenAI-compatible MCP tools", () => {
     expect(loadAnonymizationGazetteerEntriesMock).toHaveBeenCalledTimes(1);
   });
 
+  test("search batches anonymized titles by workspace", async () => {
+    searchAcrossMattersExecute.mockResolvedValue({
+      hits: [
+        {
+          entityId: "entity_1",
+          workspaceId: "ws_1",
+          name: "John Smith SPA",
+        },
+        {
+          entityId: "entity_2",
+          workspaceId: "ws_1",
+          name: "Jane Doe NDA",
+        },
+      ],
+    });
+    anonymizeTextFieldsMock.mockResolvedValue({
+      entityCount: 2,
+      fields: ["[PERSON_1] SPA", "[PERSON_2] NDA"],
+    });
+
+    const result = await handleMcpToolCall({
+      args: { query: "agreement" },
+      context: createContext({
+        scopedDb: createScopedDb([
+          {
+            entityId: "entity_1",
+            fieldId: "field_1",
+            workspaceId: "ws_1",
+          },
+          {
+            entityId: "entity_2",
+            fieldId: "field_2",
+            workspaceId: "ws_1",
+          },
+        ]),
+      }),
+      mode: "anonymized",
+      toolName: "search",
+    });
+
+    expect(parseToolPayload(result)).toEqual({
+      results: [
+        {
+          id: "entity_1",
+          title: "[PERSON_1] SPA",
+          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_1&field=field_1`,
+        },
+        {
+          id: "entity_2",
+          title: "[PERSON_2] NDA",
+          url: `${APP_BASE_URL}/workspaces/ws_1/all/pdf?entity=entity_2&field=field_2`,
+        },
+      ],
+    });
+    expect(anonymizeTextFieldsMock).toHaveBeenCalledTimes(1);
+    expect(anonymizeTextFieldsMock.mock.calls.at(0)?.[0]).toMatchObject({
+      fields: ["John Smith SPA", "Jane Doe NDA"],
+      workspaceId: "ws_1",
+    });
+  });
+
   test("search preserves empty anonymized output instead of leaking the original title", async () => {
     searchAcrossMattersExecute.mockResolvedValue({
       hits: [

--- a/bun.lock
+++ b/bun.lock
@@ -592,7 +592,7 @@
     "@better-auth/oauth-provider": "1.6.11",
     "@libpdf/core": "0.3.6",
     "@stll/anonymize-data": "0.0.6",
-    "@stll/anonymize-wasm": "1.4.5",
+    "@stll/anonymize-wasm": "1.4.7",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.0",
     "@tailwindcss/vite": "4.3.0",
@@ -1623,13 +1623,13 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@stll/aho-corasick-wasm": ["@stll/aho-corasick-wasm@1.0.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-aefKKHhFpZkS1dytxBFiqZKbjnBz08h19b3J6wl0UAtBBW+hoSbYat0Xp5IULt1Fpd4ATqFHspsfpXDb8v15Zw=="],
+    "@stll/aho-corasick-wasm": ["@stll/aho-corasick-wasm@1.0.2", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-RY1WHYZaN1S8DGCspLF/R72RsBICT0GpYfJibKVP4w93qLiiSf/Ch/0remLR5Uajk0ERfZp+Lndgfx17HLJUXw=="],
 
     "@stll/anonymize-chat": ["@stll/anonymize-chat@workspace:packages/anonymize-chat"],
 
     "@stll/anonymize-data": ["@stll/anonymize-data@0.0.6", "", {}, "sha512-lyhYWgwDTeofwrvHSVfvqhJny/8Goss3IiA49+8+RyJmry4s9PnexkPDuLIrtOuJiUZhhxZW+HzL6wrcPRUE8Q=="],
 
-    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@1.4.5", "", { "dependencies": { "@huggingface/tokenizers": "^0.1.3", "@stll/stdnum": "^1.0.0", "@stll/text-search-wasm": "^1.0.1" }, "peerDependencies": { "@stll/anonymize-data": "^0.0.6", "vite": ">=5 <10" }, "optionalPeers": ["@stll/anonymize-data", "vite"] }, "sha512-c4/DI6NlP++b4HKje57jeFsQNpqlNWlPvlLHpdHbABqcKkpE208wbXIPC08l6FbdvxG1KOVCnO5enmvBb1WqXg=="],
+    "@stll/anonymize-wasm": ["@stll/anonymize-wasm@1.4.7", "", { "dependencies": { "@huggingface/tokenizers": "^0.1.3", "@stll/stdnum": "^1.0.0", "@stll/text-search-wasm": "^1.0.4" }, "peerDependencies": { "@stll/anonymize-data": "^0.0.6", "vite": ">=5 <10" }, "optionalPeers": ["@stll/anonymize-data", "vite"] }, "sha512-vT3aEmAkyrIxT+YVDiksJAj+AvDeoFtiv9lCeY51C2BOfD5ITvbHUpnI2WtxPfFnVyMNlCT3J0FsJUAHIdkoVQ=="],
 
     "@stll/api": ["@stll/api@workspace:apps/api"],
 
@@ -1657,7 +1657,7 @@
 
     "@stll/folio": ["@stll/folio@workspace:packages/folio"],
 
-    "@stll/fuzzy-search-wasm": ["@stll/fuzzy-search-wasm@1.0.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-WLrVSlcl8jR6xcXf13EA8oyaOfQ5ceuh7Pg+mvpY+k04kV44KF7XSrx1LL5hsCVnPbYSyuiQ9sJyWHgdYMPnqA=="],
+    "@stll/fuzzy-search-wasm": ["@stll/fuzzy-search-wasm@1.1.0", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-fZ9hZejtuW0GTcR/ed1iiWmPO1JDAs6egHabRLjplTba3MeBsAZObLU9yKaC8DciF3EbtfkZ5k9uc+xlJUk0+A=="],
 
     "@stll/infosoud": ["@stll/infosoud@workspace:packages/infosoud"],
 
@@ -1671,7 +1671,7 @@
 
     "@stll/playground": ["@stll/playground@workspace:apps/playground"],
 
-    "@stll/regex-set-wasm": ["@stll/regex-set-wasm@1.0.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-K6tm0cMiX0pZI++/M8/RfGlCJBaSP/rIH9OrBueUmBsisBqIsG0POORtqz4Q2MlUuYWtlL8Fpuc/hulxAoG94Q=="],
+    "@stll/regex-set-wasm": ["@stll/regex-set-wasm@1.0.3", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-bFvUfpT1HbLc4puXwhKwiS7842bcRwQjEF5baTL+l3yvTeEKKoNPOOTFfRjs0ybW5gymBSG1VX6a//gBcKUSLQ=="],
 
     "@stll/scripts": ["@stll/scripts@workspace:packages/scripts"],
 
@@ -1681,7 +1681,7 @@
 
     "@stll/template-conditions": ["@stll/template-conditions@workspace:packages/template-conditions"],
 
-    "@stll/text-search-wasm": ["@stll/text-search-wasm@1.0.1", "", { "dependencies": { "@stll/aho-corasick-wasm": "^1.0.0", "@stll/fuzzy-search-wasm": "^1.0.0", "@stll/regex-set-wasm": "^1.0.1" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-C7e1nYUUFBLD3xqqP82SqNeo1j7cWGR7I0PeNuvPePbSlF+6H0YxZbQ/oAKfpModFb4Ur2riIDP37Ai5tUbFKQ=="],
+    "@stll/text-search-wasm": ["@stll/text-search-wasm@1.0.4", "", { "dependencies": { "@stll/aho-corasick-wasm": "^1.0.2", "@stll/fuzzy-search-wasm": "^1.1.0", "@stll/regex-set-wasm": "^1.0.3" }, "peerDependencies": { "vite": ">=5 <10" }, "optionalPeers": ["vite"] }, "sha512-qzlhHl6iTgpOBc+c+y+2/mCi5LPZ84OfW9twJpD/G83e0IUYPHOhK7A7/Lwj119vexM1++BufoKRPdb5332r0w=="],
 
     "@stll/transactional": ["@stll/transactional@workspace:packages/transactional"],
 
@@ -3888,12 +3888,6 @@
     "@react-grab/cli/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@selderee/plugin-htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
-
-    "@stll/aho-corasick-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
-
-    "@stll/fuzzy-search-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
-
-    "@stll/regex-set-wasm/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@better-auth/oauth-provider": "1.6.11",
     "@libpdf/core": "0.3.6",
     "@stll/anonymize-data": "0.0.6",
-    "@stll/anonymize-wasm": "1.4.5",
+    "@stll/anonymize-wasm": "1.4.7",
     "@t3-oss/env-core": "0.13.11",
     "@tailwindcss/postcss": "4.3.0",
     "@tailwindcss/vite": "4.3.0",


### PR DESCRIPTION
This batches MCP search result title processing by workspace and reuses the API text-processing pipeline context between calls. Search results keep workspace-scoped allowlists and output order while avoiding per-result setup and repeated prepared-search construction.

The dependency bump pulls in the runtime package version with the search performance fixes. The added test covers batching and result ordering for the search response.