### PR TITLE
fix(folio): preserve explicit-false paragraph toggles on save

### DIFF
--- a/packages/folio/src/core/docx/serializer/paragraphSerializer-toggleOverrides.test.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer-toggleOverrides.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Explicit-false paragraph toggle overrides must survive serialization and a
+ * full parse -> serialize round-trip. A toggle such as `keepNext` has three
+ * states in OOXML: a bare `<w:keepNext/>` (true), `<w:keepNext w:val="0"/>`
+ * (explicitly false, overriding an inherited style value), and absence
+ * (inherit). The serializer previously emitted the element only when the value
+ * was truthy, so an explicit `false` override was dropped on save and the
+ * inherited style value silently came back. Port of eigenpal/docx-editor #687,
+ * adapted to folio's existing true/false/undefined toggle pattern (mirrors
+ * `widowControl` and the run-property serializer).
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { Paragraph, ParagraphFormatting } from "../../types/document";
+import { parseParagraph } from "../paragraphParser";
+import type { XmlElement } from "../xmlParser";
+import { parseXmlDocument } from "../xmlParser";
+import { serializeParagraph } from "./paragraphSerializer";
+
+const BOOLEAN_TOGGLES = [
+  "keepNext",
+  "keepLines",
+  "contextualSpacing",
+  "pageBreakBefore",
+  "suppressLineNumbers",
+  "suppressAutoHyphens",
+  "bidi",
+] as const satisfies readonly (keyof ParagraphFormatting)[];
+
+type BooleanToggle = (typeof BOOLEAN_TOGGLES)[number];
+
+const TAG: Record<BooleanToggle, string> = {
+  keepNext: "w:keepNext",
+  keepLines: "w:keepLines",
+  contextualSpacing: "w:contextualSpacing",
+  pageBreakBefore: "w:pageBreakBefore",
+  suppressLineNumbers: "w:suppressLineNumbers",
+  suppressAutoHyphens: "w:suppressAutoHyphens",
+  bidi: "w:bidi",
+};
+
+const paraWith = (field: BooleanToggle, value: boolean): Paragraph => {
+  const formatting: ParagraphFormatting = {};
+  formatting[field] = value;
+  return { type: "paragraph", content: [], formatting };
+};
+
+const parseParagraphXml = (xml: string): Paragraph => {
+  const root = parseXmlDocument(xml) as XmlElement | null;
+  if (!root) {
+    throw new Error("Failed to parse paragraph XML fixture");
+  }
+  return parseParagraph(root, null, null, null, null, null);
+};
+
+describe("serializeParagraph — explicit-false paragraph toggles (eigenpal #687)", () => {
+  for (const field of BOOLEAN_TOGGLES) {
+    const tag = TAG[field];
+
+    test(`emits <${tag} w:val="0"/> when ${field} is explicitly false`, () => {
+      const xml = serializeParagraph(paraWith(field, false));
+      expect(xml).toContain(`<${tag} w:val="0"/>`);
+      // The bare (true) form must not also appear.
+      expect(xml).not.toContain(`<${tag}/>`);
+    });
+
+    test(`emits bare <${tag}/> when ${field} is true`, () => {
+      const xml = serializeParagraph(paraWith(field, true));
+      expect(xml).toContain(`<${tag}/>`);
+      expect(xml).not.toContain(`<${tag} w:val="0"/>`);
+    });
+
+    test(`omits <${tag}> entirely when ${field} is absent`, () => {
+      const xml = serializeParagraph({ type: "paragraph", content: [] });
+      expect(xml).not.toContain(tag);
+    });
+  }
+
+  test("round-trips every explicit-false toggle through parse -> serialize", () => {
+    const paragraph = parseParagraphXml(`
+      <w:p xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+        <w:pPr>
+          <w:keepNext w:val="0"/>
+          <w:keepLines w:val="0"/>
+          <w:pageBreakBefore w:val="0"/>
+          <w:suppressLineNumbers w:val="0"/>
+          <w:suppressAutoHyphens w:val="0"/>
+          <w:bidi w:val="0"/>
+          <w:contextualSpacing w:val="0"/>
+        </w:pPr>
+      </w:p>
+    `);
+
+    // The parser must carry explicit false (not collapse it to undefined/true).
+    for (const field of BOOLEAN_TOGGLES) {
+      expect(paragraph.formatting?.[field]).toBe(false);
+    }
+
+    const xml = serializeParagraph(paragraph);
+    for (const field of BOOLEAN_TOGGLES) {
+      expect(xml).toContain(`<${TAG[field]} w:val="0"/>`);
+    }
+  });
+});

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -431,38 +431,28 @@ export function serializeParagraphFormatting(
 ): string {
   const parts: string[] = [];
 
+  // Emit a boolean toggle: a bare element for true, `w:val="0"` for an explicit
+  // false (which disables a value inherited from a style, so the override
+  // survives round-trip), and nothing when absent ("inherit").
+  const pushToggle = (name: string, value: boolean | undefined): void => {
+    if (value === true) {
+      parts.push(`<w:${name}/>`);
+    } else if (value === false) {
+      parts.push(`<w:${name} w:val="0"/>`);
+    }
+  };
+
   if (formatting) {
     // Style reference (must be first)
     if (formatting.styleId) {
       parts.push(`<w:pStyle w:val="${escapeXml(formatting.styleId)}"/>`);
     }
 
-    // Keep next/lines/widow. Emit `w:val="0"` on an explicit false so an
-    // inline override that disables an inherited (style) value survives
-    // round-trip; a bare element is true and absence means "inherit".
-    if (formatting.keepNext === true) {
-      parts.push("<w:keepNext/>");
-    } else if (formatting.keepNext === false) {
-      parts.push('<w:keepNext w:val="0"/>');
-    }
-
-    if (formatting.keepLines === true) {
-      parts.push("<w:keepLines/>");
-    } else if (formatting.keepLines === false) {
-      parts.push('<w:keepLines w:val="0"/>');
-    }
-
-    if (formatting.contextualSpacing === true) {
-      parts.push("<w:contextualSpacing/>");
-    } else if (formatting.contextualSpacing === false) {
-      parts.push('<w:contextualSpacing w:val="0"/>');
-    }
-
-    if (formatting.pageBreakBefore === true) {
-      parts.push("<w:pageBreakBefore/>");
-    } else if (formatting.pageBreakBefore === false) {
-      parts.push('<w:pageBreakBefore w:val="0"/>');
-    }
+    // Keep next/lines, contextual spacing, page break before.
+    pushToggle("keepNext", formatting.keepNext);
+    pushToggle("keepLines", formatting.keepLines);
+    pushToggle("contextualSpacing", formatting.contextualSpacing);
+    pushToggle("pageBreakBefore", formatting.pageBreakBefore);
 
     // Frame properties
     const frameXml = serializeFrameProperties(formatting.frame);
@@ -471,11 +461,7 @@ export function serializeParagraphFormatting(
     }
 
     // Widow control
-    if (formatting.widowControl === false) {
-      parts.push('<w:widowControl w:val="0"/>');
-    } else if (formatting.widowControl === true) {
-      parts.push("<w:widowControl/>");
-    }
+    pushToggle("widowControl", formatting.widowControl);
 
     // Numbering
     const numPrXml = serializeNumbering(formatting.numPr);
@@ -501,19 +487,9 @@ export function serializeParagraphFormatting(
       parts.push(tabsXml);
     }
 
-    // Suppress line numbers
-    if (formatting.suppressLineNumbers === true) {
-      parts.push("<w:suppressLineNumbers/>");
-    } else if (formatting.suppressLineNumbers === false) {
-      parts.push('<w:suppressLineNumbers w:val="0"/>');
-    }
-
-    // Suppress auto hyphens
-    if (formatting.suppressAutoHyphens === true) {
-      parts.push("<w:suppressAutoHyphens/>");
-    } else if (formatting.suppressAutoHyphens === false) {
-      parts.push('<w:suppressAutoHyphens w:val="0"/>');
-    }
+    // Suppress line numbers / auto hyphens
+    pushToggle("suppressLineNumbers", formatting.suppressLineNumbers);
+    pushToggle("suppressAutoHyphens", formatting.suppressAutoHyphens);
 
     // Spacing
     const spacingXml = serializeSpacing(formatting);
@@ -528,11 +504,7 @@ export function serializeParagraphFormatting(
     }
 
     // Text direction (bidi)
-    if (formatting.bidi === true) {
-      parts.push("<w:bidi/>");
-    } else if (formatting.bidi === false) {
-      parts.push('<w:bidi w:val="0"/>');
-    }
+    pushToggle("bidi", formatting.bidi);
 
     // Justification
     if (formatting.alignment) {

--- a/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/paragraphSerializer.ts
@@ -437,21 +437,31 @@ export function serializeParagraphFormatting(
       parts.push(`<w:pStyle w:val="${escapeXml(formatting.styleId)}"/>`);
     }
 
-    // Keep next/lines/widow
-    if (formatting.keepNext) {
+    // Keep next/lines/widow. Emit `w:val="0"` on an explicit false so an
+    // inline override that disables an inherited (style) value survives
+    // round-trip; a bare element is true and absence means "inherit".
+    if (formatting.keepNext === true) {
       parts.push("<w:keepNext/>");
+    } else if (formatting.keepNext === false) {
+      parts.push('<w:keepNext w:val="0"/>');
     }
 
-    if (formatting.keepLines) {
+    if (formatting.keepLines === true) {
       parts.push("<w:keepLines/>");
+    } else if (formatting.keepLines === false) {
+      parts.push('<w:keepLines w:val="0"/>');
     }
 
-    if (formatting.contextualSpacing) {
+    if (formatting.contextualSpacing === true) {
       parts.push("<w:contextualSpacing/>");
+    } else if (formatting.contextualSpacing === false) {
+      parts.push('<w:contextualSpacing w:val="0"/>');
     }
 
-    if (formatting.pageBreakBefore) {
+    if (formatting.pageBreakBefore === true) {
       parts.push("<w:pageBreakBefore/>");
+    } else if (formatting.pageBreakBefore === false) {
+      parts.push('<w:pageBreakBefore w:val="0"/>');
     }
 
     // Frame properties
@@ -492,13 +502,17 @@ export function serializeParagraphFormatting(
     }
 
     // Suppress line numbers
-    if (formatting.suppressLineNumbers) {
+    if (formatting.suppressLineNumbers === true) {
       parts.push("<w:suppressLineNumbers/>");
+    } else if (formatting.suppressLineNumbers === false) {
+      parts.push('<w:suppressLineNumbers w:val="0"/>');
     }
 
     // Suppress auto hyphens
-    if (formatting.suppressAutoHyphens) {
+    if (formatting.suppressAutoHyphens === true) {
       parts.push("<w:suppressAutoHyphens/>");
+    } else if (formatting.suppressAutoHyphens === false) {
+      parts.push('<w:suppressAutoHyphens w:val="0"/>');
     }
 
     // Spacing
@@ -514,8 +528,10 @@ export function serializeParagraphFormatting(
     }
 
     // Text direction (bidi)
-    if (formatting.bidi) {
+    if (formatting.bidi === true) {
       parts.push("<w:bidi/>");
+    } else if (formatting.bidi === false) {
+      parts.push('<w:bidi w:val="0"/>');
     }
 
     // Justification


### PR DESCRIPTION
The paragraph serializer emitted keepNext, keepLines, contextualSpacing,
pageBreakBefore, suppressLineNumbers, suppressAutoHyphens, and bidi only
when truthy, so an explicit `<w:x w:val="0"/>` override (which disables a
value inherited from a style) was dropped on save and the inherited value
silently returned on the next open.

Emit `w:val="0"` on explicit false, a bare element on true, and nothing
when absent, matching the existing widowControl and run-property handling.
The parser and model already carried the explicit false. Port of
eigenpal/docx-editor#687, adapted to folio's true/false/undefined pattern.
