### PR TITLE
feat(folio): watermark header coverage, per-header relIds, aspect fidelity

### DIFF
--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1415,10 +1415,12 @@ export type PictureWatermark = {
   /** Relationship id of the image part in `word/_rels/header*.xml.rels`. */
   imageRId: string;
   /**
-   * Media part target the `imageRId` resolved to in the header it was parsed
-   * from (e.g. `media/image1.png`). Relationship ids are scoped per header part
-   * and commonly repeat, so propagating a watermark across headers rebinds
-   * against this stable target rather than the (ambiguous) source rId.
+   * Absolute package path of the media part the `imageRId` resolved to in the
+   * header it was parsed from (e.g. `word/media/image1.png`). Relationship ids
+   * are scoped per header part and commonly repeat, so propagating a watermark
+   * across headers rebinds against this stable, package-absolute target rather
+   * than the (ambiguous) source rId; each target header's relationship is
+   * written relative to its own part location.
    */
   imageTarget?: string;
   /** Optional scale factor (1.0 = native, 0.5 = half-size). */

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1417,6 +1417,16 @@ export type PictureWatermark = {
   /** Optional scale factor (1.0 = native, 0.5 = half-size). */
   scale?: number;
   /**
+   * Display width in points from the VML shape, captured at parse so the
+   * source aspect ratio survives a save that re-synthesizes the watermark
+   * (Word stretches the image to the shape box, so a non-2:1 box distorts a
+   * non-2:1 image). Absent for synthesized watermarks, which fall back to
+   * Word's default box scaled by `scale`.
+   */
+  widthPt?: number;
+  /** Display height in points from the VML shape. See {@link widthPt}. */
+  heightPt?: number;
+  /**
    * Whether Word's "washout" effect was applied (low contrast).
    * Default true — Word emits washout=true on every picture
    * watermark inserted via Insert → Watermark.

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1414,6 +1414,13 @@ export type PictureWatermark = {
   kind: "picture";
   /** Relationship id of the image part in `word/_rels/header*.xml.rels`. */
   imageRId: string;
+  /**
+   * Media part target the `imageRId` resolved to in the header it was parsed
+   * from (e.g. `media/image1.png`). Relationship ids are scoped per header part
+   * and commonly repeat, so propagating a watermark across headers rebinds
+   * against this stable target rather than the (ambiguous) source rId.
+   */
+  imageTarget?: string;
   /** Optional scale factor (1.0 = native, 0.5 = half-size). */
   scale?: number;
   /**

--- a/packages/docx-core/src/model/content.ts
+++ b/packages/docx-core/src/model/content.ts
@@ -1415,14 +1415,20 @@ export type PictureWatermark = {
   /** Relationship id of the image part in `word/_rels/header*.xml.rels`. */
   imageRId: string;
   /**
-   * Absolute package path of the media part the `imageRId` resolved to in the
-   * header it was parsed from (e.g. `word/media/image1.png`). Relationship ids
-   * are scoped per header part and commonly repeat, so propagating a watermark
-   * across headers rebinds against this stable, package-absolute target rather
-   * than the (ambiguous) source rId; each target header's relationship is
-   * written relative to its own part location.
+   * Stable identity of the image the `imageRId` resolved to in the header it
+   * was parsed from — an absolute package path for embedded media (e.g.
+   * `word/media/image1.png`) or the URL for a linked image (see
+   * {@link imageTargetExternal}). Relationship ids are scoped per header part
+   * and commonly repeat, so propagating a watermark across headers rebinds
+   * against this anchored target rather than the (ambiguous) source rId; each
+   * target header's relationship is written relative to its own part location.
    */
   imageTarget?: string;
+  /**
+   * When true, {@link imageTarget} is an external (linked) URL written back
+   * with `TargetMode="External"`, not an embedded package path.
+   */
+  imageTargetExternal?: boolean;
   /** Optional scale factor (1.0 = native, 0.5 = half-size). */
   scale?: number;
   /**

--- a/packages/docx-core/src/model/document.ts
+++ b/packages/docx-core/src/model/document.ts
@@ -193,6 +193,12 @@ export type DocumentSettings = {
    * defaults to 720 twips (½ inch) when absent.
    */
   defaultTabStop: number;
+  /**
+   * `w:evenAndOddHeaders` (§17.10.1) — when true, even pages use a distinct
+   * even header/footer. Word stores this in `settings.xml` (not `sectPr`), so
+   * it is a document-wide flag; absent means odd/even share one header.
+   */
+  evenAndOddHeaders?: boolean;
 };
 
 /**

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Header/footer part materialization on save.
+ *
+ * A header/footer created in memory (by the header editor, or by watermark
+ * coverage) is keyed in `package.headers`/`footers` by an rId that has no
+ * relationship in `word/_rels/document.xml.rels` yet. Without materialization
+ * the full-repack path silently drops it (`collectHeaderFooterUpdates` skips
+ * any rId it can't resolve) and the selective fast-path can't register the new
+ * part either. Materialization promotes such an entry to a real part:
+ * `word/headerN.xml` + a document relationship under its rId + a
+ * `[Content_Types].xml` Override. Selective save must bail so the full-repack
+ * path handles it. Prerequisite for watermark header coverage
+ * (eigenpal/docx-editor#684) and a standalone fix for the editor's
+ * add-header flow.
+ */
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { HeaderFooter } from "../types/document";
+import { parseDocx } from "./parser";
+import {
+  createEmptyDocx,
+  hasUnmaterializedHeaderFooter,
+  repackDocx,
+  validateDocx,
+} from "./rezip";
+import { attemptSelectiveSave } from "./selectiveSave";
+
+const firstPageHeader: HeaderFooter = {
+  type: "header",
+  hdrFtrType: "first",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        { type: "run", content: [{ type: "text", text: "TOP SECRET" }] },
+      ],
+    },
+  ],
+};
+
+describe("header/footer part materialization on save", () => {
+  test("writes the part, relationship, and Content_Types override for an in-memory header", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+
+    const synthRId = "rId_new_first";
+    doc.package.headers = new Map([[synthRId, firstPageHeader]]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      titlePg: true,
+      headerReferences: [{ type: "first", rId: synthRId }],
+    };
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerFiles = Object.keys(zip.files).filter((p) =>
+      /^word\/header\d+\.xml$/u.test(p),
+    );
+    expect(headerFiles).toHaveLength(1);
+    const headerPath = headerFiles[0]!;
+    expect(await zip.file(headerPath)!.async("text")).toContain("TOP SECRET");
+
+    const target = headerPath.replace(/^word\//u, "");
+    const rels = await zip.file("word/_rels/document.xml.rels")!.async("text");
+    expect(rels).toContain(`Id="${synthRId}"`);
+    expect(rels).toContain(`Target="${target}"`);
+
+    expect(await zip.file("[Content_Types].xml")!.async("text")).toContain(
+      `PartName="/${headerPath}"`,
+    );
+
+    // The materialized header survives a full re-parse.
+    const reparsed = await parseDocx(out, { preloadFonts: false });
+    expect(reparsed.package.headers?.size).toBe(1);
+  });
+
+  test("does not re-materialize an already-resolvable parsed header", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+    expect(hasUnmaterializedHeaderFooter(doc)).toBe(false);
+
+    doc.package.headers = new Map([["rId_new_x", { ...firstPageHeader }]]);
+    expect(hasUnmaterializedHeaderFooter(doc)).toBe(true);
+  });
+
+  test("selective save bails to full repack when a header is unmaterialized", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+    doc.package.headers = new Map([
+      ["rId_new_default", { ...firstPageHeader }],
+    ]);
+
+    const result = await attemptSelectiveSave(doc, base, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -155,6 +155,44 @@ describe("header/footer part materialization on save", () => {
     ).toBe(true);
   });
 
+  test("re-keys a materialized header whose rId collides with an existing relationship", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+    expect(doc.package.relationships).toBeDefined();
+
+    // An unrelated relationship already uses the would-be header id.
+    doc.package.relationships?.set("rId_new_default", {
+      id: "rId_new_default",
+      type: RELATIONSHIP_TYPES.image,
+      target: "media/decoration.png",
+    });
+    doc.package.headers = new Map([
+      [
+        "rId_new_default",
+        { type: "header", hdrFtrType: "default", content: [] },
+      ],
+    ]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      headerReferences: [{ type: "default", rId: "rId_new_default" }],
+    };
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const docXml = await zip.file("word/document.xml")!.async("text");
+    const refRId = /<w:headerReference[^>]*\br:id="([^"]+)"/u.exec(docXml)?.[1];
+    expect(refRId).toBeDefined();
+    // The section reference was re-pointed off the taken id to a fresh one...
+    expect(refRId).not.toBe("rId_new_default");
+    // ...and that fresh id maps to a header part.
+    const rels = await zip.file("word/_rels/document.xml.rels")!.async("text");
+    expect(rels).toMatch(
+      new RegExp(`Id="${refRId}"[^>]*Target="header\\d+\\.xml"`, "u"),
+    );
+  });
+
   test("selective save bails to full repack when a header is unmaterialized", async () => {
     const base = await createEmptyDocx();
     const doc = await parseDocx(base, { preloadFonts: false });

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -242,4 +242,53 @@ describe("header/footer part materialization on save", () => {
     });
     expect(result).toBeNull();
   });
+
+  test("re-keying a colliding header does not overwrite another new header's id", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+
+    // rId1 already exists (styles) — so the first header must be re-keyed. The
+    // minted id must not land on rId2, which a second new header already uses.
+    const para = (text: string): HeaderFooter["content"][number] => ({
+      type: "paragraph",
+      content: [{ type: "run", content: [{ type: "text", text }] }],
+    });
+    doc.package.headers = new Map([
+      [
+        "rId1",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [para("HEADER-ONE")],
+        },
+      ],
+      [
+        "rId2",
+        { type: "header", hdrFtrType: "first", content: [para("HEADER-TWO")] },
+      ],
+    ]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      titlePg: true,
+      headerReferences: [
+        { type: "default", rId: "rId1" },
+        { type: "first", rId: "rId2" },
+      ],
+    };
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerFiles = Object.keys(zip.files).filter((p) =>
+      /^word\/header\d+\.xml$/u.test(p),
+    );
+    // Two distinct header parts; neither header was overwritten/dropped.
+    expect(headerFiles).toHaveLength(2);
+    const allHeaderXml = (
+      await Promise.all(headerFiles.map((p) => zip.file(p)!.async("text")))
+    ).join("\n");
+    expect(allHeaderXml).toContain("HEADER-ONE");
+    expect(allHeaderXml).toContain("HEADER-TWO");
+  });
 });

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -23,9 +23,39 @@ import {
   createEmptyDocx,
   hasUnmaterializedHeaderFooter,
   repackDocx,
+  repackDocxFromRaw,
   validateDocx,
 } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+import { unzipDocx } from "./unzip";
+
+const headerWithInlineImage = (rId: string): HeaderFooter => ({
+  type: "header",
+  hdrFtrType: "default",
+  content: [
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "run",
+          content: [
+            {
+              type: "drawing",
+              image: {
+                type: "image",
+                rId,
+                src: ONE_PIXEL_PNG_DATA_URL,
+                filename: "header.png",
+                size: { width: 9525, height: 9525 },
+                wrap: { type: "inline" },
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
 
 const ONE_PIXEL_PNG_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
@@ -100,36 +130,7 @@ describe("header/footer part materialization on save", () => {
 
     const synthRId = "rId_new_default";
     doc.package.headers = new Map([
-      [
-        synthRId,
-        {
-          type: "header",
-          hdrFtrType: "default",
-          content: [
-            {
-              type: "paragraph",
-              content: [
-                {
-                  type: "run",
-                  content: [
-                    {
-                      type: "drawing",
-                      image: {
-                        type: "image",
-                        rId: "rId_img_1",
-                        src: ONE_PIXEL_PNG_DATA_URL,
-                        filename: "header.png",
-                        size: { width: 9525, height: 9525 },
-                        wrap: { type: "inline" },
-                      },
-                    },
-                  ],
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      [synthRId, headerWithInlineImage("rId_img_1")],
     ]);
     doc.package.document.finalSectionProperties = {
       ...doc.package.document.finalSectionProperties,
@@ -149,6 +150,40 @@ describe("header/footer part materialization on save", () => {
       .async("text");
     // The inserted image got a media part + an image relationship in the new
     // header's own rels.
+    expect(headerRels).toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
+    expect(
+      Object.keys(zip.files).some((p) => /^word\/media\/image\d+\./u.test(p)),
+    ).toBe(true);
+  });
+
+  test("materializes new header parts on the raw repack path too", async () => {
+    // repackDocxFromRaw is a separate save path; it must materialize before
+    // image processing just like repackDocx.
+    const base = await createEmptyDocx();
+    const raw = await unzipDocx(base);
+    const doc = await parseDocx(base, { preloadFonts: false });
+
+    doc.package.headers = new Map([
+      ["rId_new_default", headerWithInlineImage("rId_img_1")],
+    ]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      headerReferences: [{ type: "default", rId: "rId_new_default" }],
+    };
+
+    const out = await repackDocxFromRaw(doc, raw, {
+      updateModifiedDate: false,
+    });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerPath = Object.keys(zip.files).find((p) =>
+      /^word\/header\d+\.xml$/u.test(p),
+    );
+    expect(headerPath).toBeDefined();
+    const headerRels = await zip
+      .file(`word/_rels/${headerPath!.replace(/^word\//u, "")}.rels`)!
+      .async("text");
     expect(headerRels).toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
     expect(
       Object.keys(zip.files).some((p) => /^word\/media\/image\d+\./u.test(p)),

--- a/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
+++ b/packages/folio/src/core/docx/headerFooterMaterialize.test.ts
@@ -18,6 +18,7 @@ import JSZip from "jszip";
 
 import type { HeaderFooter } from "../types/document";
 import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
 import {
   createEmptyDocx,
   hasUnmaterializedHeaderFooter,
@@ -25,6 +26,9 @@ import {
   validateDocx,
 } from "./rezip";
 import { attemptSelectiveSave } from "./selectiveSave";
+
+const ONE_PIXEL_PNG_DATA_URL =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
 
 const firstPageHeader: HeaderFooter = {
   type: "header",
@@ -85,6 +89,70 @@ describe("header/footer part materialization on save", () => {
 
     doc.package.headers = new Map([["rId_new_x", { ...firstPageHeader }]]);
     expect(hasUnmaterializedHeaderFooter(doc)).toBe(true);
+  });
+
+  test("processes an inserted image inside a newly materialized header", async () => {
+    // Materialization must run before image processing: otherwise
+    // collectImageParts cannot see the new header (no relationship yet) and the
+    // inserted image would save with a dangling rId and no media part.
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+
+    const synthRId = "rId_new_default";
+    doc.package.headers = new Map([
+      [
+        synthRId,
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "run",
+                  content: [
+                    {
+                      type: "drawing",
+                      image: {
+                        type: "image",
+                        rId: "rId_img_1",
+                        src: ONE_PIXEL_PNG_DATA_URL,
+                        filename: "header.png",
+                        size: { width: 9525, height: 9525 },
+                        wrap: { type: "inline" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    ]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      headerReferences: [{ type: "default", rId: synthRId }],
+    };
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerPath = Object.keys(zip.files).find((p) =>
+      /^word\/header\d+\.xml$/u.test(p),
+    );
+    expect(headerPath).toBeDefined();
+    const headerRels = await zip
+      .file(`word/_rels/${headerPath!.replace(/^word\//u, "")}.rels`)!
+      .async("text");
+    // The inserted image got a media part + an image relationship in the new
+    // header's own rels.
+    expect(headerRels).toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
+    expect(
+      Object.keys(zip.files).some((p) => /^word\/media\/image\d+\./u.test(p)),
+    ).toBe(true);
   });
 
   test("selective save bails to full repack when a header is unmaterialized", async () => {

--- a/packages/folio/src/core/docx/headerFooterParser.ts
+++ b/packages/folio/src/core/docx/headerFooterParser.ts
@@ -39,7 +39,6 @@ import type {
 } from "../types/document";
 import { parseBlockContent } from "./blockContentParser";
 import type { NumberingMap } from "./numberingParser";
-import { RELATIONSHIP_TYPES } from "./relsParser";
 import type { StyleMap } from "./styleParser";
 import { parseWatermark } from "./watermarkParser";
 import { parseXml } from "./xmlParser";
@@ -130,15 +129,9 @@ export function parseHeader(
     result.watermark = watermarkResult.watermark;
     result.rawWatermarkXml = watermarkResult.rawParagraphXml;
     result.watermarkBlockIndex = watermarkResult.blockIndex;
-    // Anchor a picture watermark to its media target (resolved in this header's
-    // own rels) so cross-header propagation rebinds against a stable target
-    // instead of the per-header `imageRId`, which repeats across parts.
-    if (result.watermark.kind === "picture" && rels) {
-      const imageRel = rels.get(result.watermark.imageRId);
-      if (imageRel?.type === RELATIONSHIP_TYPES.image && imageRel.target) {
-        result.watermark.imageTarget = imageRel.target;
-      }
-    }
+    // A picture watermark's media target (PictureWatermark.imageTarget) is
+    // anchored to a stable, package-absolute path by parseHeadersAndFooters,
+    // which knows this header part's own path.
   }
   const contentRoot = watermarkResult
     ? withoutChild(rootElement, watermarkResult.hostingParagraph)

--- a/packages/folio/src/core/docx/headerFooterParser.ts
+++ b/packages/folio/src/core/docx/headerFooterParser.ts
@@ -39,6 +39,7 @@ import type {
 } from "../types/document";
 import { parseBlockContent } from "./blockContentParser";
 import type { NumberingMap } from "./numberingParser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
 import type { StyleMap } from "./styleParser";
 import { parseWatermark } from "./watermarkParser";
 import { parseXml } from "./xmlParser";
@@ -129,6 +130,15 @@ export function parseHeader(
     result.watermark = watermarkResult.watermark;
     result.rawWatermarkXml = watermarkResult.rawParagraphXml;
     result.watermarkBlockIndex = watermarkResult.blockIndex;
+    // Anchor a picture watermark to its media target (resolved in this header's
+    // own rels) so cross-header propagation rebinds against a stable target
+    // instead of the per-header `imageRId`, which repeats across parts.
+    if (result.watermark.kind === "picture" && rels) {
+      const imageRel = rels.get(result.watermark.imageRId);
+      if (imageRel?.type === RELATIONSHIP_TYPES.image && imageRel.target) {
+        result.watermark.imageTarget = imageRel.target;
+      }
+    }
   }
   const contentRoot = watermarkResult
     ? withoutChild(rootElement, watermarkResult.hostingParagraph)

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -597,6 +597,20 @@ function parseHeadersAndFooters(
           headerRels,
           media,
         );
+        // Anchor a picture watermark to the package-absolute media path so
+        // cross-header propagation can rebind it against a stable target (the
+        // per-header imageRId repeats across parts). Resolved here because this
+        // is where the header part's own rels path is known.
+        const watermark = header.watermark;
+        if (watermark?.kind === "picture") {
+          const imageRel = headerRels.get(watermark.imageRId);
+          if (imageRel?.type === RELATIONSHIP_TYPES.image && imageRel.target) {
+            watermark.imageTarget = resolveRelativePath(
+              headerRelsPath,
+              imageRel.target,
+            );
+          }
+        }
         headers.set(rId, header);
       }
     } else if (rel.type === RELATIONSHIP_TYPES.footer && rel.target) {

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -604,7 +604,13 @@ function parseHeadersAndFooters(
         const watermark = header.watermark;
         if (watermark?.kind === "picture") {
           const imageRel = headerRels.get(watermark.imageRId);
-          if (imageRel?.type === RELATIONSHIP_TYPES.image && imageRel.target) {
+          // Only anchor embedded media. An external (linked) image's target is
+          // a URL, not a package path, so it must be left untouched.
+          if (
+            imageRel?.type === RELATIONSHIP_TYPES.image &&
+            imageRel.target &&
+            imageRel.targetMode !== "External"
+          ) {
             watermark.imageTarget = resolveRelativePath(
               headerRelsPath,
               imageRel.target,

--- a/packages/folio/src/core/docx/parser.ts
+++ b/packages/folio/src/core/docx/parser.ts
@@ -604,17 +604,17 @@ function parseHeadersAndFooters(
         const watermark = header.watermark;
         if (watermark?.kind === "picture") {
           const imageRel = headerRels.get(watermark.imageRId);
-          // Only anchor embedded media. An external (linked) image's target is
-          // a URL, not a package path, so it must be left untouched.
-          if (
-            imageRel?.type === RELATIONSHIP_TYPES.image &&
-            imageRel.target &&
-            imageRel.targetMode !== "External"
-          ) {
-            watermark.imageTarget = resolveRelativePath(
-              headerRelsPath,
-              imageRel.target,
-            );
+          if (imageRel?.type === RELATIONSHIP_TYPES.image && imageRel.target) {
+            if (imageRel.targetMode === "External") {
+              // Linked image: anchor the URL as-is (not a package path).
+              watermark.imageTarget = imageRel.target;
+              watermark.imageTargetExternal = true;
+            } else {
+              watermark.imageTarget = resolveRelativePath(
+                headerRelsPath,
+                imageRel.target,
+              );
+            }
           }
         }
         headers.set(rId, header);

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -193,4 +193,109 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     });
     expect(result).toBeNull();
   });
+
+  test("rebinds a sibling header whose rId resolves to a different image", async () => {
+    // header2 already has rId "rIdImg" pointing at its own logo. The propagated
+    // watermark also carries "rIdImg" (header1's), which means the watermark
+    // image — not header2's logo. The rebind must point header2 at the
+    // watermark media, not skip because the id happens to resolve locally.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/header2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"/>
+  <Relationship Id="rId11" Type="${RELATIONSHIP_TYPES.header}" Target="header2.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><w:t>x</w:t></w:r></w:p>
+    <w:sectPr>
+      <w:headerReference w:type="default" r:id="rId10"/>
+      <w:headerReference w:type="even" r:id="rId11"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/header1.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:p><w:r><w:pict><v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="position:absolute;width:300pt;height:400pt"><v:imagedata r:id="rIdImg" o:title=""/></v:shape></w:pict></w:r></w:p>
+</w:hdr>`,
+    );
+    zip.file(
+      "word/_rels/header1.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/watermark.png"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/header2.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>even</w:t></w:r></w:p></w:hdr>`,
+    );
+    // header2 already uses rIdImg for a DIFFERENT image (its own logo).
+    zip.file(
+      "word/_rels/header2.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/logo.png"/>
+</Relationships>`,
+    );
+    zip.file("word/media/watermark.png", ONE_PIXEL_PNG_BASE64, {
+      base64: true,
+    });
+    zip.file("word/media/logo.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const out = await repackDocx(
+      setDocumentWatermark(doc, getDocumentWatermark(doc)),
+      {
+        updateModifiedDate: false,
+      },
+    );
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const header2Xml = await outZip.file("word/header2.xml")!.async("text");
+    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    expect(usedRId).toBeDefined();
+    const header2Rels = await outZip
+      .file("word/_rels/header2.xml.rels")!
+      .async("text");
+    // The watermark in header2 must resolve to the watermark image, not the logo.
+    expect(header2Rels).toMatch(
+      new RegExp(`Id="${usedRId}"[^>]*Target="media/watermark.png"`, "u"),
+    );
+  });
 });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-header picture-watermark relationship rebinding.
+ *
+ * A picture watermark's `imageRId` is local to each header part's own rels.
+ * Propagating one watermark across headers (setDocumentWatermark) or onto a
+ * coverage-created header leaves sibling headers referencing an rId that does
+ * not resolve in their rels, producing a broken `<v:imagedata r:id>`. The
+ * save-time rebind pass gives each header a relationship to the shared media in
+ * its own rels (reusing or minting), without duplicating the image bytes.
+ *
+ * eigenpal/docx-editor#684 (OOXML watermark fidelity), BUG1.
+ */
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import { getDocumentWatermark, setDocumentWatermark } from "../watermark";
+import { parseDocx } from "./parser";
+import { RELATIONSHIP_TYPES } from "./relsParser";
+import { repackDocx, validateDocx } from "./rezip";
+
+const XML = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
+const ONE_PIXEL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
+
+// A two-header DOCX whose picture watermark lives only in header1's rels.
+async function twoHeaderPictureWatermarkDocx(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "[Content_Types].xml",
+    `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/header2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+  );
+  zip.file(
+    "_rels/.rels",
+    `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/_rels/document.xml.rels",
+    `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"/>
+  <Relationship Id="rId11" Type="${RELATIONSHIP_TYPES.header}" Target="header2.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/document.xml",
+    `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r><w:t>body</w:t></w:r></w:p>
+    <w:sectPr>
+      <w:headerReference w:type="default" r:id="rId10"/>
+      <w:headerReference w:type="even" r:id="rId11"/>
+      <w:pgSz w:w="12240" w:h="15840"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`,
+  );
+  // header1 owns the picture watermark and the image relationship.
+  zip.file(
+    "word/header1.xml",
+    `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:p><w:r><w:pict><v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="position:absolute;width:300pt;height:400pt"><v:imagedata r:id="rIdImg" o:title=""/></v:shape></w:pict></w:r></w:p>
+</w:hdr>`,
+  );
+  zip.file(
+    "word/_rels/header1.xml.rels",
+    `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/image1.png"/>
+</Relationships>`,
+  );
+  zip.file(
+    "word/header2.xml",
+    `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>even</w:t></w:r></w:p></w:hdr>`,
+  );
+  zip.file("word/media/image1.png", ONE_PIXEL_PNG_BASE64, { base64: true });
+  zip.file(
+    "word/styles.xml",
+    `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+  );
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+const countMediaImages = async (zip: JSZip): Promise<number> =>
+  Object.keys(zip.files).filter((p) => /^word\/media\/image/u.test(p)).length;
+
+describe("picture watermark relationship rebinding (eigenpal #684)", () => {
+  test("setDocumentWatermark spans multiple headers without throwing and clones per header", async () => {
+    const doc = await parseDocx(await twoHeaderPictureWatermarkDocx(), {
+      preloadFonts: false,
+    });
+    expect(doc.package.headers?.size).toBe(2);
+
+    const next = setDocumentWatermark(doc, {
+      kind: "picture",
+      imageRId: "rIdImg",
+    });
+
+    const headers = [...(next.package.headers?.values() ?? [])];
+    expect(headers).toHaveLength(2);
+    expect(headers.every((h) => h.watermark?.kind === "picture")).toBe(true);
+    // Distinct objects so per-header rId rebinding cannot leak across headers.
+    expect(headers[0]!.watermark).not.toBe(headers[1]!.watermark);
+  });
+
+  test("repack rebinds the sibling header's image rId to the shared media", async () => {
+    const original = await twoHeaderPictureWatermarkDocx();
+    const doc = await parseDocx(original, { preloadFonts: false });
+
+    const watermark = getDocumentWatermark(doc);
+    expect(watermark?.kind).toBe("picture");
+
+    // Propagate the picture watermark to every header part.
+    const withWatermark = setDocumentWatermark(doc, watermark);
+    const out = await repackDocx(withWatermark, { updateModifiedDate: false });
+
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    // No duplicate media: both headers share the single image part.
+    expect(await countMediaImages(zip)).toBe(1);
+
+    const header2Rels = await zip
+      .file("word/_rels/header2.xml.rels")!
+      .async("text");
+    expect(header2Rels).toContain('Target="media/image1.png"');
+
+    // header2's imagedata rId must resolve in header2's own rels.
+    const header2Xml = await zip.file("word/header2.xml")!.async("text");
+    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    expect(usedRId).toBeDefined();
+    expect(header2Rels).toContain(`Id="${usedRId}"`);
+  });
+});

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -16,7 +16,8 @@ import JSZip from "jszip";
 import { getDocumentWatermark, setDocumentWatermark } from "../watermark";
 import { parseDocx } from "./parser";
 import { RELATIONSHIP_TYPES } from "./relsParser";
-import { repackDocx, validateDocx } from "./rezip";
+import { createEmptyDocx, repackDocx, validateDocx } from "./rezip";
+import { attemptSelectiveSave } from "./selectiveSave";
 
 const XML = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 const ONE_PIXEL_PNG_BASE64 =
@@ -144,5 +145,52 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
     expect(usedRId).toBeDefined();
     expect(header2Rels).toContain(`Id="${usedRId}"`);
+  });
+
+  test("resolves the image target from a raw-replay (non-pending) source header", async () => {
+    const original = await twoHeaderPictureWatermarkDocx();
+    const doc = await parseDocx(original, { preloadFonts: false });
+
+    // header1 (rId10) keeps its raw VML — so it is NOT pending — while header2
+    // gets a model-driven picture watermark pointing at header1's image rId.
+    // The rebind must still find the target by scanning the non-pending header.
+    const header2 = doc.package.headers?.get("rId11");
+    expect(header2).toBeDefined();
+    if (header2) {
+      header2.watermark = { kind: "picture", imageRId: "rIdImg" };
+    }
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    expect(await countMediaImages(zip)).toBe(1);
+    const header2Rels = await zip
+      .file("word/_rels/header2.xml.rels")!
+      .async("text");
+    expect(header2Rels).toContain('Target="media/image1.png"');
+  });
+
+  test("selective save bails for a single-header model-driven picture watermark", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+    doc.package.headers = new Map([
+      [
+        "rId1",
+        {
+          type: "header",
+          hdrFtrType: "default",
+          content: [],
+          watermark: { kind: "picture", imageRId: "rIdX" },
+        },
+      ],
+    ]);
+
+    const result = await attemptSelectiveSave(doc, base, {
+      changedParaIds: new Set(),
+      structuralChange: false,
+      hasUntrackedChanges: false,
+    });
+    expect(result).toBeNull();
   });
 });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -483,4 +483,85 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     expect(header2Rels).toContain('Target="../media/watermark.png"');
     expect(header2Rels).not.toContain('Target="media/watermark.png"');
   });
+
+  test("leaves an external (linked) picture watermark relationship intact", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><w:t>x</w:t></w:r></w:p>
+    <w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/header1.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:p><w:r><w:pict><v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="position:absolute;width:300pt;height:400pt"><v:imagedata r:id="rIdImg" o:title=""/></v:shape></w:pict></w:r></w:p>
+</w:hdr>`,
+    );
+    // The watermark image is a LINKED (external) relationship — a URL target.
+    zip.file(
+      "word/_rels/header1.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="https://example.com/wm.png" TargetMode="External"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    // The external target must not be anchored as a package path.
+    const wm = getDocumentWatermark(doc);
+    expect(wm?.kind).toBe("picture");
+    if (wm?.kind === "picture") {
+      expect(wm.imageTarget).toBeUndefined();
+    }
+
+    const out = await repackDocx(setDocumentWatermark(doc, wm), {
+      updateModifiedDate: false,
+    });
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const rels = await outZip
+      .file("word/_rels/header1.xml.rels")!
+      .async("text");
+    // The external relationship is preserved, not rewritten into a bogus
+    // internal "../https:/..." target.
+    expect(rels).toContain('Target="https://example.com/wm.png"');
+    expect(rels).toContain('TargetMode="External"');
+    expect(rels).not.toContain("../https");
+  });
 });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -298,4 +298,97 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
       new RegExp(`Id="${usedRId}"[^>]*Target="media/watermark.png"`, "u"),
     );
   });
+
+  test("writes a subdirectory header's image relationship to the correct rels path", async () => {
+    // A header part in a subdirectory keeps its rels at
+    // word/headers/_rels/header1.xml.rels, not a flattened word/_rels/...
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/headers/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="headers/header1.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><w:t>x</w:t></w:r></w:p>
+    <w:sectPr><w:headerReference w:type="default" r:id="rId10"/></w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/headers/header1.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>hdr</w:t></w:r></w:p></w:hdr>`,
+    );
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    // Insert a new (data-URL) image into the subdirectory header.
+    const header = doc.package.headers?.get("rId10");
+    expect(header).toBeDefined();
+    if (header) {
+      header.content = [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "run",
+              content: [
+                {
+                  type: "drawing",
+                  image: {
+                    type: "image",
+                    rId: "rId_img_1",
+                    src: `data:image/png;base64,${ONE_PIXEL_PNG_BASE64}`,
+                    filename: "h.png",
+                    size: { width: 9525, height: 9525 },
+                    wrap: { type: "inline" },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ];
+    }
+
+    const out = await repackDocx(doc, { updateModifiedDate: false });
+    const outZip = await JSZip.loadAsync(out);
+    const paths = Object.keys(outZip.files);
+    // The image relationship landed in the subdirectory rels part...
+    const subdirRels = await outZip
+      .file("word/headers/_rels/header1.xml.rels")
+      ?.async("text");
+    expect(subdirRels).toBeDefined();
+    expect(subdirRels).toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
+    // ...not the flattened, unattached path.
+    expect(paths).not.toContain("word/_rels/headers/header1.xml.rels");
+  });
 });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -391,4 +391,93 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     // ...not the flattened, unattached path.
     expect(paths).not.toContain("word/_rels/headers/header1.xml.rels");
   });
+
+  test("rebinds a subdirectory header with a target relative to that header", async () => {
+    // header1 (root) owns the watermark image; header2 lives in a subdirectory.
+    // The rebound relationship target must be relative to header2's part
+    // (../media/...), or Word resolves it under word/headers/.
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/headers/header2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"/>
+  <Relationship Id="rId11" Type="${RELATIONSHIP_TYPES.header}" Target="headers/header2.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><w:t>x</w:t></w:r></w:p>
+    <w:sectPr>
+      <w:headerReference w:type="default" r:id="rId10"/>
+      <w:headerReference w:type="even" r:id="rId11"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/header1.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:p><w:r><w:pict><v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="position:absolute;width:300pt;height:400pt"><v:imagedata r:id="rIdImg" o:title=""/></v:shape></w:pict></w:r></w:p>
+</w:hdr>`,
+    );
+    zip.file(
+      "word/_rels/header1.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="media/watermark.png"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/headers/header2.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>even</w:t></w:r></w:p></w:hdr>`,
+    );
+    zip.file("word/media/watermark.png", ONE_PIXEL_PNG_BASE64, {
+      base64: true,
+    });
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const out = await repackDocx(
+      setDocumentWatermark(doc, getDocumentWatermark(doc)),
+      { updateModifiedDate: false },
+    );
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const header2Rels = await outZip
+      .file("word/headers/_rels/header2.xml.rels")!
+      .async("text");
+    // Relative to word/headers/, the shared media is one level up.
+    expect(header2Rels).toContain('Target="../media/watermark.png"');
+    expect(header2Rels).not.toContain('Target="media/watermark.png"');
+  });
 });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -542,11 +542,12 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     const original = await zip.generateAsync({ type: "arraybuffer" });
 
     const doc = await parseDocx(original, { preloadFonts: false });
-    // The external target must not be anchored as a package path.
+    // The external target is anchored as the URL, not a package path.
     const wm = getDocumentWatermark(doc);
     expect(wm?.kind).toBe("picture");
     if (wm?.kind === "picture") {
-      expect(wm.imageTarget).toBeUndefined();
+      expect(wm.imageTarget).toBe("https://example.com/wm.png");
+      expect(wm.imageTargetExternal).toBe(true);
     }
 
     const out = await repackDocx(setDocumentWatermark(doc, wm), {

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -388,6 +388,9 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
       ?.async("text");
     expect(subdirRels).toBeDefined();
     expect(subdirRels).toContain(`Type="${RELATIONSHIP_TYPES.image}"`);
+    // Target is relative to word/headers/, so the media (word/media/...) is up one.
+    expect(subdirRels).toMatch(/Target="\.\.\/media\/image\d+\.png"/u);
+    expect(subdirRels).not.toMatch(/Target="media\/image\d+\.png"/u);
     // ...not the flattened, unattached path.
     expect(paths).not.toContain("word/_rels/headers/header1.xml.rels");
   });

--- a/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
+++ b/packages/folio/src/core/docx/pictureWatermarkRebind.test.ts
@@ -564,4 +564,93 @@ describe("picture watermark relationship rebinding (eigenpal #684)", () => {
     expect(rels).toContain('TargetMode="External"');
     expect(rels).not.toContain("../https");
   });
+
+  test("propagates an external picture watermark to sibling headers", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "[Content_Types].xml",
+      `${XML}
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/header2.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`,
+    );
+    zip.file(
+      "_rels/.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="${RELATIONSHIP_TYPES.officeDocument}" Target="word/document.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/_rels/document.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId10" Type="${RELATIONSHIP_TYPES.header}" Target="header1.xml"/>
+  <Relationship Id="rId11" Type="${RELATIONSHIP_TYPES.header}" Target="header2.xml"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/document.xml",
+      `${XML}
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:r><w:t>x</w:t></w:r></w:p>
+    <w:sectPr>
+      <w:headerReference w:type="default" r:id="rId10"/>
+      <w:headerReference w:type="even" r:id="rId11"/>
+    </w:sectPr>
+  </w:body>
+</w:document>`,
+    );
+    zip.file(
+      "word/header1.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:p><w:r><w:pict><v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="position:absolute;width:300pt;height:400pt"><v:imagedata r:id="rIdImg" o:title=""/></v:shape></w:pict></w:r></w:p>
+</w:hdr>`,
+    );
+    zip.file(
+      "word/_rels/header1.xml.rels",
+      `${XML}
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdImg" Type="${RELATIONSHIP_TYPES.image}" Target="https://example.com/wm.png" TargetMode="External"/>
+</Relationships>`,
+    );
+    zip.file(
+      "word/header2.xml",
+      `${XML}
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>even</w:t></w:r></w:p></w:hdr>`,
+    );
+    zip.file(
+      "word/styles.xml",
+      `${XML}
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"></w:styles>`,
+    );
+    const original = await zip.generateAsync({ type: "arraybuffer" });
+
+    const doc = await parseDocx(original, { preloadFonts: false });
+    const out = await repackDocx(
+      setDocumentWatermark(doc, getDocumentWatermark(doc)),
+      { updateModifiedDate: false },
+    );
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const outZip = await JSZip.loadAsync(out);
+    const header2Xml = await outZip.file("word/header2.xml")!.async("text");
+    const usedRId = /<v:imagedata[^>]*\br:id="([^"]+)"/u.exec(header2Xml)?.[1];
+    expect(usedRId).toBeDefined();
+    const header2Rels = await outZip
+      .file("word/_rels/header2.xml.rels")!
+      .async("text");
+    // The sibling header gets an external relationship to the same URL.
+    expect(header2Rels).toMatch(
+      new RegExp(
+        `Id="${usedRId}"[^>]*Target="https://example.com/wm.png"[^>]*TargetMode="External"`,
+        "u",
+      ),
+    );
+  });
 });

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -207,6 +207,31 @@ function headerFooterRelsPath(target: string): string {
   return `${directory ? `${directory}/` : ""}_rels/${name}.rels`;
 }
 
+/**
+ * Express an absolute package path as a relationship target relative to the
+ * part at `partPath`. e.g. media `word/media/image1.png` for a part at
+ * `word/headers/header2.xml` -> `../media/image1.png` (and `media/image1.png`
+ * for a part at the `word/` root). The inverse of `resolveRelativePath`.
+ */
+function relativeTargetForPart(
+  partPath: string,
+  absoluteTarget: string,
+): string {
+  const lastSlash = partPath.lastIndexOf("/");
+  const fromDir =
+    lastSlash === -1 ? [] : partPath.slice(0, lastSlash).split("/");
+  const to = absoluteTarget.split("/");
+  let shared = 0;
+  while (
+    shared < fromDir.length &&
+    shared < to.length - 1 &&
+    fromDir[shared] === to[shared]
+  ) {
+    shared += 1;
+  }
+  return `${"../".repeat(fromDir.length - shared)}${to.slice(shared).join("/")}`;
+}
+
 function collectImageParts(doc: Document): DocxPart[] {
   const parts: DocxPart[] = [
     {
@@ -1212,6 +1237,11 @@ async function materializeNewHeaderFooterParts(
   if (!rels) {
     return;
   }
+  // Cheap guard so the common repack (no in-memory parts) skips the zip scans
+  // and rels walk below.
+  if (!hasUnmaterializedHeaderFooter(doc)) {
+    return;
+  }
 
   const relEntries: string[] = [];
   const overrides: string[] = [];
@@ -1396,6 +1426,7 @@ async function rebindWatermarkRelIds(
   type PendingHeader = {
     watermark: Extract<Watermark, { kind: "picture" }>;
     relsPath: string;
+    partPath: string;
   };
   const pending: PendingHeader[] = [];
   for (const [rId, hf] of headers) {
@@ -1407,17 +1438,21 @@ async function rebindWatermarkRelIds(
     if (!rel?.target) {
       continue;
     }
-    pending.push({ watermark, relsPath: headerFooterRelsPath(rel.target) });
+    pending.push({
+      watermark,
+      relsPath: headerFooterRelsPath(rel.target),
+      partPath: headerFooterFilename(rel.target),
+    });
   }
   if (pending.length === 0) {
     return;
   }
 
-  // Read every header's rels, not only the ones being rebound: the canonical
-  // image target may live in a header whose own watermark is raw-replayed (so
-  // it is not pending). `document.xml.rels` is intentionally excluded — header
-  // rIds and body rIds both start at rId1, so scanning it could resolve a
-  // watermark to a body image that merely shares the rId number.
+  // Read every header's rels (keyed by path), not only the ones being rebound:
+  // the canonical image may live in a header whose own watermark is raw-replayed
+  // (not pending). `document.xml.rels` is excluded — header rIds and body rIds
+  // both start at rId1, so it could resolve a watermark to an unrelated body
+  // image sharing the rId.
   const relsXmlByPath = new Map<string, string>();
   const headerRelsPaths = new Set<string>(pending.map((p) => p.relsPath));
   for (const rel of rels.values()) {
@@ -1429,51 +1464,68 @@ async function rebindWatermarkRelIds(
     relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
   }
 
-  // The canonical media target for an imageRId: the source header is the one
-  // whose rels actually maps that rId to an image relationship.
-  const resolveImageTarget = (imageRId: string): string | undefined => {
-    for (const xml of relsXmlByPath.values()) {
-      const rel = parseRelationships(xml).get(imageRId);
-      if (rel?.type === RELATIONSHIP_TYPES.image && rel.target) {
-        return rel.target;
+  // Absolute (package) path the rId maps to in a header's rels, resolved
+  // relative to that part — undefined when it is not an image relationship.
+  const localImageTarget = (
+    relsXml: string,
+    relsPath: string,
+    imageRId: string,
+  ): string | undefined => {
+    const rel = parseRelationships(relsXml).get(imageRId);
+    return rel?.type === RELATIONSHIP_TYPES.image && rel.target
+      ? resolveRelativePath(relsPath, rel.target)
+      : undefined;
+  };
+
+  // The canonical media (absolute path) the watermark points at: the source
+  // header is the one whose own rels maps the rId to an image.
+  const resolveCanonical = (imageRId: string): string | undefined => {
+    for (const [relsPath, xml] of relsXmlByPath) {
+      const target = localImageTarget(xml, relsPath, imageRId);
+      if (target) {
+        return target;
       }
     }
     return undefined;
   };
 
   const changedPaths = new Set<string>();
-  for (const { watermark, relsPath } of pending) {
-    // The media target is anchored at parse time (imageTarget); fall back to a
-    // best-effort scan only for watermarks built without a parsed source.
-    const target =
-      watermark.imageTarget ?? resolveImageTarget(watermark.imageRId);
-    if (!target) {
+  for (const { watermark, relsPath, partPath } of pending) {
+    // Anchored at parse time (absolute imageTarget); fall back to a scan only
+    // for watermarks built without a parsed source.
+    const canonical =
+      watermark.imageTarget ?? resolveCanonical(watermark.imageRId);
+    if (!canonical) {
       continue; // Orphaned rId with no embedded media anywhere — cannot invent.
     }
     const relsXml = relsXmlByPath.get(relsPath) ?? EMPTY_RELS_XML;
-    const localRels = parseRelationships(relsXml);
-    const local = localRels.get(watermark.imageRId);
-    if (local?.type === RELATIONSHIP_TYPES.image && local.target === target) {
-      // Already resolves to the canonical watermark media. (A local rId that
-      // resolves to a *different* image — header rIds repeat across parts — must
-      // still be rebound, or the header would render its own unrelated image.)
+    if (localImageTarget(relsXml, relsPath, watermark.imageRId) === canonical) {
+      // Already resolves to the canonical media. (A local rId resolving to a
+      // *different* image — header rIds repeat across parts — must still be
+      // rebound.)
       continue;
     }
 
+    const localRels = parseRelationships(relsXml);
     let resolvedRId: string | undefined;
     for (const [id, rel] of localRels) {
-      if (rel.type === RELATIONSHIP_TYPES.image && rel.target === target) {
+      if (
+        rel.type === RELATIONSHIP_TYPES.image &&
+        rel.target &&
+        resolveRelativePath(relsPath, rel.target) === canonical
+      ) {
         resolvedRId = id;
         break;
       }
     }
     if (!resolvedRId) {
       resolvedRId = `rId${findMaxRId(relsXml) + 1}`;
+      const relativeTarget = relativeTargetForPart(partPath, canonical);
       relsXmlByPath.set(
         relsPath,
         relsXml.replace(
           "</Relationships>",
-          `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(target)}"/></Relationships>`,
+          `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(relativeTarget)}"/></Relationships>`,
         ),
       );
       changedPaths.add(relsPath);

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -740,7 +740,15 @@ export async function repackDocxFromRaw(
     });
   }
 
-  // Serialize and update document.xml
+  // Promote in-memory header/footer parts to real parts/relationships first, so
+  // collectImageParts sees them and processNewImages can write image relations
+  // into a newly created header/footer's own rels.
+  await materializeNewHeaderFooterParts(
+    exportDocument,
+    newZip,
+    compressionLevel,
+  );
+
   await processNewImages(
     collectImageParts(exportDocument),
     newZip,

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1368,15 +1368,18 @@ async function rebindWatermarkRelIds(
 
   const changedPaths = new Set<string>();
   for (const { watermark, relsPath } of pending) {
-    const relsXml = relsXmlByPath.get(relsPath) ?? EMPTY_RELS_XML;
-    const localRels = parseRelationships(relsXml);
-    const local = localRels.get(watermark.imageRId);
-    if (local?.type === RELATIONSHIP_TYPES.image && local.target) {
-      continue; // Already resolves in this header's own rels.
-    }
     const target = resolveImageTarget(watermark.imageRId);
     if (!target) {
       continue; // Orphaned rId with no embedded media anywhere — cannot invent.
+    }
+    const relsXml = relsXmlByPath.get(relsPath) ?? EMPTY_RELS_XML;
+    const localRels = parseRelationships(relsXml);
+    const local = localRels.get(watermark.imageRId);
+    if (local?.type === RELATIONSHIP_TYPES.image && local.target === target) {
+      // Already resolves to the canonical watermark media. (A local rId that
+      // resolves to a *different* image — header rIds repeat across parts — must
+      // still be rebound, or the header would render its own unrelated image.)
+      continue;
     }
 
     let resolvedRId: string | undefined;

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -609,6 +609,15 @@ export async function repackDocx(
     });
   }
 
+  // Promote in-memory header/footer parts to real parts/relationships first, so
+  // collectImageParts sees them and processNewImages can write image relations
+  // into a newly created header/footer's own rels.
+  await materializeNewHeaderFooterParts(
+    exportDocument,
+    newZip,
+    compressionLevel,
+  );
+
   // Process newly inserted images (data URLs → binary media files + relationships).
   // This mutates image rIds in-place so the serializer outputs correct references.
   await processNewImages(
@@ -646,17 +655,9 @@ export async function repackDocx(
     compressionOptions: { level: compressionLevel },
   });
 
-  // Promote any in-memory header/footer parts to real parts/relationships
-  // before serializing them (so collectHeaderFooterUpdates can resolve them).
-  await materializeNewHeaderFooterParts(
-    exportDocument,
-    newZip,
-    compressionLevel,
-  );
-
   // Rebind picture-watermark image rIds so each header references the image in
-  // its own rels (after materialization, so coverage-created header parts have
-  // a relationship target to anchor against).
+  // its own rels (materialization, run before image processing above, gave
+  // coverage-created header parts a relationship target to anchor against).
   await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
 
   // Serialize and update modified headers/footers
@@ -769,17 +770,9 @@ export async function repackDocxFromRaw(
     compressionOptions: { level: compressionLevel },
   });
 
-  // Promote any in-memory header/footer parts to real parts/relationships
-  // before serializing them (so collectHeaderFooterUpdates can resolve them).
-  await materializeNewHeaderFooterParts(
-    exportDocument,
-    newZip,
-    compressionLevel,
-  );
-
   // Rebind picture-watermark image rIds so each header references the image in
-  // its own rels (after materialization, so coverage-created header parts have
-  // a relationship target to anchor against).
+  // its own rels (materialization, run before image processing above, gave
+  // coverage-created header parts a relationship target to anchor against).
   await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
 
   // Serialize and update modified headers/footers

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1480,30 +1480,41 @@ async function rebindWatermarkRelIds(
     relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
   }
 
-  // Absolute (package) path the rId maps to in a header's rels, resolved
-  // relative to that part — undefined when it is not an image relationship.
-  const localImageTarget = (
-    relsXml: string,
+  // The canonical image a watermark points at: an embedded media part (as a
+  // package-absolute path) or an external (linked) URL.
+  type CanonicalImage =
+    | { mode: "internal"; absolute: string }
+    | { mode: "external"; url: string };
+
+  const relImage = (
+    rel: { type: string; target?: string; targetMode?: string } | undefined,
     relsPath: string,
-    imageRId: string,
-  ): string | undefined => {
-    const rel = parseRelationships(relsXml).get(imageRId);
-    // External (linked) images have a URL target, not a package path; leaving
-    // them unresolved here makes the rebind skip them so they stay intact.
-    return rel?.type === RELATIONSHIP_TYPES.image &&
-      rel.target &&
-      rel.targetMode !== "External"
-      ? resolveRelativePath(relsPath, rel.target)
-      : undefined;
+  ): CanonicalImage | undefined => {
+    if (rel?.type !== RELATIONSHIP_TYPES.image || !rel.target) {
+      return undefined;
+    }
+    return rel.targetMode === "External"
+      ? { mode: "external", url: rel.target }
+      : {
+          mode: "internal",
+          absolute: resolveRelativePath(relsPath, rel.target),
+        };
   };
 
-  // The canonical media (absolute path) the watermark points at: the source
-  // header is the one whose own rels maps the rId to an image.
-  const resolveCanonical = (imageRId: string): string | undefined => {
+  const sameImage = (a: CanonicalImage, b: CanonicalImage): boolean =>
+    a.mode === "internal" && b.mode === "internal"
+      ? a.absolute === b.absolute
+      : a.mode === "external" && b.mode === "external" && a.url === b.url;
+
+  // The source header is the one whose own rels maps the rId to an image.
+  const resolveCanonical = (imageRId: string): CanonicalImage | undefined => {
     for (const [relsPath, xml] of relsXmlByPath) {
-      const target = localImageTarget(xml, relsPath, imageRId);
-      if (target) {
-        return target;
+      const canonical = relImage(
+        parseRelationships(xml).get(imageRId),
+        relsPath,
+      );
+      if (canonical) {
+        return canonical;
       }
     }
     return undefined;
@@ -1511,42 +1522,45 @@ async function rebindWatermarkRelIds(
 
   const changedPaths = new Set<string>();
   for (const { watermark, relsPath, partPath } of pending) {
-    // Anchored at parse time (absolute imageTarget); fall back to a scan only
-    // for watermarks built without a parsed source.
-    const canonical =
-      watermark.imageTarget ?? resolveCanonical(watermark.imageRId);
+    // Anchored at parse time (imageTarget, embedded media only); fall back to a
+    // scan, which also recovers an external (linked) source.
+    const canonical: CanonicalImage | undefined =
+      watermark.imageTarget === undefined
+        ? resolveCanonical(watermark.imageRId)
+        : { mode: "internal", absolute: watermark.imageTarget };
     if (!canonical) {
       continue; // Orphaned rId with no embedded media anywhere — cannot invent.
     }
+
     const relsXml = relsXmlByPath.get(relsPath) ?? EMPTY_RELS_XML;
-    if (localImageTarget(relsXml, relsPath, watermark.imageRId) === canonical) {
-      // Already resolves to the canonical media. (A local rId resolving to a
+    const localRels = parseRelationships(relsXml);
+    const local = relImage(localRels.get(watermark.imageRId), relsPath);
+    if (local && sameImage(local, canonical)) {
+      // Already resolves to the canonical image. (A local rId resolving to a
       // *different* image — header rIds repeat across parts — must still be
       // rebound.)
       continue;
     }
 
-    const localRels = parseRelationships(relsXml);
+    // Reuse an existing relationship to the same image, else mint one. An
+    // external image keeps its URL and TargetMode="External".
     let resolvedRId: string | undefined;
     for (const [id, rel] of localRels) {
-      if (
-        rel.type === RELATIONSHIP_TYPES.image &&
-        rel.target &&
-        resolveRelativePath(relsPath, rel.target) === canonical
-      ) {
+      const image = relImage(rel, relsPath);
+      if (image && sameImage(image, canonical)) {
         resolvedRId = id;
         break;
       }
     }
     if (!resolvedRId) {
       resolvedRId = `rId${findMaxRId(relsXml) + 1}`;
-      const relativeTarget = relativeTargetForPart(partPath, canonical);
+      const relXml =
+        canonical.mode === "external"
+          ? `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(canonical.url)}" TargetMode="External"/>`
+          : `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(relativeTargetForPart(partPath, canonical.absolute))}"/>`;
       relsXmlByPath.set(
         relsPath,
-        relsXml.replace(
-          "</Relationships>",
-          `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(relativeTarget)}"/></Relationships>`,
-        ),
+        relsXml.replace("</Relationships>", `${relXml}</Relationships>`),
       );
       changedPaths.add(relsPath);
     }

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -444,6 +444,10 @@ async function processNewImages(
     const relsXml = await readRelsOrStub(zip, relsPath);
     let maxId = findMaxRId(relsXml);
     const relEntries: string[] = [];
+    // The part owning these rels (e.g. word/headers/header1.xml). Relationship
+    // targets are resolved relative to it, so a subdirectory header needs
+    // `../media/...` rather than `media/...`.
+    const partPath = relsPath.replace("/_rels/", "/").replace(/\.rels$/u, "");
 
     for (const image of newImages) {
       if (!image.src) {
@@ -463,9 +467,9 @@ async function processNewImages(
         compressionOptions: { level: compressionLevel },
       });
 
-      // Build relationship entry
+      // Build relationship entry (target relative to the owning part).
       relEntries.push(
-        `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.image}" Target="media/${mediaFilename}"/>`,
+        `<Relationship Id="${newRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(relativeTargetForPart(partPath, mediaPath))}"/>`,
       );
 
       extensionsAdded.add(extension);

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -194,6 +194,19 @@ function headerFooterFilename(target: string): string {
   return target.startsWith("/") ? target.slice(1) : `word/${target}`;
 }
 
+/**
+ * The relationships part for a header/footer. A part at `<dir>/<name>` keeps its
+ * rels at `<dir>/_rels/<name>.rels` — e.g. `word/headers/header1.xml` ->
+ * `word/headers/_rels/header1.xml.rels`, not a flattened `word/_rels/...`.
+ */
+function headerFooterRelsPath(target: string): string {
+  const partPath = headerFooterFilename(target);
+  const lastSlash = partPath.lastIndexOf("/");
+  const directory = lastSlash === -1 ? "" : partPath.slice(0, lastSlash);
+  const name = lastSlash === -1 ? partPath : partPath.slice(lastSlash + 1);
+  return `${directory ? `${directory}/` : ""}_rels/${name}.rels`;
+}
+
 function collectImageParts(doc: Document): DocxPart[] {
   const parts: DocxPart[] = [
     {
@@ -218,10 +231,8 @@ function collectImageParts(doc: Document): DocxPart[] {
       if (!rel || rel.type !== type || !rel.target) {
         continue;
       }
-      const filename = headerFooterFilename(rel.target);
-      const basename = filename.replace(/^word\//u, "");
       parts.push({
-        relsPath: `word/_rels/${basename}.rels`,
+        relsPath: headerFooterRelsPath(rel.target),
         blocks: headerFooter.content,
       });
     }
@@ -1340,11 +1351,6 @@ async function materializeNewHeaderFooterParts(
   }
 }
 
-const headerRelsPathFor = (target: string): string => {
-  const filename = headerFooterFilename(target).replace(/^word\//u, "");
-  return `word/_rels/${filename}.rels`;
-};
-
 /**
  * A picture watermark is "model-driven" when its raw VML was cleared (so the
  * serializer synthesizes `<v:imagedata r:id>` from `imageRId`). Its image
@@ -1401,7 +1407,7 @@ async function rebindWatermarkRelIds(
     if (!rel?.target) {
       continue;
     }
-    pending.push({ watermark, relsPath: headerRelsPathFor(rel.target) });
+    pending.push({ watermark, relsPath: headerFooterRelsPath(rel.target) });
   }
   if (pending.length === 0) {
     return;
@@ -1416,7 +1422,7 @@ async function rebindWatermarkRelIds(
   const headerRelsPaths = new Set<string>(pending.map((p) => p.relsPath));
   for (const rel of rels.values()) {
     if (rel.type === RELATIONSHIP_TYPES.header && rel.target) {
-      headerRelsPaths.add(headerRelsPathFor(rel.target));
+      headerRelsPaths.add(headerFooterRelsPath(rel.target));
     }
   }
   for (const relsPath of headerRelsPaths) {

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1488,7 +1488,11 @@ async function rebindWatermarkRelIds(
     imageRId: string,
   ): string | undefined => {
     const rel = parseRelationships(relsXml).get(imageRId);
-    return rel?.type === RELATIONSHIP_TYPES.image && rel.target
+    // External (linked) images have a URL target, not a package path; leaving
+    // them unresolved here makes the rebind skip them so they stay intact.
+    return rel?.type === RELATIONSHIP_TYPES.image &&
+      rel.target &&
+      rel.targetMode !== "External"
       ? resolveRelativePath(relsPath, rel.target)
       : undefined;
   };

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1198,26 +1198,85 @@ async function materializeNewHeaderFooterParts(
   const overrides: string[] = [];
   let maxHeaderNum = findMaxHeaderFooterNum(zip, "header");
   let maxFooterNum = findMaxHeaderFooterNum(zip, "footer");
+  let maxRId = 0;
+  for (const id of rels.keys()) {
+    const match = /^rId(\d+)$/u.exec(id);
+    if (match) {
+      // SAFETY: capture group [1] always present when the regex matches.
+      const n = Number.parseInt(match[1]!, 10);
+      if (n > maxRId) {
+        maxRId = n;
+      }
+    }
+  }
+
+  const remapRefs = (
+    refs: { rId: string }[] | undefined,
+    oldRId: string,
+    newRId: string,
+  ): void => {
+    for (const ref of refs ?? []) {
+      if (ref.rId === oldRId) {
+        ref.rId = newRId;
+      }
+    }
+  };
 
   const materialize = (
     map: Map<string, HeaderFooter> | undefined,
     relType: string,
     prefix: "header" | "footer",
     contentType: string,
+    isHeader: boolean,
   ): void => {
     if (!map) {
       return;
     }
-    for (const rId of map.keys()) {
+    for (const rId of [...map.keys()]) {
       const existing = rels.get(rId);
       if (existing && existing.type === relType && existing.target) {
-        continue;
+        continue; // Already a materialized part of this kind.
+      }
+      // When the id is already taken by an unrelated relationship, mint a fresh
+      // one and re-point the section references — reusing it would duplicate the
+      // id or resolve the header reference to the wrong (non-header) target.
+      let effectiveRId = rId;
+      if (existing) {
+        effectiveRId = `rId${++maxRId}`;
+        const headerFooter = map.get(rId);
+        if (headerFooter) {
+          map.delete(rId);
+          map.set(effectiveRId, headerFooter);
+        }
+        for (const block of doc.package.document.content) {
+          if (block.type === "paragraph") {
+            remapRefs(
+              isHeader
+                ? block.sectionProperties?.headerReferences
+                : block.sectionProperties?.footerReferences,
+              rId,
+              effectiveRId,
+            );
+          }
+        }
+        const finalProps = doc.package.document.finalSectionProperties;
+        remapRefs(
+          isHeader
+            ? finalProps?.headerReferences
+            : finalProps?.footerReferences,
+          rId,
+          effectiveRId,
+        );
       }
       const num = prefix === "header" ? ++maxHeaderNum : ++maxFooterNum;
       const filename = `${prefix}${num}.xml`;
-      rels.set(rId, { id: rId, type: relType, target: filename });
+      rels.set(effectiveRId, {
+        id: effectiveRId,
+        type: relType,
+        target: filename,
+      });
       relEntries.push(
-        `<Relationship Id="${escapeXml(rId)}" Type="${relType}" Target="${filename}"/>`,
+        `<Relationship Id="${escapeXml(effectiveRId)}" Type="${relType}" Target="${filename}"/>`,
       );
       overrides.push(
         `<Override PartName="/word/${filename}" ContentType="${contentType}"/>`,
@@ -1230,12 +1289,14 @@ async function materializeNewHeaderFooterParts(
     RELATIONSHIP_TYPES.header,
     "header",
     HEADER_CONTENT_TYPE,
+    true,
   );
   materialize(
     doc.package.footers,
     RELATIONSHIP_TYPES.footer,
     "footer",
     FOOTER_CONTENT_TYPE,
+    false,
   );
 
   if (relEntries.length === 0) {
@@ -1368,7 +1429,10 @@ async function rebindWatermarkRelIds(
 
   const changedPaths = new Set<string>();
   for (const { watermark, relsPath } of pending) {
-    const target = resolveImageTarget(watermark.imageRId);
+    // The media target is anchored at parse time (imageTarget); fall back to a
+    // best-effort scan only for watermarks built without a parsed source.
+    const target =
+      watermark.imageTarget ?? resolveImageTarget(watermark.imageRId);
     if (!target) {
       continue; // Orphaned rId with no embedded media anywhere — cannot invent.
     }

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1285,14 +1285,15 @@ const headerRelsPathFor = (target: string): string => {
 
 /**
  * A picture watermark is "model-driven" when its raw VML was cleared (so the
- * serializer synthesizes `<v:imagedata r:id>` from `imageRId`). When more than
- * one header part is involved, each needs a relationship to the image in its
- * own rels — work only the full-repack path does — so the selective fast-path
- * must bail when this returns true.
+ * serializer synthesizes `<v:imagedata r:id>` from `imageRId`). Its image
+ * relationship may need rebinding into the header's own rels — work only the
+ * full-repack path does — so the selective fast-path bails whenever any such
+ * watermark is present, regardless of header count (a single header's rId could
+ * have been set without yet resolving in that header's rels).
  */
 export function hasModelDrivenPictureWatermark(doc: Document): boolean {
   const headers = doc.package.headers;
-  if (!headers || headers.size <= 1) {
+  if (!headers) {
     return false;
   }
   for (const hf of headers.values()) {
@@ -1344,11 +1345,20 @@ async function rebindWatermarkRelIds(
     return;
   }
 
+  // Read every header's rels, not only the ones being rebound: the canonical
+  // image target may live in a header whose own watermark is raw-replayed (so
+  // it is not pending). `document.xml.rels` is intentionally excluded — header
+  // rIds and body rIds both start at rId1, so scanning it could resolve a
+  // watermark to a body image that merely shares the rId number.
   const relsXmlByPath = new Map<string, string>();
-  for (const { relsPath } of pending) {
-    if (!relsXmlByPath.has(relsPath)) {
-      relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
+  const headerRelsPaths = new Set<string>(pending.map((p) => p.relsPath));
+  for (const rel of rels.values()) {
+    if (rel.type === RELATIONSHIP_TYPES.header && rel.target) {
+      headerRelsPaths.add(headerRelsPathFor(rel.target));
     }
+  }
+  for (const relsPath of headerRelsPaths) {
+    relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
   }
 
   // The canonical media target for an imageRId: the source header is the one

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1251,8 +1251,11 @@ async function materializeNewHeaderFooterParts(
   const overrides: string[] = [];
   let maxHeaderNum = findMaxHeaderFooterNum(zip, "header");
   let maxFooterNum = findMaxHeaderFooterNum(zip, "footer");
+  // Seed the rId counter above every numeric id already in use — in the
+  // relationship map AND as a header/footer map key — so a freshly minted id
+  // can never collide with another (possibly not-yet-materialized) part.
   let maxRId = 0;
-  for (const id of rels.keys()) {
+  const considerNumericRId = (id: string): void => {
     const match = /^rId(\d+)$/u.exec(id);
     if (match) {
       // SAFETY: capture group [1] always present when the regex matches.
@@ -1261,6 +1264,15 @@ async function materializeNewHeaderFooterParts(
         maxRId = n;
       }
     }
+  };
+  for (const id of rels.keys()) {
+    considerNumericRId(id);
+  }
+  for (const id of doc.package.headers?.keys() ?? []) {
+    considerNumericRId(id);
+  }
+  for (const id of doc.package.footers?.keys() ?? []) {
+    considerNumericRId(id);
   }
 
   const remapRefs = (

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -1522,12 +1522,16 @@ async function rebindWatermarkRelIds(
 
   const changedPaths = new Set<string>();
   for (const { watermark, relsPath, partPath } of pending) {
-    // Anchored at parse time (imageTarget, embedded media only); fall back to a
-    // scan, which also recovers an external (linked) source.
-    const canonical: CanonicalImage | undefined =
-      watermark.imageTarget === undefined
-        ? resolveCanonical(watermark.imageRId)
+    // Anchored at parse time (imageTarget, embedded or external); fall back to
+    // a scan only for watermarks built without a parsed source.
+    let canonical: CanonicalImage | undefined;
+    if (watermark.imageTarget !== undefined) {
+      canonical = watermark.imageTargetExternal
+        ? { mode: "external", url: watermark.imageTarget }
         : { mode: "internal", absolute: watermark.imageTarget };
+    } else {
+      canonical = resolveCanonical(watermark.imageRId);
+    }
     if (!canonical) {
       continue; // Orphaned rId with no embedded media anywhere — cannot invent.
     }

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -38,9 +38,13 @@ import type {
   Image,
   Hyperlink,
 } from "../types/content";
-import type { Document } from "../types/document";
+import type { Document, Watermark } from "../types/document";
 import { assertValidFolioDocumentModel } from "./modelValidation";
-import { RELATIONSHIP_TYPES, resolveRelativePath } from "./relsParser";
+import {
+  parseRelationships,
+  RELATIONSHIP_TYPES,
+  resolveRelativePath,
+} from "./relsParser";
 import { serializeComments } from "./serializer/commentSerializer";
 import { serializeDocument } from "./serializer/documentSerializer";
 import { serializeHeaderFooter } from "./serializer/headerFooterSerializer";
@@ -650,6 +654,11 @@ export async function repackDocx(
     compressionLevel,
   );
 
+  // Rebind picture-watermark image rIds so each header references the image in
+  // its own rels (after materialization, so coverage-created header parts have
+  // a relationship target to anchor against).
+  await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
+
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
 
@@ -767,6 +776,11 @@ export async function repackDocxFromRaw(
     newZip,
     compressionLevel,
   );
+
+  // Rebind picture-watermark image rIds so each header references the image in
+  // its own rels (after materialization, so coverage-created header parts have
+  // a relationship target to anchor against).
+  await rebindWatermarkRelIds(exportDocument, newZip, compressionLevel);
 
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
@@ -1260,6 +1274,134 @@ async function materializeNewHeaderFooterParts(
         compression: "DEFLATE",
         compressionOptions,
       });
+    }
+  }
+}
+
+const headerRelsPathFor = (target: string): string => {
+  const filename = headerFooterFilename(target).replace(/^word\//u, "");
+  return `word/_rels/${filename}.rels`;
+};
+
+/**
+ * A picture watermark is "model-driven" when its raw VML was cleared (so the
+ * serializer synthesizes `<v:imagedata r:id>` from `imageRId`). When more than
+ * one header part is involved, each needs a relationship to the image in its
+ * own rels — work only the full-repack path does — so the selective fast-path
+ * must bail when this returns true.
+ */
+export function hasModelDrivenPictureWatermark(doc: Document): boolean {
+  const headers = doc.package.headers;
+  if (!headers || headers.size <= 1) {
+    return false;
+  }
+  for (const hf of headers.values()) {
+    if (hf.watermark?.kind === "picture" && !hf.rawWatermarkXml) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Rebind each picture watermark's `imageRId` so it resolves in its own header
+ * part's rels. A watermark propagated across headers (or onto a header created
+ * by coverage) carries the source header's rId, which is meaningless in a
+ * sibling header's `word/_rels/header*.xml.rels`. Per header: keep the rId if
+ * it already resolves; otherwise reuse an existing relationship to the same
+ * media target, or mint a new one. The media bytes are shared (preserved from
+ * the source), so no new media part is written. Raw-replay watermarks are
+ * byte-exact and skipped.
+ */
+async function rebindWatermarkRelIds(
+  doc: Document,
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const rels = doc.package.relationships;
+  const headers = doc.package.headers;
+  if (!rels || !headers) {
+    return;
+  }
+
+  type PendingHeader = {
+    watermark: Extract<Watermark, { kind: "picture" }>;
+    relsPath: string;
+  };
+  const pending: PendingHeader[] = [];
+  for (const [rId, hf] of headers) {
+    const watermark = hf.watermark;
+    if (!watermark || watermark.kind !== "picture" || hf.rawWatermarkXml) {
+      continue;
+    }
+    const rel = rels.get(rId);
+    if (!rel?.target) {
+      continue;
+    }
+    pending.push({ watermark, relsPath: headerRelsPathFor(rel.target) });
+  }
+  if (pending.length === 0) {
+    return;
+  }
+
+  const relsXmlByPath = new Map<string, string>();
+  for (const { relsPath } of pending) {
+    if (!relsXmlByPath.has(relsPath)) {
+      relsXmlByPath.set(relsPath, await readRelsOrStub(zip, relsPath));
+    }
+  }
+
+  // The canonical media target for an imageRId: the source header is the one
+  // whose rels actually maps that rId to an image relationship.
+  const resolveImageTarget = (imageRId: string): string | undefined => {
+    for (const xml of relsXmlByPath.values()) {
+      const rel = parseRelationships(xml).get(imageRId);
+      if (rel?.type === RELATIONSHIP_TYPES.image && rel.target) {
+        return rel.target;
+      }
+    }
+    return undefined;
+  };
+
+  const changedPaths = new Set<string>();
+  for (const { watermark, relsPath } of pending) {
+    const relsXml = relsXmlByPath.get(relsPath) ?? EMPTY_RELS_XML;
+    const localRels = parseRelationships(relsXml);
+    const local = localRels.get(watermark.imageRId);
+    if (local?.type === RELATIONSHIP_TYPES.image && local.target) {
+      continue; // Already resolves in this header's own rels.
+    }
+    const target = resolveImageTarget(watermark.imageRId);
+    if (!target) {
+      continue; // Orphaned rId with no embedded media anywhere — cannot invent.
+    }
+
+    let resolvedRId: string | undefined;
+    for (const [id, rel] of localRels) {
+      if (rel.type === RELATIONSHIP_TYPES.image && rel.target === target) {
+        resolvedRId = id;
+        break;
+      }
+    }
+    if (!resolvedRId) {
+      resolvedRId = `rId${findMaxRId(relsXml) + 1}`;
+      relsXmlByPath.set(
+        relsPath,
+        relsXml.replace(
+          "</Relationships>",
+          `<Relationship Id="${resolvedRId}" Type="${RELATIONSHIP_TYPES.image}" Target="${escapeXml(target)}"/></Relationships>`,
+        ),
+      );
+      changedPaths.add(relsPath);
+    }
+    watermark.imageRId = resolvedRId;
+  }
+
+  const compressionOptions = { level: compressionLevel };
+  for (const path of changedPaths) {
+    const xml = relsXmlByPath.get(path);
+    if (xml) {
+      zip.file(path, xml, { compression: "DEFLATE", compressionOptions });
     }
   }
 }

--- a/packages/folio/src/core/docx/rezip.ts
+++ b/packages/folio/src/core/docx/rezip.ts
@@ -642,6 +642,14 @@ export async function repackDocx(
     compressionOptions: { level: compressionLevel },
   });
 
+  // Promote any in-memory header/footer parts to real parts/relationships
+  // before serializing them (so collectHeaderFooterUpdates can resolve them).
+  await materializeNewHeaderFooterParts(
+    exportDocument,
+    newZip,
+    compressionLevel,
+  );
+
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
 
@@ -751,6 +759,14 @@ export async function repackDocxFromRaw(
     compression: "DEFLATE",
     compressionOptions: { level: compressionLevel },
   });
+
+  // Promote any in-memory header/footer parts to real parts/relationships
+  // before serializing them (so collectHeaderFooterUpdates can resolve them).
+  await materializeNewHeaderFooterParts(
+    exportDocument,
+    newZip,
+    compressionLevel,
+  );
 
   // Serialize and update modified headers/footers
   serializeHeadersFootersToZip(exportDocument, newZip, compressionLevel);
@@ -1098,6 +1114,156 @@ export async function addMedia(
  * Collect serialized header/footer XML updates from the document model.
  * Uses the relationship map to resolve rId → filename.
  */
+const HEADER_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml";
+const FOOTER_CONTENT_TYPE =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml";
+
+/**
+ * A header/footer is "unmaterialized" when it lives in the package map but its
+ * rId has no resolvable relationship in `document.xml.rels` — i.e. it was
+ * created in memory (header editor, watermark coverage) and still lacks a part,
+ * relationship, and `[Content_Types]` entry. The selective fast-path can't
+ * register those, so it must bail to a full repack when this returns true.
+ */
+export function hasUnmaterializedHeaderFooter(doc: Document): boolean {
+  const rels = doc.package.relationships;
+  const hasNew = (
+    map: Map<string, HeaderFooter> | undefined,
+    type: string,
+  ): boolean => {
+    if (!map) {
+      return false;
+    }
+    for (const rId of map.keys()) {
+      const rel = rels?.get(rId);
+      if (!rel || rel.type !== type || !rel.target) {
+        return true;
+      }
+    }
+    return false;
+  };
+  return (
+    hasNew(doc.package.headers, RELATIONSHIP_TYPES.header) ||
+    hasNew(doc.package.footers, RELATIONSHIP_TYPES.footer)
+  );
+}
+
+function findMaxHeaderFooterNum(
+  zip: JSZip,
+  prefix: "header" | "footer",
+): number {
+  let max = 0;
+  const pattern = new RegExp(`^word/${prefix}(\\d+)\\.xml$`, "u");
+  zip.forEach((relativePath) => {
+    const m = pattern.exec(relativePath);
+    if (m) {
+      // SAFETY: capture group [1] always present when the regex matches.
+      const num = Number.parseInt(m[1]!, 10);
+      if (num > max) {
+        max = num;
+      }
+    }
+  });
+  return max;
+}
+
+/**
+ * Materialize header/footer parts created in memory (rId present in the package
+ * map, absent from `document.xml.rels`). For each: mint a `word/<prefix>N.xml`
+ * target, add a document relationship under the *existing* rId (a valid NCName,
+ * so the section's `<w:headerReference r:id>` keeps resolving without rewriting
+ * document.xml), and a `[Content_Types].xml` Override. The part body is written
+ * afterwards by `serializeHeadersFootersToZip`, which can now resolve the new
+ * relationship.
+ */
+async function materializeNewHeaderFooterParts(
+  doc: Document,
+  zip: JSZip,
+  compressionLevel: number,
+): Promise<void> {
+  const rels = doc.package.relationships;
+  if (!rels) {
+    return;
+  }
+
+  const relEntries: string[] = [];
+  const overrides: string[] = [];
+  let maxHeaderNum = findMaxHeaderFooterNum(zip, "header");
+  let maxFooterNum = findMaxHeaderFooterNum(zip, "footer");
+
+  const materialize = (
+    map: Map<string, HeaderFooter> | undefined,
+    relType: string,
+    prefix: "header" | "footer",
+    contentType: string,
+  ): void => {
+    if (!map) {
+      return;
+    }
+    for (const rId of map.keys()) {
+      const existing = rels.get(rId);
+      if (existing && existing.type === relType && existing.target) {
+        continue;
+      }
+      const num = prefix === "header" ? ++maxHeaderNum : ++maxFooterNum;
+      const filename = `${prefix}${num}.xml`;
+      rels.set(rId, { id: rId, type: relType, target: filename });
+      relEntries.push(
+        `<Relationship Id="${escapeXml(rId)}" Type="${relType}" Target="${filename}"/>`,
+      );
+      overrides.push(
+        `<Override PartName="/word/${filename}" ContentType="${contentType}"/>`,
+      );
+    }
+  };
+
+  materialize(
+    doc.package.headers,
+    RELATIONSHIP_TYPES.header,
+    "header",
+    HEADER_CONTENT_TYPE,
+  );
+  materialize(
+    doc.package.footers,
+    RELATIONSHIP_TYPES.footer,
+    "footer",
+    FOOTER_CONTENT_TYPE,
+  );
+
+  if (relEntries.length === 0) {
+    return;
+  }
+
+  const compressionOptions = { level: compressionLevel };
+  const relsPath = "word/_rels/document.xml.rels";
+  const relsXml = await readRelsOrStub(zip, relsPath);
+  zip.file(
+    relsPath,
+    relsXml.replace(
+      "</Relationships>",
+      `${relEntries.join("")}</Relationships>`,
+    ),
+    { compression: "DEFLATE", compressionOptions },
+  );
+
+  const ctFile = zip.file("[Content_Types].xml");
+  if (ctFile) {
+    let ctXml = await ctFile.async("text");
+    const missing = overrides.filter((override) => {
+      const partName = /PartName="([^"]+)"/u.exec(override)?.[1];
+      return partName ? !ctXml.includes(`PartName="${partName}"`) : true;
+    });
+    if (missing.length > 0) {
+      ctXml = ctXml.replace("</Types>", `${missing.join("")}</Types>`);
+      zip.file("[Content_Types].xml", ctXml, {
+        compression: "DEFLATE",
+        compressionOptions,
+      });
+    }
+  }
+}
+
 export function collectHeaderFooterUpdates(doc: Document): Map<string, string> {
   const updates = new Map<string, string>();
   const rels = doc.package.relationships;

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -17,6 +17,7 @@ import {
   updateCoreProperties,
   collectHeaderFooterUpdates,
   hasUnmaterializedHeaderFooter,
+  hasModelDrivenPictureWatermark,
   COMMENTS_CONTENT_TYPE,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
@@ -137,6 +138,11 @@ export async function attemptSelectiveSave(
   // A header/footer created in memory needs a new part + relationship +
   // [Content_Types] Override, which only the full repack path writes.
   if (hasUnmaterializedHeaderFooter(doc)) {
+    return null;
+  }
+  // A picture watermark spanning multiple headers needs per-header image
+  // relationship rebinding, which only the full repack path performs.
+  if (hasModelDrivenPictureWatermark(doc)) {
     return null;
   }
   if (!validateFolioDocumentModel(doc).valid) {

--- a/packages/folio/src/core/docx/selectiveSave.ts
+++ b/packages/folio/src/core/docx/selectiveSave.ts
@@ -16,6 +16,7 @@ import {
   findMaxRId,
   updateCoreProperties,
   collectHeaderFooterUpdates,
+  hasUnmaterializedHeaderFooter,
   COMMENTS_CONTENT_TYPE,
 } from "./rezip";
 import { DEFAULT_SELECTIVE_SAVE_MAX_BYTES } from "./selectiveSaveFlags";
@@ -131,6 +132,11 @@ export async function attemptSelectiveSave(
   // Check for new images/hyperlinks that need relationship management
   const content = doc.package.document.content;
   if (hasNewImagesOrHyperlinks(content)) {
+    return null;
+  }
+  // A header/footer created in memory needs a new part + relationship +
+  // [Content_Types] Override, which only the full repack path writes.
+  if (hasUnmaterializedHeaderFooter(doc)) {
     return null;
   }
   if (!validateFolioDocumentModel(doc).valid) {

--- a/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
@@ -181,14 +181,18 @@ function synthesizePictureWatermark(
   // `WordPictureWatermark` so a future round-trip parses cleanly via
   // the id-prefix guard.
   const rId = escapeXml(watermark.imageRId);
-  const scale = watermark.scale ?? 1;
-  // Prefer the captured source dimensions so a non-2:1 image keeps its aspect
-  // ratio; fall back to Word's default box scaled by `scale` for watermarks
-  // synthesized without dimensions.
+  // `scale` (Word's default-box multiplier) wins when set: it is the documented
+  // resize knob, and the parser only records it for uniform (2:1) watermarks
+  // where it agrees with the captured dimensions. When absent — e.g. a non-2:1
+  // source — the captured per-image dimensions preserve the aspect ratio.
   const widthPt =
-    watermark.widthPt ?? PICTURE_WATERMARK_DEFAULT_WIDTH_PT * scale;
+    watermark.scale === undefined
+      ? (watermark.widthPt ?? PICTURE_WATERMARK_DEFAULT_WIDTH_PT)
+      : PICTURE_WATERMARK_DEFAULT_WIDTH_PT * watermark.scale;
   const heightPt =
-    watermark.heightPt ?? PICTURE_WATERMARK_DEFAULT_HEIGHT_PT * scale;
+    watermark.scale === undefined
+      ? (watermark.heightPt ?? PICTURE_WATERMARK_DEFAULT_HEIGHT_PT)
+      : PICTURE_WATERMARK_DEFAULT_HEIGHT_PT * watermark.scale;
   const washoutAttrs =
     watermark.washout === false
       ? ""

--- a/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
+++ b/packages/folio/src/core/docx/serializer/headerFooterSerializer.ts
@@ -182,8 +182,13 @@ function synthesizePictureWatermark(
   // the id-prefix guard.
   const rId = escapeXml(watermark.imageRId);
   const scale = watermark.scale ?? 1;
-  const widthPt = PICTURE_WATERMARK_DEFAULT_WIDTH_PT * scale;
-  const heightPt = PICTURE_WATERMARK_DEFAULT_HEIGHT_PT * scale;
+  // Prefer the captured source dimensions so a non-2:1 image keeps its aspect
+  // ratio; fall back to Word's default box scaled by `scale` for watermarks
+  // synthesized without dimensions.
+  const widthPt =
+    watermark.widthPt ?? PICTURE_WATERMARK_DEFAULT_WIDTH_PT * scale;
+  const heightPt =
+    watermark.heightPt ?? PICTURE_WATERMARK_DEFAULT_HEIGHT_PT * scale;
   const washoutAttrs =
     watermark.washout === false
       ? ""

--- a/packages/folio/src/core/docx/serializer/pictureWatermarkAspect.test.ts
+++ b/packages/folio/src/core/docx/serializer/pictureWatermarkAspect.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Picture-watermark aspect-ratio fidelity.
+ *
+ * A picture watermark parsed from a non-2:1 source carries its real
+ * width/height (in points) from the VML shape style. The synthesis path must
+ * re-emit those exact dimensions instead of Word's default 415x207 box;
+ * otherwise re-applying the watermark — which clears `rawWatermarkXml` and so
+ * forces synthesis (e.g. `setDocumentWatermark` or cross-header propagation) —
+ * stretches a non-2:1 image to 2:1 when the file is opened in Word.
+ *
+ * eigenpal/docx-editor#684 (OOXML watermark fidelity), adapted to folio's
+ * pt-based VML pipeline (folio carries explicit width/height, not EMUs).
+ */
+import { describe, expect, test } from "bun:test";
+
+import type { HeaderFooter } from "../../types/document";
+import { parseHeader } from "../headerFooterParser";
+import { serializeHeaderFooter } from "./headerFooterSerializer";
+
+const NS =
+  'xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"' +
+  ' xmlns:v="urn:schemas-microsoft-com:vml"' +
+  ' xmlns:o="urn:schemas-microsoft-com:office:office"' +
+  ' xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"';
+
+const pictureWatermarkHeader = (style: string): string =>
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr ${NS}>
+  <w:p><w:r><w:pict>
+    <v:shape id="WordPictureWatermark1" type="#_x0000_t75" style="${style}">
+      <v:imagedata r:id="rId7" o:title=""/>
+    </v:shape>
+  </w:pict></w:r></w:p>
+</w:hdr>`;
+
+const pictureHeaderFooter = (
+  watermark: Extract<
+    NonNullable<HeaderFooter["watermark"]>,
+    { kind: "picture" }
+  >,
+): HeaderFooter => ({
+  type: "header",
+  hdrFtrType: "default",
+  content: [],
+  watermark,
+});
+
+describe("picture watermark aspect ratio (eigenpal #684)", () => {
+  test("parser captures real width/height (pt) from the VML shape style", () => {
+    const header = parseHeader(
+      pictureWatermarkHeader(
+        "position:absolute;margin-left:0;margin-top:0;width:300pt;height:400pt",
+      ),
+    );
+    expect(header.watermark?.kind).toBe("picture");
+    if (header.watermark?.kind !== "picture") {
+      return;
+    }
+    expect(header.watermark.widthPt).toBe(300);
+    expect(header.watermark.heightPt).toBe(400);
+  });
+
+  test("synthesis emits the modeled width/height instead of the default box", () => {
+    const out = serializeHeaderFooter(
+      pictureHeaderFooter({
+        kind: "picture",
+        imageRId: "rId1",
+        widthPt: 300,
+        heightPt: 400,
+      }),
+    );
+    expect(out).toContain("width:300pt");
+    expect(out).toContain("height:400pt");
+    expect(out).not.toContain("width:415pt");
+    expect(out).not.toContain("height:207pt");
+  });
+
+  test("falls back to the default 415x207 box when no dimensions are modeled", () => {
+    const out = serializeHeaderFooter(
+      pictureHeaderFooter({ kind: "picture", imageRId: "rId1" }),
+    );
+    expect(out).toContain("width:415pt");
+    expect(out).toContain("height:207pt");
+  });
+
+  test("round-trips a non-2:1 watermark's dimensions through synthesis", () => {
+    // Real-world failure mode: a parsed watermark whose source is far from
+    // 2:1. Re-applying it clears rawWatermarkXml, so the serializer must
+    // synthesize the *parsed* dimensions, not Word's default box.
+    const header = parseHeader(
+      pictureWatermarkHeader(
+        "position:absolute;margin-left:0;margin-top:0;width:200pt;height:500pt",
+      ),
+    );
+    expect(header.watermark?.kind).toBe("picture");
+    if (header.watermark?.kind !== "picture") {
+      return;
+    }
+    const out = serializeHeaderFooter(pictureHeaderFooter(header.watermark));
+    expect(out).toContain("width:200pt");
+    expect(out).toContain("height:500pt");
+    expect(out).not.toContain("width:415pt");
+  });
+});

--- a/packages/folio/src/core/docx/serializer/pictureWatermarkAspect.test.ts
+++ b/packages/folio/src/core/docx/serializer/pictureWatermarkAspect.test.ts
@@ -101,4 +101,22 @@ describe("picture watermark aspect ratio (eigenpal #684)", () => {
     expect(out).toContain("height:500pt");
     expect(out).not.toContain("width:415pt");
   });
+
+  test("a scale edit overrides captured dimensions", () => {
+    // `scale` is the documented resize knob. Even when dimensions were captured
+    // at parse, changing scale must take effect on save (415x207 * scale),
+    // rather than serializing the now-stale captured size.
+    const out = serializeHeaderFooter(
+      pictureHeaderFooter({
+        kind: "picture",
+        imageRId: "rId1",
+        widthPt: 300,
+        heightPt: 400,
+        scale: 0.5,
+      }),
+    );
+    expect(out).toContain("width:207.5pt");
+    expect(out).toContain("height:103.5pt");
+    expect(out).not.toContain("width:300pt");
+  });
 });

--- a/packages/folio/src/core/docx/settingsParser.test.ts
+++ b/packages/folio/src/core/docx/settingsParser.test.ts
@@ -47,3 +47,22 @@ describe("parseSettings — w:defaultTabStop (§17.6.13)", () => {
     ).toBe(DEFAULT_TAB_STOP_TWIPS);
   });
 });
+
+describe("parseSettings — w:evenAndOddHeaders (§17.10.1)", () => {
+  test("absent flag leaves evenAndOddHeaders undefined", () => {
+    expect(parseSettings(wrap("")).evenAndOddHeaders).toBeUndefined();
+    expect(parseSettings(null).evenAndOddHeaders).toBeUndefined();
+  });
+
+  test("a bare element records the on state", () => {
+    expect(
+      parseSettings(wrap(`<w:evenAndOddHeaders/>`)).evenAndOddHeaders,
+    ).toBe(true);
+  });
+
+  test('an explicit w:val="0" is treated as off', () => {
+    expect(
+      parseSettings(wrap(`<w:evenAndOddHeaders w:val="0"/>`)).evenAndOddHeaders,
+    ).toBeUndefined();
+  });
+});

--- a/packages/folio/src/core/docx/settingsParser.ts
+++ b/packages/folio/src/core/docx/settingsParser.ts
@@ -11,7 +11,12 @@
  */
 
 import type { DocumentSettings } from "../types/document";
-import { findChild, getAttribute, parseXmlDocument } from "./xmlParser";
+import {
+  findChild,
+  getAttribute,
+  parseBooleanElement,
+  parseXmlDocument,
+} from "./xmlParser";
 import type { XmlElement } from "./xmlParser";
 
 export type { DocumentSettings };
@@ -28,9 +33,18 @@ const MAX_TAB_STOP_TWIPS = 31_680;
 
 export function parseSettings(xml: string | null): DocumentSettings {
   const root = xml ? (parseXmlDocument(xml) as XmlElement | null) : null;
-  return {
+  const settings: DocumentSettings = {
     defaultTabStop: parseDefaultTabStop(root),
   };
+  // `w:evenAndOddHeaders` lives in settings.xml, not sectPr. Only record the
+  // "on" state; absence means odd/even share one header.
+  const evenAndOddHeaders = root
+    ? findChild(root, "w", "evenAndOddHeaders")
+    : null;
+  if (evenAndOddHeaders && parseBooleanElement(evenAndOddHeaders)) {
+    settings.evenAndOddHeaders = true;
+  }
+  return settings;
 }
 
 function parseDefaultTabStop(root: XmlElement | null): number {

--- a/packages/folio/src/core/docx/watermarkCoverage.test.ts
+++ b/packages/folio/src/core/docx/watermarkCoverage.test.ts
@@ -1,0 +1,57 @@
+/**
+ * End-to-end watermark header coverage: a title-page section without its own
+ * first-page header should still show the watermark on the cover page. The
+ * coverage transform creates the header in the model; the save pipeline
+ * materializes it into a real part. eigenpal/docx-editor#684 (BUG2).
+ */
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+
+import type { HeaderFooter } from "../types/document";
+import { setDocumentWatermark } from "../watermark";
+import { parseDocx } from "./parser";
+import { createEmptyDocx, repackDocx, validateDocx } from "./rezip";
+
+describe("watermark header coverage on save (eigenpal #684)", () => {
+  test("a titlePg section without a first header gets one carrying the watermark", async () => {
+    const base = await createEmptyDocx();
+    const doc = await parseDocx(base, { preloadFonts: false });
+
+    // A default header plus a title-page final section that lacks a first header.
+    const defaultHeader: HeaderFooter = {
+      type: "header",
+      hdrFtrType: "default",
+      content: [],
+    };
+    doc.package.headers = new Map([["rIdHdr", defaultHeader]]);
+    doc.package.document.finalSectionProperties = {
+      ...doc.package.document.finalSectionProperties,
+      titlePg: true,
+      headerReferences: [{ type: "default", rId: "rIdHdr" }],
+    };
+
+    const withWatermark = setDocumentWatermark(doc, {
+      kind: "text",
+      text: "CONFIDENTIAL",
+    });
+    const out = await repackDocx(withWatermark, { updateModifiedDate: false });
+
+    expect((await validateDocx(out)).valid).toBe(true);
+
+    const zip = await JSZip.loadAsync(out);
+    const headerFiles = Object.keys(zip.files).filter((p) =>
+      /^word\/header\d+\.xml$/u.test(p),
+    );
+    // Default header + the coverage-created first-page header.
+    expect(headerFiles).toHaveLength(2);
+    for (const path of headerFiles) {
+      expect(await zip.file(path)!.async("text")).toContain("CONFIDENTIAL");
+    }
+
+    const docXml = await zip.file("word/document.xml")!.async("text");
+    expect(docXml).toMatch(/<w:headerReference[^>]*w:type="first"/u);
+
+    const reparsed = await parseDocx(out, { preloadFonts: false });
+    expect(reparsed.package.headers?.size).toBe(2);
+  });
+});

--- a/packages/folio/src/core/docx/watermarkParser.ts
+++ b/packages/folio/src/core/docx/watermarkParser.ts
@@ -391,6 +391,16 @@ function readVmlPictureWatermark(
   if (scale !== undefined) {
     watermark.scale = scale;
   }
+  // Capture the shape's real display dimensions so the source aspect ratio
+  // survives a re-synthesized save. Unlike `scale` (uniform-only), these are
+  // kept even when width and height scale differently from Word's default box.
+  const { widthPt, heightPt } = readVmlPictureWatermarkDimensions(shape);
+  if (widthPt !== undefined) {
+    watermark.widthPt = widthPt;
+  }
+  if (heightPt !== undefined) {
+    watermark.heightPt = heightPt;
+  }
   if (!readVmlPictureWatermarkHasWashout(imagedata)) {
     watermark.washout = false;
   }
@@ -432,6 +442,17 @@ function readVmlPictureWatermarkScale(shape: XmlElement): number | undefined {
   }
 
   return widthScale ?? heightScale;
+}
+
+function readVmlPictureWatermarkDimensions(shape: XmlElement): {
+  widthPt: number | undefined;
+  heightPt: number | undefined;
+} {
+  const shapeStyle = getAttribute(shape, null, "style") ?? "";
+  return {
+    widthPt: parseInlineStyleLengthPt(shapeStyle, "width"),
+    heightPt: parseInlineStyleLengthPt(shapeStyle, "height"),
+  };
 }
 
 function readVmlPictureWatermarkHasWashout(imagedata: XmlElement): boolean {

--- a/packages/folio/src/core/watermark/index.test.ts
+++ b/packages/folio/src/core/watermark/index.test.ts
@@ -86,17 +86,23 @@ describe("setDocumentWatermark", () => {
     ).toThrow(TypeError);
   });
 
-  test("throws when applying a picture watermark across multiple header parts", () => {
-    // imageRId is scoped to word/_rels/header*.xml.rels — copying it
-    // across headers without per-rels cloning would produce dangling
-    // r:id references on save.
+  test("applies a picture watermark to every header as a distinct object", () => {
+    // imageRId is scoped to word/_rels/header*.xml.rels. The setter clones
+    // the watermark per header; the save-time rebind pass (rezip) then gives
+    // each header a relationship to the shared media in its own rels.
     const doc = makeDoc({
       rId1: emptyHeader(),
       rId2: emptyHeader(),
     });
-    expect(() =>
-      setDocumentWatermark(doc, { kind: "picture", imageRId: "rId99" }),
-    ).toThrow(/picture watermarks across multiple header parts/u);
+    const next = setDocumentWatermark(doc, {
+      kind: "picture",
+      imageRId: "rId99",
+    });
+    const first = next.package.headers?.get("rId1")?.watermark;
+    const second = next.package.headers?.get("rId2")?.watermark;
+    expect(first?.kind).toBe("picture");
+    expect(second?.kind).toBe("picture");
+    expect(first).not.toBe(second);
   });
 
   test("allows a picture watermark on a single-header document", () => {

--- a/packages/folio/src/core/watermark/index.test.ts
+++ b/packages/folio/src/core/watermark/index.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
 import type { Document, HeaderFooter, Watermark } from "../types/document";
-import { getDocumentWatermark, setDocumentWatermark } from "./index";
+import {
+  ensureWatermarkHeaderCoverage,
+  getDocumentWatermark,
+  setDocumentWatermark,
+} from "./index";
 
 function makeDoc(headers: Record<string, HeaderFooter>): Document {
   return {
@@ -79,11 +83,16 @@ describe("setDocumentWatermark", () => {
     expect(next.package.headers?.get("rId2")?.watermark).toBeUndefined();
   });
 
-  test("throws when the document has no header parts", () => {
+  test("creates a default header carrying the watermark when the document has none", () => {
     const doc: Document = { package: { document: { content: [] } } };
-    expect(() =>
-      setDocumentWatermark(doc, { kind: "text", text: "x" }),
-    ).toThrow(TypeError);
+    const next = setDocumentWatermark(doc, { kind: "text", text: "DRAFT" });
+    const headers = [...(next.package.headers?.values() ?? [])];
+    expect(headers).toHaveLength(1);
+    expect(headers[0]?.watermark?.kind).toBe("text");
+    // The final section references the created default header.
+    expect(
+      next.package.document.finalSectionProperties?.headerReferences,
+    ).toContainEqual({ type: "default", rId: expect.any(String) });
   });
 
   test("applies a picture watermark to every header as a distinct object", () => {
@@ -119,5 +128,84 @@ describe("setDocumentWatermark", () => {
     const before = original.package.headers?.get("rId1")?.watermark;
     setDocumentWatermark(original, { kind: "text", text: "x" });
     expect(original.package.headers?.get("rId1")?.watermark).toBe(before);
+  });
+});
+
+describe("ensureWatermarkHeaderCoverage", () => {
+  const watermark: Watermark = { kind: "text", text: "CONFIDENTIAL" };
+
+  test("creates a first-page header for a titlePg section that lacks one", () => {
+    const doc: Document = {
+      package: {
+        document: {
+          content: [],
+          finalSectionProperties: {
+            titlePg: true,
+            headerReferences: [{ type: "default", rId: "rId1" }],
+          },
+        },
+        headers: new Map([["rId1", { ...emptyHeader(), watermark }]]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    const firstRef =
+      next.package.document.finalSectionProperties?.headerReferences?.find(
+        (ref) => ref.type === "first",
+      );
+    expect(firstRef).toBeDefined();
+    const firstHeader = firstRef && next.package.headers?.get(firstRef.rId);
+    expect(firstHeader?.hdrFtrType).toBe("first");
+    expect(firstHeader?.watermark?.kind).toBe("text");
+  });
+
+  test("creates an even header when evenAndOddHeaders is set in settings", () => {
+    const doc: Document = {
+      package: {
+        settings: { defaultTabStop: 720, evenAndOddHeaders: true },
+        document: {
+          content: [],
+          finalSectionProperties: {
+            headerReferences: [{ type: "default", rId: "rId1" }],
+          },
+        },
+        headers: new Map([["rId1", { ...emptyHeader(), watermark }]]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    const evenRef =
+      next.package.document.finalSectionProperties?.headerReferences?.find(
+        (ref) => ref.type === "even",
+      );
+    expect(evenRef).toBeDefined();
+    expect(
+      evenRef && next.package.headers?.get(evenRef.rId)?.watermark?.kind,
+    ).toBe("text");
+  });
+
+  test("preserves inheritance: does not create a type that already exists", () => {
+    const doc: Document = {
+      package: {
+        document: {
+          content: [],
+          finalSectionProperties: {
+            titlePg: true,
+            headerReferences: [
+              { type: "default", rId: "rId1" },
+              { type: "first", rId: "rId2" },
+            ],
+          },
+        },
+        headers: new Map([
+          ["rId1", emptyHeader()],
+          ["rId2", { type: "header", hdrFtrType: "first", content: [] }],
+        ]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    expect(next).toBe(doc);
+    expect(next.package.headers?.size).toBe(2);
   });
 });

--- a/packages/folio/src/core/watermark/index.test.ts
+++ b/packages/folio/src/core/watermark/index.test.ts
@@ -208,4 +208,60 @@ describe("ensureWatermarkHeaderCoverage", () => {
     expect(next).toBe(doc);
     expect(next.package.headers?.size).toBe(2);
   });
+
+  test("covers an earlier titlePg section even when a later section has its own first header", () => {
+    // Word inherits forward only, so section 1's cover page cannot inherit
+    // section 2's first header. A global "type exists somewhere" check would
+    // wrongly skip coverage for section 1.
+    const doc: Document = {
+      package: {
+        document: {
+          content: [
+            {
+              type: "paragraph",
+              content: [],
+              sectionProperties: {
+                titlePg: true,
+                headerReferences: [{ type: "default", rId: "rId1" }],
+              },
+            },
+          ],
+          finalSectionProperties: {
+            titlePg: true,
+            headerReferences: [
+              { type: "default", rId: "rId1" },
+              { type: "first", rId: "rId2" },
+            ],
+          },
+        },
+        headers: new Map([
+          ["rId1", { ...emptyHeader(), watermark }],
+          [
+            "rId2",
+            { type: "header", hdrFtrType: "first", content: [], watermark },
+          ],
+        ]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    const block = next.package.document.content[0];
+    const section1Refs =
+      block?.type === "paragraph"
+        ? block.sectionProperties?.headerReferences
+        : undefined;
+    // Section 1 (the mid-body break) gains a coverage first header...
+    const coverageRef = section1Refs?.find((ref) => ref.type === "first");
+    expect(coverageRef).toBeDefined();
+    expect(
+      coverageRef &&
+        next.package.headers?.get(coverageRef.rId)?.watermark?.kind,
+    ).toBe("text");
+    // ...while the final section keeps its own first header unchanged.
+    expect(
+      next.package.document.finalSectionProperties?.headerReferences?.filter(
+        (ref) => ref.type === "first",
+      ),
+    ).toEqual([{ type: "first", rId: "rId2" }]);
+  });
 });

--- a/packages/folio/src/core/watermark/index.test.ts
+++ b/packages/folio/src/core/watermark/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { RELATIONSHIP_TYPES } from "../docx/relsParser";
 import type { Document, HeaderFooter, Watermark } from "../types/document";
 import {
   ensureWatermarkHeaderCoverage,
@@ -263,5 +264,82 @@ describe("ensureWatermarkHeaderCoverage", () => {
         (ref) => ref.type === "first",
       ),
     ).toEqual([{ type: "first", rId: "rId2" }]);
+  });
+
+  test("covers an earlier section with no default header when a later section defines one", () => {
+    // Word cannot inherit the later section's default header backward, so the
+    // first section's normal pages need their own coverage default header.
+    const doc: Document = {
+      package: {
+        document: {
+          content: [{ type: "paragraph", content: [], sectionProperties: {} }],
+          finalSectionProperties: {
+            headerReferences: [{ type: "default", rId: "rId1" }],
+          },
+        },
+        headers: new Map([["rId1", { ...emptyHeader(), watermark }]]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    const block = next.package.document.content[0];
+    const defaultRef =
+      block?.type === "paragraph"
+        ? block.sectionProperties?.headerReferences?.find(
+            (ref) => ref.type === "default",
+          )
+        : undefined;
+    expect(defaultRef).toBeDefined();
+    expect(
+      defaultRef && next.package.headers?.get(defaultRef.rId)?.watermark?.kind,
+    ).toBe("text");
+    // The later section keeps its own default header.
+    expect(
+      next.package.document.finalSectionProperties?.headerReferences,
+    ).toEqual([{ type: "default", rId: "rId1" }]);
+  });
+
+  test("mints a coverage rId that does not collide with an existing relationship", () => {
+    const doc: Document = {
+      package: {
+        relationships: new Map([
+          [
+            "rId1",
+            {
+              id: "rId1",
+              type: RELATIONSHIP_TYPES.header,
+              target: "header1.xml",
+            },
+          ],
+          // A producer that already used the would-be coverage id for an image.
+          [
+            "rId_wm_first",
+            {
+              id: "rId_wm_first",
+              type: RELATIONSHIP_TYPES.image,
+              target: "media/logo.png",
+            },
+          ],
+        ]),
+        document: {
+          content: [],
+          finalSectionProperties: {
+            titlePg: true,
+            headerReferences: [{ type: "default", rId: "rId1" }],
+          },
+        },
+        headers: new Map([["rId1", { ...emptyHeader(), watermark }]]),
+      },
+    };
+
+    const next = ensureWatermarkHeaderCoverage(doc, watermark);
+    const firstRef =
+      next.package.document.finalSectionProperties?.headerReferences?.find(
+        (ref) => ref.type === "first",
+      );
+    expect(firstRef).toBeDefined();
+    // Did not reuse the taken id, and the minted id resolves to a new header.
+    expect(firstRef?.rId).not.toBe("rId_wm_first");
+    expect(firstRef && next.package.headers?.has(firstRef.rId)).toBe(true);
   });
 });

--- a/packages/folio/src/core/watermark/index.ts
+++ b/packages/folio/src/core/watermark/index.ts
@@ -88,16 +88,6 @@ export function setDocumentWatermark(
   return ensureWatermarkHeaderCoverage(withExisting, watermark);
 }
 
-// Synthetic rIds for coverage-created header parts. They are valid NCNames, so
-// they serialize as section `<w:headerReference r:id>` values directly; the
-// rezip materialization pass promotes them to real parts + relationships +
-// [Content_Types] entries on save.
-const COVERAGE_RID: Record<HeaderFooterType, string> = {
-  default: "rId_wm_default",
-  first: "rId_wm_first",
-  even: "rId_wm_even",
-};
-
 /**
  * Ensure the watermark shows on every page it should, even when the header
  * parts a section needs are missing:
@@ -109,11 +99,11 @@ const COVERAGE_RID: Record<HeaderFooterType, string> = {
  * - When `w:evenAndOddHeaders` is on but a section has no even header, one is
  *   created (so even pages are covered).
  *
- * A typed header is only created when no instance of that type exists anywhere
- * in the document, so Word's section-to-section header inheritance — and the
- * watermark already written to those inherited headers — is preserved. Created
- * headers use synthetic rIds that the save pipeline materializes into real
- * parts.
+ * A typed header is only created for a section that cannot inherit one of that
+ * type from itself or a preceding section (Word inherits forward only), so
+ * existing headers — and the watermark already written to them — are preserved.
+ * Created headers use freshly minted rIds that the save pipeline materializes
+ * into real parts.
  */
 export function ensureWatermarkHeaderCoverage(
   doc: Document,
@@ -122,7 +112,6 @@ export function ensureWatermarkHeaderCoverage(
   const body = doc.package.document;
   const headers = new Map<string, HeaderFooter>(doc.package.headers);
   const evenOddMode = doc.package.settings?.evenAndOddHeaders === true;
-  const noHeadersAtAll = headers.size === 0;
 
   const resolvesType = (
     props: SectionProperties,
@@ -131,6 +120,32 @@ export function ensureWatermarkHeaderCoverage(
     props.headerReferences?.some(
       (ref) => ref.type === type && headers.has(ref.rId),
     ) ?? false;
+
+  // Mint a coverage rId that collides with no existing relationship, header, or
+  // footer id (a fixed id could clash with a producer-chosen one and corrupt
+  // the saved package). Memoized per type so all sections needing the same type
+  // share one coverage header.
+  const usedRIds = new Set<string>([
+    ...(doc.package.relationships?.keys() ?? []),
+    ...headers.keys(),
+    ...(doc.package.footers?.keys() ?? []),
+  ]);
+  const coverageRIdByType = new Map<HeaderFooterType, string>();
+  const coverageRId = (type: HeaderFooterType): string => {
+    const existing = coverageRIdByType.get(type);
+    if (existing !== undefined) {
+      return existing;
+    }
+    let candidate = `rId_wm_${type}`;
+    let suffix = 1;
+    while (usedRIds.has(candidate)) {
+      suffix += 1;
+      candidate = `rId_wm_${type}_${suffix}`;
+    }
+    usedRIds.add(candidate);
+    coverageRIdByType.set(type, candidate);
+    return candidate;
+  };
 
   // Sections in document order: mid-body section breaks (paragraph sectPr)
   // first, then the body's final sectPr. `blockIndex` ties a slot back to the
@@ -163,15 +178,18 @@ export function ensureWatermarkHeaderCoverage(
         continue;
       }
       if (sectionNeedsType(slot.props) && !inherited) {
-        additions[index]?.push({ type, rId: COVERAGE_RID[type] });
+        additions[index]?.push({ type, rId: coverageRId(type) });
         inherited = true;
       }
     }
   };
 
-  if (noHeadersAtAll) {
-    planType("default", () => true);
-  }
+  // Normal pages (default), cover pages (first under titlePg), and even pages
+  // (under evenAndOddHeaders) each get coverage where a section cannot inherit
+  // that header type forward. Default runs unconditionally so a section that
+  // precedes the first existing default header — or a header-less document — is
+  // still covered.
+  planType("default", () => true);
   planType("first", (props) => props.titlePg === true);
   if (evenOddMode) {
     planType("even", () => true);
@@ -181,10 +199,14 @@ export function ensureWatermarkHeaderCoverage(
     return doc;
   }
 
-  // Materialize only the coverage headers actually referenced.
-  for (const type of new Set(additions.flat().map((ref) => ref.type))) {
-    if (!headers.has(COVERAGE_RID[type])) {
-      headers.set(COVERAGE_RID[type], {
+  // Materialize the coverage headers actually referenced (one per minted rId).
+  const coverageTypeByRId = new Map<string, HeaderFooterType>();
+  for (const ref of additions.flat()) {
+    coverageTypeByRId.set(ref.rId, ref.type);
+  }
+  for (const [rId, type] of coverageTypeByRId) {
+    if (!headers.has(rId)) {
+      headers.set(rId, {
         type: "header",
         hdrFtrType: type,
         content: [],

--- a/packages/folio/src/core/watermark/index.ts
+++ b/packages/folio/src/core/watermark/index.ts
@@ -132,74 +132,102 @@ export function ensureWatermarkHeaderCoverage(
       (ref) => ref.type === type && headers.has(ref.rId),
     ) ?? false;
 
-  const allSections: SectionProperties[] = [];
-  for (const block of body.content) {
+  // Sections in document order: mid-body section breaks (paragraph sectPr)
+  // first, then the body's final sectPr. `blockIndex` ties a slot back to the
+  // paragraph it came from for the rebuild; the final section has none.
+  type Slot = { props: SectionProperties; blockIndex: number | null };
+  const slots: Slot[] = [];
+  for (const [index, block] of body.content.entries()) {
     if (block.type === "paragraph" && block.sectionProperties) {
-      allSections.push(block.sectionProperties);
+      slots.push({ props: block.sectionProperties, blockIndex: index });
     }
   }
-  if (body.finalSectionProperties) {
-    allSections.push(body.finalSectionProperties);
+  slots.push({ props: body.finalSectionProperties ?? {}, blockIndex: null });
+
+  // Word inherits headers forward only: a section uses its own typed reference
+  // or the nearest preceding section's. Walk in document order tracking whether
+  // a resolvable header of each type is in effect; the first section that needs
+  // the type but cannot inherit one gets a coverage reference, after which
+  // later sections inherit it. (A backward-inheriting global check would miss a
+  // cover/even page that precedes the first existing typed header.)
+  type Ref = { type: HeaderFooterType; rId: string };
+  const additions: Ref[][] = slots.map(() => []);
+  const planType = (
+    type: HeaderFooterType,
+    sectionNeedsType: (props: SectionProperties) => boolean,
+  ): void => {
+    let inherited = false;
+    for (const [index, slot] of slots.entries()) {
+      if (resolvesType(slot.props, type)) {
+        inherited = true;
+        continue;
+      }
+      if (sectionNeedsType(slot.props) && !inherited) {
+        additions[index]?.push({ type, rId: COVERAGE_RID[type] });
+        inherited = true;
+      }
+    }
+  };
+
+  if (noHeadersAtAll) {
+    planType("default", () => true);
+  }
+  planType("first", (props) => props.titlePg === true);
+  if (evenOddMode) {
+    planType("even", () => true);
   }
 
-  const typeExistsAnywhere = (type: HeaderFooterType): boolean =>
-    allSections.some((props) => resolvesType(props, type));
-
-  const needsFirst = (props: SectionProperties): boolean =>
-    props.titlePg === true && !resolvesType(props, "first");
-  const needsEven = (props: SectionProperties): boolean =>
-    evenOddMode && !resolvesType(props, "even");
-
-  const createFirst =
-    !typeExistsAnywhere("first") && allSections.some(needsFirst);
-  const createEven = !typeExistsAnywhere("even") && allSections.some(needsEven);
-
-  if (!noHeadersAtAll && !createFirst && !createEven) {
+  if (additions.every((refs) => refs.length === 0)) {
     return doc;
   }
 
-  const ensureTypedHeader = (type: HeaderFooterType): string => {
-    const rId = COVERAGE_RID[type];
-    if (!headers.has(rId)) {
-      headers.set(rId, {
+  // Materialize only the coverage headers actually referenced.
+  for (const type of new Set(additions.flat().map((ref) => ref.type))) {
+    if (!headers.has(COVERAGE_RID[type])) {
+      headers.set(COVERAGE_RID[type], {
         type: "header",
         hdrFtrType: type,
         content: [],
         watermark: { ...watermark },
       });
     }
-    return rId;
-  };
+  }
 
-  const addRef = (
-    props: SectionProperties,
-    type: HeaderFooterType,
-    rId: string,
-  ): SectionProperties => ({
-    ...props,
-    headerReferences: [...(props.headerReferences ?? []), { type, rId }],
+  const withRefs = (props: SectionProperties, refs: Ref[]): SectionProperties =>
+    refs.length === 0
+      ? props
+      : {
+          ...props,
+          headerReferences: [...(props.headerReferences ?? []), ...refs],
+        };
+
+  const additionsByBlock = new Map<number, Ref[]>();
+  for (const [index, slot] of slots.entries()) {
+    if (slot.blockIndex !== null) {
+      additionsByBlock.set(slot.blockIndex, additions[index] ?? []);
+    }
+  }
+
+  const newContent = body.content.map((block, index) => {
+    const refs = additionsByBlock.get(index);
+    if (
+      block.type === "paragraph" &&
+      block.sectionProperties &&
+      refs !== undefined &&
+      refs.length > 0
+    ) {
+      return {
+        ...block,
+        sectionProperties: withRefs(block.sectionProperties, refs),
+      };
+    }
+    return block;
   });
-
-  const cover = (props: SectionProperties): SectionProperties => {
-    let next = props;
-    if (noHeadersAtAll && !resolvesType(next, "default")) {
-      next = addRef(next, "default", ensureTypedHeader("default"));
-    }
-    if (createFirst && needsFirst(props)) {
-      next = addRef(next, "first", ensureTypedHeader("first"));
-    }
-    if (createEven && needsEven(props)) {
-      next = addRef(next, "even", ensureTypedHeader("even"));
-    }
-    return next;
-  };
-
-  const newContent = body.content.map((block) =>
-    block.type === "paragraph" && block.sectionProperties
-      ? { ...block, sectionProperties: cover(block.sectionProperties) }
-      : block,
+  // The final section is always the last slot.
+  const newFinal = withRefs(
+    body.finalSectionProperties ?? {},
+    additions.at(-1) ?? [],
   );
-  const newFinal = cover(body.finalSectionProperties ?? {});
 
   return {
     ...doc,

--- a/packages/folio/src/core/watermark/index.ts
+++ b/packages/folio/src/core/watermark/index.ts
@@ -8,7 +8,13 @@
  * to every header part so all sections render it.
  */
 
-import type { Document, HeaderFooter, Watermark } from "../types/document";
+import type {
+  Document,
+  HeaderFooter,
+  HeaderFooterType,
+  SectionProperties,
+  Watermark,
+} from "../types/document";
 
 export type {
   Watermark,
@@ -35,57 +41,176 @@ export function getDocumentWatermark(doc: Document): Watermark | undefined {
 }
 
 /**
- * Set (or clear) the document's watermark. Writes the modeled
- * `watermark` to every header part, and clears the captured raw VML so
- * the serializer takes the model-driven synthesis path. Pass
+ * Set (or clear) the document's watermark. Writes the modeled `watermark` to
+ * every existing header part (clearing the captured raw VML so the serializer
+ * synthesizes from the model), then extends coverage to the header parts a
+ * document needs but lacks — see {@link ensureWatermarkHeaderCoverage}. Pass
  * `undefined` to remove the watermark from every header.
- *
- * Throws when the document has no header parts to write to — folio
- * does not synthesize a default header here because that touches
- * section relationships, content-type registration, and the rezip
- * layer. Callers facing a header-less document should add a default
- * header via the existing header-creation helpers first, then call
- * this setter.
  */
 export function setDocumentWatermark(
   doc: Document,
   watermark: Watermark | undefined,
 ): Document {
   const headers = doc.package.headers;
-  if (!headers || headers.size === 0) {
-    throw new TypeError(
-      "setDocumentWatermark: document has no header parts; add a default header before setting a watermark",
-    );
-  }
   const nextHeaders = new Map<string, HeaderFooter>();
-  for (const [rId, header] of headers) {
-    const next: HeaderFooter = { ...header };
-    if (watermark === undefined) {
-      delete next.watermark;
-      // No watermark left to position — drop the parsed block index too
-      // so the serializer doesn't emit at a phantom slot.
-      delete next.watermarkBlockIndex;
-    } else {
-      // Give every header its own watermark object. A picture watermark's
-      // `imageRId` is local to each header part's own rels; the package-layer
-      // rebind pass at save time rewrites each copy's `imageRId` to a rId that
-      // resolves in that header's `word/_rels/header*.xml.rels`. Sharing one
-      // object would let that rebind leak across headers.
-      next.watermark = { ...watermark };
+  if (headers) {
+    for (const [rId, header] of headers) {
+      const next: HeaderFooter = { ...header };
+      if (watermark === undefined) {
+        delete next.watermark;
+        // No watermark left to position — drop the parsed block index too
+        // so the serializer doesn't emit at a phantom slot.
+        delete next.watermarkBlockIndex;
+      } else {
+        // Give every header its own watermark object. A picture watermark's
+        // `imageRId` is local to each header part's own rels; the package-layer
+        // rebind pass at save time rewrites each copy's `imageRId` to a rId
+        // that resolves in that header's `word/_rels/header*.xml.rels`. Sharing
+        // one object would let that rebind leak across headers.
+        next.watermark = { ...watermark };
+      }
+      // Clear the captured raw VML so the serializer regenerates from the
+      // model. Without this, an untouched raw payload would shadow the
+      // caller's mutation. `watermarkBlockIndex` is preserved across a
+      // text/picture mutation so the new watermark appears at the same
+      // flow position as the old one.
+      delete next.rawWatermarkXml;
+      nextHeaders.set(rId, next);
     }
-    // Clear the captured raw VML so the serializer regenerates from the
-    // model. Without this, an untouched raw payload would shadow the
-    // caller's mutation. `watermarkBlockIndex` is preserved across a
-    // text/picture mutation so the new watermark appears at the same
-    // flow position as the old one.
-    delete next.rawWatermarkXml;
-    nextHeaders.set(rId, next);
   }
+  const withExisting: Document = {
+    ...doc,
+    package: { ...doc.package, headers: nextHeaders },
+  };
+  if (watermark === undefined) {
+    return withExisting;
+  }
+  return ensureWatermarkHeaderCoverage(withExisting, watermark);
+}
+
+// Synthetic rIds for coverage-created header parts. They are valid NCNames, so
+// they serialize as section `<w:headerReference r:id>` values directly; the
+// rezip materialization pass promotes them to real parts + relationships +
+// [Content_Types] entries on save.
+const COVERAGE_RID: Record<HeaderFooterType, string> = {
+  default: "rId_wm_default",
+  first: "rId_wm_first",
+  even: "rId_wm_even",
+};
+
+/**
+ * Ensure the watermark shows on every page it should, even when the header
+ * parts a section needs are missing:
+ *
+ * - A document with no headers at all gets a default header carrying the
+ *   watermark.
+ * - A section with `w:titlePg` but no first-page header gets one (so the
+ *   watermark appears on the cover page, which would otherwise be blank).
+ * - When `w:evenAndOddHeaders` is on but a section has no even header, one is
+ *   created (so even pages are covered).
+ *
+ * A typed header is only created when no instance of that type exists anywhere
+ * in the document, so Word's section-to-section header inheritance — and the
+ * watermark already written to those inherited headers — is preserved. Created
+ * headers use synthetic rIds that the save pipeline materializes into real
+ * parts.
+ */
+export function ensureWatermarkHeaderCoverage(
+  doc: Document,
+  watermark: Watermark,
+): Document {
+  const body = doc.package.document;
+  const headers = new Map<string, HeaderFooter>(doc.package.headers);
+  const evenOddMode = doc.package.settings?.evenAndOddHeaders === true;
+  const noHeadersAtAll = headers.size === 0;
+
+  const resolvesType = (
+    props: SectionProperties,
+    type: HeaderFooterType,
+  ): boolean =>
+    props.headerReferences?.some(
+      (ref) => ref.type === type && headers.has(ref.rId),
+    ) ?? false;
+
+  const allSections: SectionProperties[] = [];
+  for (const block of body.content) {
+    if (block.type === "paragraph" && block.sectionProperties) {
+      allSections.push(block.sectionProperties);
+    }
+  }
+  if (body.finalSectionProperties) {
+    allSections.push(body.finalSectionProperties);
+  }
+
+  const typeExistsAnywhere = (type: HeaderFooterType): boolean =>
+    allSections.some((props) => resolvesType(props, type));
+
+  const needsFirst = (props: SectionProperties): boolean =>
+    props.titlePg === true && !resolvesType(props, "first");
+  const needsEven = (props: SectionProperties): boolean =>
+    evenOddMode && !resolvesType(props, "even");
+
+  const createFirst =
+    !typeExistsAnywhere("first") && allSections.some(needsFirst);
+  const createEven = !typeExistsAnywhere("even") && allSections.some(needsEven);
+
+  if (!noHeadersAtAll && !createFirst && !createEven) {
+    return doc;
+  }
+
+  const ensureTypedHeader = (type: HeaderFooterType): string => {
+    const rId = COVERAGE_RID[type];
+    if (!headers.has(rId)) {
+      headers.set(rId, {
+        type: "header",
+        hdrFtrType: type,
+        content: [],
+        watermark: { ...watermark },
+      });
+    }
+    return rId;
+  };
+
+  const addRef = (
+    props: SectionProperties,
+    type: HeaderFooterType,
+    rId: string,
+  ): SectionProperties => ({
+    ...props,
+    headerReferences: [...(props.headerReferences ?? []), { type, rId }],
+  });
+
+  const cover = (props: SectionProperties): SectionProperties => {
+    let next = props;
+    if (noHeadersAtAll && !resolvesType(next, "default")) {
+      next = addRef(next, "default", ensureTypedHeader("default"));
+    }
+    if (createFirst && needsFirst(props)) {
+      next = addRef(next, "first", ensureTypedHeader("first"));
+    }
+    if (createEven && needsEven(props)) {
+      next = addRef(next, "even", ensureTypedHeader("even"));
+    }
+    return next;
+  };
+
+  const newContent = body.content.map((block) =>
+    block.type === "paragraph" && block.sectionProperties
+      ? { ...block, sectionProperties: cover(block.sectionProperties) }
+      : block,
+  );
+  const newFinal = cover(body.finalSectionProperties ?? {});
+
   return {
     ...doc,
     package: {
       ...doc.package,
-      headers: nextHeaders,
+      headers,
+      document: {
+        ...body,
+        content: newContent,
+        finalSectionProperties: newFinal,
+      },
     },
   };
 }

--- a/packages/folio/src/core/watermark/index.ts
+++ b/packages/folio/src/core/watermark/index.ts
@@ -57,17 +57,6 @@ export function setDocumentWatermark(
       "setDocumentWatermark: document has no header parts; add a default header before setting a watermark",
     );
   }
-  // Picture watermarks reference `imageRId` which is scoped to each
-  // header part's own `word/_rels/header*.xml.rels`. Copying the same
-  // rId into every header would produce `<v:imagedata r:id="..."/>`
-  // entries with no matching relationship in other headers, breaking
-  // the saved DOCX. Cross-header rId cloning lives in the package
-  // layer; this headless API stays single-header for the picture case.
-  if (watermark?.kind === "picture" && headers.size > 1) {
-    throw new TypeError(
-      "setDocumentWatermark: picture watermarks across multiple header parts require per-header relationship cloning; apply via the package layer or use a text watermark",
-    );
-  }
   const nextHeaders = new Map<string, HeaderFooter>();
   for (const [rId, header] of headers) {
     const next: HeaderFooter = { ...header };
@@ -77,7 +66,12 @@ export function setDocumentWatermark(
       // so the serializer doesn't emit at a phantom slot.
       delete next.watermarkBlockIndex;
     } else {
-      next.watermark = watermark;
+      // Give every header its own watermark object. A picture watermark's
+      // `imageRId` is local to each header part's own rels; the package-layer
+      // rebind pass at save time rewrites each copy's `imageRId` to a rId that
+      // resolves in that header's `word/_rels/header*.xml.rels`. Sharing one
+      // object would let that rebind leak across headers.
+      next.watermark = { ...watermark };
     }
     // Clear the captured raw VML so the serializer regenerates from the
     // model. Without this, an untouched raw payload would shadow the


### PR DESCRIPTION
Watermark fidelity follow-ups ported from eigenpal/docx-editor#684, plus the
enabling fixes they surfaced. Each change is its own commit with regression
tests.

## Watermark fidelity
- **Aspect ratio**: picture watermarks were always synthesized into Word's
  default 415x207pt box, stretching non-2:1 images on Word-open whenever the
  watermark was re-applied (which clears the raw VML and forces synthesis). The
  real width/height (pt) are now captured at parse and re-emitted.
- **Per-header relationships**: a picture watermark's `imageRId` is local to
  each header's rels. Spanning multiple headers previously threw; now the
  watermark is cloned per header and each header's `imageRId` is rebound at save
  to a relationship in its own rels (reuse or mint), sharing one media part.
- **Header coverage**: a watermark was absent from cover pages (`titlePg`
  without a first-page header), even pages (`evenAndOddHeaders` without an even
  header), and header-less documents. `ensureWatermarkHeaderCoverage` creates
  the missing header parts carrying the watermark, only when no instance of that
  type exists anywhere (preserving Word's header inheritance).

## Enabling fixes
- **Materialize new header/footer parts on save**: a header/footer created in
  memory had no part/relationship/Content_Types entry and was silently dropped
  on save. The repack path now promotes such entries to real parts; selective
  save bails for them. Also fixes the editor's add-header flow.
- **Parse `w:evenAndOddHeaders` from settings.xml**: it lives in settings.xml,
  not sectPr, so even/odd mode in real documents was undetected.