### PR TITLE
fix(web): preserve app state when switching language

### DIFF
--- a/apps/web/src/i18n/i18n-store.test.ts
+++ b/apps/web/src/i18n/i18n-store.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, expect, test } from "bun:test";
+
+import { useI18nStore } from "@/i18n/i18n-store";
+import en from "@/i18n/langs/en.json";
+
+// Baseline: the app has already booted in English, so the boot latch is on.
+const resetToBootedEnglish = (): void => {
+  useI18nStore.setState({
+    lang: "en",
+    messages: en,
+    loadedLang: "en",
+    isLoaded: true,
+    hasLoadedOnce: true,
+  });
+};
+
+beforeEach(() => {
+  resetToBootedEnglish();
+});
+
+test("switching to an unbundled language keeps the boot latch on", async () => {
+  const isLoadedSeen: boolean[] = [];
+  const hasLoadedOnceSeen: boolean[] = [];
+  const unsubscribe = useI18nStore.subscribe((state) => {
+    isLoadedSeen.push(state.isLoaded);
+    hasLoadedOnceSeen.push(state.hasLoadedOnce);
+  });
+
+  await useI18nStore.getState().setLang("cs");
+  unsubscribe();
+
+  // A non-English bundle is loaded async, so isLoaded must dip false while it
+  // streams in. That dip is exactly what used to unmount the app (and any
+  // in-progress onboarding) via the boot spinner.
+  expect(isLoadedSeen).toContain(false);
+
+  // The boot latch must stay on through the whole switch, so the provider
+  // keeps the app mounted and swaps the locale in place.
+  expect(hasLoadedOnceSeen.every(Boolean)).toBe(true);
+
+  const state = useI18nStore.getState();
+  expect(state.loadedLang).toBe("cs");
+  expect(state.isLoaded).toBe(true);
+  expect(state.messages).not.toBe(en);
+});
+
+test("cold boot into a persisted non-English language holds the spinner", async () => {
+  // Post-hydration cold boot: the persisted language is non-English, only the
+  // bundled English messages are loaded, and the latch has not fired yet.
+  useI18nStore.setState({
+    lang: "cs",
+    messages: en,
+    loadedLang: "en",
+    isLoaded: false,
+    hasLoadedOnce: false,
+  });
+
+  const load = useI18nStore.getState().loadMessages("cs");
+
+  // While the Czech bundle streams in the latch must stay off, so the provider
+  // keeps the boot spinner up instead of flashing the English bundle first.
+  expect(useI18nStore.getState().hasLoadedOnce).toBe(false);
+
+  await load;
+
+  const state = useI18nStore.getState();
+  expect(state.hasLoadedOnce).toBe(true);
+  expect(state.loadedLang).toBe("cs");
+});
+
+test("cold boot in English latches the spinner off synchronously", async () => {
+  // The English bundle ships with the app, so loadMessages resolves on the sync
+  // fast path and must latch before the first render (no boot spinner flash).
+  useI18nStore.setState({
+    lang: "en",
+    messages: en,
+    loadedLang: "en",
+    isLoaded: true,
+    hasLoadedOnce: false,
+  });
+
+  const load = useI18nStore.getState().loadMessages("en");
+  expect(useI18nStore.getState().hasLoadedOnce).toBe(true);
+  await load;
+});
+
+test("loadedLang and messages advance together", async () => {
+  await useI18nStore.getState().setLang("cs");
+  const afterCs = useI18nStore.getState();
+  expect(afterCs.loadedLang).toBe("cs");
+  const csMessages = afterCs.messages;
+
+  await useI18nStore.getState().setLang("en");
+  const afterEn = useI18nStore.getState();
+  expect(afterEn.loadedLang).toBe("en");
+  expect(afterEn.messages).not.toBe(csMessages);
+  expect(afterEn.hasLoadedOnce).toBe(true);
+});

--- a/apps/web/src/i18n/i18n-store.ts
+++ b/apps/web/src/i18n/i18n-store.ts
@@ -119,6 +119,10 @@ type State = {
   messages: LocaleMessages;
   loadedLang: SupportedLanguage;
   isLoaded: boolean;
+  // True once the first locale has loaded. Latches on and never resets, so a
+  // later language switch (which flips isLoaded false while the new locale
+  // streams in) cannot send the app back to the boot spinner and unmount it.
+  hasLoadedOnce: boolean;
 };
 
 type Actions = {
@@ -153,11 +157,17 @@ export const useI18nStore = create<State & Actions>()(
       messages: defaultMessages,
       loadedLang: "en",
       isLoaded: defaultLanguage === "en",
+      // No locale has finished loading at construction, so the latch starts off
+      // regardless of the browser default. loadMessages turns it on once a
+      // bundle resolves (synchronously for English, after the async import
+      // otherwise), which keeps the boot-spinner gate honest: a persisted
+      // non-English locale cannot skip the spinner before its bundle arrives.
+      hasLoadedOnce: false,
 
       loadMessages: async (lang) => {
         const state = get();
         if (state.loadedLang === lang && state.isLoaded) {
-          set({ lang });
+          set({ lang, hasLoadedOnce: true });
           setDocumentLanguage(lang);
           return;
         }
@@ -175,7 +185,11 @@ export const useI18nStore = create<State & Actions>()(
 
           const fallback = get();
           applyMessages(fallback.loadedLang, fallback.messages);
-          set({ lang: fallback.loadedLang, isLoaded: true });
+          set({
+            lang: fallback.loadedLang,
+            isLoaded: true,
+            hasLoadedOnce: true,
+          });
           return;
         }
 
@@ -184,7 +198,13 @@ export const useI18nStore = create<State & Actions>()(
         }
 
         applyMessages(lang, messages);
-        set({ lang, messages, loadedLang: lang, isLoaded: true });
+        set({
+          lang,
+          messages,
+          loadedLang: lang,
+          isLoaded: true,
+          hasLoadedOnce: true,
+        });
       },
 
       setLang: async (lang) => {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -29,17 +29,22 @@ import { routeTree } from "@/routeTree.gen";
 enableMapSet();
 
 const I18nProvider = ({ children }: PropsWithChildren) => {
-  const lang = useI18nStore((s) => s.lang);
+  const locale = useI18nStore((s) => s.loadedLang);
   const messages = useI18nStore((s) => s.messages);
-  const isLoaded = useI18nStore((s) => s.isLoaded);
+  const hasLoadedOnce = useI18nStore((s) => s.hasLoadedOnce);
 
-  if (!isLoaded) {
+  // Gate the boot spinner on the first load, not on isLoaded: a language
+  // switch flips isLoaded false while the new locale streams in, and gating
+  // the whole subtree on it would unmount the app (losing in-progress state
+  // like onboarding) on every switch. loadedLang/messages are always a
+  // consistent already-loaded pair, so the locale swaps in place instead.
+  if (!hasLoadedOnce) {
     return <DefaultPendingComponent />;
   }
 
   return (
     <IntlProvider
-      locale={lang}
+      locale={locale}
       // SAFETY: locale JSON files are shape-checked in i18n-store.ts;
       // this cast is only at the provider boundary because use-intl's
       // Messages type preserves English literal message values while


### PR DESCRIPTION
## Problem

Switching language mid-onboarding reset all wizard progress.

`setLang` flips the i18n store's `isLoaded` to `false` while the new
locale bundle streams in. `I18nProvider` gated the entire app subtree on
`isLoaded`, so every switch swapped the app for the boot spinner and
remounted it — wiping component-local state such as the onboarding
wizard's `useState`.

## Fix

- Add a `hasLoadedOnce` latch to the i18n store: it turns on after the
  first locale resolves and never resets.
- Gate the boot spinner on `hasLoadedOnce` instead of `isLoaded`, and
  render `IntlProvider` from the always-consistent `loadedLang`/`messages`
  pair. A language switch now keeps the app mounted and swaps the locale
  in place once the new bundle loads. The cold-boot spinner for non-English
  browsers is preserved (the latch is off until the first load completes).

Fixes the reset for onboarding and any other in-progress local state,
across every language switcher.