### PR TITLE
feat(chat): recap thread on revisit after a gap

### DIFF
--- a/apps/api/drizzle/20260604120000_chat_threads_recap/migration.sql
+++ b/apps/api/drizzle/20260604120000_chat_threads_recap/migration.sql
@@ -1,0 +1,15 @@
+-- Lazy "where you left off" recap cache for chat threads. When a user
+-- reopens a thread after a gap, a short recap of what was discussed
+-- and what still remains is generated from the transcript and cached
+-- on the thread row, keyed by the latest message id and the prompt
+-- version so it regenerates when either changes.
+--
+-- All four columns are nullable and default to NULL; existing threads
+-- carry no recap until their first stale revisit generates one. This
+-- is purely additive: no rewrite, no constraint, no RLS change (the
+-- thread's existing row-level policies already govern these columns).
+ALTER TABLE chat_threads
+  ADD COLUMN IF NOT EXISTS recap_text text,
+  ADD COLUMN IF NOT EXISTS recap_message_id uuid,
+  ADD COLUMN IF NOT EXISTS recap_prompt_version smallint,
+  ADD COLUMN IF NOT EXISTS recap_generated_at timestamp;

--- a/apps/api/drizzle/20260604120000_chat_threads_recap/migration.sql
+++ b/apps/api/drizzle/20260604120000_chat_threads_recap/migration.sql
@@ -4,12 +4,25 @@
 -- on the thread row, keyed by the latest message id and the prompt
 -- version so it regenerates when either changes.
 --
--- All four columns are nullable and default to NULL; existing threads
--- carry no recap until their first stale revisit generates one. This
--- is purely additive: no rewrite, no constraint, no RLS change (the
--- thread's existing row-level policies already govern these columns).
+-- The recap columns are nullable and default to NULL; existing threads
+-- carry no recap until their first stale revisit generates one. The
+-- anonymization flag defaults false and is backfilled below so recap
+-- generation can skip those threads before reading message content.
+-- This is additive: no RLS change (the thread's existing row-level
+-- policies already govern these columns).
 ALTER TABLE chat_threads
   ADD COLUMN IF NOT EXISTS recap_text text,
   ADD COLUMN IF NOT EXISTS recap_message_id uuid,
   ADD COLUMN IF NOT EXISTS recap_prompt_version smallint,
-  ADD COLUMN IF NOT EXISTS recap_generated_at timestamp;
+  ADD COLUMN IF NOT EXISTS recap_generated_at timestamp,
+  ADD COLUMN IF NOT EXISTS used_anonymization boolean NOT NULL DEFAULT false;
+
+UPDATE chat_threads
+SET used_anonymization = true
+WHERE used_anonymization = false
+  AND EXISTS (
+    SELECT 1
+    FROM chat_messages
+    WHERE chat_messages.thread_id = chat_threads.id
+      AND chat_messages.content @> '{"data":[{"type":"data-stella-anon-restorations"}]}'::jsonb
+  );

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -2853,6 +2853,21 @@ export const chatThreads = p.pgTable(
       .boolean("web_search_enabled")
       .notNull()
       .default(false),
+    /**
+     * Cached "where you left off" recap, shown as subtle grey text
+     * below the last message when the user reopens this thread after
+     * a gap (see RECAP_STALENESS_THRESHOLD_MS). Derived from the
+     * transcript and regenerated lazily when `recapMessageId` no
+     * longer matches the latest message or `recapPromptVersion`
+     * changes; all four columns stay null until the first stale
+     * revisit generates one. `recapMessageId` is a plain cache token
+     * (equality-compared only, no FK) so message truncation simply
+     * invalidates the cache rather than dangling a reference.
+     */
+    recapText: p.text("recap_text"),
+    recapMessageId: safeUuid<"chatMessage">("recap_message_id"),
+    recapPromptVersion: p.smallint("recap_prompt_version"),
+    recapGeneratedAt: p.timestamp("recap_generated_at"),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
       .timestamp("updated_at")

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -2868,6 +2868,10 @@ export const chatThreads = p.pgTable(
     recapMessageId: safeUuid<"chatMessage">("recap_message_id"),
     recapPromptVersion: p.smallint("recap_prompt_version"),
     recapGeneratedAt: p.timestamp("recap_generated_at"),
+    usedAnonymization: p
+      .boolean("used_anonymization")
+      .notNull()
+      .default(false),
     createdAt: p.timestamp("created_at").notNull().defaultNow(),
     updatedAt: p
       .timestamp("updated_at")

--- a/apps/api/src/handlers/chat/get-messages.ts
+++ b/apps/api/src/handlers/chat/get-messages.ts
@@ -53,6 +53,7 @@ const getMessages = createSafeRootHandler(
                 id: true,
                 role: true,
                 content: true,
+                createdAt: true,
               },
               orderBy: { createdAt: "asc" },
             },
@@ -84,6 +85,7 @@ const getMessages = createSafeRootHandler(
         return Result.ok({
           messages: [],
           contextMatterIds: [],
+          lastActivityAt: null,
           webSearchAvailable,
           webSearchEnabled: false,
         });
@@ -113,6 +115,11 @@ const getMessages = createSafeRootHandler(
       );
     }
 
+    // Most recent message timestamp; the client compares it against
+    // the recap staleness window to decide whether to ask for a recap.
+    const lastActivityAt =
+      thread.messages.at(-1)?.createdAt.toISOString() ?? null;
+
     return Result.ok({
       messages: thread.messages.map((row) => ({
         id: row.id,
@@ -120,6 +127,7 @@ const getMessages = createSafeRootHandler(
         parts: normalizeLegacyToolInputs(row.content.data),
       })),
       contextMatterIds: thread.contextMatterIds,
+      lastActivityAt,
       webSearchAvailable,
       webSearchEnabled: thread.webSearchEnabled,
     });

--- a/apps/api/src/handlers/chat/get-thread-recap.ts
+++ b/apps/api/src/handlers/chat/get-thread-recap.ts
@@ -159,6 +159,7 @@ const getThreadRecap = createSafeRootHandler(
     // the recap still reaches the user (it just regenerates next time).
     const persistResult = await safeDb((tx) =>
       tx
+        // audit: skip — derived recap cache maintenance; no user-authored state change
         .update(chatThreads)
         .set({
           recapText: recap,

--- a/apps/api/src/handlers/chat/get-thread-recap.ts
+++ b/apps/api/src/handlers/chat/get-thread-recap.ts
@@ -1,0 +1,181 @@
+import { Result } from "better-result";
+import { and, eq } from "drizzle-orm";
+import { t } from "elysia";
+
+import { chatThreads } from "@/api/db/schema";
+import { resolveChatScope } from "@/api/handlers/chat/chat-scope";
+import {
+  generateThreadRecapText,
+  isThreadStaleForRecap,
+  RECAP_MIN_MESSAGE_COUNT,
+  RECAP_PROMPT_VERSION,
+  threadUsedAnonymization,
+} from "@/api/handlers/chat/thread-recap";
+import { requireAIAvailable } from "@/api/lib/ai-models";
+import { captureError } from "@/api/lib/analytics";
+import { createSafeRootHandler } from "@/api/lib/api-handlers";
+import type { HandlerConfig } from "@/api/lib/api-handlers";
+import { tSafeId } from "@/api/lib/custom-schema";
+import { HandlerError } from "@/api/lib/errors/tagged-errors";
+
+const config = {
+  permissions: { chat: ["create"] },
+  params: t.Object({ threadId: tSafeId("chatThread") }),
+  query: t.Object({ workspaceId: t.Optional(tSafeId("workspace")) }),
+} satisfies HandlerConfig;
+
+type ThreadRecapResult = { recap: string | null };
+
+const getThreadRecap = createSafeRootHandler(
+  config,
+  async function* ({
+    activeWorkspaceIds,
+    orgAIConfig,
+    params: { threadId },
+    promptCachingEnabled,
+    query: { workspaceId },
+    safeDb,
+    session,
+    user,
+  }) {
+    // The recap is a non-critical nicety: when AI is unavailable we
+    // return no recap rather than blocking the thread view.
+    if (Result.isError(requireAIAvailable(orgAIConfig))) {
+      return Result.ok<ThreadRecapResult>({ recap: null });
+    }
+
+    const scope = yield* resolveChatScope({
+      accessibleWorkspaceIds: activeWorkspaceIds,
+      workspaceId,
+    });
+
+    const thread = yield* Result.await(
+      safeDb((tx) =>
+        tx.query.chatThreads.findFirst({
+          where: {
+            id: { eq: threadId },
+            userId: { eq: user.id },
+          },
+          columns: {
+            workspaceId: true,
+            recapText: true,
+            recapMessageId: true,
+            recapPromptVersion: true,
+          },
+          with: {
+            messages: {
+              columns: {
+                id: true,
+                role: true,
+                content: true,
+                createdAt: true,
+              },
+              orderBy: { createdAt: "asc" },
+            },
+          },
+        }),
+      ),
+    );
+
+    if (!thread) {
+      return Result.err(
+        new HandlerError({
+          status: 404,
+          message: "Chat thread not found",
+        }),
+      );
+    }
+
+    // Reject a scope that contradicts the persisted thread, mirroring
+    // get-messages: a workspace thread asked for as global (or vice
+    // versa) is a client bug.
+    const persistedWorkspaceId = thread.workspaceId ?? null;
+    const requestedWorkspaceId =
+      scope.scope === "workspace" ? scope.workspaceId : null;
+    if (persistedWorkspaceId !== requestedWorkspaceId) {
+      return Result.err(
+        new HandlerError({
+          status: 400,
+          message: "Chat thread scope does not match request",
+        }),
+      );
+    }
+
+    // Only recap a completed exchange the user is returning to after a
+    // gap: the latest persisted turn must be an assistant message and
+    // old enough to count as a revisit.
+    const lastMessage = thread.messages.at(-1);
+    if (
+      !lastMessage ||
+      lastMessage.role !== "assistant" ||
+      thread.messages.length < RECAP_MIN_MESSAGE_COUNT ||
+      !isThreadStaleForRecap(lastMessage.createdAt)
+    ) {
+      return Result.ok<ThreadRecapResult>({ recap: null });
+    }
+
+    const recapMessages = thread.messages.map((row) => ({
+      role: row.role,
+      parts: row.content.data,
+    }));
+
+    // Stored content holds originals; anonymized turns only ever sent
+    // placeholders to the model. Building a recap from this content
+    // and sending it to the model would bypass that boundary, so skip
+    // the recap entirely for any thread that used anonymization.
+    if (threadUsedAnonymization(recapMessages)) {
+      return Result.ok<ThreadRecapResult>({ recap: null });
+    }
+
+    // Cache hit: the stored recap already covers this exact message
+    // tail and prompt version, so no model call is needed.
+    if (
+      thread.recapText &&
+      thread.recapMessageId === lastMessage.id &&
+      thread.recapPromptVersion === RECAP_PROMPT_VERSION
+    ) {
+      return Result.ok<ThreadRecapResult>({ recap: thread.recapText });
+    }
+
+    const recap = await generateThreadRecapText({
+      messages: recapMessages,
+      organizationId: session.activeOrganizationId,
+      orgAIConfig,
+      promptCachingEnabled,
+      threadId,
+      workspaceId: persistedWorkspaceId,
+    });
+
+    if (!recap) {
+      // Deliberately not cached: a null means either an empty
+      // transcript (no model call was spent) or a transient
+      // generation failure we'd rather retry on the next revisit than
+      // suppress. Successful recaps cache below, so a thread only ever
+      // spends one model call per message tail in the common case.
+      return Result.ok<ThreadRecapResult>({ recap: null });
+    }
+
+    // Cache best-effort: a write failure should not fail the read, so
+    // the recap still reaches the user (it just regenerates next time).
+    const persistResult = await safeDb((tx) =>
+      tx
+        .update(chatThreads)
+        .set({
+          recapText: recap,
+          recapMessageId: lastMessage.id,
+          recapPromptVersion: RECAP_PROMPT_VERSION,
+          recapGeneratedAt: new Date(),
+        })
+        .where(
+          and(eq(chatThreads.id, threadId), eq(chatThreads.userId, user.id)),
+        ),
+    );
+    if (Result.isError(persistResult)) {
+      captureError(persistResult.error, { threadId });
+    }
+
+    return Result.ok<ThreadRecapResult>({ recap });
+  },
+);
+
+export default getThreadRecap;

--- a/apps/api/src/handlers/chat/get-thread-recap.ts
+++ b/apps/api/src/handlers/chat/get-thread-recap.ts
@@ -1,5 +1,5 @@
 import { Result } from "better-result";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { t } from "elysia";
 
 import { chatThreads } from "@/api/db/schema";
@@ -165,6 +165,11 @@ const getThreadRecap = createSafeRootHandler(
           recapMessageId: lastMessage.id,
           recapPromptVersion: RECAP_PROMPT_VERSION,
           recapGeneratedAt: new Date(),
+          // Caching a recap is not thread activity. Pin updatedAt to its
+          // current value (an explicit value skips the column's
+          // $onUpdate) so reopening an old thread doesn't float it to
+          // the top of the updatedAt-ordered thread list.
+          updatedAt: sql`${chatThreads.updatedAt}`,
         })
         .where(
           and(eq(chatThreads.id, threadId), eq(chatThreads.userId, user.id)),

--- a/apps/api/src/handlers/chat/get-thread-recap.ts
+++ b/apps/api/src/handlers/chat/get-thread-recap.ts
@@ -9,8 +9,11 @@ import {
   isThreadStaleForRecap,
   RECAP_MIN_MESSAGE_COUNT,
   RECAP_PROMPT_VERSION,
-  threadUsedAnonymization,
 } from "@/api/handlers/chat/thread-recap";
+import {
+  buildRecapMessageWindow,
+  RECAP_RECENT_MESSAGE_LIMIT,
+} from "@/api/handlers/chat/thread-recap-window";
 import { requireAIAvailable } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
 import { createSafeRootHandler } from "@/api/lib/api-handlers";
@@ -61,17 +64,7 @@ const getThreadRecap = createSafeRootHandler(
             recapText: true,
             recapMessageId: true,
             recapPromptVersion: true,
-          },
-          with: {
-            messages: {
-              columns: {
-                id: true,
-                role: true,
-                content: true,
-                createdAt: true,
-              },
-              orderBy: { createdAt: "asc" },
-            },
+            usedAnonymization: true,
           },
         }),
       ),
@@ -101,31 +94,69 @@ const getThreadRecap = createSafeRootHandler(
       );
     }
 
+    if (thread.usedAnonymization) {
+      return Result.ok<ThreadRecapResult>({ recap: null });
+    }
+
+    const messageWindow = yield* Result.await(
+      safeDb(async (tx) => {
+        const firstUserMessages = await tx.query.chatMessages.findMany({
+          where: {
+            threadId: { eq: threadId },
+            userId: { eq: user.id },
+            role: { eq: "user" },
+          },
+          columns: {
+            id: true,
+            role: true,
+            content: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: "asc" },
+          limit: 1,
+        });
+        const recentMessagesDesc = await tx.query.chatMessages.findMany({
+          where: {
+            threadId: { eq: threadId },
+            userId: { eq: user.id },
+          },
+          columns: {
+            id: true,
+            role: true,
+            content: true,
+            createdAt: true,
+          },
+          orderBy: { createdAt: "desc" },
+          limit: RECAP_RECENT_MESSAGE_LIMIT,
+        });
+
+        return {
+          recentCount: recentMessagesDesc.length,
+          messages: buildRecapMessageWindow({
+            firstUserMessage: firstUserMessages.at(0) ?? null,
+            recentMessagesDesc,
+          }),
+        };
+      }),
+    );
+
     // Only recap a completed exchange the user is returning to after a
     // gap: the latest persisted turn must be an assistant message and
     // old enough to count as a revisit.
-    const lastMessage = thread.messages.at(-1);
+    const lastMessage = messageWindow.messages.at(-1);
     if (
       !lastMessage ||
       lastMessage.role !== "assistant" ||
-      thread.messages.length < RECAP_MIN_MESSAGE_COUNT ||
+      messageWindow.recentCount < RECAP_MIN_MESSAGE_COUNT ||
       !isThreadStaleForRecap(lastMessage.createdAt)
     ) {
       return Result.ok<ThreadRecapResult>({ recap: null });
     }
 
-    const recapMessages = thread.messages.map((row) => ({
+    const recapMessages = messageWindow.messages.map((row) => ({
       role: row.role,
       parts: row.content.data,
     }));
-
-    // Stored content holds originals; anonymized turns only ever sent
-    // placeholders to the model. Building a recap from this content
-    // and sending it to the model would bypass that boundary, so skip
-    // the recap entirely for any thread that used anonymization.
-    if (threadUsedAnonymization(recapMessages)) {
-      return Result.ok<ThreadRecapResult>({ recap: null });
-    }
 
     // Cache hit: the stored recap already covers this exact message
     // tail and prompt version, so no model call is needed.

--- a/apps/api/src/handlers/chat/routes.ts
+++ b/apps/api/src/handlers/chat/routes.ts
@@ -2,6 +2,7 @@ import Elysia from "elysia";
 
 import deleteThread from "@/api/handlers/chat/delete-thread";
 import getMessages from "@/api/handlers/chat/get-messages";
+import getThreadRecap from "@/api/handlers/chat/get-thread-recap";
 import getThreads from "@/api/handlers/chat/get-threads";
 import resolveFileThread from "@/api/handlers/chat/resolve-file-thread";
 import sendMessage from "@/api/handlers/chat/send-message";
@@ -40,4 +41,9 @@ export const chatRoute = new Elysia({ prefix: "/chat" })
     params: getMessages.config.params,
     permissions: getMessages.config.permissions,
     query: getMessages.config.query,
+  })
+  .post("/threads/:threadId/recap", getThreadRecap.handler, {
+    params: getThreadRecap.config.params,
+    permissions: getThreadRecap.config.permissions,
+    query: getThreadRecap.config.query,
   });

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -50,6 +50,7 @@ import {
 } from "@/api/handlers/chat/persist-message";
 import { hydrateMessages, streamChat } from "@/api/handlers/chat/stream-chat";
 import { createChatThirdPartyBoundary } from "@/api/handlers/chat/third-party-boundary";
+import { shouldMarkThreadUsedAnonymization } from "@/api/handlers/chat/thread-anonymization";
 import { shouldRefreshEmptyThreadTitle } from "@/api/handlers/chat/thread-title";
 import {
   intersectAccessibleWorkspaceIds,
@@ -459,6 +460,7 @@ const sendMessage = createSafeRootHandler(
 
     yield* Result.await(
       persistMessage({
+        acceptedSendMode: body.sendMode,
         recordAuditEvent,
         safeDb,
         threadId: body.threadId,
@@ -1474,6 +1476,7 @@ const getPdfFileRefForModel = (
 };
 
 type InsertMessagesProps = {
+  acceptedSendMode: ChatSendMode | null;
   messages: ChatMessage[];
   recordAuditEvent: AuditRecorder;
   safeDb: SafeDb;
@@ -1481,11 +1484,6 @@ type InsertMessagesProps = {
   userId: SafeId<"user">;
   workspaceId: SafeId<"workspace"> | null;
 };
-
-const messagesUsedAnonymization = (messages: readonly ChatMessage[]): boolean =>
-  messages.some((message) =>
-    message.parts.some((part) => part.type === "data-stella-anon-restorations"),
-  );
 
 type ResolveAssistantMessageRefsProps = {
   messages: ChatMessage[];
@@ -1544,6 +1542,7 @@ const hydrateAssistantMessageRefs = ({
 };
 
 const insertMessages = async ({
+  acceptedSendMode,
   messages,
   recordAuditEvent,
   safeDb,
@@ -1573,7 +1572,10 @@ const insertMessages = async ({
       .update(chatThreads)
       .set({
         updatedAt: new Date(),
-        ...(messagesUsedAnonymization(messages)
+        ...(shouldMarkThreadUsedAnonymization({
+          messages,
+          sendMode: acceptedSendMode,
+        })
           ? { usedAnonymization: true }
           : {}),
       })
@@ -1595,6 +1597,7 @@ const insertMessages = async ({
 };
 
 type PersistMessageProps = {
+  acceptedSendMode?: ChatSendMode | null;
   recordAuditEvent: AuditRecorder;
   safeDb: SafeDb;
   threadId: SafeId<"chatThread">;
@@ -1611,6 +1614,7 @@ type PersistMessageProps = {
 };
 
 const persistMessage = async ({
+  acceptedSendMode = null,
   recordAuditEvent,
   safeDb,
   threadId,
@@ -1622,6 +1626,7 @@ const persistMessage = async ({
 }: PersistMessageProps) => {
   if (persistencePlan.type === "insert") {
     return await insertMessages({
+      acceptedSendMode,
       messages: [persistencePlan.message],
       recordAuditEvent,
       safeDb,
@@ -1674,7 +1679,10 @@ const persistMessage = async ({
           ...(dataWorkspaceIdsChange === undefined
             ? {}
             : { dataWorkspaceIds: dataWorkspaceIdsChange.newDataWorkspaceIds }),
-          ...(messagesUsedAnonymization([persistencePlan.message])
+          ...(shouldMarkThreadUsedAnonymization({
+            messages: [persistencePlan.message],
+            sendMode: acceptedSendMode,
+          })
             ? { usedAnonymization: true }
             : {}),
         })
@@ -1739,6 +1747,7 @@ const persistMessage = async ({
 
     yield* Result.await(
       insertMessages({
+        acceptedSendMode,
         messages: [persistencePlan.insertMessage],
         recordAuditEvent,
         safeDb,

--- a/apps/api/src/handlers/chat/send-message.ts
+++ b/apps/api/src/handlers/chat/send-message.ts
@@ -1482,6 +1482,11 @@ type InsertMessagesProps = {
   workspaceId: SafeId<"workspace"> | null;
 };
 
+const messagesUsedAnonymization = (messages: readonly ChatMessage[]): boolean =>
+  messages.some((message) =>
+    message.parts.some((part) => part.type === "data-stella-anon-restorations"),
+  );
+
 type ResolveAssistantMessageRefsProps = {
   messages: ChatMessage[];
   refRegistry: ReturnType<typeof createChatRefRegistry>;
@@ -1566,7 +1571,12 @@ const insertMessages = async ({
     );
     await tx
       .update(chatThreads)
-      .set({ updatedAt: new Date() })
+      .set({
+        updatedAt: new Date(),
+        ...(messagesUsedAnonymization(messages)
+          ? { usedAnonymization: true }
+          : {}),
+      })
       .where(eq(chatThreads.id, threadId));
 
     await recordAuditEvent(
@@ -1659,14 +1669,15 @@ const persistMessage = async ({
         .where(eq(chatMessages.id, updatedMessageId));
       await tx
         .update(chatThreads)
-        .set(
-          dataWorkspaceIdsChange === undefined
-            ? { updatedAt: new Date() }
-            : {
-                updatedAt: new Date(),
-                dataWorkspaceIds: dataWorkspaceIdsChange.newDataWorkspaceIds,
-              },
-        )
+        .set({
+          updatedAt: new Date(),
+          ...(dataWorkspaceIdsChange === undefined
+            ? {}
+            : { dataWorkspaceIds: dataWorkspaceIdsChange.newDataWorkspaceIds }),
+          ...(messagesUsedAnonymization([persistencePlan.message])
+            ? { usedAnonymization: true }
+            : {}),
+        })
         .where(eq(chatThreads.id, threadId));
 
       if (

--- a/apps/api/src/handlers/chat/thread-anonymization.test.ts
+++ b/apps/api/src/handlers/chat/thread-anonymization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
+
+import { shouldMarkThreadUsedAnonymization } from "./thread-anonymization";
+
+const messageWithParts = (parts: readonly { type: string }[]) => ({ parts });
+
+describe("chat thread anonymization marker", () => {
+  test("marks a thread as soon as an anonymized send is accepted", () => {
+    expect(
+      shouldMarkThreadUsedAnonymization({
+        messages: [messageWithParts([{ type: "text" }])],
+        sendMode: CHAT_SEND_MODE.anonymized,
+      }),
+    ).toBe(true);
+  });
+
+  test("marks restored assistant messages even without request send mode", () => {
+    expect(
+      shouldMarkThreadUsedAnonymization({
+        messages: [
+          messageWithParts([{ type: "data-stella-anon-restorations" }]),
+        ],
+        sendMode: null,
+      }),
+    ).toBe(true);
+  });
+
+  test("does not mark ordinary raw-mode messages", () => {
+    expect(
+      shouldMarkThreadUsedAnonymization({
+        messages: [messageWithParts([{ type: "text" }])],
+        sendMode: CHAT_SEND_MODE.rawOverride,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/handlers/chat/thread-anonymization.ts
+++ b/apps/api/src/handlers/chat/thread-anonymization.ts
@@ -1,0 +1,25 @@
+import { CHAT_SEND_MODE } from "@stll/anonymize-chat";
+import type { ChatSendMode } from "@stll/anonymize-chat";
+
+const ANON_RESTORATIONS_PART_TYPE = "data-stella-anon-restorations";
+
+type AnonymizationMessage = {
+  parts: readonly { type: string }[];
+};
+
+export const messagesCarryAnonymizationRestorations = (
+  messages: readonly AnonymizationMessage[],
+): boolean =>
+  messages.some((message) =>
+    message.parts.some((part) => part.type === ANON_RESTORATIONS_PART_TYPE),
+  );
+
+export const shouldMarkThreadUsedAnonymization = ({
+  messages,
+  sendMode,
+}: {
+  messages: readonly AnonymizationMessage[];
+  sendMode: ChatSendMode | null;
+}): boolean =>
+  sendMode === CHAT_SEND_MODE.anonymized ||
+  messagesCarryAnonymizationRestorations(messages);

--- a/apps/api/src/handlers/chat/thread-recap-transcript.ts
+++ b/apps/api/src/handlers/chat/thread-recap-transcript.ts
@@ -1,0 +1,149 @@
+import type { ChatMessage } from "@/api/handlers/chat/types";
+
+export const RECAP_TRANSCRIPT_MAX_CHARS = 8000;
+
+const RECAP_PRESERVED_FIRST_LINE_MAX_CHARS = 1000;
+const RECAP_OMISSION_MARKER = "\n\n[...]\n\n";
+
+export type RecapMessage = Pick<ChatMessage, "role" | "parts">;
+
+const collapseWhitespace = (value: string): string => {
+  const segments = value.trim().split(/\s/u);
+  const words: string[] = [];
+  for (const segment of segments) {
+    if (segment) {
+      words.push(segment);
+    }
+  }
+
+  return words.join(" ");
+};
+
+const messageText = (message: RecapMessage): string => {
+  const segments: string[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text" && part.text.trim()) {
+      segments.push(part.text);
+    }
+  }
+  return collapseWhitespace(segments.join("\n"));
+};
+
+const truncateLine = (line: string, maxChars: number): string => {
+  if (line.length <= maxChars) {
+    return line;
+  }
+
+  const suffix = " [...]";
+  if (maxChars <= suffix.length) {
+    return line.slice(0, maxChars);
+  }
+
+  return `${line.slice(0, maxChars - suffix.length).trimEnd()}${suffix}`;
+};
+
+const truncateLineStart = (line: string, maxChars: number): string => {
+  if (line.length <= maxChars) {
+    return line;
+  }
+
+  let prefix = "";
+  if (line.startsWith("Assistant: ")) {
+    prefix = "Assistant: ";
+  } else if (line.startsWith("User: ")) {
+    prefix = "User: ";
+  }
+  const marker = "[...] ";
+  if (prefix && maxChars > prefix.length + marker.length) {
+    const suffixLength = maxChars - prefix.length - marker.length;
+    return `${prefix}${marker}${line.slice(line.length - suffixLength).trimStart()}`;
+  }
+
+  if (maxChars > marker.length) {
+    const suffixLength = maxChars - marker.length;
+    return `${marker}${line.slice(line.length - suffixLength).trimStart()}`;
+  }
+
+  return line.slice(line.length - maxChars);
+};
+
+const buildTailTranscript = (
+  lines: readonly string[],
+  maxChars: number,
+): string => {
+  const tailLines: string[] = [];
+  let remaining = maxChars;
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index];
+    if (line === undefined) {
+      continue;
+    }
+
+    const separatorLength = tailLines.length > 0 ? 2 : 0;
+    if (line.length + separatorLength <= remaining) {
+      tailLines.unshift(line);
+      remaining -= line.length + separatorLength;
+      continue;
+    }
+
+    const lineBudget = remaining - separatorLength;
+    if (lineBudget > 0) {
+      tailLines.unshift(truncateLineStart(line, lineBudget));
+    }
+    break;
+  }
+
+  return tailLines.join("\n\n");
+};
+
+/**
+ * Flatten the transcript to plain `User:`/`Assistant:` lines, capped
+ * to a char budget filled from the most recent end. When the budget
+ * truncates the head, the original ask (first user line) is preserved
+ * so the model can still tell what the thread set out to do, which is
+ * what "what remains" is measured against.
+ */
+export const buildRecapTranscript = (
+  messages: readonly RecapMessage[],
+): string => {
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = messageText(message);
+    if (!text) {
+      continue;
+    }
+    lines.push(`${message.role === "user" ? "User" : "Assistant"}: ${text}`);
+  }
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  const full = lines.join("\n\n");
+  if (full.length <= RECAP_TRANSCRIPT_MAX_CHARS) {
+    return full;
+  }
+
+  const firstUserLine = lines.find((line) => line.startsWith("User: "));
+  const tailOnly = buildTailTranscript(lines, RECAP_TRANSCRIPT_MAX_CHARS);
+  if (!firstUserLine || tailOnly.includes(firstUserLine)) {
+    return tailOnly;
+  }
+
+  const firstLineBudget = Math.min(
+    firstUserLine.length,
+    RECAP_PRESERVED_FIRST_LINE_MAX_CHARS,
+    RECAP_TRANSCRIPT_MAX_CHARS - RECAP_OMISSION_MARKER.length,
+  );
+  const preservedFirstLine = truncateLine(firstUserLine, firstLineBudget);
+  const tailBudget =
+    RECAP_TRANSCRIPT_MAX_CHARS -
+    RECAP_OMISSION_MARKER.length -
+    preservedFirstLine.length;
+  const tail = buildTailTranscript(lines, tailBudget);
+  return `${preservedFirstLine}${RECAP_OMISSION_MARKER}${tail}`;
+};

--- a/apps/api/src/handlers/chat/thread-recap-window.ts
+++ b/apps/api/src/handlers/chat/thread-recap-window.ts
@@ -1,0 +1,25 @@
+export const RECAP_RECENT_MESSAGE_LIMIT = 24;
+
+type RecapWindowMessage = {
+  id: string;
+};
+
+type BuildRecapMessageWindowOptions<TMessage extends RecapWindowMessage> = {
+  firstUserMessage: TMessage | null;
+  recentMessagesDesc: readonly TMessage[];
+};
+
+export const buildRecapMessageWindow = <TMessage extends RecapWindowMessage>({
+  firstUserMessage,
+  recentMessagesDesc,
+}: BuildRecapMessageWindowOptions<TMessage>): TMessage[] => {
+  const recentMessages = recentMessagesDesc.toReversed();
+  if (
+    !firstUserMessage ||
+    recentMessages.some((message) => message.id === firstUserMessage.id)
+  ) {
+    return recentMessages;
+  }
+
+  return [firstUserMessage, ...recentMessages];
+};

--- a/apps/api/src/handlers/chat/thread-recap.test.ts
+++ b/apps/api/src/handlers/chat/thread-recap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RecapMessage } from "./thread-recap-transcript";
+import {
+  buildRecapTranscript,
+  RECAP_TRANSCRIPT_MAX_CHARS,
+} from "./thread-recap-transcript";
+
+const textMessage = ({
+  role,
+  text,
+}: {
+  role: "assistant" | "user";
+  text: string;
+}): RecapMessage => ({
+  role,
+  parts: [{ type: "text", text }],
+});
+
+describe("chat thread recap transcript", () => {
+  test("keeps short transcripts unchanged", () => {
+    const transcript = buildRecapTranscript([
+      textMessage({ role: "user", text: "Review this clause." }),
+      textMessage({ role: "assistant", text: "The clause is broad." }),
+    ]);
+
+    expect(transcript).toBe(
+      "User: Review this clause.\n\nAssistant: The clause is broad.",
+    );
+  });
+
+  test("preserves the first user prompt without exceeding the transcript cap", () => {
+    const firstPrompt = "Initial legal brief ".repeat(1000);
+    const recentAnswer = "Recent analysis ".repeat(1000);
+
+    const transcript = buildRecapTranscript([
+      textMessage({ role: "user", text: firstPrompt }),
+      textMessage({ role: "assistant", text: recentAnswer }),
+    ]);
+
+    expect(transcript.length).toBeLessThanOrEqual(RECAP_TRANSCRIPT_MAX_CHARS);
+    expect(transcript).toStartWith("User: Initial legal brief");
+    expect(transcript).toContain(" [...]");
+    expect(transcript).toContain("[...]");
+    expect(transcript).toContain("Assistant: ");
+    expect(transcript).toContain("Recent analysis");
+  });
+});

--- a/apps/api/src/handlers/chat/thread-recap.test.ts
+++ b/apps/api/src/handlers/chat/thread-recap.test.ts
@@ -5,6 +5,7 @@ import {
   buildRecapTranscript,
   RECAP_TRANSCRIPT_MAX_CHARS,
 } from "./thread-recap-transcript";
+import { buildRecapMessageWindow } from "./thread-recap-window";
 
 const textMessage = ({
   role,
@@ -44,5 +45,37 @@ describe("chat thread recap transcript", () => {
     expect(transcript).toContain("[...]");
     expect(transcript).toContain("Assistant: ");
     expect(transcript).toContain("Recent analysis");
+  });
+});
+
+describe("chat thread recap message window", () => {
+  test("preserves the first user turn before the recent tail", () => {
+    const messages = buildRecapMessageWindow({
+      firstUserMessage: { id: "first-user" },
+      recentMessagesDesc: [
+        { id: "latest-assistant" },
+        { id: "recent-user" },
+        { id: "older-assistant" },
+      ],
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "first-user",
+      "older-assistant",
+      "recent-user",
+      "latest-assistant",
+    ]);
+  });
+
+  test("does not duplicate the first user turn when it is already recent", () => {
+    const messages = buildRecapMessageWindow({
+      firstUserMessage: { id: "first-user" },
+      recentMessagesDesc: [{ id: "latest-assistant" }, { id: "first-user" }],
+    });
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "first-user",
+      "latest-assistant",
+    ]);
   });
 });

--- a/apps/api/src/handlers/chat/thread-recap.ts
+++ b/apps/api/src/handlers/chat/thread-recap.ts
@@ -42,21 +42,6 @@ Write in the same language as the conversation. Be specific: name the actual top
 export const isThreadStaleForRecap = (lastMessageCreatedAt: Date): boolean =>
   Date.now() - lastMessageCreatedAt.getTime() > RECAP_STALENESS_THRESHOLD_MS;
 
-/**
- * Whether any turn in the thread was sent in anonymized mode.
- * Persisted messages store originals (the anonymization boundary only
- * swaps placeholders in-transit to the model), and anonymized turns
- * leave a `data-stella-anon-restorations` part behind. A recap built
- * from stored content and sent to the model would leak those
- * originals, so callers skip the recap when this is true.
- */
-export const threadUsedAnonymization = (
-  messages: readonly RecapMessage[],
-): boolean =>
-  messages.some((message) =>
-    message.parts.some((part) => part.type === "data-stella-anon-restorations"),
-  );
-
 const stripRecapPrefix = (value: string): string => {
   const prefix = "recap:";
   if (value.slice(0, prefix.length).toLowerCase() !== prefix) {

--- a/apps/api/src/handlers/chat/thread-recap.ts
+++ b/apps/api/src/handlers/chat/thread-recap.ts
@@ -1,6 +1,9 @@
 import { generateText } from "ai";
 
-import type { ChatMessage } from "@/api/handlers/chat/types";
+import {
+  buildRecapTranscript,
+  type RecapMessage,
+} from "@/api/handlers/chat/thread-recap-transcript";
 import { getModelForRole } from "@/api/lib/ai-models";
 import type { OrgAIConfig } from "@/api/lib/ai-models";
 import { captureError } from "@/api/lib/analytics";
@@ -27,7 +30,6 @@ export const RECAP_MIN_MESSAGE_COUNT = 2;
 
 const RECAP_MAX_OUTPUT_TOKENS = 256;
 const RECAP_GENERATION_TIMEOUT_MS = 20_000;
-const RECAP_TRANSCRIPT_MAX_CHARS = 8_000;
 const RECAP_MAX_LENGTH = 700;
 
 const RECAP_SYSTEM_PROMPT = `You write a brief "where you left off" recap for someone returning to an earlier conversation with a legal assistant after a break.
@@ -39,8 +41,6 @@ Write in the same language as the conversation. Be specific: name the actual top
 /** Whether the latest message is old enough to count as a revisit. */
 export const isThreadStaleForRecap = (lastMessageCreatedAt: Date): boolean =>
   Date.now() - lastMessageCreatedAt.getTime() > RECAP_STALENESS_THRESHOLD_MS;
-
-type RecapMessage = Pick<ChatMessage, "role" | "parts">;
 
 /**
  * Whether any turn in the thread was sent in anonymized mode.
@@ -57,55 +57,34 @@ export const threadUsedAnonymization = (
     message.parts.some((part) => part.type === "data-stella-anon-restorations"),
   );
 
-const messageText = (message: RecapMessage): string => {
-  const segments: string[] = [];
-  for (const part of message.parts) {
-    if (part.type === "text" && part.text.trim()) {
-      segments.push(part.text);
-    }
+const stripRecapPrefix = (value: string): string => {
+  const prefix = "recap:";
+  if (value.slice(0, prefix.length).toLowerCase() !== prefix) {
+    return value;
   }
-  return segments.join("\n").replaceAll(/\s+/gu, " ").trim();
+
+  return value.slice(prefix.length).trimStart();
 };
 
-/**
- * Flatten the transcript to plain `User:`/`Assistant:` lines, capped
- * to a char budget filled from the most recent end. When the budget
- * truncates the head, the original ask (first user line) is preserved
- * so the model can still tell what the thread set out to do — which
- * is what "what remains" is measured against.
- */
-const buildRecapTranscript = (messages: readonly RecapMessage[]): string => {
-  const lines: string[] = [];
-  for (const message of messages) {
-    if (message.role !== "user" && message.role !== "assistant") {
-      continue;
-    }
-    const text = messageText(message);
-    if (!text) {
-      continue;
-    }
-    lines.push(`${message.role === "user" ? "User" : "Assistant"}: ${text}`);
+const isWrappingQuote = (char: string): boolean => char === '"' || char === "'";
+
+const trimWrappingQuotes = (value: string): string => {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && isWrappingQuote(value.charAt(start))) {
+    start += 1;
+  }
+  while (end > start && isWrappingQuote(value.charAt(end - 1))) {
+    end -= 1;
   }
 
-  if (lines.length === 0) {
-    return "";
-  }
-
-  const full = lines.join("\n\n");
-  if (full.length <= RECAP_TRANSCRIPT_MAX_CHARS) {
-    return full;
-  }
-
-  const firstUserLine = lines.find((line) => line.startsWith("User: "));
-  const tail = full.slice(full.length - RECAP_TRANSCRIPT_MAX_CHARS);
-  return firstUserLine && !tail.includes(firstUserLine)
-    ? `${firstUserLine}\n\n[…]\n\n${tail}`
-    : tail;
+  return value.slice(start, end);
 };
 
 const cleanRecapText = (text: string): string | null => {
-  const withoutLabel = text.trim().replace(/^recap:\s*/iu, "");
-  const unquoted = withoutLabel.replace(/^["']+|["']+$/gu, "").trim();
+  const withoutLabel = stripRecapPrefix(text.trim());
+  const unquoted = trimWrappingQuotes(withoutLabel).trim();
   const capped = unquoted.slice(0, RECAP_MAX_LENGTH).trim();
   return capped.length > 0 ? capped : null;
 };

--- a/apps/api/src/handlers/chat/thread-recap.ts
+++ b/apps/api/src/handlers/chat/thread-recap.ts
@@ -1,0 +1,170 @@
+import { generateText } from "ai";
+
+import type { ChatMessage } from "@/api/handlers/chat/types";
+import { getModelForRole } from "@/api/lib/ai-models";
+import type { OrgAIConfig } from "@/api/lib/ai-models";
+import { captureError } from "@/api/lib/analytics";
+import { createAIAnalyticsCallbacks } from "@/api/lib/analytics/ai";
+import type { SafeId } from "@/api/lib/branded-types";
+
+/**
+ * Bump when the recap prompt or output shape changes so cached
+ * recaps with an older version regenerate on the next stale revisit.
+ */
+export const RECAP_PROMPT_VERSION = 1;
+
+/**
+ * A thread counts as a "revisit" worth recapping once its latest
+ * message is at least this old. Kept loosely in sync with the
+ * frontend gate in chat-thread-recap.tsx; the server re-checks here
+ * so a stale or spoofed client request never spends a model call on a
+ * fresh thread.
+ */
+const RECAP_STALENESS_THRESHOLD_MS = 4 * 60 * 60 * 1000;
+
+/** Minimum messages before a thread has enough to recap. */
+export const RECAP_MIN_MESSAGE_COUNT = 2;
+
+const RECAP_MAX_OUTPUT_TOKENS = 256;
+const RECAP_GENERATION_TIMEOUT_MS = 20_000;
+const RECAP_TRANSCRIPT_MAX_CHARS = 8_000;
+const RECAP_MAX_LENGTH = 700;
+
+const RECAP_SYSTEM_PROMPT = `You write a brief "where you left off" recap for someone returning to an earlier conversation with a legal assistant after a break.
+
+Write 2 to 4 sentences of plain prose: no markdown, no headings, no bullet points, no greeting. First state what was discussed or accomplished, then what still remains open — unanswered questions, next steps, or unfinished work. If nothing remains open, only summarise what was covered.
+
+Write in the same language as the conversation. Be specific: name the actual topics, documents, and decisions rather than describing the conversation in the abstract. You may address the reader directly ("You were…"), but never write in the assistant's first person ("I…") and do not describe the assistant as a person. Do not invent anything that is not in the transcript. Reply with the recap text only.`;
+
+/** Whether the latest message is old enough to count as a revisit. */
+export const isThreadStaleForRecap = (lastMessageCreatedAt: Date): boolean =>
+  Date.now() - lastMessageCreatedAt.getTime() > RECAP_STALENESS_THRESHOLD_MS;
+
+type RecapMessage = Pick<ChatMessage, "role" | "parts">;
+
+/**
+ * Whether any turn in the thread was sent in anonymized mode.
+ * Persisted messages store originals (the anonymization boundary only
+ * swaps placeholders in-transit to the model), and anonymized turns
+ * leave a `data-stella-anon-restorations` part behind. A recap built
+ * from stored content and sent to the model would leak those
+ * originals, so callers skip the recap when this is true.
+ */
+export const threadUsedAnonymization = (
+  messages: readonly RecapMessage[],
+): boolean =>
+  messages.some((message) =>
+    message.parts.some((part) => part.type === "data-stella-anon-restorations"),
+  );
+
+const messageText = (message: RecapMessage): string => {
+  const segments: string[] = [];
+  for (const part of message.parts) {
+    if (part.type === "text" && part.text.trim()) {
+      segments.push(part.text);
+    }
+  }
+  return segments.join("\n").replaceAll(/\s+/gu, " ").trim();
+};
+
+/**
+ * Flatten the transcript to plain `User:`/`Assistant:` lines, capped
+ * to a char budget filled from the most recent end. When the budget
+ * truncates the head, the original ask (first user line) is preserved
+ * so the model can still tell what the thread set out to do — which
+ * is what "what remains" is measured against.
+ */
+const buildRecapTranscript = (messages: readonly RecapMessage[]): string => {
+  const lines: string[] = [];
+  for (const message of messages) {
+    if (message.role !== "user" && message.role !== "assistant") {
+      continue;
+    }
+    const text = messageText(message);
+    if (!text) {
+      continue;
+    }
+    lines.push(`${message.role === "user" ? "User" : "Assistant"}: ${text}`);
+  }
+
+  if (lines.length === 0) {
+    return "";
+  }
+
+  const full = lines.join("\n\n");
+  if (full.length <= RECAP_TRANSCRIPT_MAX_CHARS) {
+    return full;
+  }
+
+  const firstUserLine = lines.find((line) => line.startsWith("User: "));
+  const tail = full.slice(full.length - RECAP_TRANSCRIPT_MAX_CHARS);
+  return firstUserLine && !tail.includes(firstUserLine)
+    ? `${firstUserLine}\n\n[…]\n\n${tail}`
+    : tail;
+};
+
+const cleanRecapText = (text: string): string | null => {
+  const withoutLabel = text.trim().replace(/^recap:\s*/iu, "");
+  const unquoted = withoutLabel.replace(/^["']+|["']+$/gu, "").trim();
+  const capped = unquoted.slice(0, RECAP_MAX_LENGTH).trim();
+  return capped.length > 0 ? capped : null;
+};
+
+type GenerateThreadRecapTextArgs = {
+  messages: readonly RecapMessage[];
+  organizationId: SafeId<"organization">;
+  orgAIConfig: OrgAIConfig | null;
+  promptCachingEnabled: boolean;
+  threadId: SafeId<"chatThread">;
+  workspaceId: SafeId<"workspace"> | null;
+};
+
+/**
+ * Generate a recap from the thread transcript. Returns null (never
+ * throws) when there is nothing to summarise or the model call fails:
+ * the recap is a non-critical nicety, so a failure surfaces no recap
+ * rather than an error.
+ */
+export const generateThreadRecapText = async ({
+  messages,
+  organizationId,
+  orgAIConfig,
+  promptCachingEnabled,
+  threadId,
+  workspaceId,
+}: GenerateThreadRecapTextArgs): Promise<string | null> => {
+  const transcript = buildRecapTranscript(messages);
+  if (!transcript) {
+    return null;
+  }
+
+  const aiAnalytics = createAIAnalyticsCallbacks({
+    feature: "chat.thread_recap",
+    modelRole: "fast",
+    orgAIConfig,
+    properties: workspaceId ? { workspace_id: workspaceId } : {},
+    traceId: Bun.randomUUIDv7(),
+  });
+
+  try {
+    const { text } = await generateText({
+      abortSignal: AbortSignal.timeout(RECAP_GENERATION_TIMEOUT_MS),
+      maxOutputTokens: RECAP_MAX_OUTPUT_TOKENS,
+      model: getModelForRole("fast", orgAIConfig, {
+        promptCachingEnabled,
+        scopeKey: threadId,
+        organizationId,
+      }),
+      prompt: `Conversation transcript:\n\n${transcript}\n\nRecap:`,
+      system: RECAP_SYSTEM_PROMPT,
+      temperature: 0,
+      ...aiAnalytics.stepCallbacks,
+    });
+
+    return cleanRecapText(text);
+  } catch (error) {
+    aiAnalytics.captureError(error);
+    captureError(error, { threadId, feature: "chat.thread_recap" });
+    return null;
+  }
+};

--- a/apps/web/src/i18n/langs/cs.json
+++ b/apps/web/src/i18n/langs/cs.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# příloha} few {# přílohy} other {# příloh}}",
     "queuedNotice": "Zařazeno — odešle se po dokončení aktuální odpovědi",
+    "recapLoading": "Shrnutí konverzace…",
     "removeSuggestion": "(odebrat)",
     "resend": "Odeslat znovu",
     "resizeThread": "Změnit velikost konverzace",

--- a/apps/web/src/i18n/langs/de.json
+++ b/apps/web/src/i18n/langs/de.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# Anhang} other {# Anhänge}}",
     "queuedNotice": "Eingereiht – wird gesendet, sobald die aktuelle Antwort abgeschlossen ist",
+    "recapLoading": "Unterhaltung wird zusammengefasst…",
     "removeSuggestion": "(entfernen)",
     "resend": "Erneut senden",
     "resizeThread": "Konversation vergrößern oder verkleinern",

--- a/apps/web/src/i18n/langs/en.json
+++ b/apps/web/src/i18n/langs/en.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}",
     "queuedNotice": "Queued — sends when the current response finishes",
+    "recapLoading": "Recapping the conversation…",
     "removeSuggestion": "(remove)",
     "resend": "Resend",
     "resizeThread": "Resize conversation",

--- a/apps/web/src/i18n/langs/es.json
+++ b/apps/web/src/i18n/langs/es.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# adjunto} many {# adjuntos} other {# adjuntos}}",
     "queuedNotice": "En cola: se enviará cuando termine la respuesta actual",
+    "recapLoading": "Resumiendo la conversación…",
     "removeSuggestion": "(eliminar)",
     "resend": "Reenviar",
     "resizeThread": "Cambiar tamaño de la conversación",

--- a/apps/web/src/i18n/langs/et.json
+++ b/apps/web/src/i18n/langs/et.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# manus} other {# manust}}",
     "queuedNotice": "Järjekorras — saadetakse, kui praegune vastus on valmis",
+    "recapLoading": "Vestlus võetakse kokku…",
     "removeSuggestion": "(eemalda)",
     "resend": "Saada uuesti",
     "resizeThread": "Muuda vestluse suurust",

--- a/apps/web/src/i18n/langs/fr.json
+++ b/apps/web/src/i18n/langs/fr.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# pièce jointe} many {# pièces jointes} other {# pièces jointes}}",
     "queuedNotice": "En file d’attente : envoi à la fin de la réponse en cours",
+    "recapLoading": "Récapitulatif de la conversation…",
     "removeSuggestion": "(supprimer)",
     "resend": "Renvoyer",
     "resizeThread": "Redimensionner la conversation",

--- a/apps/web/src/i18n/langs/hu.json
+++ b/apps/web/src/i18n/langs/hu.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# melléklet} other {# melléklet}}",
     "queuedNotice": "Sorba állítva – a jelenlegi válasz befejeztével küldjük el",
+    "recapLoading": "A beszélgetés összefoglalása…",
     "removeSuggestion": "(eltávolítás)",
     "resend": "Újraküldés",
     "resizeThread": "Beszélgetés méretezése",

--- a/apps/web/src/i18n/langs/lt.json
+++ b/apps/web/src/i18n/langs/lt.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# priedas} few {# priedai} many {# priedo} other {# priedų}}",
     "queuedNotice": "Eilėje — bus išsiųsta, kai baigsis dabartinis atsakymas",
+    "recapLoading": "Apibendrinamas pokalbis…",
     "removeSuggestion": "(pašalinti)",
     "resend": "Siųsti dar kartą",
     "resizeThread": "Keisti pokalbio dydį",

--- a/apps/web/src/i18n/langs/lv.json
+++ b/apps/web/src/i18n/langs/lv.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, zero {# pielikumu} one {# pielikums} other {# pielikumi}}",
     "queuedNotice": "Rindā — tiks nosūtīts, kad pabeigsies pašreizējā atbilde",
+    "recapLoading": "Sarunas apkopošana…",
     "removeSuggestion": "(noņemt)",
     "resend": "Nosūtīt vēlreiz",
     "resizeThread": "Mainīt sarunas izmēru",

--- a/apps/web/src/i18n/langs/messages.gen.ts
+++ b/apps/web/src/i18n/langs/messages.gen.ts
@@ -476,6 +476,7 @@ type Messages = {
     };
     "queuedAttachmentCount": "{count, plural, one {# attachment} other {# attachments}}";
     "queuedNotice": "Queued — sends when the current response finishes";
+    "recapLoading": "Recapping the conversation…";
     "removeSuggestion": "(remove)";
     "resend": "Resend";
     "resizeThread": "Resize conversation";

--- a/apps/web/src/i18n/langs/pl.json
+++ b/apps/web/src/i18n/langs/pl.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# załącznik} few {# załączniki} many {# załączników} other {# załącznika}}",
     "queuedNotice": "W kolejce — zostanie wysłana po zakończeniu bieżącej odpowiedzi",
+    "recapLoading": "Podsumowywanie rozmowy…",
     "removeSuggestion": "(usuń)",
     "resend": "Wyślij ponownie",
     "resizeThread": "Zmień rozmiar konwersacji",

--- a/apps/web/src/i18n/langs/pt-BR.json
+++ b/apps/web/src/i18n/langs/pt-BR.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# anexo} many {# anexos} other {# anexos}}",
     "queuedNotice": "Na fila: será enviada quando a resposta atual terminar",
+    "recapLoading": "Resumindo a conversa…",
     "removeSuggestion": "(remover)",
     "resend": "Reenviar",
     "resizeThread": "Redimensionar conversa",

--- a/apps/web/src/i18n/langs/sk.json
+++ b/apps/web/src/i18n/langs/sk.json
@@ -473,6 +473,7 @@
     },
     "queuedAttachmentCount": "{count, plural, one {# príloha} few {# prílohy} other {# príloh}}",
     "queuedNotice": "V poradí – odošle sa po dokončení aktuálnej odpovede",
+    "recapLoading": "Zhrnutie konverzácie…",
     "removeSuggestion": "(odstrániť)",
     "resend": "Odoslať znova",
     "resizeThread": "Zmeniť veľkosť konverzácie",

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-page.tsx
@@ -43,6 +43,7 @@ import type { ChatPrompt } from "@/lib/prompts/types";
 import { useSavedPrompts } from "@/lib/prompts/use-saved-prompts";
 import { toSafeId } from "@/lib/safe-id";
 import { ChatAnonymizedToggle } from "@/routes/_protected.chat/-components/chat-anonymized-toggle";
+import { ChatThreadRecap } from "@/routes/_protected.chat/-components/chat-thread-recap";
 import { ChatWebSearchToggle } from "@/routes/_protected.chat/-components/chat-web-search-toggle";
 import { ThreadsSheet } from "@/routes/_protected.chat/-components/threads-sheet";
 import { useChatSession } from "@/routes/_protected.chat/-hooks/use-chat-session";
@@ -315,24 +316,36 @@ export const ChatThreadPage = ({
                   />
                 </div>
               ) : (
-                <ChatThreadMessages
-                  approvalPendingMessageId={approvalPendingMessageId}
-                  error={error}
-                  isGenerating={isGenerating}
-                  messages={messages}
-                  onAskUserEditAndRerun={handleAskUserEditAndRerun}
-                  onAskUserSubmit={handleAskUserSubmit}
-                  onCreateDocumentResolve={handleCreateDocumentResolve}
-                  onOpenCreatedDocument={handleOpenCreatedDocument}
-                  onRemoveQueuedMessage={removeQueuedMessage}
-                  onResend={resendLatestMessage}
-                  onSendWithoutAnonymization={sendWithoutAnonymization}
-                  queuedMessages={queuedMessages}
-                  showThinkingIndicator
-                  showToolCallDetails={showToolCallDetails}
-                  streamdownComponents={streamdownComponents}
-                  workspaceId={workspaceId}
-                />
+                <>
+                  <ChatThreadMessages
+                    approvalPendingMessageId={approvalPendingMessageId}
+                    error={error}
+                    isGenerating={isGenerating}
+                    messages={messages}
+                    onAskUserEditAndRerun={handleAskUserEditAndRerun}
+                    onAskUserSubmit={handleAskUserSubmit}
+                    onCreateDocumentResolve={handleCreateDocumentResolve}
+                    onOpenCreatedDocument={handleOpenCreatedDocument}
+                    onRemoveQueuedMessage={removeQueuedMessage}
+                    onResend={resendLatestMessage}
+                    onSendWithoutAnonymization={sendWithoutAnonymization}
+                    queuedMessages={queuedMessages}
+                    showThinkingIndicator
+                    showToolCallDetails={showToolCallDetails}
+                    streamdownComponents={streamdownComponents}
+                    workspaceId={workspaceId}
+                  />
+                  <ChatThreadRecap
+                    activeOrganizationId={activeOrganizationId}
+                    isGenerating={isGenerating}
+                    key={threadRef.threadId}
+                    lastActivityAt={data.lastActivityAt}
+                    lastMessageId={messages.at(-1)?.id ?? null}
+                    lastMessageRole={messages.at(-1)?.role ?? null}
+                    messageCount={messages.length}
+                    threadRef={threadRef}
+                  />
+                </>
               )}
             </ConversationContent>
             <ConversationScrollButton />

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-recap.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-recap.tsx
@@ -1,0 +1,99 @@
+import { useState } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+import { ClockIcon } from "lucide-react";
+import { useTranslations } from "use-intl";
+
+import type { PersistedChatMessage } from "@/components/chat/chat-ui-tools";
+import type { ChatThreadRef } from "@/lib/chat-thread-ref";
+import { chatThreadRecapOptions } from "@/routes/_protected.chat/-queries";
+
+// Mirrors RECAP_STALENESS_THRESHOLD_MS in
+// apps/api/src/handlers/chat/thread-recap.ts. The server re-checks
+// staleness before spending a model call, so the two only need to
+// agree loosely.
+const RECAP_STALENESS_THRESHOLD_MS = 4 * 60 * 60 * 1000;
+// A user + assistant pair is the least that has anything to recap.
+const RECAP_MIN_MESSAGE_COUNT = 2;
+
+type ChatThreadRecapProps = {
+  activeOrganizationId: string;
+  isGenerating: boolean;
+  lastActivityAt: string | null;
+  lastMessageId: string | null;
+  lastMessageRole: PersistedChatMessage["role"] | null;
+  messageCount: number;
+  threadRef: ChatThreadRef;
+};
+
+/**
+ * Subtle "where you left off" recap shown below the last message when
+ * the user reopens a thread after a gap. The component is keyed by
+ * threadId at the call site so it remounts (and re-stamps `openedAt`)
+ * per thread; it renders nothing until the thread is both idle and
+ * stale enough to count as a revisit.
+ */
+export const ChatThreadRecap = ({
+  activeOrganizationId,
+  isGenerating,
+  lastActivityAt,
+  lastMessageId,
+  lastMessageRole,
+  messageCount,
+  threadRef,
+}: ChatThreadRecapProps) => {
+  const t = useTranslations();
+  // Stamp "now" and the message the thread opened on once per mount,
+  // so the staleness check stays pure and is evaluated at thread-open
+  // time. The component is keyed by threadId at the call site, so both
+  // re-capture per thread.
+  const [openedAt] = useState(() => Date.now());
+  const [openedOnMessageId] = useState(() => lastMessageId);
+  const isStale =
+    lastActivityAt !== null &&
+    openedAt - new Date(lastActivityAt).getTime() >
+      RECAP_STALENESS_THRESHOLD_MS;
+  const eligible =
+    !isGenerating &&
+    lastMessageId !== null &&
+    // The recap describes the thread as it was reopened; once the user
+    // sends in this thread, the live last message advances past the one
+    // we opened on and the recap retires (no flash, no wasted call).
+    lastMessageId === openedOnMessageId &&
+    lastMessageRole === "assistant" &&
+    messageCount >= RECAP_MIN_MESSAGE_COUNT &&
+    isStale;
+
+  const { data, isFetching } = useQuery(
+    chatThreadRecapOptions({
+      activeOrganizationId,
+      enabled: eligible,
+      lastMessageId: lastMessageId ?? "",
+      threadRef,
+    }),
+  );
+
+  if (!eligible) {
+    return null;
+  }
+
+  if (data?.recap) {
+    return (
+      <div className="text-muted-foreground flex items-start gap-2 px-1 text-sm italic">
+        <ClockIcon aria-hidden className="mt-[0.2rem] size-3.5 shrink-0" />
+        <p>{data.recap}</p>
+      </div>
+    );
+  }
+
+  if (isFetching) {
+    return (
+      <div className="text-muted-foreground/70 flex animate-pulse items-center gap-2 px-1 text-sm italic">
+        <ClockIcon aria-hidden className="size-3.5 shrink-0" />
+        <span>{t("chat.recapLoading")}</span>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/apps/web/src/routes/_protected.chat/-components/chat-thread-recap.tsx
+++ b/apps/web/src/routes/_protected.chat/-components/chat-thread-recap.tsx
@@ -88,7 +88,7 @@ export const ChatThreadRecap = ({
 
   if (isFetching) {
     return (
-      <div className="text-muted-foreground/70 flex animate-pulse items-center gap-2 px-1 text-sm italic">
+      <div className="text-foreground-muted flex animate-pulse items-center gap-2 px-1 text-sm italic">
         <ClockIcon aria-hidden className="size-3.5 shrink-0" />
         <span>{t("chat.recapLoading")}</span>
       </div>

--- a/apps/web/src/routes/_protected.chat/-queries.ts
+++ b/apps/web/src/routes/_protected.chat/-queries.ts
@@ -181,6 +181,34 @@ export const chatKeys = {
           key.contextKind ?? "plain",
           CHAT_TRANSPORT_VERSION,
         ],
+  // Sits under the per-thread prefix (chat, org, thread, scope, …ids)
+  // so `invalidateChatThread` drops it too; keyed by the latest
+  // message id so a new turn yields a fresh entry.
+  recap: (
+    activeOrganizationId: string,
+    threadRef: ChatThreadRef,
+    lastMessageId: string,
+  ) =>
+    threadRef.scope === "global"
+      ? [
+          ...chatKeys.all,
+          activeOrganizationId,
+          "thread",
+          threadRef.scope,
+          threadRef.threadId,
+          "recap",
+          lastMessageId,
+        ]
+      : [
+          ...chatKeys.all,
+          activeOrganizationId,
+          "thread",
+          threadRef.scope,
+          threadRef.workspaceId,
+          threadRef.threadId,
+          "recap",
+          lastMessageId,
+        ],
 };
 
 type ChatThreadOptionsInput = QueryOptionsInput<
@@ -191,6 +219,8 @@ type ChatThreadOptionsInput = QueryOptionsInput<
 type ThreadFetch = {
   messages: PersistedChatMessage[];
   contextMatterIds: string[];
+  /** ISO timestamp of the most recent message, or null when empty. */
+  lastActivityAt: string | null;
   webSearchAvailable: boolean;
   webSearchEnabled: boolean;
 };
@@ -221,6 +251,7 @@ const fetchThreadMessages = async (
       return {
         messages: [],
         contextMatterIds: [],
+        lastActivityAt: null,
         webSearchAvailable: false,
         webSearchEnabled: false,
       };
@@ -232,6 +263,7 @@ const fetchThreadMessages = async (
   return {
     messages: response.data.messages,
     contextMatterIds: response.data.contextMatterIds,
+    lastActivityAt: response.data.lastActivityAt,
     webSearchAvailable: response.data.webSearchAvailable,
     webSearchEnabled: response.data.webSearchEnabled,
   };
@@ -595,6 +627,11 @@ export type ChatThreadFetched = {
    * the transport, not through this read.
    */
   contextMatterIds: string[];
+  /**
+   * ISO timestamp of the most recent persisted message (null for an
+   * empty thread). Drives the revisit-recap staleness check.
+   */
+  lastActivityAt: string | null;
   webSearchAvailable: boolean;
   /**
    * Per-thread web-search opt-in. Mutated via PATCH /chat/threads/:id
@@ -642,6 +679,7 @@ export const chatThreadOptions = ({
       const {
         messages,
         contextMatterIds,
+        lastActivityAt,
         webSearchAvailable,
         webSearchEnabled,
       } = await fetchThreadMessages(key, {
@@ -682,8 +720,63 @@ export const chatThreadOptions = ({
         sendAutomaticallyWhen: createSendAutomaticallyPredicate(),
       });
 
-      return { chat, contextMatterIds, webSearchAvailable, webSearchEnabled };
+      return {
+        chat,
+        contextMatterIds,
+        lastActivityAt,
+        webSearchAvailable,
+        webSearchEnabled,
+      };
     },
+  });
+
+type ChatThreadRecapFetched = {
+  recap: string | null;
+};
+
+const fetchThreadRecap = async (
+  threadRef: ChatThreadRef,
+): Promise<ChatThreadRecapFetched> => {
+  const response = await api.chat
+    .threads({ threadId: toSafeId<"chatThread">(threadRef.threadId) })
+    .recap.post(undefined, {
+      query:
+        threadRef.scope === "workspace"
+          ? { workspaceId: toSafeId<"workspace">(threadRef.workspaceId) }
+          : {},
+    });
+
+  if (response.error) {
+    // A recap is a non-critical nicety: surface nothing on failure,
+    // but keep the error in telemetry.
+    getAnalytics().captureError(toAPIError(response.error));
+    return { recap: null };
+  }
+
+  return { recap: response.data.recap };
+};
+
+type ChatThreadRecapOptionsArgs = {
+  activeOrganizationId: string;
+  enabled: boolean;
+  lastMessageId: string;
+  threadRef: ChatThreadRef;
+};
+
+export const chatThreadRecapOptions = ({
+  activeOrganizationId,
+  enabled,
+  lastMessageId,
+  threadRef,
+}: ChatThreadRecapOptionsArgs) =>
+  queryOptions({
+    enabled,
+    // A given message tail yields a stable recap (cached server-side),
+    // so never auto-refetch; a new message produces a new cache key.
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: STALE_TIME.FIVETEEN.MINUTES,
+    queryKey: chatKeys.recap(activeOrganizationId, threadRef, lastMessageId),
+    queryFn: async () => await fetchThreadRecap(threadRef),
   });
 
 export const groupedChatThreadsOptions = (activeOrganizationId: string) =>


### PR DESCRIPTION
## Summary
Reopening a chat thread more than a few hours after its last message now renders a subtle italic recap below the last message, summarising what was discussed and what still remains to be done.

## Behaviour
- Shows only on a genuine revisit: the last persisted turn is an assistant message, the thread has at least one exchange, and the last activity is older than a staleness window (a tunable named constant, currently 4h).
- Generated lazily in the conversation's own language via the fast model; cached on the thread row keyed by the latest message id and a prompt version, so it regenerates only when the conversation or prompt changes.
- Retires as soon as a new message is sent in the thread.

## Notes
- New `POST /chat/threads/:id/recap` endpoint re-checks staleness server-side and degrades to no recap when AI is unavailable or generation fails.
- Threads that used anonymization are skipped, so stored originals are never sent to the model outside the anonymization boundary.
- Additive migration: four nullable `recap_*` columns on `chat_threads`, no RLS change.
- i18n: one new `chat.recapLoading` key across all locales.

Closes #309
