### PR TITLE
fix(folio): sync header/footer, floating image, and table spacing fixes from eigenpal

### DIFF
--- a/packages/folio/src/core/layout-engine/contextualSpacing-table.test.ts
+++ b/packages/folio/src/core/layout-engine/contextualSpacing-table.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Contextual spacing must be applied inside table cells too, not only at the
+ * top level of the document. Without recursion into cells, two same-style
+ * paragraphs in a cell keep their before/after spacing, so the measured cell
+ * height diverges from what the painter renders. Regression for
+ * eigenpal/docx-editor#699.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { applyContextualSpacing } from "./index";
+import type { FlowBlock, ParagraphBlock, TableBlock } from "./types";
+
+function bullet(id: string, styleId: string): ParagraphBlock {
+  return {
+    kind: "paragraph",
+    id,
+    runs: [{ kind: "text", text: id }],
+    attrs: {
+      spacing: { before: 5, after: 13 },
+      contextualSpacing: true,
+      styleId,
+    },
+  };
+}
+
+function tableWith(...paragraphs: ParagraphBlock[]): TableBlock {
+  return {
+    kind: "table",
+    id: "t",
+    rows: [{ id: "r", cells: [{ id: "c", blocks: paragraphs }] }],
+  };
+}
+
+describe("applyContextualSpacing in table cells", () => {
+  test("suppresses spacing between same-style contextual paragraphs in a cell", () => {
+    const a = bullet("a", "ListBullet");
+    const b = bullet("b", "ListBullet");
+    const blocks: FlowBlock[] = [tableWith(a, b)];
+
+    applyContextualSpacing(blocks);
+
+    expect(a.attrs?.spacing?.after).toBe(0);
+    expect(b.attrs?.spacing?.before).toBe(0);
+  });
+
+  test("does not suppress spacing across differing styles in a cell", () => {
+    const a = bullet("a", "ListBullet");
+    const b = bullet("b", "Normal");
+    const blocks: FlowBlock[] = [tableWith(a, b)];
+
+    applyContextualSpacing(blocks);
+
+    expect(a.attrs?.spacing?.after).toBe(13);
+    expect(b.attrs?.spacing?.before).toBe(5);
+  });
+});

--- a/packages/folio/src/core/layout-engine/contextualSpacing-table.test.ts
+++ b/packages/folio/src/core/layout-engine/contextualSpacing-table.test.ts
@@ -9,7 +9,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { applyContextualSpacing } from "./index";
-import type { FlowBlock, ParagraphBlock, TableBlock } from "./types";
+import type {
+  FlowBlock,
+  ParagraphBlock,
+  TableBlock,
+  TextBoxBlock,
+} from "./types";
 
 function bullet(id: string, styleId: string): ParagraphBlock {
   return {
@@ -53,5 +58,22 @@ describe("applyContextualSpacing in table cells", () => {
 
     expect(a.attrs?.spacing?.after).toBe(13);
     expect(b.attrs?.spacing?.before).toBe(5);
+  });
+
+  test("suppresses spacing between same-style contextual paragraphs in a text box", () => {
+    const a = bullet("a", "ListBullet");
+    const b = bullet("b", "ListBullet");
+    const textBox: TextBoxBlock = {
+      kind: "textBox",
+      id: "tb",
+      width: 200,
+      content: [a, b],
+    };
+    const blocks: FlowBlock[] = [textBox];
+
+    applyContextualSpacing(blocks);
+
+    expect(a.attrs?.spacing?.after).toBe(0);
+    expect(b.attrs?.spacing?.before).toBe(0);
   });
 });

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -129,7 +129,7 @@ function getSpacingAfter(block: ParagraphBlock): number {
  *
  * This mutates the block attrs in-place before layout runs.
  */
-function applyContextualSpacing(blocks: FlowBlock[]): void {
+export function applyContextualSpacing(blocks: FlowBlock[]): void {
   for (let i = 0; i < blocks.length - 1; i++) {
     const curr = blocks[i]!; // SAFETY: i < blocks.length - 1
     const next = blocks[i + 1]!; // SAFETY: i + 1 < blocks.length
@@ -154,6 +154,20 @@ function applyContextualSpacing(blocks: FlowBlock[]): void {
       // Suppress spaceBefore on next paragraph
       if (nextAttrs.spacing) {
         nextAttrs.spacing = { ...nextAttrs.spacing, before: 0 };
+      }
+    }
+  }
+
+  // Recurse into table cells so contextual spacing is suppressed there too —
+  // measure, pagination, and the painter all read the (mutated) cell paragraph
+  // spacing, so they stay consistent. eigenpal/docx-editor#699.
+  for (const block of blocks) {
+    if (block.kind !== "table") {
+      continue;
+    }
+    for (const row of block.rows) {
+      for (const cell of row.cells) {
+        applyContextualSpacing(cell.blocks);
       }
     }
   }

--- a/packages/folio/src/core/layout-engine/index.ts
+++ b/packages/folio/src/core/layout-engine/index.ts
@@ -158,17 +158,19 @@ export function applyContextualSpacing(blocks: FlowBlock[]): void {
     }
   }
 
-  // Recurse into table cells so contextual spacing is suppressed there too —
-  // measure, pagination, and the painter all read the (mutated) cell paragraph
-  // spacing, so they stay consistent. eigenpal/docx-editor#699.
+  // Recurse into nested block containers (table cells and text boxes) so
+  // contextual spacing is suppressed there too — measure, pagination, and the
+  // painter all read the (mutated) paragraph spacing, so they stay consistent.
+  // eigenpal/docx-editor#699.
   for (const block of blocks) {
-    if (block.kind !== "table") {
-      continue;
-    }
-    for (const row of block.rows) {
-      for (const cell of row.cells) {
-        applyContextualSpacing(cell.blocks);
+    if (block.kind === "table") {
+      for (const row of block.rows) {
+        for (const cell of row.cells) {
+          applyContextualSpacing(cell.blocks);
+        }
       }
+    } else if (block.kind === "textBox") {
+      applyContextualSpacing(block.content);
     }
   }
 }

--- a/packages/folio/src/core/layout-painter/floating-image-maxwidth.test.ts
+++ b/packages/folio/src/core/layout-painter/floating-image-maxwidth.test.ts
@@ -1,0 +1,82 @@
+/**
+ * A painted floating image keeps its explicit OOXML size and opts out of the
+ * global `img { max-width: 100% }` reset (Tailwind preflight). Without this an
+ * image anchored near the right edge — where the remaining content width is
+ * below its own width — is capped and squashed against its fixed height.
+ * Regression for eigenpal/docx-editor#694.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  renderFloatingImagesLayer,
+  type PageFloatingImage,
+} from "./renderPage";
+
+class FakeElement {
+  className = "";
+  dataset: Record<string, string> = {};
+  style: Record<string, string> = {};
+  children: FakeElement[] = [];
+  readonly tagName: string;
+
+  constructor(tagName: string) {
+    this.tagName = tagName;
+  }
+
+  append(...children: FakeElement[]): void {
+    this.children.push(...children);
+  }
+}
+
+const fakeDocument = {
+  createElement(tagName: string): FakeElement {
+    return new FakeElement(tagName);
+  },
+} as unknown as Document;
+
+function findImg(element: FakeElement): FakeElement | undefined {
+  if (element.tagName === "img") {
+    return element;
+  }
+  for (const child of element.children) {
+    const match = findImg(child);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+function floatImg(): PageFloatingImage {
+  return {
+    src: "data:image/png;base64,AAAA",
+    width: 96,
+    height: 96,
+    side: "right",
+    x: 600,
+    y: 0,
+    distTop: 0,
+    distBottom: 0,
+    distLeft: 0,
+    distRight: 0,
+    affectsTextWrap: false,
+    behindDoc: false,
+  };
+}
+
+describe("floating image rendering", () => {
+  test("keeps explicit OOXML size and opts out of the max-width reset", () => {
+    const layer = renderFloatingImagesLayer(
+      [floatImg()],
+      fakeDocument,
+    ) as unknown as FakeElement;
+
+    const img = findImg(layer);
+    expect(img).toBeDefined();
+    expect(img!.style["width"]).toBe("96px");
+    expect(img!.style["height"]).toBe("96px");
+    expect(img!.style["maxWidth"]).toBe("none");
+    expect(img!.style["maxHeight"]).toBe("none");
+  });
+});

--- a/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
+++ b/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
@@ -73,8 +73,8 @@ describe("resolveHeaderFooterFloatLeft", () => {
       ),
     ).toBe("312px");
     // outside in the content box: contentWidth 400 - 200 = 200
-    expect(resolveHeaderFooterFloatLeft(200, { align: "outside" }, layout)).toBe(
-      "200px",
-    );
+    expect(
+      resolveHeaderFooterFloatLeft(200, { align: "outside" }, layout),
+    ).toBe("200px");
   });
 });

--- a/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
+++ b/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Header/footer anchored-object horizontal positioning. A text box (or image)
+ * anchored centered relative to the page must resolve to a centered `left`, not
+ * be pinned to the container's left edge. Regression for
+ * eigenpal/docx-editor#700.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveHeaderFooterFloatLeft,
+  type HeaderFooterLayoutInfo,
+} from "./renderPage";
+
+const layout: HeaderFooterLayoutInfo = {
+  flowTop: 50,
+  flowLeft: 100,
+  contentWidth: 400,
+  pageWidth: 612,
+  pageHeight: 792,
+  margins: { top: 72, right: 72, bottom: 72, left: 72 },
+};
+
+describe("resolveHeaderFooterFloatLeft", () => {
+  test("no position → pinned left", () => {
+    expect(resolveHeaderFooterFloatLeft(200, undefined, layout)).toBe("0");
+  });
+
+  test("center relative to page → centered on the page, in container coords", () => {
+    // (pageWidth 612 - width 200) / 2 - flowLeft 100 = 106
+    expect(
+      resolveHeaderFooterFloatLeft(
+        200,
+        { relativeTo: "page", align: "center" },
+        layout,
+      ),
+    ).toBe("106px");
+  });
+
+  test("right relative to page", () => {
+    // 612 - 200 - 100 = 312
+    expect(
+      resolveHeaderFooterFloatLeft(
+        200,
+        { relativeTo: "page", align: "right" },
+        layout,
+      ),
+    ).toBe("312px");
+  });
+
+  test("center without page anchor → centered in the content/margin box", () => {
+    // (contentWidth 400 - 200) / 2 = 100
+    expect(resolveHeaderFooterFloatLeft(200, { align: "center" }, layout)).toBe(
+      "100px",
+    );
+  });
+});

--- a/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
+++ b/packages/folio/src/core/layout-painter/header-footer-float-left.test.ts
@@ -54,4 +54,27 @@ describe("resolveHeaderFooterFloatLeft", () => {
       "100px",
     );
   });
+
+  test("inside aliases left, outside aliases right (single-sided rendering)", () => {
+    // inside → left relative to page: -flowLeft = -100
+    expect(
+      resolveHeaderFooterFloatLeft(
+        200,
+        { relativeTo: "page", align: "inside" },
+        layout,
+      ),
+    ).toBe("-100px");
+    // outside → right relative to page: 612 - 200 - 100 = 312
+    expect(
+      resolveHeaderFooterFloatLeft(
+        200,
+        { relativeTo: "page", align: "outside" },
+        layout,
+      ),
+    ).toBe("312px");
+    // outside in the content box: contentWidth 400 - 200 = 200
+    expect(resolveHeaderFooterFloatLeft(200, { align: "outside" }, layout)).toBe(
+      "200px",
+    );
+  });
 });

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -633,7 +633,14 @@ export function resolveHeaderFooterFloatLeft(
     return "0";
   }
 
-  const align = getPositionAlignment(h);
+  // Single-sided rendering: OOXML `inside`/`outside` alias `left`/`right`
+  // (matching resolveAnchoredImagePosition / the floating-table resolver).
+  let align = getPositionAlignment(h);
+  if (align === "inside") {
+    align = "left";
+  } else if (align === "outside") {
+    align = "right";
+  }
 
   if (h.relativeTo === "page") {
     if (h.posOffset !== undefined) {

--- a/packages/folio/src/core/layout-painter/renderPage.ts
+++ b/packages/folio/src/core/layout-painter/renderPage.ts
@@ -73,7 +73,7 @@ import { renderWatermarkLayer } from "./renderWatermark";
  * Page-level floating image that has been extracted from paragraphs.
  * These are positioned absolutely within the page's content area.
  */
-type PageFloatingImage = {
+export type PageFloatingImage = {
   src: string;
   width: number;
   height: number;
@@ -221,7 +221,7 @@ export type RenderPageOptions = {
   watermarkImageSrc?: string;
 };
 
-type HeaderFooterLayoutInfo = {
+export type HeaderFooterLayoutInfo = {
   flowTop: number;
   flowLeft: number;
   contentWidth: number;
@@ -610,6 +610,62 @@ function resolveHeaderFooterFloatingTablePosition(
   return { left, top };
 }
 
+/**
+ * Resolve the CSS `left` (px string) for an anchored object (image or text box)
+ * in a header/footer, honoring `wp:positionH` (relativeTo page/margin, align
+ * left/center/right, or posOffset). Shared by floating images and text boxes so
+ * a page-centered banner in the header lands centered like Word, not pinned to
+ * the left. Ported from eigenpal/docx-editor#700.
+ */
+export function resolveHeaderFooterFloatLeft(
+  width: number,
+  h:
+    | {
+        relativeTo?: string;
+        posOffset?: number;
+        align?: string;
+        alignment?: string;
+      }
+    | undefined,
+  layout: HeaderFooterLayoutInfo,
+): string {
+  if (!h) {
+    return "0";
+  }
+
+  const align = getPositionAlignment(h);
+
+  if (h.relativeTo === "page") {
+    if (h.posOffset !== undefined) {
+      return `${emuToPixels(h.posOffset) - layout.flowLeft}px`;
+    }
+    if (align === "right") {
+      return `${layout.pageWidth - width - layout.flowLeft}px`;
+    }
+    if (align === "center") {
+      return `${(layout.pageWidth - width) / 2 - layout.flowLeft}px`;
+    }
+    if (align === "left") {
+      return `${-layout.flowLeft}px`;
+    }
+  }
+
+  // `relativeTo: margin` falls through here intentionally: the header/footer
+  // content width IS the margin box, so the content-relative branch is already
+  // margin-correct.
+  if (h.posOffset !== undefined) {
+    return `${emuToPixels(h.posOffset)}px`;
+  }
+  if (align === "right") {
+    return `${layout.contentWidth - width}px`;
+  }
+  if (align === "center") {
+    return `${(layout.contentWidth - width) / 2}px`;
+  }
+
+  return "0";
+}
+
 function applyHeaderFooterFloatHorizontalPosition(
   img: HTMLImageElement,
   floatImg: {
@@ -625,48 +681,11 @@ function applyHeaderFooterFloatHorizontalPosition(
   },
   layout: HeaderFooterLayoutInfo,
 ): void {
-  const h = floatImg.position.horizontal;
-  if (!h) {
-    img.style.left = "0";
-    return;
-  }
-
-  const align = getPositionAlignment(h);
-
-  if (h.relativeTo === "page") {
-    if (h.posOffset !== undefined) {
-      img.style.left = `${emuToPixels(h.posOffset) - layout.flowLeft}px`;
-      return;
-    }
-    if (align === "right") {
-      img.style.left = `${layout.pageWidth - floatImg.width - layout.flowLeft}px`;
-      return;
-    }
-    if (align === "center") {
-      img.style.left = `${(layout.pageWidth - floatImg.width) / 2 - layout.flowLeft}px`;
-      return;
-    }
-    if (align === "left") {
-      img.style.left = `${-layout.flowLeft}px`;
-      return;
-    }
-  }
-
-  if (h.posOffset !== undefined) {
-    img.style.left = `${emuToPixels(h.posOffset)}px`;
-    return;
-  }
-
-  if (align === "right") {
-    img.style.left = `${layout.contentWidth - floatImg.width}px`;
-    return;
-  }
-  if (align === "center") {
-    img.style.left = `${(layout.contentWidth - floatImg.width) / 2}px`;
-    return;
-  }
-
-  img.style.left = "0";
+  img.style.left = resolveHeaderFooterFloatLeft(
+    floatImg.width,
+    floatImg.position.horizontal,
+    layout,
+  );
 }
 
 /**
@@ -964,7 +983,7 @@ function extractFloatingImagesFromParagraph(
  * wrapNone images, e.g. full-page letterhead backgrounds). `"front"` paints
  * above text (default for `inFront` wrapNone and side-wrapping images).
  */
-function renderFloatingImagesLayer(
+export function renderFloatingImagesLayer(
   floatingImages: PageFloatingImage[],
   doc: Document,
   layerMode: "front" | "behind" = "front",
@@ -1005,6 +1024,13 @@ function renderFloatingImagesLayer(
     img.style.width = `${floatImg.width}px`;
     img.style.height = `${floatImg.height}px`;
     img.style.display = "block";
+    // A floating image is sized explicitly from its OOXML extent and may be
+    // anchored so it bleeds into the page margin (e.g. a logo flush to the
+    // right edge). Opt out of the global `img { max-width: 100% }` reset, which
+    // would otherwise cap the width to the remaining content area and squash
+    // the image against its fixed height. eigenpal/docx-editor#694.
+    img.style.maxWidth = "none";
+    img.style.maxHeight = "none";
     if (floatImg.alt) {
       img.alt = floatImg.alt;
     }
@@ -1260,7 +1286,15 @@ function renderHeaderFooterContent(
         { document: doc },
       );
       fragEl.style.top = `${cursorY}px`;
-      fragEl.style.left = "0";
+      // Honor the anchor's horizontal position (e.g. centered relative to the
+      // page) instead of pinning the box to the left. The vertical position
+      // stays on the H/F flow cursor (positionV is not yet honored for H/F text
+      // boxes). eigenpal/docx-editor#700.
+      fragEl.style.left = resolveHeaderFooterFloatLeft(
+        measure.width,
+        block.position?.horizontal,
+        layout,
+      );
       containerEl.append(fragEl);
       cursorY += measure.height;
     }


### PR DESCRIPTION
Periodic sync of valid fixes from upstream `eigenpal/docx-editor` (MIT; folio is
Stella's fork). Previous sync covered through #690; this batch ports three small,
self-contained upstream fixes, each adapted to folio's diverged architecture and
covered by a regression test.

## Fixes

### #700 — anchored text box horizontal position in headers/footers
Header/footer text boxes were pinned to `left: 0`, ignoring their `wp:positionH`
anchor (the floating-image path already resolved it). A page-centered banner
(e.g. a "For Internal Use" classification line) now renders centered.

Extracted `resolveHeaderFooterFloatLeft(width, h, layout)` as a shared pure
function used by both the floating-image and text-box paths.

### #694 — floating images squashed near the right edge
Painted floating images set explicit width/height but did not opt out of the
global `img { max-width: 100% }` reset (Tailwind preflight). An image anchored
so its width reaches into the page margin was capped to the remaining content
width and stretched against its fixed height. The painter now sets
`maxWidth/maxHeight: none` (matching the existing header/footer image guard).

### #699 — contextual spacing inside table cells
`applyContextualSpacing` only walked top-level blocks, so two same-style
paragraphs with `w:contextualSpacing` inside a table cell kept their
before/after spacing. It now recurses into cells, keeping measure and paint
consistent. (Only the cell-recursion slice of upstream #699 applies here; the
rest of that PR depends on upstream's mid-row table-break architecture, which
folio does not yet have — tracked as follow-up.)

## Tests
- `header-footer-float-left.test.ts` — `resolveHeaderFooterFloatLeft` page/margin/center/right cases
- `floating-image-maxwidth.test.ts` — painted float keeps OOXML size + `max-width: none`
- `contextualSpacing-table.test.ts` — suppression inside a cell; no suppression across differing styles

All 374 folio layout tests pass; `tsc --noEmit` clean; oxlint clean.

## Follow-ups (separate PRs)
- #694 `topAndBottom` banner band reservation (text flows above/below a page-pinned banner).
- #698 + remainder of #699: mid-row table breaking, vMerge cell continuation across pages, cut-edge borders, measure-vs-paint spacing collapse, split-table selection clipping. Larger architectural port.
