### PR TITLE
fix(web): align recent-activity filenames across rows

### DIFF
--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -1221,7 +1221,26 @@ const OverviewRow = ({ entity, workspaceId, lang }: OverviewRowProps) => {
         />
       )}
       <span className="flex min-w-0 flex-1 items-center gap-1 truncate text-sm">
-        <span className="text-muted-foreground shrink-0">{activityLabel}</span>{" "}
+        {/* Grid overlays the active verb on invisible sizers of every verb, so
+            the column is as wide as the longest one and file names align across
+            rows regardless of locale. */}
+        <span className="text-muted-foreground grid shrink-0 justify-items-start">
+          <span
+            aria-hidden
+            className="invisible col-start-1 row-start-1 whitespace-nowrap"
+          >
+            {t("workspaces.overview.uploaded")}
+          </span>
+          <span
+            aria-hidden
+            className="invisible col-start-1 row-start-1 whitespace-nowrap"
+          >
+            {t("workspaces.overview.edited")}
+          </span>
+          <span className="col-start-1 row-start-1 whitespace-nowrap">
+            {activityLabel}
+          </span>
+        </span>
         {icon}
         <span className="truncate">{entity.name}</span>
       </span>

--- a/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
+++ b/apps/web/src/routes/_protected.workspaces/$workspaceId/-components/overview-view.tsx
@@ -1226,13 +1226,13 @@ const OverviewRow = ({ entity, workspaceId, lang }: OverviewRowProps) => {
             rows regardless of locale. */}
         <span className="text-muted-foreground grid shrink-0 justify-items-start">
           <span
-            aria-hidden
+            aria-hidden="true"
             className="invisible col-start-1 row-start-1 whitespace-nowrap"
           >
             {t("workspaces.overview.uploaded")}
           </span>
           <span
-            aria-hidden
+            aria-hidden="true"
             className="invisible col-start-1 row-start-1 whitespace-nowrap"
           >
             {t("workspaces.overview.edited")}


### PR DESCRIPTION
Pad the recent-activity verb (`uploaded`/`edited`) into a fixed-width column so file names line up across rows.

The verb span previously sized to its own text, so shorter verbs (`edited`) shifted the following icon and filename left relative to `uploaded` rows. The verb is now rendered in a CSS grid that overlays the active label on invisible sizers of every verb, so the column is always as wide as the longest verb — and alignment holds in any locale without a hardcoded width.